### PR TITLE
Controlport/cleaning up

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcpmtconverters_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcpmtconverters_thrift.h
@@ -34,6 +34,7 @@ namespace rpcpmtconverter
 
   struct to_pmt_f {
     to_pmt_f() {;}
+    virtual ~to_pmt_f() {}
     virtual pmt::pmt_t operator()(const GNURadio::Knob& knob);
   };
 

--- a/gnuradio-runtime/include/gnuradio/thrift_application_base.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_application_base.h
@@ -197,14 +197,11 @@ thrift_application_base<TserverBase, TserverClass>::thrift_application_base(Tser
 {
   gr::configure_default_loggers(d_logger, d_debug_logger, "controlport");
   d_application = _app;
-  //GR_LOG_DEBUG(d_debug_logger, "thrift_application_base: ctor");
 }
 
 template<typename TserverBase, typename TserverClass>
 void thrift_application_base<TserverBase, TserverClass>::start_application()
 {
-  //std::cerr << "thrift_application_base: start_application" << std::endl;
-
   unsigned int max_init_attempts = \
     static_cast<unsigned int>(gr::prefs::singleton()->get_long("thrift", "init_attempts",
                                                                d_default_max_init_attempts));
@@ -220,7 +217,8 @@ void thrift_application_base<TserverBase, TserverClass>::start_application()
     }
 
     if(!app_started) {
-      std::cerr << "thrift_application_base::start_application(), timeout waiting to port number might have failed?" << std::endl;
+      GR_WARN("thrift", "thrift_application_base::start_application(), "
+              "timeout waiting to port number might have failed?");
     }
 
     p_impl->d_application_initilized = true;

--- a/gnuradio-runtime/include/gnuradio/thrift_server_template.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_server_template.h
@@ -80,13 +80,13 @@ private:
 };
 
 template<typename TserverBase, typename TserverClass, typename TImplClass>
