### PR TITLE
blocks: the API for the peak_detector blocks incorrectly uses int instead of float for setting alpha.

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/peak_detector_XX.h.t
+++ b/gr-blocks/include/gnuradio/blocks/peak_detector_XX.h.t
@@ -89,7 +89,7 @@ namespace gr {
       /*! \brief Set the running average alpha
        *  \param alpha new alpha for running average
        */
-      virtual void set_alpha(int alpha) = 0;
+      virtual void set_alpha(float alpha) = 0;
 
       /*! \brief Get the threshold factor value for the rise time
        *  \return threshold factor

--- a/gr-blocks/lib/peak_detector_XX_impl.h.t
+++ b/gr-blocks/lib/peak_detector_XX_impl.h.t
@@ -49,7 +49,7 @@ namespace gr {
       void set_threshold_factor_rise(float thr) { d_threshold_factor_rise = thr; }
       void set_threshold_factor_fall(float thr) { d_threshold_factor_fall = thr; }
       void set_look_ahead(int look) { d_look_ahead = look; }
-      void set_alpha(int alpha) { d_avg_alpha = alpha; }
+      void set_alpha(float alpha) { d_avg_alpha = alpha; }
       float threshold_factor_rise() { return d_threshold_factor_rise; }
       float threshold_factor_fall() { return d_threshold_factor_fall; }
       int look_ahead() { return d_look_ahead; }


### PR DESCRIPTION
Sadly constitutes an API change, though the set_alpha is currently unusable.
