### PR TITLE
Added file_message_sink block which reads a pmt dictionary message an…

### DIFF
--- a/gr-blocks/grc/blocks_file_message_sink.xml
+++ b/gr-blocks/grc/blocks_file_message_sink.xml
@@ -1,0 +1,22 @@
+<block>
+   <name>File Message Sink</name>
+   <key>blocks_file_message_sink</key>
+   <category>File Operators</category>
+   <import>from gnuradio import blocks</import>
+   <make>blocks.file_message_sink($filename, $the_keys)</make>
+   <callback>open($filename)</callback>
+   <param>
+      <name>Filename</name>
+      <key>filename</key>
+      <type>file_save</type>
+   </param>
+   <param>
+      <name>Keys</name>
+      <key>the_keys</key>
+      <type>string</type>
+   </param>
+   <sink>
+      <name>in</name>
+      <type>message</type>
+   </sink>
+</block>

--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -182,7 +182,7 @@ install(FILES
     vector_to_streams.h
     wavfile_sink.h
     wavfile_source.h
-    DESTINATION ${GR_INCLUDE_DIR}/gnuradio/blocks
+    file_message_sink.h DESTINATION ${GR_INCLUDE_DIR}/gnuradio/blocks
     COMPONENT "blocks_devel"
 )
 

--- a/gr-blocks/include/gnuradio/blocks/file_message_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/file_message_sink.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2015 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_BLOCKS_FILE_MESSAGE_SINK_H
+#define INCLUDED_BLOCKS_FILE_MESSAGE_SINK_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/block.h>
+#include <gnuradio/blocks/file_sink_base.h>
+#include <boost/algorithm/string.hpp>
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief Write pmt values specified by keys into a comma-separated file
+     *        pmt values are stored in a dictionary
+     * \ingroup blocks
+     *
+     */
+    class BLOCKS_API file_message_sink : virtual public gr::block, virtual public file_sink_base
+    {
+     public:
+      typedef boost::shared_ptr<file_message_sink> sptr;
+
+      /*!
+       * \brief Create a new file_message_sink
+       * @param filename Name of file to write comma-separated keys
+       * @param keys Comma-separated string of keys e.g. "spre_start,pkt_end"
+       *
+       */
+      static sptr make(const char* filename, const char* keys);
+    };
+
+  } // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_BLOCKS_FILE_MESSAGE_SINK_H */
+

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -203,6 +203,7 @@ list(APPEND gr_blocks_sources
     wavfile_sink_impl.cc
     wavfile_source_impl.cc
     multiply_matrix_ff_impl.cc
+    file_message_sink_impl.cc
 )
 
 if(ENABLE_GR_CTRLPORT)

