### PR TITLE
pmt: adding pmt.uniform_vector_itemsize(pmt_t vector), returns the size ...

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -411,6 +411,9 @@ PMT_API bool is_f64vector(pmt_t x);
 PMT_API bool is_c32vector(pmt_t x);
 PMT_API bool is_c64vector(pmt_t x);
 
+//! item size in bytes if \p x is any kind of uniform numeric vector
+PMT_API size_t uniform_vector_itemsize(pmt_t x);
+
 PMT_API pmt_t make_u8vector(size_t k, uint8_t fill);
 PMT_API pmt_t make_s8vector(size_t k, int8_t fill);
 PMT_API pmt_t make_u16vector(size_t k, uint16_t fill);

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -760,6 +760,14 @@ is_uniform_vector(pmt_t x)
   return x->is_uniform_vector();
 }
 
+size_t
+uniform_vector_itemsize(pmt_t vector)
+{
+  if (!vector->is_uniform_vector())
+    throw wrong_type("pmt_uniform_vector_itemsize", vector);
+  return _uniform_vector(vector)->itemsize();
+}
+
 const void *
 uniform_vector_elements(pmt_t vector, size_t &len)
 {
@@ -775,6 +783,8 @@ uniform_vector_writable_elements(pmt_t vector, size_t &len)
     throw wrong_type("pmt_uniform_vector_writable_elements", vector);
   return _uniform_vector(vector)->uniform_writable_elements(len);
 }
+
+
 
 ////////////////////////////////////////////////////////////////////////////
 //                            Dictionaries

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -238,6 +238,7 @@ public:
   virtual const void *uniform_elements(size_t &len) = 0;
   virtual void *uniform_writable_elements(size_t &len) = 0;
   virtual size_t length() const = 0;
+  virtual size_t itemsize() const = 0;
 };
 
 #include "pmt_unv_int.h"

--- a/gnuradio-runtime/lib/pmt/unv_template.h.t
+++ b/gnuradio-runtime/lib/pmt/unv_template.h.t
@@ -14,6 +14,7 @@ public:
 
   bool is_@TAG@vector() const { return true; }
   size_t length() const { return d_v.size(); }
+  size_t itemsize() const { return sizeof(@TYPE@); }
   @TYPE@ ref(size_t k) const;
   void set(size_t k, @TYPE@ x);
   const @TYPE@ *elements(size_t &len);

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -43,6 +43,7 @@ class test_pmt(unittest.TestCase):
         s = pmt.serialize_str(v)
         d = pmt.deserialize_str(s)
         self.assertTrue(pmt.equal(v, d))
+        self.assertEqual(pmt.uniform_vector_itemsize(v), 4)
 
     def test04(self):
         v = pmt.init_f64vector(3, [11, -22, 33])
@@ -91,6 +92,7 @@ class test_pmt(unittest.TestCase):
         s = pmt.serialize_str(v)
         d = pmt.deserialize_str(s)
         self.assertTrue(pmt.equal(v, d))
+        self.assertEqual(pmt.uniform_vector_itemsize(v), 8)
 
     def test12(self):
         v = pmt.init_c64vector(3, [11 + -101j, -22 + 202j, 33 + -303j])

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -170,6 +170,7 @@ namespace pmt{
   bool is_f64vector(pmt_t x);
   bool is_c32vector(pmt_t x);
   bool is_c64vector(pmt_t x);
+  size_t uniform_vector_itemsize(pmt_t x);
   pmt_t make_u8vector(size_t k, uint8_t fill);
   pmt_t make_s8vector(size_t k, int8_t fill);
   pmt_t make_u16vector(size_t k, uint16_t fill);


### PR DESCRIPTION
...per item in bytes within a uniform vector for any kind of uniform vector
includes new QA, passes make test 100%
