### PR TITLE
volk: added missing library libmath

### DIFF
--- a/volk/lib/CMakeLists.txt
+++ b/volk/lib/CMakeLists.txt
@@ -511,6 +511,12 @@ if(MSVC)
     set_source_files_properties(${volk_sources} PROPERTIES LANGUAGE CXX)
 endif()
 
+#link libmath
+find_library(LIBM NAMES m)
+if(LIBM)
+    list(APPEND volk_libraries ${LIBM})
+endif()
+
 #create the volk runtime library
 add_library(volk SHARED ${volk_sources})
 target_link_libraries(volk ${volk_libraries})


### PR DESCRIPTION
Building libvolk gives me tons of missing libmath symbols. I'm not sure why no one else is seeing this error? But since volk is a C library and uses functions from math.h, it should probably be explicitly linked against libm. The following change includes a conditional check for libm. So if its not found (windows platform), this shouldn’t cause a build error.
