### PR TITLE
analog: Power Squelch now emit tags on start/end of bursts

### DIFF
--- a/gr-analog/grc/analog_pwr_squelch_xx.xml
+++ b/gr-analog/grc/analog_pwr_squelch_xx.xml
@@ -34,11 +34,13 @@
 	<param>
 		<name>Alpha</name>
 		<key>alpha</key>
+		<value>1e-4</value>
 		<type>real</type>
 	</param>
 	<param>
 		<name>Ramp</name>
 		<key>ramp</key>
+		<value>0</value>
 		<type>int</type>
 	</param>
 	<param>

--- a/gr-analog/include/gnuradio/analog/pwr_squelch_cc.h
+++ b/gr-analog/include/gnuradio/analog/pwr_squelch_cc.h
@@ -49,10 +49,14 @@ namespace gr {
        * \brief Make power-based squelch block.
        *
        * \param db threshold (in dB) for power squelch
-       * \param alpha Gain of averaging filter
-       * \param ramp sets response characteristic.
+       * \param alpha Gain of averaging filter. Defaults to 0.0001.
+       * \param ramp sets response characteristic. Defaults to 0.
        * \param gate if true, no output if no squelch tone.
-       *             if false, output 0's if no squelch tone.
+       *             if false, output 0's if no squelch tone (default).
+       *
+       * The block will emit a tag with the key pmt::intern("squelch_sob")
+       * with the value of pmt::PMT_NIL on the first item it passes, and with
+       * the key pmt::intern("squelch:eob") on the last item it passes.
        */
       static sptr make(double db, double alpha=0.0001,
 		       int ramp=0, bool gate=false);

--- a/gr-analog/include/gnuradio/analog/pwr_squelch_ff.h
+++ b/gr-analog/include/gnuradio/analog/pwr_squelch_ff.h
@@ -49,10 +49,14 @@ namespace gr {
        * \brief Make power-based squelch block.
        *
        * \param db threshold (in dB) for power squelch
-       * \param alpha Gain of averaging filter
-       * \param ramp sets response characteristic.
+       * \param alpha Gain of averaging filter. Defaults to 0.0001.
+       * \param ramp sets response characteristic. Defaults to 0.
        * \param gate if true, no output if no squelch tone.
-       *             if false, output 0's if no squelch tone.
+       *             if false, output 0's if no squelch tone (default).
+       *
+       * The block will emit a tag with the key pmt::intern("squelch_sob")
+       * with the value of pmt::PMT_NIL on the first item it passes, and with
+       * the key pmt::intern("squelch:eob") on the last item it passes.
        */
       static sptr make(double db, double alpha=0.0001,
 		       int ramp=0, bool gate=false);

--- a/gr-analog/lib/squelch_base_cc_impl.cc
+++ b/gr-analog/lib/squelch_base_cc_impl.cc
@@ -32,8 +32,11 @@ namespace gr {
 
     squelch_base_cc_impl::squelch_base_cc_impl(const char *name, int ramp, bool gate)
       : block(name,
-	         io_signature::make(1, 1, sizeof(float)),
-	         io_signature::make(1, 1, sizeof(float)))
+                 io_signature::make(1, 1, sizeof(float)),
+                 io_signature::make(1, 1, sizeof(float))),
+        d_sob_key(pmt::intern("squelch_sob")),
+        d_eob_key(pmt::intern("squelch_eob")),
+        d_tag_next_unmuted(true)
     {
       set_ramp(ramp);
       set_gate(gate);
@@ -92,48 +95,58 @@ namespace gr {
       gr::thread::scoped_lock l(d_setlock);
 
       for(int i = 0; i < noutput_items; i++) {
-	update_state(in[i]);
+        update_state(in[i]);
 
-	// Adjust envelope based on current state
-	switch(d_state) {
-	case ST_MUTED:
-	  if(!mute()) {
-	    d_state = d_ramp ? ST_ATTACK : ST_UNMUTED; // If not ramping, go straight to unmuted
-	  }
-	  break;
+        // Adjust envelope based on current state
+        switch(d_state) {
+          case ST_MUTED:
+            if(!mute()) {
+              d_state = d_ramp ? ST_ATTACK : ST_UNMUTED; // If not ramping, go straight to unmuted
+              if(d_state == ST_UNMUTED)
+                d_tag_next_unmuted = true;
+            }
+            break;
 
-	case ST_UNMUTED:
-	  if(mute()) {
-	    d_state = d_ramp ? ST_DECAY : ST_MUTED;    // If not ramping, go straight to muted
-	  }
-	  break;
+          case ST_UNMUTED:
+            if(d_tag_next_unmuted) {
+              d_tag_next_unmuted = false;
+              add_item_tag(0, nitems_written(0) + j, d_sob_key, pmt::PMT_NIL);
+            }
+            if(mute()) {
+              d_state = d_ramp ? ST_DECAY : ST_MUTED;    // If not ramping, go straight to muted
+              if(d_state == ST_MUTED)
+                add_item_tag(0, nitems_written(0) + j, d_eob_key, pmt::PMT_NIL);
+            }
+            break;
 
-	case ST_ATTACK:
-	  d_envelope = 0.5-std::cos(M_PI*(++d_ramped)/d_ramp)/2.0; // FIXME: precalculate window for speed
-	  if(d_ramped >= d_ramp) { // use >= in case d_ramp is set to lower value elsewhere
-	    d_state = ST_UNMUTED;
-	    d_envelope = 1.0;
-	  }
-	  break;
+          case ST_ATTACK:
+            d_envelope = 0.5-std::cos(M_PI*(++d_ramped)/d_ramp)/2.0; // FIXME: precalculate window for speed
+            if(d_ramped >= d_ramp) { // use >= in case d_ramp is set to lower value elsewhere
+              d_state = ST_UNMUTED;
+              d_tag_next_unmuted = true;
+              d_envelope = 1.0;
+            }
+            break;
 
-	case ST_DECAY:
-	  d_envelope = 0.5-std::cos(M_PI*(--d_ramped)/d_ramp)/2.0; // FIXME: precalculate window for speed
-	  if(d_ramped == 0.0) {
-	    d_state = ST_MUTED;
-	  }
-	  break;
-	};
+          case ST_DECAY:
+            d_envelope = 0.5-std::cos(M_PI*(--d_ramped)/d_ramp)/2.0; // FIXME: precalculate window for speed
+            if(d_ramped == 0.0) {
+              d_state = ST_MUTED;
+              add_item_tag(0, nitems_written(0) + j, d_eob_key, pmt::PMT_NIL);
+            }
+            break;
+        };
 
-	// If unmuted, copy input times envelope to output
-	// Otherwise, if not gating, copy zero to output
-	if(d_state != ST_MUTED) {
-	  out[j++] = in[i]*gr_complex(d_envelope, 0.0);
-	}
-	else {
-	  if(!d_gate) {
-	    out[j++] = 0.0;
-	  }
-	}
+        // If unmuted, copy input times envelope to output
+        // Otherwise, if not gating, copy zero to output
+        if(d_state != ST_MUTED) {
+          out[j++] = in[i]*gr_complex(d_envelope, 0.0);
+        }
+        else {
+          if(!d_gate) {
+            out[j++] = 0.0;
+          }
+        }
       }
 
       consume_each(noutput_items);  // Use all the inputs

--- a/gr-analog/lib/squelch_base_cc_impl.h
+++ b/gr-analog/lib/squelch_base_cc_impl.h
@@ -36,6 +36,8 @@ namespace gr {
       bool   d_gate;
       double d_envelope;
       enum { ST_MUTED, ST_ATTACK, ST_UNMUTED, ST_DECAY } d_state;
+      const pmt::pmt_t d_sob_key, d_eob_key;
+      bool d_tag_next_unmuted;
 
     protected:
       virtual void update_state(const gr_complex &sample) {};

--- a/gr-analog/lib/squelch_base_ff_impl.cc
+++ b/gr-analog/lib/squelch_base_ff_impl.cc
@@ -26,14 +26,18 @@
 
 #include "squelch_base_ff_impl.h"
 #include <gnuradio/io_signature.h>
+#include <pmt/pmt.h>
 
 namespace gr {
   namespace analog {
 
     squelch_base_ff_impl::squelch_base_ff_impl(const char *name, int ramp, bool gate)
       : block(name,
-	         io_signature::make(1, 1, sizeof(float)),
-	         io_signature::make(1, 1, sizeof(float)))
+                 io_signature::make(1, 1, sizeof(float)),
+                 io_signature::make(1, 1, sizeof(float))),
+        d_sob_key(pmt::intern("squelch_sob")),
+        d_eob_key(pmt::intern("squelch_eob")),
+        d_tag_next_unmuted(true)
     {
       set_ramp(ramp);
       set_gate(gate);
@@ -88,48 +92,61 @@ namespace gr {
       int j = 0;
 
       for(int i = 0; i < noutput_items; i++) {
-	update_state(in[i]);
+        update_state(in[i]);
 
-	// Adjust envelope based on current state
-	switch(d_state) {
-	case ST_MUTED:
-	  if(!mute())
-	    // If not ramping, go straight to unmuted
-	    d_state = d_ramp ? ST_ATTACK : ST_UNMUTED;
-	      break;
+        // Adjust envelope based on current state
+        switch(d_state) {
+          case ST_MUTED:
+            if(!mute()) {
+              // If not ramping, go straight to unmuted
+              d_state = d_ramp ? ST_ATTACK : ST_UNMUTED;
+              if(d_state == ST_UNMUTED)
+                d_tag_next_unmuted = true;
+            }
+            break;
 
-	case ST_UNMUTED:
-	  if(mute())
-	    // If not ramping, go straight to muted
-	    d_state = d_ramp ? ST_DECAY : ST_MUTED;
-	      break;
+          case ST_UNMUTED:
+            if(d_tag_next_unmuted) {
+              d_tag_next_unmuted = false;
+              add_item_tag(0, nitems_written(0) + j, d_sob_key, pmt::PMT_NIL);
+            }
+            if(mute()) {
+              // If not ramping, go straight to muted
+              d_state = d_ramp ? ST_DECAY : ST_MUTED;
+              if(d_state == ST_MUTED)
+                add_item_tag(0, nitems_written(0) + j, d_eob_key, pmt::PMT_NIL);
+            }
+            break;
 
-	case ST_ATTACK:
-	  // FIXME: precalculate window for speed
-	  d_envelope = 0.5-std::cos(M_PI*(++d_ramped)/d_ramp)/2.0;
+          case ST_ATTACK:
+            // FIXME: precalculate window for speed
+            d_envelope = 0.5-std::cos(M_PI*(++d_ramped)/d_ramp)/2.0;
 
-	  // use >= in case d_ramp is set to lower value elsewhere
-	  if(d_ramped >= d_ramp) {
-	    d_state = ST_UNMUTED;
-	    d_envelope = 1.0;
-	  }
-	  break;
+            // use >= in case d_ramp is set to lower value elsewhere
+            if(d_ramped >= d_ramp) {
+              d_state = ST_UNMUTED;
+              d_tag_next_unmuted = true;
+              d_envelope = 1.0;
+            }
+            break;
 
-	case ST_DECAY:
-	  // FIXME: precalculate window for speed
-	  d_envelope = 0.5-std::cos(M_PI*(--d_ramped)/d_ramp)/2.0;
-	  if(d_ramped == 0.0)
-	    d_state = ST_MUTED;
-	  break;
-	};
+          case ST_DECAY:
+            // FIXME: precalculate window for speed
+            d_envelope = 0.5-std::cos(M_PI*(--d_ramped)/d_ramp)/2.0;
+            if(d_ramped == 0.0) {
+              d_state = ST_MUTED;
+              add_item_tag(0, nitems_written(0) + j, d_eob_key, pmt::PMT_NIL);
+            }
+            break;
+        };
 
-	// If unmuted, copy input times envelope to output
-	// Otherwise, if not gating, copy zero to output
-	if(d_state != ST_MUTED)
-	  out[j++] = in[i]*d_envelope;
-	else
-	  if(!d_gate)
-	    out[j++] = 0.0;
+        // If unmuted, copy input times envelope to output
+        // Otherwise, if not gating, copy zero to output
+        if(d_state != ST_MUTED)
+          out[j++] = in[i]*d_envelope;
+        else
+          if(!d_gate)
+            out[j++] = 0.0;
       }
 
       consume_each(noutput_items);  // Use all the inputs

--- a/gr-analog/lib/squelch_base_ff_impl.h
+++ b/gr-analog/lib/squelch_base_ff_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_GR_SQUELCH_BASE_FF_IMPL_H
 
 #include <gnuradio/analog/squelch_base_ff.h>
+#include <pmt/pmt.h>
 
 namespace gr {
   namespace analog {
@@ -36,6 +37,8 @@ namespace gr {
       bool   d_gate;
       double d_envelope;
       enum { ST_MUTED, ST_ATTACK, ST_UNMUTED, ST_DECAY } d_state;
+      const pmt::pmt_t d_sob_key, d_eob_key;
+      bool d_tag_next_unmuted;
 
     protected:
       virtual void update_state(const float &sample) {};


### PR DESCRIPTION
The block will emit a tag with the key pmt::intern("squelch_sob") with the value of pmt::PMT_NIL on the first item it passes, and with the key pmt::intern("squelch:eob") on the last item it passes.

Added this to the `make` documentation.

Also: made the GRC XML's defaults reflect the C++ default args.

Also: indentation was mixed; unified the paragraphs I worked on.