### PR TITLE
Remove qt3 leftovers in qtgui code.

### DIFF
--- a/gr-qtgui/lib/spectrumdisplayform.ui
+++ b/gr-qtgui/lib/spectrumdisplayform.ui
@@ -506,7 +506,6 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
- <pixmapfunction></pixmapfunction>
  <customwidgets>
  <customwidget>
    <class>QwtSlider</class>


### PR DESCRIPTION
Gnuradio still depends on a qt4 that is compiled with qt3 support, because of a single line of code in `spectrumdisplayform.ui` of gr-qtgui.
