### PR TITLE
DTV ATSC updates and ControlPort Addtions

### DIFF
--- a/gr-dtv/CMakeLists.txt
+++ b/gr-dtv/CMakeLists.txt
@@ -41,6 +41,8 @@ GR_SET_GLOBAL(GR_DTV_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}/lib
 )
 
+SET(GR_PKG_DTV_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/dtv)
+
 ########################################################################
 # Begin conditional configuration
 ########################################################################

--- a/gr-dtv/examples/CMakeLists.txt
+++ b/gr-dtv/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2014 Free Software Foundation, Inc.
+# Copyright 2014-2015 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -22,6 +22,28 @@ include(GrPython)
 GR_PYTHON_INSTALL(
     PROGRAMS
     atsc_ctrlport_monitor.py
+    DESTINATION ${GR_PKG_DTV_EXAMPLES_DIR}
+    COMPONENT "dtv_python"
+)
+
+install(
+    FILES
+    README.dvbs
+    README.dvbs2
+    README.dvbt
+    README.dvbt2
+    dvbs2_tx.grc
+    dvbs_tx.grc
+    dvbt_rx_8k.grc
+    dvbt_tx_2k.grc
+    dvbt_tx_8k.grc
+    file_atsc_rx.grc
+    file_atsc_tx.grc
+    uhd_atsc_capture.grc
+    uhd_rx_atsc.grc
+    vv003-cr23.grc
+    vv009-4kfft.grc
+    vv018-miso.grc
     DESTINATION ${GR_PKG_DTV_EXAMPLES_DIR}
     COMPONENT "dtv_python"
 )

--- a/gr-dtv/examples/CMakeLists.txt
+++ b/gr-dtv/examples/CMakeLists.txt
@@ -21,6 +21,7 @@ include(GrPython)
 
 GR_PYTHON_INSTALL(
     PROGRAMS
+    atsc_ctrlport_monitor.py
     DESTINATION ${GR_PKG_DTV_EXAMPLES_DIR}
     COMPONENT "dtv_python"
 )

