### PR TITLE
Enable logging permanently and require liblog4cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,8 +401,8 @@ endif(NOT VOLK_FOUND)
 
 message(STATUS "  Override with -DENABLE_INTERNAL_VOLK=ON/OFF")
 
-# Handle gr_log enable/disable
-GR_LOGGING()
+# Handle logging
+find_package(Log4cpp)
 
 ########################################################################
 # Distribute the README file

--- a/cmake/Modules/GrMiscUtils.cmake
+++ b/cmake/Modules/GrMiscUtils.cmake
@@ -216,49 +216,6 @@ function(GR_GEN_TARGET_DEPS name var)
 endfunction(GR_GEN_TARGET_DEPS)
 
 ########################################################################
-# Control use of gr_logger
-# Usage:
-#   GR_LOGGING()
-#
-# Will set ENABLE_GR_LOG to 1 by default.
-# Can manually set with -DENABLE_GR_LOG=0|1
-########################################################################
-function(GR_LOGGING)
-  find_package(Log4cpp)
-
-  OPTION(ENABLE_GR_LOG "Use gr_logger" ON)
-  if(ENABLE_GR_LOG)
-    # If gr_logger is enabled, make it usable
-    add_definitions( -DENABLE_GR_LOG )
-
-    # also test LOG4CPP; if we have it, use this version of the logger
-    # otherwise, default to the stdout/stderr model.
-    if(LOG4CPP_FOUND)
-      SET(HAVE_LOG4CPP True CACHE INTERNAL "" FORCE)
-      add_definitions( -DHAVE_LOG4CPP )
-    else(not LOG4CPP_FOUND)
-      SET(HAVE_LOG4CPP False CACHE INTERNAL "" FORCE)
-      SET(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
-      SET(LOG4CPP_LIBRARY_DIRS "" CACHE INTERNAL "" FORCE)
-      SET(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
-    endif(LOG4CPP_FOUND)
-
-    SET(ENABLE_GR_LOG ${ENABLE_GR_LOG} CACHE INTERNAL "" FORCE)
-
-  else(ENABLE_GR_LOG)
-    SET(HAVE_LOG4CPP False CACHE INTERNAL "" FORCE)
-    SET(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
-    SET(LOG4CPP_LIBRARY_DIRS "" CACHE INTERNAL "" FORCE)
-    SET(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
-  endif(ENABLE_GR_LOG)
-
-  message(STATUS "ENABLE_GR_LOG set to ${ENABLE_GR_LOG}.")
-  message(STATUS "HAVE_LOG4CPP set to ${HAVE_LOG4CPP}.")
-  message(STATUS "LOG4CPP_LIBRARIES set to ${LOG4CPP_LIBRARIES}.")
-
-endfunction(GR_LOGGING)
-
-########################################################################
 # Run GRCC to compile .grc files into .py files.
 #
 # Usage: GRCC(filename, directory)

--- a/gnuradio-runtime/CMakeLists.txt
+++ b/gnuradio-runtime/CMakeLists.txt
@@ -37,6 +37,7 @@ GR_REGISTER_COMPONENT("gnuradio-runtime" ENABLE_GNURADIO_RUNTIME
     Boost_FOUND
     ENABLE_VOLK
     PYTHONINTERP_FOUND
+    LOG4CPP_FOUND
 )
 
 GR_SET_GLOBAL(GNURADIO_RUNTIME_INCLUDE_DIRS
@@ -133,13 +134,11 @@ install(
     COMPONENT "runtime_runtime"
 )
 
-if(ENABLE_GR_LOG AND HAVE_LOG4CPP)
 install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/gr_log_default.conf
     DESTINATION ${GR_PREFSDIR}
     COMPONENT "runtime_runtime"
 )
-endif(ENABLE_GR_LOG AND HAVE_LOG4CPP)
 
 ########################################################################
 # Add subdirectories

--- a/gnuradio-runtime/include/gnuradio/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/CMakeLists.txt
@@ -44,6 +44,7 @@ install(FILES
   hier_block2.h
   high_res_timer.h
   io_signature.h
+  logger.h
   math.h
   message.h
   misc.h
@@ -81,7 +82,6 @@ install(FILES
   rpcserver_booter_aggregator.h
   rpcserver_booter_base.h
   rpcserver_selector.h
-  ${CMAKE_CURRENT_BINARY_DIR}/logger.h
   DESTINATION ${GR_INCLUDE_DIR}/gnuradio
   COMPONENT "runtime_devel"
 )
@@ -95,11 +95,3 @@ install(FILES
   COMPONENT "runtime_devel"
 )
 endif(THRIFT_FOUND)
-
-##########################################################################
-# Configure logger
-##########################################################################
-CONFIGURE_FILE(
-  ${CMAKE_CURRENT_SOURCE_DIR}/logger.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/logger.h
-)

--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -20,12 +20,6 @@
  * Boston, MA 02110-1301, USA.
  */
 
-/*******************************************************************************
-* Author: Mark Plett
-* Description:
-*   The gr::logger module wraps the log4cpp library for logging in gnuradio
-*******************************************************************************/
-
 #ifndef INCLUDED_GR_LOGGER_H
 #define INCLUDED_GR_LOGGER_H
 
@@ -34,13 +28,6 @@
 * \brief GNU Radio logging wrapper for log4cpp library (C++ port of log4j)
 *
 */
-
-#ifndef ENABLE_GR_LOG
-#cmakedefine ENABLE_GR_LOG
-#endif
-#ifndef HAVE_LOG4CPP
-#cmakedefine HAVE_LOG4CPP
-#endif
 
 #ifdef _MSC_VER
 typedef unsigned short mode_t;
@@ -56,71 +43,6 @@ typedef unsigned short mode_t;
 #include <boost/thread.hpp>
 #include <boost/format.hpp>
 #include <pmt/pmt.h>
-
-#ifdef ENABLE_GR_LOG
-
-// We have three configurations... first logging to stdout/stderr
-#ifndef HAVE_LOG4CPP
-
-namespace gr {
-  //#warning GR logging Enabled and using std::cout
-  typedef std::string logger_ptr;
-} /* namespace gr */
-
-#define GR_LOG_DECLARE_LOGPTR(logger)
-#define GR_LOG_ASSIGN_LOGPTR(logger,name)
-#define GR_CONFIG_LOGGER(config)
-#define GR_CONFIG_AND_WATCH_LOGGER(config,period)
-#define GR_LOG_GETLOGGER(logger, name)
-#define GR_SET_LEVEL(name, level)
-#define GR_LOG_SET_LEVEL(logger, level)
-#define GR_GET_LEVEL(name, level)
-#define GR_LOG_GET_LEVEL(logger, level)
-#define GR_ADD_APPENDER(name,appender)
-#define GR_LOG_ADD_APPENDER(logger,appender)
-#define GR_SET_APPENDER(name,appender)
-#define GR_LOG_SET_APPENDER(logger,appender)
-#define GR_ADD_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_LOG_ADD_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_SET_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_LOG_SET_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_ADD_FILE_APPENDER(name,filename,append,pattern)
-#define GR_LOG_ADD_FILE_APPENDER(logger,filename,append,pattern)
-#define GR_SET_FILE_APPENDER(name,filename,append,pattern)
-#define GR_LOG_SET_FILE_APPENDER(logger,filename,append,pattern)
-#define GR_ADD_ROLLINGFILE_APPENDER(name,filename,filesize,bkup_index,append,mode,pattern)
-#define GR_LOG_ADD_ROLLINGFILE_APPENDER(logger,filename,filesize,bkup_index,append,mode,pattern)
-#define GR_GET_LOGGER_NAMES(names)
-#define GR_RESET_CONFIGURATION()
-#define GR_DEBUG(name, msg) std::cout<<"DEBUG: "<<msg<<std::endl
-#define GR_INFO(name, msg) std::cout<<"INFO: "<<msg<<std::endl
-#define GR_NOTICE(name, msg) std::cout<<"NOTICE: "<<msg<<std::endl
-#define GR_WARN(name, msg) std::cerr<<"WARN: "<<msg<<std::endl
-#define GR_ERROR(name, msg) std::cerr<<"ERROR: "<<msg<<std::endl
-#define GR_ALERT(name, msg) std::cerr<<"ERROR: "<<msg<<std::endl
-#define GR_CRIT(name, msg) std::cerr<<"ERROR: "<<msg<<std::endl
-#define GR_FATAL(name, msg) std::cerr<<"FATAL: "<<msg<<std::endl
-#define GR_EMERG(name, msg) std::cerr<<"EMERG: "<<msg<<std::endl
-#define GR_ERRORIF(name, cond, msg) {if((cond)) std::cerr<<"ERROR: "<<msg<<std::endl;}
-#define GR_ASSERT(name, cond, msg) {if(!(cond)) std::cerr<<"FATAL: "<<msg<<std::endl; assert(cond);}
-#define GR_LOG_DEBUG(logger, msg) std::cout<<"DEBUG: "<<msg<<std::endl
-#define GR_LOG_INFO(logger, msg) std::cout<<"INFO: "<<msg<<std::endl
-#define GR_LOG_NOTICE(logger, msg) std::cout<<"NOTICE: "<<msg<<std::endl
-#define GR_LOG_WARN(logger, msg) std::cerr<<"WARN: "<<msg<<std::endl
-#define GR_LOG_ERROR(logger, msg) std::cerr<<"ERROR: "<<msg<<std::endl
-#define GR_LOG_ALERT(logger, msg) std::cerr<<"ALERT: "<<msg<<std::endl
-#define GR_LOG_CRIT(logger, msg) std::cerr<<"CRIT: "<<msg<<std::endl
-#define GR_LOG_FATAL(logger, msg) std::cerr<<"FATAL: "<<msg<<std::endl
-#define GR_LOG_EMERG(logger, msg) std::cerr<<"EMERG: "<<msg<<std::endl
-#define GR_LOG_ERRORIF(logger, cond, msg) {             \
-    if((cond)) std::cerr<<"ERROR: "<<msg<<std::endl;}
-#define GR_LOG_ASSERT(logger, cond, msg) {                              \
-    if(!(cond)) {std::cerr<<"FATAL: "<<msg<<std::endl; assert(cond);};}
-
-
-#else /* HAVE_LOG4CPP */
-
-// Second configuration...logging to log4cpp
 #include <log4cpp/Category.hh>
 #include <log4cpp/PropertyConfigurator.hh>
 #include <log4cpp/FileAppender.hh>
@@ -640,69 +562,8 @@ namespace gr {
 
 } /* namespace gr */
 
-#endif /* HAVE_LOG4CPP */
-
   // If Logger disable do nothing
-#else /* ENABLE_GR_LOG */
-
 namespace gr {
-  typedef void* logger_ptr;
-} /* namespace gr */
-
-#define GR_LOG_DECLARE_LOGPTR(logger)
-#define GR_LOG_ASSIGN_LOGPTR(logger,name)
-#define GR_CONFIG_LOGGER(config)
-#define GR_CONFIG_AND_WATCH_LOGGER(config,period)
-#define GR_LOG_GETLOGGER(logger, name)
-#define GR_SET_LEVEL(name, level)
-#define GR_LOG_SET_LEVEL(logger, level)
-#define GR_GET_LEVEL(name, level)
-#define GR_LOG_GET_LEVEL(logger, level)
-#define GR_ADD_APPENDER(name,appender)
-#define GR_LOG_ADD_APPENDER(logger,appender)
-#define GR_SET_APPENDER(name,appender)
-#define GR_LOG_SET_APPENDER(logger,appender)
-#define GR_ADD_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_LOG_ADD_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_SET_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_LOG_SET_CONSOLE_APPENDER(logger,target,pattern)
-#define GR_ADD_FILE_APPENDER(name,filename,append,pattern)
-#define GR_LOG_ADD_FILE_APPENDER(logger,filename,append,pattern)
-#define GR_SET_FILE_APPENDER(name,filename,append,pattern)
-#define GR_LOG_SET_FILE_APPENDER(logger,filename,append,pattern)
-#define GR_ADD_ROLLINGFILE_APPENDER(name,filename,filesize,bkup_index,append,mode,pattern)
-#define GR_LOG_ADD_ROLLINGFILE_APPENDER(logger,filename,filesize,bkup_index,append,mode,pattern)
-#define GR_GET_LOGGER_NAMES(names)
-#define GR_RESET_CONFIGURATION()
-#define GR_DEBUG(name, msg)
-#define GR_INFO(name, msg)
-#define GR_NOTICE(name, msg)
-#define GR_WARN(name, msg)
-#define GR_ERROR(name, msg)
-#define GR_ALERT(name, msg)
-#define GR_CRIT(name, msg)
-#define GR_FATAL(name, msg)
-#define GR_EMERG(name, msg)
-#define GR_ERRORIF(name, cond, msg)
-#define GR_ASSERT(name, cond, msg)
-#define GR_LOG_DEBUG(logger, msg)
-#define GR_LOG_INFO(logger, msg)
-#define GR_LOG_NOTICE(logger, msg)
-#define GR_LOG_WARN(logger, msg)
-#define GR_LOG_ERROR(logger, msg)
-#define GR_LOG_ALERT(logger, msg)
-#define GR_LOG_CRIT(logger, msg)
-#define GR_LOG_FATAL(logger, msg)
-#define GR_LOG_EMERG(logger, msg)
-#define GR_LOG_ERRORIF(logger, cond, msg)
-#define GR_LOG_ASSERT(logger, cond, msg)
-
-#endif /* ENABLE_GR_LOG */
-
-namespace gr {
-
-  // Even if logger is disabled we'll need for methods below to exist in python.
-  // The macros these call will be disabled if ENABLE_GR_LOG is undefined
 
   /********************* Start  Classes and Methods for Python ******************/
   /*!
@@ -852,6 +713,5 @@ namespace gr {
   GR_RUNTIME_API bool update_logger_alias(const std::string &name, const std::string &alias);
 
 } /* namespace gr */
-
 
 #endif /* INCLUDED_GR_LOGGER_H */

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -35,10 +35,6 @@
 #include <stdexcept>
 #include <algorithm>
 
-
-#ifdef ENABLE_GR_LOG
-#ifdef HAVE_LOG4CPP
-
 namespace gr {
 
   bool logger_config::logger_configured(false);
@@ -311,8 +307,6 @@ namespace gr {
 
 } /* namespace gr */
 
-#endif /* HAVE_LOG4CPP */
-
 /****** Start Methods to provide Python the capabilities of the macros ********/
 void
 gr_logger_config(const std::string config_filename, unsigned int watch_period)
@@ -336,38 +330,12 @@ gr_logger_reset_config(void)
 
 // Remaining capability provided by gr::logger class in gnuradio/logger.h
 
-#else /* ENABLE_GR_LOG */
-
-/****** Start Methods to provide Python the capabilities of the macros ********/
-void
-gr_logger_config(const std::string config_filename, unsigned int watch_period)
-{
-  //NOP
-}
-
-std::vector<std::string>
-gr_logger_get_logger_names(void)
-{
-  return std::vector<std::string>(1, "");
-}
-
-void
-gr_logger_reset_config(void)
-{
-  //NOP
-}
-
-#endif /* ENABLE_GR_LOG */
-
-
 namespace gr {
 
   bool
   configure_default_loggers(gr::logger_ptr &l, gr::logger_ptr &d,
                             const std::string name)
   {
-#ifdef ENABLE_GR_LOG
-#ifdef HAVE_LOG4CPP
     prefs *p = prefs::singleton();
     std::string config_file = p->get_string("LOG", "log_config", "");
     std::string log_level = p->get_string("LOG", "log_level", "off");
@@ -407,21 +375,11 @@ namespace gr {
     }
     d = DLOG;
     return true;
-#endif /* HAVE_LOG4CPP */
-
-#else /* ENABLE_GR_LOG */
-    l = NULL;
-    d = NULL;
-    return false;
-#endif /* ENABLE_GR_LOG */
-    return false;
   }
 
   bool
   update_logger_alias(const std::string &name, const std::string &alias)
   {
-#ifdef ENABLE_GR_LOG
-#ifdef HAVE_LOG4CPP
     prefs *p = prefs::singleton();
     std::string log_file = p->get_string("LOG", "log_file", "");
     std::string debug_file = p->get_string("LOG", "debug_file", "");
@@ -442,10 +400,6 @@ namespace gr {
       }
     }
     return true;
-#endif /* HAVE_LOG4CPP */
-#endif /* ENABLE_GR_LOG */
-
-    return false;
   }
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/qa_logger.cc
+++ b/gnuradio-runtime/lib/qa_logger.cc
@@ -35,10 +35,6 @@
 void
 qa_logger::t1()
 {
-#ifdef ENABLE_GR_LOG
-  // This doesn't really test anything, more just
-  // making sure nothing's gone horribly wrong.
-
   GR_LOG_GETLOGGER(LOG,"main");
   GR_ADD_CONSOLE_APPENDER("main","cout","%d{%H:%M:%S} : %m%n");
   GR_LOG_NOTICE(LOG,"test from c++ NOTICE");
@@ -48,5 +44,4 @@ qa_logger::t1()
   GR_LOG_ERROR(LOG,"test from c++ ERROR");
   GR_LOG_FATAL(LOG,"test from c++ FATAL");
   CPPUNIT_ASSERT(true);
-#endif
 }

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -55,8 +55,6 @@ namespace gr {
     size_t max_nmsgs = static_cast<size_t>(p->get_long("DEFAULT", "max_messages", 100));
 
     // Setup the logger for the scheduler
-#ifdef ENABLE_GR_LOG
-#ifdef HAVE_LOG4CPP
     #undef LOG
     std::string config_file = p->get_string("LOG", "log_config", "");
     std::string log_level = p->get_string("LOG", "log_level", "off");
@@ -75,9 +73,6 @@ namespace gr {
         GR_LOG_SET_FILE_APPENDER(LOG, log_file , true,"%r :%p: %c{1} - %m%n");
       }
     }
-#endif /* HAVE_LOG4CPP */
-#endif /* ENABLE_GR_LOG */
-
 
     // Set thread affinity if it was set before fg was started.
     if(block->processor_affinity().size() > 0) {

--- a/gnuradio-runtime/swig/CMakeLists.txt
+++ b/gnuradio-runtime/swig/CMakeLists.txt
@@ -61,12 +61,6 @@ add_custom_target(pmt_swig DEPENDS ${SWIG_MODULE_pmt_swig_REAL_NAME})
 #    Build gnuradio-runtime swig
 ###############################################################
 
-# Only use if log4cpp is installed
-# Define ENABLE_GR_LOG for the .i file to ignore it.
-if(ENABLE_GR_LOG)
-     SET(GR_SWIG_FLAGS "-DENABLE_GR_LOG")
-endif(ENABLE_GR_LOG)
-
 if(ENABLE_GR_CTRLPORT)
   ADD_DEFINITIONS(-DGR_CTRLPORT)
   list(APPEND GR_SWIG_FLAGS -DGR_CTRLPORT)

--- a/gr-fec/lib/generic_decoder.cc
+++ b/gr-fec/lib/generic_decoder.cc
@@ -36,8 +36,6 @@ namespace gr {
       d_name = name;
       my_id = base_unique_id++;
 
-#ifdef ENABLE_GR_LOG
-#ifdef HAVE_LOG4CPP
       prefs *p = prefs::singleton();
       std::string config_file = p->get_string("LOG", "log_config", "");
       std::string log_level = p->get_string("LOG", "log_level", "off");
@@ -58,12 +56,8 @@ namespace gr {
           GR_LOG_SET_FILE_APPENDER(LOG, log_file , true,"%r :%p: %c{1} - %m%n");
         }
       }
-      d_logger = LOG;
 
-#endif /* HAVE_LOG4CPP */
-#else /* ENABLE_GR_LOG */
-      d_logger = NULL;
-#endif /* ENABLE_GR_LOG */
+      d_logger = LOG;
     }
 
     generic_decoder::~generic_decoder()

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -36,8 +36,6 @@ namespace gr {
       d_name = name;
       my_id = base_unique_id++;
 
-#ifdef ENABLE_GR_LOG
-#ifdef HAVE_LOG4CPP
       prefs *p = prefs::singleton();
       std::string config_file = p->get_string("LOG", "log_config", "");
       std::string log_level = p->get_string("LOG", "log_level", "off");
@@ -58,12 +56,8 @@ namespace gr {
           GR_LOG_SET_FILE_APPENDER(LOG, log_file , true,"%r :%p: %c{1} - %m%n");
         }
       }
-      d_logger = LOG;
 
-#endif /* HAVE_LOG4CPP */
-#else /* ENABLE_GR_LOG */
-      d_logger = NULL;
-#endif /* ENABLE_GR_LOG */
+      d_logger = LOG;
     }
 
     generic_encoder::~generic_encoder()

--- a/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrMiscUtils.cmake
+++ b/gr-utils/python/modtool/gr-newmod/cmake/Modules/GrMiscUtils.cmake
@@ -216,49 +216,6 @@ function(GR_GEN_TARGET_DEPS name var)
 endfunction(GR_GEN_TARGET_DEPS)
 
 ########################################################################
-# Control use of gr_logger
-# Usage:
-#   GR_LOGGING()
-#
-# Will set ENABLE_GR_LOG to 1 by default.
-# Can manually set with -DENABLE_GR_LOG=0|1
-########################################################################
-function(GR_LOGGING)
-  find_package(Log4cpp)
-
-  OPTION(ENABLE_GR_LOG "Use gr_logger" ON)
-  if(ENABLE_GR_LOG)
-    # If gr_logger is enabled, make it usable
-    add_definitions( -DENABLE_GR_LOG )
-
-    # also test LOG4CPP; if we have it, use this version of the logger
-    # otherwise, default to the stdout/stderr model.
-    if(LOG4CPP_FOUND)
-      SET(HAVE_LOG4CPP True CACHE INTERNAL "" FORCE)
-      add_definitions( -DHAVE_LOG4CPP )
-    else(not LOG4CPP_FOUND)
-      SET(HAVE_LOG4CPP False CACHE INTERNAL "" FORCE)
-      SET(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
-      SET(LOG4CPP_LIBRARY_DIRS "" CACHE INTERNAL "" FORCE)
-      SET(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
-    endif(LOG4CPP_FOUND)
-
-    SET(ENABLE_GR_LOG ${ENABLE_GR_LOG} CACHE INTERNAL "" FORCE)
-
-  else(ENABLE_GR_LOG)
-    SET(HAVE_LOG4CPP False CACHE INTERNAL "" FORCE)
-    SET(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
-    SET(LOG4CPP_LIBRARY_DIRS "" CACHE INTERNAL "" FORCE)
-    SET(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
-  endif(ENABLE_GR_LOG)
-
-  message(STATUS "ENABLE_GR_LOG set to ${ENABLE_GR_LOG}.")
-  message(STATUS "HAVE_LOG4CPP set to ${HAVE_LOG4CPP}.")
-  message(STATUS "LOG4CPP_LIBRARIES set to ${LOG4CPP_LIBRARIES}.")
-
-endfunction(GR_LOGGING)
-
-########################################################################
 # Run GRCC to compile .grc files into .py files.
 #
 # Usage: GRCC(filename, directory)


### PR DESCRIPTION
This branch removes all the conditionalization around the logging features of gnuradio-runtime and enables logging permanently.  It also now makes liblog4cpp a dependency for GNU Radio.