### PR TITLE
runtime: added accessor to get base address of buffer.

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -221,7 +221,7 @@ namespace gr {
 
     /*!
      * \brief Tell the scheduler \p how_many_items of input stream \p
-     * which_input were consumed. 
+     * which_input were consumed.
      * This function should be called at the end of work() or general_work(), after all processing is finished.
      */
     void consume(int which_input, int how_many_items);

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -68,6 +68,11 @@ namespace gr {
     int bufsize() const { return d_bufsize; }
 
     /*!
+     * \brief return the base address of the buffer
+     */
+    char* base() const { return d_base; }
+
+    /*!
      * \brief return pointer to write buffer.
      *
      * The return value points at space that can hold at least

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -70,7 +70,7 @@ namespace gr {
     /*!
      * \brief return the base address of the buffer
      */
-    char* base() const { return d_base; }
+    const char* base() const { return static_cast<const char*>(d_base); }
 
     /*!
      * \brief return pointer to write buffer.

--- a/gr-blocks/lib/qa_blocks.cc
+++ b/gr-blocks/lib/qa_blocks.cc
@@ -28,6 +28,7 @@
 #include <qa_blocks.h>
 #include <qa_block_tags.h>
 #include <qa_rotator.h>
+#include <qa_gr_block.h>
 
 CppUnit::TestSuite *
 qa_blocks::suite()
@@ -36,6 +37,7 @@ qa_blocks::suite()
 
   s->addTest(qa_block_tags::suite());
   s->addTest(qa_rotator::suite());
+  s->addTest(qa_gr_block::suite());
 
   return s;
 }

--- a/gr-blocks/lib/qa_gr_block.cc
+++ b/gr-blocks/lib/qa_gr_block.cc
@@ -30,19 +30,18 @@
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/null_source.h>
 
-
 // ----------------------------------------------------------------
 
 
 void
-qa_block::t0 ()
+qa_gr_block::t0 ()
 {
   // test creation of sources
   gr::block_sptr src1(gr::blocks::null_source::make(sizeof (int)));
   CPPUNIT_ASSERT_EQUAL(std::string("null_source"), src1->name ());
   CPPUNIT_ASSERT_EQUAL(0, src1->input_signature()->max_streams ());
   CPPUNIT_ASSERT_EQUAL(1, src1->output_signature()->min_streams ());
-  CPPUNIT_ASSERT_EQUAL(1, src1->output_signature()->max_streams ());
+  CPPUNIT_ASSERT_EQUAL(-1, src1->output_signature()->max_streams ());
   CPPUNIT_ASSERT_EQUAL((int) sizeof(int),
                        src1->output_signature()->sizeof_stream_item (0));
 
@@ -50,40 +49,66 @@ qa_block::t0 ()
   CPPUNIT_ASSERT_EQUAL(std::string ("null_source"), src2->name ());
   CPPUNIT_ASSERT_EQUAL(0, src2->input_signature()->max_streams ());
   CPPUNIT_ASSERT_EQUAL(1, src2->output_signature()->min_streams ());
-  CPPUNIT_ASSERT_EQUAL(1, src2->output_signature()->max_streams ());
+  CPPUNIT_ASSERT_EQUAL(-1, src2->output_signature()->max_streams ());
   CPPUNIT_ASSERT_EQUAL((int)sizeof (short),
                        src2->output_signature()->sizeof_stream_item (0));
 }
 
 
 void
-qa_block::t1 ()
+qa_gr_block::t1 ()
 {
   // test creation of sinks
   gr::block_sptr dst1 (gr::blocks::null_sink::make (sizeof (int)));
   CPPUNIT_ASSERT_EQUAL (std::string ("null_sink"), dst1->name ());
   CPPUNIT_ASSERT_EQUAL (1, dst1->input_signature()->min_streams ());
-  CPPUNIT_ASSERT_EQUAL (1, dst1->input_signature()->max_streams ());
+  CPPUNIT_ASSERT_EQUAL (-1, dst1->input_signature()->max_streams ());
   CPPUNIT_ASSERT_EQUAL ((int) sizeof (int),
-			dst1->input_signature()->sizeof_stream_item (0));
+        		dst1->input_signature()->sizeof_stream_item (0));
 
   CPPUNIT_ASSERT_EQUAL (0, dst1->output_signature()->max_streams ());
 
   gr::block_sptr dst2 (gr::blocks::null_sink::make (sizeof (short)));
   CPPUNIT_ASSERT_EQUAL (std::string ("null_sink"), dst2->name ());
   CPPUNIT_ASSERT_EQUAL (1, dst2->input_signature()->min_streams ());
-  CPPUNIT_ASSERT_EQUAL (1, dst2->input_signature()->max_streams ());
+  CPPUNIT_ASSERT_EQUAL (-1, dst2->input_signature()->max_streams ());
   CPPUNIT_ASSERT_EQUAL ((int) sizeof (short),
-			dst2->input_signature()->sizeof_stream_item (0));
+        		dst2->input_signature()->sizeof_stream_item (0));
   CPPUNIT_ASSERT_EQUAL (0, dst2->output_signature()->max_streams ());
 }
 
+#include <gnuradio/top_block.h>
+#include <gnuradio/buffer.h>
+#include <gnuradio/block_detail.h>
+#include <gnuradio/blocks/nop.h>
+
 void
-qa_block::t2 ()
+qa_gr_block::t2 ()
 {
+  gr::block_sptr src1(gr::blocks::null_source::make(sizeof (int)));
+  gr::block_sptr nop(gr::blocks::nop::make(sizeof (int)));
+  gr::block_sptr dst1 (gr::blocks::null_sink::make (sizeof (int)));
+
+  gr::top_block_sptr tb(gr::make_top_block("t2"));
+  tb->connect(src1, 0, nop, 0);
+  tb->connect(nop, 0, dst1, 0);
+  tb->start();
+
+  char *obuf = nop->detail()->output(0)->base();
+  int obsize = nop->detail()->output(0)->bufsize();
+  char *ibuf = nop->detail()->input(0)->buffer()->base();
+  int ibsize = nop->detail()->input(0)->buffer()->bufsize();
+
+  CPPUNIT_ASSERT(obuf != NULL);
+  CPPUNIT_ASSERT(ibuf != NULL);
+  CPPUNIT_ASSERT(obsize > 0);
+  CPPUNIT_ASSERT(ibsize > 0);
+
+  tb->stop();
+  tb->wait();
 }
 
 void
-qa_block::t3 ()
+qa_gr_block::t3 ()
 {
 }

--- a/gr-blocks/lib/qa_gr_block.cc
+++ b/gr-blocks/lib/qa_gr_block.cc
@@ -94,9 +94,9 @@ qa_gr_block::t2 ()
   tb->connect(nop, 0, dst1, 0);
   tb->start();
 
-  char *obuf = nop->detail()->output(0)->base();
+  const char *obuf = nop->detail()->output(0)->base();
   int obsize = nop->detail()->output(0)->bufsize();
-  char *ibuf = nop->detail()->input(0)->buffer()->base();
+  const char *ibuf = nop->detail()->input(0)->buffer()->base();
   int ibsize = nop->detail()->input(0)->buffer()->bufsize();
 
   CPPUNIT_ASSERT(obuf != NULL);

--- a/gr-blocks/lib/qa_gr_block.h
+++ b/gr-blocks/lib/qa_gr_block.h
@@ -27,9 +27,9 @@
 #include <cppunit/TestCase.h>
 #include <stdexcept>
 
-class qa_block : public CppUnit::TestCase {
+class qa_gr_block : public CppUnit::TestCase {
 
-  CPPUNIT_TEST_SUITE (qa_block);
+  CPPUNIT_TEST_SUITE (qa_gr_block);
   CPPUNIT_TEST (t0);
   CPPUNIT_TEST (t1);
   CPPUNIT_TEST (t2);


### PR DESCRIPTION
Addresses Issue #729.

Reintroduced qa_gr_block and added t2 tests to get input/output buffer size and base.

Need to include buffer.h, block.h, and block_detail.h when calling these in a block's work function.