### PR TITLE
analog: added freq msg port to sig_source

### DIFF
--- a/gr-analog/grc/analog_sig_source_x.xml
+++ b/gr-analog/grc/analog_sig_source_x.xml
@@ -97,6 +97,11 @@
 		<value>0</value>
 		<type>$type.offset_type</type>
 	</param>
+	<sink>
+		<name>freq</name>
+		<type>message</type>
+        <optional>1</optional>
+	</sink>
 	<source>
 		<name>out</name>
 		<type>$type</type>

--- a/gr-analog/grc/analog_sig_source_x.xml
+++ b/gr-analog/grc/analog_sig_source_x.xml
@@ -100,7 +100,7 @@
 	<sink>
 		<name>freq</name>
 		<type>message</type>
-        <optional>1</optional>
+		<optional>1</optional>
 	</sink>
 	<source>
 		<name>out</name>

--- a/gr-analog/lib/sig_source_X_impl.cc.t
+++ b/gr-analog/lib/sig_source_X_impl.cc.t
@@ -52,7 +52,10 @@ namespace gr {
       d_sampling_freq(sampling_freq), d_waveform(waveform),
       d_frequency(frequency), d_ampl(ampl), d_offset(offset)
     {
-      d_nco.set_freq(2 * M_PI * d_frequency / d_sampling_freq);
+      set_frequency(frequency);
+      
+      message_port_register_in(pmt::mp("freq"));
+      set_msg_handler(pmt::mp("freq"), boost::bind(&@IMPL_NAME@::set_frequency_msg, this, _1));
     }
 
     @IMPL_NAME@::~@IMPL_NAME@()

--- a/gr-analog/lib/sig_source_X_impl.h.t
+++ b/gr-analog/lib/sig_source_X_impl.h.t
@@ -59,7 +59,7 @@ namespace gr {
 
       void set_sampling_freq(double sampling_freq);
       void set_waveform(gr_waveform_t waveform);
-      void set_frequency_msg(pmt::pmt_t msg){ std::cout << "freq msg\n"; set_frequency(pmt::to_double(msg)); };
+      void set_frequency_msg(pmt::pmt_t msg){ set_frequency(pmt::to_double(msg)); };
       void set_frequency(double frequency);
       void set_amplitude(double ampl);
       void set_offset(@TYPE@ offset);

--- a/gr-analog/lib/sig_source_X_impl.h.t
+++ b/gr-analog/lib/sig_source_X_impl.h.t
@@ -59,6 +59,7 @@ namespace gr {
 
       void set_sampling_freq(double sampling_freq);
       void set_waveform(gr_waveform_t waveform);
+      void set_frequency_msg(pmt::pmt_t msg){ std::cout << "freq msg\n"; set_frequency(pmt::to_double(msg)); };
       void set_frequency(double frequency);
       void set_amplitude(double ampl);
       void set_offset(@TYPE@ offset);

--- a/gr-analog/python/analog/qa_sig_source.py
+++ b/gr-analog/python/analog/qa_sig_source.py
@@ -21,7 +21,7 @@
 #
 
 import math
-
+import pmt
 from gnuradio import gr, gr_unittest, analog, blocks
 
 class test_sig_source(gr_unittest.TestCase):
@@ -155,6 +155,20 @@ class test_sig_source(gr_unittest.TestCase):
         tb.run()
         dst_data = dst1.data()
         self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_freq_msg(self):
+        src = analog.sig_source_c(8, analog.GR_SIN_WAVE, 1.0, 1.0)
+        op = blocks.head(gr.sizeof_gr_complex, 9)
+        snk = blocks.vector_sink_c()
+        self.tb.connect(src, op, snk)
+        self.assertAlmostEqual(src.frequency(), 1.0)
+
+        frequency = 3.0
+        src._post(pmt.to_pmt('freq'), pmt.from_double(frequency))
+        self.tb.run()
+
+        self.assertAlmostEqual(src.frequency(), frequency)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_sig_source, "test_sig_source.xml")


### PR DESCRIPTION
Added message port for frequency to signal_source.
It's a new feature, so the PR is against master. Hope that's correct.
It might be debatable if the other callbacks should be integrated as well or if they deserve their own message ports. In the latter case someone who needs them may integrate them at some point.