### PR TITLE
Helped CMake maintain a clear dependency tree

### DIFF
--- a/gnuradio-runtime/lib/controlport/CMakeLists.txt
+++ b/gnuradio-runtime/lib/controlport/CMakeLists.txt
@@ -51,28 +51,28 @@ MATH(EXPR CTRLPORT_BACKENDS "${CTRLPORT_BACKENDS} + 1")
 message(STATUS "Found and enabling Thrift backend to ControlPort")
 GR_APPEND_SUBCOMPONENT("thrift")
 
-# Run Thrrift To compile C++ and Python files
+# Run Thrift To compile C++ and Python files
 message(STATUS "Running thrift to build C++ bindings")
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/thrift/)
-EXECUTE_PROCESS(
-   COMMAND ${THRIFT_BIN} --gen cpp -out ${CMAKE_CURRENT_BINARY_DIR}/thrift/ ${CMAKE_CURRENT_SOURCE_DIR}/thrift/gnuradio.thrift
-   OUTPUT_VARIABLE THRIFT_CPP_OUTPUT
-   ERROR_VARIABLE THRIFT_CPP_ERROR
-   )
 
+list(APPEND gnuradio_thrift_generated_sources
+  ${CMAKE_CURRENT_BINARY_DIR}/thrift/gnuradio_types.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/thrift/gnuradio_constants.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/thrift/ControlPort.cpp
+  )
+add_custom_command(
+  DEPENDS ${CMAKE_SOURCE_DIR}/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
+  OUTPUT ${gnuradio_thrift_generated_sources}
+  COMMAND ${THRIFT_BIN} --gen cpp -out ${CMAKE_CURRENT_BINARY_DIR}/thrift/ ${CMAKE_CURRENT_SOURCE_DIR}/thrift/gnuradio.thrift
+  )
 list(APPEND gnuradio_ctrlport_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/thrift/rpcserver_thrift.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/thrift/rpcpmtconverters_thrift.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/thrift/rpcserver_booter_thrift.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/thrift/thrift_application_base.cc
-)
-
-# add files built by compiling gnuradio.thrift
-list(APPEND gnuradio_ctrlport_sources
-  ${CMAKE_CURRENT_BINARY_DIR}/thrift/gnuradio_types.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/thrift/gnuradio_constants.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/thrift/ControlPort.cpp
-)
+  # add files built by compiling gnuradio.thrift
+  ${gnuradio_thrift_generated_sources}
+  )
 
 # Add  required libraries here
 list(APPEND gnuradio_runtime_libs

--- a/gnuradio-runtime/python/gnuradio/ctrlport/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/CMakeLists.txt
@@ -50,21 +50,7 @@ GR_PYTHON_INSTALL(
 
 if(THRIFT_FOUND)
 
-EXECUTE_PROCESS(
-   COMMAND ${THRIFT_BIN} --gen py -out ${CMAKE_CURRENT_BINARY_DIR}/ ${CMAKE_SOURCE_DIR}/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
-   OUTPUT_VARIABLE THRIFT_PY_OUTPUT
-   ERROR_VARIABLE THRIFT_PY_ERROR
-   )
-
-GR_PYTHON_INSTALL(
-    FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/RPCConnectionThrift.py
-    DESTINATION ${GR_PYTHON_DIR}/gnuradio/ctrlport/
-    COMPONENT "runtime_python"
-)
-
-GR_PYTHON_INSTALL(
-    FILES
+  list(APPEND thrift_targets
     ${CMAKE_CURRENT_BINARY_DIR}/GNURadio/__init__.py
     ${CMAKE_CURRENT_BINARY_DIR}/GNURadio/constants.py
     ${CMAKE_CURRENT_BINARY_DIR}/GNURadio/ControlPort.py
@@ -72,8 +58,25 @@ GR_PYTHON_INSTALL(
     ${CMAKE_CURRENT_BINARY_DIR}/GNURadio/StreamReceiver.py
     ${CMAKE_CURRENT_BINARY_DIR}/GNURadio/StreamReceiver-remote
     ${CMAKE_CURRENT_BINARY_DIR}/GNURadio/ttypes.py
+    )
+  add_custom_command(
+    DEPENDS ${CMAKE_SOURCE_DIR}/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
+    OUTPUT ${thrift_targets}
+    COMMAND ${THRIFT_BIN} --gen py -out ${CMAKE_CURRENT_BINARY_DIR}/ ${CMAKE_SOURCE_DIR}/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
+    )
+
+  GR_PYTHON_INSTALL(
+    FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPCConnectionThrift.py
+    DESTINATION ${GR_PYTHON_DIR}/gnuradio/ctrlport/
+    COMPONENT "runtime_python"
+    )
+
+  GR_PYTHON_INSTALL(
+    FILES
+    ${thrift_targets}
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/ctrlport/GNURadio
     COMPONENT "runtime_python"
-)
+    )
 
 endif(THRIFT_FOUND)


### PR DESCRIPTION
by converting EXECUTE_COMMAND directives to add_custom_command with
well-defined OUTPUT.

This is all that was necessary to make GNU Radio build with Ninja in
place of GNU Make.