### PR TITLE
Fix cmake issues in python3 branch

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -92,8 +92,12 @@ endmacro(GR_PYTHON_CHECK_MODULE)
 ########################################################################
 if(NOT DEFINED GR_PYTHON_DIR)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
-import site
-print(site.getsitepackages()[0])
+import os
+import sys
+if os.name == 'posix':
+    print(os.path.join('lib', 'python' + sys.version[:3], 'dist-packages'))
+if os.name == 'nt':
+    print(os.path.join('Lib', 'site-packages'))
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 endif()

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -30,11 +30,11 @@ set(__INCLUDED_GR_PYTHON_CMAKE TRUE)
 
 if (PYTHON_EXECUTABLE)
     message(STATUS "User set python executable ${PYTHON_EXECUTABLE}")
-    find_package(PythonInterp 2.7 REQUIRED)
+    find_package(PythonInterp ${GR_PYTHON_MIN_VERSION} REQUIRED)
 else (PYTHON_EXECUTABLE)
     message(STATUS "PYTHON_EXECUTABLE not set - using default python3")
     message(STATUS "Use -DPYTHON_EXECUTABLE=/path/to/python2 to build for python2.")
-    find_package(PythonInterp 3.4 REQUIRED)
+    find_package(PythonInterp ${GR_PYTHON3_MIN_VERSION} REQUIRED)
 endif (PYTHON_EXECUTABLE)
 
 if (${PYTHON_VERSION_MAJOR} VERSION_EQUAL 3)

--- a/gr-utils/CMakeLists.txt
+++ b/gr-utils/CMakeLists.txt
@@ -22,7 +22,7 @@
 ########################################################################
 include(GrPython)
 
-GR_PYTHON_CHECK_MODULE("Mako >= 0.4.2" mako "mako.__version__ >= '0.4.2'" MAKO_FOUND)
+GR_PYTHON_CHECK_MODULE("Mako >= ${GR_MAKO_MIN_VERSION}" mako "mako.__version__ >= '${GR_MAKO_MIN_VERSION}'" MAKO_FOUND)
 
 ########################################################################
 # Register component

--- a/grc/blocks/variable_struct.xml.py
+++ b/grc/blocks/variable_struct.xml.py
@@ -93,5 +93,5 @@ if __name__ == '__main__':
 
     data = make_xml(MAX_NUM_FIELDS)
 
-    with open(filename, 'w') as fp:
+    with open(filename, 'wb') as fp:
         fp.write(data.encode())


### PR DESCRIPTION
Fixes a few outstanding issues with the python3 cmake process.

@sdh11, please verify 3256314 fixes your issue with the prefix
@skoslowski, I touched a file in the GRC dir to fix a cmake error (something about expecting a string instead of bytes) and tested it with both py2 and py3, but please review (5815a58)
@jmcorgan, c274b4e should take care of all the outstanding GR_*_MIN_VERSION strings, as requested