### PR TITLE
expanded quadrature_demod_cf docs; added .grc <doc>

### DIFF
--- a/gr-analog/grc/analog_quadrature_demod_cf.xml
+++ b/gr-analog/grc/analog_quadrature_demod_cf.xml
@@ -25,4 +25,31 @@
         <name>out</name>
         <type>float</type>
     </source>
+    <doc>
+This can be used to demod FM, FSK, GMSK, etc.  The input is complex
+baseband, output is the signal frequency in relation to the sample
+rated, multiplied with the gain.
+
+Mathematically, this block calculates the product of the one-sample
+delayed input and the conjugate undelayed signal, and then calculates
+the argument of the resulting complex number:
+
+y[n] = \mathrm{arg}\left(x[n] \, \bar x [n-1]\right).
+
+Let x be a complex sinusoid with amplitude A>0, (absolute)
+frequency f\in\mathbb R and phase \phi_0\in[0;2\pi] sampled at
+f_s>0 so, without loss of generality,
+
+x[n]= A e^{j2\pi( \frac f{f_s} n + \phi_0)}\f
+
+then
+
+y[n] = \mathrm{arg}\left(A e^{j2\pi\left( \frac f{f_s} n + \phi_0\right)} \overline{A e^{j2\pi( \frac f{f_s} (n-1) + \phi_0)}}\right)\\
+ = \mathrm{arg}\left(A^2 e^{j2\pi\left( \frac f{f_s} n + \phi_0\right)} e^{-j2\pi( \frac f{f_s} (n-1) + \phi_0)}\right)\\
+ = \mathrm{arg}\left( A^2 e^{j2\pi\left( \frac f{f_s} n + \phi_0 - \frac f{f_s} (n-1) - \phi_0\right)}\right)\\
+ = \mathrm{arg}\left( A^2 e^{j2\pi\left( \frac f{f_s} n - \frac f{f_s} (n-1)\right)}\right)\\
+ = \mathrm{arg}\left( A^2 e^{j2\pi\left( \frac f{f_s} \left(n-(n-1)\right)\right)}\right)\\
+ = \mathrm{arg}\left( A^2 e^{j2\pi \frac f{f_s}}\right) \intertext{$A$ is real, so is $A^2$ and hence only \textit{scales}, therefore $\mathrm{arg}(\cdot)$ is invariant:} = \mathrm{arg}\left(e^{j2\pi \frac f{f_s}}\right)\\
+= \frac f{f_s}\\
+ </doc>
 </block>

--- a/gr-analog/include/gnuradio/analog/quadrature_demod_cf.h
+++ b/gr-analog/include/gnuradio/analog/quadrature_demod_cf.h
@@ -34,8 +34,33 @@ namespace gr {
      * \ingroup modulators_blk
      *
      * \details
-     * This can be used to demod FM, FSK, GMSK, etc.
-     * The input is complex baseband.
+     * This can be used to demod FM, FSK, GMSK, etc.  The input is complex
+     * baseband, output is the signal frequency in relation to the sample
+     * rated, multiplied with the gain.
+     *
+     * Mathematically, this block calculates the product of the one-sample
+     * delayed input and the conjugate undelayed signal, and then calculates
+     * the argument of the resulting complex number:
+     *
+     * \f$y[n] = \mathrm{arg}\left(x[n] \, \bar x [n-1]\right)\f$.
+     * 
+     * Let \f$x\f$ be a complex sinusoid with amplitude \f$A>0\f$, (absolute)
+     * frequency \f$f\in\mathbb R\f$ and phase \f$\phi_0\in[0;2\pi]\f$ sampled at
+     * \f$f_s>0\f$ so, without loss of generality,
+     *
+     * \f$x[n]= A e^{j2\pi( \frac f{f_s} n + \phi_0)}\f$
+     *
+     * then
+     *
+     * \f{align*}{ y[n] &= \mathrm{arg}\left(A e^{j2\pi\left( \frac f{f_s} n + \phi_0\right)} \overline{A e^{j2\pi( \frac f{f_s} (n-1) + \phi_0)}}\right)\\
+     *  & = \mathrm{arg}\left(A^2 e^{j2\pi\left( \frac f{f_s} n + \phi_0\right)} e^{-j2\pi( \frac f{f_s} (n-1) + \phi_0)}\right)\\
+     *  & = \mathrm{arg}\left( A^2 e^{j2\pi\left( \frac f{f_s} n + \phi_0 - \frac f{f_s} (n-1) - \phi_0\right)}\right)\\
+     *  & = \mathrm{arg}\left( A^2 e^{j2\pi\left( \frac f{f_s} n - \frac f{f_s} (n-1)\right)}\right)\\
+     *  & = \mathrm{arg}\left( A^2 e^{j2\pi\left( \frac f{f_s} \left(n-(n-1)\right)\right)}\right)\\
+     *  & = \mathrm{arg}\left( A^2 e^{j2\pi \frac f{f_s}}\right) \intertext{$A$ is real, so is $A^2$ and hence only \textit{scales}, therefore $\mathrm{arg}(\cdot)$ is invariant:} &= \mathrm{arg}\left(e^{j2\pi \frac f{f_s}}\right)\\
+     *  &= \frac f{f_s}\\
+     *  &&\blacksquare 
+     * \f}
      */
     class ANALOG_API quadrature_demod_cf : virtual public sync_block
     {


### PR DESCRIPTION
Having explained the workings of quadrature demod one too many times, here's some documentation.