### PR TITLE
Add a mechanism to cancel blocking work() function

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -182,6 +182,11 @@ namespace gr {
      */
     virtual bool stop();
 
+    /*!
+     * \brief Called to cancel a blocking work() function.
+     */
+    virtual void cancel_work();
+
     // ----------------------------------------------------------------
 
     /*!

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -132,6 +132,11 @@ namespace gr {
   }
 
   void
+  block::cancel_work()
+  {
+  }
+
+  void
   block::set_output_multiple(int multiple)
   {
     if(multiple < 1)

--- a/gnuradio-runtime/lib/scheduler_tpb.cc
+++ b/gnuradio-runtime/lib/scheduler_tpb.cc
@@ -63,23 +63,23 @@ namespace gr {
 
     basic_block_vector_t used_blocks = ffg->calc_used_blocks();
     used_blocks = ffg->topological_sort(used_blocks);
-    block_vector_t blocks = flat_flowgraph::make_block_vector(used_blocks);
+    d_blocks = flat_flowgraph::make_block_vector(used_blocks);
 
     // Ensure that the done flag is clear on all blocks
 
-    for(size_t i = 0; i < blocks.size(); i++) {
-      blocks[i]->detail()->set_done(false);
+    for(size_t i = 0; i < d_blocks.size(); i++) {
+      d_blocks[i]->detail()->set_done(false);
     }
 
     // Fire off a thead for each block
 
-    for(size_t i = 0; i < blocks.size(); i++) {
+    for(size_t i = 0; i < d_blocks.size(); i++) {
       std::stringstream name;
-      name << "thread-per-block[" << i << "]: " << blocks[i];
+      name << "thread-per-block[" << i << "]: " << d_blocks[i];
 
       // If set, use internal value instead of global value
-      if(blocks[i]->is_set_max_noutput_items()) {
-        block_max_noutput_items = blocks[i]->max_noutput_items();
+      if(d_blocks[i]->is_set_max_noutput_items()) {
+        block_max_noutput_items = d_blocks[i]->max_noutput_items();
       }
       else {
         block_max_noutput_items = max_noutput_items;
@@ -87,7 +87,7 @@ namespace gr {
 
       d_threads.create_thread(
 	    gr::thread::thread_body_wrapper<tpb_container>
-            (tpb_container(blocks[i], block_max_noutput_items),
+            (tpb_container(d_blocks[i], block_max_noutput_items),
              name.str()));
     }
   }
@@ -100,6 +100,9 @@ namespace gr {
   void
   scheduler_tpb::stop()
   {
+    for(size_t i = 0; i < d_blocks.size(); i++) {
+      d_blocks[i]->cancel_work();
+    }
     d_threads.interrupt_all();
   }
 

--- a/gnuradio-runtime/lib/scheduler_tpb.h
+++ b/gnuradio-runtime/lib/scheduler_tpb.h
@@ -34,6 +34,7 @@ namespace gr {
   class GR_RUNTIME_API scheduler_tpb : public scheduler
   {
     gr::thread::thread_group d_threads;
+    block_vector_t d_blocks;
 
   protected:
     /*!


### PR DESCRIPTION
Introduce a cancel_work() virtual function to the block class, which can
be overriden by child classes.

This function can be used to interrupt a blocking process in the work()
function.

It will be used in the gr-iio project.

Signed-off-by: Paul Cercueil <paul.cercueil@analog.com>