### PR TITLE
gnuradio-runtime: Fix sptr magic when exception thrown in hier2 constructor

### DIFF
--- a/gnuradio-runtime/include/gnuradio/sptr_magic.h
+++ b/gnuradio-runtime/include/gnuradio/sptr_magic.h
@@ -38,6 +38,7 @@ namespace gnuradio {
     public:
       static boost::shared_ptr<gr::basic_block> fetch_initial_sptr(gr::basic_block *p);
       static void create_and_stash_initial_sptr(gr::hier_block2 *p);
+      static void cancel_initial_sptr(gr::hier_block2 *p);
     };
   };
 

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -57,6 +57,8 @@ namespace gr {
 
   hier_block2::~hier_block2()
   {
+    disconnect_all();
+    gnuradio::detail::sptr_magic::cancel_initial_sptr(this);
     delete d_detail;
   }
 


### PR DESCRIPTION
Fixes #528

Previously, if an exception is thrown in constructor of a hier_block2
subclass, then :
 - The hier_block2 base destructor _will_ be called
 - The actual object is destroyed
 - But the initial sptr would be left in the static map and point to
   an invalid object
 - Whatever connection() were made might have an invalid sptr ref as well

So to fix this:
 - In the hier_block2 destructor, we explicitely disconnect() everything
 - In the base hier_block2 destructor, we call a new 'cancel sptr' method
   that will check if this object is still in the static map or not
   - If it's not: Then this is a legit call to the destructor by shared_ptr
     and everything is fine
   - If it's: Then there was an isue and the object is already being
     destroyed and we need to make sure shared_ptr doesn't try to do it
     again. We do this using a special 'disarmable' custom deleter.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>