### PR TITLE
gr_blocks: file closure fixes for msvc

### DIFF
--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -141,17 +141,7 @@ namespace gr {
     {
       close();
 
-      if(d_fp) {
-	fclose(d_fp);
-	d_fp = 0;
-      }
 
-      if(d_state == STATE_DETACHED) {
-	if(d_hdr_fp) {
-	  fclose(d_hdr_fp);
-	  d_hdr_fp = 0;
-	}
-      }
     }
 
     bool
@@ -216,6 +206,18 @@ namespace gr {
 	d_new_fp = 0;
       }
       d_updated = true;
+
+      if (d_fp) {
+        fclose(d_fp);
+        d_fp = 0;
+      }
+
+      if (d_state == STATE_DETACHED) {
+        if (d_hdr_fp) {
+          fclose(d_hdr_fp);
+          d_hdr_fp = 0;
+        }
+      }
     }
 
     void
@@ -298,10 +300,11 @@ namespace gr {
     void
     file_meta_sink_impl::update_last_header()
     {
-      if(d_state == STATE_DETACHED)
-	update_last_header_detached();
-      else
-	update_last_header_inline();
+      if(d_state == STATE_DETACHED) {
+        if (d_hdr_fp) update_last_header_detached();
+      } else {
+        if(d_fp) update_last_header_inline();
+      }
     }
 
     void

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -111,17 +111,7 @@ namespace gr {
     {
       close();
 
-      if(d_fp) {
-	fclose(d_fp);
-	d_fp = 0;
-      }
 
-      if(d_state == STATE_DETACHED) {
-	if(d_hdr_fp) {
-	  fclose(d_hdr_fp);
-	  d_hdr_fp = 0;
-	}
-      }
     }
 
     bool
@@ -339,6 +329,18 @@ namespace gr {
 	d_new_fp = 0;
       }
       d_updated = true;
+
+      if (d_fp) {
+        fclose(d_fp);
+        d_fp = 0;
+      }
+
+      if (d_state == STATE_DETACHED) {
+        if (d_hdr_fp) {
+          fclose(d_hdr_fp);
+          d_hdr_fp = 0;
+        }
+      }
     }
 
     void

--- a/gr-blocks/python/blocks/qa_file_metadata.py
+++ b/gr-blocks/python/blocks/qa_file_metadata.py
@@ -106,6 +106,7 @@ class test_file_metadata(gr_unittest.TestCase):
         self.tb.connect(src, ssnk)
         self.tb.run()
 
+        fsrc.close() 
         # Test to make sure tags with 'samp_rate' and 'rx_rate' keys
         # were generated and received correctly.
         tags = tsnk.current_tags()
@@ -187,6 +188,7 @@ class test_file_metadata(gr_unittest.TestCase):
         self.tb.connect(src, ssnk)
         self.tb.run()
 
+        fsrc.close()
         # Test to make sure tags with 'samp_rate' and 'rx_rate' keys
         # were generated and received correctly.
         tags = tsnk.current_tags()


### PR DESCRIPTION
This fixes two minor bugs in file_metadata:

1- calling close() on the block does the final update on the pmt header, but doesn't actually close the file.  That only happens on object destruction.  So the process will keep a lock on the file until the object is actually released.  So in qa_file_metadata, there is still a lock on the file when os.remove() is called.  This is not a problem in Linux, but windows is pickier and will refuse to remove the file and this fail the test.
So the first commit moves file closure from the destructor to close().  The other change is to ensure that since close() gets called again by the destructor, that the final update only occurs if the filestream is still valid.

2- The qa_file_metadata test doesn't call close() on the file source, just the file sink.  Fix just adds the close() to the tests.

Both issues will cause test fails on windows, and have been tested to pass (win only) with the fixes.  