### PR TITLE
qtgui: added a variable push button widget

### DIFF
--- a/gr-qtgui/grc/qtgui_block_tree.xml
+++ b/gr-qtgui/grc/qtgui_block_tree.xml
@@ -52,6 +52,7 @@
       <block>variable_qtgui_range</block>
       <block>variable_qtgui_chooser</block>
       <block>variable_qtgui_check_box</block>
+      <block>variable_qtgui_push_button</block>
       <block>variable_qtgui_entry</block>
       <block>variable_qtgui_label</block>
     </cat>

--- a/gr-qtgui/grc/qtgui_push_button.xml
+++ b/gr-qtgui/grc/qtgui_push_button.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Variable Push Button:
+##	a gui push button form
+###################################################
+ -->
+<block>
+	<name>QT GUI Push Button</name>
+	<key>variable_qtgui_push_button</key>
+	<import>from PyQt4 import Qt</import>
+	<var_make>self.$(id) = $(id) = $value</var_make>
+	<make>#set $win = '_%s_push_button'%$id
+#if not $label()
+	#set $label = '"%s"'%$id
+#end if
+$win = Qt.QPushButton($label)
+self._$(id)_choices = {'Pressed': $pressed, 'Released': $released}
+$(win).pressed.connect(lambda: self.set_$(id)(self._$(id)_choices['Pressed']))
+$(win).released.connect(lambda: self.set_$(id)(self._$(id)_choices['Released']))
+$(gui_hint()($win))</make>
+	<callback>self.set_$(id)($value)</callback>
+	<param>
+		<name>Label</name>
+		<key>label</key>
+		<value></value>
+		<type>string</type>
+		<hide>#if $label() then 'none' else 'part'#</hide>
+	</param>
+	<param>
+		<name>Type</name>
+		<key>type</key>
+		<value>int</value>
+		<type>enum</type>
+		<hide>part</hide>
+		<option><name>Float</name><key>real</key><opt>conv:float</opt></option>
+		<option><name>Integer</name><key>int</key><opt>conv:int</opt></option>
+		<option><name>String</name><key>string</key><opt>conv:str</opt></option>
+		<option><name>Boolean</name><key>bool</key><opt>conv:bool</opt></option>
+		<option><name>Any</name><key>raw</key><opt>conv:eval</opt></option>
+	</param>
+	<param>
+		<name>Default Value</name>
+		<key>value</key>
+		<value>0</value>
+		<type>$type</type>
+	</param>
+	<param>
+		<name>Pressed</name>
+		<key>pressed</key>
+		<value>1</value>
+		<type>$type</type>
+	</param>
+	<param>
+		<name>Released</name>
+		<key>released</key>
+		<value>0</value>
+		<type>$type</type>
+	</param>
+	<param>
+		<name>GUI Hint</name>
+		<key>gui_hint</key>
+		<value></value>
+		<type>gui_hint</type>
+		<hide>part</hide>
+	</param>
+	<doc>
+This block creates a variable push button. \
+Leave the label blank to use the variable id as the label.
+
+A push button selects between two values of similar type. \
+The variable will take on one value or the other depending \
+on whether the button is pressed or released.
+
+The GUI hint can be used to position the widget within the application. \
+The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. \
+Both the tab specification and the grid position are optional.
+	</doc>
+</block>


### PR DESCRIPTION
I added a push button widget to control the value of a variable. The variable will take on one of two user-configured values depending on whether the button is in the pushed or released state. One example use case is temporarily opening a squelch block.