### PR TITLE
filter: add missing import of filter

### DIFF
--- a/gr-filter/examples/benchmark_filters.py
+++ b/gr-filter/examples/benchmark_filters.py
@@ -24,7 +24,7 @@ import time
 import random
 from optparse import OptionParser
 from gnuradio import gr
-from gnuradio import blocks
+from gnuradio import blocks, filter
 from gnuradio.eng_option import eng_option
 
 def make_random_complex_tuple(L):


### PR DESCRIPTION
Code calls filter from filter module which is not imported.

Looks like nobody used it for loooong time. I'm goign trought examples and I have suspicion lot of them is not much usefull (too complicated for start, too much examples to pick up from, not well maintained).

Any hint how to improve this?