### PR TITLE
Volk dependency in gr-analog pkgconfig

### DIFF
--- a/gr-analog/gnuradio-analog.pc.in
+++ b/gr-analog/gnuradio-analog.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: gnuradio-analog
 Description: GNU Radio blocks for analog communications
-Requires: gnuradio-runtime
+Requires: gnuradio-runtime volk
 Version: @LIBVER@
 Libs: -L${libdir} -lgnuradio-analog
 Cflags: -I${includedir}


### PR DESCRIPTION
Projects cannot link to gnuradio-analog without this change.

```
/usr/bin/ld: warning: libvolk.so.1.0, needed by [...]/lib/libgnuradio-analog.so, not found (try using -rpath or -rpath-link
```