### PR TITLE
Termination of run-to-completion flow graphs

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -252,13 +252,6 @@ namespace gr {
      */
     pmt::pmt_t delete_head_nowait( pmt::pmt_t which_port);
 
-    /*!
-     * \param[in] which_port The message port from which to get the message.
-     * \param[in] millisec Optional timeout value (0=no timeout).
-     * \returns returns pmt at head of queue or pmt::pmt_t() if empty.
-     */
-    pmt::pmt_t delete_head_blocking(pmt::pmt_t which_port, unsigned int millisec = 0);
-
     msg_queue_t::iterator get_iterator(pmt::pmt_t which_port) {
       return msg_queue[which_port].begin();
     }

--- a/gnuradio-runtime/include/gnuradio/tpb_detail.h
+++ b/gnuradio-runtime/include/gnuradio/tpb_detail.h
@@ -58,7 +58,10 @@ namespace gr {
 
     //! Called by pmt msg posters
     void notify_msg() {
+      gr::thread::scoped_lock guard(mutex);
+      input_changed = true;
       input_cond.notify_one();
+      output_changed = true;
       output_cond.notify_one();
     }
 

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -228,29 +228,6 @@ namespace gr {
   }
 
   pmt::pmt_t
-  basic_block::delete_head_blocking(pmt::pmt_t which_port, unsigned int millisec)
-  {
-    gr::thread::scoped_lock guard(mutex);
-
-    if (millisec) {
-       boost::system_time const timeout = boost::get_system_time() + boost::posix_time::milliseconds(millisec);
-       while (empty_p(which_port)) {
-         if (!msg_queue_ready[which_port]->timed_wait(guard, timeout)) {
-           return pmt::pmt_t();
-	 }
-       }
-    } else {
-      while(empty_p(which_port)) {
-        msg_queue_ready[which_port]->wait(guard);
-      }
-    }
-
-    pmt::pmt_t m(msg_queue[which_port].front());
-    msg_queue[which_port].pop_front();
-    return m;
-  }
-
-  pmt::pmt_t
   basic_block::message_subscribers(pmt::pmt_t port)
   {
     return pmt::dict_ref(d_message_subscribers,port,pmt::PMT_NIL);

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -708,7 +708,6 @@ namespace gr {
     pmt::pmt_t op = pmt::car(msg);
     if(pmt::eqv(op, pmt::mp("done"))){
         d_finished = pmt::to_long(pmt::cdr(msg));
-        global_block_registry.notify_blk(alias());
     } else {
         std::cout << "WARNING: bad message op on system port!\n";
         pmt::print(msg);

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -749,7 +749,7 @@ namespace gr {
   bool
   block::finished()
   {
-    if((detail()->ninputs() != 0) || (detail()->noutputs() != 0))
+    if(detail()->ninputs() != 0)
       return false;
     else
       return d_finished;

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -707,7 +707,7 @@ namespace gr {
     //std::cout << "system_handler " << msg << "\n";
     pmt::pmt_t op = pmt::car(msg);
     if(pmt::eqv(op, pmt::mp("done"))){
-        d_finished = pmt::to_long(pmt::cdr(msg));
+        d_finished = pmt::to_bool(pmt::cdr(msg));
     } else {
         std::cout << "WARNING: bad message op on system port!\n";
         pmt::print(msg);
@@ -736,7 +736,7 @@ namespace gr {
 
         currlist = pmt::cdr(currlist);
         basic_block_sptr blk = global_block_registry.block_lookup(block);
-        blk->post(port, pmt::cons(pmt::mp("done"), pmt::mp(true)));
+        blk->post(port, pmt::cons(pmt::mp("done"), pmt::PMT_T));
 
         //std::cout << "notify finished --> ";
         //pmt::print(pmt::cons(block,port));

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -174,9 +174,6 @@ namespace gr {
               }
             }
           }
-	  if (d->done()) {
-	    return;
-	  }
         }
       }
       break;

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -165,8 +165,6 @@ namespace gr {
       {
         gr::thread::scoped_lock guard(d->d_tpb.mutex);
         while(!d->d_tpb.output_changed) {
-          // wait for output room or message
-          while(!d->d_tpb.output_changed)
             d->d_tpb.output_cond.wait(guard);
         }
       }

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -95,6 +95,8 @@ namespace gr {
     while(1) {
       boost::this_thread::interruption_point();
 
+      d->d_tpb.clear_changed();
+
       // handle any queued up messages
       BOOST_FOREACH(basic_block::msg_queue_map_t::value_type &i, block->msg_queue) {
         // Check if we have a message handler attached before getting
@@ -115,7 +117,6 @@ namespace gr {
         }
       }
 
-      d->d_tpb.clear_changed();
       // run one iteration if we are a connected stream block
       if(d->noutputs() >0 || d->ninputs()>0){
         s = d_exec.run_one_iteration();

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -134,6 +134,10 @@ namespace gr {
         d->set_done(true);
       }
 
+      if(!d->ninputs() && s == block_executor::READY_NO_OUTPUT) {
+        s = block_executor::BLKD_IN;
+      }
+
       switch(s){
       case block_executor::READY:              // Tell neighbors we made progress.
         d->d_tpb.notify_neighbors(d);

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -123,11 +123,16 @@ namespace gr {
       }
       else {
         s = block_executor::BLKD_IN;
+        // a msg port only block wants to shutdown
+        if(block->finished()) {
+          s = block_executor::DONE;
+        }
       }
 
-      // if msg ports think we are done, we are done
-      if(block->finished())
+      if(block->finished() && s == block_executor::READY_NO_OUTPUT) {
         s = block_executor::DONE;
+        d->set_done(true);
+      }
 
       switch(s){
       case block_executor::READY:		// Tell neighbors we made progress.

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -155,10 +155,7 @@ namespace gr {
       {
         gr::thread::scoped_lock guard(d->d_tpb.mutex);
         while(!d->d_tpb.input_changed) {
-          // wait for input or message
-          if(!d->d_tpb.input_changed && block->empty_handled_p()) {
-            d->d_tpb.input_cond.wait(guard);
-          }
+          d->d_tpb.input_cond.wait(guard);
         }
       }
       break;
@@ -168,7 +165,7 @@ namespace gr {
         gr::thread::scoped_lock guard(d->d_tpb.mutex);
         while(!d->d_tpb.output_changed) {
           // wait for output room or message
-          while(!d->d_tpb.output_changed && block->empty_handled_p())
+          while(!d->d_tpb.output_changed)
             d->d_tpb.output_cond.wait(guard);
 
           // handle all pending messages

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -168,25 +168,6 @@ namespace gr {
           // wait for output room or message
           while(!d->d_tpb.output_changed)
             d->d_tpb.output_cond.wait(guard);
-
-          // handle all pending messages
-          BOOST_FOREACH(basic_block::msg_queue_map_t::value_type &i, block->msg_queue) {
-            if(block->has_msg_handler(i.first)) {
-                while((msg = block->delete_head_nowait(i.first))) {
-                  guard.unlock();			// release lock while processing msg
-                  block->dispatch_msg(i.first, msg);
-                  guard.lock();
-                }
-            }
-            else {
-                // leave msg in queue if no handler is defined
-                // start dropping if we have too many
-                if(block->nmsgs(i.first) > max_nmsgs){
-                  GR_LOG_WARN(LOG,"asynchronous message buffer overflowing, dropping message");
-                  msg = block->delete_head_nowait(i.first);
-                }
-            }
-          }
         }
       }
       break;

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -155,8 +155,10 @@ namespace gr {
       case block_executor::BLKD_IN:            // Wait for input.
       {
         gr::thread::scoped_lock guard(d->d_tpb.mutex);
-        while(!d->d_tpb.input_changed) {
-          d->d_tpb.input_cond.wait(guard);
+
+        if(!d->d_tpb.input_changed) {
+          boost::system_time const timeout=boost::get_system_time()+ boost::posix_time::milliseconds(250);
+          d->d_tpb.input_cond.timed_wait(guard, timeout);
         }
       }
       break;

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -135,20 +135,20 @@ namespace gr {
       }
 
       switch(s){
-      case block_executor::READY:		// Tell neighbors we made progress.
+      case block_executor::READY:              // Tell neighbors we made progress.
         d->d_tpb.notify_neighbors(d);
         break;
 
-      case block_executor::READY_NO_OUTPUT:	// Notify upstream only
+      case block_executor::READY_NO_OUTPUT:    // Notify upstream only
         d->d_tpb.notify_upstream(d);
         break;
 
-      case block_executor::DONE:		// Game over.
+      case block_executor::DONE:               // Game over.
         block->notify_msg_neighbors();
         d->d_tpb.notify_neighbors(d);
         return;
 
-      case block_executor::BLKD_IN:		// Wait for input.
+      case block_executor::BLKD_IN:            // Wait for input.
       {
         gr::thread::scoped_lock guard(d->d_tpb.mutex);
         while(!d->d_tpb.input_changed) {
@@ -183,15 +183,15 @@ namespace gr {
       }
       break;
 
-      case block_executor::BLKD_OUT:	// Wait for output buffer space.
+      case block_executor::BLKD_OUT:           // Wait for output buffer space.
       {
-	gr::thread::scoped_lock guard(d->d_tpb.mutex);
-	while(!d->d_tpb.output_changed) {
-	  // wait for output room or message
-	  while(!d->d_tpb.output_changed && block->empty_handled_p())
-	    d->d_tpb.output_cond.wait(guard);
+        gr::thread::scoped_lock guard(d->d_tpb.mutex);
+        while(!d->d_tpb.output_changed) {
+          // wait for output room or message
+          while(!d->d_tpb.output_changed && block->empty_handled_p())
+            d->d_tpb.output_cond.wait(guard);
 
-	  // handle all pending messages
+          // handle all pending messages
           BOOST_FOREACH(basic_block::msg_queue_map_t::value_type &i, block->msg_queue) {
             if(block->has_msg_handler(i.first)) {
                 while((msg = block->delete_head_nowait(i.first))) {

--- a/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
@@ -52,10 +52,7 @@ namespace gr {
     int pdu_to_tagged_stream_impl::calculate_output_stream_length(const gr_vector_int &)
     {
       if (d_curr_len == 0) {
-          /* FIXME: This blocking call is far from ideal but is the best we
-	   *        can do at the moment
-	   */
-        pmt::pmt_t msg(delete_head_blocking(PDU_PORT_ID, 100));
+        pmt::pmt_t msg(delete_head_nowait(PDU_PORT_ID));
         if (msg.get() == NULL) {
           return 0;
         }

--- a/gr-blocks/python/blocks/qa_pdu.py
+++ b/gr-blocks/python/blocks/qa_pdu.py
@@ -55,18 +55,17 @@ class test_pdu(gr_unittest.TestCase):
         self.tb.connect(src, snk2)
         self.tb.connect(src, snk3)
         self.tb.msg_connect(snk3, "pdus", dbg, "store")
-        self.tb.start()
 
         # make our reference and message pmts
         port = pmt.intern("pdus")
         msg = pmt.cons( pmt.PMT_NIL, pmt.make_u8vector(16, 0xFF))
 
         # post the message
-        src.to_basic_block()._post(port, msg) # eww, what's that smell?
+        src.to_basic_block()._post(port, msg)
+        src.to_basic_block()._post(pmt.intern("system"),
+                pmt.cons(pmt.intern("done"), pmt.PMT_T))
 
-        while dbg.num_messages() < 1:
-            time.sleep(0.1)
-        self.tb.stop()
+        self.tb.start()
         self.tb.wait()
 
         # Get the vector of data from the vector sink
@@ -98,11 +97,11 @@ class test_pdu(gr_unittest.TestCase):
 
         msg = pmt.cons( pmt.PMT_NIL, pmt.init_f32vector(10, src_data))
         src.to_basic_block()._post(port, msg)
+        src.to_basic_block()._post(pmt.intern("system"),
+                pmt.cons(pmt.intern("done"), pmt.PMT_T))
 
         self.tb.start()
-        #ideally, would wait until we get ten samples
-        time.sleep(0.2)
-        self.tb.stop()
+        self.tb.wait()
 
         self.assertEqual(src_data, list(snk.data()) )
 
@@ -125,9 +124,6 @@ class test_pdu(gr_unittest.TestCase):
         self.tb.connect(src, s2ts, ts2pdu)
         self.tb.msg_connect(ts2pdu, "pdus", dbg, "store")
         self.tb.start()
-        while dbg.num_messages() < 1:
-            time.sleep(0.1)
-        self.tb.stop()
         self.tb.wait()
         result_msg = dbg.get_message(0)
         metadata = pmt.to_python(pmt.car(result_msg))
@@ -138,4 +134,3 @@ class test_pdu(gr_unittest.TestCase):
 
 if __name__ == '__main__':
     gr_unittest.run(test_pdu, "test_pdu.xml")
-


### PR DESCRIPTION
This is supposed to address [Issue #797](http://gnuradio.org/redmine/issues/797), which is about shutting down run-to-completion flow graphs as used in simulations and unit tests.

The point is that the current code does not allow to stop blocks through the message port if it has at least on stream port. This policy is implemented in [block.cc](https://github.com/gnuradio/gnuradio/blob/d13de2faffc6e9c50d353e1c3567d688b326b805/gnuradio-runtime/lib/block.cc#L753). I don't know whether this was a deliberate decision, but it's at least unexpected that this is not supported.

I think it would make sense to allow at least blocks that have only message port inputs to be shut down via the message port. (Note that blocks with a stream output are only shut down if they received a *done* message and don't produce anymore).
Apart from making simulation scripts easier to terminate, this also allows for nicer units tests as shown in the last commit.