### PR TITLE
Burst shaping blocks

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/qa_tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_tag_utils.py
@@ -76,6 +76,38 @@ class test_tag_utils (gr_unittest.TestCase):
         self.assertTrue(pmt.equal(t_tuple.value, value))
         self.assertEqual(t_tuple.offset, offset)
 
+    def test_003(self):
+        offsets = (6, 3, 8)
+        key = pmt.string_to_symbol('key')
+        srcid = pmt.string_to_symbol('qa_tag_utils')
+        tags = []
+
+        for k in offsets:
+            t = gr.tag_t()
+            t.offset = k
+            t.key = key
+            t.value = pmt.from_long(k)
+            t.srcid = srcid
+            tags.append(t)
+
+        for k, t in zip(sorted(offsets),
+                        sorted(tags, key=gr.tag_t_offset_compare_key())):
+            self.assertEqual(t.offset, k)
+            self.assertTrue(pmt.equal(t.key, key))
+            self.assertTrue(pmt.equal(t.value, pmt.from_long(k)))
+            self.assertTrue(pmt.equal(t.srcid, srcid))
+
+        tmin = min(tags, key=gr.tag_t_offset_compare_key())
+        self.assertEqual(tmin.offset, min(offsets))
+        self.assertTrue(pmt.equal(tmin.key, key))
+        self.assertTrue(pmt.equal(tmin.value, pmt.from_long(min(offsets))))
+        self.assertTrue(pmt.equal(tmin.srcid, srcid))
+
+        tmax = max(tags, key=gr.tag_t_offset_compare_key())
+        self.assertEqual(tmax.offset, max(offsets))
+        self.assertTrue(pmt.equal(tmax.key, key))
+        self.assertTrue(pmt.equal(tmax.value, pmt.from_long(max(offsets))))
+        self.assertTrue(pmt.equal(tmax.srcid, srcid))
 
 
 if __name__ == '__main__':

--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -108,3 +108,36 @@ def python_to_tag(tag_struct):
         return tag
     else:
         return None
+
+def tag_t_offset_compare_key():
+    """
+    Convert a tag_t_offset_compare function into a key=function
+    This method is modeled after functools.cmp_to_key(_func_).
+    It can be used by functions that accept a key function, such as
+    sorted(), min(), max(), etc. to compare tags by their offsets,
+    e.g., sorted(tag_list, key=gr.tag_t_offset_compare_key()).
+    """
+    class K(object):
+        def __init__(self, obj, *args):
+            self.obj = obj
+        def __lt__(self, other):
+            # x.offset < y.offset
+            return gr.tag_t_offset_compare(self.obj, other.obj)
+        def __gt__(self, other):
+            # y.offset < x.offset
+            return gr.tag_t_offset_compare(other.obj, self.obj)
+        def __eq__(self, other):
+            # not (x.offset < y.offset) and not (y.offset < x.offset)
+            return not gr.tag_t_offset_compare(self.obj, other.obj) and \
+                   not gr.tag_t_offset_compare(other.obj, self.obj)
+        def __le__(self, other):
+            # not (y.offset < x.offset)
+            return not gr.tag_t_offset_compare(other.obj, self.obj)
+        def __ge__(self, other):
+            # not (x.offset < y.offset)
+            return not gr.tag_t_offset_compare(self.obj, other.obj)
+        def __ne__(self, other):
+            # (x.offset < y.offset) or (y.offset < x.offset)
+            return gr.tag_t_offset_compare(self.obj, other.obj) or \
+                   gr.tag_t_offset_compare(other.obj, self.obj)
+    return K

