### PR TITLE
wxgui: prevent a crash caused by dividing by zero

### DIFF
--- a/gr-wxgui/python/wxgui/plotter/channel_plotter.py
+++ b/gr-wxgui/python/wxgui/plotter/channel_plotter.py
@@ -150,13 +150,13 @@ class channel_plotter(grid_plotter_base):
 			num_samps = len(samples)
 			if not num_samps: continue
 			if isinstance(samples, tuple): continue
-			if self.x_max <= self.x_min: continue
 			#linear interpolation
 			x_index = (num_samps-1)*(x_val-self.x_min)/(self.x_max-self.x_min)
 			x_index_low = int(math.floor(x_index))
 			x_index_high = int(math.ceil(x_index))
 			scale = x_index - x_index_low + self._channels[channel][TRIG_OFF_KEY]
 			y_value = (samples[x_index_high] - samples[x_index_low])*scale + samples[x_index_low]
+			if math.isnan(y_value): continue
 			label_str += '\n%s: %s'%(channel, common.eng_format(y_value, self.y_units))
 		return label_str
 


### PR DESCRIPTION
The tooltip label is calculated when the plot graph is not yet populated. This causes a division by zero error resulting in a NaN value which later cases an exception when trying to cast it into an integer. In these cases we simply do not display the engineering values (like in other exceptional cases)
