### PR TITLE
digital: Add expected TED gain for computing symbol sync loop gains

### DIFF
--- a/gr-digital/examples/demod/symbol_sync_test_complex.grc
+++ b/gr-digital/examples/demod/symbol_sync_test_complex.grc
@@ -239,7 +239,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(2304, 572)</value>
+      <value>(2288, 588)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -247,11 +247,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>gain_mu</value>
+      <value>integral_gain</value>
     </param>
     <param>
       <key>value</key>
-      <value>2.0*math.exp(-zeta*omega_n_norm)*math.sinh(zeta*omega_n_norm)</value>
+      <value>(2.0-proportional_gain-2.0*math.exp(-zeta*omega_n_norm)*(math.cosh(omega_d_norm) if zeta &gt; 1.0 else math.cos(omega_d_norm)))/ted_gain</value>
     </param>
   </block>
   <block>
@@ -262,7 +262,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>"%8.6f" % gain_mu</value>
+      <value>"%8.6f" % integral_gain</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -274,77 +274,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(2808, 572)</value>
-    </param>
-    <param>
-      <key>gui_hint</key>
-      <value>1,2,1,1</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>gain_mu_label</value>
-    </param>
-    <param>
-      <key>label</key>
-      <value>Gain Mu</value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>string</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(2304, 636)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>gain_omega</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>2.0-gain_mu-2.0*math.exp(-zeta*omega_n_norm)*(math.cosh(omega_d_norm) if zeta &gt; 1.0 else math.cos(omega_d_norm))</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_qtgui_label</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"%8.6f" % gain_omega</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>formatter</key>
-      <value>None</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(2640, 572)</value>
+      <value>(2760, 484)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -356,11 +286,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>gain_omega_label</value>
+      <value>integral_gain_label</value>
     </param>
     <param>
       <key>label</key>
-      <value>Gain Omega</value>
+      <value>Integral Gain</value>
     </param>
     <param>
       <key>type</key>
@@ -379,7 +309,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(2304, 508)</value>
+      <value>(2288, 460)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -402,7 +332,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>0.54</value>
+      <value>0.25</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -531,6 +461,76 @@
     </param>
     <param>
       <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(2288, 524)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>proportional_gain</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>2.0/ted_gain*math.exp(-zeta*omega_n_norm)*math.sinh(zeta*omega_n_norm)</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_qtgui_label</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>"%8.6f" % proportional_gain</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>formatter</key>
+      <value>None</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(2760, 564)</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value>1,2,1,1</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>proportional_gain_label</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>Proportional Gain</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>string</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
       <value>True</value>
     </param>
     <param>
@@ -558,7 +558,70 @@
     </param>
     <param>
       <key>value</key>
-      <value>1.0/math.sqrt(2.0)*0+1.3</value>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(2608, 568)</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value>1,0,1,1</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>ted_gain</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>Expected TED Gain</value>
+    </param>
+    <param>
+      <key>min_len</key>
+      <value>200</value>
+    </param>
+    <param>
+      <key>orient</key>
+      <value>Qt.Horizontal</value>
+    </param>
+    <param>
+      <key>start</key>
+      <value>0.1</value>
+    </param>
+    <param>
+      <key>step</key>
+      <value>0.1</value>
+    </param>
+    <param>
+      <key>stop</key>
+      <value>5.0</value>
+    </param>
+    <param>
+      <key>rangeType</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>widget</key>
+      <value>counter_slider</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_qtgui_range</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>1.0</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -837,7 +900,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(2752, 320)</value>
+      <value>(2752, 328)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1707,12 +1770,16 @@
       <value>True</value>
     </param>
     <param>
+      <key>ted_gain</key>
+      <value>1.0</value>
+    </param>
+    <param>
       <key>nfilters</key>
       <value>128</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(2376, 296)</value>
+      <value>(2376, 292)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/gr-digital/examples/demod/symbol_sync_test_float.grc
+++ b/gr-digital/examples/demod/symbol_sync_test_float.grc
@@ -239,76 +239,6 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1800, 484)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>gain_mu</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>2.0*math.exp(-zeta*omega_n_norm)*math.sinh(zeta*omega_n_norm)</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_qtgui_label</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"%8.6f" % gain_mu</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>formatter</key>
-      <value>None</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(2168, 500)</value>
-    </param>
-    <param>
-      <key>gui_hint</key>
-      <value>1,2,1,1</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>gain_mu_label</value>
-    </param>
-    <param>
-      <key>label</key>
-      <value>Gain Mu</value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>string</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
       <value>(1800, 548)</value>
     </param>
     <param>
@@ -317,11 +247,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>gain_omega</value>
+      <value>integral_gain</value>
     </param>
     <param>
       <key>value</key>
