### PR TITLE
qtgui: added trigger callbacks to GRC XML files

### DIFF
--- a/gr-qtgui/grc/qtgui_const_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.xml
@@ -55,6 +55,7 @@ $(gui_hint()($win))</make>
   <callback>set_update_time($update_time)</callback>
   <callback>set_title($which, $title)</callback>
   <callback>set_color($which, $color)</callback>
+  <callback>self.$(id).set_trigger_mode($tr_mode, $tr_slope, $tr_level, $tr_chan, $tr_tag)</callback>
 
   <param_tab_order>
     <tab>General</tab>

--- a/gr-qtgui/grc/qtgui_freq_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.xml
@@ -58,6 +58,7 @@ $(gui_hint()($win))</make>
   <callback>set_title($which, $title)</callback>
   <callback>set_color($which, $color)</callback>
   <callback>set_y_axis($ymin, $ymax)</callback>
+  <callback>self.$(id).set_trigger_mode($tr_mode, $tr_level, $tr_chan, $tr_tag)</callback>
 
   <param_tab_order>
     <tab>General</tab>

--- a/gr-qtgui/grc/qtgui_time_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.xml
@@ -80,6 +80,7 @@ $(gui_hint()($win))</make>
   <callback>set_color($which, $color)</callback>
   <callback>set_y_axis($ymin, $ymax)</callback>
   <callback>set_samp_rate($srate)</callback>
+  <callback>self.$(id).set_trigger_mode($tr_mode, $tr_slope, $tr_level, $tr_delay, $tr_chan, $tr_tag)</callback>
 
   <param_tab_order>
     <tab>General</tab>


### PR DESCRIPTION
Allows trigger "level" value to be updated from other QT UI elements, such as a QT GUI Range, when using GRC