### PR TITLE
digital: bug fixed in chunks_to_symbols that the callback functiion set_symbol_table didn't work with additonal qa_tests

### DIFF
--- a/gr-digital/grc/digital_chunks_to_symbols.xml
+++ b/gr-digital/grc/digital_chunks_to_symbols.xml
@@ -9,6 +9,7 @@
 	<key>digital_chunks_to_symbols_xx</key>
 	<import>from gnuradio import digital</import>
 	<make>digital.chunks_to_symbols_$(in_type.fcn)$(out_type.fcn)($symbol_table, $dimension)</make>
+        <callback>set_symbol_table($symbol_table)</callback>
 	<param>
 		<name>Input Type</name>
 		<key>in_type</key>

--- a/gr-digital/include/gnuradio/digital/chunks_to_symbols_XX.h.t
+++ b/gr-digital/include/gnuradio/digital/chunks_to_symbols_XX.h.t
@@ -68,6 +68,7 @@ namespace gr {
 
       virtual int D() const = 0;
       virtual std::vector<@O_TYPE@> symbol_table() const = 0;
+      virtual void set_symbol_table(const std::vector<@O_TYPE@> &symbol_table) =0;
     };
 
   } /* namespace digital */

--- a/gr-digital/lib/chunks_to_symbols_XX_impl.cc.t
+++ b/gr-digital/lib/chunks_to_symbols_XX_impl.cc.t
@@ -87,7 +87,7 @@ namespace gr {
 
     
     void
-    @IMPL_NAME@::set_symbol_table(std::vector<@O_TYPE@> &symbol_table)
+    @IMPL_NAME@::set_symbol_table(const std::vector<@O_TYPE@> &symbol_table)
     {
       d_symbol_table.resize(0);
       for (unsigned int i=0; i<symbol_table.size(); i++) {

--- a/gr-digital/lib/chunks_to_symbols_XX_impl.h.t
+++ b/gr-digital/lib/chunks_to_symbols_XX_impl.h.t
@@ -45,7 +45,7 @@ namespace gr {
       void set_vector_from_pmt(std::vector<gr_complex> &symbol_table, pmt::pmt_t &symbol_table_pmt);
 
       void handle_set_symbol_table(pmt::pmt_t symbol_table_pmt);
-      void set_symbol_table(std::vector<@O_TYPE@> &symbol_table);
+      void set_symbol_table(const std::vector<@O_TYPE@> &symbol_table);
       
       int D() const { return d_D; }
       std::vector<@O_TYPE@> symbol_table() const { return d_symbol_table; }

--- a/gr-digital/python/digital/qa_chunks_to_symbols.py
+++ b/gr-digital/python/digital/qa_chunks_to_symbols.py
@@ -136,6 +136,39 @@ class test_chunks_to_symbols(gr_unittest.TestCase):
         actual_result = dst.data()
         self.assertEqual(expected_result, actual_result)
 
+
+    def test_sf_callback(self):
+	constA = [-3, -1, 1, 3]
+        constB = [12, -12, 6, -6]
+        src_data = (0, 1, 2, 3, 3, 2, 1, 0)
+        expected_result=(12, -12, 6, -6, -6, 6, -12, 12)
+
+	src = blocks.vector_source_s(src_data, False, 1, "")
+        op = digital.chunks_to_symbols_sf(constA)
+        op.set_symbol_table(constB)
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
+    def test_sc_callback(self):
+        constA = [-3.0+1j, -1.0-1j, 1.0+1j, 3-1j]
+        constB = [12.0+1j, -12.0-1j, 6.0+1j, -6-1j]
+        src_data = (0, 1, 2, 3, 3, 2, 1, 0)
+        expected_result=(12.0+1j, -12.0-1j, 6.0+1j, -6-1j, -6-1j, 6+1j, -12-1j, 12+1j)
+
+	src = blocks.vector_source_s(src_data, False, 1, "")
+        op = digital.chunks_to_symbols_sc(constA)
+        op.set_symbol_table(constB)
+        dst = blocks.vector_sink_c()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
     def test_sf_tag(self):
         constA = [-3.0, -1.0, 1.0, 3]
         constB = [12.0, -12.0, 6.0, -6]


### PR DESCRIPTION
Dear Johnathan, 

I'm here to submit again the pull request that you close a while ago due to lack of qa test. 
https://github.com/gnuradio/gnuradio/pull/354
I kept the previous code which you approved and added the qa test you wanted. 

I'm sorry that I didn't update the qa_test of chunks_to_symbols on time. I added two more tests to test the callback function set_chunks_symbol_table by learning from existing qa tests with callback function tests.

Could you please check it and merge it? Please let me know if there is something wrong. 

Thanks!
Best regards!
Zhe