### PR TITLE
blocks: mark old-style message queue blocks as deprecated

### DIFF
--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -122,9 +122,6 @@
    </cat>
    <cat>
       <name>Message Tools</name>
-      <block>blocks_message_source</block>
-      <block>blocks_message_sink</block>
-      <block>blocks_message_burst_source</block>
       <block>blocks_message_strobe</block>
       <block>blocks_message_strobe_random</block>
       <block>blocks_message_debug</block>

--- a/gr-blocks/grc/blocks_message_burst_source.xml
+++ b/gr-blocks/grc/blocks_message_burst_source.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Message Burst Source</name>
 	<key>blocks_message_burst_source</key>
+        <category>[Core]/Deprecated</category>
 	<import>from gnuradio import blocks</import>
 	<make>blocks.message_burst_source($type.size*$vlen, $(id)_msgq_in)</make>
 	<param>

--- a/gr-blocks/grc/blocks_message_sink.xml
+++ b/gr-blocks/grc/blocks_message_sink.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Message Sink</name>
 	<key>blocks_message_sink</key>
+        <category>[Core]/Deprecated</category>
 	<import>from gnuradio import blocks</import>
 	<make>blocks.message_sink($type.size*$vlen, $(id)_msgq_out, $dont_block)</make>
 	<param>

--- a/gr-blocks/grc/blocks_message_source.xml
+++ b/gr-blocks/grc/blocks_message_source.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>Message Source</name>
 	<key>blocks_message_source</key>
+        <category>[Core]/Deprecated</category>
 	<import>from gnuradio import blocks</import>
 	<make>blocks.message_source($type.size*$vlen, $(id)_msgq_in)</make>
 	<param>

--- a/gr-blocks/include/gnuradio/blocks/message_burst_source.h
+++ b/gr-blocks/include/gnuradio/blocks/message_burst_source.h
@@ -32,7 +32,7 @@ namespace gr {
 
     /*!
      * \brief Turn received messages into a stream and tag them for UHD to send.
-     * \ingroup message_tools_blk
+     * \ingroup deprecated_blk
      */
     class BLOCKS_API message_burst_source : virtual public sync_block
     {

--- a/gr-blocks/include/gnuradio/blocks/message_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/message_sink.h
@@ -32,7 +32,7 @@ namespace gr {
 
     /*!
      * \brief Gather received items into messages and insert into msgq
-     * \ingroup message_tools_blk
+     * \ingroup deprecated_blk
      */
     class BLOCKS_API message_sink : virtual public sync_block
     {

--- a/gr-blocks/include/gnuradio/blocks/message_source.h
+++ b/gr-blocks/include/gnuradio/blocks/message_source.h
@@ -32,7 +32,7 @@ namespace gr {
 
     /*!
      * \brief Turn received messages into a stream
-     * \ingroup message_tools_blk
+     * \ingroup deprecated_blk
      */
     class BLOCKS_API message_source : virtual public sync_block
     {


### PR DESCRIPTION
Old-style message queue blocks are going to be removed in the 3.8 series as the current asynchronous messaging system is a superset of them.  This branch marks them deprecated in GRC.