### PR TITLE
pmt_io: adding string conversion for uniform vectors

### DIFF
--- a/gnuradio-runtime/lib/pmt/generate_unv.py
+++ b/gnuradio-runtime/lib/pmt/generate_unv.py
@@ -76,6 +76,7 @@ includes = """
 #endif
 #include <vector>
 #include <pmt/pmt.h>
+#include <boost/lexical_cast.hpp>
 #include "pmt_int.h"
 """
 

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -238,6 +238,7 @@ public:
   virtual const void *uniform_elements(size_t &len) = 0;
   virtual void *uniform_writable_elements(size_t &len) = 0;
   virtual size_t length() const = 0;
+  virtual const std::string string_ref(size_t k) const { return std::string("FIXME"); }
 };
 
 #include "pmt_unv_int.h"

--- a/gnuradio-runtime/lib/pmt/pmt_io.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_io.cc
@@ -110,9 +110,16 @@ write(pmt_t obj, std::ostream &port)
     port << "#<dict>";
   }
   else if (is_uniform_vector(obj)){
-    // FIXME
-    // port << "#<uniform-vector " << obj << ">";
-    port << "#<uniform-vector>";
+    port << "#[";
+    size_t len = length(obj);
+    if (len)
+    {
+      pmt_uniform_vector *uv = dynamic_cast<pmt_uniform_vector*>(obj.get());
+      port << uv->string_ref(0);
+      for (size_t i = 1; i < len; i++)
+	port << " " << uv->string_ref(i);
+    }
+    port <<  "]";
   }
   else {
   error:

--- a/gnuradio-runtime/lib/pmt/unv_template.cc.t
+++ b/gnuradio-runtime/lib/pmt/unv_template.cc.t
@@ -138,4 +138,10 @@ const std::vector< @TYPE@ >
   return _@TAG@vector(vector)->writable_elements(len);
 }
 
+const std::string
+pmt_@TAG@vector::string_ref(size_t k) const
+{
+  return boost::lexical_cast< std::string, @TYPE@ > (ref(k));
+}
+
 } /* namespace pmt */

--- a/gnuradio-runtime/lib/pmt/unv_template.h.t
+++ b/gnuradio-runtime/lib/pmt/unv_template.h.t
@@ -20,4 +20,5 @@ public:
   @TYPE@ *writable_elements(size_t &len);
   const void *uniform_elements(size_t &len);
   void *uniform_writable_elements(size_t &len);
+  virtual const std::string string_ref(size_t k) const;
 };


### PR DESCRIPTION
Sadly, this needed expansion of unv_template, otherwise I'd have to
hand-write gengen-style code in pmt_io.cc

partly in response to http://lists.gnu.org/archive/html/discuss-gnuradio/2014-04/msg00168.html , partly because I had that same problem and used massively ugly workarounds.

Downside of patch: 
- introduction of string functionality in the individual uniform vector classes
- dependency on boost/lexical_cast (is dependency of gnuradio-runtime, anyways)
