### PR TITLE
gr-utils: Update error message

### DIFF
--- a/gr-utils/python/utils/plot_fft_base.py
+++ b/gr-utils/python/utils/plot_fft_base.py
@@ -30,7 +30,7 @@ except ImportError:
 try:
     from pylab import *
 except ImportError:
-    print "Please install Matplotlib to run this script (http://matplotlib.sourceforge.net/)"
+    print "Please install Python Matplotlib (http://matplotlib.sourceforge.net/) and Python TkInter https://wiki.python.org/moin/TkInter to run this script"
     raise SystemExit, 1
 
 from optparse import OptionParser


### PR DESCRIPTION
Prevent people from running into the problem that "import pylab" doesn't work because python tkinter is not installed.
For example on a fresh Ubuntu or Mint system it is not enough to install python-matplotlib.
However, the true error message:
"ImportError: No module named _tkinter, please install the python-tk package"
is obfuscated towards the user.

Another good option would be to not catch this import error at all but just show the true error message from python to the user.