### PR TITLE
block python gateway: add WORK_CALLED_PRODUCE/_DONE proxy

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -41,6 +41,11 @@ namespace gr {
     GR_BLOCK_GW_WORK_INTERP,
   };
 
+  //! Magic return values from general_work, \ref gr::block::WORK_CALLED_PRODUCE
+  enum block_gw_work_return_type{
+    WORK_CALLED_PRODUCE = -2,
+    WORK_DONE = -1
+  };
   enum tag_propagation_policy_t {
     TPP_DONT = 0,
     TPP_ALL_TO_ALL = 1,


### PR DESCRIPTION
so that we can then have

    def general_work(self, input_items, output_items):
        …
        self.produce(0,2)
        self.produce(1,1)
        return gr.WORK_CALLED_PRODUCE

Includes a unit test.

We need more unit tests. There wasn't a single general block test in
qa_block_gateway.py.

Ref: 
http://lists.gnu.org/archive/html/discuss-gnuradio/2017-07/msg00338.html