### PR TITLE
logger.h.in: sys/types.h is needed for mode_t

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h.in
+++ b/gnuradio-runtime/include/gnuradio/logger.h.in
@@ -44,6 +44,8 @@
 
 #ifdef _MSC_VER
 typedef unsigned short mode_t;
+#else
+#include <sys/types.h>
 #endif
 
 #include <gnuradio/api.h>


### PR DESCRIPTION
sys/types.h must be included to have mode_t defined and to avoid this error : 
error: 'mode_t' has not been declared
like on
http://autobuild.buildroot.net/results/d58/d58889016ba347220a59e47cd032895d244e963b/

with a musl based toolchain.
