### PR TITLE
runtime: replace pmt.pmt_swig.* namespace calls with pmt.*

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -57,17 +57,17 @@ def python_to_tag(tag_struct):
                 good = True
 
         if(tag_struct.has_key('key')):
-            if(isinstance(tag_struct['key'], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct['key'], pmt.swig_int_ptr)):
                 tag.key = tag_struct['key']
                 good = True
 
         if(tag_struct.has_key('value')):
-            if(isinstance(tag_struct['value'], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct['value'], pmt.swig_int_ptr)):
                 tag.value = tag_struct['value']
                 good = True
 
         if(tag_struct.has_key('srcid')):
-            if(isinstance(tag_struct['srcid'], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct['srcid'], pmt.swig_int_ptr)):
                 tag.srcid = tag_struct['srcid']
                 good = True
 
@@ -77,15 +77,15 @@ def python_to_tag(tag_struct):
                 tag.offset = tag_struct[0]
                 good = True
 
-            if(isinstance(tag_struct[1], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct[1], pmt.swig_int_ptr)):
                 tag.key = tag_struct[1]
                 good = True
 
-            if(isinstance(tag_struct[2], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct[2], pmt.swig_int_ptr)):
                 tag.value = tag_struct[2]
                 good = True
 
-            if(isinstance(tag_struct[3], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct[3], pmt.swig_int_ptr)):
                 tag.srcid = tag_struct[3]
                 good = True
 
@@ -94,11 +94,11 @@ def python_to_tag(tag_struct):
                 tag.offset = tag_struct[0]
                 good = True
 
-            if(isinstance(tag_struct[1], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct[1], pmt.swig_int_ptr)):
                 tag.key = tag_struct[1]
                 good = True
 
-            if(isinstance(tag_struct[2], pmt.pmt_swig.swig_int_ptr)):
+            if(isinstance(tag_struct[2], pmt.swig_int_ptr)):
                 tag.value = tag_struct[2]
                 good = True
 


### PR DESCRIPTION
3 tests fail in MSVC build due to swig_int_ptr being referred to from the pmt.pmt_swig module, not the pmt module.

This syntax is only used in the python_to_tag function code, which is only called from qa tests.

This changes the reference to pmt.*, and those tests now pass on MSVC.  

Not tested on Linux.  It is not clear to me how the test would pass on py2.7 on Linux but not on Windows.  I could not come up with a set of PYTHONPATH directories that would enable the code to pass as is on win64, so I find that puzzling.
