### PR TITLE
qtgui: QWT6 compatibility for TimeDisplayForm

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/timedisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timedisplayform.h
@@ -44,6 +44,7 @@ public:
   ~TimeDisplayForm();
 
   TimeDomainDisplayPlot* getPlot();
+  const TimeDomainDisplayPlot* getPlot() const;
 
   int getNPoints() const;
   gr::qtgui::trigger_mode getTriggerMode() const;
@@ -142,6 +143,8 @@ private:
   std::string d_trig_tag_key;
 
   TimeControlPanel *d_controlpanel;
+
+  const QwtScaleDiv &axisScaleDiv(int axisId) const;
 };
 
 #endif /* TIME_DISPLAY_FORM_H */

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -216,6 +216,12 @@ TimeDisplayForm::getPlot()
   return ((TimeDomainDisplayPlot*)d_display_plot);
 }
 
+const TimeDomainDisplayPlot*
+TimeDisplayForm::getPlot() const
+{
+  return ((const TimeDomainDisplayPlot*)d_display_plot);
+}
+
 void
 TimeDisplayForm::newData(const QEvent* updateEvent)
 {
@@ -510,40 +516,50 @@ TimeDisplayForm::getTriggerTagKey() const
  * Notifcation messages from the control panel
  *******************************************************************/
 
+const QwtScaleDiv &
+TimeDisplayForm::axisScaleDiv(int axisId) const
+{
+#if QWT_VERSION >= 0x060000
+    return getPlot()->axisScaleDiv(axisId);
+#else
+    return *getPlot()->axisScaleDiv(axisId);
+#endif
+}
+
 void
 TimeDisplayForm::notifyYAxisPlus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::yLeft);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::yLeft);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
-  getPlot()->setYaxis(ax->lowerBound()+step, ax->upperBound()+step);
+  getPlot()->setYaxis(ax.lowerBound()+step, ax.upperBound()+step);
 }
 
 void
 TimeDisplayForm::notifyYAxisMinus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::yLeft);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::yLeft);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
-  getPlot()->setYaxis(ax->lowerBound()-step, ax->upperBound()-step);
+  getPlot()->setYaxis(ax.lowerBound()-step, ax.upperBound()-step);
 }
 
 void
 TimeDisplayForm::notifyYRangePlus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::yLeft);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::yLeft);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
-  getPlot()->setYaxis(ax->lowerBound()-step, ax->upperBound()+step);
+  getPlot()->setYaxis(ax.lowerBound()-step, ax.upperBound()+step);
 }
 
 void
 TimeDisplayForm::notifyYRangeMinus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::yLeft);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::yLeft);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
-  getPlot()->setYaxis(ax->lowerBound()+step, ax->upperBound()-step);
+  getPlot()->setYaxis(ax.lowerBound()+step, ax.upperBound()-step);
 }
 
 
@@ -595,8 +611,8 @@ TimeDisplayForm::notifyTriggerSlope(const QString &slope)
 void
 TimeDisplayForm::notifyTriggerLevelPlus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::yLeft);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::yLeft);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
   emit signalTriggerLevel(getTriggerLevel() + step);
 }
@@ -604,8 +620,8 @@ TimeDisplayForm::notifyTriggerLevelPlus()
 void
 TimeDisplayForm::notifyTriggerLevelMinus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::yLeft);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::yLeft);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
   emit signalTriggerLevel(getTriggerLevel() - step);
 }
@@ -613,8 +629,8 @@ TimeDisplayForm::notifyTriggerLevelMinus()
 void
 TimeDisplayForm::notifyTriggerDelayPlus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::xBottom);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::xBottom);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
   double trig = getTriggerDelay() + step / d_current_units;
   emit signalTriggerDelay(trig);
@@ -623,8 +639,8 @@ TimeDisplayForm::notifyTriggerDelayPlus()
 void
 TimeDisplayForm::notifyTriggerDelayMinus()
 {
-  QwtScaleDiv *ax = getPlot()->axisScaleDiv(QwtPlot::xBottom);
-  double range = ax->upperBound() - ax->lowerBound();
+  const QwtScaleDiv &ax = axisScaleDiv(QwtPlot::xBottom);
+  double range = ax.upperBound() - ax.lowerBound();
   double step = range/20.0;
   double trig = getTriggerDelay() - step / d_current_units;
   if(trig < 0)


### PR DESCRIPTION
commit c117e3232b32bb70d268932bcea025feb0a4cf25 breaks QWT 6 compatibility (QWT5 and QWT6 have different result types for axisScaleDiv().

I does not have QWT5 so tested only for QWT6