### PR TITLE
uniform integer distribution source.

### DIFF
--- a/gnuradio-runtime/include/gnuradio/random.h
+++ b/gnuradio-runtime/include/gnuradio/random.h
@@ -66,7 +66,7 @@ namespace gr {
     void set_integer_limits(const int minimum, const int maximum);
 
     /*!
-     * Uniform random integers in the range set by 'set_integer_limits'.
+     * Uniform random integers in the range set by 'set_integer_limits' [min, max).
      */
     int ran_int();
 

--- a/gnuradio-runtime/include/gnuradio/random.h
+++ b/gnuradio-runtime/include/gnuradio/random.h
@@ -45,16 +45,30 @@ namespace gr {
 
     boost::mt19937 *d_rng; // mersenne twister as random number generator
     boost::uniform_real<float> *d_uniform; // choose uniform distribution, default is [0,1)
+    boost::random::uniform_int_distribution<> *d_integer_dis;
     boost::variate_generator<boost::mt19937&, boost::uniform_real<float> > *d_generator;
+    boost::variate_generator<boost::mt19937&, boost::random::uniform_int_distribution<> > *d_integer_generator;
 
   public:
-    random(unsigned int seed=0);
+    random(unsigned int seed=0, int min_integer = 0, int max_integer = 2);
     ~random();
 
     /*!
      * \brief Change the seed for the initialized number generator. seed = 0 initializes the random number generator with the system time. Note that a fast initialization of various instances can result in the same seed.
      */
     void reseed(unsigned int seed);
+
+    /*!
+     * set minimum and maximum for integer random number generator.
+     * Limits are [minimum, maximum)
+     * Default: [0, std::numeric_limits< IntType >::max)]
+     */
+    void set_integer_limits(const int minimum, const int maximum);
+
+    /*!
+     * Uniform random integers in the range set by 'set_integer_limits'.
+     */
+    int ran_int();
 
     /*!
      * \brief Uniform random numbers in the range [0.0, 1.0)

--- a/gnuradio-runtime/python/gnuradio/gr/qa_random.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_random.py
@@ -23,8 +23,8 @@
 from gnuradio import gr, gr_unittest
 import numpy as np
 
-class test_random(gr_unittest.TestCase):
 
+class test_random(gr_unittest.TestCase):
     # NOTE: For tests on the output distribution of the random numbers, see gnuradio-runtime/apps/evaluation_random_numbers.py.
 
     # Check for range [0,1) of uniform distributed random numbers
@@ -42,23 +42,38 @@ class test_random(gr_unittest.TestCase):
     def test_2(self):
         num = 5
 
-        rndm0 = gr.random(42); # init with time
-        rndm1 = gr.random(42); # init with fix seed
+        rndm0 = gr.random(42)  # init with time
+        rndm1 = gr.random(42)  # init with fix seed
         for k in range(num):
-            x = rndm0.ran1();
-            y = rndm1.ran1();
-            self.assertEqual(x,y)
+            x = rndm0.ran1()
+            y = rndm1.ran1()
+            self.assertEqual(x, y)
 
         x = np.zeros(num)
         y = np.zeros(num)
-        rndm0 = gr.random(42); # init with fix seed 1
+        rndm0 = gr.random(42)  # init with fix seed 1
         for k in range(num):
-            x[k] = rndm0.ran1();
-        rndm1.reseed(43); # init with fix seed 2
+            x[k] = rndm0.ran1()
+        rndm1.reseed(43)  # init with fix seed 2
         for k in range(num):
-            y[k] = rndm0.ran1();
+            y[k] = rndm0.ran1()
         for k in range(num):
-            self.assertNotEqual(x[k],y[k])
+            self.assertNotEqual(x[k], y[k])
+
+    def test_003_integer(self):
+        nitems = 100000
+        minimum = 2
+        maximum = 42
+
+        rng = gr.random(1, minimum, maximum)
+
+        rnd_vals = np.zeros(nitems, dtype=int)
+        for i in range(nitems):
+            rnd_vals[i] = rng.ran_int()
+
+        self.assertGreaterEqual(minimum, np.min(rnd_vals))
+        self.assertLess(np.max(rnd_vals), maximum)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_random, "test_random.xml")

--- a/gnuradio-runtime/python/gnuradio/gr/qa_random.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_random.py
@@ -38,39 +38,38 @@ class test_random(gr_unittest.TestCase):
             self.assertLess(value, 1)
             self.assertGreaterEqual(value, 0)
 
-    # Check reseed method (init with time and seed as fix number)
-    def test_2(self):
+    # Same seed should yield same random values.
+    def test_2_same_seed(self):
         num = 5
-
-        rndm0 = gr.random(42)  # init with time
-        rndm1 = gr.random(42)  # init with fix seed
+        # Init with fixed seed.
+        rndm0 = gr.random(42)
+        rndm1 = gr.random(42)
         for k in range(num):
             x = rndm0.ran1()
             y = rndm1.ran1()
             self.assertEqual(x, y)
 
+    # reseed should yield same numbers.
+    def test_003_reseed(self):
+        num = 5
         x = np.zeros(num)
         y = np.zeros(num)
-        rndm0 = gr.random(42)  # init with fix seed 1
+        rndm = gr.random(43)  # init with fix seed 1
         for k in range(num):
-            x[k] = rndm0.ran1()
-        rndm1.reseed(43)  # init with fix seed 2
+            x[k] = rndm.ran1()
+        rndm.reseed(43)  # init with fix seed 2
         for k in range(num):
-            y[k] = rndm0.ran1()
-        for k in range(num):
-            self.assertNotEqual(x[k], y[k])
+            y[k] = rndm.ran1()
+        self.assertFloatTuplesAlmostEqual(x, y)
 
-    def test_003_integer(self):
+    def test_004_integer(self):
         nitems = 100000
         minimum = 2
         maximum = 42
-
         rng = gr.random(1, minimum, maximum)
-
         rnd_vals = np.zeros(nitems, dtype=int)
         for i in range(nitems):
             rnd_vals[i] = rng.ran_int()
-
         self.assertGreaterEqual(minimum, np.min(rnd_vals))
         self.assertLess(np.max(rnd_vals), maximum)
 

--- a/gr-analog/grc/CMakeLists.txt
+++ b/gr-analog/grc/CMakeLists.txt
@@ -19,3 +19,4 @@
 
 file(GLOB xml_files "*.xml")
 install(FILES ${xml_files} DESTINATION ${GRC_BLOCKS_DIR} COMPONENT "analog_python")
+

--- a/gr-analog/grc/analog_random_uniform_source_x.xml
+++ b/gr-analog/grc/analog_random_uniform_source_x.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<block>
+  <name>Random Uniform Source</name>
+  <key>analog_random_uniform_source_x</key>
+  <category>analog</category>
+  <import>from gnuradio import analog</import>
+  <make>analog.random_uniform_source_$(type.fcn)($minimum, $maximum, $seed)</make>
+
+  <param>
+    <name>Output Type</name>
+    <key>type</key>
+    <type>enum</type>
+    <option>
+      <name>Int</name>
+      <key>int</key>
+      <opt>fcn:i</opt>
+      <opt>offset_type:int</opt>
+    </option>
+    <option>
+      <name>Short</name>
+      <key>short</key>
+      <opt>fcn:s</opt>
+      <opt>offset_type:int</opt>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>byte</key>
+      <opt>fcn:b</opt>
+      <opt>offset_type:int</opt>
+    </option>
+  </param>
+
+  <param>
+    <name>Minimum</name>
+    <key>minimum</key>
+    <type>int</type>
+  </param>
+
+  <param>
+    <name>Maximum</name>
+    <key>maximum</key>
+    <type>int</type>
+  </param>
+
+  <param>
+    <name>Seed</name>
+    <key>seed</key>
+    <value>0</value>
+    <type>int</type>
+  </param>
+
+  <source>
+    <name>out</name>
+    <type>$type</type>
+  </source>
+</block>

--- a/gr-analog/include/gnuradio/analog/CMakeLists.txt
+++ b/gr-analog/include/gnuradio/analog/CMakeLists.txt
@@ -24,6 +24,7 @@ include(GrMiscUtils)
 GR_EXPAND_X_H(analog noise_source_X     s i f c)
 GR_EXPAND_X_H(analog fastnoise_source_X s i f c)
 GR_EXPAND_X_H(analog sig_source_X       s i f c)
+GR_EXPAND_X_H(analog random_uniform_source_X b s i)
 
 add_custom_target(analog_generated_includes DEPENDS
     ${generated_includes}

--- a/gr-analog/include/gnuradio/analog/random_uniform_source_X.h.t
+++ b/gr-analog/include/gnuradio/analog/random_uniform_source_X.h.t
@@ -1,0 +1,61 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/* @WARNING@ */
+
+#ifndef @GUARD_NAME@
+#define @GUARD_NAME@
+
+#include <gnuradio/analog/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace analog {
+
+    /*!
+     * \brief Uniform Random Number Generator with @TYPE@ output.
+     * \ingroup waveform_generators_blk
+     */
+    class ANALOG_API @BASE_NAME@ : virtual public sync_block
+    {
+    public:
+      // gr::analog::@BASE_NAME@::sptr
+      typedef boost::shared_ptr<@BASE_NAME@> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of analog::random_uniform_source_X.
+       *
+       * To avoid accidental use of raw pointers, analog::random_uniform_source_b's
+       * constructor is in a private implementation
+       * class. analog::random_uniform_source_b::make is the public interface for
+       * creating new instances.
+       * \param minimum defines minimal integer value output.
+       * \param maximum output values are below this value
+       * \param seed for Pseudo Random Number Generator. Defaults to 0. In this case current time is used.
+       */
+      static sptr make(int minimum, int maximum, int seed);
+    };
+
+  } /* namespace analog */
+} /* namespace gr */
+
+#endif /* @GUARD_NAME@ */

