### PR TITLE
modtool: fix detection of GNU Radio module directory

### DIFF
--- a/gr-utils/python/modtool/modtool_base.py
+++ b/gr-utils/python/modtool/modtool_base.py
@@ -131,7 +131,8 @@ class ModTool(object):
             return False
         for f in files:
             if os.path.isfile(f) and f == 'CMakeLists.txt':
-                if re.search('find_package\(GnuradioRuntime\)', open(f).read()) is not None:
+                if re.search('find_package\(GnuradioRuntime\)', open(f).read()) is not None or \
+                                re.search('find_package\(Gnuradio(\s+[0-9".]+)?\)', open(f).read()) is not None:
                     self._info['version'] = '36' # Might be 37, check that later
                     has_makefile = True
                 elif re.search('GR_REGISTER_COMPONENT', open(f).read()) is not None:


### PR DESCRIPTION
In order to identify whatever directory is valid GNU Radio module directory both string

find_package(GnuradioRuntime)

and

find_package(Gnuradio) / find_package(Gnuradio "VERSION")

should be accepted.

Check whatewe they are not commented out might be handfull, let my now if You think so.
