### PR TITLE
docs: Improving documentation (freq modulator and crc32)

### DIFF
--- a/gr-analog/include/gnuradio/analog/frequency_modulator_fc.h
+++ b/gr-analog/include/gnuradio/analog/frequency_modulator_fc.h
@@ -35,6 +35,29 @@ namespace gr {
      *
      * \details
      * float input; complex baseband output
+     *
+     * Takes a real, baseband signal (x_m[n]) and output a frequency
+     * modulated signal (y[n]) according to:
+     *
+     * \f[
+     * y[n] = exp (j 2 \pi \frac{f_{\Delta}}{f_s} \sum{x[n]})
+     * \f]
+     *
+     * Where x[n] is the input sample at time n and \f$ f_{\Delta} \f$
+     * is the frequency deviation. Common values for \f$ f_{\Delta}
+     * \f$ are 5 kHz for narrowband FM channels such as for voice
+     * systems and 75 KHz for wideband FM, like audio broadcast FM
+     * stations.
+     *
+     * In this block, the input argument is \p sensivity, not the
+     * frequency deviation.  The sensitivity specifies how much the
+     * phase changes based on the new input sample. Given a maximum
+     * deviation, \f$ f_{\Delta} \f$, and sample rate \f$f_s\f$, the
+     * sensitivity is defined as:
+     *
+     * \f[
+     * k = 2 \pi \frac{f_{\Delta}}{f_s}
+     * \f]
      */
     class ANALOG_API frequency_modulator_fc : virtual public sync_block
     {

--- a/gr-digital/include/gnuradio/digital/crc32_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_bb.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/* 
+/*
  * Copyright 2013 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -49,7 +49,8 @@ namespace gr {
 
       /*!
        * \param check Set to true if you want to check CRC, false to create CRC.
-       * \param lengthtagname Length tag key
+       * \param lengthtagname Length tag key for the tagged stream.
+       * \param packed If the data is packed or unpacked bits (default=true).
        */
       static sptr make(bool check=false, const std::string& lengthtagname="packet_len", bool packed=true);
     };
@@ -58,4 +59,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_DIGITAL_CRC32_BB_H */
-


### PR DESCRIPTION
- Better description of how the frequency modulator block behaves and
  how to calculate/set the sensitivity parameter.

- Added documentation for missing parameter in crc32_bb; fixes a
  Doxygen warning.