### PR TITLE
grc: Use vlen=1 for message blocks so they don't randomly disconnect.

### DIFF
--- a/grc/core/utils/epy_block_io.py
+++ b/grc/core/utils/epy_block_io.py
@@ -25,7 +25,7 @@ def _ports(sigs, msgs):
     for msg_key in msgs:
         if msg_key == 'system':
             continue
-        ports.append((msg_key, 'message', None))
+        ports.append((msg_key, 'message', 1))
     return ports
 
 


### PR DESCRIPTION
@skoslowski

This is a follow-up to https://github.com/gnuradio/gnuradio/pull/1118.

I noticed that every time I save an embedded Python block, its message ports get disconnected. This is because I was passing a vector length of `None`, which caused this comparison to fail:

https://github.com/gnuradio/gnuradio/blob/d4a3e0267c32912f234f5c59fc567982958e96e8/grc/core/Block.py#L469

I've changed that to 1 (as you had your your patch https://github.com/skoslowski/gnuradio/commit/685d0fd401b2aca9df38527dcfbacce3f0d11552), which solves the problem.