### PR TITLE
blocks: make vector_insert propagate tags correctly

### DIFF
--- a/gr-blocks/lib/vector_insert_X_impl.cc.t
+++ b/gr-blocks/lib/vector_insert_X_impl.cc.t
@@ -51,6 +51,7 @@ namespace gr {
       d_offset(offset),
       d_periodicity(periodicity)
     {
+      set_tag_propagation_policy(TPP_DONT); // handle tags manually
       //printf("INITIAL: periodicity = %d, offset = %d\n", periodicity, offset);
       // some sanity checks
       assert(offset < periodicity);
@@ -79,6 +80,13 @@ namespace gr {
         if(d_offset >= ((int)d_data.size())) { // if we are in the copy region
           int max_copy = std::min(std::min(noutput_items - oo, ninput_items[0] - ii),
                                   d_periodicity - d_offset);
+          std::vector<tag_t> tags;
+          get_tags_in_range(tags, 0, nitems_read(0) + ii, nitems_read(0) + max_copy + ii);
+          for(unsigned i = 0; i < tags.size(); i++)
+          {
+            //printf("copy tag from in@%d to out@%d\n", int(tags[i].offset), int(nitems_written(0) + oo + (tags[i].offset-nitems_read(0)-ii)));
+            add_item_tag(0, nitems_written(0) + oo + (tags[i].offset-nitems_read(0)-ii), tags[i].key, tags[i].value, tags[i].srcid);
+          }
           //printf("copy %d from input\n", max_copy);
           memcpy( &out[oo], &in[ii], sizeof(@TYPE@)*max_copy );
           //printf(" * memcpy returned.\n");

--- a/gr-blocks/python/blocks/qa_vector_insert.py
+++ b/gr-blocks/python/blocks/qa_vector_insert.py
@@ -53,6 +53,67 @@ class test_vector_insert(gr_unittest.TestCase):
             else:
                 self.assertEqual(0, result_data[i])
 
+    def test_002(self):  # insert tags and check their propagation, zero offset
+        period = 11000
+        offset = 0
+        insert = [1.0,] * 1000
+
+        src = blocks.null_source(gr.sizeof_float)
+        s2ts = blocks.stream_to_tagged_stream(gr.sizeof_float, 1, period-len(insert), "packet")
+        head = blocks.head(gr.sizeof_float, 1000000)
+        ins = blocks.vector_insert_f(insert, period, offset)
+        dst = blocks.vector_sink_f()
+
+        self.tb.connect(src, s2ts, head, ins, dst)
+        self.tb.run()
+
+        expected_result = (1000, 12000, 23000, 34000, 45000, 56000, 67000)
+        tags = dst.tags()
+        offsets = [tag.offset for tag in tags]
+        for i in range(len(expected_result)):
+            self.assertTrue(expected_result[i] == offsets[i])
+
+    def test_003(self):  # insert tags and check their propagation, non-zero offset
+        period = 11000
+        offset = 1000
+        insert = [1.0,] * 1000
+
+        src = blocks.null_source(gr.sizeof_float)
+        s2ts = blocks.stream_to_tagged_stream(gr.sizeof_float, 1, period-len(insert), "packet")
+        head = blocks.head(gr.sizeof_float, 1000000)
+        ins = blocks.vector_insert_f(insert, period, offset)
+        dst = blocks.vector_sink_f()
+
+        self.tb.connect(src, s2ts, head, ins, dst)
+        self.tb.run()
+
+        expected_result = (0, 11000, 22000, 33000, 44000, 55000, 66000)
+        tags = dst.tags()
+        offsets = [tag.offset for tag in tags]
+        for i in range(len(expected_result)):
+            self.assertTrue(expected_result[i] == offsets[i])
+
+    def test_004(self):  # insert tags and check their propagation, non-zero offset, multiple tags per copy region
+        period = 11000
+        offset = 1000
+        packetlen = 2000
+        insert = [1.0,] * 1000
+
+        src = blocks.null_source(gr.sizeof_float)
+        s2ts = blocks.stream_to_tagged_stream(gr.sizeof_float, 1, packetlen, "packet")
+        head = blocks.head(gr.sizeof_float, 1000000)
+        ins = blocks.vector_insert_f(insert, period, offset)
+        dst = blocks.vector_sink_f()
+
+        self.tb.connect(src, s2ts, head, ins, dst)
+        self.tb.run()
+
+        expected_result = (0, 2000, 4000, 6000, 8000, 11000, 13000, 15000, 17000, 19000, 22000, 24000, 26000)
+        tags = dst.tags()
+        offsets = [tag.offset for tag in tags]
+        for i in range(len(expected_result)):
+            self.assertTrue(expected_result[i] == offsets[i])
+
 if __name__ == '__main__':
     gr_unittest.run(test_vector_insert, "test_vector_insert.xml")
 


### PR DESCRIPTION
Previously, the block did not handle the tags correctly. I set the propagation policy to TPP_DONT and handle them manually.

Added QA tests to ensure proper behavior.