### PR TITLE
Fixed delayed tag propagation

### DIFF
--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -347,8 +347,8 @@ namespace gr {
     gr::thread::scoped_lock guard(*mutex());
 
     v.resize(0);
-    std::multimap<uint64_t,tag_t>::iterator itr = d_buffer->get_tags_lower_bound(abs_start);
-    std::multimap<uint64_t,tag_t>::iterator itr_end   = d_buffer->get_tags_upper_bound(abs_end);
+    std::multimap<uint64_t,tag_t>::iterator itr = d_buffer->get_tags_lower_bound(std::min(abs_start, abs_start - d_attr_delay));
+    std::multimap<uint64_t,tag_t>::iterator itr_end = d_buffer->get_tags_upper_bound(std::min(abs_end, abs_end - d_attr_delay));
 
     uint64_t item_time;
     while(itr != itr_end) {


### PR DESCRIPTION
This is my proposed fix. It seems that get_tags_in_range was failing to account for the offset introduced by the delay when calculating the tag lower/upper bounds. Not sure if this is the best way to fix it, but the test flow graph on the [issue #864](http://gnuradio.org/redmine/issues/864) page now passes.