### PR TITLE
bugfix: clock_recovery tag offsets are drifting over time

### DIFF
--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -67,6 +67,7 @@ namespace gr {
       set_omega(omega);			// also sets min and max omega
       set_relative_rate(1.0 / omega);
       set_history(3);			// ensure 2 extra input samples are available
+      enable_update_rate(true);  // fixes tag propagation through variable rate block
     }
 
     clock_recovery_mm_cc_impl::~clock_recovery_mm_cc_impl()

--- a/gr-digital/lib/clock_recovery_mm_ff_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_ff_impl.cc
@@ -60,6 +60,7 @@ namespace gr {
 
       set_omega(omega);			// also sets min and max omega
       set_relative_rate (1.0 / omega);
+      enable_update_rate(true);  // fixes tag propagation through variable rate block
     }
 
     clock_recovery_mm_ff_impl::~clock_recovery_mm_ff_impl()


### PR DESCRIPTION
Call enable_update_rate() so that relative rate is recalculated during
each call to work. Currently, tag offsets at the output **are drifting over time**.
This fix is already applied in msk_timing_recovery_cc but is missing
from clock_recovery_mm.

See discussion about enable_update_rate:
http://gnuradio.org/redmine/issues/652

Signed-off-by: Jonathan Brucker <jonathan.brucke@gmail.com>