--- a/gr-digital/include/gnuradio/digital/burst_shaper_XX.h.t
+++ b/gr-digital/include/gnuradio/digital/burst_shaper_XX.h.t
@@ -49,7 +49,15 @@ namespace gr {
      * directly to the head and tail of each burst.
      *
      * Length tags will be updated to include the length of any added
-     * zero padding or phasing symbols.
+     * zero padding or phasing symbols and will be placed at the
+     * beginning of the modified tagged stream. Any other tags found at
+     * the same offset as a length tag will also be placed at the
+     * beginning of the modified tagged stream, since these tags are
+     * assumed to be associated with the burst rather than a specific
+     * sample. For example, if "tx_time" tags are used to control
+     * bursts, their offsets should be consistent with their associated
+     * burst's length tags. Tags at other offsets will be placed with
+     * the samples on which they were found.
      *
      * \li input: stream of @I_TYPE@
      * \li output: stream of @O_TYPE@

--- a/gr-digital/lib/burst_shaper_XX_impl.cc.t
+++ b/gr-digital/lib/burst_shaper_XX_impl.cc.t
@@ -68,7 +68,6 @@ namespace gr {
         d_ncopy(0),
         d_limit(0),
         d_index(0),
-        d_nprocessed(0),
         d_finished(false),
         d_state(STATE_WAIT)
     {
@@ -118,7 +117,7 @@ namespace gr {
         get_tags_in_window(length_tags, 0, 0, ninput_items[0], d_length_tag_key);
         get_tags_in_window(tags, 0, 0, ninput_items[0]);
         std::sort(length_tags.rbegin(), length_tags.rend(), tag_t::offset_compare);
-        std::sort(tags.rbegin(), tags.rend(), tag_t::offset_compare);
+        std::sort(tags.begin(), tags.end(), tag_t::offset_compare);
 
         while((nwritten < noutput_items) && (nread < ninput_items[0])) {
             if(d_finished) {
@@ -128,11 +127,11 @@ namespace gr {
             nspace = noutput_items - nwritten;
             switch(d_state) {
                 case(STATE_WAIT):
-                    if(!tags.empty()) {
-                        curr_tag_index = tags.back().offset;
-                        d_ncopy = pmt::to_long(tags.back().value);
-                        tags.pop_back();
-                        nskip = (int)(curr_tag_index - d_nprocessed);
+                    if(!length_tags.empty()) {
+                        curr_tag_index = length_tags.back().offset;
+                        d_ncopy = pmt::to_long(length_tags.back().value);
+                        length_tags.pop_back();
+                        nskip = (int)(curr_tag_index - nread - nitems_read(0));
                         add_length_tag(nwritten);
                         enter_prepad();
                     }
@@ -144,7 +143,7 @@ namespace gr {
                                     boost::format("Dropping %1% samples") %
                                     nskip);
                         nread += nskip;
-                        d_nprocessed += nskip;
+                        in += nskip;
                     }
                     break;
 
@@ -274,7 +273,6 @@ namespace gr {
     void
     @IMPL_NAME@::enter_wait() {
         d_finished = true;
-        d_nprocessed += d_ncopy;
         d_index = 0;
         d_state = STATE_WAIT;
     }

--- a/gr-digital/lib/burst_shaper_XX_impl.h.t
+++ b/gr-digital/lib/burst_shaper_XX_impl.h.t
@@ -48,6 +48,7 @@ namespace gr {
       int d_ncopy;
       int d_limit;
       int d_index;
+      uint64_t d_length_tag_offset;
       bool d_finished;
       state_t d_state;
 
@@ -57,7 +58,7 @@ namespace gr {
       void apply_ramp(@O_TYPE@ *&dst, const @I_TYPE@ *&src, int &nwritten,
                       int &nread, int nspace);
       void add_length_tag(int offset);
-      void propagate_tags(std::vector<tag_t> &tags, int offset);
+      void propagate_tags(int in_offset, int out_offset, int count, bool skip=true);
       void enter_wait();
       void enter_prepad();
       void enter_rampup();

--- a/gr-digital/lib/burst_shaper_XX_impl.h.t
+++ b/gr-digital/lib/burst_shaper_XX_impl.h.t
@@ -48,7 +48,6 @@ namespace gr {
       int d_ncopy;
       int d_limit;
       int d_index;
-      uint64_t d_nprocessed;
       bool d_finished;
       state_t d_state;
 

--- a/gr-digital/python/digital/qa_burst_shaper.py
+++ b/gr-digital/python/digital/qa_burst_shaper.py
@@ -25,6 +25,7 @@ from gnuradio import gr, gr_unittest
 from gnuradio import blocks, digital
 import pmt
 import numpy as np
+import sys
 
 def make_length_tag(offset, length):
     return gr.python_to_tag({'offset' : offset,
@@ -32,13 +33,15 @@ def make_length_tag(offset, length):
                              'value' : pmt.from_long(length),
                              'srcid' : pmt.intern('qa_burst_shaper')})
 
+def make_tag(offset, key, value):
+    return gr.python_to_tag({'offset' : offset,
+                             'key' : pmt.intern(key),
+                             'value' : value,
+                             'srcid' : pmt.intern('qa_burst_shaper')})
+
 def compare_tags(a, b):
-    a = gr.tag_to_python(a)
-    b = gr.tag_to_python(b)
-    return a.key == b.key and a.offset == b.offset and \
-           a.value == b.value
-    #return a.key == b.key and a.offset == b.offset and \
-    #       a.srcid == b.srcid and a.value == b.value
+    return a.offset == b.offset and pmt.equal(a.key, b.key) and \
+           pmt.equal(a.value, b.value)
 
 class qa_burst_shaper (gr_unittest.TestCase):
 
@@ -275,6 +278,62 @@ class qa_burst_shaper (gr_unittest.TestCase):
         self.assertFloatTuplesAlmostEqual(sink.data(), expected, 6)
         for i in xrange(len(etags)):
             self.assertTrue(compare_tags(sink.tags()[i], etags[i]))
+
+    def test_tag_propagation (self):
+        prepad = 10
+        postpad = 10
+        length1 = 15
+        length2 = 25
+        gap_len = 5
+        lentag1_offset = 0
+        lentag2_offset = length1 + gap_len
+        tag1_offset = 0                     # accompanies first length tag
+        tag2_offset = length1 + gap_len     # accompanies second length tag
+        tag3_offset = 2                     # in ramp-up state
+        tag4_offset = length1 + 2           # in gap; tag will be dropped
+        tag5_offset = length1 + gap_len + 7 # in copy state
+
+        data = np.concatenate((np.ones(length1), np.zeros(gap_len),
+                               -1.0*np.ones(length2), np.zeros(10)))
+        window = np.concatenate((-2.0*np.ones(5), -4.0*np.ones(5)))
+        tags = (make_length_tag(lentag1_offset, length1),
+                make_length_tag(lentag2_offset, length2),
+                make_tag(tag1_offset, 'head', pmt.intern('tag1')),
+                make_tag(tag2_offset, 'head', pmt.intern('tag2')),
+                make_tag(tag3_offset, 'body', pmt.intern('tag3')),
+                make_tag(tag4_offset, 'body', pmt.intern('tag4')),
+                make_tag(tag5_offset, 'body', pmt.intern('tag5')))
+        expected = np.concatenate((np.zeros(prepad), window[0:5],
+                                   np.ones(length1 - len(window)), window[5:10],
+                                   np.zeros(postpad + prepad), -1.0*window[0:5],
+                                   -1.0*np.ones(length2 - len(window)),
+                                   -1.0*window[5:10], np.zeros(postpad)))
+        elentag1_offset = 0
+        elentag2_offset = length1 + prepad + postpad
+        etag1_offset = 0
+        etag2_offset = elentag2_offset
+        etag3_offset = prepad + tag3_offset
+        etag5_offset = 2*prepad + postpad + tag5_offset - gap_len
+        etags = (make_length_tag(elentag1_offset, length1 + prepad + postpad),
+                 make_length_tag(elentag2_offset, length2 + prepad + postpad),
+                 make_tag(etag1_offset, 'head', pmt.intern('tag1')),
+                 make_tag(etag2_offset, 'head', pmt.intern('tag2')),
+                 make_tag(etag3_offset, 'body', pmt.intern('tag3')),
+                 make_tag(etag5_offset, 'body', pmt.intern('tag5')))
+
+        # flowgraph
+        source = blocks.vector_source_f(data, tags=tags)
+        shaper = digital.burst_shaper_ff(window, pre_padding=prepad,
+                                         post_padding=postpad)
+        sink = blocks.vector_sink_f()
+        self.tb.connect(source, shaper, sink)
+        self.tb.run ()
+
+        # checks
+        self.assertFloatTuplesAlmostEqual(sink.data(), expected, 6)
+        for x, y in zip(sorted(sink.tags(), key=gr.tag_t_offset_compare_key()),
+                        sorted(etags, key=gr.tag_t_offset_compare_key())):
+            self.assertTrue(compare_tags(x, y))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These commits add tag propagation to the burst_shaper_XX blocks. Tags found at the same offset as a length tag are placed on the output at the beginning of padding/phasing samples. This allows tags like "tx_time" to stay in sync with the length tag. Tags found at other offsets are kept with their associated sample.

This also fixes a bug in which the read pointer would not advance if samples are dropped due to nonconsecutive tagged streams, i.e., if a new length tag is not found on the sample immediately after the last tagged stream.

Finally, this adds support for passing a key to sorted()/min()/max()/etc. for tag comparisons. The implementation of gr.tag_t_offset_compare does not work as a key.