### PR TITLE
WAV sink does WAV header completion with block 'stop'

### DIFF
--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -164,11 +164,19 @@ namespace gr {
 
     wavfile_sink_impl::~wavfile_sink_impl()
     {
+      stop();
+    }
+
+    bool wavfile_sink_impl::stop()
+    {
       if(d_new_fp) {
-	fclose(d_new_fp);
+        fclose(d_new_fp);
+        d_new_fp = NULL;
       }
 
       close();
+      
+      return true;
     }
 
     int

--- a/gr-blocks/lib/wavfile_sink_impl.h
+++ b/gr-blocks/lib/wavfile_sink_impl.h
@@ -67,6 +67,9 @@ namespace gr {
        */
       void close_wav();
 
+    protected:
+      bool stop();
+
     public:
       wavfile_sink_impl(const char *filename,
 			int n_channels,


### PR DESCRIPTION
blocks: WAV file sink's DTOR is not called, so added 'stop' override to force call of WAV file completion routine (fills in total size in RIFF header)

Probably not called due to boost interrupt on shutdown?
