### PR TITLE
uhd: Factored out symmetric functions between source and sink

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -423,6 +423,31 @@ usrp_block_impl::get_device(void)
   return _dev;
 }
 
+void
+usrp_block_impl::set_normalized_gain(double norm_gain, size_t chan)
+{
+  if (norm_gain > 1.0 || norm_gain < 0.0) {
+    throw std::runtime_error("Normalized gain out of range, must be in [0, 1].");
+  }
+  ::uhd::gain_range_t gain_range = get_gain_range(chan);
+  double abs_gain = (norm_gain * (gain_range.stop() - gain_range.start())) + gain_range.start();
+  set_gain(abs_gain, chan);
+}
+
+double
+usrp_block_impl::get_normalized_gain(size_t chan)
+{
+  ::uhd::gain_range_t gain_range = get_gain_range(chan);
+  double norm_gain =
+    (get_gain(chan) - gain_range.start()) /
+    (gain_range.stop() - gain_range.start());
+  // Avoid rounding errors:
+  if (norm_gain > 1.0) return 1.0;
+  if (norm_gain < 0.0) return 0.0;
+  return norm_gain;
+}
+
+
 /**********************************************************************
  * External Interfaces
  *********************************************************************/

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -29,13 +29,186 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/bind.hpp>
 
-#define SET_CENTER_FREQ_FROM_INTERNALS(usrp_class, tune_method) \
+// There's a whole bunch of public API calls that are nearly
+// identical between usrp_source and usrp_sink. So let's not
+// duplicate those. Usually, the only difference is that one
+// them has the string 'tx' and the other the string 'rx' in
+// the setter names.
+#define USRP_BLOCK_SYMMETRIC_METHODS_H() \
+      std::string get_subdev_spec(size_t mboard); \
+      void set_subdev_spec(const std::string &spec, size_t mboard); \
+      double get_samp_rate(void); \
+      double get_center_freq(size_t chan); \
+      ::uhd::freq_range_t get_freq_range(size_t chan); \
+      void set_gain(double gain, size_t chan); \
+      void set_gain(double gain, const std::string &name, size_t chan); \
+      double get_gain(size_t chan); \
+      double get_gain(const std::string &name, size_t chan); \
+      std::vector<std::string> get_gain_names(size_t chan); \
+      ::uhd::gain_range_t get_gain_range(size_t chan); \
+      ::uhd::gain_range_t get_gain_range(const std::string &name, size_t chan); \
+      void set_antenna(const std::string &ant, size_t chan); \
+      std::string get_antenna(size_t chan); \
+      std::vector<std::string> get_antennas(size_t chan); \
+      void set_bandwidth(double bandwidth, size_t chan); \
+      double get_bandwidth(size_t chan); \
+      ::uhd::freq_range_t get_bandwidth_range(size_t chan); \
+      ::uhd::sensor_value_t get_sensor(const std::string &name, size_t chan); \
+      std::vector<std::string> get_sensor_names(size_t chan); \
+      ::uhd::usrp::dboard_iface::sptr get_dboard_iface(size_t chan);
+
+#define USRP_BLOCK_SYMMETRIC_METHODS(sourk, trx) \
+    void \
+    usrp_##sourk##_impl::set_subdev_spec(const std::string &spec, size_t mboard) \
+    { \
+      return _dev->set_##trx##_subdev_spec(spec, mboard); \
+    } \
+ \
+    std::string \
+    usrp_##sourk##_impl::get_subdev_spec(size_t mboard) \
+    { \
+      return _dev->get_##trx##_subdev_spec(mboard).to_string(); \
+    } \
+ \
+    double \
+    usrp_##sourk##_impl::get_samp_rate(void) \
+    { \
+      return _dev->get_##trx##_rate(_stream_args.channels[0]); \
+    } \
+ \
+    double \
+    usrp_##sourk##_impl::get_center_freq(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_freq(chan); \
+    } \
+ \
     ::uhd::tune_result_t \
