### PR TITLE
Updating module imports on examples to 3.7 API

### DIFF
--- a/gnuradio-runtime/examples/mp-sched/synthetic.py
+++ b/gnuradio-runtime/examples/mp-sched/synthetic.py
@@ -19,8 +19,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-from gnuradio import gr, gru, eng_notation, blks2
-from gnuradio import blocks
+from gnuradio import gr, gru, eng_notation
+from gnuradio import blocks, filter
 from gnuradio.eng_option import eng_option
 from optparse import OptionParser
 import os

--- a/gnuradio-runtime/examples/network/audio_sink.py
+++ b/gnuradio-runtime/examples/network/audio_sink.py
@@ -21,7 +21,7 @@
 #
 
 from gnuradio import gr
-from gnuradio import blocks
+from gnuradio import blocks, audio
 from gnuradio.eng_option import eng_option
 from optparse import OptionParser
 import sys
@@ -33,7 +33,7 @@ except ImportError:
     sys.exit(1)
 
 class audio_sink(gr.top_block):
-    def __init__(self, host, port, pkt_size, sample_rate, eof, wait):
+    def __init__(self, host, port, pkt_size, sample_rate, eof):
         gr.top_block.__init__(self, "audio_sink")
         src = blocks.udp_source(gr.sizeof_float, host, port, pkt_size, eof=eof)
         dst = audio.sink(sample_rate)

--- a/gnuradio-runtime/examples/network/dial_tone_sink.py
+++ b/gnuradio-runtime/examples/network/dial_tone_sink.py
@@ -28,7 +28,7 @@ from optparse import OptionParser
 class dial_tone_sink(gr.top_block):
     def __init__(self, host, port, pkt_size, sample_rate, eof):
         gr.top_block.__init__(self, "dial_tone_sink")
-        udp = blokcs.udp_source(gr.sizeof_float, host, port, pkt_size, eof=eof)
+        udp = blocks.udp_source(gr.sizeof_float, host, port, pkt_size, eof=eof)
         sink = audio.sink(sample_rate)
         self.connect(udp, sink)
 

--- a/gnuradio-runtime/examples/network/dial_tone_source.py
+++ b/gnuradio-runtime/examples/network/dial_tone_source.py
@@ -21,7 +21,6 @@
 #
 
 from gnuradio import gr
-from gnuradio import blocks
 from gnuradio.eng_option import eng_option
 from optparse import OptionParser
 import sys
@@ -35,6 +34,10 @@ try:
     from gnuradio import blocks
 except ImportError:
     sys.stderr.write("This example requires gr-blocks.\n")
+try:
+    from gnuradio import audio
+except ImportError:
+    sys.stderr.write("This example requires gr-audio.\n")
 
 class dial_tone_source(gr.top_block):
     def __init__(self, host, port, pkt_size, sample_rate, eof):

--- a/gnuradio-runtime/examples/network/vector_sink.py
+++ b/gnuradio-runtime/examples/network/vector_sink.py
@@ -26,7 +26,7 @@ from gnuradio.eng_option import eng_option
 from optparse import OptionParser
 
 class vector_sink(gr.top_block):
-    def __init__(self, host, port, pkt_size, eof, wait):
+    def __init__(self, host, port, pkt_size, eof):
         gr.top_block.__init__(self, "vector_sink")
 
         udp = blocks.udp_source(gr.sizeof_float, host, port, pkt_size, eof=eof)

--- a/gnuradio-runtime/examples/volk_benchmark/volk_types.py
+++ b/gnuradio-runtime/examples/volk_benchmark/volk_types.py
@@ -42,6 +42,18 @@ def short_to_char(N):
 
 ######################################################################
 
+def char_to_short(N):
+    op = blocks.char_to_short()
+    tb = helper(N, op, gr.sizeof_char, gr.sizeof_short, 1, 1)
+
+######################################################################
+
+def char_to_float(N):
+    op = blocks.char_to_float()
+    tb = helper(N, op, gr.sizeof_char, gr.sizeof_float, 1, 1)
+
+#####################################################################
+
 def int_to_float(N):
     op = blocks.int_to_float()
     tb = helper(N, op, gr.sizeof_int, gr.sizeof_float, 1, 1)

--- a/gr-digital/examples/example_timing.py
+++ b/gr-digital/examples/example_timing.py
@@ -60,7 +60,7 @@ class example_timing(gr.top_block):
         self.src = blocks.vector_source_c(data.tolist(), False)
         self.rrc = filter.interp_fir_filter_ccf(sps, rrc_taps)
         self.chn = channels.channel_model(noise, foffset, toffset)
-        self.off = filter.fractional_interpolator_cc(0.20, 1.0)
+        self.off = filter.fractional_resampler_cc(0.20, 1.0)
 
         if mode == 0:
             self.clk = digital.pfb_clock_sync_ccf(sps, gain, rrc_taps_rx,


### PR DESCRIPTION
Some of the examples were updated to use 3.7 API, but the new module namespaces were never imported.
