### PR TITLE
blocks: integration supports vector input

### DIFF
--- a/gr-blocks/grc/blocks_integrate_xx.xml
+++ b/gr-blocks/grc/blocks_integrate_xx.xml
@@ -8,7 +8,7 @@
 	<name>Integrate</name>
 	<key>blocks_integrate_xx</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.integrate_$(type.fcn)($decim)</make>
+	<make>blocks.integrate_$(type.fcn)($decim, $vlen)</make>
 	<param>
 		<name>IO Type</name>
 		<key>type</key>
@@ -39,12 +39,20 @@
 		<key>decim</key>
 		<type>int</type>
 	</param>
+	<param>
+		<name>Vec Length</name>
+		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
 	<sink>
 		<name>in</name>
 		<type>$type</type>
+		<vlen>$vlen</vlen>
 	</sink>
 	<source>
 		<name>out</name>
 		<type>$type</type>
+		<vlen>$vlen</vlen>
 	</source>
 </block>

--- a/gr-blocks/include/gnuradio/blocks/integrate_XX.h.t
+++ b/gr-blocks/include/gnuradio/blocks/integrate_XX.h.t
@@ -42,7 +42,7 @@ namespace gr {
       // gr::blocks::@NAME@::sptr
       typedef boost::shared_ptr<@NAME@> sptr;
 
-      static sptr make(int decim);
+      static sptr make(int decim, int vlen = 1);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/integrate_XX_impl.cc.t
+++ b/gr-blocks/lib/integrate_XX_impl.cc.t
@@ -32,18 +32,18 @@
 namespace gr {
   namespace blocks {
 
-    @NAME@::sptr @NAME@::make(int decim)
+    @NAME@::sptr @NAME@::make(int decim, int vlen)
     {
-      return gnuradio::get_initial_sptr(new @NAME_IMPL@(decim));
+      return gnuradio::get_initial_sptr(new @NAME_IMPL@(decim, vlen));
     }
 
-    @NAME_IMPL@::@NAME_IMPL@(int decim)
+    @NAME_IMPL@::@NAME_IMPL@(int decim, int vlen)
       : sync_decimator("@NAME@",
-			  io_signature::make(1, 1, sizeof (@I_TYPE@)),
-			  io_signature::make(1, 1, sizeof (@O_TYPE@)),
+			  io_signature::make(1, 1, sizeof (@I_TYPE@) * vlen),
+			  io_signature::make(1, 1, sizeof (@O_TYPE@) * vlen),
 			  decim),
       d_decim(decim),
-      d_count(0)
+      d_vlen(vlen)
     {
     }
 
@@ -56,9 +56,14 @@ namespace gr {
       @O_TYPE@ *out = (@O_TYPE@ *)output_items[0];
 
       for (int i = 0; i < noutput_items; i++) {
-	out[i] = (@O_TYPE@)0;
-	for (int j = 0; j < d_decim; j++)
-	  out[i] += in[i*d_decim+j];
+        for (int j = 0; j < d_vlen; ++j) {
+          out[i*d_vlen + j] = (@O_TYPE@)0;
+        }
+        for (int j = 0; j < d_decim; j++) {
+          for (int k = 0; k < d_vlen; ++k) {
+            out[i*d_vlen + k] += in[i*d_decim*d_vlen + j*d_vlen + k];
+          }
+        }
       }
 
       return noutput_items;

--- a/gr-blocks/lib/integrate_XX_impl.h.t
+++ b/gr-blocks/lib/integrate_XX_impl.h.t
@@ -33,10 +33,10 @@ namespace gr {
     class BLOCKS_API @NAME_IMPL@ : public @NAME@
     {
       int d_decim;
-      int d_count;
+      int d_vlen;
 
     public:
-      @NAME_IMPL@(int decim);
+      @NAME_IMPL@(int decim, int vlen);
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,

--- a/gr-blocks/python/blocks/qa_integrate.py
+++ b/gr-blocks/python/blocks/qa_integrate.py
@@ -70,5 +70,27 @@ class test_integrate (gr_unittest.TestCase):
 	self.tb.run()
 	self.assertComplexTuplesAlmostEqual(dst_data, dst.data(), 6)
 
+    def test_004_ss_vec(self):
+	src_data = (1, 2, 3, 4, 5, 6)
+	dst_data = (9, 12)
+	vlen = 2
+	src = blocks.vector_source_s(src_data, False, vlen)
+	itg = blocks.integrate_ss(3, vlen)
+	dst = blocks.vector_sink_s(vlen)
+	self.tb.connect(src, itg, dst)
+	self.tb.run()
+	self.assertEqual(dst_data, dst.data())
+
+    def test_003_cc_vec(self):
+	src_data = [1.0+1.0j, 2.0+2.0j, 3.0+3.0j, 4.0+4.0j, 5.0+5.0j, 6.0+6.0j]
+	dst_data = [9.0+9.0j, 12.0+12.0j]
+	vlen = 2
+	src = blocks.vector_source_c(src_data, False, vlen)
+	itg = blocks.integrate_cc(3, vlen)
+	dst = blocks.vector_sink_c(vlen)
+	self.tb.connect(src, itg, dst)
+	self.tb.run()
+	self.assertComplexTuplesAlmostEqual(dst_data, dst.data(), 6)
+
 if __name__ == '__main__':
     gr_unittest.run(test_integrate, "test_integrate.xml")


### PR DESCRIPTION
Extend integration block. Allow vector input and integrate it element-vise. Output is vector if integrated items.