### PR TITLE
gr-dtv: Change the layout of the ldpc table

### DIFF
--- a/gr-dtv/lib/dvb/dvb_ldpc_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_ldpc_bb_impl.h
@@ -23,12 +23,8 @@
 
 #include <gnuradio/dtv/dvb_ldpc_bb.h>
 #include "dvb_defines.h"
+#include <boost/smart_ptr.hpp>
 
-typedef struct{
-    int table_length;
-    int d[LDPC_ENCODE_TABLE_LENGTH];
-    int p[LDPC_ENCODE_TABLE_LENGTH];
-}ldpc_encode_table;
 
 namespace gr {
   namespace dtv {
@@ -50,7 +46,8 @@ namespace gr {
       unsigned char puncturing_buffer[FRAME_SIZE_NORMAL];
       unsigned char shortening_buffer[FRAME_SIZE_NORMAL];
       void ldpc_lookup_generate(void);
-      ldpc_encode_table ldpc_encode;
+
+      int** ldpc_lut;
 
       const static int ldpc_tab_1_4N[45][13];
       const static int ldpc_tab_1_3N[60][13];


### PR DESCRIPTION
Previous behaviour with two tables:
ldpc_encode.d has all data bits
    `[0,  0,   0,    0,  1,   1,  1,   1 ...]`
ldpc_encode.p has the corresponding parity bits
    `[40, 333, 4342, 11, 231, 32, 555, 2332, ...]`
the general work function iterates over both and xors each data bit in the corresponding parity bit position.

The new algorithm uses a two-dimensional array
```
[ number of entries, entry1, entry2, ...
 [5,                 4343, 42, 2342, 42342, 244], // parity bit 0
 [5,                 22, 4455, 6456, 6345, 2424], // parity bit 1
 ...
]
```

This makes the general work function a bit simpler and apparently improves the CPU caching behaviour
