### PR TITLE
gr-uhd: channel numbers are resolved in usrp_block, work with indices in uhd_app

### DIFF
--- a/gr-uhd/apps/uhd_app.py
+++ b/gr-uhd/apps/uhd_app.py
@@ -187,17 +187,17 @@ class UHDApp(object):
         self.antenna = self.normalize_antenna_sel(args)
         if self.antenna is not None:
             for i, chan in enumerate(self.channels):
-                if not self.antenna[i] in self.usrp.get_antennas(chan):
+                if not self.antenna[i] in self.usrp.get_antennas(i):
                     self.vprint("[ERROR] {} is not a valid antenna name for this USRP device!".format(self.antenna[i]))
                     exit(1)
-                self.usrp.set_antenna(self.antenna[i], chan)
+                self.usrp.set_antenna(self.antenna[i], i)
                 self.vprint("[{prefix}] Channel {chan}: Using antenna {ant}.".format(
-                    prefix=self.prefix, chan=chan, ant=self.usrp.get_antenna(chan)
+                    prefix=self.prefix, chan=chan, ant=self.usrp.get_antenna(i)
                 ))
-        self.antenna = self.usrp.get_antenna(self.channels[0])
+        self.antenna = self.usrp.get_antenna(0)
         # Set receive daughterboard gain:
         self.set_gain(args.gain)
-        self.gain_range = self.usrp.get_gain_range(self.channels[0])
+        self.gain_range = self.usrp.get_gain_range(0)
         # Set frequency (tune request takes lo_offset):
         if hasattr(args, 'lo_offset') and args.lo_offset is not None:
             treq = uhd.tune_request(args.freq, args.lo_offset)
@@ -216,8 +216,8 @@ class UHDApp(object):
                 command_time_set = True
             except RuntimeError:
                 sys.stderr.write('[{prefix}] [WARNING] Failed to set command times.\n'.format(prefix=self.prefix))
