### PR TITLE
analog: Addresses issue #831.

### DIFF
--- a/gr-filter/lib/rational_resampler_base_XXX_impl.cc.t
+++ b/gr-filter/lib/rational_resampler_base_XXX_impl.cc.t
@@ -154,19 +154,21 @@ namespace gr {
       }
 
       unsigned int ctr = d_ctr;
+      int count = 0;
 
       int i = 0;
-      while(i < noutput_items) {
+      while((i < noutput_items) && (count < ninput_items[0])) {
 	out[i++] = d_firs[ctr]->filter(in);
 	ctr += decimation();
 	while(ctr >= interpolation()) {
 	  ctr -= interpolation();
 	  in++;
+          count++;
 	}
       }
 
       d_ctr = ctr;
-      consume_each(in - (@I_TYPE@*)input_items[0]);
+      consume_each(count);
       return i;
     }
 


### PR DESCRIPTION
We changed from using set_output_multiple(interpolate) because data
would not necessarily continue to flow through properly. This meant
that we needed to check the input size in the work function because if
we cycle through the filters, we can sometimes consume more inputs
than we've been given, which messes up the consume/produce and
bookkeeping.

It's likely that we can find a better form of the forecast function
here that does not require checking both noutput_items and
ninput_items[0] in the while loop.