### PR TITLE
Issue882 master fixes and additions

### DIFF
--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -177,6 +177,11 @@ namespace gr {
     catch(std::bad_alloc&) {
       b = make_buffer(nitems, item_size, grblock);
     }
+
+    // Set the max noutput items size here to make sure it's always
+    // set in the block and available in the start() method.
+    grblock->set_max_noutput_items(nitems);
+
     return b;
   }
 

--- a/gr-filter/lib/pfb_decimator_ccf_impl.h
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.h
@@ -40,6 +40,7 @@ namespace gr {
       bool         d_use_fft_rotator;
       bool         d_use_fft_filters;
       gr_complex  *d_rotator;
+      gr_complex  *d_tmp; // used for fft filters
       gr::thread::mutex d_mutex; // mutex to protect set/work access
 
       inline int work_fir_exp(int noutput_items,
@@ -55,7 +56,6 @@ namespace gr {
                               gr_vector_const_void_star &input_items,
                               gr_vector_void_star &output_items);
 
-
     public:
       pfb_decimator_ccf_impl(unsigned int decim,
 			     const std::vector<float> &taps,
@@ -69,6 +69,10 @@ namespace gr {
       void print_taps();
       std::vector<std::vector<float> > taps() const;
       void set_channel(const unsigned int channel);
+
+      // Overload to create/destroy d_tmp based on max_noutput_items.
+      bool start();
+      bool stop();
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
Must be merged after PR #722.

This adds the feature of setting the max_noutput_items when building the block's detail. It then fixes the PFB decimator problem better by preallocating the FFT buffer in start and destroying it in stop.