### PR TITLE
Delete obsolete configs for Log4cpp from next

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -36,11 +36,5 @@
 #ifndef GR_RPCSERVER_THRIFT
 #cmakedefine GR_RPCSERVER_THRIFT
 #endif
-#ifndef ENABLE_GR_LOG
-#cmakedefine ENABLE_GR_LOG
-#endif
-#ifndef HAVE_LOG4CPP
-#cmakedefine HAVE_LOG4CPP
-#endif
 
 #endif /* GNURADIO_CONFIG_H */

--- a/docs/doxygen/other/logger.dox
+++ b/docs/doxygen/other/logger.dox
@@ -17,12 +17,6 @@ from log4cpp (http://log4cpp.sourceforge.net/) which is readily
 available in most Linux distributions. This is an optional dependency
 and GNU Radio will work without it.
 
-When configuring GNU Radio, the -DENABLE_GR_LOG=On|Off option to cmake
-will allow the user to toggle use of the logger on and off. The logger
-defaults to "on" and will use log4cpp if it is available. If log4cpp
-is not found, the default logging will output to standard output or
-standard error, depending on the level of the log message.
-
 Logging is useful for blocks to print out certain amounts of data at
 different levels. These levels are:
 


### PR DESCRIPTION
The commits from https://github.com/gnuradio/gnuradio/pull/1195 that are for next only.