### PR TITLE
blocks: vector_sink.reset() now also clears tags

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/vector_sink_X.h.t
+++ b/gr-blocks/include/gnuradio/blocks/vector_sink_X.h.t
@@ -43,6 +43,7 @@ namespace gr {
 
       static sptr make(int vlen = 1);
 
+      //! Clear the data and tags containers.
       virtual void reset() = 0;
       virtual std::vector<@TYPE@> data() const = 0;
       virtual std::vector<tag_t> tags() const = 0;

--- a/gr-blocks/lib/vector_sink_X_impl.h.t
+++ b/gr-blocks/lib/vector_sink_X_impl.h.t
@@ -41,7 +41,7 @@ namespace gr {
       @NAME_IMPL@(int vlen);
       ~@NAME_IMPL@();
 
-      void reset() { d_data.clear(); }
+      void reset() { d_data.clear(); d_tags.clear(); }
       std::vector<@TYPE@> data() const;
       std::vector<tag_t> tags() const;
 


### PR DESCRIPTION
  Fixes bug #878.