### PR TITLE
gr-qtgui: fix Waterfall Plot label font size when no theme is applied.

### DIFF
--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -142,6 +142,7 @@ WaterfallDisplayPlot::WaterfallDisplayPlot(int nplots, QWidget* parent)
   d_half_freq = false;
   d_legend_enabled = true;
   d_nrows = 200;
+  d_color_bar_title_font_size = 18;
 
   setAxisTitle(QwtPlot::xBottom, "Frequency (Hz)");
   setAxisScaleDraw(QwtPlot::xBottom, new FreqDisplayScaleDraw(0));


### PR DESCRIPTION

gr-qtgui: default font size of the colorbar title in the Waterfall plot was never set. Now set to font size 18.