### PR TITLE
gr_modtool add: removed *out from sinks, *in from sources

### DIFF
--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -228,8 +228,16 @@ namespace gr {
 			  gr_vector_const_void_star &input_items,
 			  gr_vector_void_star &output_items)
     {
+#if $blocktype == 'source'
+#silent pass
+#else
         const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+#end if
+#if $blocktype == 'sink'
+#silent pass
+#else
         <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+#end if
 
         // Do <+signal processing+>
 


### PR DESCRIPTION
Cosmetic fix: In the C++ block_impl template the work method has convenience pointers for input and output,
regardless of whether the block is a source, a sink or an actual sync block with input and output.
With this patch: used to have.
