### PR TITLE
Throw an exception if the given K and R are not supported.

### DIFF
--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -156,6 +156,9 @@ namespace gr {
         kerneltype << k_ << d_k << r_ << d_rate;
 
         d_kernel = yp_kernel[kerneltype.str()];
+        if (d_kernel == NULL) {
+          throw std::runtime_error("cc_decoder: parameters not supported");
+        }
       }
 
       cc_decoder_impl::~cc_decoder_impl()


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/1048.

@jmcorgan 

I noticed that the decoder's limitations are already documented: https://github.com/gnuradio/gnuradio/blob/ce354379fee28872ea103eafa9164e6fc1ea54a1/gr-fec/include/gnuradio/fec/cc_decoder.h#L47-L53

So I've just added a null check to prevent the decoder from crashing when given unsupported parameters. The error is immediately visible in GRC if the parameters are changed.