### PR TITLE
msvc: fix gr_type size_t vector replace

### DIFF
--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -113,9 +113,13 @@ macro(GR_SWIG_MAKE name)
     INCLUDE(CheckTypeSize)
     CHECK_TYPE_SIZE("size_t" SIZEOF_SIZE_T)
     CHECK_TYPE_SIZE("unsigned int" SIZEOF_UINT)
+    CHECK_TYPE_SIZE("unsigned long int" SIZEOF_ULONG)
     if(${SIZEOF_SIZE_T} EQUAL ${SIZEOF_UINT})
       list(APPEND GR_SWIG_FLAGS -DSIZE_T_32)
     endif(${SIZEOF_SIZE_T} EQUAL ${SIZEOF_UINT})
+    if(${SIZEOF_SIZE_T} EQUAL ${SIZEOF_ULONG})
+      list(APPEND GR_SWIG_FLAGS -DSIZE_T_LONG)
+    endif(${SIZEOF_SIZE_T} EQUAL ${SIZEOF_ULONG})
 
     #do swig doc generation if specified
     if(GR_SWIG_DOC_FILE)

--- a/gnuradio-runtime/swig/gr_types.i
+++ b/gnuradio-runtime/swig/gr_types.i
@@ -85,7 +85,7 @@ namespace std {
   // On 32-bit systems, whenever we see std::vector<size_t>, replace it
   // with vector<unsigned int>
   %apply std::vector<unsigned int> { std::vector<size_t> };
-#else
+#elif defined(SIZE_T_LONG)
   // On 64-bit systems, whenever we see std::vector<size_t>, replace it
   // with vector<long unsigned int>
   %apply std::vector<long unsigned int> { std::vector<size_t> };


### PR DESCRIPTION
The long type is not guaranteed to be 8 bytes on all 64-bit compilers. In this case, long is 4 bytes and this causes a swig compile error for vector_map.h. This fixes the build by checking the size of long to make the swig %apply the correct size. Tested on msvc 2012 and 64-bit ubuntu.

I realize that std::vector<size_t> has been a real pain in the past. This should not break any of that previous work. It simply skips the %apply rules (which will not work anyway on LLP64 systems).