### PR TITLE
blocks: Add tag share block

### DIFF
--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -194,6 +194,7 @@
       <name>Stream Tag Tools</name>
       <block>blocks_tag_debug</block>
       <block>blocks_tag_gate</block>
+      <block>blocks_tag_share</block>
       <block>blocks_tagged_file_sink</block>
       <block>blocks_tagged_stream_mux</block>
       <block>blocks_tagged_stream_align</block>

--- a/gr-blocks/grc/blocks_tag_share.xml
+++ b/gr-blocks/grc/blocks_tag_share.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<block>
+  <name>Tag Share</name>
+  <key>blocks_tag_share</key>
+  <import>from gnuradio import blocks</import>
+  <make>blocks.tag_share($io_type.size, $share_type.size, $vlen)</make>
+
+  <param>
+    <name>IO Type</name>
+    <key>io_type</key>
+    <type>enum</type>
+    <hide>part</hide>
+    <option>
+      <name>Complex</name>
+      <key>complex</key>
+      <opt>size:gr.sizeof_gr_complex</opt>
+    </option>
+    <option>
+      <name>Float</name>
+      <key>float</key>
+      <opt>size:gr.sizeof_float</opt>
+    </option>
+    <option>
+      <name>Int</name>
+      <key>int</key>
+      <opt>size:gr.sizeof_int</opt>
+    </option>
+    <option>
+      <name>Short</name>
+      <key>short</key>
+      <opt>size:gr.sizeof_short</opt>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>byte</key>
+      <opt>size:gr.sizeof_char</opt>
+    </option>
+  </param>
+  <param>
+    <name>Share Type</name>
+    <key>share_type</key>
+    <type>enum</type>
+    <hide>part</hide>
+    <option>
+      <name>Complex</name>
+      <key>complex</key>
+      <opt>size:gr.sizeof_gr_complex</opt>
+    </option>
+    <option>
+      <name>Float</name>
+      <key>float</key>
+      <opt>size:gr.sizeof_float</opt>
+    </option>
+    <option>
+      <name>Int</name>
+      <key>int</key>
+      <opt>size:gr.sizeof_int</opt>
+    </option>
+    <option>
+      <name>Short</name>
+      <key>short</key>
+      <opt>size:gr.sizeof_short</opt>
+    </option>
+    <option>
+      <name>Byte</name>
+      <key>byte</key>
+      <opt>size:gr.sizeof_char</opt>
+    </option>
+  </param>
+  <param>
+    <name>Vec Length</name>
+    <key>vlen</key>
+    <value>1</value>
+    <type>int</type>
+    <hide>part</hide>
+  </param>
+
+  <check>$vlen &gt; 0</check>
+
+  <sink>
+    <name>in</name>
+    <type>$io_type</type>
+    <vlen>$vlen</vlen>
+  </sink>
+  <sink>
+    <name>share</name>
+    <type>$share_type</type>
+    <vlen>$vlen</vlen>
+  </sink>
+
+  <source>
+    <name>out</name>
+    <type>$io_type</type>
+    <vlen>$vlen</vlen>
+  </source>
+</block>

