### PR TITLE
uhd: Symbolic block names now match the standard naming

### DIFF
--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -63,7 +63,7 @@ namespace gr {
     usrp_sink_impl::usrp_sink_impl(const ::uhd::device_addr_t &device_addr,
                                    const ::uhd::stream_args_t &stream_args,
                                    const std::string &length_tag_name)
-      : sync_block("gr uhd usrp sink",
+      : sync_block("usrp_sink",
                       args_to_io_sig(stream_args),
                       io_signature::make(0, 0, 0)),
         _stream_args(stream_args),

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -63,7 +63,7 @@ namespace gr {
 
     usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t &device_addr,
                                        const ::uhd::stream_args_t &stream_args):
-      sync_block("gr uhd usrp source",
+      sync_block("usrp_source",
                     io_signature::make(0, 0, 0),
                     args_to_io_sig(stream_args)),
       _stream_args(stream_args),


### PR DESCRIPTION
This would go onto 'next' because technically, it's an API breakage, so you can hold off with the merge if you don't want to change next right now.

It's just a tiny change, though, so it probably wouldn't hurt, either.
