### PR TITLE
grc: slash key also activates search

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -292,7 +292,7 @@ RELOAD_BLOCKS = Action(
 )
 FIND_BLOCKS = Action(
     label='Find Blocks',
-    tooltip='Search for a block by bame or key',
+    tooltip='Search for a block by name (and key)',
     stock_id=gtk.STOCK_FIND,
     keypresses=(gtk.keysyms.f, gtk.gdk.CONTROL_MASK,
                 gtk.keysyms.slash, NO_MODS_MASK),

--- a/grc/gui/BlockTreeWindow.py
+++ b/grc/gui/BlockTreeWindow.py
@@ -220,12 +220,10 @@ class BlockTreeWindow(gtk.VBox):
             self.search_entry.set_text('')
             self.search_entry.hide()
 
-        elif event.state & gtk.gdk.CONTROL_MASK and event.keyval == gtk.keysyms.f:
+        elif (event.state & gtk.gdk.CONTROL_MASK and event.keyval == gtk.keysyms.f) \
+             or event.keyval == gtk.keysyms.slash:
             # propagation doesn't work although treeview search is disabled =(
             # manually trigger action...
-            Actions.FIND_BLOCKS.activate()
-
-        elif event.keyval == gtk.keysyms.slash:
             Actions.FIND_BLOCKS.activate()
 
         else:


### PR DESCRIPTION
 This allows to use the 'slash' key to start a search (in addition to the existing key binding).
