### PR TITLE
qtgui: fixed thread-safety in GRC variable-type blocks

### DIFF
--- a/gr-qtgui/grc/qtgui_check_box.xml
+++ b/gr-qtgui/grc/qtgui_check_box.xml
@@ -17,7 +17,7 @@
 $win = Qt.QCheckBox($label)
 self._$(id)_choices = {True: $true, False: $false}
 self._$(id)_choices_inv = dict((v,k) for k,v in self._$(id)_choices.iteritems())
-self._$(id)_callback = lambda i: $(win).setChecked(self._$(id)_choices_inv[i])
+self._$(id)_callback = lambda i: Qt.QMetaObject.invokeMethod($(win), "setChecked", Qt.Q_ARG("bool", self._$(id)_choices_inv[i]))
 self._$(id)_callback(self.$id)
 $(win).stateChanged.connect(lambda i: self.set_$(id)(self._$(id)_choices[bool(i)]))
 $(gui_hint()($win))</make>

--- a/gr-qtgui/grc/qtgui_chooser.xml
+++ b/gr-qtgui/grc/qtgui_chooser.xml
@@ -9,6 +9,7 @@
 	<name>QT GUI Chooser</name>
 	<key>variable_qtgui_chooser</key>
 	<import>from PyQt4 import Qt</import>
+	<import>from PyQt4.QtCore import QObject, pyqtSlot</import>
 	<var_make>self.$(id) = $(id) = $value</var_make>
 	<make>#slurp
 #set $all_options = [$option0, $option1, $option2, $option3, $option4][:int($num_opts())]
@@ -56,7 +57,7 @@ $(win).addWidget(Qt.QLabel($label+": "))
 self._$(id)_combo_box = Qt.QComboBox()
 $(win).addWidget(self._$(id)_combo_box)
 for label in self._$(id)_labels: self._$(id)_combo_box.addItem(label)
-self._$(id)_callback = lambda i: self._$(id)_combo_box.setCurrentIndex(self._$(id)_options.index(i))
+self._$(id)_callback = lambda i: Qt.QMetaObject.invokeMethod(self._$(id)_combo_box, "setCurrentIndex", Qt.Q_ARG("int", self._$(id)_options.index(i)))
 self._$(id)_callback(self.$id)
 self._$(id)_combo_box.currentIndexChanged.connect(
 	lambda i: self.set_$(id)(self._$(id)_options[i]))
