### PR TITLE
added the missing == operator.

### DIFF
--- a/gr-uhd/swig/uhd_swig.i
+++ b/gr-uhd/swig/uhd_swig.i
@@ -105,6 +105,10 @@
         temp -= what;
         return temp;
     }
+    bool __eq__(const uhd::time_spec_t &what)
+    {
+      return (what == *self);
+    }
 };
 
 %include <uhd/types/stream_cmd.hpp>


### PR DESCRIPTION
for some reason, SWIG doesn't infer __eq__ from the existence of a C++ == operator, which caused unexpected behaviour. 

Since expecting `uhd.time_spec_t(0) == uhd.time_spec_t(0)` to work in Python seems reasonable, that's a bug. Here's a bugfix :)