### PR TITLE
filter: Fixes CID 1046198

### DIFF
--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -30,7 +30,7 @@
 
 namespace gr {
   namespace filter {
-    
+
     pfb_synthesizer_ccf::sptr
     pfb_synthesizer_ccf::make(unsigned int numchans,
 			      const std::vector<float> &taps,
@@ -78,6 +78,7 @@ namespace gr {
 
     pfb_synthesizer_ccf_impl::~pfb_synthesizer_ccf_impl()
     {
+      delete d_fft;
       for(unsigned int i = 0; i < d_numchans; i++) {
 	delete d_filters[i];
       }


### PR DESCRIPTION
d_fft allocated in the constructor wasn't freed in the destructor.

Signed-off-by: Moritz Fischer moritz.fischer@ettus.com
