### PR TITLE
gr_modtool rename: change description and alias

### DIFF
--- a/gr-utils/python/modtool/modtool_rename.py
+++ b/gr-utils/python/modtool/modtool_rename.py
@@ -33,9 +33,9 @@ import Cheetah.Template
 
 
 class ModToolRename(ModTool):
-    """ Add block to the out-of-tree module. """
+    """ Rename a block in the out-of-tree module. """
     name = 'rename'
-    aliases = ('insert',)
+    aliases = ('rn',)
 
     def __init__(self):
         ModTool.__init__(self)

--- a/gr-utils/python/modtool/modtool_rename.py
+++ b/gr-utils/python/modtool/modtool_rename.py
@@ -35,7 +35,7 @@ import Cheetah.Template
 class ModToolRename(ModTool):
     """ Rename a block in the out-of-tree module. """
     name = 'rename'
-    aliases = ('rn',)
+    aliases = ('mv',)
 
     def __init__(self):
         ModTool.__init__(self)


### PR DESCRIPTION
Updated the description string and alias so it's not identical to the ones for `gr_modtool add`

I guess it's a bit dangerous to have an alias that could easily be mistaken for `rm`, but I couldn't think of any others...