### PR TITLE
blocks: Add Complex to IChar block

### DIFF
--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -199,6 +199,7 @@
       <name>Type Converters</name>
       <block>blocks_char_to_float</block>
       <block>blocks_char_to_short</block>
+      <block>blocks_complex_to_interleaved_char</block>
       <block>blocks_complex_to_interleaved_short</block>
       <block>blocks_complex_to_float</block>
       <block>blocks_complex_to_imag</block>

--- a/gr-blocks/grc/blocks_complex_to_interleaved_char.xml
+++ b/gr-blocks/grc/blocks_complex_to_interleaved_char.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Complex to Interleaved Char:
+###################################################
+ -->
+<block>
+	<name>Complex To IChar</name>
+	<key>blocks_complex_to_interleaved_char</key>
+	<import>from gnuradio import blocks</import>
+	<make>blocks.complex_to_interleaved_char($vector_output)</make>
+    <param>
+        <name>Vector Output</name>
+        <key>vector_output</key>
+        <value>False</value>
+        <type>enum</type>
+        <option>
+            <name>No</name>
+            <key>False</key>
+            <opt>vlen:1</opt>
+        </option>
+        <option>
+            <name>Yes</name>
+            <key>True</key>
+            <opt>vlen:2</opt>
+        </option>
+    </param>
+	<sink>
+		<name>in</name>
+		<type>complex</type>
+	</sink>
+	<source>
+		<name>out</name>
+		<type>byte</type>
+        <vlen>$vector_output.vlen</vlen>
+	</source>
+</block>

