### PR TITLE
analog: better block category (GRC) for random uniform source

### DIFF
--- a/gr-analog/grc/analog_block_tree.xml
+++ b/gr-analog/grc/analog_block_tree.xml
@@ -63,6 +63,7 @@
     <block>analog_noise_source_x</block>
     <block>analog_fastnoise_source_x</block>
     <block>analog_random_source_x</block>
+    <block>analog_random_uniform_source_x</block>
   </cat>
   <cat>
     <name>Synchronizers</name>

--- a/gr-analog/grc/analog_random_uniform_source_x.xml
+++ b/gr-analog/grc/analog_random_uniform_source_x.xml
@@ -2,7 +2,6 @@
 <block>
   <name>Random Uniform Source</name>
   <key>analog_random_uniform_source_x</key>
-  <category>analog</category>
   <import>from gnuradio import analog</import>
   <make>analog.random_uniform_source_$(type.fcn)($minimum, $maximum, $seed)</make>
 


### PR DESCRIPTION
The block was filled under "analog" - only block in that cat.
Now its under "Waveform Generators" along with the other signal sources in analog