### PR TITLE
Fix cmake support for portaudio

### DIFF
--- a/cmake/Modules/FindPortaudio.cmake
+++ b/cmake/Modules/FindPortaudio.cmake
@@ -31,5 +31,22 @@ find_library(PORTAUDIO_LIBRARIES
 
 mark_as_advanced(PORTAUDIO_INCLUDE_DIRS PORTAUDIO_LIBRARIES)
 
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(PORTAUDIO DEFAULT_MSG PORTAUDIO_INCLUDE_DIRS PORTAUDIO_LIBRARIES)
+# Found PORTAUDIO, but it may be version 18 which is not acceptable.
+if(EXISTS ${PORTAUDIO_INCLUDE_DIRS}/portaudio.h)
+  include(CheckCXXSourceCompiles)
+  include(CMakePushCheckState)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_INCLUDES ${PORTAUDIO_INCLUDE_DIRS})
+  CHECK_CXX_SOURCE_COMPILES(
+    "#include <portaudio.h>\nPaDeviceIndex pa_find_device_by_name(const char *name); int main () {return 0;}"
+    PORTAUDIO2_FOUND)
+  cmake_pop_check_state()
+  if(PORTAUDIO2_FOUND)
+    INCLUDE(FindPackageHandleStandardArgs)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(PORTAUDIO DEFAULT_MSG PORTAUDIO_INCLUDE_DIRS PORTAUDIO_LIBRARIES)
+  else(PORTAUDIO2_FOUND)
+    message(STATUS
+      "  portaudio.h not compatible (requires API 2.0)")
+    set(PORTAUDIO_FOUND FALSE)
+  endif(PORTAUDIO2_FOUND)
+endif()


### PR DESCRIPTION
The first commit fixes two issues with finding portaudio via pkg-config.  The second of these commits verifies that the located version is not portaudio18, which would produce an error when gr-audio is built.  (Ubuntu 12.04-LTS and possibly other distributions do still use portaudio18 by default and installing libportaudio19-dev is not always an option.)
