### PR TITLE
gr-zeromq: Big rework for performance and correctness

### DIFF
--- a/gr-zeromq/grc/zeromq_pub_sink.xml
+++ b/gr-zeromq/grc/zeromq_pub_sink.xml
@@ -4,7 +4,7 @@
   <key>zeromq_pub_sink</key>
   <category>ZeroMQ Interfaces</category>
   <import>from gnuradio import zeromq</import>
-  <make>zeromq.pub_sink($type.itemsize, $vlen, $address, $timeout, $pass_tags)</make>
+  <make>zeromq.pub_sink($type.itemsize, $vlen, $address, $timeout, $pass_tags, $hwm)</make>
 
   <param>
     <name>IO Type</name>
@@ -61,7 +61,23 @@
     <name>Pass Tags</name>
     <key>pass_tags</key>
     <value>False</value>
-    <type>bool</type>
+    <type>enum</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+  </param>
+
+  <param>
+    <name>High Watermark</name>
+    <key>hwm</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if $hwm() == -1 then 'part' else 'none'#</hide>
   </param>
 
   <sink>

--- a/gr-zeromq/grc/zeromq_pull_source.xml
+++ b/gr-zeromq/grc/zeromq_pull_source.xml
@@ -4,7 +4,7 @@
   <key>zeromq_pull_source</key>
   <category>ZeroMQ Interfaces</category>
   <import>from gnuradio import zeromq</import>
-  <make>zeromq.pull_source($type.itemsize, $vlen, $address, $timeout, $pass_tags)</make>
+  <make>zeromq.pull_source($type.itemsize, $vlen, $address, $timeout, $pass_tags, $hwm)</make>
 
   <param>
     <name>IO Type</name>
@@ -61,7 +61,23 @@
     <name>Pass Tags</name>
     <key>pass_tags</key>
     <value>False</value>
-    <type>bool</type>
+    <type>enum</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+  </param>
+
+  <param>
+    <name>High Watermark</name>
+    <key>hwm</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if $hwm() == -1 then 'part' else 'none'#</hide>
   </param>
 
   <source>

--- a/gr-zeromq/grc/zeromq_push_sink.xml
+++ b/gr-zeromq/grc/zeromq_push_sink.xml
@@ -4,7 +4,7 @@
   <key>zeromq_push_sink</key>
   <category>ZeroMQ Interfaces</category>
   <import>from gnuradio import zeromq</import>
-  <make>zeromq.push_sink($type.itemsize, $vlen, $address, $timeout, $pass_tags)</make>
+  <make>zeromq.push_sink($type.itemsize, $vlen, $address, $timeout, $pass_tags, $hwm)</make>
 
   <param>
     <name>IO Type</name>
@@ -61,7 +61,23 @@
     <name>Pass Tags</name>
     <key>pass_tags</key>
     <value>False</value>
-    <type>bool</type>
+    <type>enum</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+  </param>
+
+  <param>
+    <name>High Watermark</name>
+    <key>hwm</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if $hwm() == -1 then 'part' else 'none'#</hide>
   </param>
 
   <sink>

--- a/gr-zeromq/grc/zeromq_rep_sink.xml
+++ b/gr-zeromq/grc/zeromq_rep_sink.xml
@@ -4,7 +4,7 @@
   <key>zeromq_rep_sink</key>
   <category>ZeroMQ Interfaces</category>
   <import>from gnuradio import zeromq</import>
-  <make>zeromq.rep_sink($type.itemsize, $vlen, $address, $timeout, $pass_tags)</make>
+  <make>zeromq.rep_sink($type.itemsize, $vlen, $address, $timeout, $pass_tags, $hwm)</make>
 
   <param>
     <name>IO Type</name>
@@ -61,7 +61,23 @@
     <name>Pass Tags</name>
     <key>pass_tags</key>
     <value>False</value>
-    <type>bool</type>
+    <type>enum</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+  </param>
+
+  <param>
+    <name>High Watermark</name>
+    <key>hwm</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if $hwm() == -1 then 'part' else 'none'#</hide>
   </param>
 
   <sink>

--- a/gr-zeromq/grc/zeromq_req_source.xml
+++ b/gr-zeromq/grc/zeromq_req_source.xml
@@ -4,7 +4,7 @@
   <key>zeromq_req_source</key>
   <category>ZeroMQ Interfaces</category>
   <import>from gnuradio import zeromq</import>
