### PR TITLE
Changing search order for qwt

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -21,7 +21,7 @@ find_path(QWT_INCLUDE_DIRS
 )
 
 find_library (QWT_LIBRARIES
-  NAMES qwt qwt6 qwt-qt4
+  NAMES qwt6 qwt qwt-qt4
   HINTS
   ${CMAKE_INSTALL_PREFIX}/lib
   ${CMAKE_INSTALL_PREFIX}/lib64


### PR DESCRIPTION
On gentoo the qwt5 lib is named qwt and the qwt6 lib is named qwt6.
So the  actual FindQwt.cmake results in 

//Path to a file.
QWT_INCLUDE_DIRS:PATH=/usr/include/qwt6

//Path to a library.
QWT_LIBRARIES:FILEPATH=/usr/lib64/libqwt.so

That results in 

build/gr-qtgui/lib/libgnuradio-qtgui-3.7.3git.so.0.0.0: undefined symbol: _ZNK7QwtPlot9drawItemsEP8QPainterRK6QRectFPK11QwtScaleMap

when running make test.

Changing the search order ( first qwt6 then qwt ) fixes this problem.
