### PR TITLE
cmake: add GR_MODULE(zeromq...)

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake
+++ b/cmake/Modules/GnuradioConfig.cmake
@@ -133,6 +133,7 @@ GR_MODULE(UHD gnuradio-uhd gnuradio/uhd/api.h gnuradio-uhd)
 GR_MODULE(VOCODER gnuradio-vocoder gnuradio/vocoder/api.h gnuradio-vocoder)
 GR_MODULE(WAVELET gnuradio-wavelet gnuradio/wavelet/api.h gnuradio-wavelet)
 GR_MODULE(WXGUI gnuradio-wxgui gnuradio/wxgui/api.h gnuradio-wxgui)
+GR_MODULE(ZEROMQ gnuradio-zeromq gnuradio/zeromq/api.h gnuradio-zeromq)
 GR_MODULE(PMT gnuradio-runtime pmt/pmt.h gnuradio-pmt)
 GR_MODULE(VOLK volk volk/volk.h volk)
 


### PR DESCRIPTION
This allows OOT modules to set it as a required component and use
the respective link and include directories.


Tested this with my OOT and it actually links against libgnuradio-zeromq with this patch. It's possible there are other lingering zeromq integration lines missing in subtle places though.