### PR TITLE
modtool: fix template - copyrightholder field, and add_module

### DIFF
--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -143,7 +143,7 @@ class ModToolAdd(ModTool):
         elif self._info['is_component']:
             return Templates['grlicense']
         else:
-            return get_template('defaultlicense', **self._info)
+            return Templates['defaultlicense'].format(**self._info)
 
     def _write_tpl(self, tpl, path, fname):
         """ Shorthand for writing a substituted template to a file"""

--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -42,7 +42,7 @@ You should have received a copy of the GNU General Public License
 along with this software; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 51 Franklin Street,
 Boston, MA 02110-1301, USA.
-'''.format(datetime.now().year)
+''' % datetime.now().year
 
 Templates['grlicense'] = '''
 Copyright {0} Free Software Foundation, Inc.


### PR DESCRIPTION
Collision of formating for template engine and local Python string formating

  File "/usr/local/lib/python2.7/dist-packages/gnuradio/modtool/templates.py", line 45, in <module>
    '''.format(datetime.now().year)
KeyError: 'copyrightholder'

For the second patch, function get_template() does not exists, regular solution would be rendering the template using teplate engine but this is too cumbersome.
