### PR TITLE
added unit test for tag forwarding to delay

### DIFF
--- a/gr-blocks/python/blocks/qa_delay.py
+++ b/gr-blocks/python/blocks/qa_delay.py
@@ -21,6 +21,7 @@
 #
 
 from gnuradio import gr, gr_unittest, blocks
+import pmt
 
 class test_delay(gr_unittest.TestCase):
 
@@ -59,6 +60,28 @@ class test_delay(gr_unittest.TestCase):
         tb.run()
         dst_data = dst.data()
         self.assertEqual(expected_result, dst_data)
+
+    def test_020(self):
+        tb = self.tb
+        vector_sink = blocks.vector_sink_f(1)
+        ref_sink = blocks.vector_sink_f(1)
+        tags_strobe = blocks.tags_strobe(gr.sizeof_float*1, pmt.intern("TEST"), 100, pmt.intern("strobe"))
+        head = blocks.head(gr.sizeof_float*1, 10**5)
+        delay = blocks.delay(gr.sizeof_float*1, 100)
+        tb.connect((delay, 0), (head, 0))
+        tb.connect((head, 0), (vector_sink, 0))
+        tb.connect((tags_strobe, 0), (delay, 0))
+        tb.connect((tags_strobe, 0), (ref_sink, 0))
+        tb.run()
+
+        tags = vector_sink.tags()
+        self.assertNotEqual(len(tags), 0)
+        lastoffset = tags[0].offset - 100
+        for tag in tags:
+            newoffset = tag.offset
+            self.assertEqual(newoffset, lastoffset + 100)
+            lastoffset = newoffset
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_delay, "test_delay.xml")


### PR DESCRIPTION
… should honestly be a runtime QA check, but can't check in runtime
without depending on blocks, so using this place as it is functionally
important for the delay block.