### PR TITLE
Fix compilation under mingw-w64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O2")
 # Environment setup
 ########################################################################
 IF(NOT DEFINED BOOST_ROOT)
-    SET(BOOST_ROOT ${CMAKE_INSTALL_PREFIX})
+    SET(BOOST_ROOT "${CMAKE_INSTALL_PREFIX}")
 ENDIF()
 
 ########################################################################
@@ -158,7 +158,7 @@ set(GR_THEMES_DIR      ${GR_PKG_DATA_DIR}/themes CACHE PATH "Path to install QTG
 # Set location of config/prefs files in /etc
 # Special exception if prefix is /usr so we don't make a /usr/etc.
 set(GR_CONF_DIR etc CACHE PATH "Path to install config files")
-string(COMPARE EQUAL ${CMAKE_INSTALL_PREFIX} "/usr" isusr)
+string(COMPARE EQUAL "${CMAKE_INSTALL_PREFIX}" "/usr" isusr)
 if(isusr)
   set(SYSCONFDIR "/${GR_CONF_DIR}" CACHE PATH "System configuration directory")
 else(isusr)

--- a/cmake/Modules/GrBoost.cmake
+++ b/cmake/Modules/GrBoost.cmake
@@ -31,8 +31,13 @@ set(BOOST_REQUIRED_COMPONENTS
     program_options
     filesystem
     system
-    thread
 )
+
+if (MINGW)
+	set(BOOST_REQUIRED_COMPONENTS ${BOOST_REQUIRED_COMPONENTS} thread_win32)
+else(MINGW)
+	set(BOOST_REQUIRED_COMPONENTS ${BOOST_REQUIRED_COMPONENTS} thread)
+endif(MINGW)
 
 if(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
     list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix

--- a/gnuradio-runtime/include/gnuradio/high_res_timer.h
+++ b/gnuradio-runtime/include/gnuradio/high_res_timer.h
@@ -107,7 +107,7 @@ namespace gr {
 
 ////////////////////////////////////////////////////////////////////////
 #ifdef GNURADIO_HRT_USE_QUERY_PERFORMANCE_COUNTER
-    #include <Windows.h>
+    #include <windows.h>
 
     inline gr::high_res_timer_type gr::high_res_timer_now(void){
         LARGE_INTEGER counts;

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -149,7 +149,7 @@ CHECK_INCLUDE_FILE_CXX(windows.h HAVE_WINDOWS_H)
 IF(HAVE_WINDOWS_H)
     ADD_DEFINITIONS(-DHAVE_WINDOWS_H -DUSING_WINSOCK -DWIN32_LEAN_AND_MEAN)
     MESSAGE(STATUS "Adding windows libs to gnuradio runtime libs...")
-    LIST(APPEND gnuradio_runtime_libs WS2_32.lib WSock32.lib)
+    LIST(APPEND gnuradio_runtime_libs ws2_32 wsock32)
 ENDIF(HAVE_WINDOWS_H)
 
 #need to link with librt on ubuntu 11.10 for shm_*

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -31,9 +31,9 @@ message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
 #double escape for windows backslash path separators
-string(REPLACE "\\" "\\\\" prefix ${prefix})
-string(REPLACE "\\" "\\\\" SYSCONFDIR ${SYSCONFDIR})
-string(REPLACE "\\" "\\\\" GR_PREFSDIR ${GR_PREFSDIR})
+string(REPLACE "\\" "\\\\" prefix "${prefix}")
+string(REPLACE "\\" "\\\\" SYSCONFDIR "${SYSCONFDIR}")
+string(REPLACE "\\" "\\\\" GR_PREFSDIR "${GR_PREFSDIR}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/constants.cc.in

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -318,7 +318,7 @@ namespace gr {
     const int alignment = volk_get_alignment();
     for(int i = 0; i < block->detail()->ninputs(); i++) {
       void *r = (void*)block->detail()->input(i)->read_pointer();
-      unsigned long int ri = (unsigned long int)r % alignment;
+      uintptr_t ri = (uintptr_t)r % alignment;
       //std::cerr << "reader: " << r << "  alignment: " << ri << std::endl;
       if(ri != 0) {
         size_t itemsize = block->detail()->input(i)->get_sizeof_item();
@@ -330,7 +330,7 @@ namespace gr {
 
     for(int i = 0; i < block->detail()->noutputs(); i++) {
       void *w = (void*)block->detail()->output(i)->write_pointer();
-      unsigned long int wi = (unsigned long int)w % alignment;
+      uintptr_t wi = (uintptr_t)w % alignment;
       //std::cerr << "writer: " << w << "  alignment: " << wi << std::endl;
       if(wi != 0) {
         size_t itemsize = block->detail()->output(i)->get_sizeof_item();

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -65,7 +65,41 @@ namespace gr {
 #endif
 
 
-#if defined(HAVE_PTHREAD_SETSCHEDPARAM)
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+
+#include <windows.h>
+
+namespace gr {
+  namespace impl {
+
+    rt_status_t enable_realtime_scheduling(rt_sched_param p)
+    {
+      //set the priority class on the process
+      int pri_class = (true)? REALTIME_PRIORITY_CLASS : NORMAL_PRIORITY_CLASS;
+      if(SetPriorityClass(GetCurrentProcess(), pri_class) == 0)
+        return RT_OTHER_ERROR;
+
+      //scale the priority value to the constants
+      int priorities[] = {
+        THREAD_PRIORITY_IDLE, THREAD_PRIORITY_LOWEST, THREAD_PRIORITY_BELOW_NORMAL, THREAD_PRIORITY_NORMAL,
+        THREAD_PRIORITY_ABOVE_NORMAL, THREAD_PRIORITY_HIGHEST, THREAD_PRIORITY_TIME_CRITICAL
+      };
+      const double priority = double(p.priority)/(rt_priority_max() - rt_priority_min());
+      size_t pri_index = size_t((priority+1.0)*6/2.0); // -1 -> 0, +1 -> 6
+      pri_index %= sizeof(priorities)/sizeof(*priorities); //range check
+
+      //set the thread priority on the thread
+      if(SetThreadPriority(GetCurrentThread(), priorities[pri_index]) == 0)
+        return RT_OTHER_ERROR;
+
+      //printf("SetPriorityClass + SetThreadPriority\n");
+      return RT_OK;
+    }
+
+  } // namespace impl
+} // namespace gr
+
+#elif defined(HAVE_PTHREAD_SETSCHEDPARAM)
 
 namespace gr {
   namespace impl {
@@ -135,40 +169,6 @@ namespace gr {
       }
 
       //printf("SCHED_FIFO enabled with priority = %d\n", pri);
-      return RT_OK;
-    }
-
-  } // namespace impl
-} // namespace gr
-
-#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
-
-#include <windows.h>
-
-namespace gr {
-  namespace impl {
-
-    rt_status_t enable_realtime_scheduling(rt_sched_param p)
-    {
-      //set the priority class on the process
-      int pri_class = (true)? REALTIME_PRIORITY_CLASS : NORMAL_PRIORITY_CLASS;
-      if(SetPriorityClass(GetCurrentProcess(), pri_class) == 0)
-        return RT_OTHER_ERROR;
-
-      //scale the priority value to the constants
-      int priorities[] = {
-        THREAD_PRIORITY_IDLE, THREAD_PRIORITY_LOWEST, THREAD_PRIORITY_BELOW_NORMAL, THREAD_PRIORITY_NORMAL,
-        THREAD_PRIORITY_ABOVE_NORMAL, THREAD_PRIORITY_HIGHEST, THREAD_PRIORITY_TIME_CRITICAL
-      };
-      const double priority = double(p.priority)/(rt_priority_max() - rt_priority_min());
-      size_t pri_index = size_t((priority+1.0)*6/2.0); // -1 -> 0, +1 -> 6
-      pri_index %= sizeof(priorities)/sizeof(*priorities); //range check
-
-      //set the thread priority on the thread
-      if(SetThreadPriority(GetCurrentThread(), priorities[pri_index]) == 0)
-        return RT_OTHER_ERROR;
-
-      //printf("SetPriorityClass + SetThreadPriority\n");
       return RT_OK;
     }
 

--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -28,7 +28,7 @@
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace gr {
   namespace thread {
@@ -111,6 +111,7 @@ namespace gr {
       // Not implemented on Windows
       return -1;
     }
+#ifndef __MINGW32__
 #pragma pack(push,8)
     typedef struct tagTHREADNAME_INFO
     {
@@ -152,6 +153,13 @@ namespace gr {
 
       _set_thread_name(thread, name.c_str(), dwThreadId);
     }
+#else
+    void
+    set_thread_name(gr_thread_t thread, std::string name)
+    {
+        /* Not implemented on mingw-w64 */
+    }
+#endif /* !__MINGW32__ */
 
   } /* namespace thread */
 } /* namespace gr */

--- a/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
+++ b/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
@@ -34,7 +34,7 @@
 namespace gr {
   namespace thread {
 
-#if defined(HAVE_PTHREAD_SIGMASK) && defined(HAVE_SIGNAL_H)
+#if defined(HAVE_PTHREAD_SIGMASK) && defined(HAVE_SIGNAL_H) && !defined(__MINGW32__)
 
     void mask_signals()
     {

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -37,8 +37,8 @@ namespace gr {
   {
     //std::cerr << "tpb_thread_body: " << block << std::endl;
 
-#ifdef _MSC_VER
-    #include <Windows.h>
+#if defined(_MSC_VER) || defined(__MINGW32__)
+    #include <windows.h>
     thread::set_thread_name(GetCurrentThread(), boost::str(boost::format("%s%d") % block->name() % block->unique_id()));
 #else
     thread::set_thread_name(pthread_self(), boost::str(boost::format("%s%d") % block->name() % block->unique_id()));

--- a/gr-blocks/lib/ConfigChecks.cmake
+++ b/gr-blocks/lib/ConfigChecks.cmake
@@ -56,7 +56,7 @@ CHECK_INCLUDE_FILE_CXX(windows.h HAVE_WINDOWS_H)
 IF(HAVE_WINDOWS_H)
     ADD_DEFINITIONS(-DHAVE_WINDOWS_H -DUSING_WINSOCK)
     MESSAGE(STATUS "Adding windows libs to gr blocks libs...")
-    LIST(APPEND blocks_libs WS2_32.lib WSock32.lib)
+    LIST(APPEND blocks_libs ws2_32 wsock32)
 ENDIF(HAVE_WINDOWS_H)
 
 ########################################################################


### PR DESCRIPTION
This set of patches fix a few issues reported when compiling GNU Radio using mingw-w64 under Linux.