### PR TITLE
qtgui: whitespace fix (gcc warning "misleading-indentation")

### DIFF
--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -284,12 +284,12 @@ void VectorDisplayPlot::setYAxisLabel(const QString &label)
 
 void VectorDisplayPlot::setXAxisUnit(const QString &unit)
 {
-    ((VectorDisplayZoomer*)d_zoomer)->setXUnits(unit);
+  ((VectorDisplayZoomer*)d_zoomer)->setXUnits(unit);
 }
 
 void VectorDisplayPlot::setYAxisUnit(const QString &unit)
 {
-    ((VectorDisplayZoomer*)d_zoomer)->setYUnits(unit);
+  ((VectorDisplayZoomer*)d_zoomer)->setYUnits(unit);
 }
 
 void
@@ -301,17 +301,17 @@ VectorDisplayPlot::setXAxisValues(
   if((start != d_x_axis_start) || (step != d_x_axis_step))
     reset = true;
 
-    d_x_axis_start = start;
-    d_x_axis_step = step;
+  d_x_axis_start = start;
+  d_x_axis_step = step;
 
-    if((axisScaleDraw(QwtPlot::xBottom) != NULL) && (d_zoomer != NULL)) {
-      setAxisTitle(QwtPlot::xBottom, d_x_axis_label);
-      if(reset) {
-        _resetXAxisPoints();
-        clearMaxData();
-        clearMinData();
-      }
+  if((axisScaleDraw(QwtPlot::xBottom) != NULL) && (d_zoomer != NULL)) {
+    setAxisTitle(QwtPlot::xBottom, d_x_axis_label);
+    if(reset) {
+      _resetXAxisPoints();
+      clearMaxData();
+      clearMinData();
     }
+  }
 }
 
 void


### PR DESCRIPTION
```
[ 79%] Building CXX object gr-qtgui/lib/CMakeFiles/gnuradio-qtgui.dir/VectorDisplayPlot.cc.o
/home/koslowski/code/gnuradio_build/gr-qtgui/lib/VectorDisplayPlot.cc: In member function ‘void VectorDisplayPlot::setXAxisValues(double, double)’:
/home/koslowski/code/gnuradio_build/gr-qtgui/lib/VectorDisplayPlot.cc:301:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if((start != d_x_axis_start) || (step != d_x_axis_step))
   ^~
/home/koslowski/code/gnuradio_build/gr-qtgui/lib/VectorDisplayPlot.cc:304:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
     d_x_axis_start = start;
     ^~~~~~~~~~~~~~

```