### PR TITLE
digital: clarify gmsk doc

### DIFF
--- a/gr-digital/python/digital/gmsk.py
+++ b/gr-digital/python/digital/gmsk.py
@@ -59,8 +59,8 @@ class gmsk_mod(gr.hier_block2):
     Hierarchical block for Gaussian Minimum Shift Key (GMSK)
     modulation.
     
-    The input is a byte stream (unsigned char) and the
-    output is the complex modulated signal at baseband.
+    The input is a byte stream (unsigned char with packed bits)
+    and the output is the complex modulated signal at baseband.
     
     Args:
         samples_per_symbol: samples per baud >= 2 (integer)


### PR DESCRIPTION
This small note might save some time for someone who want to use GMSK Mod and spend before lot of time with GMSK Demod where stream of unpacked bits (one bit per byte) is used as a output.