-    usrp_class::_set_center_freq_from_internals(size_t chan) \
+    usrp_##sourk##_impl::_set_center_freq_from_internals(size_t chan) \
     { \
       _chans_to_tune.reset(chan); \
-      return _dev->tune_method(_curr_tune_req[chan], _stream_args.channels[chan]); \
+      return _dev->set_##trx##_freq(_curr_tune_req[chan], _stream_args.channels[chan]); \
+    } \
+ \
+    ::uhd::freq_range_t \
+    usrp_##sourk##_impl::get_freq_range(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_freq_range(chan); \
+    } \
+ \
+    void \
+    usrp_##sourk##_impl::set_gain(double gain, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->set_##trx##_gain(gain, chan); \
+    } \
+ \
+    void \
+    usrp_##sourk##_impl::set_gain(double gain, const std::string &name, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->set_##trx##_gain(gain, name, chan); \
+    } \
+ \
+    double \
+    usrp_##sourk##_impl::get_gain(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_gain(chan); \
+    } \
+ \
+    double \
+    usrp_##sourk##_impl::get_gain(const std::string &name, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_gain(name, chan); \
+    } \
+ \
+    std::vector<std::string> \
+    usrp_##sourk##_impl::get_gain_names(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_gain_names(chan); \
+    } \
+ \
+    ::uhd::gain_range_t \
+    usrp_##sourk##_impl::get_gain_range(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_gain_range(chan); \
+    } \
+ \
+    ::uhd::gain_range_t \
+    usrp_##sourk##_impl::get_gain_range(const std::string &name, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_gain_range(name, chan); \
+    } \
+ \
+    void \
+    usrp_##sourk##_impl::set_antenna(const std::string &ant, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->set_##trx##_antenna(ant, chan); \
+    } \
+ \
+    std::string \
+    usrp_##sourk##_impl::get_antenna(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_antenna(chan); \
+    } \
+ \
+    std::vector<std::string> \
+    usrp_##sourk##_impl::get_antennas(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_antennas(chan); \
+    } \
+ \
+    void \
+    usrp_##sourk##_impl::set_bandwidth(double bandwidth, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->set_##trx##_bandwidth(bandwidth, chan); \
+    } \
+ \
+    double \
+    usrp_##sourk##_impl::get_bandwidth(size_t chan) \
+    { \
+        chan = _stream_args.channels[chan]; \
+        return _dev->get_##trx##_bandwidth(chan); \
+    } \
+ \
+    ::uhd::freq_range_t \
+    usrp_##sourk##_impl::get_bandwidth_range(size_t chan) \
+    { \
+        chan = _stream_args.channels[chan]; \
+        return _dev->get_##trx##_bandwidth_range(chan); \
+    } \
+ \
+    ::uhd::sensor_value_t \
+    usrp_##sourk##_impl::get_sensor(const std::string &name, size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_sensor(name, chan); \
+    } \
+ \
+    std::vector<std::string> \
+    usrp_##sourk##_impl::get_sensor_names(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_sensor_names(chan); \
+    } \
+ \
+    ::uhd::usrp::dboard_iface::sptr \
+    usrp_##sourk##_impl::get_dboard_iface(size_t chan) \
+    { \
+      chan = _stream_args.channels[chan]; \
+      return _dev->get_##trx##_dboard_iface(chan); \
     }
