### PR TITLE
Addition of PDU block setters and GRC callbacks

### DIFF
--- a/gr-blocks/grc/blocks_pdu_filter.xml
+++ b/gr-blocks/grc/blocks_pdu_filter.xml
@@ -10,6 +10,9 @@
 	<import>from gnuradio import blocks</import>
 	<import>import pmt</import>
 	<make>blocks.pdu_filter($k, $v, $invert)</make>
+	<callback>set_key($k)</callback>
+	<callback>set_val($v)</callback>
+	<callback>set_inversion($invert)</callback>
 	<param>
 		<name>Key</name>
 		<key>k</key>
@@ -26,7 +29,7 @@
         <name>Invert Filter</name>
         <key>invert</key>
         <value>False</value>
-        <type>enum</type>
+        <type>bool</type>
         <option>
             <name>No</name>
             <key>False</key>

--- a/gr-blocks/grc/blocks_pdu_remove.xml
+++ b/gr-blocks/grc/blocks_pdu_remove.xml
@@ -10,6 +10,7 @@
 	<import>from gnuradio import blocks</import>
 	<import>import pmt</import>
 	<make>blocks.pdu_remove($k)</make>
+	<callback>set_key($k)</callback>
 	<param>
 		<name>Key</name>
 		<key>k</key>

--- a/gr-blocks/grc/blocks_pdu_set.xml
+++ b/gr-blocks/grc/blocks_pdu_set.xml
@@ -10,6 +10,8 @@
 	<import>from gnuradio import blocks</import>
 	<import>import pmt</import>
 	<make>blocks.pdu_set($k, $v)</make>
+	<callback>set_key($k)</callback>
+	<callback>set_val($v)</callback>
 	<param>
 		<name>Key</name>
 		<key>k</key>

--- a/gr-blocks/include/gnuradio/blocks/pdu_filter.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_filter.h
@@ -44,6 +44,9 @@ namespace gr {
        * \brief Construct a PDU filter
        */
       static sptr make(pmt::pmt_t k, pmt::pmt_t v, bool invert = false);
+      virtual void set_key(pmt::pmt_t key) = 0;
+      virtual void set_val(pmt::pmt_t val) = 0;
+      virtual void set_inversion(bool invert) = 0;
     };
 
   } /* namespace blocks */

--- a/gr-blocks/include/gnuradio/blocks/pdu_remove.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_remove.h
@@ -44,6 +44,7 @@ namespace gr {
        * \brief Construct a PDU meta remove block
        */
       static sptr make(pmt::pmt_t k);
+      virtual void set_key(pmt::pmt_t key) = 0;
     };
 
   } /* namespace blocks */

--- a/gr-blocks/include/gnuradio/blocks/pdu_set.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_set.h
@@ -44,6 +44,8 @@ namespace gr {
        * \brief Construct a PDU meta set block
        */
       static sptr make(pmt::pmt_t k, pmt::pmt_t v);
+      virtual void set_key(pmt::pmt_t key) = 0;
+      virtual void set_val(pmt::pmt_t val) = 0;
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/pdu_filter_impl.h
+++ b/gr-blocks/lib/pdu_filter_impl.h
@@ -38,6 +38,9 @@ namespace gr {
     public:
       pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert);
       void handle_msg(pmt::pmt_t msg);
+      void set_key(pmt::pmt_t key) { d_k = key; };
+      void set_val(pmt::pmt_t val) { d_v = val; };
+      void set_inversion(bool invert) { d_invert = invert; };
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/pdu_remove_impl.h
+++ b/gr-blocks/lib/pdu_remove_impl.h
@@ -36,6 +36,7 @@ namespace gr {
     public:
       pdu_remove_impl(pmt::pmt_t k);
       void handle_msg(pmt::pmt_t msg);
+      void set_key(pmt::pmt_t key) { d_k = key; };
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/pdu_set_impl.h
+++ b/gr-blocks/lib/pdu_set_impl.h
@@ -37,6 +37,8 @@ namespace gr {
     public:
       pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v);
       void handle_msg(pmt::pmt_t msg);
+      void set_key(pmt::pmt_t key) { d_k = key; };
+      void set_val(pmt::pmt_t val) { d_v = val; };
     };
 
   } /* namespace blocks */


### PR DESCRIPTION
Added public setters for the PDU metadata manipulation blocks pdu_filter, pdu_remove, and pdu_set and callbacks in associated GRC files. Also changed 'inversion' parameter of PDU filter GRC from an enum to bool so it can be assigned to a variable in GRC.