### PR TITLE
qtgui: Fix bug in trackerText for Frequency Sink

### DIFF
--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -607,7 +607,6 @@ FrequencyDisplayPlot::setYLabel(const std::string &label,
   if(unit.length() > 0)
     l += " (" + unit + ")";
   setAxisTitle(QwtPlot::yLeft, QString(l.c_str()));
-  ((FreqDisplayZoomer*)d_zoomer)->setUnitType(unit);
 }
 
 void


### PR DESCRIPTION
Next to the cursor in the QT GUI Frequency Sink, the Y axis unit label (usually
dB) is shown instead of the X axis label (kHz, MHz etc).

(2nd try)