+
 
 namespace gr {
   namespace uhd {
@@ -52,6 +225,7 @@ namespace gr {
        * Public API calls (see usrp_block.h for docs)
        **********************************************************************/
       // Getters
+      double get_normalized_gain(size_t chan);
       ::uhd::sensor_value_t get_mboard_sensor(const std::string &name, size_t mboard);
       std::vector<std::string> get_mboard_sensor_names(size_t mboard);
       std::string get_time_source(const size_t mboard);
@@ -70,6 +244,7 @@ namespace gr {
       );
 
       // Setters
+      void set_normalized_gain(double gain, size_t chan);
       void set_clock_config(const ::uhd::clock_config_t &clock_config, size_t mboard);
       void set_time_source(const std::string &source, const size_t mboard);
       void set_clock_source(const std::string &source, const size_t mboard);

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -78,6 +78,9 @@ namespace gr {
     {
     }
 
+    USRP_BLOCK_SYMMETRIC_METHODS(sink, tx)
+
+    // More symmetric methods, but with preprocessor macros
     ::uhd::dict<std::string, std::string>
     usrp_sink_impl::get_usrp_info(size_t chan)
     {
@@ -87,35 +90,6 @@ namespace gr {
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
-    }
-
-    void
-    usrp_sink_impl::set_subdev_spec(const std::string &spec,
-                                    size_t mboard)
-    {
-      return _dev->set_tx_subdev_spec(spec, mboard);
-    }
-
-    std::string
-    usrp_sink_impl::get_subdev_spec(size_t mboard)
-    {
-      return _dev->get_tx_subdev_spec(mboard).to_string();
-    }
-
-    void
-    usrp_sink_impl::set_samp_rate(double rate)
-    {
-        BOOST_FOREACH(const size_t chan, _stream_args.channels)
-        {
-            _dev->set_tx_rate(rate, chan);
-        }
-      _sample_rate = this->get_samp_rate();
-    }
-
-    double
-    usrp_sink_impl::get_samp_rate(void)
-    {
-      return _dev->get_tx_rate(_stream_args.channels[0]);
     }
 
     ::uhd::meta_range_t
@@ -128,152 +102,9 @@ namespace gr {
 #endif
     }
 
-    ::uhd::tune_result_t
-    usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request,
-                                    size_t chan)
-    {
-      _curr_tune_req[chan] = tune_request;
-      chan = _stream_args.channels[chan];
-      return _dev->set_tx_freq(tune_request, chan);
-    }
-
-    SET_CENTER_FREQ_FROM_INTERNALS(usrp_sink_impl, set_tx_freq);
-
-    double
-    usrp_sink_impl::get_center_freq(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_freq(chan);
-    }
-
-    ::uhd::freq_range_t
-    usrp_sink_impl::get_freq_range(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_freq_range(chan);
-    }
-
-    void
-    usrp_sink_impl::set_gain(double gain, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_tx_gain(gain, chan);
-    }
-
-    void
-    usrp_sink_impl::set_gain(double gain,
-                             const std::string &name,
-                             size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_tx_gain(gain, name, chan);
-    }
-
-    void usrp_sink_impl::set_normalized_gain(double norm_gain, size_t chan)
-    {
-      if (norm_gain > 1.0 || norm_gain < 0.0) {
-        throw std::runtime_error("Normalized gain out of range, must be in [0, 1].");
-      }
-      ::uhd::gain_range_t gain_range = get_gain_range(chan);
-      double abs_gain = (norm_gain * (gain_range.stop() - gain_range.start())) + gain_range.start();
-      set_gain(abs_gain, chan);
-    }
-
-    double
-    usrp_sink_impl::get_gain(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_gain(chan);
-    }
-
-    double
-    usrp_sink_impl::get_gain(const std::string &name, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_gain(name, chan);
-    }
-
-    double
-    usrp_sink_impl::get_normalized_gain(size_t chan)
-    {
-      ::uhd::gain_range_t gain_range = get_gain_range(chan);
-      double norm_gain =
-        (get_gain(chan) - gain_range.start()) /
-        (gain_range.stop() - gain_range.start());
-      // Avoid rounding errors:
-      if (norm_gain > 1.0) return 1.0;
-      if (norm_gain < 0.0) return 0.0;
-      return norm_gain;
-    }
-
-    std::vector<std::string>
-    usrp_sink_impl::get_gain_names(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_gain_names(chan);
-    }
-
-    ::uhd::gain_range_t
-    usrp_sink_impl::get_gain_range(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_gain_range(chan);
-    }
-
-    ::uhd::gain_range_t
-    usrp_sink_impl::get_gain_range(const std::string &name,
-                                   size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_gain_range(name, chan);
-    }
-
-    void
-    usrp_sink_impl::set_antenna(const std::string &ant,
-                                size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_tx_antenna(ant, chan);
-    }
-
-    std::string
-    usrp_sink_impl::get_antenna(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_antenna(chan);
-    }
-
-    std::vector<std::string>
-    usrp_sink_impl::get_antennas(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_antennas(chan);
-    }
-
-    void
-    usrp_sink_impl::set_bandwidth(double bandwidth, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_tx_bandwidth(bandwidth, chan);
-    }
-
-    double
-    usrp_sink_impl::get_bandwidth(size_t chan)
-    {
-        chan = _stream_args.channels[chan];
-        return _dev->get_tx_bandwidth(chan);
-    }
-
-    ::uhd::freq_range_t
-    usrp_sink_impl::get_bandwidth_range(size_t chan)
-    {
-        chan = _stream_args.channels[chan];
-        return _dev->get_tx_bandwidth_range(chan);
-    }
-
     void
     usrp_sink_impl::set_dc_offset(const std::complex<double> &offset,
-                                  size_t chan)
+                                    size_t chan)
     {
       chan = _stream_args.channels[chan];
 #ifdef UHD_USRP_MULTI_USRP_FRONTEND_CAL_API
@@ -285,7 +116,7 @@ namespace gr {
 
     void
     usrp_sink_impl::set_iq_balance(const std::complex<double> &correction,
-                                   size_t chan)
+                                     size_t chan)
     {
       chan = _stream_args.channels[chan];
 #ifdef UHD_USRP_MULTI_USRP_FRONTEND_CAL_API
@@ -293,27 +124,6 @@ namespace gr {
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
-    }
-
-    ::uhd::sensor_value_t
-    usrp_sink_impl::get_sensor(const std::string &name, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_sensor(name, chan);
-    }
-
-    std::vector<std::string>
-    usrp_sink_impl::get_sensor_names(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_sensor_names(chan);
-    }
-
-    ::uhd::usrp::dboard_iface::sptr
-    usrp_sink_impl::get_dboard_iface(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_tx_dboard_iface(chan);
     }
 
     void
@@ -325,6 +135,27 @@ namespace gr {
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
+    }
+
+    // Non-symmetric public API calls:
+
+    void
+    usrp_sink_impl::set_samp_rate(double rate)
+    {
+        BOOST_FOREACH(const size_t chan, _stream_args.channels)
+        {
+            _dev->set_tx_rate(rate, chan);
+        }
+      _sample_rate = this->get_samp_rate();
+    }
+
+    ::uhd::tune_result_t
+    usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request,
+                                    size_t chan)
+    {
+      _curr_tune_req[chan] = tune_request;
+      chan = _stream_args.channels[chan];
+      return _dev->set_tx_freq(tune_request, chan);
     }
 
     /***********************************************************************

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -60,40 +60,23 @@ namespace gr {
                       const std::string &length_tag_name);
       ~usrp_sink_impl();
 
-      ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
-      double get_samp_rate(void);
-      ::uhd::meta_range_t get_samp_rates(void);
-      double get_center_freq(size_t chan);
-      ::uhd::freq_range_t get_freq_range(size_t chan);
-      double get_gain(size_t chan);
-      double get_gain(const std::string &name, size_t chan);
-      double get_normalized_gain(size_t chan);
-      std::vector<std::string> get_gain_names(size_t chan);
-      ::uhd::gain_range_t get_gain_range(size_t chan);
-      ::uhd::gain_range_t get_gain_range(const std::string &name, size_t chan);
-      std::string get_antenna(size_t chan);
-      std::vector<std::string> get_antennas(size_t chan);
-      ::uhd::sensor_value_t get_sensor(const std::string &name, size_t chan);
-      std::vector<std::string> get_sensor_names(size_t chan);
-      ::uhd::usrp::dboard_iface::sptr get_dboard_iface(size_t chan);
+      // Symmetric getters/setters (common between source and sink)
+      USRP_BLOCK_SYMMETRIC_METHODS_H();
 
-      void set_subdev_spec(const std::string &spec, size_t mboard);
-      std::string get_subdev_spec(size_t mboard);
-      void set_samp_rate(double rate);
-      ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
-                                         size_t chan);
-      void set_gain(double gain, size_t chan);
-      void set_gain(double gain, const std::string &name, size_t chan);
-      void set_normalized_gain(double gain, size_t chan);
-      void set_antenna(const std::string &ant, size_t chan);
-      void set_bandwidth(double bandwidth, size_t chan);
-      double get_bandwidth(size_t chan);
-      ::uhd::freq_range_t get_bandwidth_range(size_t chan);
+      // Also symmetric, but can't be moved to usrp_block for now:
+      ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
+      ::uhd::meta_range_t get_samp_rates(void);
       void set_dc_offset(const std::complex<double> &offset, size_t chan);
       void set_iq_balance(const std::complex<double> &correction, size_t chan);
       void set_stream_args(const ::uhd::stream_args_t &stream_args);
+
+      // Non-symmetric setters:
+      void set_samp_rate(double rate);
+      ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
+                                         size_t chan);
       void set_start_time(const ::uhd::time_spec_t &time);
 
+      // Stream-related commands
       bool start(void);
       bool stop(void);
 

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -83,6 +83,9 @@ namespace gr {
     {
     }
 
+    USRP_BLOCK_SYMMETRIC_METHODS(source, rx)
+
+    // More symmetric methods, but with preprocessor macros
     ::uhd::dict<std::string, std::string>
     usrp_source_impl::get_usrp_info(size_t chan)
     {
@@ -94,193 +97,11 @@ namespace gr {
 #endif
     }
 
-    void
-    usrp_source_impl::set_subdev_spec(const std::string &spec, size_t mboard)
-    {
-      return _dev->set_rx_subdev_spec(spec, mboard);
-    }
-
-    std::string
-    usrp_source_impl::get_subdev_spec(size_t mboard)
-    {
-      return _dev->get_rx_subdev_spec(mboard).to_string();
-    }
-
-    void
-    usrp_source_impl::set_samp_rate(double rate)
-    {
-        BOOST_FOREACH(const size_t chan, _stream_args.channels)
-        {
-            _dev->set_rx_rate(rate, chan);
-        }
-      _samp_rate = this->get_samp_rate();
-      _tag_now = true;
-    }
-
-    double
-    usrp_source_impl::get_samp_rate(void)
-    {
-      return _dev->get_rx_rate(_stream_args.channels[0]);
-    }
-
     ::uhd::meta_range_t
     usrp_source_impl::get_samp_rates(void)
     {
 #ifdef UHD_USRP_MULTI_USRP_GET_RATES_API
       return _dev->get_rx_rates(_stream_args.channels[0]);
-#else
-      throw std::runtime_error("not implemented in this version");
-#endif
-    }
-
-    ::uhd::tune_result_t
-    usrp_source_impl::set_center_freq(const ::uhd::tune_request_t tune_request,
-                                      size_t chan)
-    {
-      const size_t user_chan = chan;
-      chan = _stream_args.channels[chan];
-      const ::uhd::tune_result_t res = _dev->set_rx_freq(tune_request, chan);
-      _center_freq = this->get_center_freq(user_chan);
-      _tag_now = true;
-      return res;
-    }
-
-    SET_CENTER_FREQ_FROM_INTERNALS(usrp_source_impl, set_rx_freq);
-
-    double
-    usrp_source_impl::get_center_freq(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_freq(chan);
-    }
-
-    ::uhd::freq_range_t
-    usrp_source_impl::get_freq_range(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_freq_range(chan);
-    }
-
-    void
-    usrp_source_impl::set_gain(double gain, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_rx_gain(gain, chan);
-    }
-
-    void
-    usrp_source_impl::set_gain(double gain, const std::string &name, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_rx_gain(gain, name, chan);
-    }
-
-    void usrp_source_impl::set_normalized_gain(double norm_gain, size_t chan)
-    {
-      if (norm_gain > 1.0 || norm_gain < 0.0) {
-        throw std::runtime_error("Normalized gain out of range, must be in [0, 1].");
-      }
-      ::uhd::gain_range_t gain_range = get_gain_range(chan);
-      double abs_gain = (norm_gain * (gain_range.stop() - gain_range.start())) + gain_range.start();
-      set_gain(abs_gain, chan);
-    }
-
-    double
-    usrp_source_impl::get_gain(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_gain(chan);
-    }
-
-    double
-    usrp_source_impl::get_gain(const std::string &name, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_gain(name, chan);
-    }
-
-    double
-    usrp_source_impl::get_normalized_gain(size_t chan)
-    {
-      ::uhd::gain_range_t gain_range = get_gain_range(chan);
-      double norm_gain =
-        (get_gain(chan) - gain_range.start()) /
-        (gain_range.stop() - gain_range.start());
-      // Avoid rounding errors:
-      if (norm_gain > 1.0) return 1.0;
-      if (norm_gain < 0.0) return 0.0;
-      return norm_gain;
-    }
-
-    std::vector<std::string>
-    usrp_source_impl::get_gain_names(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_gain_names(chan);
-    }
-
-    ::uhd::gain_range_t
-    usrp_source_impl::get_gain_range(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_gain_range(chan);
-    }
-
-    ::uhd::gain_range_t
-    usrp_source_impl::get_gain_range(const std::string &name, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_gain_range(name, chan);
-    }
-
-    void
-    usrp_source_impl::set_antenna(const std::string &ant, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_rx_antenna(ant, chan);
-    }
-
-    std::string
-    usrp_source_impl::get_antenna(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_antenna(chan);
-    }
-
-    std::vector<std::string>
-    usrp_source_impl::get_antennas(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_antennas(chan);
-    }
-
-    void
-    usrp_source_impl::set_bandwidth(double bandwidth, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->set_rx_bandwidth(bandwidth, chan);
-    }
-
-    double
-    usrp_source_impl::get_bandwidth(size_t chan)
-    {
-        chan = _stream_args.channels[chan];
-        return _dev->get_rx_bandwidth(chan);
-    }
-
-    ::uhd::freq_range_t
-    usrp_source_impl::get_bandwidth_range(size_t chan)
-    {
-        chan = _stream_args.channels[chan];
-        return _dev->get_rx_bandwidth_range(chan);
-    }
-
-    void
-    usrp_source_impl::set_auto_dc_offset(const bool enable, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-#ifdef UHD_USRP_MULTI_USRP_FRONTEND_CAL_API
-      return _dev->set_rx_dc_offset(enable, chan);
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
@@ -299,18 +120,6 @@ namespace gr {
     }
 
     void
-    usrp_source_impl::set_auto_iq_balance(const bool enable, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-#ifdef UHD_USRP_MULTI_USRP_FRONTEND_IQ_AUTO_API
-      return _dev->set_rx_iq_balance(enable, chan);
-#else
-      throw std::runtime_error("not implemented in this version");
-#endif
-    }
-
-
-    void
     usrp_source_impl::set_iq_balance(const std::complex<double> &correction,
                                      size_t chan)
     {
@@ -322,33 +131,59 @@ namespace gr {
 #endif
     }
 
-    ::uhd::sensor_value_t
-    usrp_source_impl::get_sensor(const std::string &name, size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_sensor(name, chan);
-    }
-
-    std::vector<std::string>
-    usrp_source_impl::get_sensor_names(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_sensor_names(chan);
-    }
-
-    ::uhd::usrp::dboard_iface::sptr
-    usrp_source_impl::get_dboard_iface(size_t chan)
-    {
-      chan = _stream_args.channels[chan];
-      return _dev->get_rx_dboard_iface(chan);
-    }
-
     void
     usrp_source_impl::set_stream_args(const ::uhd::stream_args_t &stream_args)
     {
       _update_stream_args(stream_args);
 #ifdef GR_UHD_USE_STREAM_API
       _rx_stream.reset();
+#else
+      throw std::runtime_error("not implemented in this version");
+#endif
+    }
+
+    // Non-symmetric public API calls:
+
+    void
+    usrp_source_impl::set_samp_rate(double rate)
+    {
+        BOOST_FOREACH(const size_t chan, _stream_args.channels)
+        {
+            _dev->set_rx_rate(rate, chan);
+        }
+      _samp_rate = this->get_samp_rate();
+      _tag_now = true;
+    }
+
+    ::uhd::tune_result_t
+    usrp_source_impl::set_center_freq(const ::uhd::tune_request_t tune_request,
+                                      size_t chan)
+    {
+      const size_t user_chan = chan;
+      chan = _stream_args.channels[chan];
+      const ::uhd::tune_result_t res = _dev->set_rx_freq(tune_request, chan);
+      _center_freq = this->get_center_freq(user_chan);
+      _tag_now = true;
+      return res;
+    }
+
+    void
+    usrp_source_impl::set_auto_dc_offset(const bool enable, size_t chan)
+    {
+      chan = _stream_args.channels[chan];
+#ifdef UHD_USRP_MULTI_USRP_FRONTEND_CAL_API
+      return _dev->set_rx_dc_offset(enable, chan);
+#else
+      throw std::runtime_error("not implemented in this version");
+#endif
+    }
+
+    void
+    usrp_source_impl::set_auto_iq_balance(const bool enable, size_t chan)
+    {
+      chan = _stream_args.channels[chan];
+#ifdef UHD_USRP_MULTI_USRP_FRONTEND_IQ_AUTO_API
+      return _dev->set_rx_iq_balance(enable, chan);
 #else
       throw std::runtime_error("not implemented in this version");
 #endif

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -58,44 +58,25 @@ namespace gr {
                        const ::uhd::stream_args_t &stream_args);
       ~usrp_source_impl();
 
-      // Get Commands
-      ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
-      std::string get_subdev_spec(size_t mboard);
-      double get_samp_rate(void);
-      ::uhd::meta_range_t get_samp_rates(void);
-      double get_center_freq(size_t chan);
-      ::uhd::freq_range_t get_freq_range(size_t chan);
-      double get_gain(size_t chan);
-      double get_gain(const std::string &name, size_t chan);
-      double get_normalized_gain(size_t chan);
-      std::vector<std::string> get_gain_names(size_t chan);
-      ::uhd::gain_range_t get_gain_range(size_t chan);
-      ::uhd::gain_range_t get_gain_range(const std::string &name, size_t chan);
-      std::string get_antenna(size_t chan);
-      std::vector<std::string> get_antennas(size_t chan);
-      ::uhd::sensor_value_t get_sensor(const std::string &name, size_t chan);
-      std::vector<std::string> get_sensor_names(size_t chan);
-      ::uhd::usrp::dboard_iface::sptr get_dboard_iface(size_t chan);
+      // Symmetric getters/setters (common between source and sink)
+      USRP_BLOCK_SYMMETRIC_METHODS_H();
 
-      // Set Commands
-      void set_subdev_spec(const std::string &spec, size_t mboard);
+      // Also symmetric, but can't be moved to usrp_block for now:
+      ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
+      ::uhd::meta_range_t get_samp_rates(void);
+      void set_dc_offset(const std::complex<double> &offset, size_t chan);
+      void set_iq_balance(const std::complex<double> &correction, size_t chan);
+      void set_stream_args(const ::uhd::stream_args_t &stream_args);
+
+      // Non-symmetric setters:
       void set_samp_rate(double rate);
       ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan);
-      void set_gain(double gain, size_t chan);
-      void set_gain(double gain, const std::string &name, size_t chan);
-      void set_normalized_gain(double gain, size_t chan);
-      void set_antenna(const std::string &ant, size_t chan);
-      void set_bandwidth(double bandwidth, size_t chan);
-      double get_bandwidth(size_t chan);
-      ::uhd::freq_range_t get_bandwidth_range(size_t chan);
       void set_auto_dc_offset(const bool enable, size_t chan);
-      void set_dc_offset(const std::complex<double> &offset, size_t chan);
       void set_auto_iq_balance(const bool enable, size_t chan);
-      void set_iq_balance(const std::complex<double> &correction, size_t chan);
-      void set_stream_args(const ::uhd::stream_args_t &stream_args);
       void set_start_time(const ::uhd::time_spec_t &time);
 
+      // Stream-related commands
       void issue_stream_cmd(const ::uhd::stream_cmd_t &cmd);
       void flush(void);
       bool start(void);


### PR DESCRIPTION
usrp_source and usrp_sink have lots of functions that are nearly
identical, but not quite. Because of these differences, they need
to be both defined and declared in usrp_source. Here, we move all
the symmetric functions into the usrp_block_impl.* files using the
preprocessor.