### PR TITLE
gnuradio-runtime/swig/tags.i: Fix swig operator= warning messages

### DIFF
--- a/gnuradio-runtime/swig/tags.i
+++ b/gnuradio-runtime/swig/tags.i
@@ -25,6 +25,7 @@
 
 %import <pmt_swig.i> //for pmt support
 
+%ignore gr::tag_t::operator=;
 %include <gnuradio/tags.h>
 
 //gives support for a vector of tags (get tags in range)


### PR DESCRIPTION
gnuradio-runtime/swig/tags.i -- Old code use to spit out swig operator= warning messages whenever building anything that included gnuradio.i; new code fixes that.

Attempt #2 with a proper repo base...