### PR TITLE
GRC block comments

### DIFF
--- a/grc/base/Block.py
+++ b/grc/base/Block.py
@@ -185,6 +185,17 @@ class Block(Element):
                              })
                     ))
 
+        self.get_params().append(self.get_parent().get_parent().Param(
+                block=self,
+                n=odict({'name': 'Comment',
+                         'key': 'comment',
+                         'type': 'string',
+                         'hide': 'part',
+                         'value': '',
+                         'tab': ADVANCED_PARAM_TAB
+                         })
+                ))
+
 
     def back_ofthe_bus(self, portlist):
         portlist.sort(key=lambda p: p._type == 'bus')
@@ -226,6 +237,7 @@ class Block(Element):
     def get_children(self): return self.get_ports() + self.get_params()
     def get_children_gui(self): return self.get_ports_gui() + self.get_params()
     def get_block_wrapper_path(self): return self._block_wrapper_path
+    def get_comment(self): return self.get_param('comment').get_value()
 
     ##############################################
     # Access Params

--- a/grc/base/Block.py
+++ b/grc/base/Block.py
@@ -189,7 +189,7 @@ class Block(Element):
                 block=self,
                 n=odict({'name': 'Comment',
                          'key': 'comment',
-                         'type': 'string',
+                         'type': 'multiline',
                          'hide': 'part',
                          'value': '',
                          'tab': ADVANCED_PARAM_TAB

--- a/grc/gui/ActionHandler.py
+++ b/grc/gui/ActionHandler.py
@@ -407,16 +407,22 @@ class ActionHandler:
         elif action == Actions.BLOCK_PARAM_MODIFY:
             selected_block = self.get_flow_graph().get_selected_block()
             if selected_block:
-                if PropsDialog(selected_block).run():
-                    #save the new state
-                    self.get_flow_graph().update()
-                    self.get_page().get_state_cache().save_new_state(self.get_flow_graph().export_data())
-                    self.get_page().set_saved(False)
-                else:
-                    #restore the current state
-                    n = self.get_page().get_state_cache().get_current_state()
-                    self.get_flow_graph().import_data(n)
-                    self.get_flow_graph().update()
+                dialog = PropsDialog(selected_block)
+                response = gtk.RESPONSE_APPLY
+                while response == gtk.RESPONSE_APPLY:  # do while construct: rerun the dialog if Apply was hit
+                    response = dialog.run()
+                    if response == gtk.RESPONSE_APPLY:
+                        self.get_flow_graph().update()
+                        Actions.ELEMENT_SELECT()  # empty action, that updates the main window and flowgraph
+                    elif response == gtk.RESPONSE_ACCEPT:
+                        self.get_flow_graph().update()
+                        self.get_page().get_state_cache().save_new_state(self.get_flow_graph().export_data())
+                        self.get_page().set_saved(False)
+                    else:  # restore the current state
+                        n = self.get_page().get_state_cache().get_current_state()
+                        self.get_flow_graph().import_data(n)
+                        self.get_flow_graph().update()
+                dialog.destroy()
         ##################################################
         # View Parser Errors
         ##################################################

--- a/grc/gui/ActionHandler.py
+++ b/grc/gui/ActionHandler.py
@@ -122,7 +122,8 @@ class ActionHandler:
                 Actions.TOGGLE_REPORTS_WINDOW, Actions.TOGGLE_HIDE_DISABLED_BLOCKS,
                 Actions.TOOLS_RUN_FDESIGN, Actions.TOGGLE_SCROLL_LOCK,
                 Actions.CLEAR_REPORTS, Actions.SAVE_REPORTS,
-                Actions.TOGGLE_AUTO_HIDE_PORT_LABELS, Actions.TOGGLE_SNAP_TO_GRID
+                Actions.TOGGLE_AUTO_HIDE_PORT_LABELS, Actions.TOGGLE_SNAP_TO_GRID,
+                Actions.TOGGLE_SHOW_BLOCK_COMMENTS,
             ): action.set_sensitive(True)
             if ParseXML.xml_failures:
                 Messages.send_xml_errors_if_any(ParseXML.xml_failures)
@@ -143,7 +144,8 @@ class ActionHandler:
                 Actions.TOGGLE_BLOCKS_WINDOW,
                 Actions.TOGGLE_AUTO_HIDE_PORT_LABELS,
                 Actions.TOGGLE_SCROLL_LOCK,
-                Actions.TOGGLE_SNAP_TO_GRID
+                Actions.TOGGLE_SNAP_TO_GRID,
+                Actions.TOGGLE_SHOW_BLOCK_COMMENTS,
             ): action.load_from_preferences()
         elif action == Actions.APPLICATION_QUIT:
             if self.main_window.close_pages():
