### PR TITLE
gnuradio-config-info: Added --enabled-components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,13 @@ CONFIGURE_FILE(
   ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-runtime/include/gnuradio/config.h
 )
 
+#Re-generate the constants file, now that we actually know which components will be enabled.
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-runtime/lib/constants.cc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-runtime/lib/constants.cc
+    ESCAPE_QUOTES
+@ONLY)
+
 # Install config.h in include/gnuradio
 install(
     FILES

--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -26,26 +26,29 @@
 
 #include <gnuradio/constants.h>
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 #include <iostream>
 
 namespace po = boost::program_options;
+using boost::format;
 
 int
 main(int argc, char **argv)
 {
-  po::options_description desc("Program options: gnuradio [options]");
+  po::options_description desc((format("Program options: %1% [options]") % argv[0]).str());
   po::variables_map vm;
 
   desc.add_options()
     ("help,h", "print help message")
-    ("prefix", "print gnuradio installation prefix")
-    ("sysconfdir", "print gnuradio system configuration directory")
-    ("prefsdir", "print gnuradio preferences directory")
-    ("builddate", "print gnuradio build date (RFC2822 format)")
-    ("cc", "print gnuradio C compiler version")
-    ("cxx", "print gnuradio C++ compiler version")
-    ("cflags", "print gnuradio CFLAGS")
-    ("version,v", "print gnuradio version")
+    ("prefix", "print GNU Radio installation prefix")
+    ("sysconfdir", "print GNU Radio system configuration directory")
+    ("prefsdir", "print GNU Radio preferences directory")
+    ("builddate", "print GNU Radio build date (RFC2822 format)")
+    ("enabled-components", "print GNU Radio build time enabled components")
+    ("cc", "print GNU Radio C compiler version")
+    ("cxx", "print GNU Radio C++ compiler version")
+    ("cflags", "print GNU Radio CFLAGS")
+    ("version,v", "print GNU Radio version")
     ;
 
   try {
@@ -74,6 +77,9 @@ main(int argc, char **argv)
 
   if(vm.count("builddate"))
     std::cout << gr::build_date() << std::endl;
+
+  if(vm.count("enabled-components"))
+    std::cout << gr::build_time_enabled_components() << std::endl;
 
   if(vm.count("version"))
     std::cout << gr::version() << std::endl;

--- a/gnuradio-runtime/include/gnuradio/constants.h
+++ b/gnuradio-runtime/include/gnuradio/constants.h
@@ -83,6 +83,11 @@ namespace gr {
    */
   GR_RUNTIME_API const std::string  compiler_flags();
 
+  /*!
+   * \brief return build-time enabled components
+   */
+  GR_RUNTIME_API const std::string  build_time_enabled_components();
+
 } /* namespace gr */
 
 #endif /* INCLUDED_GR_CONSTANTS_H */

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ string(REPLACE "\\" "\\\\" GR_PREFSDIR ${GR_PREFSDIR})
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/constants.cc.in
     ${CMAKE_CURRENT_BINARY_DIR}/constants.cc
+    ESCAPE_QUOTES
 @ONLY)
 
 list(APPEND gnuradio_runtime_sources ${CMAKE_CURRENT_BINARY_DIR}/constants.cc)

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -95,4 +95,9 @@ namespace gr {
     return "@COMPILER_INFO@";
   }
 
+  const std::string
+  build_time_enabled_components()
+  {
+    return "@_gr_enabled_components@";
+  }
 } /* namespace gr */


### PR DESCRIPTION
Since this should reflect the CMake enabled components,
having the cmake variable set correctly demanded generating constants.cc after CMake has been run.
Since the autonomity of the gnuradio-runtime/CMakeLists.txt shouldn't
be reduced, this is done twice; the build-time overhead is minimal.