### PR TITLE
pmt: Fixing #if boost version checks in pmt_t.

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -63,7 +63,7 @@ pmt_base::operator delete(void *p, size_t size)
 
 #endif
 
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53))
+#if ((BOOST_VERSION / 100000 >= 1) && (BOOST_VERSION / 100 % 1000 >= 53)) 
 void intrusive_ptr_add_ref(pmt_base* p)
 {
   p->refcount_.fetch_add(1, boost::memory_order_relaxed);

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -24,7 +24,8 @@
 
 #include <pmt/pmt.h>
 #include <boost/utility.hpp>
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
+#include <boost/version.hpp>
+#if ((BOOST_VERSION / 100000 >= 1) && (BOOST_VERSION / 100 % 1000 >= 53)) 
   #include <boost/atomic.hpp>
 #else
   // boost::atomic not available before 1.53
@@ -43,7 +44,7 @@ namespace pmt {
 
 class PMT_API pmt_base : boost::noncopyable {
 
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
+#if ((BOOST_VERSION / 100000 >= 1) && (BOOST_VERSION / 100 % 1000 >= 53)) 
   mutable boost::atomic<int> refcount_;
 #else
   // boost::atomic not available before 1.53
@@ -52,7 +53,7 @@ class PMT_API pmt_base : boost::noncopyable {
 #endif
 
 protected:
-#if ((BOOST_VER_MAJOR >= 1) && (BOOST_VER_MINOR >= 53)) 
+#if ((BOOST_VERSION / 100000 >= 1) && (BOOST_VERSION / 100 % 1000 >= 53)) 
   pmt_base() : refcount_(0) {};
 #else
   // boost::atomic not available before 1.53


### PR DESCRIPTION
Made some copy paste errors in the #if guards to support the old boost version, resulting in a silent failure towards the old code.  Thanks to @bastibl for pointing this out earlier.