### PR TITLE
Lower memory usage for gcc during swig compile

### DIFF
--- a/gr-digital/swig/CMakeLists.txt
+++ b/gr-digital/swig/CMakeLists.txt
@@ -24,13 +24,14 @@ include(GrPython)
 include(GrSwig)
 
 set(GR_SWIG_INCLUDE_DIRS
-    ${GR_DIGITAL_INCLUDE_DIRS}
-    ${GR_BLOCKS_INCLUDE_DIRS}
-    ${GR_ANALOG_INCLUDE_DIRS}
-    ${GR_FFT_INCLUDE_DIRS}
-    ${GR_FILTER_INCLUDE_DIRS}
-    ${GNURADIO_RUNTIME_SWIG_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
+  ${GR_DIGITAL_INCLUDE_DIRS}
+  ${GR_BLOCKS_INCLUDE_DIRS}
+  ${GR_ANALOG_INCLUDE_DIRS}
+  ${GR_FFT_INCLUDE_DIRS}
+  ${GR_FILTER_INCLUDE_DIRS}
+  ${GNURADIO_RUNTIME_INCLUDE_DIRS}
+  ${GNURADIO_RUNTIME_SWIG_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 if(ENABLE_GR_CTRLPORT)
@@ -38,32 +39,59 @@ if(ENABLE_GR_CTRLPORT)
 endif(ENABLE_GR_CTRLPORT)
 
 # Setup swig docs to depend on includes and pull in from build directory
-set(GR_SWIG_TARGET_DEPS digital_generated_includes)
-set(GR_SWIG_DOC_FILE ${CMAKE_CURRENT_BINARY_DIR}/digital_swig_doc.i)
-set(GR_SWIG_DOC_DIRS
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/digital_swig.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/digital_swig.py
+@ONLY)
+# We split up the swig files into multiple sections to minimize the
+# memory overhead. If a .i file grows too large, create a new file
+# named 'digital_swigN.i' and add it to this list.
+#
+# Also add the line "from swig_digitalN import *" line to
+# digital_swig.py.in.
+set(GR_SWIG_DIGITAL_IFILES
+  digital_swig0
+  digital_swig1
+)
+
+
+foreach(swigfile ${GR_SWIG_DIGITAL_IFILES})
+  set(GR_SWIG_DOC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${swigfile}_doc.i)
+  set(GR_SWIG_DOC_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/gnuradio/digital
     ${CMAKE_CURRENT_BINARY_DIR}/../include/gnuradio/digital
+  )
+
+  set(GR_SWIG_DOCS_TARGET_DEPS runtime_swig_swig_doc)
+  set(GR_SWIG_TARGET_DEPS digital_generated_includes)
+  set(GR_SWIG_LIBRARIES gnuradio-digital gnuradio-filter 
+          gnuradio-analog gnuradio-blocks)
+  GR_SWIG_MAKE(${swigfile} ${swigfile}.i)
+
+  GR_SWIG_INSTALL(
+    TARGETS ${swigfile}
+    DESTINATION ${GR_PYTHON_DIR}/gnuradio/digital
+    COMPONENT "digital_python")
+
+  list(APPEND SWIGFILES ${swigfile}.i)
+  list(APPEND SWIGDOCFILES ${CMAKE_CURRENT_BINARY_DIR}/${swigfile}_doc.i)
+endforeach(swigfile)
+
+install(
+    FILES
+    ${SWIGFILES}
+    ${SWIGDOCFILES}
+    constellation.i
+    ofdm_equalizer.i
+    packet_header.i
+    DESTINATION ${GR_INCLUDE_DIR}/gnuradio/swig
+    COMPONENT "digital_swig"
+
 )
-set(GR_SWIG_DOCS_TARGET_DEPS runtime_swig_swig_doc)
 
-set(GR_SWIG_LIBRARIES gnuradio-digital
-  gnuradio-filter gnuradio-analog gnuradio-blocks)
-
-GR_SWIG_MAKE(digital_swig digital_swig.i)
-
-GR_SWIG_INSTALL(
-    TARGETS digital_swig
+GR_PYTHON_INSTALL(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/digital_swig.py
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/digital
     COMPONENT "digital_python"
 )
 
-install(
-    FILES
-    digital_swig.i
-    constellation.i
-    ofdm_equalizer.i
-    packet_header.i
-    ${CMAKE_CURRENT_BINARY_DIR}/digital_swig_doc.i
-    DESTINATION ${GR_INCLUDE_DIR}/gnuradio/swig
-    COMPONENT "digital_swig"
-)

--- a/gr-digital/swig/digital_swig.py.in
+++ b/gr-digital/swig/digital_swig.py.in
@@ -1,0 +1,20 @@
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from digital_swig0 import *
+from digital_swig1 import *
+                                 

--- a/gr-digital/swig/digital_swig0.i
+++ b/gr-digital/swig/digital_swig0.i
@@ -27,7 +27,7 @@
 %include "stdint.i"
 
 //load generated python docstrings
-%include "digital_swig_doc.i"
+%include "digital_swig0_doc.i"
 
 %include "gnuradio/analog/cpm.h"
 
@@ -85,37 +85,6 @@
 #include "gnuradio/digital/mpsk_receiver_cc.h"
 #include "gnuradio/digital/mpsk_snr_est.h"
 #include "gnuradio/digital/mpsk_snr_est_cc.h"
-#include "gnuradio/digital/msk_timing_recovery_cc.h"
-#include "gnuradio/digital/ofdm_carrier_allocator_cvc.h"
-#include "gnuradio/digital/ofdm_chanest_vcvc.h"
-#include "gnuradio/digital/ofdm_cyclic_prefixer.h"
-#include "gnuradio/digital/ofdm_equalizer_base.h"
-#include "gnuradio/digital/ofdm_equalizer_simpledfe.h"
-#include "gnuradio/digital/ofdm_equalizer_static.h"
-#include "gnuradio/digital/ofdm_frame_acquisition.h"
-#include "gnuradio/digital/ofdm_frame_equalizer_vcvc.h"
-#include "gnuradio/digital/ofdm_frame_sink.h"
-#include "gnuradio/digital/ofdm_insert_preamble.h"
-#include "gnuradio/digital/ofdm_mapper_bcv.h"
-#include "gnuradio/digital/ofdm_sampler.h"
-#include "gnuradio/digital/ofdm_serializer_vcc.h"
-#include "gnuradio/digital/ofdm_sync_sc_cfb.h"
-#include "gnuradio/digital/packet_header_default.h"
-#include "gnuradio/digital/packet_header_ofdm.h"
-#include "gnuradio/digital/packet_headergenerator_bb.h"
-#include "gnuradio/digital/packet_headerparser_b.h"
-#include "gnuradio/digital/packet_sink.h"
-#include "gnuradio/digital/pfb_clock_sync_ccf.h"
-#include "gnuradio/digital/pfb_clock_sync_fff.h"
-#include "gnuradio/digital/pn_correlator_cc.h"
-#include "gnuradio/digital/probe_density_b.h"
-#include "gnuradio/digital/probe_mpsk_snr_est_c.h"
-#include "gnuradio/digital/scrambler_bb.h"
-#include "gnuradio/digital/simple_correlator.h"
-#include "gnuradio/digital/simple_framer.h"
-#include "gnuradio/digital/ofdm_serializer_vcc.h"
-#include "gnuradio/digital/packet_headerparser_b.h"
-#include "gnuradio/digital/header_payload_demux.h"
 %}
 
 %include "gnuradio/digital/additive_scrambler_bb.h"
@@ -166,34 +135,6 @@
 %include "gnuradio/digital/mpsk_receiver_cc.h"
 %include "gnuradio/digital/mpsk_snr_est.h"
 %include "gnuradio/digital/mpsk_snr_est_cc.h"
-%include "gnuradio/digital/msk_timing_recovery_cc.h"
-%include "gnuradio/digital/ofdm_carrier_allocator_cvc.h"
-%include "gnuradio/digital/ofdm_chanest_vcvc.h"
-%include "gnuradio/digital/ofdm_cyclic_prefixer.h"
-%include "gnuradio/digital/ofdm_equalizer_base.h"
-%include "gnuradio/digital/ofdm_equalizer_simpledfe.h"
-%include "gnuradio/digital/ofdm_equalizer_static.h"
-%include "gnuradio/digital/ofdm_frame_acquisition.h"
-%include "gnuradio/digital/ofdm_frame_equalizer_vcvc.h"
-%include "gnuradio/digital/ofdm_frame_sink.h"
-%include "gnuradio/digital/ofdm_insert_preamble.h"
-%include "gnuradio/digital/ofdm_mapper_bcv.h"
-%include "gnuradio/digital/ofdm_sampler.h"
-%include "gnuradio/digital/ofdm_serializer_vcc.h"
-%include "gnuradio/digital/ofdm_sync_sc_cfb.h"
-%include "gnuradio/digital/packet_header_default.h"
-%include "gnuradio/digital/packet_header_ofdm.h"
-%include "gnuradio/digital/packet_headergenerator_bb.h"
-%include "gnuradio/digital/packet_headerparser_b.h"
-%include "gnuradio/digital/packet_sink.h"
-%include "gnuradio/digital/pfb_clock_sync_ccf.h"
-%include "gnuradio/digital/pfb_clock_sync_fff.h"
-%include "gnuradio/digital/pn_correlator_cc.h"
-%include "gnuradio/digital/probe_density_b.h"
-%include "gnuradio/digital/probe_mpsk_snr_est_c.h"
-%include "gnuradio/digital/scrambler_bb.h"
-%include "gnuradio/digital/simple_correlator.h"
-%include "gnuradio/digital/simple_framer.h"
 
 GR_SWIG_BLOCK_MAGIC2(digital, additive_scrambler_bb);
 GR_SWIG_BLOCK_MAGIC2(digital, binary_slicer_fb);
@@ -237,33 +178,7 @@ GR_SWIG_BLOCK_MAGIC2(digital, lms_dd_equalizer_cc);
 GR_SWIG_BLOCK_MAGIC2(digital, map_bb);
 GR_SWIG_BLOCK_MAGIC2(digital, mpsk_receiver_cc);
 GR_SWIG_BLOCK_MAGIC2(digital, mpsk_snr_est_cc);
-GR_SWIG_BLOCK_MAGIC2(digital, msk_timing_recovery_cc);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_carrier_allocator_cvc);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_chanest_vcvc);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_cyclic_prefixer);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_frame_acquisition);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_frame_equalizer_vcvc);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_frame_sink);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_insert_preamble);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_mapper_bcv);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_sampler);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_serializer_vcc);
-GR_SWIG_BLOCK_MAGIC2(digital, ofdm_sync_sc_cfb);
-GR_SWIG_BLOCK_MAGIC2(digital, packet_headergenerator_bb);
-GR_SWIG_BLOCK_MAGIC2(digital, packet_headerparser_b);
-GR_SWIG_BLOCK_MAGIC2(digital, packet_sink);
-GR_SWIG_BLOCK_MAGIC2(digital, pfb_clock_sync_ccf);
-GR_SWIG_BLOCK_MAGIC2(digital, pfb_clock_sync_fff);
-GR_SWIG_BLOCK_MAGIC2(digital, pn_correlator_cc);
-GR_SWIG_BLOCK_MAGIC2(digital, probe_density_b);
-GR_SWIG_BLOCK_MAGIC2(digital, probe_mpsk_snr_est_c);
-GR_SWIG_BLOCK_MAGIC2(digital, scrambler_bb);
-GR_SWIG_BLOCK_MAGIC2(digital, simple_correlator);
-GR_SWIG_BLOCK_MAGIC2(digital, simple_framer);
 
 GR_SWIG_BLOCK_MAGIC_FACTORY(digital, cpmmod_bc, gmskmod_bc);
 
