### PR TITLE
gr-blocks: fix SIGSEG when destructing file source

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -71,9 +71,12 @@ namespace gr {
 
     file_source_impl::~file_source_impl()
     {
-      fclose ((FILE*)d_fp);
+      if(d_fp)
+        fclose ((FILE*)d_fp);
+      if(d_new_fp)
+        fclose ((FILE*)d_new_fp);
     }
-    
+
     bool
     file_source_impl::seek(long seek_point, int whence)
     {


### PR DESCRIPTION
There is no anny condition restricting values of d_fp/d_new_fp when destructor is called, all must be handled correctly.
