### PR TITLE
Fix getter for level to report in dB rather then internal units.

### DIFF
--- a/gr-analog/lib/probe_avg_mag_sqrd_c_impl.cc
+++ b/gr-analog/lib/probe_avg_mag_sqrd_c_impl.cc
@@ -74,6 +74,13 @@ namespace gr {
       return 10 * std::log10(d_threshold);
     }
 
+
+    double
+    probe_avg_mag_sqrd_c_impl::level() const
+    {
+      return 10 * std::log10(d_level);
+    }
+
     void
     probe_avg_mag_sqrd_c_impl::set_threshold(double decibels)
     {

--- a/gr-analog/lib/probe_avg_mag_sqrd_c_impl.h
+++ b/gr-analog/lib/probe_avg_mag_sqrd_c_impl.h
@@ -42,7 +42,7 @@ namespace gr {
       ~probe_avg_mag_sqrd_c_impl();
 
       bool unmuted() const { return d_unmuted; }
-      double level() const { return d_level; }
+      double level() const;
 
       double threshold() const;
 

--- a/gr-analog/lib/probe_avg_mag_sqrd_cf_impl.cc
+++ b/gr-analog/lib/probe_avg_mag_sqrd_cf_impl.cc
@@ -76,6 +76,12 @@ namespace gr {
       return 10 * std::log10(d_threshold);
     }
 
+    double
+    probe_avg_mag_sqrd_cf_impl::level() const
+    {
+      return 10 * std::log10(d_level);
+    }
+
     void
     probe_avg_mag_sqrd_cf_impl::set_threshold(double decibels)
     {

--- a/gr-analog/lib/probe_avg_mag_sqrd_cf_impl.h
+++ b/gr-analog/lib/probe_avg_mag_sqrd_cf_impl.h
@@ -42,7 +42,7 @@ namespace gr {
       ~probe_avg_mag_sqrd_cf_impl();
 
       bool unmuted() const { return d_unmuted; }
-      double level() const { return d_level; }
+      double level() const;
 
       double threshold() const;
 


### PR DESCRIPTION
Should resolve https://github.com/gnuradio/gnuradio/issues/1163

> Basically, the `analog.probe_avg_mag_sqrd_c()` probe has it's units specified in dB, but it returns it's internal value in another format (raw average of the magnitude squared of the the input). 
> 
> This gets confusing quickly, when you use the `analog.probe_avg_mag_sqrd_c().level()` interface to see what your signal levels are, set the threshold based on those units (note that the units for `analog.probe_avg_mag_sqrd_c().level()` are not specified), and then you have a signal that never unmutes.
> 
> Ideally, either the units for `analog.probe_avg_mag_sqrd_c().level()` should be converted to dB, or the units you use to specify the threshold should be in the same scale as `level()` returns.
> 
> Basically, it's possible to have a context where: `probe.level() > probe.threshold()` is `True`, but `probe.unmuted()` is `False`. I only figured out what was going on by actually looking at the C++ source.


I don't currently have a dev env, so I haven't been able to test this, but it's simple enough that I think it should be OK.

I just copied the getter for the threshold.