### PR TITLE
qtgui: OOM fix

### DIFF
--- a/gr-qtgui/python/qtgui/range.py
+++ b/gr-qtgui/python/qtgui/range.py
@@ -22,7 +22,6 @@
 #
 
 from PyQt4 import Qt, QtCore, QtGui
-import numpy
 
 class Range(object):
     def __init__(self, minv, maxv, step, default, min_length):


### PR DESCRIPTION

qtgui: fixes the need to use memory to store the range values. Now uses linear mapping functions. The counter box now also waits for an enter or defocus.

nsteps = (max-min)/step  + 1
The number of ticks displayed are also being adjusted to either 'nsteps' or 'min_length', which ever is less.

