### PR TITLE
runtime: addresses issue #713.

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -100,6 +100,13 @@ namespace gr {
     // Return the number of items written on output stream which_output
     uint64_t nitems_written(unsigned int which_output);
 
+    // sets nitems_read and nitems_written to 0 for all input/output
+    // buffers.
+    void reset_nitem_counters();
+
+    // Clears all tags from the input buffers.
+    void clear_tags();
+
     /*!
      * \brief  Adds a new tag to the given output stream.
      *

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -100,6 +100,8 @@ namespace gr {
 
     uint64_t nitems_written() { return d_abs_write_offset; }
 
+    void reset_nitem_counter() { d_abs_write_offset = 0; }
+
     size_t get_sizeof_item() { return d_sizeof_item; }
 
     /*!
@@ -287,6 +289,8 @@ namespace gr {
     gr::thread::mutex *mutex() { return d_buffer->mutex(); }
 
     uint64_t nitems_read() { return d_abs_read_offset; }
+
+    void reset_nitem_counter() { d_abs_read_offset = 0; }
 
     size_t get_sizeof_item() { return d_buffer->get_sizeof_item(); }
 

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -162,6 +162,26 @@ namespace gr {
   }
 
   void
+  block_detail::reset_nitem_counters()
+  {
+    for(unsigned int i = 0; i < d_ninputs; i++) {
+      d_input[i]->reset_nitem_counter();
+    }
+    for(unsigned int o = 0; o < d_noutputs; o++) {
+      d_output[o]->reset_nitem_counter();
+    }
+  }
+
+  void
+  block_detail::clear_tags()
+  {
+    for(unsigned int i = 0; i < d_ninputs; i++) {
+      uint64_t max_time = 0xFFFFFFFFFFFFFFFF; // from now to the end of time
+      d_input[i]->buffer()->prune_tags(max_time);
+    }
+  }
+
+  void
   block_detail::add_item_tag(unsigned int which_output, const tag_t &tag)
   {
     if(!pmt::is_symbol(tag.key)) {

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -225,9 +225,10 @@ namespace gr {
           std::cout << "merge: allocating new detail for block " << (*p) << std::endl;
         block->set_detail(allocate_block_detail(block));
       }
-      else
+      else {
         if(FLAT_FLOWGRAPH_DEBUG)
           std::cout << "merge: reusing original detail for block " << (*p) << std::endl;
+      }
     }
 
     // Calculate the old edges that will be going away, and clear the
@@ -311,6 +312,9 @@ namespace gr {
       // Now deal with the fact that the block details might have
       // changed numbers of inputs and outputs vs. in the old
       // flowgraph.
+
+      block->detail()->reset_nitem_counters();
+      block->detail()->clear_tags();
     }
   }
 


### PR DESCRIPTION
When disconnecting and reconnecting, buffers can change and new
buffers will have their item counters zeroed out. Buffers held over
will keep their current item counters at some value >> 0. In the case
of the pfb_arb_resampler of issue #713, the rate update in the
scheduler was getting confusing numbers and setting the rates to
ridiculous values. Also, tags emitted from these new blocks will have
offsets meaningless to the other blocks that held on to their buffers.

This patch tells the scheduler to reset all buffer item counters (read
and write) to 0 when connections are merged. So upon a lock/unlock and
reset event, all buffers' counters are reset.