### PR TITLE
gr-blocks: Make tap/tun configurable, fix GRC spec to be consistent with IFF_TAP

### DIFF
--- a/gr-blocks/grc/blocks_tuntap_pdu.xml
+++ b/gr-blocks/grc/blocks_tuntap_pdu.xml
@@ -8,11 +8,11 @@
   <name>TUNTAP PDU</name>
   <key>blocks_tuntap_pdu</key>
   <import>from gnuradio import blocks</import>
-  <make>blocks.tuntap_pdu($ifn, $mtu)</make>
+  <make>blocks.tuntap_pdu($ifn, $mtu, $istunflag)</make>
   <param>
     <name>Interface Name</name>
     <key>ifn</key>
-    <value>tun0</value>
+    <value>tap0</value>
     <type>string</type>
   </param>
   <param>
@@ -20,6 +20,20 @@
     <key>mtu</key>
     <value>10000</value>
     <type>int</type>
+  </param>
+  <param>
+    <name>Flag</name>
+    <key>istunflag</key>
+    <value>False</value>
+    <type>enum</type>
+    <option>
+	<name>TUN(IP Packet)</name>
+	<key>True</key>
+    </option>
+    <option>
+	<name>TAP(Ethernet Frame)</name>
+	<key>False</key>
+    </option>
   </param>
   <sink>
     <name>pdus</name>

--- a/gr-blocks/include/gnuradio/blocks/tuntap_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/tuntap_pdu.h
@@ -43,8 +43,9 @@ namespace gr {
        * \brief Construct a TUNTAP PDU interface
        * \param dev Device name to create
        * \param MTU Maximum Transmission Unit size
+	   * \param istunflag Flag to indicate TUN or Tap
        */
-      static sptr make(std::string dev, int MTU=10000);
+      static sptr make(std::string dev, int MTU=10000, bool istunflag=false);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/tuntap_pdu_impl.h
+++ b/gr-blocks/lib/tuntap_pdu_impl.h
@@ -38,10 +38,11 @@ namespace gr {
 #if (defined(linux) || defined(__linux) || defined(__linux__))
     private:
       std::string d_dev;
-      int tun_alloc(char *dev, int flags = IFF_TAP | IFF_NO_PI);
+      bool d_istunflag;
+      int tun_alloc(char *dev, int flags);
 
     public:
-      tuntap_pdu_impl(std::string dev, int MTU);
+      tuntap_pdu_impl(std::string dev, int MTU, bool istunflag);
 #endif
     };
 


### PR DESCRIPTION
Made tap/tun selectable in GRC.  Fixed GRC .xml default device name of "tun0" although default flag was IFF_TAP.