### PR TITLE
digital: Fix error in HDLC framer rejecting packets when falsely determined to be "out of frame"

### DIFF
--- a/gr-digital/lib/hdlc_deframer_bp_impl.cc
+++ b/gr-digital/lib/hdlc_deframer_bp_impl.cc
@@ -56,7 +56,6 @@ namespace gr {
         d_bitctr=0;
         d_ones=0;
         d_pktbuf = new unsigned char[length_max+2];
-        d_in_frame=false;
     }
 
     /*
@@ -106,28 +105,23 @@ namespace gr {
                         }
                         else {
                         }
-                        d_in_frame=false;
                     } else {
-                        d_in_frame=true;
                     }
                     d_bitctr=0;
                     d_bytectr=0;
                 } else { //unstuff
                 }
             } else { //not 5+ continuous ones
-                if(d_in_frame) {
-                    if(d_bytectr > d_length_max) {
-                        d_bytectr=0;
+                if(d_bytectr > d_length_max) {
+                    d_bytectr=0;
+                    d_bitctr=0;
+                } else {
+                    d_pktbuf[d_bytectr]>>=1;
+                    if (bit) d_pktbuf[d_bytectr] |= 0x80;
+                    d_bitctr++;
+                    if (d_bitctr==8) {
                         d_bitctr=0;
-                        d_in_frame=false;
-                    } else {
-                        d_pktbuf[d_bytectr]>>=1;
-                        if (bit) d_pktbuf[d_bytectr] |= 0x80;
-                        d_bitctr++;
-                        if (d_bitctr==8) {
-                            d_bitctr=0;
-                            d_bytectr++;
-                        }
+                        d_bytectr++;
                     }
                 }
             }

--- a/gr-digital/lib/hdlc_deframer_bp_impl.h
+++ b/gr-digital/lib/hdlc_deframer_bp_impl.h
@@ -36,7 +36,6 @@ namespace gr {
         size_t d_ones;
         size_t d_bytectr;
         size_t d_bitctr;
-        bool d_in_frame;
         unsigned char *d_pktbuf;
 
         unsigned int crc_ccitt(unsigned char *data, size_t len);


### PR DESCRIPTION
No need for the HDLC deframer to keep state at all -- framing is simply a packet separator.
