### PR TITLE
Make the client connecting the server continually until the connection is built successfully.

### DIFF
--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -157,7 +157,6 @@ class ModToolRemove(ModTool):
             print "Deleting occurrences of %s from %s/CMakeLists.txt..." % (b, path)
             for var in makefile_vars:
                 ed.remove_value(var, b)
-
             if cmakeedit_func is not None:
                 cmakeedit_func(b, ed)
         ed.write()

--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -155,9 +155,9 @@ class ModToolRemove(ModTool):
             self.scm.remove_file(f)
             os.unlink(f)
             print "Deleting occurrences of %s from %s/CMakeLists.txt..." % (b, path)
-            if re.match('lib/qa_\w*',f) is None:
-                for var in makefile_vars:
-                    ed.remove_value(var, b)
+            for var in makefile_vars:
+                ed.remove_value(var, b)
+
             if cmakeedit_func is not None:
                 cmakeedit_func(b, ed)
         ed.write()

--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -155,8 +155,9 @@ class ModToolRemove(ModTool):
             self.scm.remove_file(f)
             os.unlink(f)
             print "Deleting occurrences of %s from %s/CMakeLists.txt..." % (b, path)
-            for var in makefile_vars:
-                ed.remove_value(var, b)
+            if re.match('lib/qa_\w*',f) is None:
+                for var in makefile_vars:
+                    ed.remove_value(var, b)
             if cmakeedit_func is not None:
                 cmakeedit_func(b, ed)
         ed.write()

--- a/grc/grc_gnuradio/blks2/tcp.py
+++ b/grc/grc_gnuradio/blks2/tcp.py
@@ -22,6 +22,7 @@
 from gnuradio import gr, blocks
 import socket
 import os
+import time
 
 def _get_sock_fd(addr, port, server):
     """
@@ -44,7 +45,16 @@ def _get_sock_fd(addr, port, server):
         clientsock, address = sock.accept()
         return os.dup(clientsock.fileno())
     else:
-        sock.connect((addr, port))
+        while True:
+	    try:
+		print "Try to connect server!"		
+        	sock.connect((addr, port))
+	    except:
+		 print "Connection failed,try again!"
+		 time.sleep(1)
+		 continue
+	    break
+	print "Connected to server!"		
         return os.dup(sock.fileno())
 
 class tcp_source(gr.hier_block2):


### PR DESCRIPTION
Hi, recently, I'm debugging a distributed GNU Radio programs, which run in two PCs and exchange data through the tcp block of the repository. I feel a little inconvenient when debugging the programs. I must start the client program after the server program has been running. The order about starting the programs is very important or they won't start work. The main problem is the client just connects the server one time, and it will quit if the server would not start listening. The restriction affects my working efficiency a little, maybe, we can make it easier. 
Make the client connecting the server continually until it connects the server successfully. I adopted this method in my work. Maybe, it is a suggestion for you. 
Thank you. 