### PR TITLE
digital: fix access code mask in correlate_access_code_XX_ts

### DIFF
--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -84,8 +84,8 @@ namespace gr {
       if(d_len > 64)
         return false;
 
-      // set len top bits to 1.
-      d_mask = ((~0ULL) >> (64 - d_len)) << (64 - d_len);
+      // set len least significant bits to 1.
+      d_mask = ((~0ULL) >> (64 - d_len));
 
       d_access_code = 0;
       for(unsigned i=0; i < d_len; i++){

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -84,8 +84,8 @@ namespace gr {
       if(d_len > 64)
         return false;
 
-      // set len top bits to 1.
-      d_mask = ((~0ULL) >> (64 - d_len)) << (64 - d_len);
+      // set len least significant bits to 1.
+      d_mask = ((~0ULL) >> (64 - d_len));
 
       d_access_code = 0;
       for(unsigned i=0; i < d_len; i++){


### PR DESCRIPTION
Fixes the mask used in the correlate_access_code_XX_ts blocks to use the access_code_length least significant bits instead of most significant bits.