### PR TITLE
gnuradio-runtime: Fix pmt serialization for double

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -297,7 +297,7 @@ serialize(pmt_t obj, std::streambuf &sb)
     }
 
     if(is_real(obj)) {
-      float i = to_double(obj);
+      double i = to_double(obj);
       ok = serialize_untagged_u8(PST_DOUBLE, sb);
       ok &= serialize_untagged_f64(i, sb);
       return ok;


### PR DESCRIPTION
double was wrongly casted to float