### PR TITLE
gr_modtool: Added try: clause for SWIG import, fixing python-only OOT modules

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/python/__init__.py
+++ b/gr-utils/python/modtool/gr-newmod/python/__init__.py
@@ -42,7 +42,11 @@ if _RTLD_GLOBAL != 0:
 
 
 # import swig generated symbols into the howto namespace
-from howto_swig import *
+try:
+	# this might fail if the module is python-only
+	from howto_swig import *
+except ImportError:
+	pass
 
 # import any pure python here
 #


### PR DESCRIPTION
**init**.py used to throw an ImportError when trying to load
a python-only OOT module.
