### PR TITLE
GRC path enhancements

### DIFF
--- a/grc/gui/Preferences.py
+++ b/grc/gui/Preferences.py
@@ -24,7 +24,7 @@ _platform = None
 _config_parser = ConfigParser.ConfigParser()
 
 def file_extension(): return '.'+_platform.get_key()
-def _prefs_file(): return os.path.join(os.path.expanduser('~'), file_extension())
+def _prefs_file(): return os.environ.get('GRC_PREFS_PATH', os.path.join(os.path.expanduser('~'), file_extension()))
 
 def load(platform):
     global _platform
@@ -32,9 +32,11 @@ def load(platform):
     #create sections
     _config_parser.add_section('main')
     _config_parser.add_section('files_open')
+    print "Reading preferences from:", _prefs_file()
     try: _config_parser.read(_prefs_file())
     except: pass
 def save():
+    print "Writing preferences to:", _prefs_file()
     try: _config_parser.write(open(_prefs_file(), 'w'))
     except: pass
 

--- a/grc/python/Constants.py
+++ b/grc/python/Constants.py
@@ -25,7 +25,7 @@ _gr_prefs = gr.prefs()
 
 #setup paths
 PATH_SEP = {'/':':', '\\':';'}[os.path.sep]
-HIER_BLOCKS_LIB_DIR = os.path.join(os.path.expanduser('~'), '.grc_gnuradio')
+HIER_BLOCKS_LIB_DIR = os.path.join(os.path.expanduser('~'), os.environ.get('GRC_HIER_PATH', '.grc_gnuradio'))
 BLOCKS_DIRS = filter( #filter blank strings
     lambda x: x, PATH_SEP.join([
         os.environ.get('GRC_BLOCKS_PATH', ''),

--- a/grc/python/Platform.py
+++ b/grc/python/Platform.py
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 """
 
 import os
+from collections import OrderedDict
 from gnuradio import gr
 from .. base.Platform import Platform as _Platform
 from .. gui.Platform import Platform as _GUIPlatform
@@ -43,7 +44,20 @@ class Platform(_Platform, _GUIPlatform):
         #ensure hier dir
         if not os.path.exists(HIER_BLOCKS_LIB_DIR): os.mkdir(HIER_BLOCKS_LIB_DIR)
         #convert block paths to absolute paths
-        block_paths = set(map(os.path.abspath, BLOCKS_DIRS))
+        # Create a mapping from the absolute path to what was passed in
+        user_to_abs_path = map(lambda x: (os.path.abspath(x), x), BLOCKS_DIRS)
+        # Keep each unique absolute path and maintain order
+        paths_dict = OrderedDict(user_to_abs_path)
+        # Prepare the ordered, unique absolute path list for _Platform
+        block_paths = paths_dict.keys()
+        # Print out the paths that are used (differently, depending on whether they
+        #   were transformed from their original state)
+        print "Block paths:"
+        for p in block_paths:
+            if p != paths_dict[p]:
+                print "\t%s (%s)" % (paths_dict[p], p)
+            else:
+                print "\t%s" % (p)
         #init
         _Platform.__init__(
             self,


### PR DESCRIPTION
grc: honour order of block paths, print them out on startup, override hier block and pref file path with GRC_HIER_PATH & GRC_PREFS_PATH
