### PR TITLE
qtgui: fixed a small bug in the time sink

### DIFF
--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -520,7 +520,7 @@ namespace gr {
       uint64_t nr = nitems_read(d_trigger_channel/2);
       std::vector<gr::tag_t> tags;
       get_tags_in_range(tags, d_trigger_channel/2,
-                        nr, nr + nitems,
+                        nr, nr + nitems + 1,
                         d_trigger_tag_key);
       if(tags.size() > 0) {
         d_triggered = true;
@@ -616,7 +616,7 @@ namespace gr {
 
         uint64_t nr = nitems_read(idx);
         std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, idx, nr, nr + nitems);
+        get_tags_in_range(tags, idx, nr, nr + nitems + 1);
         for(size_t t = 0; t < tags.size(); t++) {
           tags[t].offset = tags[t].offset - nr + (d_index-d_start-1);
         }

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -522,7 +522,7 @@ namespace gr {
       uint64_t nr = nitems_read(d_trigger_channel);
       std::vector<gr::tag_t> tags;
       get_tags_in_range(tags, d_trigger_channel,
-                        nr, nr + nitems,
+                        nr, nr + nitems + 1,
                         d_trigger_tag_key);
       if(tags.size() > 0) {
         d_triggered = true;
@@ -611,7 +611,7 @@ namespace gr {
 
         uint64_t nr = nitems_read(idx);
         std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, idx, nr, nr + nitems);
+        get_tags_in_range(tags, idx, nr, nr + nitems + 1);
         for(size_t t = 0; t < tags.size(); t++) {
           tags[t].offset = tags[t].offset - nr + (d_index-d_start-1);
         }


### PR DESCRIPTION
Where it could miss a tag to display every now and then.

This is probably related to bug #751 (http://gnuradio.org/redmine/issues/751), but it's hard to see since the tag has to be 1 item beyond the window we were actually looking in. I'm not entirely sure that I understand this fix, but my guess is that it's related to the fact that history = 2 for these blocks.