### PR TITLE
blocks: Add concatenate block

### DIFF
--- a/gr-blocks/grc/blocks_block_tree.xml
+++ b/gr-blocks/grc/blocks_block_tree.xml
@@ -170,6 +170,7 @@
    </cat>
    <cat>
       <name>Stream Operators</name>
+      <block>blocks_concatenate</block>
       <block>blocks_deinterleave</block>
       <block>blocks_interleave</block>
       <block>blocks_keep_m_in_n</block>

--- a/gr-blocks/grc/blocks_concatenate.xml
+++ b/gr-blocks/grc/blocks_concatenate.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<block>
+  <name>Concatenate</name>
+  <key>blocks_concatenate</key>
+  <import>from gnuradio import blocks</import>
+  <make>blocks.concatenate($type.size*$vlen, $ninputs)</make>
+
+  <param>
+        <name>N input streams</name>
+        <key>ninputs</key>
+        <value>2</value>
+        <type>int</type>
+  </param>
+  <param>
+       <name>Type</name>
+       <key>type</key>
+       <type>enum</type>
+       <option>
+           <name>Complex</name>
+           <key>complex</key>
+           <opt>size:gr.sizeof_gr_complex</opt>
+       </option>
+       <option>
+           <name>Float</name>
+           <key>float</key>
+           <opt>size:gr.sizeof_float</opt>
+       </option>
+       <option>
+           <name>Int</name>
+           <key>int</key>
+           <opt>size:gr.sizeof_int</opt>
+       </option>
+       <option>
+           <name>Short</name>
+           <key>short</key>
+           <opt>size:gr.sizeof_short</opt>
+       </option>
+       <option>
+           <name>Byte</name>
+           <key>byte</key>
+           <opt>size:gr.sizeof_char</opt>
+       </option>
+  </param>
+  <param>
+        <name>Vec Length</name>
+        <key>vlen</key>
+        <value>1</value>
+        <type>int</type>
+  </param>
+  <check>$vlen &gt; 0</check>
+
+
+  <sink>
+    <name>in</name>
+    <type>$type</type>
+    <vlen>$vlen</vlen>
+    <nports>$ninputs</nports>
+  </sink>
+
+  <source>
+    <name>out</name>
+    <type>$type</type>
+    <vlen>$vlen</vlen>
+  </source>
+</block>

--- a/gr-blocks/grc/blocks_concatenate.xml
+++ b/gr-blocks/grc/blocks_concatenate.xml
@@ -3,7 +3,9 @@
   <name>Concatenate</name>
   <key>blocks_concatenate</key>
   <import>from gnuradio import blocks</import>
-  <make>blocks.concatenate($type.size*$vlen, $ninputs)</make>
+  <make>blocks.concatenate($type.size*$vlen, $ninputs)
+self.$(id).set_tag_parts($tag_parts)</make>
+  <callback>self.$(id).set_tag_parts($tag_parts)</callback>
 
   <param>
         <name>N input streams</name>
@@ -47,6 +49,22 @@
         <value>1</value>
         <type>int</type>
   </param>
+
+  <param>
+      <name>Tag parts</name>
+      <key>tag_parts</key>
+      <value>False</value>
+      <type>bool</type>
+      <option>
+          <name>Yes</name>
+          <key>True</key>
+      </option>
+      <option>
+          <name>No</name>
+          <key>False</key>
+      </option>
+  </param>
+
   <check>$vlen &gt; 0</check>
 
 

