### PR TITLE
runtime: support dynamically located gnuradio installs

### DIFF
--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -24,6 +24,7 @@
 #include <config.h>
 #endif
 
+#include <stdlib.h>
 #include <gnuradio/constants.h>
 
 namespace gr {
@@ -31,18 +32,36 @@ namespace gr {
   const std::string
   prefix()
   {
+    //Use "GR_PREFIX" environment variable when specified
+    const char *prefix = getenv("GR_PREFIX");
+    if (prefix != NULL) return prefix;
+
     return "@prefix@";
   }
 
   const std::string
   sysconfdir()
   {
+    //Provide the sysconfdir in terms of prefix()
+    //when the "GR_PREFIX" environment var is specified.
+    if (getenv("GR_PREFIX") != NULL)
+    {
+      return prefix() + "/@GR_CONF_DIR@";
+    }
+
     return "@SYSCONFDIR@";
   }
 
   const std::string
   prefsdir()
   {
+    //Provide the prefsdir in terms of sysconfdir()
+    //when the "GR_PREFIX" environment var is specified.
+    if (getenv("GR_PREFIX") != NULL)
+    {
+      return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
+    }
+
     return "@GR_PREFSDIR@";
   }
 


### PR DESCRIPTION
Support a "GR_PREFIX" env var to overload prefix() with. When this env var is specified, sysconfdir() and prefsdir() also changes to reflect this using the same directory logic specified in the top level CMakeLists.txt Behaviour is unchanged when the GR_PREFIX environment variable is not specified.

The goal is to support relocated installs, for example when using ubuntu snap packages. We currently have [packages for GQRX and GRC](https://myriadrf.org/blog/snap-packages-limesdr/) that rely on this. I was using a similar change [mentioned here](https://github.com/pothosware/gnuradio/issues/22) for the  windows installer. Let me know if this works or I can make a similar change. I would love to have a feature like this in the upstream.
