### PR TITLE
examples: enforce IPv4 in all example addresses

### DIFF
--- a/gnuradio-runtime/examples/network/audio_source.py
+++ b/gnuradio-runtime/examples/network/audio_source.py
@@ -41,7 +41,7 @@ class audio_source(gr.top_block):
 
 if __name__ == '__main__':
     parser = OptionParser(option_class=eng_option)
-    parser.add_option("", "--host", type="string", default="localhost",
+    parser.add_option("", "--host", type="string", default="127.0.0.1",
                       help="Remote host name (domain name or IP address")
     parser.add_option("", "--port", type="int", default=65500,
                       help="port number to connect to")

--- a/gnuradio-runtime/examples/network/dial_tone_source.py
+++ b/gnuradio-runtime/examples/network/dial_tone_source.py
@@ -53,7 +53,7 @@ class dial_tone_source(gr.top_block):
 
 if __name__ == '__main__':
     parser = OptionParser(option_class=eng_option)
-    parser.add_option("", "--host", type="string", default="localhost",
+    parser.add_option("", "--host", type="string", default="127.0.0.1",
                       help="Remote host name (domain name or IP address")
     parser.add_option("", "--port", type="int", default=65500,
                       help="port number to connect to")

--- a/gnuradio-runtime/examples/network/vector_source.py
+++ b/gnuradio-runtime/examples/network/vector_source.py
@@ -35,7 +35,7 @@ class vector_source(gr.top_block):
 
 if __name__ == '__main__':
     parser = OptionParser(option_class=eng_option)
-    parser.add_option("", "--host", type="string", default="localhost",
+    parser.add_option("", "--host", type="string", default="127.0.0.1",
                       help="Remote host name (domain name or IP address")
     parser.add_option("", "--port", type="int", default=65500,
                       help="port number to connect to")


### PR DESCRIPTION
Fixes issue where the pair examples (network***sink and network***source) does not work together.

localhost might be resolve to ::1 on IPv6 enabled hosts, but the client is listening only on 0.0.0.0 (IPv4) addresses.

PS: It would be much nicer solution to honor udp_source documentation and listen on ALL interfaces when no address is specified, instead of just not listening at all. I might try to fix this latter.