### PR TITLE
added utf8 encoding line to python templates

### DIFF
--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -303,6 +303,7 @@ namespace gr {
 
 # Python block
 Templates['block_python'] = '''\#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 ${str_to_python_comment($license)}
 #
 #if $blocktype == 'noblock'
@@ -457,6 +458,7 @@ namespace gr {
 
 # Python QA code
 Templates['qa_python'] = '''\#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 ${str_to_python_comment($license)}
 #
 


### PR DESCRIPTION
python breaks if it encounters special characters in files without specified encoding.
Which is especially funny if you've got umlauts in your name.

This minimal patch fixes that by adding a -_\- encoding:.. -_\- line.