-      <value>2.0-gain_mu-2.0*math.exp(-zeta*omega_n_norm)*(math.cosh(omega_d_norm) if zeta &gt; 1.0 else math.cos(omega_d_norm))</value>
+      <value>(2.0-proportional_gain-2.0*math.exp(-zeta*omega_n_norm)*(math.cosh(omega_d_norm) if zeta &gt; 1.0 else math.cos(omega_d_norm)))/ted_gain</value>
     </param>
   </block>
   <block>
@@ -332,7 +262,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>"%8.6f" % gain_omega</value>
+      <value>"%8.6f" % integral_gain</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -344,7 +274,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(2168, 420)</value>
+      <value>(2296, 420)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -356,11 +286,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>gain_omega_label</value>
+      <value>integral_gain_label</value>
     </param>
     <param>
       <key>label</key>
-      <value>Gain Omega</value>
+      <value>Integral Gain</value>
     </param>
     <param>
       <key>type</key>
@@ -402,7 +332,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>0.58</value>
+      <value>0.07</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -531,6 +461,76 @@
     </param>
     <param>
       <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1800, 484)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>proportional_gain</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>2.0/ted_gain*math.exp(-zeta*omega_n_norm)*math.sinh(zeta*omega_n_norm)</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_qtgui_label</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>"%8.6f" % proportional_gain</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>formatter</key>
+      <value>None</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(2296, 500)</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value>1,2,1,1</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>proportional_gain_label</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>Proportional Gain</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>string</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
       <value>True</value>
     </param>
     <param>
@@ -558,7 +558,70 @@
     </param>
     <param>
       <key>value</key>
-      <value>1.0/math.sqrt(2.0)*0+1.5</value>
+      <value>1.0</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(2120, 536)</value>
+    </param>
+    <param>
+      <key>gui_hint</key>
+      <value>1,0,1,1</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>ted_gain</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>Expected TED Gain</value>
+    </param>
+    <param>
+      <key>min_len</key>
+      <value>200</value>
+    </param>
+    <param>
+      <key>orient</key>
+      <value>Qt.Horizontal</value>
+    </param>
+    <param>
+      <key>start</key>
+      <value>0.1</value>
+    </param>
+    <param>
+      <key>step</key>
+      <value>0.1</value>
+    </param>
+    <param>
+      <key>stop</key>
+      <value>5.0</value>
+    </param>
+    <param>
+      <key>rangeType</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>widget</key>
+      <value>counter_slider</value>
+    </param>
+  </block>
+  <block>
+    <key>variable_qtgui_range</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>1.0</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -1527,12 +1590,16 @@
       <value>True</value>
     </param>
     <param>
+      <key>ted_gain</key>
+      <value>1.0</value>
+    </param>
+    <param>
       <key>nfilters</key>
       <value>128</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1944, 280)</value>
+      <value>(1944, 276)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/gr-digital/grc/digital_symbol_sync_xx.xml
+++ b/gr-digital/grc/digital_symbol_sync_xx.xml
@@ -26,10 +26,11 @@
     <category>[Core]/Synchronizers</category>
     <import>from gnuradio import digital</import>
     <import>from gnuradio import filter</import>
-    <make>digital.symbol_sync_$(type)($ted_type, $sps, $loop_bw, $damping, $max_dev, $osps, $constellation, $resamp_type, $nfilters, $pfb_mf_taps)</make>
+    <make>digital.symbol_sync_$(type)($ted_type, $sps, $loop_bw, $damping, $ted_gain, $max_dev, $osps, $constellation, $resamp_type, $nfilters, $pfb_mf_taps)</make>
 
     <callback>set_loop_bandwidth($loop_bw)</callback>
     <callback>set_damping_factor($damping)</callback>
+    <callback>set_ted_gain($ted_gain)</callback>
 
     <param>
         <name>I/O Type</name>
@@ -112,6 +113,12 @@
         <type>real</type>
     </param>
     <param>
+        <name>Expected TED Gain</name>
+        <key>ted_gain</key>
+        <value>1.0</value>
+        <type>real</type>
+    </param>
+    <param>
         <name>Loop Bandwidth</name>
         <key>loop_bw</key>
         <value>0.045</value>
@@ -120,7 +127,7 @@
     <param>
         <name>Damping Factor</name>
         <key>damping</key>
-        <value>1.0/math.sqrt(2.0)</value>
+        <value>1.0</value>
         <type>real</type>
     </param>
     <param>

