### PR TITLE
blocks: Fixed UDP source bug

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/udp_source.h
+++ b/gr-blocks/include/gnuradio/blocks/udp_source.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2007-2010,2013 Free Software Foundation, Inc.
+ * Copyright 2007-2010,2013,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -43,7 +43,7 @@ namespace gr {
        * \brief UDP Source Constructor
        *
        * \param itemsize     The size (in bytes) of the item datatype
-       * \param host         The name or IP address of the receiving host; can be
+       * \param host         The name or IP address of the transmitting host; can be
        *                     NULL, None, or "0.0.0.0" to allow reading from any
        *                     interface on the host
        * \param port         The port number on which to receive data; use 0 to

--- a/gr-blocks/lib/udp_source_impl.h
+++ b/gr-blocks/lib/udp_source_impl.h
@@ -44,6 +44,8 @@ namespace gr {
       ssize_t d_sent;         // track how much of d_residbuf we've outputted
       size_t  d_offset;       // point to residbuf location offset
 
+      static const int BUF_SIZE_PAYLOADS; //!< The d_residbuf size in multiples of d_payload_size
+
       std::string d_host;
       unsigned short d_port;
 


### PR DESCRIPTION
Before, it would actually read too few bytes from the
incoming buffer.
Also removed some 'magic' constants and replaced by const
variables.