### PR TITLE
audio: fix osx variety to work with debug (again).

### DIFF
--- a/gr-audio/include/gnuradio/audio/osx_impl.h
+++ b/gr-audio/include/gnuradio/audio/osx_impl.h
@@ -33,10 +33,6 @@
 #include <AudioToolbox/AudioToolbox.h>
 #include <AudioUnit/AudioUnit.h>
 
-namespace gr {
-namespace audio {
-namespace osx {
-
 // Check the version of MacOSX being used
 #ifdef __APPLE_CC__
 #include <AvailabilityMacros.h>
@@ -50,15 +46,19 @@ namespace osx {
 
 // helper function to print an ASBD
 
-extern std::ostream& GR_AUDIO_API
+std::ostream& GR_AUDIO_API
 operator<<
 (std::ostream& s,
  const AudioStreamBasicDescription& asbd);
 
+namespace gr {
+namespace audio {
+namespace osx {
+
 // returns the number of channels for the provided AudioDeviceID,
 // input and/or output depending on if the pointer is valid.
 
-extern void GR_AUDIO_API
+void GR_AUDIO_API
 get_num_channels_for_audio_device_id
 (AudioDeviceID ad_id,
  UInt32* n_input,
@@ -70,7 +70,7 @@ get_num_channels_for_audio_device_id
 // matching names.  If the device name is empty, then match all
 // input or output devices.
 
-extern void GR_AUDIO_API
+void GR_AUDIO_API
 find_audio_devices
 (const std::string& device_name,
  bool is_input,

--- a/gr-audio/lib/osx/osx_common.h
+++ b/gr-audio/lib/osx/osx_common.h
@@ -29,8 +29,13 @@ namespace gr {
 namespace audio {
 namespace osx {
 
+#ifndef _OSX_AU_DEBUG_
 #define _OSX_AU_DEBUG_ 0
+#endif
+
+#ifndef _OSX_AU_DEBUG_RENDER_
 #define _OSX_AU_DEBUG_RENDER_ 0
+#endif
 
 #define check_error_and_throw(err,what,throw_str)			\
   if(err) {                                                             \

--- a/gr-audio/lib/osx/osx_impl.cc
+++ b/gr-audio/lib/osx/osx_impl.cc
@@ -33,10 +33,6 @@
 #include <locale>
 #include <stdexcept>
 
-namespace gr {
-namespace audio {
-namespace osx {
-
 std::ostream&
 operator<<
 (std::ostream& s,
@@ -69,6 +65,10 @@ operator<<
   s << "  Bits / Channel   : " << asbd.mBitsPerChannel;
   return(s);
 };
+
+namespace gr {
+namespace audio {
+namespace osx {
 
 static UInt32
 _get_num_channels


### PR DESCRIPTION
Allow for internal or external specification of _OSX_*_DEBUG_ flags.