### PR TITLE
gr_modtool: correctly rename GRC files

### DIFF
--- a/gr-utils/python/modtool/modtool_rename.py
+++ b/gr-utils/python/modtool/modtool_rename.py
@@ -168,7 +168,7 @@ class ModToolRename(ModTool):
         grcfile = './grc/' + module + '_' + old + '.xml'
         self._run_file_replace(grcfile, old, new)
         self._run_cmakelists('./grc/', old, new)
-        self._run_file_rename('./grc/', old, new)
+        self._run_file_rename('./grc/', module + '_' + old, module + '_' + new)
 
     def _run_cmakelists(self, path, first, second):
         filename = path + 'CMakeLists.txt'


### PR DESCRIPTION
The `gr_modtool rename` command attempts to move GRC XML files based on block name, however the files have the module name prefixed, and attempts to rename the wrong files. This fixes that.