### PR TITLE
gr-digital: packet.py _packet_encoder_thread run() buffer clips payload data

### DIFF
--- a/gr-digital/python/grc_gnuradio/blks2/packet.py
+++ b/gr-digital/python/grc_gnuradio/blks2/packet.py
@@ -54,13 +54,21 @@ class _packet_encoder_thread(_threading.Thread):
         self.start()
 
     def run(self):
-        sample = '' #residual sample
         while self.keep_running:
+            sample = ''  # residual sample
             msg = self._msgq.delete_head() #blocking read of message queue
             sample = sample + msg.to_string() #get the body of the msg as a string
+
             while len(sample) >= self._payload_length:
                 payload = sample[:self._payload_length]
                 sample = sample[self._payload_length:]
+
+                #check if sample has remaining data to transmit that is shorter than the payload length
+                if len(sample) > 0 and len(sample) < self._payload_length:
+                    #arbitrary padding to satisfy send on next loop for payload less than _payload_length
+                    padding = ('x' * (self._payload_length - len(sample)))
+                    sample = sample + padding
+
                 self._send(payload)
 
 class packet_encoder(gr.hier_block2):
@@ -106,6 +114,7 @@ class packet_encoder(gr.hier_block2):
         )
         #connect
         self.connect(msg_source, self)
+
 
         print "Warning: the blks2.packet_encoder block is deprecated."
 
@@ -197,9 +206,10 @@ class packet_mod_base(gr.hier_block2):
     """
 
     def __init__(self, packet_source=None, payload_length=0):
+
         if not payload_length: #get payload length
             payload_length = DEFAULT_PAYLOAD_LEN
-        if payload_length%self._item_size_in != 0:  #verify that packet length is a multiple of the stream size
+        if (payload_length % self._item_size_in) != 0:  #verify that packet length is a multiple of the stream size
             raise ValueError, 'The payload length: "%d" is not a mutiple of the stream size: "%d".'%(payload_length, self._item_size_in)
         #initialize hier2
         gr.hier_block2.__init__(


### PR DESCRIPTION
This is a repull of #1360 to base the commit off maint. The current run() function in the _packet_encoder_thread clips the end of samples who's sample length modulo payload_length is greater than zero. The hack applied here is to append padding characters to satisfy the payload_length and allow for the remaining sample to be flushed on the next cycle. Current testing transmits a .jpg using a flow as follows: File source -> packet encoder -> dpsk mod -> dpsk demod -> packet decoder -> file sink. The input file is 37,075 bytes in size. The output file is 36,864 bytes in size. A 211 byte difference still exists from the file source / sink and is noted in #1362 . 