### PR TITLE
Change the default flowgraph window size to 3840x2160.  

### DIFF
--- a/grc/blocks/options.xml
+++ b/grc/blocks/options.xml
@@ -49,9 +49,9 @@ else: self.stop(); self.wait()</callback>
 		<hide>#if $description() then 'none' else 'part'#</hide>
 	</param>
 	<param>
-		<name>Window Size</name>
-		<key>window_size</key>
-		<value>1280, 1024</value>
+		<name>Window Size</name> 
+		<key>window_size</key><!--This is the flowgraph window size -->
+		<value>3840, 2160</value>
 		<type>int_vector</type>
 		<hide>part</hide>
 	</param>


### PR DESCRIPTION
I have a 4k monitor and I up-scale the text make it easier on the eyes.  The default flow graph size of 1280x1024 would only allow me to put in a handful of blocks.  This also allow people with two monitors to have the window across the two monitors.

Thank you,
James