### PR TITLE
added message outputs for asynchronous messages from uhd::tx_streamer

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -377,12 +377,21 @@ set_lo_export_enabled(\$lo_export$(n), uhd.ALL_LOS, $n)
 		<type>\$type.type</type>
 		<nports>\$nchan</nports>
 	</$sourk>
+#if $sourk == 'source'
 	<source>
-		<name>async_messages</name>
+		<name>rx_metad</name>
 		<type>message</type>
 		<optional>1</optional>
 		<hide>\$hide_cmd_port</hide>
 	</source>
+#else
+	<source>
+		<name>tx_async</name>
+		<type>message</type>
+		<optional>1</optional>
+		<hide>\$hide_cmd_port</hide>
+	</source>
+#end if
 	<doc>
 The UHD USRP $sourk.title() Block:
 

--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -377,6 +377,12 @@ set_lo_export_enabled(\$lo_export$(n), uhd.ALL_LOS, $n)
 		<type>\$type.type</type>
 		<nports>\$nchan</nports>
 	</$sourk>
+	<source>
+		<name>async_messages</name>
+		<type>message</type>
+		<optional>1</optional>
+		<hide>\$hide_cmd_port</hide>
+	</source>
 	<doc>
 The UHD USRP $sourk.title() Block:
 

--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -379,7 +379,7 @@ set_lo_export_enabled(\$lo_export$(n), uhd.ALL_LOS, $n)
 	</$sourk>
 #if $sourk == 'source'
 	<source>
-		<name>rx_metad</name>
+		<name>rx_metadata</name>
 		<type>message</type>
 		<optional>1</optional>
 		<hide>\$hide_cmd_port</hide>

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -27,6 +27,9 @@ using namespace gr::uhd;
 
 const double usrp_block_impl::LOCK_TIMEOUT = 1.5;
 
+const pmt::pmt_t usrp_block_impl::COMMAND_PORT = pmt::mp("command");
+const pmt::pmt_t usrp_block_impl::ASYNC_MSG_PORT = pmt::mp("async_messages");
+
 const pmt::pmt_t CMD_CHAN_KEY = pmt::mp("chan");
 const pmt::pmt_t CMD_GAIN_KEY = pmt::mp("gain");
 const pmt::pmt_t CMD_FREQ_KEY = pmt::mp("freq");
@@ -74,11 +77,12 @@ usrp_block_impl::usrp_block_impl(
   _check_mboard_sensors_locked();
 
   // Set up message ports:
-  message_port_register_in(pmt::mp("command"));
+  message_port_register_in(COMMAND_PORT);
   set_msg_handler(
-      pmt::mp("command"),
+      COMMAND_PORT,
       boost::bind(&usrp_block_impl::msg_handler_command, this, _1)
   );
+  message_port_register_out(ASYNC_MSG_PORT);
 
 // cuz we lazy:
 #define REGISTER_CMD_HANDLER(key, _handler) register_msg_cmd_handler(key, boost::bind(&usrp_block_impl::_handler, this, _1, _2, _3))

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -28,7 +28,6 @@ using namespace gr::uhd;
 const double usrp_block_impl::LOCK_TIMEOUT = 1.5;
 
 const pmt::pmt_t usrp_block_impl::COMMAND_PORT = pmt::mp("command");
-const pmt::pmt_t usrp_block_impl::ASYNC_MSG_PORT = pmt::mp("async_messages");
 
 const pmt::pmt_t CMD_CHAN_KEY = pmt::mp("chan");
 const pmt::pmt_t CMD_GAIN_KEY = pmt::mp("gain");
@@ -82,7 +81,6 @@ usrp_block_impl::usrp_block_impl(
       COMMAND_PORT,
       boost::bind(&usrp_block_impl::msg_handler_command, this, _1)
   );
-  message_port_register_out(ASYNC_MSG_PORT);
 
 // cuz we lazy:
 #define REGISTER_CMD_HANDLER(key, _handler) register_msg_cmd_handler(key, boost::bind(&usrp_block_impl::_handler, this, _1, _2, _3))

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -121,7 +121,6 @@ namespace gr {
        * Canonical Message Port Names
        **********************************************************************/
       static const pmt::pmt_t COMMAND_PORT;
-      static const pmt::pmt_t ASYNC_MSG_PORT;
 
       /**********************************************************************
        * Command Interface

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -118,6 +118,12 @@ namespace gr {
       );
 
       /**********************************************************************
+       * Canonical Message Port Names
+       **********************************************************************/
+      static const pmt::pmt_t COMMAND_PORT;
+      static const pmt::pmt_t ASYNC_MSG_PORT;
+
+      /**********************************************************************
        * Command Interface
        **********************************************************************/
       //! Receives commands and handles them

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -70,6 +70,9 @@ namespace gr {
         _nitems_to_send(0)
     {
       _sample_rate = get_samp_rate();
+#ifdef GR_UHD_USE_STREAM_API
+      message_port_register_out(TX_ASYNC_MSG_PORT);
+#endif
     }
 
     usrp_sink_impl::~usrp_sink_impl()
@@ -544,8 +547,8 @@ namespace gr {
         } else if (in_burst_cmd_offset < max_count) {
           BOOST_FOREACH(const pmt::pmt_t &cmd_pmt, commands_in_burst) {
             _pending_cmds.push_back(cmd_pmt);
-          }
         }
+      }
       }
 
       if (found_time_tag) {
@@ -581,7 +584,7 @@ namespace gr {
                  pmt::from_double(async_md.time_spec.get_frac_secs()));
               dic = pmt::dict_add(dic, pmt::mp("time"), timespec);
             }
-            message_port_pub(ASYNC_MSG_PORT, dic);
+            message_port_pub(TX_ASYNC_MSG_PORT, dic);
           }
         } else {
           // handle the case that no async_msg was available; usually, this should be ignored for being OK.
@@ -589,7 +592,7 @@ namespace gr {
           /* 
              pmt::pmt_t dic = pmt::make_dict();
              dic = pmt::dict_add(dic, pmt::mp("timeout"), pmt::from_bool(true));
-             message_port_pub(ASYNC_MSG_PORT, dic);
+             message_port_pub(TX_ASYNC_MSG_PORT, dic);
              */
         }
       }

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -29,6 +29,7 @@ static const pmt::pmt_t EOB_KEY = pmt::string_to_symbol("tx_eob");
 static const pmt::pmt_t TIME_KEY = pmt::string_to_symbol("tx_time");
 static const pmt::pmt_t FREQ_KEY = pmt::string_to_symbol("tx_freq");
 static const pmt::pmt_t COMMAND_KEY = pmt::string_to_symbol("tx_command");
