### PR TITLE
uhd: Added controlport interface for UHD sink's "command" message handler

### DIFF
--- a/gr-blocks/examples/ctrlport/usrp_sink_controller.py
+++ b/gr-blocks/examples/ctrlport/usrp_sink_controller.py
@@ -10,7 +10,7 @@ parser.add_option("-H", "--host", type="string", default="localhost",
                   help="Hostname to connect to (default=%default)")
 parser.add_option("-p", "--port", type="int", default=9090,
                   help="Port of Controlport instance on host (default=%default)")
-parser.add_option("-a", "--alias", type="string", default="gr uhd usrp source0",
+parser.add_option("-a", "--alias", type="string", default="gr uhd usrp sink0",
                   help="The UHD block's alias to control (default=%default)")
 options, args = parser.parse_args()
 
@@ -30,7 +30,7 @@ if(cmd == "tune" or cmd == "time"):
     sys.stderr.write("This application currently does not support the 'tune' or 'time' UHD "
                      "message commands.\n\n")
     sys.exit(1)
-if(cmd == "antenna"):
+elif(cmd == "antenna"):
     val = pmt.intern(val)
 else:
     val = pmt.from_double(float(val))

--- a/gr-blocks/examples/ctrlport/usrp_source_control.grc
+++ b/gr-blocks/examples/ctrlport/usrp_source_control.grc
@@ -41,6 +41,10 @@
       <value>qt_gui</value>
     </param>
     <param>
+      <key>hier_block_src_path</key>
+      <value>.:</value>
+    </param>
+    <param>
       <key>id</key>
       <value>usrp_source_control</value>
     </param>
@@ -49,8 +53,16 @@
       <value>0</value>
     </param>
     <param>
+      <key>qt_qss_theme</key>
+      <value></value>
+    </param>
+    <param>
       <key>realtime_scheduling</key>
       <value></value>
+    </param>
+    <param>
+      <key>run_command</key>
+      <value>{python} -u {filename}</value>
     </param>
     <param>
       <key>run_options</key>
@@ -746,7 +758,7 @@
     <key>uhd_usrp_source</key>
     <param>
       <key>alias</key>
-      <value>usrp_source0</value>
+      <value></value>
     </param>
     <param>
       <key>ant0</key>

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -618,5 +618,18 @@ namespace gr {
       return true;
     }
 
+
+    void
+    usrp_sink_impl::setup_rpc()
+    {
+#ifdef GR_CTRLPORT
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_handler<usrp_block>(
+          alias(), "command",
+          "", "UHD Commands",
+          RPC_PRIVLVL_MIN, DISPNULL)));
+#endif /* GR_CTRLPORT */
+    }
+
   } /* namespace uhd */
 } /* namespace gr */

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -103,6 +103,8 @@ namespace gr {
 
       inline void tag_work(int &ninput_items);
 
+      void setup_rpc();
+
     private:
       //! Like set_center_freq(), but uses _curr_freq and _curr_lo_offset
       ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan);


### PR DESCRIPTION
Also added an example, usrp_sink_controller.py, to excercise this
feature. Fixed up the source example, too, to better manage parsing
options and setting the UHD source block alias (defaults to 'gr uhd
usrp source0', which is the default for any flowgraph with a single
UHD source block).