-  <make>zeromq.req_source($type.itemsize, $vlen, $address, $timeout, $pass_tags)</make>
+  <make>zeromq.req_source($type.itemsize, $vlen, $address, $timeout, $pass_tags, $hwm)</make>
 
   <param>
     <name>IO Type</name>
@@ -61,7 +61,23 @@
     <name>Pass Tags</name>
     <key>pass_tags</key>
     <value>False</value>
-    <type>bool</type>
+    <type>enum</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+  </param>
+
+  <param>
+    <name>High Watermark</name>
+    <key>hwm</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if $hwm() == -1 then 'part' else 'none'#</hide>
   </param>
 
   <source>

--- a/gr-zeromq/grc/zeromq_sub_source.xml
+++ b/gr-zeromq/grc/zeromq_sub_source.xml
@@ -4,7 +4,7 @@
   <key>zeromq_sub_source</key>
   <category>ZeroMQ Interfaces</category>
   <import>from gnuradio import zeromq</import>
-  <make>zeromq.sub_source($type.itemsize, $vlen, $address, $timeout, $pass_tags)</make>
+  <make>zeromq.sub_source($type.itemsize, $vlen, $address, $timeout, $pass_tags, $hwm)</make>
 
   <param>
     <name>IO Type</name>
@@ -61,7 +61,23 @@
     <name>Pass Tags</name>
     <key>pass_tags</key>
     <value>False</value>
