### PR TITLE
qtgui: removing all references to aligned volk calls

### DIFF
--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -266,10 +266,10 @@ SpectrumGUIClass::updateWindow(const bool updateDisplayFlag,
     }
 
     if((complexTimeDomainData != NULL) && (complexTimeDomainDataSize > 0)) {
-      volk_32fc_deinterleave_64f_x2_a(_realTimeDomainPoints,
-                                      _imagTimeDomainPoints,
-				      (const lv_32fc_t *)complexTimeDomainData,
-				      complexTimeDomainDataSize);
+      volk_32fc_deinterleave_64f_x2(_realTimeDomainPoints,
+                                    _imagTimeDomainPoints,
+                                    (const lv_32fc_t *)complexTimeDomainData,
+                                    complexTimeDomainDataSize);
       timeDomainBufferSize = complexTimeDomainDataSize;
     }
   }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -641,7 +641,7 @@ namespace gr {
             for(int x = 0; x < d_fftsize; x++) {
               d_magbufs[n][x] = (double)((1.0-d_fftavg)*d_magbufs[n][x] + (d_fftavg)*d_fbuf[x]);
             }
-            //volk_32f_convert_64f_a(d_magbufs[n], d_fbuf, d_fftsize);
+            //volk_32f_convert_64f(d_magbufs[n], d_fbuf, d_fftsize);
           }
 
           // Test trigger off signal power in d_magbufs

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -646,7 +646,7 @@ namespace gr {
             for(int x = 0; x < d_fftsize; x++) {
               d_magbufs[n][x] = (double)((1.0-d_fftavg)*d_magbufs[n][x] + (d_fftavg)*d_fbuf[x]);
             }
-            //volk_32f_convert_64f_a(d_magbufs[n], d_fbuf, d_fftsize);
+            //volk_32f_convert_64f(d_magbufs[n], d_fbuf, d_fftsize);
           }
 
           // Test trigger off signal power in d_magbufs

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -494,7 +494,7 @@ namespace gr {
               for(int x = 0; x < d_fftsize; x++) {
                 d_magbufs[n][x] = (double)((1.0-d_fftavg)*d_magbufs[n][x] + (d_fftavg)*d_fbuf[x]);
               }
-              //volk_32f_convert_64f_a(d_magbufs[n], d_fbuf, d_fftsize);
+              //volk_32f_convert_64f(d_magbufs[n], d_fbuf, d_fftsize);
             }
 
 	    d_last_time = gr::high_res_timer_now();

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -465,7 +465,7 @@ namespace gr {
         }
       }
     }
-    
+
     void
     waterfall_sink_f_impl::set_time_per_fft(double t)
     {
@@ -502,7 +502,7 @@ namespace gr {
               for(int x = 0; x < d_fftsize; x++) {
                 d_magbufs[n][x] = (double)((1.0-d_fftavg)*d_magbufs[n][x] + (d_fftavg)*d_fbuf[x]);
               }
-              //volk_32f_convert_64f_a(d_magbufs[n], d_fbuf, d_fftsize);
+              //volk_32f_convert_64f(d_magbufs[n], d_fbuf, d_fftsize);
             }
 
 	    d_last_time = gr::high_res_timer_now();


### PR DESCRIPTION
Even the commented calls, just in case we uncomment them and forget at that point.