### PR TITLE
fix gr-digital/examples/ofdm/tunnel.py error: option mismatch

### DIFF
--- a/gr-digital/examples/ofdm/tunnel.py
+++ b/gr-digital/examples/ofdm/tunnel.py
@@ -89,15 +89,16 @@ class my_top_block(gr.top_block):
 
         self.source = uhd_receiver(options.args,
                                    options.bandwidth,
-                                   options.rx_freq, options.rx_gain,
+                                   options.rx_freq,
+                                   options.lo_offset, options.rx_gain,
                                    options.spec, options.antenna,
-                                   options.verbose)
+                                   options.clock_source, options.verbose)
 
         self.sink = uhd_transmitter(options.args,
-                                    options.bandwidth,
-                                    options.tx_freq, options.tx_gain,
+                                    options.bandwidth, options.tx_freq,
+                                    options.lo_offset, options.tx_gain,
                                     options.spec, options.antenna,
-                                    options.verbose)
+                                    options.clock_source, options.verbose)
 
         self.txpath = transmit_path(options)
         self.rxpath = receive_path(callback, options)


### PR DESCRIPTION
An error occurred when running:

gr-digital/examples/ofdm//tunnel.py -m bpsk --tx-amplitude=0.8 -W 2M -f 2.4G --rx-gain=15 -A TX/RX

with error info as below:

Traceback (most recent call last):
  File "./tunnel.py", line 269, in <module>
    main()
  File "./tunnel.py", line 239, in main
    tb = my_top_block(mac.phy_rx_callback, options)
  File "./tunnel.py", line 95, in __init__
    options.verbose)
  File "/usr/share/gnuradio/examples/digital/ofdm/uhd_interface.py", line 182, in __init__
    freq, lo_offset, gain, spec, antenna, clock_source)
  File "/usr/share/gnuradio/examples/digital/ofdm/uhd_interface.py", line 59, in __init__
    self.u.set_subdev_spec(spec, 0)
  File "/usr/lib/python2.7/dist-packages/gnuradio/uhd/uhd_swig.py", line 2757, in set_subdev_spec
    return _uhd_swig.usrp_source_sptr_set_subdev_spec(self, *args, **kwargs)
RuntimeError: AssertionError: assertion failed:
  :TX/RX is not a valid rx subdevice specification on mboard 0.
  possible values are: [A:0].

it turns out that the arguments of uhd_receiver and uhd_transmitter are mismatched. This commit fix this error.