### PR TITLE
Fix bugs in atsc_field_sync_mux.

### DIFF
--- a/gr-atsc/src/lib/atsc_field_sync_mux.cc
+++ b/gr-atsc/src/lib/atsc_field_sync_mux.cc
@@ -37,7 +37,7 @@ atsc_make_field_sync_mux()
 }
 
 atsc_field_sync_mux::atsc_field_sync_mux()
-  : gr_sync_block("atsc_field_sync_mux",
+  : gr_block("atsc_field_sync_mux",
 		  gr_make_io_signature(1, 1, sizeof(atsc_data_segment)),
 		  gr_make_io_signature(1, 1, sizeof(atsc_data_segment)))
 {
@@ -148,21 +148,24 @@ atsc_field_sync_mux::forecast (int noutput_items, gr_vector_int &ninput_items_re
 {
   unsigned ninputs = ninput_items_required.size();
   for (unsigned i = 0; i < ninputs; i++)
-    ninput_items_required[i] = fixed_rate_noutput_to_ninput (noutput_items);
+    ninput_items_required[i] = noutput_items;
 
 }
 
 
 int
-atsc_field_sync_mux::work (int noutput_items,
+atsc_field_sync_mux::general_work (int noutput_items,
+		       gr_vector_int &ninput_items,
 		       gr_vector_const_void_star &input_items,
 		       gr_vector_void_star &output_items)
 {
+  int in_length = ninput_items[0];
   const atsc_data_segment *in = (const atsc_data_segment *) input_items[0];
   atsc_data_segment *out = (atsc_data_segment *) output_items[0];
 
-  unsigned int index = 0;
-  for (int outdex = 0; outdex < noutput_items; outdex++){
+  int index = 0;
+  int outdex = 0;
+  for (outdex = 0; outdex < noutput_items && index < in_length; outdex++){
 
     assert (in[index].pli.regular_seg_p ());
 
@@ -197,7 +200,6 @@ atsc_field_sync_mux::work (int noutput_items,
     }
   }
 
-  d_current_index += index;
-
-  return noutput_items;
+  this->consume_each(index);
+  return outdex;
 }

--- a/gr-atsc/src/lib/atsc_field_sync_mux.h
+++ b/gr-atsc/src/lib/atsc_field_sync_mux.h
@@ -37,7 +37,7 @@ ATSC_API atsc_field_sync_mux_sptr atsc_make_field_sync_mux();
  *
  * input: atsc_data_segment; output: atsc_data_segment
  */
-class ATSC_API atsc_field_sync_mux : public gr_sync_block
+class ATSC_API atsc_field_sync_mux : public gr_block
 {
   friend ATSC_API atsc_field_sync_mux_sptr atsc_make_field_sync_mux();
 
@@ -45,17 +45,20 @@ class ATSC_API atsc_field_sync_mux : public gr_sync_block
 
 public:
   void forecast (int noutput_items, gr_vector_int &ninput_items_required);
-  int work (int noutput_items,
+  int general_work (int noutput_items,
+	    gr_vector_int &ninput_items,
 	    gr_vector_const_void_star &input_items,
 	    gr_vector_void_star &output_items);
 
 
   static const int      N_SAVED_SYMBOLS = 12;
 
-  void reset() { /* nop */ }
+  void reset()
+  {
+    d_already_output_field_sync = false;
+  }
 
 protected:
-  gr_uint64             d_current_index;
   bool                  d_already_output_field_sync;
   unsigned char         d_saved_symbols[N_SAVED_SYMBOLS];
 };


### PR DESCRIPTION
Since this block inserts field syncs into the data stream, clearly
it needs to be a gr_block rather than a gr_sync_block.  Also, the
d_already_output_field_sync variable needs to be initialized and
the d_current_index variable is unusued and thus can be deleted.

With these fixes in place, I've successfully transmitted an MPEG
transport stream with a USRP N210 and received it on my television.