--- a/gr-analog/lib/CMakeLists.txt
+++ b/gr-analog/lib/CMakeLists.txt
@@ -46,6 +46,7 @@ include(GrMiscUtils)
 GR_EXPAND_X_CC_H(analog noise_source_X_impl     s i f c)
 GR_EXPAND_X_CC_H(analog fastnoise_source_X_impl s i f c)
 GR_EXPAND_X_CC_H(analog sig_source_X_impl     s i f c)
+GR_EXPAND_X_CC_H(analog random_uniform_source_X_impl b s i)
 
 ########################################################################
 # Setup library

--- a/gr-analog/lib/random_uniform_source_X_impl.cc.t
+++ b/gr-analog/lib/random_uniform_source_X_impl.cc.t
@@ -1,0 +1,83 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/* @WARNING@ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "@IMPL_NAME@.h"
+#include <gnuradio/io_signature.h>
+
+namespace gr {
+  namespace analog {
+
+    @BASE_NAME@::sptr
+    @BASE_NAME@::make(int minimum, int maximum, int seed)
+    {
+      return gnuradio::get_initial_sptr(new @IMPL_NAME@(minimum, maximum, seed));
+    }
+
+    @IMPL_NAME@::@IMPL_NAME@(int minimum, int maximum, int seed)
+    : sync_block("@BASE_NAME@",
+            io_signature::make(0, 0, 0),
+            io_signature::make(1, 1, sizeof(@TYPE@)))
+    {
+      d_rng = new gr::random(seed, minimum, maximum);
+    }
+
+    @IMPL_NAME@::~@IMPL_NAME@()
+    {
+      delete d_rng;
+    }
+
+    int
+    @IMPL_NAME@::random_int()
+    {
+      return d_rng->ran_int();
+    }
+
+    int
+    @IMPL_NAME@::work(int noutput_items,
+              gr_vector_const_void_star &input_items,
+              gr_vector_void_star &output_items)
+    {
+      @TYPE@ *out = (@TYPE@*)output_items[0];
+
+      for(int i = 0; i < noutput_items; i++){
+        *out++ = (@TYPE@) random_int();
+      }
+
+      // Tell runtime system how many output items we produced.
+      return noutput_items;
+    }
+
+
+
+
+
+
+
+
+  } /* namespace analog */
+} /* namespace gr */

