### PR TITLE
analog: added missing install squelch_base_cc.h

### DIFF
--- a/gr-analog/include/gnuradio/analog/CMakeLists.txt
+++ b/gr-analog/include/gnuradio/analog/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2012,2014 Free Software Foundation, Inc.
+# Copyright 2012-2015 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -41,6 +41,7 @@ install(FILES
     agc2.h
     noise_type.h
     squelch_base_ff.h
+    squelch_base_cc.h
     agc_cc.h
     agc_ff.h
     agc2_cc.h


### PR DESCRIPTION
I included gnuradio/analog/pwr_squelch_cc.h and got 
```
fatal error: gnuradio/analog/squelch_base_cc.h
```
A simple case of the missing install rules.