### PR TITLE
 ":Invalid argument" errors fixed for Windows XP/7

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -45,12 +45,15 @@ namespace gr {
    * The simplest thing that could possibly work:
    *  the key is the filename; the value is the file contents.
    */
+  char prefs_path_buffer[128];
   static const char *
   pathname(const char *key)
   {
     static fs::path path;
     path = fs::path(gr::appdata_path()) / ".gnuradio" / "prefs" / key;
-    return path.string().c_str();
+    strcpy(prefs_path_buffer,path.string().c_str());
+    //return path.string().c_str();  //  DANGEROUS !!  return dangling pointer (invalid pointer) in Windows
+    return prefs_path_buffer;
   }
 
   static void

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -83,12 +83,15 @@ namespace gr {
       return s_planning_mutex;
     }
 
+    char wisdom_paht_buffer[256];
     static const char *
     wisdom_filename()
     {
       static fs::path path;
       path = fs::path(gr::appdata_path()) / ".gr_fftw_wisdom";
-      return path.string().c_str();
+      // return path.string().c_str(); // DANGEROUS !!  return invalid pointer in Windows XP,7
+      strcpy(wisdom_paht_buffer,path.string().c_str());
+	    return wisdom_paht_buffer;
     }
 
     static void

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -83,15 +83,15 @@ namespace gr {
       return s_planning_mutex;
     }
 
-    char wisdom_paht_buffer[256];
+    char wisdom_path_buffer[256];
     static const char *
     wisdom_filename()
     {
       static fs::path path;
       path = fs::path(gr::appdata_path()) / ".gr_fftw_wisdom";
       // return path.string().c_str(); // DANGEROUS !!  return invalid pointer in Windows XP,7
-      strcpy(wisdom_paht_buffer,path.string().c_str());
-	    return wisdom_paht_buffer;
+      strcpy(wisdom_path_buffer,path.string().c_str());
+      return wisdom_path_buffer;
     }
 
     static void


### PR DESCRIPTION
1. The following error messages occurs In Windows XP/7
   :Invalid argument 
   :Invalid argument 
   :Invalid argument 

2. Because of 
  return path.string().c_str();    //  DANGEROUS !!  return invalid pointer  in Windows XP/7
