### PR TITLE
runtime: add qa for fast_atan2f, removed a float equality test

### DIFF
--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -213,6 +213,7 @@ list(APPEND test_gnuradio_runtime_sources
   math/qa_fxpt_vco.cc
   math/qa_math.cc
   math/qa_sincos.cc
+  math/qa_fast_atan2f.cc
   qa_buffer.cc
   qa_io_signature.cc
   qa_circular_file.cc

--- a/gnuradio-runtime/lib/math/fast_atan2f.cc
+++ b/gnuradio-runtime/lib/math/fast_atan2f.cc
@@ -128,13 +128,13 @@ namespace gr {
     float alpha, angle, base_angle;
     int index;
 
-    /* don't divide by zero! */		// FIXME could get hosed with -0.0
-    if((y == 0.0) && (x == 0.0))
-      return 0.0;
-
     /* normalize to +/- 45 degree range */
     y_abs = fabsf(y);
     x_abs = fabsf(x);
+    /* don't divide by zero! */
+    if((y_abs < 1.5E-5) && (x_abs < 1.5E-5))
+      return 0.0;
+
     //z = (y_abs < x_abs ? y_abs / x_abs : x_abs / y_abs);
     if(y_abs < x_abs)
       z = y_abs / x_abs;

--- a/gnuradio-runtime/lib/math/qa_fast_atan2f.cc
+++ b/gnuradio-runtime/lib/math/qa_fast_atan2f.cc
@@ -1,0 +1,51 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <qa_fast_atan2f.h>
+#include <gnuradio/math.h>
+#include <cppunit/TestAssert.h>
+#include <cmath>
+
+void
+qa_fast_atan2f::t1()
+{
+  static const unsigned int N = 100;
+  float c_atan2;
+  float gr_atan2f;
+  
+  for(float i = -N/2; i < N/2; i++) {
+    for(float j =-N/2; i < N/2; i++) {
+      float x = i/10.0;
+      float y = j/10.0;
+      c_atan2 = atan2(x, y);
+      
+      gr_atan2f = gr::fast_atan2f(x, y);
+      
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(c_atan2, gr_atan2f, 0.0001);
+    }
+  }
+}
+

--- a/gnuradio-runtime/lib/math/qa_fast_atan2f.h
+++ b/gnuradio-runtime/lib/math/qa_fast_atan2f.h
@@ -1,0 +1,39 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef _QA_FAST_ATAN2F_H_
+#define _QA_FAST_ATAN2F_H_
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+class qa_fast_atan2f : public CppUnit::TestCase
+{
+  CPPUNIT_TEST_SUITE(qa_fast_atan2f);
+  CPPUNIT_TEST(t1);
+  CPPUNIT_TEST_SUITE_END();
+  
+private:
+  void t1();
+};
+
+#endif /* _QA_FAST_ATAN2F_H_ */

--- a/gnuradio-runtime/lib/qa_runtime.cc
+++ b/gnuradio-runtime/lib/qa_runtime.cc
@@ -40,6 +40,7 @@
 #include <qa_math.h>
 #include <qa_vmcircbuf.h>
 #include <qa_sincos.h>
+#include <qa_fast_atan2f.h>
 
 CppUnit::TestSuite *
 qa_runtime::suite()
@@ -56,6 +57,7 @@ qa_runtime::suite()
   s->addTest(qa_math::suite());
   s->addTest(qa_vmcircbuf::suite());
   s->addTest(qa_sincos::suite());
+  s->addTest(qa_fast_atan2f::suite());
 
   return s;
 }


### PR DESCRIPTION
The float equality check was probably never resulting in true, so I changed it to a threshold comparison. This also fixes the labelled FIXME. The table look up is at best .0015 rad off from a 0 angle, so 1.5e-3 threshold would probably work. I made it 1.5e-5 because there's some interpolation based on table lookup; to be honest I didn't go through and calculate what the threshold should be given resolution (probably ballpark of 7e-4). This will also speed up the cases where the angle is very close to 0.

I shall henceforth implement a better atan.
