### PR TITLE
Changed the affinity/CPU masks from int to size_t (master)

### DIFF
--- a/docs/doxygen/other/thread_affinity.dox
+++ b/docs/doxygen/other/thread_affinity.dox
@@ -50,7 +50,7 @@ Each block has two new data members:
 A block can set and unset its affinity at any time using the
 following member functions:
 
-- gr::block::set_processor_affinity(const std::vector<int> &mask)
+- gr::block::set_processor_affinity(const std::vector<std::size_t> &mask)
 - gr::block::unset_processor_affinity()
 
 Where \p mask is a vector of core numbers to set the thread's affinity
@@ -76,7 +76,7 @@ to that affinity setting.
 The gr::hier_block2 class supports the same API interface to the block
 thread affinity:
 
-- gr::hier_block2::set_processor_affinity(const std::vector<int> &mask)
+- gr::hier_block2::set_processor_affinity(const std::vector<std::size_t> &mask)
 - gr::hier_block2::unset_processor_affinity()
 - gr::hier_block2::processor_affinity()
 

--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -376,13 +376,13 @@ namespace gr {
       d_msg_handlers[which_port] = msg_handler_t(msg_handler);
     }
 
-    virtual void set_processor_affinity(const std::vector<int> &mask)
+    virtual void set_processor_affinity(const std::vector<std::size_t> &mask)
     { throw std::runtime_error("set_processor_affinity not overloaded in child class."); }
 
     virtual void unset_processor_affinity()
     { throw std::runtime_error("unset_processor_affinity not overloaded in child class."); }
 
