### PR TITLE
runtime: Disable CPU_SET macros for FreeBSD.

### DIFF
--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -115,7 +115,8 @@ namespace gr {
 } /* namespace gr */
 
 
-#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) || \
+    defined(__FreeBSD__)
 
 namespace gr {
   namespace thread {


### PR DESCRIPTION
Like OSX, FreeBSD doesn't define the CPU_SET family of macros. This change is trivial in terms of copyright, and shouldn't require copyright assignment.
