### PR TITLE
cmake: Fix python linking in Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,10 @@ include(GrBoost)
 find_package(PythonLibs 2)
 find_package(SWIG)
 
+if(APPLE)
+    set(PYTHON_LIBRARY "-undefined dynamic_lookup")
+endif(APPLE)
+
 if(SWIG_FOUND)
     # Minimum SWIG version required is 1.3.31
     set(SWIG_VERSION_CHECK FALSE)


### PR DESCRIPTION
If using Homebrew and linking python with -lpython, running any executable will show: 
```
Fatal Python error: PyThreadState_Get: no current thread
```
Replace -lpython with -undefined dynamic_lookup works.
