### PR TITLE
fcd: add CoreFoundation library in Darwin only

### DIFF
--- a/gr-fcd/lib/CMakeLists.txt
+++ b/gr-fcd/lib/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   FIND_LIBRARY(IOKIT_LIBRARY IOKit)
   list(APPEND fcd_libs ${IOKIT_LIBRARY})
+  FIND_LIBRARY(CF_LIBRARY CoreFoundation)
+  list(APPEND fcd_libs ${CF_LIBRARY})
 elseif (NOT WIN32)
   list(APPEND fcd_libs
     ${LIBUSB_LIBRARIES}


### PR DESCRIPTION
subject says it all. simple tweak. the MacOS FCD interface uses CoreFoundation functions, so link to the library. This extra linkage is technically only required on non-Apple compilers (e.g., GCC), but it won't hurt to have it in place for Apple compilers too.