@@ -400,6 +402,8 @@ class ActionHandler:
             for page in self.main_window.get_pages():
                 page.get_flow_graph().create_shapes()
         elif action == Actions.TOGGLE_SNAP_TO_GRID:
+            action.save_to_preferences()
+        elif action == Actions.TOGGLE_SHOW_BLOCK_COMMENTS:
             action.save_to_preferences()
         ##################################################
         # Param Modifications

--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -263,6 +263,11 @@ TOGGLE_AUTO_HIDE_PORT_LABELS = ToggleAction(
     tooltip='Automatically hide port labels',
     preference_name='auto_hide_port_labels'
 )
+TOGGLE_SHOW_BLOCK_COMMENTS = ToggleAction(
+    label='Show Block Comments',
+    tooltip="Show comment beneath each block",
+    preference_name='show_block_comments'
+)
 BLOCK_CREATE_HIER = Action(
     label='C_reate Hier',
     tooltip='Create hier block from selected blocks',

--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -99,6 +99,7 @@ MENU_BAR_LIST = (
         Actions.TOGGLE_HIDE_DISABLED_BLOCKS,
         Actions.TOGGLE_AUTO_HIDE_PORT_LABELS,
         Actions.TOGGLE_SNAP_TO_GRID,
+        Actions.TOGGLE_SHOW_BLOCK_COMMENTS,
         None,
         Actions.ERRORS_WINDOW_DISPLAY,
         Actions.FIND_BLOCKS,

--- a/grc/gui/Block.py
+++ b/grc/gui/Block.py
@@ -35,6 +35,9 @@ import pango
 BLOCK_MARKUP_TMPL="""\
 #set $foreground = $block.is_valid() and 'black' or 'red'
 <span foreground="$foreground" font_desc="$font"><b>$encode($block.get_name())</b></span>"""
+COMMENT_MARKUP_TMPL="""\
+#set $foreground = $block.get_enabled() and '#444' or '#888'
+<span foreground="$foreground" font_desc="$font">$encode($block.get_comment())</span>"""
 
 class Block(Element):
     """The graphical signal block."""
@@ -68,6 +71,7 @@ class Block(Element):
             })
         ))
         Element.__init__(self)
+        self._comment_pixmap = None
 
     def get_coordinate(self):
         """
@@ -203,6 +207,23 @@ class Block(Element):
                 for ports in (self.get_sources_gui(), self.get_sinks_gui())
             ]
         ))
+        self.create_comment_label()
+
+    def create_comment_label(self):
+        comment = self.get_comment()
+        if comment:
+            layout = gtk.DrawingArea().create_pango_layout('')
+            layout.set_markup(Utils.parse_template(COMMENT_MARKUP_TMPL, block=self, font=BLOCK_FONT))
+            width, height = layout.get_pixel_size()
+            pixmap = self.get_parent().new_pixmap(width, height)
+            gc = pixmap.new_gc()
+            gc.set_foreground(Colors.FLOWGRAPH_BACKGROUND_COLOR)
+            pixmap.draw_rectangle(gc, True, 0, 0, width, height)
+            pixmap.draw_layout(gc, 0, 0, layout)
+            self._comment_pixmap = pixmap
+        else:
+            self._comment_pixmap = None
+
 
     def draw(self, gc, window):
         """
@@ -243,3 +264,11 @@ class Block(Element):
             port_selected = port.what_is_selected(coor, coor_m)
             if port_selected: return port_selected
         return Element.what_is_selected(self, coor, coor_m)
+
+    def draw_comment(self, gc, window):
+        if not self._comment_pixmap:
+            return
+
+        x, y = self.get_coordinate()
+        window.draw_drawable(gc, self._comment_pixmap, 0, 0, x,
+                             y + self.H + BLOCK_LABEL_PADDING, -1, -1)

