### PR TITLE
gr-filter: Add a convenience freq_xlating_fft_filter block

### DIFF
--- a/gr-filter/grc/CMakeLists.txt
+++ b/gr-filter/grc/CMakeLists.txt
@@ -26,6 +26,7 @@ install(FILES
     filter_filterbank_vcvcf.xml
     filter_fractional_interpolator_xx.xml
     filter_fractional_resampler_xx.xml
+    filter_freq_xlating_fft_filter_ccc.xml
     filter_freq_xlating_fir_filter_xxx.xml
     filter_hilbert_fc.xml
     filter_iir_filter_xxx.xml

--- a/gr-filter/grc/filter_block_tree.xml
+++ b/gr-filter/grc/filter_block_tree.xml
@@ -56,6 +56,7 @@
 	</cat>
 	<cat>
 		<name>Channelizers</name>
+		<block>freq_xlating_fft_filter_ccc</block>
 		<block>freq_xlating_fir_filter_xxx</block>
 		<block>pfb_channelizer_ccf</block>
 		<block>pfb_channelizer_hier_ccf</block>

--- a/gr-filter/grc/filter_freq_xlating_fft_filter_ccc.xml
+++ b/gr-filter/grc/filter_freq_xlating_fft_filter_ccc.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Frequency Xlating FFT Filter
+###################################################
+ -->
+<block>
+	<name>Frequency Xlating FFT Filter</name>
+	<key>freq_xlating_fft_filter_ccc</key>
+	<import>from gnuradio import filter</import>
+	<import>from gnuradio.filter import firdes</import>
+	<make>filter.freq_xlating_fft_filter_ccc($decim, $taps, $center_freq, $samp_rate)
+self.$(id).set_nthreads($nthreads)
+self.$(id).declare_sample_delay($samp_delay)</make>
+	<callback>set_taps($taps)</callback>
+	<callback>set_center_freq($center_freq)</callback>
+	<callback>set_nthreads($nthreads)</callback>
+	<param>
+		<name>Decimation</name>
+		<key>decim</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<param>
+		<name>Taps</name>
+		<key>taps</key>
+		<type>complex_vector</type>
+	</param>
+	<param>
+		<name>Center Frequency</name>
+		<key>center_freq</key>
+		<value>0</value>
+		<type>real</type>
+	</param>
+	<param>
+		<name>Sample Rate</name>
+		<key>samp_rate</key>
+		<value>samp_rate</value>
+		<type>real</type>
+	</param>
+	<param>
+		<name>Sample Delay</name>
+		<key>samp_delay</key>
+                <value>0</value>
+		<type>int</type>
+                <hide>part</hide>
+	</param>
+	<param>
+		<name>Num. Threads</name>
+		<key>nthreads</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<sink>
+		<name>in</name>
+		<type>complex</type>
+	</sink>
+	<source>
+		<name>out</name>
+		<type>complex</type>
+	</source>
+</block>

--- a/gr-filter/python/filter/CMakeLists.txt
+++ b/gr-filter/python/filter/CMakeLists.txt
@@ -24,6 +24,7 @@ GR_PYTHON_INSTALL(
     FILES
     __init__.py
     filterbank.py
+    freq_xlating_fft_filter.py
     optfir.py
     pfb.py
     rational_resampler.py

--- a/gr-filter/python/filter/__init__.py
+++ b/gr-filter/python/filter/__init__.py
@@ -31,6 +31,7 @@ except ImportError:
     __path__.append(os.path.join(dirname, "..", "..", "swig"))
     from filter_swig import *
 from filterbank import *
+from freq_xlating_fft_filter import *
 from rational_resampler import *
 import pfb
 import optfir

--- a/gr-filter/python/filter/freq_xlating_fft_filter.py
+++ b/gr-filter/python/filter/freq_xlating_fft_filter.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2013 Sylvain Munaut <tnt@246tNt.com>
+#
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+import math
+import cmath
+
+from gnuradio import gr
+from gnuradio.blocks import rotator_cc
+
+from filter_swig import fft_filter_ccc
+
+
+__all__ = [ 'freq_xlating_fft_filter_ccc' ]
+
+
+class freq_xlating_fft_filter_ccc(gr.hier_block2):
+
+    def __init__(self, decim, taps, center_freq, samp_rate):
+        gr.hier_block2.__init__(
+            self,
+            'freq_xlating_fft_filter_ccc',
+            gr.io_signature(1, 1, gr.sizeof_gr_complex),
+            gr.io_signature(1, 1, gr.sizeof_gr_complex),
+        )
+
+        # Save args
+        self.decim       = decim
+        self.taps        = taps
+        self.center_freq = center_freq
+        self.samp_rate   = samp_rate
+
+        # Sub blocks
+        self._filter = fft_filter_ccc(decim, taps)
+        self._rotator = rotator_cc(0.0)
+
+        self.connect(self, self._filter, self._rotator, self)
+
+        # Refresh
+        self._refresh()
+
+    def _rotate_taps(self, taps, phase_inc):
+        return [ x * cmath.exp(i * phase_inc * 1j) for i,x in enumerate(taps) ]
+
+    def _refresh(self):
+        phase_inc = (2.0 * math.pi * self.center_freq) / self.samp_rate
+        rtaps = self._rotate_taps(self.taps, phase_inc)
+        self._filter.set_taps(rtaps)
+        self._rotator.set_phase_inc(- self.decim * phase_inc)
+
+    def set_taps(self, taps):
+        self.taps = taps
+        self._refresh()
+
+    def set_center_freq(self, center_freq):
+        self.center_freq = center_freq
+        self._refresh()
+
+    def set_nthreads(self, nthreads):
+        self._filter.set_nthreads(nthreads)
+
+    def declare_sample_delay(self, samp_delay):
+        self._filter.declare_sample_delay(samp_delay)


### PR DESCRIPTION
It's meant as a GRC convenience mainly. It's in python only and implemented
as a hier block encapsulating a FFT filter + rotator

Signed-off-by: Sylvain Munaut tnt@246tNt.com
