### PR TITLE
Backwards compatibility fix for pygtk 2.16 (centos6).

### DIFF
--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -197,26 +197,35 @@ class MainWindow(gtk.Window):
         #  to be hidden as well.
 
         if panel == self.BLOCKS:
-            self.btwin.set_visible(visibility)
+            if visibility:
+	        self.btwin.show()
+            else:
+	        self.btwin.hide()
         elif panel == self.CONSOLE:
-            self.console_window.set_visible(visibility)
+            if visibility:
+	        self.console_window.show()
+            else:
+	        self.console_window.hide()
         elif panel == self.VARIABLES:
-            self.vars.set_visible(visibility)
+            if visibility:
+	        self.vars.show()
+            else:
+	        self.vars.hide()
         else:
             return
 
         if self.variable_panel_sidebar:
             # If both the variable editor and block panels are hidden, hide the right container
-            if not self.btwin.get_visible() and not self.vars.get_visible():
+            if not (self.btwin.flags() & gtk.VISIBLE) and not (self.vars.flags() & gtk.VISIBLE):
                 self.right.hide()
             else:
                 self.right.show()
         else:
-            if not self.btwin.get_visible():
+            if not (self.btwin.flags() & gtk.VISIBLE):
                 self.right.hide()
             else:
                 self.right.show()
-            if not self.vars.get_visible() and not self.console_window.get_visible():
+            if not (self.vars.flags() & gtk.VISIBLE) and not (self.console_window.flags() & gtk.VISIBLE):
                 self.left_subpanel.hide()
             else:
                 self.left_subpanel.show()

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -216,16 +216,16 @@ class MainWindow(gtk.Window):
 
         if self.variable_panel_sidebar:
             # If both the variable editor and block panels are hidden, hide the right container
-            if not (self.btwin.flags() & gtk.VISIBLE) and not (self.vars.flags() & gtk.VISIBLE):
+            if not (self.btwin.get_property('visible')) and not (self.vars.get_property('visible')):
                 self.right.hide()
             else:
                 self.right.show()
         else:
-            if not (self.btwin.flags() & gtk.VISIBLE):
+            if not (self.btwin.get_property('visible')):
                 self.right.hide()
             else:
                 self.right.show()
-            if not (self.vars.flags() & gtk.VISIBLE) and not (self.console_window.flags() & gtk.VISIBLE):
+            if not (self.vars.get_property('visible')) and not (self.console_window.get_property('visible')):
                 self.left_subpanel.hide()
             else:
                 self.left_subpanel.show()


### PR DESCRIPTION
Hi all,

After building gnuradio maint branch on Centos6 & running gnuradio-companion I was getting these errors:

> <<< Welcome to GNU Radio Companion 3.7.10.1 >>>
> 
> Block paths:
>         /tools/gnuradio/install/20160824-maint/share/gnuradio/grc/blocks
> Traceback (most recent call last):
>   File "/tools/gnuradio/install/20160824-maint/lib64/python2.7/site-packages/gnuradio/grc/gui/ActionHandler.py", line 397, in _handle_action
>     main.update_panel_visibility(main.BLOCKS, action.get_active())
>   File "/tools/gnuradio/install/20160824-maint/lib64/python2.7/site-packages/gnuradio/grc/gui/MainWindow.py", line 200, in update_panel_visibility
>     self.btwin.set_visible(visibility)
> AttributeError: 'BlockTreeWindow' object has no attribute 'set_visible' 

Had to make some changes to grc/gui/MainWindow.py to work around this issue, fix is similar to the following commit: http://gnuradio.org/redmine/projects/gnuradio/repository/revisions/56b13077335a814f3a72c8c759209bcc484ec712/diff/grc/gui/ActionHandler.py

Cheers,

Mcihael