### PR TITLE
Provide correct URLs in the doxygen build guide

### DIFF
--- a/docs/doxygen/other/build_guide.dox
+++ b/docs/doxygen/other/build_guide.dox
@@ -24,11 +24,11 @@ installation tool (apt-get, pkg_install, YaST, yum, urpmi, etc.)
 first. Most recent systems have these packages available.
 
 \subsection dep_global Global Dependencies
-\li git                      http://code.google.com/p/msysgit
+\li git                      http://git-scm.com/downloads
 \li cmake       (>= 2.6.3)   http://www.cmake.org/cmake/resources/software.html
-\li boost       (>= 1.35)    http://www.boostpro.com/download
-\li cppunit     (>= 1.9.14)  http://gaiacrtn.free.fr/cppunit/index.html
-\li fftw3f      (>= 3.0.1)   http://www.fftw.org/install/windows.html
+\li boost       (>= 1.35)    http://www.boost.org/users/download/
+\li cppunit     (>= 1.9.14)  http://freedesktop.org/wiki/Software/cppunit/
+\li fftw3f      (>= 3.0.1)   http://www.fftw.org/download.html
 
 \subsection dep_python Python Wrappers
 \li python      (>= 2.5)     http://www.python.org/download/


### PR DESCRIPTION
The previous URLs were directed to windows packages. The current ones
direct to correct URLS.