### PR TITLE
fix UDP test

### DIFF
--- a/gr-blocks/python/blocks/qa_udp_source_sink.py
+++ b/gr-blocks/python/blocks/qa_udp_source_sink.py
@@ -89,7 +89,7 @@ class test_udp_sink_source(gr_unittest.TestCase):
         rcv_port = udp_rcv.get_port()
 
         udp_snd = blocks.udp_sink(gr.sizeof_float, '127.0.0.1', port)
-        udp_snd.connect('localhost', rcv_port)
+        udp_snd.connect('127.0.0.1', rcv_port)
 
         n_data = 16
         src_data = [float(x) for x in range(n_data)]


### PR DESCRIPTION
Test may fail because localhost might be resolved as '::1' (IPv6) whereas server listens on IPv4 only (0.0.0.0).

This might be also fixed by using 'localhost' as addres for both server and client or use IPv6 (::) for server which will posibly (platform dependent) go dual stack. But the second option expects IPv6 urned on by default, which I try to avoid.