-// Properly package up non-block objects
 %include "constellation.i"
-%include "packet_header.i"
-%include "ofdm_equalizer.i"

--- a/gr-digital/swig/digital_swig1.i
+++ b/gr-digital/swig/digital_swig1.i
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2011-2015 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#define DIGITAL_API
+#define ANALOG_API
+#define BLOCKS_API
+
+%include "gnuradio.i"
+%include "stdint.i"
+
+//load generated python docstrings
+%include "digital_swig1_doc.i"
+
+//%include "gnuradio/analog/cpm.h"
+
+%{
+#include <gnuradio/blocks/control_loop.h>
+%}
+%include <gnuradio/blocks/control_loop.h>
+
+%{
+#include "gnuradio/digital/mpsk_snr_est.h"
+#include "gnuradio/digital/mpsk_snr_est_cc.h"
+#include "gnuradio/digital/msk_timing_recovery_cc.h"
+#include "gnuradio/digital/ofdm_carrier_allocator_cvc.h"
+#include "gnuradio/digital/ofdm_chanest_vcvc.h"
+#include "gnuradio/digital/ofdm_cyclic_prefixer.h"
+#include "gnuradio/digital/ofdm_equalizer_base.h"
+#include "gnuradio/digital/ofdm_equalizer_simpledfe.h"
+#include "gnuradio/digital/ofdm_equalizer_static.h"
+#include "gnuradio/digital/ofdm_frame_acquisition.h"
+#include "gnuradio/digital/ofdm_frame_equalizer_vcvc.h"
+#include "gnuradio/digital/ofdm_frame_sink.h"
+#include "gnuradio/digital/ofdm_insert_preamble.h"
+#include "gnuradio/digital/ofdm_mapper_bcv.h"
+#include "gnuradio/digital/ofdm_sampler.h"
+#include "gnuradio/digital/ofdm_serializer_vcc.h"
+#include "gnuradio/digital/ofdm_sync_sc_cfb.h"
+#include "gnuradio/digital/packet_header_default.h"
+#include "gnuradio/digital/packet_header_ofdm.h"
+#include "gnuradio/digital/packet_headergenerator_bb.h"
+#include "gnuradio/digital/packet_headerparser_b.h"
+#include "gnuradio/digital/packet_sink.h"
+#include "gnuradio/digital/pfb_clock_sync_ccf.h"
+#include "gnuradio/digital/pfb_clock_sync_fff.h"
+#include "gnuradio/digital/pn_correlator_cc.h"
+#include "gnuradio/digital/probe_density_b.h"
+#include "gnuradio/digital/probe_mpsk_snr_est_c.h"
+#include "gnuradio/digital/scrambler_bb.h"
+#include "gnuradio/digital/simple_correlator.h"
+#include "gnuradio/digital/simple_framer.h"
+#include "gnuradio/digital/ofdm_serializer_vcc.h"
+#include "gnuradio/digital/packet_headerparser_b.h"
+#include "gnuradio/digital/header_payload_demux.h"
+%}
+
+%include "gnuradio/digital/mpsk_snr_est.h"
+%include "gnuradio/digital/mpsk_snr_est_cc.h"
+%include "gnuradio/digital/msk_timing_recovery_cc.h"
+%include "gnuradio/digital/ofdm_carrier_allocator_cvc.h"
+%include "gnuradio/digital/ofdm_chanest_vcvc.h"
+%include "gnuradio/digital/ofdm_cyclic_prefixer.h"
+%include "gnuradio/digital/ofdm_equalizer_base.h"
+%include "gnuradio/digital/ofdm_equalizer_simpledfe.h"
+%include "gnuradio/digital/ofdm_equalizer_static.h"
+%include "gnuradio/digital/ofdm_frame_acquisition.h"
+%include "gnuradio/digital/ofdm_frame_equalizer_vcvc.h"
+%include "gnuradio/digital/ofdm_frame_sink.h"
+%include "gnuradio/digital/ofdm_insert_preamble.h"
+%include "gnuradio/digital/ofdm_mapper_bcv.h"
+%include "gnuradio/digital/ofdm_sampler.h"
+%include "gnuradio/digital/ofdm_serializer_vcc.h"
+%include "gnuradio/digital/ofdm_sync_sc_cfb.h"
+%include "gnuradio/digital/packet_header_default.h"
+%include "gnuradio/digital/packet_header_ofdm.h"
+%include "gnuradio/digital/packet_headergenerator_bb.h"
+%include "gnuradio/digital/packet_headerparser_b.h"
+%include "gnuradio/digital/packet_sink.h"
+%include "gnuradio/digital/pfb_clock_sync_ccf.h"
+%include "gnuradio/digital/pfb_clock_sync_fff.h"
+%include "gnuradio/digital/pn_correlator_cc.h"
+%include "gnuradio/digital/probe_density_b.h"
+%include "gnuradio/digital/probe_mpsk_snr_est_c.h"
+%include "gnuradio/digital/scrambler_bb.h"
+%include "gnuradio/digital/simple_correlator.h"
+%include "gnuradio/digital/simple_framer.h"
+
+GR_SWIG_BLOCK_MAGIC2(digital, msk_timing_recovery_cc);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_carrier_allocator_cvc);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_chanest_vcvc);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_cyclic_prefixer);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_frame_acquisition);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_frame_equalizer_vcvc);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_frame_sink);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_insert_preamble);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_mapper_bcv);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_sampler);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_serializer_vcc);
+GR_SWIG_BLOCK_MAGIC2(digital, ofdm_sync_sc_cfb);
+GR_SWIG_BLOCK_MAGIC2(digital, packet_headergenerator_bb);
+GR_SWIG_BLOCK_MAGIC2(digital, packet_headerparser_b);
+GR_SWIG_BLOCK_MAGIC2(digital, packet_sink);
+GR_SWIG_BLOCK_MAGIC2(digital, pfb_clock_sync_ccf);
+GR_SWIG_BLOCK_MAGIC2(digital, pfb_clock_sync_fff);
+GR_SWIG_BLOCK_MAGIC2(digital, pn_correlator_cc);
+GR_SWIG_BLOCK_MAGIC2(digital, probe_density_b);
+GR_SWIG_BLOCK_MAGIC2(digital, probe_mpsk_snr_est_c);
+GR_SWIG_BLOCK_MAGIC2(digital, scrambler_bb);
+GR_SWIG_BLOCK_MAGIC2(digital, simple_correlator);
+GR_SWIG_BLOCK_MAGIC2(digital, simple_framer);
+
+%include "packet_header.i"
+%include "ofdm_equalizer.i"

