### PR TITLE
Support vector types in embedded Python blocks.

### DIFF
--- a/grc/core/Block.py
+++ b/grc/core/Block.py
@@ -462,10 +462,11 @@ class Block(Element):
             iter_ports = iter(ports)
             ports_new = []
             port_current = next(iter_ports, None)
-            for key, port_type in port_specs:
+            for key, port_type, vlen in port_specs:
                 reuse_port = (
                     port_current is not None and
                     port_current.get_type() == port_type and
+                    port_current.get_vlen() == vlen and
                     (key.isdigit() or port_current.get_key() == key)
                 )
                 if reuse_port:
@@ -476,6 +477,8 @@ class Block(Element):
                     if port_type == 'message':
                         n['name'] = key
                         n['optional'] = '1'
+                    if vlen > 1:
+                        n['vlen'] = str(vlen)
                     port = platform.Port(block=self, n=n, dir=direction)
                 ports_new.append(port)
             # replace old port list with new one

--- a/grc/core/utils/epy_block_io.py
+++ b/grc/core/utils/epy_block_io.py
@@ -17,14 +17,15 @@ BlockIO = collections.namedtuple('BlockIO', 'name cls params sinks sources doc c
 def _ports(sigs, msgs):
     ports = list()
     for i, dtype in enumerate(sigs):
-        port_type = TYPE_MAP.get(dtype.name, None)
+        port_type = TYPE_MAP.get(dtype.base.name, None)
         if not port_type:
             raise ValueError("Can't map {0!r} to GRC port type".format(dtype))
-        ports.append((str(i), port_type))
+        vlen = dtype.shape[0] if len(dtype.shape) > 0 else 1
+        ports.append((str(i), port_type, vlen))
     for msg_key in msgs:
         if msg_key == 'system':
             continue
-        ports.append((msg_key, 'message'))
+        ports.append((msg_key, 'message', None))
     return ports
 
 
@@ -122,4 +123,3 @@ class blk(gr.sync_block):
     """
     from pprint import pprint
     pprint(dict(extract(blk_code)._asdict()))
-


### PR DESCRIPTION
@skoslowski 

Currenty, embedded Python blocks don't support vector types. For instance, if you put `in_sig=[(np.complex64, 16)]` in your Python code, the following error occurs:
```
  File "/home/argilo/pybombs/lib/python2.7/dist-packages/gnuradio/grc/core/Block.py", line 465, in update_ports
    for key, port_type in port_specs:
ValueError: too many values to unpack
```
This patch adds support for vector types, hopefully without breaking anything else.