### PR TITLE
dark.qss: cause forced-on data lines to die in a fire

### DIFF
--- a/gr-qtgui/themes/dark.qss
+++ b/gr-qtgui/themes/dark.qss
@@ -15,7 +15,6 @@ DisplayPlot {
     qproperty-line_color1: green;
     qproperty-line_color2: green;
     qproperty-line_color3: green;
-    qproperty-line_style1: SolidLine;
     qproperty-line_style2: DashLine;
     qproperty-line_style3: DotLine;
     qproperty-axes_label_font_size: 18;


### PR DESCRIPTION
these aren't on by default for any other theme.
who really wants to connect their const plot thusly with such a default behavior?