@@ -68,13 +69,19 @@ self._$(id)_combo_box.currentIndexChanged.connect(
 #set $win = 'self._%s_group_box'%$id
 $win = Qt.QGroupBox($label)
 self._$(id)_box = $(orient)()
-self._$(id)_button_group = Qt.QButtonGroup()
+class variable_chooser_button_group(Qt.QButtonGroup):
+    def __init__(self, parent=None):
+        Qt.QButtonGroup.__init__(self, parent)
+    @pyqtSlot(int)
+    def updateButtonChecked(self, button_id):
+        self.button(button_id).setChecked(True)
+self._$(id)_button_group = variable_chooser_button_group()
 $(win).setLayout(self._$(id)_box)
 for i, label in enumerate(self._$(id)_labels):
 	radio_button = Qt.QRadioButton(label)
 	self._$(id)_box.addWidget(radio_button)
 	self._$(id)_button_group.addButton(radio_button, i)
-self._$(id)_callback = lambda i: self._$(id)_button_group.button(self._$(id)_options.index(i)).setChecked(True)
+self._$(id)_callback = lambda i: Qt.QMetaObject.invokeMethod(self._$(id)_button_group, "updateButtonChecked", Qt.Q_ARG("int", self._$(id)_options.index(i)))
 self._$(id)_callback(self.$id)
 self._$(id)_button_group.buttonClicked[int].connect(
 	lambda i: self.set_$(id)(self._$(id)_options[i]))

--- a/gr-qtgui/grc/qtgui_entry.xml
+++ b/gr-qtgui/grc/qtgui_entry.xml
@@ -23,7 +23,7 @@ self._$(id)_line_edit.returnPressed.connect(
 	lambda: self.set_$(id)($(type.conv)(self._$(id)_line_edit.text().toAscii())))
 $(gui_hint()($win))</make>
 	<callback>self.set_$(id)($value)</callback>
-	<callback>self._$(id)_line_edit.setText($(type.str)($id))</callback>
+	<callback>Qt.QMetaObject.invokeMethod(self._$(id)_line_edit, "setText", Qt.Q_ARG("QString", $(type.str)($id)))</callback>
 	<param>
 		<name>Label</name>
 		<key>label</key>

--- a/gr-qtgui/grc/qtgui_label.xml
+++ b/gr-qtgui/grc/qtgui_label.xml
@@ -21,7 +21,7 @@ self._$(id)_label = Qt.QLabel(str(self.$id))
 self._$(id)_tool_bar.addWidget(self._$(id)_label)
 $(gui_hint()($win))</make>
 	<callback>self.set_$(id)($value)</callback>
-	<callback>self._$(id)_label.setText($(type.str)($id))</callback>
+	<callback>Qt.QMetaObject.invokeMethod(self._$(id)_label, "setText", Qt.Q_ARG("QString", $(type.str)($id)))</callback>
 	<param>
 		<name>Label</name>
 		<key>label</key>

--- a/gr-qtgui/grc/qtgui_range.xml
+++ b/gr-qtgui/grc/qtgui_range.xml
@@ -9,6 +9,7 @@
 	<name>QT GUI Range</name>
 	<key>variable_qtgui_range</key>
 	<import>from PyQt4 import Qt</import>
+	<import>from PyQt4.QtCore import QObject, pyqtSlot</import>
 	<import>import PyQt4.Qwt5 as Qwt</import>
 	<var_make>self.$(id) = $(id) = $value</var_make>
 	<make>#set $win = 'self._%s_layout'%$id
@@ -53,7 +54,13 @@ $(win).addWidget(self._$(id)_label)
 ########################################################################
 $win = Qt.QHBoxLayout()
 $(win).addWidget(Qt.QLabel($label+": "))
-self._$(id)_counter = Qwt.QwtCounter()
+class qwt_counter_fixed(Qwt.QwtCounter):
+    def __init__(self, parent=None):
+        Qwt.QwtCounter.__init__(self, parent)
+    @pyqtSlot('double')
+    def setValue(self, value):
+        super(Qwt.QwtCounter, self).setValue(value)
+self._$(id)_counter = qwt_counter_fixed()
 self._$(id)_counter.setRange($start, $stop, $step)
 self._$(id)_counter.setNumButtons(2)
 self._$(id)_counter.setMinimumWidth($min_len)
@@ -88,7 +95,13 @@ $win = Qt.QVBoxLayout()
 self._$(id)_tool_bar = Qt.QToolBar(self)
 $(win).addWidget(self._$(id)_tool_bar)
 self._$(id)_tool_bar.addWidget(Qt.QLabel($label+": "))
-self._$(id)_counter = Qwt.QwtCounter()
+class qwt_counter_fixed(Qwt.QwtCounter):
+    def __init__(self, parent=None):
+        Qwt.QwtCounter.__init__(self, parent)
+    @pyqtSlot('double')
+    def setValue(self, value):
+        super(Qwt.QwtCounter, self).setValue(value)
+self._$(id)_counter = qwt_counter_fixed()
 self._$(id)_counter.setRange($start, $stop, $step)
 self._$(id)_counter.setNumButtons(2)
 self._$(id)_counter.setValue(self.$id)
@@ -104,20 +117,20 @@ $(win).addWidget(self._$(id)_slider)
 $(gui_hint()($win))</make>
 	<callback>self.set_$(id)($value)</callback>
 	<callback>#if $widget() == "knob"
-self._$(id)_knob.setValue($id)
+Qt.QMetaObject.invokeMethod(self._$(id)_knob, "setValue", Qt.Q_ARG("double", $id))
 #end if
 #if $widget() == "thermo"
-self._$(id)_thermo.setValue($id)
+Qt.QMetaObject.invokeMethod(self._$(id)_thermo, "setValue", Qt.Q_ARG("double", $id))
 #end if
 #if $widget() == "counter"
-self._$(id)_counter.setValue($id)
+Qt.QMetaObject.invokeMethod(self._$(id)_counter, "setValue", Qt.Q_ARG("double", $id))
 #end if
 #if $widget() == "slider"
-self._$(id)_slider.setValue($id)
+Qt.QMetaObject.invokeMethod(self._$(id)_slider, "setValue", Qt.Q_ARG("double", $id))
 #end if
 #if $widget() == "counter_slider"
-self._$(id)_counter.setValue($id)
-self._$(id)_slider.setValue($id)
+Qt.QMetaObject.invokeMethod(self._$(id)_counter, "setValue", Qt.Q_ARG("double", $id))
+Qt.QMetaObject.invokeMethod(self._$(id)_slider, "setValue", Qt.Q_ARG("double", $id))
 #end if</callback>
 	<param>
 		<name>Label</name>


### PR DESCRIPTION
Partial bugfix for thread-safety issues in qtgui. Variable-type blocks fixed only.
_Analysis showed potential problems in sinks also. I tried to fix that too, but I confused with complex code and many dead/outdated fragments. Discussion in mailing list: "Bug: gr-qtgui: wrong design of variable-type blocks for GRC (category /GUI Widgets/QT)"..._
