### PR TITLE
sort input files

### DIFF
--- a/gr-utils/python/modtool/modtool_makexml.py
+++ b/gr-utils/python/modtool/modtool_makexml.py
@@ -79,7 +79,7 @@ class ModToolMakeXML(ModTool):
 
     def _search_files(self, path, path_glob):
         """ Search for files matching pattern in the given path. """
-        files = glob.glob("%s/%s"% (path, path_glob))
+        files = sorted(glob.glob("%s/%s"% (path, path_glob)))
         files_filt = []
         print "Searching for matching files in %s/:" % path
         for f in files:

--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -127,7 +127,7 @@ class ModToolRemove(ModTool):
         # 1. Create a filtered list
         files = []
         for g in globs:
-            files = files + glob.glob("%s/%s"% (path, g))
+            files = files + sorted(glob.glob("%s/%s"% (path, g)))
         files_filt = []
         print "Searching for matching files in %s/:" % path
         for f in files:


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.

such diffs affected volk-config-info volk_profile volk.h volk_typedefs.h gnuradio/xml/index.xml gnuradio/html/volk_8h_source.html etc
http://rb.zq1.de/compare.factory-20170531/gnuradio-compare.out