### PR TITLE
cmake: In Python files only, remove all shebanging (anywhere) ...

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -185,7 +185,6 @@ function(GR_PYTHON_INSTALL)
             COMPONENT ${GR_PYTHON_INSTALL_COMPONENT}
         )
 
-
     ####################################################################
     elseif(GR_PYTHON_INSTALL_PROGRAMS)
     ####################################################################
@@ -207,7 +206,7 @@ function(GR_PYTHON_INSTALL)
             add_custom_command(
                 OUTPUT ${pyexefile} DEPENDS ${pyfile}
                 COMMAND ${PYTHON_EXECUTABLE} -c
-                "open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())"
+                "import re; R=re.compile('^\#!.*$\\n',flags=re.MULTILINE); open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+R.sub('',open('${pyfile}','r').read()))"
                 COMMENT "Shebangin ${pyfile_name}"
                 VERBATIM
             )

--- a/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrPython.cmake
+++ b/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrPython.cmake
@@ -185,7 +185,6 @@ function(GR_PYTHON_INSTALL)
             COMPONENT ${GR_PYTHON_INSTALL_COMPONENT}
         )
 
-
     ####################################################################
     elseif(GR_PYTHON_INSTALL_PROGRAMS)
     ####################################################################
@@ -207,7 +206,7 @@ function(GR_PYTHON_INSTALL)
             add_custom_command(
                 OUTPUT ${pyexefile} DEPENDS ${pyfile}
                 COMMAND ${PYTHON_EXECUTABLE} -c
-                "open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())"
+                "import re; R=re.compile('^\#!.*$\\n',flags=re.MULTILINE); open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+R.sub('',open('${pyfile}','r').read()))"
                 COMMENT "Shebangin ${pyfile_name}"
                 VERBATIM
             )

--- a/volk/cmake/GrPython.cmake
+++ b/volk/cmake/GrPython.cmake
@@ -199,7 +199,7 @@ function(VOLK_PYTHON_INSTALL)
             add_custom_command(
                 OUTPUT ${pyexefile} DEPENDS ${pyfile}
                 COMMAND ${PYTHON_EXECUTABLE} -c
-                "open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())"
+                "import re; R=re.compile('^\#!.*$\\n',flags=re.MULTILINE); open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+R.sub('',open('${pyfile}','r').read()))"
                 COMMENT "Shebangin ${pyfile_name}"
                 VERBATIM
             )


### PR DESCRIPTION
... then prepend that used for GNU Radio. For GR issue tracker #707 < http://gnuradio.org/redmine/issues/707 >. This is the solution that @mbr0wn and I agreed upon (a long time ago; better late than later, right?).