### PR TITLE
uhd: Fixed "reducing chan number" bug

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -298,6 +298,7 @@ self.\$(id).set_bandwidth(\$bw$(n), $n)
 	<check>$max_mboards >= \$num_mboards</check>
 	<check>\$num_mboards > 0</check>
 	<check>\$nchan >= \$num_mboards</check>
+	<check>(not \$stream_chans()) or (\$nchan == len(\$stream_chans))</check>
 	<$sourk>
 		<name>$direction</name>
 		<type>\$type.type</type>


### PR DESCRIPTION
In some cases, there could be an error when reducing the number
of chans for UHD device in GRC (e.g. going from 2 chans to 1).
This adds another check which will alert the user.
