### PR TITLE
UNIX (local) socket stream source and sink

### DIFF
--- a/docs/sphinx/source/blocks/index.rst
+++ b/docs/sphinx/source/blocks/index.rst
@@ -248,6 +248,7 @@ Networking Tools
 .. autosummary::
    :nosignatures:
 
+   gnuradio.blocks.local_stream_server_sink
    gnuradio.blocks.socket_pdu
    gnuradio.blocks.tuntap_pdu
    gnuradio.blocks.udp_sink

--- a/docs/sphinx/source/blocks/networking_tools_blk.rst
+++ b/docs/sphinx/source/blocks/networking_tools_blk.rst
@@ -1,6 +1,7 @@
 gnuradio.blocks: Networking Tools
 =================================
 
+.. autoblock:: gnuradio.blocks.local_stream_server_sink
 .. autoblock:: gnuradio.blocks.socket_pdu
 .. autoblock:: gnuradio.blocks.tuntap_pdu
 .. autoblock:: gnuradio.blocks.udp_sink

--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -144,6 +144,7 @@
 	</cat>
 	<cat>
 	        <name>Networking Tools</name>
+		<block>blocks_local_stream_server_sink</block>
 		<block>blocks_tuntap_pdu</block>
 		<block>blocks_socket_pdu</block>
 		<block>blocks_udp_source</block>

--- a/gr-blocks/grc/blocks_local_stream_server_sink.xml
+++ b/gr-blocks/grc/blocks_local_stream_server_sink.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Local Stream Socket Server Sink
+###################################################
+ -->
+<block>
+	<name>Local Stream Socket Server Sink</name>
+	<key>blocks_local_stream_server_sink</key>
+	<import>from gnuradio import blocks</import>
+	<make>blocks.local_stream_server_sink($type.size*$vlen, $addr, $noblock, $congestion, $buf_size)</make>
+	<param>
+		<name>Input Type</name>
+		<key>type</key>
+		<type>enum</type>
+		<option>
+			<name>Complex</name>
+			<key>complex</key>
+			<opt>size:gr.sizeof_gr_complex</opt>
+		</option>
+		<option>
+			<name>Float</name>
+			<key>float</key>
+			<opt>size:gr.sizeof_float</opt>
+		</option>
+		<option>
+			<name>Int</name>
+			<key>int</key>
+			<opt>size:gr.sizeof_int</opt>
+		</option>
+		<option>
+			<name>Short</name>
+			<key>short</key>
+			<opt>size:gr.sizeof_short</opt>
+		</option>
+		<option>
+			<name>Byte</name>
+			<key>byte</key>
+			<opt>size:gr.sizeof_char</opt>
+		</option>
+	</param>
+	<param>
+		<name>Address</name>
+		<key>addr</key>
+		<type>string</type>
+	</param>
+	<param>
+		<name>Nonblocking Mode</name>
+		<key>noblock</key>
+		<type>enum</type>
+		<value>False</value>
+		<option>
+			<name>On</name>
+			<key>True</key>
+		</option>
+		<option>
+			<name>Off</name>
+			<key>False</key>
+		</option>
+	</param>
+	<param>
+		<name>Congestion Handling</name>
+		<key>congestion</key>
+		<type>enum</type>
+		<value>0</value>
+		<option>
+			<name>Block</name>
+			<key>0</key>
+		</option>
+		<option>
+			<name>Disconnect</name>
+			<key>1</key>
+		</option>
+	</param>
+	<param>
+		<name>Buffer Size</name>
+		<key>buf_size</key>
+		<value>128 * 1024</value>
+		<type>int</type>
+	</param>
+	<param>
+		<name>Vec Length</name>
+		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<check>$vlen &gt; 0</check>
+	<sink>
+		<name>in</name>
+		<type>$type</type>
+		<vlen>$vlen</vlen>
+	</sink>
+</block>

