### PR TITLE
Fixes for the Wno-dev warnings

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -207,8 +207,9 @@ function(GR_PYTHON_INSTALL)
             add_custom_command(
                 OUTPUT ${pyexefile} DEPENDS ${pyfile}
                 COMMAND ${PYTHON_EXECUTABLE} -c
-                \"open('${pyexefile}', 'w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())\"
+                "open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())"
                 COMMENT "Shebangin ${pyfile_name}"
+                VERBATIM
             )
 
             #on windows, python files need an extension to execute

--- a/gnuradio-runtime/lib/pmt/CMakeLists.txt
+++ b/gnuradio-runtime/lib/pmt/CMakeLists.txt
@@ -68,8 +68,9 @@ add_custom_command(
         ${CMAKE_CURRENT_SOURCE_DIR}/unv_template.cc.t
         ${CMAKE_CURRENT_SOURCE_DIR}/unv_qa_template.cc.t
     COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_DASH_B} -c
-    \"import os,sys\;srcdir='${CMAKE_CURRENT_SOURCE_DIR}'\;sys.path.append(srcdir)\;os.environ['srcdir']=srcdir\;from generate_unv import main\;main()\"
+    "import os, sys; srcdir='${CMAKE_CURRENT_SOURCE_DIR}'; sys.path.append(srcdir); os.environ['srcdir']=srcdir; from generate_unv import main; main()"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
 )
 
 set(pmt_sources

--- a/volk/cmake/GrPython.cmake
+++ b/volk/cmake/GrPython.cmake
@@ -199,8 +199,9 @@ function(VOLK_PYTHON_INSTALL)
             add_custom_command(
                 OUTPUT ${pyexefile} DEPENDS ${pyfile}
                 COMMAND ${PYTHON_EXECUTABLE} -c
-                \"open('${pyexefile}', 'w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())\"
+                "open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())"
                 COMMENT "Shebangin ${pyfile_name}"
+                VERBATIM
             )
 
             #on windows, python files need an extension to execute


### PR DESCRIPTION
Use VERBATIM in custom commands to fix quoting, to make CMake happy with the Python command being issued.  This change should be compatible with both CMake 2.6 and 2.8; see "add_custom_command", VERBATIM in both 2.6 and 2.8 docs:
< http://www.cmake.org/cmake/help/v2.8.12/cmake.html#command:add_custom_command >
< http://www.cmake.org/cmake/help/cmake2.6docs.html#command:add_custom_command >
This change works for me on OSX, but should be OS agnostic.
