### PR TITLE
crc32 unpack

### DIFF
--- a/gr-digital/grc/digital_crc32_bb.xml
+++ b/gr-digital/grc/digital_crc32_bb.xml
@@ -2,7 +2,7 @@
   <name>Stream CRC32</name>
   <key>digital_crc32_bb</key>
   <import>from gnuradio import digital</import>
-  <make>digital.crc32_bb($check, $lengthtagname)</make>
+  <make>digital.crc32_bb($check, $lengthtagname, $packed)</make>
   <param>
 	  <name>Mode</name>
 	  <key>check</key>
@@ -21,6 +21,20 @@
     <key>lengthtagname</key>
     <value>"packet_len"</value>
     <type>string</type>
+  </param>
+  <param>
+    <name>Packed</name>
+    <key>packed</key>
+    <value>True</value>
+    <type>bool</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
   </param>
   <sink>
     <name>in</name>

--- a/gr-digital/include/gnuradio/digital/crc32_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_bb.h
@@ -51,7 +51,7 @@ namespace gr {
        * \param check Set to true if you want to check CRC, false to create CRC.
        * \param lengthtagname Length tag key
        */
-      static sptr make(bool check=false, const std::string& lengthtagname="packet_len");
+      static sptr make(bool check=false, const std::string& lengthtagname="packet_len", bool packed=true);
     };
 
   } // namespace digital

