### PR TITLE
Bug fix: performance counter's clock option (i.e. thread or monotonic…

### DIFF
--- a/gnuradio-runtime/lib/top_block.cc
+++ b/gnuradio-runtime/lib/top_block.cc
@@ -59,6 +59,17 @@ namespace gr {
   void
   top_block::start(int max_noutput_items)
   {
+#ifdef GNURADIO_HRT_USE_CLOCK_GETTIME
+    std::string initial_clock = prefs::singleton()->get_string("PerfCounters", "clock", "thread");
+    if(initial_clock.compare("thread") == 0){
+        gr::high_res_timer_source = CLOCK_THREAD_CPUTIME_ID;
+    } else if(initial_clock.compare("monotonic") == 0){
+        gr::high_res_timer_source = CLOCK_MONOTONIC;
+    } else {
+        throw std::runtime_error("bad argument for PerfCounters.clock!");
+    }
+#endif
+
     d_impl->start(max_noutput_items);
 
     if(prefs::singleton()->get_bool("ControlPort", "on", false)) {
@@ -186,14 +197,6 @@ namespace gr {
     }
 
 #ifdef GNURADIO_HRT_USE_CLOCK_GETTIME
-    std::string initial_clock = prefs::singleton()->get_string("PerfCounters", "clock", "thread");
-    if(initial_clock.compare("thread") == 0){
-        gr::high_res_timer_source = CLOCK_THREAD_CPUTIME_ID;
-    } else if(initial_clock.compare("monotonic") == 0){
-        gr::high_res_timer_source = CLOCK_MONOTONIC;
-    } else {
-        throw std::runtime_error("bad argument for PerfCounters.clock!");
-    }
     add_rpc_variable(
         rpcbasic_sptr(new rpcbasic_register_variable_rw<int>(
         alias(), "perfcounter_clock",


### PR DESCRIPTION
…) was honored only if controlport was enabled.