### PR TITLE
grc: toggle visibility of report and block tree widgets

### DIFF
--- a/grc/gui/ActionHandler.py
+++ b/grc/gui/ActionHandler.py
@@ -113,7 +113,8 @@ class ActionHandler:
                 Actions.FLOW_GRAPH_OPEN, Actions.FLOW_GRAPH_SAVE_AS,
                 Actions.FLOW_GRAPH_CLOSE, Actions.ABOUT_WINDOW_DISPLAY,
                 Actions.FLOW_GRAPH_SCREEN_CAPTURE, Actions.HELP_WINDOW_DISPLAY,
-                Actions.TYPES_WINDOW_DISPLAY,
+                Actions.TYPES_WINDOW_DISPLAY, Actions.TOGGLE_BLOCKTREE_WIDGET,
+                Actions.TOGGLE_REPORT_WIDGET,
             ): action.set_sensitive(True)
             if not self.init_file_paths:
                 self.init_file_paths = Preferences.files_open()
@@ -349,6 +350,12 @@ class ActionHandler:
             Dialogs.TypesDialog(self.get_flow_graph().get_parent())
         elif action == Actions.ERRORS_WINDOW_DISPLAY:
             Dialogs.ErrorsDialog(self.get_flow_graph())
+        elif action == Actions.TOGGLE_REPORT_WIDGET:
+            widget = self.main_window.reports_scrolled_window
+            widget.set_visible(not widget.get_visible())
+        elif action == Actions.TOGGLE_BLOCKTREE_WIDGET:
+            widget = self.main_window.btwin
+            widget.set_visible(not widget.get_visible())
         ##################################################
         # Param Modifications
         ##################################################
@@ -447,6 +454,7 @@ class ActionHandler:
             self.main_window.btwin.clear();
             self.platform.load_block_tree(self.main_window.btwin);
         elif action == Actions.FIND_BLOCKS:
+            self.main_window.btwin.show()
             self.main_window.btwin.search_entry.show()
             self.main_window.set_focus(self.main_window.btwin.search_entry)
         elif action == Actions.OPEN_HIER:

--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -233,6 +233,16 @@ ERRORS_WINDOW_DISPLAY = Action(
     tooltip='View flow graph errors',
     stock_id=gtk.STOCK_DIALOG_ERROR,
 )
+TOGGLE_REPORT_WIDGET = Action(
+    label='_Reports',
+    tooltip='Toggle visibility of the Report widget',
+    keypresses=(gtk.keysyms.r, gtk.gdk.CONTROL_MASK),
+)
+TOGGLE_BLOCKTREE_WIDGET = Action(
+    label='_Block Tree',
+    tooltip='Toggle visibility of the block tree widget',
+    keypresses=(gtk.keysyms.b, gtk.gdk.CONTROL_MASK),
+)
 ABOUT_WINDOW_DISPLAY = Action(
     label='_About',
     tooltip='About this program',

--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -88,7 +88,10 @@ MENU_BAR_LIST = (
         Actions.BLOCK_PARAM_MODIFY,
     ]),
     (gtk.Action('View', '_View', None, None), [
+        Actions.TOGGLE_BLOCKTREE_WIDGET,
+        Actions.TOGGLE_REPORT_WIDGET,
         Actions.ERRORS_WINDOW_DISPLAY,
+        None,
         Actions.FIND_BLOCKS,
     ]),
     (gtk.Action('Build', '_Build', None, None), [

--- a/grc/gui/BlockTreeWindow.py
+++ b/grc/gui/BlockTreeWindow.py
@@ -226,6 +226,10 @@ class BlockTreeWindow(gtk.VBox):
             # manually trigger action...
             Actions.FIND_BLOCKS.activate()
 
+        elif event.state & gtk.gdk.CONTROL_MASK and event.keyval == gtk.keysyms.b:
+            # ugly...
+            Actions.TOGGLE_BLOCKTREE_WIDGET.activate()
+
         else:
             return False # propagate event
 


### PR DESCRIPTION
This enable people to hide the block tree and reports widgets. Useful when working on a small screen or for demos.
The settings are not permanent for now. Can be added if it is deemed useful.

Also, this fixes another issue with the search entry focus, I have come across coding this
