### PR TITLE
qtgui: Added the ability to control the Y axis label for the freq sink

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.xml
@@ -22,6 +22,7 @@ qtgui.$(type.fcn)(
 )
 self.$(id).set_update_time($update_time)
 self.$(id).set_y_axis($ymin, $ymax)
+self.$(id).set_y_label($label, $units)
 self.$(id).set_trigger_mode($tr_mode, $tr_level, $tr_chan, $tr_tag)
 self.$(id).enable_autoscale($autoscale)
 self.$(id).enable_grid($grid)
@@ -248,6 +249,22 @@ $(gui_hint()($win))</make>
     <key>ymax</key>
     <value>10</value>
     <type>real</type>
+    <hide>part</hide>
+  </param>
+
+  <param>
+    <name>Y label</name>
+    <key>label</key>
+    <value>Relative Gain</value>
+    <type>string</type>
+    <hide>part</hide>
+  </param>
+
+  <param>
+    <name>Y units</name>
+    <key>units</key>
+    <value>dB</value>
+    <type>string</type>
     <hide>part</hide>
   </param>
 

--- a/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
@@ -118,6 +118,9 @@ public slots:
 
   void setPlotPosHalf(bool half);
 
+  void setYLabel(const std::string &label,
+                 const std::string &unit);
+
   void clearMaxData();
   void clearMinData();
 

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -128,6 +128,7 @@ namespace gr {
       virtual void set_update_time(double t) = 0;
 
       virtual void set_title(const std::string &title) = 0;
+      virtual void set_y_label(const std::string &label, const std::string &unit) = 0;
       virtual void set_line_label(int which, const std::string &label) = 0;
       virtual void set_line_color(int which, const std::string &color) = 0;
       virtual void set_line_width(int which, int width) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -126,7 +126,9 @@ namespace gr {
       virtual void set_y_axis(double min, double max) = 0;
 
       virtual void set_update_time(double t) = 0;
+
       virtual void set_title(const std::string &title) = 0;
+      virtual void set_y_label(const std::string &label, const std::string &unit) = 0;
       virtual void set_line_label(int which, const std::string &label) = 0;
       virtual void set_line_color(int which, const std::string &color) = 0;
       virtual void set_line_width(int which, int width) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -75,6 +75,8 @@ public slots:
   void setFrequencyRange(const double centerfreq,
 			 const double bandwidth);
   void setYaxis(double min, double max);
+  void setYLabel(const std::string &label,
+                 const std::string &unit="");
   void setYMax(const QString &m);
   void setYMin(const QString &m);
   void autoScale(bool en);

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -97,7 +97,7 @@ FrequencyDisplayPlot::FrequencyDisplayPlot(int nplots, QWidget* parent)
   d_ymax = 10;
   setAxisScaleEngine(QwtPlot::yLeft, new QwtLinearScaleEngine);
   setAxisScale(QwtPlot::yLeft, d_ymin, d_ymax);
-  setAxisTitle(QwtPlot::yLeft, "Power (dB)");
+  setAxisTitle(QwtPlot::yLeft, "Relative Gain (dB)");
 
   QList<QColor> default_colors;
   default_colors << QColor(Qt::blue) << QColor(Qt::red) << QColor(Qt::green)
@@ -597,6 +597,17 @@ FrequencyDisplayPlot::onPickerPointSelected6(const QPointF & p)
   //fprintf(stderr,"onPickerPointSelected %f %f %d\n", point.x(), point.y(), d_xdata_multiplier);
   point.setX(point.x() * d_xdata_multiplier);
   emit plotPointSelected(point);
+}
+
+void
+FrequencyDisplayPlot::setYLabel(const std::string &label,
+                                const std::string &unit)
+{
+  std::string l = label;
+  if(unit.length() > 0)
+    l += " (" + unit + ")";
+  setAxisTitle(QwtPlot::yLeft, QString(l.c_str()));
+  ((FreqDisplayZoomer*)d_zoomer)->setUnitType(unit);
 }
 
 void

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -266,6 +266,13 @@ namespace gr {
     }
 
     void
+    freq_sink_c_impl::set_y_label(const std::string &label,
+                                  const std::string &unit)
+    {
+        d_main_gui->setYLabel(label, unit);
+    }
+
+    void
     freq_sink_c_impl::set_update_time(double t)
     {
       //convert update time to ticks

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -123,6 +123,7 @@ namespace gr {
       void set_update_time(double t);
 
       void set_title(const std::string &title);
+      void set_y_label(const std::string &label, const std::string &unit);
       void set_line_label(int which, const std::string &label);
       void set_line_color(int which, const std::string &color);
       void set_line_width(int which, int width);

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -265,6 +265,13 @@ namespace gr {
     }
 
     void
+    freq_sink_f_impl::set_y_label(const std::string &label,
+                                  const std::string &unit)
+    {
+        d_main_gui->setYLabel(label, unit);
+    }
+
+    void
     freq_sink_f_impl::set_update_time(double t)
     {
       //convert update time to ticks

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -122,6 +122,7 @@ namespace gr {
 
       void set_update_time(double t);
       void set_title(const std::string &title);
+      void set_y_label(const std::string &label, const std::string &unit);
       void set_line_label(int which, const std::string &label);
       void set_line_color(int which, const std::string &color);
       void set_line_width(int which, int width);

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -323,6 +323,12 @@ FreqDisplayForm::setYaxis(double min, double max)
   getPlot()->setYaxis(min, max);
 }
 
+void FreqDisplayForm::setYLabel(const std::string &label,
+                                const std::string &unit)
+{
+  getPlot()->setYLabel(label, unit);
+}
+
 void
 FreqDisplayForm::setYMax(const QString &m)
 {


### PR DESCRIPTION
- Useful if the input device is calibrated and one wants to display Power (dBm) rather than Relative Gain (dB)