### PR TITLE
runtime: cleanup: Removing leftovers.

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -61,7 +61,6 @@ namespace gr {
     typedef boost::function<void(pmt::pmt_t)> msg_handler_t;
 
   private:
-    //msg_handler_t d_msg_handler;
     typedef std::map<pmt::pmt_t , msg_handler_t, pmt::comparator> d_msg_handlers_t;
     d_msg_handlers_t d_msg_handlers;
 


### PR DESCRIPTION
message_handler_t d_message_handler variable was commented out
anyway, so obviously no longer needed.

Signed-off-by: Moritz Fischer <moritz.fischer@ettus.com>