### PR TITLE
qtgui: fixes issue #889.

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.xml
@@ -110,7 +110,7 @@ $(gui_hint()($win))</make>
     <key>fftsize</key>
     <value>1024</value>
     <type>int</type>
-    <hide>#if $type.t == 'message' then 'all' else 'all'#</hide>
+    <hide>#if $type.t == 'message' then 'all' else 'none'#</hide>
   </param>
 
   <param>


### PR DESCRIPTION
Typo caused FFT size to not show up in properties box.