### PR TITLE
Fix assertions in DVBT blocks.

### DIFF
--- a/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc
@@ -161,14 +161,13 @@ namespace gr {
       // We output one byte for a symbol of m bits
       // The out/in rate in bytes is: 8n/km (Bytes)
 
-      assert(d_ninput % 1);
-      assert(d_noutput % 1512);
+      assert(d_noutput % 1512 == 0);
 
       // Set output items multiple of 4
       set_output_multiple(4);
 
       // Set relative rate out/in
-      assert((d_noutput * d_k * d_m) % (d_ninput * 8 * d_n));
+      assert((d_noutput * d_k * d_m) % (d_ninput * 8 * d_n) == 0);
       set_relative_rate((float)(d_ninput * 8 * d_n) / (float)d_noutput * d_k * d_m);
 
       // calculate in and out block sizes

--- a/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
@@ -578,7 +578,7 @@ namespace gr {
        *
        * out/in rate is therefore km/8n in bytes
        */
-      assert((d_k * d_m) % (8 * d_n));
+      assert((d_k * d_m) % (8 * d_n) == 0);
       set_relative_rate((d_k * d_m) / (8 * d_n));
 
       assert ((d_bsize * d_n) % d_m == 0);


### PR DESCRIPTION
There are some busted assertions in GNU Radio's DVBT blocks, which result in failures like this:

`python: /home/argilo/pybombs/src/gnuradio/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc:164: gr::dtv::dvbt_inner_coder_impl::dvbt_inner_coder_impl(int, int, gr::dtv::dvb_constellation_t, gr::dtv::dvbt_hierarchy_t, gr::dtv::dvb_code_rate_t): Assertion 'd_ninput % 1' failed.`

Unfortunately, the version of GNU Radio that ships with Ubuntu 16.04 has assertions compiled in, so DVBT is unusable. Building from source works around the problem, since release builds are compiled without assertions.

/cc @BogdanDIA @AdamLaurie