### PR TITLE
v3.7.10 win+misc fixes

### DIFF
--- a/cmake/msvc/config.h
+++ b/cmake/msvc/config.h
@@ -62,4 +62,7 @@ static inline float rintf(float x){return (x > 0.0f)? floorf(x + 0.5f) : ceilf(x
 static inline long int random (void) { return rand(); }
 static inline void srandom (unsigned int seed) { srand(seed); }
 
+#define srand48(seed) srand(seed)
+#define drand48() (double(rand()) / RAND_MAX)
+
 #endif // _MSC_CONFIG_H_ ]

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -64,10 +64,16 @@ namespace gr {
     return tmp_path();
   }
 
-  const char *userconf_path()
+  std::string __userconf_path()
   {
     boost::filesystem::path p(appdata_path());
     p = p / ".gnuradio";
+    return p.string();
+  }
+
+  const char *userconf_path()
+  {
+    static std::string p(__userconf_path());
     return p.c_str();
   }
 

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -24,6 +24,10 @@
 #include "config.h"
 #endif
 
+#ifdef _MSC_VER
+#include <io.h>
+#endif
+
 #include "audio_registry.h"
 #include <portaudio_sink.h>
 #include <portaudio_impl.h>

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -24,6 +24,10 @@
 #include "config.h"
 #endif
 
+#ifdef _MSC_VER
+#include <io.h>
+#endif
+
 #include "audio_registry.h"
 #include <portaudio_source.h>
 #include <portaudio_impl.h>

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -66,7 +66,7 @@ namespace gr {
 	d_osps(osps), d_error(0), d_out_idx(0)
     {
       if(taps.size() == 0)
-        throw std::runtime_error("pfb_clock_sync_ccf: please specify a filter.\n");
+        throw std::runtime_error("pfb_clock_sync_fff: please specify a filter.\n");
 
       // Let scheduler adjust our relative_rate.
       enable_update_rate(true);

--- a/gr-fec/include/gnuradio/fec/polar_decoder_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_common.h
@@ -68,7 +68,7 @@ namespace gr {
         bool set_frame_size(unsigned int frame_size){return false;};
 
       private:
-        static BOOST_CONSTEXPR_OR_CONST float D_LLR_FACTOR = -2.19722458f;
+        static BOOST_CONSTEXPR_OR_CONST float D_LLR_FACTOR;
         unsigned int d_frozen_bit_counter;
 
       protected:

--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -34,6 +34,8 @@ namespace gr {
   namespace fec {
     namespace code {
 
+      const float polar_decoder_common::D_LLR_FACTOR = -2.19722458f;
+
       polar_decoder_common::polar_decoder_common(int block_size, int num_info_bits,
                                                  std::vector<int> frozen_bit_positions,
                                                  std::vector<char> frozen_bit_values) :


### PR DESCRIPTION
Misc windows fixes and other issues when updating to v3.7.10. Comments are in the commit messages, and individual commits can easily be cherry picked if need be. The userconf_path() issue looks like it could cause some undefined behaviour. Don't let that one go.

A VC14 [PothosSDR windows installer](https://github.com/pothosware/PothosSDR/wiki/GNURadio) is available with v3.7.10 grc, gr-drm, gr-rds, gqrx, gr-osmosdr. Initial testing appears to be fine. Please let me know if there are any issues with the installer or questions about the patches. Thanks!