### PR TITLE
wxgui: running python slider.py now works again

### DIFF
--- a/gr-wxgui/python/wxgui/slider.py
+++ b/gr-wxgui/python/wxgui/slider.py
@@ -25,12 +25,12 @@ def slider(parent, min, max, callback):
 # ----------------------------------------------------------------
 if __name__ == '__main__':
 
-    from gnuradio.wxgui import stdgui
+    from gnuradio.wxgui import stdgui2
 
-    class demo_graph(stdgui.gui_flow_graph):
+    class demo_graph(stdgui2.std_top_block):
 
         def __init__(self, frame, panel, vbox, argv):
-            stdgui.gui_flow_graph.__init__ (self, frame, panel, vbox, argv)
+            stdgui2.std_top_block.__init__ (self, frame, panel, vbox, argv)
 
             vbox.Add(slider(panel, 23, 47, self.my_callback1), 1, wx.ALIGN_CENTER)
             vbox.Add(slider(panel, -100, 100, self.my_callback2), 1, wx.ALIGN_CENTER)
@@ -42,7 +42,7 @@ if __name__ == '__main__':
             print "cb2 = ", val
 
     def main ():
-        app = stdgui.stdapp (demo_graph, "Slider Demo")
+        app = stdgui2.stdapp (demo_graph, "Slider Demo")
         app.MainLoop ()
 
     main ()


### PR DESCRIPTION
Investing Baokun Liu's question on discuss-gr from 2013-10-09, I found out that the demo mode of the wxgui slider was broken.
Fixed that.
