### PR TITLE
runtime: fix a circular dependency for older compilers

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -30,6 +30,8 @@
 #include <gnuradio/rpcmanager.h>
 #include <gnuradio/rpcserver_selector.h>
 #include <gnuradio/rpcserver_base.h>
+class rpcbasic_base;
+typedef boost::shared_ptr<rpcbasic_base> rpcbasic_sptr;
 #include <gnuradio/block_registry.h>
 
 
@@ -583,9 +585,6 @@ public:
   rpcbasic_base() {}
   virtual ~rpcbasic_base() {};
 };
-
-
-typedef boost::shared_ptr<rpcbasic_base> rpcbasic_sptr;
 
 
 


### PR DESCRIPTION
I know this is really ugly, but it's the only option I'm seeing to break a circular dependency chain for dumb preprocessors. I can reformat it if there's a less bad option.
