### PR TITLE
pmt: Added float conversion

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -201,6 +201,7 @@ PMT_API bool is_real(pmt_t obj);
 
 //! Return the pmt value that represents double \p x.
 PMT_API pmt_t from_double(double x);
+PMT_API pmt_t from_float(float x);
 
 /*!
  * \brief Convert pmt to double if possible.
@@ -210,6 +211,15 @@ PMT_API pmt_t from_double(double x);
  * a wrong_type exception is raised.
  */
 PMT_API double to_double(pmt_t x);
+
+/*!
+ * \brief Convert pmt to float if possible.
+ *
+ * This basically is to_double() with a type-cast; the PMT stores
+ * the value as a double in any case. Use this when strict typing
+ * is required.
+ */
+PMT_API float to_float(pmt_t x);
 
 /*
  * ------------------------------------------------------------------------

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -368,6 +368,12 @@ from_double(double x)
   return pmt_t(new pmt_real(x));
 }
 
+pmt_t
+from_float(float x)
+{
+  return pmt_t(new pmt_real(x));
+}
+
 double
 to_double(pmt_t x)
 {
@@ -377,6 +383,12 @@ to_double(pmt_t x)
     return _integer(x)->value();
 
   throw wrong_type("pmt_to_double", x);
+}
+
+float
+to_float(pmt_t x)
+{
+  return float(to_double(x));
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -125,6 +125,15 @@ qa_pmt_prims::test_reals()
   CPPUNIT_ASSERT_EQUAL(-1.0, pmt::to_double(m1));
   CPPUNIT_ASSERT_EQUAL(1.0, pmt::to_double(p1));
   CPPUNIT_ASSERT_EQUAL(1.0, pmt::to_double(pmt::from_long(1)));
+
+  pmt::pmt_t p2 = pmt::from_float(1);
+  pmt::pmt_t m2 = pmt::from_float(-1);
+  CPPUNIT_ASSERT(pmt::is_real(p2));
+  CPPUNIT_ASSERT(pmt::is_real(m2));
+  CPPUNIT_ASSERT_THROW(pmt::to_float(pmt::PMT_T), pmt::wrong_type);
+  CPPUNIT_ASSERT_EQUAL(float(-1.0), pmt::to_float(m2));
+  CPPUNIT_ASSERT_EQUAL(float(1.0), pmt::to_float(p2));
+  CPPUNIT_ASSERT_EQUAL(float(1.0), pmt::to_float(pmt::from_long(1)));
 }
 
 void

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -36,7 +36,9 @@ class test_pmt(unittest.TestCase):
         const = 123765
         x_pmt = pmt.from_double(const)
         x_int = pmt.to_double(x_pmt)
+        x_float = pmt.to_float(x_pmt)
         self.assertEqual(x_int, const)
+        self.assertEqual(x_float, const)
 
     def test03(self):
         v = pmt.init_f32vector(3, [11, -22, 33])

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -111,6 +111,8 @@ namespace pmt{
   bool is_real(pmt_t obj);
   pmt_t from_double(double x);
   double to_double(pmt_t x);
+  pmt_t from_float(double x);
+  double to_float(pmt_t x);
 
   bool is_complex(pmt_t obj);
   pmt_t make_rectangular(double re, double im);


### PR DESCRIPTION
Added to_float() and from_float(). These are basically aliases
for *_double() with a type cast for when strict typing is necessary
(e.g. SWIG won't accept an f32 value when using from_double()).
