### PR TITLE
fec: fixed missing 'packed_bits' handling in extended encoder

### DIFF
--- a/gr-fec/include/gnuradio/fec/dummy_encoder.h
+++ b/gr-fec/include/gnuradio/fec/dummy_encoder.h
@@ -52,7 +52,7 @@ namespace gr {
          *        tagged stream style, this is the maximum allowable
          *        number of bits per frame.
          */
-        static generic_encoder::sptr make(int frame_size);
+        static generic_encoder::sptr make(int frame_size, bool pack = false, bool packed_bits = false);
 
         /*!
          * Sets the uncoded frame size to \p frame_size. If \p

--- a/gr-fec/lib/dummy_encoder_impl.cc
+++ b/gr-fec/lib/dummy_encoder_impl.cc
@@ -34,14 +34,16 @@ namespace gr {
     namespace code {
 
       generic_encoder::sptr
-      dummy_encoder::make(int frame_size)
+      dummy_encoder::make(int frame_size, bool pack, bool packed_bits)
       {
         return generic_encoder::sptr
-          (new dummy_encoder_impl(frame_size));
+          (new dummy_encoder_impl(frame_size, pack, packed_bits));
       }
 
-      dummy_encoder_impl::dummy_encoder_impl(int frame_size)
-        : generic_encoder("dummy_encoder")
+      dummy_encoder_impl::dummy_encoder_impl(int frame_size, bool pack, bool packed_bits)
+        : generic_encoder("dummy_encoder"),
+          d_pack_input(pack),
+          d_packed_bits_output(packed_bits)
       {
         d_max_frame_size = frame_size;
         set_frame_size(frame_size);
@@ -61,6 +63,18 @@ namespace gr {
       dummy_encoder_impl::get_input_size()
       {
         return d_frame_size;
+      }
+
+      const char*
+      dummy_encoder_impl::get_input_conversion()
+      {
+        return d_pack_input ? "pack" : "none";
+      }
+
+      const char*
+      dummy_encoder_impl::get_output_conversion()
+      {
+        return d_packed_bits_output ? "packed_bits" : "none";
       }
 
       bool

--- a/gr-fec/lib/dummy_encoder_impl.h
+++ b/gr-fec/lib/dummy_encoder_impl.h
@@ -38,12 +38,16 @@ namespace gr {
         void generic_work(void *inbuffer, void *outbuffer);
         int get_output_size();
         int get_input_size();
+        const char* get_input_conversion();
+        const char* get_output_conversion();
+        bool d_pack_input;
+        bool d_packed_bits_output;
 
         unsigned int d_max_frame_size;
         unsigned int d_frame_size;
 
       public:
-        dummy_encoder_impl(int frame_size);
+        dummy_encoder_impl(int frame_size, bool pack = false, bool packed_bits = false);
         ~dummy_encoder_impl();
 
         bool set_frame_size(unsigned int frame_size);

--- a/gr-fec/python/fec/extended_encoder.py
+++ b/gr-fec/python/fec/extended_encoder.py
@@ -60,6 +60,9 @@ class extended_encoder(gr.hier_block2):
                                            gr.sizeof_char,
                                            gr.sizeof_char))
 
+        if fec.get_encoder_output_conversion(encoder_obj_list[0]) == "packed_bits":
+            self.blocks.append(blocks.packed_to_unpacked_bb(1, gr.GR_MSB_FIRST))
+
         if self.puncpat != '11':
             self.blocks.append(fec.puncture_bb(len(puncpat), read_bitlist(puncpat), 0))
 

--- a/gr-fec/python/fec/qa_fecapi_dummy.py
+++ b/gr-fec/python/fec/qa_fecapi_dummy.py
@@ -20,9 +20,10 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from gnuradio import gr, gr_unittest
+from gnuradio import gr, gr_unittest, blocks
 import fec_swig as fec
 from _qa_helper import _qa_helper
+import numpy as np
 
 from extended_encoder import extended_encoder
 from extended_decoder import extended_decoder
@@ -185,6 +186,52 @@ class test_fecapi_dummy(gr_unittest.TestCase):
         threading = 'capillary'
 
         self.assertRaises(AttributeError, lambda: extended_decoder(dec, threading=threading, puncpat="11"))
+
+    def test_extended_pack_data(self):
+        # test if extended encoder gets correct values for input and output conversion.
+        n_frames = 10
+        frame_size = 32
+
+        data = np.random.randint(0, 2, n_frames * frame_size)
+        packed_data = np.packbits(data)
+
+        tb = gr.top_block()
+
+        src = blocks.vector_source_b(data)
+        snk0 = blocks.vector_sink_b(1)
+        snk1 = blocks.vector_sink_b(1)
+        snk2 = blocks.vector_sink_b(1)
+        snk3 = blocks.vector_sink_b(1)
+
+        packer = blocks.pack_k_bits_bb(8)
+        tb.connect(src, packer, snk0)
+
+        enc_unpacked = fec.dummy_encoder_make(frame_size, False, False)
+        ext_enc_unp = extended_encoder(enc_unpacked, threading='none', puncpat='11')
+        tb.connect(src, ext_enc_unp, snk1)
+
+        enc_pack = fec.dummy_encoder_make(frame_size // 8, True, False)
+        ext_enc_pack = extended_encoder(enc_pack, threading='none', puncpat='11')
+        tb.connect(src, ext_enc_pack, snk2)
+
+        enc_packed_bits = fec.dummy_encoder_make(frame_size // 8, False, True)
+        ext_enc_packed_bits = extended_encoder(enc_packed_bits, threading='none', puncpat='11')
+        tb.connect(packer, ext_enc_packed_bits, snk3)
+
+        tb.run()
+
+        r0 = snk0.data()
+        r1 = snk1.data()
+        r2 = snk2.data()
+        r3 = snk3.data()
+
+        data = tuple(data)
+        packed_data = tuple(packed_data)
+        self.assertTupleEqual(packed_data, r0)
+        self.assertTupleEqual(data, r1)
+        self.assertTupleEqual(packed_data, r2)
+        self.assertTupleEqual(data, r3)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_fecapi_dummy, "test_fecapi_dummy.xml")


### PR DESCRIPTION
This is a reissue of pull request #554 
Added QA code to dummy_encoder to be able to test get_{input/output}_conversion.
Also added QA code to test conversions.