### PR TITLE
grc: Strip trailing whitespace from Python output.

### DIFF
--- a/grc/core/generator/Generator.py
+++ b/grc/core/generator/Generator.py
@@ -249,7 +249,7 @@ class TopBlockGenerator(object):
         }
         # Build the template
         t = Template(open(FLOW_GRAPH_TEMPLATE, 'r').read(), namespace)
-        output.append((self.file_path, str(t)))
+        output.append((self.file_path, "\n".join(line.rstrip() for line in str(t).split("\n"))))
         return output
 
 


### PR DESCRIPTION
@skoslowski 

Many XML files have trailing whitespace in their `<make>` (e.g. https://github.com/gnuradio/gnuradio/blob/d4a3e0267c32912f234f5c59fc567982958e96e8/grc/blocks/gr_stream_domain.xml#L15-L16), and this whitespace flows through into GRC's Python output, making tools like `git diff` unhappy. This could be fixed in the XML files, but since that would involve out-of-tree modules it seems like a better approach would be to strip trailing whitespace just after producing the Python code in GRC. This patch appears to solve the problem.