### PR TITLE
Install OOT modules to PyBOMBS prefix if defined

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/CMakeLists.txt
+++ b/gr-utils/python/modtool/gr-newmod/CMakeLists.txt
@@ -24,6 +24,12 @@ cmake_minimum_required(VERSION 2.6)
 project(gr-howto CXX C)
 enable_testing()
 
+#install to PyBOMBS target prefix if defined
+if(DEFINED ENV{PYBOMBS_PREFIX})
+    set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})
+    message(STATUS "PyBOMBS installed GNU Radio. Setting CMAKE_INSTALL_PREFIX to $ENV{PYBOMBS_PREFIX}")
+endif()
+
 #select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE "Release")


### PR DESCRIPTION
Makes the OOT module's default CMake install the module to the PyBOMBS install prefix if defined.  I found that without specifying this on the command line, the default PyBOMBS GNU Radio install won't find your OOT modules.