### PR TITLE
Set max noutput items

### DIFF
--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -177,6 +177,13 @@ namespace gr {
     catch(std::bad_alloc&) {
       b = make_buffer(nitems, item_size, grblock);
     }
+
+    // Set the max noutput items size here to make sure it's always
+    // set in the block and available in the start() method.
+    // But don't overwrite if the user has set this externally.
+    if(!grblock->is_set_max_noutput_items())
+      grblock->set_max_noutput_items(nitems);
+
     return b;
   }
 

--- a/gr-blocks/python/blocks/qa_block_behavior.py
+++ b/gr-blocks/python/blocks/qa_block_behavior.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest, blocks
+
+class test_block_behavior(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_000(self):
+        '''
+        Tests the max noutput sizes set by the scheduler. When creating
+        the block, there is no block_detail and so the max buffer size
+        is 0. When the top_block is run, it builds the detail and
+        buffers and sets the max value. test_0001 tests when the
+        max_noutput_items is set by hand.
+
+        '''
+
+        src = blocks.null_source(gr.sizeof_float)
+        op  = blocks.head(gr.sizeof_float, 100)
+        snk = blocks.null_sink(gr.sizeof_float)
+
+        maxn_pre = op.max_noutput_items()
+
+        self.tb.connect(src, op, snk)
+        self.tb.run()
+
+        maxn_post = op.max_noutput_items()
+
+        self.assertEqual(maxn_pre, 0)
+        self.assertEqual(maxn_post, 16384)
+
+    def test_001(self):
+        '''
+        Tests the max noutput size when being explicitly set.
+        '''
+
+        src = blocks.null_source(gr.sizeof_float)
+        op  = blocks.head(gr.sizeof_float, 100)
+        snk = blocks.null_sink(gr.sizeof_float)
+
+        op.set_max_noutput_items(1024)
+
+        maxn_pre = op.max_noutput_items()
+
+        self.tb.connect(src, op, snk)
+        self.tb.run()
+
+        maxn_post = op.max_noutput_items()
+
+        self.assertEqual(maxn_pre, 1024)
+        self.assertEqual(maxn_post, 1024)
+
+if __name__ == '__main__':
+    gr_unittest.run(test_block_behavior, "test_block_behavior.xml")

--- a/gr-filter/lib/pfb_decimator_ccf_impl.h
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.h
@@ -40,6 +40,7 @@ namespace gr {
       bool         d_use_fft_rotator;
       bool         d_use_fft_filters;
       gr_complex  *d_rotator;
+      gr_complex  *d_tmp; // used for fft filters
       gr::thread::mutex d_mutex; // mutex to protect set/work access
 
       inline int work_fir_exp(int noutput_items,
@@ -55,7 +56,6 @@ namespace gr {
                               gr_vector_const_void_star &input_items,
                               gr_vector_void_star &output_items);
 
-
     public:
       pfb_decimator_ccf_impl(unsigned int decim,
 			     const std::vector<float> &taps,
@@ -69,6 +69,10 @@ namespace gr {
       void print_taps();
       std::vector<std::vector<float> > taps() const;
       void set_channel(const unsigned int channel);
+
+      // Overload to create/destroy d_tmp based on max_noutput_items.
+      bool start();
+      bool stop();
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
Adds a feature where the max_noutput_items is always set for a block by the scheduler based on its own calculations, even if a user didn't explicitly call it.

Uses this new feature to pre-allocate FFT buffers in the PFB decimation filters in start instead of requiring a malloc every call to work.