### PR TITLE
analog: add ControlPort interfaces to frequency_modulator block.

### DIFF
--- a/gr-analog/lib/CMakeLists.txt
+++ b/gr-analog/lib/CMakeLists.txt
@@ -110,17 +110,6 @@ GR_LIBRARY_FOO(gnuradio-analog RUNTIME_COMPONENT "analog_runtime" DEVEL_COMPONEN
 add_dependencies(gnuradio-analog analog_generated_includes analog_generated_swigs gnuradio-filter)
 
 if(ENABLE_STATIC_LIBS)
-  if(ENABLE_GR_CTRLPORT)
-    # Remove GR_CTRLPORT set this target's definitions.
-    # Makes sure we don't try to use ControlPort stuff in source files
-    GET_DIRECTORY_PROPERTY(STATIC_DEFS COMPILE_DEFINITIONS)
-    list(REMOVE_ITEM STATIC_DEFS "GR_CTRLPORT")
-    SET_PROPERTY(DIRECTORY PROPERTY COMPILE_DEFINITIONS "${STATIC_DEFS}")
-
-    # readd it to the target since we removed it from the directory-wide list.
-    SET_PROPERTY(TARGET gnuradio-analog APPEND PROPERTY COMPILE_DEFINITIONS "GR_CTRLPORT")
-  endif(ENABLE_GR_CTRLPORT)
-
   add_library(gnuradio-analog_static STATIC ${analog_sources})
 
   add_dependencies(gnuradio-analog_static

--- a/gr-analog/lib/frequency_modulator_fc_impl.cc
+++ b/gr-analog/lib/frequency_modulator_fc_impl.cc
@@ -76,5 +76,27 @@ namespace gr {
       return noutput_items;
     }
 
+    void
+    frequency_modulator_fc_impl::setup_rpc()
+    {
+#ifdef GR_CTRLPORT
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_get<frequency_modulator_fc, float>(
+	  alias(), "sensitivity",
+	  &frequency_modulator_fc::sensitivity,
+	  pmt::mp(-1024.0f), pmt::mp(1024.0f), pmt::mp(0.0f),
+	  "", "Sensitivity", RPC_PRIVLVL_MIN,
+          DISPTIME | DISPOPTSTRIP)));
+
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_set<frequency_modulator_fc, float>(
+	  alias(), "sensitivity",
+	  &frequency_modulator_fc::set_sensitivity,
+	  pmt::mp(-1024.0f), pmt::mp(1024.0f), pmt::mp(0.0f),
+	  "", "sensitivity",
+	  RPC_PRIVLVL_MIN, DISPNULL)));
+#endif /* GR_CTRLPORT */
+
+    }
   } /* namespace analog */
 } /* namespace gr */

--- a/gr-analog/lib/frequency_modulator_fc_impl.h
+++ b/gr-analog/lib/frequency_modulator_fc_impl.h
@@ -41,6 +41,8 @@ namespace gr {
       void set_sensitivity(float sens) { d_sensitivity = sens; }
       float sensitivity() const { return d_sensitivity; }
 
+      void setup_rpc();
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);


### PR DESCRIPTION
Change cmake file to allow ControlPort even for static library builds.