### PR TITLE
gr::prefs: user conf dir unified, gnuradio-config-info "--prefs"

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -25,6 +25,8 @@
 #endif
 
 #include <gnuradio/constants.h>
+#include <gnuradio/sys_paths.h>
+#include <gnuradio/prefs.h>
 #include <boost/program_options.hpp>
 #include <boost/format.hpp>
 #include <iostream>
@@ -43,6 +45,8 @@ main(int argc, char **argv)
     ("prefix", "print GNU Radio installation prefix")
     ("sysconfdir", "print GNU Radio system configuration directory")
     ("prefsdir", "print GNU Radio preferences directory")
+    ("userprefsdir", "print GNU Radio user preferences directory")
+    ("prefs", "print GNU Radio preferences")
     ("builddate", "print GNU Radio build date (RFC2822 format)")
     ("enabled-components", "print GNU Radio build time enabled components")
     ("cc", "print GNU Radio C compiler version")
@@ -74,6 +78,12 @@ main(int argc, char **argv)
 
   if(vm.count("prefsdir"))
     std::cout << gr::prefsdir() << std::endl;
+
+  if(vm.count("userprefsdir"))
+    std::cout << gr::userconf_path() << std::endl;
+
+  if(vm.count("prefs"))
+    std::cout << gr::prefs::singleton()->to_string() << std::endl;
 
   if(vm.count("builddate"))
     std::cout << gr::build_date() << std::endl;

--- a/gnuradio-runtime/include/gnuradio/sys_paths.h
+++ b/gnuradio-runtime/include/gnuradio/sys_paths.h
@@ -32,6 +32,9 @@ namespace gr {
   //! directory to store application data
   GR_RUNTIME_API const char *appdata_path();
 
+  //! directory to store user configuration
+  GR_RUNTIME_API const char *userconf_path();
+
 } /* namespace gr */
 
 #endif /* GR_SYS_PATHS_H */

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -77,10 +77,9 @@ namespace gr {
     // Find if there is a ~/.gnuradio/config.conf file and add this to
     // the end of the file list to override any preferences in the
     // installed path config files.
-    fs::path homedir = fs::path(gr::appdata_path());
-    homedir = homedir/".gnuradio/config.conf";
-    if(fs::exists(homedir)) {
-      fnames.push_back(homedir.string());
+    fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    if(fs::exists(userconf)) {
+      fnames.push_back(userconf.string());
     }
 
     return fnames;
@@ -222,10 +221,8 @@ namespace gr {
   prefs::save()
   {
     std::string conf = to_string();
-
-    fs::path homedir = fs::path(gr::appdata_path());
-    homedir = homedir/".gnuradio/config.conf";
-    fs::ofstream fout(homedir);
+    fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    fs::ofstream fout(userconf);
     fout << conf;
     fout.close();
   }

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -23,6 +23,8 @@
 #include <cstdlib> //getenv
 #include <cstdio>  //P_tmpdir (maybe)
 
+#include <boost/filesystem/path.hpp>
+
 namespace gr {
 
   const char *tmp_path()
@@ -60,6 +62,13 @@ namespace gr {
 
     //fall-through case, nothing worked
     return tmp_path();
+  }
+
+  const char *userconf_path()
+  {
+    boost::filesystem::path p(appdata_path());
+    p = p / ".gnuradio";
+    return p.c_str();
   }
 
 }  /* namespace gr */


### PR DESCRIPTION
To more easily debug gr::prefs issues, added

```
Program options: gnuradio-config-info [options]:
...
  --userprefsdir        print GNU Radio user preferences directory
  --prefs               print GNU Radio preferences
```

Also, unified setting of user conf dir