### PR TITLE
Add doc to the modtool's template

### DIFF
--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -554,6 +554,11 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
     <name>out</name>
     <type><!-- e.g. int, float, complex, byte, short, xxx_vector, ...--></type>
   </source>
+
+  <!-- Short description of the module -->
+  <doc>
+<!-- e.g. Transforms each "foo" input into "bar" -->
+  </doc>
 </block>
 '''
 


### PR DESCRIPTION
Most blocks lack the xml documentation, which makes discovery in
gnuradio-companion difficult. Make doc show up in the template by defualt
as an incentive to provide it.