### PR TITLE
max and min now accept a vector output length to allow for sane multi…

### DIFF
--- a/gr-blocks/grc/blocks_max_xx.xml
+++ b/gr-blocks/grc/blocks_max_xx.xml
@@ -9,7 +9,7 @@
 	<name>Max</name>
 	<key>blocks_max_xx</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.max_$(type.fcn)($vlen)</make>
+	<make>blocks.max_$(type.fcn)($vlen,$vlen_out)</make>
 	<param>
 		<name>IO Type</name>
 		<key>type</key>
@@ -37,8 +37,14 @@
 		<type>int</type>
 	</param>
 	<param>
-		<name>Vec Length</name>
+		<name>Input Vec Length</name>
 		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<param>
+		<name>Output Vec Length</name>
+		<key>vlen_out</key>
 		<value>1</value>
 		<type>int</type>
 	</param>
@@ -53,6 +59,6 @@
 	<source>
 		<name>out</name>
 		<type>$type</type>
-		<vlen>1</vlen>
+		<vlen>$vlen_out</vlen>
 	</source>
 </block>

--- a/gr-blocks/grc/blocks_min_xx.xml
+++ b/gr-blocks/grc/blocks_min_xx.xml
@@ -9,7 +9,7 @@
 	<name>Min</name>
 	<key>blocks_min_xx</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.min_$(type.fcn)($vlen)</make>
+	<make>blocks.min_$(type.fcn)($vlen,$vlen_out)</make>
 	<param>
 		<name>IO Type</name>
 		<key>type</key>
@@ -37,8 +37,14 @@
 		<type>int</type>
 	</param>
 	<param>
-		<name>Vec Length</name>
+		<name>Input Vec Length</name>
 		<key>vlen</key>
+		<value>1</value>
+		<type>int</type>
+	</param>
+	<param>
+		<name>Output Vec Length</name>
+		<key>vlen_out</key>
 		<value>1</value>
 		<type>int</type>
 	</param>
@@ -53,6 +59,6 @@
 	<source>
 		<name>out</name>
 		<type>$type</type>
-		<vlen>1</vlen>
+		<vlen>$vlen_out</vlen>
 	</source>
 </block>