--- a/gr-trellis/swig/CMakeLists.txt
+++ b/gr-trellis/swig/CMakeLists.txt
@@ -37,26 +37,53 @@ if(ENABLE_GR_CTRLPORT)
 endif(ENABLE_GR_CTRLPORT)
 
 # Setup swig docs to depend on includes and pull in from build directory
-set(GR_SWIG_TARGET_DEPS trellis_generated_includes)
-set(GR_SWIG_DOC_FILE ${CMAKE_CURRENT_BINARY_DIR}/trellis_swig_doc.i)
-set(GR_SWIG_DOC_DIRS
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/trellis_swig.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/trellis_swig.py
+@ONLY)
+# We split up the swig files into multiple sections to minimize the
+# memory overhead. If a .i file grows too large, create a new file
+# named 'trellis_swigN.i' and add it to this list.
+#
+# Also add the line "from swig_digitalN import *" line to
+# blocks_swig.py.in.
+set(GR_SWIG_TRELLIS_IFILES
+  trellis_swig0
+  trellis_swig1
+)
+
+foreach(swigfile ${GR_SWIG_TRELLIS_IFILES})
+  # Setup swig docs to depend on includes and pull in from build directory
+  set(GR_SWIG_TARGET_DEPS trellis_generated_includes)
+  set(GR_SWIG_DOC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${swigfile}_doc.i)
+  set(GR_SWIG_DOC_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/gnuradio/trellis
     ${CMAKE_CURRENT_BINARY_DIR}/../include/gnuradio/trellis
-)
-set(GR_SWIG_DOCS_TARGET_DEPS runtime_swig_swig_doc)
-
-GR_SWIG_MAKE(trellis_swig trellis_swig.i)
-
-GR_SWIG_INSTALL(
-    TARGETS trellis_swig
+  )
+  set(GR_SWIG_DOCS_TARGET_DEPS runtime_swig_swig_doc)
+	
+  GR_SWIG_MAKE(${swigfile} ${swigfile}.i)
+	
+  GR_SWIG_INSTALL(
+    TARGETS ${swigfile}
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/trellis
     COMPONENT "trellis_python"
-)
+  )
+
+  list(APPEND SWIGFILES ${swigfile}.i)
+  list(APPEND SWIGDOCFILES ${CMAKE_CURRENT_BINARY_DIR}/${swigfile}_doc.i)
+endforeach(swigfile)
 
 install(
     FILES
-    trellis_swig.i
-    ${CMAKE_CURRENT_BINARY_DIR}/trellis_swig_doc.i
+    ${SWIGFILES}
+    ${SWIGDOCFILES}
     DESTINATION ${GR_INCLUDE_DIR}/gnuradio/swig
     COMPONENT "trellis_swig"
+)
+
+GR_PYTHON_INSTALL(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/trellis_swig.py
+    DESTINATION ${GR_PYTHON_DIR}/gnuradio/trellis
+    COMPONENT "trellis_python"
 )

