### PR TITLE
Fix uhd_rx_nogui so it runs.

### DIFF
--- a/gr-uhd/apps/uhd_rx_nogui
+++ b/gr-uhd/apps/uhd_rx_nogui
@@ -163,8 +163,7 @@ class app_top_block(gr.top_block):
 
 	AGC = analog.agc_cc(1.0/channel_rate,  # Time constant
                             1.0,     	       # Reference power
-                            1.0,               # Initial gain
-                            1.0)	       # Maximum gain
+                            1.0)	       # Gain
 
 	DEMOD = demod(channel_rate, audio_decim)
 


### PR DESCRIPTION
Updated the number of gain arguments to analog.agc_cc from 2 to 1. This
eliminates an error that stops the script.

Signed-off-by: Philip Balister <philip@balister.org>