--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -169,6 +169,7 @@ install(FILES
     sub_ff.h
     tag_debug.h
     tag_gate.h
+    tag_share.h
     tagged_file_sink.h
     tagged_stream_align.h
     tagged_stream_mux.h

--- a/gr-blocks/include/gnuradio/blocks/tag_share.h
+++ b/gr-blocks/include/gnuradio/blocks/tag_share.h
@@ -1,0 +1,68 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_BLOCKS_TAG_SHARE_H
+#define INCLUDED_BLOCKS_TAG_SHARE_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief Adds tags from Input 1 onto Input 0's stream.
+     * \ingroup blocks
+     *
+     * \details
+     * This block utilizes the GNU Radio runtime's tag propagation policy
+     * to transfer or share Input 1's tags to Input 0's stream. This is
+     * useful when a signal is detected via a correlate_access_code_bb or
+     * a threshold crossing from a complex_to_mag_squared block. The tag from
+     * that detection is on the alternate stream, either bytes or floats.
+     * Often there is further signal processing that should be done on the 
+     * complex stream. This block allows the detection tags to be added to
+     * the complex stream to trigger downstream processing without the need of
+     * redundant trigger inputs on all subsequent blocks.
+     */
+    class BLOCKS_API tag_share : virtual public gr::sync_block
+    {
+     public:
+      typedef boost::shared_ptr<tag_share> sptr;
+
+      /*!
+       * \param sizeof_io_item The size of the Input 0/Output 0 stream type. Input 0
+       * stream items will be directly copied to Output 0.
+       * \param sizeof_share_item The size of the Input 1 (tag share) stream type. This
+       * stream type does not have to match the input/output stream type. Tags from
+       * Input 1's items will be combined with Input 0's item tags and outputted on
+       * Output 0.
+       */
+      static sptr make(size_t sizeof_io_item, size_t sizeof_share_item, size_t vlen = 1);
+    };
+
+  } // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_BLOCKS_TAG_SHARE_H */
+

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -190,6 +190,7 @@ list(APPEND gr_blocks_sources
     streams_to_vector_impl.cc
     stretch_ff_impl.cc
     sub_ff_impl.cc
+    tag_share_impl.cc
     tagged_file_sink_impl.cc
     tagged_stream_to_pdu_impl.cc
     tagged_stream_multiply_length_impl.cc

--- a/gr-blocks/lib/tag_share_impl.cc
+++ b/gr-blocks/lib/tag_share_impl.cc
@@ -1,0 +1,79 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "tag_share_impl.h"
+
+namespace gr {
+  namespace blocks {
+
+    tag_share::sptr
+    tag_share::make(size_t sizeof_io_item, size_t sizeof_share_item, size_t vlen)
+    {
+      return gnuradio::get_initial_sptr
+        (new tag_share_impl(sizeof_io_item, sizeof_share_item, vlen));
+    }
+
+    /*
+     * The private constructor
+     */
+    tag_share_impl::tag_share_impl(size_t sizeof_io_item, size_t sizeof_share_item, size_t vlen)
+      : gr::sync_block("tag_share",
+              gr::io_signature::make2(2, 2, sizeof_io_item*vlen, sizeof_share_item*vlen),
+              gr::io_signature::make(1, 1, sizeof_io_item*vlen)),
+        d_sizeof_io_item(sizeof_io_item),
+        d_vlen(vlen)
+    {
+      // This is the entire premise of the block -- to have the GNU Radio runtime
+      // propagate all the tags from Input 0 and Input 1 to Output 0.
+      set_tag_propagation_policy(TPP_ALL_TO_ALL);
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    tag_share_impl::~tag_share_impl()
+    {
+    }
+
+    int
+    tag_share_impl::work(int noutput_items,
+        gr_vector_const_void_star &input_items,
+        gr_vector_void_star &output_items)
+    {
+      const void *in = (const void *) input_items[0];
+      void *out = (void *) output_items[0];
+
+      // Input 0 passes through to Output 0
+      memcpy(out, in, d_sizeof_io_item*d_vlen*noutput_items);
+
+      // Tell runtime system how many output items we produced.
+      return noutput_items;
+    }
+
+  } /* namespace blocks */
+} /* namespace gr */
+

--- a/gr-blocks/lib/tag_share_impl.h
+++ b/gr-blocks/lib/tag_share_impl.h
@@ -1,0 +1,51 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_TAG_SHARE_IMPL_H
+#define INCLUDED_BLOCKS_TAG_SHARE_IMPL_H
+
+#include <gnuradio/blocks/tag_share.h>
+
+namespace gr {
+  namespace blocks {
+
+    class tag_share_impl : public tag_share
+    {
+     private:
+      size_t d_sizeof_io_item;
+      size_t d_vlen;
+      
+     public:
+      tag_share_impl(size_t sizeof_io_item, size_t sizeof_share_item, size_t vlen);
+      ~tag_share_impl();
+
+      // Where all the action really happens
+      int work(int noutput_items,
+         gr_vector_const_void_star &input_items,
+         gr_vector_void_star &output_items);
+    };
+
+  } // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_BLOCKS_TAG_SHARE_IMPL_H */
+

--- a/gr-blocks/python/blocks/qa_tag_share.py
+++ b/gr-blocks/python/blocks/qa_tag_share.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2017 Free Software Foundation, Inc.
+# 
+# This file is part of GNU Radio
+# 
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+import pmt
+
+class qa_tag_share(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_t(self):
+        # Constants
+        tag_key = 'in1_tag'
+        tag_value = 0
+        tag_offset = 0
+        in0_value = 1.0+1.0j
+        in1_value = 2.717
+        in0_data = (in0_value,)*10
+        in1_data = (in1_value,)*10
+        sink_data = in0_data
+
+        tag = gr.tag_t()
+        tag.key = pmt.to_pmt(tag_key)
+        tag.value = pmt.to_pmt(tag_value)
+        tag.offset = tag_offset
+
+        # Only tag Input 1 of the share block and see if it transfers
+        # to Output 0. Also verify that Input 0 stream is propagated to
+        # Output 0.
+        in0 = blocks.vector_source_c(in0_data, False, 1)
+        in1 = blocks.vector_source_f(in1_data, False, 1, (tag,))
+        tag_share = blocks.tag_share(gr.sizeof_gr_complex, gr.sizeof_float)
+        sink = blocks.vector_sink_c(1)
+
+        self.tb.connect(in0, (tag_share,0))
+        self.tb.connect(in1, (tag_share,1))
+        self.tb.connect(tag_share, sink)
+        self.tb.run()
+
+        self.assertEqual(len(sink.tags()), 1)
+        self.assertEqual(pmt.to_python(sink.tags()[0].key), tag_key)
+        self.assertEqual(pmt.to_python(sink.tags()[0].value), tag_value)
+        self.assertEqual(sink.tags()[0].offset, tag_offset)
+        self.assertEqual(sink.data(), sink_data)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_tag_share, 'qa_tag_share.xml')

--- a/gr-blocks/swig/blocks_swig6.i
+++ b/gr-blocks/swig/blocks_swig6.i
@@ -32,6 +32,7 @@
 
 %{
 #include "gnuradio/blocks/tag_gate.h"
+#include "gnuradio/blocks/tag_share.h"
 #include "gnuradio/blocks/tagged_stream_align.h"
 #include "gnuradio/blocks/tagged_stream_mux.h"
 #include "gnuradio/blocks/tagged_stream_multiply_length.h"
@@ -58,6 +59,7 @@
 %}
 
 %include "gnuradio/blocks/tag_gate.h"
+%include "gnuradio/blocks/tag_share.h"
 %include "gnuradio/blocks/tagged_stream_align.h"
 %include "gnuradio/blocks/tagged_stream_mux.h"
 %include "gnuradio/blocks/tagged_stream_multiply_length.h"
@@ -83,6 +85,7 @@
 %include "gnuradio/blocks/xor_ii.h"
 
 GR_SWIG_BLOCK_MAGIC2(blocks, tag_gate);
+GR_SWIG_BLOCK_MAGIC2(blocks, tag_share);
 GR_SWIG_BLOCK_MAGIC2(blocks, tagged_stream_align);
 GR_SWIG_BLOCK_MAGIC2(blocks, tagged_stream_mux);
 GR_SWIG_BLOCK_MAGIC2(blocks, tagged_stream_multiply_length);


### PR DESCRIPTION
The tag share block is used to transfer or share tags from one stream to another. The block takes two inputs and one output. The Input 0 stream is propagated to Output 0. In addition, the tags from Input 1 are added to the Input 0 stream. This is useful for transferring a detection tag from a correlate_access_code_bb block to the main complex stream, for example.

This is my first pull request, so let me know if things look right. I did build and test this, so everything should work.