### PR TITLE
qtgui: fix stylesheet for qt5

### DIFF
--- a/gr-qtgui/python/qtgui/util.py.cmakein
+++ b/gr-qtgui/python/qtgui/util.py.cmakein
@@ -25,7 +25,7 @@
 from gnuradio import gr
 
 def check_set_qss():
-    app = QtGui.qApp
+    app = QtWidgets.qApp
     qssfile = gr.prefs().get_string("qtgui","qss","")
     if(len(qssfile)>0):
         try:


### PR DESCRIPTION
With QT5, the qApp seems to be part of QtWidgets. The PY_QT_IMPORT macro is already prepared for that, but seemingly utils.py was not updated.