### PR TITLE
added set_min_output_buffer call, as that seems to be in particular demand

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -143,6 +143,14 @@ namespace gr {
       return gr::block::set_output_multiple(multiple);
     }
 
+    void block__set_min_output_buffer(int port, long size) {
+      return gr::block::set_min_output_buffer(port, size);
+    }
+
+    void block__set_min_output_buffer(long size) {
+      return gr::block::set_min_output_buffer(size);
+    }
+
     int block__output_multiple(void) const {
       return gr::block::output_multiple();
     }


### PR DESCRIPTION
Please excuse the fact that this is far from the comprehensive wrapping check we should be doing.

Fixes the acute issue of http://stackoverflow.com/questions/37870987/gnuradio-set-minimum-input-output-buffer-size-for-a-python-block