### PR TITLE
add attributes for clang compiler

### DIFF
--- a/gnuradio-runtime/include/gnuradio/attributes.h
+++ b/gnuradio-runtime/include/gnuradio/attributes.h
@@ -37,6 +37,13 @@
 #    define __GR_ATTR_EXPORT
 #    define __GR_ATTR_IMPORT
 #  endif
+#elif defined __clang__
+#  define __GR_ATTR_ALIGNED(x) __attribute__((aligned(x)))
+#  define __GR_ATTR_UNUSED     __attribute__((unused))
+#  define __GR_ATTR_INLINE     __attribute__((always_inline))
+#  define __GR_ATTR_DEPRECATED __attribute__((deprecated))
+#  define __GR_ATTR_EXPORT     __attribute__((visibility("default")))
+#  define __GR_ATTR_IMPORT     __attribute__((visibility("default")))
 #elif _MSC_VER
 #  define __GR_ATTR_ALIGNED(x) __declspec(align(x))
 #  define __GR_ATTR_UNUSED


### PR DESCRIPTION
Quick change to add attributes that (should) work with the Clang compiler. In my testing, these seem to work -- the compiler does not complain, and the attributes seem to be as they are declared.
