### PR TITLE
runtime: addresses issue 768.

### DIFF
--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -370,11 +370,24 @@ namespace gr {
       // ask the block how much input they need to produce noutput_items
       m->forecast (noutput_items, d_ninput_items_required);
 
-      // See if we've got sufficient input available
+      // See if we've got sufficient input available and make sure we
+      // didn't overflow on the input.
       int i;
-      for(i = 0; i < d->ninputs (); i++)
+      for(i = 0; i < d->ninputs (); i++) {
         if(d_ninput_items_required[i] > d_ninput_items[i])	// not enough
           break;
+
+        if(d_ninput_items_required[i] < 0) {
+          std::cerr << "\nsched: <block " << m->name()
+                    << " (" << m->unique_id() << ")>"
+                    << " thinks its ninput_items required is "
+                    << d_ninput_items_required[i]
+                    << " and cannot be negative.\n"
+                    << "Some parameterization is wrong. "
+                    << "Too large a decimation value?\n\n";
+          goto were_done;
+        }
+      }
 
       if(i < d->ninputs()) {			// not enough input on input[i]
         // if we can, try reducing the size of our output request


### PR DESCRIPTION
Because of the data types in use here, d_ninput_items_required can
overflow and become negative, which then causes bad addressing of the
input buffer in a block's work function. Even if we were using
unsigned types, we might still have situations of overflow; it
wouldn't crash in this case but cause wrong addressing, anyways.

We might be able to catch and handle this situation better. This fix
tests for the condition and shuts down the flowgraph with an error
message. Basically, parameters that cause this effect are well out of
bounds of what we want to handle, anyways.