### PR TITLE
Added squelch_base_cc.h

### DIFF
--- a/gr-analog/include/gnuradio/analog/CMakeLists.txt
+++ b/gr-analog/include/gnuradio/analog/CMakeLists.txt
@@ -41,6 +41,7 @@ install(FILES
     agc2.h
     noise_type.h
     squelch_base_ff.h
+    squelch_base_cc.h
     agc_cc.h
     agc_ff.h
     agc2_cc.h


### PR DESCRIPTION
squelch_base_cc.h was not included in the cmake file and was not getting installed. As a result thing like power squelch couldn't be used because they include squelch_base_cc.h