### PR TITLE
gr-fec: switch possible C++11 code from 'constexpr' to just 'const'.

### DIFF
--- a/gr-fec/include/gnuradio/fec/polar_decoder_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_common.h
@@ -28,10 +28,6 @@
 #include <gnuradio/fec/generic_decoder.h>
 #include <gnuradio/fec/polar_common.h>
 
-#ifndef BOOST_CONSTEXPR_OR_CONST
-#define BOOST_CONSTEXPR_OR_CONST const
-#endif
-
 namespace gr {
   namespace fec {
     namespace code {
@@ -68,7 +64,7 @@ namespace gr {
         bool set_frame_size(unsigned int frame_size){return false;};
 
       private:
-        static BOOST_CONSTEXPR_OR_CONST float D_LLR_FACTOR;
+        static const float D_LLR_FACTOR;
         unsigned int d_frozen_bit_counter;
 
       protected:


### PR DESCRIPTION
Subject says it all. Simple fix to not require C++11 tweaks in GNU Radio when building with Thrift (which does require C++11). Discussed http://lists.gnu.org/archive/html/discuss-gnuradio/2017-03/msg00054.html .