### PR TITLE
qtgui: Fixes problem with half spectrum when set to 2048.

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
@@ -147,6 +147,7 @@ private:
 
   double d_start_frequency;
   double d_stop_frequency;
+  double d_center_frequency;
   double d_ymax;
   double d_ymin;
   bool   d_half_freq;

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -109,6 +109,7 @@ private:
 
   double d_start_frequency;
   double d_stop_frequency;
+  double d_center_frequency;
   int    d_xaxis_multiplier;
   bool   d_half_freq;
   bool   d_legend_enabled;

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -290,7 +290,7 @@ FrequencyDisplayPlot::setFrequencyRange(const double centerfreq,
   double startFreq;
   double stopFreq = (centerfreq + bandwidth/2.0f) / units;
   if(d_half_freq)
-    startFreq = 0;
+    startFreq = centerfreq / units;
   else
     startFreq = (centerfreq - bandwidth/2.0f) / units;
 
@@ -303,6 +303,7 @@ FrequencyDisplayPlot::setFrequencyRange(const double centerfreq,
   if(stopFreq > startFreq) {
     d_start_frequency = startFreq;
     d_stop_frequency = stopFreq;
+    d_center_frequency = centerfreq / units;
 
     if((axisScaleDraw(QwtPlot::xBottom) != NULL) && (d_zoomer != NULL)) {
       double display_units = ceil(log10(units)/2.0);
@@ -493,7 +494,7 @@ FrequencyDisplayPlot::setPlotPosHalf(bool half)
 {
   d_half_freq = half;
   if(half)
-    d_start_frequency = 0;
+    d_start_frequency = d_center_frequency;
 }
 
 

--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -138,7 +138,7 @@ WaterfallDisplayPlot::WaterfallDisplayPlot(int nplots, QWidget* parent)
   d_stop_frequency = 1;
 
   resize(parent->width(), parent->height());
-  d_numPoints = 1024;
+  d_numPoints = 0;
   d_half_freq = false;
   d_legend_enabled = true;
 
@@ -230,7 +230,7 @@ WaterfallDisplayPlot::setFrequencyRange(const double centerfreq,
   double startFreq;
   double stopFreq = (centerfreq + bandwidth/2.0f) / units;
   if(d_half_freq)
-    startFreq = 0;
+    startFreq = centerfreq / units;
   else
     startFreq = (centerfreq - bandwidth/2.0f) / units;
 
@@ -244,6 +244,7 @@ WaterfallDisplayPlot::setFrequencyRange(const double centerfreq,
   if(stopFreq > startFreq) {
     d_start_frequency = startFreq;
     d_stop_frequency = stopFreq;
+    d_center_frequency = centerfreq / units;
 
     if((axisScaleDraw(QwtPlot::xBottom) != NULL) && (d_zoomer != NULL)) {
       double display_units = ceil(log10(units)/2.0);
@@ -633,7 +634,7 @@ WaterfallDisplayPlot::setPlotPosHalf(bool half)
 {
   d_half_freq = half;
   if(half)
-    d_start_frequency = 0;
+    d_start_frequency = d_center_frequency;
 }
 
 


### PR DESCRIPTION
Same issue we saw before in Issue # 767; fixed in commit
fce06576a937bf16f12b012e2739e07ad8860f67

Also provides a fix for the half spectrum case when a center frequency
is specified. Used to pin it to 0.