### PR TITLE
Fixed up the int/size_t handling in hb2's new max/min_output... methods

### DIFF
--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -56,7 +56,7 @@ namespace gr {
      * \brief Private implementation details of gr::hier_block2
      */
     hier_block2_detail *d_detail;
-    
+
 
   protected:
     hier_block2(void) {} // allows pure virtual interface sub-classes
@@ -174,32 +174,32 @@ namespace gr {
     /*!
      * \brief Returns max buffer size (itemcount) on output port \p i.
      */
-    size_t max_output_buffer(size_t i=0);
+    int max_output_buffer(size_t port=0);
 
     /*!
      * \brief Sets max buffer size (itemcount) on all output ports.
      */
-    void set_max_output_buffer(size_t max_output_buffer);
+    void set_max_output_buffer(int max_output_buffer);
 
     /*!
      * \brief Sets max buffer size (itemcount) on output port \p port.
      */
-    void set_max_output_buffer(int port, size_t max_output_buffer);
+    void set_max_output_buffer(size_t port, int max_output_buffer);
 
     /*!
      * \brief Returns min buffer size (itemcount) on output port \p i.
      */
-    size_t min_output_buffer(size_t i=0);
+    int min_output_buffer(size_t port=0);
 
     /*!
      * \brief Sets min buffer size (itemcount) on all output ports.
      */
-    void set_min_output_buffer(size_t min_output_buffer);
+    void set_min_output_buffer(int min_output_buffer);
 
     /*!
      * \brief Sets min buffer size (itemcount) on output port \p port.
      */
-    void set_min_output_buffer(int port, size_t min_output_buffer);
+    void set_min_output_buffer(size_t port, int min_output_buffer);
 
 
     // This is a public method for ease of code organization, but should be
@@ -265,7 +265,7 @@ namespace gr {
      * call could be misleading.
      */
     std::vector<int> processor_affinity();
-    
+
     /*!
      * \brief Get if all block min buffers should be set.
      *
@@ -273,7 +273,7 @@ namespace gr {
      * should be set or just the block ports connected to the hier ports.
      */
     bool all_min_output_buffer_p(void);
-    
+
     /*!
      * \brief Get if all block max buffers should be set.
      *

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -182,97 +182,89 @@ namespace gr {
     return dot_graph_fg(hierblock2->flatten());
   }
 
-  size_t
-  hier_block2::max_output_buffer(size_t i)
+  int
+  hier_block2::max_output_buffer(size_t port)
   {
-    if(i >= d_detail->d_max_output_buffer.size())
-      throw std::invalid_argument("hier_block2::max_output_buffer: port out of range.");
-    return d_detail->d_max_output_buffer[i];
+    if(port >= d_detail->d_max_output_buffer.size())
+      throw std::invalid_argument("hier_block2::max_output_buffer(int): port out of range.");
+    return d_detail->d_max_output_buffer[port];
   }
-  
+
   void
-  hier_block2::set_max_output_buffer(size_t max_output_buffer)
+  hier_block2::set_max_output_buffer(int max_output_buffer)
   {
     if(output_signature()->max_streams()>0)
     {
       if(d_detail->d_max_output_buffer.size() == 0)
-        throw std::length_error("hier_block2::max_output_buffer: out_sig greater than zero, buff_vect isn't");
-      for(size_t idx = 0; idx < output_signature()->max_streams(); idx++){
+        throw std::length_error("hier_block2::set_max_output_buffer(int): out_sig greater than zero, buff_vect isn't");
+      for(int idx = 0; idx < output_signature()->max_streams(); idx++){
         d_detail->d_max_output_buffer[idx] = max_output_buffer;
       }
     }
   }
-  
+
   void
-  hier_block2::set_max_output_buffer(int port, size_t max_output_buffer)
+  hier_block2::set_max_output_buffer(size_t port, int max_output_buffer)
   {
-    if((size_t)port >= d_detail->d_max_output_buffer.size())
-      throw std::invalid_argument("hier_block2::max_output_buffer: port out of range.");
+    if(port >= d_detail->d_max_output_buffer.size())
+      throw std::invalid_argument("hier_block2::set_max_output_buffer(size_t,int): port out of range.");
     else{
       d_detail->d_max_output_buffer[port] = max_output_buffer;
     }
   }
 
-  size_t
-  hier_block2::min_output_buffer(size_t i)
+  int
+  hier_block2::min_output_buffer(size_t port)
   {
-    if(i >= d_detail->d_min_output_buffer.size())
-      throw std::invalid_argument("hier_block2::min_output_buffer: port out of range.");
-    return d_detail->d_min_output_buffer[i];
+    if(port >= d_detail->d_min_output_buffer.size())
+      throw std::invalid_argument("hier_block2::min_output_buffer(size_t): port out of range.");
+    return d_detail->d_min_output_buffer[port];
   }
 
   void
-  hier_block2::set_min_output_buffer(size_t min_output_buffer)
+  hier_block2::set_min_output_buffer(int min_output_buffer)
   {
     if(output_signature()->max_streams()>0)
     {
       if(d_detail->d_min_output_buffer.size() == 0)
-        throw std::length_error("hier_block2::min_output_buffer: out_sig greater than zero, buff_vect isn't");
-      for(size_t idx = 0; idx < output_signature()->max_streams(); idx++){
+        throw std::length_error("hier_block2::set_min_output_buffer(int): out_sig greater than zero, buff_vect isn't");
+      for(int idx = 0; idx < output_signature()->max_streams(); idx++){
         d_detail->d_min_output_buffer[idx] = min_output_buffer;
       }
     }
   }
 
   void
-  hier_block2::set_min_output_buffer(int port, size_t min_output_buffer)
+  hier_block2::set_min_output_buffer(size_t port, int min_output_buffer)
   {
-    if((size_t)port >= d_detail->d_min_output_buffer.size())
-      throw std::invalid_argument("hier_block2::min_output_buffer: port out of range.");
+    if(port >= d_detail->d_min_output_buffer.size())
+      throw std::invalid_argument("hier_block2::set_min_output_buffer(size_t,int): port out of range.");
     else{
       d_detail->d_min_output_buffer[port] = min_output_buffer;
     }
   }
-  
+
   bool
   hier_block2::all_min_output_buffer_p(void)
   {
-    if(d_detail->d_min_output_buffer.size() > 0){
-      bool all_equal = true;
-      for(int idx = 1; (idx < d_detail->d_min_output_buffer.size()) && all_equal; idx++){
-        if(d_detail->d_min_output_buffer[0] != d_detail->d_min_output_buffer[idx])
-          all_equal = false;
-      }
-      return all_equal;
-    }
-    else{
+    if(!d_detail->d_min_output_buffer.size())
       return false;
+    for(size_t idx = 1; idx < d_detail->d_min_output_buffer.size(); idx++){
+      if(d_detail->d_min_output_buffer[0] != d_detail->d_min_output_buffer[idx])
+        return false;
     }
+    return true;
   }
   bool
   hier_block2::all_max_output_buffer_p(void)
   {
-    if(d_detail->d_max_output_buffer.size() > 0){
-      bool all_equal = true;
-      for(int idx = 1; (idx < d_detail->d_max_output_buffer.size()) && all_equal; idx++){
-        if(d_detail->d_max_output_buffer[0] != d_detail->d_max_output_buffer[idx])
-          all_equal = false;
-      }
-      return all_equal;
-    }
-    else{
+    if(!d_detail->d_max_output_buffer.size())
       return false;
+    for(size_t idx = 1; idx < d_detail->d_max_output_buffer.size(); idx++){
+      if(d_detail->d_max_output_buffer[0] != d_detail->d_max_output_buffer[idx])
+        return false;
     }
+    return true;
   }
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -516,8 +516,9 @@ namespace gr {
 
     // Only run setup_rpc if ControlPort config param is enabled.
     bool ctrlport_on = prefs::singleton()->get_bool("ControlPort", "on", false);
-    
-    size_t min_buff(0), max_buff(0);
+
+    int min_buff = 0;
+    int max_buff = 0;
     // Determine how the buffers should be set
     bool set_all_min_buff = d_owner->all_min_output_buffer_p();
     bool set_all_max_buff = d_owner->all_max_output_buffer_p();


### PR DESCRIPTION
alongside with minor beautifications.
Fixes all compile warnings related to signed/unsigned comparison.

port now uniformly `size_t`, in/output buffer min/max int, to keep it unified with gr::block.

Changing to size_t (which would make sense for buffer sizes) might be considered API break, so it may be 3.8 material; internally would need to add flags for unlimited/unallocated buffers, where GR uses -1 right now. Would also need changes to block_executor (since return value of general work has "magical" negative values).