### PR TITLE
add description to the optparse call

### DIFF
--- a/grc/python/flow_graph.tmpl
+++ b/grc/python/flow_graph.tmpl
@@ -336,7 +336,11 @@ $short_id#slurp
 
 
 def argument_parser():
-    parser = OptionParser(option_class=eng_option, usage="%prog: [options]")
+    description = None
+#if $flow_graph.get_option('description')
+    description = '''$flow_graph.get_option('description')'''
+#end if
+    parser = OptionParser(option_class=eng_option, usage="%prog: [options]", description=description)
     #for $param in $parameters
         #set $type = $param.get_param('type').get_value()
         #if $type


### PR DESCRIPTION
this allows the "Description" field from the GRC Options block to set the program description to something helpful when you run "./my_gnuradio_program.py --help"