### PR TITLE
gr_modtool rename: fix description and alias

### DIFF
--- a/gr-utils/python/modtool/modtool_rename.py
+++ b/gr-utils/python/modtool/modtool_rename.py
@@ -33,9 +33,9 @@ import Cheetah.Template
 
 
 class ModToolRename(ModTool):
-    """ Add block to the out-of-tree module. """
+    """ Rename a block in the out-of-tree module. """
     name = 'rename'
-    aliases = ('insert',)
+    aliases = ('mv',)
 
     def __init__(self):
         ModTool.__init__(self)


### PR DESCRIPTION
same changes as in #778, but in a single commit and based off `maint`