### PR TITLE
grc: respect display scaling for block positions, canvas size and props dialog

### DIFF
--- a/grc/gui/ActionHandler.py
+++ b/grc/gui/ActionHandler.py
@@ -23,7 +23,7 @@ import gtk
 import os
 import subprocess
 
-from . import Dialogs, Preferences, Actions, Executor, Constants
+from . import Dialogs, Preferences, Actions, Executor, Constants, Utils
 from .FileDialogs import (OpenFlowGraphFileDialog, SaveFlowGraphFileDialog,
                           SaveConsoleFileDialog, SaveScreenShotDialog,
                           OpenQSSFileDialog)
@@ -688,8 +688,10 @@ class ActionHandler:
         Actions.FLOW_GRAPH_SAVE.set_sensitive(not page.get_saved())
         main.update()
         try: #set the size of the flow graph area (if changed)
-            new_size = (flow_graph.get_option('window_size') or
-                        self.platform.config.default_canvas_size)
+            new_size = Utils.scale(
+                flow_graph.get_option('window_size') or
+                self.platform.config.default_canvas_size
+            )
             if flow_graph.get_size() != tuple(new_size):
                 flow_graph.set_size(*new_size)
         except: pass

--- a/grc/gui/Block.py
+++ b/grc/gui/Block.py
@@ -95,9 +95,8 @@ class Block(Element, _Block):
         """
         proximity = Constants.BORDER_PROXIMITY_SENSITIVITY
         try: #should evaluate to tuple
-            coor = eval(self.get_param('_coordinate').get_value())
-            x, y = map(int, coor)
-            fgW,fgH = self.get_parent().get_size()
+            x, y = Utils.scale(eval(self.get_param('_coordinate').get_value()))
+            fgW, fgH = self.get_parent().get_size()
             if x <= 0:
                 x = 0
             elif x >= fgW - proximity:
@@ -124,7 +123,7 @@ class Block(Element, _Block):
                 Utils.align_to_grid(coor[0] + offset_x) - offset_x,
                 Utils.align_to_grid(coor[1] + offset_y) - offset_y
             )
-        self.get_param('_coordinate').set_value(str(coor))
+        self.get_param('_coordinate').set_value(str(Utils.scale(coor, reverse=True)))
 
     def bound_move_delta(self, delta_coor):
         """
@@ -141,11 +140,11 @@ class Block(Element, _Block):
 
         try:
             fgW, fgH = self.get_parent().get_size()
-            x, y = map(int, eval(self.get_param("_coordinate").get_value()))
+            x, y = Utils.scale(eval(self.get_param('_coordinate').get_value()))
             if self.is_horizontal():
-               sW, sH = self.W, self.H
+                sW, sH = self.W, self.H
             else:
-               sW, sH = self.H, self.W
+                sW, sH = self.H, self.W
 
             if x + dX < 0:
                 dX = -x
@@ -154,7 +153,7 @@ class Block(Element, _Block):
             if y + dY < 0:
                 dY = -y
             elif dY + y + sH >= fgH:
-               dY = fgH - y - sH
+                dY = fgH - y - sH
         except:
             pass
 

--- a/grc/gui/Constants.py
+++ b/grc/gui/Constants.py
@@ -96,6 +96,8 @@ SCROLL_DISTANCE = 15
 # How close the mouse click can be to a line and register a connection select.
 LINE_SELECT_SENSITIVITY = 5
 
+DPI_SCALING = gtk.gdk.screen_get_default().get_resolution() / 96.0
+
 
 def update_font_size(font_size):
     global PORT_SEPARATION, BLOCK_FONT, PORT_FONT, PARAM_FONT, FONT_SIZE

--- a/grc/gui/FlowGraph.py
+++ b/grc/gui/FlowGraph.py
@@ -407,7 +407,7 @@ class FlowGraph(Element, _Flowgraph):
         Draw the pixmap to the drawable window of this flow graph.
         """
 
-        W,H = self.get_size()
+        W, H = self.get_size()
         hide_disabled_blocks = Actions.TOGGLE_HIDE_DISABLED_BLOCKS.get_active()
         hide_variables = Actions.TOGGLE_HIDE_VARIABLES.get_active()
 

--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -23,7 +23,7 @@ import gtk
 
 import Actions
 from Dialogs import SimpleTextDisplay
-from Constants import MIN_DIALOG_WIDTH, MIN_DIALOG_HEIGHT, FONT_SIZE
+from Constants import MIN_DIALOG_WIDTH, MIN_DIALOG_HEIGHT, FONT_SIZE, DPI_SCALING
 import Utils
 import pango
 
@@ -72,7 +72,8 @@ class PropsDialog(gtk.Dialog):
                      gtk.STOCK_APPLY, gtk.RESPONSE_APPLY)
         )
         self.set_response_sensitive(gtk.RESPONSE_APPLY, False)
-        self.set_size_request(MIN_DIALOG_WIDTH, MIN_DIALOG_HEIGHT)
+        self.set_size_request(MIN_DIALOG_WIDTH +DPI_SCALING,
+                              MIN_DIALOG_HEIGHT * DPI_SCALING)
         self._block = block
 
         vpaned = gtk.VPaned()

--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -24,7 +24,7 @@ import gobject
 
 from Cheetah.Template import Template
 
-from Constants import POSSIBLE_ROTATIONS, CANVAS_GRID_SIZE
+from Constants import POSSIBLE_ROTATIONS, CANVAS_GRID_SIZE, DPI_SCALING
 
 
 def rotate_pixmap(gc, src_pixmap, dst_pixmap, angle=gtk.gdk.PIXBUF_ROTATE_COUNTERCLOCKWISE):
@@ -131,3 +131,8 @@ def align_to_grid(coor, mode=round):
     except TypeError:
         x = coor
         return align(coor)
+
+
+def scale(coor, reverse=False):
+    factor = DPI_SCALING if not reverse else 1 / DPI_SCALING
+    return tuple(int(x * factor) for x in coor)


### PR DESCRIPTION
This is an attempt to fix the GRC flowgraph display for high DPI displays with display scaling != 1

Right now, increasing the display scaling increases the font size on the canvas, but results in all of the blocks overlapping. This scales the coordinates of blocks to match their increase in size.

The result is not perfect - arrow heads and the grid size don't get scaled. 

I consider this a bug fix, but I really want this tested thoroughly, get other people take before we go off merge it.