### PR TITLE
gr-dtv: optimize bbscrambler

### DIFF
--- a/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.cc
+++ b/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.cc
@@ -268,6 +268,8 @@ namespace gr {
           sr |= 0x4000;
         }
       }
+      bb_randomize64 = (uint64_t*)&bb_randomise[0];
+
     }
 
     int
@@ -275,12 +277,12 @@ namespace gr {
                           gr_vector_const_void_star &input_items,
                           gr_vector_void_star &output_items)
     {
-      const unsigned char *in = (const unsigned char *) input_items[0];
-      unsigned char *out = (unsigned char *) output_items[0];
+      const uint64_t *in = (const uint64_t *) input_items[0];
+      uint64_t *out = (uint64_t *) output_items[0];
 
       for (int i = 0; i < noutput_items; i += kbch) {
-        for (int j = 0; j < (int)kbch; ++j) {
-          out[i + j] = in[i + j] ^ bb_randomise[j];
+        for (int j = 0; j < kbch/8; ++j) {
+          *out++ = *in++ ^ bb_randomize64[j];
         }
       }
 

--- a/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.cc
+++ b/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.cc
@@ -277,6 +277,7 @@ namespace gr {
                           gr_vector_const_void_star &input_items,
                           gr_vector_void_star &output_items)
     {
+      // noutput_items is multiple of kbch and kbch is always divisible by 8
       const uint64_t *in = (const uint64_t *) input_items[0];
       uint64_t *out = (uint64_t *) output_items[0];
 

--- a/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.h
@@ -30,8 +30,9 @@ namespace gr {
     class dvb_bbscrambler_bb_impl : public dvb_bbscrambler_bb
     {
      private:
-      unsigned int kbch;
+      int kbch;
       unsigned char bb_randomise[FRAME_SIZE_NORMAL];
+      uint64_t* bb_randomize64;
       void init_bb_randomiser(void);
 
      public:


### PR DESCRIPTION
Because kbch is always a multiple of 8, we can xor 8 bytes at once in the scrambler by casting to an uint64_t. This gives a small speed improvement.