### PR TITLE
fix QA code for fast_atan2f to explicitly use std::isnan

### DIFF
--- a/gnuradio-runtime/lib/math/qa_fast_atan2f.cc
+++ b/gnuradio-runtime/lib/math/qa_fast_atan2f.cc
@@ -92,7 +92,7 @@ qa_fast_atan2f::t2()
   x = inf;
   y = inf;
   gr_atan2f = gr::fast_atan2f(x, y);
-  CPPUNIT_ASSERT(isnan(gr_atan2f));
+  CPPUNIT_ASSERT(std::isnan(gr_atan2f));
 
 
   /* Test x as NAN */
@@ -123,11 +123,11 @@ qa_fast_atan2f::t2()
   x = inf;
   y = nan;
   gr_atan2f = gr::fast_atan2f(x, y);
-  CPPUNIT_ASSERT(isnan(gr_atan2f));
+  CPPUNIT_ASSERT(std::isnan(gr_atan2f));
 
   x = nan;
   y = inf;
   gr_atan2f = gr::fast_atan2f(x, y);
-  CPPUNIT_ASSERT(isnan(gr_atan2f));
+  CPPUNIT_ASSERT(std::isnan(gr_atan2f));
 }
 


### PR DESCRIPTION
subject says it all ... this QA code won't compile for me (on OSX, but I think this must be the case in general) because "isnan" is not defined in the current namespace. Using "std::isnan" does the trick, and should not hurt any other OS / compiler compilation since it is just making the namespace explicit instead of implicit. - MLD