+static const pmt::pmt_t TX_ASYNC_MSG_PORT = pmt::string_to_symbol("tx_async");
 
 namespace gr {
   namespace uhd {

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -111,6 +111,8 @@ namespace gr {
 
 #ifdef GR_UHD_USE_STREAM_API
       ::uhd::tx_streamer::sptr _tx_stream;
+      void _async_loop();
+      gr::thread::thread _async_thread;
 #endif
       ::uhd::tx_metadata_t _metadata;
       double _sample_rate;

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -81,6 +81,7 @@ namespace gr {
       _center_freq = this->get_center_freq(0);
 #ifdef GR_UHD_USE_STREAM_API
       _samps_per_packet = 1;
+      message_port_register_out(RX_METADATA_MSG_PORT);
 #endif
       register_msg_cmd_handler(CMD_TAG_KEY, boost::bind(&usrp_source_impl::_cmd_handler_tag, this, _1));
     }
@@ -670,7 +671,7 @@ namespace gr {
                pmt::from_double(_metadata.time_spec.get_frac_secs()));
             dic = pmt::dict_add(dic, pmt::mp("time"), timespec);
           }
-          message_port_pub(ASYNC_MSG_PORT, dic);
+          message_port_pub(RX_METADATA_MSG_PORT, dic);
         }
         //ignore overflows and try work again
 
@@ -692,7 +693,7 @@ namespace gr {
                pmt::from_double(_metadata.time_spec.get_frac_secs()));
             dic = pmt::dict_add(dic, pmt::mp("time"), timespec);
           }
-          message_port_pub(ASYNC_MSG_PORT, dic);
+          message_port_pub(RX_METADATA_MSG_PORT, dic);
         }
         return num_samps;
       }

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2010-2015 Free Software Foundation, Inc.
+ * Copyright 2010-2016 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -661,7 +661,8 @@ namespace gr {
       case ::uhd::rx_metadata_t::ERROR_CODE_OVERFLOW:
         _tag_now = true;
 
-        //publish message
+        //publish message, only if someone's listening
+        if(! pmt::is_null(d_message_subscribers) )
         {
           pmt::pmt_t dic = pmt::make_dict();
           dic = pmt::dict_add(dic, pmt::mp("code"), pmt::from_long(_metadata.error_code));
@@ -681,7 +682,8 @@ namespace gr {
         //GR_LOG_WARN(d_logger, boost::format("USRP Source Block caught rx error: %d") % _metadata.strerror());
         GR_LOG_WARN(d_logger, boost::format("USRP Source Block caught rx error code: %d") % _metadata.error_code);
 
-        //publish message
+        //publish message, only if someone's listening
+        if(! pmt::is_null(d_message_subscribers) )
         {
           pmt::pmt_t dic = pmt::make_dict();
           dic = pmt::dict_add(dic, pmt::mp("code"), pmt::from_long(_metadata.error_code));

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -28,7 +28,7 @@
 static const pmt::pmt_t TIME_KEY = pmt::string_to_symbol("rx_time");
 static const pmt::pmt_t RATE_KEY = pmt::string_to_symbol("rx_rate");
 static const pmt::pmt_t FREQ_KEY = pmt::string_to_symbol("rx_freq");
-static const pmt::pmt_t RX_METADATA_MSG_PORT = pmt::string_to_symbol("rx_metad");
+static const pmt::pmt_t RX_METADATA_MSG_PORT = pmt::string_to_symbol("rx_metadata");
 
 namespace gr {
   namespace uhd {

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -28,6 +28,7 @@
 static const pmt::pmt_t TIME_KEY = pmt::string_to_symbol("rx_time");
 static const pmt::pmt_t RATE_KEY = pmt::string_to_symbol("rx_rate");
 static const pmt::pmt_t FREQ_KEY = pmt::string_to_symbol("rx_freq");
+static const pmt::pmt_t RX_METADATA_MSG_PORT = pmt::string_to_symbol("rx_metad");
 
 namespace gr {
   namespace uhd {


### PR DESCRIPTION
This competes with gr::uhd::amsg_source, but that uses the deprecated uhd::device::recv_async_msgs() as well as it only posts messages to an old-style message queue, neither of which are future proof.

This adds an output message port to USRP Sink and Source. Sink already works, Source has to be modified (minor).


The output messages are pmt dicts, with the following fields:

* code: event code, such as underrun, sequence error etc. For details, see http://files.ettus.com/manual/structuhd_1_1async__metadata__t.html
* channel: the effecting channel
* time_spec: Only present if the async metadata specifies it has a timestamp. Follows the gr::uhd time_spec shape pmt::pair(uint64_t full seconds, double fractional seconds)
* user payload data: TX streamers can put 4 x 32bit of custom data in this. pmt::u32vector of length 4.