### PR TITLE
remove gr_int* types, #618

### DIFF
--- a/gnuradio-runtime/include/gnuradio/fxpt.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/types.h>
+#include <stdint.h>
 
 namespace gr {
 
@@ -47,18 +48,18 @@ namespace gr {
     static const float TWO_TO_THE_31;
 
   public:
-    static gr_int32
+    static int32_t
       float_to_fixed(float x)
     {
       // Fold x into -PI to PI.
       int d = (int)floor(x/2/PI+0.5);
       x -= d*2*PI;
       // And convert to an integer.
-      return (gr_int32) ((float) x * TWO_TO_THE_31 / PI);
+      return (int32_t) ((float) x * TWO_TO_THE_31 / PI);
     }
 
     static float
-      fixed_to_float (gr_int32 x)
+      fixed_to_float (int32_t x)
     {
       return x * (PI / TWO_TO_THE_31);
     }
@@ -67,9 +68,9 @@ namespace gr {
      * \brief Given a fixed point angle x, return float sine (x)
      */
     static float
-      sin(gr_int32 x)
+      sin(int32_t x)
     {
-      gr_uint32 ux = x;
+      uint32_t ux = x;
       int index = ux >> (WORDBITS - NBITS);
       return s_sine_table[index][0] * (ux >> 1) + s_sine_table[index][1];
     }
@@ -78,9 +79,9 @@ namespace gr {
      * \brief Given a fixed point angle x, return float cosine (x)
      */
     static float
-      cos (gr_int32 x)
+      cos (int32_t x)
     {
-      gr_uint32 ux = x + 0x40000000;
+      uint32_t ux = x + 0x40000000;
       int index = ux >> (WORDBITS - NBITS);
       return s_sine_table[index][0] * (ux >> 1) + s_sine_table[index][1];
     }
@@ -88,9 +89,9 @@ namespace gr {
     /*
      * \brief Given a fixedpoint angle x, return float cos(x) and sin (x)
      */
-    static void sincos(gr_int32 x, float *s, float *c)
+    static void sincos(int32_t x, float *s, float *c)
     {
-      gr_uint32 ux = x;
+      uint32_t ux = x;
       int sin_index = ux >> (WORDBITS - NBITS);
       *s = s_sine_table[sin_index][0] * (ux >> 1) + s_sine_table[sin_index][1];
 

--- a/gnuradio-runtime/include/gnuradio/fxpt_vco.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt_vco.h
@@ -34,7 +34,7 @@ namespace gr {
    * \ingroup misc
    */
   class /*GR_RUNTIME_API*/ fxpt_vco {
-    gr_int32 d_phase;
+    int32_t d_phase;
 
   public:
     fxpt_vco () : d_phase(0) {}

--- a/gnuradio-runtime/lib/math/qa_fxpt.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt.cc
@@ -51,9 +51,9 @@ qa_fxpt::t0()
      * sometimes the answer is off by a few bits at the bottom.
      * Hence, the disabled check.
      */
-    CPPUNIT_ASSERT_EQUAL((gr_int32)0x40000000, gr::fxpt::float_to_fixed(M_PI/2));
-    CPPUNIT_ASSERT_EQUAL((gr_int32)0,          gr::fxpt::float_to_fixed(0));
-    CPPUNIT_ASSERT_EQUAL((gr_int32)0x80000000, gr::fxpt::float_to_fixed(-M_PI));
+    CPPUNIT_ASSERT_EQUAL((int32_t)0x40000000, gr::fxpt::float_to_fixed(M_PI/2));
+    CPPUNIT_ASSERT_EQUAL((int32_t)0,          gr::fxpt::float_to_fixed(0));
+    CPPUNIT_ASSERT_EQUAL((int32_t)0x80000000, gr::fxpt::float_to_fixed(-M_PI));
   }
 }
 

--- a/gr-analog/lib/frequency_modulator_fc_impl.cc
+++ b/gr-analog/lib/frequency_modulator_fc_impl.cc
@@ -70,7 +70,7 @@ namespace gr {
 
 	float oi, oq;
 
-	gr_int32 angle = gr::fxpt::float_to_fixed (d_phase);
+	int32_t angle = gr::fxpt::float_to_fixed (d_phase);
 	gr::fxpt::sincos(angle, &oq, &oi);
 	out[i] = gr_complex(oi, oq);
       }

--- a/gr-atsc/include/gnuradio/atsc/field_sync_demux.h
+++ b/gr-atsc/include/gnuradio/atsc/field_sync_demux.h
@@ -63,8 +63,8 @@ protected:
   bool            d_locked;
   bool            d_in_field2;
   int             d_segment_number;
-  gr_uint64       d_next_input;
-  gr_uint64       d_lost_index;         // diagnostic fluff
+  uint64_t        d_next_input;
+  uint64_t        d_lost_index;         // diagnostic fluff
 
   unsigned long long d_inputs0_index;	// for inputs[0].index
   unsigned long	  d_inputs0_size;		// for inputs[0].size

--- a/gr-audio/lib/alsa/alsa_sink.cc
+++ b/gr-audio/lib/alsa/alsa_sink.cc
@@ -330,7 +330,7 @@ namespace gr {
                         gr_vector_const_void_star &input_items,
                         gr_vector_void_star &output_items)
     {
-      typedef gr_int16 sample_t;  // the type of samples we're creating
+      typedef int16_t sample_t;  // the type of samples we're creating
       static const float scale_factor = std::pow(2.0f, 16-1) - 1;
 
       unsigned int nchan = input_items.size();
@@ -370,7 +370,7 @@ namespace gr {
                         gr_vector_const_void_star &input_items,
                         gr_vector_void_star &output_items)
     {
-      typedef gr_int32 sample_t; // the type of samples we're creating
+      typedef int32_t sample_t; // the type of samples we're creating
       static const float scale_factor = std::pow(2.0f, 32-1) - 1;
 
       unsigned int nchan = input_items.size();
@@ -411,7 +411,7 @@ namespace gr {
                             gr_vector_const_void_star &input_items,
                             gr_vector_void_star &output_items)
     {
-      typedef gr_int16 sample_t; // the type of samples we're creating
+      typedef int16_t sample_t; // the type of samples we're creating
       static const float scale_factor = std::pow(2.0f, 16-1) - 1;
 
       assert(input_items.size () == 1);
@@ -452,7 +452,7 @@ namespace gr {
                             gr_vector_const_void_star &input_items,
                             gr_vector_void_star &output_items)
     {
-      typedef gr_int32 sample_t; // the type of samples we're creating
+      typedef int32_t sample_t; // the type of samples we're creating
       static const float scale_factor = std::pow(2.0f, 32-1) - 1;
 
       assert(input_items.size () == 1);

--- a/gr-audio/lib/alsa/alsa_source.cc
+++ b/gr-audio/lib/alsa/alsa_source.cc
@@ -310,7 +310,7 @@ namespace gr {
                           gr_vector_const_void_star &input_items,
                           gr_vector_void_star &output_items)
     {
-      typedef gr_int16 sample_t; // the type of samples we're creating
+      typedef int16_t sample_t; // the type of samples we're creating
       static const float scale_factor = 1.0 / std::pow(2.0f, 16-1);
 
       unsigned int nchan = output_items.size ();
@@ -348,7 +348,7 @@ namespace gr {
                               gr_vector_const_void_star &input_items,
                               gr_vector_void_star &output_items)
     {
-      typedef gr_int16 sample_t; // the type of samples we're creating
+      typedef int16_t sample_t; // the type of samples we're creating
       static const float scale_factor = 1.0 / std::pow(2.0f, 16-1);
 
       float **out = (float**)&output_items[0];
@@ -385,7 +385,7 @@ namespace gr {
                           gr_vector_const_void_star &input_items,
                           gr_vector_void_star &output_items)
     {
-      typedef gr_int32 sample_t; // the type of samples we're creating
+      typedef int32_t sample_t; // the type of samples we're creating
       static const float scale_factor = 1.0 / std::pow(2.0f, 32-1);
 
       unsigned int nchan = output_items.size ();
@@ -423,7 +423,7 @@ namespace gr {
                               gr_vector_const_void_star &input_items,
                               gr_vector_void_star &output_items)
     {
-      typedef gr_int32 sample_t; // the type of samples we're creating
+      typedef int32_t sample_t; // the type of samples we're creating
       static const float scale_factor = 1.0 / std::pow(2.0f, 32-1);
 
       float **out = (float**)&output_items[0];

--- a/gr-pager/lib/flex_parse_impl.cc
+++ b/gr-pager/lib/flex_parse_impl.cc
@@ -43,7 +43,7 @@ namespace gr {
 
     flex_parse_impl::flex_parse_impl(msg_queue::sptr queue, float freq) :
       sync_block("flex_parse",
-		    io_signature::make(1, 1, sizeof(gr_int32)),
+		    io_signature::make(1, 1, sizeof(int32_t)),
 		    io_signature::make(0, 0, 0)),
       d_queue(queue),
       d_freq(freq)
@@ -59,7 +59,7 @@ namespace gr {
 			      gr_vector_const_void_star &input_items,
 			      gr_vector_void_star &output_items)
     {
-      const gr_int32 *in = (const gr_int32 *)input_items[0];
+      const int32_t *in = (const int32_t *)input_items[0];
 
       int i = 0;
       while(i < noutput_items) {


### PR DESCRIPTION
Also fixes cases where types.h was included withought previous inclusion of config.h, this leads to use of "backup" definitions of gr_int* types and in cases where it is not required and thus to potential errors.