### PR TITLE
digital: Fixes to packet_header_ofdm

### DIFF
--- a/gr-digital/include/gnuradio/digital/packet_header_ofdm.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_ofdm.h
@@ -109,7 +109,6 @@ namespace gr {
      protected:
       pmt::pmt_t d_frame_len_tag_key; //!< Tag key of the additional frame length tag
       const std::vector<std::vector<int> > d_occupied_carriers; //!< Which carriers/symbols carry data
-      int d_syms_per_set; //!< Helper variable: Total number of elements in d_occupied_carriers
       int d_bits_per_payload_sym;
       std::vector<unsigned char> d_scramble_mask; //!< Bits are xor'd with this before tx'ing
     };

--- a/gr-digital/lib/packet_header_default.cc
+++ b/gr-digital/lib/packet_header_default.cc
@@ -62,12 +62,10 @@ namespace gr {
     }
 
     bool packet_header_default::header_formatter(
-	long packet_len,
+        long packet_len,
         unsigned char *out,
-
-	const std::vector<tag_t> &tags
-    )
-    {
+        const std::vector<tag_t> &tags
+    ) {
       packet_len &= 0x0FFF;
       d_crc_impl.reset();
       d_crc_impl.process_bytes((void const *) &packet_len, 2);

--- a/gr-digital/lib/packet_headergenerator_bb_impl.cc
+++ b/gr-digital/lib/packet_headergenerator_bb_impl.cc
@@ -68,7 +68,8 @@ namespace gr {
       set_relative_rate(d_formatter->header_len());
       set_tag_propagation_policy(TPP_DONT);
     }
-void 
+
+    void
     packet_headergenerator_bb_impl::set_header_formatter(packet_header_default::sptr header_formatter)
     {
       gr::thread::scoped_lock guard(d_setlock);

--- a/gr-digital/python/digital/qa_packet_headerparser_b.py
+++ b/gr-digital/python/digital/qa_packet_headerparser_b.py
@@ -97,6 +97,9 @@ class qa_packet_headerparser_b (gr_unittest.TestCase):
         """ Header 1: 193 bytes
         Header 2: 8 bytes
         2 bits per complex symbol, 32 carriers => 64 bits = 8 bytes per OFDM symbol
+                                    4 carriers =>  8 bits = 1 byte  per OFDM symbol
+                                    8 carriers => 16 bits = 2 bytes per OFDM symbol
+        Means we need 52 carriers to store the 193 bytes.
         """
         encoded_headers = (
             #   | Number of bytes                    | Packet number                      | CRC
@@ -107,7 +110,7 @@ class qa_packet_headerparser_b (gr_unittest.TestCase):
         frame_len_tagname = "frame_len"
         src = blocks.vector_source_b(encoded_headers)
         header_formatter = digital.packet_header_ofdm(
-                (range(32),), # 32 carriers are occupied (which doesn't matter here)
+                (range(32),range(4),range(8)), # 32/4/8 carriers are occupied (which doesn't matter here)
                 1,         # 1 OFDM symbol per header (= 32 bits)
                 packet_len_tagname,
                 frame_len_tagname,
@@ -127,7 +130,7 @@ class qa_packet_headerparser_b (gr_unittest.TestCase):
         msg1 = pmt.to_python(sink.get_message(0))
         msg2 = pmt.to_python(sink.get_message(1))
         # Multiply with 4 because unpacked bytes have only two bits
-        self.assertEqual(msg1, {'packet_len': 193*4, 'frame_len': 25, 'packet_num': 0})
+        self.assertEqual(msg1, {'packet_len': 193*4, 'frame_len': 52, 'packet_num': 0})
         self.assertEqual(msg2, {'packet_len': 8*4, 'frame_len': 1, 'packet_num': 1})
 
     def test_004_ofdm_scramble(self):


### PR DESCRIPTION
- For unusual carrier allocations, the parser would report the wrong
  number of payload OFDM symbols => Fixed.
- Updated QA code to track this use case.
- Minor whitespace/indentation fixes