### PR TITLE
gnuradio-runtime: added logger to flat_flowgraph and print out a warning...

### DIFF
--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -50,6 +50,7 @@ namespace gr {
 
   flat_flowgraph::flat_flowgraph()
   {
+    configure_default_loggers(d_logger, d_debug_logger, "flat_flowgraph");
   }
 
   flat_flowgraph::~flat_flowgraph()
@@ -107,6 +108,13 @@ namespace gr {
       detail->set_output(i, buffer);
 
       // Update the block's max_output_buffer based on what was actually allocated.
+      if((grblock->max_output_buffer(i) != buffer->bufsize()) && (grblock->max_output_buffer(i) != -1))
+        GR_LOG_WARN(d_logger, boost::format("Block (%1%) max output buffer set to %2% instead of requested %3%") \
+                      % grblock->alias() % buffer->bufsize() % grblock->max_output_buffer(i));
+        //std::cout << ">>> Warning: Block (" << grblock->alias()
+        //          << ") max output buffer set to " << buffer->bufsize()
+        //          << " instead of requested " << grblock->max_output_buffer(i)
+        //          << std::endl;
       grblock->set_max_output_buffer(i, buffer->bufsize());
     }
 

--- a/gnuradio-runtime/lib/flat_flowgraph.h
+++ b/gnuradio-runtime/lib/flat_flowgraph.h
@@ -26,6 +26,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/flowgraph.h>
 #include <gnuradio/block.h>
+#include <gnuradio/logger.h>
 
 namespace gr {
 
@@ -89,6 +90,9 @@ namespace gr {
      * start and restarts.
      */
     void setup_buffer_alignment(block_sptr block);
+
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
   };
 
 } /* namespace gr */


### PR DESCRIPTION
... for when the max_output_buffer isn't set to the requested value