### PR TITLE
fec block 'ber_bf' needs refactoring

### DIFF
--- a/gr-fec/lib/ber_bf_impl.cc
+++ b/gr-fec/lib/ber_bf_impl.cc
@@ -53,26 +53,25 @@ namespace gr {
     }
 
     int
-    ber_bf_impl::general_work(int noutput_items,
-                              gr_vector_int& ninput_items,
+    ber_bf_impl::general_work(int noutput_items, gr_vector_int& ninput_items,
                               gr_vector_const_void_star &input_items,
                               gr_vector_void_star &output_items)
     {
+      unsigned char *inbuffer0 = (unsigned char *) input_items[0];
+      unsigned char *inbuffer1 = (unsigned char *) input_items[1];
+      float *outbuffer = (float *) output_items[0];
+
+      int items = ninput_items[0] <= ninput_items[1] ? ninput_items[0] : ninput_items[1];
+
       if(d_test_mode) {
         if(d_total_errors >= d_berminerrors) {
           return -1;
         }
         else {
-          unsigned char *inbuffer0 = (unsigned char *)input_items[0];
-          unsigned char *inbuffer1 = (unsigned char *)input_items[1];
-          float *outbuffer = (float *)output_items[0];
-
-          int items = ninput_items[0] <= ninput_items[1] ? ninput_items[0] : ninput_items[1];
-
           if(items > 0) {
             uint32_t ret;
             for(int i = 0; i < items; i++) {
-              volk_32u_popcnt(&ret, static_cast<uint32_t>(inbuffer0[i]^inbuffer1[i]));
+              volk_32u_popcnt(&ret, static_cast<uint32_t>(inbuffer0[i] ^ inbuffer1[i]));
               d_total_errors += ret;
             }
             d_total += items;
@@ -80,12 +79,12 @@ namespace gr {
           consume_each(items);
 
           if(d_total_errors >= d_berminerrors) {
-            outbuffer[0] = log10(((double)d_total_errors)/(d_total * 8.0));
-            GR_LOG_INFO(d_logger, boost::format("    %1% over %2% --> %3%") \
-                        % d_total_errors % (d_total * 8) % outbuffer[0]);
+            outbuffer[0] = log10(((double) d_total_errors) / (d_total * 8.0));
+            GR_LOG_INFO(d_logger, boost::format("    %1% over %2% --> %3%")
+                    % d_total_errors % (d_total * 8) % outbuffer[0]);
             return 1;
           }
-          else if(log10(((double)d_berminerrors)/(d_total * 8.0)) < d_ber_limit) {
+          else if(log10(((double) d_berminerrors) / (d_total * 8.0)) < d_ber_limit) {
             GR_LOG_INFO(d_logger, "    Min. BER limit reached");
             outbuffer[0] = d_ber_limit;
             d_total_errors = d_berminerrors + 1;
@@ -97,21 +96,15 @@ namespace gr {
         }
       }
       else { // streaming mode
-        unsigned char *inbuffer0 = (unsigned char *)input_items[0];
-        unsigned char *inbuffer1 = (unsigned char *)input_items[1];
-        float *outbuffer = (float *)output_items[0];
-
-        int items = ninput_items[0] <= ninput_items[1] ? ninput_items[0] : ninput_items[1];
-
         if(items > 0) {
           uint32_t ret;
           for(int i = 0; i < items; i++) {
-            volk_32u_popcnt(&ret, static_cast<uint32_t>(inbuffer0[i]^inbuffer1[i]));
+            volk_32u_popcnt(&ret, static_cast<uint32_t>(inbuffer0[i] ^ inbuffer1[i]));
             d_total_errors += ret;
           }
 
           d_total += items;
-          outbuffer[0] = log10(((double)d_total_errors)/(d_total * 8.0));
+          outbuffer[0] = log10(((double) d_total_errors) / (d_total * 8.0));
 
           consume_each(items);
           return 1;

--- a/gr-fec/lib/ber_bf_impl.h
+++ b/gr-fec/lib/ber_bf_impl.h
@@ -37,6 +37,9 @@ namespace gr {
       int d_berminerrors;
       float d_ber_limit;
 
+      inline float calculate_log_ber() const;
+      inline void update_counters(const int items, const unsigned char *inbuffer0, const unsigned char *inbuffer1);
+
     public:
       ber_bf_impl(bool d_test_mode = false, int berminerrors=100, float ber_limit=-7.0);
       ~ber_bf_impl();

--- a/gr-fec/python/fec/qa_ber_bf.py
+++ b/gr-fec/python/fec/qa_ber_bf.py
@@ -20,13 +20,13 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from gnuradio import gr, gr_unittest
+from gnuradio import gr, gr_unittest, blocks
 import fec_swig as fec
-import blocks_swig as blocks
-import numpy, copy
+import numpy
+import copy
+
 
 class test_ber_bf(gr_unittest.TestCase):
-
     def setUp(self):
         self.tb = gr.top_block()
 
@@ -45,16 +45,16 @@ class test_ber_bf(gr_unittest.TestCase):
 
         src0 = blocks.vector_source_b(data0)
         src1 = blocks.vector_source_b(data1)
-	op  = fec.ber_bf(mode)
-	dst = blocks.vector_sink_f()
+        op = fec.ber_bf(mode)
+        dst = blocks.vector_sink_f()
 
-	self.tb.connect(src0, (op,0))
-        self.tb.connect(src1, (op,1))
+        self.tb.connect(src0, (op, 0))
+        self.tb.connect(src1, (op, 1))
         self.tb.connect(op, dst)
-	self.tb.run()
+        self.tb.run()
 
         data = dst.data()
-        expected_result = [numpy.log10(1.0/(8.0*N)),]
+        expected_result = [numpy.log10(1.0 / (8.0 * N)), ]
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
 
@@ -70,16 +70,16 @@ class test_ber_bf(gr_unittest.TestCase):
 
         src0 = blocks.vector_source_b(data0)
         src1 = blocks.vector_source_b(data1)
-	op  = fec.ber_bf(mode, 1)
-	dst = blocks.vector_sink_f()
+        op = fec.ber_bf(mode, 1)
+        dst = blocks.vector_sink_f()
 
-	self.tb.connect(src0, (op,0))
-        self.tb.connect(src1, (op,1))
+        self.tb.connect(src0, (op, 0))
+        self.tb.connect(src1, (op, 1))
         self.tb.connect(op, dst)
-	self.tb.run()
+        self.tb.run()
 
         data = dst.data()
-        expected_result = [numpy.log10(1.0/(8.0*N)),]
+        expected_result = [numpy.log10(1.0 / (8.0 * N)), ]
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
 
@@ -95,16 +95,16 @@ class test_ber_bf(gr_unittest.TestCase):
 
         src0 = blocks.vector_source_b(data0)
         src1 = blocks.vector_source_b(data1)
-	op  = fec.ber_bf(mode, 1, -2.0)
-	dst = blocks.vector_sink_f()
+        op = fec.ber_bf(mode, 1, -2.0)
+        dst = blocks.vector_sink_f()
 
-	self.tb.connect(src0, (op,0))
-        self.tb.connect(src1, (op,1))
+        self.tb.connect(src0, (op, 0))
+        self.tb.connect(src1, (op, 1))
         self.tb.connect(op, dst)
-	self.tb.run()
+        self.tb.run()
 
         data = dst.data()
-        expected_result = [numpy.log10(8.0/(8.0*N)),]
+        expected_result = [numpy.log10(8.0 / (8.0 * N)), ]
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
 
@@ -121,21 +121,22 @@ class test_ber_bf(gr_unittest.TestCase):
 
         src0 = blocks.vector_source_b(data0)
         src1 = blocks.vector_source_b(data1)
-	op  = fec.ber_bf(mode, 10, -2.0)
-	dst = blocks.vector_sink_f()
+        op = fec.ber_bf(mode, 10, -2.0)
+        dst = blocks.vector_sink_f()
 
-	self.tb.connect(src0, (op,0))
-        self.tb.connect(src1, (op,1))
+        self.tb.connect(src0, (op, 0))
+        self.tb.connect(src1, (op, 1))
         self.tb.connect(op, dst)
-	self.tb.run()
+        self.tb.run()
 
         data = dst.data()
-        expected_result = [-2.0,]
+        expected_result = [-2.0, ]
 
         print data
         print expected_result
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_ber_bf, "test_ber_bf.xml")

--- a/gr-fec/python/fec/qa_ber_bf.py
+++ b/gr-fec/python/fec/qa_ber_bf.py
@@ -54,7 +54,7 @@ class test_ber_bf(gr_unittest.TestCase):
         self.tb.run()
 
         data = dst.data()
-        expected_result = [numpy.log10(1.0 / (8.0 * N)), ]
+        expected_result = self.log_ber(1., N) # [numpy.log10(1.0 / (8.0 * N)), ]
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
 
@@ -79,7 +79,7 @@ class test_ber_bf(gr_unittest.TestCase):
         self.tb.run()
 
         data = dst.data()
-        expected_result = [numpy.log10(1.0 / (8.0 * N)), ]
+        expected_result = self.log_ber(1., N)
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
 
@@ -104,7 +104,7 @@ class test_ber_bf(gr_unittest.TestCase):
         self.tb.run()
 
         data = dst.data()
-        expected_result = [numpy.log10(8.0 / (8.0 * N)), ]
+        expected_result = self.log_ber(8., N)
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
 
@@ -136,6 +136,36 @@ class test_ber_bf(gr_unittest.TestCase):
         print expected_result
 
         self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
+
+    def test_004(self):
+        # Cause 16 consecutive bit errors out of 8*N bits
+        # make sure bytes are only read once.
+        # using streaming mode
+
+        mode = False
+        N = 10000
+        data0 = numpy.random.randint(0, 256, N).tolist()
+        data1 = copy.deepcopy(data0)
+        data1[0] ^= 0xFF
+        data1[1] ^= 0xFF
+
+        src0 = blocks.vector_source_b(data0)
+        src1 = blocks.vector_source_b(data1)
+        op = fec.ber_bf(mode)
+        dst = blocks.vector_sink_f()
+
+        self.tb.connect(src0, (op, 0))
+        self.tb.connect(src1, (op, 1))
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        data = dst.data()
+        expected_result = self.log_ber(16, N)
+
+        self.assertFloatTuplesAlmostEqual(expected_result, data, 5)
+
+    def log_ber(self, n_errors, N):
+        return numpy.log10(1. * n_errors / (8.0 * N)),
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This block has a test mode. In work this gets split in 2 large if-statements. They contain a lot of duplicate code. I moved some code out of the if-statement. All the other code is almost duplicate, but It has subtle differences when calling consume_each. This should be fixed, though.
I issued this pull request in order to open a debate over this.