### PR TITLE
runtime: stop catching errors from primitive_connect in connect decorator

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/qa_hier_block2.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_hier_block2.py
@@ -66,14 +66,12 @@ class test_hier_block2(gr_unittest.TestCase):
         self.assertEqual(expected, self.call_log)
 
     def test_005(self):
-        with self.assertRaises(ValueError) as c:
+        with self.assertRaises(ValueError):
             self.multi((self.Block(), 5))
-        self.assertIsInstance(c.exception, ValueError)
 
     def test_006(self):
-        with self.assertRaises(ValueError) as c:
-            self.multi(self.Block(), (self.Block(), 5, 5))
-        self.assertIsInstance(c.exception, ValueError)
+        with self.assertRaises(ValueError):
+            self.multi(self.Block(), (5, 5))
 
     def test_007(self):
         b1, b2 = self.Block(), self.Block()
@@ -84,6 +82,10 @@ class test_hier_block2(gr_unittest.TestCase):
         f, b1, b2 = self.multi, self.Block(), self.Block()
         self.opt((b1, "in"), (b2, "out"))
         self.assertEqual([(b1, "in", b2, "out")], self.call_log)
+
+    def test_009(self):
+        with self.assertRaises(ValueError):
+            self.multi(self.Block(), 5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current implementation catches exceptions thrown by primitive_connect() and raises a generic error. The original error message is lost. 

Now, such exceptions are no longer caught which helps with debugging. If for example the item size of source and sink doesn't match you get the original error. 

In addition, in cases where errors were caught during the endpoint handling, the original error message is appended.

Also, removed double assertion of raised exception type in corresponding qa tests.