### PR TITLE
blocks: stream_to_tagged_stream: Fix tag offset not reset after unlock()

### DIFF
--- a/gr-blocks/lib/stream_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/stream_to_tagged_stream_impl.cc
@@ -84,6 +84,13 @@ namespace gr {
         return noutput_items;
     }
 
+    bool
+    stream_to_tagged_stream_impl::start()
+    {
+        d_next_tag_pos = 0;
+        return true;
+    }
+
   } /* namespace blocks */
 } /* namespace gr */
 

--- a/gr-blocks/lib/stream_to_tagged_stream_impl.h
+++ b/gr-blocks/lib/stream_to_tagged_stream_impl.h
@@ -46,6 +46,8 @@ namespace gr {
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);
+
+      bool start();
     };
 
   } // namespace blocks


### PR DESCRIPTION
Fixes #1091.

Signed-off-by: Paul Cercueil <paul.cercueil@analog.com>