### PR TITLE
gnuradio-runtime/hier_block2: Allow changing of IO sig in the constructor

### DIFF
--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -328,10 +328,44 @@ namespace gr {
   }
 
   void
+  hier_block2_detail::refresh_io_signature()
+  {
+    int min_inputs  = d_owner->input_signature()->min_streams();
+    int max_inputs  = d_owner->input_signature()->max_streams();
+    int min_outputs = d_owner->output_signature()->min_streams();
+    int max_outputs = d_owner->output_signature()->max_streams();
+
+    if(max_inputs == io_signature::IO_INFINITE ||
+       max_outputs == io_signature::IO_INFINITE ||
+       (min_inputs != max_inputs) ||(min_outputs != max_outputs) ) {
+      std::stringstream msg;
+      msg << "Hierarchical blocks do not yet support arbitrary or"
+        << " variable numbers of inputs or outputs (" << d_owner->name() << ")";
+      throw std::runtime_error(msg.str());
+    }
+
+    // Check for # input change
+    if ((signed)d_inputs.size() != max_inputs)
+    {
+      d_inputs.resize(max_inputs);
+    }
+
+    // Check for # output change
+    if ((signed)d_outputs.size() != max_outputs)
+    {
+      d_outputs.resize(max_outputs);
+      d_min_output_buffer.resize(max_outputs, 0);
+      d_max_output_buffer.resize(max_outputs, 0);
+    }
+  }
+
+  void
   hier_block2_detail::connect_input(int my_port, int port,
                                     basic_block_sptr block)
   {
     std::stringstream msg;
+
+    refresh_io_signature();
 
     if(my_port < 0 || my_port >= (signed)d_inputs.size()) {
       msg << "input port " << my_port << " out of range for " << block;
@@ -356,6 +390,8 @@ namespace gr {
   {
     std::stringstream msg;
 
+    refresh_io_signature();
+
     if(my_port < 0 || my_port >= (signed)d_outputs.size()) {
       msg << "output port " << my_port << " out of range for " << block;
       throw std::invalid_argument(msg.str());
@@ -375,6 +411,8 @@ namespace gr {
                                        basic_block_sptr block)
   {
     std::stringstream msg;
+
+    refresh_io_signature();
 
     if(my_port < 0 || my_port >= (signed)d_inputs.size()) {
       msg << "input port number " << my_port << " out of range for " << block;
@@ -398,6 +436,8 @@ namespace gr {
                                         basic_block_sptr block)
   {
     std::stringstream msg;
+
+    refresh_io_signature();
 
     if(my_port < 0 || my_port >= (signed)d_outputs.size()) {
       msg << "output port number " << my_port << " out of range for " << block;

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -71,6 +71,7 @@ namespace gr {
     endpoint_vector_t d_outputs;             // Single internal endpoint per external output
     basic_block_vector_t d_blocks;
 
+    void refresh_io_signature();
     void connect_input(int my_port, int port, basic_block_sptr block);
     void connect_output(int my_port, int port, basic_block_sptr block);
     void disconnect_input(int my_port, int port, basic_block_sptr block);


### PR DESCRIPTION
Fixes #719

The issue is that the hier_block2 detail creates some vectors for the
in/out ports to hold where to connect them to during the flatten and
what the min/max output buffer size are.

But subclasses are allowed to change the io signature in their constructor
so before actually using those vectors, we recheck if we should update
their size.

If there is a new io signature with more port, they're initialized to
default values (i.e. not connected). And if the new signature has less
ports, we just drop the connection (which is fine since it's all in the
subclass constructor, before they've been used for anything).

In both cases, just using .resize() on the vector is enough.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>