--- a/gr-blocks/include/gnuradio/blocks/max_XX.h.t
+++ b/gr-blocks/include/gnuradio/blocks/max_XX.h.t
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2007,2013-2014 Free Software Foundation, Inc.
+ * Copyright 2014,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -38,9 +38,13 @@ namespace gr {
      *
      * \details
      * Data is passed in as a vector of length \p vlen from multiple
-     * input sources. It will look through these streams of \p vlen
+     * input sources.  If vlen_out == 1 then 
+     * It will look through these streams of \p vlen
      * data items and the output stream will contain the maximum value
      * in the vector.
+     * If vlen_out == vlen and not equal to 1 then
+     * output will be a vector with individual items selected from
+     * the maximum corresponding input vector items.
      */
     class BLOCKS_API @NAME@ : virtual public sync_block
     {
@@ -48,7 +52,7 @@ namespace gr {
       // gr::blocks::@NAME@::sptr
       typedef boost::shared_ptr<@NAME@> sptr;
 
-      static sptr make(size_t vlen);
+      static sptr make(size_t vlen, size_t vlen_out = 1);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/include/gnuradio/blocks/min_XX.h.t
+++ b/gr-blocks/include/gnuradio/blocks/min_XX.h.t
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2014 Free Software Foundation, Inc.
+ * Copyright 2014,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -38,9 +38,13 @@ namespace gr {
      *
      * \details
      * Data is passed in as a vector of length \p vlen from multiple
-     * input sources. It will look through these streams of \p vlen
+     * input sources.  If vlen_out == 1 then 
+     * It will look through these streams of \p vlen
      * data items and the output stream will contain the minimum value
      * in the vector.
+     * If vlen_out == vlen and not equal to 1 then
+     * output will be a vector with individual items selected from
+     * the minimum corresponding input vector items.
      */
     class BLOCKS_API @NAME@ : virtual public sync_block
     {
@@ -48,7 +52,7 @@ namespace gr {
       // gr::blocks::@NAME@::sptr
       typedef boost::shared_ptr<@NAME@> sptr;
 
-      static sptr make(size_t vlen);
+      static sptr make(size_t vlen, size_t vlen_out = 1);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/max_XX_impl.cc.t
+++ b/gr-blocks/lib/max_XX_impl.cc.t
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2007 Free Software Foundation, Inc.
+ * Copyright 2014,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -33,18 +33,19 @@ namespace gr {
   namespace blocks {
 
     @NAME@::sptr
-    @NAME@::make(size_t vlen)
+    @NAME@::make(size_t vlen, size_t vlen_out)
     {
       return gnuradio::get_initial_sptr
-        (new @NAME_IMPL@(vlen));
+        (new @NAME_IMPL@(vlen,vlen_out));
     }
 
-    @NAME_IMPL@::@NAME_IMPL@(size_t vlen)
+    @NAME_IMPL@::@NAME_IMPL@(size_t vlen, size_t vlen_out)
     : sync_block("@BASE_NAME@",
-                    io_signature::make(1, -1, vlen*sizeof(@I_TYPE@)),
-                    io_signature::make(1, 1, sizeof(@O_TYPE@))),
-      d_vlen(vlen)
+                 io_signature::make(1, -1, vlen*sizeof(@I_TYPE@)),
+                 io_signature::make(1, 1, vlen_out*sizeof(@O_TYPE@))),
+      d_vlen(vlen), d_vlen_out(vlen_out)
     {
+      assert((vlen_out == vlen) || (vlen_out == 1));
     }
 
     @NAME_IMPL@::~@NAME_IMPL@()
@@ -60,22 +61,36 @@ namespace gr {
 
       int ninputs = input_items.size();
 
-      for(int i = 0; i < noutput_items; i++) {
-        @I_TYPE@ max = ((@I_TYPE@ *)input_items[0])[i*d_vlen];
+      if(d_vlen_out == 1)
+	for(int i = 0; i < noutput_items; i++) {
+	  @I_TYPE@ max = ((@I_TYPE@ *)input_items[0])[i*d_vlen];
+	  
+	  for(int j = 0; j < (int)d_vlen; j++ ) {
+	    for(int k = 0; k < ninputs; k++) {
+	      if(((@I_TYPE@ *)input_items[k])[i*d_vlen + j] > max) {
+		max = ((@I_TYPE@*)input_items[k])[i*d_vlen + j];
+	      }
+	    }
+	  }
+	  
+	  *optr++ = (@O_TYPE@)max;
+	}
 
-        for(int j = 0; j < (int)d_vlen; j++ ) {
-          for(int k = 0; k < ninputs; k++) {
-            if(((@I_TYPE@ *)input_items[k])[i*d_vlen + j] > max) {
-              max = ((@I_TYPE@*)input_items[k])[i*d_vlen + j];
-            }
-          }
-        }
-
-        *optr++ = (@O_TYPE@)max;
-      }
+      else // vector mode output
+	for(int i = 0; i < noutput_items * d_vlen_out; i++) {
+	  @I_TYPE@ max = ((@I_TYPE@ *)input_items[0])[i];
+	  
+	  for(int k = 1; k < ninputs; k++) {
+	    if(((@I_TYPE@ *)input_items[k])[i] > max) {
+	      max = ((@I_TYPE@*)input_items[k])[i];
+	    }
+	  }
+	  
+	  *optr++ = (@O_TYPE@)max;
+	}
+      
       return noutput_items;
     }
 
   } /* namespace blocks */
 } /* namespace gr */
-

--- a/gr-blocks/lib/max_XX_impl.h.t
+++ b/gr-blocks/lib/max_XX_impl.h.t
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2007,2013 Free Software Foundation, Inc.
+ * Copyright 2014,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -33,10 +33,10 @@ namespace gr {
     class @NAME_IMPL@ : public @NAME@
     {
     private:
-      size_t d_vlen;
+      size_t d_vlen, d_vlen_out;
 
     public:
-      @NAME_IMPL@(size_t vlen);
+      @NAME_IMPL@(size_t vlen, size_t vlen_out);
       ~@NAME_IMPL@();
 
       int work(int noutput_items,

--- a/gr-blocks/lib/min_XX_impl.cc.t
+++ b/gr-blocks/lib/min_XX_impl.cc.t
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2014 Free Software Foundation, Inc.
+ * Copyright 2014,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -33,18 +33,19 @@ namespace gr {
   namespace blocks {
 
     @NAME@::sptr
-    @NAME@::make(size_t vlen)
+    @NAME@::make(size_t vlen, size_t vlen_out)
     {
       return gnuradio::get_initial_sptr
-        (new @NAME_IMPL@(vlen));
+        (new @NAME_IMPL@(vlen,vlen_out));
     }
 
-    @NAME_IMPL@::@NAME_IMPL@(size_t vlen)
+    @NAME_IMPL@::@NAME_IMPL@(size_t vlen, size_t vlen_out)
     : sync_block("@BASE_NAME@",
                  io_signature::make(1, -1, vlen*sizeof(@I_TYPE@)),
-                 io_signature::make(1, 1, sizeof(@O_TYPE@))),
-      d_vlen(vlen)
+                 io_signature::make(1, 1, vlen_out*sizeof(@O_TYPE@))),
+      d_vlen(vlen), d_vlen_out(vlen_out)
     {
+      assert((vlen_out == vlen) || (vlen_out == 1));
     }
 
     @NAME_IMPL@::~@NAME_IMPL@()
@@ -60,19 +61,34 @@ namespace gr {
 
       int ninputs = input_items.size();
 
-      for(int i = 0; i < noutput_items; i++) {
-        @I_TYPE@ min = ((@I_TYPE@ *)input_items[0])[i*d_vlen];
+      if(d_vlen_out == 1)
+	for(int i = 0; i < noutput_items; i++) {
+	  @I_TYPE@ min = ((@I_TYPE@ *)input_items[0])[i*d_vlen];
+	  
+	  for(int j = 0; j < (int)d_vlen; j++ ) {
+	    for(int k = 0; k < ninputs; k++) {
+	      if(((@I_TYPE@ *)input_items[k])[i*d_vlen + j] < min) {
+		min = ((@I_TYPE@*)input_items[k])[i*d_vlen + j];
+	      }
+	    }
+	  }
+	  
+	  *optr++ = (@O_TYPE@)min;
+	}
 
-        for(int j = 0; j < (int)d_vlen; j++ ) {
-          for(int k = 0; k < ninputs; k++) {
-            if(((@I_TYPE@ *)input_items[k])[i*d_vlen + j] < min) {
-              min = ((@I_TYPE@*)input_items[k])[i*d_vlen + j];
-            }
-          }
-        }
-
-        *optr++ = (@O_TYPE@)min;
-      }
+      else // vector mode output
+	for(int i = 0; i < noutput_items * d_vlen_out; i++) {
+	  @I_TYPE@ min = ((@I_TYPE@ *)input_items[0])[i];
+	  
+	  for(int k = 1; k < ninputs; k++) {
+	    if(((@I_TYPE@ *)input_items[k])[i] < min) {
+	      min = ((@I_TYPE@*)input_items[k])[i];
+	    }
+	  }
+	  
+	  *optr++ = (@O_TYPE@)min;
+	}
+      
       return noutput_items;
     }
 

--- a/gr-blocks/lib/min_XX_impl.h.t
+++ b/gr-blocks/lib/min_XX_impl.h.t
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2014 Free Software Foundation, Inc.
+ * Copyright 2014,2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -33,10 +33,10 @@ namespace gr {
     class @NAME_IMPL@ : public @NAME@
     {
     private:
-      size_t d_vlen;
+      size_t d_vlen, d_vlen_out;
 
     public:
-      @NAME_IMPL@(size_t vlen);
+      @NAME_IMPL@(size_t vlen, size_t vlen_out);
       ~@NAME_IMPL@();
 
       int work(int noutput_items,


### PR DESCRIPTION
…ple input vector mode.  Defaults to off.

Operation unchanged unless enabled by setting vlen_out to be equal to vlen.  Used only when you have multiple input vectors and want the output to be a vector of the same length as the input vectors, containing the elementwise max/min.
