### PR TITLE
float internally, double in API: Honest signatures for honest people

### DIFF
--- a/gr-analog/include/gnuradio/analog/frequency_modulator_fc.h
+++ b/gr-analog/include/gnuradio/analog/frequency_modulator_fc.h
@@ -47,7 +47,7 @@ namespace gr {
        *
        * \param sensitivity radians/sample = amplitude * sensitivity
        */
-      static sptr make(double sensitivity);
+      static sptr make(float sensitivity);
 
       virtual void set_sensitivity(float sens) = 0;
       virtual float sensitivity() const = 0;

--- a/gr-analog/lib/frequency_modulator_fc_impl.cc
+++ b/gr-analog/lib/frequency_modulator_fc_impl.cc
@@ -34,13 +34,13 @@ namespace gr {
   namespace analog {
 
     frequency_modulator_fc::sptr
-    frequency_modulator_fc::make(double sensitivity)
+    frequency_modulator_fc::make(float sensitivity)
     {
       return gnuradio::get_initial_sptr
 	(new frequency_modulator_fc_impl(sensitivity));
     }
 
-    frequency_modulator_fc_impl::frequency_modulator_fc_impl(double sensitivity)
+    frequency_modulator_fc_impl::frequency_modulator_fc_impl(float sensitivity)
       : sync_block("frequency_modulator_fc",
 		      io_signature::make(1, 1, sizeof(float)),
 		      io_signature::make(1, 1, sizeof(gr_complex))),

--- a/gr-analog/lib/frequency_modulator_fc_impl.h
+++ b/gr-analog/lib/frequency_modulator_fc_impl.h
@@ -35,7 +35,7 @@ namespace gr {
       float d_phase;
 
     public:
-      frequency_modulator_fc_impl(double sensitivity);
+      frequency_modulator_fc_impl(float sensitivity);
       ~frequency_modulator_fc_impl();
 
       void set_sensitivity(float sens) { d_sensitivity = sens; }


### PR DESCRIPTION
I can see why the API preferred to have double (for later implementation
changes). No one complained, so accuracy is probably sufficient. Time to
be honest about the signature.