### PR TITLE
Fixes tag propagation errors due to double-to-int truncation

### DIFF
--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -121,7 +121,6 @@ namespace gr {
         else {
           for(t = rtags.begin(); t != rtags.end(); t++) {
             tag_t new_tag = *t;
-            //new_tag.offset *= rrate;
             new_tag.offset = ((double)new_tag.offset * rrate) + 0.5;
             for(int o = 0; o < d->noutputs(); o++)
               d->output(o)->add_item_tag(new_tag);
@@ -141,7 +140,6 @@ namespace gr {
           std::vector<tag_t>::iterator t;
           for(t = rtags.begin(); t != rtags.end(); t++) {
             tag_t new_tag = *t;
-            //new_tag.offset *= rrate;
             new_tag.offset = ((double)new_tag.offset * rrate) + 0.5;
             d->output(i)->add_item_tag(new_tag);
           }


### PR DESCRIPTION
For small rrate values the inaccuracies of floating point math can lead to off-by-one errors for tag propagation. Adding 0.5 is akin to rounding to the nearest sample value, which should lead to more accurate tag placement.

For example, if you multiply 6120 and 1/6120 you may end up with 0.999999..., which C will truncate to 0 when converting to an int. The preferred value would be 1.
