### PR TITLE
Custom buffers

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -130,7 +130,7 @@ namespace gr {
     bool fixed_rate() const { return d_fixed_rate; }
 
     // ----------------------------------------------------------------
-    //		override these to define your behavior
+    //  override these to define your behavior
     // ----------------------------------------------------------------
 
     /*!
@@ -626,12 +626,12 @@ namespace gr {
 
     // ----------------------------------------------------------------------------
 
-	/*!
-	 * \brief the system message handler
+    /*!
+     * \brief the system message handler
      */
     void system_handler(pmt::pmt_t msg);
 
-	/*!
+    /*!
      * \brief returns true when execution has completed due to a message connection
     */
     bool finished();
@@ -838,11 +838,11 @@ namespace gr {
     void set_detail(block_detail_sptr detail) { d_detail = detail; }
 
    /*! \brief Tell msg neighbors we are finished
-	*/
+    */
    void notify_msg_neighbors();
 
    /*! \brief Make sure we dont think we are finished
-	*/
+    */
    void clear_finished(){ d_finished = false; }
 
   };

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -180,6 +180,16 @@ namespace gr {
      */
     virtual bool stop();
 
+    /*!
+     * \brief Called to perform any post-constructor initialization.
+     *
+     * This allows a block to perform any setup that may need to happen
+     * which cannot be performed in the constructor. For example, if
+     * the block uses a custom memory allocator, it can be done in
+     * this function.
+     */
+    virtual bool init();
+
     // ----------------------------------------------------------------
 
     /*!

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -195,7 +195,7 @@ namespace gr {
      * This allows a block to allocate the buffer, but only if the block
      * indicated it wants to allocate buffers in it's io_signature.
      */
-    virtual buffer_sptr allocate_input_buffer(int port);
+    virtual buffer_sptr allocate_upstream_output_buffer(int port);
 
     /*!
      * \brief Called to perform buffer allocation for a specific input port.

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -184,11 +184,26 @@ namespace gr {
      * \brief Called to perform any post-constructor initialization.
      *
      * This allows a block to perform any setup that may need to happen
-     * which cannot be performed in the constructor. For example, if
-     * the block uses a custom memory allocator, it can be done in
-     * this function.
+     * which cannot be performed in the constructor. This will be called
+     * during flat_flowgraph::setup_connections()
      */
     virtual bool init();
+
+    /*!
+     * \brief Called to perform buffer allocation for a specific input port.
+     *
+     * This allows a block to allocate the buffer, but only if the block
+     * indicated it wants to allocate buffers in it's io_signature.
+     */
+    virtual buffer_sptr allocate_input_buffer(int port);
+
+    /*!
+     * \brief Called to perform buffer allocation for a specific input port.
+     *
+     * This allows a block to allocate the buffer, but only if the block
+     * indicated it wants to allocate buffers in it's io_signature.
+     */
+    virtual buffer_sptr allocate_output_buffer(int port);
 
     // ----------------------------------------------------------------
 

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -28,6 +28,7 @@
 #include <gnuradio/tags.h>
 #include <boost/weak_ptr.hpp>
 #include <gnuradio/thread/thread.h>
+#include <gnuradio/logger.h>
 #include <map>
 
 namespace gr {
@@ -142,6 +143,8 @@ namespace gr {
     friend GR_RUNTIME_API buffer_sptr make_buffer(int nitems, size_t sizeof_item, block_sptr link);
     friend GR_RUNTIME_API buffer_reader_sptr buffer_add_reader
       (buffer_sptr buf, int nzero_preload, block_sptr link, int delay);
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
   protected:
     /*!

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -135,7 +135,7 @@ namespace gr {
     std::multimap<uint64_t,tag_t>::iterator get_tags_lower_bound(uint64_t x) { return d_item_tags.lower_bound(x); }
     std::multimap<uint64_t,tag_t>::iterator get_tags_upper_bound(uint64_t x) { return d_item_tags.upper_bound(x); }
 
-    // -------------------------------------------------------------------------
+    virtual bool allocate_buffer();
 
   private:
     friend class buffer_reader;
@@ -157,17 +157,17 @@ namespace gr {
      * dependent boundary.  This is typically the system page size, but
      * under MS windows is 64KB.
      */
-    buffer(int nitems, size_t sizeof_item, block_sptr link);
+    buffer(unsigned int nitems, size_t sizeof_item, block_sptr link);
 
     char                              *d_base;     // base address of buffer
     unsigned int                       d_bufsize;  // in items
+    size_t                             d_sizeof_item;  // in bytes
 
     // Keep track of maximum sample delay of any reader; Only prune tags past this.
     unsigned d_max_reader_delay;
 
   private:
-    gr::vmcircbuf                 *d_vmcircbuf;
-    size_t                        d_sizeof_item;  // in bytes
+    gr::vmcircbuf                *d_vmcircbuf;
     std::vector<buffer_reader *>  d_readers;
     boost::weak_ptr<block>        d_link;         // block that writes to this buffer
 
@@ -203,8 +203,6 @@ namespace gr {
       assert((unsigned) s < d_bufsize);
       return s;
     }
-
-    virtual bool allocate_buffer(int nitems, size_t sizeof_item);
 
     /*!
      * \brief disassociate \p reader from this buffer

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -144,8 +144,23 @@ namespace gr {
       (buffer_sptr buf, int nzero_preload, block_sptr link, int delay);
 
   protected:
-    char			       *d_base;		// base address of buffer
-    unsigned int			d_bufsize;	// in items
+    /*!
+     * \brief constructor is protected.  Use gr::make_buffer to create instances.
+     *
+     * Allocate a buffer that holds at least \p nitems of size \p sizeof_item.
+     *
+     * \param nitems is the minimum number of items the buffer will hold.
+     * \param sizeof_item is the size of an item in bytes.
+     * \param link is the block that writes to this buffer.
+     *
+     * The total size of the buffer will be rounded up to a system
+     * dependent boundary.  This is typically the system page size, but
+     * under MS windows is 64KB.
+     */
+    buffer(int nitems, size_t sizeof_item, block_sptr link);
+
+    char                              *d_base;     // base address of buffer
+    unsigned int                       d_bufsize;  // in items
 
     // Keep track of maximum sample delay of any reader; Only prune tags past this.
     unsigned d_max_reader_delay;
@@ -190,21 +205,6 @@ namespace gr {
     }
 
     virtual bool allocate_buffer(int nitems, size_t sizeof_item);
-
-    /*!
-     * \brief constructor is private.  Use gr_make_buffer to create instances.
-     *
-     * Allocate a buffer that holds at least \p nitems of size \p sizeof_item.
-     *
-     * \param nitems is the minimum number of items the buffer will hold.
-     * \param sizeof_item is the size of an item in bytes.
-     * \param link is the block that writes to this buffer.
-     *
-     * The total size of the buffer will be rounded up to a system
-     * dependent boundary.  This is typically the system page size, but
-     * under MS windows is 64KB.
-     */
-    buffer(int nitems, size_t sizeof_item, block_sptr link);
 
     /*!
      * \brief disassociate \p reader from this buffer

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -166,21 +166,21 @@ namespace gr {
     unsigned d_max_reader_delay;
 
   private:
-    gr::vmcircbuf		       *d_vmcircbuf;
-    size_t	 			d_sizeof_item;	// in bytes
-    std::vector<buffer_reader *>	d_readers;
-    boost::weak_ptr<block>		d_link;		// block that writes to this buffer
+    gr::vmcircbuf                 *d_vmcircbuf;
+    size_t                        d_sizeof_item;  // in bytes
+    std::vector<buffer_reader *>  d_readers;
+    boost::weak_ptr<block>        d_link;         // block that writes to this buffer
 
     //
     // The mutex protects d_write_index, d_abs_write_offset, d_done, d_item_tags
     // and the d_read_index's and d_abs_read_offset's in the buffer readers.
     //
-    gr::thread::mutex			d_mutex;
-    unsigned int			d_write_index;	// in items [0,d_bufsize)
-    uint64_t                            d_abs_write_offset; // num items written since the start
-    bool				d_done;
-    std::multimap<uint64_t,tag_t>                   d_item_tags;
-    uint64_t                            d_last_min_items_read;
+    gr::thread::mutex               d_mutex;
+    unsigned int                    d_write_index;	// in items [0,d_bufsize)
+    uint64_t                        d_abs_write_offset; // num items written since the start
+    bool                            d_done;
+    std::multimap<uint64_t,tag_t>   d_item_tags;
+    uint64_t                        d_last_min_items_read;
 
     unsigned index_add(unsigned a, unsigned b)
     {
@@ -312,7 +312,7 @@ namespace gr {
     void get_tags_in_range(std::vector<tag_t> &v,
                            uint64_t abs_start,
                            uint64_t abs_end,
-			   long id);
+                           long id);
 
     // -------------------------------------------------------------------------
 

--- a/gnuradio-runtime/include/gnuradio/io_signature.h
+++ b/gnuradio-runtime/include/gnuradio/io_signature.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2007 Free Software Foundation, Inc.
+ * Copyright 2004,2007,2014 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -25,6 +25,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/runtime_types.h>
+#include <stdint.h>
 
 namespace gr {
 
@@ -34,15 +35,24 @@ namespace gr {
    */
   class GR_RUNTIME_API io_signature
   {
-    int			d_min_streams;
-    int			d_max_streams;
-    std::vector<int>	d_sizeof_stream_item;
+    int			  d_min_streams;
+    int			  d_max_streams;
+    std::vector<int>	  d_sizeof_stream_item;
+    std::vector<uint32_t> d_stream_flags;
 
     io_signature(int min_streams, int max_streams,
-                 const std::vector<int> &sizeof_stream_items);
+                 const std::vector<int> &sizeof_stream_items,
+		 const std::vector<uint32_t> &stream_flags);
 
   public:
     typedef boost::shared_ptr<io_signature> sptr;
+
+    typedef enum io_flags {
+      DEFAULT_FLAGS  = 0,
+      MEM_BLOCK_ALLOC = 1 << 0,
+      MEM_BLOCK_SINGLE = 1 << 1,
+      MEM_BLOCK_ODD = 1 << 2
+    } io_flags_t;
 
     static const int IO_INFINITE = -1;
 
@@ -55,9 +65,11 @@ namespace gr {
      * \param min_streams  specify minimum number of streams (>= 0)
      * \param max_streams  specify maximum number of streams (>= min_streams or -1 -> infinite)
      * \param sizeof_stream_item  specify the size of the items in each stream
+     * \param flags  specify the io flags for the stream
      */
     static sptr make(int min_streams, int max_streams,
-                     int sizeof_stream_item);
+                     int sizeof_stream_item, 
+		     uint32_t flags = DEFAULT_FLAGS);
 
     /*!
      * \brief Create an i/o signature
@@ -66,10 +78,14 @@ namespace gr {
      * \param max_streams  specify maximum number of streams (>= min_streams or -1 -> infinite)
      * \param sizeof_stream_item1 specify the size of the items in the first stream
      * \param sizeof_stream_item2 specify the size of the items in the second and subsequent streams
+     * \param flags1  specify the io flags for the first stream
+     * \param flags2  specify the io flags for the second and subsequent streams
      */
     static sptr make2(int min_streams, int max_streams,
                       int sizeof_stream_item1,
-                      int sizeof_stream_item2);
+                      int sizeof_stream_item2, 
+		      uint32_t flags1 = DEFAULT_FLAGS,
+		      uint32_t flags2 = DEFAULT_FLAGS);
 
     /*!
      * \brief Create an i/o signature
@@ -79,11 +95,17 @@ namespace gr {
      * \param sizeof_stream_item1 specify the size of the items in the first stream
      * \param sizeof_stream_item2 specify the size of the items in the second stream
      * \param sizeof_stream_item3 specify the size of the items in the third and subsequent streams
+     * \param flags1  specify the io flags for the first stream
+     * \param flags2  specify the io flags for the second stream
+     * \param flags3  specify the io flags for the third and subsequent streams
      */
     static sptr make3(int min_streams, int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
-                      int sizeof_stream_item3);
+                      int sizeof_stream_item3,
+		      uint32_t flags1 = DEFAULT_FLAGS,
+		      uint32_t flags2 = DEFAULT_FLAGS,
+		      uint32_t flags3 = DEFAULT_FLAGS);
 
     /*!
      * \brief Create an i/o signature
@@ -91,6 +113,7 @@ namespace gr {
      * \param min_streams  specify minimum number of streams (>= 0)
      * \param max_streams  specify maximum number of streams (>= min_streams or -1 -> infinite)
      * \param sizeof_stream_items specify the size of the items in the streams
+     * \param stream_flags  specify the io flags for the streams
      *
      * If there are more streams than there are entries in
      * sizeof_stream_items, the value of the last entry in
@@ -98,12 +121,15 @@ namespace gr {
      * sizeof_stream_items must contain at least 1 entry.
      */
     static sptr makev(int min_streams, int max_streams,
-                      const std::vector<int> &sizeof_stream_items);
+                      const std::vector<int> &sizeof_stream_items,
+		      const std::vector<uint32_t> &stream_flags = std::vector<uint32_t>(0));
 
     int min_streams() const { return d_min_streams; }
     int max_streams() const { return d_max_streams; }
     int sizeof_stream_item(int index) const;
+    uint32_t stream_flags(int index) const;
     std::vector<int> sizeof_stream_items() const;
+    std::vector<uint32_t> stream_flags() const;
   };
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/io_signature.h
+++ b/gnuradio-runtime/include/gnuradio/io_signature.h
@@ -35,14 +35,13 @@ namespace gr {
    */
   class GR_RUNTIME_API io_signature
   {
-    int			  d_min_streams;
-    int			  d_max_streams;
-    std::vector<int>	  d_sizeof_stream_item;
+    int d_min_streams;
+    int  d_max_streams;
+    std::vector<int> d_sizeof_stream_item;
     std::vector<uint32_t> d_stream_flags;
 
-    io_signature(int min_streams, int max_streams,
-                 const std::vector<int> &sizeof_stream_items,
-		 const std::vector<uint32_t> &stream_flags);
+    io_signature(int min_streams, int max_streams, const std::vector<int> &sizeof_stream_items,
+            const std::vector<uint32_t> &stream_flags);
 
   public:
     typedef boost::shared_ptr<io_signature> sptr;
@@ -67,9 +66,7 @@ namespace gr {
      * \param sizeof_stream_item  specify the size of the items in each stream
      * \param flags  specify the io flags for the stream
      */
-    static sptr make(int min_streams, int max_streams,
-                     int sizeof_stream_item, 
-		     uint32_t flags = DEFAULT_FLAGS);
+    static sptr make(int min_streams, int max_streams, int sizeof_stream_item, uint32_t flags = DEFAULT_FLAGS);
 
     /*!
      * \brief Create an i/o signature
@@ -81,11 +78,8 @@ namespace gr {
      * \param flags1  specify the io flags for the first stream
      * \param flags2  specify the io flags for the second and subsequent streams
      */
-    static sptr make2(int min_streams, int max_streams,
-                      int sizeof_stream_item1,
-                      int sizeof_stream_item2, 
-		      uint32_t flags1 = DEFAULT_FLAGS,
-		      uint32_t flags2 = DEFAULT_FLAGS);
+    static sptr make2(int min_streams, int max_streams, int sizeof_stream_item1, int sizeof_stream_item2,
+                      uint32_t flags1 = DEFAULT_FLAGS, uint32_t flags2 = DEFAULT_FLAGS);
 
     /*!
      * \brief Create an i/o signature
@@ -99,13 +93,9 @@ namespace gr {
      * \param flags2  specify the io flags for the second stream
      * \param flags3  specify the io flags for the third and subsequent streams
      */
-    static sptr make3(int min_streams, int max_streams,
-                      int sizeof_stream_item1,
-                      int sizeof_stream_item2,
-                      int sizeof_stream_item3,
-		      uint32_t flags1 = DEFAULT_FLAGS,
-		      uint32_t flags2 = DEFAULT_FLAGS,
-		      uint32_t flags3 = DEFAULT_FLAGS);
+    static sptr make3(int min_streams, int max_streams, int sizeof_stream_item1, int sizeof_stream_item2,
+                      int sizeof_stream_item3, uint32_t flags1 = DEFAULT_FLAGS, uint32_t flags2 = DEFAULT_FLAGS,
+                      uint32_t flags3 = DEFAULT_FLAGS);
 
     /*!
      * \brief Create an i/o signature
@@ -120,9 +110,8 @@ namespace gr {
      * sizeof_stream_items is used for the missing values.
      * sizeof_stream_items must contain at least 1 entry.
      */
-    static sptr makev(int min_streams, int max_streams,
-                      const std::vector<int> &sizeof_stream_items,
-		      const std::vector<uint32_t> &stream_flags = std::vector<uint32_t>(0));
+    static sptr makev(int min_streams, int max_streams, const std::vector<int> &sizeof_stream_items,
+                      const std::vector<uint32_t> &stream_flags = std::vector<uint32_t>(0));
 
     int min_streams() const { return d_min_streams; }
     int max_streams() const { return d_max_streams; }

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -138,9 +138,9 @@ namespace gr {
   }
 
 
-  buffer_sptr block::allocate_input_buffer(int port)
+  buffer_sptr block::allocate_upstream_output_buffer(int port)
   {
-    throw std::runtime_error("Block did not define allocate_input_buffer() function properly");
+    throw std::runtime_error("Block did not define allocate_upstream_output_buffer() function properly");
   }
 
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -213,7 +213,6 @@ namespace gr {
       return d_detail->nitems_read(which_input);
     }
     else {
-      //throw std::runtime_error("No block_detail associated with block yet");
       return 0;
     }
   }
@@ -225,7 +224,6 @@ namespace gr {
       return d_detail->nitems_written(which_output);
     }
     else {
-      //throw std::runtime_error("No block_detail associated with block yet");
       return 0;
     }
   }
@@ -305,9 +303,9 @@ namespace gr {
   void
   block::set_max_noutput_items(int m)
   {
-    if(m <= 0)
+    if(m <= 0) {
       throw std::runtime_error("block::set_max_noutput_items: value for max_noutput_items must be greater than 0.\n");
-
+    }
     d_max_noutput_items = m;
     d_max_noutput_items_set = true;
   }
@@ -379,8 +377,9 @@ namespace gr {
   long
   block::max_output_buffer(size_t i)
   {
-    if(i >= d_max_output_buffer.size())
+    if(i >= d_max_output_buffer.size()) {
       throw std::invalid_argument("basic_block::max_output_buffer: port out of range.");
+    }
     return d_max_output_buffer[i];
   }
 
@@ -395,17 +394,19 @@ namespace gr {
   void
   block::set_max_output_buffer(int port, long max_output_buffer)
   {
-    if((size_t)port >= d_max_output_buffer.size())
+    if((size_t)port >= d_max_output_buffer.size()) {
       d_max_output_buffer.push_back(max_output_buffer);
-    else
+    } else {
       d_max_output_buffer[port] = max_output_buffer;
+    }
   }
 
   long
   block::min_output_buffer(size_t i)
   {
-    if(i >= d_min_output_buffer.size())
+    if(i >= d_min_output_buffer.size()) {
       throw std::invalid_argument("basic_block::min_output_buffer: port out of range.");
+    }
     return d_min_output_buffer[i];
   }
 
@@ -421,10 +422,11 @@ namespace gr {
   void
   block::set_min_output_buffer(int port, long min_output_buffer)
   {
-    if((size_t)port >= d_min_output_buffer.size())
+    if((size_t)port >= d_min_output_buffer.size()) {
       d_min_output_buffer.push_back(min_output_buffer);
-    else
+    } else {
       d_min_output_buffer[port] = min_output_buffer;
+    }
   }
 
 
@@ -686,8 +688,7 @@ namespace gr {
   block::pc_throughput_avg() {
     if(d_detail) {
       return d_detail->pc_throughput_avg();
-    }
-    else {
+    } else {
       return 0;
     }
   }
@@ -704,7 +705,6 @@ namespace gr {
   void
   block::system_handler(pmt::pmt_t msg)
   {
-    //std::cout << "system_handler " << msg << "\n";
     pmt::pmt_t op = pmt::car(msg);
     if(pmt::eqv(op, pmt::mp("done"))){
         d_finished = pmt::to_long(pmt::cdr(msg));
@@ -739,10 +739,6 @@ namespace gr {
         basic_block_sptr blk = global_block_registry.block_lookup(block);
         blk->post(port, pmt::cons(pmt::mp("done"), pmt::mp(true)));
 
-        //std::cout << "notify finished --> ";
-        //pmt::print(pmt::cons(block,port));
-        //std::cout << "\n";
-
         }
     }
   }
@@ -750,10 +746,11 @@ namespace gr {
   bool
   block::finished()
   {
-    if((detail()->ninputs() != 0) || (detail()->noutputs() != 0))
+    if((detail()->ninputs() != 0) || (detail()->noutputs() != 0)) {
       return false;
-    else
+    } else {
       return d_finished;
+    }
   }
 
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -131,6 +131,12 @@ namespace gr {
     return true;
   }
 
+  bool
+  block::init()
+  {
+      return true;
+  }
+
   void
   block::set_output_multiple(int multiple)
   {

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -137,6 +137,18 @@ namespace gr {
       return true;
   }
 
+
+  buffer_sptr block::allocate_input_buffer(int port)
+  {
+    throw std::runtime_error("Block did not define allocate_input_buffer() function properly");
+  }
+
+
+  buffer_sptr block::allocate_output_buffer(int port)
+  {
+    throw std::runtime_error("Block did not define allocate_output_buffer() function properly");
+  }
+
   void
   block::set_output_multiple(int multiple)
   {

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -475,7 +475,17 @@ namespace gr {
 
       if(d->d_produce_or > 0)   // block produced something
         return READY;
-
+      // We didn't produce any output even though we called general_work.
+      // We have (most likely) consumed some input.
+      /*
+      // If this is a source, it's broken.
+      if(d->source_p()) {
+        std::cerr << "block_executor: source " << m
+                  << " produced no output.  We're marking it DONE.\n";
+        // FIXME maybe we ought to raise an exception...
+        goto were_done;
+      }
+      */
       // Have the caller try again...
       return READY_NO_OUTPUT;
     }

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -476,19 +476,6 @@ namespace gr {
       if(d->d_produce_or > 0)   // block produced something
         return READY;
 
-      // We didn't produce any output even though we called general_work.
-      // We have (most likely) consumed some input.
-
-      /*
-      // If this is a source, it's broken.
-      if(d->source_p()) {
-        std::cerr << "block_executor: source " << m
-                  << " produced no output.  We're marking it DONE.\n";
-        // FIXME maybe we ought to raise an exception...
-        goto were_done;
-      }
-      */
-
       // Have the caller try again...
       return READY_NO_OUTPUT;
     }

--- a/gnuradio-runtime/lib/block_executor.h
+++ b/gnuradio-runtime/lib/block_executor.h
@@ -42,11 +42,11 @@ namespace gr {
 
     // These are allocated here so we don't have to on each iteration
 
-    gr_vector_int		d_ninput_items_required;
-    gr_vector_int		d_ninput_items;
-    gr_vector_const_void_star	d_input_items;
-    std::vector<bool>		d_input_done;
-    gr_vector_void_star		d_output_items;
+    gr_vector_int               d_ninput_items_required;
+    gr_vector_int               d_ninput_items;
+    gr_vector_const_void_star   d_input_items;
+    std::vector<bool>           d_input_done;
+    gr_vector_void_star         d_output_items;
     std::vector<uint64_t>       d_start_nitems_read; //stores where tag counts are before work
     std::vector<tag_t>          d_returned_tags;
     int                         d_max_noutput_items;
@@ -60,11 +60,11 @@ namespace gr {
     ~block_executor();
 
     enum state {
-      READY,	        // We made progress; everything's cool.
+      READY,            // We made progress; everything's cool.
       READY_NO_OUTPUT,  // We consumed some input, but produced no output.
-      BLKD_IN,	        // no progress; we're blocked waiting for input data.
-      BLKD_OUT,	        // no progress; we're blocked waiting for output buffer space.
-      DONE,	        // we're done; don't call me again.
+      BLKD_IN,          // no progress; we're blocked waiting for input data.
+      BLKD_OUT,         // no progress; we're blocked waiting for output buffer space.
+      DONE,             // we're done; don't call me again.
     };
 
     /*

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -80,11 +80,11 @@ namespace gr {
 
 
   buffer::buffer(unsigned int nitems, size_t sizeof_item, block_sptr link)
-    : d_base(0), d_bufsize(nitems), d_max_reader_delay(0), d_vmcircbuf(0),
-      d_sizeof_item(sizeof_item), d_link(link),
-      d_write_index(0), d_abs_write_offset(0), d_done(false),
+    : d_base(0), d_bufsize(nitems), d_sizeof_item(sizeof_item),  d_max_reader_delay(0),
+      d_vmcircbuf(0), d_link(link), d_write_index(0), d_abs_write_offset(0), d_done(false),
       d_last_min_items_read(0)
   {
+    configure_default_loggers(d_logger, d_debug_logger, "buffer");
     s_buffer_count++;
   }
 
@@ -124,19 +124,21 @@ namespace gr {
     // This only happens if sizeof_item is not a power of two.
 
     if(nitems > 2 * orig_nitems && nitems * static_cast<int>(d_sizeof_item) > granularity){
-      std::cerr << "gr::buffer::allocate_buffer: warning: tried to allocate\n"
-                << "   " << orig_nitems << " items of size "
-                << d_sizeof_item << ". Due to alignment requirements\n"
-                << "   " << nitems << " were allocated.  If this isn't OK, consider padding\n"
-                << "   your structure to a power-of-two bytes.\n"
-                << "   On this platform, our allocation granularity is " << granularity << " bytes.\n";
+      GR_LOG_DEBUG(d_debug_logger,
+                   boost::format("gr::buffer::allocate_buffer: warning: tried to allocate\n"
+                    "   %i items of size %i. Due to alignment requirements\n"
+                    "   %i were allocated.  If this isn't OK, consider padding\n"
+                    "   your structure to a power-of-two bytes.\n"
+                    "   On this platform, our allocation granularity is %i bytes.\n"
+                   ) % orig_nitems % d_sizeof_item % nitems % granularity);
+
     }
 
     d_bufsize = nitems;
     d_vmcircbuf = gr::vmcircbuf_sysconfig::make(d_bufsize * d_sizeof_item);
     if(d_vmcircbuf == 0){
-      std::cerr << "gr::buffer::allocate_buffer: failed to allocate buffer of size "
-                << d_bufsize * d_sizeof_item / 1024 << " KB\n";
+      GR_LOG_DEBUG(d_debug_logger, boost::format("gr::buffer::allocate_buffer: failed to allocate buffer of size %i KB")
+                                   % (d_bufsize * d_sizeof_item / 1024));
       return false;
     }
 

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -35,11 +35,11 @@
 
 namespace gr {
 
-  static long s_buffer_count = 0;		// counts for debugging storage mgmt
+  static long s_buffer_count = 0;   // counts for debugging storage mgmt
   static long s_buffer_reader_count = 0;
 
   /* ----------------------------------------------------------------------------
-  			Notes on storage management
+            Notes on storage management
 
    Pretty much all the fundamental classes are now using the
    shared_ptr stuff for automatic reference counting. To ensure that
@@ -149,7 +149,7 @@ namespace gr {
   buffer::space_available()
   {
     if(d_readers.empty())
-      return d_bufsize - 1;	// See comment below
+      return d_bufsize - 1; // See comment below
 
     else {
       // Find out the maximum amount of data available to our readers
@@ -201,7 +201,7 @@ namespace gr {
 
     buffer_reader_sptr r(new buffer_reader(buf,
                                            buf->index_sub(buf->d_write_index,
-                                                          nzero_preload),
+                                           nzero_preload),
                                            link));
     r->declare_sample_delay(delay);
     buf->d_readers.push_back(r.get ());

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -234,7 +234,7 @@ namespace gr {
           std::cout << "Input buffer is owned by block " << grblock << std::endl;
           std::cout << "Setting output " << src_port << " from edge " << (*e) << std::endl;
         }
-        buffer_sptr dst_buffer = grblock->allocate_input_buffer(src_port);
+        buffer_sptr dst_buffer = grblock->allocate_upstream_output_buffer(src_port);
         if (FLAT_FLOWGRAPH_DEBUG) {
           std::cout << "Allocated custom input buffer for block " << block << std::endl;
         }

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -240,6 +240,7 @@ namespace gr {
               std::cout << "merge: reusing original detail for block " << (*p) << std::endl;
           }
       }
+      block->init();
     }
 
     // Calculate the old edges that will be going away, and clear the

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -64,7 +64,12 @@ namespace gr {
 
     // Assign block details to blocks
     for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
-        cast_to_block_sptr(*p)->set_detail(allocate_block_detail(*p));
+      block_sptr block = cast_to_block_sptr(*p);
+      block->set_detail(allocate_block_detail(*p));
+      if(FLAT_FLOWGRAPH_DEBUG) {
+        std::cout << "Calling " << block << " init() function" << std::endl;
+      }
+      block->init();
     }
 
     // Connect inputs to outputs for each block
@@ -79,7 +84,7 @@ namespace gr {
     // Connect message ports
     for(msg_edge_viter_t i = d_msg_edges.begin(); i != d_msg_edges.end(); i++) {
       if(FLAT_FLOWGRAPH_DEBUG) {
-          std::cout << boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
+        std::cout << boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
                   i->src().block() % i->src().port() %
                   i->dst().block() % i->dst().port();
       }
@@ -95,32 +100,41 @@ namespace gr {
     block_detail_sptr detail = make_block_detail(ninputs, noutputs);
 
     block_sptr grblock = cast_to_block_sptr(block);
-    if(!grblock)
+    if(!grblock) {
       throw std::runtime_error(
-        (boost::format("allocate_block_detail found non-gr::block (%s)")%
-        block->alias()).str());
+              (boost::format("allocate_block_detail found non-gr::block (%s)") %
+               block->alias()).str());
+    }
 
     if(FLAT_FLOWGRAPH_DEBUG) {
-        std::cout << "Creating block detail for " << block << std::endl;
+      std::cout << "Creating block detail for " << block << std::endl;
     }
 
     for(int i = 0; i < noutputs; i++) {
       grblock->expand_minmax_buffer(i);
-
-      buffer_sptr buffer = allocate_buffer(block, i);
-      if(FLAT_FLOWGRAPH_DEBUG) {
+      if (grblock->d_output_signature->stream_flags(i) == gr::io_signature::MEM_BLOCK_ALLOC) {
+        buffer_sptr buffer = grblock->allocate_output_buffer(i);
+        if (FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "Allocated custom buffer for " << block << ":" << i << std::endl;
+        }
+        detail->set_output(i, buffer);
+      } else {
+        buffer_sptr buffer = allocate_buffer(block, i);
+        if (FLAT_FLOWGRAPH_DEBUG) {
           std::cout << "Allocated buffer for output " << block << ":" << i << std::endl;
+        }
+        detail->set_output(i, buffer);
       }
-      detail->set_output(i, buffer);
-
+      buffer_sptr buffer = detail->output(i);
       // Update the block's max_output_buffer based on what was actually allocated.
-      if((grblock->max_output_buffer(i) != buffer->bufsize()) && (grblock->max_output_buffer(i) != -1))
-        GR_LOG_WARN(d_logger, boost::format("Block (%1%) max output buffer set to %2%"
-                                            " instead of requested %3%") \
+      if ((grblock->max_output_buffer(i) != buffer->bufsize()) && (grblock->max_output_buffer(i) != -1)) {
+        GR_LOG_WARN(d_logger,
+                    boost::format("Block (%1%) max output buffer set to %2%"
+                                                " instead of requested %3%") \
                     % grblock->alias() % buffer->bufsize() % grblock->max_output_buffer(i));
-      grblock->set_max_output_buffer(i, buffer->bufsize());
+        grblock->set_max_output_buffer(i, buffer->bufsize());
+      }
     }
-
     return detail;
   }
 
@@ -151,8 +165,9 @@ namespace gr {
     if(grblock->max_output_buffer(port) > 0) {
       nitems = std::min((long)nitems, grblock->max_output_buffer(port));
       nitems -= nitems%grblock->output_multiple();
-      if(nitems < 1)
-        throw std::runtime_error("problems allocating a buffer with the given max output buffer constraint!");
+      if(nitems < 1) {
+          throw std::runtime_error("problems allocating a buffer with the given max output buffer constraint!");
+      }
     }
     else if(grblock->min_output_buffer(port) > 0) {
       nitems = std::max((long)nitems, grblock->min_output_buffer(port));
@@ -206,16 +221,32 @@ namespace gr {
       int src_port = e->src().port();
       basic_block_sptr src_block = e->src().block();
       block_sptr src_grblock = cast_to_block_sptr(src_block);
-      if(!src_grblock) {
-          throw std::runtime_error("connect_block_inputs found non-gr::block");
+      if (!src_grblock) {
+        throw std::runtime_error("connect_block_inputs found non-gr::block");
+      }
+      if ((grblock->input_signature()->stream_flags(dst_port) & gr::io_signature::MEM_BLOCK_ALLOC) ==
+          gr::io_signature::MEM_BLOCK_ALLOC) {
+        if ((src_grblock->output_signature()->stream_flags(src_port) & gr::io_signature::MEM_BLOCK_ALLOC) ==
+            gr::io_signature::MEM_BLOCK_ALLOC) {
+          throw std::runtime_error("Input and output ports of connected blocks cannot both be MEM_BLOCK_ALLOC");
+        }
+        if (FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "Input buffer is owned by block " << grblock << std::endl;
+          std::cout << "Setting output " << src_port << " from edge " << (*e) << std::endl;
+        }
+        buffer_sptr dst_buffer = grblock->allocate_input_buffer(src_port);
+        if (FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "Allocated custom input buffer for block " << block << std::endl;
+        }
+        src_grblock->detail()->set_output(src_port, dst_buffer);
       }
       buffer_sptr src_buffer = src_grblock->detail()->output(src_port);
 
-      if(FLAT_FLOWGRAPH_DEBUG) {
-          std::cout << "Setting input " << dst_port << " from edge " << (*e) << std::endl;
+      if (FLAT_FLOWGRAPH_DEBUG) {
+        std::cout << "Setting input " << dst_port << " from edge " << (*e) << std::endl;
       }
 
-      detail->set_input(dst_port, buffer_add_reader(src_buffer, grblock->history()-1, grblock,
+      detail->set_input(dst_port, buffer_add_reader(src_buffer, grblock->history() - 1, grblock,
                                                     grblock->sample_delay(src_port)));
     }
   }
@@ -239,6 +270,9 @@ namespace gr {
           if (FLAT_FLOWGRAPH_DEBUG) {
               std::cout << "merge: reusing original detail for block " << (*p) << std::endl;
           }
+      }
+      if(FLAT_FLOWGRAPH_DEBUG) {
+        std::cout << "Calling " << block << " init() function" << std::endl;
       }
       block->init();
     }

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -63,8 +63,9 @@ namespace gr {
     basic_block_vector_t blocks = calc_used_blocks();
 
     // Assign block details to blocks
-    for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++)
-      cast_to_block_sptr(*p)->set_detail(allocate_block_detail(*p));
+    for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
+        cast_to_block_sptr(*p)->set_detail(allocate_block_detail(*p));
+    }
 
     // Connect inputs to outputs for each block
     for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
@@ -75,12 +76,13 @@ namespace gr {
       block->set_is_unaligned(false);
     }
 
-    // Connect message ports connetions
+    // Connect message ports
     for(msg_edge_viter_t i = d_msg_edges.begin(); i != d_msg_edges.end(); i++) {
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
-          i->src().block() % i->src().port() %
-          i->dst().block() % i->dst().port();
+      if(FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
+                  i->src().block() % i->src().port() %
+                  i->dst().block() % i->dst().port();
+      }
       i->src().block()->message_port_sub(i->src().port(), pmt::cons(i->dst().block()->alias_pmt(), i->dst().port()));
     }
   }
@@ -88,8 +90,8 @@ namespace gr {
   block_detail_sptr
   flat_flowgraph::allocate_block_detail(basic_block_sptr block)
   {
-    int ninputs = calc_used_ports(block, true).size();
-    int noutputs = calc_used_ports(block, false).size();
+    unsigned int ninputs = calc_used_ports(block, true).size();
+    unsigned int noutputs = calc_used_ports(block, false).size();
     block_detail_sptr detail = make_block_detail(ninputs, noutputs);
 
     block_sptr grblock = cast_to_block_sptr(block);
@@ -98,15 +100,17 @@ namespace gr {
         (boost::format("allocate_block_detail found non-gr::block (%s)")%
         block->alias()).str());
 
-    if(FLAT_FLOWGRAPH_DEBUG)
-      std::cout << "Creating block detail for " << block << std::endl;
+    if(FLAT_FLOWGRAPH_DEBUG) {
+        std::cout << "Creating block detail for " << block << std::endl;
+    }
 
     for(int i = 0; i < noutputs; i++) {
       grblock->expand_minmax_buffer(i);
 
       buffer_sptr buffer = allocate_buffer(block, i);
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "Allocated buffer for output " << block << ":" << i << std::endl;
+      if(FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "Allocated buffer for output " << block << ":" << i << std::endl;
+      }
       detail->set_output(i, buffer);
 
       // Update the block's max_output_buffer based on what was actually allocated.
@@ -124,8 +128,9 @@ namespace gr {
   flat_flowgraph::allocate_buffer(basic_block_sptr block, int port)
   {
     block_sptr grblock = cast_to_block_sptr(block);
-    if(!grblock)
-      throw std::runtime_error("allocate_buffer found non-gr::block");
+    if(!grblock) {
+        throw std::runtime_error("allocate_buffer found non-gr::block");
+    }
     int item_size = block->output_signature()->sizeof_stream_item(port);
 
     // *2 because we're now only filling them 1/2 way in order to
@@ -134,8 +139,9 @@ namespace gr {
     int nitems = s_fixed_buffer_size * 2 / item_size;
 
     // Make sure there are at least twice the output_multiple no. of items
-    if(nitems < 2*grblock->output_multiple())	// Note: this means output_multiple()
-      nitems = 2*grblock->output_multiple();	// can't be changed by block dynamically
+    if(nitems < 2*grblock->output_multiple()) {  // Note: this means output_multiple()
+        nitems = 2 * grblock->output_multiple();    // can't be changed by block dynamically
+    }
 
     // If any downstream blocks are decimators and/or have a large output_multiple,
     // ensure we have a buffer at least twice their decimation factor*output_multiple
@@ -143,23 +149,24 @@ namespace gr {
 
     // limit buffer size if indicated
     if(grblock->max_output_buffer(port) > 0) {
-      //std::cout << "constraining output items to " << block->max_output_buffer(port) << "\n";
-      nitems = std::min((long)nitems, (long)grblock->max_output_buffer(port));
+      nitems = std::min((long)nitems, grblock->max_output_buffer(port));
       nitems -= nitems%grblock->output_multiple();
       if(nitems < 1)
         throw std::runtime_error("problems allocating a buffer with the given max output buffer constraint!");
     }
     else if(grblock->min_output_buffer(port) > 0) {
-      nitems = std::max((long)nitems, (long)grblock->min_output_buffer(port));
+      nitems = std::max((long)nitems, grblock->min_output_buffer(port));
       nitems -= nitems%grblock->output_multiple();
-      if(nitems < 1)
-        throw std::runtime_error("problems allocating a buffer with the given min output buffer constraint!");
+      if(nitems < 1) {
+          throw std::runtime_error("problems allocating a buffer with the given min output buffer constraint!");
+      }
     }
 
     for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
       block_sptr dgrblock = cast_to_block_sptr(*p);
-      if(!dgrblock)
-        throw std::runtime_error("allocate_buffer found non-gr::block");
+      if(!dgrblock) {
+          throw std::runtime_error("allocate_buffer found non-gr::block");
+      }
 
       double decimation = (1.0/dgrblock->relative_rate());
       int multiple      = dgrblock->output_multiple();
@@ -167,7 +174,6 @@ namespace gr {
       nitems = std::max(nitems, static_cast<int>(2*(decimation*multiple+history)));
     }
 
-    //  std::cout << "make_buffer(" << nitems << ", " << item_size << ", " << grblock << "\n";
     // We're going to let this fail once and retry. If that fails,
     // throw and exit.
     buffer_sptr b;
@@ -184,8 +190,9 @@ namespace gr {
   flat_flowgraph::connect_block_inputs(basic_block_sptr block)
   {
     block_sptr grblock = cast_to_block_sptr(block);
-    if (!grblock)
-      throw std::runtime_error("connect_block_inputs found non-gr::block");
+    if (!grblock) {
+        throw std::runtime_error("connect_block_inputs found non-gr::block");
+    }
 
     // Get its detail and edges that feed into it
     block_detail_sptr detail = grblock->detail();
@@ -199,12 +206,14 @@ namespace gr {
       int src_port = e->src().port();
       basic_block_sptr src_block = e->src().block();
       block_sptr src_grblock = cast_to_block_sptr(src_block);
-      if(!src_grblock)
-        throw std::runtime_error("connect_block_inputs found non-gr::block");
+      if(!src_grblock) {
+          throw std::runtime_error("connect_block_inputs found non-gr::block");
+      }
       buffer_sptr src_buffer = src_grblock->detail()->output(src_port);
 
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "Setting input " << dst_port << " from edge " << (*e) << std::endl;
+      if(FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "Setting input " << dst_port << " from edge " << (*e) << std::endl;
+      }
 
       detail->set_input(dst_port, buffer_add_reader(src_buffer, grblock->history()-1, grblock,
                                                     grblock->sample_delay(src_port)));
@@ -221,38 +230,45 @@ namespace gr {
       block_sptr block = cast_to_block_sptr(*p);
 
       if(!block->detail()) {
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "merge: allocating new detail for block " << (*p) << std::endl;
+        if(FLAT_FLOWGRAPH_DEBUG) {
+            std::cout << "merge: allocating new detail for block " << (*p) << std::endl;
+        }
         block->set_detail(allocate_block_detail(block));
       }
-      else
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "merge: reusing original detail for block " << (*p) << std::endl;
+      else {
+          if (FLAT_FLOWGRAPH_DEBUG) {
+              std::cout << "merge: reusing original detail for block " << (*p) << std::endl;
+          }
+      }
     }
 
     // Calculate the old edges that will be going away, and clear the
     // buffer readers on the RHS.
     for(edge_viter_t old_edge = old_ffg->d_edges.begin(); old_edge != old_ffg->d_edges.end(); old_edge++) {
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "merge: testing old edge " << (*old_edge) << "...";
+      if(FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "merge: testing old edge " << (*old_edge) << "...";
+      }
 
       edge_viter_t new_edge;
       for(new_edge = d_edges.begin(); new_edge != d_edges.end(); new_edge++)
         if(new_edge->src() == old_edge->src() &&
-           new_edge->dst() == old_edge->dst())
-          break;
+           new_edge->dst() == old_edge->dst()) {
+            break;
+        }
 
       if(new_edge == d_edges.end()) { // not found in new edge list
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "not in new edge list" << std::endl;
+        if(FLAT_FLOWGRAPH_DEBUG) {
+            std::cout << "not in new edge list" << std::endl;
+        }
         // zero the buffer reader on RHS of old edge
         block_sptr block(cast_to_block_sptr(old_edge->dst().block()));
         int port = old_edge->dst().port();
         block->detail()->set_input(port, buffer_reader_sptr());
       }
       else {
-        if (FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "found in new edge list" << std::endl;
+        if (FLAT_FLOWGRAPH_DEBUG) {
+            std::cout << "found in new edge list" << std::endl;
+        }
       }
     }
 
@@ -260,20 +276,23 @@ namespace gr {
     for(basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
       block_sptr block = cast_to_block_sptr(*p);
 
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "merge: merging " << (*p) << "...";
+      if(FLAT_FLOWGRAPH_DEBUG) {
+          std::cout << "merge: merging " << (*p) << "...";
+      }
 
       if(old_ffg->has_block_p(*p)) {
         // Block exists in old flow graph
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "used in old flow graph" << std::endl;
+        if(FLAT_FLOWGRAPH_DEBUG) {
+            std::cout << "used in old flow graph" << std::endl;
+        }
         block_detail_sptr detail = block->detail();
 
         // Iterate through the inputs and see what needs to be done
         int ninputs = calc_used_ports(block, true).size(); // Might be different now
         for(int i = 0; i < ninputs; i++) {
-          if(FLAT_FLOWGRAPH_DEBUG)
-            std::cout << "Checking input " << block << ":" << i << "...";
+          if(FLAT_FLOWGRAPH_DEBUG) {
+              std::cout << "Checking input " << block << ":" << i << "...";
+          }
           edge edge = calc_upstream_edge(*p, i);
 
           // Fish out old buffer reader and see if it matches correct buffer from edge list
@@ -286,12 +305,14 @@ namespace gr {
 
           // If there's a match, use it
           if(old_reader && (src_buffer == old_reader->buffer())) {
-            if(FLAT_FLOWGRAPH_DEBUG)
-              std::cout << "matched, reusing" << std::endl;
+            if(FLAT_FLOWGRAPH_DEBUG) {
+                std::cout << "matched, reusing" << std::endl;
+            }
           }
           else {
-            if(FLAT_FLOWGRAPH_DEBUG)
-              std::cout << "needs a new reader" << std::endl;
+            if(FLAT_FLOWGRAPH_DEBUG) {
+                std::cout << "needs a new reader" << std::endl;
+            }
 
             // Create new buffer reader and assign
             detail->set_input(i, buffer_add_reader(src_buffer, block->history()-1, block));
@@ -300,8 +321,9 @@ namespace gr {
       }
       else {
         // Block is new, it just needs buffer readers at this point
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "new block" << std::endl;
+        if(FLAT_FLOWGRAPH_DEBUG) {
+            std::cout << "new block" << std::endl;
+        }
         connect_block_inputs(block);
 
         // Make sure all buffers are aligned
@@ -321,7 +343,6 @@ namespace gr {
     for(int i = 0; i < block->detail()->ninputs(); i++) {
       void *r = (void*)block->detail()->input(i)->read_pointer();
       unsigned long int ri = (unsigned long int)r % alignment;
-      //std::cerr << "reader: " << r << "  alignment: " << ri << std::endl;
       if(ri != 0) {
         size_t itemsize = block->detail()->input(i)->get_sizeof_item();
         block->detail()->input(i)->update_read_pointer(alignment-ri/itemsize);
@@ -333,7 +354,6 @@ namespace gr {
     for(int i = 0; i < block->detail()->noutputs(); i++) {
       void *w = (void*)block->detail()->output(i)->write_pointer();
       unsigned long int wi = (unsigned long int)w % alignment;
-      //std::cerr << "writer: " << w << "  alignment: " << wi << std::endl;
       if(wi != 0) {
         size_t itemsize = block->detail()->output(i)->get_sizeof_item();
         block->detail()->output(i)->update_write_pointer(alignment-wi/itemsize);
@@ -347,8 +367,9 @@ namespace gr {
   flat_flowgraph::edge_list()
   {
     std::stringstream s;
-    for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++)
-      s << (*e) << std::endl;
+    for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++) {
+        s << (*e) << std::endl;
+    }
     return s.str();
   }
 
@@ -356,15 +377,17 @@ namespace gr {
   flat_flowgraph::msg_edge_list()
   {
     std::stringstream s;
-    for(msg_edge_viter_t e = d_msg_edges.begin(); e != d_msg_edges.end(); e++)
-      s << (*e) << std::endl;
+    for(msg_edge_viter_t e = d_msg_edges.begin(); e != d_msg_edges.end(); e++) {
+        s << (*e) << std::endl;
+    }
     return s.str();
   }
 
   void flat_flowgraph::dump()
   {
-    for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++)
-      std::cout << " edge: " << (*e) << std::endl;
+    for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++) {
+        std::cout << " edge: " << (*e) << std::endl;
+    }
 
     for(basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
       std::cout << " block: " << (*p) << std::endl;
@@ -437,8 +460,9 @@ namespace gr {
   flat_flowgraph::replace_endpoint(const msg_endpoint &e, const msg_endpoint &r, bool is_src)
   {
     size_t n_replr(0);
-    if(FLAT_FLOWGRAPH_DEBUG)
-      std::cout << boost::format("flat_flowgraph::replace_endpoint( %s, %s, %d )\n") % e.block()% r.block()% is_src;
+    if(FLAT_FLOWGRAPH_DEBUG) {
+        std::cout << boost::format("flat_flowgraph::replace_endpoint( %s, %s, %d )\n") % e.block() % r.block() % is_src;
+    }
     for(size_t i=0; i<d_msg_edges.size(); i++) {
       if(is_src) {
         if(d_msg_edges[i].src() == e) {

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -115,7 +115,7 @@ namespace gr {
       if (grblock->d_output_signature->stream_flags(i) == gr::io_signature::MEM_BLOCK_ALLOC) {
         buffer_sptr buffer = grblock->allocate_output_buffer(i);
         if (FLAT_FLOWGRAPH_DEBUG) {
-          std::cout << "Allocated custom buffer for " << block << ":" << i << std::endl;
+          std::cout << "Allocated custom buffer for output " << block << ":" << i << std::endl;
         }
         detail->set_output(i, buffer);
       } else {
@@ -189,14 +189,14 @@ namespace gr {
       nitems = std::max(nitems, static_cast<int>(2*(decimation*multiple+history)));
     }
 
+    buffer_sptr b;
+    b = make_buffer(nitems, item_size, grblock);
     // We're going to let this fail once and retry. If that fails,
     // throw and exit.
-    buffer_sptr b;
-    try {
-      b = make_buffer(nitems, item_size, grblock);
-    }
-    catch(std::bad_alloc&) {
-      b = make_buffer(nitems, item_size, grblock);
+    if (!b->allocate_buffer()) {
+      if (!b->allocate_buffer()) {
+        throw std::bad_alloc();
+      }
     }
     return b;
   }

--- a/gnuradio-runtime/lib/flat_flowgraph.h
+++ b/gnuradio-runtime/lib/flat_flowgraph.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2006,2007,2013 Free Software Foundation, Inc.
+ * Copyright 2006, 2007, 2013, 2014, 2015 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -25,7 +25,6 @@
 #endif
 
 #include "hier_block2_detail.h"
-#include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <stdexcept>
 #include <sstream>
@@ -87,8 +86,9 @@ namespace gr {
     hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
 
     if(hblock && hblock.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "connect: block is hierarchical, setting parent to " << this << std::endl;
+      }
       hblock->d_detail->d_parent_detail = this;
     }
 
@@ -101,9 +101,10 @@ namespace gr {
   {
     std::stringstream msg;
 
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "connecting: " << endpoint(src, src_port)
                 << " -> " << endpoint(dst, dst_port) << std::endl;
+    }
 
     if(src.get() == dst.get())
       throw std::invalid_argument("connect: src and destination blocks cannot be the same");
@@ -112,14 +113,16 @@ namespace gr {
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if(src_block && src.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "connect: src is hierarchical, setting parent to " << this << std::endl;
+      }
       src_block->d_detail->d_parent_detail = this;
     }
 
     if(dst_block && dst.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "connect: dst is hierarchical, setting parent to " << this << std::endl;
+      }
       dst_block->d_detail->d_parent_detail = this;
     }
 
@@ -155,8 +158,9 @@ namespace gr {
   hier_block2_detail::msg_connect(basic_block_sptr src, pmt::pmt_t srcport,
                                   basic_block_sptr dst, pmt::pmt_t dstport)
   {
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "connecting message port..." << std::endl;
+    }
 
     // add block uniquely to list to internal blocks
     if(std::find(d_blocks.begin(), d_blocks.end(), dst) == d_blocks.end()){
@@ -179,22 +183,24 @@ namespace gr {
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if(src_block && src.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "msg_connect: src is hierarchical, setting parent to " << this << std::endl;
+      }
       src_block->d_detail->d_parent_detail = this;
     }
 
     if(dst_block && dst.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "msg_connect: dst is hierarchical, setting parent to " << this << std::endl;
+      }
       dst_block->d_detail->d_parent_detail = this;
     }
 
     // add edge for this message connection
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << boost::format("msg_connect( (%s, %s, %d), (%s, %s, %d) )\n") % \
-        src % srcport % hier_out %
-        dst % dstport % hier_in;
+      src % srcport % hier_out % dst % dstport % hier_in;
+    }
     d_fg->connect(msg_endpoint(src, srcport, hier_out), msg_endpoint(dst, dstport, hier_in));
   }
 
@@ -202,8 +208,9 @@ namespace gr {
   hier_block2_detail::msg_disconnect(basic_block_sptr src, pmt::pmt_t srcport,
                                      basic_block_sptr dst, pmt::pmt_t dstport)
   {
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "disconnecting message port..." << std::endl;
+    }
 
     // remove edge for this message connection
     bool hier_in=false, hier_out=false;
@@ -258,8 +265,9 @@ namespace gr {
 
         hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
         if(block && block.get() != d_owner) {
-          if(HIER_BLOCK2_DETAIL_DEBUG)
+          if(HIER_BLOCK2_DETAIL_DEBUG) {
             std::cout << "disconnect: block is hierarchical, clearing parent" << std::endl;
+          }
           hblock->d_detail->d_parent_detail = 0;
         }
 
@@ -274,8 +282,9 @@ namespace gr {
       if((*p).src().block() == block || (*p).dst().block() == block) {
         edges.push_back(*p);
 
-        if(HIER_BLOCK2_DETAIL_DEBUG)
+        if(HIER_BLOCK2_DETAIL_DEBUG) {
           std::cout << "disconnect: block found in edge " << (*p) << std::endl;
+        }
       }
     }
 
@@ -295,33 +304,39 @@ namespace gr {
   hier_block2_detail::disconnect(basic_block_sptr src, int src_port,
                                  basic_block_sptr dst, int dst_port)
   {
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "disconnecting: " << endpoint(src, src_port)
                 << " -> " << endpoint(dst, dst_port) << std::endl;
+    }
 
-    if(src.get() == dst.get())
+    if(src.get() == dst.get()) {
       throw std::invalid_argument("disconnect: source and destination blocks cannot be the same");
+    }
 
     hier_block2_sptr src_block(cast_to_hier_block2_sptr(src));
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if(src_block && src.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "disconnect: src is hierarchical, clearing parent" << std::endl;
+      }
       src_block->d_detail->d_parent_detail = 0;
     }
 
     if(dst_block && dst.get() != d_owner) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "disconnect: dst is hierarchical, clearing parent" << std::endl;
+      }
       dst_block->d_detail->d_parent_detail = 0;
     }
 
-    if(src.get() == d_owner)
+    if(src.get() == d_owner) {
       return disconnect_input(src_port, dst_port, dst);
+    }
 
-    if(dst.get() == d_owner)
+    if(dst.get() == d_owner) {
       return disconnect_output(dst_port, src_port, src);
+    }
 
     // Internal connections
     d_fg->disconnect(src, src_port, dst, dst_port);
@@ -418,10 +433,11 @@ namespace gr {
   {
     std::stringstream msg;
 
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "Resolving port " << port << " as an "
                 << (is_input ? "input" : "output")
                 << " of " << d_owner->name() << std::endl;
+    }
 
     endpoint_vector_t result;
 
@@ -492,8 +508,9 @@ namespace gr {
 
     // Check if endpoint is a leaf node
     if(cast_to_block_sptr(endp.block())) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "Block " << endp.block() << " is a leaf node, returning." << std::endl;
+      }
       result.push_back(endp);
       return result;
     }
@@ -501,10 +518,11 @@ namespace gr {
     // Check if endpoint is a hierarchical block
     hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(endp.block()));
     if(hier_block2) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "Resolving endpoint " << endp << " as an "
                   << (is_input ? "input" : "output")
                   << ", recursing" << std::endl;
+      }
       return hier_block2->d_detail->resolve_port(endp.port(), is_input);
     }
 
@@ -516,15 +534,16 @@ namespace gr {
   void
   hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
   {
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << " ** Flattening " << d_owner->name() << " parent: " << d_parent_detail << std::endl;
+    }
     bool is_top_block = (d_parent_detail == NULL);
 
     // Add my edges to the flow graph, resolving references to actual endpoints
     edge_vector_t edges = d_fg->edges();
     msg_edge_vector_t msg_edges = d_fg->msg_edges();
     edge_viter_t p;
-    msg_edge_viter_t q,u;
+    msg_edge_viter_t q;
 
     // Only run setup_rpc if ControlPort config param is enabled.
     bool ctrlport_on = prefs::singleton()->get_bool("ControlPort", "on", false);
@@ -678,12 +697,14 @@ namespace gr {
       }
     }
 
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "Flattening stream connections: " << std::endl;
+    }
 
     for(p = edges.begin(); p != edges.end(); p++) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "Flattening edge " << (*p) << std::endl;
+      }
 
       endpoint_vector_t src_endps = resolve_endpoint(p->src(), false);
       endpoint_vector_t dst_endps = resolve_endpoint(p->dst(), true);
@@ -691,64 +712,58 @@ namespace gr {
       endpoint_viter_t s, d;
       for(s = src_endps.begin(); s != src_endps.end(); s++) {
         for(d = dst_endps.begin(); d != dst_endps.end(); d++) {
-          if(HIER_BLOCK2_DETAIL_DEBUG)
+          if(HIER_BLOCK2_DETAIL_DEBUG) {
             std::cout << (*s) << "->" << (*d) << std::endl;
+          }
           sfg->connect(*s, *d);
         }
       }
     }
 
     // loop through flattening hierarchical connections
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "Flattening msg connections: " << std::endl;
+    }
 
     std::vector<std::pair<msg_endpoint, bool> > resolved_endpoints;
     for(q = msg_edges.begin(); q != msg_edges.end(); q++) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << boost::format(" flattening edge ( %s, %s, %d) -> ( %s, %s, %d)\n") % \
           q->src().block() % q->src().port() % q->src().is_hier() % q->dst().block() % \
           q->dst().port() % q->dst().is_hier();
-
+      }
 
       if(q->src().is_hier() && q->src().block().get() == d_owner){
         // connection into this block ..
-        if(HIER_BLOCK2_DETAIL_DEBUG)
+        if(HIER_BLOCK2_DETAIL_DEBUG) {
           std::cout << "hier incoming port: " << q->src() << std::endl;
+        }
         sfg->replace_endpoint(q->src(), q->dst(), false);
         resolved_endpoints.push_back( std::pair<msg_endpoint,bool>( q->src(), false));
       } else
       if(q->dst().is_hier() && q->dst().block().get() == d_owner){
         // connection out of this block
-        if(HIER_BLOCK2_DETAIL_DEBUG)
+        if(HIER_BLOCK2_DETAIL_DEBUG) {
           std::cout << "hier outgoing port: " << q->dst() << std::endl;
+        }
         sfg->replace_endpoint(q->dst(), q->src(), true);
         resolved_endpoints.push_back( std::pair<msg_endpoint,bool>(q->dst(), true));
       } else {
         // internal connection only
-        if(HIER_BLOCK2_DETAIL_DEBUG)
+        if(HIER_BLOCK2_DETAIL_DEBUG) {
           std::cout << "internal msg connection: " << q->src() << "-->" << q->dst() << std::endl;
+        }
         sfg->connect( q->src(), q->dst() );
       }
     }
 
     for(std::vector<std::pair<msg_endpoint, bool> >::iterator it = resolved_endpoints.begin();
         it != resolved_endpoints.end(); it++) {
-      if(HIER_BLOCK2_DETAIL_DEBUG)
+      if(HIER_BLOCK2_DETAIL_DEBUG) {
         std::cout << "sfg->clear_endpoint(" << (*it).first << ", " << (*it).second << ") " << std::endl;
+      }
       sfg->clear_endpoint((*it).first, (*it).second);
     }
-
-    /*
-    // connect primitive edges in the new fg
-    for(q = msg_edges.begin(); q != msg_edges.end(); q++) {
-      if((!q->src().is_hier()) && (!q->dst().is_hier())) {
-        sfg->connect(q->src(), q->dst());
-      }
-      else {
-        std::cout << "not connecting hier connection!" << std::endl;
-      }
-    }
-    */
 
     // Construct unique list of blocks used either in edges, inputs,
     // outputs, or by themselves.  I still hate STL.
@@ -757,8 +772,9 @@ namespace gr {
 
     // First add the list of singleton blocks
     std::vector<basic_block_sptr>::const_iterator b;   // Because flatten_aux is const
-    for(b = d_blocks.begin(); b != d_blocks.end(); b++)
-      tmp.push_back(*b);
+    for(b = d_blocks.begin(); b != d_blocks.end(); b++) {
+        tmp.push_back(*b);
+    }
 
     // Now add the list of connected input blocks
     std::stringstream msg;
@@ -769,8 +785,9 @@ namespace gr {
         throw std::runtime_error(msg.str());
       }
 
-      for(unsigned int j = 0; j < d_inputs[i].size(); j++)
-        tmp.push_back(d_inputs[i][j].block());
+      for(unsigned int j = 0; j < d_inputs[i].size(); j++) {
+          tmp.push_back(d_inputs[i][j].block());
+      }
     }
 
     for(unsigned int i = 0; i < d_outputs.size(); i++) {
@@ -846,9 +863,10 @@ namespace gr {
     for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
       hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(*p));
       if(hier_block2 && (hier_block2.get() != d_owner)) {
-        if(HIER_BLOCK2_DETAIL_DEBUG)
+        if(HIER_BLOCK2_DETAIL_DEBUG) {
           std::cout << "flatten_aux: recursing into hierarchical block "
                     << hier_block2->alias() << std::endl;
+        }
         hier_block2->d_detail->flatten_aux(sfg);
       }
     }
@@ -870,25 +888,29 @@ namespace gr {
   void
   hier_block2_detail::lock()
   {
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "lock: entered in " << this << std::endl;
+    }
 
-    if(d_parent_detail)
+    if(d_parent_detail) {
       d_parent_detail->lock();
-    else
+    } else {
       d_owner->lock();
+    }
   }
 
   void
   hier_block2_detail::unlock()
   {
-    if(HIER_BLOCK2_DETAIL_DEBUG)
+    if(HIER_BLOCK2_DETAIL_DEBUG) {
       std::cout << "unlock: entered in " << this << std::endl;
+    }
 
-    if(d_parent_detail)
+    if(d_parent_detail) {
       d_parent_detail->unlock();
-    else
+    } else {
       d_owner->unlock();
+    }
   }
 
   void

--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2007,2013 Free Software Foundation, Inc.
+ * Copyright 2004,2007,2014 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -32,54 +32,71 @@ namespace gr {
 
   gr::io_signature::sptr
   io_signature::makev(int min_streams, int max_streams,
-                      const std::vector<int> &sizeof_stream_items)
+                      const std::vector<int> &sizeof_stream_items,
+		      const std::vector<uint32_t> &stream_flags)
   {
     return gr::io_signature::sptr
       (new io_signature(min_streams, max_streams,
-                        sizeof_stream_items));
+                        sizeof_stream_items, stream_flags));
   }
 
   gr::io_signature::sptr
   io_signature::make(int min_streams, int max_streams,
-                     int sizeof_stream_item)
+                     int sizeof_stream_item,
+		     uint32_t flags)
   {
     std::vector<int> sizeof_items(1);
+    std::vector<uint32_t> stream_flags(1);
     sizeof_items[0] = sizeof_stream_item;
-    return io_signature::makev(min_streams, max_streams, sizeof_items);
+    stream_flags[0] = flags;
+    return io_signature::makev(min_streams, max_streams, sizeof_items, stream_flags);
   }
 
   gr::io_signature::sptr
   io_signature::make2(int min_streams, int max_streams,
                       int sizeof_stream_item1,
-                      int sizeof_stream_item2)
+                      int sizeof_stream_item2,
+		      uint32_t flags1,
+		      uint32_t flags2)
   {
     std::vector<int> sizeof_items(2);
+    std::vector<uint32_t> stream_flags(2);
     sizeof_items[0] = sizeof_stream_item1;
     sizeof_items[1] = sizeof_stream_item2;
-    return io_signature::makev(min_streams, max_streams, sizeof_items);
+    stream_flags[0] = flags1;
+    stream_flags[1] = flags2;
+    return io_signature::makev(min_streams, max_streams, sizeof_items, stream_flags);
   }
 
   gr::io_signature::sptr
   io_signature::make3(int min_streams, int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
-                      int sizeof_stream_item3)
+                      int sizeof_stream_item3,
+		      uint32_t flags1,
+		      uint32_t flags2,
+		      uint32_t flags3)
   {
     std::vector<int> sizeof_items(3);
+    std::vector<uint32_t> stream_flags(3);
     sizeof_items[0] = sizeof_stream_item1;
     sizeof_items[1] = sizeof_stream_item2;
     sizeof_items[2] = sizeof_stream_item3;
-    return io_signature::makev(min_streams, max_streams, sizeof_items);
+    stream_flags[0] = flags1;
+    stream_flags[1] = flags2;
+    stream_flags[2] = flags3;
+    return io_signature::makev(min_streams, max_streams, sizeof_items, stream_flags);
   }
 
   // ------------------------------------------------------------------------
 
   io_signature::io_signature(int min_streams, int max_streams,
-                             const std::vector<int> &sizeof_stream_items)
+                             const std::vector<int> &sizeof_stream_items,
+			     const std::vector<uint32_t> &stream_flags)
   {
     if(min_streams < 0
        || (max_streams != IO_INFINITE && max_streams < min_streams))
-      throw std::invalid_argument ("gr::io_signature(1)");
+      throw std::invalid_argument("gr::io_signature(1)");
 
     if(sizeof_stream_items.size() < 1)
       throw std::invalid_argument("gr::io_signature(2)");
@@ -92,6 +109,20 @@ namespace gr {
     d_min_streams = min_streams;
     d_max_streams = max_streams;
     d_sizeof_stream_item = sizeof_stream_items;
+
+    // If user doesn't supply stream flags, make vector of defaults
+    // of the same size as sizeof_stream_items
+    if(stream_flags.size() == 0) {
+      for (size_t i = 0; i < sizeof_stream_items.size(); i++)
+	d_stream_flags.push_back(io_signature::DEFAULT_FLAGS);
+    }
+    else {
+      // Make sure user supplied vector matches
+      if(sizeof_stream_items.size() != stream_flags.size())
+	throw std::invalid_argument("gr::io_signature(4)");
+
+      d_stream_flags = stream_flags;
+    }
   }
 
   io_signature::~io_signature()
@@ -108,10 +139,26 @@ namespace gr {
     return d_sizeof_stream_item[std::min(index, d_sizeof_stream_item.size() - 1)];
   }
 
+  uint32_t
+  io_signature::stream_flags(int _index) const
+  {
+    if(_index < 0)
+      throw std::invalid_argument("gr::io_signature::sizeof_stream_item");
+
+    size_t index = _index;
+    return d_stream_flags[std::min(index, d_stream_flags.size() - 1)];
+  }
+
   std::vector<int>
   io_signature::sizeof_stream_items() const
   {
     return d_sizeof_stream_item;
+  }
+
+  std::vector<uint32_t>
+  io_signature::stream_flags() const
+  {
+    return d_stream_flags;
   }
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -33,17 +33,16 @@ namespace gr {
   gr::io_signature::sptr
   io_signature::makev(int min_streams, int max_streams,
                       const std::vector<int> &sizeof_stream_items,
-		      const std::vector<uint32_t> &stream_flags)
+                      const std::vector<uint32_t> &stream_flags)
   {
     return gr::io_signature::sptr
-      (new io_signature(min_streams, max_streams,
-                        sizeof_stream_items, stream_flags));
+      (new io_signature(min_streams, max_streams, sizeof_stream_items, stream_flags));
   }
 
   gr::io_signature::sptr
   io_signature::make(int min_streams, int max_streams,
                      int sizeof_stream_item,
-		     uint32_t flags)
+                     uint32_t flags)
   {
     std::vector<int> sizeof_items(1);
     std::vector<uint32_t> stream_flags(1);
@@ -56,8 +55,8 @@ namespace gr {
   io_signature::make2(int min_streams, int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
-		      uint32_t flags1,
-		      uint32_t flags2)
+                      uint32_t flags1,
+                      uint32_t flags2)
   {
     std::vector<int> sizeof_items(2);
     std::vector<uint32_t> stream_flags(2);
@@ -73,9 +72,9 @@ namespace gr {
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
                       int sizeof_stream_item3,
-		      uint32_t flags1,
-		      uint32_t flags2,
-		      uint32_t flags3)
+                      uint32_t flags1,
+                      uint32_t flags2,
+                      uint32_t flags3)
   {
     std::vector<int> sizeof_items(3);
     std::vector<uint32_t> stream_flags(3);
@@ -92,7 +91,7 @@ namespace gr {
 
   io_signature::io_signature(int min_streams, int max_streams,
                              const std::vector<int> &sizeof_stream_items,
-			     const std::vector<uint32_t> &stream_flags)
+                             const std::vector<uint32_t> &stream_flags)
   {
     if(min_streams < 0
        || (max_streams != IO_INFINITE && max_streams < min_streams))

--- a/gnuradio-runtime/lib/qa_buffer.cc
+++ b/gnuradio-runtime/lib/qa_buffer.cc
@@ -54,6 +54,7 @@ t0_body()
   int counter = 0;
 
   gr::buffer_sptr buf(gr::make_buffer(nitems, sizeof(int), gr::block_sptr()));
+  buf->allocate_buffer();
 
   int last_sa;
   int sa;
@@ -89,6 +90,7 @@ t1_body()
   int read_counter = 0;
 
   gr::buffer_sptr buf(gr::make_buffer(nitems, sizeof(int), gr::block_sptr()));
+  buf->allocate_buffer();
   gr::buffer_reader_sptr r1(gr::buffer_add_reader(buf, 0, gr::block_sptr()));
 
   int sa;
@@ -161,6 +163,7 @@ t2_body()
   int nitems = (64 * (1L << 10)) / sizeof(int);  // 64K worth of ints
 
   gr::buffer_sptr buf(gr::make_buffer(nitems, sizeof(int), gr::block_sptr()));
+  buf->allocate_buffer();
   gr::buffer_reader_sptr r1(gr::buffer_add_reader(buf, 0, gr::block_sptr()));
 
   int read_counter = 0;
@@ -227,6 +230,7 @@ t3_body()
 
   static const int N = 5;
   gr::buffer_sptr buf(gr::make_buffer(nitems, sizeof(int), gr::block_sptr()));
+  buf->allocate_buffer();
   gr::buffer_reader_sptr reader[N];
   int read_counter[N];
   int write_counter = 0;

--- a/gnuradio-runtime/lib/qa_io_signature.cc
+++ b/gnuradio-runtime/lib/qa_io_signature.cc
@@ -63,3 +63,26 @@ qa_io_signature::t3()
   CPPUNIT_ASSERT_EQUAL(p->sizeof_stream_item(3), 3);
   CPPUNIT_ASSERT_EQUAL(p->sizeof_stream_item(4), 3);
 }
+
+void
+qa_io_signature::t4_stream_flags() {
+    gr::io_signature::sptr default_flags_io = gr::io_signature::make(0, 5, 1, gr::io_signature::DEFAULT_FLAGS);
+    gr::io_signature::sptr block_mem_alloc = gr::io_signature::make(0, gr::io_signature::IO_INFINITE, 1,
+                                                                    gr::io_signature::MEM_BLOCK_ALLOC);
+    gr::io_signature::sptr mem_alloc_single = gr::io_signature::make(0, 5, 1, gr::io_signature::MEM_BLOCK_ALLOC |
+                                                                              gr::io_signature::MEM_BLOCK_SINGLE);
+    gr::io_signature::sptr mem_alloc_odd = gr::io_signature::make(0, 5, 1, gr::io_signature::MEM_BLOCK_ALLOC |
+                                                                           gr::io_signature::MEM_BLOCK_ODD);
+    int port = 0;
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(gr::io_signature::DEFAULT_FLAGS), default_flags_io->stream_flags(port));
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(gr::io_signature::MEM_BLOCK_ALLOC),
+                         block_mem_alloc->stream_flags(port) & gr::io_signature::MEM_BLOCK_ALLOC);
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(gr::io_signature::MEM_BLOCK_SINGLE),
+                         mem_alloc_single->stream_flags(port) & gr::io_signature::MEM_BLOCK_SINGLE);
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(gr::io_signature::MEM_BLOCK_ALLOC),
+                         mem_alloc_single->stream_flags(port) & gr::io_signature::MEM_BLOCK_ALLOC);
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(gr::io_signature::MEM_BLOCK_ODD),
+                         mem_alloc_odd->stream_flags(port) & gr::io_signature::MEM_BLOCK_ODD);
+    CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(gr::io_signature::MEM_BLOCK_ALLOC),
+                         mem_alloc_odd->stream_flags(port) & gr::io_signature::MEM_BLOCK_ALLOC);
+}

--- a/gnuradio-runtime/lib/qa_io_signature.h
+++ b/gnuradio-runtime/lib/qa_io_signature.h
@@ -34,6 +34,7 @@ class qa_io_signature : public CppUnit::TestCase
   CPPUNIT_TEST_EXCEPTION(t1, std::invalid_argument);
   CPPUNIT_TEST(t2);
   CPPUNIT_TEST(t3);
+  CPPUNIT_TEST(t4_stream_flags);
   CPPUNIT_TEST_SUITE_END();
 
  private:
@@ -41,6 +42,7 @@ class qa_io_signature : public CppUnit::TestCase
   void t1();
   void t2();
   void t3();
+  void t4_stream_flags();
 };
 
 #endif /* INCLUDED_QA_GR_IO_SIGNATURE_H */

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -31,12 +31,6 @@
 #include <gnuradio/top_block.h>
 #include <gnuradio/prefs.h>
 
-#include <stdexcept>
-#include <iostream>
-#include <string.h>
-#include <unistd.h>
-#include <stdlib.h>
-
 namespace gr {
 
 #define GR_TOP_BLOCK_IMPL_DEBUG 0

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -25,17 +25,12 @@
 
 #include "tpb_thread_body.h"
 #include <gnuradio/prefs.h>
-#include <boost/thread.hpp>
-#include <boost/foreach.hpp>
-#include <pmt/pmt.h>
-#include <iostream>
 
 namespace gr {
 
   tpb_thread_body::tpb_thread_body(block_sptr block, int max_noutput_items)
     : d_exec(block, max_noutput_items)
   {
-    //std::cerr << "tpb_thread_body: " << block << std::endl;
 
 #ifdef _MSC_VER
     #include <Windows.h>

--- a/gnuradio-runtime/swig/io_signature.i
+++ b/gnuradio-runtime/swig/io_signature.i
@@ -24,9 +24,8 @@ namespace gr {
 
   class GR_RUNTIME_API io_signature
   {
-    io_signature(int min_streams, int max_streams,
-                 const std::vector<int> &sizeof_stream_items,
-		 const std::vector<uint32_t> &stream_flags);
+    io_signature(int min_streams, int max_streams, const std::vector<int> &sizeof_stream_items,
+                   const std::vector<uint32_t> &stream_flags);
 
   public:
     typedef boost::shared_ptr<io_signature> sptr;
@@ -46,24 +45,14 @@ namespace gr {
     ~io_signature();
 
 
-    static sptr make(int min_streams, int max_streams,
-                     int sizeof_stream_item,
-		     uint32_t flags = DEFAULT_FLAGS);
-    static sptr make2(int min_streams, int max_streams,
-                      int sizeof_stream_item1,
-                      int sizeof_stream_item2,
-		      uint32_t flags1 = DEFAULT_FLAGS,
-		      uint32_t flags2 = DEFAULT_FLAGS);
-    static sptr make3(int min_streams, int max_streams,
-                      int sizeof_stream_item1,
-                      int sizeof_stream_item2,
-                      int sizeof_stream_item3,
-		      uint32_t flags1 = DEFAULT_FLAGS,
-		      uint32_t flags2 = DEFAULT_FLAGS,
-		      uint32_t flags3 = DEFAULT_FLAGS);
-    static sptr makev(int min_streams, int max_streams,
-                      const std::vector<int> &sizeof_stream_items,
-		      const std::vector<uint32_t> &stream_flags = std::vector<uint32_t>(0));
+    static sptr make(int min_streams, int max_streams, int sizeof_stream_item, uint32_t flags = DEFAULT_FLAGS);
+    static sptr make2(int min_streams, int max_streams, int sizeof_stream_item1, int sizeof_stream_item2,
+                          uint32_t flags1 = DEFAULT_FLAGS, uint32_t flags2 = DEFAULT_FLAGS);
+    static sptr make3(int min_streams, int max_streams, int sizeof_stream_item1, int sizeof_stream_item2,
+                          int sizeof_stream_item3, uint32_t flags1 = DEFAULT_FLAGS, uint32_t flags2 = DEFAULT_FLAGS,
+                          uint32_t flags3 = DEFAULT_FLAGS);
+    static sptr makev(int min_streams, int max_streams, const std::vector<int> &sizeof_stream_items,
+                          const std::vector<uint32_t> &stream_flags = std::vector<uint32_t>(0));
 
     int min_streams() const { return d_min_streams; }
     int max_streams() const { return d_max_streams; }

--- a/gnuradio-runtime/swig/io_signature.i
+++ b/gnuradio-runtime/swig/io_signature.i
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2005,2007,2013 Free Software Foundation, Inc.
+ * Copyright 2004,2005,2007,2014 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -25,10 +25,18 @@ namespace gr {
   class GR_RUNTIME_API io_signature
   {
     io_signature(int min_streams, int max_streams,
-                 const std::vector<int> &sizeof_stream_items);
+                 const std::vector<int> &sizeof_stream_items,
+		 const std::vector<uint32_t> &stream_flags);
 
   public:
     typedef boost::shared_ptr<io_signature> sptr;
+
+    typedef enum io_flags {
+      DEFAULT_FLAGS  = 0,
+      MEM_BLOCK_ALLOC = 1 << 0,
+      MEM_BLOCK_SINGLE = 1 << 1,
+      MEM_BLOCK_ODD = 1 << 2
+    } io_flags_t;
 
     // Avoids a swig warning, otherwise we could just
     // #include <gnuradio/io_signature.h> instead of redoing this
@@ -39,21 +47,30 @@ namespace gr {
 
 
     static sptr make(int min_streams, int max_streams,
-                     int sizeof_stream_item);
+                     int sizeof_stream_item,
+		     uint32_t flags = DEFAULT_FLAGS);
     static sptr make2(int min_streams, int max_streams,
                       int sizeof_stream_item1,
-                      int sizeof_stream_item2);
+                      int sizeof_stream_item2,
+		      uint32_t flags1 = DEFAULT_FLAGS,
+		      uint32_t flags2 = DEFAULT_FLAGS);
     static sptr make3(int min_streams, int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
-                      int sizeof_stream_item3);
+                      int sizeof_stream_item3,
+		      uint32_t flags1 = DEFAULT_FLAGS,
+		      uint32_t flags2 = DEFAULT_FLAGS,
+		      uint32_t flags3 = DEFAULT_FLAGS);
     static sptr makev(int min_streams, int max_streams,
-                      const std::vector<int> &sizeof_stream_items);
+                      const std::vector<int> &sizeof_stream_items,
+		      const std::vector<uint32_t> &stream_flags = std::vector<uint32_t>(0));
 
     int min_streams() const { return d_min_streams; }
     int max_streams() const { return d_max_streams; }
     int sizeof_stream_item(int index) const;
+    uint32_t stream_flags(int index) const;
     std::vector<int> sizeof_stream_items() const;
+    std::vector<uint32_t> stream_flags() const;
   };
 
 } /* namespace gr */

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -75,6 +75,7 @@ namespace gr {
 
       // FYI, the buffer indicies are in units of samples.
       d_writer = gr::make_buffer(N_BUFFERS * bufsize_samples, sizeof(sample_t));
+      d_writer->allocate_buffer();
       d_reader = gr::buffer_add_reader(d_writer, 0);
     }
 

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -75,6 +75,7 @@ namespace gr {
 
       // FYI, the buffer indicies are in units of samples.
       d_writer = gr::make_buffer(N_BUFFERS * bufsize_samples, sizeof(sample_t));
+      d_writer->allocate_buffer();
       d_reader = gr::buffer_add_reader(d_writer, 0);
     }
 

--- a/gr-blocks/lib/qa_gr_block.cc
+++ b/gr-blocks/lib/qa_gr_block.cc
@@ -80,6 +80,7 @@ namespace gr {
       // Here be dragons...
       block_sptr block_ptr = cast_to_block_sptr(shared_from_this()); // shared_from_this() to make sure we don't delete ourselves
       buffer_sptr buffer = make_buffer(nitems, item_size, block_ptr);
+      buffer->allocate_buffer();
       return buffer;
     }
     class test_custom_buffers_sink : virtual public sync_block {
@@ -125,6 +126,7 @@ namespace gr {
       // Here be dragons...
       block_sptr block_ptr = cast_to_block_sptr(shared_from_this()); // shared_from_this() to make sure we don't delete ourselves
       buffer_sptr my_buffer = make_buffer(nitems, item_size, block_ptr);
+      my_buffer->allocate_buffer();
       return my_buffer;
     }
   }

--- a/gr-blocks/lib/qa_gr_block.cc
+++ b/gr-blocks/lib/qa_gr_block.cc
@@ -110,7 +110,7 @@ namespace gr {
         return noutput_items;
       }
 
-      virtual buffer_sptr allocate_input_buffer(int port);
+      virtual buffer_sptr allocate_upstream_output_buffer(int port);
     };
 
     test_custom_buffers_sink::sptr test_custom_buffers_sink::make(size_t sizeof_stream_item)
@@ -118,7 +118,7 @@ namespace gr {
       return gnuradio::get_initial_sptr(new test_custom_buffers_sink_impl(sizeof_stream_item));
     }
 
-    buffer_sptr test_custom_buffers_sink_impl::allocate_input_buffer(int port)
+    buffer_sptr test_custom_buffers_sink_impl::allocate_upstream_output_buffer(int port)
     {
       // make output buffer
       int item_size = this->input_signature()->sizeof_stream_item(port);

--- a/gr-blocks/lib/qa_gr_block.h
+++ b/gr-blocks/lib/qa_gr_block.h
@@ -33,14 +33,18 @@ class qa_gr_block : public CppUnit::TestCase {
   CPPUNIT_TEST (t0);
   CPPUNIT_TEST (t1);
   CPPUNIT_TEST (t2);
-  CPPUNIT_TEST (t3);
+  CPPUNIT_TEST (t3_custom_allocator_output);
+  CPPUNIT_TEST (t4_throw_connected_mem_blocks);
+  CPPUNIT_TEST (t5_custom_allocator_input);
   CPPUNIT_TEST_SUITE_END ();
 
  private:
   void t0 ();
   void t1 ();
   void t2 ();
-  void t3 ();
+  void t3_custom_allocator_output();
+  void t4_throw_connected_mem_blocks();
+  void t5_custom_allocator_input();
 
 };
 


### PR DESCRIPTION
Addresses issue #730

This add's the ability to tell the scheduler that a block wants to allocate input/output buffers, and modified gr::buffer to allow sub-classing. The scheduler must then be modified to a.) Ensure that two blocks are not both trying to allocate the same buffer (i.e. upstream block wants to allocate output buffer, downstream wants to allocate input buffer) and b.) deal with lifecycle management of the buffers (e.g. during the flattening of flowgraphs as well as lock()/unlock(), etc.) since that does not coincide with block creation/destruction.

There is new QA code to provide coverage of the changes, however more testing should be done to ensure existing code has not been broken. Note that the only known case of blocks using gr::buffer's directly is the in-tree portaudio blocks.