### PR TITLE
qtgui: time and freq plot behavior mods.

### DIFF
--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -218,8 +218,10 @@ FrequencyDisplayPlot::FrequencyDisplayPlot(int nplots, QWidget* parent)
   QWidget *w;
   w = legend()->find(d_min_fft_plot_curve);
   ((QwtLegendItem*)w)->setChecked(true);
+  ((QwtLegendItem*)w)->setVisible(false);
   w = legend()->find(d_max_fft_plot_curve);
   ((QwtLegendItem*)w)->setChecked(true);
+  ((QwtLegendItem*)w)->setVisible(false);
   legend()->setVisible(false);
 #else /* QWT_VERSION < 0x060100 */
   QWidget *w;

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -48,6 +48,11 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
   d_clicked = false;
   d_clicked_freq = 0;
 
+  d_trig_mode = gr::qtgui::TRIG_MODE_FREE;
+  d_trig_level = 0;
+  d_trig_channel = 0;
+  d_trig_tag_key = "";
+
   d_sizemenu = new FFTSizeMenu(this);
   d_avgmenu = new FFTAverageMenu(this);
   d_winmenu = new FFTWindowMenu(this);
@@ -435,7 +440,7 @@ FreqDisplayForm::updateTrigger(gr::qtgui::trigger_mode mode)
   }
 
   // if tag mode, popup tag key box to set
-  if(d_trig_mode == gr::qtgui::TRIG_MODE_TAG)
+  if((d_trig_tag_key == "") && (d_trig_mode == gr::qtgui::TRIG_MODE_TAG))
     d_tr_tag_key_act->activate(QAction::Trigger);
 
   emit signalReplot();

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -37,6 +37,13 @@ TimeDisplayForm::TimeDisplayForm(int nplots, QWidget* parent)
   d_semilogy = false;
   d_current_units = 1;
 
+  d_trig_mode = gr::qtgui::TRIG_MODE_FREE;
+  d_trig_slope = gr::qtgui::TRIG_SLOPE_POS;
+  d_trig_level = 0;
+  d_trig_delay = 0;
+  d_trig_channel = 0;
+  d_trig_tag_key = "";
+
   d_int_validator = new QIntValidator(this);
   d_int_validator->setBottom(0);
 
@@ -382,7 +389,7 @@ TimeDisplayForm::updateTrigger(gr::qtgui::trigger_mode mode)
   }
 
   // if tag mode, popup tag key box to set
-  if(d_trig_mode == gr::qtgui::TRIG_MODE_TAG)
+  if((d_trig_tag_key == "") && (d_trig_mode == gr::qtgui::TRIG_MODE_TAG))
     d_tr_tag_key_act->activate(QAction::Trigger);
 
   emit signalReplot();


### PR DESCRIPTION
- Fixes a problem of shown min/max in legend in QWT < 6.1.
- Initializes trigger variables.
- If tag key is set, don't ask when setting tag trigger mode.