### PR TITLE
grc/blocks: Fix XML RPC server to allow proper flowgraph termination

### DIFF
--- a/grc/blocks/xmlrpc_server.xml
+++ b/grc/blocks/xmlrpc_server.xml
@@ -11,7 +11,9 @@
 	<import>import threading</import>
 	<make>SimpleXMLRPCServer.SimpleXMLRPCServer(($addr, $port), allow_none=True)
 self.$(id).register_instance(self)
-threading.Thread(target=self.$(id).serve_forever).start()</make>
+self.$(id)_thread = threading.Thread(target=self.$(id).serve_forever)
+self.$(id)_thread.daemon = True
+self.$(id)_thread.start()</make>
 	<param>
 		<name>Address</name>
 		<key>addr</key>


### PR DESCRIPTION
Without this, the XML RPC server thread will stay alive and the program
will never terminate.

By making it a 'daemon' thread, if it's the only thread left alive, python
will automatically terminate it.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>