### PR TITLE
blocks: message strobe shutdown fix.

### DIFF
--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -54,8 +54,6 @@ namespace gr {
         d_msg(msg)
     {
       message_port_register_out(pmt::mp("strobe"));
-      d_thread = boost::shared_ptr<gr::thread::thread>
-        (new gr::thread::thread(boost::bind(&message_strobe_impl::run, this)));
 
       message_port_register_in(pmt::mp("set_msg"));
       set_msg_handler(pmt::mp("set_msg"),
@@ -64,9 +62,26 @@ namespace gr {
 
     message_strobe_impl::~message_strobe_impl()
     {
+    }
+
+    bool
+    message_strobe_impl::start()
+    {
+      d_thread = boost::shared_ptr<gr::thread::thread>
+        (new gr::thread::thread(boost::bind(&message_strobe_impl::run, this)));
+
+      return block::start();
+    }
+
+    bool
+    message_strobe_impl::stop()
+    {
+      // Shut down the thread
       d_finished = true;
       d_thread->interrupt();
       d_thread->join();
+
+      return block::stop();
     }
 
     void message_strobe_impl::run()

--- a/gr-blocks/lib/message_strobe_impl.h
+++ b/gr-blocks/lib/message_strobe_impl.h
@@ -46,6 +46,11 @@ namespace gr {
       pmt::pmt_t msg() const { return d_msg; }
       void set_period(float period_ms) { d_period_ms = period_ms; }
       float period() const { return d_period_ms; }
+
+      // Overloading these to start and stop the internal thread that
+      // periodically produces the message.
+      bool start();
+      bool stop();
     };
 
   } /* namespace blocks */


### PR DESCRIPTION
On embedded systems, this block's destructure was not getting called
in the right order and the flowgraph would hang because this block's
thread running run would never quit. Moving the start and stop
handling of this thread to the start/stop functions of the block fix
this. Also makes sure that the block is only producing messages when
the flowgraph is running.