### PR TITLE
Fix a segfault issue for QT time sink

### DIFF
--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -563,12 +563,15 @@ namespace gr {
                         nr, nr + nitems + 1,
                         d_trigger_tag_key);
       if(tags.size() > 0) {
-        d_triggered = true;
         trigger_index = tags[0].offset - nr;
-        d_start = d_index + trigger_index - d_trigger_delay - 1;
-        d_end = d_start + d_size;
-        d_trigger_count = 0;
-        _adjust_tags(-d_start);
+        int start = d_index + trigger_index - d_trigger_delay - 1;
+        if (start >= 0) {
+            d_triggered = true;
+            d_start = start;
+            d_end = d_start + d_size;
+            d_trigger_count = 0;
+            _adjust_tags(-d_start);
+        }
       }
     }
 

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -558,12 +558,15 @@ namespace gr {
                         nr, nr + nitems + 1,
                         d_trigger_tag_key);
       if(tags.size() > 0) {
-        d_triggered = true;
         trigger_index = tags[0].offset - nr;
-        d_start = d_index + trigger_index - d_trigger_delay - 1;
-        d_end = d_start + d_size;
-        d_trigger_count = 0;
-        _adjust_tags(-d_start);
+        int start = d_index + trigger_index - d_trigger_delay - 1;
+        if (start >= 0) {
+            d_triggered = true;
+            d_start = start;
+            d_end = d_start + d_size;
+            d_trigger_count = 0;
+            _adjust_tags(-d_start);
+        }
       }
     }
 


### PR DESCRIPTION
When running with trigger mode set to "tag", there is
a corner case where d_start becomes -1, and the flow
graph crashes.


Somebody else should please run some regression tests.

On my side, this does at least eliminate an annoying segfault - which occurs quite often when there are MANY tags..