### PR TITLE
volk: fix popcnt puppter on 32-bit x86 builds

### DIFF
--- a/volk/kernels/volk/volk_64u_popcntpuppet_64u.h
+++ b/volk/kernels/volk/volk_64u_popcntpuppet_64u.h
@@ -36,7 +36,7 @@ static inline void volk_64u_popcntpuppet_64u_generic(uint64_t* outVector, const 
 }
 #endif /* LV_HAVE_GENERIC */
 
-#ifdef LV_HAVE_SSE4_2
+#if LV_HAVE_SSE4_2 && LV_HAVE_64
 static inline void volk_64u_popcntpuppet_64u_a_sse4_2(uint64_t* outVector, const uint64_t* inVector, unsigned int num_points){
     unsigned int ii;
     for(ii=0; ii < num_points; ++ii) {


### PR DESCRIPTION
Fix a build error on 32-bit x86es that came up on ML.
