### PR TITLE
logpwrfft did `ref_scale/2`, which led to integer div in Py2

### DIFF
--- a/gr-fft/python/fft/logpwrfft.py
+++ b/gr-fft/python/fft/logpwrfft.py
@@ -69,8 +69,8 @@ class _logpwrfft_base(gr.hier_block2):
         self._avg = filter.single_pole_iir_filter_ff(1.0, fft_size)
         self._log = blocks.nlog10_ff(10, fft_size,
                                      -20*math.log10(fft_size)              # Adjust for number of bins
-                                     -10*math.log10(window_power/fft_size) # Adjust for windowing loss
-                                     -20*math.log10(ref_scale/2))      # Adjust for reference scale
+                                     -10*math.log10(float(window_power)/fft_size) # Adjust for windowing loss
+                                     -20*math.log10(float(ref_scale)/2))      # Adjust for reference scale
         self.connect(self, self._sd, fft, c2magsq, self._avg, self._log, self)
 
         self._average = average


### PR DESCRIPTION
That is especially hurt as the GRC template puts defaults to
`ref_scale=2` (int literal!) and if someone uses `1`, they'll get zero
internally in logpwrfft, and that leads to errors.