### PR TITLE
Fix compilation under MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,10 @@ endif(MSVC)
 
 if(WIN32)
 	add_definitions(-D_USE_MATH_DEFINES)
+
+	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+		add_definitions(-DMS_WIN64)
+	endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 endif(WIN32)
 
 # Record Compiler Info for record

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -26,7 +26,7 @@
 #include <volk/volk.h>
 #include <fftw3.h>
 
-#ifdef _MSC_VER //http://www.fftw.org/install/windows.html#DLLwisdom
+#ifdef _WIN32 //http://www.fftw.org/install/windows.html#DLLwisdom
 static void my_fftw_write_char(char c, void *f) { fputc(c, (FILE *) f); }
 #define fftw_export_wisdom_to_file(f) fftw_export_wisdom(my_fftw_write_char, (void*) (f))
 #define fftwf_export_wisdom_to_file(f) fftwf_export_wisdom(my_fftw_write_char, (void*) (f))
@@ -40,7 +40,7 @@ static int my_fftw_read_char(void *f) { return fgetc((FILE *) f); }
 #include <io.h>
 #define O_NOCTTY 0
 #define O_NONBLOCK 0
-#endif //_MSC_VER
+#endif //_WIN32
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This set of two commits fix the compilation of gnuradio-runtime and gr-fft under mingw-w64, on 32-bit and 64-bit versions of Windows.