### PR TITLE
modtool: add basic support for GRC modules in block tree

### DIFF
--- a/gr-utils/python/modtool/grc_xml_generator.py
+++ b/gr-utils/python/modtool/grc_xml_generator.py
@@ -35,7 +35,7 @@ class GRCXMLGenerator(object):
         # Can't make a dict 'cause order matters
         self._header = (('name', blockname.replace('_', ' ').capitalize()),
                         ('key', '%s_%s' % (modname, blockname)),
-                        ('category', modname.upper()),
+                        ('category', '[%s]' % modname.upper()),
                         ('import', 'import %s' % modname),
                         ('make', '%s.%s(%s)' % (modname, blockname, ', '.join(params_list)))
                        )

--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -521,7 +521,7 @@ Templates['grc_xml'] = '''<?xml version="1.0"?>
 <block>
   <name>$blockname</name>
   <key>${modname}_$blockname</key>
-  <category>$modname</category>
+  <category>[$modname]</category>
   <import>import $modname</import>
   <make>${modname}.${blockname}(${strip_arg_types_grc($arglist)})</make>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.


### PR DESCRIPTION
This adds basic support for the recently merged modules in the GRC block tree - namely decorating the root category with square brackets.

It would be nice to have a 'default GRC category' option in the CLI. But this requires to store the info between runs of modtool newmod and e.g. add, which AFAIK is not possible at the moment!?