### PR TITLE
filter: add msg port to set params in fractional resampler

### DIFF
--- a/gr-filter/grc/filter_fractional_resampler_xx.xml
+++ b/gr-filter/grc/filter_fractional_resampler_xx.xml
@@ -42,7 +42,12 @@
 	<sink>
 		<name>rate</name>
 		<type>float</type>
-                <optional>1</optional>
+    <optional>1</optional>
+	</sink>
+	<sink>
+		<name>msg_in</name>
+		<type>message</type>
+    <optional>1</optional>
 	</sink>
 	<source>
 		<name>out</name>

--- a/gr-filter/include/gnuradio/filter/fractional_resampler_cc.h
+++ b/gr-filter/include/gnuradio/filter/fractional_resampler_cc.h
@@ -32,6 +32,10 @@ namespace gr {
     /*!
      * \brief resampling MMSE filter with complex input, complex output
      * \ingroup resamplers_blk
+     *
+     * \details
+     * The resampling ration and mu parameters can be set with a pmt dict
+     * message with the keys "resamp_ratio" and "mu".
      */
     class FILTER_API fractional_resampler_cc : virtual public block
     {

--- a/gr-filter/include/gnuradio/filter/fractional_resampler_ff.h
+++ b/gr-filter/include/gnuradio/filter/fractional_resampler_ff.h
@@ -32,7 +32,12 @@ namespace gr {
     /*!
      * \brief Resampling MMSE filter with float input, float output
      * \ingroup resamplers_blk
+     *
+     * \details
+     * The resampling ration and mu parameters can be set with a pmt dict
+     * message with the keys "resamp_ratio" and "mu".
      */
+
     class FILTER_API fractional_resampler_ff : virtual public block
     {
     public:

--- a/gr-filter/lib/fractional_resampler_cc_impl.cc
+++ b/gr-filter/lib/fractional_resampler_cc_impl.cc
@@ -52,11 +52,37 @@ namespace gr {
 	throw std::out_of_range("phase shift ratio must be > 0 and < 1");
 
       set_relative_rate(1.0 / resamp_ratio);
+      message_port_register_in(pmt::intern("msg_in"));
+      set_msg_handler(pmt::intern("msg_in"), boost::bind(
+              &fractional_resampler_cc_impl::handle_msg, this, _1));
     }
 
     fractional_resampler_cc_impl::~fractional_resampler_cc_impl()
     {
       delete d_resamp;
+    }
+
+    void
+    fractional_resampler_cc_impl::handle_msg(pmt::pmt_t msg) {
+      if(!pmt::is_dict(msg))
+        return;
+      // set resamp_ratio or mu by message dict
+      if(pmt::dict_has_key(msg, pmt::intern("resamp_ratio"))) {
+        set_resamp_ratio(
+          pmt::to_float(
+            pmt::dict_ref(msg, pmt::intern("resamp_ratio"),
+            pmt::from_float(resamp_ratio()))
+          )
+        );
+      }
+      if(pmt::dict_has_key(msg, pmt::intern("mu"))) {
+        set_mu(
+          pmt::to_float(
+            pmt::dict_ref(msg, pmt::intern("mu"),
+            pmt::from_float(mu()))
+          )
+        );
+      }
     }
 
     void

--- a/gr-filter/lib/fractional_resampler_cc_impl.h
+++ b/gr-filter/lib/fractional_resampler_cc_impl.h
@@ -42,6 +42,8 @@ namespace gr {
                                    float resamp_ratio);
       ~fractional_resampler_cc_impl();
 
+      void handle_msg(pmt::pmt_t msg);
+
       void forecast(int noutput_items,
 		    gr_vector_int &ninput_items_required);
       int general_work(int noutput_items,

--- a/gr-filter/lib/fractional_resampler_ff_impl.cc
+++ b/gr-filter/lib/fractional_resampler_ff_impl.cc
@@ -52,11 +52,38 @@ namespace gr {
 	throw std::out_of_range("phase shift ratio must be > 0 and < 1");
 
       set_relative_rate(1.0 / resamp_ratio);
+
+      message_port_register_in(pmt::intern("msg_in"));
+      set_msg_handler(pmt::intern("msg_in"), boost::bind(
+              &fractional_resampler_ff_impl::handle_msg, this, _1));
     }
 
     fractional_resampler_ff_impl::~fractional_resampler_ff_impl()
     {
       delete d_resamp;
+    }
+
+    void
+    fractional_resampler_ff_impl::handle_msg(pmt::pmt_t msg) {
+      if(!pmt::is_dict(msg))
+        return;
+      // set resamp_ratio or mu by message dict
+      if(pmt::dict_has_key(msg, pmt::intern("resamp_ratio"))) {
+        set_resamp_ratio(
+          pmt::to_float(
+            pmt::dict_ref(msg, pmt::intern("resamp_ratio"),
+            pmt::from_float(resamp_ratio()))
+          )
+        );
+      }
+      if(pmt::dict_has_key(msg, pmt::intern("mu"))) {
+        set_mu(
+          pmt::to_float(
+            pmt::dict_ref(msg, pmt::intern("mu"),
+            pmt::from_float(mu()))
+          )
+        );
+      }
     }
 
     void

--- a/gr-filter/lib/fractional_resampler_ff_impl.h
+++ b/gr-filter/lib/fractional_resampler_ff_impl.h
@@ -42,6 +42,8 @@ namespace gr {
                                    float resamp_ratio);
       ~fractional_resampler_ff_impl();
 
+      void handle_msg(pmt::pmt_t msg);
+
       void forecast(int noutput_items,
 		    gr_vector_int &ninput_items_required);
       int general_work(int noutput_items,


### PR DESCRIPTION
Resulting from recent discussion on the list, I added a message port for dict messages to set parameters `resamp_ratio` and `mu` in the fractional resampler block. If wanted, other blocks can be extended in the same way.