### PR TITLE
grc: Terminate the process instead of Killing with Terminate button (F7)

### DIFF
--- a/grc/gui/ActionHandler.py
+++ b/grc/gui/ActionHandler.py
@@ -626,9 +626,9 @@ class ActionHandler:
         elif action == Actions.FLOW_GRAPH_KILL:
             if page.get_proc():
                 try:
-                    page.get_proc().kill()
+                    page.term_proc()
                 except:
-                    print "could not kill process: %d" % page.get_proc().pid
+                    print "could not terminate process: %d" % page.get_proc().pid
         elif action == Actions.PAGE_CHANGE:  # pass and run the global actions
             pass
         elif action == Actions.RELOAD_BLOCKS:

--- a/grc/gui/NotebookPage.py
+++ b/grc/gui/NotebookPage.py
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 import pygtk
 pygtk.require('2.0')
 import gtk
+import gobject
 import Actions
 from StateCache import StateCache
 from Constants import MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT
@@ -151,6 +152,30 @@ class NotebookPage(gtk.HBox):
             process: the new subprocess
         """
         self.process = process
+
+    def term_proc(self):
+        """
+        Terminate the subprocess object
+
+        Add a callback to kill the process
+        after 2 seconds if not already terminated
+        """
+        def kill(process):
+            """
+            Kill process if not already terminated
+
+            Called by gobject.timeout_add
+
+            Returns:
+                False to stop timeout_add periodic calls
+            """
+            is_terminated = process.poll()
+            if is_terminated is None:
+                process.kill()
+            return False
+
+        self.get_proc().terminate()
+        gobject.timeout_add(2000, kill, self.get_proc())
 
     def get_flow_graph(self):
         """


### PR DESCRIPTION
Currently, GRC terminate button (F7) sends SIGKILL to the ongoing Python program.

This PR is an attempt to send SIGTERM signal in order to allow cleanup before termination. Also, sends SIGKILL signal to the process after 4 seconds if Python program couldn't terminate with SIGTERM.

Since, many hardware takes around 2 seconds to disconnect, 4 seconds should be more than enough for cleaning up.