### PR TITLE
digital: additive scrambler cleanup

### DIFF
--- a/gr-digital/grc/digital_additive_scrambler_bb.xml
+++ b/gr-digital/grc/digital_additive_scrambler_bb.xml
@@ -8,7 +8,7 @@
 	<name>Additive Scrambler</name>
 	<key>digital_additive_scrambler_bb</key>
 	<import>from gnuradio import digital</import>
-	<make>digital.additive_scrambler_bb($mask, $seed, $len, $count, reset_tag_key=$reset_tag_key)</make>
+	<make>digital.additive_scrambler_bb($mask, $seed, $len, count=$count, bits_per_byte=$bits_per_byte, reset_tag_key=$reset_tag_key)</make>
 	<param>
 		<name>Mask</name>
 		<key>mask</key>
@@ -34,9 +34,15 @@
 		<type>int</type>
 	</param>
 	<param>
+		<name>Bits per byte</name>
+		<key>bits_per_byte</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<param>
 		<name>Reset tag key</name>
 		<key>reset_tag_key</key>
-		<value></value>
+		<value>""</value>
 		<type>string</type>
 	</param>
 	<sink>

--- a/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
@@ -28,7 +28,7 @@
 
 namespace gr {
   namespace digital {
-    
+
     /*!
      * \ingroup coding_blk
      *

--- a/gr-digital/lib/additive_scrambler_bb_impl.cc
+++ b/gr-digital/lib/additive_scrambler_bb_impl.cc
@@ -29,7 +29,7 @@
 
 namespace gr {
   namespace digital {
-    
+
     additive_scrambler_bb::sptr
     additive_scrambler_bb::make (int mask, int seed,
 				 int len, int count,
@@ -67,8 +67,8 @@ namespace gr {
     }
 
     int
-    additive_scrambler_bb_impl::mask() const 
-    { 
+    additive_scrambler_bb_impl::mask() const
+    {
       return d_lfsr.mask();
     }
 

--- a/gr-digital/lib/additive_scrambler_bb_impl.h
+++ b/gr-digital/lib/additive_scrambler_bb_impl.h
@@ -28,7 +28,7 @@
 
 namespace gr {
   namespace digital {
-    
+
     class additive_scrambler_bb_impl
       : public additive_scrambler_bb
     {


### PR DESCRIPTION
Added missing `bits_per_byte` parameter and cleaned up formatting of defaults in additive scrambler GRC block; cleaned up whitespace in C++ files.