### PR TITLE
digital: add constructor warning for deprecated mpsk_receiver_cc

### DIFF
--- a/gr-digital/lib/mpsk_receiver_cc_impl.cc
+++ b/gr-digital/lib/mpsk_receiver_cc_impl.cc
@@ -69,6 +69,8 @@ namespace gr {
 	d_omega_rel(omega_rel), d_max_omega(0), d_min_omega(0),
 	d_p_2T(0), d_p_1T(0), d_p_0T(0), d_c_2T(0), d_c_1T(0), d_c_0T(0)
     {
+      GR_LOG_WARN(d_logger, "The gr::digital::mpsk_receiver_cc block is deprecated.");
+
       d_interp = new gr::filter::mmse_fir_interpolator_cc();
       d_dl_idx = 0;
 


### PR DESCRIPTION
Adds a warning during constructor time when the block is used.  A previous commit has already changed the API header file and XML file for deprecation.