### PR TITLE
digital: addresses issue #876.

### DIFF
--- a/gr-digital/include/gnuradio/digital/constellation_receiver_cb.h
+++ b/gr-digital/include/gnuradio/digital/constellation_receiver_cb.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/digital/api.h>
 #include <gnuradio/digital/constellation.h>
+#include <gnuradio/blocks/control_loop.h>
 #include <gnuradio/block.h>
 
 namespace gr {
@@ -55,7 +56,8 @@ namespace gr {
      *    current phase of the receiver.
      */
     class DIGITAL_API constellation_receiver_cb
-      : virtual public block
+      : virtual public block,
+        virtual public blocks::control_loop
     {
     public:
       // gr::digital::constellation_receiver_cb::sptr

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -217,14 +217,13 @@ namespace gr {
       // Setters
       add_rpc_variable(
           rpcbasic_sptr(new rpcbasic_register_set<control_loop, float>(
-	      alias(), "loop bw",
+	      alias(), "loop_bw",
 	      &control_loop::set_loop_bandwidth,
 	      pmt::mp(0.0f), pmt::mp(1.0f), pmt::mp(0.0f),
 	      "", "Loop bandwidth",
 	      RPC_PRIVLVL_MIN, DISPNULL)));
 #endif /* GR_CTRLPORT */
     }
-
 
   } /* namespace digital */
 } /* namespace gr */

--- a/gr-digital/lib/constellation_receiver_cb_impl.h
+++ b/gr-digital/lib/constellation_receiver_cb_impl.h
@@ -26,13 +26,12 @@
 #include <gnuradio/digital/constellation_receiver_cb.h>
 #include <gnuradio/attributes.h>
 #include <gnuradio/gr_complex.h>
-#include <gnuradio/blocks/control_loop.h>
 
 namespace gr {
   namespace digital {
 
     class constellation_receiver_cb_impl
-      : public constellation_receiver_cb, blocks::control_loop
+      : public constellation_receiver_cb
     {
     public:
       constellation_receiver_cb_impl(constellation_sptr constell,

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -277,7 +277,7 @@ namespace gr {
       // Setters
       add_rpc_variable(
           rpcbasic_sptr(new rpcbasic_register_set<control_loop, float>(
-	      alias(), "loop bw",
+	      alias(), "loop_bw",
 	      &control_loop::set_loop_bandwidth,
 	      pmt::mp(0.0f), pmt::mp(1.0f), pmt::mp(0.0f),
 	      "", "Loop bandwidth",


### PR DESCRIPTION
The constellation receiver controlport interface was modeled after the
costas_loop_cc block, but the inheritance of the two blocks to
control_loop was different. This changes the inheritance of
constellation_reciever_cb.

It also fixes the name of the "loop_bw" parameter to be consistent
between the set and get ControlPort interfaces.