### PR TITLE
Mark mod blocks for 3.8 deprecation

### DIFF
--- a/gr-analog/grc/analog_block_tree.xml
+++ b/gr-analog/grc/analog_block_tree.xml
@@ -42,7 +42,6 @@
   </cat>
   <cat>
     <name>Modulators</name>
-    <block>analog_cpfsk_bc</block>
     <block>analog_frequency_modulator_fc</block>
     <block>analog_phase_modulator_fc</block>
     <block>analog_quadrature_demod_cf</block>

--- a/gr-analog/grc/analog_cpfsk_bc.xml
+++ b/gr-analog/grc/analog_cpfsk_bc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>CPFSK</name>
 	<key>analog_cpfsk_bc</key>
+  	<category>[Core]/Deprecated</category>
 	<import>from gnuradio import analog</import>
 	<make>analog.cpfsk_bc($k, $amplitude, $samples_per_symbol)</make>
 	<callback>set_amplitude($amplitude)</callback>

--- a/gr-analog/include/gnuradio/analog/cpfsk_bc.h
+++ b/gr-analog/include/gnuradio/analog/cpfsk_bc.h
@@ -31,6 +31,7 @@ namespace gr {
      * \brief Perform continuous phase 2-level frequency shift keying modulation
      * on an input stream of unpacked bits.
      * \ingroup modulators_blk
+     * \ingroup deprecated_blk
      */
     class ANALOG_API cpfsk_bc : virtual public sync_interpolator
     {

--- a/gr-digital/grc/digital_block_tree.xml
+++ b/gr-digital/grc/digital_block_tree.xml
@@ -48,17 +48,11 @@
   <cat>
     <name>Modulators</name>
     <block>digital_cpmmod_bc</block>
-    <block>digital_dxpsk_mod</block>
-    <block>digital_dxpsk_demod</block>
     <block>digital_gfsk_mod</block>
     <block>digital_gfsk_demod</block>
     <block>digital_gmskmod_bc</block>
     <block>digital_gmsk_mod</block>
     <block>digital_gmsk_demod</block>
-    <block>digital_psk_mod</block>
-    <block>digital_psk_demod</block>
-    <block>digital_qam_mod</block>
-    <block>digital_qam_demod</block>
     <block>digital_constellation_modulator</block>
     <block>digital_constellation_receiver_cb</block>
     <block>variable_constellation</block>

--- a/gr-digital/grc/digital_dxpsk_demod.xml
+++ b/gr-digital/grc/digital_dxpsk_demod.xml
@@ -29,6 +29,7 @@
 <block>
 	<name>DPSK Demod</name>
 	<key>digital_dxpsk_demod</key>
+  	<category>[Core]/Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.$(type)_demod(
 	samples_per_symbol=$samples_per_symbol,

--- a/gr-digital/grc/digital_dxpsk_mod.xml
+++ b/gr-digital/grc/digital_dxpsk_mod.xml
@@ -29,6 +29,7 @@
 <block>
 	<name>DPSK Mod</name>
 	<key>digital_dxpsk_mod</key>
+	<category>[Core]/Deprecated</category>
 	<import>from gnuradio import digital</import>
 	<make>digital.$(type)_mod(
 	samples_per_symbol=$samples_per_symbol,

--- a/gr-digital/grc/digital_mpsk_receiver_cc.xml
+++ b/gr-digital/grc/digital_mpsk_receiver_cc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>MPSK Receiver</name>
 	<key>digital_mpsk_receiver_cc</key>
+  	<category>[Core]/Deprecated</category>
 	<import>from gnuradio import digital;import cmath</import>
 	<make>digital.mpsk_receiver_cc($M, $theta, $w, $fmin, $fmax, $mu, $gain_mu, $omega, $gain_omega, $omega_relative_limit)</make>
 	<callback>set_loop_bandwidth($w)</callback>

--- a/gr-digital/grc/digital_psk_demod.xml
+++ b/gr-digital/grc/digital_psk_demod.xml
@@ -29,6 +29,7 @@
 <block>
   <name>PSK Demod</name>
   <key>digital_psk_demod</key>
+  <category>[Core]/Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.psk.psk_demod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_psk_mod.xml
+++ b/gr-digital/grc/digital_psk_mod.xml
@@ -29,6 +29,7 @@
 <block>
   <name>PSK Mod</name>
   <key>digital_psk_mod</key>
+  <category>[Core]/Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.psk.psk_mod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_qam_demod.xml
+++ b/gr-digital/grc/digital_qam_demod.xml
@@ -29,6 +29,7 @@
 <block>
   <name>QAM Demod</name>
   <key>digital_qam_demod</key>
+  <category>[Core]/Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.qam.qam_demod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_qam_mod.xml
+++ b/gr-digital/grc/digital_qam_mod.xml
@@ -29,6 +29,7 @@
 <block>
   <name>QAM Mod</name>
   <key>digital_qam_mod</key>
+  <category>[Core]/Deprecated</category>
   <import>from gnuradio import digital</import>
   <make>digital.qam.qam_mod(
   constellation_points=$constellation_points,

--- a/gr-digital/include/gnuradio/digital/mpsk_receiver_cc.h
+++ b/gr-digital/include/gnuradio/digital/mpsk_receiver_cc.h
@@ -34,6 +34,7 @@ namespace gr {
      * \brief This block takes care of receiving M-PSK modulated
      * signals through phase, frequency, and symbol synchronization.
      * \ingroup synchronizers_blk
+     * \ingroup deprecated_blk
      *
      * \details
      * It performs carrier frequency and phase locking as well as


### PR DESCRIPTION
Retrying #813 with modulation blocks only