### PR TITLE
grc: fix column widths on dpi scalings != 1

### DIFF
--- a/grc/gui/Param.py
+++ b/grc/gui/Param.py
@@ -25,6 +25,7 @@ import gtk
 
 from . import Colors, Utils, Constants
 from .Element import Element
+from . import Utils
 
 from ..core.Param import Param as _Param
 
@@ -39,7 +40,7 @@ class InputParam(gtk.HBox):
         self._changed_callback = changed_callback
         self._editing_callback = editing_callback
         self.label = gtk.Label() #no label, markup is added by set_markup
-        self.label.set_size_request(150, -1)
+        self.label.set_size_request(Utils.scale_scalar(150), -1)
         self.pack_start(self.label, False)
         self.set_markup = lambda m: self.label.set_markup(m)
         self.tp = None

--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -136,3 +136,7 @@ def align_to_grid(coor, mode=round):
 def scale(coor, reverse=False):
     factor = DPI_SCALING if not reverse else 1 / DPI_SCALING
     return tuple(int(x * factor) for x in coor)
+
+def scale_scalar(coor, reverse=False):
+    factor = DPI_SCALING if not reverse else 1 / DPI_SCALING
+    return int(coor * factor)

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -26,6 +26,7 @@ import gobject
 
 from . import Actions
 from . import Preferences
+from . import Utils
 from .Constants import DEFAULT_BLOCKS_WINDOW_WIDTH
 
 BLOCK_INDEX = 0
@@ -111,9 +112,9 @@ class VariableEditor(gtk.VBox):
         id_column = gtk.TreeViewColumn("Id", self.id_cell, text=ID_INDEX)
         id_column.set_name("id")
         id_column.set_resizable(True)
-        id_column.set_max_width(300)
-        id_column.set_min_width(80)
-        id_column.set_fixed_width(100)
+        id_column.set_max_width(Utils.scale_scalar(300))
+        id_column.set_min_width(Utils.scale_scalar(80))
+        id_column.set_fixed_width(Utils.scale_scalar(100))
         id_column.set_sizing(gtk.TREE_VIEW_COLUMN_FIXED)
         id_column.set_cell_data_func(self.id_cell, self.set_properties)
         self.id_column = id_column
@@ -129,7 +130,7 @@ class VariableEditor(gtk.VBox):
         value_column.set_name("value")
         value_column.set_resizable(False)
         value_column.set_expand(True)
-        value_column.set_min_width(100)
+        value_column.set_min_width(Utils.scale_scalar(100))
         value_column.set_sizing(gtk.TREE_VIEW_COLUMN_AUTOSIZE)
         value_column.set_cell_data_func(self.value_cell, self.set_value)
         self.value_column = value_column


### PR DESCRIPTION
In addition to #1074 , some column widths (variable names, parameter names in block props, etc.) are hard-coded. This change multiplies these values with the applied scaling.