### PR TITLE
CID 1240027: Reset iterator when erase() called

### DIFF
--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -252,10 +252,7 @@ namespace gr {
     */
     std::multimap<uint64_t, tag_t>::iterator end_itr = d_item_tags.lower_bound(max_time);
     std::multimap<uint64_t, tag_t>::iterator begin_itr = d_item_tags.begin();
-    while (begin_itr != end_itr) {
-      d_item_tags.erase(begin_itr);
-      begin_itr = d_item_tags.begin();
-    }
+    d_item_tags.erase(begin_itr, end_itr);
   }
 
   long


### PR DESCRIPTION
iterator is invalidated when erase() is called: we need to re-fetch the beginning