--- a/grc/gui/Block.py
+++ b/grc/gui/Block.py
@@ -217,13 +217,12 @@ class Block(Element):
             width, height = layout.get_pixel_size()
             pixmap = self.get_parent().new_pixmap(width, height)
             gc = pixmap.new_gc()
-            gc.set_foreground(Colors.FLOWGRAPH_BACKGROUND_COLOR)
+            gc.set_foreground(Colors.COMMENT_BACKGROUND_COLOR)
             pixmap.draw_rectangle(gc, True, 0, 0, width, height)
             pixmap.draw_layout(gc, 0, 0, layout)
             self._comment_pixmap = pixmap
         else:
             self._comment_pixmap = None
-
 
     def draw(self, gc, window):
         """

--- a/grc/gui/Colors.py
+++ b/grc/gui/Colors.py
@@ -34,6 +34,7 @@ try:
     ENTRYENUM_CUSTOM_COLOR = get_color('#EEEEEE')
     #flow graph color constants
     FLOWGRAPH_BACKGROUND_COLOR = get_color('#FFF9FF')
+    COMMENT_BACKGROUND_COLOR = get_color('#F3F3F3')
     #block color constants
     BLOCK_ENABLED_COLOR = get_color('#F1ECFF')
     BLOCK_DISABLED_COLOR = get_color('#CCCCCC')

--- a/grc/gui/FlowGraph.py
+++ b/grc/gui/FlowGraph.py
@@ -281,12 +281,10 @@ class FlowGraph(Element):
         gc.set_foreground(Colors.FLOWGRAPH_BACKGROUND_COLOR)
         window.draw_rectangle(gc, True, 0, 0, W, H)
         # draw comments first
-        hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
         if Actions.TOGGLE_SHOW_BLOCK_COMMENTS.get_active():
             for block in self.get_blocks():
-                if hide_disabled_blocks and not block.get_enabled():
-                    continue  # skip hidden disabled block comments
-                block.draw_comment(gc, window)
+                if block.get_enabled():
+                    block.draw_comment(gc, window)
         #draw multi select rectangle
         if self.mouse_pressed and (not self.get_selected_elements() or self.get_ctrl_mask()):
             #coordinates
@@ -301,6 +299,7 @@ class FlowGraph(Element):
             gc.set_foreground(Colors.BORDER_COLOR)
             window.draw_rectangle(gc, False, x, y, w, h)
         #draw blocks on top of connections
+        hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
         for element in self.get_connections() + self.get_blocks():
             if hide_disabled_blocks and not element.get_enabled():
                 continue  # skip hidden disabled blocks and connections

--- a/grc/gui/FlowGraph.py
+++ b/grc/gui/FlowGraph.py
@@ -280,6 +280,12 @@ class FlowGraph(Element):
         #draw the background
         gc.set_foreground(Colors.FLOWGRAPH_BACKGROUND_COLOR)
         window.draw_rectangle(gc, True, 0, 0, W, H)
+        # draw comments first
+        hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
+        for block in self.get_blocks():
+            if hide_disabled_blocks and not block.get_enabled():
+                continue  # skip hidden disabled block comments
+            block.draw_comment(gc, window)
         #draw multi select rectangle
         if self.mouse_pressed and (not self.get_selected_elements() or self.get_ctrl_mask()):
             #coordinates
@@ -295,7 +301,7 @@ class FlowGraph(Element):
             window.draw_rectangle(gc, False, x, y, w, h)
         #draw blocks on top of connections
         for element in self.get_connections() + self.get_blocks():
-            if Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active() and not element.get_enabled():
+            if hide_disabled_blocks and not element.get_enabled():
                 continue  # skip hidden disabled blocks and connections
             element.draw(gc, window)
         #draw selected blocks on top of selected connections

--- a/grc/gui/FlowGraph.py
+++ b/grc/gui/FlowGraph.py
@@ -282,10 +282,11 @@ class FlowGraph(Element):
         window.draw_rectangle(gc, True, 0, 0, W, H)
         # draw comments first
         hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
-        for block in self.get_blocks():
-            if hide_disabled_blocks and not block.get_enabled():
-                continue  # skip hidden disabled block comments
-            block.draw_comment(gc, window)
+        if Actions.TOGGLE_SHOW_BLOCK_COMMENTS.get_active():
+            for block in self.get_blocks():
+                if hide_disabled_blocks and not block.get_enabled():
+                    continue  # skip hidden disabled block comments
+                block.draw_comment(gc, window)
         #draw multi select rectangle
         if self.mouse_pressed and (not self.get_selected_elements() or self.get_ctrl_mask()):
             #coordinates

--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -169,7 +169,8 @@ class PropsDialog(gtk.Dialog):
                     if param.get_hide() == 'all':
                         continue
                     box_all_valid = box_all_valid and param.is_valid()
-                    vbox.pack_start(param.get_input(self._handle_changed, self._activate_apply), False)
+                    input_widget = param.get_input(self._handle_changed, self._activate_apply)
+                    vbox.pack_start(input_widget, input_widget.expand)
                 label.set_markup(Utils.parse_template(TAB_LABEL_MARKUP_TMPL, valid=box_all_valid, tab=tab))
                 #show params box with new params
                 vbox.show_all()
@@ -191,7 +192,10 @@ class PropsDialog(gtk.Dialog):
         Returns:
             false to forward the keypress
         """
