### PR TITLE
gr-fft: fix object reuse issue causing qa_fft hang on win32

### DIFF
--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -36,6 +36,10 @@ static int my_fftw_read_char(void *f) { return fgetc((FILE *) f); }
 #define fftw_import_wisdom_from_file(f) fftw_import_wisdom(my_fftw_read_char, (void*) (f))
 #define fftwf_import_wisdom_from_file(f) fftwf_import_wisdom(my_fftw_read_char, (void*) (f))
 #define fftwl_import_wisdom_from_file(f) fftwl_import_wisdom(my_fftw_read_char, (void*) (f))
+#include <fcntl.h> 
+#include <io.h>
+#define O_NOCTTY 0
+#define O_NONBLOCK 0
 #endif //_MSC_VER
 
 #include <stdlib.h>


### PR DESCRIPTION
Initially, on win32 building gr-fft will error due to missing win-specific file handling headers.

After applying first commit to fix that, then qa_fft will hang.

A new wisdom_lock object is being created in the wisdom_unlock() routine, which then throws an exception when unlock() is called because the new object isn't locked. This then aborts the make() routine without unlocking the original object or the mutex.  Then when wisdom_lock() gets called in the next test, the mutex is still locked and the application hangs. 

Fix just creates a single static wisdom_lock object and reuses it for both calls.