### PR TITLE
runtime: added blocking message pub'ing in basic_block

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -68,7 +68,8 @@ namespace gr {
     typedef std::deque<pmt::pmt_t> msg_queue_t;
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator> msg_queue_map_t;
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator>::iterator msg_queue_map_itr;
-    std::map<pmt::pmt_t, boost::shared_ptr<boost::condition_variable>, pmt::comparator> msg_queue_ready;
+    std::map<pmt::pmt_t, boost::shared_ptr<boost::condition_variable>, pmt::comparator> msg_queue_ready, msg_queue_waiting;
+    std::map<pmt::pmt_t, bool, pmt::comparator> msg_queue_blocking_setting;
   
     gr::thread::mutex mutex;          //< protects all vars
   
@@ -155,7 +156,7 @@ namespace gr {
     void set_block_alias(std::string name);
   
     // ** Message passing interface **
-    void message_port_register_in(pmt::pmt_t port_id);
+    void message_port_register_in(pmt::pmt_t port_id, bool blocking = false);
     void message_port_register_out(pmt::pmt_t port_id);
     void message_port_pub(pmt::pmt_t port_id, pmt::pmt_t msg);
     void message_port_sub(pmt::pmt_t port_id, pmt::pmt_t target);

--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -219,8 +219,8 @@ namespace gr {
     }
 
     /* Message passing interface */
-    void block__message_port_register_in(pmt::pmt_t port_id) {
-      gr::basic_block::message_port_register_in(port_id);
+    void block__message_port_register_in(pmt::pmt_t port_id, bool blocking = false) {
+      gr::basic_block::message_port_register_in(port_id, blocking);
     }
 
     void block__message_port_register_out(pmt::pmt_t port_id) {
@@ -257,6 +257,19 @@ namespace gr {
         throw std::runtime_error("attempt to set_msg_handler_feval() on bad input message port!"); 
       }
       d_msg_handlers_feval[which_port] = msg_handler;
+    }
+    
+    pmt::pmt_t block__delete_head_nowait(pmt::pmt_t which_port)
+    {
+      return gr::basic_block::delete_head_nowait(which_port);
+    }
+    
+    pmt::pmt_t block__pop_msg_queue(pmt::pmt_t which_port)
+    {
+      pmt::pmt_t msg = block__delete_head_nowait(which_port);
+      if (msg.get() == NULL)    // Cannot return 'NULL' to Python, so in this special case we return 'PMT_NIL'
+        msg = pmt::PMT_NIL;
+      return msg;
     }
 
   protected:

--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -116,7 +116,8 @@ class gateway_block(object):
         prefix = 'block__'
         for attr in [x for x in dir(self.__gateway) if x.startswith(prefix)]:
             setattr(self, attr.replace(prefix, ''), getattr(self.__gateway, attr))
-        self.pop_msg_queue = lambda: gr.block_gw_pop_msg_queue_safe(self.__gateway)
+        self.pop_msg_queue = lambda x: gr.block_gw_pop_msg_queue_safe(self.__gateway, x)
+        self.post_msg = lambda x, y: gr.block_gw_post_msg_safe(self.__gateway, x, y)
 
     def to_basic_block(self):
         """

--- a/gnuradio-runtime/swig/block_gateway.i
+++ b/gnuradio-runtime/swig/block_gateway.i
@@ -47,3 +47,20 @@ block_gateway_sptr.__repr__ = lambda self: "<block_gateway>"
 block_gateway = block_gateway.make;
 %}
 
+%inline %{
+
+pmt::pmt_t block_gw_pop_msg_queue_safe(boost::shared_ptr<gr::block_gateway> block_gw, pmt::pmt_t which_port){
+    pmt::pmt_t msg;
+    GR_PYTHON_BLOCKING_CODE(
+        msg = block_gw->block__pop_msg_queue(which_port);
+    )
+    return msg;
+}
+
+void block_gw_post_msg_safe(boost::shared_ptr<gr::block_gateway> block_gw, pmt::pmt_t port_id, pmt::pmt_t msg){
+    GR_PYTHON_BLOCKING_CODE(
+        block_gw->block__message_port_pub(port_id, msg);
+    )
+}
+
+%}


### PR DESCRIPTION
(made relevant scheduler changes so 'work' is called for message-port-only blocks), added 'pop_msg_queue' and 'post_msg' to Python block via block gateway

A blocking message queue is created by passing 'true' in the second parameter of 'message_port_register_in'. Any caller posting to that queue will block if the queue is not empty (this mechanism can be used to provide back-pressure in a network comms setup, for instance).

The idea is that such message-port-only blocks (without normal 'stream' IO ports) will use the work function to _optionally_ pop messages from their queue (instead of registering a message handler that would always automatically service all pending messages).

The new Python functions allow Python blocks to post messages in a potentially blocking fashion, but release the Python GIL so the entire app doesn't freeze, as well as _optionally_ popping a message from a queue in the Pythonic block's 'work' function.
