### PR TITLE
GRC: add support for '\b' characters in the (graphical) console output.

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -35,11 +35,31 @@ class TextDisplay(gtk.TextView):
         text_buffer = gtk.TextBuffer()
         text_buffer.set_text(text)
         self.set_text = text_buffer.set_text
-        self.insert = lambda line: text_buffer.insert(text_buffer.get_end_iter(), line)
         gtk.TextView.__init__(self, text_buffer)
         self.set_editable(False)
         self.set_cursor_visible(False)
         self.set_wrap_mode(gtk.WRAP_WORD_CHAR)
+
+    def insert(self, line):
+        # make backspaces work
+        line = self._consume_backspaces(line)
+        # add the remaining text to buffer
+        self.get_buffer().insert(self.get_buffer().get_end_iter(), line)
+
+    def _consume_backspaces(self, line):
+        """removes text from the buffer if line starts with \b*"""
+        if not line: return
+        # for each \b delete one char from the buffer
+        back_count = 0
+        start_iter = self.get_buffer().get_end_iter()
+        while line[back_count] == '\b':
+            # stop at the beginning of a line
+            if not start_iter.starts_line(): start_iter.backward_char()
+            back_count += 1
+        # remove chars
+        self.get_buffer().delete(start_iter, self.get_buffer().get_end_iter())
+        # return remaining text
+        return line[back_count:]
 
 def MessageDialogHelper(type, buttons, title=None, markup=None):
     """

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -154,8 +154,8 @@ class MainWindow(gtk.Window):
         """
         self.text_display.insert(line)
         vadj = self.reports_scrolled_window.get_vadjustment()
-        vadj.set_value(vadj.upper)
-        vadj.emit('changed')
+        vadj.value = vadj.upper - vadj.page_size
+        vadj.changed()
 
     ############################################################
     # Pages: create and close


### PR DESCRIPTION
During the initialization of e.g. the B210 the FPGA loading progress is shown and then updated using backspace characters. The console in the GRC main window can not process these resulting in a pretty ugly output. This patch emulates the behavior of a normal console. It deletes one char from the buffer for each '\b' at the beginning of the input line.
