### PR TITLE
grc: Fixing GRC not saving the options block's ID

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -386,7 +386,7 @@ class Block(Element):
             data['id'] = self.key
         data['parameters'] = collections.OrderedDict(sorted(
             (param_id, param.value) for param_id, param in self.params.items()
-            if param_id != 'id'
+            if (param_id != 'id' or self.key == 'options')
         ))
         data['states'] = collections.OrderedDict(sorted(self.states.items()))
         return data


### PR DESCRIPTION
Steps to reproduce:

Launch GRC, create a flowgraph with an ID in the options block. Save it, close it and open it again. The ID is gone. You can also see in the .grc file that there is no ID.

This change fixes the problem, but I'm not 110% confident that this is the appropriate fix. 
Please advise :)