### PR TITLE
Check RX/TX streamers::sptr before flush/reset

### DIFF
--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -551,7 +551,8 @@ namespace gr {
     {
       _update_stream_args(stream_args);
 #ifdef GR_UHD_USE_STREAM_API
-      _tx_stream.reset();
+      if(_tx_stream)
+        _tx_stream.reset();
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
@@ -834,7 +835,8 @@ namespace gr {
       _nitems_to_send = 0;
 
 #ifdef GR_UHD_USE_STREAM_API
-      _tx_stream->send(gr_vector_const_void_star(_nchan), 0, _metadata, 1.0);
+      if(_tx_stream)
+        _tx_stream->send(gr_vector_const_void_star(_nchan), 0, _metadata, 1.0);
 #else
       _dev->get_device()->send
         (gr_vector_const_void_star(_nchan), 0, _metadata,

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -538,7 +538,8 @@ namespace gr {
     {
       _update_stream_args(stream_args);
 #ifdef GR_UHD_USE_STREAM_API
-      _rx_stream.reset();
+      if(_rx_stream)
+        _rx_stream.reset();
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
@@ -599,7 +600,12 @@ namespace gr {
       while(true) {
 #ifdef GR_UHD_USE_STREAM_API
         const size_t bpi = ::uhd::convert::get_bytes_per_item(_stream_args.cpu_format);
-        _rx_stream->recv(outputs, nbytes/bpi, _metadata, 0.0);
+        if(_rx_stream)
+          // get the remaining samples out of the buffers
+          _rx_stream->recv(outputs, nbytes/bpi, _metadata, 0.0);
+        else
+          // no rx streamer -- nothing to flush
+          break; 
 #else
         _dev->get_device()->recv
           (outputs, nbytes/_type->size, _metadata, *_type,


### PR DESCRIPTION
Current code triggers a segfault when user uses the stream arg setter
before starting the flowgraph.

Another surprising use case that segfaults is

```c++
tb->start();
usrp_source->stop();
```

which is a clever way to allow streaming to start when the user calls
`usrp_source->issue_stream_cmd(...)` rather than as soon as GNU Radio runs
without using `set_start_time` (e.g. when the start time is unknown at FG
initialization).