### PR TITLE
grc: fix parameter blocks, empty Short ID and string type

### DIFF
--- a/grc/blocks/parameter.xml
+++ b/grc/blocks/parameter.xml
@@ -55,7 +55,7 @@
 		</option>
 		<option>
 			<name>String</name>
-			<key>string</key>
+			<key>str</key>
 			<opt>type:string</opt>
         </option>
         <!-- Do not forget to add option value type handler import into

--- a/grc/core/generator/flow_graph.tmpl
+++ b/grc/core/generator/flow_graph.tmpl
@@ -347,7 +347,10 @@ def argument_parser():
         #if $type
             #silent $params_eq_list.append('%s=options.%s'%($param.get_id(), $param.get_id()))
     parser.add_argument(
-        "$make_short_id($param)", "--$param.get_id().replace('_', '-')", dest="$param.get_id()", type=$type, default=$make_default($type, $param),
+        #if $make_short_id($param)
+        "$make_short_id($param)", #slurp
+        #end if
+        "--$param.get_id().replace('_', '-')", dest="$param.get_id()", type=$type, default=$make_default($type, $param),
         help="Set $($param.get_param('label').get_evaluated() or $param.get_id()) [default=%default]")
         #end if
     #end for


### PR DESCRIPTION
param block was pretty broken after PR #688
wrong string type passed outside of quotes + can't pass empty string short arg to arg parser