### PR TITLE
modtool: update python docstring generation

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/docs/doxygen/doxyxml/doxyindex.py
+++ b/gr-utils/python/modtool/gr-newmod/docs/doxygen/doxyxml/doxyindex.py
@@ -43,13 +43,16 @@ class DoxyIndex(Base):
         self._root = index.parse(os.path.join(self._xml_path, 'index.xml'))
         for mem in self._root.compound:
             converted = self.convert_mem(mem)
-            # For files we want the contents to be accessible directly
-            # from the parent rather than having to go through the file
-            # object.
+            # For files and namespaces we want the contents to be
+            # accessible directly from the parent rather than having
+            # to go through the file object.
             if self.get_cls(mem) == DoxyFile:
                 if mem.name.endswith('.h'):
                     self._members += converted.members()
                     self._members.append(converted)
+            elif self.get_cls(mem) == DoxyNamespace:
+                self._members += converted.members()
+                self._members.append(converted)
             else:
                 self._members.append(converted)
 
@@ -80,12 +83,28 @@ class DoxyCompMem(Base):
         self._data['brief_description'] = bd
         self._data['detailed_description'] = dd
 
+    def set_parameters(self, data):
+        vs = [ddc.value for ddc in data.detaileddescription.content_]
+        pls = []
+        for v in vs:
+            if hasattr(v, 'parameterlist'):
+                pls += v.parameterlist
+        pis = []
+        for pl in pls:
+            pis += pl.parameteritem
+        dpis = []
+        for pi in pis:
+            dpi = DoxyParameterItem(pi)
+            dpi._parse()
+            dpis.append(dpi)
+        self._data['params'] = dpis
+
+
 class DoxyCompound(DoxyCompMem):
     pass
 
 class DoxyMember(DoxyCompMem):
     pass
-
 
 class DoxyFunction(DoxyMember):
 
@@ -98,10 +117,13 @@ class DoxyFunction(DoxyMember):
             return
         super(DoxyFunction, self)._parse()
         self.set_descriptions(self._parse_data)
-        self._data['params'] = []
-        prms = self._parse_data.param
-        for prm in prms:
-            self._data['params'].append(DoxyParam(prm))
+        self.set_parameters(self._parse_data)
+        if not self._data['params']:
+            # If the params weren't set by a comment then just grab the names.
+            self._data['params'] = []
+            prms = self._parse_data.param
+            for prm in prms:
+                self._data['params'].append(DoxyParam(prm))
 
     brief_description = property(lambda self: self.data()['brief_description'])
     detailed_description = property(lambda self: self.data()['detailed_description'])
@@ -121,9 +143,39 @@ class DoxyParam(DoxyMember):
         self.set_descriptions(self._parse_data)
         self._data['declname'] = self._parse_data.declname
 
+    @property
+    def description(self):
+        descriptions = []
+        if self.brief_description:
+            descriptions.append(self.brief_description)
+        if self.detailed_description:
+            descriptions.append(self.detailed_description)
+        return '\n\n'.join(descriptions)
+
     brief_description = property(lambda self: self.data()['brief_description'])
     detailed_description = property(lambda self: self.data()['detailed_description'])
-    declname = property(lambda self: self.data()['declname'])
+    name = property(lambda self: self.data()['declname'])
+
+class DoxyParameterItem(DoxyMember):
+    """A different representation of a parameter in Doxygen."""
+
+    def _parse(self):
+        if self._parsed:
+            return
+        super(DoxyParameterItem, self)._parse()
+        names = []
+        for nl in self._parse_data.parameternamelist:
+            for pn in nl.parametername:
+                names.append(description(pn))
+        # Just take first name
+        self._data['name'] = names[0]
+        # Get description
+        pd = description(self._parse_data.get_parameterdescription())
+        self._data['description'] = pd
+
+    description = property(lambda self: self.data()['description'])
+    name = property(lambda self: self.data()['name'])
+
 
 class DoxyClass(DoxyCompound):
 
@@ -139,12 +191,14 @@ class DoxyClass(DoxyCompound):
         if self._error:
             return
         self.set_descriptions(self._retrieved_data.compounddef)
+        self.set_parameters(self._retrieved_data.compounddef)
         # Sectiondef.kind tells about whether private or public.
         # We just ignore this for now.
         self.process_memberdefs()
 
     brief_description = property(lambda self: self.data()['brief_description'])
     detailed_description = property(lambda self: self.data()['detailed_description'])
+    params = property(lambda self: self.data()['params'])
 
 Base.mem_classes.append(DoxyClass)
 
@@ -176,6 +230,16 @@ class DoxyNamespace(DoxyCompound):
     __module__ = "gnuradio.utils.doxyxml"
 
     kind = 'namespace'
+
+    def _parse(self):
+        if self._parsed:
+            return
+        super(DoxyNamespace, self)._parse()
+        self.retrieve_data()
+        self.set_descriptions(self._retrieved_data.compounddef)
+        if self._error:
+            return
+        self.process_memberdefs()
 
 Base.mem_classes.append(DoxyNamespace)
 
@@ -227,11 +291,11 @@ class DoxyOther(Base):
 
     __module__ = "gnuradio.utils.doxyxml"
 
-    kinds = set(['variable', 'struct', 'union', 'define', 'typedef', 'enum', 'dir', 'page'])
+    kinds = set(['variable', 'struct', 'union', 'define', 'typedef', 'enum',
+                 'dir', 'page', 'signal', 'slot', 'property'])
 
     @classmethod
     def can_parse(cls, obj):
         return obj.kind in cls.kinds
 
 Base.mem_classes.append(DoxyOther)
-


### PR DESCRIPTION
I noticed docstrings are created differently for in-tree and out-of-tree modules. Since the docstrings for in-tree modules are more extensive, It would be nice to also have the same structure for OOTs.

NOTE: The changed files are just copied from the global docs folder. @skoslowski stated it could be sensible to use symlinks here. Would this work or potentionally break anything?