### PR TITLE
digital: Addresses issue #812.

### DIFF
--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -308,6 +308,9 @@ namespace gr {
       // Normalize the taps
       for(unsigned int i = 0; i < difftaps.size(); i++) {
         difftaps[i] *= d_nfilters/pwr;
+        if(difftaps[i] != difftaps[i]) {
+          throw std::runtime_error("pfb_clock_sync_ccf::create_diff_taps produced NaN.");
+        }
       }
     }
 

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -287,6 +287,9 @@ namespace gr {
       // Normalize the taps
       for(unsigned int i = 0; i < difftaps.size(); i++) {
         difftaps[i] *= d_nfilters/pwr;
+        if(difftaps[i] != difftaps[i]) {
+          throw std::runtime_error("pfb_clock_sync_fff::create_diff_taps produced NaN.");
+        }
       }
     }
 


### PR DESCRIPTION
If the taps are all the same value, the differential taps become NaNs
during create_diff_taps. Having this type of filter doesn't make sense
in this algorithm, so there's nothing to fix. But now, we check to see
if the diff taps are NaN and throw a runtime_error if detected.