### PR TITLE
Filter docs

### DIFF
--- a/gr-filter/include/gnuradio/filter/firdes.h
+++ b/gr-filter/include/gnuradio/filter/firdes.h
@@ -348,9 +348,10 @@ namespace gr {
       /*!
        * \brief design a Gaussian filter
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p symbols per bit:	symbol rate, must be a factor of sample rate
-       * \p ntaps:		number of taps
+       * \p gain:           overall gain of filter (typically 1.0)
+       * \p symbols/bit:    symbol rate, must be a factor of sample rate
+       * \p bt:             bandwidth to bitrate ratio
+       * \p ntaps:          number of taps
        */
       static std::vector<float>
 	gaussian(double gain,

--- a/gr-filter/include/gnuradio/filter/firdes.h
+++ b/gr-filter/include/gnuradio/filter/firdes.h
@@ -89,7 +89,7 @@ namespace gr {
        *
        * \param gain                overall gain of filter (typically 1.0)
        * \param sampling_freq       sampling freq (Hz)
-       * \param cutoff_freq         center of transition band (Hz)
+       * \param cutoff_freq         beginning of transition band (Hz)
        * \param transition_width    width of transition band (Hz)
        * \param attenuation_dB      required stopband attenuation
        * \param window              one of firdes::win_type

--- a/gr-filter/include/gnuradio/filter/firdes.h
+++ b/gr-filter/include/gnuradio/filter/firdes.h
@@ -60,304 +60,282 @@ namespace gr {
       // ... class methods ...
 
       /*!
-       * \brief use "window method" to design a low-pass FIR filter
+       * \brief Use "window method" to design a low-pass FIR filter.  The
+       * normalized width of the transition band is what sets the number of
+       * taps required.  Narrow --> more taps.  Window type determines maximum
+       * attenuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       *			The normalized width of the transition
-       *			band is what sets the number of taps
-       *			required.  Narrow --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param cutoff_freq	        center of transition band (Hz)
+       * \param transition_width	width of transition band (Hz)
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
        */
       static std::vector<float>
-	low_pass(double gain,
-		 double sampling_freq,
-		 double cutoff_freq,		// Hz center of transition band
-		 double transition_width,	// Hz width of transition band
-		 win_type window = WIN_HAMMING,
-		 double beta = 6.76);		// used only with Kaiser
+      low_pass(double gain,
+        double sampling_freq,
+        double cutoff_freq,		// Hz center of transition band
+        double transition_width,	// Hz width of transition band
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);		// used only with Kaiser
 
       /*!
-       * \brief use "window method" to design a low-pass FIR filter
+       * \brief Use "window method" to design a low-pass FIR filter.  The
+       * normalized width of the transition band and the required stop band
+       * attenuation is what sets the number of taps required.  Narrow --> more
+       * taps More attenuation --> more taps. The window type determines
+       * maximum attentuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       * \p attenuation_dB      required stopband attenuation
-       *			The normalized width of the transition
-       *			band and the required stop band
-       *                        attenuation is what sets the number of taps
-       *			required.  Narrow --> more taps
-       *                        More attenuatin --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
-       */
-
-      static std::vector<float>
-	low_pass_2(double gain,
-		   double sampling_freq,
-		   double cutoff_freq,		// Hz beginning transition band
-		   double transition_width,	// Hz width of transition band
-		   double attenuation_dB,       // out of band attenuation dB
-		   win_type window = WIN_HAMMING,
-		   double beta = 6.76);		// used only with Kaiser
-
-      /*!
-       * \brief use "window method" to design a high-pass FIR filter
-       *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       *			The normalized width of the transition
-       *			band is what sets the number of taps
-       *			required.  Narrow --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
-       */
-
-      static std::vector<float>
-	high_pass(double gain,
-		  double sampling_freq,
-		  double cutoff_freq,		// Hz center of transition band
-		  double transition_width,	// Hz width of transition band
-		  win_type window = WIN_HAMMING,
-		  double beta = 6.76);		// used only with Kaiser
-
-      /*!
-       * \brief use "window method" to design a high-pass FIR filter
-       *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       * \p attenuation_dB      out of band attenuation
-       *			The normalized width of the transition
-       *			band and the required stop band
-       *                        attenuation is what sets the number of taps
-       *			required.  Narrow --> more taps
-       *                        More attenuation --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
-       */
-
-      static std::vector<float>
-	high_pass_2(double gain,
-		    double sampling_freq,
-		    double cutoff_freq,		// Hz center of transition band
-		    double transition_width,	// Hz width of transition band
-		    double attenuation_dB,      // out of band attenuation dB
-		    win_type window = WIN_HAMMING,
-		    double beta = 6.76);	// used only with Kaiser
-
-      /*!
-       * \brief use "window method" to design a band-pass FIR filter
-       *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p low_cutoff_freq:	center of transition band (Hz)
-       * \p high_cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       *			The normalized width of the transition
-       *			band is what sets the number of taps
-       *			required.  Narrow --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param cutoff_freq         center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz)
+       * \param attenuation_dB      required stopband attenuation
+       * \param window              one of firdes::win_type
+       * \param beta		        parameter for Kaiser window
        */
       static std::vector<float>
-	band_pass(double gain,
-		  double sampling_freq,
-		  double low_cutoff_freq,	// Hz center of transition band
-		  double high_cutoff_freq,	// Hz center of transition band
-		  double transition_width,	// Hz width of transition band
-		  win_type window = WIN_HAMMING,
-		  double beta = 6.76);		// used only with Kaiser
+      low_pass_2(double gain,
+        double sampling_freq,
+        double cutoff_freq,		// Hz beginning transition band
+        double transition_width,	// Hz width of transition band
+        double attenuation_dB,       // out of band attenuation dB
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);		// used only with Kaiser
 
       /*!
-       * \brief use "window method" to design a band-pass FIR filter
+       * \brief Use "window method" to design a high-pass FIR filter.  The
+       * normalized width of the transition band is what sets the number of
+       * taps required.  Narrow --> more taps. The window determines maximum
+       * attenuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p low_cutoff_freq:	center of transition band (Hz)
-       * \p high_cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       * \p attenuation_dB      out of band attenuation
-       *			The normalized width of the transition
-       *			band and the required stop band
-       *                        attenuation is what sets the number of taps
-       *			required.  Narrow --> more taps
-       *                        More attenuation --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param cutoff_freq         center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz)
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
        */
-
       static std::vector<float>
-	band_pass_2(double gain,
-		    double sampling_freq,
-		    double low_cutoff_freq,	// Hz beginning transition band
-		    double high_cutoff_freq,	// Hz beginning transition band
-		    double transition_width,	// Hz width of transition band
-		    double attenuation_dB,      // out of band attenuation dB
-		    win_type window = WIN_HAMMING,
-		    double beta = 6.76);	// used only with Kaiser
+      high_pass(double gain,
+        double sampling_freq,
+        double cutoff_freq,		// Hz center of transition band
+        double transition_width,	// Hz width of transition band
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);		// used only with Kaiser
 
       /*!
-       * \brief use "window method" to design a complex band-pass FIR filter
+       * \brief Use "window method" to design a high-pass FIR filter. The
+       * normalized width of the transition band and the required stop band
+       * attenuation is what sets the number of taps required.  Narrow --> more
+       * taps More attenuation --> more taps. The window determines maximum
+       * attenuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p low_cutoff_freq:	center of transition band (Hz)
-       * \p high_cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       *			The normalized width of the transition
-       *			band is what sets the number of taps
-       *			required.  Narrow --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param cutoff_freq         center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz).
+       * \param attenuation_dB      out of band attenuation
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
+       */
+      static std::vector<float>
+      high_pass_2(double gain,
+        double sampling_freq,
+        double cutoff_freq,		// Hz center of transition band
+        double transition_width,	// Hz width of transition band
+        double attenuation_dB,      // out of band attenuation dB
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);	// used only with Kaiser
+
+      /*!
+       * \brief Use "window method" to design a band-pass FIR filter. The
+       * normalized width of the transition band is what sets the number of
+       * taps required.  Narrow --> more taps. The window determines maximum
+       * attenuation and passband ripple.
+       *
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param low_cutoff_freq     center of transition band (Hz)
+       * \param high_cutoff_freq    center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz).
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
+       */
+      static std::vector<float>
+      band_pass(double gain,
+        double sampling_freq,
+        double low_cutoff_freq,	// Hz center of transition band
+        double high_cutoff_freq,	// Hz center of transition band
+        double transition_width,	// Hz width of transition band
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);		// used only with Kaiser
+
+      /*!
+       * \brief Use "window method" to design a band-pass FIR filter.  The
+       * normalized width of the transition band and the required stop band
+       * attenuation is what sets the number of taps required.  Narrow --> more
+       * taps.  More attenuation --> more taps.  Window type determines maximum
+       * attenuation and passband ripple.
+       *
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param low_cutoff_freq     center of transition band (Hz)
+       * \param high_cutoff_freq    center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz).
+       * \param attenuation_dB      out of band attenuation
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
+       */
+      static std::vector<float>
+      band_pass_2(double gain,
+        double sampling_freq,
+        double low_cutoff_freq,	// Hz beginning transition band
+        double high_cutoff_freq,	// Hz beginning transition band
+        double transition_width,	// Hz width of transition band
+        double attenuation_dB,      // out of band attenuation dB
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);	// used only with Kaiser
+
+      /*!
+       * \brief Use the "window method" to design a complex band-pass FIR
+       * filter.  The normalized width of the transition band is what sets the
+       * number of taps required.  Narrow --> more taps. The window type
+       * determines maximum attenuation and passband ripple.
+       *
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param low_cutoff_freq     center of transition band (Hz)
+       * \param high_cutoff_freq    center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz)
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
        */
       static std::vector<gr_complex>
-	complex_band_pass(double gain,
-			  double sampling_freq,
-			  double low_cutoff_freq,	// Hz center of transition band
-			  double high_cutoff_freq,	// Hz center of transition band
-			  double transition_width,	// Hz width of transition band
-			  win_type window = WIN_HAMMING,
-			  double beta = 6.76);		// used only with Kaiser
+      complex_band_pass(double gain,
+        double sampling_freq,
+        double low_cutoff_freq,	// Hz center of transition band
+        double high_cutoff_freq,	// Hz center of transition band
+        double transition_width,	// Hz width of transition band
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);		// used only with Kaiser
 
       /*!
-       * \brief use "window method" to design a complex band-pass FIR filter
+       * \brief Use "window method" to design a complex band-pass FIR filter.
+       * The normalized width of the transition band and the required stop band
+       * attenuation is what sets the number of taps required.  Narrow --> more
+       * taps More attenuation --> more taps. Window type determines maximum
+       * attenuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p low_cutoff_freq:	center of transition band (Hz)
-       * \p high_cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       * \p attenuation_dB      out of band attenuation
-       *			The normalized width of the transition
-       *			band and the required stop band
-       *                        attenuation is what sets the number of taps
-       *			required.  Narrow --> more taps
-       *                        More attenuation --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param low_cutoff_freq     center of transition band (Hz)
+       * \param high_cutoff_freq    center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz)
+       * \param attenuation_dB      out of band attenuation
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
        */
-
       static std::vector<gr_complex>
-	complex_band_pass_2(double gain,
-			    double sampling_freq,
-			    double low_cutoff_freq,	// Hz beginning transition band
-			    double high_cutoff_freq,	// Hz beginning transition band
-			    double transition_width,	// Hz width of transition band
-			    double attenuation_dB,      // out of band attenuation dB
-			    win_type window = WIN_HAMMING,
-			    double beta = 6.76);	// used only with Kaiser
+      complex_band_pass_2(double gain,
+        double sampling_freq,
+        double low_cutoff_freq,	// Hz beginning transition band
+        double high_cutoff_freq,	// Hz beginning transition band
+        double transition_width,	// Hz width of transition band
+        double attenuation_dB,      // out of band attenuation dB
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);	// used only with Kaiser
 
       /*!
-       * \brief use "window method" to design a band-reject FIR filter
+       * \brief Use "window method" to design a band-reject FIR filter.  The
+       * normalized width of the transition band is what sets the number of
+       * taps required.  Narrow --> more taps. Window type determines maximum
+       * attenuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p low_cutoff_freq:	center of transition band (Hz)
-       * \p high_cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       *			The normalized width of the transition
-       *			band is what sets the number of taps
-       *			required.  Narrow --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param low_cutoff_freq     center of transition band (Hz)
+       * \param high_cutoff_freq    center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz)
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
        */
-
       static std::vector<float>
-	band_reject(double gain,
-		    double sampling_freq,
-		    double low_cutoff_freq,	// Hz center of transition band
-		    double high_cutoff_freq,	// Hz center of transition band
-		    double transition_width,	// Hz width of transition band
-		    win_type window = WIN_HAMMING,
-		    double beta = 6.76);	// used only with Kaiser
+      band_reject(double gain,
+        double sampling_freq,
+        double low_cutoff_freq,	// Hz center of transition band
+        double high_cutoff_freq,	// Hz center of transition band
+        double transition_width,	// Hz width of transition band
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);	// used only with Kaiser
 
       /*!
-       * \brief use "window method" to design a band-reject FIR filter
+       * \brief Use "window method" to design a band-reject FIR filter.  The
+       * normalized width of the transition band and the required stop band
+       * attenuation is what sets the number of taps required.  Narrow --> more
+       * taps More attenuation --> more taps.  Window type determines maximum
+       * attenuation and passband ripple.
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p low_cutoff_freq:	center of transition band (Hz)
-       * \p high_cutoff_freq:	center of transition band (Hz)
-       * \p transition_width:	width of transition band (Hz).
-       * \p attenuation_dB      out of band attenuation
-       *			The normalized width of the transition
-       *			band and the required stop band
-       *                        attenuation is what sets the number of taps
-       *			required.  Narrow --> more taps
-       *                        More attenuation --> more taps
-       * \p window_type: 	What kind of window to use. Determines
-       *			maximum attenuation and passband ripple.
-       * \p beta:		parameter for Kaiser window
+       * \param gain                overall gain of filter (typically 1.0)
+       * \param sampling_freq       sampling freq (Hz)
+       * \param low_cutoff_freq     center of transition band (Hz)
+       * \param high_cutoff_freq    center of transition band (Hz)
+       * \param transition_width    width of transition band (Hz).
+       * \param attenuation_dB      out of band attenuation
+       * \param window              one of firdes::win_type
+       * \param beta                parameter for Kaiser window
        */
-
       static std::vector<float>
-	band_reject_2(double gain,
-		      double sampling_freq,
-		      double low_cutoff_freq,	// Hz beginning transition band
-		      double high_cutoff_freq,	// Hz beginning transition band
-		      double transition_width,	// Hz width of transition band
-		      double attenuation_dB,    // out of band attenuation dB
-		      win_type window = WIN_HAMMING,
-		      double beta = 6.76);	// used only with Kaiser
+      band_reject_2(double gain,
+        double sampling_freq,
+        double low_cutoff_freq,	// Hz beginning transition band
+        double high_cutoff_freq,	// Hz beginning transition band
+        double transition_width,	// Hz width of transition band
+        double attenuation_dB,    // out of band attenuation dB
+        win_type window = WIN_HAMMING,
+        double beta = 6.76);	// used only with Kaiser
 
       /*!\brief design a Hilbert Transform Filter
        *
-       * \p ntaps:              Number of taps, must be odd
-       * \p window_type:        What kind of window to use
-       * \p beta:               Only used for Kaiser
+       * \param ntaps           number of taps, must be odd
+       * \param windowtype      one kind of firdes::win_type
+       * \param beta            parameter for Kaiser window
        */
       static std::vector<float>
-	hilbert(unsigned int ntaps = 19,
-		win_type windowtype = WIN_RECTANGULAR,
-		double beta = 6.76);
+      hilbert(unsigned int ntaps = 19,
+        win_type windowtype = WIN_RECTANGULAR,
+        double beta = 6.76);
 
       /*!
        * \brief design a Root Cosine FIR Filter (do we need a window?)
        *
-       * \p gain:		overall gain of filter (typically 1.0)
-       * \p sampling_freq:	sampling freq (Hz)
-       * \p symbol rate:	symbol rate, must be a factor of sample rate
-       * \p alpha:		excess bandwidth factor
-       * \p ntaps:		number of taps
+       * \param gain            overall gain of filter (typically 1.0)
+       * \param sampling_freq   sampling freq (Hz)
+       * \param symbol_rate     symbol rate, must be a factor of sample rate
+       * \param alpha           excess bandwidth factor
+       * \param ntaps           number of taps
        */
       static std::vector<float>
-	root_raised_cosine(double gain,
-			   double sampling_freq,
-			   double symbol_rate, // Symbol rate, NOT bitrate (unless BPSK)
-			   double alpha,       // Excess Bandwidth Factor
-			   int ntaps);
+      root_raised_cosine(double gain,
+        double sampling_freq,
+        double symbol_rate, // Symbol rate, NOT bitrate (unless BPSK)
+        double alpha,       // Excess Bandwidth Factor
+        int ntaps);
 
       /*!
        * \brief design a Gaussian filter
        *
-       * \p gain:           overall gain of filter (typically 1.0)
-       * \p symbols/bit:    symbol rate, must be a factor of sample rate
-       * \p bt:             bandwidth to bitrate ratio
-       * \p ntaps:          number of taps
+       * \param gain    overall gain of filter (typically 1.0)
+       * \param spb     symbol rate, must be a factor of sample rate
+       * \param bt      bandwidth to bitrate ratio
+       * \param ntaps   number of taps
        */
       static std::vector<float>
-	gaussian(double gain,
-		 double spb,
-		 double bt,     // Bandwidth to bitrate ratio
-		 int ntaps);
+      gaussian(double gain,
+        double spb,
+        double bt,     // Bandwidth to bitrate ratio
+        int ntaps);
 
     private:
       static double bessi0(double x);

--- a/gr-filter/lib/firdes.cc
+++ b/gr-filter/lib/firdes.cc
@@ -590,13 +590,13 @@ namespace gr {
       double t0 = -0.5 * ntaps;
       double ts;
       for(int i=0;i<ntaps;i++) {
-	t0++;
-	ts = s*dt*t0;
-	taps[i] = exp(-0.5*ts*ts);
-	scale += taps[i];
+        t0++;
+        ts = s*dt*t0;
+        taps[i] = exp(-0.5*ts*ts);
+        scale += taps[i];
       }
       for(int i=0;i<ntaps;i++)
-	taps[i] = taps[i] / scale * gain;
+        taps[i] = taps[i] / scale * gain;
 
       return taps;
     }


### PR DESCRIPTION
Firdes docs (parameters) don't look so hot, so this fixes up formatting and moves some language around. Also, fixes a couple of errors in the docs (missing bt parameter for gaussian, and cutoff specificed as center or beginning of low_pass_2) .

Since I was already mucking with formatting of the docs I took some liberties with whitespace on the declarations as well.