### PR TITLE
uhd: Fix order of include dirs

### DIFF
--- a/gr-uhd/lib/CMakeLists.txt
+++ b/gr-uhd/lib/CMakeLists.txt
@@ -21,12 +21,12 @@
 # Setup the include and linker paths
 ########################################################################
 include_directories(
+    ${UHD_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${GR_UHD_INCLUDE_DIRS}
     ${GNURADIO_RUNTIME_INCLUDE_DIRS}
     ${LOG4CXX_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
-    ${UHD_INCLUDE_DIRS}
 )
 
 link_directories(

--- a/gr-uhd/swig/CMakeLists.txt
+++ b/gr-uhd/swig/CMakeLists.txt
@@ -26,10 +26,10 @@ include(GrSwig)
 set(GR_SWIG_FLAGS -DGR_HAVE_UHD) #needed to parse uhd_swig.i
 
 set(GR_SWIG_INCLUDE_DIRS
+    ${UHD_INCLUDE_DIRS}
     ${GR_UHD_INCLUDE_DIRS}
     ${GNURADIO_RUNTIME_SWIG_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
-    ${UHD_INCLUDE_DIRS}
 )
 
 if(ENABLE_GR_CTRLPORT)


### PR DESCRIPTION
Boost_INCLUDE_DIRS could previously "undo" UHD_INCLUDE_DIRS if it
pointed to the same location as a UHD installation that was *not*
selected via UHD_INCLUDE_DIRS.