### PR TITLE
fec: add getter to 'ber_bf' total_errors member, change counter types…

### DIFF
--- a/gr-fec/include/gnuradio/fec/ber_bf.h
+++ b/gr-fec/include/gnuradio/fec/ber_bf.h
@@ -67,6 +67,11 @@ namespace gr {
       typedef boost::shared_ptr<ber_bf> sptr;
 
       /*!
+       * Get total number of errors counter value.
+       */
+      virtual long total_errors() = 0;
+
+      /*!
        * Calculate the BER between two streams of data.
        *
        * \param test_mode false for normal streaming mode (default);

--- a/gr-fec/lib/ber_bf_impl.cc
+++ b/gr-fec/lib/ber_bf_impl.cc
@@ -96,7 +96,8 @@ namespace gr {
                     % d_total_errors % (d_total * 8) % outbuffer[0]);
             return 1;
           }
-          else if(calculate_log_ber() < d_ber_limit){
+          // check for total_errors to prevent early shutdown at high SNR simulations
+          else if(calculate_log_ber() < d_ber_limit && d_total_errors > 0){
             GR_LOG_INFO(d_logger, "    Min. BER limit reached");
             outbuffer[0] = d_ber_limit;
             d_total_errors = d_berminerrors + 1;

--- a/gr-fec/lib/ber_bf_impl.h
+++ b/gr-fec/lib/ber_bf_impl.h
@@ -31,8 +31,8 @@ namespace gr {
     class FEC_API ber_bf_impl : public ber_bf
     {
     private:
-      int d_total_errors;
-      int d_total;
+      long d_total_errors;
+      long d_total;
       bool d_test_mode;
       int d_berminerrors;
       float d_ber_limit;
@@ -48,6 +48,8 @@ namespace gr {
                        gr_vector_int& ninput_items,
                        gr_vector_const_void_star &input_items,
                        gr_vector_void_star &output_items);
+
+      long total_errors() {return d_total_errors;};
     };
 
   } /* namespace fec */


### PR DESCRIPTION
This commit fixes 2 bugs and adds a getter.
If ber_bf would run for a long time, the internal counters, mostly 'total_items', experience overflows. Thus I changed their type to long.

If a simulation in 'test_mode' did not produce any bit errors for the first call to work in ber_bf, it returned 'WORK_DONE' immediately. Now it checks if any bit errors ever occurred before. If that's not the case it will continue to run.

I needed a getter for total_items counter. So I added it.