### PR TITLE
gr::blocks::repeat: add runtime interpolation adjustment

### DIFF
--- a/gr-blocks/grc/blocks_repeat.xml
+++ b/gr-blocks/grc/blocks_repeat.xml
@@ -9,6 +9,7 @@
 	<key>blocks_repeat</key>
 	<import>from gnuradio import blocks</import>
 	<make>blocks.repeat($type.size*$vlen, $interp)</make>
+	<callback>set_interpolation($interp)</callback>
 	<param>
 		<name>Type</name>
 		<key>type</key>

--- a/gr-blocks/include/gnuradio/blocks/repeat.h
+++ b/gr-blocks/include/gnuradio/blocks/repeat.h
@@ -32,6 +32,10 @@ namespace gr {
     /*!
      * \brief repeat each input \p repeat times
      * \ingroup stream_operators_blk
+     *
+     * Message Ports:
+     *   * interpolation (in):
+     *      Takes a pmt_pair(pmt::mp("interpolation"), pmt_long interp), setting the interpolation to interp.
      */
     class BLOCKS_API repeat : virtual public sync_interpolator
     {

--- a/gr-blocks/include/gnuradio/blocks/repeat.h
+++ b/gr-blocks/include/gnuradio/blocks/repeat.h
@@ -46,6 +46,20 @@ namespace gr {
        * \param repeat number of times to repeat the input
        */
       static sptr make(size_t itemsize, int repeat);
+
+      /*!
+       * \brief Return current interpolation
+       */
+      virtual int interpolation() const = 0;
+
+      /*!
+       * \brief sets the interpolation
+       *
+       * Call this method in a callback to adjust the interpolation at run time.
+       *
+       * \param interp interpolation to be set
+       */
+      virtual void set_interpolation(int interp) = 0;
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -43,13 +43,26 @@ namespace gr {
 	d_itemsize(itemsize),
 	d_interp(interp)
     {
+        message_port_register_in(pmt::mp("interpolation"));
+        set_msg_handler(pmt::mp("interpolation"),
+                boost::bind(&repeat_impl::msg_set_interpolation, this, _1));
     }
 
     void
+    repeat_impl::msg_set_interpolation(pmt::pmt_t msg)
+    {
+        // Dynamization by Kevin McQuiggin:
+        d_interp = pmt::to_long(pmt::cdr(msg));
+        sync_interpolator::set_interpolation(d_interp);
+    }
+    void
     repeat_impl::set_interpolation(int interp)
     {
-      d_interp = interp;
-      sync_interpolator::set_interpolation(d_interp);
+        // This ensures that interpolation is only changed between calls to work
+        // (and not in the middle of an ongoing work)
+        _post(  pmt::mp("interpolation"), /* port */
+                pmt::cons(pmt::mp("interpolation"), pmt::from_long(interp)) /* pair */
+        );
     }
 
     int

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -45,6 +45,13 @@ namespace gr {
     {
     }
 
+    void
+    repeat_impl::set_interpolation(int interp)
+    {
+      d_interp = interp;
+      sync_interpolator::set_interpolation(d_interp);
+    }
+
     int
     repeat_impl::work(int noutput_items,
 		      gr_vector_const_void_star &input_items,

--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -36,6 +36,10 @@ namespace gr {
     public:
       repeat_impl(size_t itemsize, int d_interp);
 
+      int interpolation() const { return d_interp; }
+      void set_interpolation(int interp);
+
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);

--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -43,6 +43,8 @@ namespace gr {
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);
+    private:
+      void msg_set_interpolation(pmt::pmt_t msg);
     };
 
   } /* namespace blocks */


### PR DESCRIPTION
* Addition by Kevin McQuiggin: Repeat now can be reconfigured at runtime
* Thread safety by me: reconfiguration moved to msg handler