### PR TITLE
qtgui: fixed examples using qss theme.

### DIFF
--- a/gr-qtgui/examples/pyqt_example_c.py
+++ b/gr-qtgui/examples/pyqt_example_c.py
@@ -151,7 +151,7 @@ class my_top_block(gr.top_block):
         fftsize = 2048
 
         self.qapp = QtGui.QApplication(sys.argv)
-        ss = open('dark.qss')
+        ss = open(gr.prefix() + '/share/gnuradio/themes/dark.qss')
         sstext = ss.read()
         ss.close()
         self.qapp.setStyleSheet(sstext)
@@ -190,4 +190,3 @@ if __name__ == "__main__":
     tb.start()
     tb.qapp.exec_()
     tb.stop()
-

--- a/gr-qtgui/examples/pyqt_freq_c.py
+++ b/gr-qtgui/examples/pyqt_freq_c.py
@@ -151,7 +151,7 @@ class my_top_block(gr.top_block):
         npts = 2048
 
         self.qapp = QtGui.QApplication(sys.argv)
-        ss = open('dark.qss')
+        ss = open(gr.prefix() + '/share/gnuradio/themes/dark.qss')
         sstext = ss.read()
         ss.close()
         self.qapp.setStyleSheet(sstext)
@@ -191,4 +191,3 @@ if __name__ == "__main__":
     tb.start()
     tb.qapp.exec_()
     tb.stop()
-

--- a/gr-qtgui/examples/pyqt_time_c.py
+++ b/gr-qtgui/examples/pyqt_time_c.py
@@ -151,7 +151,7 @@ class my_top_block(gr.top_block):
         npts = 2048
 
         self.qapp = QtGui.QApplication(sys.argv)
-        ss = open('dark.qss')
+        ss = open(gr.prefix() + '/share/gnuradio/themes/dark.qss')
         sstext = ss.read()
         ss.close()
         self.qapp.setStyleSheet(sstext)
@@ -205,4 +205,3 @@ if __name__ == "__main__":
     tb.start()
     tb.qapp.exec_()
     tb.stop()
-

--- a/gr-qtgui/examples/pyqt_waterfall_c.py
+++ b/gr-qtgui/examples/pyqt_waterfall_c.py
@@ -153,7 +153,7 @@ class my_top_block(gr.top_block):
         taps = filter.firdes.complex_band_pass_2(1, Rs, 1500, 2500, 100, 60)
 
         self.qapp = QtGui.QApplication(sys.argv)
-        ss = open('dark.qss')
+        ss = open(gr.prefix() + '/share/gnuradio/themes/dark.qss')
         sstext = ss.read()
         ss.close()
         self.qapp.setStyleSheet(sstext)
@@ -193,4 +193,3 @@ if __name__ == "__main__":
     tb.start()
     tb.qapp.exec_()
     tb.stop()
-


### PR DESCRIPTION
Look at installation prefix/share/gnuradio/themes for the location of
the dark.qss, which was moved from being in the examples directory.