### PR TITLE
qtgui: fixed a stray +1 that was duplicating tags.

### DIFF
--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -652,7 +652,7 @@ namespace gr {
 
         uint64_t nr = nitems_read(n);
         std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, n, nr, nr + nitems + 1);
+        get_tags_in_range(tags, n, nr, nr + nitems);
         for(size_t t = 0; t < tags.size(); t++) {
           tags[t].offset = tags[t].offset - nr + (d_index-d_start-1);
         }

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -643,7 +643,7 @@ namespace gr {
 
         uint64_t nr = nitems_read(idx);
         std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, idx, nr, nr + nitems + 1);
+        get_tags_in_range(tags, idx, nr, nr + nitems);
         for(size_t t = 0; t < tags.size(); t++) {
           tags[t].offset = tags[t].offset - nr + (d_index-d_start-1);
         }


### PR DESCRIPTION
When this was looking at the very end of the buffer, the +1 was a
look-ahead based on history; but this would then become the 0th
element the next call to work and would double up on that tag.