### PR TITLE
Fixed garbled Doxygen formatting of channel map

### DIFF
--- a/gr-filter/include/gnuradio/filter/pfb_channelizer_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_channelizer_ccf.h
@@ -165,10 +165,11 @@ namespace gr {
 
       /*!
        * Set the channel map. Channels are numbers as:
-       *
-       *     N/2+1 | ... | N-1 | 0 | 1 |  2 | ... | N/2
-       *    <------------------- 0 -------------------->
-       *                        freq
+       * <pre>
+       *  N/2+1 | ... | N-1 | 0 | 1 |  2 | ... | N/2
+       * <------------------- 0 -------------------->
+       *                     freq
+       * </pre>
        *
        * So output stream 0 comes from channel 0, etc. Setting a new
        * channel map allows the user to specify which channel in frequency

--- a/gr-filter/include/gnuradio/filter/pfb_synthesizer_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_synthesizer_ccf.h
@@ -123,9 +123,11 @@ namespace gr {
 
       /*!
        * Set the channel map. Channels are numbers as:
-       *     N/2+1 | ... | N-1 | 0 | 1 |  2 | ... | N/2
-       *    <------------------- 0 -------------------->
-       *                        freq
+       * <pre>
+       *  N/2+1 | ... | N-1 | 0 | 1 |  2 | ... | N/2
+       * <------------------- 0 -------------------->
+       *                    freq
+       * </pre>
        *
        * So input stream 0 goes to channel 0, etc. Setting a new channel
        * map allows the user to specify where in frequency he/she wants


### PR DESCRIPTION
used to be

> Channels are numbers as: N/2+1 | ... | N-1 | 0 | 1 | 2 | ... | N/2 <----------------— 0 -----------------—> freq

in one line, due to doxygen not formatting as preformatted text.

Used `<pre>` to fix that.