--- a/gr-blocks/lib/file_message_sink_impl.cc
+++ b/gr-blocks/lib/file_message_sink_impl.cc
@@ -1,0 +1,113 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2015 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "file_message_sink_impl.h"
+#include <stdexcept>
+
+namespace gr {
+  namespace blocks {
+
+    file_message_sink::sptr
+    file_message_sink::make(const char* filename, const char* keys)
+    {
+      return gnuradio::get_initial_sptr
+        (new file_message_sink_impl(filename, keys));
+    }
+    void file_message_sink_impl::write_str(std::string& str){
+          // Required call in file_sink_base to update pointer
+          do_update();
+          if(!d_fp ){
+            std::cout << "d_fp is null" << std::endl;
+            return;
+          }
+          if( fputs(str.c_str(),d_fp) == 0 ){
+            if( ferror(d_fp)) {
+              std::stringstream s;
+              s << "file_message_sink write failed w/error " << fileno(d_fp) << std::endl;
+              throw std::runtime_error(s.str());
+            }
+          }
+    }
+    void
+      file_message_sink_impl::process_msg(pmt::pmt_t msg){
+        pmt::pmt_t blob,dict;
+        //pmt::print(msg);
+        // If pair, assume (dict,blob) is the tuple
+        // Otherwise, just assume msg is a PMT dictionary
+        if( pmt::is_pair(msg) ){
+          dict = pmt::car(msg);
+          blob = pmt::cdr(msg);
+        }else{
+          dict = msg;
+        }
+        if( pmt::is_dict(msg) ){
+          pmt::pmt_t spre_start = pmt::dict_ref(dict,pmt::intern("spre_start"),pmt::PMT_NIL);
+          pmt::pmt_t pkt_end = pmt::dict_ref(dict,pmt::intern("pkt_end"),pmt::PMT_NIL);
+          // std::cout << "spre_start=" << pmt::write_string(spre_start) << ","
+          //   << "pkt_end=" << pmt::write_string(pkt_end) << std::endl;
+          std::string spre_start_s = pmt::write_string(spre_start);
+          std::string pkt_end_s = pmt::write_string(pkt_end);
+          std::string line(spre_start_s + "," + pkt_end_s + "\n");
+          write_str(line);
+        }
+      }
+    /*
+     * The private constructor
+     */
+    file_message_sink_impl::file_message_sink_impl(const char* filename, const char* keys)
+      : gr::block("file_message_sink",
+              gr::io_signature::make(0,0,0),
+              gr::io_signature::make(0,0,0)),
+      file_sink_base(filename,false,false)
+    {
+      message_port_register_in(pmt::mp("in"));
+      set_msg_handler(pmt::mp("in"), boost::bind(&file_message_sink_impl::process_msg, this, _1));
+      std::string keys_s(keys);
+      // Parse comma-delimited keys into vector
+      boost::split(d_keys,keys_s,boost::is_any_of(","));
+      std::string hdr;
+      // Write file header
+      for( std::vector<std::string>::iterator it = d_keys.begin(); it != d_keys.end(); ++it){
+        hdr += *it;
+        if( it < d_keys.end()-1){
+          hdr += ",";
+        }
+      }
+      hdr += '\n';
+      do_update();
+      write_str(hdr);
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    file_message_sink_impl::~file_message_sink_impl()
+    {
+    }
+  } /* namespace blocks */
+} /* namespace gr */
+

--- a/gr-blocks/lib/file_message_sink_impl.h
+++ b/gr-blocks/lib/file_message_sink_impl.h
@@ -1,0 +1,56 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2015 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_FILE_MESSAGE_SINK_IMPL_H
+#define INCLUDED_BLOCKS_FILE_MESSAGE_SINK_IMPL_H
+
+#include <gnuradio/blocks/file_message_sink.h>
+
+namespace gr {
+  namespace blocks {
+
+    class file_message_sink_impl : public file_message_sink
+    {
+     private:
+      // Message handler for incoming async msgs
+      void process_msg(pmt::pmt_t msg);
+      void write_str(std::string& str);
+      // Keys to write to file
+      std::vector<std::string> d_keys;
+     public:
+      file_message_sink_impl(const char* filename, const char* keys);
+      ~file_message_sink_impl();
+
+      // Where all the action really happens
+      //void forecast (int noutput_items, gr_vector_int &ninput_items_required);
+      /**
+      int general_work(int noutput_items,
+		       gr_vector_int &ninput_items,
+		       gr_vector_const_void_star &input_items,
+		       gr_vector_void_star &output_items); **/
+    };
+
+  } // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_BLOCKS_FILE_MESSAGE_SINK_IMPL_H */
+

--- a/gr-blocks/swig/blocks_swig0.i
+++ b/gr-blocks/swig/blocks_swig0.i
@@ -41,6 +41,7 @@
 #include "gnuradio/blocks/file_source.h"
 #include "gnuradio/blocks/file_meta_sink.h"
 #include "gnuradio/blocks/file_meta_source.h"
+#include "gnuradio/blocks/file_message_sink.h"
 #include "gnuradio/blocks/head.h"
 #include "gnuradio/blocks/message_debug.h"
 #include "gnuradio/blocks/message_sink.h"
@@ -67,6 +68,7 @@
 %include "gnuradio/blocks/file_source.h"
 %include "gnuradio/blocks/file_meta_sink.h"
 %include "gnuradio/blocks/file_meta_source.h"
+%include "gnuradio/blocks/file_message_sink.h"
 %include "gnuradio/blocks/head.h"
 %include "gnuradio/blocks/message_debug.h"
 %include "gnuradio/blocks/message_sink.h"
@@ -90,6 +92,7 @@ GR_SWIG_BLOCK_MAGIC2(blocks, file_sink);
 GR_SWIG_BLOCK_MAGIC2(blocks, file_source);
 GR_SWIG_BLOCK_MAGIC2(blocks, file_meta_sink);
 GR_SWIG_BLOCK_MAGIC2(blocks, file_meta_source);
+GR_SWIG_BLOCK_MAGIC2(blocks, file_message_sink);
 GR_SWIG_BLOCK_MAGIC2(blocks, head);
 GR_SWIG_BLOCK_MAGIC2(blocks, message_debug);
 GR_SWIG_BLOCK_MAGIC2(blocks, message_sink);


### PR DESCRIPTION
Dumps specified key,value pairs from a dictionary in a GR message to a file. See discussion for additional details. The basic idea is that you might have metadata associated with some type of binary blob (e.g. a PDU) and you wish to dump particular metadata to a file. 
https://lists.gnu.org/archive/html/discuss-gnuradio/2015-08/msg00271.html