### PR TITLE
udp sink: actually send 0-byte packets at EOF

### DIFF
--- a/gr-blocks/lib/udp_sink_impl.cc
+++ b/gr-blocks/lib/udp_sink_impl.cc
@@ -99,7 +99,7 @@ namespace gr {
       gr::thread::scoped_lock guard(d_mutex);  // protect d_socket from work()
 
       // Send a few zero-length packets to signal receiver we are done
-      boost::array<char, 1> send_buf = {{ 0 }};
+      boost::array<char, 0> send_buf;
       if(d_eof) {
         int i;
         for(i = 0; i < 3; i++)

--- a/gr-blocks/lib/udp_source_impl.cc
+++ b/gr-blocks/lib/udp_source_impl.cc
@@ -149,7 +149,7 @@ namespace gr {
       if(!error) {
         {
           boost::lock_guard<gr::thread::mutex> lock(d_udp_mutex);
-          if(d_eof && (bytes_transferred == 1) && (d_rxbuf[0] == 0x00)) {
+          if(d_eof && (bytes_transferred == 0)) {
             // If we are using EOF notification, test for it and don't
             // add anything to the output.
             d_residual = WORK_DONE;


### PR DESCRIPTION
The UDP block with the `eof` option is intended to send three 0-byte UDP packets when disconnecting from the stream. However, it actually sends three 1-byte packets containing a 0 byte, thus appending three 0 bytes to the stream, which is unintended (and sort of corrupts the stream by creating unaligned data at the end).
