### PR TITLE
Add frequency accessor/modifier to CTCSS squelch

### DIFF
--- a/gr-analog/grc/analog_ctcss_squelch_ff.xml
+++ b/gr-analog/grc/analog_ctcss_squelch_ff.xml
@@ -32,6 +32,7 @@
 	<import>from gnuradio import analog</import>
 	<make>analog.ctcss_squelch_ff($rate, $freq, $level, $len, $ramp, $gate)</make>
 	<callback>set_level($level)</callback>
+	<callback>set_frequency($freq)</callback>
 	<param>
 		<name>Sampling Rate (Hz)</name>
 		<key>rate</key>

--- a/gr-analog/include/gnuradio/analog/ctcss_squelch_ff.h
+++ b/gr-analog/include/gnuradio/analog/ctcss_squelch_ff.h
@@ -63,6 +63,8 @@ namespace gr {
       virtual float level() const = 0;
       virtual void set_level(float level) = 0;
       virtual int len() const = 0;
+      virtual float frequency() const = 0;
+      virtual void set_frequency(float frequency) = 0;
 
       virtual int ramp() const = 0;
       virtual void set_ramp(int ramp) = 0;

--- a/gr-analog/lib/ctcss_squelch_ff_impl.cc
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.cc
@@ -55,6 +55,25 @@ namespace gr {
       return -1;
     }
 
+    void
+    ctcss_squelch_ff_impl::compute_freqs(const float &freq,
+                                         float &f_l, float &f_r)
+    {
+      int i = find_tone(freq);
+
+      // Non-standard tones or edge tones get 2% guard band, otherwise
+      // guards are set at adjacent ctcss tone frequencies
+      if(i == -1 || i == 0)
+	f_l = freq*0.98;
+      else
+	f_l = ctcss_tones[i-1];
+
+      if(i == -1 || i == max_tone_index)
+	f_r = freq*1.02;
+      else
+	f_r = ctcss_tones[i+1];
+    }
+
     ctcss_squelch_ff_impl::ctcss_squelch_ff_impl(int rate, float freq, float level,
 						 int len, int ramp, bool gate)
       :	block("ctcss_squelch_ff",
@@ -71,20 +90,8 @@ namespace gr {
       else
 	d_len = len;
 
-      int i = find_tone(freq);
-
-      // Non-standard tones or edge tones get 2% guard band, otherwise
-      // guards are set at adjacent ctcss tone frequencies
       float f_l, f_r;
-      if(i == -1 || i == 0)
-	f_l = freq*0.98;
-      else
-	f_l = ctcss_tones[i-1];
-
-      if(i == -1 || i == max_tone_index)
-	f_r = freq*1.02;
-      else
-	f_r = ctcss_tones[i+1];
+      compute_freqs(d_freq, f_l, f_r);
 
       d_goertzel_l = new fft::goertzel(rate, d_len, f_l);
       d_goertzel_c = new fft::goertzel(rate, d_len, freq);

--- a/gr-analog/lib/ctcss_squelch_ff_impl.cc
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.cc
@@ -149,5 +149,20 @@ namespace gr {
       }
     }
 
+    void
+    ctcss_squelch_ff_impl::set_level(float level)
+    {
+      gr::thread::scoped_lock l(d_setlock);
+      d_level = level;
+    }
+
+    void
+    ctcss_squelch_ff_impl::set_frequency(float frequency)
+    {
+      gr::thread::scoped_lock l(d_setlock);
+      d_freq = frequency;
+      update_fft_params();
+    }
+
   } /* namespace analog */
 } /* namespace gr */

--- a/gr-analog/lib/ctcss_squelch_ff_impl.cc
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.cc
@@ -74,6 +74,17 @@ namespace gr {
 	f_r = ctcss_tones[i+1];
     }
 
