### PR TITLE
Modified add_custom_command to not try to execute ""

### DIFF
--- a/cmake/Modules/UseSWIG.cmake
+++ b/cmake/Modules/UseSWIG.cmake
@@ -224,9 +224,9 @@ print(re.sub('\\W', '_', '${name} ${reldir} ' + unique))"
   foreach(swig_gen_file ${${outfiles}})
     add_custom_command(
       OUTPUT ${swig_gen_file}
-      COMMAND
+      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate "${swig_gen_file}"
       DEPENDS ${_target}
-      COMMENT
+      COMMENT "dummy command to show ${_target} dependency of ${swig_gen_file}"
     )
   endforeach()
 

--- a/gr-utils/python/modtool/gr-newmod/cmake/Modules/UseSWIG.cmake
+++ b/gr-utils/python/modtool/gr-newmod/cmake/Modules/UseSWIG.cmake
@@ -224,9 +224,9 @@ print(re.sub('\\W', '_', '${name} ${reldir} ' + unique))"
   foreach(swig_gen_file ${${outfiles}})
     add_custom_command(
       OUTPUT ${swig_gen_file}
-      COMMAND ""
+      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate "${swig_gen_file}"
       DEPENDS ${_target}
-      COMMENT ""
+      COMMENT "dummy command to show ${_target} dependency of ${swig_gen_file}"
     )
   endforeach()
 


### PR DESCRIPTION
former custom command called ""; this works fine on build systems were
this is expanded by shell, but fails on some of my systems where
add_custom_command's COMMAND parameter is directly executed (because
there's no executable "").