### PR TITLE
gr-fec: fixed signed/unsigned comparison

### DIFF
--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -111,8 +111,8 @@ namespace gr {
       const uint8_t* bits_in = pmt::u8vector_elements(bits, o0);
 
       bool variable_framesize = d_encoder->set_frame_size(nbits_in);
-      size_t nbits_out = 0;
-      size_t nblocks = 1;
+      int nbits_out = 0;
+      int nblocks = 1;
       if( variable_framesize ){
         nbits_out = d_encoder->get_output_size();
         } else {
@@ -135,7 +135,7 @@ namespace gr {
         d_encoder->generic_work((void*)d_bits_in, (void*)bits_out);
       }
       else {
-        for(size_t i=0; i<nblocks; i++){
+        for(int i=0; i<nblocks; i++){
             d_encoder->generic_work((void*) &bits_in[i*d_encoder->get_input_size()], (void*)&bits_out[i*d_encoder->get_output_size()]);
             }
       }


### PR DESCRIPTION
int for all the things, since `generic_encoder::get*size` returns `int`, not
`size_t`.