### PR TITLE
Added bidirectional conversion between complex numbers and mag/phase

### DIFF
--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -202,6 +202,7 @@
       <block>blocks_complex_to_interleaved_char</block>
       <block>blocks_complex_to_interleaved_short</block>
       <block>blocks_complex_to_float</block>
+      <block>blocks_complex_to_magphase</block>
       <block>blocks_complex_to_imag</block>
       <block>blocks_complex_to_real</block>
       <block>blocks_complex_to_mag</block>
@@ -209,6 +210,7 @@
       <block>blocks_complex_to_arg</block>
       <block>blocks_float_to_char</block>
       <block>blocks_float_to_complex</block>
+      <block>blocks_magphase_to_complex</block>
       <block>blocks_float_to_int</block>
       <block>blocks_float_to_short</block>
       <block>blocks_float_to_uchar</block>

--- a/gr-blocks/grc/blocks_complex_to_magphase.xml
+++ b/gr-blocks/grc/blocks_complex_to_magphase.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Complex to Magnitude and Phase (floats):
+##	two output streams
+###################################################
+ -->
+<block>
+	<name>Complex To Mag Phase</name>
+	<key>blocks_complex_to_magphase</key>
+	<import>from gnuradio import blocks</import>
+	<make>blocks.complex_to_magphase($vlen)</make>
+	<param>
+		<name>Vec Length</name>
+		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<check>$vlen &gt; 0</check>
+	<sink>
+		<name>in</name>
+		<type>complex</type>
+		<vlen>$vlen</vlen>
+	</sink>
+	<source>
+		<name>mag</name>
+		<type>float</type>
+		<vlen>$vlen</vlen>
+	</source>
+	<source>
+		<name>phase</name>
+		<type>float</type>
+		<vlen>$vlen</vlen>
+		<optional>1</optional>
+	</source>
+</block>

--- a/gr-blocks/grc/blocks_magphase_to_complex.xml
+++ b/gr-blocks/grc/blocks_magphase_to_complex.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+###################################################
+##Magnitue and Phase to Complex:
+##	Two input streams
+###################################################
+ -->
+<block>
+	<name>Magnitude and Phase To Complex</name>
+	<key>blocks_magphase_to_complex</key>
+	<import>from gnuradio import blocks</import>
+	<make>blocks.magphase_to_complex($vlen)</make>
+	<param>
+		<name>Vec Length</name>
+		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<check>$vlen &gt; 0</check>
+	<sink>
+		<name>mag</name>
+		<type>float</type>
+		<vlen>$vlen</vlen>
+	</sink>
+	<sink>
+		<name>phase</name>
+		<type>float</type>
+		<vlen>$vlen</vlen>
+		<optional>1</optional>
+	</sink>
+	<source>
+		<name>out</name>
+		<type>complex</type>
+		<vlen>$vlen</vlen>
+	</source>
+</block>

