### PR TITLE
uhd: add command handler to add a time tag

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -31,6 +31,8 @@
 namespace gr {
   namespace uhd {
 
+    const pmt::pmt_t CMD_TAG_KEY = pmt::mp("tag");
+
     usrp_source::sptr
     usrp_source::make(const ::uhd::device_addr_t &device_addr,
                       const ::uhd::io_type_t &io_type,
@@ -80,6 +82,7 @@ namespace gr {
 #ifdef GR_UHD_USE_STREAM_API
       _samps_per_packet = 1;
 #endif
+      register_msg_cmd_handler(CMD_TAG_KEY, boost::bind(&usrp_source_impl::_cmd_handler_tag, this, _1));
     }
 
     usrp_source_impl::~usrp_source_impl()
@@ -356,6 +359,12 @@ namespace gr {
 #else
       throw std::runtime_error("not implemented in this version");
 #endif
+    }
+
+    void
+    usrp_source_impl::_cmd_handler_tag(const pmt::pmt_t &tag)
+    {
+      _tag_now = true;
     }
 
     void

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -112,6 +112,7 @@ namespace gr {
     private:
       //! Like set_center_freq(), but uses _curr_freq and _curr_lo_offset
       ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan);
+      void _cmd_handler_tag(const pmt::pmt_t &tag);
 
 #ifdef GR_UHD_USE_STREAM_API
       ::uhd::rx_streamer::sptr _rx_stream;


### PR DESCRIPTION
@mbr0wn this is useful for allowing downstream blocks to do a sanity check that they are still on the time that they think they are on. There's some code style opinions here that you may care about.

Also, you *could* argue that this isn't entirely necessary; however, it's nice for other flowgraphs receiving samples over pub/sub zmq or UDP socket PDU  to be able to have a periodic reminder that the stream is or is not on what they think it is.