### PR TITLE
blocks: peak_detector2 is updated with a bug fixed, two additional parameters and optional avg output

### DIFF
--- a/gr-blocks/grc/blocks_peak_detector2_fb.xml
+++ b/gr-blocks/grc/blocks_peak_detector2_fb.xml
@@ -8,7 +8,7 @@
 	<name>Peak Detector2</name>
 	<key>blocks_peak_detector2_fb</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.peak_detector2_fb($threshold_factor_rise, $look_ahead, $alpha)</make>
+	<make>blocks.peak_detector2_fb($threshold_factor_rise, $look_ahead, $alpha, $cont_avg, $fixed_window)</make>
 	<callback>set_threshold_factor_rise($threshold_factor_rise)</callback>
 	<callback>set_look_ahead($look_ahead)</callback>
 	<callback>set_alpha($alpha)</callback>
@@ -30,12 +30,63 @@
                 <value>0.001</value>
 		<type>real</type>
 	</param>
+        <param>
+        	<name>Average Type</name>
+        	<key>cont_avg</key>
+        	<value>True</value>
+        	<type>enum</type>
+        	<option>
+          		<name>Continuous</name>
+          		<key>True</key>
+        	</option>
+        	<option>
+          		<name>Intermittent</name>
+          		<key>False</key>
+        	</option>
+        </param>
+        <param>
+        	<name>Look Ahead Type</name>
+        	<key>fixed_window</key>
+        	<value>True</value>
+        	<type>enum</type>
+        	<option>
+          		<name>Fixed</name>
+          		<key>True</key>
+        	</option>
+        	<option>
+          		<name>Sliding</name>
+          		<key>False</key>
+        	</option>
+        </param>
+        <param>
+            <name>Debug</name>
+            <key>debug</key>
+            <value>True</value>
+            <type>enum</type>
+            <hide>part</hide>
+            <option>
+              <name>No</name>
+              <key>True</key>
+            </option>
+            <option>
+              <name>Yes</name>
+              <key>False</key>
+            </option>
+          </param>
+
 	<sink>
 		<name>in</name>
 		<type>float</type>
 	</sink>
+
 	<source>
 		<name>out</name>
 		<type>byte</type>
+	</source>
+	<source>
+		<name>sigout</name>
+		<type>float</type>
+                <optional>1</optional>
+                <hide>$debug</hide>
 	</source>
 </block>

--- a/gr-blocks/grc/blocks_peak_detector2_fb.xml
+++ b/gr-blocks/grc/blocks_peak_detector2_fb.xml
@@ -8,7 +8,7 @@
 	<name>Peak Detector2</name>
 	<key>blocks_peak_detector2_fb</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.peak_detector2_fb($threshold_factor_rise, $look_ahead, $alpha, $cont_avg, $fixed_window)</make>
+	<make>blocks.peak_detector2_fb($threshold_factor_rise, $look_ahead, $alpha, $cont_avg)</make>
 	<callback>set_threshold_factor_rise($threshold_factor_rise)</callback>
 	<callback>set_look_ahead($look_ahead)</callback>
 	<callback>set_alpha($alpha)</callback>
@@ -41,20 +41,6 @@
         	</option>
         	<option>
           		<name>Intermittent</name>
-          		<key>False</key>
-        	</option>
-        </param>
-        <param>
-        	<name>Look Ahead Type</name>
-        	<key>fixed_window</key>
-        	<value>True</value>
-        	<type>enum</type>
-        	<option>
-          		<name>Fixed</name>
-          		<key>True</key>
-        	</option>
-        	<option>
-          		<name>Sliding</name>
           		<key>False</key>
         	</option>
         </param>

