### PR TITLE
tag_t default copy constructor / operator= bug

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tags.h
+++ b/gnuradio-runtime/include/gnuradio/tags.h
@@ -69,6 +69,24 @@ namespace gr {
     {
     }
 
+    tag_t(const tag_t &rhs)
+      : offset(rhs.offset),
+        key(rhs.key),
+        value(rhs.value),
+        srcid(rhs.srcid)
+    {
+    }
+    tag_t& operator=(const tag_t &rhs)
+    {
+      if (this != &rhs) {
+        offset = rhs.offset;
+        key = rhs.key;
+        value = rhs.value;
+        srcid = rhs.srcid;
+      }
+      return (*this);
+    }
+
     ~tag_t()
     {
     }


### PR DESCRIPTION
When tag_t's are copied or operator='d, its pmt_t's are shallow copied resulting in the pmt's boost::intrusive_ptr reference counter being off by one.  This results in double deletes and can easily be seen in valgrind on program shutdown.

This pull request addresses this by explicitly defining a tag_t copy constructor and operator= to ensure deep copying of the pmt's.