### PR TITLE
volk: add check for posix_memalign ...

### DIFF
--- a/volk/lib/CMakeLists.txt
+++ b/volk/lib/CMakeLists.txt
@@ -66,6 +66,18 @@ if(COMPILER_NAME MATCHES "GNU")
 endif()
 
 ########################################################################
+# check for posix_memalign, since some OSs do not internally define
+# _XOPEN_SOURCE or _POSIX_C_SOURCE; they leave this to the user.
+########################################################################
+
+include(CheckFunctionExists)
+CHECK_FUNCTION_EXISTS(posix_memalign HAVE_POSIX_MEMALIGN)
+
+if(HAVE_POSIX_MEMALIGN)
+      add_definitions(-DHAVE_POSIX_MEMALIGN)
+endif(HAVE_POSIX_MEMALIGN)
+
+########################################################################
 # detect x86 flavor of CPU
 ########################################################################
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86|x86|x86_64|amd64)$")

--- a/volk/lib/volk_malloc.c
+++ b/volk/lib/volk_malloc.c
@@ -54,7 +54,7 @@
 
 // Otherwise, test if we are a POSIX or X/Open system
 // This only has a restriction that alignment be a power of 2.
-#if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+#if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
 
 void *volk_malloc(size_t size, size_t alignment)
 {
@@ -75,7 +75,7 @@ void volk_free(void *ptr)
 }
 
 // No standard handlers; we'll do it ourselves.
-#else // _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+#else // _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
 
 typedef struct mbuf_t {
   void *orig;
@@ -171,6 +171,6 @@ void volk_free(void *ptr)
   fprintf(stderr, "VOLK: tried to free a non-VOLK pointer\n");
 }
 
-#endif // _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+#endif // _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
 
 //#endif // _ISOC11_SOURCE


### PR DESCRIPTION
... for OSs that do not directly set _XOPEN_SOURCE or _POSIX_C_SOURCE; define and use the new variable when found. This fix is OS generic: if posix_memalign is found, use it.

This pull is in response to the GR thread about volk and posix_memalign not playing nicely on OSX. This change fixes that issue for OSX 10.8+ (maybe 10.7, too; I haven't checked). That said, GR issue 710 is still relevant for OSX 10.6- and maybe 10.7.  I'm glad Apple got their stuff together for this function; I wish they would do so others, too, but I guess 1 step at a time ... - MLD
