### PR TITLE
block.h: Note about when to call consume()

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -222,7 +222,7 @@ namespace gr {
     /*!
      * \brief Tell the scheduler \p how_many_items of input stream \p
      * which_input were consumed. 
-     * After this call, the input buffer must be considered invalid.
+     * This function should be called at the end of work() or general_work(), after all processing is finished.
      */
     void consume(int which_input, int how_many_items);
 


### PR DESCRIPTION
Up to now, it is not clearly stated that calling consume() in a general_work() function invalidates the input buffer. Looking at the code it's obvious but a little clarification won't hurt.
