### PR TITLE
clarify missing module exception.

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -20,18 +20,23 @@
 # Boston, MA 02110-1301, USA.
 #
 
+import sys, time, re, pprint
 import random,math,operator
-import networkx as nx
-import matplotlib
-matplotlib.use("QT4Agg")
-import matplotlib.pyplot as plt
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
-from matplotlib.figure import Figure
+try:
+    import networkx as nx
+    import matplotlib
+    matplotlib.use("QT4Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+    from matplotlib.figure import Figure
+except ImportError:
+    print sys.argv[0], "requires networkx and matplotlib.", \
+       "Please check that they are installed and try again."
+    sys.exit(1)
 
 from PyQt4 import QtCore,Qt,Qwt5
 import PyQt4.QtGui as QtGui
-import sys, time, re, pprint
 import itertools
 
 from gnuradio import gr, ctrlport


### PR DESCRIPTION
reduces surprise and tells me what i need to do to fix it. I don't imagine everyone will be using perf monitors, so i'm not going to pull in another 25MB of dependencies by adding it to the gnuradio recipe.