### PR TITLE
fec: extended encoder now appends unpack_k_bits(8) block after encode…

### DIFF
--- a/gr-fec/python/fec/extended_encoder.py
+++ b/gr-fec/python/fec/extended_encoder.py
@@ -60,6 +60,9 @@ class extended_encoder(gr.hier_block2):
                                            gr.sizeof_char,
                                            gr.sizeof_char))
 
+        if fec.get_encoder_output_conversion(encoder_obj_list[0]) == "packed_bits":
+            self.blocks.append(blocks.packed_to_unpacked_bb(1, gr.GR_MSB_FIRST))
+
         if self.puncpat != '11':
             self.blocks.append(fec.puncture_bb(len(puncpat), read_bitlist(puncpat), 0))
 


### PR DESCRIPTION
extended encoder now appends blocks.packed_to_unpacked_bb(1, gr.GR_MSB_FIRST) block after encoder to satisfy get_output_conversion() = "packed_bits" behaviour.