### PR TITLE
docs: remove obsolete doxygen XML tags

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -1637,18 +1637,6 @@ GENERATE_XML           = @enable_xml_docs@
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/docs/doxygen/Doxyfile.swig_doc.in
+++ b/docs/doxygen/Doxyfile.swig_doc.in
@@ -1471,18 +1471,6 @@ GENERATE_XML           = YES
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.in
+++ b/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.in
@@ -1503,18 +1503,6 @@ GENERATE_XML           = @enable_xml_docs@
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that

--- a/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.swig_doc.in
+++ b/gr-utils/python/modtool/gr-newmod/docs/doxygen/Doxyfile.swig_doc.in
@@ -1471,18 +1471,6 @@ GENERATE_XML           = YES
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify an XML DTD,
-# which can be used by a validating XML parser to check the
-# syntax of the XML files.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
 # and cross-referencing information) to the XML output. Note that


### PR DESCRIPTION
 "The items XML_SCHEMA and XML_DTD are not used and there is no plan
  for using them, so declared obsolete."
  -- Ddoxygen commit ba31ee73aad3bdc6b3854add2db01c302c9cf19c
  This patch reduces noise about obsolete settings from Doxygen.