### PR TITLE
fixed an overflow issue in unpack_k_bits::unpack

### DIFF
--- a/gr-blocks/lib/unpack_k_bits.cc
+++ b/gr-blocks/lib/unpack_k_bits.cc
@@ -50,7 +50,7 @@ namespace gr {
         int n = 0;
         for(int i = 0; i < nbytes; i++) {
           unsigned int t = bytes[i];
-          for(unsigned int j = d_k - 1; j >= 0; j--)
+          for(int j = d_k - 1; j >= 0; j--)
             bits[n++] = (t >> j) & 0x01;
         }
       }


### PR DESCRIPTION
having j as an unsigned int causes an overflow, most likely causing a segfault
