### PR TITLE
grc: fix attr-style enum param lookup in Cheeteh

### DIFF
--- a/grc/core/Param.py
+++ b/grc/core/Param.py
@@ -135,6 +135,14 @@ class TemplateArg(object):
     def __getitem__(self, item):
         return str(self._param.get_opt(item)) if self._param.is_enum() else NotImplemented
 
+    def __getattr__(self, item):
+        if not self._param.is_enum():
+            raise AttributeError()
+        try:
+            return str(self._param.get_opt(item))
+        except KeyError:
+            raise AttributeError()
+
     def __str__(self):
         return str(self._param.to_code())
 


### PR DESCRIPTION
This apparently fixes issue @guruofquality was having with enum opts in cheetah templates.

Reported here:  https://github.com/gnuradio/gnuradio/commit/2708f33f4531b33c212c60c3cc1fc3d3a92b5ae1#commitcomment-23327018

I can't seem to reproduce this: current maint branch, same Python version (I guess same Cheetah version too?)
I tried a simple fg with a bunch of null sinks/sources that use any vary this kind of parameter, always get correct string interpolation. 

I don't mind merging this anyway, I am curious though, why this works for me. @guruofquality, do you maybe have an example for me?