### PR TITLE
blocks: added callback functions to stream_to_tagged_stream

### DIFF
--- a/gr-blocks/grc/blocks_stream_to_tagged_stream.xml
+++ b/gr-blocks/grc/blocks_stream_to_tagged_stream.xml
@@ -4,6 +4,8 @@
 	<key>blocks_stream_to_tagged_stream</key>
 	<import>from gnuradio import blocks</import>
 	<make>blocks.stream_to_tagged_stream($type.size, $vlen, $packet_len, $len_tag_key)</make>
+	<callback>set_packet_len($packet_len)</callback>
+	<callback>set_packet_len_pmt($packet_len)</callback>
 	<param>
 		<name>Type</name>
 		<key>type</key>

--- a/gr-blocks/include/gnuradio/blocks/stream_to_tagged_stream.h
+++ b/gr-blocks/include/gnuradio/blocks/stream_to_tagged_stream.h
@@ -59,6 +59,8 @@ namespace gr {
 	  unsigned packet_len,
 	  const std::string &len_tag_key
       );
+      virtual void set_packet_len(unsigned packet_len) =0;
+      virtual void set_packet_len_pmt(unsigned packet_len) =0;
     };
 
   } // namespace blocks

--- a/gr-blocks/lib/stream_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/stream_to_tagged_stream_impl.cc
@@ -53,11 +53,24 @@ namespace gr {
     {
     }
 
+    void
+    stream_to_tagged_stream_impl::set_packet_len(unsigned packet_len)
+    {
+	gr::thread::scoped_lock guard(d_setlock);
+	d_packet_len = packet_len;
+    }      
+    void
+    stream_to_tagged_stream_impl::set_packet_len_pmt(unsigned packet_len)
+    {
+	gr::thread::scoped_lock guard(d_setlock);
+	d_packet_len_pmt=pmt::from_long(packet_len);
+    }      
     int
     stream_to_tagged_stream_impl::work(int noutput_items,
 			  gr_vector_const_void_star &input_items,
 			  gr_vector_void_star &output_items)
     {
+	gr::thread::scoped_lock guard(d_setlock);
         const unsigned char *in = (const unsigned char *) input_items[0];
         unsigned char *out = (unsigned char *) output_items[0];
 	// Copy data

--- a/gr-blocks/lib/stream_to_tagged_stream_impl.h
+++ b/gr-blocks/lib/stream_to_tagged_stream_impl.h
@@ -40,6 +40,8 @@ namespace gr {
      public:
       stream_to_tagged_stream_impl(size_t itemsize, int vlen, unsigned packet_len, const std::string &tag_len_key);
       ~stream_to_tagged_stream_impl();
+      void set_packet_len(unsigned packet_len);
+      void set_packet_len_pmt(unsigned packet_len);
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
Hi @jmcorgan ,

I opened this pull request for the callback functions we added to stream_to_tagged_stream. Because in our adaptive modulation/coding system, the packet length might be changed for different modulation/coding scheme. That's why we want to add callback functions for packet_len and packet_len_pmt. 

Could you review and merge it?

Thanks!
Best,
Zhe