-    <type>bool</type>
+    <type>enum</type>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+  </param>
+
+  <param>
+    <name>High Watermark</name>
+    <key>hwm</key>
+    <value>-1</value>
+    <type>int</type>
+    <hide>#if $hwm() == -1 then 'part' else 'none'#</hide>
   </param>
 
   <source>

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -53,9 +53,10 @@ namespace gr {
        * \param address  ZMQ socket address specifier.
        * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
        * \param pass_tags Whether sink will serialize and pass tags over the link.
+       * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false);
+                       int timeout=100, bool pass_tags=false, int hwm=-1);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -50,9 +50,10 @@ namespace gr {
        * \param address  ZMQ socket address specifier.
        * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
+       * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false);
+                       int timeout=100, bool pass_tags=false, int hwm=-1);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -54,9 +54,10 @@ namespace gr {
        * \param address  ZMQ socket address specifier.
        * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
        * \param pass_tags Whether sink will serialize and pass tags over the link.
+       * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false);
+                       int timeout=100, bool pass_tags=false, int hwm=-1);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -52,9 +52,10 @@ namespace gr {
        * \param address  ZMQ socket address specifier.
        * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
        * \param pass_tags Whether sink will serialize and pass tags over the link.
+       * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false);
+                       int timeout=100, bool pass_tags=false, int hwm=-1);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -50,9 +50,10 @@ namespace gr {
        * \param address  ZMQ socket address specifier.
        * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
+       * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false);
+                       int timeout=100, bool pass_tags=false, int hwm=-1);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -50,9 +50,10 @@ namespace gr {
        * \param address  ZMQ socket address specifier.
        * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
+       * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false);
+                       int timeout=100, bool pass_tags=false, int hwm=-1);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/CMakeLists.txt
+++ b/gr-zeromq/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ endif(ENABLE_GR_CTRLPORT)
 # Setup library
 ########################################################################
 list(APPEND zeromq_sources
+  base_impl.cc
   pub_sink_impl.cc
   pub_msg_sink_impl.cc
   sub_source_impl.cc

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -1,0 +1,198 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "base_impl.h"
+#include "tag_headers.h"
+
+namespace gr {
+  namespace zeromq {
+
+    base_impl::base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags)
+      : d_vsize(itemsize * vlen), d_timeout(timeout), d_pass_tags(pass_tags)
+    {
+      /* "Fix" timeout value (ms for new API, us for old API) */
+      int major, minor, patch;
+      zmq::version (&major, &minor, &patch);
+
+      if (major < 3) {
+        d_timeout *= 1000;
+      }
+
+      /* Create context & socket */
+      d_context = new zmq::context_t(1);
+      d_socket = new zmq::socket_t(*d_context, type);
+    }
+
+    base_impl::~base_impl()
+    {
+        d_socket->close();
+        delete d_socket;
+        delete d_context;
+    }
+
+
+    base_sink_impl::base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
+        : base_impl(type, itemsize, vlen, timeout, pass_tags)
+    {
+      /* Set high watermark */
+      if (hwm >= 0) {
+#ifdef ZMQ_SNDHWM
+        d_socket->setsockopt(ZMQ_SNDHWM, &hwm, sizeof(hwm));
+#else // major < 3
+        uint64_t tmp = hwm;
+        d_socket->setsockopt(ZMQ_HWM, &tmp, sizeof(tmp));
+#endif
+      }
+
+      /* Bind */
+      d_socket->bind(address);
+    }
+
+    int
+    base_sink_impl::send_message(const void *in_buf, const int in_nitems, const uint64_t in_offset)
+    {
+      /* Meta-data header */
+      std::string header("");
+      if(d_pass_tags){
+        std::vector<gr::tag_t> tags;
+        get_tags_in_range(tags, 0, in_offset, in_offset + in_nitems);
+        header = gen_tag_header(in_offset, tags);
+      }
+
+      /* Create message */
+      size_t payload_len = in_nitems * d_vsize;
+      size_t msg_len = d_pass_tags ? payload_len + header.length() : payload_len;
+      zmq::message_t msg(msg_len);
+
+      if(d_pass_tags){
+        memcpy(msg.data(), header.c_str(), header.length());
+        memcpy((uint8_t*)msg.data() + header.length(), in_buf, payload_len);
+      } else {
+        memcpy(msg.data(), in_buf, payload_len);
+      }
+
+      /* Send */
+      d_socket->send(msg);
+
+      /* Report back */
+      return in_nitems;
+    }
+
+    base_source_impl::base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
+        : base_impl(type, itemsize, vlen, timeout, pass_tags),
+          d_consumed_bytes(0), d_consumed_items(0)
+    {
+      /* Set high watermark */
+      if (hwm >= 0) {
+#ifdef ZMQ_RCVHWM
+        d_socket->setsockopt(ZMQ_RCVHWM, &hwm, sizeof(hwm));
+#else // major < 3
+        uint64_t tmp = hwm;
+        d_socket->setsockopt(ZMQ_HWM, &tmp, sizeof(tmp));
+#endif
+      }
+
+      /* Connect */
+      d_socket->connect(address);
+    }
+
+    bool
+    base_source_impl::has_pending()
+    {
+      return d_msg.size() > d_consumed_bytes;
+    }
+
+    int
+    base_source_impl::flush_pending(void *out_buf, const int out_nitems, const uint64_t out_offset)
+    {
+      /* How much to copy in this call */
+      int to_copy_items = std::min(out_nitems, (int)((d_msg.size() - d_consumed_bytes) / d_vsize));
+      int to_copy_bytes = d_vsize * to_copy_items;
+
+      /* Copy actual data */
+      memcpy(out_buf, (uint8_t*)d_msg.data() + d_consumed_bytes, to_copy_bytes);
+
+      /* Add tags matching this segment of samples */
+      for (unsigned int i=0; i<d_tags.size(); i++)
+      {
+        if ((d_tags[i].offset >= (uint64_t)d_consumed_items) &&
+            (d_tags[i].offset  < (uint64_t)d_consumed_items + to_copy_items))
+        {
+          gr::tag_t nt = d_tags[i];
+          nt.offset += out_offset - d_consumed_items;
+          add_item_tag(0, nt);
+        }
+      }
+
+      /* Update pointer */
+      d_consumed_items += to_copy_items;
+      d_consumed_bytes += to_copy_bytes;
+
+      return to_copy_items;
+    }
+
+    bool
+    base_source_impl::load_message(bool wait)
+    {
+      /* Poll for input */
+      zmq::pollitem_t items[] = { { *d_socket, 0, ZMQ_POLLIN, 0 } };
+      zmq::poll(&items[0], 1, wait ? d_timeout : 0);
+
+      if (!(items[0].revents & ZMQ_POLLIN))
+        return false;
+
+      /* Reset */
+      d_msg.rebuild();
+      d_tags.clear();
+      d_consumed_items = 0;
+      d_consumed_bytes = 0;
+
+      /* Get the message */
+      d_socket->recv(&d_msg);
+
+      /* Parse header */
+      if (d_pass_tags)
+      {
+        uint64_t rcv_offset;
+
+        /* Parse header */
+        d_consumed_bytes = parse_tag_header(d_msg, rcv_offset, d_tags);
+
+        /* Fixup the tags offset to be relative to the start of this message */
+        for (unsigned int i=0; i<d_tags.size(); i++) {
+          d_tags[i].offset -= rcv_offset;
+        }
+      }
+
+      /* We got one ! */
+      return true;
+    }
+
+  } /* namespace zeromq */
+} /* namespace gr */
+
+// vim: ts=2 sw=2 expandtab

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -1,0 +1,77 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_ZEROMQ_BASE_IMPL_H
+#define INCLUDED_ZEROMQ_BASE_IMPL_H
+
+#include <zmq.hpp>
+
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace zeromq {
+
+    class base_impl : public virtual gr::sync_block
+    {
+    public:
+      base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
+      virtual ~base_impl();
+
+    protected:
+      zmq::context_t  *d_context;
+      zmq::socket_t   *d_socket;
+      size_t          d_vsize;
+      int             d_timeout;
+      bool            d_pass_tags;
+    };
+
+    class base_sink_impl : public base_impl
+    {
+    public:
+      base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
+
+    protected:
+      int send_message(const void *in_buf, const int in_nitems, const uint64_t in_offset);
+    };
+
+    class base_source_impl : public base_impl
+    {
+    public:
+      base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
+
+    protected:
+      zmq::message_t d_msg;
+      std::vector<gr::tag_t> d_tags;
+      size_t d_consumed_bytes;
+      int    d_consumed_items;
+
+      bool has_pending();
+      int  flush_pending(void *out_buf, const int out_nitems, const uint64_t out_offset);
+      bool load_message(bool wait);
+    };
+
+  } // namespace zeromq
+} // namespace gr
+
+#endif /* INCLUDED_ZEROMQ_BASE_IMPL_H */
+
+// vim: ts=2 sw=2 expandtab