--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -88,6 +88,7 @@ install(FILES
     check_lfsr_32k_s.h
     complex_to_interleaved_short.h
     complex_to_float.h
+    complex_to_magphase.h
     complex_to_imag.h
     complex_to_real.h
     complex_to_mag.h
@@ -106,6 +107,7 @@ install(FILES
     file_meta_source.h
     float_to_char.h
     float_to_complex.h
+    magphase_to_complex.h
     float_to_int.h
     float_to_short.h
     float_to_uchar.h

--- a/gr-blocks/include/gnuradio/blocks/complex_to_magphase.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_magphase.h
@@ -1,0 +1,57 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2005,2012,2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_COMPLEX_TO_MAGPHASE_H
+#define INCLUDED_BLOCKS_COMPLEX_TO_MAGPHASE_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief Convert a stream of gr_complex to magnitude and phase (both floats)
+     * \ingroup type_converters_blk
+     *
+     * \details
+     * output[0] is the magnitude
+     * output[1] is the phase (in radians)
+     */
+    class BLOCKS_API complex_to_magphase : virtual public sync_block
+    {
+    public:
+      // gr::blocks::complex_to_magphase_ff::sptr
+      typedef boost::shared_ptr<complex_to_magphase> sptr;
+
+      /*!
+       * Build a complex to magnitude and phase block.
+       *
+       * \param vlen vector len (default 1)
+       */
+      static sptr make(size_t vlen=1);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_BLOCKS_COMPLEX_TO_MAGPHASE_H */

--- a/gr-blocks/include/gnuradio/blocks/magphase_to_complex.h
+++ b/gr-blocks/include/gnuradio/blocks/magphase_to_complex.h
@@ -1,0 +1,53 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_MAGPHASE_TO_COMPLEX_H
+#define INCLUDED_BLOCKS_MAGPHASE_TO_COMPLEX_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief two floats in (mag and phase), complex out
+     * \ingroup type_converters_blk
+     */
+    class BLOCKS_API magphase_to_complex : virtual public sync_block
+    {
+    public:
+      // gr::blocks::magphase_to_complex_ff::sptr
+      typedef boost::shared_ptr<magphase_to_complex> sptr;
+
+      /*!
+       * Build a mag and phase to complex block.
+       *
+       * \param vlen vector len (default 1)
+       */
+      static sptr make(size_t vlen=1);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_BLOCKS_MAGPHASE_TO_COMPLEX_H */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -103,6 +103,7 @@ list(APPEND gr_blocks_sources
     complex_to_interleaved_char_impl.cc
     complex_to_interleaved_short_impl.cc
     complex_to_float_impl.cc
+    complex_to_magphase_impl.cc
     complex_to_real_impl.cc
     complex_to_imag_impl.cc
     complex_to_mag_impl.cc
@@ -121,6 +122,7 @@ list(APPEND gr_blocks_sources
     file_meta_source_impl.cc
     float_to_char_impl.cc
     float_to_complex_impl.cc
+    magphase_to_complex_impl.cc
     float_array_to_int.cc
     float_to_int_impl.cc
     float_to_short_impl.cc

--- a/gr-blocks/lib/complex_to_magphase_impl.cc
+++ b/gr-blocks/lib/complex_to_magphase_impl.cc
@@ -1,0 +1,73 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "complex_to_magphase_impl.h"
+#include <gnuradio/io_signature.h>
+#include <volk/volk.h>
+#include <gnuradio/math.h>
+
+namespace gr {
+  namespace blocks {
+
+    complex_to_magphase::sptr complex_to_magphase::make(size_t vlen)
+    {
+      return gnuradio::get_initial_sptr(new complex_to_magphase_impl(vlen));
+    }
+
+    complex_to_magphase_impl::complex_to_magphase_impl(size_t vlen)
+      : sync_block("complex_to_magphase",
+		      io_signature::make (1, 1, sizeof(gr_complex)*vlen),
+		      io_signature::make (2, 2, sizeof(float)*vlen)),
+	d_vlen(vlen)
+    {
+      const int alignment_multiple =
+	volk_get_alignment() / sizeof(float);
+      set_alignment(std::max(1,alignment_multiple));
+    }
+
+    int
+    complex_to_magphase_impl::work(int noutput_items,
+				   gr_vector_const_void_star &input_items,
+				   gr_vector_void_star &output_items)
+    {
+      const gr_complex *in = (const gr_complex *) input_items[0];
+      float *out0 = (float *) output_items[0];
+      float* out1 = (float *) output_items[1];
+      int noi = noutput_items * d_vlen;
+
+      volk_32fc_magnitude_32f_u(out0, in, noi);
+
+      // The fast_atan2f is faster than Volk
+      for (int i = 0; i < noi; i++){
+	//    out[i] = std::arg (in[i]);
+	out1[i] = gr::fast_atan2f(in[i]);
+      }
+
+      return noutput_items;
+    }
+
+  } /* namespace blocks */
+}/* namespace gr */

--- a/gr-blocks/lib/complex_to_magphase_impl.cc
+++ b/gr-blocks/lib/complex_to_magphase_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2015 Free Software Foundation, Inc.
+ * Copyright 2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *

--- a/gr-blocks/lib/complex_to_magphase_impl.h
+++ b/gr-blocks/lib/complex_to_magphase_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2015 Free Software Foundation, Inc.
+ * Copyright 2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *

--- a/gr-blocks/lib/complex_to_magphase_impl.h
+++ b/gr-blocks/lib/complex_to_magphase_impl.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_COMPLEX_TO_MAGPHASE_IMPL_H
+#define INCLUDED_COMPLEX_TO_MAGPHASE_IMPL_H
+
+#include <gnuradio/blocks/complex_to_magphase.h>
+
+namespace gr {
+  namespace blocks {
+
+    class BLOCKS_API complex_to_magphase_impl : public complex_to_magphase
+    {
+      size_t d_vlen;
+
+    public:
+      complex_to_magphase_impl(size_t vlen);
+
+      int work(int noutput_items,
+	       gr_vector_const_void_star &input_items,
+	       gr_vector_void_star &output_items);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+
+#endif /* INCLUDED_COMPLEX_TO_MAGPHASE_IMPL_H */

--- a/gr-blocks/lib/magphase_to_complex_impl.cc
+++ b/gr-blocks/lib/magphase_to_complex_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2015 Free Software Foundation, Inc.
+ * Copyright 2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *

--- a/gr-blocks/lib/magphase_to_complex_impl.cc
+++ b/gr-blocks/lib/magphase_to_complex_impl.cc
@@ -1,0 +1,68 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "magphase_to_complex_impl.h"
+#include <gnuradio/io_signature.h>
+#include <volk/volk.h>
+
+namespace gr {
+  namespace blocks {
+
+    magphase_to_complex::sptr
+    magphase_to_complex::make(size_t vlen)
+    {
+      return gnuradio::get_initial_sptr
+        (new magphase_to_complex_impl(vlen));
+    }
+
+    magphase_to_complex_impl::magphase_to_complex_impl(size_t vlen)
+      : sync_block("magphase_to_complex",
+                   io_signature::make(2, 2, sizeof(float)*vlen),
+                   io_signature::make(1, 1, sizeof(gr_complex)*vlen)),
+	d_vlen(vlen)
+    {
+      const int alignment_multiple =
+	volk_get_alignment() / sizeof(float);
+      set_alignment(std::max(1,alignment_multiple));
+    }
+
+    int
+    magphase_to_complex_impl::work(int noutput_items,
+				   gr_vector_const_void_star &input_items,
+				   gr_vector_void_star &output_items)
+    {
+      float        *mag = (float *)input_items[0];
+      float        *phase = (float *)input_items[1];
+      gr_complex *out = (gr_complex *) output_items[0];
+
+      for (size_t j = 0; j < noutput_items*d_vlen; j++)
+        out[j] = gr_complex (mag[j]*cos(phase[j]),mag[j]*sin(phase[j]));
+      
+      return noutput_items;
+    }
+
+  } /* namespace blocks */
+}/* namespace gr */

--- a/gr-blocks/lib/magphase_to_complex_impl.h
+++ b/gr-blocks/lib/magphase_to_complex_impl.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2012,2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_MAGPHASE_TO_COMPLEX_IMPL_H
+#define INCLUDED_MAGPHASE_TO_COMPLEX_IMPL_H
+
+#include <gnuradio/blocks/magphase_to_complex.h>
+
+namespace gr {
+  namespace blocks {
+
+    class BLOCKS_API magphase_to_complex_impl : public magphase_to_complex
+    {
+      size_t d_vlen;
+
+    public:
+      magphase_to_complex_impl(size_t vlen);
+
+      int work(int noutput_items,
+	       gr_vector_const_void_star &input_items,
+	       gr_vector_void_star &output_items);
+    };
+
+  } /* namespace blocks */
+} /* namespace gr */
+
+
+#endif /* INCLUDED_MAGPHASE_TO_COMPLEX_IMPL_H */

--- a/gr-blocks/lib/magphase_to_complex_impl.h
+++ b/gr-blocks/lib/magphase_to_complex_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2015 Free Software Foundation, Inc.
+ * Copyright 2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *

--- a/gr-blocks/swig/blocks_swig2.i
+++ b/gr-blocks/swig/blocks_swig2.i
@@ -65,6 +65,7 @@
 #include "gnuradio/blocks/complex_to_interleaved_char.h"
 #include "gnuradio/blocks/complex_to_interleaved_short.h"
 #include "gnuradio/blocks/complex_to_float.h"
+#include "gnuradio/blocks/complex_to_magphase.h"
 #include "gnuradio/blocks/complex_to_real.h"
 #include "gnuradio/blocks/complex_to_imag.h"
 #include "gnuradio/blocks/complex_to_mag.h"
@@ -112,6 +113,7 @@
 %include "gnuradio/blocks/complex_to_interleaved_char.h"
 %include "gnuradio/blocks/complex_to_interleaved_short.h"
 %include "gnuradio/blocks/complex_to_float.h"
+%include "gnuradio/blocks/complex_to_magphase.h"
 %include "gnuradio/blocks/complex_to_real.h"
 %include "gnuradio/blocks/complex_to_imag.h"
 %include "gnuradio/blocks/complex_to_mag.h"
@@ -158,6 +160,7 @@ GR_SWIG_BLOCK_MAGIC2(blocks, check_lfsr_32k_s);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_interleaved_char);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_interleaved_short);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_float);
+GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_magphase);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_real);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_imag);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_mag);

--- a/gr-blocks/swig/blocks_swig3.i
+++ b/gr-blocks/swig/blocks_swig3.i
@@ -30,6 +30,7 @@
 %{
 #include "gnuradio/blocks/float_to_char.h"
 #include "gnuradio/blocks/float_to_complex.h"
+#include "gnuradio/blocks/magphase_to_complex.h"
 #include "gnuradio/blocks/float_to_int.h"
 #include "gnuradio/blocks/float_to_short.h"
 #include "gnuradio/blocks/float_to_uchar.h"
@@ -77,6 +78,7 @@
 
 %include "gnuradio/blocks/float_to_char.h"
 %include "gnuradio/blocks/float_to_complex.h"
+%include "gnuradio/blocks/magphase_to_complex.h"
 %include "gnuradio/blocks/float_to_int.h"
 %include "gnuradio/blocks/float_to_short.h"
 %include "gnuradio/blocks/float_to_uchar.h"
@@ -123,6 +125,7 @@
 
 GR_SWIG_BLOCK_MAGIC2(blocks, float_to_char);
 GR_SWIG_BLOCK_MAGIC2(blocks, float_to_complex);
+GR_SWIG_BLOCK_MAGIC2(blocks, magphase_to_complex);
 GR_SWIG_BLOCK_MAGIC2(blocks, float_to_int);
 GR_SWIG_BLOCK_MAGIC2(blocks, float_to_short);
 GR_SWIG_BLOCK_MAGIC2(blocks, float_to_uchar);


### PR DESCRIPTION
These blocks are generally useful, but specifically they come in handy when doing amplifier linearization, crest factor reduction, and modeling.