-        if event.keyval == gtk.keysyms.Return and event.state & gtk.gdk.CONTROL_MASK == 0:
+        if (event.keyval == gtk.keysyms.Return and
+            event.state & gtk.gdk.CONTROL_MASK == 0 and
+            not isinstance(widget.get_focus(), gtk.TextView)
+        ):
             self.response(gtk.RESPONSE_ACCEPT)
             return True  # handled here
         return False  # forward the keypress

--- a/grc/python/Param.py
+++ b/grc/python/Param.py
@@ -57,7 +57,7 @@ class Param(_Param, _GUIParam):
         'complex', 'real', 'float', 'int',
         'complex_vector', 'real_vector', 'float_vector', 'int_vector',
         'hex', 'string', 'bool',
-        'file_open', 'file_save',
+        'file_open', 'file_save', 'multiline',
         'id', 'stream_id',
         'grid_pos', 'notebook', 'gui_hint',
         'import',
@@ -206,14 +206,6 @@ class Param(_Param, _GUIParam):
         self._lisitify_flag = False
         self._stringify_flag = False
         self._hostage_cells = list()
-        def eval_string(v):
-            try:
-                e = self.get_parent().get_parent().evaluate(v)
-                if isinstance(e, str): return e
-                raise Exception #want to stringify
-            except:
-                self._stringify_flag = True
-                return v
         t = self.get_type()
         v = self.get_value()
         #########################
@@ -280,9 +272,15 @@ class Param(_Param, _GUIParam):
         #########################
         # String Types
         #########################
-        elif t in ('string', 'file_open', 'file_save'):
+        elif t in ('string', 'file_open', 'file_save', 'multiline'):
             #do not check if file/directory exists, that is a runtime issue
-            e = eval_string(v)
+            try:
+                e = self.get_parent().get_parent().evaluate(v)
+                if not isinstance(e, str):
+                    raise Exception()
+            except:
+                self._stringify_flag = True
+                e = v
             return str(e)
         #########################
         # Unique ID Type
@@ -413,7 +411,7 @@ class Param(_Param, _GUIParam):
         """
         v = self.get_value()
         t = self.get_type()
-        if t in ('string', 'file_open', 'file_save'): #string types
+        if t in ('string', 'file_open', 'file_save', 'multiline'): #string types
             if not self._init: self.evaluate()
             if self._stringify_flag: return '"%s"'%v.replace('"', '\"')
             else: return v


### PR DESCRIPTION
As requested, a copy of issue #780. **Note: this is on top of master_grcwg**. 
Here the original text and some screen shots.



This adds simple unformatted text comments to each block on the canvas via a param in the advanced tap (for now). These are displayed left-aligned beneath the block.
To ease entry a new param type "multiline" has been added which allows for multi-line text entry.

Feedback is appreciated:
- hide comments for disabled blocks?
- center align comments beneath blocks?
- use string param type background color for multiline entry box?

![Main](http://gnuradio.org/redmine/attachments/download/855/block_comments_demo1.png)
![Props](http://gnuradio.org/redmine/attachments/download/854/block_comments_demo2.png)