### PR TITLE
qtgui: adds ability to set the tag text and background colors.

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
@@ -37,6 +37,10 @@ class TimeDomainDisplayPlot: public DisplayPlot
 {
   Q_OBJECT
 
+  Q_PROPERTY ( QColor tag_text_color READ getTagTextColor WRITE setTagTextColor )
+  Q_PROPERTY ( QColor tag_background_color READ getTagBackgroundColor WRITE setTagBackgroundColor )
+  Q_PROPERTY ( Qt::BrushStyle tag_background_style READ getTagBackgroundStyle WRITE setTagBackgroundStyle )
+
 public:
   TimeDomainDisplayPlot(int nplots, QWidget*);
   virtual ~TimeDomainDisplayPlot();
@@ -51,6 +55,10 @@ public:
   void stemPlot(bool en);
 
   double sampleRate() const;
+
+  const QColor getTagTextColor();
+  const QColor getTagBackgroundColor();
+  const Qt::BrushStyle getTagBackgroundStyle();
 
 public slots:
   void setSampleRate(double sr, double units,
@@ -72,6 +80,10 @@ public slots:
   void attachTriggerLines(bool en);
   void setTriggerLines(double x, double y);
 
+  void setTagTextColor(QColor c);
+  void setTagBackgroundColor(QColor c);
+  void setTagBackgroundStyle(Qt::BrushStyle b);
+
 private:
   void _resetXAxisPoints();
   void _autoScale(double bottom, double top);
@@ -87,6 +99,10 @@ private:
 
   std::vector< std::vector<QwtPlotMarker*> > d_tag_markers;
   std::vector<bool> d_tag_markers_en;
+
+  QColor d_tag_text_color;
+  QColor d_tag_background_color;
+  Qt::BrushStyle d_tag_background_style;
 
   QwtPlotMarker *d_trigger_lines[2];
 };

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -135,6 +135,10 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
   d_xdata = new double[d_numPoints];
   memset(d_xdata, 0x0, d_numPoints*sizeof(double));
 
+  d_tag_text_color = Qt::black;
+  d_tag_background_color = Qt::white;
+  d_tag_background_style = Qt::NoBrush;
+
   d_zoomer = new TimeDomainDisplayZoomer(canvas(), 0);
 
 #if QWT_VERSION < 0x060000
@@ -381,7 +385,14 @@ TimeDomainDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
               QString orig = (*mitr)->label().text();
               s << std::endl;
               orig.prepend(s.str().c_str());
-              (*mitr)->setLabel(orig);
+
+              QwtText newtext(orig);
+              newtext.setColor(getTagTextColor());
+
+              QBrush brush(getTagBackgroundColor(), getTagBackgroundStyle());
+              newtext.setBackgroundBrush(brush);
+
+              (*mitr)->setLabel(newtext);
             }
           }
 
@@ -597,6 +608,43 @@ TimeDomainDisplayPlot::enableTagMarker(int which, bool en)
   else
     throw std::runtime_error("TimeDomainDisplayPlot: enabled tag marker does not exist.\n");
 }
+
+const QColor
+TimeDomainDisplayPlot::getTagTextColor()
+{
+  return d_tag_text_color;
+}
+
+const QColor
+TimeDomainDisplayPlot::getTagBackgroundColor()
+{
+  return d_tag_background_color;
+}
+
+const Qt::BrushStyle
+TimeDomainDisplayPlot::getTagBackgroundStyle()
+{
+  return d_tag_background_style;
+}
+
+void
+TimeDomainDisplayPlot::setTagTextColor(QColor c)
+{
+  d_tag_text_color = c;
+}
+
+void
+TimeDomainDisplayPlot::setTagBackgroundColor(QColor c)
+{
+  d_tag_background_color = c;
+}
+
+void
+TimeDomainDisplayPlot::setTagBackgroundStyle(Qt::BrushStyle b)
+{
+  d_tag_background_style = b;
+}
+
 
 void
 TimeDomainDisplayPlot::setYLabel(const std::string &label,

--- a/gr-qtgui/themes/alt.qss
+++ b/gr-qtgui/themes/alt.qss
@@ -27,6 +27,12 @@ DisplayPlot {
     qproperty-axes_label_font_size: 18;
 }
 
+TimeDomainDisplayPlot {
+    qproperty-tag_text_color: blue;
+    qproperty-tag_background_color: grey;
+    qproperty-tag_background_style: Dense4Pattern;
+}
+
 WaterfallDisplayPlot {
     qproperty-intensity_color_map_type1: 5;
     qproperty-low_intensity_color: black;

--- a/gr-qtgui/themes/dark.qss
+++ b/gr-qtgui/themes/dark.qss
@@ -21,6 +21,12 @@ DisplayPlot {
     qproperty-axes_label_font_size: 18;
 }
 
+TimeDomainDisplayPlot {
+    qproperty-tag_text_color: blue;
+    qproperty-tag_background_color: grey;
+    qproperty-tag_background_style: Dense4Pattern;
+}
+
 WaterfallDisplayPlot {
     qproperty-intensity_color_map_type1: 1;
     qproperty-low_intensity_color: black;
@@ -122,5 +128,3 @@ QTabBar::tab:selected {
     background-color: rgb(200, 200, 200);
     color: black;
 }
-
-


### PR DESCRIPTION
The alt.qss and dark.qss set these values now so the text is not black
on a black canvas.

The qproperty-tag_background_style is a Qt::BrushStyle type:
http://doc.qt.io/qt-4.8/qt.html#BrushStyle-enum