### PR TITLE
Extend dot-graph generator to draw hierarchical blocks

### DIFF
--- a/gnuradio-runtime/include/gnuradio/flowgraph.h
+++ b/gnuradio-runtime/include/gnuradio/flowgraph.h
@@ -265,7 +265,6 @@ namespace gr {
     return os;
   }
 
-  std::string dot_graph_fg (flowgraph_sptr fg);
 
 } /* namespace gr */
 

--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -174,7 +174,11 @@ namespace gr {
     // ignored by the user.
     flat_flowgraph_sptr flatten() const;
 
-    hier_block2_sptr to_hier_block2(); // Needed for Python type coercion
+    // flatten wrapper method that produces a dot-graph string
+    void flatten_dot(flat_flowgraph_sptr new_ffg, std::stringstream *dot_out) const;
+
+    // Needed for Python type coercion
+    hier_block2_sptr to_hier_block2();
 
     bool has_msg_port(pmt::pmt_t which_port) {
       return message_port_is_hier(which_port) || basic_block::has_msg_port(which_port);

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -523,33 +523,4 @@ namespace gr {
     throw std::runtime_error("disconnect called on non-connected edge!");
   }
 
-  std::string
-  dot_graph_fg(flowgraph_sptr fg)
-  {
-    basic_block_vector_t blocks = fg->calc_used_blocks();
-    edge_vector_t edges = fg->edges();
-
-    std::stringstream out;
-
-    out << "digraph flowgraph {" << std::endl;
-
-    // Define nodes and set labels
-    for(basic_block_viter_t block = blocks.begin(); block != blocks.end(); ++block) {
-      out << (*block)->unique_id()
-          << " [ label=\"" << (*block)->name() << "\" ]"
-          << std::endl;
-    }
-
-    // Define edges
-    for(edge_viter_t edge = edges.begin(); edge != edges.end(); ++edge) {
-      out << edge->src().block()->unique_id()
-          << " -> "
-          << edge->dst().block()->unique_id() << std::endl;
-    }
-
-    out << "}" << std::endl;
-
-    return out.str();
-  }
-
 } /* namespace gr */

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -29,6 +29,8 @@
 #include <gnuradio/flowgraph.h>
 #include "hier_block2_detail.h"
 #include <iostream>
+#include <stdio.h>
+#include <gnuradio/flowgraph.h>
 
 namespace gr {
 
@@ -159,6 +161,35 @@ namespace gr {
   }
 
   void
+  hier_block2::flatten_dot(flat_flowgraph_sptr new_ffg, std::stringstream *dot_out) const
+  {
+    d_detail->flatten_aux(new_ffg, dot_out);
+  }
+
+  std::string
+  dot_graph(hier_block2_sptr hierblock2)
+  {
+    flat_flowgraph_sptr new_ffg = make_flat_flowgraph();
+    std::stringstream dot_out;
+    // write dot-graph string
+    dot_out << "digraph flowgraph {" << std::endl;
+    // flatten flowgraph, recursively writes strings of edges/nodes
+    hierblock2->flatten_dot(new_ffg, &dot_out);
+    // Define edges
+    edge_vector_t edges = new_ffg->edges();
+    for (edge_viter_t edge = edges.begin(); edge != edges.end(); ++edge) {
+      // write dot-graph string
+      dot_out << edge->src().block()->unique_id()
+        << " -> "
+        << edge->dst().block()->unique_id()
+        << std::endl;
+    }
+    dot_out << "}";
+
+    return dot_out.str();
+  }
+
+  void
   hier_block2::set_processor_affinity(const std::vector<int> &mask)
   {
     d_detail->set_processor_affinity(mask);
@@ -174,12 +205,6 @@ namespace gr {
   hier_block2::processor_affinity()
   {
     return d_detail->processor_affinity();
-  }
-
-  std::string
-  dot_graph(hier_block2_sptr hierblock2)
-  {
-    return dot_graph_fg(hierblock2->flatten());
   }
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -500,10 +500,17 @@ namespace gr {
   }
 
   void
-  hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
+  hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg, std::stringstream *dot_out/* = NULL*/) const
   {
     if(HIER_BLOCK2_DETAIL_DEBUG)
       std::cout << " ** Flattening " << d_owner->name() << std::endl;
+
+    // write dot-graph string
+    if (dot_out != NULL) {
+      *dot_out << "subgraph cluster" << (d_owner)->unique_id()
+        << "{ label=\""
+        << d_owner->name() << "\"" << std::endl;
+    }
 
     // Add my edges to the flow graph, resolving references to actual endpoints
     edge_vector_t edges = d_fg->edges();
@@ -655,8 +662,20 @@ namespace gr {
         if(HIER_BLOCK2_DETAIL_DEBUG)
           std::cout << "flatten_aux: recursing into hierarchical block "
                     << hier_block2 << std::endl;
-        hier_block2->d_detail->flatten_aux(sfg);
+        hier_block2->d_detail->flatten_aux(sfg,dot_out);
       }
+      else{
+        // write dot-graph string
+        if (dot_out != NULL) {
+          *dot_out <<  (*p)->unique_id() 
+            << " [ label=\"" << (*p)->name() << "\" ]"
+            << std::endl;
+        }
+      }
+    }
+    // write dot-graph string
+    if (dot_out != NULL) {
+      *dot_out << "}" << std::endl;
     }
   }
 

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -52,8 +52,7 @@ namespace gr {
     void disconnect_all();
     void lock();
     void unlock();
-    void flatten_aux(flat_flowgraph_sptr sfg) const;
-
+    void flatten_aux(flat_flowgraph_sptr sfg, std::stringstream *dot_out = NULL) const;
     void set_processor_affinity(const std::vector<int> &mask);
     void unset_processor_affinity();
     std::vector<int> processor_affinity();

--- a/gr-blocks/lib/sub_ff_impl.cc
+++ b/gr-blocks/lib/sub_ff_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     sub_ff_impl::sub_ff_impl(size_t vlen)
-      : sync_block("@sub_ff",
+      : sync_block("sub_ff",
                    io_signature::make(1, -1, sizeof(float)*vlen),
                    io_signature::make(1,  1, sizeof(float)*vlen)),
       d_vlen(vlen)

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -64,7 +64,7 @@ namespace gr {
     usrp_sink_impl::usrp_sink_impl(const ::uhd::device_addr_t &device_addr,
                                    const ::uhd::stream_args_t &stream_args,
                                    const std::string &length_tag_name)
-      : sync_block("gr uhd usrp sink",
+      : sync_block("gr_uhd_usrp_sink",
                       args_to_io_sig(stream_args),
                       io_signature::make(0, 0, 0)),
         usrp_common_impl(device_addr, stream_args, length_tag_name),

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -64,7 +64,7 @@ namespace gr {
 
     usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t &device_addr,
                                        const ::uhd::stream_args_t &stream_args):
-      sync_block("gr uhd usrp source",
+      sync_block("gr_uhd_usrp_source",
                     io_signature::make(0, 0, 0),
                     args_to_io_sig(stream_args)),
       usrp_common_impl(device_addr, stream_args, ""),


### PR DESCRIPTION
Changed the implementation to use a stringstream pointer in flatten_aux that defaults to NULL.