### PR TITLE
fix a bug when updating lib/CMakeList.txt after remove a block which include QA C++ code

### DIFF
--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -155,8 +155,9 @@ class ModToolRemove(ModTool):
             self.scm.remove_file(f)
             os.unlink(f)
             print "Deleting occurrences of %s from %s/CMakeLists.txt..." % (b, path)
-            for var in makefile_vars:
-                ed.remove_value(var, b)
+            if re.match('lib/qa_\w*',f) is None:
+                for var in makefile_vars:
+                    ed.remove_value(var, b)
             if cmakeedit_func is not None:
                 cmakeedit_func(b, ed)
         ed.write()


### PR DESCRIPTION
Recent I try to test my OOT modules which is include several blocks. Add I found  CMake won't run successfully after I remove a block which includes QA C++ code.I took a weekend to find the reason of this bug and fixed it.
The reason of this bug is that the modtool_rm.py cann't delete the string "${CMAKE_CURRENT_SOURCE_DIR}/qa_block1.cc" in lib/CMakeList.txt correctly when I run the "gr_modtool rm block" command. Actually the code about deleting the sting is right, but the program will delete the string "qa_block1.cc" mistakenly before running the code. So when the program plan to delete the "${CMAKE_CURRENT_SOURCE_DIR}/qa_block1.cc", the string have not been existed.Finally, the lib/CMakeList.txt is not update correctly. 