--- a/gr-trellis/swig/trellis_swig.py.in
+++ b/gr-trellis/swig/trellis_swig.py.in
@@ -1,0 +1,20 @@
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from trellis_swig0 import *
+from trellis_swig1 import *
+                                 

--- a/gr-trellis/swig/trellis_swig0.i
+++ b/gr-trellis/swig/trellis_swig0.i
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2012 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#define TRELLIS_API
+#define DIGITAL_API
+
+%include "gnuradio.i"
+
+//load generated python docstrings
+%include "trellis_swig0_doc.i"
+
+%include "gnuradio/digital/metric_type.h"
+%include "gnuradio/digital/constellation.h"
+%include "gnuradio/trellis/siso_type.h"
+%include "gnuradio/trellis/fsm.h"
+%include "gnuradio/trellis/interleaver.h"
+
+%{
+#include "gnuradio/trellis/constellation_metrics_cf.h"
+#include "gnuradio/trellis/permutation.h"
+#include "gnuradio/trellis/siso_combined_f.h"
+#include "gnuradio/trellis/siso_f.h"
+#include "gnuradio/trellis/encoder_bb.h"
+#include "gnuradio/trellis/encoder_bs.h"
+#include "gnuradio/trellis/encoder_bi.h"
+#include "gnuradio/trellis/encoder_ss.h"
+#include "gnuradio/trellis/encoder_si.h"
+#include "gnuradio/trellis/encoder_ii.h"
+#include "gnuradio/trellis/sccc_encoder_bb.h"
+#include "gnuradio/trellis/sccc_encoder_bs.h"
+#include "gnuradio/trellis/sccc_encoder_bi.h"
+#include "gnuradio/trellis/sccc_encoder_ss.h"
+#include "gnuradio/trellis/sccc_encoder_si.h"
+#include "gnuradio/trellis/sccc_encoder_ii.h"
+#include "gnuradio/trellis/pccc_encoder_bb.h"
+#include "gnuradio/trellis/pccc_encoder_bs.h"
+#include "gnuradio/trellis/pccc_encoder_bi.h"
+#include "gnuradio/trellis/pccc_encoder_ss.h"
+#include "gnuradio/trellis/pccc_encoder_si.h"
+#include "gnuradio/trellis/pccc_encoder_ii.h"
+#include "gnuradio/trellis/metrics_s.h"
+#include "gnuradio/trellis/metrics_i.h"
+#include "gnuradio/trellis/metrics_f.h"
+#include "gnuradio/trellis/metrics_c.h"
+%}
+
+%include "gnuradio/trellis/constellation_metrics_cf.h"
+%include "gnuradio/trellis/permutation.h"
+%include "gnuradio/trellis/siso_combined_f.h"
+%include "gnuradio/trellis/siso_f.h"
+%include "gnuradio/trellis/encoder_bb.h"
+%include "gnuradio/trellis/encoder_bs.h"
+%include "gnuradio/trellis/encoder_bi.h"
+%include "gnuradio/trellis/encoder_ss.h"
+%include "gnuradio/trellis/encoder_si.h"
+%include "gnuradio/trellis/encoder_ii.h"
+%include "gnuradio/trellis/sccc_encoder_bb.h"
+%include "gnuradio/trellis/sccc_encoder_bs.h"
+%include "gnuradio/trellis/sccc_encoder_bi.h"
+%include "gnuradio/trellis/sccc_encoder_ss.h"
+%include "gnuradio/trellis/sccc_encoder_si.h"
+%include "gnuradio/trellis/sccc_encoder_ii.h"
+%include "gnuradio/trellis/pccc_encoder_bb.h"
+%include "gnuradio/trellis/pccc_encoder_bs.h"
+%include "gnuradio/trellis/pccc_encoder_bi.h"
+%include "gnuradio/trellis/pccc_encoder_ss.h"
+%include "gnuradio/trellis/pccc_encoder_si.h"
+%include "gnuradio/trellis/pccc_encoder_ii.h"
+%include "gnuradio/trellis/metrics_s.h"
+%include "gnuradio/trellis/metrics_i.h"
+%include "gnuradio/trellis/metrics_f.h"
+%include "gnuradio/trellis/metrics_c.h"
+
+
+GR_SWIG_BLOCK_MAGIC2(trellis, constellation_metrics_cf);
+GR_SWIG_BLOCK_MAGIC2(trellis, permutation);
+GR_SWIG_BLOCK_MAGIC2(trellis, siso_combined_f);
+GR_SWIG_BLOCK_MAGIC2(trellis, siso_f);
+GR_SWIG_BLOCK_MAGIC2(trellis, encoder_bb);
+GR_SWIG_BLOCK_MAGIC2(trellis, encoder_bs);
+GR_SWIG_BLOCK_MAGIC2(trellis, encoder_bi);
+GR_SWIG_BLOCK_MAGIC2(trellis, encoder_ss);
+GR_SWIG_BLOCK_MAGIC2(trellis, encoder_si);
+GR_SWIG_BLOCK_MAGIC2(trellis, encoder_ii);
+GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_bb);
+GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_bs);
+GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_bi);
+GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_ss);
+GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_si);
+GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_ii);
+GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_bb);
+GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_bs);
+GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_bi);
+GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_ss);
+GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_si);
+GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_ii);
+GR_SWIG_BLOCK_MAGIC2(trellis, metrics_s);
+GR_SWIG_BLOCK_MAGIC2(trellis, metrics_i);
+GR_SWIG_BLOCK_MAGIC2(trellis, metrics_f);
+GR_SWIG_BLOCK_MAGIC2(trellis, metrics_c);
+

