### PR TITLE
iir filter stability

### DIFF
--- a/gr-filter/include/gnuradio/filter/iir_filter.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter.h
@@ -79,7 +79,7 @@ namespace gr {
        * \endcode
        */
       template<class i_type, class o_type, class tap_type, class acc_type>
-      class iir_filter
+      class FILTER_API iir_filter
       {
       public:
 	/*!

--- a/gr-filter/include/gnuradio/filter/iir_filter.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter.h
@@ -35,7 +35,7 @@ namespace gr {
       /*!
        * \brief base class template for Infinite Impulse Response filter (IIR)
        */
-      template<class i_type, class o_type, class tap_type>
+      template<class i_type, class o_type, class tap_type, class acc_type>
       class iir_filter
       {
       public:
@@ -135,18 +135,18 @@ namespace gr {
 	std::vector<tap_type>	d_fbtaps;
 	int 			d_latest_n;
 	int 			d_latest_m;
-	std::vector<o_type>	d_prev_output;
+	std::vector<acc_type>	d_prev_output;
 	std::vector<i_type>	d_prev_input;
       };
 
       //
       // general case.  We may want to specialize this
       //
-      template<class i_type, class o_type, class tap_type>
+      template<class i_type, class o_type, class tap_type, class acc_type>
       o_type
-      iir_filter<i_type, o_type, tap_type>::filter(const i_type input)
+      iir_filter<i_type, o_type, tap_type, acc_type>::filter(const i_type input)
       {
-	o_type acc;
+	acc_type acc;
 	unsigned i = 0;
 	unsigned n = ntaps_ff();
 	unsigned m = ntaps_fb();
@@ -181,9 +181,9 @@ namespace gr {
 	return (o_type)acc;
       }
 
-      template<class i_type, class o_type, class tap_type>
+      template<class i_type, class o_type, class tap_type, class acc_type>
       void
-      iir_filter<i_type, o_type, tap_type>::filter_n(o_type output[],
+      iir_filter<i_type, o_type, tap_type, acc_type>::filter_n(o_type output[],
 						     const i_type input[],
 						     long n)
       {
@@ -193,15 +193,15 @@ namespace gr {
 
       template<>
       gr_complex
-      iir_filter<gr_complex, gr_complex, float>::filter(const gr_complex input);
+      iir_filter<gr_complex, gr_complex, float, gr_complex>::filter(const gr_complex input);
 
       template<>
       gr_complex
-      iir_filter<gr_complex, gr_complex, double>::filter(const gr_complex input);
+      iir_filter<gr_complex, gr_complex, double, gr_complexd>::filter(const gr_complex input);
 
       template<>
       gr_complex
-      iir_filter<gr_complex, gr_complex, gr_complexd>::filter(const gr_complex input);
+      iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd>::filter(const gr_complex input);
 
     } /* namespace kernel */
   } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/iir_filter.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter.h
@@ -33,7 +33,50 @@ namespace gr {
     namespace kernel {
 
       /*!
-       * \brief base class template for Infinite Impulse Response filter (IIR)
+       * \brief Base class template for Infinite Impulse Response filter (IIR)
+       *
+       * \details
+       *
+       * This class provides a templated kernel for IIR filters. These
+       * iir_filters can be instantiated with a set of feed-forward
+       * and feed-back taps in the constructor. We then call the
+       * iir_filter::filter function to add a new sample to the
+       * filter, or iir_filter::filter_n to add a vector of samples to
+       * be filtered.
+       *
+       * Instantiating a filter means defining the templates for the
+       * data types being processed by the filter. There are four templates:
+       *
+       * \li i_type the data type of the input data (i.e., float).
+       * \li o_type the data type of the output data (i.e., float).
+       * \li tap_type the data type of the filter taps (i.e., double).
+       * \li acc_type the data type of the internal accumulator (i.e., double).
+       *
+       * The acc_type is specified to control how data is handled
+       * internally in the filter. This should always be the highest
+       * precision data type of any of the first three. Often, IIR
+       * filters require double-precision values in the taps for
+       * stability, and so the internal accumulator should also be
+       * double precision.
+       *
+       * Example:
+       *
+       * \code
+       * gr::filter::kernel::iir_filter<float,float,double,double> iir_filt(fftaps, fbtaps);
+       * ...
+       * float y = iir_filt.filter(x);
+       *
+       * <or>
+       *
+       * iir_filt.filter(y, x, N); // y and x are float arrays
+       * \endcode
+       *
+       * Another example for handling complex samples with
+       * double-precision taps (see filter::iir_filter_ccz):
+       *
+       * \code
+       * gr:;filter::kernel::iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd> iir_filt(fftaps, fbtaps);
+       * \endcode
        */
       template<class i_type, class o_type, class tap_type, class acc_type>
       class iir_filter
@@ -208,4 +251,3 @@ namespace gr {
 } /* namespace gr */
 
 #endif /* INCLUDED_IIR_FILTER_H */
-

--- a/gr-filter/lib/iir_filter.cc
+++ b/gr-filter/lib/iir_filter.cc
@@ -28,7 +28,7 @@ namespace gr {
 
       template<>
       gr_complex
-      iir_filter<gr_complex, gr_complex, float>::filter(const gr_complex input)
+      iir_filter<gr_complex, gr_complex, float, gr_complex>::filter(const gr_complex input)
       {
 	gr_complex acc;
 	unsigned i = 0;
@@ -67,7 +67,7 @@ namespace gr {
 
       template<>
       gr_complex
-      iir_filter<gr_complex, gr_complex, double>::filter(const gr_complex input)
+      iir_filter<gr_complex, gr_complex, double, gr_complexd>::filter(const gr_complex input)
       {
 	gr_complexd acc;
 	unsigned i = 0;
@@ -106,7 +106,7 @@ namespace gr {
 
       template<>
       gr_complex
-      iir_filter<gr_complex, gr_complex, gr_complexd>::filter(const gr_complex input)
+      iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd>::filter(const gr_complex input)
       {
 	gr_complexd acc;
 	unsigned i = 0;

--- a/gr-filter/lib/iir_filter_ccc_impl.cc
+++ b/gr-filter/lib/iir_filter_ccc_impl.cc
@@ -48,7 +48,7 @@ namespace gr {
 		   io_signature::make(1, 1, sizeof(gr_complex))),
 	d_updated(false)
     {
-      d_iir = new kernel::iir_filter<gr_complex, gr_complex, gr_complex>(fftaps, fbtaps, oldstyle);
+      d_iir = new kernel::iir_filter<gr_complex, gr_complex, gr_complex, gr_complex>(fftaps, fbtaps, oldstyle);
     }
 
     iir_filter_ccc_impl::~iir_filter_ccc_impl()

--- a/gr-filter/lib/iir_filter_ccc_impl.h
+++ b/gr-filter/lib/iir_filter_ccc_impl.h
@@ -33,7 +33,7 @@ namespace gr {
     {
     private:
       bool d_updated;
-      kernel::iir_filter<gr_complex, gr_complex, gr_complex> *d_iir;
+      kernel::iir_filter<gr_complex, gr_complex, gr_complex, gr_complex> *d_iir;
       std::vector<gr_complex> d_new_fftaps;
       std::vector<gr_complex> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ccd_impl.cc
+++ b/gr-filter/lib/iir_filter_ccd_impl.cc
@@ -48,7 +48,7 @@ namespace gr {
 		   io_signature::make(1, 1, sizeof(gr_complex))),
 	d_updated(false)
     {
-      d_iir = new kernel::iir_filter<gr_complex, gr_complex, double>(fftaps, fbtaps, oldstyle);
+      d_iir = new kernel::iir_filter<gr_complex, gr_complex, double, gr_complexd>(fftaps, fbtaps, oldstyle);
     }
 
     iir_filter_ccd_impl::~iir_filter_ccd_impl()

--- a/gr-filter/lib/iir_filter_ccd_impl.h
+++ b/gr-filter/lib/iir_filter_ccd_impl.h
@@ -33,7 +33,7 @@ namespace gr {
     {
     private:
       bool d_updated;
-      kernel::iir_filter<gr_complex, gr_complex, double> *d_iir;
+      kernel::iir_filter<gr_complex, gr_complex, double, gr_complexd> *d_iir;
       std::vector<double> d_new_fftaps;
       std::vector<double> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ccf_impl.cc
+++ b/gr-filter/lib/iir_filter_ccf_impl.cc
@@ -48,7 +48,7 @@ namespace gr {
 		   io_signature::make(1, 1, sizeof(gr_complex))),
 	d_updated(false)
     {
-      d_iir = new kernel::iir_filter<gr_complex, gr_complex, float>(fftaps, fbtaps, oldstyle);
+      d_iir = new kernel::iir_filter<gr_complex, gr_complex, float, gr_complex>(fftaps, fbtaps, oldstyle);
     }
 
     iir_filter_ccf_impl::~iir_filter_ccf_impl()

--- a/gr-filter/lib/iir_filter_ccf_impl.h
+++ b/gr-filter/lib/iir_filter_ccf_impl.h
@@ -33,7 +33,7 @@ namespace gr {
     {
     private:
       bool d_updated;
-      kernel::iir_filter<gr_complex, gr_complex, float> *d_iir;
+      kernel::iir_filter<gr_complex, gr_complex, float, gr_complex> *d_iir;
       std::vector<float> d_new_fftaps;
       std::vector<float> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ccz_impl.cc
+++ b/gr-filter/lib/iir_filter_ccz_impl.cc
@@ -48,7 +48,7 @@ namespace gr {
 		   io_signature::make(1, 1, sizeof(gr_complex))),
 	d_updated(false)
     {
-      d_iir = new kernel::iir_filter<gr_complex, gr_complex, gr_complexd>(fftaps, fbtaps, oldstyle);
+      d_iir = new kernel::iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd>(fftaps, fbtaps, oldstyle);
     }
 
     iir_filter_ccz_impl::~iir_filter_ccz_impl()

--- a/gr-filter/lib/iir_filter_ccz_impl.h
+++ b/gr-filter/lib/iir_filter_ccz_impl.h
@@ -33,7 +33,7 @@ namespace gr {
     {
     private:
       bool d_updated;
-      kernel::iir_filter<gr_complex, gr_complex, gr_complexd> *d_iir;
+      kernel::iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd> *d_iir;
       std::vector<gr_complexd> d_new_fftaps;
       std::vector<gr_complexd> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ffd_impl.cc
+++ b/gr-filter/lib/iir_filter_ffd_impl.cc
@@ -48,7 +48,7 @@ namespace gr {
 		      io_signature::make(1, 1, sizeof (float))),
 	d_updated(false)
     {
-      d_iir = new kernel::iir_filter<float,float,double>(fftaps, fbtaps, oldstyle);
+      d_iir = new kernel::iir_filter<float,float,double,double>(fftaps, fbtaps, oldstyle);
     }
 
     iir_filter_ffd_impl::~iir_filter_ffd_impl()

--- a/gr-filter/lib/iir_filter_ffd_impl.h
+++ b/gr-filter/lib/iir_filter_ffd_impl.h
@@ -33,7 +33,7 @@ namespace gr {
     {
     private:
       bool d_updated;
-      kernel::iir_filter<float,float,double> *d_iir;
+      kernel::iir_filter<float,float,double,double> *d_iir;
       std::vector<double> d_new_fftaps;
       std::vector<double> d_new_fbtaps;
 


### PR DESCRIPTION
Adding template for filter stability of higher-precision taps.

Adds docs and exports kernels from library (FILTER_API).