### PR TITLE
Fixed storing references to temporary values in RPC infrastructure

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpccallbackregister_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpccallbackregister_base.h
@@ -104,11 +104,11 @@ struct callbackregister_base
   callbackregister_base() {;}
   virtual ~callbackregister_base() {;}
 
-  virtual void registerConfigureCallback(const std::string &id, const configureCallback_t callback) = 0;
+  virtual void registerConfigureCallback(const std::string &id, const configureCallback_t &callback) = 0;
   virtual void unregisterConfigureCallback(const std::string &id) = 0;
-  virtual void registerQueryCallback(const std::string &id, const queryCallback_t callback) = 0;
+  virtual void registerQueryCallback(const std::string &id, const queryCallback_t &callback) = 0;
   virtual void unregisterQueryCallback(const std::string &id) = 0;
-  virtual void registerHandlerCallback(const std::string &id, const handlerCallback_t callback) = 0;
+  virtual void registerHandlerCallback(const std::string &id, const handlerCallback_t &callback) = 0;
   virtual void unregisterHandlerCallback(const std::string &id) = 0;
 };
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_aggregator.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_aggregator.h
@@ -34,13 +34,13 @@ public:
   rpcserver_aggregator();
   virtual ~rpcserver_aggregator();
 
-  void registerConfigureCallback(const std::string &id, const configureCallback_t callback);
+  void registerConfigureCallback(const std::string &id, const configureCallback_t &callback);
   void unregisterConfigureCallback(const std::string &id);
 
-  void registerQueryCallback(const std::string &id, const queryCallback_t callback);
+  void registerQueryCallback(const std::string &id, const queryCallback_t &callback);
   void unregisterQueryCallback(const std::string &id);
 
-  void registerHandlerCallback(const std::string &id, const handlerCallback_t callback);
+  void registerHandlerCallback(const std::string &id, const handlerCallback_t &callback);
   void unregisterHandlerCallback(const std::string &id);
 
   void registerServer(rpcmanager_base::rpcserver_booter_base_sptr server);
@@ -53,7 +53,7 @@ private:
   template<class T, typename Tcallback>
   struct registerConfigureCallback_f: public std::unary_function<T,void>
   {
-    registerConfigureCallback_f(const std::string &_id,  const Tcallback _callback)
+    registerConfigureCallback_f(const std::string &_id,  const Tcallback &_callback)
       : id(_id), callback(_callback)
     {;}
 
@@ -75,7 +75,7 @@ private:
   template<class T, typename Tcallback>
   struct registerQueryCallback_f: public std::unary_function<T,void>
   {
-    registerQueryCallback_f(const std::string &_id,  const Tcallback _callback)
+    registerQueryCallback_f(const std::string &_id,  const Tcallback &_callback)
       : id(_id), callback(_callback)
     {;}
 
@@ -99,7 +99,7 @@ private:
   template<class T, typename Tcallback>
   struct registerHandlerCallback_f: public std::unary_function<T,void>
   {
-    registerHandlerCallback_f(const std::string &_id,  const Tcallback _callback)
+    registerHandlerCallback_f(const std::string &_id,  const Tcallback &_callback)
       : id(_id), callback(_callback)
     {;}
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_base.h
@@ -31,13 +31,13 @@ public:
   rpcserver_base() : cur_priv(RPC_PRIVLVL_ALL) {;}
   virtual ~rpcserver_base() {;}
 
-  virtual void registerConfigureCallback(const std::string &id, const configureCallback_t callback) = 0;
+  virtual void registerConfigureCallback(const std::string &id, const configureCallback_t &callback) = 0;
   virtual void unregisterConfigureCallback(const std::string &id) = 0;
 
-  virtual void registerQueryCallback(const std::string &id, const queryCallback_t callback) = 0;
+  virtual void registerQueryCallback(const std::string &id, const queryCallback_t &callback) = 0;
   virtual void unregisterQueryCallback(const std::string &id) = 0;
 
-  virtual void registerHandlerCallback(const std::string &id, const handlerCallback_t callback) = 0;
+  virtual void registerHandlerCallback(const std::string &id, const handlerCallback_t &callback) = 0;
   virtual void unregisterHandlerCallback(const std::string &id) = 0;
 
   virtual void setCurPrivLevel(const priv_lvl_t priv) { cur_priv = priv; }

--- a/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
+++ b/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
@@ -47,7 +47,7 @@ rpcserver_aggregator::registeredServers()
 
 void
 rpcserver_aggregator::registerConfigureCallback(const std::string &id,
-						const configureCallback_t callback)
+						const configureCallback_t &callback)
 {
   std::for_each(d_serverlist.begin(), d_serverlist.end(),
 		registerConfigureCallback_f<rpcmanager_base::rpcserver_booter_base_sptr, configureCallback_t>(id, callback));
@@ -61,7 +61,7 @@ rpcserver_aggregator::unregisterConfigureCallback(const std::string &id)
 }
 
 void
-rpcserver_aggregator::registerQueryCallback(const std::string &id, const queryCallback_t callback)
+rpcserver_aggregator::registerQueryCallback(const std::string &id, const queryCallback_t &callback)
 {
   std::for_each(d_serverlist.begin(), d_serverlist.end(),
 		registerQueryCallback_f<rpcmanager_base::rpcserver_booter_base_sptr, queryCallback_t>(id, callback));
@@ -78,7 +78,7 @@ rpcserver_aggregator::unregisterQueryCallback(const std::string &id)
 
 void
 rpcserver_aggregator::registerHandlerCallback(const std::string &id,
-                                              const handlerCallback_t callback)
+                                              const handlerCallback_t &callback)
 {
   std::for_each(d_serverlist.begin(), d_serverlist.end(),
 		registerHandlerCallback_f<rpcmanager_base::rpcserver_booter_base_sptr, handlerCallback_t>(id, callback));


### PR DESCRIPTION
The RPC aggregator and friends were taking callback objects passed by
value, and then internally called, again by value, constructors which
initialized reference fields to these parameters.

This has the effect of storing references to temporary objects. Chances
are, no-one is using that code, or compiler UB saved our collective
behinds.

In any case, we might need to more carefully dissect the RPC code. There
be dragons.