### PR TITLE
Primarily MSVC specific changes to allow for a native windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,11 @@ set(VERSION_INFO_MINOR_VERSION 10)
 set(VERSION_INFO_MAINT_VERSION git)
 include(GrVersion) #setup version info
 
-# Append -O2 optimization flag for Debug builds
-SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
-SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O2")
-
+# Append -O2 optimization flag for Debug builds (Not on MSVC since conflicts with RTC1 flag)
+IF (NOT MSVC)
+    SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
+    SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O2")
+ENDIF()
 ########################################################################
 # Environment setup
 ########################################################################
@@ -120,6 +121,9 @@ IF(MSVC)
     ELSE(MSVC12) #Visual Studio 12
         SET(cmake_c_compiler_version "Microsoft Visual Studio 12.0")
         SET(cmake_cxx_compiler_version "Microsoft Visual Studio 12.0")
+    ELSE(MSVC14) #Visual Studio 14
+        SET(cmake_c_compiler_version "Microsoft Visual Studio 14.0")
+        SET(cmake_cxx_compiler_version "Microsoft Visual Studio 14.0")
     ENDIF()
 ELSE()
     execute_process(COMMAND ${CMAKE_C_COMPILER} --version

--- a/cmake/Modules/FindGSL.cmake
+++ b/cmake/Modules/FindGSL.cmake
@@ -44,7 +44,7 @@ if( WIN32 AND NOT CYGWIN AND NOT MSYS )
 
 		# look for gsl cblas library
     find_library( GSL_CBLAS_LIBRARY
-        NAMES gslcblas
+        NAMES gslcblas cblas
       )
     if( GSL_CBLAS_LIBRARY )
       set( GSL_CBLAS_FOUND ON )

--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -9,6 +9,7 @@ find_path(QWT_INCLUDE_DIRS
   NAMES qwt_global.h
   HINTS
   ${CMAKE_INSTALL_PREFIX}/include/qwt
+  ${CMAKE_PREFIX_PATH}/include/qwt
   PATHS
   /usr/local/include/qwt-qt4
   /usr/local/include/qwt
@@ -22,10 +23,11 @@ find_path(QWT_INCLUDE_DIRS
 )
 
 find_library (QWT_LIBRARIES
-  NAMES qwt6 qwt6-qt4 qwt qwt-qt4
+  NAMES qwt6 qwt6-qt4 qwt qwt-qt4 qwt5
   HINTS
   ${CMAKE_INSTALL_PREFIX}/lib
   ${CMAKE_INSTALL_PREFIX}/lib64
+  ${CMAKE_PREFIX_PATH}/lib 
   PATHS
   /usr/local/lib
   /usr/lib

--- a/cmake/Modules/UseSWIG.cmake
+++ b/cmake/Modules/UseSWIG.cmake
@@ -224,9 +224,9 @@ print(re.sub('\\W', '_', '${name} ${reldir} ' + unique))"
   foreach(swig_gen_file ${${outfiles}})
     add_custom_command(
       OUTPUT ${swig_gen_file}
-      COMMAND ""
+      COMMAND 
       DEPENDS ${_target}
-      COMMENT ""
+      COMMENT 
     )
   endforeach()
 

--- a/cmake/msvc/CMakeCache.VS2015.txt
+++ b/cmake/msvc/CMakeCache.VS2015.txt
@@ -1,0 +1,22 @@
+# This Cache file is used with the windows binary build to assist CMake in finding all the necessary dependencies
+# To use, place this is the build/cmake directory and reload the cache in CMake, then re-configure
+# This is only useful if you are using the native windows build template built by gnieboer
+
+# Basic parameters to define the root for the native windows build 
+CMAKE_PREFIX_PATH:PATH=C:\gr-build
+CMAKE_INSTALL_PREFIX:PATH=C:\gr-build\src-stage3\staged_install
+ENABLE_MSVC_AVX2_ONLY_MODE:BOOL=OFF
+
+# Where the swig utility is 
+SWIG_DIR:PATH=C:\gr-build\bin
+
+# Ensure we are using this specific VS2015 build of python not a system build 
+PYTHON_EXECUTABLE:FILEPATH=C:\gr-build\src-stage2-python\Python27\python.exe
+QA_PYTHON_EXECUTABLE:FILEPATH=C:\gr-build\src-stage2-python\Python27\python.exe
+PYTHON_LIBRARY:FILEPATH=C:\gr-build\src-stage2-python\Python27\libs\python27.lib
+PYTHON_INCLUDE_DIR:PATH=C:\gr-build\src-stage2-python\Python27\include 
+
+# Qt destination as CMAKE will find a generic system install by default 
+QT_QMAKE_EXECUTABLE:FILEPATH=C:\gr-build\src-stage1-dependencies\Qt4\bin\qmake.exe
+
+SPHINX_EXECUTABLE:FILEPATH=C:/gr-build/src-stage2-Python/Python27/Scripts/sphinx-build.exe

--- a/cmake/msvc/config.h
+++ b/cmake/msvc/config.h
@@ -32,8 +32,9 @@ static inline float rintf(float x){return (x > 0.0f)? floorf(x + 0.5f) : ceilf(x
 ////////////////////////////////////////////////////////////////////////
 // math constants
 ////////////////////////////////////////////////////////////////////////
-#define INFINITY HUGE_VAL
-
+#if (!_MSC_VER >= 1900)
+# define INFINITY   HUGE_VAL
+#endif 
 # define M_E		2.7182818284590452354	/* e */
 # define M_LOG2E	1.4426950408889634074	/* log_2 e */
 # define M_LOG10E	0.43429448190325182765	/* log_10 e */

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -59,6 +59,15 @@ namespace gr {
    */
   class GR_RUNTIME_API block : public basic_block
   {
+
+#if (_MSC_VER >= 1900)
+	  // Replacing C++11 implicitly defined copy/move operators
+	  // Otherwise will not compile on VS2015
+  protected:
+	  block(const block&) {};
+	  block& operator=(const block&) { return block(); };
+#endif
+
   public:
 
     //! Magic return values from general_work

--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -63,6 +63,12 @@ namespace gr {
     hier_block2(const std::string &name,
                 gr::io_signature::sptr input_signature,
                 gr::io_signature::sptr output_signature);
+#if (_MSC_VER >= 1900)
+	// Replacing C++11 implicitly defined copy/move operators
+	// Otherwise will not compile on VS2015
+	hier_block2(const hier_block2&) {};
+	hier_block2& operator=(const hier_block2&) { return hier_block2(); };
+#endif 
 
   public:
     virtual ~hier_block2();

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -127,7 +127,7 @@ namespace gr {
               x = 2.0*ran1()-1.0;
               y = 2.0*ran1()-1.0;
               s = x*x+y*y;
-          }while(not(s<1.0));
+          }while(s >= 1 || s == 0);
           d_gauss_stored = true;
           d_gauss_value = x*sqrt(-2.0*log(s)/s);
           return y*sqrt(-2.0*log(s)/s);

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -34,6 +34,9 @@
 #include <unistd.h>
 #include <stdexcept>
 #include <string.h>
+#ifdef _MSC_VER
+#include <io.h>
+#endif 
 
 namespace gr {
   namespace audio {

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -34,6 +34,9 @@
 #include <unistd.h>
 #include <stdexcept>
 #include <string.h>
+#ifdef _MSC_VER
+#include <io.h>
+#endif 
 
 namespace gr {
   namespace audio {

--- a/gr-dtv/lib/CMakeLists.txt
+++ b/gr-dtv/lib/CMakeLists.txt
@@ -133,10 +133,21 @@ list(APPEND dtv_libs
 )
 
 include (CheckCCompilerFlag)
-CHECK_C_COMPILER_FLAG ("-msse2" SSE2_SUPPORTED)
+if (MSVC)
+	# 64-bit MSVC always supports SSE2 
+	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(SSE2_SUPPORTED true)
+	else ()
+		CHECK_C_COMPILER_FLAG ("/arch:SSE2" SSE2_SUPPORTED)
+	endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+else ()
+	CHECK_C_COMPILER_FLAG ("-msse2" SSE2_SUPPORTED)
+endif(MSVC)
 
 if(SSE2_SUPPORTED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2")
+	if (!MSVC)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2")
+	endif ()
     ADD_DEFINITIONS(-DDTV_SSE2)
 endif(SSE2_SUPPORTED)
 

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
@@ -135,7 +135,11 @@ namespace gr {
 
       // First index of d_b is Bit interleaver number
       // Second index of d_b is the position inside Bit interleaver
-      unsigned char d_b[d_v][d_bsize];
+#ifdef _MSC_VER
+	  unsigned char ** d_b = (unsigned char**)alloca(sizeof(char) * (d_v * d_bsize));
+#else
+	  unsigned char d_b[d_v][d_bsize];
+#endif
 
       for (int bcount = 0; bcount < bmax; bcount++) {
         for (int w = 0; w < d_bsize; w++) {

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
@@ -136,7 +136,11 @@ namespace gr {
 
       // First index of d_b is Bit interleaver number
       // Second index of d_b is the position inside the Bit interleaver
-      unsigned char d_b[d_v][d_bsize];
+#ifdef _MSC_VER
+	  unsigned char ** d_b = (unsigned char**)alloca(sizeof(char) * (d_v * d_bsize));
+#else
+	  unsigned char d_b[d_v][d_bsize];
+#endif
 
       for (int bcount = 0; bcount < bmax; bcount++) {
         for (int i = 0; i < d_bsize; i++) {

--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
@@ -103,8 +103,13 @@ namespace gr {
       int low, size;
 
       // Array to store peak positions
+#ifndef _MSC_VER
       int peak_pos[d_fft_length];
       float d_phi[d_fft_length];
+#else 
+	  int * peak_pos = (int *)alloca(sizeof(int) * d_fft_length);
+	  float * d_phi = (float *)alloca(sizeof(float) * d_fft_length);
+#endif
 
       // Calculate norm
       low = lookup_stop - (d_cp_length + d_fft_length - 1);

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon.cc
@@ -245,13 +245,23 @@ namespace gr {
     int
     dvbt_reed_solomon::rs_decode(unsigned char *data, unsigned char *eras, const int no_eras)
     {
-      unsigned char sigma[2 * d_t + 1];
-      unsigned char b[2 * d_t + 1];
-      unsigned char T[2 * d_t + 1];
-      unsigned char reg[2 * d_t + 1];
-      unsigned char root[2 * d_t + 1];
-      unsigned char loc[2 * d_t + 1];
-      unsigned char omega[2 * d_t];
+#ifndef _MSC_VER
+		unsigned char sigma[2 * d_t + 1];
+		unsigned char b[2 * d_t + 1];
+		unsigned char T[2 * d_t + 1];
+		unsigned char reg[2 * d_t + 1];
+		unsigned char root[2 * d_t + 1];
+		unsigned char loc[2 * d_t + 1];
+		unsigned char omega[2 * d_t];
+#else 
+		unsigned char * sigma = (unsigned char*)alloca(sizeof(char) * (2 * d_t + 1));
+		unsigned char * b = (unsigned char*)alloca(sizeof(char) * (2 * d_t + 1));
+		unsigned char * T = (unsigned char*)alloca(sizeof(char) * (2 * d_t + 1));
+		unsigned char * reg = (unsigned char*)alloca(sizeof(char) * (2 * d_t + 1));
+		unsigned char * root = (unsigned char*)alloca(sizeof(char) * (2 * d_t + 1));
+		unsigned char * loc = (unsigned char*)alloca(sizeof(char) * (2 * d_t + 1));
+		unsigned char * omega = (unsigned char*)alloca(sizeof(char) * (2 * d_t));
+#endif
 
       // Compute erasure locator polynomial
       memset(sigma, 0, 2 * d_t + 1);

--- a/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
@@ -71,10 +71,17 @@ namespace gr {
     };
 
 #ifdef DTV_SSE2
+#if defined (_MSC_VER)
+	_declspec(align(16)) __m128i dvbt_viterbi_decoder_impl::d_metric0[4];
+	_declspec(align(16)) __m128i dvbt_viterbi_decoder_impl::d_metric1[4];
+	_declspec(align(16)) __m128i dvbt_viterbi_decoder_impl::d_path0[4];
+	_declspec(align(16)) __m128i dvbt_viterbi_decoder_impl::d_path1[4];
+#else
     __m128i dvbt_viterbi_decoder_impl::d_metric0[4] __attribute__ ((aligned(16)));
     __m128i dvbt_viterbi_decoder_impl::d_metric1[4] __attribute__ ((aligned(16)));
     __m128i dvbt_viterbi_decoder_impl::d_path0[4] __attribute__ ((aligned(16)));
     __m128i dvbt_viterbi_decoder_impl::d_path1[4] __attribute__ ((aligned(16)));
+#endif
 #else
     unsigned char dvbt_viterbi_decoder_impl::d_metric0_generic[64] __attribute__ ((aligned(16)));
     unsigned char dvbt_viterbi_decoder_impl::d_metric1_generic[64] __attribute__ ((aligned(16)));
@@ -83,13 +90,22 @@ namespace gr {
 #endif
 
 #ifdef DTV_SSE2
+#if defined (_MSC_VER)
+	_declspec(align(16)) branchtab27 dvbt_viterbi_decoder_impl::Branchtab27_sse2[2];
+#else
     branchtab27 dvbt_viterbi_decoder_impl::Branchtab27_sse2[2] __attribute__ ((aligned(16)));
+#endif
 #else
     branchtab27 dvbt_viterbi_decoder_impl::Branchtab27_generic[2] __attribute__ ((aligned(16)));
 #endif
 
+#if defined(_MSC_VER)
+	_declspec(align(16)) unsigned char dvbt_viterbi_decoder_impl::mmresult[64];
+	_declspec(align(16)) unsigned char dvbt_viterbi_decoder_impl::ppresult[TRACEBACK_MAX][64];
+#else
     unsigned char dvbt_viterbi_decoder_impl::mmresult[64] __attribute__((aligned(16)));
     unsigned char dvbt_viterbi_decoder_impl::ppresult[TRACEBACK_MAX][64] __attribute__((aligned(16)));
+#endif
 
 #ifdef DTV_SSE2
     void

--- a/gr-fec/include/gnuradio/fec/polar_decoder_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_common.h
@@ -64,7 +64,7 @@ namespace gr {
         bool set_frame_size(unsigned int frame_size){return false;};
 
       private:
-        static const float D_LLR_FACTOR = -2.19722458f;
+		static const float D_LLR_FACTOR; // = -2.19722458f;
         unsigned int d_frozen_bit_counter;
 
       protected:

--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -34,6 +34,8 @@ namespace gr {
   namespace fec {
     namespace code {
 
+	  const float polar_decoder_common::D_LLR_FACTOR = -2.19722458f;
+
       polar_decoder_common::polar_decoder_common(int block_size, int num_info_bits,
                                                  std::vector<int> frozen_bit_positions,
                                                  std::vector<char> frozen_bit_values) :

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -158,6 +158,11 @@ list(APPEND qtgui_libs
     ${FFTW3F_LIBRARIES}
     ${LOG4CPP_LIBRARIES}
 )
+if (WIN32)
+  list(APPEND qtgui_libs
+    dwrite
+  )
+endif(WIN32)
 
 include(GrPython)
 if(ENABLE_PYTHON)

--- a/gr-vocoder/lib/codec2/fdmdv.c
+++ b/gr-vocoder/lib/codec2/fdmdv.c
@@ -25,7 +25,7 @@
   along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef _MSC_VER
+#if (_MSC_VER < 1800) // round() not available before VS 2013
 #define round(number) number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5)
 #endif
 

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -24,6 +24,10 @@
 #include "config.h"
 #endif
 
+#if (_MSC_VER >= 1900)
+#include <boost/thread/thread.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#endif
 #include <gnuradio/io_signature.h>
 #include "pull_msg_source_impl.h"
 #include "tag_headers.h"
@@ -102,7 +106,11 @@ namespace gr {
           message_port_pub(pmt::mp("out"), m);
 
         } else {
-          usleep(100);
+#if (_MSC_VER >= 1900)
+			boost::this_thread::sleep(boost::posix_time::microseconds(100));
+#else
+			usleep(100);
+#endif
         }
       }
     }

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -24,6 +24,10 @@
 #include "config.h"
 #endif
 
+#if (_MSC_VER >= 1900)
+#include <boost/thread/thread.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#endif
 #include <gnuradio/io_signature.h>
 #include "req_msg_source_impl.h"
 #include "tag_headers.h"
@@ -114,7 +118,11 @@ namespace gr {
           message_port_pub(pmt::mp("out"), m);
 
         } else {
-          usleep(100);
+#if (_MSC_VER >= 1900)
+			boost::this_thread::sleep(boost::posix_time::microseconds(100));
+#else
+			usleep(100);
+#endif
         }
       }
     }

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -24,6 +24,10 @@
 #include "config.h"
 #endif
 
+#if (_MSC_VER >= 1900)
+#include <boost/thread/thread.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#endif
 #include <gnuradio/io_signature.h>
 #include "sub_msg_source_impl.h"
 #include "tag_headers.h"
@@ -101,7 +105,11 @@ namespace gr {
 
           message_port_pub(pmt::mp("out"), m);
         } else {
-          usleep(100);
+#if (_MSC_VER >= 1900)
+			boost::this_thread::sleep(boost::posix_time::microseconds(100));
+#else
+			usleep(100);
+#endif
         }
       }
     }

--- a/grc/python/Generator.py
+++ b/grc/python/Generator.py
@@ -23,6 +23,7 @@ import subprocess
 import tempfile
 import shlex
 import codecs
+import platform
 from distutils.spawn import find_executable
 
 from Cheetah.Template import Template
@@ -130,8 +131,10 @@ class TopBlockGenerator(object):
             return ' '.join(repr(arg) if ' ' in arg else arg for arg in args)
 
         run_command = self._flow_graph.get_option('run_command')
+        if platform.system() == 'Windows' : usePosix = False 
+        else: usePosix = True 
         cmds = shlex.split(run_command.format(python=sys.executable,
-                                              filename=self.get_file_path()))
+                                              filename=self.get_file_path()), posix=usePosix)
 
         # when in no gui mode on linux, use a graphical terminal (looks nice)
         xterm_executable = find_executable(XTERM_EXECUTABLE)


### PR DESCRIPTION
A series of commits that will allow gnuradio to build natively with cmake and VS 2015.

Most will truly only impact MSVC compilers, but three do potentially impact all builds.

I would look closest at block.h and hier_block2.h, as that code fixes a strange problem with implied copy/move constructors in C++11 (remarkably C++11 can't be disabled in MSVC) that only affects these two classes, I believe because they are "intermediate" classes in an inheritance chain.  I'm not sure if the error is standard C++11 behavior, or MSVC implementation-unique.  Either way, declaring those constructors explicitly was the only option to get it to build, and I'm not familiar enough with the rest of the gr-block code to be able to say for certain there's not some hidden impact.