--- a/gr-analog/lib/random_uniform_source_X_impl.cc.t
+++ b/gr-analog/lib/random_uniform_source_X_impl.cc.t
@@ -52,7 +52,7 @@ namespace gr {
     }
 
     int
-    @IMPL_NAME@::random_int()
+    @IMPL_NAME@::random_value()
     {
       return d_rng->ran_int();
     }
@@ -65,7 +65,7 @@ namespace gr {
       @TYPE@ *out = (@TYPE@*)output_items[0];
 
       for(int i = 0; i < noutput_items; i++){
-        *out++ = (@TYPE@) random_int();
+        *out++ = (@TYPE@) random_value();
       }
 
       // Tell runtime system how many output items we produced.

--- a/gr-analog/lib/random_uniform_source_X_impl.h.t
+++ b/gr-analog/lib/random_uniform_source_X_impl.h.t
@@ -45,7 +45,7 @@ namespace gr {
            gr_vector_const_void_star &input_items,
            gr_vector_void_star &output_items);
 
-      int random_int();
+      int random_value();
     };
 
   } /* namespace filter */

--- a/gr-analog/lib/random_uniform_source_X_impl.h.t
+++ b/gr-analog/lib/random_uniform_source_X_impl.h.t
@@ -1,0 +1,54 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+// @WARNING@
+
+#ifndef @GUARD_NAME@
+#define @GUARD_NAME@
+
+#include <gnuradio/analog/@BASE_NAME@.h>
+#include <gnuradio/random.h>
+
+namespace gr {
+  namespace analog {
+
+    class @IMPL_NAME@ : public @BASE_NAME@
+    {
+    private:
+      gr::random *d_rng;
+
+    public:
+      @IMPL_NAME@(int minimum, int maximum, int seed);
+      ~@IMPL_NAME@();
+
+      // Where all the action really happens
+      int work(int noutput_items,
+           gr_vector_const_void_star &input_items,
+           gr_vector_void_star &output_items);
+
+      int random_int();
+    };
+
+  } /* namespace filter */
+} /* namespace gr */
+
+#endif /* @GUARD_NAME@ */