--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -95,6 +95,7 @@ install(FILES
     complex_to_mag_squared.h
     complex_to_arg.h
     conjugate_cc.h
+    concatenate.h
     copy.h
     deinterleave.h
     delay.h

--- a/gr-blocks/include/gnuradio/blocks/concatenate.h
+++ b/gr-blocks/include/gnuradio/blocks/concatenate.h
@@ -1,0 +1,61 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_BLOCKS_CONCATENATE_H
+#define INCLUDED_BLOCKS_CONCATENATE_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/block.h>
+
+namespace gr {
+  namespace blocks {
+
+    /*!
+     * \brief Concatenate full streams
+     * \ingroup stream_operators_blk
+     *
+     * \details
+     * This block takes the input from several sources and put all the items
+     * after each other. All the items from the source connected to the
+     * first input are produced first, then all the items from the second
+     * source, and so on. The upstream blocks need to return -1 in the
+     * general_work method to make this block aware of when they have
+     * completed producing items.
+     */
+    class BLOCKS_API concatenate : virtual public gr::block
+    {
+     public:
+      typedef boost::shared_ptr<concatenate> sptr;
+
+      /*!
+       * \param itemsize The size of the items at all inputs and outputs.
+       * \param ninputs Number of input streams to concatenate
+       */
+      static sptr make(size_t itemsize, int ninputs);
+    };
+
+  } // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_BLOCKS_CONCATENATE_H */
+

--- a/gr-blocks/include/gnuradio/blocks/concatenate.h
+++ b/gr-blocks/include/gnuradio/blocks/concatenate.h
@@ -52,6 +52,8 @@ namespace gr {
        * \param ninputs Number of input streams to concatenate
        */
       static sptr make(size_t itemsize, int ninputs);
+
+      virtual void set_tag_parts(bool val)=0;
     };
 
   } // namespace blocks

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -109,6 +109,7 @@ list(APPEND gr_blocks_sources
     complex_to_mag_squared_impl.cc
     complex_to_arg_impl.cc
     conjugate_cc_impl.cc
+    concatenate_impl.cc
     copy_impl.cc
     deinterleave_impl.cc
     divide_cc_impl.cc

--- a/gr-blocks/lib/concatenate_impl.cc
+++ b/gr-blocks/lib/concatenate_impl.cc
@@ -1,0 +1,143 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include <gnuradio/buffer.h>
+#include <boost/thread.hpp>
+#include "concatenate_impl.h"
+
+namespace gr {
+  namespace blocks {
+
+    concatenate::sptr
+    concatenate::make(size_t itemsize, int ninputs)
+    {
+      return gnuradio::get_initial_sptr
+        (new concatenate_impl(itemsize, ninputs));
+    }
+
+    /*
+     * The private constructor
+     */
+    concatenate_impl::concatenate_impl(size_t itemsize, int ninputs)
+      : gr::block("concatenate",
+              gr::io_signature::make(ninputs, ninputs, itemsize),
+              gr::io_signature::make(1, 1, itemsize)),
+        d_itemsize(itemsize), d_ninputs(ninputs), d_current_done(false),
+        d_current_input(0)
+    {
+
+      set_tag_propagation_policy(TPP_DONT);
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    concatenate_impl::~concatenate_impl()
+    {
+    }
+
+    bool
+    concatenate_impl::start()
+    {
+      d_block_detail = this->detail().get();
+      return true;
+    }
+
+    void
+    concatenate_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required)
+    {
+      int d_ninput_items;
+      bool d_input_done;
+      int current_ninput_items_required;
+
+      current_ninput_items_required = noutput_items;
+
+      if (d_current_input >= 0 && d_current_input < d_ninputs) {
+        gr::thread::scoped_lock guard(*d_block_detail->input(d_current_input)->mutex());
+        d_ninput_items = d_block_detail->input(d_current_input)->items_available ();
+        d_input_done = d_block_detail->input(d_current_input)->done();
+        if (d_input_done) {
+          d_current_done = true;
+          d_current_samples_left = d_ninput_items;
+          current_ninput_items_required = 0;
+        }
+      }
+
+      for(int i=0; i < d_ninputs; i++) {
+        if (i == d_current_input)
+          ninput_items_required[i] = current_ninput_items_required;
+        else
+          ninput_items_required[i] = 0;
+      }
+    }
+
+    int
+    concatenate_impl::general_work (int noutput_items,
+                       gr_vector_int &ninput_items,
+                       gr_vector_const_void_star &input_items,
+                       gr_vector_void_star &output_items)
+    {
+      int minval;
+      int produced = 0;
+
+      const char *in;
+      if (d_current_input >= 0)
+        in = (const char *) input_items[d_current_input];
+      char *out = (char *) output_items[0];
+
+      if (d_current_input == -1)
+        return -1;
+
+      minval = std::min(ninput_items[d_current_input], noutput_items);
+      memcpy(out, in, d_itemsize * minval);
+      produced += minval;
+
+      // Tell runtime system how many input items we consumed.
+      // We only consume from one input at a time.
+      consume (d_current_input, produced);
+
+      // If the current input stream has stopped producing items,
+      // check if we have consumed as many as there were left
+      // when forecast was called. In that case, go to the
+      // next input.
+      if (d_current_done) {
+        if(d_current_samples_left == produced) {
+          d_current_input++;
+          d_current_done = false;
+          if (d_current_input >= d_ninputs) {
+            d_current_input = -1;
+          }
+        }
+      }
+
+      // Tell runtime system how many output items we produced.
+      return produced;
+    }
+
+  } /* namespace blocks */
+} /* namespace gr */
+

--- a/gr-blocks/lib/concatenate_impl.h
+++ b/gr-blocks/lib/concatenate_impl.h
@@ -26,6 +26,8 @@
 #include <gnuradio/blocks/concatenate.h>
 #include <gnuradio/block_detail.h>
 
+static const pmt::pmt_t BEGIN_KEY = pmt::string_to_symbol("concatenated");
+
 namespace gr {
   namespace blocks {
 
@@ -36,7 +38,11 @@ namespace gr {
       int d_ninputs;
       bool d_current_done;
       int d_current_input;
+      bool d_tag_parts;
+      int d_last_input;
+
       int d_current_samples_left;
+      pmt::pmt_t _id;
 
       gr::block_detail *d_block_detail;
 
@@ -53,6 +59,8 @@ namespace gr {
            gr_vector_void_star &output_items);
 
       bool start();
+
+      void set_tag_parts(bool);
     };
 
   } // namespace blocks

--- a/gr-blocks/lib/concatenate_impl.h
+++ b/gr-blocks/lib/concatenate_impl.h
@@ -1,0 +1,62 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2017 Free Software Foundation, Inc.
+ * 
+ * This file is part of GNU Radio
+ * 
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_BLOCKS_CONCATENATE_IMPL_H
+#define INCLUDED_BLOCKS_CONCATENATE_IMPL_H
+
+#include <gnuradio/blocks/concatenate.h>
+#include <gnuradio/block_detail.h>
+
+namespace gr {
+  namespace blocks {
+
+    class concatenate_impl : public concatenate
+    {
+     private:
+      size_t d_itemsize;
+      int d_ninputs;
+      bool d_current_done;
+      int d_current_input;
+      int d_current_samples_left;
+
+      gr::block_detail *d_block_detail;
+
+     public:
+      concatenate_impl(size_t itemsize, int ninputs);
+      ~concatenate_impl();
+
+      // Where all the action really happens
+      void forecast (int noutput_items, gr_vector_int &ninput_items_required);
+
+      int general_work(int noutput_items,
+           gr_vector_int &ninput_items,
+           gr_vector_const_void_star &input_items,
+           gr_vector_void_star &output_items);
+
+      bool start();
+    };
+
+  } // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_BLOCKS_CONCATENATE_IMPL_H */
+

--- a/gr-blocks/python/blocks/qa_concatenate.py
+++ b/gr-blocks/python/blocks/qa_concatenate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2017 Free Software Foundation, Inc.
+# 
+# This file is part of GNU Radio
+# 
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+
+class qa_concatenate (gr_unittest.TestCase):
+
+    def setUp (self):
+        self.tb = gr.top_block ()
+
+    def tearDown (self):
+        self.tb = None
+
+    def test_001_t (self):
+        # set up fg
+        dut = blocks.concatenate(gr.sizeof_gr_complex, 3)
+        src0 = blocks.vector_source_c([1,2,4,5])
+        src1 = blocks.vector_source_c([9,9,9,9])
+        src2 = blocks.vector_source_c([0,0,0,0,0,0,0,0,0,0,1])
+        dst = blocks.vector_sink_c()
+        self.tb.connect(src0, (dut,0))
+        self.tb.connect(src1, (dut,1))
+        self.tb.connect(src2, (dut,2))
+        self.tb.connect(dut, dst)
+        self.tb.run ()
+        # check data
+        self.assertEqual(dst.data() , ((1+0j), (2+0j), (4+0j), (5+0j), (9+0j), (9+0j), (9+0j), (9+0j), 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, (1+0j)))
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_concatenate, "qa_concatenate.xml")

--- a/gr-blocks/swig/blocks_swig2.i
+++ b/gr-blocks/swig/blocks_swig2.i
@@ -51,6 +51,7 @@
 #include "gnuradio/blocks/complex_to_mag.h"
 #include "gnuradio/blocks/complex_to_mag_squared.h"
 #include "gnuradio/blocks/complex_to_arg.h"
+#include "gnuradio/blocks/concatenate.h"
 #include "gnuradio/blocks/conjugate_cc.h"
 %}
 
@@ -74,6 +75,7 @@
 %include "gnuradio/blocks/complex_to_mag.h"
 %include "gnuradio/blocks/complex_to_mag_squared.h"
 %include "gnuradio/blocks/complex_to_arg.h"
+%include "gnuradio/blocks/concatenate.h"
 %include "gnuradio/blocks/conjugate_cc.h"
 
 GR_SWIG_BLOCK_MAGIC2(blocks, and_const_bb);
@@ -96,4 +98,5 @@ GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_imag);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_mag);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_mag_squared);
 GR_SWIG_BLOCK_MAGIC2(blocks, complex_to_arg);
+GR_SWIG_BLOCK_MAGIC2(blocks, concatenate);
 GR_SWIG_BLOCK_MAGIC2(blocks, conjugate_cc);


### PR DESCRIPTION
This block takes the input from several sources and put all the items
after each other. All the items from the source connected to the
first input are produced first, then all the items from the second
source, and so on. The upstream blocks need to return -1 in the
general_work method to make this block aware of when they have
completed producing items.

It can be useful for appending a vector (vector_source) to the end of a file
(file_source), appending one file to another file etc.


This is an example of a flow graph:
![flow_graph](https://cloud.githubusercontent.com/assets/1938710/25317926/6978eda0-2883-11e7-8440-02878b62975f.png)
The number of inputs has been set to 4. The file /tmp/mydata.cfile is prepended with 1000 zeros from the vector_source. Then 1000 zeros are added between the file /tmp/mydata.cfile and /tmp/mydata2.cfile.

![settings](https://cloud.githubusercontent.com/assets/1938710/25317927/7056be2c-2883-11e7-80db-b63d0cade2b2.png)


The block allows any data type and vector length. The type is common to all inputs and the output.