--- a/gr-zeromq/lib/pub_sink_impl.cc
+++ b/gr-zeromq/lib/pub_sink_impl.cc
@@ -32,35 +32,19 @@ namespace gr {
   namespace zeromq {
 
     pub_sink::sptr
-    pub_sink::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags)
+    pub_sink::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
     {
       return gnuradio::get_initial_sptr
-        (new pub_sink_impl(itemsize, vlen, address, timeout, pass_tags));
+        (new pub_sink_impl(itemsize, vlen, address, timeout, pass_tags, hwm));
     }
 
-    pub_sink_impl::pub_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags)
+    pub_sink_impl::pub_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
       : gr::sync_block("pub_sink",
                        gr::io_signature::make(1, 1, itemsize * vlen),
                        gr::io_signature::make(0, 0, 0)),
-        d_itemsize(itemsize), d_vlen(vlen), d_timeout(timeout), d_pass_tags(pass_tags)
+        base_sink_impl(ZMQ_PUB, itemsize, vlen, address, timeout, pass_tags, hwm)
     {
-      int major, minor, patch;
-      zmq::version (&major, &minor, &patch);
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_PUB);
-      int time = 0;
-      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-      d_socket->bind(address);
-    }
-
-    pub_sink_impl::~pub_sink_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
+      /* All is delegated */
     }
 
     int
@@ -68,33 +52,10 @@ namespace gr {
                         gr_vector_const_void_star &input_items,
                         gr_vector_void_star &output_items)
     {
-      const char *in = (const char *)input_items[0];
-
-      // encode the current offset, # tags, and tags into header
-    std::string header("");
-    if(d_pass_tags){
-      uint64_t offset = nitems_read(0);
-      std::vector<gr::tag_t> tags;
-      get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0)+noutput_items);
-      header = gen_tag_header( offset, tags );  
-      }
-
-      // create message copy and send
-      int payloadlen = d_itemsize * d_vlen * noutput_items;
-      int msglen = d_pass_tags ? payloadlen + header.length() : payloadlen;
-      zmq::message_t msg(msglen);
-
-      if(d_pass_tags){
-        memcpy((void*) msg.data(), header.c_str(), header.length() );
-        memcpy((uint8_t *)msg.data() + header.length(), in, d_itemsize*d_vlen*noutput_items);
-        } else {
-        memcpy((uint8_t *)msg.data(), in, d_itemsize*d_vlen*noutput_items);
-        }
-    
-      d_socket->send(msg);
-
-      return noutput_items;
+      return send_message(input_items[0], noutput_items, nitems_read(0));
     }
 
   } /* namespace zeromq */
 } /* namespace gr */
+
+// vim: ts=2 sw=2 expandtab