--- a/gr-analog/python/analog/qa_random_uniform_source.py
+++ b/gr-analog/python/analog/qa_random_uniform_source.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2015 Free Software Foundation, Inc.
+# 
+# This file is part of GNU Radio
+# 
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+import analog_swig as analog
+import numpy as np
+
+
+class qa_random_uniform_source(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_byte(self):
+        minimum = 0
+        maximum = 5
+        seed = 3
+        n_items = 10000
+        rnd_src = analog.random_uniform_source_b(minimum, maximum, seed)
+        head = blocks.head(1, n_items)
+        snk = blocks.vector_sink_b(1)
+        self.tb.connect(rnd_src, head, snk)
+        # set up fg
+        self.tb.run()
+        # check data
+        res = snk.data()
+        self.assertGreaterEqual(minimum, np.min(res))
+        self.assertLess(np.max(res), maximum)
+
+    def test_002_short(self):
+        minimum = 42
+        maximum = 1025
+        seed = 3
+        n_items = 10000
+        rnd_src = analog.random_uniform_source_s(minimum, maximum, seed)
+        head = blocks.head(2, n_items)
+        snk = blocks.vector_sink_s(1)
+        self.tb.connect(rnd_src, head, snk)
+        # set up fg
+        self.tb.run()
+        # check data
+        res = snk.data()
+        self.assertGreaterEqual(minimum, np.min(res))
+        self.assertLess(np.max(res), maximum)
+
+    def test_003_int(self):
+        minimum = 2 ** 12 - 2
+        maximum = 2 ** 17 + 5
+        seed = 3
+        n_items = 10000
+        rnd_src = analog.random_uniform_source_i(minimum, maximum, seed)
+        head = blocks.head(4, n_items)
+        snk = blocks.vector_sink_i(1)
+        self.tb.connect(rnd_src, head, snk)
+        # set up fg
+        self.tb.run()
+        # check data
+        res = snk.data()
+        # plt.hist(res)
+        # plt.show()
+
+        self.assertGreaterEqual(np.min(res), minimum)
+        self.assertLess(np.max(res), maximum)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_random_uniform_source, "qa_random_uniform_source.xml")

--- a/gr-analog/swig/analog_swig.i
+++ b/gr-analog/swig/analog_swig.i
@@ -74,6 +74,9 @@
 #include "gnuradio/analog/simple_squelch_cc.h"
 #include "gnuradio/analog/squelch_base_cc.h"
 #include "gnuradio/analog/squelch_base_ff.h"
+#include "gnuradio/analog/random_uniform_source_b.h"
+#include "gnuradio/analog/random_uniform_source_s.h"
+#include "gnuradio/analog/random_uniform_source_i.h"
 %}
 
 %include "gnuradio/analog/cpm.h"
@@ -116,6 +119,9 @@
 %include "gnuradio/analog/simple_squelch_cc.h"
 %include "gnuradio/analog/squelch_base_cc.h"
 %include "gnuradio/analog/squelch_base_ff.h"
+%include "gnuradio/analog/random_uniform_source_b.h"
+%include "gnuradio/analog/random_uniform_source_s.h"
+%include "gnuradio/analog/random_uniform_source_i.h"
 
 GR_SWIG_BLOCK_MAGIC2(analog, agc_cc);
 GR_SWIG_BLOCK_MAGIC2(analog, agc_ff);
@@ -152,3 +158,6 @@ GR_SWIG_BLOCK_MAGIC2(analog, sig_source_i);
 GR_SWIG_BLOCK_MAGIC2(analog, sig_source_f);
 GR_SWIG_BLOCK_MAGIC2(analog, sig_source_c);
 GR_SWIG_BLOCK_MAGIC2(analog, simple_squelch_cc);
+GR_SWIG_BLOCK_MAGIC2(analog, random_uniform_source_b);
+GR_SWIG_BLOCK_MAGIC2(analog, random_uniform_source_s);
+GR_SWIG_BLOCK_MAGIC2(analog, random_uniform_source_i);


### PR DESCRIPTION
Added new call to GR random class to add uniform integer values in range.
'reseed' function calls should now work as intended.

In 'gr-analog':
Added random_uniform_source_X template to create byte/short/integer sources.

Source is needed as an addition to 'Random Source' which just wraps a numpy.randint() call into a vector source. This is not a suitable solution in case one needs 500M symbols. In this case setup time grows to more than 30s.