### PR TITLE
Head block nitems setter was 'int' and fails for items larger than 2^31

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/head.h
+++ b/gr-blocks/include/gnuradio/blocks/head.h
@@ -47,7 +47,7 @@ namespace gr {
                        uint64_t nitems);
 
       virtual void reset() = 0;
-      virtual void set_length(int nitems) = 0;
+      virtual void set_length(uint64_t nitems) = 0;
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/head_impl.h
+++ b/gr-blocks/lib/head_impl.h
@@ -39,7 +39,7 @@ namespace gr {
       ~head_impl();
 
       void reset() { d_ncopied_items = 0; }
-      void set_length(int nitems) { d_nitems = nitems; }
+      void set_length(uint64_t nitems) { d_nitems = nitems; }
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,


### PR DESCRIPTION
This fixes that and makes the type consistent with d_nitems (uint64_t).