### PR TITLE
Fix minor grc issues in gr-digital:

### DIFF
--- a/gr-digital/grc/digital_header_payload_demux.xml
+++ b/gr-digital/grc/digital_header_payload_demux.xml
@@ -112,6 +112,7 @@
   <sink>
     <name>trigger</name>
     <type>byte</type>
+    <optional>1</optional>
   </sink>
   <sink>
     <name>header_data</name>

--- a/gr-digital/grc/digital_packet_headerparser_b_default.xml
+++ b/gr-digital/grc/digital_packet_headerparser_b_default.xml
@@ -19,7 +19,7 @@
     <type>byte</type>
   </sink>
   <source>
-    <name>out</name>
+    <name>header_data</name>
     <type>message</type>
   </source>
 </block>


### PR DESCRIPTION
* trigger sink of header_payload_demux should be optional
* message source of packet_headerparser_b_default is named
"header_data", not "out"