--- a/gr-blocks/include/gnuradio/blocks/complex_to_interleaved_char.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_interleaved_char.h
@@ -1,0 +1,60 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_COMPLEX_TO_INTERLEAVED_CHAR_H
+#define INCLUDED_BLOCKS_COMPLEX_TO_INTERLEAVED_CHAR_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_interpolator.h>
+
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief Convert stream of complex to a stream of interleaved chars.
+     * \ingroup type_converters_blk
+     *
+     * \details
+     * The output stream contains chars with twice as many output
+     * items as input items. For every complex input item, we produce
+     * two output chars that contain the real part and imaginary part
+     * converted to chars:
+     *
+     * \li output[0][n] = static_cast<char>(input[0][m].real());
+     * \li output[0][n+1] = static_cast<char>(input[0][m].imag());
+     */
+    class BLOCKS_API complex_to_interleaved_char : virtual public sync_interpolator
+    {
+    public:
+      // gr::blocks::complex_to_interleaved_char::sptr
+      typedef boost::shared_ptr<complex_to_interleaved_char> sptr;
+
+      /*!
+       * Build a complex to interleaved chars block.
+       */
+      static sptr make(bool vector=false);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_BLOCKS_COMPLEX_TO_INTERLEAVED_CHAR_H */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -96,6 +96,7 @@ list(APPEND gr_blocks_sources
     char_to_float_impl.cc
     char_to_short_impl.cc
     check_lfsr_32k_s_impl.cc
+    complex_to_interleaved_char_impl.cc
     complex_to_interleaved_short_impl.cc
     complex_to_float_impl.cc
     complex_to_real_impl.cc

--- a/gr-blocks/lib/complex_to_interleaved_char_impl.cc
+++ b/gr-blocks/lib/complex_to_interleaved_char_impl.cc
@@ -1,0 +1,65 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+* Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "complex_to_interleaved_char_impl.h"
+#include <gnuradio/io_signature.h>
+
+namespace gr {
+  namespace blocks {
+
+    complex_to_interleaved_char::sptr complex_to_interleaved_char::make(bool vector)
+    {
+      return gnuradio::get_initial_sptr(new complex_to_interleaved_char_impl(vector));
+    }
+
+    complex_to_interleaved_char_impl::complex_to_interleaved_char_impl(bool vector)
+      : sync_interpolator("complex_to_interleaved_char",
+			     io_signature::make (1, 1, sizeof(gr_complex)),
+			     io_signature::make (1, 1, vector?2*sizeof(char):sizeof(char)),
+			     vector?1:2),
+        d_vector(vector)
+    {
+    }
+
+    int
+    complex_to_interleaved_char_impl::work(int noutput_items,
+					    gr_vector_const_void_star &input_items,
+					    gr_vector_void_star &output_items)
+    {
+      const gr_complex *in = (const gr_complex *) input_items[0];
+      char *out = (char *) output_items[0];
+
+      int npairs = (d_vector?noutput_items:noutput_items/2);
+      for (int i = 0; i < npairs; i++){
+        *out++ = (char) lrintf(in[i].real());	// FIXME saturate?
+        *out++ = (char) lrintf(in[i].imag());
+      }
+
+      return noutput_items;
+    }
+
+  } /* namespace blocks */
+}/* namespace gr */

--- a/gr-blocks/lib/complex_to_interleaved_char_impl.h
+++ b/gr-blocks/lib/complex_to_interleaved_char_impl.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_COMPLEX_TO_INTERLEAVED_CHAR_IMPL_H
+#define INCLUDED_COMPLEX_TO_INTERLEAVED_CHAR_IMPL_H
+
+#include <gnuradio/blocks/complex_to_interleaved_char.h>
+
+namespace gr {
+  namespace blocks {
+
+    class BLOCKS_API complex_to_interleaved_char_impl : public complex_to_interleaved_char
+    {
+    private:
+      bool d_vector;
+    public:
+      complex_to_interleaved_char_impl(bool vector);
+
+      int work(int noutput_items,
+	       gr_vector_const_void_star &input_items,
+	       gr_vector_void_star &output_items);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+
+#endif /* INCLUDED_COMPLEX_TO_INTERLEAVED_CHAR_IMPL_H */

--- a/gr-blocks/python/blocks/qa_type_conversions.py
+++ b/gr-blocks/python/blocks/qa_type_conversions.py
@@ -62,6 +62,16 @@ class test_type_conversions(gr_unittest.TestCase):
         self.tb.run()
         self.assertEqual(expected_data, dst.data())
 
+    def test_complex_to_interleaved_char(self):
+        src_data = (1+2j, 3+4j, 5+6j, 7+8j, 9+10j)
+        expected_data = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        src = blocks.vector_source_c(src_data)
+        op = blocks.complex_to_interleaved_char()
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        self.assertEqual(expected_data, dst.data())
+
     def test_complex_to_interleaved_short(self):
         src_data = (1+2j, 3+4j, 5+6j, 7+8j, 9+10j)
         expected_data = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)

--- a/gr-blocks/swig/blocks_swig2.i
+++ b/gr-blocks/swig/blocks_swig2.i
@@ -62,6 +62,7 @@
 #include "gnuradio/blocks/char_to_float.h"
 #include "gnuradio/blocks/char_to_short.h"
 #include "gnuradio/blocks/check_lfsr_32k_s.h"
+#include "gnuradio/blocks/complex_to_interleaved_char.h"
 #include "gnuradio/blocks/complex_to_interleaved_short.h"
 #include "gnuradio/blocks/complex_to_float.h"
 #include "gnuradio/blocks/complex_to_real.h"
@@ -108,6 +109,7 @@
 %include "gnuradio/blocks/burst_tagger.h"
 %include "gnuradio/blocks/char_to_short.h"
 %include "gnuradio/blocks/check_lfsr_32k_s.h"
+%include "gnuradio/blocks/complex_to_interleaved_char.h"
 %include "gnuradio/blocks/complex_to_interleaved_short.h"
 %include "gnuradio/blocks/complex_to_float.h"
 %include "gnuradio/blocks/complex_to_real.h"
@@ -153,6 +155,7 @@ GR_SWIG_BLOCK_MAGIC2(blocks, burst_tagger);
 GR_SWIG_BLOCK_MAGIC2(blocks, char_to_float);
 GR_SWIG_BLOCK_MAGIC2(blocks, char_to_short);
 GR_SWIG_BLOCK_MAGIC2(blocks, check_lfsr_32k_s);
+GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_interleaved_char);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_interleaved_short);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_float);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_real);


### PR DESCRIPTION
This one seemed to be missing - for shorts there's the pair `Complex to IShort` & `IShort to Complex` but for chars only `IChar to Complex` exists at the moment.