### PR TITLE
FindQwt.cmake: Add search path from Qwt5 on Fedora 24.

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -22,6 +22,7 @@ find_path(QWT_INCLUDE_DIRS
   /usr/include/qwt6
   /usr/include/qwt-${QWT_QT_VERSION}
   /usr/include/qwt
+  /usr/include/${QWT_QT_VERSION}/qwt
   /usr/include/qwt5
   /opt/local/include/qwt
   /sw/include/qwt


### PR DESCRIPTION
Signed-off-by: Philip Balister <philip@balister.org>