### PR TITLE
":Invalid argument" error fixed for Windows XP/7/8

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -46,7 +46,7 @@ namespace gr {
    *  the key is the filename; the value is the file contents.
    */
 
-  static string
+  static std::string
   pathname(const char *key)
   {
     static fs::path path;

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -83,7 +83,7 @@ namespace gr {
       return s_planning_mutex;
     }
 
-    static string
+    static std::string
     wisdom_filename()
     {
       static fs::path path;
@@ -95,13 +95,13 @@ namespace gr {
     static void
     import_wisdom()
     {
-      const string filename = wisdom_filename ();
+      const std::string filename = wisdom_filename ();
       FILE *fp = fopen (filename.c_str(), "r");
       if (fp != 0){
         int r = fftwf_import_wisdom_from_file (fp);
         fclose (fp);
         if (!r){
-          fprintf (stderr, "gr::fft: can't import wisdom from %s\n", filename);
+          fprintf (stderr, "gr::fft: can't import wisdom from %s\n", filename.c_str());
         }
       }
     }
@@ -125,7 +125,7 @@ namespace gr {
     static void
     export_wisdom()
     {
-      const string filename = wisdom_filename ();
+      const std::string filename = wisdom_filename ();
       FILE *fp = fopen (filename.c_str(), "w");
       if (fp != 0){
         fftwf_export_wisdom_to_file (fp);
@@ -133,7 +133,7 @@ namespace gr {
       }
       else {
         fprintf (stderr, "fft_impl_fftw: ");
-        perror (filename);
+        perror (filename.c_str());
       }
     }
 


### PR DESCRIPTION
The following error messages occurs In Windows XP, 7
   :Invalid argument 
   :Invalid argument 
   :Invalid argument 

The reason is 
 return path.string().c_str();  //  DANGEROUS !!  return invalid pointer  in Windows XP/7/8 
