### PR TITLE
uhd_rx_cfile --normalized-gain flag now works.

### DIFF
--- a/gr-uhd/apps/uhd_rx_cfile
+++ b/gr-uhd/apps/uhd_rx_cfile
@@ -108,7 +108,10 @@ class rx_cfile_block(gr.top_block):
                 print("[UHD_RX] Channel {chan} gain: {g} dB".format(chan=chan, g=self._u.get_gain(chan)))
         else:
             for chan in self.channels:
-                self._u.set_gain(options.gain, chan)
+                if options.normalized_gain:
+                    self._u.set_normalized_gain(options.gain, chan)
+                else:
+                    self._u.set_gain(options.gain, chan)
         gain = self._u.get_gain(self.channels[0])
         # Set frequency (tune request takes lo_offset):
         if options.lo_offset is not None:


### PR DESCRIPTION
I was running `uhd_rx_cfile` and tried using the `--normalized-gain` flag with a gain value of 0.75. The output file was incredibly quiet because the gain was still being set as dB. Turns out that the script doesn't use the flag, even though it exists. I fixed that.