### PR TITLE
digital: Add Bits per Symbol parameter to header_format_default

### DIFF
--- a/gr-digital/grc/variable_header_format_default.xml
+++ b/gr-digital/grc/variable_header_format_default.xml
@@ -10,12 +10,12 @@
   <import>from gnuradio import digital</import>
   <var_make>
 #if int($access_code())==0 #
-self.$(id) = $(id) = digital.header_format_default(digital.packet_utils.default_access_code, $threshold)
+self.$(id) = $(id) = digital.header_format_default(digital.packet_utils.default_access_code, $threshold, $bps)
 #else
-self.$(id) = $(id) = digital.header_format_default($access_code, $threshold)
+self.$(id) = $(id) = digital.header_format_default($access_code, $threshold, $bps)
 #end if
   </var_make>
-  <var_value>digital.header_format_default($access_code, $threshold)</var_value>
+  <var_value>digital.header_format_default($access_code, $threshold, $bps)</var_value>
   <make></make>
 
   <param>
@@ -29,6 +29,13 @@ self.$(id) = $(id) = digital.header_format_default($access_code, $threshold)
     <name>Threshold</name>
     <key>threshold</key>
     <value>0</value>
+    <type>int</type>
+  </param>
+
+  <param>
+    <name>Payload Bits per Symbol</name>
+    <key>bps</key>
+    <value>1</value>
     <type>int</type>
   </param>
 

--- a/gr-digital/include/gnuradio/digital/header_format_counter.h
+++ b/gr-digital/include/gnuradio/digital/header_format_counter.h
@@ -112,7 +112,6 @@ namespace gr {
 
     protected:
       uint16_t d_counter;    //!< keeps track of the number of packets transmitted
-      uint16_t d_bps;        //!< bits/sec of payload modulation
 
       //! Verify that the header is valid
       bool header_ok();

--- a/gr-digital/include/gnuradio/digital/header_format_default.h
+++ b/gr-digital/include/gnuradio/digital/header_format_default.h
@@ -82,7 +82,8 @@ namespace gr {
       : public header_format_base
     {
      public:
-      header_format_default(const std::string &access_code, int threshold);
+      header_format_default(const std::string &access_code, int threshold,
+                            int bps);
       virtual ~header_format_default();
 
       /*!
@@ -179,12 +180,17 @@ namespace gr {
        * receiver. Can be up to 64-bits long.
        * \param threshold How many bits can be wrong in the access
        * code and still count as correct.
+       * \param bps The number of bits/second used in the payload's
+       * modulator.
        */
-      static sptr make(const std::string &access_code, int threshold);
+      static sptr make(const std::string &access_code, int threshold,
+                       int bps = 1);
 
     protected:
       uint64_t d_access_code;        //!< register to hold the access code
       size_t d_access_code_len;      //!< length in bits of the access code
+
+      uint16_t d_bps;                //!< bits/sec of payload modulation
 
       unsigned long long d_data_reg; //!< used to look for access_code
       unsigned long long d_mask;     /*!< masks access_code bits (top N bits are set where

--- a/gr-digital/lib/header_format_counter.cc
+++ b/gr-digital/lib/header_format_counter.cc
@@ -44,9 +44,8 @@ namespace gr {
 
     header_format_counter::header_format_counter(const std::string &access_code,
                                                  int threshold, int bps)
-      : header_format_default(access_code, threshold)
+      : header_format_default(access_code, threshold, bps)
     {
-      d_bps = bps;
       d_counter = 0;
     }
 

--- a/gr-digital/lib/header_format_default.cc
+++ b/gr-digital/lib/header_format_default.cc
@@ -34,16 +34,16 @@ namespace gr {
 
     header_format_default::sptr
     header_format_default::make(const std::string &access_code,
-                                int threshold)
+                                int threshold, int bps)
     {
       return header_format_default::sptr
-        (new header_format_default(access_code, threshold));
+       (new header_format_default(access_code, threshold, bps));
     }
 
     header_format_default::header_format_default(const std::string &access_code,
-                                                 int threshold)
+                                                 int threshold, int bps)
       : header_format_base(),
-        d_data_reg(0), d_mask(0), d_threshold(0),
+        d_bps(bps), d_data_reg(0), d_mask(0), d_threshold(0),
         d_pkt_len(0), d_pkt_count(0), d_nbits(0)
     {
       if(!set_access_code(access_code)) {
@@ -214,7 +214,7 @@ namespace gr {
 
       d_info = pmt::make_dict();
       d_info = pmt::dict_add(d_info, pmt::intern("payload symbols"),
-                             pmt::from_long(8*len));
+                             pmt::from_long(8*len / d_bps));
       return static_cast<int>(len);
     }
 

--- a/gr-digital/python/digital/qa_packet_format.py
+++ b/gr-digital/python/digital/qa_packet_format.py
@@ -20,7 +20,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-import random, time, struct
+import time, struct
 import pmt
 from gnuradio import gr, gr_unittest, digital, blocks
 from gnuradio.digital import packet_utils
@@ -78,6 +78,51 @@ class test_packet_format_fb(gr_unittest.TestCase):
         self.assertEqual(length, rx_length)
         self.assertEqual(length, len(payload))
         self.assertEqual(send_str, payload[0:length])
+
+
+    def test_packet_parse_default(self):
+        ac = packet_utils.default_access_code
+        length = '0000000000000001'
+
+        hdr_format_1bps = digital.header_format_default(ac, 0)
+        hdr_format_4bps = digital.header_format_default(ac, 0, 4)
+
+        ac_bits = [int(x) & 1 for x in ac]
+        length_bits = [int(x) & 1 for x in length]
+        header_bits = ac_bits + length_bits + length_bits
+
+        src_hdr = blocks.vector_source_b(header_bits)
+
+        parser_1bps = digital.protocol_parser_b(hdr_format_1bps)
+        parser_4bps = digital.protocol_parser_b(hdr_format_4bps)
+
+        snk_hdr_1bps = blocks.message_debug()
+        snk_hdr_4bps = blocks.message_debug()
+
+        self.tb.connect(src_hdr, parser_1bps)
+        self.tb.connect(src_hdr, parser_4bps)
+
+        self.tb.msg_connect(parser_1bps, 'info', snk_hdr_1bps, 'store')
+        self.tb.msg_connect(parser_4bps, 'info', snk_hdr_4bps, 'store')
+
+        self.tb.start()
+        while (snk_hdr_1bps.num_messages() < 1) and (snk_hdr_4bps.num_messages() < 1):
+            time.sleep(0.1)
+        self.tb.stop()
+        self.tb.wait()
+
+        result_1bps = snk_hdr_1bps.get_message(0)
+        result_4bps = snk_hdr_4bps.get_message(0)
+
+        self.assertTrue(pmt.dict_has_key(
+            result_1bps, pmt.intern('payload symbols')))
+        self.assertEqual(pmt.to_long(pmt.dict_ref(
+            result_1bps, pmt.intern('payload symbols'), pmt.PMT_F)), 8)
+
+        self.assertTrue(pmt.dict_has_key(
+            result_4bps, pmt.intern('payload symbols')))
+        self.assertEqual(pmt.to_long(pmt.dict_ref(
+            result_4bps, pmt.intern('payload symbols'), pmt.PMT_F)), 2)
 
 
     def test_packet_format_async_counter(self):


### PR DESCRIPTION
Added payload bits per symbol parameter to the header_format_default
block. This allows it to be used with payload modulations besides, for
example, BPSK.

Fixes #1162