### PR TITLE
gr-qtgui: allows time_sink to have up to 24 inputs instead of 12

### DIFF
--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -170,8 +170,14 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
   colors << QColor(Qt::blue) << QColor(Qt::red) << QColor(Qt::green)
 	 << QColor(Qt::black) << QColor(Qt::cyan) << QColor(Qt::magenta)
 	 << QColor(Qt::yellow) << QColor(Qt::gray) << QColor(Qt::darkRed)
+	 << QColor(Qt::darkGreen) << QColor(Qt::darkBlue) << QColor(Qt::darkGray)
+	 // cycle through all colors again to increase time_sink_f input limit
+	 // from 12 to 24, otherwise you get a segfault
+	 << QColor(Qt::blue) << QColor(Qt::red) << QColor(Qt::green)
+	 << QColor(Qt::black) << QColor(Qt::cyan) << QColor(Qt::magenta)
+	 << QColor(Qt::yellow) << QColor(Qt::gray) << QColor(Qt::darkRed)
 	 << QColor(Qt::darkGreen) << QColor(Qt::darkBlue) << QColor(Qt::darkGray);
-
+	 
   // Setup dataPoints and plot vectors
   // Automatically deleted when parent is deleted
   for(int i = 0; i < d_nplots; i++) {

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -55,6 +55,9 @@ namespace gr {
 	d_size(size), d_buffer_size(2*size), d_samp_rate(samp_rate), d_name(name),
 	d_nconnections(2*nconnections), d_parent(parent)
     {
+      if(nconnections > 12)
+        throw std::runtime_error("time_sink_c only supports up to 12 inputs");
+
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
       // life of the qApplication:

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -57,6 +57,9 @@ namespace gr {
 	d_size(size), d_buffer_size(2*size), d_samp_rate(samp_rate), d_name(name),
 	d_nconnections(nconnections), d_parent(parent)
     {
+      if(nconnections > 24)
+        throw std::runtime_error("time_sink_f only supports up to 24 inputs");
+
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
       // life of the qApplication:


### PR DESCRIPTION
fixes #1317 