### PR TITLE
Fix invalid Asio buffer usage in tcp_connection

### DIFF
--- a/gr-blocks/lib/socket_pdu_impl.h
+++ b/gr-blocks/lib/socket_pdu_impl.h
@@ -24,7 +24,6 @@
 #define INCLUDED_BLOCKS_SOCKET_PDU_IMPL_H
 
 #include <gnuradio/blocks/socket_pdu.h>
-#include "stream_pdu_base.h"
 #include "tcp_connection.h"
 
 namespace gr {

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -55,12 +55,11 @@ namespace gr {
     {
       size_t len = pmt::blob_length(vector);
 
-      // Asio async_write() requires the buffer to remain valid until the handler is called. It will be
-      // deleted in tcp_connection::handle_write.
-      char* txbuf = new char[len];
+      // Asio async_write() requires the buffer to remain valid until the handler is called.
+      boost::shared_ptr<char[]> txbuf(new char[len]);
 
       size_t temp = 0;
-      memcpy(txbuf, pmt::uniform_vector_elements(vector, temp), len);
+      memcpy(txbuf.get(), pmt::uniform_vector_elements(vector, temp), len);
 
       size_t offset = 0;
       while (offset < len) {
@@ -68,7 +67,7 @@ namespace gr {
         // FIXME: Note that this has the effect of breaking a large PDU into several smaller PDUs, each
         // containing <= MTU bytes. Is this the desired behavior?
         size_t send_len = std::min((len - offset), d_buf.size());
-        boost::asio::async_write(d_socket, boost::asio::buffer(txbuf + offset, send_len),
+        boost::asio::async_write(d_socket, boost::asio::buffer(txbuf.get() + offset, send_len),
           boost::bind(&tcp_connection::handle_write, this, txbuf,
             boost::asio::placeholders::error,
             boost::asio::placeholders::bytes_transferred));

--- a/gr-blocks/lib/tcp_connection.h
+++ b/gr-blocks/lib/tcp_connection.h
@@ -25,6 +25,7 @@
 
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
+#include <boost/shared_ptr.hpp>
 #include <pmt/pmt.h>
 
 namespace gr {
@@ -53,9 +54,8 @@ namespace gr {
       void start(gr::basic_block *block);
       void send(pmt::pmt_t vector);
       void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-      void handle_write(char* txbuf, const boost::system::error_code& error, size_t bytes_transferred) {
-          delete[] txbuf;
-      }
+      void handle_write(boost::shared_ptr<char[]> txbuf, const boost::system::error_code& error,
+                        size_t bytes_transferred) { }
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/tcp_connection.h
+++ b/gr-blocks/lib/tcp_connection.h
@@ -53,7 +53,9 @@ namespace gr {
       void start(gr::basic_block *block);
       void send(pmt::pmt_t vector);
       void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-      void handle_write(const boost::system::error_code& error, size_t bytes_transferred) { }
+      void handle_write(char* txbuf, const boost::system::error_code& error, size_t bytes_transferred) {
+          delete[] txbuf;
+      }
     };
 
   } /* namespace blocks */

--- a/gr-blocks/python/blocks/qa_socket_pdu.py
+++ b/gr-blocks/python/blocks/qa_socket_pdu.py
@@ -100,6 +100,35 @@ class qa_socket_pdu (gr_unittest.TestCase):
         #self.tb.connect(pdu_to_ts, head, sink)
         self.tb.run()
 
+    def test_004 (self):
+        # Test that the TCP server can stream PDUs <= the MTU size.
+        port = str(random.Random().randint(0, 30000) + 10000)
+        mtu = 10000
+        srcdata = tuple([x % 256 for x in xrange(mtu)])
+        data = pmt.init_u8vector(srcdata.__len__(), srcdata)
+        pdu_msg = pmt.cons(pmt.PMT_NIL, data)
+
+        self.pdu_source = blocks.message_strobe(pdu_msg, 500)
+        self.pdu_send = blocks.socket_pdu("TCP_SERVER", "localhost", port, mtu)
+        self.pdu_recv = blocks.socket_pdu("TCP_CLIENT", "localhost", port, mtu)
+        self.pdu_sink = blocks.message_debug()
+
+        self.tb.msg_connect(self.pdu_source, "strobe", self.pdu_send, "pdus")
+        self.tb.msg_connect(self.pdu_recv, "pdus", self.pdu_sink, "store")
+
+        self.tb.start()
+        while self.pdu_sink.num_messages() < 1:
+            time.sleep(0.1)
+        self.tb.stop()
+        self.tb.wait()
+
+        received = self.pdu_sink.get_message(0)
+        received_data = pmt.cdr(received)
+        msg_data = []
+        for i in xrange(mtu):
+            msg_data.append(pmt.u8vector_ref(received_data, i))
+        self.assertEqual(srcdata, tuple(msg_data))
+
 if __name__ == '__main__':
     gr_unittest.run(qa_socket_pdu, "qa_socket_pdu.xml")
 

--- a/gr-blocks/python/blocks/qa_socket_pdu.py
+++ b/gr-blocks/python/blocks/qa_socket_pdu.py
@@ -117,8 +117,7 @@ class qa_socket_pdu (gr_unittest.TestCase):
         self.tb.msg_connect(self.pdu_recv, "pdus", self.pdu_sink, "store")
 
         self.tb.start()
-        while self.pdu_sink.num_messages() < 1:
-            time.sleep(0.1)
+        time.sleep(1)
         self.tb.stop()
         self.tb.wait()
 


### PR DESCRIPTION
Asio requires that the underlying buffer passed to `async_write()` remain valid valid until the handler was called. The previous version was allocating a vector on the stack which gets destroyed once the `send()` method returns. Added a test case for the TCP server.

I'm on the fence about the raw pointer usage for `txbuf`. I considered using `boost::shared_ptr` (though that has the overhead of a ref count). I can switch this to a `std::unique_ptr` if Gnuradio can use C++11 features.

I also discovered the interesting behavior wrt PDUs larger than the configured MTU and left a corresponding comment for developers of the future.