### PR TITLE
blocks: added sleep to pdu_to_tagged_stream so it doesn't have to spin...

### DIFF
--- a/gr-blocks/grc/blocks_pdu_to_tagged_stream.xml
+++ b/gr-blocks/grc/blocks_pdu_to_tagged_stream.xml
@@ -8,7 +8,7 @@
   <name>PDU to Tagged Stream</name>
   <key>blocks_pdu_to_tagged_stream</key>
   <import>from gnuradio import blocks</import>
-  <make>blocks.pdu_to_tagged_stream($type.tv, $tag)</make>
+  <make>blocks.pdu_to_tagged_stream($type.tv, $tag, $sleep_duration)</make>
   <param>
     <name>Item Type</name>
     <key>type</key>
@@ -35,6 +35,12 @@
     <value>packet_len</value>
     <type>string</type>
   </param>
+  <param>
+    <name>Sleep duration</name>
+    <key>sleep_duration</key>
+    <value>0</value>
+    <type>int</type>
+  </param>
   <sink>
     <name>pdus</name>
     <type>message</type>
@@ -43,4 +49,5 @@
     <name>out</name>
     <type>$type</type>
   </source>
+  <doc>Sleep duration (ms): set to > 0 to allow thread to sleep while waiting for a message</doc>
 </block>

--- a/gr-blocks/include/gnuradio/blocks/pdu_to_tagged_stream.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_to_tagged_stream.h
@@ -45,9 +45,10 @@ namespace gr {
        * \param type PDU type of pdu::vector_type
        * \param lengthtagname The name of the tag that specifies how long the packet is.
        *                      Defaults to 'packet_len'.
+       * \param sleep_duration Time to sleep (ms) haven't not received a packet.
        */
       static sptr make(pdu::vector_type type,
-                       const std::string& lengthtagname="packet_len");
+                       const std::string& lengthtagname="packet_len", int sleep_duration=0);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/pdu_to_tagged_stream_impl.h
+++ b/gr-blocks/lib/pdu_to_tagged_stream_impl.h
@@ -34,9 +34,11 @@ namespace gr {
       pdu::vector_type     d_type;
       std::vector<uint8_t> d_remain;
       pmt::pmt_t           d_tag;
+      int                  d_sleep_duration;
+      bool                 d_no_message;
 
     public:
-      pdu_to_tagged_stream_impl(pdu::vector_type type, const std::string& lengthtagname="packet_len");
+      pdu_to_tagged_stream_impl(pdu::vector_type type, const std::string& lengthtagname="packet_len", int sleep_duration=0);
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
...when there is no message available (after already polling for one unsuccessfully)

Default behaviour is the same (will spin). CPU consumption can be reduced by having it sleep for a small period of time (otherwise entire core will be used for spinning).