+    void
+    ctcss_squelch_ff_impl::update_fft_params()
+    {
+        float f_l, f_r;
+        compute_freqs(d_freq, f_l, f_r);
+
+        d_goertzel_l->set_params(d_rate, d_len, f_l);
+        d_goertzel_c->set_params(d_rate, d_len, d_freq);
+        d_goertzel_r->set_params(d_rate, d_len, f_r);
+    }
+
     ctcss_squelch_ff_impl::ctcss_squelch_ff_impl(int rate, float freq, float level,
 						 int len, int ramp, bool gate)
       :	block("ctcss_squelch_ff",
@@ -83,19 +94,20 @@ namespace gr {
     {
       d_freq = freq;
       d_level = level;
+      d_rate = rate;
 
       // Default is 100 ms detection time
       if(len == 0)
-	d_len = (int)(rate/10.0);
+        d_len = (int)(d_rate/10.0);
       else
-	d_len = len;
+        d_len = len;
 
       float f_l, f_r;
       compute_freqs(d_freq, f_l, f_r);
 
-      d_goertzel_l = new fft::goertzel(rate, d_len, f_l);
-      d_goertzel_c = new fft::goertzel(rate, d_len, freq);
-      d_goertzel_r = new fft::goertzel(rate, d_len, f_r);
+      d_goertzel_l = new fft::goertzel(d_rate, d_len, f_l);
+      d_goertzel_c = new fft::goertzel(d_rate, d_len, freq);
+      d_goertzel_r = new fft::goertzel(d_rate, d_len, f_r);
 
       d_mute = true;
     }

--- a/gr-analog/lib/ctcss_squelch_ff_impl.h
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.h
@@ -42,7 +42,7 @@ namespace gr {
       fft::goertzel *d_goertzel_c;
       fft::goertzel *d_goertzel_r;
 
-      int find_tone(float freq);
+      static int find_tone(float freq);
 
     protected:
       virtual void update_state(const float &in);

--- a/gr-analog/lib/ctcss_squelch_ff_impl.h
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.h
@@ -59,15 +59,10 @@ namespace gr {
 
       std::vector<float> squelch_range() const;
       float level() const { return d_level; }
-      void set_level(float level) { d_level = level; }
+      void set_level(float level);
       int len() const { return d_len; }
       float frequency() const { return d_freq; }
-
-      void set_frequency(float frequency)
-      {
-          d_freq = frequency;
-          update_fft_params();
-      }
+      void set_frequency(float frequency);
 
       int ramp() const { return squelch_base_ff_impl::ramp(); }
       void set_ramp(int ramp) { squelch_base_ff_impl::set_ramp(ramp); }

--- a/gr-analog/lib/ctcss_squelch_ff_impl.h
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.h
@@ -36,6 +36,7 @@ namespace gr {
       float d_freq;
       float d_level;
       int   d_len;
+      int   d_rate;
       bool  d_mute;
 
       fft::goertzel *d_goertzel_l;
@@ -44,6 +45,8 @@ namespace gr {
 
       static int find_tone(float freq);
       static void compute_freqs(const float &freq, float &f_l, float &f_r);
+
+      void update_fft_params();
 
     protected:
       virtual void update_state(const float &in);
@@ -58,6 +61,13 @@ namespace gr {
       float level() const { return d_level; }
       void set_level(float level) { d_level = level; }
       int len() const { return d_len; }
+      float frequency() const { return d_freq; }
+
+      void set_frequency(float frequency)
+      {
+          d_freq = frequency;
+          update_fft_params();
+      }
 
       int ramp() const { return squelch_base_ff_impl::ramp(); }
       void set_ramp(int ramp) { squelch_base_ff_impl::set_ramp(ramp); }

--- a/gr-analog/lib/ctcss_squelch_ff_impl.h
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.h
@@ -43,6 +43,7 @@ namespace gr {
       fft::goertzel *d_goertzel_r;
 
       static int find_tone(float freq);
+      static void compute_freqs(const float &freq, float &f_l, float &f_r);
 
     protected:
       virtual void update_state(const float &in);

--- a/gr-analog/lib/pwr_squelch_cc_impl.cc
+++ b/gr-analog/lib/pwr_squelch_cc_impl.cc
@@ -69,5 +69,19 @@ namespace gr {
       d_pwr = d_iir.filter(in.real()*in.real()+in.imag()*in.imag());
     }
 
+    void
+    pwr_squelch_cc_impl::set_threshold(double db)
+    {
+        gr::thread::scoped_lock l(d_setlock);
+        d_threshold = std::pow(10.0, db/10);
+    }
+
+    void
+    pwr_squelch_cc_impl::set_alpha(double alpha)
+    {
+        gr::thread::scoped_lock l(d_setlock);
+        d_iir.set_taps(alpha);
+    }
+
   } /* namespace analog */
 } /* namespace gr */

--- a/gr-analog/lib/pwr_squelch_cc_impl.h
+++ b/gr-analog/lib/pwr_squelch_cc_impl.h
@@ -51,8 +51,8 @@ namespace gr {
       std::vector<float> squelch_range() const;
 
       double threshold() const { return 10*log10(d_threshold); }
-      void set_threshold(double db) { d_threshold = std::pow(10.0, db/10); }
-      void set_alpha(double alpha) { d_iir.set_taps(alpha); }
+      void set_threshold(double db);
+      void set_alpha(double alpha);
 
       int ramp() const { return squelch_base_cc_impl::ramp(); }
       void set_ramp(int ramp) { squelch_base_cc_impl::set_ramp(ramp); }

--- a/gr-analog/lib/squelch_base_cc_impl.cc
+++ b/gr-analog/lib/squelch_base_cc_impl.cc
@@ -55,6 +55,7 @@ namespace gr {
     void
     squelch_base_cc_impl::set_ramp(int ramp)
     {
+      gr::thread::scoped_lock l(d_setlock);
       d_ramp = ramp;
     }
 
@@ -67,6 +68,7 @@ namespace gr {
     void
     squelch_base_cc_impl::set_gate(bool gate)
     {
+      gr::thread::scoped_lock l(d_setlock);
       d_gate = gate;
     }
 
@@ -86,6 +88,8 @@ namespace gr {
       gr_complex *out = (gr_complex *) output_items[0];
 
       int j = 0;
+
+      gr::thread::scoped_lock l(d_setlock);
 
       for(int i = 0; i < noutput_items; i++) {
 	update_state(in[i]);


### PR DESCRIPTION
While working on a GRC graph that uses the CTCSS squelch block, I found that I was unable to change the frequency used for the CTCSS squelch at run-time (e.g., via values from a QT GUI Chooser).  This is due to the fact that this parameter is fixed when the block is created. An accessor and modifier for the frequency parameter have been introduced.

This change has been broken into three separate patches just to better articulate the rationale for the changes made.  Let me know if you want them squashed, changed, or dropped.