--- a/gr-zeromq/lib/pub_sink_impl.h
+++ b/gr-zeromq/lib/pub_sink_impl.h
@@ -26,22 +26,15 @@
 #include <gnuradio/zeromq/pub_sink.h>
 #include <zmq.hpp>
 
+#include "base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class pub_sink_impl : public pub_sink
+    class pub_sink_impl : public pub_sink, public base_sink_impl
     {
-    private:
-      size_t          d_itemsize;
-      size_t          d_vlen;
-      float           d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      bool            d_pass_tags;
-
     public:
-      pub_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags);
-      ~pub_sink_impl();
+      pub_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,

--- a/gr-zeromq/lib/pull_source_impl.h
+++ b/gr-zeromq/lib/pull_source_impl.h
@@ -26,22 +26,15 @@
 #include <gnuradio/zeromq/pull_source.h>
 #include <zmq.hpp>
 
+#include "base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class pull_source_impl : public pull_source
+    class pull_source_impl : public pull_source, public base_source_impl
     {
-    private:
-      size_t          d_itemsize;
-      size_t          d_vlen;
-      int             d_timeout; // microseconds, -1 is blocking
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      bool            d_pass_tags;
-
     public:
-      pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags);
-      ~pull_source_impl();
+      pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,

--- a/gr-zeromq/lib/push_sink_impl.h
+++ b/gr-zeromq/lib/push_sink_impl.h
@@ -26,22 +26,15 @@
 #include <gnuradio/zeromq/push_sink.h>
 #include <zmq.hpp>
 
+#include "base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class push_sink_impl : public push_sink
+    class push_sink_impl : public push_sink, public base_sink_impl
     {
-    private:
-      size_t          d_itemsize;
-      size_t          d_vlen;
-      float           d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      bool            d_pass_tags;
-
     public:
-      push_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags);
-      ~push_sink_impl();
+      push_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,

--- a/gr-zeromq/lib/rep_sink_impl.h
+++ b/gr-zeromq/lib/rep_sink_impl.h
@@ -26,22 +26,15 @@
 #include <gnuradio/zeromq/rep_sink.h>
 #include <zmq.hpp>
 
+#include "base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class rep_sink_impl : public rep_sink
+    class rep_sink_impl : public rep_sink, public base_sink_impl
     {
-    private:
-      size_t          d_itemsize;
-      size_t          d_vlen;
-      int             d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      bool            d_pass_tags;
-
     public:
-      rep_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags);
-      ~rep_sink_impl();
+      rep_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,

--- a/gr-zeromq/lib/req_source_impl.cc
+++ b/gr-zeromq/lib/req_source_impl.cc
@@ -32,38 +32,20 @@ namespace gr {
   namespace zeromq {
 
     req_source::sptr
-    req_source::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags)
+    req_source::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
     {
       return gnuradio::get_initial_sptr
-        (new req_source_impl(itemsize, vlen, address, timeout, pass_tags));
+        (new req_source_impl(itemsize, vlen, address, timeout, pass_tags, hwm));
     }
 
-    req_source_impl::req_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags)
+    req_source_impl::req_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
       : gr::sync_block("req_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
-        d_itemsize(itemsize), d_vlen(vlen), d_timeout(timeout), d_pass_tags(pass_tags)
+        base_source_impl(ZMQ_REQ, itemsize, vlen, address, timeout, pass_tags, hwm),
+        d_req_pending(false)
     {
-      int major, minor, patch;
-      zmq::version (&major, &minor, &patch);
-
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_REQ);
-
-      int time = 0;
-      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-      d_socket->connect (address);
-    }
-
-    req_source_impl::~req_source_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
+      /* All is delegated */
     }
 
     int