--- a/gr-dtv/examples/atsc_ctrlport_monitor.py
+++ b/gr-dtv/examples/atsc_ctrlport_monitor.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 Free Software Foundation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+import sys
+import matplotlib
+matplotlib.use("QT4Agg")
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
+import scipy
+from scipy import fftpack
+
+"""
+If a host is running the ATSC receiver chain with ControlPort
+turned on, this script will connect to the host using the hostname and
+port pair of the ControlPort instance and display metrics of the
+receiver. The ATSC publishes information about the succes of the
+Reed-Solomon decoder and Viterbi metrics for use here in displaying
+the link quality. This also gets the equalizer taps of the receiver
+and displays the frequency response.
+"""
+
+class atsc_ctrlport_monitor:
+    def __init__(self, host, port):
+        argv = [None, host, port]
+        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        self.radio = radiosys.client
+        print self.radio
+
+
+        vt_init_key = 'dtv_atsc_viterbi_decoder0::decoder_metrics'
+        data = self.radio.getKnobs([vt_init_key])[vt_init_key]
+        init_metric = scipy.mean(data.value)
+        self._viterbi_metric = 100*[init_metric,]
+
+        table_col_labels = ('Num Packets', 'Error Rate', 'Packet Error Rate',
+                            'Viterbi Metric', 'SNR')
+
+        self._fig = plt.figure(1, figsize=(12,12), facecolor='w')
+        self._sp0 = self._fig.add_subplot(4,1,1)
+        self._sp1 = self._fig.add_subplot(4,1,2)
+        self._sp2 = self._fig.add_subplot(4,1,3)
+        self._plot_taps = self._sp0.plot([], [], 'k', linewidth=2)
+        self._plot_psd  = self._sp1.plot([], [], 'k', linewidth=2)
+        self._plot_data = self._sp2.plot([], [], 'ok', linewidth=2, markersize=4, alpha=0.05)
+
+        self._ax2 = self._fig.add_subplot(4,1,4)
+        self._table = self._ax2.table(cellText=[len(table_col_labels)*['0']],
+                                      colLabels=table_col_labels,
+                                      loc='center')
+        self._ax2.axis('off')
+        cells = self._table.properties()['child_artists']
+        for c in cells:
+            c.set_lw(0.1) # set's line width
+            c.set_ls('solid')
+            c.set_height(0.2)
+
+        ani = animation.FuncAnimation(self._fig, self.update_data, frames=200,
+                                      fargs=(self._plot_taps[0], self._plot_psd[0],
+                                             self._plot_data[0], self._table),
+                                      init_func=self.init_function,
+                                      blit=True)
+        plt.show()
+
+    def update_data(self, x, taps, psd, syms, table):
+        try:
+            eqdata_key = 'dtv_atsc_equalizer0::taps'
+            symdata_key = 'dtv_atsc_equalizer0::data'
+            rs_nump_key = 'dtv_atsc_rs_decoder0::num_packets'
+            rs_numbp_key = 'dtv_atsc_rs_decoder0::num_bad_packets'
+            rs_numerrs_key = 'dtv_atsc_rs_decoder0::num_errors_corrected'
+            vt_metrics_key = 'dtv_atsc_viterbi_decoder0::decoder_metrics'
+            snr_key = 'probe2_f0::SNR'
+
+            data = self.radio.getKnobs([])
+            eqdata = data[eqdata_key]
+            symdata = data[symdata_key]
+            rs_num_packets = data[rs_nump_key]
+            rs_num_bad_packets = data[rs_numbp_key]
+            rs_num_errors_corrected = data[rs_numerrs_key]
+            vt_decoder_metrics = data[vt_metrics_key]
+            snr_est = data[snr_key]
+
+            vt_decoder_metrics = scipy.mean(vt_decoder_metrics.value)
+            self._viterbi_metric.pop()
+            self._viterbi_metric.insert(0, vt_decoder_metrics)
+
+        except:
+            sys.stderr.write("Lost connection, exiting")
+            sys.exit(1)
+
+        ntaps = len(eqdata.value)
+        taps.set_ydata(eqdata.value)
+        taps.set_xdata(xrange(ntaps))
+        self._sp0.set_xlim(0, ntaps)
+        self._sp0.set_ylim(min(eqdata.value), max(eqdata.value))
+
+        fs = 6.25e6
+        freq = scipy.linspace(-fs/2, fs/2, 10000)
+        H = fftpack.fftshift(fftpack.fft(eqdata.value, 10000))
+        HdB = 20.0*scipy.log10(abs(H))
+        psd.set_ydata(HdB)
+        psd.set_xdata(freq)
+        self._sp1.set_xlim(0, fs/2)
+        self._sp1.set_ylim([min(HdB), max(HdB)])
+        self._sp1.set_yticks([min(HdB), max(HdB)])
+        self._sp1.set_yticklabels(["min", "max"])
+
+        nsyms = len(symdata.value)
+        syms.set_ydata(symdata.value)
+        syms.set_xdata(nsyms*[0,])
+        self._sp2.set_xlim([-1, 1])
+        self._sp2.set_ylim([-10, 10])
+
+        per = float(rs_num_bad_packets.value) / float(rs_num_packets.value)
+        ber = float(rs_num_errors_corrected.value) / float(187*rs_num_packets.value)
+
+        table._cells[(1,0)]._text.set_text("{0}".format(rs_num_packets.value))
+        table._cells[(1,1)]._text.set_text("{0:.2g}".format(ber))
+        table._cells[(1,2)]._text.set_text("{0:.2g}".format(per))
+        table._cells[(1,3)]._text.set_text("{0:.1f}".format(scipy.mean(self._viterbi_metric)))
+        table._cells[(1,4)]._text.set_text("{0:.4f}".format(snr_est.value[0]))
+
+        return (taps, psd, syms, table)
+
+    def init_function(self):
+        return self._plot_taps + self._plot_psd + self._plot_data
+
+if __name__ == "__main__":
+    host = sys.argv[1]
+    port = sys.argv[2]
+    m = atsc_ctrlport_monitor(host, port)

