### PR TITLE
qtgui: Fix Axis Labels checkbox Control Panel checkbox sync issue

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/freqcontrolpanel.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqcontrolpanel.h
@@ -45,6 +45,7 @@ public:
 public slots:
   void notifyAvgSlider(int val);
   void toggleGrid(bool en);
+  void toggleAxisLabels(bool en);
   void toggleMaxHold(bool en);
   void toggleMinHold(bool en);
 

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -229,6 +229,12 @@ FreqControlPanel::toggleGrid(bool en)
 }
 
 void
+FreqControlPanel::toggleAxisLabels(bool en)
+{
+  d_axislabels_check->setChecked(en);
+}
+
+void
 FreqControlPanel::toggleMaxHold(bool en)
 {
   d_maxhold_check->setChecked(en);

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -177,6 +177,8 @@ FreqDisplayForm::setupControlPanel()
   // Connect action items in menu to controlpanel widgets
   connect(d_grid_act, SIGNAL(triggered(bool)),
           d_controlpanel, SLOT(toggleGrid(bool)));
+  connect(d_axislabelsmenu, SIGNAL(triggered(bool)),
+          d_controlpanel, SLOT(toggleAxisLabels(bool)));
   connect(d_sizemenu, SIGNAL(whichTrigger(int)),
 	  d_controlpanel, SLOT(toggleFFTSize(int)));
   connect(d_winmenu, SIGNAL(whichTrigger(gr::filter::firdes::win_type)),
@@ -199,6 +201,7 @@ FreqDisplayForm::setupControlPanel()
   d_layout->addLayout(d_controlpanel, 0, 1);
 
   d_controlpanel->toggleGrid(d_grid_act->isChecked());
+  d_controlpanel->toggleAxisLabels(d_axislabelsmenu->isChecked());
   d_controlpanelmenu->setChecked(true);
   d_controlpanel->toggleTriggerMode(getTriggerMode());
   d_controlpanel->toggleMaxHold(d_maxhold_act->isChecked());


### PR DESCRIPTION
The Axis Labels checkbox in the Control Panel for the Frequency Sink did not
synchronize its state with settings in other parts of the block, like initial
settings and center mouse button menu.