### PR TITLE
	modified:   grc/blocks_tag_gate.xml

### DIFF
--- a/gr-blocks/grc/blocks_tag_gate.xml
+++ b/gr-blocks/grc/blocks_tag_gate.xml
@@ -4,7 +4,7 @@
   <key>blocks_tag_gate</key>
   <import>from gnuradio import blocks</import>
   <make>blocks.tag_gate($type.size * $vlen, $propagate_tags)
-self.$(id).set_single_key($single_key))</make>
+self.$(id).set_single_key($single_key)</make>
   <callback>self.$(id).set_single_key($single_key)</callback>
 
   <param>


### PR DESCRIPTION
BUGFIX: Removed extraneous ')' from grc/blocks_tag_gate.xml which was causing a syntax error in the generated Python code.