### PR TITLE
grc: switched to ToggleActions; made visibility settings persistent

### DIFF
--- a/grc/gui/ActionHandler.py
+++ b/grc/gui/ActionHandler.py
@@ -113,8 +113,8 @@ class ActionHandler:
                 Actions.FLOW_GRAPH_OPEN, Actions.FLOW_GRAPH_SAVE_AS,
                 Actions.FLOW_GRAPH_CLOSE, Actions.ABOUT_WINDOW_DISPLAY,
                 Actions.FLOW_GRAPH_SCREEN_CAPTURE, Actions.HELP_WINDOW_DISPLAY,
-                Actions.TYPES_WINDOW_DISPLAY, Actions.TOGGLE_BLOCKTREE_WIDGET,
-                Actions.TOGGLE_REPORT_WIDGET,
+                Actions.TYPES_WINDOW_DISPLAY, Actions.TOGGLE_BLOCKS_WINDOW,
+                Actions.TOGGLE_REPORTS_WINDOW,
             ): action.set_sensitive(True)
             if not self.init_file_paths:
                 self.init_file_paths = Preferences.files_open()
@@ -126,6 +126,8 @@ class ActionHandler:
             if not self.get_page(): self.main_window.new_page() #ensure that at least a blank page exists
 
             self.main_window.btwin.search_entry.hide()
+            Actions.TOGGLE_REPORTS_WINDOW.set_active(Preferences.reports_window_visibility())
+            Actions.TOGGLE_BLOCKS_WINDOW.set_active(Preferences.blocks_window_visibility())
         elif action == Actions.APPLICATION_QUIT:
             if self.main_window.close_pages():
                 gtk.main_quit()
@@ -350,12 +352,14 @@ class ActionHandler:
             Dialogs.TypesDialog(self.get_flow_graph().get_parent())
         elif action == Actions.ERRORS_WINDOW_DISPLAY:
             Dialogs.ErrorsDialog(self.get_flow_graph())
-        elif action == Actions.TOGGLE_REPORT_WIDGET:
-            widget = self.main_window.reports_scrolled_window
-            widget.set_visible(not widget.get_visible())
-        elif action == Actions.TOGGLE_BLOCKTREE_WIDGET:
-            widget = self.main_window.btwin
-            widget.set_visible(not widget.get_visible())
+        elif action == Actions.TOGGLE_REPORTS_WINDOW:
+            visible = action.get_active()
+            self.main_window.reports_scrolled_window.set_visible(visible)
+            Preferences.reports_window_visibility(visible)
+        elif action == Actions.TOGGLE_BLOCKS_WINDOW:
+            visible = action.get_active()
+            self.main_window.btwin.set_visible(visible)
+            Preferences.blocks_window_visibility(visible)
         ##################################################
         # Param Modifications
         ##################################################

--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -57,27 +57,13 @@ def get_all_actions(): return _all_actions_list
 _accel_group = gtk.AccelGroup()
 def get_accel_group(): return _accel_group
 
-class Action(gtk.Action):
+
+class _ActionBase(object):
     """
-    A custom Action class based on gtk.Action.
-    Pass additional arguments such as keypresses.
+    Base class for Action and ToggleAction
     Register actions and keypresses with this module.
     """
-
-    def __init__(self, keypresses=(), name=None, label=None, tooltip=None, stock_id=None):
-        """
-        Create a new Action instance.
-        
-        Args:
-            key_presses: a tuple of (keyval1, mod_mask1, keyval2, mod_mask2, ...)
-            the: regular gtk.Action parameters (defaults to None)
-        """
-        if name is None: name = label
-        gtk.Action.__init__(self,
-            name=name, label=label,
-            tooltip=tooltip, stock_id=stock_id,
-        )
-        #register this action
+    def __init__(self, label, keypresses):
         _all_actions_list.append(self)
         for i in range(len(keypresses)/2):
             keyval, mod_mask = keypresses[i*2:(i+1)*2]