--- a/gr-dtv/include/gnuradio/dtv/atsc_equalizer.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_equalizer.h
@@ -45,6 +45,8 @@ namespace gr {
        * \brief Make a new instance of gr::dtv::atsc_equalizer.
        */
       static sptr make();
+
+      virtual std::vector<float> taps() const = 0;
     };
 
   } /* namespace dtv */

--- a/gr-dtv/include/gnuradio/dtv/atsc_equalizer.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_equalizer.h
@@ -47,6 +47,7 @@ namespace gr {
       static sptr make();
 
       virtual std::vector<float> taps() const = 0;
+      virtual std::vector<float> data() const = 0;
     };
 
   } /* namespace dtv */

--- a/gr-dtv/include/gnuradio/dtv/atsc_rs_decoder.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_rs_decoder.h
@@ -42,6 +42,21 @@ namespace gr {
       typedef boost::shared_ptr<atsc_rs_decoder> sptr;
 
       /*!
+       * Returns the number of errors corrected by the decoder.
+       */
+      virtual int num_errors_corrected() const = 0;
+
+      /*!
+       * Returns the number of bad packets rejected by the decoder.
+       */
+      virtual int num_bad_packets() const = 0;
+
+      /*!
+       * Returns the total number of packets seen by the decoder.
+       */
+      virtual int num_packets() const = 0;
+
+      /*!
        * \brief Make a new instance of gr::dtv::atsc_rs_decoder.
        */
       static sptr make();

--- a/gr-dtv/include/gnuradio/dtv/atsc_viterbi_decoder.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_viterbi_decoder.h
@@ -45,6 +45,12 @@ namespace gr {
        * \brief Make a new instance of gr::dtv::atsc_viterbi_decoder.
        */
       static sptr make();
+
+      /*!
+       * For each decoder, returns the current best state of the
+       * decoding metrics.
+       */
+      virtual std::vector<float> decoder_metrics() const = 0;
     };
 
   } /* namespace dtv */

--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.cc
@@ -96,6 +96,13 @@ namespace gr {
       return d_taps;
     }
 
+    std::vector<float>
+    atsc_equalizer_impl::data() const
+    {
+      std::vector<float> ret(&data_mem2[0], &data_mem2[ATSC_DATA_SEGMENT_LENGTH-1]);
+      return ret;
+    }
+
     void
     atsc_equalizer_impl::filterN(const float *input_samples,
                                  float *output_samples,
@@ -205,6 +212,16 @@ namespace gr {
 	  pmt::make_f32vector(1,10),
 	  pmt::make_f32vector(1,0),
 	  "", "Equalizer Taps", RPC_PRIVLVL_MIN,
+          DISPTIME)));
+
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<atsc_equalizer, std::vector<float> >(
+	  alias(), "data",
+	  &atsc_equalizer::data,
+	  pmt::make_f32vector(1,-10),
+	  pmt::make_f32vector(1,10),
+	  pmt::make_f32vector(1,0),
+	  "", "Post-equalizer Data", RPC_PRIVLVL_MIN,
           DISPTIME)));
 #endif /* GR_CTRLPORT */
     }

--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.cc
@@ -90,6 +90,12 @@ namespace gr {
     {
     }
 
+    std::vector<float>
+    atsc_equalizer_impl::taps() const
+    {
+      return d_taps;
+    }
+
     void
     atsc_equalizer_impl::filterN(const float *input_samples,
                                  float *output_samples,
@@ -185,6 +191,22 @@ namespace gr {
 
       consume_each(noutput_items);
       return output_produced;
+    }
+
+    void
+    atsc_equalizer_impl::setup_rpc()
+    {
+#ifdef GR_CTRLPORT
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<atsc_equalizer, std::vector<float> >(
+	  alias(), "taps",
+	  &atsc_equalizer::taps,
+	  pmt::make_f32vector(1,-10),
+	  pmt::make_f32vector(1,10),
+	  pmt::make_f32vector(1,0),
+	  "", "Equalizer Taps", RPC_PRIVLVL_MIN,
+          DISPTIME)));
+#endif /* GR_CTRLPORT */
     }
 
   } /* namespace dtv */

