### PR TITLE
pmt: Removing support for boost < 1.53 in ~pmt_t.

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -63,7 +63,6 @@ pmt_base::operator delete(void *p, size_t size)
 
 #endif
 
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53))
 void intrusive_ptr_add_ref(pmt_base* p)
 {
   p->refcount_.fetch_add(1, boost::memory_order_relaxed);
@@ -75,13 +74,6 @@ void intrusive_ptr_release(pmt_base* p) {
     delete p;
   }
 }
-#else
-// boost::atomic not available before 1.53
-// This section will be removed when support for boost 1.48 ceases
-// NB: This code is prone to segfault on non-Intel architectures.
-void intrusive_ptr_add_ref(pmt_base* p) { ++(p->count_); }
-void intrusive_ptr_release(pmt_base* p) { if (--(p->count_) == 0 ) delete p; }
-#endif
  
 pmt_base::~pmt_base()
 {

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -24,13 +24,7 @@
 
 #include <pmt/pmt.h>
 #include <boost/utility.hpp>
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
-  #include <boost/atomic.hpp>
-#else
-  // boost::atomic not available before 1.53
-  // This section will be removed when support for boost 1.48 ceases
-  #include <boost/detail/atomic_count.hpp>
-#endif
+#include <boost/atomic.hpp>
 
 /*
  * EVERYTHING IN THIS FILE IS PRIVATE TO THE IMPLEMENTATION!
@@ -42,23 +36,10 @@
 namespace pmt {
 
 class PMT_API pmt_base : boost::noncopyable {
-
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
   mutable boost::atomic<int> refcount_;
-#else
-  // boost::atomic not available before 1.53
-  // This section will be removed when support for boost 1.48 ceases
-  mutable boost::detail::atomic_count count_;
-#endif
 
 protected:
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
   pmt_base() : refcount_(0) {};
-#else
-  // boost::atomic not available before 1.53
-  // This section will be removed when support for boost 1.48 ceases
-  pmt_base() : count_(0) {};
-#endif
   virtual ~pmt_base();
 
 public:


### PR DESCRIPTION
next will not have to support boost < 1.53; removing from pmt_t destructor functions.