### PR TITLE
TPB automatically names threads for Linux & Windows

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -149,6 +149,9 @@ namespace gr {
      * Note: this does not work on OSX
      */
     GR_RUNTIME_API int set_thread_priority(gr_thread_t thread, int priority);
+    
+    GR_RUNTIME_API void set_thread_name(gr_thread_t thread,
+                                        std::string name);
 
   } /* namespace thread */
 } /* namespace gr */

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -36,6 +36,8 @@ namespace gr {
     : d_exec(block, max_noutput_items)
   {
     //std::cerr << "tpb_thread_body: " << block << std::endl;
+    
+    thread::set_thread_name(pthread_self(), boost::str(boost::format("%s%d") % block->name() % block->unique_id()));
 
     block_detail *d = block->detail().get();
     block_executor::state s;


### PR DESCRIPTION
runtime: added ability to name threads, TPB scheduler automatically names each block's thread
