### PR TITLE
Avoid enforcing unnecessary build constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,6 @@
 # Boston, MA 02110-1301, USA.
 
 ########################################################################
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-    message(FATAL_ERROR "Prevented in-tree build. This is bad practice.")
-endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-
-########################################################################
 # Project setup
 ########################################################################
 cmake_minimum_required(VERSION 2.6)


### PR DESCRIPTION
Placing a build constraint in a CMakeLists.txt file like this can complicate build processes for downstream users.  While out-of-source builds are the modern way to build source code, in-source builds are still nevertheless a legitimate way to build code.  In this case, a warning message to the user is likely a more appropriate way to convey to a user the fact that they are using an outdated build strategy.