### PR TITLE
gr-fec: Fix errors when using the LDPC blocks in GRC

### DIFF
--- a/gr-fec/examples/ber_curve_gen_ldpc.grc
+++ b/gr-fec/examples/ber_curve_gen_ldpc.grc
@@ -249,7 +249,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(632, 547)</value>
+      <value>(700, 547)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -367,11 +367,7 @@
     </param>
   </block>
   <block>
-    <key>variable_ldpc_encoder_def</key>
-    <param>
-      <key>file</key>
-      <value></value>
-    </param>
+    <key>variable_ldpc_encoder_H_def</key>
     <param>
       <key>comment</key>
       <value></value>
@@ -397,12 +393,12 @@
       <value>0</value>
     </param>
     <param>
-      <key>gap</key>
-      <value>0</value>
-    </param>
-    <param>
       <key>id</key>
       <value>enc_ldpc</value>
+    </param>
+    <param>
+      <key>H</key>
+      <value>H</value>
     </param>
     <param>
       <key>value</key>
@@ -414,7 +410,7 @@
     </param>
   </block>
   <block>
-    <key>variable_ldpc_gen_mtrx_encoder_def</key>
+    <key>variable_ldpc_encoder_G_def</key>
     <param>
       <key>comment</key>
       <value></value>
@@ -433,7 +429,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(624, 427)</value>
+      <value>(700, 427)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1003,7 +999,7 @@
     </param>
     <param>
       <key>label3</key>
-      <value>LDPC (R.U. matrix)</value>
+      <value>LDPC (H matrix)</value>
     </param>
     <param>
       <key>marker3</key>

--- a/gr-fec/grc/fec_bercurve_generator.xml
+++ b/gr-fec/grc/fec_bercurve_generator.xml
@@ -91,5 +91,14 @@
   </source>
 
   <doc>
+    Note that this block tries to launch many parallel codes to run simultaneously. Thus, it requires that the definitions for each encoder and decoder (specified in the "Encoder list" and "Decoder list") be configured with a parallelism > 0. If the parallelism for one of the encoder or decoder definition blocks is configured to 0, you will likely see an error like:
+
+    generic_decoder=decoder_list[i],
+    TypeError: 'generic_decoder_sptr' object does not support indexing
+
+    or
+
+    generic_encoder=encoder_list[i],
+    TypeError: 'generic_encoder_sptr' object does not support indexing
   </doc>
 </block>

--- a/gr-fec/grc/variable_ldpc_bit_flip_decoder.xml
+++ b/gr-fec/grc/variable_ldpc_bit_flip_decoder.xml
@@ -10,11 +10,11 @@
     <import>from gnuradio import fec</import>
     <var_make>
 #if int($ndim())==0 #
-self.$(id) = $(id) = fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_ptr(), $max_iterations)
+self.$(id) = $(id) = fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), $max_iterations)
 #else if int($ndim())==1 #
-self.$(id) = $(id) = map((lambda a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_ptr(), $max_iterations)), range(0,$dim1)) #slurp
+self.$(id) = $(id) = map((lambda a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), $max_iterations)), range(0,$dim1)) #slurp
 #else
-self.$(id) = $(id) = map((lambda b: map((lambda a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_ptr(), $max_iterations)), range(0,$dim2))), range(0,$dim1)) #slurp
+self.$(id) = $(id) = map((lambda b: map((lambda a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), $max_iterations)), range(0,$dim2))), range(0,$dim1)) #slurp
 #end if</var_make>
     <make></make>
 

--- a/gr-fec/grc/variable_ldpc_encoder_G.xml
+++ b/gr-fec/grc/variable_ldpc_encoder_G.xml
@@ -13,9 +13,9 @@
 #if int($ndim())==0 #
 self.$(id) = $(id) = fec.ldpc_gen_mtrx_encoder_make($G)
 #else if int($ndim())==1 #
-self.$(id) = $(id) = map((lambda a: fec.ldpc_encoder_make($G)), range(0,$dim1)) #slurp
+self.$(id) = $(id) = map((lambda a: fec.ldpc_gen_mtrx_encoder_make($G)), range(0,$dim1)) #slurp
 #else
-self.$(id) = $(id) = map((lambda b: map((lambda a: fec.ldpc_encoder_make($G)), range(0,$dim2))), range(0,$dim1)) #slurp
+self.$(id) = $(id) = map((lambda b: map((lambda a: fec.ldpc_gen_mtrx_encoder_make($G)), range(0,$dim2))), range(0,$dim1)) #slurp
 #end if</var_make>
   <make></make>
 

--- a/gr-fec/python/fec/bercurve_generator.py
+++ b/gr-fec/python/fec/bercurve_generator.py
@@ -44,6 +44,12 @@ class bercurve_generator(gr.hier_block2):
         self.deinterleave = blocks.deinterleave(gr.sizeof_char*1)
         self.connect(self.random_gen_b_0, self.deinterleave)
         self.ber_generators = []
+
+        # FIXME It would be good to check that the encoder_list and
+        # decoder_list have parallelism set to > 0. If parallelism
+        # is set to 0, a map isn't passed and an indexing error is
+        # thrown on line 53 or 54 below.
+
         for i in range(0, len(esno)):
             ber_generator_temp = fec_test(
                 generic_encoder=encoder_list[i],


### PR DESCRIPTION
- Addressing a few errors seen when using the gr-fec LDPC blocks in GRC
- Fixing a GRC example file that gives a "missing block" error
- Adding a bit of documentation