### PR TITLE
gr-uhd: disable boost thread interrupts during send() and recv() calls in work

### DIFF
--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -367,6 +367,7 @@ namespace gr {
         }
       }
 
+      boost::this_thread::disable_interruption disable_interrupt;
 #ifdef GR_UHD_USE_STREAM_API
       //send all ninput_items with metadata
       const size_t num_sent = _tx_stream->send
@@ -376,6 +377,7 @@ namespace gr {
         (input_items, ninput_items, _metadata,
          *_type, ::uhd::device::SEND_MODE_FULL_BUFF, 1.0);
 #endif
+      boost::this_thread::restore_interruption restore_interrupt(disable_interrupt);
 
       //if using length_tags, decrement items left to send by the number of samples sent
       if(not pmt::is_null(_length_tag_key) && _nitems_to_send > 0) {

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -610,6 +610,7 @@ namespace gr {
                            gr_vector_void_star &output_items)
     {
       boost::recursive_mutex::scoped_lock lock(d_mutex);
+      boost::this_thread::disable_interruption disable_interrupt;
 #ifdef GR_UHD_USE_STREAM_API
       //In order to allow for low-latency:
       //We receive all available packets without timeout.
@@ -632,8 +633,8 @@ namespace gr {
            ::uhd::device::RECV_MODE_ONE_PACKET, 1.0);
       }
 #endif
-
-      //handle possible errors conditions
+      boost::this_thread::restore_interruption restore_interrupt(disable_interrupt);
+      // handle possible errors conditions
       switch(_metadata.error_code) {
       case ::uhd::rx_metadata_t::ERROR_CODE_NONE:
         if(_tag_now) {


### PR DESCRIPTION
This PR fixes an issue with multi-channel RX and probably TX. Where the scheduler kills the work thread while uhd still is updating the transport buffers. This can result in a bad state and crashes the application during new recv() calls in flush().

The disable_interruption object guards the recv() and send() calls from being interrupted.