### PR TITLE
pmt: Adding memory fence to ~pmt_t for proper multi-core ARM execution.

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -24,7 +24,13 @@
 
 #include <pmt/pmt.h>
 #include <boost/utility.hpp>
-#include <boost/detail/atomic_count.hpp>
+#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
+  #include <boost/atomic.hpp>
+#else
+  // boost::atomic not available before 1.53
+  // This section will be removed when support for boost 1.48 ceases
+  #include <boost/detail/atomic_count.hpp>
+#endif
 
 /*
  * EVERYTHING IN THIS FILE IS PRIVATE TO THE IMPLEMENTATION!
@@ -36,10 +42,23 @@
 namespace pmt {
 
 class PMT_API pmt_base : boost::noncopyable {
+
+#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
+  mutable boost::atomic<int> refcount_;
+#else
+  // boost::atomic not available before 1.53
+  // This section will be removed when support for boost 1.48 ceases
   mutable boost::detail::atomic_count count_;
+#endif
 
 protected:
+#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
+  pmt_base() : refcount_(0) {};
+#else
+  // boost::atomic not available before 1.53
+  // This section will be removed when support for boost 1.48 ceases
   pmt_base() : count_(0) {};
+#endif
   virtual ~pmt_base();
 
 public:


### PR DESCRIPTION
Occasionally, flowgraphs running on my E3xx processor would segfault in the pmt_t destructor (an odd place to crash).  When this segfault happens, it's common (but not guaranteed) for the top of the coredump backtrace to be at 0x0000001c or 0x00000018. Always near or at the top was always a pmt destructor, such as ~pmt_pair() or ~pmt_tuple().

After reading up in Boost Reference Counter Example Implementation, it seems as though we need to add a memory fence to ensure proper memory ordering (this issue did not happen on Intel processors due to the stronger memory model there).

This commit changes the pmt_t's internal implementation (pmt_int.h and pmt.cc) of intrusive_ptr_add_ref and intrusive_ptr_release to be exactly like boost's recommended example, and seems to prevent this kind of segfault.

Additionally, since Ubuntu 12.04 comes with boost 1.48, which does not have boost/atomic.hpp, the changes are wrapped in #if conditions until support for this configuration is discontinued.