### PR TITLE
replace OptionParser by ArgumentParser - batch 2

### DIFF
--- a/gnuradio-runtime/examples/mp-sched/synthetic.py
+++ b/gnuradio-runtime/examples/mp-sched/synthetic.py
@@ -21,8 +21,8 @@
 
 from gnuradio import gr, eng_notation
 from gnuradio import blocks, filter
-from gnuradio.eng_option import eng_option
-from optparse import OptionParser
+from gnuradio.eng_arg import eng_float, intx
+from argparse import ArgumentParser
 import os
 
 
@@ -50,38 +50,35 @@ class top(gr.top_block):
         gr.top_block.__init__(self)
 
         default_nsamples = 10e6
-        parser=OptionParser(option_class=eng_option)
-        parser.add_option("-p", "--npipelines", type="intx", default=1,
-                          metavar="NPIPES", help="the number of pipelines to create (default=%default)")
-        parser.add_option("-s", "--nstages", type="intx", default=1,
-                          metavar="NSTAGES", help="the number of stages in each pipeline (default=%default)")
-        parser.add_option("-N", "--nsamples", type="eng_float", default=default_nsamples,
+        parser = ArgumentParser()
+        parser.add_argument("-p", "--npipelines", type=intx, default=1,
+                          metavar="NPIPES", help="the number of pipelines to create (default=%(default)s)")
+        parser.add_argument("-s", "--nstages", type=intx, default=1, metavar="NSTAGES",
+                          help="the number of stages in each pipeline (default=%(default)s)")
+        parser.add_argument("-N", "--nsamples", type=eng_float, default=default_nsamples,
                           help=("the number of samples to run through the graph (default=%s)" %
                                 (eng_notation.num_to_str(default_nsamples))))
-        parser.add_option("-m", "--machine-readable", action="store_true", default=False,
+        parser.add_argument("-m", "--machine-readable", action="store_true", default=False,
                           help="enable machine readable output")
 
-        (options, args) = parser.parse_args()
-        if len(args) != 0:
-            parser.print_help()
-            raise SystemExit, 1
+        args = parser.parse_args()
 
-        self.npipes = options.npipelines
-        self.nstages = options.nstages
-        self.nsamples = options.nsamples
-        self.machine_readable = options.machine_readable
+        self.npipes = args.npipelines
+        self.nstages = args.nstages
+        self.nsamples = args.nsamples
+        self.machine_readable = args.machine_readable
 
         ntaps = 256
 
         # Something vaguely like floating point ops
-        self.flop = 2 * ntaps * options.npipelines * options.nstages * options.nsamples
+        self.flop = 2 * ntaps * args.npipelines * args.nstages * args.nsamples
 
         src = blocks.null_source(gr.sizeof_float)
-        head = blocks.head(gr.sizeof_float, int(options.nsamples))
+        head = blocks.head(gr.sizeof_float, int(args.nsamples))
         self.connect(src, head)
 
-        for n in range(options.npipelines):
-            self.connect(head, pipeline(options.nstages, ntaps))
+        for n in range(args.npipelines):
+            self.connect(head, pipeline(args.nstages, ntaps))
 
 
 def time_it(tb):

--- a/gnuradio-runtime/examples/network/vector_sink.py
+++ b/gnuradio-runtime/examples/network/vector_sink.py
@@ -22,8 +22,8 @@
 
 from gnuradio import gr
 from gnuradio import blocks
-from gnuradio.eng_option import eng_option
-from optparse import OptionParser
+from gnuradio.eng_arg import eng_float, intx
+from argparse import ArgumentParser
 
 class vector_sink(gr.top_block):
     def __init__(self, host, port, pkt_size, eof):
@@ -34,24 +34,20 @@ class vector_sink(gr.top_block):
         self.connect(udp, sink)
 
 if __name__ == "__main__":
-    parser = OptionParser(option_class=eng_option)
-    parser.add_option("", "--host", type="string", default="0.0.0.0",
+    parser = ArgumentParser()
+    parser.add_argument("-H", "--host", default="0.0.0.0",
                       help="local host name (domain name or IP address)")
-    parser.add_option("", "--port", type="int", default=65500,
+    parser.add_argument("-p", "--port", type=int, default=65500,
                       help="port value to listen to for connection")
-    parser.add_option("", "--packet-size", type="int", default=1471,
+    parser.add_argument("-s", "--packet-size", type=int, default=1471,
                       help="packet size.")
-    parser.add_option("", "--no-eof", action="store_true", default=False,
+    parser.add_argument("--no-eof", action="store_true", default=False,
                       help="don't send EOF on disconnect")
-    (options, args) = parser.parse_args()
-    if len(args) != 0:
-        parser.print_help()
-        raise SystemExit, 1
-
+    args = parser.parse_args()
     # Create an instance of a hierarchical block
-    top_block = vector_sink(options.host, options.port,
-                            options.packet_size,
-                            not options.no_eof)
+    top_block = vector_sink(args.host, args.port,
+                            args.packet_size,
+                            not args.no_eof)
 
     try:
         # Run forever

--- a/gr-audio/examples/python/audio_copy.py
+++ b/gr-audio/examples/python/audio_copy.py
@@ -22,29 +22,26 @@
 
 from gnuradio import gr
 from gnuradio import audio
-from gnuradio.eng_option import eng_option
-from optparse import OptionParser
+from gnuradio.eng_arg import eng_float
+from argparse import ArgumentParser
 
 class my_top_block(gr.top_block):
 
     def __init__(self):
         gr.top_block.__init__(self)
 
-        parser = OptionParser(option_class=eng_option)
-        parser.add_option("-I", "--audio-input", type="string", default="",
+        parser = ArgumentParser()
+        parser.add_argument("-I", "--audio-input", default="",
                           help="pcm input device name.  E.g., hw:0,0 or /dev/dsp")
-        parser.add_option("-O", "--audio-output", type="string", default="",
+        parser.add_argument("-O", "--audio-output", default="",
                           help="pcm output device name.  E.g., hw:0,0 or /dev/dsp")
-        parser.add_option("-r", "--sample-rate", type="eng_float", default=48000,
-                          help="set sample rate to RATE (48000)")
-        (options, args) = parser.parse_args ()
-        if len(args) != 0:
-            parser.print_help()
-            raise SystemExit, 1
+        parser.add_argument("-r", "--sample-rate", type=eng_float, default=48000,
+                          help="set sample rate, default=%(default)s")
+        args = parser.parse_args ()
 
-        sample_rate = int(options.sample_rate)
-        src = audio.source (sample_rate, options.audio_input)
-        dst = audio.sink (sample_rate, options.audio_output)
+        sample_rate = int(args.sample_rate)
+        src = audio.source (sample_rate, args.audio_input)
+        dst = audio.sink (sample_rate, args.audio_output)
 
         # Determine the maximum number of outputs on the source and
         # maximum number of inputs on the sink, then connect together

--- a/gr-audio/examples/python/audio_fft.py
+++ b/gr-audio/examples/python/audio_fft.py
@@ -46,9 +46,9 @@ class app_top_block(stdgui2.std_top_block):
                           help="set sample rate to RATE (48000)")
 
         (options, args) = parser.parse_args()
-	sample_rate = int(options.sample_rate)
+        sample_rate = int(options.sample_rate)
 
-	if len(args) != 0:
+        if len(args) != 0:
             parser.print_help()
             sys.exit(1)
 
@@ -62,9 +62,9 @@ class app_top_block(stdgui2.std_top_block):
             self.scope = scopesink2.scope_sink_f(panel, sample_rate=sample_rate)
         else:
             self.scope = fftsink2.fft_sink_f (panel, fft_size=1024, sample_rate=sample_rate, fft_rate=30,
-					      ref_scale=1.0, ref_level=0, y_divs=12)
+                                              ref_scale=1.0, ref_level=0, y_divs=12)
 
-	self.src = audio.source (sample_rate, options.audio_input)
+        self.src = audio.source (sample_rate, options.audio_input)
 
         self.connect(self.src, self.scope)
 
@@ -82,7 +82,7 @@ class app_top_block(stdgui2.std_top_block):
 
         vbox.Add(self.scope.win, 10, wx.EXPAND)
 
-	#self._build_subpanel(vbox)
+        #self._build_subpanel(vbox)
 
     def _build_subpanel(self, vbox_arg):
         # build a secondary information panel (sometimes hidden)

--- a/gr-audio/examples/python/audio_fft.py
+++ b/gr-audio/examples/python/audio_fft.py
@@ -21,10 +21,9 @@
 #
 
 from gnuradio import gr, gru, audio
-from gnuradio import eng_notation
-from gnuradio.eng_option import eng_option
+from gnuradio.eng_arg import eng_float
 from gnuradio.wxgui import stdgui2, fftsink2, waterfallsink2, scopesink2, form, slider
-from optparse import OptionParser
+from argparse import ArgumentParser
 import wx
 import sys
 
@@ -35,36 +34,32 @@ class app_top_block(stdgui2.std_top_block):
         self.frame = frame
         self.panel = panel
 
-        parser = OptionParser(option_class=eng_option)
+        parser = ArgumentParser()
         parser.add_option("-W", "--waterfall", action="store_true", default=False,
                           help="Enable waterfall display")
         parser.add_option("-S", "--oscilloscope", action="store_true", default=False,
                           help="Enable oscilloscope display")
-        parser.add_option("-I", "--audio-input", type="string", default="",
+        parser.add_option("-I", "--audio-input", default="",
                           help="pcm input device name.  E.g., hw:0,0 or /dev/dsp")
-        parser.add_option("-r", "--sample-rate", type="eng_float", default=48000,
-                          help="set sample rate to RATE (48000)")
+        parser.add_option("-r", "--sample-rate", type=eng_float, default=48000,
+                          help="set sample rate to RATE (%(default)s)")
 
-        (options, args) = parser.parse_args()
-        sample_rate = int(options.sample_rate)
-
-        if len(args) != 0:
-            parser.print_help()
-            sys.exit(1)
+        args = parser.parse_args()
+        sample_rate = int(args.sample_rate)
 
         self.show_debug_info = True
 
         # build the graph
-        if options.waterfall:
+        if args.waterfall:
             self.scope = \
               waterfallsink2.waterfall_sink_f (panel, fft_size=1024, sample_rate=sample_rate)
-        elif options.oscilloscope:
+        elif args.oscilloscope:
             self.scope = scopesink2.scope_sink_f(panel, sample_rate=sample_rate)
         else:
             self.scope = fftsink2.fft_sink_f (panel, fft_size=1024, sample_rate=sample_rate, fft_rate=30,
                                               ref_scale=1.0, ref_level=0, y_divs=12)
 
-        self.src = audio.source (sample_rate, options.audio_input)
+        self.src = audio.source (sample_rate, args.audio_input)
 
         self.connect(self.src, self.scope)
 

--- a/gr-audio/examples/python/dial_tone.py
+++ b/gr-audio/examples/python/dial_tone.py
@@ -22,8 +22,8 @@
 
 from gnuradio import gr
 from gnuradio import audio
-from gnuradio.eng_option import eng_option
-from optparse import OptionParser
+from gnuradio.eng_arg import eng_float
+from argparse import ArgumentParser
 
 try:
     from gnuradio import analog
@@ -36,22 +36,19 @@ class my_top_block(gr.top_block):
     def __init__(self):
         gr.top_block.__init__(self)
 
-        parser = OptionParser(option_class=eng_option)
-        parser.add_option("-O", "--audio-output", type="string", default="",
+        parser = ArgumentParser()
+        parser.add_argument("-O", "--audio-output", default="",
                           help="pcm output device name.  E.g., hw:0,0 or /dev/dsp")
-        parser.add_option("-r", "--sample-rate", type="eng_float", default=48000,
-                          help="set sample rate to RATE (48000)")
-        (options, args) = parser.parse_args()
-        if len(args) != 0:
-            parser.print_help()
-            raise SystemExit, 1
+        parser.add_argument("-r", "--sample-rate", type=eng_float, default=48000,
+                          help="set sample rate, default=%(default)s")
+        args = parser.parse_args()
 
-        sample_rate = int(options.sample_rate)
+        sample_rate = int(args.sample_rate)
         ampl = 0.1
 
         src0 = analog.sig_source_f(sample_rate, analog.GR_SIN_WAVE, 350, ampl)
         src1 = analog.sig_source_f(sample_rate, analog.GR_SIN_WAVE, 440, ampl)
-        dst = audio.sink(sample_rate, options.audio_output)
+        dst = audio.sink(sample_rate, args.audio_output)
         self.connect(src0, (dst, 0))
         self.connect(src1, (dst, 1))
 

--- a/gr-digital/python/digital/cpm.py
+++ b/gr-digital/python/digital/cpm.py
@@ -33,7 +33,7 @@ import numpy
 import digital_swig
 import modulation_utils
 
-# default values (used in __init__ and add_options)
+# default values (used in __init__)
 _def_samples_per_symbol = 2
 _def_bits_per_symbol = 1
 _def_h_numerator = 1
@@ -203,15 +203,6 @@ class cpm_mod(gr.hier_block2):
                      blocks.file_sink(gr.sizeof_float, "filter.dat"))
         self.connect(self.fmmod,
                      blocks.file_sink(gr.sizeof_gr_complex, "fmmod.dat"))
-
-
-    def add_options(parser):
-        """
-        Adds CPM modulation-specific options to the standard parser
-        """
-        parser.add_option("", "--bt", type="float", default=_def_bt,
-                          help="set bandwidth-time product [default=%default] (GMSK)")
-    add_options=staticmethod(add_options)
 
 
     def extract_kwargs_from_options(options):

--- a/gr-digital/python/digital/generic_mod_demod.py
+++ b/gr-digital/python/digital/generic_mod_demod.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     import analog_swig as analog
 
-# default values (used in __init__ and add_options)
+# default values (used in __init__)
 _def_samples_per_symbol = 2
 _def_excess_bw = 0.35
 _def_verbose = False
@@ -174,13 +174,6 @@ class generic_mod(gr.hier_block2):
 
     def bits_per_symbol(self):   # static method that's also callable on an instance
         return self._constellation.bits_per_symbol()
-
-    def add_options(parser):
-        """
-        Adds generic modulation options to the standard parser
-        """
-        add_common_options(parser)
-    add_options=staticmethod(add_options)
 
     def extract_kwargs_from_options(cls, options):
         """
@@ -371,21 +364,6 @@ class generic_demod(gr.hier_block2):
                          blocks.file_sink(gr.sizeof_char, "rx_symbol_mapper.8b"))
         self.connect(self.unpack,
                      blocks.file_sink(gr.sizeof_char, "rx_unpack.8b"))
-
-    def add_options(parser):
-        """
-        Adds generic demodulation options to the standard parser
-        """
-        # Add options shared with modulator.
-        add_common_options(parser)
-        # Add options specific to demodulator.
-        parser.add_option("", "--freq-bw", type="float", default=_def_freq_bw,
-                          help="set frequency lock loop lock-in bandwidth [default=%default]")
-        parser.add_option("", "--phase-bw", type="float", default=_def_phase_bw,
-                          help="set phase tracking loop lock-in bandwidth [default=%default]")
-        parser.add_option("", "--timing-bw", type="float", default=_def_timing_bw,
-                          help="set timing symbol sync loop gain lock-in bandwidth [default=%default]")
-    add_options=staticmethod(add_options)
 
     def extract_kwargs_from_options(cls, options):
         """

--- a/gr-digital/python/digital/gfsk.py
+++ b/gr-digital/python/digital/gfsk.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     import filter_swig as filter
 
-# default values (used in __init__ and add_options)
+# default values (used in __init__)
 _def_samples_per_symbol = 2
 _def_sensitivity = 1
 _def_bt = 0.35
@@ -151,15 +151,6 @@ class gfsk_mod(gr.hier_block2):
                      blocks.file_sink(gr.sizeof_float, "gaussian_filter.dat"))
         self.connect(self.fmmod,
                      blocks.file_sink(gr.sizeof_gr_complex, "fmmod.dat"))
-
-
-    def add_options(parser):
-        """
-        Adds GFSK modulation-specific options to the standard parser
-        """
-        parser.add_option("", "--bt", type="float", default=_def_bt,
-                          help="set bandwidth-time product [default=%default] (GFSK)")
-    add_options=staticmethod(add_options)
 
 
     def extract_kwargs_from_options(options):
@@ -277,20 +268,6 @@ class gfsk_demod(gr.hier_block2):
                     blocks.file_sink(gr.sizeof_float, "clock_recovery.dat"))
         self.connect(self.slicer,
                     blocks.file_sink(gr.sizeof_char, "slicer.dat"))
-
-    def add_options(parser):
-        """
-        Adds GFSK demodulation-specific options to the standard parser
-        """
-        parser.add_option("", "--gain-mu", type="float", default=_def_gain_mu,
-                          help="M&M clock recovery gain mu [default=%default] (GFSK/PSK)")
-        parser.add_option("", "--mu", type="float", default=_def_mu,
-                          help="M&M clock recovery mu [default=%default] (GFSK/PSK)")
-        parser.add_option("", "--omega-relative-limit", type="float", default=_def_omega_relative_limit,
-                          help="M&M clock recovery omega relative limit [default=%default] (GFSK/PSK)")
-        parser.add_option("", "--freq-error", type="float", default=_def_freq_error,
-                          help="M&M clock recovery frequency error [default=%default] (GFSK)")
-    add_options=staticmethod(add_options)
 
     def extract_kwargs_from_options(options):
         """

--- a/gr-digital/python/digital/gmsk.py
+++ b/gr-digital/python/digital/gmsk.py
@@ -34,7 +34,7 @@ from gnuradio import gr, blocks, analog, filter
 import modulation_utils
 import digital_swig as digital
 
-# default values (used in __init__ and add_options)
+# default values (used in __init__)
 _def_samples_per_symbol = 2
 _def_bt = 0.35
 _def_verbose = False
@@ -141,15 +141,6 @@ class gmsk_mod(gr.hier_block2):
                      blocks.file_sink(gr.sizeof_float, "gaussian_filter.dat"))
         self.connect(self.fmmod,
                      blocks.file_sink(gr.sizeof_gr_complex, "fmmod.dat"))
-
-
-    def add_options(parser):
-        """
-        Adds GMSK modulation-specific options to the standard parser
-        """
-        parser.add_option("", "--bt", type="float", default=_def_bt,
-                          help="set bandwidth-time product [default=%default] (GMSK)")
-    add_options=staticmethod(add_options)
 
 
     def extract_kwargs_from_options(options):
@@ -262,19 +253,6 @@ class gmsk_demod(gr.hier_block2):
         self.connect(self.slicer,
                     blocks.file_sink(gr.sizeof_char, "slicer.dat"))
 
-    def add_options(parser):
-        """
-        Adds GMSK demodulation-specific options to the standard parser
-        """
-        parser.add_option("", "--gain-mu", type="float", default=_def_gain_mu,
-                          help="M&M clock recovery gain mu [default=%default] (GMSK/PSK)")
-        parser.add_option("", "--mu", type="float", default=_def_mu,
-                          help="M&M clock recovery mu [default=%default] (GMSK/PSK)")
-        parser.add_option("", "--omega-relative-limit", type="float", default=_def_omega_relative_limit,
-                          help="M&M clock recovery omega relative limit [default=%default] (GMSK/PSK)")
-        parser.add_option("", "--freq-error", type="float", default=_def_freq_error,
-                          help="M&M clock recovery frequency error [default=%default] (GMSK)")
-    add_options=staticmethod(add_options)
 
     def extract_kwargs_from_options(options):
         """

--- a/gr-digital/python/digital/ofdm.py
+++ b/gr-digital/python/digital/ofdm.py
@@ -146,21 +146,6 @@ class ofdm_mod(gr.hier_block2):
             msg = gr.message_from_string(pkt)
         self._pkt_input.msgq().insert_tail(msg)
 
-    def add_options(normal, expert):
-        """
-        Adds OFDM-specific options to the Options Parser
-        """
-        normal.add_option("-m", "--modulation", type="string", default="bpsk",
-                          help="set modulation type (bpsk, qpsk, 8psk, qam{16,64}) [default=%default]")
-        expert.add_option("", "--fft-length", type="intx", default=512,
-                          help="set the number of FFT bins [default=%default]")
-        expert.add_option("", "--occupied-tones", type="intx", default=200,
-                          help="set the number of occupied FFT bins [default=%default]")
-        expert.add_option("", "--cp-length", type="intx", default=128,
-                          help="set the number of bits in the cyclic prefix [default=%default]")
-    # Make a static method to call before instantiation
-    add_options = staticmethod(add_options)
-
     def _print_verbage(self):
         """
         Prints information about the OFDM modulator
@@ -266,23 +251,6 @@ class ofdm_demod(gr.hier_block2):
             self._print_verbage()
             
         self._watcher = _queue_watcher_thread(self._rcvd_pktq, callback)
-
-    def add_options(normal, expert):
-        """
-        Adds OFDM-specific options to the Options Parser
-        """
-        normal.add_option("-m", "--modulation", type="string", default="bpsk",
-                          help="set modulation type (bpsk or qpsk) [default=%default]")
-        expert.add_option("", "--fft-length", type="intx", default=512,
-                          help="set the number of FFT bins [default=%default]")
-        expert.add_option("", "--occupied-tones", type="intx", default=200,
-                          help="set the number of occupied FFT bins [default=%default]")
-        expert.add_option("", "--cp-length", type="intx", default=128,
-                          help="set the number of bits in the cyclic prefix [default=%default]")
-        expert.add_option("", "--snr", type="float", default=30.0,
-                          help="SNR estimate [default=%default]")
-    # Make a static method to call before instantiation
-    add_options = staticmethod(add_options)
 
     def _print_verbage(self):
         """


### PR DESCRIPTION
Just modernization + one clean-up.

The last commit (2d25aa0) removes functions add_options from few modules. There is several reasons to do so.
  * I doubt they are used anywhere
  * It seems non-coherent to have program arguments in module
  * Default argument values are not set, but  default=%s is used in parameter help
  * It easier to remove it than add equivalent function for ArgumentParser (and it would merely duplicate code)
  * Which modules should have add_options implemented?

This one is just for gr-digital section, there is a bit more of this add_options stuff.