### PR TITLE
digital: add loop var outputs to costas_loop_cc

### DIFF
--- a/gr-digital/grc/digital_costas_loop_cc.xml
+++ b/gr-digital/grc/digital_costas_loop_cc.xml
@@ -61,4 +61,14 @@
     <type>float</type>
     <optional>1</optional>
   </source>
+  <source>
+    <name>phase</name>
+    <type>float</type>
+    <optional>1</optional>
+  </source>
+  <source>
+    <name>error</name>
+    <type>float</type>
+    <optional>1</optional>
+  </source>
 </block>


### PR DESCRIPTION
The costas_loop_cc block has an optional 2nd output port for the frequency estimate of the control loop.   This commit adds two additional optional output ports for the phase and error as well.  The goal was to match the output port options of fll_band_edge_cc.