### PR TITLE
Max block does not work in GRC when IO Type is Short

### DIFF
--- a/gr-blocks/grc/blocks_max_xx.xml
+++ b/gr-blocks/grc/blocks_max_xx.xml
@@ -27,7 +27,7 @@
 		<option>
 			<name>Short</name>
 			<key>short</key>
-			<opt>fcn:dd</opt>
+			<opt>fcn:ss</opt>
 		</option>
 	</param>
 	<param>


### PR DESCRIPTION
Because of a typo in blocks_max_xx.xml, the Max block does not work in GNU Radio Companion when the IO Type is set to Short.

To reproduce the problem, create a flow graph with a null source connected to a Max block connected to a null sink, and set all three blocks to use Short.  Click the execute button, and you'll see the following error:

Traceback (most recent call last):
  File "/home/argilo/Documents/gnuradio/top_block.py", line 62, in <module>
    tb = top_block()
  File "/home/argilo/Documents/gnuradio/top_block.py", line 34, in **init**
    self.blocks_max_xx_0 = blocks.max_dd(1)
AttributeError: 'module' object has no attribute 'max_dd'

After applying this patch, the flow graph executes correctly.