@@ -110,6 +96,52 @@ class Action(gtk.Action):
         Emit the activate signal when called with ().
         """
         self.emit('activate')
+
+
+class Action(gtk.Action, _ActionBase):
+    """
+    A custom Action class based on gtk.Action.
+    Pass additional arguments such as keypresses.
+    """
+
+    def __init__(self, keypresses=(), name=None, label=None, tooltip=None, stock_id=None):
+        """
+        Create a new Action instance.
+
+        Args:
+            key_presses: a tuple of (keyval1, mod_mask1, keyval2, mod_mask2, ...)
+            the: regular gtk.Action parameters (defaults to None)
+        """
+        if name is None: name = label
+        gtk.Action.__init__(self,
+            name=name, label=label,
+            tooltip=tooltip, stock_id=stock_id,
+        )
+        #register this action
+        _ActionBase.__init__(self, label, keypresses)
+
+
+class ToggleAction(gtk.ToggleAction, _ActionBase):
+    """
+    A custom Action class based on gtk.ToggleAction.
+    Pass additional arguments such as keypresses.
+    """
+
+    def __init__(self, keypresses=(), name=None, label=None, tooltip=None, stock_id=None):
+        """
+        Create a new ToggleAction instance.
+
+        Args:
+            key_presses: a tuple of (keyval1, mod_mask1, keyval2, mod_mask2, ...)
+            the: regular gtk.Action parameters (defaults to None)
+        """
+        if name is None: name = label
+        gtk.ToggleAction.__init__(self,
+            name=name, label=label,
+            tooltip=tooltip, stock_id=stock_id,
+        )
+        #register this action
+        _ActionBase.__init__(self, label, keypresses)
 
 ########################################################################
 # Actions
@@ -233,13 +265,13 @@ ERRORS_WINDOW_DISPLAY = Action(
     tooltip='View flow graph errors',
     stock_id=gtk.STOCK_DIALOG_ERROR,
 )
-TOGGLE_REPORT_WIDGET = Action(
-    label='_Reports',
+TOGGLE_REPORTS_WINDOW = ToggleAction(
+    label='Show _Reports',
     tooltip='Toggle visibility of the Report widget',
     keypresses=(gtk.keysyms.r, gtk.gdk.CONTROL_MASK),
 )
-TOGGLE_BLOCKTREE_WIDGET = Action(
-    label='_Block Tree',
+TOGGLE_BLOCKS_WINDOW = ToggleAction(
+    label='Show _Block Tree',
     tooltip='Toggle visibility of the block tree widget',
     keypresses=(gtk.keysyms.b, gtk.gdk.CONTROL_MASK),
 )

--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -57,6 +57,7 @@ TOOLBAR_LIST = (
 )
 
 ##The list of actions and categories for the menu bar.
+
 MENU_BAR_LIST = (
     (gtk.Action('File', '_File', None, None), [
         Actions.FLOW_GRAPH_NEW,
@@ -88,10 +89,10 @@ MENU_BAR_LIST = (
         Actions.BLOCK_PARAM_MODIFY,
     ]),
     (gtk.Action('View', '_View', None, None), [
-        Actions.TOGGLE_BLOCKTREE_WIDGET,
-        Actions.TOGGLE_REPORT_WIDGET,
-        Actions.ERRORS_WINDOW_DISPLAY,
+        Actions.TOGGLE_BLOCKS_WINDOW,
+        Actions.TOGGLE_REPORTS_WINDOW,
         None,
+        Actions.ERRORS_WINDOW_DISPLAY,
         Actions.FIND_BLOCKS,
     ]),
     (gtk.Action('Build', '_Build', None, None), [
@@ -106,7 +107,6 @@ MENU_BAR_LIST = (
         Actions.ABOUT_WINDOW_DISPLAY,
     ]),
 )
-
 class Toolbar(gtk.Toolbar):
     """The gtk toolbar with actions added from the toolbar list."""
 

--- a/grc/gui/BlockTreeWindow.py
+++ b/grc/gui/BlockTreeWindow.py
@@ -228,7 +228,7 @@ class BlockTreeWindow(gtk.VBox):
 
         elif event.state & gtk.gdk.CONTROL_MASK and event.keyval == gtk.keysyms.b:
             # ugly...
-            Actions.TOGGLE_BLOCKTREE_WIDGET.activate()
+            Actions.TOGGLE_BLOCKS_WINDOW.activate()
 
         else:
             return False # propagate event

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -109,6 +109,8 @@ class MainWindow(gtk.Window):
         self.flow_graph_vpaned.set_position(Preferences.reports_window_position())
         self.hpaned.set_position(Preferences.blocks_window_position())
         self.show_all()
+        self.reports_scrolled_window.hide()
+        self.btwin.hide()
 
     ############################################################
     # Event Handlers

--- a/grc/gui/Preferences.py
+++ b/grc/gui/Preferences.py
@@ -84,3 +84,15 @@ def blocks_window_position(pos=None):
     else:
         try: return _config_parser.getint('main', 'blocks_window_position') or 1 #greater than 0
         except: return -1
+
+def reports_window_visibility(visible=None):
+    if visible is not None: _config_parser.set('main', 'reports_window_visible', visible)
+    else:
+        try: return _config_parser.getboolean('main', 'reports_window_visible')
+        except: return True
+
+def blocks_window_visibility(visible=None):
+    if visible is not None: _config_parser.set('main', 'blocks_window_visible', visible)
+    else:
+        try: return _config_parser.getboolean('main', 'blocks_window_visible')
+        except: return True


### PR DESCRIPTION
(new pull request since to other one is closed)

> However, it would be useful to have the state of the report and search visibility shown as a check mark next to the menu entry, and change the menu entry to "Toggle ...".

Good point. I switched to ToggleActions as you suggested. Also, the toggle states are saved between sessions now. For the labels I prefer "Show...". I think it better go's with the check marks. Without the check marks "Toggle..." is better. What do you think?
