### PR TITLE
blocks: peak detector fix initial value

### DIFF
--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -27,6 +27,7 @@
 #include "peak_detector2_fb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <string.h>
+#include <limits>
 
 namespace gr {
   namespace blocks {
@@ -109,7 +110,7 @@ namespace gr {
             sigout[i]=d_avg;
           if(iptr[i] > d_avg * (1.0f + d_threshold_factor_rise)) {
             d_found = true;
-            d_peak_val = -(float)INFINITY;
+            d_peak_val = std::numeric_limits<float>::min();
             set_output_multiple(d_look_ahead);
             return i;
           }

--- a/gr-blocks/lib/peak_detector_XX_impl.cc.t
+++ b/gr-blocks/lib/peak_detector_XX_impl.cc.t
@@ -29,6 +29,7 @@
 #include "@NAME_IMPL@.h"
 #include <gnuradio/io_signature.h>
 #include <string.h>
+#include <limits>
 
 namespace gr {
   namespace blocks {
@@ -70,7 +71,7 @@ namespace gr {
 
       memset(optr, 0, noutput_items*sizeof(char));
 
-      @I_TYPE@ peak_val = -(@I_TYPE@)INFINITY;
+      @I_TYPE@ peak_val = std::numeric_limits<@I_TYPE@>::min();
       int peak_ind = 0;
       unsigned char state = 0;
       int i = 0;

--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
@@ -25,6 +25,7 @@
 #include <gnuradio/io_signature.h>
 #include "dvbt_ofdm_sym_acquisition_impl.h"
 #include <complex>
+#include <limits>
 #include <gnuradio/math.h>
 #include <gnuradio/expj.h>
 #include <volk/volk.h>
@@ -37,8 +38,8 @@ namespace gr {
     {
       d_avg_alpha = alpha;
       d_threshold_factor_rise = threshold_factor_rise;
-      d_avg_max = - (float)INFINITY;
-      d_avg_min =   (float)INFINITY;
+      d_avg_max = std::numeric_limits<float>::min();
+      d_avg_min = std::numeric_limits<float>::max();
 
       return (0);
     }
@@ -54,7 +55,7 @@ namespace gr {
       peak_pos_length = 1; 
       if (datain_length >= d_fft_length) {
         float min = datain[(peak_index + d_fft_length / 2) % d_fft_length];
-        if (d_avg_min == (float)INFINITY) {
+        if (d_avg_min == std::numeric_limits<float>::max()) {
           d_avg_min = min;
         }
         else {
@@ -62,7 +63,7 @@ namespace gr {
         }
       }
 
-      if (d_avg_max == -(float)INFINITY) {
+      if (d_avg_max == std::numeric_limits<float>::min()) {
         // Initialize d_avg_max with the first value. 
         d_avg_max = datain[peak_index];
       }


### PR DESCRIPTION
The initialization with `int val = -(int)INFINITY;` works for me on Linux, but not on my mac.

```
basti@tronn ~/sync >> cat foo.c 
#include <iostream>
#include <math.h>

int main() {
	int i;
	i = -(int)INFINITY;
	std::cout << "value: " << i << std::endl;
	return 0;
}
basti@tronn ~/sync >> g++ -o foo foo.c
basti@tronn ~/sync >> ./foo 
value: 108650432
basti@tronn ~/sync >> ./foo 
value: 44863424
basti@tronn ~/sync >> ./foo 
value: 241270720
```
This patch uses `std::numeric_limits`, which AFAIS is part of C++98.

The changes for floats are not strictly required. I think float are the special case where `float foo = -(float)INFINITY;` works, but maybe it's nicer.