### PR TITLE
grc: Move the XInitThreads to "As Early As Possible"

### DIFF
--- a/grc/python/flow_graph.tmpl
+++ b/grc/python/flow_graph.tmpl
@@ -30,6 +30,19 @@ $DIVIDER
 # Generated: $time.ctime()
 $DIVIDER
 
+# Call XInitThreads as the _very_ first thing.
+# After some Qt import, it's too late
+#if $generate_options in ('wx_gui', 'qt_gui')
+import ctypes
+import sys
+if sys.platform.startswith('linux'):
+    try:
+        x11 = ctypes.cdll.LoadLibrary('libX11.so')
+        x11.XInitThreads()
+    except:
+        print "Warning: failed to XInitThreads()"
+#end if
+
 ########################################################
 ##Create Imports
 ########################################################
@@ -267,16 +280,6 @@ $short_id#slurp
 #end def
 #if $generate_options != 'hb'
 if __name__ == '__main__':
-    #if $generate_options in ('wx_gui', 'qt_gui')
-    import ctypes
-    import sys
-    if sys.platform.startswith('linux'):
-        try:
-            x11 = ctypes.cdll.LoadLibrary('libX11.so')
-            x11.XInitThreads()
-        except:
-            print "Warning: failed to XInitThreads()"
-    #end if
     parser = OptionParser(option_class=eng_option, usage="%prog: [options]")
     #set $params_eq_list = list()
     #for $param in $parameters


### PR DESCRIPTION
Seems some newer Qt do Xlib call right when doing the imports
which then means that doing it in the main() is too late.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>