### PR TITLE
runtime: tweak to block_executor

### DIFF
--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -391,7 +391,9 @@ namespace gr {
 
       if(i < d->ninputs()) {			// not enough input on input[i]
         // if we can, try reducing the size of our output request
-        if(noutput_items > m->output_multiple()) {
+        // ... if there are any inputs available
+        if((d_ninput_items[i] != 0) &&
+           (noutput_items > m->output_multiple())) {
           noutput_items /= 2;
           noutput_items = round_up(noutput_items, m->output_multiple());
           goto try_again;


### PR DESCRIPTION
When trying to execute a block and there is not enough incoming data on some input, if there is no data on the input then handle as if BLKD_IN; do not try smaller noutput_items, since there is a much greater chance that waiting for input will be just as effective as trying smaller noutput_items -- and, will certainly take less CPU time.
