### PR TITLE
gr-digital: reformat file_source_impl for readability

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -51,143 +51,137 @@
 #endif
 
 namespace gr {
-  namespace blocks {
+	namespace blocks {
 
-    file_source::sptr file_source::make(size_t itemsize, const char *filename, bool repeat)
-    {
-      return gnuradio::get_initial_sptr
-	(new file_source_impl(itemsize, filename, repeat));
-    }
+file_source::sptr file_source::make(size_t itemsize, const char *filename, bool repeat)
+{
+	return gnuradio::get_initial_sptr(new file_source_impl(itemsize, filename, repeat));
+} //end make
 
-    file_source_impl::file_source_impl(size_t itemsize, const char *filename, bool repeat)
-      : sync_block("file_source",
-		      io_signature::make(0, 0, 0),
-		      io_signature::make(1, 1, itemsize)),
-	d_itemsize(itemsize), d_fp(0), d_new_fp(0), d_repeat(repeat),
-	d_updated(false)
-    {
-      open(filename, repeat);
-      do_update();
-    }
+file_source_impl::file_source_impl(size_t itemsize, const char *filename, bool repeat)
+	: sync_block("file_source",
+		io_signature::make(0, 0, 0),
+		io_signature::make(1, 1, itemsize)),
+		d_itemsize(itemsize), d_fp(0), d_new_fp(0),
+		d_repeat(repeat),
+		d_updated(false)
+{
+	open(filename, repeat);
+	do_update();
+} //end constructor
 
-    file_source_impl::~file_source_impl()
-    {
-      if(d_fp)
-        fclose ((FILE*)d_fp);
-      if(d_new_fp)
-        fclose ((FILE*)d_new_fp);
-    }
+file_source_impl::~file_source_impl()
+{
+	if(d_fp){
+		fclose ((FILE*)d_fp);
+	if(d_new_fp)
+		fclose ((FILE*)d_new_fp);
+} //end destructor
 
-    bool
-    file_source_impl::seek(long seek_point, int whence)
-    {
-      return fseek((FILE*)d_fp, seek_point *d_itemsize, whence) == 0;
-    }
+bool file_source_impl::seek(long seek_point, int whence)
+{
+	return fseek((FILE*)d_fp, seek_point *d_itemsize, whence) == 0;
+} //end seek
 
 
-    void
-    file_source_impl::open(const char *filename, bool repeat)
-    {
-      // obtain exclusive access for duration of this function
-      gr::thread::scoped_lock lock(fp_mutex);
+void file_source_impl::open(const char *filename, bool repeat)
+{
+	// obtain exclusive access for duration of this function
+	gr::thread::scoped_lock lock(fp_mutex);
 
-      int fd;
-
-      // we use "open" to use to the O_LARGEFILE flag
-      if((fd = ::open(filename, O_RDONLY | OUR_O_LARGEFILE | OUR_O_BINARY)) < 0) {
-	perror(filename);
-	throw std::runtime_error("can't open file");
-      }
-
-      if(d_new_fp) {
-	fclose(d_new_fp);
-	d_new_fp = 0;
-      }
-
-      if((d_new_fp = fdopen (fd, "rb")) == NULL) {
-	perror(filename);
-	::close(fd);	// don't leak file descriptor if fdopen fails
-	throw std::runtime_error("can't open file");
-      }
-
-      d_updated = true;
-      d_repeat = repeat;
-    }
-
-    void
-    file_source_impl::close()
-    {
-      // obtain exclusive access for duration of this function
-      gr::thread::scoped_lock lock(fp_mutex);
-
-      if(d_new_fp != NULL) {
-	fclose(d_new_fp);
-	d_new_fp = NULL;
-      }
-      d_updated = true;
-    }
-
-    void
-    file_source_impl::do_update()
-    {
-      if(d_updated) {
-	gr::thread::scoped_lock lock(fp_mutex); // hold while in scope
-
-	if(d_fp)
-	  fclose(d_fp);
-
-	d_fp = d_new_fp;    // install new file pointer
-	d_new_fp = 0;
-	d_updated = false;
-      }
-    }
-
-    int
-    file_source_impl::work(int noutput_items,
-			   gr_vector_const_void_star &input_items,
-			   gr_vector_void_star &output_items)
-    {
-      char *o = (char*)output_items[0];
-      int i;
-      int size = noutput_items;
-
-      do_update();       // update d_fp is reqd
-      if(d_fp == NULL)
-	throw std::runtime_error("work with file not open");
-
-      gr::thread::scoped_lock lock(fp_mutex); // hold for the rest of this function
-      while(size) {
-	i = fread(o, d_itemsize, size, (FILE*)d_fp);
-
-	size -= i;
-	o += i * d_itemsize;
-
-	if(size == 0)		// done
-	  break;
-
-	if(i > 0)			// short read, try again
-	  continue;
-
-	// We got a zero from fread.  This is either EOF or error.  In
-	// any event, if we're in repeat mode, seek back to the beginning
-	// of the file and try again, else break
-	if(!d_repeat)
-	  break;
-
-	if(fseek ((FILE *) d_fp, 0, SEEK_SET) == -1) {
-	  fprintf(stderr, "[%s] fseek failed\n", __FILE__);
-	  exit(-1);
+	int fd;
+	// we use "open" to use to the O_LARGEFILE flag
+	if((fd = ::open(filename, O_RDONLY | OUR_O_LARGEFILE | OUR_O_BINARY)) < 0) {
+		perror(filename);
+		throw std::runtime_error("can't open file");
 	}
-      }
 
-      if(size > 0) {	     		// EOF or error
-	if(size == noutput_items)       // we didn't read anything; say we're done
-	  return -1;
-	return noutput_items - size;	// else return partial result
-      }
+	if(d_new_fp) {
+		fclose(d_new_fp);
+		d_new_fp = 0;
+	}
 
-      return noutput_items;
-    }
+	if((d_new_fp = fdopen (fd, "rb")) == NULL) {
+		perror(filename);
+		::close(fd);	// don't leak file descriptor if fdopen fails
+		throw std::runtime_error("can't open file");
+	}
 
-  } /* namespace blocks */
+	d_updated = true;
+	d_repeat = repeat;
+} //end open
+
+void file_source_impl::close()
+{
+	// obtain exclusive access for duration of this function
+	gr::thread::scoped_lock lock(fp_mutex);
+
+	if(d_new_fp != NULL) {
+		fclose(d_new_fp);
+		d_new_fp = NULL;
+	}
+	d_updated = true;
+} //end close
+
+void file_source_impl::do_update()
+{
+	if(d_updated) {
+		gr::thread::scoped_lock lock(fp_mutex); // hold while in scope
+
+		if(d_fp)
+			fclose(d_fp);
+
+		d_fp = d_new_fp;    // install new file pointer
+		d_new_fp = 0;
+		d_updated = false;
+	}
+} //end do_update
+
+int file_source_impl::work(int noutput_items,
+		gr_vector_const_void_star &input_items,
+		gr_vector_void_star &output_items)
+{
+	char *o = (char*)output_items[0];
+	int i;
+	int size = noutput_items;
+	do_update();       // update d_fp is read
+
+	if(d_fp == NULL)
+		throw std::runtime_error("work with file not open");
+
+	gr::thread::scoped_lock lock(fp_mutex); // hold for the rest of this function
+	while(size) {
+		i = fread(o, d_itemsize, size, (FILE*)d_fp);
+		size -= i;
+		o += i * d_itemsize;
+
+		if(size == 0)		// done
+			break;
+
+		if(i > 0)			// short read, try again
+			continue;
+
+		// We got a zero from fread.  This is either EOF or error.  In
+		// any event, if we're in repeat mode, seek back to the beginning
+		// of the file and try again, else break
+		if(!d_repeat)
+			break;
+
+		if(fseek ((FILE *) d_fp, 0, SEEK_SET) == -1) {
+			fprintf(stderr, "[%s] fseek failed\n", __FILE__);
+			exit(-1);
+		}
+	} //end while loop
+
+	if(size > 0) {	     		// EOF or error
+		if(size == noutput_items)       // we didn't read anything; say we're done
+			return -1;
+
+		return noutput_items - size;	// else return partial result
+	}
+
+	return noutput_items;
+} // end work
+
+	} /* namespace blocks */
 } /* namespace gr */


### PR DESCRIPTION
Modify to eliminate alternating tab and spaces which makes readability difficult depending on the dev editor. Add end of function comments.