### PR TITLE
Fix locking issue during repeated lock-unlock

### DIFF
--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -82,6 +82,7 @@ namespace gr {
     gr::thread::mutex d_mutex;    // protects d_state and d_lock_count
     tb_state d_state;
     int d_lock_count;
+    bool d_retry_wait;
     boost::condition_variable d_lock_cond;
     int d_max_noutput_items;
 

--- a/gr-blocks/python/blocks/qa_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_hier_block2.py
@@ -2,6 +2,7 @@
 
 from gnuradio import gr, gr_unittest, blocks
 import numpy
+import threading
 import time
 
 class add_ff(gr.sync_block):
@@ -427,7 +428,7 @@ class test_hier_block2(gr_unittest.TestCase):
         procs = hblock.processor_affinity()
         self.assertEquals((0,), procs)
 
-    def test_lock_unlock(self):
+    def test_34a_lock_unlock(self):
         hblock = gr.top_block("test_block")
         src = blocks.null_source(gr.sizeof_float)
         throttle = blocks.throttle(gr.sizeof_float, 32000)
@@ -441,6 +442,29 @@ class test_hier_block2(gr_unittest.TestCase):
         hblock.unlock()
         hblock.stop()
         hblock.wait()
+
+    def test_34b_lock_unlock(self):
+        hblock = gr.top_block("test_block")
+        src = blocks.null_source(gr.sizeof_float)
+        throttle = blocks.throttle(gr.sizeof_float, 32000)
+        sink = blocks.null_sink(gr.sizeof_float)
+        hblock.connect(src, throttle, sink)
+        hblock.set_processor_affinity([0,])
+        def thread_01(hblock, cls):
+            cls.test_34b_val = 10
+            hblock.lock()
+            cls.test_34b_val = 20
+            hblock.unlock()
+            cls.test_34b_val = 30
+            time.sleep(0.5)
+            cls.test_34b_val = 40
+            hblock.stop()
+        hblock.start()
+        self.test_34b_val = 0
+        t1 = threading.Thread(target=thread_01, args=(hblock, self, ))
+        t1.start()
+        hblock.wait()
+        self.assertEqual(40, self.test_34b_val)
 
 if __name__ == "__main__":
     gr_unittest.run(test_hier_block2, "test_hier_block2.xml")


### PR DESCRIPTION
This commits fix issue when wait() thinks it is finished and exists, but should not. It happends after call of lock()/unlock().
