### PR TITLE
Updated URL to UHD manual in USRP sink and source blocks

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -437,7 +437,7 @@ When a nonempty string is given, the USRP sink will look for length tags \\
 to determine transmit burst lengths.
 
 See the UHD manual for more detailed documentation:
-http://code.ettus.com/redmine/ettus/projects/uhd/wiki
+http://uhd.ettus.com
 	</doc>
 </block>
 """


### PR DESCRIPTION
The Redmine resource has been turned off. http://uhd.ettus.com is the main link to the UHD manual now.

This may be more appropriate targeted to maint as there is no functional change but fixes a dead link?