--- a/gr-trellis/swig/trellis_swig1.i
+++ b/gr-trellis/swig/trellis_swig1.i
@@ -25,41 +25,15 @@
 %include "gnuradio.i"
 
 //load generated python docstrings
-%include "trellis_swig_doc.i"
+%include "trellis_swig1_doc.i"
 
 %include "gnuradio/digital/metric_type.h"
-%include "gnuradio/digital/constellation.h"
+//%include "gnuradio/digital/constellation.h"
 %include "gnuradio/trellis/siso_type.h"
 %include "gnuradio/trellis/fsm.h"
 %include "gnuradio/trellis/interleaver.h"
 
 %{
-#include "gnuradio/trellis/constellation_metrics_cf.h"
-#include "gnuradio/trellis/permutation.h"
-#include "gnuradio/trellis/siso_combined_f.h"
-#include "gnuradio/trellis/siso_f.h"
-#include "gnuradio/trellis/encoder_bb.h"
-#include "gnuradio/trellis/encoder_bs.h"
-#include "gnuradio/trellis/encoder_bi.h"
-#include "gnuradio/trellis/encoder_ss.h"
-#include "gnuradio/trellis/encoder_si.h"
-#include "gnuradio/trellis/encoder_ii.h"
-#include "gnuradio/trellis/sccc_encoder_bb.h"
-#include "gnuradio/trellis/sccc_encoder_bs.h"
-#include "gnuradio/trellis/sccc_encoder_bi.h"
-#include "gnuradio/trellis/sccc_encoder_ss.h"
-#include "gnuradio/trellis/sccc_encoder_si.h"
-#include "gnuradio/trellis/sccc_encoder_ii.h"
-#include "gnuradio/trellis/pccc_encoder_bb.h"
-#include "gnuradio/trellis/pccc_encoder_bs.h"
-#include "gnuradio/trellis/pccc_encoder_bi.h"
-#include "gnuradio/trellis/pccc_encoder_ss.h"
-#include "gnuradio/trellis/pccc_encoder_si.h"
-#include "gnuradio/trellis/pccc_encoder_ii.h"
-#include "gnuradio/trellis/metrics_s.h"
-#include "gnuradio/trellis/metrics_i.h"
-#include "gnuradio/trellis/metrics_f.h"
-#include "gnuradio/trellis/metrics_c.h"
 #include "gnuradio/trellis/pccc_decoder_b.h"
 #include "gnuradio/trellis/pccc_decoder_s.h"
 #include "gnuradio/trellis/pccc_decoder_i.h"
@@ -95,32 +69,6 @@
 #include "gnuradio/trellis/sccc_decoder_combined_ci.h"
 %}
 
