### PR TITLE
analog: fix check of sample rate vs audio rate

### DIFF
--- a/gr-analog/grc/analog_nbfm_rx.xml
+++ b/gr-analog/grc/analog_nbfm_rx.xml
@@ -36,7 +36,7 @@
 		<value>5e3</value>
 		<type>real</type>
 	</param>
-	<check>$quad_rate%$audio_rate == 0</check>
+	<check>($quad_rate)%($audio_rate) == 0</check>
 	<sink>
 		<name>in</name>
 		<type>complex</type>

--- a/gr-analog/grc/analog_nbfm_tx.xml
+++ b/gr-analog/grc/analog_nbfm_tx.xml
@@ -36,7 +36,7 @@
 		<value>5e3</value>
 		<type>real</type>
 	</param>
-	<check>$quad_rate%$audio_rate == 0</check>
+	<check>($quad_rate)%($audio_rate) == 0</check>
 	<sink>
 		<name>in</name>
 		<type>float</type>

--- a/gr-analog/grc/analog_wfm_tx.xml
+++ b/gr-analog/grc/analog_wfm_tx.xml
@@ -36,7 +36,7 @@
 		<value>75e3</value>
 		<type>real</type>
 	</param>
-	<check>$quad_rate%$audio_rate == 0</check>
+	<check>($quad_rate)%($audio_rate) == 0</check>
 	<sink>
 		<name>in</name>
 		<type>float</type>


### PR DESCRIPTION
Variables in XML blocks are substituted by the content of filed value
from GRC block. Content of field in GRC block can be any python expression
and expression can contain operators (like +). Some operators have lower
priority than % (modulo). This leads to wrong (from user field of view) evaluation of
expression as a whole. Just add parentheses fix this.