### PR TITLE
trellis: bug fixed:adding a missing callback function set_K in trellis_ecoder

### DIFF
--- a/gr-trellis/grc/trellis_encoder_xx.xml
+++ b/gr-trellis/grc/trellis_encoder_xx.xml
@@ -13,6 +13,7 @@
   <make> trellis.encoder_$(type)(trellis.fsm($fsm_args), $init_state, $blocklength) if $blockwise else trellis.encoder_$(type)(trellis.fsm($fsm_args), $init_state) </make>
   <callback>set_FSM(trellis.fsm($fsm_args))</callback>
   <callback>set_ST($init_state)</callback>
+  <callback>set_K($blocklength)</callback>
   <param>
     <name>Type</name>
     <key>type</key>


### PR DESCRIPTION
Hi Johnathan, 

I made a new branch called trellisupdate and included the bug fix here. I'm trying to merge to maint. 

Could you check it ?

Thanks!
Best,
Zhe