@@ -71,49 +53,56 @@ namespace gr {
                           gr_vector_const_void_star &input_items,
                           gr_vector_void_star &output_items)
     {
-      char *out = (char*)output_items[0];
+#if 0
+#endif
+      uint8_t *out = (uint8_t *) output_items[0];
+      bool first = true;
+      int done = 0;
 
-      zmq::pollitem_t itemsout[] = { { *d_socket, 0, ZMQ_POLLOUT, 0 } };
-      zmq::poll (&itemsout[0], 1, d_timeout);
+      /* Process as much as we can */
+      while (1)
+      {
+        if (has_pending())
+        {
+          /* Flush anything pending */
+          done += flush_pending(out + (done * d_vsize), noutput_items - done, nitems_written(0) + done);
 
-      //  If we got a reply, process
-      if (itemsout[0].revents & ZMQ_POLLOUT) {
-        // Request data, FIXME non portable?
-        zmq::message_t request(sizeof(int));
-        memcpy ((void *) request.data (), &noutput_items, sizeof(int));
-        d_socket->send(request);
-      }
-
-      zmq::pollitem_t itemsin[] = { { *d_socket, 0, ZMQ_POLLIN, 0 } };
-      zmq::poll(&itemsin[0], 1, d_timeout);
-
-      //  If we got a reply, process
-      if (itemsin[0].revents & ZMQ_POLLIN) {
-        // Receive data
-        zmq::message_t reply;
-        d_socket->recv(&reply);
-
-        // Deserialize header data / tags
-        std::string buf(static_cast<char*>(reply.data()), reply.size());
-
-        if(d_pass_tags){
-          uint64_t rcv_offset;
-          std::vector<gr::tag_t> tags;
-          buf = parse_tag_header(buf, rcv_offset, tags);
-          for(size_t i=0; i<tags.size(); i++){
-            tags[i].offset -= rcv_offset - nitems_written(0);
-            add_item_tag(0, tags[i]);
-          }
+          /* No more space ? */
+          if (done == noutput_items)
+            break;
         }
+        else
+        {
+          /* Send request if needed */
+          if (!d_req_pending)
+          {
+            /* The REP/REQ pattern state machine guarantees we can send at this point */
+            uint32_t req_len = noutput_items - done;
+            zmq::message_t request(sizeof(uint32_t));
+            memcpy ((void *) request.data (), &req_len, sizeof(uint32_t));
+            d_socket->send(request);
 
+            d_req_pending = true;
+          }
 
-        // Copy to ouput buffer and return
-        memcpy(out, (void *)&buf[0], buf.size());
-        return buf.size()/(d_itemsize*d_vlen);
+          /* Try to get the next message */
+          if (!load_message(first))
+            break;  /* No message, we're done for now */
+
+          /* Got response */
+          d_req_pending = false;
+
+          /* Not the first anymore */
+          first = false;
+        }
       }
+
+      return done;
 
       return 0;
     }
 
   } /* namespace zeromq */
 } /* namespace gr */
+
+// vim: ts=2 sw=2 expandtab

--- a/gr-zeromq/lib/req_source_impl.h
+++ b/gr-zeromq/lib/req_source_impl.h
@@ -26,26 +26,22 @@
 #include <gnuradio/zeromq/req_source.h>
 #include <zmq.hpp>
 
+#include "base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class req_source_impl : public req_source
+    class req_source_impl : public req_source, public base_source_impl
     {
-    private:
-      size_t          d_itemsize;
-      size_t          d_vlen;
-      int             d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      bool            d_pass_tags;
-
     public:
-      req_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags);
-      ~req_source_impl();
+      req_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+    private:
+      bool d_req_pending;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -32,40 +32,20 @@ namespace gr {
   namespace zeromq {
 
     sub_source::sptr
-    sub_source::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags)
+    sub_source::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
     {
       return gnuradio::get_initial_sptr
-        (new sub_source_impl(itemsize, vlen, address, timeout, pass_tags));
+        (new sub_source_impl(itemsize, vlen, address, timeout, pass_tags, hwm));
     }
 
-    sub_source_impl::sub_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags)
+    sub_source_impl::sub_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
       : gr::sync_block("sub_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
-        d_itemsize(itemsize), d_vlen(vlen), d_timeout(timeout), d_pass_tags(pass_tags)
+        base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm)
     {
-      int major, minor, patch;
-      zmq::version (&major, &minor, &patch);
-
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_SUB);
-
+      /* Subscribe */
       d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
-      d_socket->connect (address);
-    }
-
-    /*
-     * Our virtual destructor.
-     */
-    sub_source_impl::~sub_source_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
     }
 
     int
