### PR TITLE
digital: deprecate correlate_and_sync

### DIFF
--- a/gr-digital/grc/digital_block_tree.xml
+++ b/gr-digital/grc/digital_block_tree.xml
@@ -126,7 +126,6 @@
     <block>digital_pfb_clock_sync_xxx</block>
     <block>digital_pn_correlator_cc</block>
     <block>digital_corr_est_cc</block>
-    <block>digital_correlate_and_sync_cc</block>
   </cat>
   <cat>
     <name>Waveform Generators</name>

--- a/gr-digital/grc/digital_correlate_and_sync_cc.xml
+++ b/gr-digital/grc/digital_correlate_and_sync_cc.xml
@@ -2,6 +2,7 @@
 <block>
   <name>Correlate and Sync</name>
   <key>digital_correlate_and_sync_cc</key>
+  <category>[Core]/Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.correlate_and_sync_cc($symbols, $filter, $sps)</make>
   <param>

--- a/gr-digital/include/gnuradio/digital/correlate_and_sync_cc.h
+++ b/gr-digital/include/gnuradio/digital/correlate_and_sync_cc.h
@@ -32,7 +32,7 @@ namespace gr {
 
     /*!
      * \brief Correlate to a preamble and send time/phase sync info
-     * \ingroup synchronizers_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * Input:


### PR DESCRIPTION
This branch deprecates the gr::digital::correlate_and_sync block, which is replaced by the corr_est block