### PR TITLE
CMake: Fix dummy command in UseSWIG.cmake

### DIFF
--- a/cmake/Modules/UseSWIG.cmake
+++ b/cmake/Modules/UseSWIG.cmake
@@ -224,9 +224,9 @@ print(re.sub('\\W', '_', '${name} ${reldir} ' + unique))"
   foreach(swig_gen_file ${${outfiles}})
     add_custom_command(
       OUTPUT ${swig_gen_file}
-      COMMAND ""
+      COMMAND
       DEPENDS ${_target}
-      COMMENT ""
+      COMMENT
     )
   endforeach()
 


### PR DESCRIPTION
Having the COMMAND parameter of the add_custom_command() function as an
empty string only works on Linux when generating Makefiles. It did not
work on Linux when using a different generator (in my case, Ninja), or
when building under Visual Studio.

This commit changes the empty string for a real command that will work
on all system / build system couples possible.

Signed-off-by: Paul Cercueil <paul.cercueil@analog.com>