@@ -73,47 +53,37 @@ namespace gr {
                            gr_vector_const_void_star &input_items,
                            gr_vector_void_star &output_items)
     {
-      char *out = (char*)output_items[0];
+      uint8_t *out = (uint8_t *) output_items[0];
+      bool first = true;
+      int done = 0;
 
-      zmq::pollitem_t items[] = { { *d_socket, 0, ZMQ_POLLIN, 0 } };
-      zmq::poll (&items[0], 1, d_timeout);
+      /* Process as much as we can */
+      while (1)
+      {
+        if (has_pending())
+        {
+          /* Flush anything pending */
+          done += flush_pending(out + (done * d_vsize), noutput_items - done, nitems_written(0) + done);
 
-      //  If we got a reply, process
-      if (items[0].revents & ZMQ_POLLIN) {
-
-        // Receive data
-        zmq::message_t msg;
-        d_socket->recv(&msg);
-
-        // Deserialize header data / tags
-        std::string buf(static_cast<char*>(msg.data()), msg.size());
-
-        if(d_pass_tags){
-          uint64_t rcv_offset;
-          std::vector<gr::tag_t> tags;
-
-          buf = parse_tag_header(buf, rcv_offset, tags);
-
-          for(size_t i=0; i<tags.size(); i++) {
-            tags[i].offset -= rcv_offset - nitems_written(0);
-            add_item_tag(0, tags[i]);
-          }
+          /* No more space ? */
+          if (done == noutput_items)
+            break;
         }
+        else
+        {
+          /* Try to get the next message */
+          if (!load_message(first))
+            break;  /* No message, we're done for now */
 
-        // Copy to ouput buffer and return
-        if (buf.size() >= d_itemsize*d_vlen*noutput_items) {
-          memcpy(out, (void *)&buf[0], d_itemsize*d_vlen*noutput_items);
-          return noutput_items;
-        }
-        else {
-          memcpy(out, (void *)&buf[0], buf.size());
-          return buf.size()/(d_itemsize*d_vlen);
+          /* Not the first anymore */
+          first = false;
         }
       }
-      else {
-        return 0; // FIXME: someday when the scheduler does all the poll/selects
-      }
+
+      return done;
     }
 
   } /* namespace zeromq */
 } /* namespace gr */
+
+// vim: ts=2 sw=2 expandtab

--- a/gr-zeromq/lib/sub_source_impl.h
+++ b/gr-zeromq/lib/sub_source_impl.h
@@ -24,28 +24,21 @@
 #define INCLUDED_ZEROMQ_SUB_SOURCE_IMPL_H
 
 #include <gnuradio/zeromq/sub_source.h>
-#include "zmq.hpp"
+#include <zmq.hpp>
+
+#include "base_impl.h"
 
 namespace gr {
   namespace zeromq {
 
-    class sub_source_impl : public sub_source
+    class sub_source_impl : public sub_source,  public base_source_impl
     {
-     private:
-      size_t          d_itemsize;
-      size_t          d_vlen;
-      int             d_timeout; // microseconds, -1 is blocking
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      bool            d_pass_tags;
-
-     public:
-      sub_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags);
-      ~sub_source_impl();
+    public:
+      sub_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
       int work(int noutput_items,
-	           gr_vector_const_void_star &input_items,
-	           gr_vector_void_star &output_items);
+               gr_vector_const_void_star &input_items,
+               gr_vector_void_star &output_items);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/tag_headers.h
+++ b/gr-zeromq/lib/tag_headers.h
@@ -27,12 +27,13 @@
 #include <gnuradio/block.h>
 #include <sstream>
 #include <cstring>
+#include <zmq.hpp>
 
 namespace gr {
   namespace zeromq {
 
-    std::string gen_tag_header(uint64_t &offset, std::vector<gr::tag_t> &tags);
-    std::string parse_tag_header(std::string &buf_in, uint64_t &offset_out, std::vector<gr::tag_t> &tags_out);
+    std::string gen_tag_header(uint64_t offset, std::vector<gr::tag_t> &tags);
+    size_t parse_tag_header(zmq::message_t &msg, uint64_t &offset_out, std::vector<gr::tag_t> &tags_out);
     
   } /* namespace zeromq */
 } /* namespace gr */


### PR DESCRIPTION
 - Use class hierarchy trying to maximize code re-use.
 - Dont' drop samples on receive if the output buffer doesn't have
   enough space.
 - Don't drop tags on receive by putting tags in the future.
 - Better metadata creation/parsing avoiding copying lots data.
 - Always do as much work as possible in a single call to work()
   to avoid scheduler overhead as long as possible.
 - Allow setting the  high watermark to avoid older version of
   zeromq's default of buffering infinite messages and causing a
   paging thrash to/from disk when the flow graph can't keep up.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>