### PR TITLE
analog: add missing probe_avg_mag_sqrd_cf block to GRC definition

### DIFF
--- a/gr-analog/grc/analog_probe_avg_mag_sqrd_x.xml
+++ b/gr-analog/grc/analog_probe_avg_mag_sqrd_x.xml
@@ -20,11 +20,25 @@
 			<name>Complex</name>
 			<key>c</key>
 			<opt>input:complex</opt>
+			<opt>output:float</opt>
+			<opt>optional:1</opt>
+			<opt>hide:all</opt>
 		</option>
 		<option>
 			<name>Float</name>
 			<key>f</key>
 			<opt>input:float</opt>
+			<opt>output:float</opt>
+			<opt>optional:1</opt>
+			<opt>hide:all</opt>
+		</option>
+		<option>
+			<name>Complex->Float</name>
+			<key>cf</key>
+			<opt>input:complex</opt>
+			<opt>output:float</opt>
+			<opt>optional:0</opt>
+			<opt>hide:</opt>
 		</option>
 	</param>
 	<param>
@@ -43,6 +57,12 @@
 		<name>in</name>
 		<type>$type.input</type>
 	</sink>
+	<source>
+		<name>out</name>
+		<type>$type.output</type>
+		<optional>$type.optional</optional>
+		<hide>$type.hide</hide>
+	</source>
 	<doc>
 Available functions to probe: level()
 

--- a/gr-analog/grc/analog_probe_avg_mag_sqrd_x.xml
+++ b/gr-analog/grc/analog_probe_avg_mag_sqrd_x.xml
@@ -20,7 +20,6 @@
 			<name>Complex</name>
 			<key>c</key>
 			<opt>input:complex</opt>
-			<opt>output:float</opt>
 			<opt>optional:1</opt>
 			<opt>hide:all</opt>
 		</option>
@@ -28,7 +27,6 @@
 			<name>Float</name>
 			<key>f</key>
 			<opt>input:float</opt>
-			<opt>output:float</opt>
 			<opt>optional:1</opt>
 			<opt>hide:all</opt>
 		</option>
@@ -36,7 +34,6 @@
 			<name>Complex->Float</name>
 			<key>cf</key>
 			<opt>input:complex</opt>
-			<opt>output:float</opt>
 			<opt>optional:0</opt>
 			<opt>hide:</opt>
 		</option>
@@ -59,7 +56,7 @@
 	</sink>
 	<source>
 		<name>out</name>
-		<type>$type.output</type>
+		<type>float</type>
 		<optional>$type.optional</optional>
 		<hide>$type.hide</hide>
 	</source>


### PR DESCRIPTION
Allows GRC users to choose the probe average mag squared block with float output in GRC. When using the standard `probe_avg_mag_sqrd_c` and `probe_avg_mag_sqrd_f` blocks, the output port is automatically hidden and set to optional to allow for no connection. When using `probe_avg_mag_sqrd_cf`, the output port is displayed on the GRC canvas. Currently the XML parser evaluates all `<optional>` tags to `True`, so the required output connection for the `_cf` block is not enforced. However, #1200 adds cheetah template parsing for `<optional>` tags on ports, which will allow the required output connection to be enforced.