--- a/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
@@ -97,6 +97,15 @@ namespace gr {
        * Damping = 1.0f is a critically-damped loop.
        * Damping > 1.0f is an over-damped loop.
        *
+       * \param ted_gain
+       * Expected gain of the timing error detector, given the TED in use
+       * and the anticipated input amplitude, pulse shape, and Es/No.
+       * This value is the slope of the TED's S-curve at timing offset tau = 0.
+       * This value is normally computed by the user analytically or by
+       * simulation in a tool outside of GNURadio.
+       * This value must be correct for the loop filter gains to be computed
+       * properly from the desired input loop bandwidth and damping factor.
+       *
        * \param max_deviation
        * Maximum absolute deviation of the average clock period estimate
        * from the user specified nominal clock period in samples per symbol.
@@ -126,7 +135,8 @@ namespace gr {
       static sptr make(enum ted_type detector_type,
                        float sps,
                        float loop_bw,
-                       float damping_factor = 2.0f,
+                       float damping_factor = 1.0f,
+                       float ted_gain = 1.0f,
                        float max_deviation = 1.5f,
                        int osps = 1,
                        constellation_sptr slicer = constellation_sptr(),
@@ -155,6 +165,15 @@ namespace gr {
        * set gains, the value returned by this method will be inaccurate/stale.
        */
       virtual float damping_factor() const = 0;
+
+      /*!
+       * \brief Returns the user provided expected gain of the Timing Error
+       * Detector.
+       *
+       * \details
+       * See the documenation for set_ted_gain() for more details.
+       */
+      virtual float ted_gain() const = 0;
 
       /*!
        * \brief Returns the PI filter proportional gain, alpha.
@@ -222,6 +241,25 @@ namespace gr {
        * \param zeta    loop damping factor
        */
       virtual void set_damping_factor (float zeta) = 0;
+
+      /*!
+       * \brief Set the expected gain of the Timing Error Detector.
+       *
+       * \details
+       * Sets the expected gain of the timing error detector, given the TED in
+       * use and the anticipated input amplitude, pulse shape, and Es/No.
+       * This value is the slope of the TED's S-curve at timing offset tau = 0.
+       * This value is normally computed by the user analytically or by
+       * simulation in a tool outside of GNURadio.
+       * This value must be correct for the loop filter gains to be computed
+       * properly from the desired input loop bandwidth and damping factor.
+       *
+       * When a new ted_gain is set, the gains, alpha and beta,
+       * of the loop are automatcally recalculated.
+       *
+       * \param ted_gain    expected gain of the timing error detector
+       */
+      virtual void set_ted_gain (float ted_gain) = 0;
 
       /*!
        * \brief Set the PI filter proportional gain, alpha.

--- a/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
@@ -97,6 +97,15 @@ namespace gr {
        * Damping = 1.0f is a critically-damped loop.
        * Damping > 1.0f is an over-damped loop.
        *
+       * \param ted_gain
+       * Expected gain of the timing error detector, given the TED in use
+       * and the anticipated input amplitude, pulse shape, and Es/No.
+       * This value is the slope of the TED's S-curve at timing offset tau = 0.
+       * This value is normally computed by the user analytically or by
+       * simulation in a tool outside of GNURadio.
+       * This value must be correct for the loop filter gains to be computed
+       * properly from the desired input loop bandwidth and damping factor.
+       *
        * \param max_deviation
        * Maximum absolute deviation of the average clock period estimate
        * from the user specified nominal clock period in samples per symbol.
@@ -126,7 +135,8 @@ namespace gr {
       static sptr make(enum ted_type detector_type,
                        float sps,
                        float loop_bw,
-                       float damping_factor = 2.0f,
+                       float damping_factor = 1.0f,
+                       float ted_gain = 1.0f,
                        float max_deviation = 1.5f,
                        int osps = 1,
                        constellation_sptr slicer = constellation_sptr(),
@@ -155,6 +165,15 @@ namespace gr {
        * set gains, the value returned by this method will be inaccurate/stale.
        */
       virtual float damping_factor() const = 0;
+
+      /*!
+       * \brief Returns the user provided expected gain of the Timing Error
+       * Detector.
+       *
+       * \details
+       * See the documenation for set_ted_gain() for more details.
+       */
+      virtual float ted_gain() const = 0;
 
       /*!
        * \brief Returns the PI filter proportional gain, alpha.
@@ -222,6 +241,25 @@ namespace gr {
        * \param zeta    loop damping factor
        */
       virtual void set_damping_factor (float zeta) = 0;
+
+      /*!
+       * \brief Set the expected gain of the Timing Error Detector.
+       *
+       * \details
+       * Sets the expected gain of the timing error detector, given the TED in
+       * use and the anticipated input amplitude, pulse shape, and Es/No.
+       * This value is the slope of the TED's S-curve at timing offset tau = 0.
+       * This value is normally computed by the user analytically or by
+       * simulation in a tool outside of GNURadio.
+       * This value must be correct for the loop filter gains to be computed
+       * properly from the desired input loop bandwidth and damping factor.
+       *
+       * When a new ted_gain is set, the gains, alpha and beta,
+       * of the loop are automatcally recalculated.
+       *
+       * \param ted_gain    expected gain of the timing error detector
+       */
+      virtual void set_ted_gain (float ted_gain) = 0;
 
       /*!
        * \brief Set the PI filter proportional gain, alpha.

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -38,6 +38,7 @@ namespace gr {
                          float sps,
                          float loop_bw,
                          float damping_factor,
+                         float ted_gain,
                          float max_deviation,
                          int osps,
                          constellation_sptr slicer,
@@ -50,6 +51,7 @@ namespace gr {
                                  sps,
                                  loop_bw,
                                  damping_factor,
+                                 ted_gain,
                                  max_deviation,
                                  osps,
                                  slicer,
@@ -63,6 +65,7 @@ namespace gr {
                            float sps,
                            float loop_bw,
                            float damping_factor,
+                           float ted_gain,
                            float max_deviation,
                            int osps,
                            constellation_sptr slicer,
@@ -146,7 +149,8 @@ namespace gr {
                                         sps + max_deviation,
                                         sps - max_deviation,
                                         sps,
-                                        damping_factor);
+                                        damping_factor,
+                                        ted_gain);
 
       // Timing Error Detector
       d_ted->sync_reset();

--- a/gr-digital/lib/symbol_sync_cc_impl.h
+++ b/gr-digital/lib/symbol_sync_cc_impl.h
@@ -38,6 +38,7 @@ namespace gr {
                           float sps,
                           float loop_bw,
                           float damping_factor,
+                          float ted_gain,
                           float max_deviation,
                           int osps,
                           constellation_sptr slicer,
@@ -55,6 +56,7 @@ namespace gr {
       // Symbol Clock Tracking and Estimation
       float loop_bandwidth() const { return d_clock->get_loop_bandwidth(); }
       float damping_factor() const { return d_clock->get_damping_factor(); }
+      float ted_gain() const { return d_clock->get_ted_gain(); }
       float alpha() const { return d_clock->get_alpha(); }
       float beta() const { return d_clock->get_beta(); }
 
@@ -64,6 +66,7 @@ namespace gr {
       void set_damping_factor (float zeta) {
           d_clock->set_damping_factor(zeta);
       }
+      void set_ted_gain (float ted_gain) { d_clock->set_ted_gain(ted_gain); }
       void set_alpha (float alpha) { d_clock->set_alpha(alpha); }
       void set_beta (float beta) { d_clock->set_beta(beta); }
 

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -38,6 +38,7 @@ namespace gr {
                          float sps,
                          float loop_bw,
                          float damping_factor,
+                         float ted_gain,
                          float max_deviation,
                          int osps,
                          constellation_sptr slicer,
@@ -50,6 +51,7 @@ namespace gr {
                                  sps,
                                  loop_bw,
                                  damping_factor,
+                                 ted_gain,
                                  max_deviation,
                                  osps,
                                  slicer,
@@ -63,6 +65,7 @@ namespace gr {
                            float sps,
                            float loop_bw,
                            float damping_factor,
+                           float ted_gain,
                            float max_deviation,
                            int osps,
                            constellation_sptr slicer,
@@ -146,7 +149,8 @@ namespace gr {
                                         sps + max_deviation,
                                         sps - max_deviation,
                                         sps,
-                                        damping_factor);
+                                        damping_factor,
+                                        ted_gain);
 
       // Timing Error Detector
       d_ted->sync_reset();

--- a/gr-digital/lib/symbol_sync_ff_impl.h
+++ b/gr-digital/lib/symbol_sync_ff_impl.h
@@ -38,6 +38,7 @@ namespace gr {
                           float sps,
                           float loop_bw,
                           float damping_factor,
+                          float ted_gain,
                           float max_deviation,
                           int osps,
                           constellation_sptr slicer,
@@ -55,6 +56,7 @@ namespace gr {
       // Symbol Clock Tracking and Estimation
       float loop_bandwidth() const { return d_clock->get_loop_bandwidth(); }
       float damping_factor() const { return d_clock->get_damping_factor(); }
+      float ted_gain() const { return d_clock->get_ted_gain(); }
       float alpha() const { return d_clock->get_alpha(); }
       float beta() const { return d_clock->get_beta(); }
 
@@ -64,6 +66,7 @@ namespace gr {
       void set_damping_factor (float zeta) {
           d_clock->set_damping_factor(zeta);
       }
+      void set_ted_gain (float ted_gain) { d_clock->set_ted_gain(ted_gain); }
       void set_alpha (float alpha) { d_clock->set_alpha(alpha); }
       void set_beta (float beta) { d_clock->set_beta(beta); }
 


### PR DESCRIPTION
The computation of proportional (alpha) and intergal (beta) loop
gains in the symbol synchronizer blocks neglected to account for
the timing error detector gain.  Add expected timing error
detector gain as a user configurable parameter.