### PR TITLE
runtime: do not return buffer created on stack #722

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -68,9 +68,8 @@ namespace gr {
 
     std::vector<gr::vmcircbuf_factory *> all = all_factories ();
 
-    const char *name = gr::vmcircbuf_prefs::get(FACTORY_PREF_KEY);
-
-    if(name) {
+    char name[1024];
+    if (gr::vmcircbuf_prefs::get(FACTORY_PREF_KEY, name, sizeof(name)) >= 0) {
       for(unsigned int i = 0; i < all.size (); i++) {
         if(strncmp(name, all[i]->name(), strlen(all[i]->name())) == 0) {
           s_default_factory = all[i];

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -65,11 +65,9 @@ namespace gr {
       fs::create_directory(path);
   }
 
-  const char *
-  vmcircbuf_prefs::get(const char *key)
+  int
+  vmcircbuf_prefs::get(const char *key, char *value, int value_size)
   {
-    static char buf[1024];
-
     gr::thread::scoped_lock guard(s_vm_mutex);
 
     FILE *fp = fopen(pathname (key), "r");
@@ -78,17 +76,17 @@ namespace gr {
       return 0;
     }
 
-    memset(buf, 0, sizeof (buf));
-    size_t ret = fread(buf, 1, sizeof(buf) - 1, fp);
-    if(ret == 0) {
+    const size_t ret = fread(value, 1, value_size - 1, fp);
+    value[ret] = '\0';
+    if(ret == 0 && !feof(fp)) {
       if(ferror(fp) != 0) {
         perror(pathname (key));
         fclose(fp);
-        return 0;
+        return -1;
       }
     }
     fclose(fp);
-    return buf;
+    return ret;
   }
 
   void

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.h
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.h
@@ -30,7 +30,7 @@ namespace gr {
   class GR_RUNTIME_API vmcircbuf_prefs
   {
   public:
-    static const char *get(const char *key);
+    static int get(const char *key, char *value, int value_size);
     static void set(const char *key, const char *value);
   };
 


### PR DESCRIPTION
This fix use of bufer allocated on stack. It should fix bug #722.

I does not performed anny extra testing, just compiled GNURadio and run QA. Someone (bug reporter?) should try if this fix rally solves all in #722.