### PR TITLE
gr-utils: modtool: add option --copyright to add author name

### DIFF
--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -53,6 +53,8 @@ class ModToolAdd(ModTool):
                 choices=self._block_types, default=None, help="One of %s." % ', '.join(self._block_types))
         ogroup.add_option("--license-file", type="string", default=None,
                 help="File containing the license header for every source code file.")
+        ogroup.add_option("--copyright", type="string", default=None,
+                help="Name of the copyright holder (you or your company) MUST be a quoted string.")
         ogroup.add_option("--argument-list", type="string", default=None,
                 help="The argument list for the constructor and make functions.")
         ogroup.add_option("--add-python-qa", action="store_true", default=None,
@@ -77,7 +79,6 @@ class ModToolAdd(ModTool):
                 self._info['blocktype'] = raw_input("Enter block type: ")
                 if self._info['blocktype'] not in self._block_types:
                     print 'Must be one of ' + str(self._block_types)
-
         # Allow user to specify language interactively if not set
         self._info['lang'] = options.lang
         if self._info['lang'] is None:
@@ -102,8 +103,12 @@ class ModToolAdd(ModTool):
             raise ModToolException('Invalid block name.')
         print "Block/code identifier: " + self._info['blockname']
         self._info['fullblockname'] = self._info['modname'] + '_' + self._info['blockname']
+        self._info['copyrightholder'] = options.copyright
+        if self._info['copyrightholder'] is None:
+            self._info['copyrightholder'] = '<+YOU OR YOUR COMPANY+>'
+        elif self._info['is_component']:
+            print "For GNUradio components the FSF is added as copyright holder"
         self._info['license'] = self.setup_choose_license()
-
         if options.argument_list is not None:
             self._info['arglist'] = options.argument_list
         else:
@@ -140,7 +145,7 @@ class ModToolAdd(ModTool):
         elif self._info['is_component']:
             return Templates['grlicense']
         else:
-            return Templates['defaultlicense']
+            return get_template('defaultlicense', **self._info)
 
     def _write_tpl(self, tpl, path, fname):
         """ Shorthand for writing a substituted template to a file"""

--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -103,11 +103,13 @@ class ModToolAdd(ModTool):
             raise ModToolException('Invalid block name.')
         print "Block/code identifier: " + self._info['blockname']
         self._info['fullblockname'] = self._info['modname'] + '_' + self._info['blockname']
-        self._info['copyrightholder'] = options.copyright
-        if self._info['copyrightholder'] is None:
-            self._info['copyrightholder'] = '<+YOU OR YOUR COMPANY+>'
-        elif self._info['is_component']:
-            print "For GNUradio components the FSF is added as copyright holder"
+        if not options.license_file:
+            self._info['copyrightholder'] = options.copyright
+            if self._info['copyrightholder'] is None:
+                self._info['copyrightholder'] = '<+YOU OR YOUR COMPANY+>'
+            elif self._info['is_component']:
+                print "For GNU Radio components the FSF is added as copyright holder"
+        self._license_file = options.license_file
         self._info['license'] = self.setup_choose_license()
         if options.argument_list is not None:
             self._info['arglist'] = options.argument_list
@@ -127,7 +129,6 @@ class ModToolAdd(ModTool):
             print "Warning: Autotools modules are not supported. ",
             print "Files will be created, but Makefiles will not be edited."
             self._skip_cmakefiles = True
-        self._license_file = options.license_file
 
     def setup_choose_license(self):
         """ Select a license by the following rules, in this order:

--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -26,7 +26,7 @@ Templates = {}
 
 # Default licence
 Templates['defaultlicense'] = '''
-Copyright %d <+YOU OR YOUR COMPANY+>.
+Copyright %d ${copyrightholder}.
 
 This is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Maybe this option would be nice to have to add one's name with gr_modtool instead manually or with sed. Since we are using templates anyway we can give an option. Fallback is current behaviour, maybe an interactive behaviour is also desirable?