### PR TITLE
Rename s_host (MSVC fix)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/sys_paths.h
+++ b/gnuradio-runtime/include/gnuradio/sys_paths.h
@@ -24,6 +24,8 @@
 
 #include <gnuradio/api.h>
 
+#include <boost/filesystem/path.hpp>
+
 namespace gr {
 
   //! directory to create temporary files
@@ -33,7 +35,7 @@ namespace gr {
   GR_RUNTIME_API const char *appdata_path();
 
   //! directory to store user configuration
-  GR_RUNTIME_API const char *userconf_path();
+  GR_RUNTIME_API const boost::filesystem::path::value_type *userconf_path();
 
 } /* namespace gr */
 

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -23,8 +23,6 @@
 #include <cstdlib> //getenv
 #include <cstdio>  //P_tmpdir (maybe)
 
-#include <boost/filesystem/path.hpp>
-
 namespace gr {
 
   const char *tmp_path()
@@ -64,7 +62,7 @@ namespace gr {
     return tmp_path();
   }
 
-  const char *userconf_path()
+  const boost::filesystem::path::value_type *userconf_path()
   {
     boost::filesystem::path p(appdata_path());
     p = p / ".gnuradio";

--- a/gr-blocks/lib/tcp_server_sink_impl.cc
+++ b/gr-blocks/lib/tcp_server_sink_impl.cc
@@ -58,10 +58,10 @@ namespace gr {
       d_buf(new uint8_t[BUF_SIZE]),
       d_writing(0)
       {
-        std::string s_port = (boost::format("%d") % port).str();
-        std::string s_host = host.empty() ? std::string("localhost") : host;
+        std::string s__port = (boost::format("%d") % port).str();
+        std::string s__host = host.empty() ? std::string("localhost") : host;
         boost::asio::ip::tcp::resolver resolver(d_io_service);
-        boost::asio::ip::tcp::resolver::query query(s_host, s_port,
+        boost::asio::ip::tcp::resolver::query query(s__host, s__port,
             boost::asio::ip::resolver_query_base::passive);
         d_endpoint = *resolver.resolve(query);
 


### PR DESCRIPTION
s_host is defined in the win32 inaddr.h file, so this just renames it to s__host to avoid the collision.