--- a/gr-digital/lib/crc32_bb_impl.cc
+++ b/gr-digital/lib/crc32_bb_impl.cc
@@ -31,29 +31,37 @@ namespace gr {
   namespace digital {
 
     crc32_bb::sptr
-    crc32_bb::make(bool check, const std::string &lengthtagname) {
-      return gnuradio::get_initial_sptr(new crc32_bb_impl(check, lengthtagname));
+    crc32_bb::make(bool check, const std::string &lengthtagname, bool packed) {
+      return gnuradio::get_initial_sptr(new crc32_bb_impl(check, lengthtagname, packed));
     }
 
-    crc32_bb_impl::crc32_bb_impl(bool check, const std::string &lengthtagname)
+    crc32_bb_impl::crc32_bb_impl(bool check, const std::string &lengthtagname, bool packed)
         : tagged_stream_block("crc32_bb",
                               io_signature::make(1, 1, sizeof(char)),
                               io_signature::make(1, 1, sizeof(char)),
                               lengthtagname),
-          d_check(check),
+          d_check(check), d_packed(packed),
           d_npass(0), d_nfail(0) {
+      d_crc_length = 4;
+      if (!d_packed) {
+        d_crc_length = 32;
+        d_unpacked_crc = new char[d_crc_length];
+      }
       set_tag_propagation_policy(TPP_DONT);
     }
 
     crc32_bb_impl::~crc32_bb_impl() {
+      if (!d_packed){
+        delete[] d_unpacked_crc;
+      }
     }
 
     int
     crc32_bb_impl::calculate_output_stream_length(const gr_vector_int &ninput_items) {
       if (d_check) {
-        return ninput_items[0] - 4;
+        return ninput_items[0] - d_crc_length;
       } else {
-        return ninput_items[0] + 4;
+        return ninput_items[0] + d_crc_length;
       }
     }
 
@@ -65,25 +73,43 @@ namespace gr {
       const unsigned char *in = (const unsigned char *) input_items[0];
       unsigned char *out = (unsigned char *) output_items[0];
       long packet_length = ninput_items[0];
-      int packet_size_diff = d_check ? -4 : 4;
+      int packet_size_diff = d_check ? -d_crc_length : d_crc_length;
       unsigned int crc;
 
       if (d_check) {
         d_crc_impl.reset();
-        d_crc_impl.process_bytes(in, packet_length - 4);
+        d_crc_impl.process_bytes(in, packet_length - d_crc_length);
         crc = d_crc_impl();
-        if (crc != *(unsigned int *) (in + packet_length - 4)) { // Drop package
-          d_nfail++;
-          return 0;
+        if (d_packed) {
+          if (crc != *(unsigned int *) (in + packet_length - d_crc_length)) { // Drop package
+            d_nfail++;
+            return 0;
+          }
+        }
+        else{
+          for(int i=0; i < d_crc_length; i++){
+            if(((crc >> i) & 0x1) != *(in + packet_length - d_crc_length + i)) { // Drop package
+              d_nfail++;
+              return 0;
+            }
+          }
         }
         d_npass++;
-        memcpy((void *) out, (const void *) in, packet_length - 4);
+        memcpy((void *) out, (const void *) in, packet_length - d_crc_length);
       } else {
         d_crc_impl.reset();
         d_crc_impl.process_bytes(in, packet_length);
         crc = d_crc_impl();
         memcpy((void *) out, (const void *) in, packet_length);
-        memcpy((void *) (out + packet_length), &crc, 4); // FIXME big-endian/little-endian, this might be wrong
+        if (d_packed) {
+          memcpy((void *) (out + packet_length), &crc, d_crc_length); // FIXME big-endian/little-endian, this might be wrong
+        }
+        else {
+          for (int i = 0; i < d_crc_length; i++) { // unpack CRC and store in buffer
+            d_unpacked_crc[i] = (crc >> i) & 0x1;
+          }
+          memcpy((void *) (out + packet_length), (void *) d_unpacked_crc, d_crc_length);
+        }
       }
 
       std::vector <tag_t> tags;
@@ -91,7 +117,7 @@ namespace gr {
       for (size_t i = 0; i < tags.size(); i++) {
         tags[i].offset -= nitems_read(0);
         if (d_check && tags[i].offset > (unsigned int) (packet_length + packet_size_diff)) {
-          tags[i].offset = packet_length - 5;
+          tags[i].offset = packet_length - d_crc_length - 1;
         }
         add_item_tag(0, nitems_written(0) + tags[i].offset,
                      tags[i].key,

--- a/gr-digital/lib/crc32_bb_impl.h
+++ b/gr-digital/lib/crc32_bb_impl.h
@@ -33,10 +33,13 @@ namespace gr {
     {
      private:
       bool d_check;
+      bool d_packed;
       boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true>    d_crc_impl;
+      int d_crc_length;
+      char *d_unpacked_crc;
 
      public:
-      crc32_bb_impl(bool check, const std::string& lengthtagname);
+      crc32_bb_impl(bool check, const std::string& lengthtagname, bool packed);
       ~crc32_bb_impl();
 
       int calculate_output_stream_length(const gr_vector_int &ninput_items);

--- a/gr-digital/python/digital/qa_crc32_bb.py
+++ b/gr-digital/python/digital/qa_crc32_bb.py
@@ -156,5 +156,135 @@ class qa_crc32_bb (gr_unittest.TestCase):
         self.tb.run()
         self.assertEqual([len(data)-5,], [tag.offset for tag in sink.tags() if pmt.symbol_to_string(tag.key) == 'tag1'])
 
+    # NOTE: What follows are the same tests as before but with the packed flag set to False
+
+    def test_006_crc_len (self):
+        """ Make sure the output of a CRC set is 32 (unpacked) bytes longer than the input. """
+        data = range(16)
+        src = blocks.vector_source_b(data)
+        crc = digital.crc32_bb(False, self.tsb_key, False)
+        sink = blocks.tsb_vector_sink_b(tsb_key=self.tsb_key)
+        self.tb.connect(
+                src,
+                blocks.stream_to_tagged_stream(gr.sizeof_char, 1, len(data), self.tsb_key),
+                crc,
+                sink
+        )
+        self.tb.run()
+        # Check that the packets before crc_check are 4 bytes longer that the input.
+        self.assertEqual(len(data)+32, len(sink.data()[0]))
+
+    def test_007_crc_equal (self):
+        """ Go through CRC set / CRC check and make sure the output
+        is the same as the input. """
+        data = (0, 1, 2, 3, 4, 5, 6, 7, 8)
+        src = blocks.vector_source_b(data)
+        crc = digital.crc32_bb(False, self.tsb_key, False)
+        crc_check = digital.crc32_bb(True, self.tsb_key, False)
+        sink = blocks.tsb_vector_sink_b(tsb_key=self.tsb_key)
+        self.tb.connect(
+                src,
+                blocks.stream_to_tagged_stream(gr.sizeof_char, 1, len(data), self.tsb_key),
+                crc,
+                crc_check,
+                sink
+        )
+        self.tb.run()
+        # Check that the packets after crc_check are the same as input.
+        self.assertEqual(data, sink.data()[0])
+
+    def test_008_crc_correct_lentag (self):
+        tag_name = "length"
+        pack_len = 8
+        packets = range(pack_len*2)
+        tag1 = gr.tag_t()
+        tag1.offset = 0
+        tag1.key = pmt.string_to_symbol(tag_name)
+        tag1.value = pmt.from_long(pack_len)
+        tag2 = gr.tag_t()
+        tag2.offset = pack_len
+        tag2.key = pmt.string_to_symbol(tag_name)
+        tag2.value = pmt.from_long(pack_len)
+        testtag1 = gr.tag_t()
+        testtag1.offset = 1
+        testtag1.key = pmt.string_to_symbol("tag1")
+        testtag1.value = pmt.from_long(0)
+        testtag2 = gr.tag_t()
+        testtag2.offset = pack_len
+        testtag2.key = pmt.string_to_symbol("tag2")
+        testtag2.value = pmt.from_long(0)
+        testtag3 = gr.tag_t()
+        testtag3.offset = len(packets)-1
+        testtag3.key = pmt.string_to_symbol("tag3")
+        testtag3.value = pmt.from_long(0)
+        src = blocks.vector_source_b(packets, False, 1, (testtag1, testtag2, testtag3))
+        crc = digital.crc32_bb(False, self.tsb_key, False)
+        sink = blocks.tsb_vector_sink_b(tsb_key=self.tsb_key)
+        self.tb.connect(
+                src,
+                blocks.stream_to_tagged_stream(gr.sizeof_char, 1, pack_len, self.tsb_key),
+                crc,
+                sink
+        )
+        self.tb.run()
+        self.assertEqual(len(sink.data()), 2)
+        self.assertEqual(len(sink.data()[0]), (pack_len+32))
+        self.assertEqual(len(sink.data()[1]), (pack_len+32))
+        correct_offsets = {'tag1': 1, 'tag2': 8+32, 'tag3': 15+32}
+        tags_found = {'tag1': False, 'tag2': False, 'tag3': False}
+        for tag in sink.tags():
+            key = pmt.symbol_to_string(tag.key)
+            if key in correct_offsets.keys():
+                tags_found[key] = True
+                self.assertEqual(correct_offsets[key], tag.offset)
+        self.assertTrue(all(tags_found.values()))
+
+
+    def test_009_fail (self):
+        """ Corrupt the data and make sure it fails CRC test. """
+        data = (0, 1, 2, 3, 4, 5, 6, 7)
+        src = blocks.vector_source_b(data)
+        crc = digital.crc32_bb(False, self.tsb_key, False)
+        crc_check = digital.crc32_bb(True, self.tsb_key, False)
+        corruptor = blocks.add_const_bb(1)
+        sink = blocks.tsb_vector_sink_b(tsb_key=self.tsb_key)
+        self.tb.connect(
+                src,
+                blocks.stream_to_tagged_stream(gr.sizeof_char, 1, len(data), self.tsb_key),
+                crc,
+                corruptor,
+                crc_check,
+                sink
+        )
+        self.tb.run()
+        # crc_check will drop invalid packets
+        self.assertEqual(len(sink.data()), 0)
+
+    def test_0010_tag_propagation (self):
+        """ Make sure tags on the CRC aren't lost. """
+        # Data with precalculated CRC
+        data = (
+            0, 1, 2, 3, 4, 5, 6, 7, 8,
+            0, 1, 0, 0, 0, 0, 0, 0,
+            1, 1, 0, 0, 0, 0, 1, 0,
+            1, 0, 0, 0, 0, 1, 1, 1,
+            0, 0, 1, 1, 1, 1, 0, 1
+        ) # 2, 67, 225, 188
+        testtag = gr.tag_t()
+        testtag.offset = len(data)-1
+        testtag.key = pmt.string_to_symbol('tag1')
+        testtag.value = pmt.from_long(0)
+        src = blocks.vector_source_b(data, False, 1, (testtag,))
+        crc_check = digital.crc32_bb(True, self.tsb_key, False)
+        sink = blocks.tsb_vector_sink_b(tsb_key=self.tsb_key)
+        self.tb.connect(
+                src,
+                blocks.stream_to_tagged_stream(gr.sizeof_char, 1, len(data), self.tsb_key),
+                crc_check,
+                sink
+        )
+        self.tb.run()
+        self.assertEqual([len(data)-33,], [tag.offset for tag in sink.tags() if pmt.symbol_to_string(tag.key) == 'tag1'])
+
 if __name__ == '__main__':
     gr_unittest.run(qa_crc32_bb, "qa_crc32_bb.xml")


### PR DESCRIPTION
Added an option to the "Stream CRC32" block that allows operation on a stream of unpacked bytes, i.e. 0s and 1s.

The default behavior remains unchanged, the GRC block now let's you choose between "Packed" and "Unpacked". I also extended the unit tests accordingly.

As there was a wild mixture of tabs and spaces in the code, I also reformatted the code and replaced the tabs with 2 spaces.