-    virtual std::vector<int> processor_affinity()
+    virtual std::vector<std::size_t> processor_affinity()
     { throw std::runtime_error("processor_affinity not overloaded in child class."); }
   };
 

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -595,9 +595,9 @@ namespace gr {
     /*!
      * \brief Set the thread's affinity to processor core \p n.
      *
-     * \param mask a vector of ints of the core numbers available to this block.
+     * \param mask a vector of std::size_t of the core numbers available to this block.
      */
-    void set_processor_affinity(const std::vector<int> &mask);
+    void set_processor_affinity(const std::vector<std::size_t> &mask);
 
     /*!
      * \brief Remove processor affinity to a specific core.
@@ -607,7 +607,7 @@ namespace gr {
     /*!
      * \brief Get the current processor affinity.
      */
-    std::vector<int> processor_affinity() { return d_affinity; }
+    std::vector<std::size_t> processor_affinity() { return d_affinity; }
 
     /*!
      * \brief Get the current thread priority in use
@@ -652,7 +652,7 @@ namespace gr {
     int                   d_max_noutput_items;         // value of max_noutput_items for this block
     int                   d_min_noutput_items;
     tag_propagation_policy_t d_tag_propagation_policy; // policy for moving tags downstream
-    std::vector<int>      d_affinity;              // thread affinity proc. mask
+    std::vector<std::size_t>      d_affinity;              // thread affinity proc. mask
     int                   d_priority;              // thread priority level
     bool                  d_pc_rpc_set;
     bool                  d_update_rate;           // should sched update rel rate?

--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -181,10 +181,10 @@ namespace gr {
      * \brief Set core affinity of block to the cores in the vector
      * mask.
      *
-     * \param mask a vector of ints of the core numbers available to
+     * \param mask a vector of std::size_t of the core numbers available to
      * this block.
      */
-    void set_processor_affinity(const std::vector<int> &mask);
+    void set_processor_affinity(const std::vector<std::size_t> &mask);
 
     /*!
      * \brief Unset core affinity.

--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -248,7 +248,7 @@ namespace gr {
      *
      * \param mask a vector of ints of the core numbers available to this block.
      */
-    void set_processor_affinity(const std::vector<int> &mask);
+    void set_processor_affinity(const std::vector<std::size_t> &mask);
 
     /*!
      * \brief Remove processor affinity for all blocks in hier_block2.
@@ -264,7 +264,7 @@ namespace gr {
      * interface. If any block has been individually set, then this
      * call could be misleading.
      */
-    std::vector<int> processor_affinity();
+    std::vector<std::size_t> processor_affinity();
 
     /*!
      * \brief Get if all block min buffers should be set.

--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -77,7 +77,7 @@ namespace gr {
      * do support in this way since 10.5 is not what we want or can
      * use in this fashion).
      */
-    GR_RUNTIME_API void thread_bind_to_processor(const std::vector<int> &mask);
+    GR_RUNTIME_API void thread_bind_to_processor(const std::vector<std::size_t> &mask);
 
     /*! \brief Convineince function to bind the current thread to a single core.
      *
@@ -89,7 +89,7 @@ namespace gr {
      * do support in this way since 10.5 is not what we want or can
      * use in this fashion).
      */
-    GR_RUNTIME_API void thread_bind_to_processor(int n);
+    GR_RUNTIME_API void thread_bind_to_processor(std::size_t n);
 
     /*! \brief Bind a thread to a set of cores.
      *
@@ -104,7 +104,7 @@ namespace gr {
      * use in this fashion).
      */
     GR_RUNTIME_API void thread_bind_to_processor(gr_thread_t thread,
-                                                 const std::vector<int> &mask);
+                                                 const std::vector<std::size_t> &mask);
 
 
     /*! \brief Convineince function to bind the a thread to a single core.

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -325,7 +325,7 @@ namespace gr {
   }
 
   void
-  block::set_processor_affinity(const std::vector<int> &mask)
+  block::set_processor_affinity(const std::vector<std::size_t> &mask)
   {
     d_affinity = mask;
     if(d_detail) {

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -251,7 +251,7 @@ namespace gr {
   }
 
   void
-  block_detail::set_processor_affinity(const std::vector<int> &mask)
+  block_detail::set_processor_affinity(const std::vector<std::size_t> &mask)
   {
     if(threaded) {
       try {

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -161,7 +161,7 @@ namespace gr {
   }
 
   void
-  hier_block2::set_processor_affinity(const std::vector<int> &mask)
+  hier_block2::set_processor_affinity(const std::vector<std::size_t> &mask)
   {
     d_detail->set_processor_affinity(mask);
   }
@@ -172,7 +172,7 @@ namespace gr {
     d_detail->unset_processor_affinity();
   }
 
-  std::vector<int>
+  std::vector<std::size_t>
   hier_block2::processor_affinity()
   {
     return d_detail->processor_affinity();

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -928,7 +928,7 @@ namespace gr {
   }
 
   void
-  hier_block2_detail::set_processor_affinity(const std::vector<int> &mask)
+  hier_block2_detail::set_processor_affinity(const std::vector<std::size_t> &mask)
   {
     basic_block_vector_t tmp = d_fg->calc_used_blocks();
     for(basic_block_viter_t p = tmp.begin(); p != tmp.end(); p++) {
@@ -945,7 +945,7 @@ namespace gr {
     }
   }
 
-  std::vector<int>
+  std::vector<std::size_t>
   hier_block2_detail::processor_affinity()
   {
     basic_block_vector_t tmp = d_fg->calc_used_blocks();

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -54,9 +54,9 @@ namespace gr {
     void unlock();
     void flatten_aux(flat_flowgraph_sptr sfg) const;
 
-    void set_processor_affinity(const std::vector<int> &mask);
+    void set_processor_affinity(const std::vector<std::size_t> &mask);
     void unset_processor_affinity();
-    std::vector<int> processor_affinity();
+    std::vector<std::size_t> processor_affinity();
     
     // Track output buffer min/max settings
     std::vector<size_t> d_max_output_buffer;

--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -40,33 +40,33 @@ namespace gr {
     }
 
     void
-    thread_bind_to_processor(int n)
+    thread_bind_to_processor(std::size_t n)
     {
-      std::vector<int> mask(1, n);
+      std::vector<std::size_t> mask(1, n);
       thread_bind_to_processor(get_current_thread_id(), mask);
     }
 
     void
-    thread_bind_to_processor(const std::vector<int> &mask)
+    thread_bind_to_processor(const std::vector<std::size_t> &mask)
     {
       thread_bind_to_processor(get_current_thread_id(), mask);
     }
 
     void
-    thread_bind_to_processor(gr_thread_t thread, int n)
+    thread_bind_to_processor(gr_thread_t thread, std::size_t n)
     {
-      std::vector<int> mask(1, n);
+      std::vector<std::size_t> mask(1, n);
       thread_bind_to_processor(thread, mask);
     }
 
     void
-    thread_bind_to_processor(gr_thread_t thread, const std::vector<int> &mask)
+    thread_bind_to_processor(gr_thread_t thread, const std::vector<std::size_t> &mask)
     {
       //DWORD_PTR mask = (1 << n);
       DWORD_PTR dword_mask = 0;
 
-      std::vector<int> _mask = mask;
-      std::vector<int>::iterator itr;
+      std::vector<std::size_t> _mask = mask;
+      std::vector<std::size_t>::iterator itr;
       for(itr = _mask.begin(); itr != _mask.end(); itr++)
         dword_mask |= (1 << (*itr));
 
@@ -179,25 +179,25 @@ namespace gr {
     }
 
     void
-    thread_bind_to_processor(int n)
+    thread_bind_to_processor(std::size_t n)
     {
       // Not implemented on OSX
     }
 
     void
-    thread_bind_to_processor(gr_thread_t thread, int n)
+    thread_bind_to_processor(gr_thread_t thread, std::size_t n)
     {
       // Not implemented on OSX
     }
 
     void
-    thread_bind_to_processor(const std::vector<int> &mask)
+    thread_bind_to_processor(const std::vector<std::size_t> &mask)
     {
       // Not implemented on OSX
     }
 
     void
-    thread_bind_to_processor(gr_thread_t thread, const std::vector<int> &mask)
+    thread_bind_to_processor(gr_thread_t thread, const std::vector<std::size_t> &mask)
     {
       // Not implemented on OSX
     }
@@ -262,32 +262,32 @@ namespace gr {
     }
 
     void
-    thread_bind_to_processor(int n)
+    thread_bind_to_processor(std::size_t n)
     {
-      std::vector<int> mask(1, n);
+      std::vector<std::size_t> mask(1, n);
       thread_bind_to_processor(get_current_thread_id(), mask);
     }
 
     void
-    thread_bind_to_processor(const std::vector<int> &mask)
+    thread_bind_to_processor(const std::vector<std::size_t> &mask)
     {
       thread_bind_to_processor(get_current_thread_id(), mask);
     }
 
     void
-    thread_bind_to_processor(gr_thread_t thread, int n)
+    thread_bind_to_processor(gr_thread_t thread, std::size_t n)
     {
-      std::vector<int> mask(1, n);
+      std::vector<std::size_t> mask(1, n);
       thread_bind_to_processor(thread, mask);
     }
 
     void
-    thread_bind_to_processor(gr_thread_t thread, const std::vector<int> &mask)
+    thread_bind_to_processor(gr_thread_t thread, const std::vector<std::size_t> &mask)
     {
       cpu_set_t set;
       size_t len = sizeof(cpu_set_t);
-      std::vector<int> _mask = mask;
-      std::vector<int>::iterator itr;
+      std::vector<std::size_t> _mask = mask;
+      std::vector<std::size_t>::iterator itr;
 
       CPU_ZERO(&set);
       for(itr = _mask.begin(); itr != _mask.end(); itr++)

--- a/gnuradio-runtime/swig/block.i
+++ b/gnuradio-runtime/swig/block.i
@@ -99,9 +99,9 @@ class gr::block : public gr::basic_block
   float pc_throughput_avg();
 
   // Methods to manage processor affinity.
-  void set_processor_affinity(const std::vector<int> &mask);
+  void set_processor_affinity(const std::vector<std::size_t> &mask);
   void unset_processor_affinity();
-  std::vector<int> processor_affinity();
+  std::vector<std::size_t> processor_affinity();
 
   // Methods to manage thread priority
   int active_thread_priority();

--- a/gnuradio-runtime/swig/hier_block2.i
+++ b/gnuradio-runtime/swig/hier_block2.i
@@ -87,9 +87,9 @@ namespace gr {
     void message_port_register_hier_in(pmt::pmt_t port_id);
     void message_port_register_hier_out(pmt::pmt_t port_id);
 
-    void set_processor_affinity(const std::vector<int> &mask);
+    void set_processor_affinity(const std::vector<std::size_t> &mask);
     void unset_processor_affinity();
-    std::vector<int> processor_affinity();
+    std::vector<std::size_t> processor_affinity();
 
     // Methods to manage block's min/max buffer sizes.
     size_t max_output_buffer(int i);

--- a/gr-blocks/lib/qa_gr_top_block.cc
+++ b/gr-blocks/lib/qa_gr_top_block.cc
@@ -278,7 +278,7 @@ void qa_top_block::t11_set_block_affinity()
   gr::block_sptr src (gr::blocks::null_source::make(sizeof(float)));
   gr::block_sptr snk (gr::blocks::null_sink::make(sizeof(float)));
 
-  std::vector<int> set(1, 0), ret;
+  std::vector<std::size_t> set(1, 0), ret;
   src->set_processor_affinity(set);
 
   tb->connect(src, 0, snk, 0);


### PR DESCRIPTION
Master-based version of #1225: 

Follows discussion on
https://bugzilla.redhat.com/show_bug.cgi?id=1143914 .

Since the reasoning back then was "it's totally OK if Fedora has this
patch, but we don't know whether ancient SWIG on other distros works
with that", and we're now bumping the SWIG version (#1222), it's time ot
upstream this patch.