### PR TITLE
blocks: fixed problem with setting peak detector's alpha value.

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
+++ b/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
@@ -71,7 +71,7 @@ namespace gr {
       /*! \brief Set the running average alpha
        *  \param alpha new alpha for running average
        */
-      virtual void set_alpha(int alpha) = 0;
+      virtual void set_alpha(float alpha) = 0;
 
       /*! \brief Get the threshold factor value for the rise time
        *  \return threshold factor

--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -43,8 +43,8 @@ namespace gr {
     peak_detector2_fb_impl::peak_detector2_fb_impl(float threshold_factor_rise,
                                                    int look_ahead, float alpha)
       : sync_block("peak_detector2_fb",
-                      io_signature::make(1, 1, sizeof(float)),
-                      io_signature::make2(1, 2, sizeof(char), sizeof(float))),
+                   io_signature::make(1, 1, sizeof(float)),
+                   io_signature::make2(1, 2, sizeof(char), sizeof(float))),
         d_threshold_factor_rise(threshold_factor_rise),
         d_look_ahead(look_ahead), d_alpha(alpha), d_avg(0.0f), d_found(false)
     {
@@ -61,8 +61,6 @@ namespace gr {
     {
       float *iptr = (float *)input_items[0];
       char *optr = (char *)output_items[0];
-
-      assert(noutput_items >= 2);
 
       memset(optr, 0, noutput_items*sizeof(char));
 
@@ -114,5 +112,3 @@ namespace gr {
 
   } /* namespace blocks */
 } /* namespace gr */
-
-

--- a/gr-blocks/lib/peak_detector2_fb_impl.h
+++ b/gr-blocks/lib/peak_detector2_fb_impl.h
@@ -47,7 +47,7 @@ namespace gr {
 
       void set_threshold_factor_rise(float thr) { d_threshold_factor_rise = thr; }
       void set_look_ahead(int look) { d_look_ahead = look; }
-      void set_alpha(int alpha) { d_alpha = alpha; }
+      void set_alpha(float alpha) { d_alpha = alpha; }
 
       float threshold_factor_rise() { return d_threshold_factor_rise; }
       int look_ahead() { return d_look_ahead; }


### PR DESCRIPTION
This changes the public interface from an int to a float. But the
alpha must be between 0 and 1 for it to make any sense, so if this is
being used, it's never producing the right answer. Also, it's likely
that this change will be transparent to anyone who is trying to set
it.