### PR TITLE
gr::prefs config file parse overhaul

### DIFF
--- a/gnuradio-runtime/include/gnuradio/prefs.h
+++ b/gnuradio-runtime/include/gnuradio/prefs.h
@@ -165,8 +165,7 @@ namespace gr {
 
   protected:
     virtual std::vector<std::string> _sys_prefs_filenames();
-    virtual std::string _read_files(const std::vector<std::string> &filenames);
-    virtual void _convert_to_map(const std::string &conf);
+    virtual void _read_files(const std::vector<std::string> &filenames);
     virtual char * option_to_env(std::string section, std::string option);
 
   private:


### PR DESCRIPTION
replaced fragile, yet ugly, own parser by
`boost::program_option::parse_config_file`

depends on https://github.com/gnuradio/gnuradio/pull/818, so if possible,
merge that first.