### PR TITLE
DisplayForm: Print samples when saving screenshot

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -183,6 +183,7 @@ public:
   int getYaxisLabelFontSize() const;
   int getXaxisLabelFontSize() const;
   int getAxesLabelFontSize() const;
+  std::vector<std::vector<double> > getPlotData() const;
 
   // Make sure to create your won PlotNewData method in the derived
   // class:

--- a/gr-qtgui/include/gnuradio/qtgui/displayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/displayform.h
@@ -30,6 +30,7 @@
 
 #include <qwt_plot_grid.h>
 #include <qwt_plot_layout.h>
+#include <qwt_plot_curve.h>
 
 #include <gnuradio/qtgui/DisplayPlot.h>
 #include <gnuradio/qtgui/form_menus.h>

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -266,6 +266,27 @@ DisplayPlot::getAxesLabelFontSize() const {
   return fs;
 }
 
+/* Return y data for all plots */
+std::vector<std::vector<double> >
+DisplayPlot::getPlotData() const {
+  std::vector<std::vector<double> > ydata;
+  for (size_t plot = 0; plot < d_plot_curve.size(); plot++) {
+    std::vector<double> plot_ydata;
+    QwtPlotCurve *plot_curve = d_plot_curve[plot];
+#if QWT_VERSION < 0x060000
+    for (int i = 0; i < plot_curve->dataSize(); i++) {
+      plot_ydata.push_back(plot_curve->y(i));
+    }
+#else
+    for (size_t i = 0; i < plot_curve->dataSize(); i++) {
+      plot_ydata.push_back(plot_curve->sample(i).y());
+    }
+#endif
+    ydata.push_back(plot_ydata);
+  }
+  return ydata;
+}
+
 void
 DisplayPlot::setLineWidth(int which, int width)
 {

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -313,12 +313,25 @@ DisplayForm::setStop(bool on)
     // will auto-detach if already attached.
     d_display_plot->setStop(false);
     d_stop_state = false;
+    d_display_plot->replot();
   }
   else {
     d_display_plot->setStop(true);
     d_stop_state = true;
+    d_display_plot->replot();
+
+    // print samples of d_display_plot
+    std::vector<std::vector<double> > ydata = getPlot()->getPlotData();
+    std::cout << "Plot stopped. Samples:" << std::endl;
+    for (size_t plot = 0; plot < ydata.size(); plot++) {
+      std::vector<double> plot_ydata = ydata[plot];
+      std::cout << "Plot curve # " << plot <<  std::endl;
+      for (size_t i = 0; i < plot_ydata.size(); i++) {
+        std::cout << plot_ydata[i] << ", ";
+      }
+      std::cout << std::endl;
+    }
   }
-  d_display_plot->replot();
 }
 
 void


### PR DESCRIPTION
I mailed this to the list before ([archive link](https://lists.gnu.org/archive/html/discuss-gnuradio/2016-04/msg00209.html)).

This makes gr-qtgui **print out the samples when saving a screenshot**. You'll then have 1. a fast tool to snapshot your signals and 2. accurate data in case you need further analysis or different plot style.
Example output:
```
Screenshot:
Plot curve # 0 , Label: Re{Data 0}
0.923486, 0.903486, 0.883486, 0.863486, 0.843486, 0.823486, 0.803486, 0.783486, 0.763486, 0.743486, 0.723486, 0.703486, 0.683486, 0.663486, 0.643486, 0.623486, 
Plot curve # 1 , Label: Im{Data 0}
0.576514, 0.596514, 0.616514, 0.636514, 0.656514, 0.676514, 0.696514, 0.716514, 0.736514, 0.756514, 0.776514, 0.796514, 0.816514, 0.836514, 0.856514, 0.876514, 
Plot curve # 2 , Label: Re{Data 1}
0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
Plot curve # 3 , Label: Im{Data 1}
1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
```

I hacked this into the gr-qtgui code. My concern is that with a high refresh rate
1. screenshot and samples might not perfectly match
2. plot_curve's data pointers are freed.
However I do not know the gr-qtgui code well, my code behave well as far as I tested it. With a high number of samples and multiple plots, stdout might be too slow.

It would be nice to save data such as sample rate, x/y range etc. to be able to recreate the plots, but you can't get that info from the plot_curve.

What do you think of this feature and it's implementation?

--Merlin Chlosta