### PR TITLE
Fft avx alignment

### DIFF
--- a/gr-fft/lib/CMakeLists.txt
+++ b/gr-fft/lib/CMakeLists.txt
@@ -57,6 +57,7 @@ endif(ENABLE_GR_CTRLPORT)
 
 list(APPEND fft_libs
     gnuradio-runtime
+    ${VOLK_LIBRARIES}
     ${Boost_LIBRARIES}
     ${FFTW3F_LIBRARIES}
 )

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -22,6 +22,8 @@
 
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/sys_paths.h>
+#include <gnuradio/gr_complex.h>
+#include <volk/volk.h>
 #include <fftw3.h>
 
 #ifdef _MSC_VER //http://www.fftw.org/install/windows.html#DLLwisdom
@@ -36,7 +38,6 @@ static int my_fftw_read_char(void *f) { return fgetc((FILE *) f); }
 #define fftwl_import_wisdom_from_file(f) fftwl_import_wisdom(my_fftw_read_char, (void*) (f))
 #endif //_MSC_VER
 
-#include <gnuradio/gr_complex.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -53,25 +54,25 @@ namespace gr {
     gr_complex *
     malloc_complex(int size)
     {
-      return (gr_complex*)fftwf_malloc(sizeof(gr_complex)*size);
+      return (gr_complex*) volk_malloc (sizeof (gr_complex)*size, volk_get_alignment ());
     }
 
     float *
     malloc_float(int size)
     {
-      return (float*)fftwf_malloc(sizeof(float)*size);
+      return (float*) volk_malloc (sizeof (float)*size, volk_get_alignment ());
     }
 
     double *
     malloc_double(int size)
     {
-      return (double*)fftwf_malloc(sizeof(double)*size);
+      return (double*) volk_malloc (sizeof (double)*size, volk_get_alignment ());
     }
 
     void
     free(void *b)
     {
-      fftwf_free(b);
+      volk_free(b);
     }
 
     boost::mutex &
@@ -149,14 +150,14 @@ namespace gr {
       }
 
       d_fft_size = fft_size;
-      d_inbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * inbuf_length ());
+      d_inbuf = (gr_complex *) volk_malloc (sizeof (gr_complex) * inbuf_length (), volk_get_alignment ());
       if (d_inbuf == 0) {
-        throw std::runtime_error ("fftwf_malloc");
+        throw std::runtime_error ("volk_malloc");
       }
-      d_outbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * outbuf_length ());
+      d_outbuf = (gr_complex *) volk_malloc (sizeof (gr_complex) * outbuf_length (), volk_get_alignment ());
       if (d_outbuf == 0) {
-        fftwf_free (d_inbuf);
-        throw std::runtime_error ("fftwf_malloc");
+        volk_free (d_inbuf);
+        throw std::runtime_error ("volk_malloc");
       }
 
       d_nthreads = nthreads;
@@ -182,8 +183,8 @@ namespace gr {
       planner::scoped_lock lock(planner::mutex());
 
       fftwf_destroy_plan ((fftwf_plan) d_plan);
-      fftwf_free (d_inbuf);
-      fftwf_free (d_outbuf);
+      volk_free (d_inbuf);
+      volk_free (d_outbuf);
     }
 
     void
@@ -219,15 +220,15 @@ namespace gr {
       }
 
       d_fft_size = fft_size;
-      d_inbuf = (float *) fftwf_malloc (sizeof (float) * inbuf_length ());
+      d_inbuf = (float *) volk_malloc (sizeof (float) * inbuf_length (), volk_get_alignment ());
       if (d_inbuf == 0) {
-        throw std::runtime_error ("fftwf_malloc");
+        throw std::runtime_error ("volk_malloc");
       }
 
-      d_outbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * outbuf_length ());
+      d_outbuf = (gr_complex *) volk_malloc (sizeof (gr_complex) * outbuf_length (), volk_get_alignment ());
       if (d_outbuf == 0) {
-        fftwf_free (d_inbuf);
-        throw std::runtime_error ("fftwf_malloc");
+        volk_free (d_inbuf);
+        throw std::runtime_error ("volk_malloc");
       }
 
       d_nthreads = nthreads;
@@ -252,8 +253,8 @@ namespace gr {
       planner::scoped_lock lock(planner::mutex());
 
       fftwf_destroy_plan ((fftwf_plan) d_plan);
-      fftwf_free (d_inbuf);
-      fftwf_free (d_outbuf);
+      volk_free (d_inbuf);
+      volk_free (d_outbuf);
     }
 
     void
@@ -289,15 +290,15 @@ namespace gr {
       }
 
       d_fft_size = fft_size;
-      d_inbuf = (gr_complex *) fftwf_malloc (sizeof (gr_complex) * inbuf_length ());
+      d_inbuf = (gr_complex *) volk_malloc (sizeof (gr_complex) * inbuf_length (), volk_get_alignment ());
       if (d_inbuf == 0) {
-        throw std::runtime_error ("fftwf_malloc");
+        throw std::runtime_error ("volk_malloc");
       }
 
-      d_outbuf = (float *) fftwf_malloc (sizeof (float) * outbuf_length ());
+      d_outbuf = (float *) volk_malloc (sizeof (float) * outbuf_length (), volk_get_alignment ());
       if (d_outbuf == 0) {
-        fftwf_free (d_inbuf);
-        throw std::runtime_error ("fftwf_malloc");
+        volk_free (d_inbuf);
+        throw std::runtime_error ("volk_malloc");
       }
 
       d_nthreads = nthreads;
@@ -325,8 +326,8 @@ namespace gr {
       planner::scoped_lock lock(planner::mutex());
 
       fftwf_destroy_plan ((fftwf_plan) d_plan);
-      fftwf_free (d_inbuf);
-      fftwf_free (d_outbuf);
+      volk_free (d_inbuf);
+      volk_free (d_outbuf);
     }
 
     void


### PR DESCRIPTION
Always use volk_malloc and free, never fftwf_malloc/free, because it might not be built with AVX support which will cause alignment faults when these buffers are fed in to VOLK.