### PR TITLE
gr-blocks: fixes the broken example simple_copy.grc

### DIFF
--- a/gr-blocks/examples/ctrlport/simple_copy.grc
+++ b/gr-blocks/examples/ctrlport/simple_copy.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.9'?>
+<?grc format='1' created='3.7.11'?>
 <flow_graph>
   <timestamp>Sat Mar 16 22:03:14 2013</timestamp>
   <block>
@@ -41,6 +41,10 @@
       <value>qt_gui</value>
     </param>
     <param>
+      <key>hier_block_src_path</key>
+      <value>.:</value>
+    </param>
+    <param>
       <key>id</key>
       <value>simple_copy</value>
     </param>
@@ -49,8 +53,16 @@
       <value>0</value>
     </param>
     <param>
+      <key>qt_qss_theme</key>
+      <value></value>
+    </param>
+    <param>
       <key>realtime_scheduling</key>
       <value></value>
+    </param>
+    <param>
+      <key>run_command</key>
+      <value>{python} -u {filename}</value>
     </param>
     <param>
       <key>run_options</key>
@@ -381,10 +393,90 @@ to enable/disablethis block</value>
     </param>
   </block>
   <block>
+    <key>epy_block</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_io_cache</key>
+      <value>('Null Msg Source', 'blk', [], [], [('fake_output', 'message', 1)], '', [])</value>
+    </param>
+    <param>
+      <key>_source_code</key>
+      <value># Block that doesn't do anything, just used to get a msg input port on another block exposed to ControlPort
+from gnuradio import gr
+import pmt
+class blk(gr.basic_block):
+    def __init__(self): 
+        gr.basic_block.__init__(self,name='Null Msg Source',in_sig=[],out_sig=[])
+        self.message_port_register_out(pmt.intern("fake_output"))
+</value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(357, 218)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>epy_block_0</value>
+    </param>
+  </block>
+  <block>
+    <key>note</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value>Make sure to turn on ControlPort (edit ~/.gnuradio/config.conf)
+and run the following script to toggle Copy block:
+cd /src/gnuradio/gr-blocks/examples/ctrlport
+python simple_copy_controller.py 127.0.0.1 &lt;PORT&gt; true</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(352, 13)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>note_0</value>
+    </param>
+    <param>
+      <key>note</key>
+      <value></value>
+    </param>
+  </block>
+  <block>
     <key>qtgui_time_sink_x</key>
     <param>
       <key>autoscale</key>
       <value>False</value>
+    </param>
+    <param>
+      <key>axislabels</key>
+      <value>True</value>
     </param>
     <param>
       <key>alias</key>
@@ -768,5 +860,11 @@ to enable/disablethis block</value>
     <sink_block_id>blocks_add_xx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>epy_block_0</source_block_id>
+    <sink_block_id>blocks_copy_0</sink_block_id>
+    <source_key>fake_output</source_key>
+    <sink_key>en</sink_key>
   </connection>
 </flow_graph>


### PR DESCRIPTION
In Issue #1302 I mentioned how the example simple_copy.grc (located in gr-blocks/examples/ctrlport/) just doesn't work.  Maybe at one point it worked, but the reason it currently doesn't is because msg input ports that are not connected to anything are not exposed and accessible via ControlPort.  Now that may be a bug in itself, not sure, but to make a quick fix for this example I created an embedded python block that has a msg output port but doesn't actually send out any messages (think of it like a "null msg source").  Then I connected it to the Copy block, thus exposing the msg input port and allowing this example to work.  I also went ahead and added a Note block giving the user some tips for getting the example to work.  So it's an ugly fix but at least the example works now, and I didn't change any other files.