### PR TITLE
digital: use GR_LOG for debug/error in correlate_access_code_* blocks

### DIFF
--- a/gr-digital/lib/correlate_access_code_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_impl.cc
@@ -27,13 +27,12 @@
 #include "correlate_access_code_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/blocks/count_bits.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 #include <cstdio>
 
 namespace gr {
   namespace digital {
-
-#define VERBOSE 0
 
     correlate_access_code_bb::sptr
     correlate_access_code_bb::make(const std::string &access_code, int threshold)
@@ -51,6 +50,7 @@ namespace gr {
 	d_threshold(threshold)
     {
       if(!set_access_code(access_code)) {
+	GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
 	throw std::out_of_range ("access_code is > 64 bits");
       }
     }
@@ -109,14 +109,12 @@ namespace gr {
 	// test for access code with up to threshold errors
 	new_flag = (nwrong <= d_threshold);
 
-#if VERBOSE
 	if(new_flag) {
-	  fprintf(stderr, "access code found: %llx\n", d_access_code);
+	  GR_LOG_DEBUG(d_logger, boost::format("access code found: %llx") % d_access_code);
 	}
 	else {
-	  fprintf(stderr, "%llx  ==>  %llx\n", d_access_code, d_data_reg);
+	  GR_LOG_DEBUG(d_logger, boost::format("%llx  ==>  %llx") % d_access_code % d_data_reg);
 	}
-#endif
 
 	// shift in new data and new flag
 	d_data_reg = (d_data_reg << 1) | (in[i] & 0x1);

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -26,6 +26,7 @@
 
 #include "correlate_access_code_bb_ts_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 #include <volk/volk.h>
 #include <cstdio>
@@ -33,8 +34,6 @@
 
 namespace gr {
   namespace digital {
-
-#define VERBOSE 0
 
     correlate_access_code_bb_ts::sptr
     correlate_access_code_bb_ts::make(const std::string &access_code,
@@ -58,6 +57,7 @@ namespace gr {
       set_tag_propagation_policy(TPP_DONT);
 
       if(!set_access_code(access_code)) {
+	GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
 	throw std::out_of_range ("access_code is > 64 bits");
       }
 
@@ -91,10 +91,9 @@ namespace gr {
       for(unsigned i=0; i < d_len; i++){
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
       }
-      if(VERBOSE) {
-          std::cerr << "Access code: " << std::hex << d_access_code << std::dec << std::endl;
-          std::cerr << "Mask: " << std::hex << d_mask << std::dec << std::endl;
-      }
+
+      GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
+      GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
 
       return true;
     }

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -27,6 +27,7 @@
 #include "correlate_access_code_ff_ts_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 #include <volk/volk.h>
 #include <cstdio>
@@ -34,8 +35,6 @@
 
 namespace gr {
   namespace digital {
-
-#define VERBOSE 0
 
     correlate_access_code_ff_ts::sptr
     correlate_access_code_ff_ts::make(const std::string &access_code,
@@ -58,6 +57,7 @@ namespace gr {
       set_tag_propagation_policy(TPP_DONT);
 
       if(!set_access_code(access_code)) {
+	GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
 	throw std::out_of_range ("access_code is > 64 bits");
       }
 
@@ -91,10 +91,9 @@ namespace gr {
       for(unsigned i=0; i < d_len; i++){
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
       }
-      if(VERBOSE) {
-          std::cerr << "Access code: " << std::hex << d_access_code << std::dec << std::endl;
-          std::cerr << "Mask: " << std::hex << d_mask << std::dec << std::endl;
-      }
+
+      GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
+      GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
 
       return true;
     }

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -26,6 +26,7 @@
 
 #include "correlate_access_code_tag_bb_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 #include <volk/volk.h>
 #include <cstdio>
@@ -33,8 +34,6 @@
 
 namespace gr {
   namespace digital {
-
-#define VERBOSE 0
 
     correlate_access_code_tag_bb::sptr
     correlate_access_code_tag_bb::make(const std::string &access_code,
@@ -56,6 +55,7 @@ namespace gr {
 	d_threshold(threshold), d_len(0)
     {
       if(!set_access_code(access_code)) {
+	GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
 	throw std::out_of_range ("access_code is > 64 bits");
       }
 
@@ -85,10 +85,8 @@ namespace gr {
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
       }
 
-      if(VERBOSE) {
-          std::cerr << "Access code: " << std::hex << d_access_code << std::dec << std::endl;
-          std::cerr << "Mask: " << std::hex << d_mask << std::dec << std::endl;
-      }
+      GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
+      GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
 
       return true;
     }
@@ -116,8 +114,7 @@ namespace gr {
 	// shift in new data
 	d_data_reg = (d_data_reg << 1) | (in[i] & 0x1);
 	if(nwrong <= d_threshold) {
-	  if(VERBOSE)
-	    std::cerr << "writing tag at sample " << abs_out_sample_cnt + i << std::endl;
+	  GR_LOG_DEBUG(d_logger, boost::format("writing tag at sample %llu") % (abs_out_sample_cnt + i));
 	  add_item_tag(0, //stream ID
 		       abs_out_sample_cnt + i, //sample
 		       d_key,      //frame info

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -27,6 +27,7 @@
 #include "correlate_access_code_tag_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 #include <volk/volk.h>
 #include <cstdio>
@@ -34,8 +35,6 @@
 
 namespace gr {
   namespace digital {
-
-#define VERBOSE 0
 
     correlate_access_code_tag_ff::sptr
     correlate_access_code_tag_ff::make(const std::string &access_code,
@@ -57,6 +56,7 @@ namespace gr {
 	d_threshold(threshold), d_len(0)
     {
       if(!set_access_code(access_code)) {
+	GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
 	throw std::out_of_range ("access_code is > 64 bits");
       }
 
@@ -86,10 +86,8 @@ namespace gr {
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
       }
 
-      if(VERBOSE) {
-          std::cerr << "Access code: " << std::hex << d_access_code << std::dec << std::endl;
-          std::cerr << "Mask: " << std::hex << d_mask << std::dec << std::endl;
-      }
+      GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
+      GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
 
       return true;
     }
@@ -117,8 +115,7 @@ namespace gr {
 	// shift in new data
 	d_data_reg = (d_data_reg << 1) | (gr::branchless_binary_slicer(in[i]) & 0x1);
 	if(nwrong <= d_threshold) {
-	  if(VERBOSE)
-	    std::cerr << "writing tag at sample " << abs_out_sample_cnt + i << std::endl;
+	  GR_LOG_DEBUG(d_logger, boost::format("writing tag at sample %llu") % (abs_out_sample_cnt + i));
 	  add_item_tag(0, //stream ID
 		       abs_out_sample_cnt + i, //sample
 		       d_key,      //frame info


### PR DESCRIPTION
Replace "if(VERBOSE)" output with GR_LOG_DEBUG statements. Report errors using GR_LOG_ERROR before throwing in constructor.