### PR TITLE
Fix the VOLKized fft_vcc_fftw and QA code

### DIFF
--- a/gr-fft/lib/fft_vcc_fftw.cc
+++ b/gr-fft/lib/fft_vcc_fftw.cc
@@ -103,8 +103,8 @@ namespace gr {
         if(!d_forward && d_shift) {
           unsigned int offset = (!d_forward && d_shift)?(d_fft_size/2):0;
           int fft_m_offset = d_fft_size - offset;
-          volk_32fc_32f_multiply_32fc(&dst[fft_m_offset], in, &d_window[0], offset);
-          volk_32fc_32f_multiply_32fc(&dst[0], in, &d_window[0], d_fft_size);
+          volk_32fc_32f_multiply_32fc(&dst[fft_m_offset], &in[0], &d_window[0], offset);
+          volk_32fc_32f_multiply_32fc(&dst[0], &in[offset], &d_window[offset], d_fft_size-offset);
         }
         else {
           volk_32fc_32f_multiply_32fc(&dst[0], in, &d_window[0], d_fft_size);


### PR DESCRIPTION
The QA code did not cover all the cases being VOLKized, and thus failed to notice the incorrect pointer math.
This QA code (correctly!) fails on the previous commit, and (correctly!) passes with this fix to fft_vcc_fftw.cc.
Thanks to awalls-cx18 for noticing this, and providing the correct array indexing call to VOLK.
Fixes issue #844