### PR TITLE
packet.py _packet_encoder_thread run() buffer clips payload data

### DIFF
--- a/gr-digital/lib/correlate_access_code_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_impl.cc
@@ -109,6 +109,8 @@ namespace gr {
 	// test for access code with up to threshold errors
 	new_flag = (nwrong <= d_threshold);
 
+/*
+	//Removed due to persistent logging to console of access code on each call to new_flag
 	if(new_flag) {
 	  GR_LOG_DEBUG(d_logger, boost::format("access code found: %llx") % d_access_code);
 	}
@@ -116,6 +118,7 @@ namespace gr {
 	  GR_LOG_DEBUG(d_logger, boost::format("%llx  ==>  %llx") % d_access_code % d_data_reg);
 	}
 
+*/
 	// shift in new data and new flag
 	d_data_reg = (d_data_reg << 1) | (in[i] & 0x1);
 	d_flag_reg = (d_flag_reg << 1);

--- a/gr-digital/python/grc_gnuradio/blks2/packet.py
+++ b/gr-digital/python/grc_gnuradio/blks2/packet.py
@@ -54,7 +54,6 @@ class _packet_encoder_thread(_threading.Thread):
         self.start()
 
     def run(self):
-        count = 0
         while self.keep_running:
             sample = ''  # residual sample
             msg = self._msgq.delete_head() #blocking read of message queue
@@ -64,12 +63,11 @@ class _packet_encoder_thread(_threading.Thread):
                 payload = sample[:self._payload_length]
                 sample = sample[self._payload_length:]
 
-                print "payload length: ", len(payload), " sample length: ", len(sample)
+                #check if sample has remaining data to transmit that is shorter than the payload length
                 if len(sample) > 0 and len(sample) < self._payload_length:
-                    print "adding padding"
+                    #arbitrary padding to satisfy send on next loop for payload less than _payload_length
                     padding = ('x' * (self._payload_length - len(sample)))
                     sample = sample + padding
-                    print "new sample length: ", len(sample)
 
                 self._send(payload)
 


### PR DESCRIPTION
The current run() function in the _packet_encoder_thread clips the end of samples who's sample length modulo payload_length is greater than zero. The hack applied here is to append padding characters to satisfy the payload_length and allow for the remaining sample to be flushed on the next cycle. Current testing transmits a .jpg using a flow as follows: File source -> packet encoder -> dpsk mod -> dpsk demod -> packet decoder -> file sink. The input file is 37,075 bytes in size. The output file is 36,864 bytes in size. A 211 byte difference still needs to be tracked and patched.