### PR TITLE
Fix 64 bit OpenEmbedded builds.

### DIFF
--- a/cmake/Modules/GrPlatform.cmake
+++ b/cmake/Modules/GrPlatform.cmake
@@ -29,15 +29,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(LINUX TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/debian_version")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/debian_version")
     set(DEBIAN TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/redhat-release")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/redhat-release")
     set(REDHAT TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/slackware-version")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/slackware-version")
     set(SLACKWARE TRUE)
 endif()
 

--- a/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrPlatform.cmake
+++ b/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrPlatform.cmake
@@ -29,15 +29,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(LINUX TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/debian_version")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/debian_version")
     set(DEBIAN TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/redhat-release")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/redhat-release")
     set(REDHAT TRUE)
 endif()
 
-if(LINUX AND EXISTS "/etc/slackware-version")
+if(NOT CMAKE_CROSSCOMPILING AND LINUX AND EXISTS "/etc/slackware-version")
     set(SLACKWARE TRUE)
 endif()
 


### PR DESCRIPTION
GNU Radio is looking at files on the build system to determine if it should
use the lib64 directory. This doesn't work on cross builds. Do not set
REDHAT, DEBIAN, or SLACKWARE if cross compiling.

Also fix gr-newmod so modules do the right thing.

Signed-off-by: Philip Balister <philip@balister.org>