--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.h
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.h
@@ -59,6 +59,10 @@ namespace gr {
       atsc_equalizer_impl();
       ~atsc_equalizer_impl();
 
+      void setup_rpc();
+
+      std::vector<float> taps() const;
+
       virtual int general_work(int noutput_items,
                                gr_vector_int &ninput_items,
                                gr_vector_const_void_star &input_items,

--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.h
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.h
@@ -46,7 +46,7 @@ namespace gr {
       void adaptN(const float *input_samples, const float *training_pattern,
                   float *output_samples, int nsamples);
 
-      float d_taps[NTAPS];
+      std::vector<float> d_taps;
 
       float data_mem[ATSC_DATA_SEGMENT_LENGTH + NTAPS]; // Buffer for previous data packet
       float data_mem2[ATSC_DATA_SEGMENT_LENGTH];

--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.h
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.h
@@ -62,6 +62,7 @@ namespace gr {
       void setup_rpc();
 
       std::vector<float> taps() const;
+      std::vector<float> data() const;
 
       virtual int general_work(int noutput_items,
                                gr_vector_int &ninput_items,

--- a/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
@@ -131,14 +131,9 @@ namespace gr {
 	d_total_packets++;
         #if 0
         if (d_total_packets > 1000) {
-          // FIXME: convert to logger
-          GR_LOG_DEBUG(d_logger, boost::format("Error rate: %1%\tPacket error rate: %2%") \
+          GR_LOG_INFO(d_logger, boost::format("Error rate: %1%\tPacket error rate: %2%") \
                        % ((float)d_nerrors_corrrected_count/(ATSC_MPEG_DATA_LENGTH*d_total_packets))
                        % ((float)d_bad_packet_count/d_total_packets));
-
-          //d_nerrors_corrrected_count = 0;
-          //d_bad_packet_count = 0;
-          //d_total_packets = 0;
         }
         #endif
       }

--- a/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
@@ -56,9 +56,9 @@ namespace gr {
     {
       d_rs = init_rs_char(rs_init_symsize, rs_init_gfpoly, rs_init_fcr, rs_init_prim, rs_init_nroots);
       assert (d_rs != 0);
-      nerrors_corrrected_count = 0;
-      bad_packet_count = 0;
-      total_packets = 0;
+      d_nerrors_corrrected_count = 0;
+      d_bad_packet_count = 0;
+      d_total_packets = 0;
     }
 
     int atsc_rs_decoder_impl::decode (atsc_mpeg_packet_no_sync &out, const atsc_mpeg_packet_rs_encoded &in)
@@ -89,6 +89,24 @@ namespace gr {
     }
 
     int
+    atsc_rs_decoder_impl::num_errors_corrected() const
+    {
+      return d_nerrors_corrrected_count;
+    }
+
+    int
+    atsc_rs_decoder_impl::num_bad_packets() const
+    {
+      return d_bad_packet_count;
+    }
+
+    int
+    atsc_rs_decoder_impl::num_packets() const
+    {
+      return d_total_packets;
+    }
+
+    int
     atsc_rs_decoder_impl::work(int noutput_items,
                                gr_vector_const_void_star &input_items,
                                gr_vector_void_star &output_items)
@@ -102,29 +120,67 @@ namespace gr {
 
         int nerrors_corrrected = decode(out[i], in[i]);
         out[i].pli.set_transport_error(nerrors_corrrected == -1);
-        if (nerrors_corrrected == -1)
-          bad_packet_count++;
-        else
-          nerrors_corrrected_count += nerrors_corrrected;
+        if (nerrors_corrrected == -1) {
+          d_bad_packet_count++;
+          d_nerrors_corrrected_count += 10; // lower bound estimate; most this RS can fix
+        }
+        else {
+          d_nerrors_corrrected_count += nerrors_corrrected;
+        }
 
-	total_packets++;
+	d_total_packets++;
         #if 0
-        if (total_packets > 1000) {
+        if (d_total_packets > 1000) {
           // FIXME: convert to logger
-          std::cout << "Error rate: "
-                    << (float)nerrors_corrrected_count/total_packets
-                    << "\tPacket error rate: "
-                    << (float)bad_packet_count/total_packets
-                    << std::endl;
+          GR_LOG_DEBUG(d_logger, boost::format("Error rate: %1%\tPacket error rate: %2%") \
+                       % ((float)d_nerrors_corrrected_count/(ATSC_MPEG_DATA_LENGTH*d_total_packets))
+                       % ((float)d_bad_packet_count/d_total_packets));
 
-          nerrors_corrrected_count = 0;
-          bad_packet_count = 0;
-          total_packets = 0;
+          //d_nerrors_corrrected_count = 0;
+          //d_bad_packet_count = 0;
+          //d_total_packets = 0;
         }
         #endif
       }
 
       return noutput_items;
+    }
+
+
+    void
+    atsc_rs_decoder_impl::setup_rpc()
+    {
+#ifdef GR_CTRLPORT
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<atsc_rs_decoder, int >(
+	  alias(), "num_errors_corrected",
+	  &atsc_rs_decoder::num_errors_corrected,
+	  pmt::from_long(0),
+	  pmt::from_long(10000000),
+	  pmt::from_long(0),
+	  "", "Number of errors corrected", RPC_PRIVLVL_MIN,
+          DISPTIME)));
+
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<atsc_rs_decoder, int >(
+	  alias(), "num_bad_packets",
+	  &atsc_rs_decoder::num_bad_packets,
+	  pmt::from_long(0),
+	  pmt::from_long(10000000),
+	  pmt::from_long(0),
+	  "", "Number of bad packets", RPC_PRIVLVL_MIN,
+          DISPTIME)));
+
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<atsc_rs_decoder, int >(
+	  alias(), "num_packets",
+	  &atsc_rs_decoder::num_packets,
+	  pmt::from_long(0),
+	  pmt::from_long(10000000),
+	  pmt::from_long(0),
+	  "", "Number of packets", RPC_PRIVLVL_MIN,
+          DISPTIME)));
+#endif /* GR_CTRLPORT */
     }
 
   } /* namespace dtv */

