### PR TITLE
cmake: use VOLK_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,8 @@ if(NOT VOLK_FOUND)
         ${CMAKE_CURRENT_BINARY_DIR}/volk/include
     )
 
+    set(VOLK_LIBRARIES volk)
+
     if(ENABLE_VOLK)
 
     include(GrPackage)

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -132,7 +132,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
 endif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)")
 
 list(APPEND gnuradio_runtime_libs
-    volk
+    ${VOLK_LIBRARIES}
     gnuradio-pmt
     ${Boost_LIBRARIES}
     ${LOG4CPP_LIBRARIES}

--- a/gr-analog/lib/CMakeLists.txt
+++ b/gr-analog/lib/CMakeLists.txt
@@ -96,7 +96,7 @@ IF(MSVC)
 ENDIF(MSVC)
 
 list(APPEND analog_libs
-    volk
+    ${VOLK_LIBRARIES}
     gnuradio-runtime
     gnuradio-blocks
     gnuradio-filter

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -235,7 +235,7 @@ ENDIF(MSVC)
 
 list(APPEND blocks_libs
     gnuradio-runtime
-    volk
+    ${VOLK_LIBRARIES}
     ${Boost_LIBRARIES}
     ${BLOCKS_LIBRARIES}
     ${LOG4CPP_LIBRARIES}

--- a/gr-channels/lib/CMakeLists.txt
+++ b/gr-channels/lib/CMakeLists.txt
@@ -66,7 +66,7 @@ if(MSVC)
 endif(MSVC)
 
 list(APPEND channels_libs
-    volk
+    ${VOLK_LIBRARIES}
     gnuradio-runtime
     gnuradio-filter
     gnuradio-analog

--- a/gr-digital/lib/CMakeLists.txt
+++ b/gr-digital/lib/CMakeLists.txt
@@ -132,7 +132,7 @@ IF(MSVC)
 ENDIF(MSVC)
 
 list(APPEND digital_libs
-    volk
+    ${VOLK_LIBRARIES}
     gnuradio-runtime
     gnuradio-filter
     gnuradio-blocks

--- a/gr-dtv/lib/CMakeLists.txt
+++ b/gr-dtv/lib/CMakeLists.txt
@@ -102,7 +102,7 @@ list(APPEND dtv_sources
 endif(ENABLE_GR_CTRLPORT)
 
 list(APPEND dtv_libs
-    volk
+    ${VOLK_LIBRARIES}
     gnuradio-runtime
     gnuradio-analog
     gnuradio-filter

--- a/gr-fec/lib/CMakeLists.txt
+++ b/gr-fec/lib/CMakeLists.txt
@@ -90,7 +90,7 @@ endif(MSVC)
 list(APPEND gnuradio_fec_libs
     gnuradio-blocks
     gnuradio-runtime
-    volk
+    ${VOLK_LIBRARIES}
     ${Boost_LIBRARIES}
     ${LOG4CPP_LIBRARIES}
 )

--- a/gr-filter/lib/CMakeLists.txt
+++ b/gr-filter/lib/CMakeLists.txt
@@ -112,7 +112,7 @@ list(APPEND filter_libs
     gnuradio-runtime
     gnuradio-fft
     gnuradio-blocks
-    volk
+    ${VOLK_LIBRARIES}
     ${Boost_LIBRARIES}
 )
 

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -148,7 +148,7 @@ list(APPEND qtgui_libs
     gnuradio-runtime
     gnuradio-fft
     gnuradio-filter
-    volk
+    ${VOLK_LIBRARIES}
     ${QWT_LIBRARIES}
     ${QT_LIBRARIES}
     ${FFTW3F_LIBRARIES}

--- a/gr-wxgui/lib/CMakeLists.txt
+++ b/gr-wxgui/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ ENDIF(MSVC)
 
 list(APPEND wxgui_libs
     gnuradio-runtime
-    volk
+    ${VOLK_LIBRARIES}
     ${Boost_LIBRARIES}
     ${BLOCKS_LIBRARIES}
     ${LOG4CPP_LIBRARIES}


### PR DESCRIPTION
@n-west: test build with volk submodule:

- external pre-installed volk library from its master (to a custom location)
- use submodule to build in-tree (can this be forced?)

These patches make both cases work for me.