### PR TITLE
uhd: re-Fix order of include dirs ...

### DIFF
--- a/gr-uhd/lib/CMakeLists.txt
+++ b/gr-uhd/lib/CMakeLists.txt
@@ -21,10 +21,10 @@
 # Setup the include and linker paths
 ########################################################################
 include_directories(
-    ${UHD_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${GR_UHD_INCLUDE_DIRS}
     ${GNURADIO_RUNTIME_INCLUDE_DIRS}
+    ${UHD_INCLUDE_DIRS}
     ${LOG4CXX_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
 )

--- a/gr-uhd/swig/CMakeLists.txt
+++ b/gr-uhd/swig/CMakeLists.txt
@@ -26,9 +26,9 @@ include(GrSwig)
 set(GR_SWIG_FLAGS -DGR_HAVE_UHD) #needed to parse uhd_swig.i
 
 set(GR_SWIG_INCLUDE_DIRS
-    ${UHD_INCLUDE_DIRS}
     ${GR_UHD_INCLUDE_DIRS}
     ${GNURADIO_RUNTIME_SWIG_INCLUDE_DIRS}
+    ${UHD_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
... done in 7ad6ff1b such that UHD_INCLUDE_DIRS comes before Boost but after all internal directories.