### PR TITLE
qtgui: fixes issue #767.

### DIFF
--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -90,7 +90,7 @@ FrequencyDisplayPlot::FrequencyDisplayPlot(int nplots, QWidget* parent)
   d_start_frequency = -1;
   d_stop_frequency = 1;
 
-  d_numPoints = 1024;
+  d_numPoints = 0;
   d_min_fft_data = new double[d_numPoints];
   d_max_fft_data = new double[d_numPoints];
   d_xdata = new double[d_numPoints];
@@ -286,7 +286,6 @@ FrequencyDisplayPlot::setFrequencyRange(const double centerfreq,
     startFreq = 0;
   else
     startFreq = (centerfreq - bandwidth/2.0f) / units;
-
 
   d_xdata_multiplier = units;
 

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -198,7 +198,10 @@ namespace gr {
     void
     freq_sink_c_impl::set_fft_size(const int fftsize)
     {
-      d_main_gui->setFFTSize(fftsize);
+      if((fftsize > 16) && (fftsize < 16384))
+        d_main_gui->setFFTSize(fftsize);
+      else
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
     }
 
     int

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -197,7 +197,10 @@ namespace gr {
     void
     freq_sink_f_impl::set_fft_size(const int fftsize)
     {
-      d_main_gui->setFFTSize(fftsize);
+      if((fftsize > 16) && (fftsize < 16384))
+        d_main_gui->setFFTSize(fftsize);
+      else
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
     }
 
     int


### PR DESCRIPTION
If FFT Size is set to 2048 and the half-width is selected for the
float graph type, then this would cause the x-axis display to show
-fs/2 to +fs/2 instead of the correct 0 to +fs/2. The problem was the
default numpoints was 1024, so with half 2048, the resetting of the
x-axis call was never hitting. Setting to 0 to force updates during
the first display.

Also puts protections around the allowable FFT sizes.