### PR TITLE
gr_uhd: added subtraction and addition to time_spec_t

### DIFF
--- a/gr-uhd/python/uhd/qa_uhd.py
+++ b/gr-uhd/python/uhd/qa_uhd.py
@@ -35,6 +35,14 @@ class test_uhd(gr_unittest.TestCase):
         They may not have a UHD device connected, etc.  Don't try to run anything"""
         pass
 
+    def test_time_spec_t (self):
+        seconds = 42.0
+        time = uhd.time_spec_t(seconds)
+        twice_time = time + time;
+        zero_time = time - time;
+        self.assertEqual(time.get_real_secs() * 2,  seconds * 2 )
+        self.assertEqual(time.get_real_secs() - time.get_real_secs() , 0.0)
+
     def test_stream_args_channel_foo(self):
         """
         Try to manipulate the stream args channels for proper swig'ing checks.

--- a/gr-uhd/swig/uhd_swig.i
+++ b/gr-uhd/swig/uhd_swig.i
@@ -84,6 +84,21 @@
 
 %include <uhd/types/time_spec.hpp>
 
+%extend uhd::time_spec_t{
+    uhd::time_spec_t __add__(const uhd::time_spec_t &what)
+    {
+        uhd::time_spec_t temp = *self;
+        temp += what;
+        return temp;
+    }
+    uhd::time_spec_t __sub__(const uhd::time_spec_t &what)
+    {
+        uhd::time_spec_t temp = *self;
+        temp -= what;
+        return temp;
+    }
+};
+
 %include <uhd/types/stream_cmd.hpp>
 
 %include <uhd/types/clock_config.hpp>


### PR DESCRIPTION
Fixing a long lasting problem:

``` python
from gnuradio import uhd
t = uhd.time_spec_t(42.0)
sum = t + t
### Operator not defined.
```

This is due to SWIG not understanding Boost's operator.hpp automatic operator generation magic.

Fixed by extending the time_spec_t class from withing SWIG.

Minimal self test passes.