--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -113,6 +113,7 @@ install(FILES
     keep_m_in_n.h
     keep_one_in_n.h
     lfsr_32k_source_s.h
+    local_stream_server_sink.h
     message_debug.h
     message_sink.h
     message_source.h

--- a/gr-blocks/include/gnuradio/blocks/local_stream_server_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/local_stream_server_sink.h
@@ -1,0 +1,75 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_LOCAL_STREAM_SERVER_SINK_H
+#define INCLUDED_BLOCKS_LOCAL_STREAM_SERVER_SINK_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief Send data trought local stream socket.
+     * \ingroup networking_tools_blk
+     *
+     * \details
+     * Listen on local socket and send data to clients. Data are
+     * duplicated for each client.
+     */
+    class BLOCKS_API local_stream_server_sink : virtual public gr::sync_block
+    {
+    public:
+      // gr::blocks::local_stream_server_sink::sptr
+      typedef boost::shared_ptr<local_stream_server_sink> sptr;
+
+      /*!
+       * What to do when output buffers are full.
+       */
+      typedef enum {
+        CONGESTION_BLOCK = 0,   // block until buffers are emptied
+        CONGESTION_CLOSE = 1    // close connections causing congestion
+      } congestion_t;
+
+      /*!
+       * \brief Local Stream Socket Server Sink Constructor
+       *
+       * \param itemsize     The size (in bytes) of the item datatype
+       * \param address      Name of socket to bind.
+       * \param noblock      If false, wait until first client connects before
+       *                     streaming starts. In non blocking mode
+       *                     (noblock=true), drop data onto floor if no client
+       *                     is connected.
+       * \param congestion   What to do when output buffers are full.
+       * \param buf_size     Size of output buffer.
+       */
+      static sptr make(size_t itemsize, const std::string &address,
+                       bool noblock = false,
+                       congestion_t congestion = CONGESTION_BLOCK,
+                       size_t buf_size = 128 * 1024);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_BLOCKS_LOCAL_STREAM_SERVER_SINK_H */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -130,6 +130,7 @@ list(APPEND gr_blocks_sources
     keep_m_in_n_impl.cc
     keep_one_in_n_impl.cc
     lfsr_32k_source_s_impl.cc
+    local_stream_server_sink_impl.cc
     message_debug_impl.cc
     message_sink_impl.cc
     message_source_impl.cc

--- a/gr-blocks/lib/local_stream_server_sink_impl.cc
+++ b/gr-blocks/lib/local_stream_server_sink_impl.cc
@@ -1,0 +1,205 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "local_stream_server_sink_impl.h"
+#include <gnuradio/io_signature.h>
+#include <algorithm>
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/format.hpp>
+#include <gnuradio/thread/thread.h>
+#include <stdexcept>
+#include <stdio.h>
+#include <string.h>
+
+namespace gr {
+  namespace blocks {
+
+    local_stream_server_sink::sptr
+      local_stream_server_sink::make(size_t itemsize,
+          const std::string &address, bool noblock, congestion_t congestion,
+          size_t buf_size)
+      {
+        return gnuradio::get_initial_sptr
+          (new local_stream_server_sink_impl(itemsize, address, noblock,
+                                             congestion, buf_size));
+      }
+
+    local_stream_server_sink_impl::local_stream_server_sink_impl(
+        size_t itemsize, const std::string &address, bool noblock,
+        congestion_t congestion, size_t buf_size)
+      : sync_block("local_stream_server_sink",
+          io_signature::make(1, 1, itemsize),
+          io_signature::make(0, 0, 0)),
+      d_itemsize(itemsize),
+      d_endpoint(address),
+      d_acceptor(d_io_service),
+      d_congestion(congestion),
+      d_buf_size(buf_size),
+      d_buf_offs(0),
+      d_buf(new uint8_t[buf_size]),
+      d_nwriting(0)
+      {
+        if (address.c_str()[0]) {
+          ::unlink(address.c_str());
+        }
+        d_acceptor.open(d_endpoint.protocol());
+        d_acceptor.set_option(boost::asio::local::stream_protocol::acceptor::reuse_address(true));
+        d_acceptor.bind(d_endpoint);
+        d_acceptor.listen();
+
+        if (!noblock) {
+          d_socket.reset(new boost::asio::local::stream_protocol::socket(d_io_service));
+          d_acceptor.accept(*d_socket, d_endpoint);
+          d_clients.insert(std::make_pair(d_socket.release(), 0));
+        }
+
+        d_socket.reset(new boost::asio::local::stream_protocol::socket(d_io_service));
+        d_acceptor.async_accept(*d_socket, boost::bind(&local_stream_server_sink_impl::do_accept,
+              this, boost::asio::placeholders::error));
+        d_io_serv_thread = boost::thread(
+            boost::bind(&boost::asio::io_service::run, &d_io_service));
+      }
+
+    void
+    local_stream_server_sink_impl::do_accept(const boost::system::error_code& error)
+    {
+      if (!error) {
+        gr::thread::scoped_lock guard(d_writing_mut);
+        d_clients.insert(std::make_pair(d_socket.release(), 0));
+        d_socket.reset(new boost::asio::local::stream_protocol::socket(d_io_service));
+        d_acceptor.async_accept(*d_socket, boost::bind(&local_stream_server_sink_impl::do_accept,
+              this, boost::asio::placeholders::error));
+      }
+    }
+
+    void
+    local_stream_server_sink_impl::do_write(const boost::system::error_code& error,
+        size_t len, client_map_t::iterator i)
+    {
+      gr::thread::scoped_lock guard(d_writing_mut);
+
+      if (error) {
+        delete i->first;
+        d_clients.erase(i);
+        --d_nwriting;
+        d_writing_cond.notify_one();
+        return;
+      }
+
+      if (i->second < d_buf_offs) {
+        const size_t noutput_size = d_buf_offs - i->second;
+        void *buf = d_buf.get() + i->second;
+        boost::asio::async_write(*i->first, boost::asio::buffer(buf, noutput_size),
+            boost::bind(&local_stream_server_sink_impl::do_write, this,
+              boost::asio::placeholders::error,
+              boost::asio::placeholders::bytes_transferred,
+              i));
+        i->second = d_buf_offs;
+        d_writing_cond.notify_one();
+        return;
+      }
+
+      i->second = 0;
+      --d_nwriting;
+      d_writing_cond.notify_one();
+    }
+
+    local_stream_server_sink_impl::~local_stream_server_sink_impl()
+    {
+      gr::thread::scoped_lock guard(d_writing_mut);
+      while (d_nwriting) {
+        d_writing_cond.wait(guard);
+      }
+
+      BOOST_FOREACH(client_map_t::value_type &i, d_clients) {
+        delete i.first;
+      }
+      d_clients.clear();
+
+      d_io_service.reset();
+      d_io_service.stop();
+      d_io_serv_thread.join();
+
+      if (d_endpoint.path().c_str()[0]) {
+        ::unlink(d_endpoint.path().c_str());
+      }
+    }
+
+    int
+    local_stream_server_sink_impl::work (int noutput_items,
+        gr_vector_const_void_star &input_items,
+        gr_vector_void_star &output_items)
+    {
+      const char *in = (const char *) input_items[0];
+
+      gr::thread::scoped_lock guard(d_writing_mut);
+
+      const size_t noutput_size = noutput_items * d_itemsize;
+      if (noutput_size > d_buf_size) {
+        throw std::runtime_error("Processing blog bigger than output buffer");
+      }
+      if (!d_nwriting) {
+        d_buf_offs = 0;
+      }
+      if (noutput_size > (d_buf_size - d_buf_offs)) {
+        if (d_congestion == CONGESTION_CLOSE) {
+          BOOST_FOREACH(client_map_t::value_type &i, d_clients) {
+            if (i.second) {
+              i.first->cancel();
+              fprintf(stderr, "Socket closed due too congestion\n");
+            }
+          }
+        }
+        while (d_nwriting) {
+          d_writing_cond.wait(guard);
+        }
+        d_buf_offs = 0;
+      }
+
+      void *buf = d_buf.get() + d_buf_offs;
+      memcpy(buf, in, noutput_size);
+      d_buf_offs += noutput_size;
+      for (client_map_t::iterator i = d_clients.begin();
+          i != d_clients.end(); ++i) {
+        if (i->second) {
+          continue;
+        }
+        boost::asio::async_write(*i->first, boost::asio::buffer(buf, noutput_size),
+            boost::bind(&local_stream_server_sink_impl::do_write, this,
+              boost::asio::placeholders::error,
+              boost::asio::placeholders::bytes_transferred,
+              i));
+        i->second = noutput_size;
+      }
+      d_nwriting = d_clients.size();
+
+      return noutput_items;
+    }
+
+  } /* namespace blocks */
+} /* namespace gr */
+

--- a/gr-blocks/lib/local_stream_server_sink_impl.h
+++ b/gr-blocks/lib/local_stream_server_sink_impl.h
@@ -1,0 +1,76 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GR_LOCAL_STREAM_SERVER_SINK_IMPL_H
+#define INCLUDED_GR_LOCAL_STREAM_SERVER_SINK_IMPL_H
+
+#include <gnuradio/blocks/local_stream_server_sink.h>
+#include <boost/asio.hpp>
+#include <map>
+#include <boost/ptr_container/ptr_vector.hpp>
+
+namespace gr {
+  namespace blocks {
+
+    class local_stream_server_sink_impl : public local_stream_server_sink
+    {
+    private:
+      // store socket and number of bytes writen by currend send_async operation
+      typedef std::map<boost::asio::local::stream_protocol::socket *, size_t> client_map_t;
+
+      size_t d_itemsize;
+
+      boost::asio::io_service d_io_service;
+      gr::thread::thread d_io_serv_thread;
+      boost::asio::local::stream_protocol::endpoint d_endpoint;
+      std::auto_ptr<boost::asio::local::stream_protocol::socket> d_socket;
+      client_map_t d_clients;
+      boost::asio::local::stream_protocol::acceptor d_acceptor;
+
+      congestion_t d_congestion;
+      size_t d_buf_size;
+      size_t d_buf_offs;
+      boost::shared_ptr<uint8_t> d_buf;
+
+      int d_nwriting;
+      boost::condition_variable d_writing_cond;
+      boost::mutex d_writing_mut;
+
+      void do_accept(const boost::system::error_code& error);
+      void do_write(const boost::system::error_code& error, std::size_t len,
+              client_map_t::iterator);
+
+    public:
+      local_stream_server_sink_impl(size_t itemsize,
+                    const std::string &address, bool noblock,
+                    congestion_t congestion, size_t buf_size);
+      ~local_stream_server_sink_impl();
+
+      int work(int noutput_items,
+               gr_vector_const_void_star &input_items,
+               gr_vector_void_star &output_items);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_LOCAL_STREAM_SERVER_SINK_IMPL_H */

--- a/gr-blocks/python/blocks/qa_local_stream_server_sink.py
+++ b/gr-blocks/python/blocks/qa_local_stream_server_sink.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest, blocks
+import os
+import socket
+from time import sleep
+
+from threading import Timer
+from multiprocessing import Process
+
+class test_sock_sink(gr_unittest.TestCase):
+
+    def setUp(self):
+        os.environ['GR_CONF_CONTROLPORT_ON'] = 'False'
+        self.tb_snd = gr.top_block()
+        self.tb_rcv = gr.top_block()
+
+    def tearDown(self):
+        self.tb_rcv = None
+        self.tb_snd = None
+
+    def _sock_client(self):
+        dst = blocks.vector_sink_s()
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        for t in (0, 0.2):
+# wait until server listens
+            sleep(t)
+            try:
+                sock.connect(self.addr)
+            except socket.error as e:
+                if e.errno != 111:
+                    raise
+                continue
+            break
+        fd = os.dup(sock.fileno())
+        self.tb_rcv.connect(blocks.file_descriptor_source(self.itemsize, fd), dst)
+        self.tb_rcv.run()
+        self.assertEqual(self.data, dst.data())
+
+    def test_001(self):
+        self.addr = '/var/tmp/test_sock_gr_wtf_fuck_shit'
+        self.itemsize = gr.sizeof_short
+        n_data = 16
+        self.data = tuple([x + 0x30 for x in range(n_data)])
+
+# local_stream_server_sink blocks until client does not connect, start client process first
+        p = Process(target=self._sock_client)
+        p.start()
+
+        src = blocks.vector_source_s(self.data, False)
+        sock_snd = blocks.local_stream_server_sink(self.itemsize, self.addr, False)
+        self.tb_snd.connect(src, sock_snd)
+
+        self.tb_snd.run()
+        del sock_snd
+        self.tb_snd = None
+        p.join()
+
+    def stop_rcv(self):
+        self.timeout = True
+        self.tb_rcv.stop()
+        #print "tb_rcv stopped by Timer"
+
+if __name__ == '__main__':
+    gr_unittest.run(test_sock_sink, "test_local_stream_server_sink.xml")
+

--- a/gr-blocks/swig/blocks_swig0.i
+++ b/gr-blocks/swig/blocks_swig0.i
@@ -42,6 +42,7 @@
 #include "gnuradio/blocks/file_meta_sink.h"
 #include "gnuradio/blocks/file_meta_source.h"
 #include "gnuradio/blocks/head.h"
+#include "gnuradio/blocks/local_stream_server_sink.h"
 #include "gnuradio/blocks/message_debug.h"
 #include "gnuradio/blocks/message_sink.h"
 #include "gnuradio/blocks/message_source.h"
@@ -68,6 +69,7 @@
 %include "gnuradio/blocks/file_meta_sink.h"
 %include "gnuradio/blocks/file_meta_source.h"
 %include "gnuradio/blocks/head.h"
+%include "gnuradio/blocks/local_stream_server_sink.h"
 %include "gnuradio/blocks/message_debug.h"
 %include "gnuradio/blocks/message_sink.h"
 %include "gnuradio/blocks/message_source.h"
@@ -91,6 +93,7 @@ GR_SWIG_BLOCK_MAGIC2(blocks, file_source);
 GR_SWIG_BLOCK_MAGIC2(blocks, file_meta_sink);
 GR_SWIG_BLOCK_MAGIC2(blocks, file_meta_source);
 GR_SWIG_BLOCK_MAGIC2(blocks, head);
+GR_SWIG_BLOCK_MAGIC2(blocks, local_stream_server_sink);
 GR_SWIG_BLOCK_MAGIC2(blocks, message_debug);
 GR_SWIG_BLOCK_MAGIC2(blocks, message_sink);
 GR_SWIG_BLOCK_MAGIC2(blocks, message_source);

--- a/grc/blocks/block_tree.xml
+++ b/grc/blocks/block_tree.xml
@@ -25,6 +25,7 @@
 	</cat>
 	<cat>
 		<name>Networking Tools</name>
+		<block>blks2_local_stream_source</block>
 		<block>blks2_tcp_source</block>
 		<block>blks2_tcp_sink</block>
 	</cat>

--- a/grc/blocks/local_stream_source.xml
+++ b/grc/blocks/local_stream_source.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Local Stream Socket Source: Custom blks2 block
+###################################################
+ -->
+<block>
+	<name>Local Stream Socket Source</name>
+	<key>blks2_local_stream_source</key>
+	<import>from grc_gnuradio import blks2 as grc_blks2</import>
+	<make>grc_blks2.local_stream_source(itemsize=$type.size*$vlen, addr=$addr)</make>
+	<param>
+		<name>Output Type</name>
+		<key>type</key>
+		<type>enum</type>
+		<option>
+			<name>Complex</name>
+			<key>complex</key>
+			<opt>size:gr.sizeof_gr_complex</opt>
+		</option>
+		<option>
+			<name>Float</name>
+			<key>float</key>
+			<opt>size:gr.sizeof_float</opt>
+		</option>
+		<option>
+			<name>Int</name>
+			<key>int</key>
+			<opt>size:gr.sizeof_int</opt>
+		</option>
+		<option>
+			<name>Short</name>
+			<key>short</key>
+			<opt>size:gr.sizeof_short</opt>
+		</option>
+		<option>
+			<name>Byte</name>
+			<key>byte</key>
+			<opt>size:gr.sizeof_char</opt>
+		</option>
+	</param>
+	<param>
+		<name>Address</name>
+		<key>addr</key>
+		<value></value>
+		<type>string</type>
+	</param>
+	<param>
+		<name>Vec Length</name>
+		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<check>$vlen &gt; 0</check>
+	<source>
+		<name>out</name>
+		<type>$type</type>
+		<vlen>$vlen</vlen>
+	</source>
+	<doc>
+	</doc>
+</block>

--- a/grc/grc_gnuradio/blks2/__init__.py
+++ b/grc/grc_gnuradio/blks2/__init__.py
@@ -24,3 +24,5 @@ from packet import options, packet_encoder, packet_decoder, \
     packet_demod_b, packet_demod_s, packet_demod_i, packet_demod_f, packet_demod_c
 from error_rate import error_rate
 from tcp import tcp_source, tcp_sink
+from local_stream import local_stream_source
+

--- a/grc/grc_gnuradio/blks2/local_stream.py
+++ b/grc/grc_gnuradio/blks2/local_stream.py
@@ -1,4 +1,5 @@
-# Copyright 2011 Free Software Foundation, Inc.
+#
+# Copyright 2015 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -16,21 +17,20 @@
 # along with GNU Radio; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
+#
 
-########################################################################
-GR_PYTHON_INSTALL(
-    FILES __init__.py
-    DESTINATION ${GR_PYTHON_DIR}/grc_gnuradio
-    COMPONENT "grc"
-)
+from gnuradio import gr, blocks
+import socket
+import os
 
-GR_PYTHON_INSTALL(FILES
-    blks2/__init__.py
-    blks2/error_rate.py
-    blks2/local_stream.py
-    blks2/packet.py
-    blks2/selector.py
-    blks2/tcp.py
-    DESTINATION ${GR_PYTHON_DIR}/grc_gnuradio/blks2
-    COMPONENT "grc"
-)
+class local_stream_source(gr.hier_block2):
+    def __init__(self, itemsize, addr):
+        gr.hier_block2.__init__(
+            self, 'local_stream_source',
+            gr.io_signature(0, 0, 0),
+            gr.io_signature(1, 1, itemsize),
+        )
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(addr)
+        fd = os.dup(sock.fileno())
+        self.connect(blocks.file_descriptor_source(itemsize, fd), self)


### PR DESCRIPTION
Add two new blocks, sink and source for local (UNIX) socket. Source is implemented as a simple Python module, but sink is C++ module and have some unique features.

  Sink features
  - adjustable output buffer size
  - multiple clients can be connected (data are duplicated for each client)
  - optional nonblocking mode, usefull for realtime data processing
  - optional congestion prevention, usefull for realtime data processing

Because of this features sink is implemented only as a socket server, whereas source is implemented only as a socket client.

QA does not have 100% coverage but i does not found reasonable way to do it, the basic features are tested.