### PR TITLE
Length translation between tagged streams and PDUs

### DIFF
--- a/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
@@ -65,7 +65,7 @@ namespace gr {
 
         d_curr_meta = pmt::car(msg);
         d_curr_vect = pmt::cdr(msg);
-        d_curr_len = pmt::length(d_curr_vect);
+        d_curr_len = pmt::length(d_curr_vect) / pdu::itemsize(d_type);
       }
 
       return d_curr_len;

--- a/gr-blocks/lib/tagged_stream_to_pdu_impl.cc
+++ b/gr-blocks/lib/tagged_stream_to_pdu_impl.cc
@@ -67,7 +67,7 @@ namespace gr {
       }
 
       // Grab data, throw into vector
-      d_pdu_vector = pdu::make_pdu_vector(d_type, in, ninput_items[0]);
+      d_pdu_vector = pdu::make_pdu_vector(d_type, in, ninput_items[0]*pdu::itemsize(d_type));
 
       // Send msg
       pmt::pmt_t msg = pmt::cons(d_pdu_meta, d_pdu_vector);


### PR DESCRIPTION
It appears the length of PDUs is in bytes and tagged streams are in samples. This creates issues when sending non-byte pdu data over networks. I don't know if this is the proper way to fix this, but it seems to resolve the issue. See my post here for an example: http://lists.gnu.org/archive/html/discuss-gnuradio/2016-02/msg00045.html