### PR TITLE
zeromq: add port getter for streaming zmq blocks

### DIFF
--- a/gr-zeromq/include/gnuradio/zeromq/CMakeLists.txt
+++ b/gr-zeromq/include/gnuradio/zeromq/CMakeLists.txt
@@ -22,6 +22,7 @@
 ########################################################################
 install(FILES
   api.h
+  stream_base.h
   pub_sink.h
   pub_msg_sink.h
   sub_source.h

--- a/gr-zeromq/include/gnuradio/zeromq/msg_base.h
+++ b/gr-zeromq/include/gnuradio/zeromq/msg_base.h
@@ -20,41 +20,50 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef INCLUDED_ZEROMQ_PUB_MSG_SINK_H
-#define INCLUDED_ZEROMQ_PUB_MSG_SINK_H
+#ifndef INCLUDED_ZEROMQ_MSG_BASE_H
+#define INCLUDED_ZEROMQ_MSG_BASE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/zeromq/msg_base.h>
+#include <gnuradio/block.h>
 
 namespace gr {
   namespace zeromq {
 
     /*!
-     * \brief Sink the contents of a msg port to a ZMQ PUB socket
+     * \brief Base class providing public API for message zeromq blocks
      * \ingroup zeromq
-     *
-     * \details
-     * This block acts a message port receiver and writes individual
-     * messages to a ZMQ PUB socket.  A PUB socket may have
-     * subscribers and will pass all incoming messages to each
-     * subscriber.  Subscribers can be either another gr-zeromq source
-     * block or a non-GNU Radio ZMQ socket.
      */
-    class ZEROMQ_API pub_msg_sink : virtual public msg_base
+    class ZEROMQ_API msg_base : public gr::block
     {
-    public:
-      typedef boost::shared_ptr<pub_msg_sink> sptr;
-
-      /*!
-       * \brief Return a shared_ptr to a new instance of zeromq::pub_msg_sink.
-       *
-       * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+    protected:
+      /*
+       * Required for virtual inheritance
        */
-      static sptr make(char *address, int timeout=100);
-    };
+      msg_base() {};
+      /*
+       * Actual ctor passed through to block
+       */
+      msg_base(const std::string &name,
+               gr::io_signature::sptr input_signature,
+               gr::io_signature::sptr output_signature) :
+          block(name, input_signature, output_signature) {};
+
+    public:
+    /*!
+     * \brief Return the endpoint address
+     */
+    virtual std::string endpoint() = 0;
+
+    /*!
+     * \brief Set the zeromq endpoint
+     *
+     * \param address the endpoint address
+     */
+    virtual void set_endpoint(const char* address) = 0;
+
+  };
 
   } // namespace zeromq
 } // namespace gr
 
