### PR TITLE
Update FindQwt.cmake to support qwt6-qt4

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -22,7 +22,7 @@ find_path(QWT_INCLUDE_DIRS
 )
 
 find_library (QWT_LIBRARIES
-  NAMES qwt6 qwt qwt-qt4
+  NAMES qwt6 qwt6-qt4 qwt qwt-qt4
   HINTS
   ${CMAKE_INSTALL_PREFIX}/lib
   ${CMAKE_INSTALL_PREFIX}/lib64


### PR DESCRIPTION
allow finding qwt6-qt4 library.  Some distros have added support for both qt4 and qt5 in qwt6, the common name the library uses appears to be qwt6-qt4.  The pre-existance of the qwt-qt4 entry suggests this naming convention is reasonably standard (or at least this isn't a unique hack)