### PR TITLE
vocoder: possible fix for public header codec2.h

### DIFF
--- a/gr-vocoder/include/gnuradio/vocoder/codec2.h
+++ b/gr-vocoder/include/gnuradio/vocoder/codec2.h
@@ -25,9 +25,12 @@
 
 #include <gnuradio/vocoder/api.h>
 
-extern "C" {
-#include "../lib/codec2/codec2.h"
-}
+#define CODEC2_MODE_3200 0
+#define CODEC2_MODE_2400 1
+#define CODEC2_MODE_1600 2
+#define CODEC2_MODE_1400 3
+#define CODEC2_MODE_1300 4
+#define CODEC2_MODE_1200 5
 
 namespace gr {
   namespace vocoder {


### PR DESCRIPTION
I know that this may not be an ideal fix, but it gets my code compiling. Anyway, I just need to bring this to the dev's attention.

```
gnuradio/vocoder/codec2.h includes internal header in lib/ for defines.
This include avoids duplication of those defines for the in-tree build,
but it fails compilation when building against the installed headers.
This fix assumes that the ability to build against the installed header
outweighs the duplication cost of the #defines in the internal codec2.h
```