### PR TITLE
runtime: possible bug fix for limited-run flowgraphs with message-only blocks

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -750,7 +750,10 @@ namespace gr {
   bool
   block::finished()
   {
-    return d_finished;
+    if((detail()->ninputs() != 0) || (detail()->noutputs() != 0))
+      return false;
+    else
+      return d_finished;
   }
 
 


### PR DESCRIPTION
This needs a review to think if it might interact poorly with anything else, messages or streaming related.