### PR TITLE
fec: xml template doesn't produce duplicate var def's anymore

### DIFF
--- a/gr-fec/grc/fec_extended_decoder.xml
+++ b/gr-fec/grc/fec_extended_decoder.xml
@@ -3,7 +3,7 @@
   <name>FEC Extended Decoder</name>
   <key>fec_extended_decoder</key>
   <import>from gnuradio import fec</import>
-  <make>self.$(id) = $(id) = fec.extended_decoder(decoder_obj_list=$decoder_list, threading=$threadtype.arg, ann=$ann, puncpat=$puncpat, integration_period=10000)</make>
+  <make>fec.extended_decoder(decoder_obj_list=$decoder_list, threading=$threadtype.arg, ann=$ann, puncpat=$puncpat, integration_period=10000)</make>
 
   <param>
     <name>fake val</name>


### PR DESCRIPTION
XML template generated code like:
self.$(id) = self.$(id) = ...
This is of course unnecessary and should be fixed.
now generated code looks like:
self.$(id) = fec.extended_decoder(...)
It's exactly the same code as in extended_encoder now.