### PR TITLE
digital: ofdm benchmark_rx fft conflict fix

### DIFF
--- a/gr-digital/python/digital/ofdm_receiver.py
+++ b/gr-digital/python/digital/ofdm_receiver.py
@@ -22,6 +22,7 @@
 
 import math
 from numpy import fft
+from gnuradio import fft as gr_fft
 from gnuradio import gr
 from gnuradio import analog
 from gnuradio import blocks
@@ -125,7 +126,7 @@ class ofdm_receiver(gr.hier_block2):
         self.nco = analog.frequency_modulator_fc(nco_sensitivity)         # generate a signal proportional to frequency error of sync block
         self.sigmix = blocks.multiply_cc()
         self.sampler = digital.ofdm_sampler(fft_length, fft_length+cp_length)
-        self.fft_demod = fft.fft_vcc(fft_length, True, win, True)
+        self.fft_demod = gr_fft.fft_vcc(fft_length, True, win, True)
         self.ofdm_frame_acq = digital.ofdm_frame_acquisition(occupied_tones,
                                                                   fft_length,
                                                                   cp_length, ks[0])


### PR DESCRIPTION
Fixes the following error in the gr 3.7 OFDM benchmark_rx code due to conflict with numpy 'fft' and gnuradio's 'fft':

Traceback (most recent call last):
  File "./benchmark_rx.py", line 122, in <module>
    main()
  File "./benchmark_rx.py", line 111, in main
    tb = my_top_block(rx_callback, options)
  File "./benchmark_rx.py", line 55, in **init**
    self.rxpath = receive_path(callback, options)
  File "/home/m/play/gr/pybombs/src/gnuradio/gr-digital/examples/ofdm/receive_path.py", line 50, in **init**
    callback=self._rx_callback)
  File "/usr/local/lib/python2.7/dist-packages/gnuradio/digital/ofdm.py", line 224, in __init__
    options.log)
  File "/usr/local/lib/python2.7/dist-packages/gnuradio/digital/ofdm_receiver.py", line 128, in **init**
    self.fft_demod = fft.fft_vcc(fft_length, True, win, True)
AttributeError: 'module' object has no attribute 'fft_vcc'
