### PR TITLE
Marked blocks and headers for deprecation

### DIFF
--- a/gr-analog/grc/analog_cpfsk_bc.xml
+++ b/gr-analog/grc/analog_cpfsk_bc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>CPFSK</name>
 	<key>analog_cpfsk_bc</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import analog</import>
 	<make>analog.cpfsk_bc($k, $amplitude, $samples_per_symbol)</make>
 	<callback>set_amplitude($amplitude)</callback>

--- a/gr-analog/include/gnuradio/analog/cpfsk_bc.h
+++ b/gr-analog/include/gnuradio/analog/cpfsk_bc.h
@@ -31,6 +31,7 @@ namespace gr {
      * \brief Perform continuous phase 2-level frequency shift keying modulation
      * on an input stream of unpacked bits.
      * \ingroup modulators_blk
+     * \ingroup deprecated_blk
      */
     class ANALOG_API cpfsk_bc : virtual public sync_interpolator
     {

--- a/gr-digital/grc/digital_dxpsk_demod.xml
+++ b/gr-digital/grc/digital_dxpsk_demod.xml
@@ -2,19 +2,19 @@
 
 <!--
  Copyright 2009,2010,2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,6 +29,7 @@
 <block>
 	<name>DPSK Demod</name>
 	<key>digital_dxpsk_demod</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.$(type)_demod(
 	samples_per_symbol=$samples_per_symbol,

--- a/gr-digital/grc/digital_dxpsk_mod.xml
+++ b/gr-digital/grc/digital_dxpsk_mod.xml
@@ -2,19 +2,19 @@
 
 <!--
  Copyright 2009,2010,2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,6 +29,7 @@
 <block>
 	<name>DPSK Mod</name>
 	<key>digital_dxpsk_mod</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.$(type)_mod(
 	samples_per_symbol=$samples_per_symbol,

--- a/gr-digital/grc/digital_mpsk_receiver_cc.xml
+++ b/gr-digital/grc/digital_mpsk_receiver_cc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>MPSK Receiver</name>
 	<key>digital_mpsk_receiver_cc</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital;import cmath</import>
 	<make>digital.mpsk_receiver_cc($M, $theta, $w, $fmin, $fmax, $mu, $gain_mu, $omega, $gain_omega, $omega_relative_limit)</make>
 	<callback>set_loop_bandwidth($w)</callback>

--- a/gr-digital/grc/digital_ofdm_frame_acquisition.xml
+++ b/gr-digital/grc/digital_ofdm_frame_acquisition.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!--
  Copyright 2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -28,6 +28,7 @@
 <block>
 	<name>OFDM Frame Acquisition</name>
 	<key>digital_ofdm_frame_acquisition</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.ofdm_frame_acquisition($occupied_carriers, $fft_length, $cplen, $known_symbol, $max_fft_shift_len)</make>
 	<param>

--- a/gr-digital/grc/digital_ofdm_frame_sink.xml
+++ b/gr-digital/grc/digital_ofdm_frame_sink.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!--
  Copyright 2012 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -28,6 +28,7 @@
 <block>
 	<name>OFDM Frame Sink</name>
 	<key>digital_ofdm_frame_sink</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.ofdm_frame_sink($syms, $vals, $queue, $occ_tones, $ph_gain, $frq_gain)</make>
 	<param>

--- a/gr-digital/grc/digital_ofdm_insert_preamble.xml
+++ b/gr-digital/grc/digital_ofdm_insert_preamble.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!--
  Copyright 2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -28,6 +28,7 @@
 <block>
 	<name>OFDM Insert Preamble</name>
 	<key>digital_ofdm_insert_preamble</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.ofdm_insert_preamble($fft_length, $preamble)</make>
 	<param>

--- a/gr-digital/grc/digital_ofdm_sampler.xml
+++ b/gr-digital/grc/digital_ofdm_sampler.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!--
  Copyright 2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -28,6 +28,7 @@
 <block>
 	<name>OFDM Sampler</name>
 	<key>digital_ofdm_sampler</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.ofdm_sampler($fft_length, $symbol_length, $timeout)</make>
 	<param>

--- a/gr-digital/grc/digital_packet_headergenerator_bb.xml
+++ b/gr-digital/grc/digital_packet_headergenerator_bb.xml
@@ -1,6 +1,7 @@
 <block>
   <name>Packet Header Generator</name>
   <key>digital_packet_headergenerator_bb</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.packet_headergenerator_bb($header_formatter, $len_tag_key)</make>
   <callback>set_header_formatter($header_formatter)</callback>

--- a/gr-digital/grc/digital_packet_headergenerator_bb_default.xml
+++ b/gr-digital/grc/digital_packet_headergenerator_bb_default.xml
@@ -1,6 +1,7 @@
 <block>
   <name>Packet Header Generator (Default)</name>
   <key>digital_packet_headergenerator_bb_default</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.packet_headergenerator_bb($header_len, $len_tag_key)</make>
   <param>
@@ -23,4 +24,3 @@
     <type>byte</type>
   </source>
 </block>
-

--- a/gr-digital/grc/digital_packet_headerparser_b.xml
+++ b/gr-digital/grc/digital_packet_headerparser_b.xml
@@ -1,6 +1,7 @@
 <block>
   <name>Packet Header Parser</name>
   <key>digital_packet_headerparser_b</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.packet_headerparser_b($header_formatter)</make>
   <param>

--- a/gr-digital/grc/digital_packet_headerparser_b_default.xml
+++ b/gr-digital/grc/digital_packet_headerparser_b_default.xml
@@ -1,6 +1,7 @@
 <block>
   <name>Packet Header Parser (Default)</name>
   <key>digital_packet_headerparser_b_default</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.packet_headerparser_b($header_len, $len_tag_key)</make>
   <param>
@@ -23,4 +24,3 @@
     <type>message</type>
   </source>
 </block>
-

--- a/gr-digital/grc/digital_psk_demod.xml
+++ b/gr-digital/grc/digital_psk_demod.xml
@@ -2,19 +2,19 @@
 
 <!--
  Copyright 2009,2010,2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,6 +29,7 @@
 <block>
   <name>PSK Demod</name>
   <key>digital_psk_demod</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.psk.psk_demod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_psk_mod.xml
+++ b/gr-digital/grc/digital_psk_mod.xml
@@ -2,19 +2,19 @@
 
 <!--
  Copyright 2009,2010,2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,6 +29,7 @@
 <block>
   <name>PSK Mod</name>
   <key>digital_psk_mod</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.psk.psk_mod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_qam_demod.xml
+++ b/gr-digital/grc/digital_qam_demod.xml
@@ -2,19 +2,19 @@
 
 <!--
  Copyright 2009,2010,2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,6 +29,7 @@
 <block>
   <name>QAM Demod</name>
   <key>digital_qam_demod</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.qam.qam_demod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_qam_mod.xml
+++ b/gr-digital/grc/digital_qam_mod.xml
@@ -2,19 +2,19 @@
 
 <!--
  Copyright 2009,2010,2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,6 +29,7 @@
 <block>
   <name>QAM Mod</name>
   <key>digital_qam_mod</key>
+  <category>Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.qam.qam_mod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_simple_correlator.xml
+++ b/gr-digital/grc/digital_simple_correlator.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Simple Correlator</name>
 	<key>digital_simple_correlator</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.simple_correlator($payload_bytesize)</make>
 	<param>

--- a/gr-digital/grc/digital_simple_framer.xml
+++ b/gr-digital/grc/digital_simple_framer.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Simple Framer</name>
 	<key>digital_simple_framer</key>
+	<category>Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.simple_framer($payload_bytesize)</make>
 	<param>

--- a/gr-digital/include/gnuradio/digital/mpsk_receiver_cc.h
+++ b/gr-digital/include/gnuradio/digital/mpsk_receiver_cc.h
@@ -34,6 +34,7 @@ namespace gr {
      * \brief This block takes care of receiving M-PSK modulated
      * signals through phase, frequency, and symbol synchronization.
      * \ingroup synchronizers_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * It performs carrier frequency and phase locking as well as

--- a/gr-digital/include/gnuradio/digital/ofdm_frame_acquisition.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_frame_acquisition.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2006,2007,2011,2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,11 +29,12 @@
 
 namespace gr {
   namespace digital {
-    
+
     /*!
      * \brief take a vector of complex constellation points in from an
      * FFT and performs a correlation and equalization.
      * \ingroup ofdm_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * This block takes the output of an FFT of a received OFDM symbol
@@ -55,7 +56,7 @@ namespace gr {
       // gr::digital::ofdm_frame_acquisition::sptr
       typedef boost::shared_ptr<ofdm_frame_acquisition> sptr;
 
-      /*! 
+      /*!
        * Make an OFDM correlator and equalizer.
        *
        * \param occupied_carriers   The number of subcarriers with data in the received symbol
@@ -67,9 +68,9 @@ namespace gr {
        */
       static sptr make(unsigned int occupied_carriers, unsigned int fft_length,
 		       unsigned int cplen,
-		       const std::vector<gr_complex> &known_symbol, 
+		       const std::vector<gr_complex> &known_symbol,
 		       unsigned int max_fft_shift_len=4);
-  
+
       /*!
        * \brief Return an estimate of the SNR of the channel
        */

--- a/gr-digital/include/gnuradio/digital/ofdm_frame_sink.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_frame_sink.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2007,2011,2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -29,12 +29,13 @@
 
 namespace gr {
   namespace digital {
-    
+
     /*!
      * \brief Takes an OFDM symbol in, demaps it into bits of 0's and
      * 1's, packs them into packets, and sends to to a message queue
      * sink.
      * \ingroup ofdm_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * NOTE: The mod input parameter simply chooses a pre-defined
@@ -58,7 +59,7 @@ namespace gr {
        * \param phase_gain gain of the phase tracking loop
        * \param freq_gain gain of the frequency tracking loop
        */
-      static sptr make(const std::vector<gr_complex> &sym_position, 
+      static sptr make(const std::vector<gr_complex> &sym_position,
 		       const std::vector<char> &sym_value_out,
 		       msg_queue::sptr target_queue,
 		       int occupied_tones,

--- a/gr-digital/include/gnuradio/digital/ofdm_insert_preamble.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_insert_preamble.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2007,2011,2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -28,11 +28,12 @@
 
 namespace gr {
   namespace digital {
-    
+
     /*!
      * \brief insert "pre-modulated" preamble symbols before each payload.
      * \ingroup ofdm_blk
      * \ingroup synchronizers_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * <pre>
@@ -60,7 +61,7 @@ namespace gr {
     public:
       // gr::digital::ofdm_insert_preamble::sptr
       typedef boost::shared_ptr<ofdm_insert_preamble> sptr;
-      
+
       /*!
        * Make an OFDM preamble inserter block.
        *

--- a/gr-digital/include/gnuradio/digital/ofdm_mapper_bcv.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_mapper_bcv.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2006,2007,2011,2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -35,6 +35,7 @@ namespace gr {
      * constellation points suitable for IFFT input to be used in an
      * ofdm modulator.
      * \ingroup ofdm_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * Abstract class must be subclassed with specific mapping.
@@ -54,7 +55,7 @@ namespace gr {
        * \param fft_length The size of the FFT vector (occupied_carriers + unused carriers)
        */
       static sptr make(const std::vector<gr_complex> &constellation,
-		       unsigned msgq_limit, 
+		       unsigned msgq_limit,
 		       unsigned occupied_carriers,
 		       unsigned int fft_length);
 

--- a/gr-digital/include/gnuradio/digital/ofdm_sampler.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_sampler.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2007,2011,2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -28,10 +28,11 @@
 
 namespace gr {
   namespace digital {
-    
+
     /*!
      * \brief does the rest of the OFDM stuff
      * \ingroup ofdm_blk
+     * \ingroup deprecated_blk
      */
     class DIGITAL_API ofdm_sampler : virtual public block
     {
@@ -46,7 +47,7 @@ namespace gr {
        * \param symbol_length Length of the full symbol (fft_length + CP length)
        * \param timeout timeout in samples when we stop looking for a symbol after initial ack.
        */
-      static sptr make(unsigned int fft_length, 
+      static sptr make(unsigned int fft_length,
 		       unsigned int symbol_length,
 		       unsigned int timeout=1000);
     };

--- a/gr-digital/include/gnuradio/digital/packet_header_default.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_default.h
@@ -33,6 +33,7 @@ namespace gr {
     /*!
      * \brief Default header formatter for digital packet transmission.
      * \ingroup packet_operators_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * For bursty/packetized digital transmission, packets are usually prepended

--- a/gr-digital/include/gnuradio/digital/packet_header_ofdm.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_ofdm.h
@@ -1,18 +1,18 @@
 /* -*- c++ -*- */
 /* Copyright 2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -32,6 +32,7 @@ namespace gr {
     /*!
      * \brief Header utility for OFDM signals.
      * \ingroup ofdm_blk
+     * \ingroup deprecated_blk
      */
     class DIGITAL_API packet_header_ofdm : public packet_header_default
     {
@@ -118,4 +119,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_DIGITAL_PACKET_HEADER_OFDM_H */
-

--- a/gr-digital/include/gnuradio/digital/packet_headergenerator_bb.h
+++ b/gr-digital/include/gnuradio/digital/packet_headergenerator_bb.h
@@ -1,18 +1,18 @@
 /* -*- c++ -*- */
 /* Copyright 2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -32,6 +32,7 @@ namespace gr {
     /*!
      * \brief Generates a header for a tagged, streamed packet.
      * \ingroup packet_operators_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * Input: A tagged stream. This is consumed entirely, it is not appended
@@ -72,4 +73,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_PACKET_HEADERGENERATOR_BB_H */
-

--- a/gr-digital/include/gnuradio/digital/packet_headerparser_b.h
+++ b/gr-digital/include/gnuradio/digital/packet_headerparser_b.h
@@ -1,18 +1,18 @@
 /* -*- c++ -*- */
 /* Copyright 2012 Free Software Foundation, Inc.
- * 
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -32,6 +32,7 @@ namespace gr {
     /*!
      * \brief Post header metadata as a PMT
      * \ingroup packet_operators_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * In a sense, this is the inverse block to packet_headergenerator_bb.
@@ -68,4 +69,3 @@ namespace gr {
 } // namespace gr
 
 #endif /* INCLUDED_DIGITAL_PACKET_HEADERPARSER_B_H */
-


### PR DESCRIPTION
According to the planned 3.8 cleanup, I marked all blocks for deprecation that are planned to be deleted.
Marking includes Doxygen group `deprecated_blk` for C++ headers and category `Deprecated` for GRC blocks.
(Maybe) still missing: 

- Corresponding GRC block for `python/digital/pkt.py` (if there is any)
- Corresponding GRC blocks for `packet_header_default` and `packet_header_ofdm` (if there is any)
- Corresponding GRC block for `ofdm_mapper_bcv.*` (if there is any)
