### PR TITLE
cmake: qwt prefere correct version

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -29,7 +29,7 @@ find_path(QWT_INCLUDE_DIRS
 )
 
 find_library (QWT_LIBRARIES
-  NAMES qwt6 qwt6-${QWT_QT_VERSION} qwt qwt-${QWT_QT_VERSION} qwt5 qwtd5
+  NAMES qwt6-${QWT_QT_VERSION} qwt-${QWT_QT_VERSION} qwt6 qwt qwt5 qwtd5
   HINTS
   ${CMAKE_INSTALL_PREFIX}/lib
   ${CMAKE_INSTALL_PREFIX}/lib64


### PR DESCRIPTION
For me, this fixes https://github.com/gnuradio/gnuradio/issues/1059. I think the problem is that cmake preferred qwt-qt4 over qwt-qt5.

It's not perfect since cmake doesn't assure that QT and QWT are compatible, but it should at least prefer the correct version.