### PR TITLE
Fix for #647 - GUI Tabs do not switch on WX GUI Scope sink channels on OS X

### DIFF
--- a/gr-wxgui/python/wxgui/forms/forms.py
+++ b/gr-wxgui/python/wxgui/forms/forms.py
@@ -515,13 +515,13 @@ class notebook(_chooser_base):
 		_chooser_base.__init__(self, **kwargs)
 		assert len(pages) == len(self._choices)
 		self._notebook = notebook
-		self._notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGED, self._handle)
+		self._notebook.Bind(wx.EVT_NOTEBOOK_PAGE_CHANGING, self._handle)
 		#add pages, setting the label on each tab
 		for i, page in enumerate(pages):
 			self._notebook.AddPage(page, self._labels[i])
 		self._add_widget(self._notebook)
 
-	def _handle(self, event): self[INT_KEY] = self._notebook.GetSelection()
+	def _handle(self, event): self[INT_KEY] = event.GetSelection()
 	# SetSelection triggers a page change event (deprecated, breaks on Windows) and ChangeSelection does not
 	def _update(self, i): self._notebook.ChangeSelection(i)
 


### PR DESCRIPTION
With this patch, the bug is not showing anymore. It was only tested by
me on Mac OS X - not on Linux nor other platforms.
The possible regressions introduced by fix should be limited to the
notebook chooser forms only.

The 2 modifications seems to be necessary:
- The "changing" event seems to work where the "changed" does not
- when calling GetSelection, the notebook is not updated yet. So we need to get the information from the event itself (not the notebook)

Hint: If you already have a running GnuRadio installation, you can test the modifications very quickly, without re-building it:
Juts apply the patch on you git working copy, and launch "python gr-wxgui/python/wxgui/scopesink_gl.py". You should be able to click on the four buttons of the notebook : Ch1, Ch2, Trig, XY, confirm that the panels switch and are not empty.