--- a/gr-dtv/lib/atsc/atsc_rs_decoder_impl.h
+++ b/gr-dtv/lib/atsc/atsc_rs_decoder_impl.h
@@ -36,14 +36,21 @@ namespace gr {
     class atsc_rs_decoder_impl : public atsc_rs_decoder
     {
     private:
-      int nerrors_corrrected_count;
-      int bad_packet_count;
-      int total_packets;
+      int d_nerrors_corrrected_count;
+      int d_bad_packet_count;
+      int d_total_packets;
+      int d_total_bits;
       void *d_rs;
 
     public:
       atsc_rs_decoder_impl();
       ~atsc_rs_decoder_impl();
+
+      void setup_rpc();
+
+      int num_errors_corrected() const;
+      int num_bad_packets() const;
+      int num_packets() const;
 
       /*!
        * Decode RS encoded packet.

--- a/gr-dtv/lib/atsc/atsc_single_viterbi.cc
+++ b/gr-dtv/lib/atsc/atsc_single_viterbi.cc
@@ -28,7 +28,7 @@ namespace gr {
 
     /* was_sent is a table of what symbol we get given what bit pair
        was sent and what state we where in [state][pair] */
-    const int atsc_single_viterbi::was_sent[4][4] = {
+    const int atsc_single_viterbi::d_was_sent[4][4] = {
       {0,2,4,6},
       {0,2,4,6},
       {1,3,5,7},
@@ -37,7 +37,7 @@ namespace gr {
 
     /* transition_table is a table of what state we were in
        given current state and bit pair sent [state][pair] */
-    const int atsc_single_viterbi::transition_table[4][4] = {
+    const int atsc_single_viterbi::d_transition_table[4][4] = {
       {0,2,0,2},
       {2,0,2,0},
       {1,3,1,3},
@@ -49,11 +49,12 @@ namespace gr {
     {
       for (unsigned int i = 0; i<2; i++)
         for (unsigned int j = 0; j<4; j++) {
-          path_metrics[i][j] = 0;
-          traceback[i][j] = 0;
+          d_path_metrics[i][j] = 0;
+          d_traceback[i][j] = 0;
         }
-      post_coder_state = 0;
-      phase = 0;
+      d_post_coder_state = 0;
+      d_phase = 0;
+      d_best_state_metric = 100000;
     }
 
     atsc_single_viterbi::atsc_single_viterbi()
@@ -61,17 +62,24 @@ namespace gr {
       reset();
     }
 
+    float
+    atsc_single_viterbi::best_state_metric() const
+    {
+      return d_best_state_metric;
+    }
+
     char
     atsc_single_viterbi::decode(float input)
     {
       unsigned int best_state = 0;
-      float best_state_metric = 100000;
+      //float best_state_metric = 100000;
+      d_best_state_metric = 100000;
 
       /* Precompute distances from input to each possible symbol */
-      float distances[8] = { (float)fabs( input + 7 ), (float)fabs( input + 5 ),
-                             (float)fabs( input + 3 ), (float)fabs( input + 1 ),
-                             (float)fabs( input - 1 ), (float)fabs( input - 3 ),
-                             (float)fabs( input - 5 ), (float)fabs( input - 7 ) };
+      float distances[8] = { fabsf( input + 7 ), fabsf( input + 5 ),
+                             fabsf( input + 3 ), fabsf( input + 1 ),
+                             fabsf( input - 1 ), fabsf( input - 3 ),
+                             fabsf( input - 5 ), fabsf( input - 7 ) };
 
       /* We start by iterating over all possible states */
       for (unsigned int state = 0; state < 4; state++) {
@@ -79,15 +87,20 @@ namespace gr {
            states to the state we are testing, we only need to look at
            the 4 paths that can be taken given the 2-bit input */
         int min_metric_symb = 0;
-        float min_metric = distances[was_sent[state][0]] + path_metrics[phase][transition_table[state][0]];
+        float min_metric = distances[d_was_sent[state][0]] +
+          d_path_metrics[d_phase][d_transition_table[state][0]];
+
         for (unsigned int symbol_sent = 1; symbol_sent < 4; symbol_sent++)
-          if( (distances[was_sent[state][symbol_sent]] + path_metrics[phase][transition_table[state][symbol_sent]]) < min_metric) {
-            min_metric = distances[was_sent[state][symbol_sent]] + path_metrics[phase][transition_table[state][symbol_sent]];
+          if( (distances[d_was_sent[state][symbol_sent]] +
+               d_path_metrics[d_phase][d_transition_table[state][symbol_sent]]) < min_metric) {
+            min_metric = distances[d_was_sent[state][symbol_sent]] +
+              d_path_metrics[d_phase][d_transition_table[state][symbol_sent]];
             min_metric_symb = symbol_sent;
           }
 
-        path_metrics[phase^1][state] = min_metric;
-        traceback[phase^1][state] = (((unsigned long long)min_metric_symb) << 62) | (traceback[phase][transition_table[state][min_metric_symb]] >> 2);
+        d_path_metrics[d_phase^1][state] = min_metric;
+        d_traceback[d_phase^1][state] = (((unsigned long long)min_metric_symb) << 62) |
+          (d_traceback[d_phase][d_transition_table[state][min_metric_symb]] >> 2);
 
         /* If this is the most probable state so far remember it, this
            only needs to be checked when we are about to output a path
@@ -98,26 +111,24 @@ namespace gr {
            head state path will tend towards the optimal path with a
            probability approaching 1 in just 8 or so transitions
         */
-        if(min_metric <= best_state_metric) {
-          best_state_metric = min_metric;
+        if(min_metric <= d_best_state_metric) {
+          d_best_state_metric = min_metric;
           best_state = state;
         }
       }
 
-      if(best_state_metric > 10000) {
+      if(d_best_state_metric > 10000) {
         for(unsigned int state = 0; state < 4; state++)
-          path_metrics[phase^1][state] -= best_state_metric;
+          d_path_metrics[d_phase^1][state] -= d_best_state_metric;
       }
-      phase ^= 1;
+      d_phase ^= 1;
 
-      int y2 = (0x2 & traceback[phase][best_state]) >> 1;
-      int x2 = y2 ^ post_coder_state;
-      post_coder_state = y2;
+      int y2 = (0x2 & d_traceback[d_phase][best_state]) >> 1;
+      int x2 = y2 ^ d_post_coder_state;
+      d_post_coder_state = y2;
 
-      return ( x2 << 1 ) | (0x1 & traceback[phase][best_state]);
+      return ( x2 << 1 ) | (0x1 & d_traceback[d_phase][best_state]);
     }
 
   } /* namespace dtv */
 } /* namespace gr */
-
-

--- a/gr-dtv/lib/atsc/atsc_single_viterbi.h
+++ b/gr-dtv/lib/atsc/atsc_single_viterbi.h
@@ -44,14 +44,17 @@ namespace gr {
       //! internal delay of decoder
       static int delay () { return TB_LEN - 1; }
 
-    protected:
-      static const int transition_table[4][4];
-      static const int was_sent[4][4];
+      float best_state_metric() const;
 
-      float path_metrics [2][4];
-      unsigned long long traceback [2][4];
-      unsigned char phase;
-      int post_coder_state;
+    protected:
+      static const int d_transition_table[4][4];
+      static const int d_was_sent[4][4];
+
+      float d_path_metrics [2][4];
+      unsigned long long d_traceback [2][4];
+      unsigned char d_phase;
+      int d_post_coder_state;
+      float d_best_state_metric;
     };
 
   } /* namespace dtv */

--- a/gr-dtv/lib/atsc/atsc_viterbi_decoder_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_viterbi_decoder_impl.cc
@@ -77,6 +77,15 @@ namespace gr {
         fifo[i]->reset();
     }
 
+    std::vector<float>
+    atsc_viterbi_decoder_impl::decoder_metrics() const
+    {
+      std::vector<float> metrics(NCODERS);
+      for (int i = 0; i < NCODERS; i++)
+        metrics[i] = viterbi[i].best_state_metric();
+      return metrics;
+    }
+
     int
     atsc_viterbi_decoder_impl::work(int noutput_items,
                                     gr_vector_const_void_star &input_items,
@@ -133,6 +142,22 @@ namespace gr {
       }
 
       return noutput_items;
+    }
+
+    void
+    atsc_viterbi_decoder_impl::setup_rpc()
+    {
+#ifdef GR_CTRLPORT
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<atsc_viterbi_decoder, std::vector<float> >(
+	  alias(), "decoder_metrics",
+	  &atsc_viterbi_decoder::decoder_metrics,
+	  pmt::make_f32vector(1,0),
+	  pmt::make_f32vector(1,100000),
+	  pmt::make_f32vector(1,0),
+	  "", "Viterbi decoder metrics", RPC_PRIVLVL_MIN,
+          DISPTIME)));
+#endif /* GR_CTRLPORT */
     }
 
   } /* namespace dtv */

--- a/gr-dtv/lib/atsc/atsc_viterbi_decoder_impl.h
+++ b/gr-dtv/lib/atsc/atsc_viterbi_decoder_impl.h
@@ -63,7 +63,11 @@ namespace gr {
       atsc_viterbi_decoder_impl();
       ~atsc_viterbi_decoder_impl();
 
+      void setup_rpc();
+
       void reset();
+
+      std::vector<float> decoder_metrics() const;
 
       virtual int work(int noutput_items,
                        gr_vector_const_void_star &input_items,


### PR DESCRIPTION
This makes a few changes to the code for speeding up a few parts.

It also adds ControlPort hooks to a few of the blocks so they can emit information and statistics about their operations. An example ControlPort application produces a crude display of this information.