--- a/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
+++ b/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
@@ -36,7 +36,7 @@ namespace gr {
      * \details
      * If a peak is detected, this block outputs a 1, or it outputs
      * 0's. A separate debug output may be connected, to view the
-     * internal EWMA described below.
+     * internal estimated mean described below.
      */
     class BLOCKS_API peak_detector2_fb : virtual public sync_block
     {
@@ -45,18 +45,26 @@ namespace gr {
       typedef boost::shared_ptr<peak_detector2_fb> sptr;
 
       /*!
-       * Build a peak detector block with float in, byte out.
+       * Build a peak detector block with float in, byte out, (and optional float out).
        *
-       * \param threshold_factor_rise The threshold factor determins
-       *        when a peak is present. An EWMA average of the signal is
+       * \param threshold_factor_rise The threshold factor determines
+       *        when a peak is present. An autoregressive average of the input signal is
        *        calculated and when the value of the signal goes over
-       *        threshold_factor_rise*average, we call the peak.
+       *        threshold_factor_rise*average, we assume we are in the neighborhood of a peak.
        * \param look_ahead The look-ahead value is used when the
-       *        threshold is found to locate the peak within this range.
-       * \param alpha The gain value of a single-pole moving average filter.
+       *        threshold is crossed to locate the peak within this range (when fixed_window is true).
+       *        Alternatively (when fixed_window is false) when a peak is detected, the search is repeated for the next window of size look_ahead and the process repeats itself.
+       * \param alpha One minus the pole of a single-pole autoregressive filter that evaluates the average of the input signal.
+       * \param cont_avg The type of averaging. The average is only calculated 
+       *        when the value of signal is below threshold_factor_rise*average when
+       *        cont_avg is false. Otherwise, the average is also calculated when 
+       *	the value of signal is above the threshold_factor_rise*average. 
+       * \param fixed_window The type of look_ahead window. The look_ahead range 
+       *        is fixed if fixed_window is true. Otherwise, the look_ahead range 
+       *        is reset whenever a new peak is located.        
        */
       static sptr make(float threshold_factor_rise=7,
-                       int look_ahead=1000, float alpha=0.001);
+                       int look_ahead=1000, float alpha=0.001, bool cont_avg =true, bool fixed_window = true);
 
       /*! \brief Set the threshold factor value for the rise time
        *  \param thr new threshold factor

--- a/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
+++ b/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
@@ -52,19 +52,15 @@ namespace gr {
        *        calculated and when the value of the signal goes over
        *        threshold_factor_rise*average, we assume we are in the neighborhood of a peak.
        * \param look_ahead The look-ahead value is used when the
-       *        threshold is crossed to locate the peak within this range (when fixed_window is true).
-       *        Alternatively (when fixed_window is false) when a peak is detected, the search is repeated for the next window of size look_ahead and the process repeats itself.
+       *        threshold is crossed to locate the peak within this range
        * \param alpha One minus the pole of a single-pole autoregressive filter that evaluates the average of the input signal.
        * \param cont_avg The type of averaging. The average is only calculated 
        *        when the value of signal is below threshold_factor_rise*average when
        *        cont_avg is false. Otherwise, the average is also calculated when 
        *	the value of signal is above the threshold_factor_rise*average. 
-       * \param fixed_window The type of look_ahead window. The look_ahead range 
-       *        is fixed if fixed_window is true. Otherwise, the look_ahead range 
-       *        is reset whenever a new peak is located.        
        */
       static sptr make(float threshold_factor_rise=7,
-                       int look_ahead=1000, float alpha=0.001, bool cont_avg =true, bool fixed_window = true);
+                       int look_ahead=1000, float alpha=0.001, bool cont_avg =true);
 
       /*! \brief Set the threshold factor value for the rise time
        *  \param thr new threshold factor

--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -33,20 +33,20 @@ namespace gr {
 
     peak_detector2_fb::sptr
     peak_detector2_fb::make(float threshold_factor_rise,
-                            int look_ahead, float alpha, bool cont_avg, bool fixed_window)
+                            int look_ahead, float alpha, bool cont_avg)
     {
       return gnuradio::get_initial_sptr
         (new peak_detector2_fb_impl(threshold_factor_rise,
-                                    look_ahead, alpha, cont_avg, fixed_window));
+                                    look_ahead, alpha, cont_avg));
     }
 
     peak_detector2_fb_impl::peak_detector2_fb_impl(float threshold_factor_rise,
-                                                   int look_ahead, float alpha, bool cont_avg, bool fixed_window)
+                                                   int look_ahead, float alpha, bool cont_avg)
       : sync_block("peak_detector2_fb",
                       io_signature::make(1, 1, sizeof(float)),
                       io_signature::make2(1, 2, sizeof(char), sizeof(float))),
         d_threshold_factor_rise(threshold_factor_rise),
-        d_look_ahead(look_ahead), d_alpha(alpha), d_avg(0.0f), d_found(false), d_cont_avg(cont_avg), d_fixed_window(fixed_window)
+        d_look_ahead(look_ahead), d_alpha(alpha), d_avg(0.0f), d_found(false), d_cont_avg(cont_avg)
     {
     }
 
@@ -63,53 +63,59 @@ namespace gr {
       char *optr = (char *)output_items[0];
       float *sigout;
 
+      //printf("nout=%d\n",noutput_items);
       if(output_items.size() == 2)
           sigout = (float *)output_items[1];
 
       memset(optr, 0, noutput_items*sizeof(char));
 
       if(d_found==false) { // have not crossed threshold yet
-        //printf("Have not crossed threshold yet\n");
+        //printf("State: d_found=false\n");
         for(int i=0;i<noutput_items;i++) {
           d_avg = d_alpha*iptr[i] + (1.0f - d_alpha)*d_avg;
+          //printf("avg=%f\n",d_avg);
           if(output_items.size() == 2)
             sigout[i]=d_avg;
           if(iptr[i] > d_avg * d_threshold_factor_rise) {
             //printf("i= %d, THRESHOLD CROSSED upwards\n", i);
             d_found = true;
             d_peak_val = -(float)INFINITY;
+            d_remaining = d_look_ahead;
             return i;
           }
         }
         return noutput_items;
       } // end d_found==false
-      else if(noutput_items>=d_look_ahead) { // can complete in this call
-        //printf("Can complete in this call\n");
-        for(int i=0;i<d_look_ahead;i++) {
+      else { // d_found==true
+        //printf("State: d_found=true, d_remaining=%d, nout=%d\n",d_remaining,noutput_items);
+        int nn=std::min(d_remaining,noutput_items); // minimum samples we can process
+        for(int i=0;i<nn;i++) {
           if(d_cont_avg){
             d_avg = d_alpha*iptr[i] + (1.0f - d_alpha)*d_avg;
+            //printf("avg=%f\n",d_avg);
           }
           if(output_items.size() == 2)
             sigout[i]=d_avg;
           if(iptr[i] > d_peak_val) {
             d_peak_val = iptr[i];
-            if(d_fixed_window){
-              d_peak_ind=0;
-              return i; // process all input before peak
-            }
-            else{
-              d_peak_ind =i;
-            }
+            d_peak_ind =i;
+            //printf("found peak=%f, at %d\n",d_peak_val,d_peak_ind);
           }
         }
-        optr[d_peak_ind] = 1;
-        d_found = false; // start searching again
-        //printf("Set flag at d_peak_ind=%d\n",d_peak_ind);
-        return d_look_ahead;
-      } // end can complete in this call
-      else { // cannot complete in this call
-        return 0; // ask for more
-      }
+
+        if(d_remaining<=noutput_items) { // done
+            optr[d_peak_ind] = 1;
+            d_found = false; // start searching again
+            return d_remaining;
+        }
+        else {
+             d_remaining-=d_peak_ind;
+             int pi=d_peak_ind;
+             d_peak_ind=0;
+             return pi; // process all input before peak
+        }
+
+      } // end d_found==true
     }
 
   } /* namespace blocks */

--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -33,20 +33,20 @@ namespace gr {
 
     peak_detector2_fb::sptr
     peak_detector2_fb::make(float threshold_factor_rise,
-                            int look_ahead, float alpha)
+                            int look_ahead, float alpha, bool cont_avg, bool fixed_window)
     {
       return gnuradio::get_initial_sptr
         (new peak_detector2_fb_impl(threshold_factor_rise,
-                                    look_ahead, alpha));
+                                    look_ahead, alpha, cont_avg, fixed_window));
     }
 
     peak_detector2_fb_impl::peak_detector2_fb_impl(float threshold_factor_rise,
-                                                   int look_ahead, float alpha)
+                                                   int look_ahead, float alpha, bool cont_avg, bool fixed_window)
       : sync_block("peak_detector2_fb",
                       io_signature::make(1, 1, sizeof(float)),
                       io_signature::make2(1, 2, sizeof(char), sizeof(float))),
         d_threshold_factor_rise(threshold_factor_rise),