-        for chan in self.channels:
-            self.tr = self.usrp.set_center_freq(treq, chan)
+        for i, chan in enumerate(self.channels):
+            self.tr = self.usrp.set_center_freq(treq, i)
             if self.tr == None:
                 sys.stderr.write('[{prefix}] [ERROR] Failed to set center frequency on channel {chan}\n'.format(
                     prefix=self.prefix, chan=chan
@@ -228,7 +228,7 @@ class UHDApp(object):
                 self.usrp.clear_command_time(mb_idx)
             self.vprint("Syncing channels...".format(prefix=self.prefix))
             time.sleep(COMMAND_DELAY)
-        self.freq = self.usrp.get_center_freq(self.channels[0])
+        self.freq = self.usrp.get_center_freq(0)
         if args.show_async_msg:
             self.async_msgq = gr.msg_queue(0)
             self.async_src = uhd.amsg_source("", self.async_msgq)
@@ -243,17 +243,17 @@ class UHDApp(object):
         if gain is None:
             if self.args.verbose:
                 self.vprint("Defaulting to mid-point gains:".format(prefix=self.prefix))
-            for chan in self.channels:
-                self.usrp.set_normalized_gain(.5, chan)
+            for i, chan in enumerate(self.channels):
+                self.usrp.set_normalized_gain(.5, i)
                 if self.args.verbose:
                     self.vprint("Channel {chan} gain: {g} dB".format(
-                        prefix=self.prefix, chan=chan, g=self.usrp.get_gain(chan)
+                        prefix=self.prefix, chan=chan, g=self.usrp.get_gain(i)
                     ))
         else:
             self.vprint("Setting gain to {g} dB.".format(g=gain))
-            for chan in self.channels:
+            for chan in range( len( self.channels ) ):
                 self.usrp.set_gain(gain, chan)
-        self.gain = self.usrp.get_gain(self.channels[0])
+        self.gain = self.usrp.get_gain(0)
 
     def set_freq(self, freq, skip_sync=False):
         """
@@ -275,8 +275,8 @@ class UHDApp(object):
                 command_time_set = True
             except RuntimeError:
                 sys.stderr.write('[{prefix}] [WARNING] Failed to set command times.\n'.format(prefix=self.prefix))
-        for chan in self.channels:
-            self.tr = self.usrp.set_center_freq(treq, chan)
+        for i, chan in enumerate(self.channels ):
+            self.tr = self.usrp.set_center_freq(treq, i)
             if self.tr == None:
                 sys.stderr.write('[{prefix}] [ERROR] Failed to set center frequency on channel {chan}\n'.format(
                     prefix=self.prefix, chan=chan
@@ -287,7 +287,7 @@ class UHDApp(object):
                 self.usrp.clear_command_time(mb_idx)
             self.vprint("Syncing channels...".format(prefix=self.prefix))
             time.sleep(COMMAND_DELAY)
-        self.freq = self.usrp.get_center_freq(self.channels[0])
+        self.freq = self.usrp.get_center_freq(0)
         self.vprint("First channel has freq: {freq} MHz.".format(freq=self.freq/1e6))
 
     @staticmethod

--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -126,8 +126,8 @@ class uhd_fft(gr.top_block, Qt.QWidget, UHDApp):
         # Blocks
         ##################################################
         self.setup_usrp(uhd.usrp_source, args)
-        self._ant_options = self.usrp.get_antennas(self.channels[0])
-        for c in self.channels:
+        self._ant_options = self.usrp.get_antennas(0)
+        for c in range(len(self.channels)):
             self.usrp.set_bandwidth(self.samp_rate, c)
         self.usrp_device_info = self.get_usrp_info_string(compact=True, tx_or_rx='rx')
 
@@ -320,7 +320,7 @@ class uhd_fft(gr.top_block, Qt.QWidget, UHDApp):
         self.top_grid_layout.addWidget(self._lo_locked_probe_tool_bar, 4,0,1,2)
         def _current_freq_probe():
             while True:
-                val = self.usrp.get_center_freq(self.channels[0])
+                val = self.usrp.get_center_freq(0)
                 try:
                     if val != self.freq:
                         self.set_freq_qt(val, tune_source='freqsink_msg')
@@ -347,15 +347,15 @@ class uhd_fft(gr.top_block, Qt.QWidget, UHDApp):
         ##################################################
         self.msg_connect((self.qtgui_freq_sink_x_0, 'freq'), (self.qtgui_freq_sink_x_0, 'freq'))
         self.msg_connect((self.qtgui_freq_sink_x_0, 'freq'), (self.usrp, 'command'))
-        for c, idx in enumerate(self.channels):
-            self.connect((self.usrp, c), (self.qtgui_freq_sink_x_0, idx))
-            self.connect((self.usrp, c), (self.qtgui_time_sink_x_0, idx))
-            self.connect((self.usrp, c), (self.qtgui_waterfall_sink_x_0, idx))
+        for idx in range(len(self.channels)):
+            self.connect((self.usrp, idx), (self.qtgui_freq_sink_x_0, idx))
+            self.connect((self.usrp, idx), (self.qtgui_time_sink_x_0, idx))
+            self.connect((self.usrp, idx), (self.qtgui_waterfall_sink_x_0, idx))
         if args.phase_relations and len(self.channels) > 1:
-            for c, idx in enumerate(self.channels[:-1]):
+            for idx in range(len(self.channels[:-1])):
                 self.connect_phase_plot(
-                        (self.usrp, c),
-                        (self.usrp, self.channels[idx+1]),
+                        (self.usrp, idx),
+                        (self.usrp, idx+1),
                         (self.qtgui_phase_plot, idx)
                 )
 
@@ -430,7 +430,7 @@ class uhd_fft(gr.top_block, Qt.QWidget, UHDApp):
         self.qtgui_time_sink_x_0.set_samp_rate(self.samp_rate)
         self.qtgui_waterfall_sink_x_0.set_frequency_range(self.freq, self.samp_rate)
         self.usrp.set_samp_rate(self.samp_rate)
-        for c in self.channels:
+        for c in range(len(self.channels)):
             self.usrp.set_bandwidth(self.samp_rate, c)
 
     def set_lo_locked_probe(self, lo_locked_probe):
@@ -440,7 +440,7 @@ class uhd_fft(gr.top_block, Qt.QWidget, UHDApp):
     def set_ant(self, ant):
         self.antenna = ant
         self._ant_callback(self.antenna)
-        for c in self.channels:
+        for c in range(len(self.channels)):
             self.usrp.set_antenna(self.antenna, c)
 
 


### PR DESCRIPTION
Currently uhd_app resolves channel indices to real channel numbers and hands them down to usrp_{source,sink}. This causes issues if one leaves out channels in between (e.g. --channels 0,2,3) or does not use channel 0 as the first channel (e.g. --channels 1).
Then usrp_{source, sink} tries to access the array of channel numbers with the already resovled channel numbers and in the mentioned cases above it will access random memory. 

This can be reproduced by calling `uhd_fft -f 1e9 --channels 1` if a two channel capable USRP is connected.

This PR modifies the use of channel numbers in uhd_app and fixes remaining issues in uhd_fft. There might be some more apps where this is used incorrectly.