### PR TITLE
blocks: added 'MTU' and 'tcp_no_delay' params for 'socket_pdu'

### DIFF
--- a/gr-blocks/grc/blocks_socket_pdu.xml
+++ b/gr-blocks/grc/blocks_socket_pdu.xml
@@ -8,7 +8,7 @@
   <name>Socket PDU</name>
   <key>blocks_socket_pdu</key>
   <import>from gnuradio import blocks</import>
-  <make>blocks.socket_pdu($type, $host, $port, $mtu)</make>
+  <make>blocks.socket_pdu($type, $host, $port, $mtu, $tcp_no_delay)</make>
   <param>
     <name>Type</name>
     <key>type</key>
@@ -49,6 +49,31 @@
     <value>10000</value>
     <type>int</type>
   </param>
+  <param>
+    <name>TCP No Delay</name>
+    <key>tcp_no_delay</key>
+    <value>False</value>
+    <type>enum</type>
+    <hide>
+#if (($type() == '"TCP_CLIENT"') or ($type() == '"TCP_SERVER"'))
+#if (str($tcp_no_delay()) == 'False')
+part
+#else
+none
+#end if
+#else
+all
+#end if
+</hide>
+    <option>
+      <name>Enabled</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>Disabled</name>
+      <key>False</key>
+    </option>
+  </param>
   <sink>
     <name>pdus</name>
     <type>message</type>
@@ -59,4 +84,5 @@
     <type>message</type>
     <optional>1</optional>
   </source>
+  <doc>For server modes, leave Host blank to bind to all interfaces (equivalent to 0.0.0.0).</doc>
 </block>

--- a/gr-blocks/include/gnuradio/blocks/socket_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/socket_pdu.h
@@ -45,8 +45,9 @@ namespace gr {
        * \param addr network address to use
        * \param port network port to use
        * \param MTU maximum transmission unit
+       * \param tcp_no_delay TCP No Delay option (set to True to disable Nagle algorithm)
        */
-      static sptr make(std::string type, std::string addr, std::string port, int MTU=10000);
+      static sptr make(std::string type, std::string addr, std::string port, int MTU=10000, bool tcp_no_delay=false);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/socket_pdu_impl.h
+++ b/gr-blocks/lib/socket_pdu_impl.h
@@ -34,13 +34,14 @@ namespace gr {
     {
     private:
       boost::asio::io_service d_io_service;
-      boost::array<char, 10000> d_rxbuf;
+      std::vector<char> d_rxbuf;
       void run_io_service() { d_io_service.run(); }
 
       // TCP specific
       boost::asio::ip::tcp::endpoint d_tcp_endpoint;
       std::vector<tcp_connection::sptr> d_tcp_connections;
       void handle_tcp_read(const boost::system::error_code& error, size_t bytes_transferred);
+      bool d_tcp_no_delay;
 
       // TCP server specific
       boost::shared_ptr<boost::asio::ip::tcp::acceptor> d_acceptor_tcp;
@@ -60,7 +61,7 @@ namespace gr {
       void udp_send(pmt::pmt_t msg);
     
     public:
-      socket_pdu_impl(std::string type, std::string addr, std::string port, int MTU);
+      socket_pdu_impl(std::string type, std::string addr, std::string port, int MTU = 10000, bool tcp_no_delay = false);
     };
 
   } /* namespace blocks */


### PR DESCRIPTION
...(and GRC option), applied MTU (buffer size) to TCP/UDP send, separate TCP/UDP server endpoint resolvers for empty/0.0.0.0 Host param (listen on all interfaces)

Whitespace clean-up.
