### PR TITLE
+ Fixed Bug in qa_multiply_matrix_ff test_005_t

### DIFF
--- a/gr-blocks/python/blocks/qa_multiply_matrix_ff.py
+++ b/gr-blocks/python/blocks/qa_multiply_matrix_ff.py
@@ -144,9 +144,9 @@ class test_multiply_matrix_ff (gr_unittest.TestCase):
         tag2.offset = 0
         tag2.key = pmt.intern("in2")
         tag2.value = pmt.PMT_T
-        self.run_once(X_in, A, tpp=999, tags=(tag1, tag2))
-        self.assertTrue(pmt.equal(tag1.key, self.the_tags[1][0].key))
-        self.assertTrue(pmt.equal(tag2.key, self.the_tags[0][0].key))
+        self.run_once(X_in, A, tpp=gr.TPP_ONE_TO_ONE, tags=(tag1, tag2))
+        self.assertTrue(pmt.equal(tag1.key, self.the_tags[0][0].key))
+        self.assertTrue(pmt.equal(tag2.key, self.the_tags[1][0].key))
 
     #def test_006_t (self):
         #""" Message passing """


### PR DESCRIPTION
test_005_t (Tag propagation) in qa_multiply_matrix_ff failed. The tag propagation policy in test#5 was set to 999 which led to a false policy. Changed that value to gr.TPP_ONE_TO_ONE, which I suppose is the desired behavior. Also the final tag asserts where reversed so that the two false tags were compared. Now the test completes.