-%include "gnuradio/trellis/constellation_metrics_cf.h"
-%include "gnuradio/trellis/permutation.h"
-%include "gnuradio/trellis/siso_combined_f.h"
-%include "gnuradio/trellis/siso_f.h"
-%include "gnuradio/trellis/encoder_bb.h"
-%include "gnuradio/trellis/encoder_bs.h"
-%include "gnuradio/trellis/encoder_bi.h"
-%include "gnuradio/trellis/encoder_ss.h"
-%include "gnuradio/trellis/encoder_si.h"
-%include "gnuradio/trellis/encoder_ii.h"
-%include "gnuradio/trellis/sccc_encoder_bb.h"
-%include "gnuradio/trellis/sccc_encoder_bs.h"
-%include "gnuradio/trellis/sccc_encoder_bi.h"
-%include "gnuradio/trellis/sccc_encoder_ss.h"
-%include "gnuradio/trellis/sccc_encoder_si.h"
-%include "gnuradio/trellis/sccc_encoder_ii.h"
-%include "gnuradio/trellis/pccc_encoder_bb.h"
-%include "gnuradio/trellis/pccc_encoder_bs.h"
-%include "gnuradio/trellis/pccc_encoder_bi.h"
-%include "gnuradio/trellis/pccc_encoder_ss.h"
-%include "gnuradio/trellis/pccc_encoder_si.h"
-%include "gnuradio/trellis/pccc_encoder_ii.h"
-%include "gnuradio/trellis/metrics_s.h"
-%include "gnuradio/trellis/metrics_i.h"
-%include "gnuradio/trellis/metrics_f.h"
-%include "gnuradio/trellis/metrics_c.h"
 %include "gnuradio/trellis/pccc_decoder_b.h"
 %include "gnuradio/trellis/pccc_decoder_s.h"
 %include "gnuradio/trellis/pccc_decoder_i.h"
