### PR TITLE
blocks: resolve char sign ambiguity causing problems with gcc 4.9.2

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/add_const_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_bb.h
@@ -44,17 +44,17 @@ namespace gr {
        * \brief Create an instance of add_const_bb
        * \param k additive constant
        */
-      static sptr make(char k);
+      static sptr make(unsigned char k);
 
       /*!
        * \brief Return additive constant
        */
-      virtual char k() const = 0;
+      virtual unsigned char k() const = 0;
 
       /*!
        * \brief Set additive constant
        */
-      virtual void set_k(char k) = 0;
+      virtual void set_k(unsigned char k) = 0;
     };
 
   }

--- a/gr-blocks/lib/add_const_bb_impl.cc
+++ b/gr-blocks/lib/add_const_bb_impl.cc
@@ -30,16 +30,16 @@
 namespace gr {
   namespace blocks {
 
-    add_const_bb::sptr add_const_bb::make(char k)
+    add_const_bb::sptr add_const_bb::make(unsigned char k)
     {
       return gnuradio::get_initial_sptr
         (new add_const_bb_impl(k));
     }
 
-    add_const_bb_impl::add_const_bb_impl(char k)
+    add_const_bb_impl::add_const_bb_impl(unsigned char k)
       : sync_block("add_const_bb",
-                   io_signature::make (1, 1, sizeof(char)),
-                   io_signature::make (1, 1, sizeof(char))),
+                   io_signature::make (1, 1, sizeof(unsigned char)),
+                   io_signature::make (1, 1, sizeof(unsigned char))),
         d_k(k)
     {
     }
@@ -53,8 +53,8 @@ namespace gr {
                             gr_vector_const_void_star &input_items,
                             gr_vector_void_star &output_items)
     {
-      const char *iptr = (const char *) input_items[0];
-      char *optr = (char *) output_items[0];
+      const unsigned char *iptr = (const unsigned char *) input_items[0];
+      unsigned char *optr = (unsigned char *) output_items[0];
 
       int size = noutput_items;
 
@@ -82,7 +82,7 @@ namespace gr {
     {
 #ifdef GR_CTRLPORT
       add_rpc_variable(
-        rpcbasic_sptr(new rpcbasic_register_get<add_const_bb, char>(
+        rpcbasic_sptr(new rpcbasic_register_get<add_const_bb, unsigned char>(
 	  alias(), "Constant",
 	  &add_const_bb::k,
 	  pmt::from_long(-128),
@@ -92,7 +92,7 @@ namespace gr {
           DISPTIME | DISPOPTCPLX | DISPOPTSTRIP)));
 
       add_rpc_variable(
-        rpcbasic_sptr(new rpcbasic_register_set<add_const_bb, char>(
+        rpcbasic_sptr(new rpcbasic_register_set<add_const_bb, unsigned char>(
 	  alias(), "Constant",
 	  &add_const_bb::set_k,
 	  pmt::from_long(-128),

--- a/gr-blocks/lib/add_const_bb_impl.h
+++ b/gr-blocks/lib/add_const_bb_impl.h
@@ -31,16 +31,16 @@ namespace gr {
     class BLOCKS_API add_const_bb_impl : public add_const_bb
     {
     private:
-      char d_k;
+      unsigned char d_k;
 
     public:
-      add_const_bb_impl(char k);
+      add_const_bb_impl(unsigned char k);
       ~add_const_bb_impl();
 
       void setup_rpc();
 
-      char k() const { return d_k; }
-      void set_k(char k) { d_k = k; }
+      unsigned char k() const { return d_k; }
+      void set_k(unsigned char k) { d_k = k; }
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
this is a build breaker on gcc 4.6.3 due to incorrect interchangeable use of "char" and "unsigned char" in the block and with GRCP templates in the add_const_bb block.