### PR TITLE
Moved setting of d_finished from ctor to start()

### DIFF
--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -67,6 +67,9 @@ namespace gr {
     bool
     message_strobe_impl::start()
     {
+      // NOTE: d_finished should be something explicitely thread safe. But since
+      // nothing breaks on concurrent access, I'll just leave it as bool.
+      d_finished = false;
       d_thread = boost::shared_ptr<gr::thread::thread>
         (new gr::thread::thread(boost::bind(&message_strobe_impl::run, this)));
 


### PR DESCRIPTION
Making the message_strobe able to cope with reconfiguration.

Ref:
http://lists.gnu.org/archive/html/discuss-gnuradio/2015-04/msg00285.html