### PR TITLE
runtime: add barrier to sync block startup

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -27,6 +27,8 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/condition_variable.hpp>
+#include <boost/thread/barrier.hpp>
+#include <boost/shared_ptr.hpp>
 #include <vector>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
@@ -46,6 +48,8 @@ namespace gr {
     typedef boost::mutex                     mutex;
     typedef boost::unique_lock<boost::mutex> scoped_lock;
     typedef boost::condition_variable        condition_variable;
+    typedef boost::barrier                   barrier;
+    typedef boost::shared_ptr<barrier>       barrier_sptr;
 
     /*! \brief a system-dependent typedef for the underlying thread type.
      */

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -32,7 +32,7 @@
 
 namespace gr {
 
-  tpb_thread_body::tpb_thread_body(block_sptr block, int max_noutput_items)
+  tpb_thread_body::tpb_thread_body(block_sptr block, gr::thread::barrier_sptr start_sync, int max_noutput_items)
     : d_exec(block, max_noutput_items)
   {
     //std::cerr << "tpb_thread_body: " << block << std::endl;
@@ -92,6 +92,7 @@ namespace gr {
     // make sure our block isnt finished
     block->clear_finished();
 
+    start_sync->wait();
     while(1) {
       tpb_loop_top:
       boost::this_thread::interruption_point();

--- a/gnuradio-runtime/lib/tpb_thread_body.h
+++ b/gnuradio-runtime/lib/tpb_thread_body.h
@@ -24,6 +24,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/block.h>
 #include <gnuradio/block_detail.h>
+#include <gnuradio/thread/thread.h>
 #include "block_executor.h"
 
 namespace gr {
@@ -40,7 +41,7 @@ namespace gr {
     block_executor d_exec;
 
   public:
-    tpb_thread_body(block_sptr block, int max_noutput_items=100000);
+    tpb_thread_body(block_sptr block,  thread::barrier_sptr start_sync, int max_noutput_items=100000);
     ~tpb_thread_body();
   };
 


### PR DESCRIPTION
Juts want to see how the QA tests turn out now. Definitively not ready to merge