### PR TITLE
BUGFIX: Removed persistent logging to console present in correlate_access_code_bb_impl.cc

### DIFF
--- a/gr-digital/lib/correlate_access_code_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_impl.cc
@@ -109,6 +109,8 @@ namespace gr {
 	// test for access code with up to threshold errors
 	new_flag = (nwrong <= d_threshold);
 
+/*
+	//Removed due to persistent logging to console of access code on each call to new_flag
 	if(new_flag) {
 	  GR_LOG_DEBUG(d_logger, boost::format("access code found: %llx") % d_access_code);
 	}
@@ -116,6 +118,7 @@ namespace gr {
 	  GR_LOG_DEBUG(d_logger, boost::format("%llx  ==>  %llx") % d_access_code % d_data_reg);
 	}
 
+*/
 	// shift in new data and new flag
 	d_data_reg = (d_data_reg << 1) | (in[i] & 0x1);
 	d_flag_reg = (d_flag_reg << 1);


### PR DESCRIPTION
Removed persistent logging to console present in packet decode as a result of new_flag calls in correlate_access_code_bb_impl.cc. Test flow: File source -> packet encoder -> dpsk mod -> dpsk demod -> packet decoder -> time sink.