### PR TITLE
uhd_siggen_gui: fix attribute error for lo_locked

### DIFF
--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -426,7 +426,7 @@ class uhd_siggen_gui(Qt.QWidget):
     def set_lo_locked_probe_0(self, lo_locked_probe_0):
         Qt.QMetaObject.invokeMethod(
                 self._lo_locked_probe_0_label, "setText",
-                Qt.Q_ARG("QString", str(self.lo_locked_probe_0))
+                Qt.Q_ARG("QString", str(lo_locked_probe_0))
         )
 
 


### PR DESCRIPTION
UHD_SIGGEN_GUI is never showing if the LO is locked. It was traced down to this assignation that was leading to an Attribute error (which is avoided at the try/except at line 266). 
