### PR TITLE
Fix swig c++ dependency tracking

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/swig/CMakeLists.txt
+++ b/gr-utils/python/modtool/gr-newmod/swig/CMakeLists.txt
@@ -47,6 +47,14 @@ set(GR_SWIG_LIBRARIES gnuradio-howto)
 set(GR_SWIG_DOC_FILE ${CMAKE_CURRENT_BINARY_DIR}/howto_swig_doc.i)
 set(GR_SWIG_DOC_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
+foreach(howto_source_file ${howto_sources})
+    if(IS_ABSOLUTE howto_source_file)
+        list(APPEND GR_SWIG_SOURCE_DEPS ${howto_source_file})
+    else()
+        list(APPEND GR_SWIG_SOURCE_DEPS ${CMAKE_SOURCE_DIR}/lib/${howto_source_file})
+    endif()
+endforeach()
+
 GR_SWIG_MAKE(howto_swig howto_swig.i)
 
 ########################################################################


### PR DESCRIPTION
This is an attempt at fixing the issue specified in #1318. As I mentioned there, this isn't a perfect solution since it doesn't take the headers into account.

An alternate thought I had is that there could be a cmake variable (`modname_public_headers` maybe?) in `include/CMakeLists.txt` with all the public headers and then that variable could be used both for the `install` statement and promoted to parent scope as well so that it could be used instead of `${modname_sources}` in the `swig/CMakeLists.txt` file to handle the dependency.