### PR TITLE
ControlPort: Start RPC on blocks that only have message connections

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -1637,18 +1637,6 @@ GENERATE_XML           = @enable_xml_docs@
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/docs/doxygen/Doxyfile.swig_doc.in
+++ b/docs/doxygen/Doxyfile.swig_doc.in
@@ -1471,18 +1471,6 @@ GENERATE_XML           = YES
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -594,12 +594,6 @@ namespace gr {
       basic_block_sptr b;
       b = p->src().block();
 
-      if(ctrlport_on) {
-        if(!b->is_rpc_set()) {
-          b->setup_rpc();
-          b->rpc_set();
-        }
-      }
       if(set_all_min_buff){
         //sets the min buff for every block within hier_block2
         if(min_buff != 0){
@@ -656,12 +650,7 @@ namespace gr {
       }
 
       b = p->dst().block();
-      if(ctrlport_on) {
-        if(!b->is_rpc_set()) {
-          b->setup_rpc();
-          b->rpc_set();
-        }
-      }
+
       if(set_all_min_buff){
         //sets the min buff for every block within hier_block2
         if(min_buff != 0){
@@ -797,8 +786,16 @@ namespace gr {
 
     // First add the list of singleton blocks
     std::vector<basic_block_sptr>::const_iterator b;   // Because flatten_aux is const
-    for(b = d_blocks.begin(); b != d_blocks.end(); b++)
+    for(b = d_blocks.begin(); b != d_blocks.end(); b++) {
       tmp.push_back(*b);
+      // for every block, attempt to setup RPC
+      if(ctrlport_on) {
+        if(!(*b)->is_rpc_set()) {
+          (*b)->setup_rpc();
+          (*b)->rpc_set();
+        }
+      }
+    }
 
     // Now add the list of connected input blocks
     std::stringstream msg;

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -733,6 +733,21 @@ namespace gr {
 
     std::vector<std::pair<msg_endpoint, bool> > resolved_endpoints;
     for(q = msg_edges.begin(); q != msg_edges.end(); q++) {
+
+      if(ctrlport_on) {
+        basic_block_sptr b;
+        b = q->src().block();
+        if(!b->is_rpc_set()) {
+          b->setup_rpc();
+          b->rpc_set();
+        }
+        b = q->dst().block();
+        if(!b->is_rpc_set()) {
+          b->setup_rpc();
+          b->rpc_set();
+        }
+      }
+
       if(HIER_BLOCK2_DETAIL_DEBUG)
         std::cout << boost::format(" flattening edge ( %s, %s, %d) -> ( %s, %s, %d)\n") % \
           q->src().block() % q->src().port() % q->src().is_hier() % q->dst().block() % \

--- a/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.in
+++ b/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.in
@@ -1503,18 +1503,6 @@ GENERATE_XML           = @enable_xml_docs@
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.swig_doc.in
+++ b/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.swig_doc.in
@@ -1471,18 +1471,6 @@ GENERATE_XML           = YES
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that


### PR DESCRIPTION
This PR addresses https://github.com/gnuradio/gnuradio/issues/1110 by including logic to call setup_rpc() on blocks that only have message port connections.