### PR TITLE
uhd: Always query current frequency when outputting tags

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -79,7 +79,6 @@ namespace gr {
       _id = pmt::string_to_symbol(str.str());
 
       _samp_rate = this->get_samp_rate();
-      _center_freq = this->get_center_freq(0);
 #ifdef GR_UHD_USE_STREAM_API
       _samps_per_packet = 1;
 #endif
@@ -144,10 +143,8 @@ namespace gr {
     usrp_source_impl::set_center_freq(const ::uhd::tune_request_t tune_request,
                                       size_t chan)
     {
-      const size_t user_chan = chan;
       chan = _stream_args.channels[chan];
       const ::uhd::tune_result_t res = _dev->set_rx_freq(tune_request, chan);
-      _center_freq = this->get_center_freq(user_chan);
       _tag_now = true;
       return res;
     }
@@ -657,7 +654,7 @@ namespace gr {
             this->add_item_tag(i, nitems_written(0), RATE_KEY,
                                pmt::from_double(_samp_rate), _id);
             this->add_item_tag(i, nitems_written(0), FREQ_KEY,
-                               pmt::from_double(_center_freq), _id);
+                               pmt::from_double(this->get_center_freq(i)), _id);
           }
         }
         break;

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -135,7 +135,6 @@ namespace gr {
 
       //tag shadows
       double _samp_rate;
-      double _center_freq;
 
       boost::recursive_mutex d_mutex;
     };


### PR DESCRIPTION
This fixes two issues:
- When updating the frequency via messages, the new tags now reflect the
  actual frequency
- When different channels have different center frequencies, every
  channel reports its own frequency accurately