### PR TITLE
fix #594 - deadlock in unlock() when called from Python

### DIFF
--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -86,6 +86,9 @@ namespace gr {
 
   top_block_impl::~top_block_impl()
   {
+    if (d_lock_count) {
+      std::cerr << "error: destroying locked block." << std::endl;
+    }
     d_owner = 0;
   }
 
@@ -129,6 +132,21 @@ namespace gr {
   void
   top_block_impl::wait()
   {
+    do {
+      wait_for_jobs();
+      {
+        gr::thread::scoped_lock lock(d_mutex);
+        if (d_lock_count) {
+          d_lock_cond.wait(lock);
+          continue;
+        }
+      }
+    } while(false);
+  }
+
+  void
+  top_block_impl::wait_for_jobs()
+  {
     if(d_scheduler)
       d_scheduler->wait();
 
@@ -141,6 +159,7 @@ namespace gr {
   top_block_impl::lock()
   {
     gr::thread::scoped_lock lock(d_mutex);
+    stop();
     d_lock_count++;
   }
 
@@ -158,6 +177,7 @@ namespace gr {
     if(d_lock_count > 0 || d_state == IDLE) // nothing to do
       return;
 
+    d_lock_cond.notify_all();
     restart();
   }
 
@@ -167,8 +187,7 @@ namespace gr {
   void
   top_block_impl::restart()
   {
-    stop();		     // Stop scheduler and wait for completion
-    wait();
+    wait_for_jobs();
 
     // Create new simple flow graph
     flat_flowgraph_sptr new_ffg = d_owner->flatten();

--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -82,10 +82,12 @@ namespace gr {
     gr::thread::mutex d_mutex;    // protects d_state and d_lock_count
     tb_state d_state;
     int d_lock_count;
+    boost::condition_variable d_lock_cond;
     int d_max_noutput_items;
 
   private:
     void restart();
+    void wait_for_jobs();
   };
 
 } /* namespace gr */

--- a/gnuradio-runtime/python/gnuradio/gr/top_block.py
+++ b/gnuradio-runtime/python/gnuradio/gr/top_block.py
@@ -22,7 +22,7 @@
 from runtime_swig import top_block_swig, \
     top_block_wait_unlocked, top_block_run_unlocked, \
     top_block_start_unlocked, top_block_stop_unlocked, \
-    dot_graph_tb
+    top_block_unlock_unlocked, dot_graph_tb
 
 #import gnuradio.gr.gr_threading as _threading
 import gr_threading as _threading
@@ -117,6 +117,12 @@ class top_block(hier_block2):
         """
         self.start(max_noutput_items)
         self.wait()
+
+    def unlock(self):
+        """
+        Release lock and continue execution of flow-graph.
+        """
+        top_block_unlock_unlocked(self._impl)
 
     def wait(self):
         """

--- a/gnuradio-runtime/swig/top_block.i
+++ b/gnuradio-runtime/swig/top_block.i
@@ -89,6 +89,14 @@ void top_block_stop_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
     )
 }
 
+void top_block_unlock_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
+{
+    GR_PYTHON_BLOCKING_CODE
+    (
+        r->unlock();
+    )
+}
+
 std::string
 dot_graph_tb(gr::top_block_sptr r)
 {

--- a/gr-blocks/python/blocks/qa_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_hier_block2.py
@@ -2,6 +2,7 @@
 
 from gnuradio import gr, gr_unittest, blocks
 import numpy
+import time
 
 class add_ff(gr.sync_block):
     def __init__(self):
@@ -425,6 +426,21 @@ class test_hier_block2(gr_unittest.TestCase):
         hblock.set_processor_affinity([0,])
         procs = hblock.processor_affinity()
         self.assertEquals((0,), procs)
+
+    def test_lock_unlock(self):
+        hblock = gr.top_block("test_block")
+        src = blocks.null_source(gr.sizeof_float)
+        throttle = blocks.throttle(gr.sizeof_float, 32000)
+        hier = multiply_const_ff(0.5)
+        sink = blocks.null_sink(gr.sizeof_float)
+        hblock.connect(src, throttle, hier, sink)
+        hblock.set_processor_affinity([0,])
+        hblock.start()
+        time.sleep(1)
+        hblock.lock()
+        hblock.unlock()
+        hblock.stop()
+        hblock.wait()
 
 if __name__ == "__main__":
     gr_unittest.run(test_hier_block2, "test_hier_block2.xml")


### PR DESCRIPTION
See comments in individula patches for details.

I give it some testing but it should be inspected more thoroughly.

Side note:
This fix allows some more intriguing code to be writen and thus some more bugs probably appear.
I personaly fall into "sched: <block fft_filter_ccc (19)> is requesting more input data".