### PR TITLE
Detect GNU Radio components installed in a non-standard prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,12 +425,17 @@ endif(ENABLE_GR_CTRLPORT)
 #    http://www.cmake.org/Wiki/CMake/Tutorials/Packaging
 
 configure_file(
+  ${CMAKE_SOURCE_DIR}/cmake/Modules/GnuradioConfig.cmake.in
+  ${CMAKE_BINARY_DIR}/cmake/Modules/GnuradioConfig.cmake
+@ONLY)
+
+configure_file(
   ${CMAKE_SOURCE_DIR}/cmake/Modules/GnuradioConfigVersion.cmake.in
   ${CMAKE_BINARY_DIR}/cmake/Modules/GnuradioConfigVersion.cmake
 @ONLY)
 
 SET(cmake_configs
-  ${CMAKE_SOURCE_DIR}/cmake/Modules/GnuradioConfig.cmake
+  ${CMAKE_BINARY_DIR}/cmake/Modules/GnuradioConfig.cmake
   ${CMAKE_BINARY_DIR}/cmake/Modules/GnuradioConfigVersion.cmake
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,9 @@ if(NOT VOLK_FOUND)
 
     set(VOLK_LIBRARIES volk)
 
+    set(VOLK_INSTALL_LIBRARY_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+    set(VOLK_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+
     if(ENABLE_VOLK)
 
         include(GrPackage)
@@ -344,6 +347,9 @@ if(NOT VOLK_FOUND)
 else()
     message(STATUS "  An external VOLK has been found and will be used for build.")
     set(ENABLE_VOLK TRUE)
+
+    get_filename_component(VOLK_INSTALL_LIBRARY_DIR "${VOLK_LIBRARIES}" DIRECTORY)
+    set(VOLK_INSTALL_INCLUDE_DIR ${VOLK_INCLUDE_DIRS})
 endif(NOT VOLK_FOUND)
 
 message(STATUS "  Override with -DENABLE_INTERNAL_VOLK=ON/OFF")

--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -72,6 +72,7 @@ function(GR_MODULE EXTVAR PCNAME INCFILE LIBFILE)
             ${CMAKE_INSTALL_PREFIX}/include
         PATHS /usr/local/include
               /usr/include
+              "@CMAKE_INSTALL_PREFIX@/include"
     )
 
     # look for libs
@@ -87,6 +88,7 @@ function(GR_MODULE EXTVAR PCNAME INCFILE LIBFILE)
                   /usr/local/lib64
                   /usr/lib
                   /usr/lib64
+                  "@CMAKE_INSTALL_PREFIX@/lib"
         )
 	list(APPEND ${LIBVAR_NAME} ${${LIBVAR_NAME}_${libname}})
     endforeach(libname)

--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -73,6 +73,7 @@ function(GR_MODULE EXTVAR PCNAME INCFILE LIBFILE)
         PATHS /usr/local/include
               /usr/include
               "@CMAKE_INSTALL_PREFIX@/include"
+              "@VOLK_INSTALL_INCLUDE_DIR@"
     )
 
     # look for libs
@@ -89,6 +90,7 @@ function(GR_MODULE EXTVAR PCNAME INCFILE LIBFILE)
                   /usr/lib
                   /usr/lib64
                   "@CMAKE_INSTALL_PREFIX@/lib"
+                  "@VOLK_INSTALL_LIBRARY_DIR@"
         )
 	list(APPEND ${LIBVAR_NAME} ${${LIBVAR_NAME}_${libname}})
     endforeach(libname)


### PR DESCRIPTION
The projects using GnuradioConfig.cmake (by doing "find_package(Gnuradio)" in CMake) failed to detect the various GNU Radio components if GNU Radio was installed in a non-standard prefix.

This set of two commits address this issue.

Signed-off-by: Paul Cercueil <paul.cercueil@analog.com>