### PR TITLE
Added memory fence to pmt_t for proper multi-core ARM execution

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -31,6 +31,7 @@
 #include <pmt/pmt_pool.h>
 #include <stdio.h>
 #include <string.h>
+#include <boost/atomic.hpp>
 
 namespace pmt {
 
@@ -63,9 +64,18 @@ pmt_base::operator delete(void *p, size_t size)
 
 #endif
 
-void intrusive_ptr_add_ref(pmt_base* p) { ++(p->count_); }
-void intrusive_ptr_release(pmt_base* p) { if (--(p->count_) == 0 ) delete p; }
+void intrusive_ptr_add_ref(pmt_base* p)
+{
+  p->refcount_.fetch_add(1, boost::memory_order_relaxed);
+}
 
+void intrusive_ptr_release(pmt_base* p) {
+  if (p->refcount_.fetch_sub(1, boost::memory_order_release) == 1) {
+    boost::atomic_thread_fence(boost::memory_order_acquire);
+    delete p;
+  }
+}
+ 
 pmt_base::~pmt_base()
 {
   // nop -- out of line virtual destructor

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -24,8 +24,7 @@
 
 #include <pmt/pmt.h>
 #include <boost/utility.hpp>
-#include <boost/detail/atomic_count.hpp>
-
+#include <boost/atomic.hpp>
 /*
  * EVERYTHING IN THIS FILE IS PRIVATE TO THE IMPLEMENTATION!
  *
@@ -36,10 +35,11 @@
 namespace pmt {
 
 class PMT_API pmt_base : boost::noncopyable {
-  mutable boost::detail::atomic_count count_;
+  mutable boost::atomic<int> refcount_;
+
 
 protected:
-  pmt_base() : count_(0) {};
+  pmt_base() : refcount_(0) {};
   virtual ~pmt_base();
 
 public:


### PR DESCRIPTION
Occasionally, flowgraphs running on my E3xx processor would segfault in the pmt_t destructor (an odd place to crash).  In one particular flowgraph, this happened roughly every hour to 1.5 hours.  When this segfault happens, it's common (but not guaranteed) for the top of the coredump backtrace to be at 0x0000001c or 0x00000018.  Always near or at the top was always a pmt destructor, such as ~pmt_pair() or ~pmt_tuple().

After reading up in [Boost Reference Counter Example Implementation](http://www.boost.org/doc/libs/1_57_0/doc/html/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters), it seems as though we need to add a memory fence to ensure proper memory ordering (this issue did not happen on Intel processors due to the stronger memory model).

This pull request changes the pmt_t's internal implementation (pmt_int.h and pmt.cc) of intrusive_ptr_add_ref and intrusive_ptr_release to be exactly like boost's recommended example, and seems to prevent this kind of segfault in my testing so far (my flowgraph running on 3x E312's ran for 3, 8, and 9 hours last night, due to my own segfaults in other code).