-        d_look_ahead(look_ahead), d_alpha(alpha), d_avg(0.0f), d_found(false)
+        d_look_ahead(look_ahead), d_alpha(alpha), d_avg(0.0f), d_found(false), d_cont_avg(cont_avg), d_fixed_window(fixed_window)
     {
     }
 
@@ -61,58 +61,56 @@ namespace gr {
     {
       float *iptr = (float *)input_items[0];
       char *optr = (char *)output_items[0];
+      float *sigout;
 
-      assert(noutput_items >= 2);
+      if(output_items.size() == 2)
+          sigout = (float *)output_items[1];
 
       memset(optr, 0, noutput_items*sizeof(char));
 
-      for(int i = 0; i < noutput_items; i++) {
-        if(!d_found) {
-          // Have not yet detected presence of peak
-          if(iptr[i] > d_avg * (1.0f + d_threshold_factor_rise)) {
+      if(d_found==false) { // have not crossed threshold yet
+        //printf("Have not crossed threshold yet\n");
+        for(int i=0;i<noutput_items;i++) {
+          d_avg = d_alpha*iptr[i] + (1.0f - d_alpha)*d_avg;
+          if(output_items.size() == 2)
+            sigout[i]=d_avg;
+          if(iptr[i] > d_avg * d_threshold_factor_rise) {
+            //printf("i= %d, THRESHOLD CROSSED upwards\n", i);
             d_found = true;
-            d_look_ahead_remaining = d_look_ahead;
             d_peak_val = -(float)INFINITY;
+            return i;
           }
-          else {
+        }
+        return noutput_items;
+      } // end d_found==false
+      else if(noutput_items>=d_look_ahead) { // can complete in this call
+        //printf("Can complete in this call\n");
+        for(int i=0;i<d_look_ahead;i++) {
+          if(d_cont_avg){
             d_avg = d_alpha*iptr[i] + (1.0f - d_alpha)*d_avg;
           }
-        }
-        else {
-          // Detected presence of peak
+          if(output_items.size() == 2)
+            sigout[i]=d_avg;
           if(iptr[i] > d_peak_val) {
             d_peak_val = iptr[i];
-            d_peak_ind = i;
+            if(d_fixed_window){
+              d_peak_ind=0;
+              return i; // process all input before peak
+            }
+            else{
+              d_peak_ind =i;
+            }
           }
-          else if(d_look_ahead_remaining <= 0) {
-            optr[d_peak_ind] = 1;
-            d_found = false;
-            d_avg = iptr[i];
-          }
-
-          // Have not yet located peak, loop and keep searching.
-          d_look_ahead_remaining--;
         }
-
-        // Every iteration of the loop, write debugging signal out if
-        // connected:
-        if(output_items.size() == 2) {
-          float *sigout = (float *)output_items[1];
-          sigout[i] = d_avg;
-        }
-      } // loop
-
-      if(!d_found)
-        return noutput_items;
-
-      // else if detected presence, keep searching during the next call to work.
-      int tmp = d_peak_ind;
-      d_peak_ind = 1;
-
-      return tmp - 1;
+        optr[d_peak_ind] = 1;
+        d_found = false; // start searching again
+        //printf("Set flag at d_peak_ind=%d\n",d_peak_ind);
+        return d_look_ahead;
+      } // end can complete in this call
+      else { // cannot complete in this call
+        return 0; // ask for more
+      }
     }
 
   } /* namespace blocks */
 } /* namespace gr */
-
-

--- a/gr-blocks/lib/peak_detector2_fb_impl.h
+++ b/gr-blocks/lib/peak_detector2_fb_impl.h
@@ -33,7 +33,8 @@ namespace gr {
     private:
       float d_threshold_factor_rise;
       int d_look_ahead;
-      int d_look_ahead_remaining;
+      bool d_cont_avg;
+      bool d_fixed_window;
       int d_peak_ind;
       float d_peak_val;
       float d_alpha;
@@ -42,7 +43,7 @@ namespace gr {
 
     public:
       peak_detector2_fb_impl(float threshold_factor_rise,
-                             int look_ahead, float alpha);
+                             int look_ahead, float alpha, bool cont_avg=true, bool fixed_window=true);
       ~peak_detector2_fb_impl();
 
       void set_threshold_factor_rise(float thr) { d_threshold_factor_rise = thr; }

--- a/gr-blocks/lib/peak_detector2_fb_impl.h
+++ b/gr-blocks/lib/peak_detector2_fb_impl.h
@@ -34,16 +34,16 @@ namespace gr {
       float d_threshold_factor_rise;
       int d_look_ahead;
       bool d_cont_avg;
-      bool d_fixed_window;
       int d_peak_ind;
       float d_peak_val;
       float d_alpha;
       float d_avg;
       bool d_found;
+      int d_remaining;
 
     public:
       peak_detector2_fb_impl(float threshold_factor_rise,
-                             int look_ahead, float alpha, bool cont_avg=true, bool fixed_window=true);
+                             int look_ahead, float alpha, bool cont_avg=true);
       ~peak_detector2_fb_impl();
 
       void set_threshold_factor_rise(float thr) { d_threshold_factor_rise = thr; }

--- a/gr-blocks/python/blocks/qa_peak_detector2.py
+++ b/gr-blocks/python/blocks/qa_peak_detector2.py
@@ -31,26 +31,28 @@ class test_peak_detector2(gr_unittest.TestCase):
         self.tb = None
 
     def test_regen1(self):
+        # test that the new peak_detector2 works and the previous peak_detector2 fails
         tb = self.tb
-
-        data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-                9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-        expected_result = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-
+        l=8100
+        n=20
+        m = 100
+        data = l*(0,)+ (10,)+ m*(1,)+(100,)+ n*(1,)
+        expected_result = (l+1+m)*(0L,)+(1L,) +n*(0L,)
 
         src = blocks.vector_source_f(data, False)
-        regen = blocks.peak_detector2_fb()
+        regen = blocks.peak_detector2_fb(5, (m+10), 0.1)
+        nulls = blocks.null_sink(gr.sizeof_float)
         dst = blocks.vector_sink_b()
-
         tb.connect(src, regen)
-        tb.connect(regen, dst)
+        tb.connect((regen,1), nulls)
+        tb.connect((regen,0), dst)
+        
         tb.run()
-
         dst_data = dst.data()
-
+        
+        self.assertEqual(len(expected_result), len(dst_data))
         self.assertEqual(expected_result, dst_data)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_peak_detector2, "test_peak_detector2.xml")


### PR DESCRIPTION
Dear all, 

We found a bug in peak_detector2 when we were using it previously, so we tried to fix it. To make the peak_detector2 more functional, we added two more parameters. Besides, we made an optional output of the average for debugging. 

Bug description: 
In the previous block, the stall problem always happens at the end of the noutput_items buffer. When the time "work" function is called, the threshold is passed and a peak is found in the term "i" which "d_peak_ind" is set to. When the input index is close to noutput_items, the for loop may end after setting tmp = d_peak_ind and return tmp-1. Since only tmp-1 is returned, it's possible that tmp -1 is less than noutput_items. So the next time the scheduler may set a very small noutput_items. For example, 2, and the d_found is still true. So the next time the work function is called, it directly goes to the peak finding mode and search for the peak. For noutput_items =2, it will end shortly and it's highly possible that the very first input is detected as the peak, so tmp is set to 0. In that case, what we return now will be tmp-1 = -1 which is impossible. That's why the system stalls. 

You can also check the post below and run the example attached in the post to see the bug.
http://gnuradio.4.n7.nabble.com/Peak-Detector2-stalls-simulation-td51761.html

Bug Fixing:
To avoid such a circumstance, we rewrite the peak_detector2 block in the state machine way that only one state is active everytime "work" is called. We made sure that we'll wait for enough output buffers before we start to locate the peak within the look_ahead. 

Additional parameters:

The additional parameter is the average type. This parameter gives the user two options, to calculate the auto-regressive average all the time or to calculate the average only when the value of input signal is below threshold_factor_rise*average. The first option is more accurate but requires more computational resource, while the second option is more computational friendly but less accurate. The user can decide by the character of their application. 

We were about to add another parameter to enable the "sliding window" option. But it seems there is an unsolved bug. So we decided to drop it for now.

Optional avg output:
When we want to debug the peak_detector2 by adding the average_output port, we have to edit the xml file and rebuild the gnuradio which is inconvenient. So we make the average_out port an optional output by adding one parameter "Debug" in xml file. When "Debug" is enabled, the block will have an additional output port avg_out. When "Debug" is disabled, the avg_out port will be hiden.

QA TEST:

We also modified the qa_test to make the test work for the new peak_detector2 but fails for the old peak_detector2. I think you can also see the bug by running the qa_test with the original peak_detector2. 
 
This is our update to the peak_detector2 which makes it robuster and more functional. Could you check and merge it? 

Best regards,
Zhe