### PR TITLE
Tag work

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tags.h
+++ b/gnuradio-runtime/include/gnuradio/tags.h
@@ -60,6 +60,18 @@ namespace gr {
       return (t.key == key) && (t.value == value) && \
       (t.srcid == srcid) && (t.offset == offset);
     }
+
+    tag_t()
+      : offset(0),
+        key(pmt::PMT_NIL),
+        value(pmt::PMT_NIL),
+        srcid(pmt::PMT_F)    // consistent with default srcid value in block::add_item_tag
+    {
+    }
+
+    ~tag_t()
+    {
+    }
   };
 
 } /* namespace gr */

--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -8,7 +8,7 @@ class PythonTag(object):
         self.offset = None
         self.key    = None
         self.value  = None
-        self.srcid  = pmt.PMT_F
+        self.srcid  = False
 
 def tag_to_python(tag):
     """ Convert a stream tag to a Python-readable object """

--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -8,7 +8,7 @@ class PythonTag(object):
         self.offset = None
         self.key    = None
         self.value  = None
-        self.srcid  = None
+        self.srcid  = pmt.PMT_F
 
 def tag_to_python(tag):
     """ Convert a stream tag to a Python-readable object """

--- a/gr-blocks/lib/vector_source_X_impl.cc.t
+++ b/gr-blocks/lib/vector_source_X_impl.cc.t
@@ -133,7 +133,8 @@ namespace gr {
         }
         for(unsigned t = 0; t < d_tags.size(); t++) {
           if((d_tags[t].offset >= d_offset) && (d_tags[t].offset < d_offset+n))
-            add_item_tag(0, d_tags[t].offset, d_tags[t].key, d_tags[t].value);
+            add_item_tag(0, d_tags[t].offset, d_tags[t].key, d_tags[t].value,
+                         d_tags[t].srcid);
         }
         d_offset += n;
         return n/d_vlen;

--- a/gr-blocks/python/blocks/qa_vector_sink_source.py
+++ b/gr-blocks/python/blocks/qa_vector_sink_source.py
@@ -21,7 +21,21 @@
 #
 
 from gnuradio import gr, gr_unittest, blocks
+import pmt
 import math
+
+def make_tag(key, value, offset, srcid=None):
+    tag = gr.tag_t()
+    tag.key = pmt.string_to_symbol(key)
+    tag.value = pmt.to_pmt(value)
+    tag.offset = offset
+    if srcid is not None:
+        tag.srcid = pmt.to_pmt(srcid)
+    return tag
+
+def compare_tags(a, b):
+    return a.offset == b.offset and pmt.equal(a.key, b.key) and \
+           pmt.equal(a.value, b.value) and pmt.equal(a.srcid, b.srcid)
 
 class test_vector_sink_source(gr_unittest.TestCase):
 
@@ -59,6 +73,44 @@ class test_vector_sink_source(gr_unittest.TestCase):
         src_data = [float(x) for x in range(16)]
         expected_result = tuple(src_data)
         self.assertRaises(RuntimeError, lambda : blocks.vector_source_f(src_data, False, 3))
+
+    def test_004(self):
+        src_data = [float(x) for x in range(16)]
+        expected_result = tuple(src_data)
+        src_tags = tuple([make_tag('key', 'val', 0, 'src')])
+        expected_tags = src_tags[:]
+
+        src = blocks.vector_source_f(src_data, repeat=False, tags=src_tags)
+        dst = blocks.vector_sink_f()
+
+        self.tb.connect(src, dst)
+        self.tb.run()
+        result_data = dst.data()
+        result_tags = dst.tags()
+        self.assertEqual(expected_result, result_data)
+        self.assertEqual(len(result_tags), 1)
+        self.assertTrue(compare_tags(expected_tags[0], result_tags[0]))
+
+    def test_005(self):
+        length = 16
+        src_data = [float(x) for x in range(length)]
+        expected_result = tuple(src_data + src_data)
+        src_tags = tuple([make_tag('key', 'val', 0, 'src')])
+        expected_tags = tuple([make_tag('key', 'val', 0, 'src'),
+                               make_tag('key', 'val', length, 'src')])
+
+        src = blocks.vector_source_f(src_data, repeat=True, tags=src_tags)
+        head = blocks.head(gr.sizeof_float, 2*length)
+        dst = blocks.vector_sink_f()
+
+        self.tb.connect(src, head, dst)
+        self.tb.run()
+        result_data = dst.data()
+        result_tags = dst.tags()
+        self.assertEqual(expected_result, result_data)
+        self.assertEqual(len(result_tags), 2)
+        self.assertTrue(compare_tags(expected_tags[0], result_tags[0]))
+        self.assertTrue(compare_tags(expected_tags[1], result_tags[1]))
 
 if __name__ == '__main__':
     gr_unittest.run(test_vector_sink_source, "test_vector_sink_source.xml")


### PR DESCRIPTION
These commits probably deserve some discussion. I discovered that `vector_source_X` did not propagate a `srcid` when not using repeating mode. When testing out a fix, this broke QA tests for a few blocks. It turns out that these QA tests instantiate `gr.tag_t`'s and fill in `offset`, `key`, and `value` fields while leaving `srcid` blank. The problem is that the default constructor inferred by the compiler doesn't initialize the fields to anything meaningful, so referencing a field before setting it causes a segfault. As an example of this segfault, try this:

```python
from gnuradio import gr
t = gr.tag_t()
print t.srcid
```
I solved this problem by adding a default constructor and a default destructor to `gr::tag_t`. It sets `offset` to 0, `key` and `value` to `pmt::PMT_NIL`, and `srcid` to `pmt::PMT_F` to be consistent with the default `srcid` argument in `gr::block::add_item_tag`. Perhaps for 3.8 we should investigate setting this to `pmt::PMT_NIL`, which makes more sense to me.

Finally, I noticed that vector sink/source QA code did not have any tag tests, so I added these. All QA tests passed on my machine after making these changes.