### PR TITLE
grc: change default filepath to documents dir for windows only

### DIFF
--- a/grc/gui/Constants.py
+++ b/grc/gui/Constants.py
@@ -23,7 +23,7 @@ from ..core.Constants import *
 
 
 # default path for the open/save dialogs
-DEFAULT_FILE_PATH = os.getcwd()
+DEFAULT_FILE_PATH = os.getcwd() if os.name != 'nt' else os.path.expanduser("~/Documents")
 
 # file extensions
 IMAGE_FILE_EXTENSION = '.png'


### PR DESCRIPTION
The default filepath for open/save dialogs in GRC is os.getcwd, which in windows is the read-only /bin sub-directory.
This change will make the default (for windows only) the user's Documents directory.