### PR TITLE
Fix gnuradio for wxPython3/GTK+3

### DIFF
--- a/gr-wxgui/python/wxgui/plotter/gltext.py
+++ b/gr-wxgui/python/wxgui/plotter/gltext.py
@@ -149,6 +149,10 @@ class TextElement(object):
         # get a memory dc
         dc = wx.MemoryDC()
 
+        # Select an empty bitmap into the MemoryDC - otherwise the call to
+        # GetMultiLineTextExtent() may fail below
+        dc.SelectObject(wx.EmptyBitmap(1,1))
+
         # set our font
         dc.SetFont(self._font)
 


### PR DESCRIPTION
MemoryDC needs to have a bitmap selected before using it