### PR TITLE
Length translation between tagged streams and PDUs (v2)

### DIFF
--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -61,7 +61,7 @@ namespace gr {
       pmt::pmt_t vector = pmt::cdr(pdu);
       std::cout << "* MESSAGE DEBUG PRINT PDU VERBOSE *\n";
       pmt::print(meta);
-      size_t len = pmt::length(vector);
+      size_t len = pmt::blob_length(vector);
       std::cout << "pdu_length = " << len << std::endl;
       std::cout << "contents = " << std::endl;
       size_t offset(0);

--- a/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
@@ -65,7 +65,8 @@ namespace gr {
 
         d_curr_meta = pmt::car(msg);
         d_curr_vect = pmt::cdr(msg);
-        d_curr_len = pmt::length(d_curr_vect);
+        // do not assume the length of  PMT is in items (e.g.: from socket_pdu)
+        d_curr_len = pmt::blob_length(d_curr_vect)/d_itemsize;
       }
 
       return d_curr_len;

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -196,7 +196,7 @@ namespace gr {
     socket_pdu_impl::tcp_client_send(pmt::pmt_t msg)
     {
       pmt::pmt_t vector = pmt::cdr(msg);
-      size_t len = pmt::length(vector);
+      size_t len = pmt::blob_length(vector);
       size_t offset = 0;
       std::vector<char> txbuf(std::min(len, d_rxbuf.size()));
       while (offset < len) {
@@ -214,7 +214,7 @@ namespace gr {
         return;
 
       pmt::pmt_t vector = pmt::cdr(msg);
-      size_t len = pmt::length(vector);
+      size_t len = pmt::blob_length(vector);
       size_t offset = 0;
       std::vector<char> txbuf(std::min(len, d_rxbuf.size()));
       while (offset < len) {

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -53,7 +53,7 @@ namespace gr {
     void
     tcp_connection::send(pmt::pmt_t vector)
     {
-      size_t len = pmt::length(vector);
+      size_t len = pmt::blob_length(vector);
       size_t offset = 0;
       std::vector<char> txbuf(std::min(len, d_buf.size()));
       while (offset < len) {


### PR DESCRIPTION
When sending PDU data over the network, socket_pdu treats length values as bytes, however PDUs can have data in either u8vector, f32vector or c64vector. This fix relies on blob_length instead of length when socket_pdu determines how much data to transfer over the network. In general, if the block is hard-coded to treat the PDU vector as u8's, it should use blob_length which provides bytes as opposed to length() which provides nitems.

When reading PDUs over the network with socket_pdu, datatype (therefore nitems) is unknown is always treated as bytes. Because the datatype is unknown, PDU to Tagged Stream should not calculate nitems based on the length by assuming the PMT type is the same as the output type (which is not the case for PDUs from socket). Rather this is manually done from blob_length (bytes) and desired itemsize which is known from user-selected output type at instantiation.

The print_pdu function of the message_debug block as point out by jcorgan in the previous PR also has this issue, which was addressed the same way.

The previous attempt to fix this is here: https://github.com/gnuradio/gnuradio/pull/737
A flowgraph demonstrating the issue was posted to the mailing list here: http://lists.gnu.org/archive/html/discuss-gnuradio/2016-02/msg00045.html

It was pointed out by awalls in IRC that this also stream_pdu_base may have the same issue. I took a look and it appears the send side accounts for the item length vs payload length, and the receive side without knowledge of vector type uses a u8vector (which is now properly handled by pdu_to_tagged_stream).