### PR TITLE
runtime: fixed case where tagged stream blocks produce zero length tags

### DIFF
--- a/gnuradio-runtime/lib/tagged_stream_block.cc
+++ b/gnuradio-runtime/lib/tagged_stream_block.cc
@@ -134,7 +134,9 @@ namespace gr {
     for(int i = 0; i < (int) d_n_input_items_reqd.size(); i++) {
       consume(i, d_n_input_items_reqd[i]);
     }
-    update_length_tags(n_produced, output_items.size());
+    if (n_produced > 0) {
+      update_length_tags(n_produced, output_items.size());
+    }
 
     d_n_input_items_reqd.assign(input_items.size(), 0);
 


### PR DESCRIPTION
This fixes a potential hiccup when a tagged stream block produces zero outputs. Before, it would add a zero-length tag on the first item of the next block.
