### PR TITLE
blocks: adding a variable tag_object to help build tags.

### DIFF
--- a/gr-blocks/examples/vector_source_with_tags.grc
+++ b/gr-blocks/examples/vector_source_with_tags.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<?grc format='1' created='3.7.6'?>
+<?grc format='1' created='3.7.7'?>
 <flow_graph>
   <timestamp>Mon Sep 22 11:59:58 2014</timestamp>
   <block>
@@ -53,66 +53,20 @@
       <value></value>
     </param>
     <param>
+      <key>thread_safe_setters</key>
+      <value></value>
+    </param>
+    <param>
       <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
       <value></value>
     </param>
     <param>
       <key>_coordinate</key>
       <value>(10, 10)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>id</key>
-      <value>tag1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>gr.tag_utils.python_to_tag((1, pmt.intern('mark'), pmt.PMT_T))</value>
-    </param>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(16, 267)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>id</key>
-      <value>tag0</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>gr.tag_utils.python_to_tag((0, pmt.intern('mark'), pmt.PMT_T, pmt.intern("src")))</value>
-    </param>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(16, 203)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -135,6 +89,10 @@
     </param>
     <param>
       <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
       <value></value>
     </param>
     <param>
@@ -162,6 +120,10 @@
     </param>
     <param>
       <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
       <value></value>
     </param>
     <param>
@@ -216,59 +178,12 @@
       <value>0</value>
     </param>
     <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
       <key>_coordinate</key>
       <value>(272, 123)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-  </block>
-  <block>
-    <key>blocks_tag_debug</key>
-    <param>
-      <key>id</key>
-      <value>blocks_tag_debug_0</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>float</value>
-    </param>
-    <param>
-      <key>name</key>
-      <value></value>
-    </param>
-    <param>
-      <key>filter</key>
-      <value>""</value>
-    </param>
-    <param>
-      <key>num_inputs</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>vlen</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>display</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(456, 195)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -320,6 +235,10 @@
     <param>
       <key>maxoutbuf</key>
       <value>0</value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -387,6 +306,10 @@
     <param>
       <key>update_time</key>
       <value>0.10</value>
+    </param>
+    <param>
+      <key>ctrlpanel</key>
+      <value>False</value>
     </param>
     <param>
       <key>entags</key>
@@ -669,8 +592,216 @@
       <value></value>
     </param>
     <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
       <key>_coordinate</key>
       <value>(456, 107)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_tag_object</key>
+    <param>
+      <key>id</key>
+      <value>tag0</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>offset</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>key</key>
+      <value>pmt.intern("mark")</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>pmt.PMT_T</value>
+    </param>
+    <param>
+      <key>src</key>
+      <value>pmt.intern("src")</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(16, 195)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_qtgui_range</key>
+    <param>
+      <key>id</key>
+      <value>tag1_offset</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>Tag 1 Offset</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>start</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>stop</key>
+      <value>10</value>
+    </param>
+    <param>
+      <key>step</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>widget</key>
+      <value>counter_slider</value>
+    </param>
+    <param>
+      <key>orient</key>
+      <value>Qt.Horizontal</value>
+    </param>
+    <param>
+      <key>min_len</key>
+      <value>200</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value></value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(256, 323)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_tag_object</key>
+    <param>
+      <key>id</key>
+      <value>tag1</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>offset</key>
+      <value>tag1_offset</value>
+    </param>
+    <param>
+      <key>key</key>
+      <value>pmt.intern("mark2")</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>pmt.from_long(12345)</value>
+    </param>
+    <param>
+      <key>src</key>
+      <value>pmt.intern("tag1")</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(112, 195)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_tag_debug</key>
+    <param>
+      <key>id</key>
+      <value>blocks_tag_debug_0</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>False</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>name</key>
+      <value></value>
+    </param>
+    <param>
+      <key>filter</key>
+      <value>""</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>display</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(456, 195)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -221,4 +221,8 @@
       <block>blocks_vco_f</block>
       <block>blocks_vco_c</block>
    </cat>
+   <cat>
+      <name>Variables</name>
+      <block>variable_tag_object</block>
+   </cat>
 </cat>

--- a/gr-blocks/grc/blocks_tag_object.xml
+++ b/gr-blocks/grc/blocks_tag_object.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+## Tag Object: creates a tag
+###################################################
+ -->
+<block>
+  <name>Tag Object</name>
+  <key>variable_tag_object</key>
+  <var_make>self.$(id) = $(id) = gr.tag_utils.python_to_tag(($offset, $key, $value, $src))</var_make>
+  <make></make>
+
+  <param>
+    <name>Offset</name>
+    <key>offset</key>
+    <value>0</value>
+    <type>int</type>
+  </param>
+
+  <param>
+    <name>Key</name>
+    <key>key</key>
+    <value>pmt.intern("key")</value>
+    <type>raw</type>
+  </param>
+
+  <param>
+    <name>Value</name>
+    <key>value</key>
+    <value>pmt.intern("value")</value>
+    <type>raw</type>
+  </param>
+
+  <param>
+    <name>Source ID</name>
+    <key>src</key>
+    <value>pmt.intern("src")</value>
+    <type>raw</type>
+  </param>
+
+  <doc>
+    This block creates a tag object. While tags are based on an
+    absolute offset, this is based on a relative offset that must be
+    appropriately translated by the block using it. For example, this
+    is used by the vector_source blocks, which will treat a 0 offset
+    in the tag as the first item in the stream when the vector starts
+    or repeats.
+
+    The tag objects are created using the python_to_tag Python
+    function to make it easy to generate a tag_t in Python. The call
+    looks like:
+
+        gr.tag_utils.python_to_tag(($offset, $key, $value, $src))
+  </doc>
+</block>


### PR DESCRIPTION
Edit boxes to set the tag's offset, key, value, and source id to make
it easier to create and use tags in a flwograph. the gr-blocks example
vector_source_with_tags.grc has been updated to use this.