### PR TITLE
controlport: using the 'binary' Thrift data type to work better with Java

### DIFF
--- a/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
+++ b/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
@@ -105,6 +105,6 @@ service ControlPort {
         KnobMap getKnobs(1:KnobIDList knobs);
         KnobMap getRe(1:KnobIDList knobs);
         KnobPropMap properties(1:KnobIDList knobs);
-        void postMessage(1:string blk_alias, 2:string port, 3:string msg);
+        void postMessage(1:string blk_alias, 2:string port, 3:binary msg);
         void shutdown();
 }


### PR DESCRIPTION
Java String class can change data from an arbitrary byte[] object. We
use the ByteBuffer class now when passing data to ControlPort's
postMessage function, which manages the underlying data properly.