### PR TITLE
Runtime: Logging via gr::logger instead of cout

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -24,6 +24,7 @@
 #define INCLUDED_GR_BASIC_BLOCK_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/sptr_magic.h>
 #include <gnuradio/msg_accepter.h>
 #include <gnuradio/runtime_types.h>
@@ -92,6 +93,11 @@ namespace gr {
     std::vector<boost::any> d_rpc_vars; // container for all RPC variables
 
     basic_block(void) {} // allows pure virtual interface sub-classes
+
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
     //! Protected constructor prevents instantiation by non-derived classes
     basic_block(const std::string &name,

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -26,7 +26,6 @@
 #include <gnuradio/api.h>
 #include <gnuradio/basic_block.h>
 #include <gnuradio/tags.h>
-#include <gnuradio/logger.h>
 
 namespace gr {
 
@@ -826,11 +825,6 @@ namespace gr {
      * Used by calling gr::thread::scoped_lock l(d_setlock);
      */
     gr::thread::mutex d_setlock;
-
-    /*! Used by blocks to access the logger system.
-     */
-    gr::logger_ptr d_logger;
-    gr::logger_ptr d_debug_logger;
 
     // These are really only for internal use, but leaving them public avoids
     // having to work up an ever-varying list of friend GR_RUNTIME_APIs

--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -24,6 +24,7 @@
 #define INCLUDED_GR_RUNTIME_BLOCK_DETAIL_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tpb_detail.h>
 #include <gnuradio/tags.h>
@@ -278,6 +279,11 @@ namespace gr {
     float d_pc_counter;
 
     block_detail(unsigned int ninputs, unsigned int noutputs);
+
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
     friend struct tpb_detail;
 

--- a/gnuradio-runtime/include/gnuradio/block_registry.h
+++ b/gnuradio-runtime/include/gnuradio/block_registry.h
@@ -24,6 +24,7 @@
 #define GR_RUNTIME_BLOCK_REGISTRY_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/basic_block.h>
 #include <map>
 
@@ -61,6 +62,12 @@ namespace gr {
     pmt::pmt_t d_ref_map;
     std::map< std::string, block*> primitive_map;
     gr::thread::mutex d_mutex;
+
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
   };
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -24,6 +24,7 @@
 #define INCLUDED_GR_RUNTIME_BUFFER_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <boost/weak_ptr.hpp>
@@ -144,6 +145,11 @@ namespace gr {
     friend GR_RUNTIME_API buffer_sptr make_buffer(int nitems, size_t sizeof_item, block_sptr link);
     friend GR_RUNTIME_API buffer_reader_sptr buffer_add_reader
       (buffer_sptr buf, int nzero_preload, block_sptr link, int delay);
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
 
   protected:
     char			       *d_base;		// base address of buffer

--- a/gnuradio-runtime/include/gnuradio/flowgraph.h
+++ b/gnuradio-runtime/include/gnuradio/flowgraph.h
@@ -264,6 +264,13 @@ namespace gr {
     basic_block_vector_t sort_sources_first(basic_block_vector_t &blocks);
     bool source_p(basic_block_sptr block);
     void topological_dfs_visit(basic_block_sptr block, basic_block_vector_t &output);
+
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
+
   };
 
   // Convenience functions

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -30,6 +30,7 @@
 #include <gnuradio/rpcmanager.h>
 #include <gnuradio/rpcserver_selector.h>
 #include <gnuradio/rpcserver_base.h>
+#include <gnuradio/block_registry.h>
 
 // Fixes circular dependency issue before including block_registry.h
 class rpcbasic_base;

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -30,7 +30,6 @@
 #include <gnuradio/rpcmanager.h>
 #include <gnuradio/rpcserver_selector.h>
 #include <gnuradio/rpcserver_base.h>
-#include <gnuradio/block_registry.h>
 
 // Fixes circular dependency issue before including block_registry.h
 class rpcbasic_base;

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -54,8 +54,8 @@ namespace gr {
       d_rpc_set(false),
       d_message_subscribers(pmt::make_dict())
   {
-    configure_default_loggers(d_logger, d_debug_logger, symbol_name());
     s_ncurrently_allocated++;
+    configure_default_loggers(d_logger, d_debug_logger, symbol_name());
   }
 
   basic_block::~basic_block()

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -26,7 +26,6 @@
 
 #include <gnuradio/basic_block.h>
 #include <gnuradio/block_registry.h>
-#include <gnuradio/logger.h>
 #include <stdexcept>
 #include <sstream>
 #include <iostream>
@@ -55,6 +54,7 @@ namespace gr {
       d_rpc_set(false),
       d_message_subscribers(pmt::make_dict())
   {
+    configure_default_loggers(d_logger, d_debug_logger, symbol_name());
     s_ncurrently_allocated++;
   }
 
@@ -93,6 +93,7 @@ namespace gr {
   basic_block::message_port_register_in(pmt::pmt_t port_id)
   {
     if(!pmt::is_symbol(port_id)) {
+      GR_LOG_ERROR (d_logger, "message_port_register_in: bad port id");
       throw std::runtime_error("message_port_register_in: bad port id");
     }
     msg_queue[port_id] = msg_queue_t();
@@ -116,9 +117,11 @@ namespace gr {
   basic_block::message_port_register_out(pmt::pmt_t port_id)
   {
     if(!pmt::is_symbol(port_id)) {
+      GR_LOG_ERROR (d_logger, "message_port_register_out: bad port id");
       throw std::runtime_error("message_port_register_out: bad port id");
     }
     if(pmt::dict_has_key(d_message_subscribers, port_id)) {
+      GR_LOG_ERROR (d_logger, "message_port_register_out: port already in use");
       throw std::runtime_error("message_port_register_out: port already in use");
     }
     d_message_subscribers = pmt::dict_add(d_message_subscribers, port_id, pmt::PMT_NIL);
@@ -140,6 +143,7 @@ namespace gr {
   void basic_block::message_port_pub(pmt::pmt_t port_id, pmt::pmt_t msg)
   {
     if(!pmt::dict_has_key(d_message_subscribers, port_id)) {
+      GR_LOG_ERROR (d_logger, "port does not exist");
       throw std::runtime_error("port does not exist");
     }
 
@@ -165,6 +169,7 @@ namespace gr {
       std::stringstream ss;
       ss << "Port does not exist: \"" << pmt::write_string(port_id) << "\" on block: "
          << pmt::write_string(target) << std::endl;
+      GR_LOG_ERROR (d_logger, ss);
       throw std::runtime_error(ss.str());
     }
     pmt::pmt_t currlist = pmt::dict_ref(d_message_subscribers,port_id,pmt::PMT_NIL);
@@ -181,6 +186,7 @@ namespace gr {
       std::stringstream ss;
       ss << "Port does not exist: \"" << pmt::write_string(port_id) << "\" on block: "
          << pmt::write_string(target) << std::endl;
+      GR_LOG_ERROR (d_logger, ss);
       throw std::runtime_error(ss.str());
     }
 
@@ -201,7 +207,8 @@ namespace gr {
     gr::thread::scoped_lock guard(mutex);
 
     if((msg_queue.find(which_port) == msg_queue.end()) || (msg_queue_ready.find(which_port) == msg_queue_ready.end())) {
-      std::cout << "target port = " << pmt::symbol_to_string(which_port) << std::endl;
+      GR_LOG_DEBUG (d_debug_logger, "target port = " << pmt::symbol_to_string(which_port));
+      GR_LOG_ERROR (d_logger, "attempted to insert_tail on invalid queue!");
       throw std::runtime_error("attempted to insert_tail on invalid queue!");
     }
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -421,7 +421,7 @@ namespace gr {
   void
   block::set_min_output_buffer(long min_output_buffer)
   {
-    GR_LOG_DEBUG(d_debug_logger,"set_min_output_buffer on block " << unique_id() << " to " << min_output_buffer);
+    GR_LOG_DEBUG (d_debug_logger,"set_min_output_buffer on block " << unique_id() << " to " << min_output_buffer);
     for(int i=0; i<output_signature()->max_streams(); i++) {
       set_min_output_buffer(i, min_output_buffer);
     }
@@ -713,14 +713,14 @@ namespace gr {
   void
   block::system_handler(pmt::pmt_t msg)
   {
-    GR_LOG_DEBUG(d_debug_logger, "system_handler " << msg);
+    GR_LOG_DEBUG (d_debug_logger, "system_handler " << msg);
     pmt::pmt_t op = pmt::car(msg);
     if(pmt::eqv(op, pmt::mp("done"))){
         d_finished = pmt::to_long(pmt::cdr(msg));
         global_block_registry.notify_blk(alias());
     } else {
-        GR_LOG_WARN(d_logger, "WARNING: bad message op on system port!\n");
-        pmt::print(msg);
+        GR_LOG_WARN (d_logger, "WARNING: bad message op on system port!\n");
+        GR_LOG_WARN (d_logger, msg);
     }
   }
 
@@ -748,10 +748,11 @@ namespace gr {
         basic_block_sptr blk = global_block_registry.block_lookup(block);
         blk->post(port, pmt::cons(pmt::mp("done"), pmt::mp(true)));
 
-        //GR_LOG_DEBUG (d_debug_logger, "notify finished -->");
-        //pmt::print(pmt::cons(block,port));
-
-        }
+        std::ostringstream msg;
+        msg << "notify finished --> ";
+        msg << pmt::cons(block,port);
+        GR_LOG_DEBUG (d_debug_logger, msg.str());
+      }
     }
   }
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -134,9 +134,10 @@ namespace gr {
   void
   block::set_output_multiple(int multiple)
   {
-    if(multiple < 1)
+    if(multiple < 1) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block::set_output_multiple");
       throw std::invalid_argument("block::set_output_multiple");
-
+    }
     d_output_multiple_set = true;
     d_output_multiple = multiple;
   }
@@ -144,9 +145,10 @@ namespace gr {
   void
   block::set_alignment(int multiple)
   {
-    if(multiple < 1)
+    if(multiple < 1) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block::set_alignment_multiple");
       throw std::invalid_argument("block::set_alignment_multiple");
-
+    }
     d_output_multiple = multiple;
   }
 
@@ -155,9 +157,10 @@ namespace gr {
   {
     // unaligned value must be less than 0 and it doesn't make sense
     // that it's larger than the alignment value.
-    if((na < 0) || (na > d_output_multiple))
+    if((na < 0) || (na > d_output_multiple)) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block::set_unaligned");
       throw std::invalid_argument("block::set_unaligned");
-
+    }
     d_unaligned = na;
   }
 
@@ -170,9 +173,10 @@ namespace gr {
   void
   block::set_relative_rate(double relative_rate)
   {
-    if(relative_rate < 0.0)
+    if(relative_rate < 0.0) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block::set_relative_rate");
       throw std::invalid_argument("block::set_relative_rate");
-
+    }
     d_relative_rate = relative_rate;
   }
 
@@ -305,9 +309,10 @@ namespace gr {
   void
   block::set_max_noutput_items(int m)
   {
-    if(m <= 0)
+    if(m <= 0) {
+      GR_LOG_ERROR (d_logger, "runtime_error: block::set_max_noutput_items: value for max_noutput_items must be greater than 0.\n");
       throw std::runtime_error("block::set_max_noutput_items: value for max_noutput_items must be greater than 0.\n");
-
+    }
     d_max_noutput_items = m;
     d_max_noutput_items_set = true;
   }
@@ -379,8 +384,10 @@ namespace gr {
   long
   block::max_output_buffer(size_t i)
   {
-    if(i >= d_max_output_buffer.size())
+    if(i >= d_max_output_buffer.size()) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: basic_block::max_output_buffer: port out of range.");
       throw std::invalid_argument("basic_block::max_output_buffer: port out of range.");
+    }
     return d_max_output_buffer[i];
   }
 
@@ -404,15 +411,17 @@ namespace gr {
   long
   block::min_output_buffer(size_t i)
   {
-    if(i >= d_min_output_buffer.size())
+    if(i >= d_min_output_buffer.size()) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: basic_block::min_output_buffer: port out of range.");
       throw std::invalid_argument("basic_block::min_output_buffer: port out of range.");
+    }
     return d_min_output_buffer[i];
   }
 
   void
   block::set_min_output_buffer(long min_output_buffer)
   {
-    std::cout << "set_min_output_buffer on block " << unique_id() << " to " << min_output_buffer << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,"set_min_output_buffer on block " << unique_id() << " to " << min_output_buffer);
     for(int i=0; i<output_signature()->max_streams(); i++) {
       set_min_output_buffer(i, min_output_buffer);
     }
@@ -704,13 +713,13 @@ namespace gr {
   void
   block::system_handler(pmt::pmt_t msg)
   {
-    //std::cout << "system_handler " << msg << "\n";
+    GR_LOG_DEBUG(d_debug_logger, "system_handler " << msg);
     pmt::pmt_t op = pmt::car(msg);
     if(pmt::eqv(op, pmt::mp("done"))){
         d_finished = pmt::to_long(pmt::cdr(msg));
         global_block_registry.notify_blk(alias());
     } else {
-        std::cout << "WARNING: bad message op on system port!\n";
+        GR_LOG_WARN(d_logger, "WARNING: bad message op on system port!\n");
         pmt::print(msg);
     }
   }
@@ -739,9 +748,8 @@ namespace gr {
         basic_block_sptr blk = global_block_registry.block_lookup(block);
         blk->post(port, pmt::cons(pmt::mp("done"), pmt::mp(true)));
 
-        //std::cout << "notify finished --> ";
+        //GR_LOG_DEBUG (d_debug_logger, "notify finished -->");
         //pmt::print(pmt::cons(block,port));
-        //std::cout << "\n";
 
         }
     }

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -75,18 +75,20 @@ namespace gr {
   void
   block_detail::set_input(unsigned int which, buffer_reader_sptr reader)
   {
-    if(which >= d_ninputs)
+    if(which >= d_ninputs) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block_detail::set_input");
       throw std::invalid_argument("block_detail::set_input");
-
+    }
     d_input[which] = reader;
   }
 
   void
   block_detail::set_output(unsigned int which, buffer_sptr buffer)
   {
-    if(which >= d_noutputs)
+    if(which >= d_noutputs) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block_detail::set_output");
       throw std::invalid_argument("block_detail::set_output");
-
+    }
     d_output[which] = buffer;
   }
 
@@ -156,16 +158,20 @@ namespace gr {
   uint64_t
   block_detail::nitems_read(unsigned int which_input)
   {
-    if(which_input >= d_ninputs)
+    if(which_input >= d_ninputs) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block_detail::n_input_items");
       throw std::invalid_argument ("block_detail::n_input_items");
+    }
     return d_input[which_input]->nitems_read();
   }
 
   uint64_t
   block_detail::nitems_written(unsigned int which_output)
   {
-    if(which_output >= d_noutputs)
+    if(which_output >= d_noutputs) {
+      GR_LOG_ERROR (d_logger, "invalid_argument: block_detail::n_output_items");
       throw std::invalid_argument ("block_detail::n_output_items");
+    }
     return d_output[which_output]->nitems_written();
   }
 
@@ -193,6 +199,7 @@ namespace gr {
   block_detail::add_item_tag(unsigned int which_output, const tag_t &tag)
   {
     if(!pmt::is_symbol(tag.key)) {
+      GR_LOG_ERROR (d_logger, "pmt::wrong_type: block_detail::add_item_tag key");
       throw pmt::wrong_type("block_detail::add_item_tag key", tag.key);
     }
     else {
@@ -205,6 +212,7 @@ namespace gr {
   block_detail::remove_item_tag(unsigned int which_input, const tag_t &tag, long id)
   {
     if(!pmt::is_symbol(tag.key)) {
+      GR_LOG_ERROR (d_logger, "pmt::wrong_type: block_detail::add_item_tag key");
       throw pmt::wrong_type("block_detail::add_item_tag key", tag.key);
     }
     else {
@@ -258,7 +266,7 @@ namespace gr {
         gr::thread::thread_bind_to_processor(thread, mask);
       }
       catch (std::runtime_error e) {
-        std::cerr << "set_processor_affinity: invalid mask."  << std::endl;;
+        GR_LOG_ERROR (d_logger, "set_processor_affinity: invalid mask.");
       }
     }
   }

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -64,6 +64,7 @@ namespace gr {
   {
     s_ncurrently_allocated++;
     d_pc_start_time = gr::high_res_timer_now();
+    configure_default_loggers(d_logger, d_debug_logger, "block_detail");
   }
 
   block_detail::~block_detail()

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -76,8 +76,9 @@ namespace gr {
       gr::thread::scoped_lock guard(*d->output(i)->mutex());
       int avail_n = round_down(d->output(i)->space_available(), output_multiple);
       int best_n = round_down(d->output(i)->bufsize()/2, output_multiple);
-      if(best_n < min_noutput_items)
+      if(best_n < min_noutput_items) {
         throw std::runtime_error("Buffer too small for min_noutput_items");
+      }
       int n = std::min(avail_n, best_n);
       if(n < min_noutput_items){  // We're blocked on output.
         if(d->output(i)->done()){ // Downstream is done, therefore we're done.
@@ -146,7 +147,6 @@ namespace gr {
         }
       }
       else  {
-        std::cerr << "Error: block_executor: propagation_policy 'ONE-TO-ONE' requires ninputs == noutputs" << std::endl;
         return false;
       }
 
@@ -378,13 +378,13 @@ namespace gr {
           break;
 
         if(d_ninput_items_required[i] < 0) {
-          std::cerr << "\nsched: <block " << m->name()
+          GR_LOG_ERROR (d_logger, "\nsched: <block " << m->name()
                     << " (" << m->unique_id() << ")>"
                     << " thinks its ninput_items required is "
                     << d_ninput_items_required[i]
                     << " and cannot be negative.\n"
                     << "Some parameterization is wrong. "
-                    << "Too large a decimation value?\n\n";
+                    << "Too large a decimation value?\n");
           goto were_done;
         }
       }
@@ -405,7 +405,7 @@ namespace gr {
         // Is it possible to ever fulfill this request?
         if(d_ninput_items_required[i] > d->input(i)->max_possible_items_available()) {
           // Nope, never going to happen...
-          std::cerr << "\nsched: <block " << m->name()
+          GR_LOG_ERROR (d_logger, "\nsched: <block " << m->name()
                     << " (" << m->unique_id() << ")>"
                     << " is requesting more input data\n"
                     << "  than we can provide.\n"
@@ -413,7 +413,7 @@ namespace gr {
                     << d_ninput_items_required[i] << "\n"
                     << "  max_possible_items_available = "
                     << d->input(i)->max_possible_items_available() << "\n"
-                    << "  If this is a filter, consider reducing the number of taps.\n";
+                    << "  If this is a filter, consider reducing the number of taps.");
           goto were_done;
         }
 
@@ -496,8 +496,8 @@ namespace gr {
       /*
       // If this is a source, it's broken.
       if(d->source_p()) {
-        std::cerr << "block_executor: source " << m
-                  << " produced no output.  We're marking it DONE.\n";
+        GR_LOG_ERROR (d_logger, "block_executor: source " << m
+                  << " produced no output.  We're marking it DONE.");
         // FIXME maybe we ought to raise an exception...
         goto were_done;
       }

--- a/gnuradio-runtime/lib/block_executor.h
+++ b/gnuradio-runtime/lib/block_executor.h
@@ -24,6 +24,7 @@
 #define INCLUDED_GR_RUNTIME_BLOCK_EXECUTOR_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <fstream>
@@ -36,6 +37,13 @@ namespace gr {
    */
   class GR_RUNTIME_API block_executor
   {
+  private:
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
+
   protected:
     block_sptr     d_block;    // The block we're trying to run
     std::ofstream *d_log;

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -34,6 +34,7 @@ namespace gr {
   block_registry::block_registry()
   {
     d_ref_map = pmt::make_dict();
+    configure_default_loggers(d_logger, d_debug_logger, "block_registry");
   }
 
   long

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -74,7 +74,7 @@ namespace gr {
   {
     std::stringstream ss;
     ss << block->name() << block->symbolic_id();
-    //std::cout << "register_symbolic_name: " << ss.str() << std::endl;
+    GR_LOG_DEBUG (d_debug_logger, "register_symbolic_name: " << ss.str());
     register_symbolic_name(block, ss.str());
     return ss.str();
   }
@@ -85,6 +85,7 @@ namespace gr {
     gr::thread::scoped_lock guard(d_mutex);
 
     if(pmt::dict_has_key(d_ref_map, pmt::intern(name))) {
+      GR_LOG_ERROR (d_logger, "symbol already exists, can not re-use!");
       throw std::runtime_error("symbol already exists, can not re-use!");
     }
     d_ref_map = pmt::dict_add(d_ref_map, pmt::intern(name), pmt::make_any(block));
@@ -96,6 +97,7 @@ namespace gr {
     gr::thread::scoped_lock guard(d_mutex);
 
     if(pmt::dict_has_key(d_ref_map, pmt::intern(name))) {
+      GR_LOG_ERROR (d_logger, "symbol already exists, can not re-use!");
       throw std::runtime_error("symbol already exists, can not re-use!");
     }
 
@@ -117,6 +119,7 @@ namespace gr {
 
     pmt::pmt_t ref = pmt::dict_ref(d_ref_map, symbol, pmt::PMT_NIL);
     if(pmt::eq(ref, pmt::PMT_NIL)) {
+      GR_LOG_ERROR (d_logger, "block lookup failed! block not found!");
       throw std::runtime_error("block lookup failed! block not found!");
     }
     basic_block* blk = boost::any_cast<basic_block*>(pmt::any_ref(ref));

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -125,19 +125,20 @@ namespace gr {
     // This only happens if sizeof_item is not a power of two.
 
     if(nitems > 2 * orig_nitems && nitems * (int) sizeof_item > granularity){
-      std::cerr << "gr::buffer::allocate_buffer: warning: tried to allocate\n"
+      GR_LOG_WARN (d_logger, "gr::buffer::allocate_buffer: warning: tried to allocate\n"
                 << "   " << orig_nitems << " items of size "
                 << sizeof_item << ". Due to alignment requirements\n"
                 << "   " << nitems << " were allocated.  If this isn't OK, consider padding\n"
                 << "   your structure to a power-of-two bytes.\n"
-                << "   On this platform, our allocation granularity is " << granularity << " bytes.\n";
+                << "   On this platform, our allocation granularity is " << granularity << " bytes.");
     }
 
     d_bufsize = nitems;
     d_vmcircbuf = gr::vmcircbuf_sysconfig::make(d_bufsize * d_sizeof_item);
     if(d_vmcircbuf == 0){
-      std::cerr << "gr::buffer::allocate_buffer: failed to allocate buffer of size "
-                << d_bufsize * d_sizeof_item / 1024 << " KB\n";
+      GR_LOG_ERROR (d_logger, "gr::buffer::allocate_buffer: failed to allocate buffer of size "
+                << d_bufsize * d_sizeof_item / 1024 << " KB");
+
       return false;
     }
 
@@ -196,9 +197,9 @@ namespace gr {
   buffer_reader_sptr
   buffer_add_reader(buffer_sptr buf, int nzero_preload, block_sptr link, int delay)
   {
-    if(nzero_preload < 0)
+    if(nzero_preload < 0) {
       throw std::invalid_argument("buffer_add_reader: nzero_preload must be >= 0");
-
+    }
     buffer_reader_sptr r(new buffer_reader(buf,
                                            buf->index_sub(buf->d_write_index,
                                                           nzero_preload),
@@ -215,9 +216,10 @@ namespace gr {
     std::vector<buffer_reader *>::iterator result =
       std::find(d_readers.begin(), d_readers.end(), reader);
 
-    if(result == d_readers.end())
+    if(result == d_readers.end()) {
+      GR_LOG_ERROR (d_logger, "buffer::drop_reader");
       throw std::invalid_argument("buffer::drop_reader");    // we didn't find it...
-
+    }
     d_readers.erase(result);
   }
 

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -85,6 +85,8 @@ namespace gr {
       d_write_index(0), d_abs_write_offset(0), d_done(false),
       d_last_min_items_read(0)
   {
+    configure_default_loggers(d_logger, d_debug_logger, "buffer");
+
     if(!allocate_buffer (nitems, sizeof_item))
       throw std::bad_alloc ();
 
@@ -124,7 +126,7 @@ namespace gr {
     // If we rounded-up a whole bunch, give the user a heads up.
     // This only happens if sizeof_item is not a power of two.
 
-    if(nitems > 2 * orig_nitems && nitems * (int) sizeof_item > granularity){
+    if(nitems > 2 * orig_nitems && nitems * (int) sizeof_item > granularity) {
       GR_LOG_WARN (d_logger, "gr::buffer::allocate_buffer: warning: tried to allocate\n"
                 << "   " << orig_nitems << " items of size "
                 << sizeof_item << ". Due to alignment requirements\n"

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -108,7 +108,7 @@ namespace gr {
 
       // Update the block's max_output_buffer based on what was actually allocated.
       if((grblock->max_output_buffer(i) != buffer->bufsize()) && (grblock->max_output_buffer(i) != -1))
-        GR_LOG_WARN(d_logger, boost::format("Block (%1%) max output buffer set to %2%"
+        GR_LOG_WARN (d_logger, boost::format("Block (%1%) max output buffer set to %2%"
                                             " instead of requested %3%") \
                     % grblock->alias() % buffer->bufsize() % grblock->max_output_buffer(i));
       grblock->set_max_output_buffer(i, buffer->bufsize());
@@ -142,7 +142,7 @@ namespace gr {
 
     // limit buffer size if indicated
     if(grblock->max_output_buffer(port) > 0) {
-      //GR_LOG_DEBUG (d_debug_logger, "constraining output items to " << block->max_output_buffer(port));
+      GR_LOG_DEBUG (d_debug_logger, "constraining output items to " << grblock->max_output_buffer(port));
       nitems = std::min((long)nitems, (long)grblock->max_output_buffer(port));
       nitems -= nitems%grblock->output_multiple();
       if(nitems < 1) {
@@ -172,7 +172,7 @@ namespace gr {
       nitems = std::max(nitems, static_cast<int>(2*(decimation*multiple+history)));
     }
 
-    GR_LOG_DEBUG(d_debug_logger, "make_buffer(" << nitems << ", " << item_size << ", " << grblock);
+    GR_LOG_DEBUG (d_debug_logger, "make_buffer(" << nitems << ", " << item_size << ", " << grblock);
     // We're going to let this fail once and retry. If that fails,
     // throw and exit.
     buffer_sptr b;
@@ -235,18 +235,18 @@ namespace gr {
       block_sptr block = cast_to_block_sptr(*p);
 
       if(!block->detail()) {
-        GR_LOG_DEBUG(d_debug_logger, "merge: allocating new detail for block " << (*p));
+        GR_LOG_DEBUG (d_debug_logger, "merge: allocating new detail for block " << (*p));
         block->set_detail(allocate_block_detail(block));
       }
       else {
-        GR_LOG_DEBUG(d_debug_logger, "merge: reusing original detail for block " << (*p));
+        GR_LOG_DEBUG (d_debug_logger, "merge: reusing original detail for block " << (*p));
       }
     }
 
     // Calculate the old edges that will be going away, and clear the
     // buffer readers on the RHS.
     for(edge_viter_t old_edge = old_ffg->d_edges.begin(); old_edge != old_ffg->d_edges.end(); old_edge++) {
-      GR_LOG_DEBUG(d_debug_logger, "merge: testing old edge " << (*old_edge) << "...");
+      GR_LOG_DEBUG (d_debug_logger, "merge: testing old edge " << (*old_edge) << "...");
       edge_viter_t new_edge;
       for(new_edge = d_edges.begin(); new_edge != d_edges.end(); new_edge++)
         if(new_edge->src() == old_edge->src() &&
@@ -254,14 +254,14 @@ namespace gr {
           break;
 
       if(new_edge == d_edges.end()) { // not found in new edge list
-        GR_LOG_DEBUG(d_debug_logger, "not in new edge list");
+        GR_LOG_DEBUG (d_debug_logger, "not in new edge list");
         // zero the buffer reader on RHS of old edge
         block_sptr block(cast_to_block_sptr(old_edge->dst().block()));
         int port = old_edge->dst().port();
         block->detail()->set_input(port, buffer_reader_sptr());
       }
       else {
-        GR_LOG_DEBUG(d_debug_logger, "found in new edge list");
+        GR_LOG_DEBUG (d_debug_logger, "found in new edge list");
       }
     }
 
@@ -269,10 +269,10 @@ namespace gr {
     for(basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
       block_sptr block = cast_to_block_sptr(*p);
 
-      GR_LOG_DEBUG(d_debug_logger, "merge: merging " << (*p) << "...");
+      GR_LOG_DEBUG (d_debug_logger, "merge: merging " << (*p) << "...");
       if(old_ffg->has_block_p(*p)) {
         // Block exists in old flow graph
-        GR_LOG_DEBUG(d_debug_logger, "used in old flow graph");
+        GR_LOG_DEBUG (d_debug_logger, "used in old flow graph");
         block_detail_sptr detail = block->detail();
 
         // Iterate through the inputs and see what needs to be done

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -378,24 +378,24 @@ namespace gr {
   void flat_flowgraph::dump()
   {
     for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++) {
-      GR_LOG_INFO (d_logger, " edge: " << (*e));
+      GR_LOG_DEBUG (d_debug_logger, " edge: " << (*e));
     }
 
     for(basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
-      GR_LOG_INFO (d_logger, " block: " << (*p));
+      GR_LOG_DEBUG (d_debug_logger, " block: " << (*p));
       block_detail_sptr detail = cast_to_block_sptr(*p)->detail();
-      GR_LOG_INFO (d_logger, "  detail @" << detail << ":");
+      GR_LOG_DEBUG (d_debug_logger, "  detail @" << detail << ":");
 
       int ni = detail->ninputs();
       int no = detail->noutputs();
       for(int i = 0; i < no; i++) {
         buffer_sptr buffer = detail->output(i);
-        GR_LOG_INFO (d_logger, "   output " << i << ": " << buffer);
+        GR_LOG_DEBUG (d_debug_logger, "   output " << i << ": " << buffer);
       }
 
       for(int i = 0; i < ni; i++) {
         buffer_reader_sptr reader = detail->input(i);
-        GR_LOG_INFO (d_logger, "   reader " <<  i << ": " << reader
+        GR_LOG_DEBUG (d_debug_logger, "   reader " <<  i << ": " << reader
                   << " reading from buffer=" << reader->buffer());
       }
     }

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -35,8 +35,6 @@
 
 namespace gr {
 
-#define FLAT_FLOWGRAPH_DEBUG  0
-
 // 32Kbyte buffer size between blocks
 #define GR_FIXED_BUFFER_SIZE (32*(1L<<10))
 
@@ -77,10 +75,9 @@ namespace gr {
 
     // Connect message ports connetions
     for(msg_edge_viter_t i = d_msg_edges.begin(); i != d_msg_edges.end(); i++) {
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
-          i->src().block() % i->src().port() %
-          i->dst().block() % i->dst().port();
+      GR_LOG_DEBUG (d_debug_logger, boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
+                                            i->src().block() % i->src().port() %
+                                            i->dst().block() % i->dst().port());
       i->src().block()->message_port_sub(i->src().port(), pmt::cons(i->dst().block()->alias_pmt(), i->dst().port()));
     }
   }
@@ -93,20 +90,20 @@ namespace gr {
     block_detail_sptr detail = make_block_detail(ninputs, noutputs);
 
     block_sptr grblock = cast_to_block_sptr(block);
-    if(!grblock)
+    if(!grblock) {
+      GR_LOG_ERROR (d_logger, (boost::format("allocate_block_detail found non-gr::block (%s)")%
+			          block->alias()).str());
       throw std::runtime_error(
         (boost::format("allocate_block_detail found non-gr::block (%s)")%
         block->alias()).str());
+    }
 
-    if(FLAT_FLOWGRAPH_DEBUG)
-      std::cout << "Creating block detail for " << block << std::endl;
-
+    GR_LOG_DEBUG (d_debug_logger, "Creating block detail for " << block);
     for(int i = 0; i < noutputs; i++) {
       grblock->expand_minmax_buffer(i);
 
       buffer_sptr buffer = allocate_buffer(block, i);
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "Allocated buffer for output " << block << ":" << i << std::endl;
+      GR_LOG_DEBUG (d_debug_logger, "Allocated buffer for output " << block << ":" << i);
       detail->set_output(i, buffer);
 
       // Update the block's max_output_buffer based on what was actually allocated.
@@ -124,8 +121,10 @@ namespace gr {
   flat_flowgraph::allocate_buffer(basic_block_sptr block, int port)
   {
     block_sptr grblock = cast_to_block_sptr(block);
-    if(!grblock)
+    if(!grblock) {
+      GR_LOG_ERROR (d_logger, "allocate_buffer found non-gr::block");
       throw std::runtime_error("allocate_buffer found non-gr::block");
+    }
     int item_size = block->output_signature()->sizeof_stream_item(port);
 
     // *2 because we're now only filling them 1/2 way in order to
@@ -143,23 +142,29 @@ namespace gr {
 
     // limit buffer size if indicated
     if(grblock->max_output_buffer(port) > 0) {
-      //std::cout << "constraining output items to " << block->max_output_buffer(port) << "\n";
+      //GR_LOG_DEBUG (d_debug_logger, "constraining output items to " << block->max_output_buffer(port));
       nitems = std::min((long)nitems, (long)grblock->max_output_buffer(port));
       nitems -= nitems%grblock->output_multiple();
-      if(nitems < 1)
+      if(nitems < 1) {
+        GR_LOG_ERROR (d_logger, "problems allocating a buffer with the given max output buffer constraint!");
         throw std::runtime_error("problems allocating a buffer with the given max output buffer constraint!");
+      }
     }
     else if(grblock->min_output_buffer(port) > 0) {
       nitems = std::max((long)nitems, (long)grblock->min_output_buffer(port));
       nitems -= nitems%grblock->output_multiple();
-      if(nitems < 1)
+      if(nitems < 1) {
+        GR_LOG_ERROR (d_logger, "problems allocating a buffer with the given min output buffer constraint!");
         throw std::runtime_error("problems allocating a buffer with the given min output buffer constraint!");
+      }
     }
 
     for(basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
       block_sptr dgrblock = cast_to_block_sptr(*p);
-      if(!dgrblock)
+      if(!dgrblock) {
+        GR_LOG_ERROR (d_logger, "allocate_buffer found non-gr::block");
         throw std::runtime_error("allocate_buffer found non-gr::block");
+      }
 
       double decimation = (1.0/dgrblock->relative_rate());
       int multiple      = dgrblock->output_multiple();
@@ -167,7 +172,7 @@ namespace gr {
       nitems = std::max(nitems, static_cast<int>(2*(decimation*multiple+history)));
     }
 
-    //  std::cout << "make_buffer(" << nitems << ", " << item_size << ", " << grblock << "\n";
+    GR_LOG_DEBUG(d_debug_logger, "make_buffer(" << nitems << ", " << item_size << ", " << grblock);
     // We're going to let this fail once and retry. If that fails,
     // throw and exit.
     buffer_sptr b;
@@ -191,8 +196,10 @@ namespace gr {
   flat_flowgraph::connect_block_inputs(basic_block_sptr block)
   {
     block_sptr grblock = cast_to_block_sptr(block);
-    if (!grblock)
+    if (!grblock) {
+      GR_LOG_ERROR (d_logger, "connect_block_inputs found non-gr::block");
       throw std::runtime_error("connect_block_inputs found non-gr::block");
+    }
 
     // Get its detail and edges that feed into it
     block_detail_sptr detail = grblock->detail();
@@ -206,13 +213,13 @@ namespace gr {
       int src_port = e->src().port();
       basic_block_sptr src_block = e->src().block();
       block_sptr src_grblock = cast_to_block_sptr(src_block);
-      if(!src_grblock)
+      if(!src_grblock) {
+        GR_LOG_ERROR (d_logger, "connect_block_inputs found non-gr::block");
         throw std::runtime_error("connect_block_inputs found non-gr::block");
+      }
       buffer_sptr src_buffer = src_grblock->detail()->output(src_port);
 
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "Setting input " << dst_port << " from edge " << (*e) << std::endl;
-
+      GR_LOG_DEBUG (d_debug_logger, "Setting input " << dst_port << " from edge " << (*e));
       detail->set_input(dst_port, buffer_add_reader(src_buffer, grblock->history()-1, grblock,
                                                     grblock->sample_delay(src_port)));
     }
@@ -228,22 +235,18 @@ namespace gr {
       block_sptr block = cast_to_block_sptr(*p);
 
       if(!block->detail()) {
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "merge: allocating new detail for block " << (*p) << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, "merge: allocating new detail for block " << (*p));
         block->set_detail(allocate_block_detail(block));
       }
       else {
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "merge: reusing original detail for block " << (*p) << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, "merge: reusing original detail for block " << (*p));
       }
     }
 
     // Calculate the old edges that will be going away, and clear the
     // buffer readers on the RHS.
     for(edge_viter_t old_edge = old_ffg->d_edges.begin(); old_edge != old_ffg->d_edges.end(); old_edge++) {
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "merge: testing old edge " << (*old_edge) << "...";
-
+      GR_LOG_DEBUG(d_debug_logger, "merge: testing old edge " << (*old_edge) << "...");
       edge_viter_t new_edge;
       for(new_edge = d_edges.begin(); new_edge != d_edges.end(); new_edge++)
         if(new_edge->src() == old_edge->src() &&
@@ -251,16 +254,14 @@ namespace gr {
           break;
 
       if(new_edge == d_edges.end()) { // not found in new edge list
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "not in new edge list" << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, "not in new edge list");
         // zero the buffer reader on RHS of old edge
         block_sptr block(cast_to_block_sptr(old_edge->dst().block()));
         int port = old_edge->dst().port();
         block->detail()->set_input(port, buffer_reader_sptr());
       }
       else {
-        if (FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "found in new edge list" << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, "found in new edge list");
       }
     }
 
@@ -268,20 +269,16 @@ namespace gr {
     for(basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
       block_sptr block = cast_to_block_sptr(*p);
 
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "merge: merging " << (*p) << "...";
-
+      GR_LOG_DEBUG(d_debug_logger, "merge: merging " << (*p) << "...");
       if(old_ffg->has_block_p(*p)) {
         // Block exists in old flow graph
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "used in old flow graph" << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, "used in old flow graph");
         block_detail_sptr detail = block->detail();
 
         // Iterate through the inputs and see what needs to be done
         int ninputs = calc_used_ports(block, true).size(); // Might be different now
         for(int i = 0; i < ninputs; i++) {
-          if(FLAT_FLOWGRAPH_DEBUG)
-            std::cout << "Checking input " << block << ":" << i << "...";
+          GR_LOG_DEBUG (d_debug_logger, "Checking input " << block << ":" << i << "...");
           edge edge = calc_upstream_edge(*p, i);
 
           // Fish out old buffer reader and see if it matches correct buffer from edge list
@@ -294,12 +291,10 @@ namespace gr {
 
           // If there's a match, use it
           if(old_reader && (src_buffer == old_reader->buffer())) {
-            if(FLAT_FLOWGRAPH_DEBUG)
-              std::cout << "matched, reusing" << std::endl;
+            GR_LOG_DEBUG (d_debug_logger, "matched, reusing");
           }
           else {
-            if(FLAT_FLOWGRAPH_DEBUG)
-              std::cout << "needs a new reader" << std::endl;
+            GR_LOG_DEBUG (d_debug_logger, "needs a new reader");
 
             // Create new buffer reader and assign
             detail->set_input(i, buffer_add_reader(src_buffer, block->history()-1, block));
@@ -308,8 +303,7 @@ namespace gr {
       }
       else {
         // Block is new, it just needs buffer readers at this point
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "new block" << std::endl;
+        GR_LOG_DEBUG (d_debug_logger, "new block");
         connect_block_inputs(block);
 
         // Make sure all buffers are aligned
@@ -318,10 +312,10 @@ namespace gr {
 
       // Connect message ports connetions
       for(msg_edge_viter_t i = d_msg_edges.begin(); i != d_msg_edges.end(); i++) {
-          if(FLAT_FLOWGRAPH_DEBUG)
-              std::cout << boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
-                  i->src().block() % i->src().port() %
-                  i->dst().block() % i->dst().port();
+          GR_LOG_DEBUG (d_debug_logger, boost::format("flat_fg connecting msg primitives: (%s, %s)->(%s, %s)\n") %
+              i->src().block() % i->src().port() %
+              i->dst().block() % i->dst().port());
+
           i->src().block()->message_port_sub(i->src().port(), pmt::cons(i->dst().block()->alias_pmt(), i->dst().port()));
       }
 
@@ -341,7 +335,7 @@ namespace gr {
     for(int i = 0; i < block->detail()->ninputs(); i++) {
       void *r = (void*)block->detail()->input(i)->read_pointer();
       uintptr_t ri = (uintptr_t)r % alignment;
-      //std::cerr << "reader: " << r << "  alignment: " << ri << std::endl;
+      GR_LOG_INFO (d_logger, "reader: " << r << "  alignment: " << ri);
       if(ri != 0) {
         size_t itemsize = block->detail()->input(i)->get_sizeof_item();
         block->detail()->input(i)->update_read_pointer((alignment-ri)/itemsize);
@@ -353,7 +347,7 @@ namespace gr {
     for(int i = 0; i < block->detail()->noutputs(); i++) {
       void *w = (void*)block->detail()->output(i)->write_pointer();
       uintptr_t wi = (uintptr_t)w % alignment;
-      //std::cerr << "writer: " << w << "  alignment: " << wi << std::endl;
+      GR_LOG_INFO (d_logger, "writer: " << w << "  alignment: " << wi);
       if(wi != 0) {
         size_t itemsize = block->detail()->output(i)->get_sizeof_item();
         block->detail()->output(i)->update_write_pointer((alignment-wi)/itemsize);
@@ -383,25 +377,26 @@ namespace gr {
 
   void flat_flowgraph::dump()
   {
-    for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++)
-      std::cout << " edge: " << (*e) << std::endl;
+    for(edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++) {
+      GR_LOG_INFO (d_logger, " edge: " << (*e));
+    }
 
     for(basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
-      std::cout << " block: " << (*p) << std::endl;
+      GR_LOG_INFO (d_logger, " block: " << (*p));
       block_detail_sptr detail = cast_to_block_sptr(*p)->detail();
-      std::cout << "  detail @" << detail << ":" << std::endl;
+      GR_LOG_INFO (d_logger, "  detail @" << detail << ":");
 
       int ni = detail->ninputs();
       int no = detail->noutputs();
       for(int i = 0; i < no; i++) {
         buffer_sptr buffer = detail->output(i);
-        std::cout << "   output " << i << ": " << buffer << std::endl;
+        GR_LOG_INFO (d_logger, "   output " << i << ": " << buffer);
       }
 
       for(int i = 0; i < ni; i++) {
         buffer_reader_sptr reader = detail->input(i);
-        std::cout << "   reader " <<  i << ": " << reader
-                  << " reading from buffer=" << reader->buffer() << std::endl;
+        GR_LOG_INFO (d_logger, "   reader " <<  i << ": " << reader
+                  << " reading from buffer=" << reader->buffer());
       }
     }
   }
@@ -439,14 +434,11 @@ namespace gr {
   void
   flat_flowgraph::clear_hier()
   {
-    if(FLAT_FLOWGRAPH_DEBUG)
-      std::cout << "Clear_hier()" << std::endl;
+    GR_LOG_DEBUG (d_debug_logger, "Clear_hier()");
     for(size_t i=0; i<d_msg_edges.size(); i++) {
-      if(FLAT_FLOWGRAPH_DEBUG)
-        std::cout << "edge: " << d_msg_edges[i].src() << "-->" << d_msg_edges[i].dst() << std::endl;
+      GR_LOG_DEBUG (d_debug_logger, "edge: " << d_msg_edges[i].src() << "-->" << d_msg_edges[i].dst());
       if(d_msg_edges[i].src().is_hier() || d_msg_edges[i].dst().is_hier()){
-        if(FLAT_FLOWGRAPH_DEBUG)
-          std::cout << "is hier" << std::endl;
+        GR_LOG_DEBUG (d_debug_logger, "is hier");
         d_msg_edges.erase(d_msg_edges.begin() + i);
         i--;
       }
@@ -457,23 +449,20 @@ namespace gr {
   flat_flowgraph::replace_endpoint(const msg_endpoint &e, const msg_endpoint &r, bool is_src)
   {
     size_t n_replr(0);
-    if(FLAT_FLOWGRAPH_DEBUG)
-      std::cout << boost::format("flat_flowgraph::replace_endpoint( %s, %s, %d )\n") % e.block()% r.block()% is_src;
+    GR_LOG_DEBUG (d_debug_logger, boost::format("flat_flowgraph::replace_endpoint( %s, %s, %d )") % e.block()% r.block()% is_src);
     for(size_t i=0; i<d_msg_edges.size(); i++) {
       if(is_src) {
         if(d_msg_edges[i].src() == e) {
-          if(FLAT_FLOWGRAPH_DEBUG)
-            std::cout << boost::format("flat_flowgraph::replace_endpoint() flattening to ( %s, %s )\n") \
-              % r% d_msg_edges[i].dst();
+          GR_LOG_DEBUG (d_debug_logger, boost::format("flat_flowgraph::replace_endpoint() flattening to ( %s, %s )") \
+              % r% d_msg_edges[i].dst());
           d_msg_edges.push_back( msg_edge(r, d_msg_edges[i].dst() ) );
           n_replr++;
         }
       }
       else {
         if(d_msg_edges[i].dst() == e) {
-          if(FLAT_FLOWGRAPH_DEBUG)
-            std::cout << boost::format("flat_flowgraph::replace_endpoint() flattening to ( %s, %s )\n") \
-              % r% d_msg_edges[i].src();
+          GR_LOG_DEBUG (d_debug_logger, boost::format("flat_flowgraph::replace_endpoint() flattening to ( %s, %s )") \
+              % r% d_msg_edges[i].src());
           d_msg_edges.push_back( msg_edge(d_msg_edges[i].src(), r ) );
           n_replr++;
         }

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -115,7 +115,7 @@ namespace gr {
             << " using ninputs=" << ninputs
             << ", noutputs=" << noutputs;
         GR_LOG_ERROR (d_logger, msg);
-	throw std::runtime_error(msg.str());
+        throw std::runtime_error(msg.str());
       }
     }
   }

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -42,6 +42,7 @@ namespace gr {
 
   flowgraph::flowgraph()
   {
+    configure_default_loggers(d_logger, d_debug_logger, "flowgraph");
   }
 
   flowgraph::~flowgraph()

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -32,8 +32,6 @@
 
 namespace gr {
 
-#define GR_HIER_BLOCK2_DEBUG 0
-
   hier_block2_sptr
   make_hier_block2(const std::string &name,
                    gr::io_signature::sptr input_signature,

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -107,7 +107,7 @@ namespace gr {
                 << " -> " << endpoint(dst, dst_port));
 
     if(src.get() == dst.get()) {
-      GR_LOG_ERROR(d_logger, "connect: src and destination blocks cannot be the same");
+      GR_LOG_ERROR (d_logger, "connect: src and destination blocks cannot be the same");
       throw std::invalid_argument("connect: src and destination blocks cannot be the same");
     }
     hier_block2_sptr src_block(cast_to_hier_block2_sptr(src));
@@ -157,7 +157,7 @@ namespace gr {
   hier_block2_detail::msg_connect(basic_block_sptr src, pmt::pmt_t srcport,
                                   basic_block_sptr dst, pmt::pmt_t dstport)
   {
-    GR_LOG_ERROR (d_logger, "connecting message port...");
+    GR_LOG_DEBUG (d_debug_logger, "connecting message port...");
 
     // add block uniquely to list to internal blocks
     if(std::find(d_blocks.begin(), d_blocks.end(), dst) == d_blocks.end()){
@@ -559,7 +559,7 @@ namespace gr {
   void
   hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
   {
-    GR_LOG_DEBUG (d_logger, " ** Flattening " << d_owner->name() << " parent: " << d_parent_detail);
+    GR_LOG_DEBUG (d_debug_logger, " ** Flattening " << d_owner->name() << " parent: " << d_parent_detail);
     bool is_top_block = (d_parent_detail == NULL);
 
     // Add my edges to the flow graph, resolving references to actual endpoints

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -43,6 +43,8 @@ namespace gr {
     int min_outputs = owner->output_signature()->min_streams();
     int max_outputs = owner->output_signature()->max_streams();
 
+    configure_default_loggers(d_logger, d_debug_logger, "hier_block2_detail");
+
     if(max_inputs == io_signature::IO_INFINITE ||
        max_outputs == io_signature::IO_INFINITE ||
        (min_inputs != max_inputs) ||(min_outputs != max_outputs) ) {

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -90,7 +90,7 @@ namespace gr {
     hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
 
     if(hblock && hblock.get() != d_owner) {
-      GR_LOG_DEBUG(d_debug_logger, "connect: block is hierarchical, setting parent to " << this);
+      GR_LOG_DEBUG (d_debug_logger, "connect: block is hierarchical, setting parent to " << this);
       hblock->d_detail->d_parent_detail = this;
     }
 

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -57,7 +57,7 @@ namespace gr {
     void set_processor_affinity(const std::vector<int> &mask);
     void unset_processor_affinity();
     std::vector<int> processor_affinity();
-    
+
     // Track output buffer min/max settings
     std::vector<size_t> d_max_output_buffer;
     std::vector<size_t> d_min_output_buffer;
@@ -79,6 +79,12 @@ namespace gr {
 
     endpoint_vector_t resolve_port(int port, bool is_input);
     endpoint_vector_t resolve_endpoint(const endpoint &endp, bool is_input) const;
+
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
   };
 
 } /* namespace gr */


### PR DESCRIPTION
Regarding issue #970 

I changed `cout` and `cerr` to gr:logger in most files. Kindly review it. This won't be final. It needs a verification and discussion. Let me know if I have missed some serious points.