### PR TITLE
Volkize fft

### DIFF
--- a/gr-fft/include/gnuradio/fft/fft.h
+++ b/gr-fft/include/gnuradio/fft/fft.h
@@ -69,11 +69,11 @@ namespace gr {
      * \ingroup misc
      */
     class FFT_API fft_complex {
-      int	      d_fft_size;
+      int         d_fft_size;
       int         d_nthreads;
       gr_complex *d_inbuf;
       gr_complex *d_outbuf;
-      void	     *d_plan;
+      void       *d_plan;
 
     public:
       fft_complex(int fft_size, bool forward = true, int nthreads=1);
@@ -112,11 +112,11 @@ namespace gr {
      * \ingroup misc
      */
     class FFT_API fft_real_fwd {
-      int	  d_fft_size;
+      int     d_fft_size;
       int         d_nthreads;
-      float	 *d_inbuf;
+      float  *d_inbuf;
       gr_complex *d_outbuf;
-      void	 *d_plan;
+      void   *d_plan;
 
     public:
       fft_real_fwd (int fft_size, int nthreads=1);
@@ -155,11 +155,11 @@ namespace gr {
      * \ingroup misc
      */
     class FFT_API fft_real_rev {
-      int	      d_fft_size;
+      int         d_fft_size;
       int         d_nthreads;
       gr_complex *d_inbuf;
-      float	     *d_outbuf;
-      void	     *d_plan;
+      float      *d_outbuf;
+      void       *d_plan;
 
     public:
       fft_real_rev(int fft_size, int nthreads=1);

--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -35,13 +35,13 @@ namespace gr {
     public:
 
       enum win_type {
- 	WIN_HAMMING = 0,         //!< Hamming window; max attenuation 53 dB
- 	WIN_HANN = 1,            //!< Hann window; max attenuation 44 dB
- 	WIN_BLACKMAN = 2,        //!< Blackman window; max attenuation 74 dB
-	WIN_RECTANGULAR = 3,     //!< Basic rectangular window; max attenuation 21 dB
-	WIN_KAISER = 4,          //!< Kaiser window; max attenuation see window::max_attenuation
-	WIN_BLACKMAN_hARRIS = 5, //!< Blackman-harris window; max attenuation 92 dB
- 	WIN_BLACKMAN_HARRIS = 5, //!< alias to WIN_BLACKMAN_hARRIS for capitalization consistency
+        WIN_HAMMING = 0,         //!< Hamming window; max attenuation 53 dB
+        WIN_HANN = 1,            //!< Hann window; max attenuation 44 dB
+        WIN_BLACKMAN = 2,        //!< Blackman window; max attenuation 74 dB
+        WIN_RECTANGULAR = 3,     //!< Basic rectangular window; max attenuation 21 dB
+        WIN_KAISER = 4,          //!< Kaiser window; max attenuation see window::max_attenuation
+        WIN_BLACKMAN_hARRIS = 5, //!< Blackman-harris window; max attenuation 92 dB
+        WIN_BLACKMAN_HARRIS = 5, //!< alias to WIN_BLACKMAN_hARRIS for capitalization consistency
         WIN_BARTLETT = 6,        //!< Barlett (triangular) window; max attenuation 26 dB
         WIN_FLATTOP = 7,         //!< flat top window; useful in FFTs; max attenuation 93 dB
       };

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -96,11 +96,11 @@ namespace gr {
       const char *filename = wisdom_filename ();
       FILE *fp = fopen (filename, "r");
       if (fp != 0){
-	int r = fftwf_import_wisdom_from_file (fp);
-	fclose (fp);
-	if (!r){
-	  fprintf (stderr, "gr::fft: can't import wisdom from %s\n", filename);
-	}
+        int r = fftwf_import_wisdom_from_file (fp);
+        fclose (fp);
+        if (!r){
+          fprintf (stderr, "gr::fft: can't import wisdom from %s\n", filename);
+        }
       }
     }
 
@@ -111,10 +111,10 @@ namespace gr {
 
 #ifdef FFTW3F_THREADS
       if (fftw_threads_inited == 0)
-	{
-	  fftw_threads_inited = 1;
-	  fftwf_init_threads();
-	}
+    {
+      fftw_threads_inited = 1;
+      fftwf_init_threads();
+    }
 
       fftwf_plan_with_nthreads(nthreads);
 #endif
@@ -126,12 +126,12 @@ namespace gr {
       const char *filename = wisdom_filename ();
       FILE *fp = fopen (filename, "w");
       if (fp != 0){
-	fftwf_export_wisdom_to_file (fp);
-	fclose (fp);
+        fftwf_export_wisdom_to_file (fp);
+        fclose (fp);
       }
       else {
-	fprintf (stderr, "fft_impl_fftw: ");
-	perror (filename);
+        fprintf (stderr, "fft_impl_fftw: ");
+        perror (filename);
       }
     }
 
@@ -144,18 +144,19 @@ namespace gr {
 
       assert (sizeof (fftwf_complex) == sizeof (gr_complex));
 
-      if (fft_size <= 0)
-	throw std::out_of_range ("fft_impl_fftw: invalid fft_size");
+      if (fft_size <= 0){
+        throw std::out_of_range ("fft_impl_fftw: invalid fft_size");
+      }
 
       d_fft_size = fft_size;
       d_inbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * inbuf_length ());
-      if (d_inbuf == 0)
-	throw std::runtime_error ("fftwf_malloc");
-
+      if (d_inbuf == 0) {
+        throw std::runtime_error ("fftwf_malloc");
+      }
       d_outbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * outbuf_length ());
-      if (d_outbuf == 0){
-	fftwf_free (d_inbuf);
-	throw std::runtime_error ("fftwf_malloc");
+      if (d_outbuf == 0) {
+        fftwf_free (d_inbuf);
+        throw std::runtime_error ("fftwf_malloc");
       }
 
       d_nthreads = nthreads;
@@ -163,14 +164,14 @@ namespace gr {
       import_wisdom();	// load prior wisdom from disk
 
       d_plan = fftwf_plan_dft_1d (fft_size,
-				  reinterpret_cast<fftwf_complex *>(d_inbuf),
-				  reinterpret_cast<fftwf_complex *>(d_outbuf),
-				  forward ? FFTW_FORWARD : FFTW_BACKWARD,
-				  FFTW_MEASURE);
+                  reinterpret_cast<fftwf_complex *>(d_inbuf),
+                  reinterpret_cast<fftwf_complex *>(d_outbuf),
+                  forward ? FFTW_FORWARD : FFTW_BACKWARD,
+                  FFTW_MEASURE);
 
       if (d_plan == NULL) {
-	fprintf(stderr, "gr::fft: error creating plan\n");
-	throw std::runtime_error ("fftwf_plan_dft_1d failed");
+        fprintf(stderr, "gr::fft: error creating plan\n");
+        throw std::runtime_error ("fftwf_plan_dft_1d failed");
       }
       export_wisdom();	// store new wisdom to disk
     }
@@ -188,8 +189,9 @@ namespace gr {
     void
     fft_complex::set_nthreads(int n)
     {
-      if (n <= 0)
-	throw std::out_of_range ("gr::fft: invalid number of threads");
+      if (n <= 0) {
+        throw std::out_of_range ("gr::fft: invalid number of threads");
+      }
       d_nthreads = n;
 
 #ifdef FFTW3F_THREADS
@@ -212,18 +214,20 @@ namespace gr {
 
       assert (sizeof (fftwf_complex) == sizeof (gr_complex));
 
-      if (fft_size <= 0)
-	throw std::out_of_range ("gr::fft: invalid fft_size");
+      if (fft_size <= 0) {
+        throw std::out_of_range ("gr::fft: invalid fft_size");
+      }
 
       d_fft_size = fft_size;
       d_inbuf = (float *) fftwf_malloc (sizeof (float) * inbuf_length ());
-      if (d_inbuf == 0)
-	throw std::runtime_error ("fftwf_malloc");
+      if (d_inbuf == 0) {
+        throw std::runtime_error ("fftwf_malloc");
+      }
 
       d_outbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * outbuf_length ());
-      if (d_outbuf == 0){
-	fftwf_free (d_inbuf);
-	throw std::runtime_error ("fftwf_malloc");
+      if (d_outbuf == 0) {
+        fftwf_free (d_inbuf);
+        throw std::runtime_error ("fftwf_malloc");
       }
 
       d_nthreads = nthreads;
@@ -231,13 +235,13 @@ namespace gr {
       import_wisdom();	// load prior wisdom from disk
 
       d_plan = fftwf_plan_dft_r2c_1d (fft_size,
-				      d_inbuf,
-				      reinterpret_cast<fftwf_complex *>(d_outbuf),
-				      FFTW_MEASURE);
+                      d_inbuf,
+                      reinterpret_cast<fftwf_complex *>(d_outbuf),
+                      FFTW_MEASURE);
 
       if (d_plan == NULL) {
-	fprintf(stderr, "gr::fft::fft_real_fwd: error creating plan\n");
-	throw std::runtime_error ("fftwf_plan_dft_r2c_1d failed");
+        fprintf(stderr, "gr::fft::fft_real_fwd: error creating plan\n");
+        throw std::runtime_error ("fftwf_plan_dft_r2c_1d failed");
       }
       export_wisdom();	// store new wisdom to disk
     }
@@ -255,8 +259,9 @@ namespace gr {
     void
     fft_real_fwd::set_nthreads(int n)
     {
-      if (n <= 0)
-	throw std::out_of_range ("gr::fft::fft_real_fwd::set_nthreads: invalid number of threads");
+      if (n <= 0) {
+        throw std::out_of_range ("gr::fft::fft_real_fwd::set_nthreads: invalid number of threads");
+      }
       d_nthreads = n;
 
 #ifdef FFTW3F_THREADS
@@ -279,18 +284,20 @@ namespace gr {
 
       assert (sizeof (fftwf_complex) == sizeof (gr_complex));
 
-      if (fft_size <= 0)
-	throw std::out_of_range ("gr::fft::fft_real_rev: invalid fft_size");
+      if (fft_size <= 0) {
+        throw std::out_of_range ("gr::fft::fft_real_rev: invalid fft_size");
+      }
 
       d_fft_size = fft_size;
       d_inbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * inbuf_length ());
-      if (d_inbuf == 0)
-	throw std::runtime_error ("fftwf_malloc");
+      if (d_inbuf == 0) {
+        throw std::runtime_error ("fftwf_malloc");
+      }
 
       d_outbuf = (float *) fftwf_malloc (sizeof (float) * outbuf_length ());
-      if (d_outbuf == 0){
-	fftwf_free (d_inbuf);
-	throw std::runtime_error ("fftwf_malloc");
+      if (d_outbuf == 0) {
+        fftwf_free (d_inbuf);
+        throw std::runtime_error ("fftwf_malloc");
       }
 
       d_nthreads = nthreads;
@@ -301,13 +308,13 @@ namespace gr {
       // will be called in multiple threads, we've got to ensure single
       // threaded access.  They are not thread-safe.
       d_plan = fftwf_plan_dft_c2r_1d (fft_size,
-				      reinterpret_cast<fftwf_complex *>(d_inbuf),
-				      d_outbuf,
-				      FFTW_MEASURE);
+                      reinterpret_cast<fftwf_complex *>(d_inbuf),
+                      d_outbuf,
+                      FFTW_MEASURE);
 
       if (d_plan == NULL) {
-	fprintf(stderr, "gr::fft::fft_real_rev: error creating plan\n");
-	throw std::runtime_error ("fftwf_plan_dft_c2r_1d failed");
+        fprintf(stderr, "gr::fft::fft_real_rev: error creating plan\n");
+        throw std::runtime_error ("fftwf_plan_dft_c2r_1d failed");
       }
       export_wisdom ();	// store new wisdom to disk
     }
@@ -325,8 +332,9 @@ namespace gr {
     void
     fft_real_rev::set_nthreads(int n)
     {
-      if (n <= 0)
-	throw std::out_of_range ("gr::fft::fft_real_rev::set_nthreads: invalid number of threads");
+      if (n <= 0) {
+        throw std::out_of_range ("gr::fft::fft_real_rev::set_nthreads: invalid number of threads");
+      }
       d_nthreads = n;
 
 #ifdef FFTW3F_THREADS

--- a/gr-fft/lib/fft_vcc_fftw.cc
+++ b/gr-fft/lib/fft_vcc_fftw.cc
@@ -33,21 +33,21 @@ namespace gr {
   namespace fft {
 
     fft_vcc::sptr fft_vcc::make(int fft_size, bool forward,
-				const std::vector<float> &window,
-				bool shift, int nthreads)
+                const std::vector<float> &window,
+                bool shift, int nthreads)
     {
       return gnuradio::get_initial_sptr(new fft_vcc_fftw
-					(fft_size, forward, window,
-					 shift, nthreads));
+                    (fft_size, forward, window,
+                     shift, nthreads));
     }
 
     fft_vcc_fftw::fft_vcc_fftw(int fft_size, bool forward,
-			       const std::vector<float> &window,
-			       bool shift, int nthreads)
+                   const std::vector<float> &window,
+                   bool shift, int nthreads)
       : sync_block("fft_vcc_fftw",
-		      io_signature::make(1, 1, fft_size * sizeof(gr_complex)),
-		      io_signature::make(1, 1, fft_size * sizeof(gr_complex))),
-	d_fft_size(fft_size), d_forward(forward), d_shift(shift)
+              io_signature::make(1, 1, fft_size * sizeof(gr_complex)),
+              io_signature::make(1, 1, fft_size * sizeof(gr_complex))),
+    d_fft_size(fft_size), d_forward(forward), d_shift(shift)
     {
       d_fft = new fft_complex(d_fft_size, forward, nthreads);
       if(!set_window(window))
@@ -75,17 +75,17 @@ namespace gr {
     fft_vcc_fftw::set_window(const std::vector<float> &window)
     {
       if(window.size()==0 || window.size()==d_fft_size) {
-	d_window=window;
-	return true;
+    d_window=window;
+    return true;
       }
       else
-	return false;
+    return false;
     }
 
     int
     fft_vcc_fftw::work(int noutput_items,
-		       gr_vector_const_void_star &input_items,
-		       gr_vector_void_star &output_items)
+               gr_vector_const_void_star &input_items,
+               gr_vector_void_star &output_items)
     {
       const gr_complex *in = (const gr_complex *) input_items[0];
       gr_complex *out = (gr_complex *) output_items[0];
@@ -97,49 +97,49 @@ namespace gr {
 
       while(count++ < noutput_items) {
 
-	// copy input into optimally aligned buffer
-	if(d_window.size()) {
-	  gr_complex *dst = d_fft->get_inbuf();
-	  if(!d_forward && d_shift) {
-	    unsigned int offset = (!d_forward && d_shift)?(d_fft_size/2):0;
-	    int fft_m_offset = d_fft_size - offset;
-	    for(unsigned int i = 0; i < offset; i++)		// apply window
-	      dst[i+fft_m_offset] = in[i] * d_window[i];
-	    for(unsigned int i = offset; i < d_fft_size; i++)	// apply window
-	      dst[i-offset] = in[i] * d_window[i];
-	  }
-	  else {
-	    for(unsigned int i = 0; i < d_fft_size; i++)		// apply window
-	      dst[i] = in[i] * d_window[i];
-	  }
-	}
-	else {
-	  if(!d_forward && d_shift) {  // apply an ifft shift on the data
-	    gr_complex *dst = d_fft->get_inbuf();
-	    unsigned int len = (unsigned int)(floor(d_fft_size/2.0)); // half length of complex array
-	    memcpy(&dst[0], &in[len], sizeof(gr_complex)*(d_fft_size - len));
-	    memcpy(&dst[d_fft_size - len], &in[0], sizeof(gr_complex)*len);
-	  }
-	  else {
-	    memcpy(d_fft->get_inbuf(), in, input_data_size);
-	  }
-	}
+      // copy input into optimally aligned buffer
+      if(d_window.size()) {
+        gr_complex *dst = d_fft->get_inbuf();
+        if(!d_forward && d_shift) {
+          unsigned int offset = (!d_forward && d_shift)?(d_fft_size/2):0;
+          int fft_m_offset = d_fft_size - offset;
+          for(unsigned int i = 0; i < offset; i++)          // apply window
+            dst[i+fft_m_offset] = in[i] * d_window[i];
+          for(unsigned int i = offset; i < d_fft_size; i++) // apply window
+            dst[i-offset] = in[i] * d_window[i];
+        }
+        else {
+          for(unsigned int i = 0; i < d_fft_size; i++)      // apply window
+            dst[i] = in[i] * d_window[i];
+        }
+      }
+      else {
+        if(!d_forward && d_shift) {  // apply an ifft shift on the data
+          gr_complex *dst = d_fft->get_inbuf();
+          unsigned int len = (unsigned int)(floor(d_fft_size/2.0)); // half length of complex array
+          memcpy(&dst[0], &in[len], sizeof(gr_complex)*(d_fft_size - len));
+          memcpy(&dst[d_fft_size - len], &in[0], sizeof(gr_complex)*len);
+        }
+        else {
+          memcpy(d_fft->get_inbuf(), in, input_data_size);
+        }
+      }
 
-	// compute the fft
-	d_fft->execute();
+      // compute the fft
+      d_fft->execute();
 
-	// copy result to our output
-	if(d_forward && d_shift) {  // apply a fft shift on the data
-	  unsigned int len = (unsigned int)(ceil(d_fft_size/2.0));
-	  memcpy(&out[0], &d_fft->get_outbuf()[len], sizeof(gr_complex)*(d_fft_size - len));
-	  memcpy(&out[d_fft_size - len], &d_fft->get_outbuf()[0], sizeof(gr_complex)*len);
-	}
-	else {
-	  memcpy (out, d_fft->get_outbuf (), output_data_size);
-	}
+      // copy result to our output
+      if(d_forward && d_shift) {  // apply a fft shift on the data
+        unsigned int len = (unsigned int)(ceil(d_fft_size/2.0));
+        memcpy(&out[0], &d_fft->get_outbuf()[len], sizeof(gr_complex)*(d_fft_size - len));
+        memcpy(&out[d_fft_size - len], &d_fft->get_outbuf()[0], sizeof(gr_complex)*len);
+      }
+      else {
+        memcpy (out, d_fft->get_outbuf (), output_data_size);
+      }
 
-	in  += d_fft_size;
-	out += d_fft_size;
+      in  += d_fft_size;
+      out += d_fft_size;
       }
 
       return noutput_items;

--- a/gr-fft/lib/fft_vcc_fftw.cc
+++ b/gr-fft/lib/fft_vcc_fftw.cc
@@ -25,9 +25,9 @@
 #endif
 
 #include "fft_vcc_fftw.h"
-#include <gnuradio/io_signature.h>
 #include <math.h>
 #include <string.h>
+#include <volk/volk.h>
 
 namespace gr {
   namespace fft {
@@ -103,14 +103,11 @@ namespace gr {
         if(!d_forward && d_shift) {
           unsigned int offset = (!d_forward && d_shift)?(d_fft_size/2):0;
           int fft_m_offset = d_fft_size - offset;
-          for(unsigned int i = 0; i < offset; i++)          // apply window
-            dst[i+fft_m_offset] = in[i] * d_window[i];
-          for(unsigned int i = offset; i < d_fft_size; i++) // apply window
-            dst[i-offset] = in[i] * d_window[i];
+          volk_32fc_32f_multiply_32fc(&dst[fft_m_offset], in, &d_window[0], offset);
+          volk_32fc_32f_multiply_32fc(&dst[0], in, &d_window[0], d_fft_size);
         }
         else {
-          for(unsigned int i = 0; i < d_fft_size; i++)      // apply window
-            dst[i] = in[i] * d_window[i];
+          volk_32fc_32f_multiply_32fc(&dst[0], in, &d_window[0], d_fft_size);
         }
       }
       else {

--- a/gr-fft/lib/fft_vcc_fftw.h
+++ b/gr-fft/lib/fft_vcc_fftw.h
@@ -40,8 +40,8 @@ namespace gr {
 
     public:
       fft_vcc_fftw(int fft_size, bool forward,
-		   const std::vector<float> &window,
-		   bool shift, int nthreads=1);
+           const std::vector<float> &window,
+           bool shift, int nthreads=1);
 
       ~fft_vcc_fftw();
 
@@ -50,8 +50,8 @@ namespace gr {
       bool set_window(const std::vector<float> &window);
 
       int work(int noutput_items,
-	       gr_vector_const_void_star &input_items,
-	       gr_vector_void_star &output_items);
+           gr_vector_const_void_star &input_items,
+           gr_vector_void_star &output_items);
     };
 
   } /* namespace fft */

--- a/gr-fft/python/fft/qa_fft.py
+++ b/gr-fft/python/fft/qa_fft.py
@@ -19,195 +19,149 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-import sys
-import random
-
 from gnuradio import gr, gr_unittest, fft, blocks
 
-primes = (2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,
-          59,61,67,71,73,79,83,89,97,101,103,107,109,113,127,131,
-          137,139,149,151,157,163,167,173,179,181,191,193,197,199,211,223,
-          227,229,233,239,241,251,257,263,269,271,277,281,283,293,307,311)
+primes = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131,
+          137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223,
+          227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311)
+
+primes_transformed = ((4377 + 4516j),
+                      (-1706.1268310546875 + 1638.4256591796875j),
+                      (-915.2083740234375 + 660.69427490234375j),
+                      (-660.370361328125 + 381.59600830078125j),
+                      (-499.96044921875 + 238.41630554199219j),
+                      (-462.26748657226562 + 152.88948059082031j),
+                      (-377.98440551757812 + 77.5928955078125j),
+                      (-346.85821533203125 + 47.152004241943359j),
+                      (-295 + 20j),
+                      (-286.33609008789062 - 22.257017135620117j),
+                      (-271.52999877929688 - 33.081821441650391j),
+                      (-224.6358642578125 - 67.019538879394531j),
+                      (-244.24473571777344 - 91.524826049804688j),
+                      (-203.09068298339844 - 108.54627227783203j),
+                      (-198.45195007324219 - 115.90768432617188j),
+                      (-182.97744750976562 - 128.12318420410156j),
+                      (-167 - 180j),
+                      (-130.33688354492188 - 173.83778381347656j),
+                      (-141.19784545898438 - 190.28807067871094j),
+                      (-111.09677124023438 - 214.48896789550781j),
+                      (-70.039543151855469 - 242.41630554199219j),
+                      (-68.960540771484375 - 228.30015563964844j),
+                      (-53.049201965332031 - 291.47097778320312j),
+                      (-28.695289611816406 - 317.64553833007812j),
+                      (57 - 300j),
+                      (45.301143646240234 - 335.69509887695312j),
+                      (91.936195373535156 - 373.32437133789062j),
+                      (172.09465026855469 - 439.275146484375j),
+                      (242.24473571777344 - 504.47515869140625j),
+                      (387.81732177734375 - 666.6788330078125j),
+                      (689.48553466796875 - 918.2142333984375j),
+                      (1646.539306640625 - 1694.1956787109375j))
 
 
 class test_fft(gr_unittest.TestCase):
-
     def setUp(self):
-        pass
+        self.tb = gr.top_block()
+        self.fft_size = 32
 
     def tearDown(self):
         pass
 
     def assert_fft_ok2(self, expected_result, result_data):
         expected_result = expected_result[:len(result_data)]
-        self.assertComplexTuplesAlmostEqual2 (expected_result, result_data,
-                                              abs_eps=1e-9, rel_eps=4e-4)
-
-    def assert_fft_float_ok2(self, expected_result, result_data, abs_eps=1e-9, rel_eps=4e-4):
-        expected_result = expected_result[:len(result_data)]
-        self.assertFloatTuplesAlmostEqual2 (expected_result, result_data,
-                                            abs_eps, rel_eps)
+        self.assertComplexTuplesAlmostEqual2(expected_result, result_data,
+                                             abs_eps=1e-9, rel_eps=4e-4)
 
     def test_001(self):
-        tb = gr.top_block()
-        fft_size = 32
-        src_data = tuple([complex(primes[2*i], primes[2*i+1]) for i in range(fft_size)])
-
-        expected_result = ((4377+4516j),
-                           (-1706.1268310546875+1638.4256591796875j),
-                           (-915.2083740234375+660.69427490234375j),
-                           (-660.370361328125+381.59600830078125j),
-                           (-499.96044921875+238.41630554199219j),
-                           (-462.26748657226562+152.88948059082031j),
-                           (-377.98440551757812+77.5928955078125j),
-                           (-346.85821533203125+47.152004241943359j),
-                           (-295+20j),
-                           (-286.33609008789062-22.257017135620117j),
-                           (-271.52999877929688-33.081821441650391j),
-                           (-224.6358642578125-67.019538879394531j),
-                           (-244.24473571777344-91.524826049804688j),
-                           (-203.09068298339844-108.54627227783203j),
-                           (-198.45195007324219-115.90768432617188j),
-                           (-182.97744750976562-128.12318420410156j),
-                           (-167-180j),
-                           (-130.33688354492188-173.83778381347656j),
-                           (-141.19784545898438-190.28807067871094j),
-                           (-111.09677124023438-214.48896789550781j),
-                           (-70.039543151855469-242.41630554199219j),
-                           (-68.960540771484375-228.30015563964844j),
-                           (-53.049201965332031-291.47097778320312j),
-                           (-28.695289611816406-317.64553833007812j),
-                           (57-300j),
-                           (45.301143646240234-335.69509887695312j),
-                           (91.936195373535156-373.32437133789062j),
-                           (172.09465026855469-439.275146484375j),
-                           (242.24473571777344-504.47515869140625j),
-                           (387.81732177734375-666.6788330078125j),
-                           (689.48553466796875-918.2142333984375j),
-                           (1646.539306640625-1694.1956787109375j))
+        src_data = tuple([complex(primes[2 * i], primes[2 * i + 1]) for i in range(self.fft_size)])
+        expected_result = primes_transformed
 
         src = blocks.vector_source_c(src_data)
-        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, fft_size)
-        op  = fft.fft_vcc(fft_size, True, [], False)
-        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, fft_size)
+        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, self.fft_size)
+        op = fft.fft_vcc(self.fft_size, True, [], False)
+        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, self.fft_size)
         dst = blocks.vector_sink_c()
-        tb.connect(src, s2v, op, v2s, dst)
-        tb.run()
+        self.tb.connect(src, s2v, op, v2s, dst)
+        self.tb.run()
         result_data = dst.data()
-        #print 'expected:', expected_result
-        #print 'results: ', result_data
-        #self.assertComplexTuplesAlmostEqual (expected_result, result_data, 5)
         self.assert_fft_ok2(expected_result, result_data)
 
     def test_002(self):
-        tb = gr.top_block()
-        fft_size = 32
-
-        tmp_data = ((4377+4516j),
-                    (-1706.1268310546875+1638.4256591796875j),
-                    (-915.2083740234375+660.69427490234375j),
-                    (-660.370361328125+381.59600830078125j),
-                    (-499.96044921875+238.41630554199219j),
-                    (-462.26748657226562+152.88948059082031j),
-                    (-377.98440551757812+77.5928955078125j),
-                    (-346.85821533203125+47.152004241943359j),
-                    (-295+20j),
-                    (-286.33609008789062-22.257017135620117j),
-                    (-271.52999877929688-33.081821441650391j),
-                    (-224.6358642578125-67.019538879394531j),
-                    (-244.24473571777344-91.524826049804688j),
-                    (-203.09068298339844-108.54627227783203j),
-                    (-198.45195007324219-115.90768432617188j),
-                    (-182.97744750976562-128.12318420410156j),
-                    (-167-180j),
-                    (-130.33688354492188-173.83778381347656j),
-                    (-141.19784545898438-190.28807067871094j),
-                    (-111.09677124023438-214.48896789550781j),
-                    (-70.039543151855469-242.41630554199219j),
-                    (-68.960540771484375-228.30015563964844j),
-                    (-53.049201965332031-291.47097778320312j),
-                    (-28.695289611816406-317.64553833007812j),
-                    (57-300j),
-                    (45.301143646240234-335.69509887695312j),
-                    (91.936195373535156-373.32437133789062j),
-                    (172.09465026855469-439.275146484375j),
-                    (242.24473571777344-504.47515869140625j),
-                    (387.81732177734375-666.6788330078125j),
-                    (689.48553466796875-918.2142333984375j),
-                    (1646.539306640625-1694.1956787109375j))
-
-        src_data = tuple([x/fft_size for x in tmp_data])
-
-        expected_result = tuple([complex(primes[2*i], primes[2*i+1]) for i in range(fft_size)])
+        src_data = tuple([x / self.fft_size for x in primes_transformed])
+        expected_result = tuple([complex(primes[2 * i], primes[2 * i + 1]) for i in range(self.fft_size)])
 
         src = blocks.vector_source_c(src_data)
-        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, fft_size)
-        op  = fft.fft_vcc(fft_size, False, [], False)
-        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, fft_size)
+        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, self.fft_size)
+        op = fft.fft_vcc(self.fft_size, False, [], False)
+        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, self.fft_size)
         dst = blocks.vector_sink_c()
-        tb.connect(src, s2v, op, v2s, dst)
-        tb.run()
+        self.tb.connect(src, s2v, op, v2s, dst)
+        self.tb.run()
         result_data = dst.data()
-        #print 'expected:', expected_result
-        #print 'results: ', result_data
-        #self.assertComplexTuplesAlmostEqual (expected_result, result_data, 5)
         self.assert_fft_ok2(expected_result, result_data)
 
     def test_003(self):
         # Same test as above, only use 2 threads
-
-        tb = gr.top_block()
-        fft_size = 32
-
-        tmp_data = ((4377+4516j),
-                    (-1706.1268310546875+1638.4256591796875j),
-                    (-915.2083740234375+660.69427490234375j),
-                    (-660.370361328125+381.59600830078125j),
-                    (-499.96044921875+238.41630554199219j),
-                    (-462.26748657226562+152.88948059082031j),
-                    (-377.98440551757812+77.5928955078125j),
-                    (-346.85821533203125+47.152004241943359j),
-                    (-295+20j),
-                    (-286.33609008789062-22.257017135620117j),
-                    (-271.52999877929688-33.081821441650391j),
-                    (-224.6358642578125-67.019538879394531j),
-                    (-244.24473571777344-91.524826049804688j),
-                    (-203.09068298339844-108.54627227783203j),
-                    (-198.45195007324219-115.90768432617188j),
-                    (-182.97744750976562-128.12318420410156j),
-                    (-167-180j),
-                    (-130.33688354492188-173.83778381347656j),
-                    (-141.19784545898438-190.28807067871094j),
-                    (-111.09677124023438-214.48896789550781j),
-                    (-70.039543151855469-242.41630554199219j),
-                    (-68.960540771484375-228.30015563964844j),
-                    (-53.049201965332031-291.47097778320312j),
-                    (-28.695289611816406-317.64553833007812j),
-                    (57-300j),
-                    (45.301143646240234-335.69509887695312j),
-                    (91.936195373535156-373.32437133789062j),
-                    (172.09465026855469-439.275146484375j),
-                    (242.24473571777344-504.47515869140625j),
-                    (387.81732177734375-666.6788330078125j),
-                    (689.48553466796875-918.2142333984375j),
-                    (1646.539306640625-1694.1956787109375j))
-
-        src_data = tuple([x/fft_size for x in tmp_data])
-
-        expected_result = tuple([complex(primes[2*i], primes[2*i+1]) for i in range(fft_size)])
-
+        src_data = tuple([x / self.fft_size for x in primes_transformed])
+        expected_result = tuple([complex(primes[2 * i], primes[2 * i + 1]) for i in range(self.fft_size)])
         nthreads = 2
 
         src = blocks.vector_source_c(src_data)
-        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, fft_size)
-        op  = fft.fft_vcc(fft_size, False, [], False, nthreads)
-        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, fft_size)
+        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, self.fft_size)
+        op = fft.fft_vcc(self.fft_size, False, [], False, nthreads)
+        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, self.fft_size)
         dst = blocks.vector_sink_c()
-        tb.connect(src, s2v, op, v2s, dst)
-        tb.run()
+        self.tb.connect(src, s2v, op, v2s, dst)
+        self.tb.run()
+        result_data = dst.data()
+        self.assert_fft_ok2(expected_result, result_data)
+
+    def test_windows(self):
+        src_data = tuple([complex(primes[2 * i], primes[2 * i + 1]) for i in range(self.fft_size)])
+        expected_result = ((2238.9174 + 2310.4750j),
+                           (-1603.7416 - 466.7420j),
+                           (116.7449 - 70.8553j),
+                           (-13.9157 + 19.0855j),
+                           (-4.8283 + 16.7025j),
+                           (-43.7425 + 16.9871j),
+                           (-16.1904 + 1.7494j),
+                           (-32.3797 + 6.9964j),
+                           (-13.5283 + 7.7721j),
+                           (-24.3276 - 7.5378j),
+                           (-29.2711 + 4.5709j),
+                           (-2.7124 - 6.6307j),
+                           (-33.5486 - 8.3485j),
+                           (-8.3016 - 9.9534j),
+                           (-18.8590 - 8.3501j),
+                           (-13.9092 - 1.1396j),
+                           (-17.7626 - 26.9281j),
+                           (0.0182 - 8.9000j),
+                           (-19.9143 - 14.1320j),
+                           (-10.3073 - 15.5759j),
+                           (3.5800 - 29.1835j),
+                           (-7.5263 - 1.5900j),
+                           (-3.0392 - 31.7445j),
+                           (-15.1355 - 33.6158j),
+                           (28.2345 - 11.4373j),
+                           (-6.0055 - 27.0418j),
+                           (5.2074 - 21.2431j),
+                           (23.1617 - 31.8610j),
+                           (13.6494 - 11.1982j),
+                           (14.7145 - 14.4113j),
+                           (-60.0053 + 114.7418j),
+                           (-440.1561 - 1632.9807j))
+        window = fft.window_hamming(ntaps=self.fft_size)
+
+        src = blocks.vector_source_c(src_data)
+        s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, self.fft_size)
+        op = fft.fft_vcc(self.fft_size, True, window, False)
+        v2s = blocks.vector_to_stream(gr.sizeof_gr_complex, self.fft_size)
+        dst = blocks.vector_sink_c()
+        self.tb.connect(src, s2v, op, v2s, dst)
+        self.tb.run()
         result_data = dst.data()
         self.assert_fft_ok2(expected_result, result_data)
 
 if __name__ == '__main__':
     gr_unittest.run(test_fft, "test_fft.xml")
-

--- a/gr-fft/python/fft/qa_fft.py
+++ b/gr-fft/python/fft/qa_fft.py
@@ -33,10 +33,10 @@ primes = (2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,
 class test_fft(gr_unittest.TestCase):
 
     def setUp(self):
-	pass
+        pass
 
     def tearDown(self):
-	pass
+        pass
 
     def assert_fft_ok2(self, expected_result, result_data):
         expected_result = expected_result[:len(result_data)]
@@ -49,7 +49,7 @@ class test_fft(gr_unittest.TestCase):
                                             abs_eps, rel_eps)
 
     def test_001(self):
-	tb = gr.top_block()
+        tb = gr.top_block()
         fft_size = 32
         src_data = tuple([complex(primes[2*i], primes[2*i+1]) for i in range(fft_size)])
 
@@ -100,7 +100,7 @@ class test_fft(gr_unittest.TestCase):
         self.assert_fft_ok2(expected_result, result_data)
 
     def test_002(self):
-	tb = gr.top_block()
+        tb = gr.top_block()
         fft_size = 32
 
         tmp_data = ((4377+4516j),
@@ -156,7 +156,7 @@ class test_fft(gr_unittest.TestCase):
     def test_003(self):
         # Same test as above, only use 2 threads
 
-	tb = gr.top_block()
+        tb = gr.top_block()
         fft_size = 32
 
         tmp_data = ((4377+4516j),


### PR DESCRIPTION
fft_vcc_fftw had several for loops in the work function that were easy to replace with calls to volk_32fc_32f_multiply_32fc. However, the QA tests did not cover the case of using a window function, so I added that to help ensure the volk calls were being applied appropriately. It is probably still a good idea to do some additional testing to make sure I didn't miss some corner case.