### PR TITLE
Fix inconsistent in naming

### DIFF
--- a/gr-digital/grc/digital_constellation_modulator.xml
+++ b/gr-digital/grc/digital_constellation_modulator.xml
@@ -86,7 +86,7 @@
     </option>
   </param>
   <param>
-    <name>Logging</name>
+    <name>Log</name>
     <key>log</key>
     <value>False</value>
     <type>bool</type>

--- a/gr-digital/grc/digital_dxpsk_demod.xml
+++ b/gr-digital/grc/digital_dxpsk_demod.xml
@@ -114,7 +114,7 @@
 		</option>
 	</param>
 	<param>
-		<name>Logging</name>
+		<name>Log</name>
 		<key>log</key>
 		<value>False</value>
 		<type>bool</type>

--- a/gr-digital/grc/digital_dxpsk_mod.xml
+++ b/gr-digital/grc/digital_dxpsk_mod.xml
@@ -91,7 +91,7 @@
 		</option>
 	</param>
 	<param>
-		<name>Logging</name>
+		<name>Log</name>
 		<key>log</key>
 		<value>False</value>
 		<type>bool</type>

--- a/gr-digital/grc/digital_gfsk_demod.xml
+++ b/gr-digital/grc/digital_gfsk_demod.xml
@@ -70,7 +70,7 @@
 		</option>
 	</param>
 	<param>
-		<name>Logging</name>
+		<name>Log</name>
 		<key>log</key>
 		<value>False</value>
 		<type>bool</type>

--- a/gr-digital/grc/digital_gfsk_mod.xml
+++ b/gr-digital/grc/digital_gfsk_mod.xml
@@ -49,7 +49,7 @@
 		</option>
 	</param>
 	<param>
-		<name>Logging</name>
+		<name>Log</name>
 		<key>log</key>
 		<value>False</value>
 		<type>bool</type>

--- a/gr-digital/grc/digital_gmsk_demod.xml
+++ b/gr-digital/grc/digital_gmsk_demod.xml
@@ -63,7 +63,7 @@
 		</option>
 	</param>
 	<param>
-		<name>Logging</name>
+		<name>Log</name>
 		<key>log</key>
 		<value>False</value>
 		<type>bool</type>

--- a/gr-digital/grc/digital_gmsk_mod.xml
+++ b/gr-digital/grc/digital_gmsk_mod.xml
@@ -42,7 +42,7 @@
 		</option>
 	</param>
 	<param>
-		<name>Logging</name>
+		<name>Log</name>
 		<key>log</key>
 		<value>False</value>
 		<type>bool</type>

--- a/gr-digital/grc/digital_psk_demod.xml
+++ b/gr-digital/grc/digital_psk_demod.xml
@@ -120,7 +120,7 @@
     </option>
   </param>
   <param>
-    <name>Logging</name>
+    <name>Log</name>
     <key>log</key>
     <value>False</value>
     <type>bool</type>

--- a/gr-digital/grc/digital_psk_mod.xml
+++ b/gr-digital/grc/digital_psk_mod.xml
@@ -100,7 +100,7 @@
     </option>
   </param>
   <param>
-    <name>Logging</name>
+    <name>Log</name>
     <key>log</key>
     <value>False</value>
     <type>bool</type>

--- a/gr-digital/grc/digital_qam_demod.xml
+++ b/gr-digital/grc/digital_qam_demod.xml
@@ -121,7 +121,7 @@
     </option>
   </param>
   <param>
-    <name>Logging</name>
+    <name>Log</name>
     <key>log</key>
     <value>False</value>
     <type>bool</type>

--- a/gr-digital/grc/digital_qam_mod.xml
+++ b/gr-digital/grc/digital_qam_mod.xml
@@ -100,7 +100,7 @@
     </option>
   </param>
   <param>
-    <name>Logging</name>
+    <name>Log</name>
     <key>log</key>
     <value>False</value>
     <type>bool</type>

--- a/gr-digital/python/digital/gmsk.py
+++ b/gr-digital/python/digital/gmsk.py
@@ -66,7 +66,7 @@ class gmsk_mod(gr.hier_block2):
         samples_per_symbol: samples per baud >= 2 (integer)
         bt: Gaussian filter bandwidth * symbol time (float)
         verbose: Print information about modulator? (boolean)
-        debug: Print modulation data to files? (boolean)
+        log: Print modulation data to files? (boolean)
     """
 
     def __init__(self,
@@ -176,12 +176,12 @@ class gmsk_demod(gr.hier_block2):
     
     Args:
         samples_per_symbol: samples per baud (integer)
-        verbose: Print information about modulator? (boolean)
-        log: Print modualtion data to files? (boolean)
         gain_mu: controls rate of mu adjustment (float)
         mu: fractional delay [0.0, 1.0] (float)
         omega_relative_limit: sets max variation in omega (float)
         freq_error: bit rate error as a fraction (float)
+        verbose: Print information about modulator? (boolean)
+        log: Print modualtion data to files? (boolean)
     """
     
     def __init__(self,

--- a/gr-digital/python/digital/packet_utils.py
+++ b/gr-digital/python/digital/packet_utils.py
@@ -113,7 +113,9 @@ def make_packet(payload, samples_per_symbol, bits_per_symbol,
         bits_per_symbol: (needed for padding calculation) (int)
         preamble: string of ascii 0's and 1's
         access_code: string of ascii 0's and 1's
+        pad_for_usrp: If true, packets are padded such that they end up a multiple of 128 samples(512 bytes)
         whitener_offset: offset into whitener string to use [0-16)
+        whitening: Whether to turn on data whitening(scrambling) (boolean)
     
     Packet will have access code at the beginning, followed by length, payload
     and finally CRC-32.

--- a/grc/grc_gnuradio/blks2/packet.py
+++ b/grc/grc_gnuradio/blks2/packet.py
@@ -75,9 +75,9 @@ class packet_encoder(gr.hier_block2):
         Args:
             samples_per_symbol: number of samples per symbol
             bits_per_symbol: number of bits per symbol
+            preamble: string of ascii 0's and 1's
             access_code: AKA sync vector
             pad_for_usrp: If true, packets are padded such that they end up a multiple of 128 samples
-            payload_length: number of bytes in a data-stream slice
         """
         #setup parameters
         self._samples_per_symbol = samples_per_symbol


### PR DESCRIPTION
(1) In the XML files, all keys except "log" are used as parameter names.
(2) gmsk.py documents "log" as "debug".
(3) ofdm_sync_pn.py uses "logging", but all others use "log".