-thrift_server_template<TserverBase, TserverClass, TImplClass>::thrift_server_template
-(TImplClass* _this) : thrift_application_base<TserverBase, TImplClass>(_this),
-d_handler(new TserverClass()),
-d_processor(new GNURadio::ControlPortProcessor(d_handler)),
-d_serverTransport(),
-d_transportFactory(),
-d_protocolFactory(new thrift::protocol::TBinaryProtocolFactory())
+thrift_server_template<TserverBase, TserverClass, TImplClass>::thrift_server_template(TImplClass* _this)
+  : thrift_application_base<TserverBase, TImplClass>(_this),
+    d_handler(new TserverClass()),
+    d_processor(new GNURadio::ControlPortProcessor(d_handler)),
+    d_serverTransport(),
+    d_transportFactory(),
+    d_protocolFactory(new thrift::protocol::TBinaryProtocolFactory())
 {
   gr::logger_ptr logger, debug_logger;
   gr::configure_default_loggers(logger, debug_logger, "controlport");
@@ -101,39 +101,45 @@ d_protocolFactory(new thrift::protocol::TBinaryProtocolFactory())
   // Collect configuration options from the Thrift config file;
   // defaults if the config file doesn't exist or list the specific
   // options.
-  port = static_cast<unsigned int>(gr::prefs::singleton()->get_long("thrift", "port",
-                                                                    thrift_application_base<TserverBase, TImplClass>::d_default_thrift_port));
-  nthreads = static_cast<unsigned int>(gr::prefs::singleton()->get_long("thrift", "nthreads",
-                                                                        thrift_application_base<TserverBase, TImplClass>::d_default_num_thrift_threads));
-  buffersize = static_cast<unsigned int>(gr::prefs::singleton()->get_long("thrift", "buffersize",
-                                                                          thrift_application_base<TserverBase, TImplClass>::d_default_thrift_buffer_size));
+  port = static_cast<unsigned int>
+    (gr::prefs::singleton()->get_long("thrift", "port",
+                                      thrift_application_base<TserverBase,
+                                      TImplClass>::d_default_thrift_port));
+  nthreads = static_cast<unsigned int>
+    (gr::prefs::singleton()->get_long("thrift", "nthreads",
+                                      thrift_application_base<TserverBase,
+                                      TImplClass>::d_default_num_thrift_threads));
+  buffersize = static_cast<unsigned int>
+    (gr::prefs::singleton()->get_long("thrift", "buffersize",
+                                      thrift_application_base<TserverBase,
+                                      TImplClass>::d_default_thrift_buffer_size));
 
   d_serverTransport.reset(new thrift::transport::TServerSocket(port));
 
   d_transportFactory.reset(new thrift_server_template::TBufferedTransportFactory(buffersize));
 
-
   if(nthreads <= 1) {
-      // "Thrift: Single-threaded server"
-      //std::cout << "Thrift Single-threaded server" << std::endl;
-      thrift_application_base<TserverBase, TImplClass>::d_thriftserver.reset(
-          new thrift::server::TSimpleServer(d_processor, d_serverTransport, d_transportFactory, d_protocolFactory));
+    // "Thrift: Single-threaded server"
+    //std::cout << "Thrift Single-threaded server" << std::endl;
+    thrift_application_base<TserverBase, TImplClass>::d_thriftserver.reset
+      (new thrift::server::TSimpleServer(d_processor, d_serverTransport,
+                                         d_transportFactory, d_protocolFactory));
   }
   else {
-      //std::cout << "Thrift Multi-threaded server : " << d_nthreads << std::endl;
-      boost::shared_ptr<thrift::concurrency::ThreadManager> threadManager(
-          thrift::concurrency::ThreadManager::newSimpleThreadManager(nthreads));
+    //std::cout << "Thrift Multi-threaded server : " << d_nthreads << std::endl;
+    boost::shared_ptr<thrift::concurrency::ThreadManager> threadManager
+      (thrift::concurrency::ThreadManager::newSimpleThreadManager(nthreads));
 
-      threadManager->threadFactory(
-          boost::shared_ptr<thrift::concurrency::PlatformThreadFactory>(
-              new thrift::concurrency::PlatformThreadFactory()));
+    threadManager->threadFactory
+      (boost::shared_ptr<thrift::concurrency::PlatformThreadFactory>
+       (new thrift::concurrency::PlatformThreadFactory()));
 
-      threadManager->start();
+    threadManager->start();
 
-      thrift_application_base<TserverBase, TImplClass>::d_thriftserver.reset(
-          new thrift::server::TThreadPoolServer(d_processor, d_serverTransport,
-                                                d_transportFactory, d_protocolFactory,
-                                                threadManager));
+    thrift_application_base<TserverBase, TImplClass>::d_thriftserver.reset
+      (new thrift::server::TThreadPoolServer(d_processor, d_serverTransport,
+                                             d_transportFactory, d_protocolFactory,
+                                             threadManager));
   }
 }
 

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -208,20 +208,23 @@ add_dependencies(gnuradio-runtime
 # STATIC LIB BUILD
 #######################################################
 if(ENABLE_STATIC_LIBS)
-  # Remove controlport-specific source files from staticlibs build
+  # Remove controlport-specific source files from staticlibs build if
+  # ICE is the backend since it does not build statically.
   if(ENABLE_GR_CTRLPORT)
-    list(REMOVE_ITEM gnuradio_runtime_sources
-      ${gnuradio_ctrlport_sources}
-      )
+    if(ICE_FOUND)
+      list(REMOVE_ITEM gnuradio_runtime_sources
+        ${gnuradio_ctrlport_sources}
+        )
 
-    # Remove GR_CTRLPORT set this target's definitions.
-    # Makes sure we don't try to use ControlPort stuff in source files
-    GET_DIRECTORY_PROPERTY(STATIC_DEFS COMPILE_DEFINITIONS)
-    list(REMOVE_ITEM STATIC_DEFS "GR_CTRLPORT")
-    SET_PROPERTY(DIRECTORY PROPERTY COMPILE_DEFINITIONS "${STATIC_DEFS}")
+      # Remove GR_CTRLPORT set this target's definitions.
+      # Makes sure we don't try to use ControlPort stuff in source files
+      GET_DIRECTORY_PROPERTY(STATIC_DEFS COMPILE_DEFINITIONS)
+      list(REMOVE_ITEM STATIC_DEFS "GR_CTRLPORT")
+      SET_PROPERTY(DIRECTORY PROPERTY COMPILE_DEFINITIONS "${STATIC_DEFS}")
 
-    # readd it to the target since we removed it from the directory-wide list.
-    SET_PROPERTY(TARGET gnuradio-runtime APPEND PROPERTY COMPILE_DEFINITIONS "GR_CTRLPORT")
+      # readd it to the target since we removed it from the directory-wide list.
+      SET_PROPERTY(TARGET gnuradio-runtime APPEND PROPERTY COMPILE_DEFINITIONS "GR_CTRLPORT")
+    endif(ICE_FOUND)
   endif(ENABLE_GR_CTRLPORT)
 
   add_library(gnuradio-runtime_static STATIC ${gnuradio_runtime_sources})

--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -162,7 +162,7 @@ rpcpmtconverter::to_pmt_int_f::operator()(const GNURadio::Knob& knob)
 pmt::pmt_t
 rpcpmtconverter::to_pmt_long_f::operator()(const GNURadio::Knob& knob)
 {
-  return pmt::mp(knob.value.a_long);
+  return pmt::from_long(knob.value.a_long);
 }
 
 pmt::pmt_t

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc
@@ -124,7 +124,7 @@ bool thrift_application_base<rpcserver_base, rpcserver_booter_thrift>::applicati
 
     set_endpoint(endpoint);
 
-    GR_LOG_INFO(d_logger, "Apache Thrift: " + endpoint);
+    GR_INFO("thrift_application_base", "Apache Thrift: " + endpoint);
     d_thirft_is_running = true;
     result = true;
   }

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -251,18 +251,20 @@ GR_LIBRARY_FOO(gnuradio-blocks RUNTIME_COMPONENT "blocks_runtime" DEVEL_COMPONEN
 if(ENABLE_STATIC_LIBS)
   # Remove controlport-specific source files from staticlibs build
   if(ENABLE_GR_CTRLPORT)
-    list(REMOVE_ITEM gr_blocks_sources
-      ${blocks_ctrlport_sources}
-      )
+    if(ICE_FOUND)
+      list(REMOVE_ITEM gr_blocks_sources
+        ${blocks_ctrlport_sources}
+        )
 
-    # Remove GR_CTRLPORT set this target's definitions.
-    # Makes sure we don't try to use ControlPort stuff in source files
-    GET_DIRECTORY_PROPERTY(STATIC_DEFS COMPILE_DEFINITIONS)
-    list(REMOVE_ITEM STATIC_DEFS "GR_CTRLPORT")
-    SET_PROPERTY(DIRECTORY PROPERTY COMPILE_DEFINITIONS "${STATIC_DEFS}")
+      # Remove GR_CTRLPORT set this target's definitions.
+      # Makes sure we don't try to use ControlPort stuff in source files
+      GET_DIRECTORY_PROPERTY(STATIC_DEFS COMPILE_DEFINITIONS)
+      list(REMOVE_ITEM STATIC_DEFS "GR_CTRLPORT")
+      SET_PROPERTY(DIRECTORY PROPERTY COMPILE_DEFINITIONS "${STATIC_DEFS}")
 
-    # readd it to the target since we removed it from the directory-wide list.
-    SET_PROPERTY(TARGET gnuradio-blocks APPEND PROPERTY COMPILE_DEFINITIONS "GR_CTRLPORT")
+      # readd it to the target since we removed it from the directory-wide list.
+      SET_PROPERTY(TARGET gnuradio-blocks APPEND PROPERTY COMPILE_DEFINITIONS "GR_CTRLPORT")
+    endif(ICE_FOUND)
   endif(ENABLE_GR_CTRLPORT)
 
   add_library(gnuradio-blocks_static STATIC ${gr_blocks_sources})


### PR DESCRIPTION
This mostly addresses issues I found with a newer version of Boost (1.58) and for cross compiling.