### PR TITLE
added tag_propagation_policy_t to block_gateway

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -41,6 +41,12 @@ namespace gr {
     GR_BLOCK_GW_WORK_INTERP,
   };
 
+  enum tag_propagation_policy_t {
+    TPP_DONT = 0,
+    TPP_ALL_TO_ALL = 1,
+    TPP_ONE_TO_ONE = 2
+  };
+
   /*!
    * Shared message structure between python and gateway.
    * Each action type represents a scheduler-called function.


### PR DESCRIPTION
Adding an enum tag_propagation_policy_t to the gr namespace in block_gateway.h.

This adds TPP_DONT etc to the gr. module. Therefore, self.set_tag_propagation_policy works from python now, too:

``` python
from gnuradio import gr

class my_block(gr.basic_block):
    def __init__(self):
...
        self.set_tag_propagation_policy(gr.TPP_DONT)

```