@@ -155,32 +103,7 @@
 %include "gnuradio/trellis/sccc_decoder_combined_cs.h"
 %include "gnuradio/trellis/sccc_decoder_combined_ci.h"
 
-GR_SWIG_BLOCK_MAGIC2(trellis, constellation_metrics_cf);
-GR_SWIG_BLOCK_MAGIC2(trellis, permutation);
-GR_SWIG_BLOCK_MAGIC2(trellis, siso_combined_f);
-GR_SWIG_BLOCK_MAGIC2(trellis, siso_f);
-GR_SWIG_BLOCK_MAGIC2(trellis, encoder_bb);
-GR_SWIG_BLOCK_MAGIC2(trellis, encoder_bs);
-GR_SWIG_BLOCK_MAGIC2(trellis, encoder_bi);
-GR_SWIG_BLOCK_MAGIC2(trellis, encoder_ss);
-GR_SWIG_BLOCK_MAGIC2(trellis, encoder_si);
-GR_SWIG_BLOCK_MAGIC2(trellis, encoder_ii);
-GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_bb);
-GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_bs);
-GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_bi);
-GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_ss);
-GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_si);
-GR_SWIG_BLOCK_MAGIC2(trellis, sccc_encoder_ii);
-GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_bb);
-GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_bs);
-GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_bi);
-GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_ss);
-GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_si);
-GR_SWIG_BLOCK_MAGIC2(trellis, pccc_encoder_ii);
-GR_SWIG_BLOCK_MAGIC2(trellis, metrics_s);
-GR_SWIG_BLOCK_MAGIC2(trellis, metrics_i);
-GR_SWIG_BLOCK_MAGIC2(trellis, metrics_f);
-GR_SWIG_BLOCK_MAGIC2(trellis, metrics_c);
+
 GR_SWIG_BLOCK_MAGIC2(trellis, pccc_decoder_b);
 GR_SWIG_BLOCK_MAGIC2(trellis, pccc_decoder_s);
 GR_SWIG_BLOCK_MAGIC2(trellis, pccc_decoder_i);


### PR DESCRIPTION
I updated gr-digital and gr-trellis to use multiple swig interface files based off of what was used in gr-blocks.  This allows a compile on less than 1GB of memory.