### PR TITLE
Updated gr_modtool CMake files to properly handle template expansion

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/CMakeLists.txt
+++ b/gr-utils/python/modtool/gr-newmod/CMakeLists.txt
@@ -112,6 +112,7 @@ find_package(Doxygen)
 # API compatible version required.
 set(GR_REQUIRED_COMPONENTS RUNTIME)
 find_package(Gnuradio "3.7.2" REQUIRED)
+list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 if(NOT CPPUNIT_FOUND)
     message(FATAL_ERROR "CppUnit required to compile howto")

--- a/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrMiscUtils.cmake
+++ b/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrMiscUtils.cmake
@@ -363,6 +363,7 @@ macro(GR_EXPAND_X_H component root)
 
 import sys, os, re
 sys.path.append('${GR_RUNTIME_PYTHONPATH}')
+sys.path.append('${CMAKE_SOURCE_DIR}/python')
 os.environ['srcdir'] = '${CMAKE_CURRENT_SOURCE_DIR}'
 os.chdir('${CMAKE_CURRENT_BINARY_DIR}')
 
@@ -406,6 +407,7 @@ macro(GR_EXPAND_X_CC_H component root)
 
 import sys, os, re
 sys.path.append('${GR_RUNTIME_PYTHONPATH}')
+sys.path.append('${CMAKE_SOURCE_DIR}/python')
 os.environ['srcdir'] = '${CMAKE_CURRENT_SOURCE_DIR}'
 os.chdir('${CMAKE_CURRENT_BINARY_DIR}')
 
@@ -466,6 +468,7 @@ macro(GR_EXPAND_X_CC_H_IMPL component root)
 
 import sys, os, re
 sys.path.append('${GR_RUNTIME_PYTHONPATH}')
+sys.path.append('${CMAKE_SOURCE_DIR}/python')
 os.environ['srcdir'] = '${CMAKE_CURRENT_SOURCE_DIR}'
 os.chdir('${CMAKE_CURRENT_BINARY_DIR}')
 


### PR DESCRIPTION
Previously template expansion failed for OOT modules due to incorrectly configured python paths. The expansion would attempt to find build_utils.py and fail. This fix adds this path to the pythonpath during build, and also makes a larger change of truly defaulting to use the in-OOT-module CMake modules in <modpath>/cmake/Modules as opposed to the default ones installed with GR.

I believe this was the intention all along due to this comment https://github.com/gnuradio/gnuradio/blob/master/gr-utils/python/modtool/gr-newmod/CMakeLists.txt#L34 however the in the process of finding the GR package (https://github.com/gnuradio/gnuradio/blob/master/gr-utils/python/modtool/gr-newmod/CMakeLists.txt#L114) the default CMake module path (<prefix>/lib/cmake/gnuradio) gets higher priority. 

This fix re-appends the OOT module's CMake module path as higher priority after finding GR (which results in it being in the search path twice...but I don't know how to fix that....).

See discussion here: http://lists.gnu.org/archive/html/discuss-gnuradio/2016-03/msg00673.html