### PR TITLE
changed URL from old svn / utah.edu to gnuradio.org doxygen

### DIFF
--- a/gr-trellis/examples/python/README
+++ b/gr-trellis/examples/python/README
@@ -1,6 +1,6 @@
 Here we have several test programs for use with the gr-trellis implementation.
 Documentation can be found in
-http://gnuradio.utah.edu/svn/gnuradio/trunk/gr-trellis/doc/gr-trellis.html
+http://gnuradio.org/doc/doxygen/group__trellis__coding__blk.html
 
 fsm_utils.py contains several useful functions.
 


### PR DESCRIPTION
mini fix: the gr-trellis/examples/README was referring to an ancient URL for gr-trellis documentation.
Updated that to current doxygen module URL.
