### PR TITLE
fix: fixed a performance bug in buffer::get_tags_in_range.

### DIFF
--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -346,7 +346,7 @@ namespace gr {
   {
     gr::thread::scoped_lock guard(*mutex());
 
-    v.resize(0);
+    v.clear();
     std::multimap<uint64_t,tag_t>::iterator itr = d_buffer->get_tags_lower_bound(std::min(abs_start, abs_start - d_attr_delay));
     std::multimap<uint64_t,tag_t>::iterator itr_end = d_buffer->get_tags_upper_bound(std::min(abs_end, abs_end - d_attr_delay));
 


### PR DESCRIPTION
buffer::get_tags_in_range called v.resize(0) instead of v.clear() to clear out the input vector.  This causes needless memory allocation of the default value for the second argument to resize.  In applications that make heavy use of tags, this can cause significant performance problems as get_tags_in_range performs an extra allocation and deallocation.