### PR TITLE
Enabled Line2 configuration for QT GUI Time Sink Complex Message

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.xml
@@ -46,8 +46,8 @@ markers = [$marker1, $marker2, $marker3, $marker4, $marker5,
 alphas = [$alpha1, $alpha2, $alpha3, $alpha4, $alpha5,
           $alpha6, $alpha7, $alpha8, $alpha9, $alpha10]
 
-#if($type() == "complex")
-for i in xrange(2*$nconnections):
+#if($type() == "complex" or $type() == "msg_complex")
+for i in xrange(#if $type.t == 'message' then 2 else 2*$nconnections#):
     if len(labels[i]) == 0:
         if(i % 2 == 0):
             self.$(id).set_line_label(i, "Re{{Data {0}}}".format(i/2))
@@ -540,14 +540,14 @@ $(gui_hint()($win))</make>
     <base_key>label1</base_key>
     <name>Line 2 Label</name>
     <key>label2</key>
-    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1)) then 'part' else 'all'#</hide>
+    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1) or ($type() == "msg_complex")) then 'part' else 'all'#</hide>
   </param>
 
   <param>
     <base_key>width1</base_key>
     <name>Line 2 Width</name>
     <key>width2</key>
-    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1)) then 'part' else 'all'#</hide>
+    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1) or ($type() == "msg_complex")) then 'part' else 'all'#</hide>
   </param>
 
   <param>
@@ -555,28 +555,28 @@ $(gui_hint()($win))</make>
     <name>Line 2 Color</name>
     <key>color2</key>
     <value>"red"</value>
-    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1)) then 'part' else 'all'#</hide>
+    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1) or ($type() == "msg_complex")) then 'part' else 'all'#</hide>
   </param>
 
   <param>
     <base_key>style1</base_key>
     <name>Line 2 Style</name>
     <key>style2</key>
-    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1)) then 'part' else 'all'#</hide>
+    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1) or ($type() == "msg_complex")) then 'part' else 'all'#</hide>
   </param>
 
   <param>
     <base_key>marker1</base_key>
     <name>Line 2 Marker</name>
     <key>marker2</key>
-    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1)) then 'part' else 'all'#</hide>
+    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1) or ($type() == "msg_complex")) then 'part' else 'all'#</hide>
   </param>
 
   <param>
     <base_key>alpha1</base_key>
     <name>Line 2 Alpha</name>
     <key>alpha2</key>
-    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1)) then 'part' else 'all'#</hide>
+    <hide>#if (int($nconnections()) >= 2 or ($type() == "complex" and int($nconnections()) >= 1) or ($type() == "msg_complex")) then 'part' else 'all'#</hide>
   </param>
 
 


### PR DESCRIPTION
Attempt to solve #1124 

Line 2 configuration options were hiding for input type Complex Message. Enabled the display when the input is of Complex Message type. 

Also, added a condition in `make`, to consider the values of Line 2 parameters when the input is of Complex Message type.

I am not sure whether this pull request should be to `maint` or `master`.