### PR TITLE
gitignore: git now ignores the build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.pyc
 *.pyo
+build/


### PR DESCRIPTION
Hey -

Just a simple change to the root .gitignore to add the build/ directory.

This is a really minor change, but is something that I have always done in my personal repositories. I figured I might as well try for a pull request in case anyone else agrees.

Cheers,
Ben
