### PR TITLE
soft decoding: fix calc_soft_dec() crash dute to uninitialized pre_diff_...

### DIFF
--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -285,8 +285,7 @@ namespace gr {
 
         for(int j = 0; j < k; j++) {
           // Get the bit at the jth index
-          int mask = 1 << j;
-          int bit = (d_pre_diff_code[i] & mask) >> j;
+          int bit = ((d_apply_pre_diff_code ? d_pre_diff_code[i] : i) >> j) & 0x1;
 
           // If the bit is a 0, add to the probability of a zero
           if(bit == 0)


### PR DESCRIPTION
The constellation soft decoder crashes with this test script, the patch fixes this by checking whether the pre_diff_code is initialized.

---
# !/usr/bin/env python

from gnuradio import gr, blocks, digital, analog

con = digital.constellation_bpsk()
# con = digital.constellation_qpsk()

top = gr.top_block()
top.connect(analog.fastnoise_source_c(analog.GR_GAUSSIAN, 1.0),
      digital.constellation_soft_decoder_cf(con.base()),
      blocks.null_sink(gr.sizeof_float))
## top.run()
