### PR TITLE
blocks: added smoother to throttle to decrease delay

### DIFF
--- a/gr-blocks/grc/blocks_throttle.xml
+++ b/gr-blocks/grc/blocks_throttle.xml
@@ -9,7 +9,7 @@
 	<key>blocks_throttle</key>
 	<throttle>1</throttle>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.throttle($type.size*$vlen, $samples_per_second,$ignoretag)</make>
+	<make>blocks.throttle($type.size*$vlen, $samples_per_second, $ignoretag, $max_noutput_items) if $Limit else blocks.throttle($type.size*$vlen, $samples_per_second,$ignoretag,-1)</make>
         <callback>set_sample_rate($samples_per_second)</callback>
 	<param>
 		<name>Type</name>
@@ -59,6 +59,28 @@
         <value>True</value>
         <type>bool</type>
         <hide>#if str($ignoretag()) == 'True' then 'part' else 'none'#</hide>
+    </param>
+    <param>
+    	<name>Limit number of output items</name>
+    	<key>Limit</key>
+    	<value>False</value>
+    	<type>enum</type>
+    	<hide>part</hide>
+    	<option>
+      	  <name>On</name>
+      	  <key>True</key>
+    	</option>
+    	<option>
+      	  <name>Off</name>
+          <key>False</key>
+    	</option>
+    </param>
+    <param>
+     	<name>Max noutput items</name>
+     	<key>max_noutput_items</key>
+     	<value>100</value>
+     	<type>int</type>
+     	<hide>#if $Limit() == 'True' then 'none' else 'all'#</hide>
     </param>
 	<check>$vlen &gt; 0</check>
 	<sink>

--- a/gr-blocks/include/gnuradio/blocks/throttle.h
+++ b/gr-blocks/include/gnuradio/blocks/throttle.h
@@ -48,7 +48,7 @@ namespace gr {
     public:
       typedef boost::shared_ptr<throttle> sptr;
 
-      static sptr make(size_t itemsize, double samples_per_sec, bool ignore_tags=true);
+      static sptr make(size_t itemsize, double samples_per_sec, bool ignore_tags=true, int max_noutput_items=-1);
 
       //! Sets the sample rate in samples per second.
       virtual void set_sample_rate(double rate) = 0;

--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -35,22 +35,26 @@ namespace gr {
   namespace blocks {
 
     throttle::sptr
-    throttle::make(size_t itemsize, double samples_per_sec, bool ignore_tags)
+    throttle::make(size_t itemsize, double samples_per_sec, bool ignore_tags, int max_noutput_items)
     {
-      return gnuradio::get_initial_sptr
-        (new throttle_impl(itemsize, samples_per_sec, ignore_tags));
+        return gnuradio::get_initial_sptr
+          (new throttle_impl(itemsize, samples_per_sec, ignore_tags, max_noutput_items));
     }
 
     throttle_impl::throttle_impl(size_t itemsize,
                                  double samples_per_second,
-                                 bool ignore_tags)
+                                 bool ignore_tags,
+				 int max_noutput_items)
       : sync_block("throttle",
                       io_signature::make(1, 1, itemsize),
                       io_signature::make(1, 1, itemsize)),
         d_itemsize(itemsize),
-        d_ignore_tags(ignore_tags)
+        d_ignore_tags(ignore_tags),
+        d_max_noutput_items(max_noutput_items)
     {
       set_sample_rate(samples_per_second);
+      if (d_max_noutput_items>0)
+        set_max_noutput_items(d_max_noutput_items);
     }
 
     throttle_impl::~throttle_impl()
@@ -86,6 +90,8 @@ namespace gr {
                         gr_vector_const_void_star &input_items,
                         gr_vector_void_star &output_items)
     {
+
+
       // check for updated rx_rate tag
       if(!d_ignore_tags){
         uint64_t abs_N = nitems_read(0);

--- a/gr-blocks/lib/throttle_impl.h
+++ b/gr-blocks/lib/throttle_impl.h
@@ -36,9 +36,10 @@ namespace gr {
       uint64_t d_total_samples;
       double d_samps_per_tick, d_samps_per_us;
       bool d_ignore_tags;
+      int d_max_noutput_items;
 
     public:
-      throttle_impl(size_t itemsize, double samples_per_sec, bool ignore_tags=true);
+      throttle_impl(size_t itemsize, double samples_per_sec, bool ignore_tags=true, int max_noutput_items=-1);
       ~throttle_impl();
 
       // Overloading gr::block::start to reset timer


### PR DESCRIPTION
Hi @jmcorgan 

@anastas found there exists huge delay in a system we are working on due to some buffer in the queue. He modified the throttle to decrease the delay by decreasing the samples throttle process at a time.
So the throttle was modified by adding an optional parameter max_noutput_items.

Could you check and merge it please?

Thanks!
Best,
Zhe