### PR TITLE
fec: LDPC: patch for issue #847.

### DIFF
--- a/gr-fec/lib/fec_mtrx_impl.cc
+++ b/gr-fec/lib/fec_mtrx_impl.cc
@@ -479,9 +479,11 @@ namespace gr {
 
         gsl_matrix *identity = gsl_matrix_alloc(n,n);
         gsl_matrix_set_identity(identity);
-        int test_if_equal = gsl_matrix_equal(identity,test);
+        //int test_if_equal = gsl_matrix_equal(identity,test);
+        gsl_matrix_sub(identity, test); // should be null set if equal
+        double test_if_not_equal = gsl_matrix_max(identity);
 
-        if (!test_if_equal) {
+        if(test_if_not_equal > 0) {
           throw "Error in calc_inverse_mod2(): The matrix inverse found is not valid.\n";
         }
 

--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -77,13 +77,16 @@ namespace gr {
         }
 
         // Check if the identity matrix exists in the right spot.
-        int test_if_equal = gsl_matrix_equal(identity, I_test);
+        //int test_if_equal = gsl_matrix_equal(identity, I_test);
+        gsl_matrix_sub(identity, I_test); // should be null set if equal
+        double test_if_not_equal = gsl_matrix_max(identity);
 
         // Free memory
         gsl_matrix_free(identity);
         gsl_matrix_free(I_test);
 
-        if(!test_if_equal) {
+        //if(!test_if_equal) {
+        if(test_if_not_equal > 0) {
           GR_LOG_ERROR(d_logger,
                        "Error in ldpc_G_matrix_impl constructor. It appears "
                        "that the given alist file did not contain either a "


### PR DESCRIPTION
GSL didn't introduce gsl_matrix_equal until 1.15 and GNU Radio only
requires 1.10. This is an attempt to calculate if the two matrices are
equal by subtracting one from the other and seeing if the max element
is greater than 0 (all elements should be 0 if they are the same
matrix).