### PR TITLE
Fix: out-of-bounds memset

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -1321,7 +1321,7 @@ namespace gr {
       int temp, offset_bits = 0;
       unsigned char b, value;
       unsigned int shift[6];
-      int plen = FRAME_SIZE_SHORT - NBCH_1_4;
+      int plen = FRAME_SIZE_SHORT - NBCH_1_2;
       const unsigned char *d;
       unsigned char *p;
       unsigned char *l1post = l1_interleave;


### PR DESCRIPTION
Ron says:

>Marcus,
>Looks like a copy and paste bug. I must have copied line 1149:
> `int plen = FRAME_SIZE_SHORT - NBCH_1_4;`
>from the previous function add_l1pre().
>So the fix would be to change line 1324 to:
>`int plen = FRAME_SIZE_SHORT - NBCH_1_2;`