### PR TITLE
Fixes Coverity Defect 1229872: Memory leak in `atsci_equalizer_lms2` DTOR

### DIFF
--- a/gr-atsc/lib/atsci_equalizer_lms2.cc
+++ b/gr-atsc/lib/atsci_equalizer_lms2.cc
@@ -90,6 +90,7 @@ atsci_equalizer_lms2::atsci_equalizer_lms2 ()
 
 atsci_equalizer_lms2::~atsci_equalizer_lms2 ()
 {
+  fclose(trainingfile);
 }
 
 void


### PR DESCRIPTION
Simple issue of a missing `fclose` on an open file handle causing a memory leak.