-#endif /* INCLUDED_ZEROMQ_PUB_MSG_SINK_H */
+#endif /* INCLUDED_ZEROMQ_MSG_BASE_H */

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -57,6 +57,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return the endpoint address
+       */
+      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_PUB_SINK_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -40,7 +40,7 @@ namespace gr {
      * subscriber.  Subscribers can be either another gr-zeromq source
      * block or a non-GNU Radio ZMQ socket.
      */
-    class ZEROMQ_API pub_sink : virtual public gr::sync_block
+    class ZEROMQ_API pub_sink : virtual public stream_base
     {
     public:
       typedef boost::shared_ptr<pub_sink> sptr;
@@ -58,10 +58,6 @@ namespace gr {
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
 
-      /*!
-       * \brief Return the endpoint address
-       */
-      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_PULL_MSG_SOURCE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/block.h>
+#include <gnuradio/zeromq/msg_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -37,7 +37,7 @@ namespace gr {
      * This block will connect to a ZMQ PUSH socket, then convert
      * received messages to outgoing async messages.
      */
-    class ZEROMQ_API pull_msg_source : virtual public gr::block
+    class ZEROMQ_API pull_msg_source : virtual public msg_base
     {
     public:
       typedef boost::shared_ptr<pull_msg_source> sptr;

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -54,6 +54,10 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+      /*!
+       * \brief Return the endpoint address
+       */
+      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_PULL_SOURCE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -37,7 +37,7 @@ namespace gr {
      * This block will connect to a ZMQ PUSH socket, then produce all
      * incoming messages as streaming output.
      */
-    class ZEROMQ_API pull_source : virtual public gr::sync_block
+    class ZEROMQ_API pull_source : virtual public stream_base
     {
     public:
       typedef boost::shared_ptr<pull_source> sptr;
@@ -54,10 +54,7 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
-      /*!
-       * \brief Return the endpoint address
-       */
-      virtual std::string endpoint() = 0;
+
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_PUSH_MSG_SINK_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/block.h>
+#include <gnuradio/zeromq/msg_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -39,7 +39,7 @@ namespace gr {
      * PULL socket can be either another gr-zeromq source block or a
      * non-GNU Radio ZMQ socket.
      */
-    class ZEROMQ_API push_msg_sink : virtual public gr::block
+    class ZEROMQ_API push_msg_sink : virtual public msg_base
     {
     public:
       typedef boost::shared_ptr<push_msg_sink> sptr;

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -58,6 +58,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return the endpoint address
+       */
+      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_PUSH_SINK_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -41,7 +41,7 @@ namespace gr {
      * non-GNU Radio ZMQ socket.
      *
      */
-    class ZEROMQ_API push_sink : virtual public gr::sync_block
+    class ZEROMQ_API push_sink : virtual public stream_base
     {
     public:
       typedef boost::shared_ptr<push_sink> sptr;
@@ -58,11 +58,6 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
-
-      /*!
-       * \brief Return the endpoint address
-       */
-      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_REP_MSG_SINK_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/block.h>
+#include <gnuradio/zeromq/msg_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -39,7 +39,7 @@ namespace gr {
      * REQ socket can be either another gr-zeromq source block or a
      * non-GNU Radio ZMQ socket.
      */
-    class ZEROMQ_API rep_msg_sink : virtual public gr::block
+    class ZEROMQ_API rep_msg_sink : virtual public msg_base
     {
     public:
       typedef boost::shared_ptr<rep_msg_sink> sptr;

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -56,6 +56,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return the endpoint address
+       */
+      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_REP_SINK_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -39,7 +39,7 @@ namespace gr {
      * only send its contents to an attached REQ socket when it
      * requests items.
      */
-    class ZEROMQ_API rep_sink : virtual public gr::sync_block
+    class ZEROMQ_API rep_sink : virtual public stream_base
     {
     public:
       typedef boost::shared_ptr<rep_sink> sptr;
@@ -56,11 +56,6 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
-
-      /*!
-       * \brief Return the endpoint address
-       */
-      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_REQ_MSG_SOURCE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/block.h>
+#include <gnuradio/zeromq/msg_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -37,7 +37,7 @@ namespace gr {
      * This block will connect to a ZMQ REP socket, then resend all
      * incoming messages as asynchronous messages.
      */
-    class ZEROMQ_API req_msg_source : virtual public gr::block
+    class ZEROMQ_API req_msg_source : virtual public msg_base
     {
     public:
       typedef boost::shared_ptr<req_msg_source> sptr;

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_REQ_SOURCE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -37,7 +37,7 @@ namespace gr {
      * This block will connect to a ZMQ REP socket, then produce all
      * incoming messages as streaming output.
      */
-    class ZEROMQ_API req_source : virtual public gr::sync_block
+    class ZEROMQ_API req_source : virtual public stream_base
     {
     public:
       typedef boost::shared_ptr<req_source> sptr;
@@ -54,11 +54,6 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
-
-      /*!
-       * \brief Return the endpoint address
-       */
-      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -54,6 +54,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return the endpoint address
+       */
+      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/stream_base.h
+++ b/gr-zeromq/include/gnuradio/zeromq/stream_base.h
@@ -1,0 +1,64 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef GNURADIO_ZMQ_STREAM_BASE_H
+#define GNURADIO_ZMQ_STREAM_BASE_H
+
+#include <gnuradio/zeromq/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+    namespace zeromq {
+
+      /*!
+       * \brief Base class providing public API for streaming zeromq blocks
+       * \ingroup zeromq
+       */
+      class ZEROMQ_API stream_base : public gr::sync_block
+      {
+      protected:
+        /*
+         * Required for virtual inheritance
+         */
+        stream_base() {};
+        /*
+         * The actual ctor that passes through to sync_block
+         */
+        stream_base(const std::string &name,
+                    gr::io_signature::sptr input_signature,
+                    gr::io_signature::sptr output_signature) :
+            sync_block(name, input_signature, output_signature) {};
+
+      public:
+        /*!
+         * \brief Return the endpoint address
+         */
+        virtual std::string endpoint() = 0;
+      };
+
+  } // namespace zeromq
+} // namespace gr
+
+
+
+
+#endif //GNURADIO_ZMQ_STREAM_BASE_H

--- a/gr-zeromq/include/gnuradio/zeromq/stream_base.h
+++ b/gr-zeromq/include/gnuradio/zeromq/stream_base.h
@@ -53,6 +53,13 @@ namespace gr {
          * \brief Return the endpoint address
          */
         virtual std::string endpoint() = 0;
+
+        /*!
+         * \brief Set the zeromq endpoint
+         *
+         * \param address the endpoint address
+         */
+        virtual void set_endpoint(const char* address) = 0;
       };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_SUB_MSG_SOURCE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/block.h>
+#include <gnuradio/zeromq/msg_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -37,7 +37,7 @@ namespace gr {
      * This block will connect to a ZMQ PUB socket, then convert them
      * to outgoing async messages
      */
-    class ZEROMQ_API sub_msg_source : virtual public gr::block
+    class ZEROMQ_API sub_msg_source : virtual public msg_base
     {
     public:
       typedef boost::shared_ptr<sub_msg_source> sptr;

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_SUB_SOURCE_H
 
 #include <gnuradio/zeromq/api.h>
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
@@ -37,7 +37,7 @@ namespace gr {
      * This block will connect to a ZMQ PUB socket, then produce all
      * incoming messages as streaming output.
      */
-    class ZEROMQ_API sub_source : virtual public gr::sync_block
+    class ZEROMQ_API sub_source : virtual public stream_base
     {
     public:
       typedef boost::shared_ptr<sub_source> sptr;
@@ -54,11 +54,6 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
-
-      /*!
-       * \brief Return the endpoint address
-       */
-      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -54,6 +54,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return the endpoint address
+       */
+      virtual std::string endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/CMakeLists.txt
+++ b/gr-zeromq/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ endif(ENABLE_GR_CTRLPORT)
 ########################################################################
 list(APPEND zeromq_sources
   base_impl.cc
+  msg_base_impl.cc
   pub_sink_impl.cc
   pub_msg_sink_impl.cc
   sub_source_impl.cc

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -31,7 +31,7 @@
 namespace gr {
   namespace zeromq {
 
-    base_impl::base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags)
+    base_impl::base_impl(size_t type, size_t itemsize, size_t vlen, int timeout, bool pass_tags)
       : d_vsize(itemsize * vlen), d_timeout(timeout), d_pass_tags(pass_tags)
     {
       /* "Fix" timeout value (ms for new API, us for old API) */
@@ -64,8 +64,8 @@ namespace gr {
     }
 
 
-
-    base_sink_impl::base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
+    base_sink_impl::base_sink_impl(size_t type, size_t itemsize, size_t vlen, char *address, int timeout,
+                                   bool pass_tags, int hwm)
         : base_impl(type, itemsize, vlen, timeout, pass_tags)
     {
       /* Set high watermark */

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -25,13 +25,14 @@
 #endif
 
 #include <gnuradio/io_signature.h>
+#include <gnuradio/attributes.h>
 #include "base_impl.h"
 #include "tag_headers.h"
 
 namespace gr {
   namespace zeromq {
 
-    base_impl::base_impl(size_t type, size_t itemsize, size_t vlen, int timeout, bool pass_tags)
+    base_impl::base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags)
       : d_type(type), d_vsize(itemsize * vlen), d_timeout(timeout), d_pass_tags(pass_tags)
     {
       /* "Fix" timeout value (ms for new API, us for old API) */
@@ -71,14 +72,14 @@ namespace gr {
     std::string
     base_impl::endpoint()
     {
-      size_t len;
-      char endpoint[1024];
+      size_t len = 1024;
+      __GR_VLA(char, endpoint, len);
       d_socket->getsockopt(ZMQ_LAST_ENDPOINT, endpoint, &len);
-      return std::string(endpoint);
+      return std::string(endpoint, len-1);
     }
 
 
-    base_sink_impl::base_sink_impl(size_t type, size_t itemsize, size_t vlen, char *address, int timeout,
+    base_sink_impl::base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout,
                                    bool pass_tags, int hwm)
         : base_impl(type, itemsize, vlen, timeout, pass_tags)
     {

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -54,6 +54,16 @@ namespace gr {
         delete d_context;
     }
 
+    std::string
+    base_impl::endpoint()
+    {
+      size_t len;
+      char endpoint[1024];
+      d_socket->getsockopt(ZMQ_LAST_ENDPOINT, endpoint, &len);
+      return std::string(endpoint);
+    }
+
+
 
     base_sink_impl::base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
         : base_impl(type, itemsize, vlen, timeout, pass_tags)

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -24,21 +24,22 @@
 #define INCLUDED_ZEROMQ_BASE_IMPL_H
 
 #include <zmq.hpp>
-
-#include <gnuradio/sync_block.h>
+#include <gnuradio/zeromq/stream_base.h>
 
 namespace gr {
   namespace zeromq {
 
-    class base_impl : public virtual gr::sync_block
+    /*
+     * The common base implementation
+     */
+    class base_impl : virtual public stream_base
     {
     public:
-      base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
       virtual ~base_impl();
       std::string endpoint();
 
-
     protected:
+      base_impl(size_t type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
       size_t          d_vsize;
@@ -46,21 +47,23 @@ namespace gr {
       bool            d_pass_tags;
     };
 
+    /*
+     * The base sink implementation
+     */
     class base_sink_impl : public base_impl
     {
-    public:
-      base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
-
     protected:
+      base_sink_impl(size_t type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
       int send_message(const void *in_buf, const int in_nitems, const uint64_t in_offset);
     };
 
+    /*
+     * The base source implementation
+     */
     class base_source_impl : public base_impl
     {
-    public:
-      base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
-
     protected:
+      base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
       zmq::message_t d_msg;
       std::vector<gr::tag_t> d_tags;
       size_t d_consumed_bytes;

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -35,6 +35,8 @@ namespace gr {
     public:
       base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
       virtual ~base_impl();
+      std::string endpoint();
+
 
     protected:
       zmq::context_t  *d_context;

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -40,11 +40,16 @@ namespace gr {
 
     protected:
       base_impl(size_t type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
+      void set_hwm();
+      virtual void setup_socket() {};
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
+      size_t          d_type;
       size_t          d_vsize;
       int             d_timeout;
       bool            d_pass_tags;
+      int             d_hwm;
+      gr::thread::mutex d_mutex;
     };
 
     /*
@@ -52,6 +57,10 @@ namespace gr {
      */
     class base_sink_impl : public base_impl
     {
+    public:
+      std::string endpoint() {return base_impl::endpoint();};
+      void set_endpoint(const char* address);
+
     protected:
       base_sink_impl(size_t type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
       int send_message(const void *in_buf, const int in_nitems, const uint64_t in_offset);
@@ -62,6 +71,10 @@ namespace gr {
      */
     class base_source_impl : public base_impl
     {
+    public:
+      std::string endpoint() {return base_impl::endpoint();};
+      void set_endpoint(const char* address);
+
     protected:
       base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
       zmq::message_t d_msg;

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -39,12 +39,12 @@ namespace gr {
       std::string endpoint();
 
     protected:
-      base_impl(size_t type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
+      base_impl(int type, size_t itemsize, size_t vlen, int timeout, bool pass_tags);
       void set_hwm();
       virtual void setup_socket() {};
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
-      size_t          d_type;
+      int             d_type;
       size_t          d_vsize;
       int             d_timeout;
       bool            d_pass_tags;
@@ -62,7 +62,7 @@ namespace gr {
       void set_endpoint(const char* address);
 
     protected:
-      base_sink_impl(size_t type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
+      base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
       int send_message(const void *in_buf, const int in_nitems, const uint64_t in_offset);
     };
 

--- a/gr-zeromq/lib/msg_base_impl.cc
+++ b/gr-zeromq/lib/msg_base_impl.cc
@@ -49,6 +49,7 @@ namespace gr {
 
     msg_base_impl::~msg_base_impl()
     {
+      stop();
       d_socket->close();
       delete d_socket;
       delete d_context;

--- a/gr-zeromq/lib/msg_base_impl.cc
+++ b/gr-zeromq/lib/msg_base_impl.cc
@@ -1,0 +1,180 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+
+#include "msg_base_impl.h"
+
+namespace gr {
+  namespace zeromq {
+
+    /*
+     * Common Base Section
+     */
+    msg_base_impl::msg_base_impl(int type, char *address, int timeout)
+      : type(type)
+    {
+      int major, minor, patch;
+      zmq::version (&major, &minor, &patch);
+      if (major < 3) {
+        d_timeout = timeout*1000;
+      }
+
+      d_context = new zmq::context_t(1);
+      d_socket = new zmq::socket_t(*d_context, type);
+    }
+
+    msg_base_impl::~msg_base_impl()
+    {
+      d_socket->close();
+      delete d_socket;
+      delete d_context;
+    }
+
+    void msg_base_impl::handler(pmt::pmt_t msg)
+    {
+      gr::thread::scoped_lock guard(d_mutex);
+      std::stringbuf sb("");
+      pmt::serialize(msg, sb);
+      std::string s = sb.str();
+      zmq::message_t zmsg(s.size());
+
+      memcpy(zmsg.data(), s.c_str(), s.size());
+      d_socket->send(zmsg);
+    }
+
+    bool msg_base_impl::start()
+    {
+      /*
+       * This is overloaded from the gnuradio start/stop and is implemented here
+       * because the "default" start/stop is either nothing or start the thread
+       * for sub, pull
+       */
+      if (type == ZMQ_SUB || type == ZMQ_PULL) {
+        d_zmq_finished = false;
+        d_thread = new boost::thread(boost::bind(&msg_base_impl::readloop, this));
+      }
+      return true;
+    }
+
+    bool msg_base_impl::stop()
+    {
+      if (type == ZMQ_SUB || type == ZMQ_PULL) {
+        d_zmq_finished = true;
+        d_thread->join();
+      }
+      return true;
+    }
+
+    void msg_base_impl::readloop()
+    {
+      gr::thread::scoped_lock guard(d_mutex);
+      while(!d_zmq_finished){
+        zmq::pollitem_t items[] = { { static_cast<void *>(*d_socket), 0, ZMQ_POLLIN, 0 } };
+        zmq::poll(&items[0], 1, d_timeout);
+
+        //  If we got a reply, process
+        if (items[0].revents & ZMQ_POLLIN) {
+
+          // Receive data
+          zmq::message_t msg;
+          d_socket->recv(&msg);
+
+          std::string buf(static_cast<char*>(msg.data()), msg.size());
+          std::stringbuf sb(buf);
+          pmt::pmt_t m = pmt::deserialize(sb);
+          message_port_pub(pmt::mp("out"), m);
+        } else {
+          boost::this_thread::sleep(boost::posix_time::microseconds(100));
+        }
+      }
+    }
+
+    std::string msg_base_impl::endpoint()
+    {
+      size_t len = 1024;
+      __GR_VLA(char, endpoint, len);
+      d_socket->getsockopt(ZMQ_LAST_ENDPOINT, endpoint, &len);
+      return std::string(endpoint, len-1);
+    }
+
+    /*
+     * Sink Base
+     */
+    msg_base_sink_impl::msg_base_sink_impl(int type, char *address, int timeout)
+        : msg_base_impl(type, address, timeout)
+    {
+      int time = 0;
+      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
+      d_socket->bind(address);
+
+      message_port_register_in(pmt::mp("in"));
+      // ZMQ_REP has to manually check queue and wait for requests
+      if (type != ZMQ_REP) {
+        set_msg_handler( pmt::mp("in"),
+                         boost::bind(&msg_base_sink_impl::handler, this, _1));
+
+      }
+    }
+
+    void msg_base_sink_impl::set_endpoint(const char *address)
+    {
+      stop();
+      gr::thread::scoped_lock guard(d_mutex);
+      d_socket->close();
+      delete d_socket;
+
+      d_socket = new zmq::socket_t(*d_context, type);
+      int time = 0;
+      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
+      d_socket->bind(address);
+      start();
+    }
+
+    /*
+     * Source Base
+     */
+    msg_base_source_impl::msg_base_source_impl(int type, char *address, int timeout)
+        : msg_base_impl(type, address, timeout)
+    {
+      d_socket->connect (address);
+      message_port_register_out(pmt::mp("out"));
+    }
+
+    void msg_base_source_impl::set_endpoint(const char *address)
+    {
+      stop();
+      gr::thread::scoped_lock guard(d_mutex);
+      d_socket->close();
+      delete d_socket;
+
+      d_socket = new zmq::socket_t(*d_context, type);
+      d_socket->connect(address);
+      start();
+    }
+
+  }
+}

--- a/gr-zeromq/lib/msg_base_impl.h
+++ b/gr-zeromq/lib/msg_base_impl.h
@@ -37,14 +37,16 @@ namespace gr {
     public:
       virtual ~msg_base_impl();
       std::string endpoint();
-      bool d_zmq_finished; // public in old sub_msg_source -- should it be?
 
     protected:
       msg_base_impl(int type, char *address, int timeout=100);
       void handler(pmt::pmt_t msg);
+      virtual void setup_socket() {};
       virtual bool start();
       virtual bool stop();
       virtual void readloop();
+      bool d_zmq_finished; // public in old sub_msg_source -- should it be?
+      int d_zmq_started;
       int type;
       gr::thread::mutex d_mutex;
       boost::thread* d_thread;

--- a/gr-zeromq/lib/msg_base_impl.h
+++ b/gr-zeromq/lib/msg_base_impl.h
@@ -1,0 +1,85 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2016 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio.
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_GNURADIO_ZEROMQ_MSG_BASE_IMPL_H
+#define INCLUDED_GNURADIO_ZEROMQ_MSG_BASE_IMPL_H
+
+#include <zmq.hpp>
+#include <gnuradio/zeromq/msg_base.h>
+
+namespace gr {
+  namespace zeromq {
+
+    /*
+     * The common base implementation
+     */
+    class msg_base_impl : virtual public msg_base
+    {
+    public:
+      virtual ~msg_base_impl();
+      std::string endpoint();
+      bool d_zmq_finished; // public in old sub_msg_source -- should it be?
+
+    protected:
+      msg_base_impl(int type, char *address, int timeout=100);
+      void handler(pmt::pmt_t msg);
+      virtual bool start();
+      virtual bool stop();
+      virtual void readloop();
+      int type;
+      gr::thread::mutex d_mutex;
+      boost::thread* d_thread;
+      float d_timeout;
+      zmq::context_t* d_context;
+      zmq::socket_t* d_socket;
+    };
+
+    /*
+     * The base sink implementation
+     */
+    class msg_base_sink_impl : public msg_base_impl
+    {
+    public:
+      std::string endpoint() {return msg_base_impl::endpoint();};
+      void set_endpoint(const char* address);
+
+    protected:
+      msg_base_sink_impl(int type, char *address, int timeout=100);
+    };
+
+    /*
+     * The base source implementation
+     */
+    class msg_base_source_impl : public msg_base_impl
+    {
+    public:
+      std::string endpoint() {return msg_base_impl::endpoint();};
+      void set_endpoint(const char* address);
+
+    protected:
+      msg_base_source_impl(int type, char *address, int timeout=100);
+    };
+
+  }
+}
+
+#endif //INCLUDED_GNURADIO_MSG_BASE_IMPL_H

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2016 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -26,7 +26,6 @@
 
 #include <gnuradio/io_signature.h>
 #include "pub_msg_sink_impl.h"
-#include "tag_headers.h"
 
 namespace gr {
   namespace zeromq {
@@ -39,44 +38,11 @@ namespace gr {
     }
 
     pub_msg_sink_impl::pub_msg_sink_impl(char *address, int timeout)
-      : gr::block("pub_msg_sink",
+      : msg_base("pub_msg_sink",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+        msg_base_sink_impl(ZMQ_PUB, address, timeout)
     {
-      int major, minor, patch;
-      zmq::version (&major, &minor, &patch);
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_PUB);
-      int time = 0;
-      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-      d_socket->bind(address);
-
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler( pmt::mp("in"),
-        boost::bind(&pub_msg_sink_impl::handler, this, _1));
-    }
-
-    pub_msg_sink_impl::~pub_msg_sink_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
-    }
-
-    void pub_msg_sink_impl::handler(pmt::pmt_t msg)
-    {
-      std::stringbuf sb("");
-      pmt::serialize(msg, sb);
-      std::string s = sb.str();
-      zmq::message_t zmsg(s.size());
-
-      memcpy(zmsg.data(), s.c_str(), s.size());
-      d_socket->send(zmsg);
     }
 
   } /* namespace zeromq */

--- a/gr-zeromq/lib/pub_msg_sink_impl.h
+++ b/gr-zeromq/lib/pub_msg_sink_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2016 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -26,21 +26,15 @@
 #include <gnuradio/zeromq/pub_msg_sink.h>
 #include <zmq.hpp>
 
+#include "msg_base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class pub_msg_sink_impl : public pub_msg_sink
+    class pub_msg_sink_impl : public msg_base_sink_impl, public pub_msg_sink
     {
-    private:
-      float           d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-
     public:
       pub_msg_sink_impl(char *address, int timeout);
-      ~pub_msg_sink_impl();
-
-      void handler(pmt::pmt_t msg);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pub_sink_impl.cc
+++ b/gr-zeromq/lib/pub_sink_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     pub_sink_impl::pub_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
-      : gr::sync_block("pub_sink",
+      : stream_base("pub_sink",
                        gr::io_signature::make(1, 1, itemsize * vlen),
                        gr::io_signature::make(0, 0, 0)),
         base_sink_impl(ZMQ_PUB, itemsize, vlen, address, timeout, pass_tags, hwm)

--- a/gr-zeromq/lib/pub_sink_impl.h
+++ b/gr-zeromq/lib/pub_sink_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pub_sink_impl.h
+++ b/gr-zeromq/lib/pub_sink_impl.h
@@ -39,8 +39,6 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
-
-      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -25,10 +25,7 @@
 #endif
 
 #include <gnuradio/io_signature.h>
-#include <boost/thread/thread.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include "pull_msg_source_impl.h"
-#include "tag_headers.h"
 
 namespace gr {
   namespace zeromq {
@@ -36,77 +33,17 @@ namespace gr {
     pull_msg_source::sptr
     pull_msg_source::make(char *address, int timeout)
     {
+      std::cout << "in make" << std::endl;
       return gnuradio::get_initial_sptr
         (new pull_msg_source_impl(address, timeout));
     }
 
     pull_msg_source_impl::pull_msg_source_impl(char *address, int timeout)
-      : gr::block("pull_msg_source",
+      : msg_base("pull_msg_source",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+        msg_base_source_impl(ZMQ_PULL, address, timeout)
     {
-      int major, minor, patch;
-      zmq::version (&major, &minor, &patch);
-
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_PULL);
-
-      int time = 0;
-      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-      d_socket->connect (address);
-
-      message_port_register_out(pmt::mp("out"));
-    }
-
-    pull_msg_source_impl::~pull_msg_source_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
-    }
-
-    bool pull_msg_source_impl::start()
-    {
-      d_finished = false;
-      d_thread = new boost::thread(boost::bind(&pull_msg_source_impl::readloop, this));
-      return true;
-    }
-
-    bool pull_msg_source_impl::stop()
-    {
-      d_finished = true;
-      d_thread->join();
-      return true;
-    }
-
-    void pull_msg_source_impl::readloop()
-    {
-      while(!d_finished){
-
-        zmq::pollitem_t items[] = { { static_cast<void *>(*d_socket), 0, ZMQ_POLLIN, 0 } };
-        zmq::poll (&items[0], 1, d_timeout);
-
-        //  If we got a reply, process
-        if (items[0].revents & ZMQ_POLLIN) {
-
-          // Receive data
-          zmq::message_t msg;
-          d_socket->recv(&msg);
-
-          std::string buf(static_cast<char*>(msg.data()), msg.size());
-          std::stringbuf sb(buf);
-          pmt::pmt_t m = pmt::deserialize(sb);
-          message_port_pub(pmt::mp("out"), m);
-
-        } else {
-          boost::this_thread::sleep(boost::posix_time::microseconds(100));
-        }
-      }
     }
 
   } /* namespace zeromq */

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -26,27 +26,15 @@
 #include <gnuradio/zeromq/pull_msg_source.h>
 #include <zmq.hpp>
 
+#include "msg_base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class pull_msg_source_impl : public pull_msg_source
+    class pull_msg_source_impl : public msg_base_source_impl, public pull_msg_source
     {
-    private:
-      int             d_timeout; // microseconds, -1 is blocking
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      boost::thread   *d_thread;
-
-      void readloop();
-
     public:
-      bool d_finished;
-
       pull_msg_source_impl(char *address, int timeout);
-      ~pull_msg_source_impl();
-
-      bool start();
-      bool stop();
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pull_source_impl.cc
+++ b/gr-zeromq/lib/pull_source_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     pull_source_impl::pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
-      : gr::sync_block("pull_source",
+      : stream_base("pull_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
         base_source_impl(ZMQ_PULL, itemsize, vlen, address, timeout, pass_tags, hwm)

--- a/gr-zeromq/lib/pull_source_impl.h
+++ b/gr-zeromq/lib/pull_source_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pull_source_impl.h
+++ b/gr-zeromq/lib/pull_source_impl.h
@@ -39,8 +39,6 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
-
-      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/push_msg_sink_impl.cc
+++ b/gr-zeromq/lib/push_msg_sink_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2016 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -26,7 +26,6 @@
 
 #include <gnuradio/io_signature.h>
 #include "push_msg_sink_impl.h"
-#include "tag_headers.h"
 
 namespace gr {
   namespace zeromq {
@@ -39,46 +38,11 @@ namespace gr {
     }
 
     push_msg_sink_impl::push_msg_sink_impl(char *address, int timeout)
-      : gr::block("push_msg_sink",
+      : msg_base("push_msg_sink",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+        msg_base_sink_impl(ZMQ_PUSH, address, timeout)
     {
-      int major, minor, patch;
-      zmq::version (&major, &minor, &patch);
-
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_PUSH);
-
-      int time = 0;
-      d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-      d_socket->bind(address);
-
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
-                      boost::bind(&push_msg_sink_impl::handler, this, _1));
-    }
-
-    push_msg_sink_impl::~push_msg_sink_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
-    }
-
-    void push_msg_sink_impl::handler(pmt::pmt_t msg)
-    {
-      std::stringbuf sb("");
-      pmt::serialize( msg, sb );
-      std::string s = sb.str();
-      zmq::message_t zmsg(s.size());
-
-      memcpy(zmsg.data(), s.c_str(), s.size());
-      d_socket->send(zmsg);
     }
 
   } /* namespace zeromq */

--- a/gr-zeromq/lib/push_msg_sink_impl.h
+++ b/gr-zeromq/lib/push_msg_sink_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2016 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -26,21 +26,15 @@
 #include <gnuradio/zeromq/push_msg_sink.h>
 #include <zmq.hpp>
 
+#include "msg_base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class push_msg_sink_impl : public push_msg_sink
+    class push_msg_sink_impl : public msg_base_sink_impl, public push_msg_sink
     {
-    private:
-      float           d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-
     public:
       push_msg_sink_impl(char *address, int timeout);
-      ~push_msg_sink_impl();
-
-      void handler(pmt::pmt_t msg);
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/push_sink_impl.cc
+++ b/gr-zeromq/lib/push_sink_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     push_sink_impl::push_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
-      : gr::sync_block("push_sink",
+      : stream_base("push_sink",
                        gr::io_signature::make(1, 1, itemsize * vlen),
                        gr::io_signature::make(0, 0, 0)),
         base_sink_impl(ZMQ_PUSH, itemsize, vlen, address, timeout, pass_tags, hwm)

--- a/gr-zeromq/lib/push_sink_impl.h
+++ b/gr-zeromq/lib/push_sink_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/push_sink_impl.h
+++ b/gr-zeromq/lib/push_sink_impl.h
@@ -39,8 +39,6 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
-
-      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -55,8 +55,10 @@ namespace gr {
 
     bool rep_msg_sink_impl::stop()
     {
-      d_zmq_finished = true;
-      d_thread->join();
+      if (d_zmq_started) {
+        d_zmq_finished = true;
+        d_thread->join();
+      }
       return true;
     }
 

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -48,6 +48,7 @@ namespace gr {
 
     bool rep_msg_sink_impl::start()
     {
+      d_zmq_started = true;
       d_zmq_finished = false;
       d_thread = new boost::thread(boost::bind(&rep_msg_sink_impl::readloop, this));
       return true;
@@ -57,7 +58,11 @@ namespace gr {
     {
       if (d_zmq_started) {
         d_zmq_finished = true;
-        d_thread->join();
+        if (d_thread != NULL) {
+          d_thread->join();
+        }
+        delete d_thread;
+        d_thread = NULL;
       }
       return true;
     }

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -26,23 +26,18 @@
 #include <gnuradio/zeromq/rep_msg_sink.h>
 #include <zmq.hpp>
 
+#include "msg_base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class rep_msg_sink_impl : public rep_msg_sink
+    class rep_msg_sink_impl : public msg_base_sink_impl, public rep_msg_sink
     {
     private:
-      int             d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      boost::thread   *d_thread;
-      bool            d_finished;
-
-      void            readloop();
+      void readloop();
 
     public:
       rep_msg_sink_impl(char *address, int timeout);
-      ~rep_msg_sink_impl();
 
       bool start();
       bool stop();

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     rep_sink_impl::rep_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
-      : gr::sync_block("rep_sink",
+      : stream_base("rep_sink",
                        gr::io_signature::make(1, 1, itemsize * vlen),
                        gr::io_signature::make(0, 0, 0)),
         base_sink_impl(ZMQ_REP, itemsize, vlen, address, timeout, pass_tags, hwm)

--- a/gr-zeromq/lib/rep_sink_impl.h
+++ b/gr-zeromq/lib/rep_sink_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/rep_sink_impl.h
+++ b/gr-zeromq/lib/rep_sink_impl.h
@@ -39,8 +39,6 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
-
-      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -28,7 +28,6 @@
 #include <boost/thread/thread.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include "req_msg_source_impl.h"
-#include "tag_headers.h"
 
 namespace gr {
   namespace zeromq {
@@ -41,54 +40,32 @@ namespace gr {
     }
 
     req_msg_source_impl::req_msg_source_impl(char *address, int timeout)
-      : gr::block("req_msg_source",
+      : msg_base("req_msg_source",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+        msg_base_source_impl(ZMQ_REQ, address, timeout)
     {
-      int major, minor, patch;
-      zmq::version(&major, &minor, &patch);
-
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_REQ);
-
       int time = 0;
       d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-      d_socket->connect (address);
-
-      message_port_register_out(pmt::mp("out"));
-    }
-
-    req_msg_source_impl::~req_msg_source_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
     }
 
     bool req_msg_source_impl::start()
     {
-      d_finished = false;
+      d_zmq_finished = false;
       d_thread = new boost::thread(boost::bind(&req_msg_source_impl::readloop, this));
       return true;
     }
 
     bool req_msg_source_impl::stop()
     {
-      d_finished = true;
+      d_zmq_finished = true;
       d_thread->join();
       return true;
     }
 
     void req_msg_source_impl::readloop()
     {
-      while(!d_finished){
-        //std::cout << "readloop\n";
-
+      while(!d_zmq_finished){
         zmq::pollitem_t itemsout[] = { { static_cast<void *>(*d_socket), 0, ZMQ_POLLOUT, 0 } };
         zmq::poll(&itemsout[0], 1, d_timeout);
 

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -51,6 +51,7 @@ namespace gr {
 
     bool req_msg_source_impl::start()
     {
+      d_zmq_started = true;
       d_zmq_finished = false;
       d_thread = new boost::thread(boost::bind(&req_msg_source_impl::readloop, this));
       return true;
@@ -58,8 +59,14 @@ namespace gr {
 
     bool req_msg_source_impl::stop()
     {
-      d_zmq_finished = true;
-      d_thread->join();
+      if (d_zmq_started) {
+        if (d_thread != NULL) {
+          d_zmq_finished = true;
+          d_thread->join();
+          delete d_thread;
+          d_thread = NULL;
+        }
+      }
       return true;
     }
 

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -26,24 +26,18 @@
 #include <gnuradio/zeromq/req_msg_source.h>
 #include <zmq.hpp>
 
+#include "msg_base_impl.h"
+
 namespace gr {
   namespace zeromq {
 
-    class req_msg_source_impl : public req_msg_source
+    class req_msg_source_impl : public msg_base_source_impl, public req_msg_source
     {
     private:
-      int             d_timeout;
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      boost::thread   *d_thread;
-
       void readloop();
 
     public:
-      bool d_finished;
-
       req_msg_source_impl(char *address, int timeout);
-      ~req_msg_source_impl();
 
       bool start();
       bool stop();

--- a/gr-zeromq/lib/req_source_impl.cc
+++ b/gr-zeromq/lib/req_source_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     req_source_impl::req_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
-      : gr::sync_block("req_source",
+      : stream_base("req_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
         base_source_impl(ZMQ_REQ, itemsize, vlen, address, timeout, pass_tags, hwm),

--- a/gr-zeromq/lib/req_source_impl.h
+++ b/gr-zeromq/lib/req_source_impl.h
@@ -40,6 +40,8 @@ namespace gr {
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
 
+      std::string endpoint() {return base_impl::endpoint();}
+
     private:
       bool d_req_pending;
     };

--- a/gr-zeromq/lib/req_source_impl.h
+++ b/gr-zeromq/lib/req_source_impl.h
@@ -40,8 +40,6 @@ namespace gr {
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
 
-      std::string endpoint() {return base_impl::endpoint();}
-
     private:
       bool d_req_pending;
     };

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -41,71 +41,12 @@ namespace gr {
     }
 
     sub_msg_source_impl::sub_msg_source_impl(char *address, int timeout)
-      : gr::block("sub_msg_source",
+      : msg_base("sub_msg_source",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+        msg_base_source_impl(ZMQ_SUB, address, timeout)
     {
-      int major, minor, patch;
-      zmq::version(&major, &minor, &patch);
-
-      if (major < 3) {
-        d_timeout = timeout*1000;
-      }
-
-      d_context = new zmq::context_t(1);
-      d_socket = new zmq::socket_t(*d_context, ZMQ_SUB);
-
       d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
-      d_socket->connect (address);
-
-      message_port_register_out(pmt::mp("out"));
-    }
-
-    sub_msg_source_impl::~sub_msg_source_impl()
-    {
-      d_socket->close();
-      delete d_socket;
-      delete d_context;
-    }
-
-    bool sub_msg_source_impl::start()
-    {
-      d_finished = false;
-      d_thread = new boost::thread(boost::bind(&sub_msg_source_impl::readloop, this));
-      return true;
-    }
-
-    bool sub_msg_source_impl::stop()
-    {
-      d_finished = true;
-      d_thread->join();
-      return true;
-    }
-
-    void sub_msg_source_impl::readloop()
-    {
-      while(!d_finished){
-
-        zmq::pollitem_t items[] = { { static_cast<void *>(*d_socket), 0, ZMQ_POLLIN, 0 } };
-        zmq::poll(&items[0], 1, d_timeout);
-
-        //  If we got a reply, process
-        if (items[0].revents & ZMQ_POLLIN) {
-
-          // Receive data
-          zmq::message_t msg;
-          d_socket->recv(&msg);
-
-          std::string buf(static_cast<char*>(msg.data()), msg.size());
-          std::stringbuf sb(buf);
-          pmt::pmt_t m = pmt::deserialize(sb);
-
-          message_port_pub(pmt::mp("out"), m);
-        } else {
-          boost::this_thread::sleep(boost::posix_time::microseconds(100));
-        }
-      }
     }
 
   } /* namespace zeromq */

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -46,6 +46,11 @@ namespace gr {
                   gr::io_signature::make(0, 0, 0)),
         msg_base_source_impl(ZMQ_SUB, address, timeout)
     {
+      setup_socket();
+    }
+
+    void sub_msg_source_impl::setup_socket()
+    {
       d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
     }
 

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -34,6 +34,8 @@ namespace gr {
     {
      public:
       sub_msg_source_impl(char *address, int timeout);
+    protected:
+      void setup_socket();
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -24,29 +24,16 @@
 #define INCLUDED_ZEROMQ_SUB_MSG_SOURCE_IMPL_H
 
 #include <gnuradio/zeromq/sub_msg_source.h>
+#include "msg_base_impl.h"
 #include "zmq.hpp"
 
 namespace gr {
   namespace zeromq {
 
-    class sub_msg_source_impl : public sub_msg_source
+    class sub_msg_source_impl : public msg_base_source_impl, public sub_msg_source
     {
-     private:
-      int             d_timeout; // microseconds, -1 is blocking
-      zmq::context_t  *d_context;
-      zmq::socket_t   *d_socket;
-      boost::thread   *d_thread;
-
-      void readloop();
-
      public:
-      bool d_finished;
-
       sub_msg_source_impl(char *address, int timeout);
-      ~sub_msg_source_impl();
-
-      bool start();
-      bool stop();
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -39,7 +39,7 @@ namespace gr {
     }
 
     sub_source_impl::sub_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
-      : gr::sync_block("sub_source",
+      : stream_base("sub_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
         base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm)

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -44,6 +44,11 @@ namespace gr {
                        gr::io_signature::make(1, 1, itemsize * vlen)),
         base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm)
     {
+    }
+
+    void
+    sub_source_impl::setup_socket()
+    {
       /* Subscribe */
       d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
     }

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -44,6 +44,7 @@ namespace gr {
                        gr::io_signature::make(1, 1, itemsize * vlen)),
         base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm)
     {
+      setup_socket();
     }
 
     void

--- a/gr-zeromq/lib/sub_source_impl.h
+++ b/gr-zeromq/lib/sub_source_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/sub_source_impl.h
+++ b/gr-zeromq/lib/sub_source_impl.h
@@ -36,11 +36,10 @@ namespace gr {
     public:
       sub_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
 
+      void setup_socket();
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
-
-      std::string endpoint() {return base_impl::endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_pubsub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_pubsub.py
@@ -43,8 +43,10 @@ class qa_zeromq_msg_pubsub (gr_unittest.TestCase):
         msg_src = blocks.message_strobe(msgs, 1)
         msg_sink = blocks.message_debug()
         endpoint = "tcp://127.0.0.1:"
-        zeromq_pub_sink = zeromq.pub_msg_sink(endpoint + "5542")
-        zeromq_sub_source = zeromq.sub_msg_source(endpoint + "5542", 0)
+        zeromq_pub_sink = zeromq.pub_msg_sink(endpoint + "*")
+        port = zeromq_pub_sink.endpoint().split(":")[-1]
+        zeromq_sub_source = zeromq.sub_msg_source(endpoint + port, 0)
+        zeromq_sub_source.set_endpoint(endpoint + port)
         self.tb.msg_connect(msg_src, "strobe", zeromq_pub_sink, "in")
         self.tb.msg_connect(zeromq_sub_source, "out", msg_sink, "store")
         self.tb.start()

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_pubsub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_pubsub.py
@@ -40,7 +40,7 @@ class qa_zeromq_msg_pubsub (gr_unittest.TestCase):
         # The best msg source we have is the strobe, we don't really
         # care how many msgs go through, so just strobe fast enough to
         # guarantee > 1
-        msg_src = blocks.message_strobe(msgs, 10)
+        msg_src = blocks.message_strobe(msgs, 1)
         msg_sink = blocks.message_debug()
         endpoint = "tcp://127.0.0.1:"
         zeromq_pub_sink = zeromq.pub_msg_sink(endpoint + "5542")

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_pubsub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_pubsub.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest, blocks, zeromq
+import pmt
+import time
+
+class qa_zeromq_msg_pubsub (gr_unittest.TestCase):
+
+    def setUp (self):
+        self.tb = gr.top_block ()
+
+    def tearDown (self):
+        self.tb = None
+
+    def test_001 (self):
+        # test msg pub sub blocks
+        vlen = 10
+        src_data = range(vlen)*100
+        msgs = pmt.init_f32vector(len(src_data), src_data)
+        # The best msg source we have is the strobe, we don't really
+        # care how many msgs go through, so just strobe fast enough to
+        # guarantee > 1
+        msg_src = blocks.message_strobe(msgs, 10)
+        msg_sink = blocks.message_debug()
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_pub_sink = zeromq.pub_msg_sink(endpoint + "5542")
+        zeromq_sub_source = zeromq.sub_msg_source(endpoint + "5542", 0)
+        self.tb.msg_connect(msg_src, "strobe", zeromq_pub_sink, "in")
+        self.tb.msg_connect(zeromq_sub_source, "out", msg_sink, "store")
+        self.tb.start()
+        time.sleep(0.25)
+        self.tb.stop()
+        self.tb.wait()
+        rcvd_message = pmt.f32vector_elements(msg_sink.get_message(0))
+        self.assertFloatTuplesAlmostEqual(rcvd_message, src_data)
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_zeromq_msg_pubsub)

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_pushpull.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_pushpull.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest, blocks, zeromq
+import pmt
+import time
+
+class qa_zeromq_msg_pushpull (gr_unittest.TestCase):
+
+    def setUp (self):
+        self.tb = gr.top_block ()
+
+    def tearDown (self):
+        self.tb = None
+
+    def test_001 (self):
+        # test msg push pull blocks
+        vlen = 10
+        src_data = range(vlen)*100
+        msgs = pmt.init_f32vector(len(src_data), src_data)
+        # The best msg source we have is the strobe, we don't really
+        # care how many msgs go through, so just strobe fast enough to
+        # guarantee > 1
+        msg_src = blocks.message_strobe(msgs, 10)
+        msg_sink = blocks.message_debug()
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_push_sink = zeromq.push_msg_sink(endpoint + "5543")
+        zeromq_pull_source = zeromq.pull_msg_source(endpoint + "5543", 0)
+        self.tb.msg_connect(msg_src, "strobe", zeromq_push_sink, "in")
+        self.tb.msg_connect(zeromq_pull_source, "out", msg_sink, "store")
+        self.tb.start()
+        time.sleep(0.25)
+        self.tb.stop()
+        self.tb.wait()
+        rcvd_message = pmt.f32vector_elements(msg_sink.get_message(0))
+        self.assertFloatTuplesAlmostEqual(rcvd_message, src_data)
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_zeromq_msg_pushpull)

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_pushpull.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_pushpull.py
@@ -43,8 +43,10 @@ class qa_zeromq_msg_pushpull (gr_unittest.TestCase):
         msg_src = blocks.message_strobe(msgs, 1)
         msg_sink = blocks.message_debug()
         endpoint = "tcp://127.0.0.1:"
-        zeromq_push_sink = zeromq.push_msg_sink(endpoint + "5543")
-        zeromq_pull_source = zeromq.pull_msg_source(endpoint + "5543", 0)
+        zeromq_push_sink = zeromq.push_msg_sink(endpoint + "*")
+        port = zeromq_push_sink.endpoint().split(":")[-1]
+        zeromq_pull_source = zeromq.pull_msg_source(endpoint + port, 0)
+        zeromq_pull_source.set_endpoint(endpoint + port)
         self.tb.msg_connect(msg_src, "strobe", zeromq_push_sink, "in")
         self.tb.msg_connect(zeromq_pull_source, "out", msg_sink, "store")
         self.tb.start()

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_pushpull.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_pushpull.py
@@ -40,7 +40,7 @@ class qa_zeromq_msg_pushpull (gr_unittest.TestCase):
         # The best msg source we have is the strobe, we don't really
         # care how many msgs go through, so just strobe fast enough to
         # guarantee > 1
-        msg_src = blocks.message_strobe(msgs, 10)
+        msg_src = blocks.message_strobe(msgs, 1)
         msg_sink = blocks.message_debug()
         endpoint = "tcp://127.0.0.1:"
         zeromq_push_sink = zeromq.push_msg_sink(endpoint + "5543")

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_reqrep.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_reqrep.py
@@ -43,8 +43,10 @@ class qa_zeromq_msg_reqrep (gr_unittest.TestCase):
         msg_src = blocks.message_strobe(msgs, 1)
         msg_sink = blocks.message_debug()
         endpoint = "tcp://127.0.0.1:"
-        zeromq_rep_sink = zeromq.rep_msg_sink(endpoint + "5544")
-        zeromq_req_source = zeromq.req_msg_source(endpoint + "5544", 0)
+        zeromq_rep_sink = zeromq.rep_msg_sink(endpoint + "*")
+        port = zeromq_rep_sink.endpoint().split(":")[-1]
+        zeromq_req_source = zeromq.req_msg_source(endpoint + port, 0)
+        zeromq_req_source.set_endpoint(endpoint + port)
         self.tb.msg_connect(msg_src, "strobe", zeromq_rep_sink, "in")
         self.tb.msg_connect(zeromq_req_source, "out", msg_sink, "store")
         self.tb.start()

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_reqrep.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_reqrep.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest, blocks, zeromq
+import pmt
+import time
+
+class qa_zeromq_msg_reqrep (gr_unittest.TestCase):
+
+    def setUp (self):
+        self.tb = gr.top_block ()
+
+    def tearDown (self):
+        self.tb = None
+
+    def test_001 (self):
+        # test msg req rep blocks
+        vlen = 10
+        src_data = range(vlen)*100
+        msgs = pmt.init_f32vector(len(src_data), src_data)
+        # The best msg source we have is the strobe, we don't really
+        # care how many msgs go through, so just strobe fast enough to
+        # guarantee > 1
+        msg_src = blocks.message_strobe(msgs, 10)
+        msg_sink = blocks.message_debug()
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_rep_sink = zeromq.rep_msg_sink(endpoint + "5544")
+        zeromq_req_source = zeromq.req_msg_source(endpoint + "5544", 0)
+        self.tb.msg_connect(msg_src, "strobe", zeromq_rep_sink, "in")
+        self.tb.msg_connect(zeromq_req_source, "out", msg_sink, "store")
+        self.tb.start()
+        time.sleep(0.25)
+        self.tb.stop()
+        self.tb.wait()
+        rcvd_message = pmt.f32vector_elements(msg_sink.get_message(0))
+        self.assertFloatTuplesAlmostEqual(rcvd_message, src_data)
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_zeromq_msg_reqrep)

--- a/gr-zeromq/python/zeromq/qa_zeromq_msg_reqrep.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_msg_reqrep.py
@@ -40,7 +40,7 @@ class qa_zeromq_msg_reqrep (gr_unittest.TestCase):
         # The best msg source we have is the strobe, we don't really
         # care how many msgs go through, so just strobe fast enough to
         # guarantee > 1
-        msg_src = blocks.message_strobe(msgs, 10)
+        msg_src = blocks.message_strobe(msgs, 1)
         msg_sink = blocks.message_debug()
         endpoint = "tcp://127.0.0.1:"
         zeromq_rep_sink = zeromq.rep_msg_sink(endpoint + "5544")

--- a/gr-zeromq/python/zeromq/qa_zeromq_pub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pub.py
@@ -38,10 +38,12 @@ class qa_zeromq_pub (gr_unittest.TestCase):
         self.rx_data = None
         src_data = range(vlen)*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5555")
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, endpoint + "*")
+        port = zeromq_pub_sink.endpoint().split(":")[-1]
         self.tb.connect(src, zeromq_pub_sink)
         self.probe_manager = zeromq.probe_manager()
-        self.probe_manager.add_socket("tcp://127.0.0.1:5555", 'float32', self.recv_data)
+        self.probe_manager.add_socket(endpoint + port, 'float32', self.recv_data)
         self.tb.run()
         self.probe_manager.watcher()
         self.assertFloatTuplesAlmostEqual(self.rx_data, src_data)

--- a/gr-zeromq/python/zeromq/qa_zeromq_pubsub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pubsub.py
@@ -48,5 +48,12 @@ class qa_zeromq_pubsub (gr_unittest.TestCase):
         self.tb.wait()
         self.assertFloatTuplesAlmostEqual(sink.data(), src_data)
 
+    def test_002(self):
+        # Test getting the endpoint returns a port we explicitly set endpoint to
+        endpoint = "tcp://127.0.0.1:5554"
+        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, 1, endpoint, 0)
+        self.assertEqual(endpoint, zeromq_pub_sink.endpoint())
+
+
 if __name__ == '__main__':
     gr_unittest.run(qa_zeromq_pubsub)

--- a/gr-zeromq/python/zeromq/qa_zeromq_pubsub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pubsub.py
@@ -37,8 +37,10 @@ class qa_zeromq_pubsub (gr_unittest.TestCase):
         vlen = 10
         src_data = range(vlen)*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5556", 0)
-        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5556", 0)
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, endpoint + "*", 0)
+        port = zeromq_pub_sink.endpoint().split(":")[-1]
+        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, endpoint + port, 0)
         sink = blocks.vector_sink_f(vlen)
         self.tb.connect(src, zeromq_pub_sink)
         self.tb.connect(zeromq_sub_source, sink)
@@ -53,7 +55,6 @@ class qa_zeromq_pubsub (gr_unittest.TestCase):
         endpoint = "tcp://127.0.0.1:5554"
         zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, 1, endpoint, 0)
         self.assertEqual(endpoint, zeromq_pub_sink.endpoint())
-
 
 if __name__ == '__main__':
     gr_unittest.run(qa_zeromq_pubsub)

--- a/gr-zeromq/python/zeromq/qa_zeromq_pushpull.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pushpull.py
@@ -35,8 +35,10 @@ class qa_zeromq_pushpull (gr_unittest.TestCase):
         vlen = 10
         src_data = range(vlen)*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_push_sink = zeromq.push_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5557")
-        zeromq_pull_source = zeromq.pull_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5557", 0)
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_push_sink = zeromq.push_sink(gr.sizeof_float, vlen, endpoint + "*")
+        port = zeromq_push_sink.endpoint().split(":")[-1]
+        zeromq_pull_source = zeromq.pull_source(gr.sizeof_float, vlen, endpoint + port, 0)
         sink = blocks.vector_sink_f(vlen)
         self.tb.connect(src, zeromq_push_sink)
         self.tb.connect(zeromq_pull_source, sink)

--- a/gr-zeromq/python/zeromq/qa_zeromq_reqrep.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_reqrep.py
@@ -38,8 +38,10 @@ class qa_zeromq_reqrep (gr_unittest.TestCase):
         vlen = 10
         src_data = range(vlen)*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_rep_sink = zeromq.rep_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5558", 0)
-        zeromq_req_source = zeromq.req_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5558", 0)
+        endpoint = "tcp://127.0.0.1:"
+        zeromq_rep_sink = zeromq.rep_sink(gr.sizeof_float, vlen, endpoint + "*", 0)
+        port = zeromq_rep_sink.endpoint().split(":")[-1]
+        zeromq_req_source = zeromq.req_source(gr.sizeof_float, vlen, endpoint + port, 0)
         sink = blocks.vector_sink_f(vlen)
         self.tb.connect(src, zeromq_rep_sink)
         self.tb.connect(zeromq_req_source, sink)

--- a/gr-zeromq/swig/zeromq_swig.i
+++ b/gr-zeromq/swig/zeromq_swig.i
@@ -29,6 +29,7 @@
 
 %{
 #include "gnuradio/zeromq/stream_base.h"
+#include "gnuradio/zeromq/msg_base.h"
 #include "gnuradio/zeromq/pub_sink.h"
 #include "gnuradio/zeromq/pub_msg_sink.h"
 #include "gnuradio/zeromq/push_sink.h"
@@ -44,6 +45,7 @@
 %}
 
 %include "gnuradio/zeromq/stream_base.h"
+%include "gnuradio/zeromq/msg_base.h"
 %include "gnuradio/zeromq/pub_sink.h"
 %include "gnuradio/zeromq/pub_msg_sink.h"
 %include "gnuradio/zeromq/push_sink.h"

--- a/gr-zeromq/swig/zeromq_swig.i
+++ b/gr-zeromq/swig/zeromq_swig.i
@@ -28,6 +28,7 @@
 %include "zeromq_swig_doc.i"
 
 %{
+#include "gnuradio/zeromq/stream_base.h"
 #include "gnuradio/zeromq/pub_sink.h"
 #include "gnuradio/zeromq/pub_msg_sink.h"
 #include "gnuradio/zeromq/push_sink.h"
@@ -42,6 +43,7 @@
 #include "gnuradio/zeromq/req_msg_source.h"
 %}
 
+%include "gnuradio/zeromq/stream_base.h"
 %include "gnuradio/zeromq/pub_sink.h"
 %include "gnuradio/zeromq/pub_msg_sink.h"
 %include "gnuradio/zeromq/push_sink.h"


### PR DESCRIPTION
Add a port getter/accessor that parses the zmq endpoint. If it is
tcp, then parse out the port and return as an integer. New QA tests
- the port accessor with a known port
- the loopback test for pubsub that already exists, but uses
  an ephermeral port for the sink that is read back for the source
  to attach to

---

Current issue that I have with this is that it requires some string parsing and that the message blocks don't inherit from base_{source,sink}_impl so they don't get the feature. Also, we might want to make this more generic as an endpoint() accessor and force users of it to parse the port on their own. That's a design choice I don't have strong feelings on since I only care about the port and this makes it easier for me although it is less generic and potentially more error prone due to string parsing.
