### PR TITLE
virtual destructor

### DIFF
--- a/gr-digital/include/gnuradio/digital/packet_header_default.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_default.h
@@ -55,7 +55,7 @@ namespace gr {
 		      const std::string &len_tag_key="packet_len",
 		      const std::string &num_tag_key="packet_num",
 		      int bits_per_byte=1);
-      ~packet_header_default();
+      virtual ~packet_header_default();
 
       sptr base() { return shared_from_this(); };
       sptr formatter() { return shared_from_this(); };


### PR DESCRIPTION
For review, since my compiler complained that without a virtual destructor, deletion of packet_header_ofdm/default might lead to undefined behaviour (and he's got a point).
