### PR TITLE
qtgui: fixed issue with controlpanel in the frequency display.

### DIFF
--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -21,6 +21,7 @@
  */
 
 #include <gnuradio/qtgui/freqcontrolpanel.h>
+#include <cmath>
 
 FreqControlPanel::FreqControlPanel(FreqDisplayForm *form)
   : QVBoxLayout(),
@@ -245,7 +246,7 @@ FreqControlPanel::notifyAvgSlider(int val)
 void
 FreqControlPanel::toggleFFTSize(int val)
 {
-  int index = static_cast<int>(logf(static_cast<float>(val))/logf(2.0f)) - 5;
+  int index = static_cast<int>(round(logf(static_cast<float>(val))/logf(2.0f))) - 5;
   d_fft_size_combo->setCurrentIndex(index);
 }
 


### PR DESCRIPTION
The logf calculation might produce a value slightly less than the even
number it should, so casting it to an integer would round it
down. Using round() to fix the problem.