### PR TITLE
blocks: added callback function set_k_and_l to repack bits

### DIFF
--- a/gr-blocks/grc/blocks_repack_bits_bb.xml
+++ b/gr-blocks/grc/blocks_repack_bits_bb.xml
@@ -3,7 +3,7 @@
   <key>blocks_repack_bits_bb</key>
   <import>from gnuradio import blocks</import>
   <make>blocks.repack_bits_bb($k, $l, $len_tag_key, $align_output, $endianness)</make>
-
+  <callback>set_k_and_l($k,$l)</callback>
   <param>
     <name>Bits per input byte</name>
     <key>k</key>

--- a/gr-blocks/include/gnuradio/blocks/repack_bits_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/repack_bits_bb.h
@@ -80,6 +80,7 @@ namespace gr {
        */
       static sptr make(int k, int l=8, const std::string &tsb_tag_key="",
                        bool align_output=false, endianness_t endianness=GR_LSB_FIRST);
+      virtual void set_k_and_l(int k, int l) =0;//callback function for bits per input byte k and bits per output byte l.
     };
 
   } // namespace blocks

--- a/gr-blocks/lib/repack_bits_bb_impl.cc
+++ b/gr-blocks/lib/repack_bits_bb_impl.cc
@@ -58,6 +58,15 @@ namespace gr {
       set_relative_rate((double) d_k / d_l);
     }
 
+    void 
+    repack_bits_bb_impl::set_k_and_l(int k, int l)
+    { 
+      gr::thread::scoped_lock guard(d_setlock);
+      d_k = k;
+      d_l = l;
+      set_relative_rate((double) d_k / d_l);
+      }
+
     repack_bits_bb_impl::~repack_bits_bb_impl()
     {
     }
@@ -79,6 +88,7 @@ namespace gr {
                        gr_vector_const_void_star &input_items,
                        gr_vector_void_star &output_items)
     {
+      gr::thread::scoped_lock guard(d_setlock);
       const unsigned char *in = (const unsigned char *) input_items[0];
       unsigned char *out = (unsigned char *) output_items[0];
       int bytes_to_write = noutput_items;

--- a/gr-blocks/lib/repack_bits_bb_impl.h
+++ b/gr-blocks/lib/repack_bits_bb_impl.h
@@ -31,8 +31,8 @@ namespace gr {
     class repack_bits_bb_impl : public repack_bits_bb
     {
      private:
-      const int d_k; //! Bits on input stream
-      const int d_l; //! Bits on output stream
+      int d_k; //! Bits on input stream
+      int d_l; //! Bits on output stream
       const bool d_packet_mode;
       int d_in_index; // Current bit of input byte
       int d_out_index; // Current bit of output byte
@@ -46,7 +46,7 @@ namespace gr {
       repack_bits_bb_impl(int k, int l, const std::string &len_tag_key,
                           bool align_output, endianness_t endianness=GR_LSB_FIRST);
       ~repack_bits_bb_impl();
-
+      void set_k_and_l(int k, int l);//callback function for bits per input byte k and bits per output byte l
       int work(int noutput_items,
 	       gr_vector_int &ninput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
Hi @jmcorgan , 

In this pull request, we added a callback function set_k_and_l to update both bits per input and output bytes of repack_bits in gr-blocks to make it able to be changed dynamically. It is used in our adaptive modulation/coding system too. 

Thanks!
Best,
Zhe