### PR TITLE
gr-digital: Correlate access code callbacks

### DIFF
--- a/gr-digital/grc/digital_correlate_access_code_tag_xx.xml
+++ b/gr-digital/grc/digital_correlate_access_code_tag_xx.xml
@@ -9,6 +9,10 @@
 	<key>digital_correlate_access_code_tag_xx</key>
 	<import>from gnuradio import digital</import>
 	<make>digital.correlate_access_code_tag_$(type.fcn)($access_code, $threshold, $tagname)</make>
+	<callback>set_access_code($access_code)</callback>
+	<callback>set_threshold($threshold)</callback>
+	<callback>set_tagname($tagname)</callback>
+
 	<param>
 		<name>IO Type</name>
 		<key>type</key>

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_tag_bb.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_tag_bb.h
@@ -63,6 +63,8 @@ namespace gr {
        *                    e.g., "010101010111000100"
        */
       virtual bool set_access_code(const std::string &access_code) = 0;
+      virtual void set_threshold(int threshold) = 0;
+      virtual void set_tagname(const std::string &tagname) = 0;
     };
 
   } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_tag_ff.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_tag_ff.h
@@ -64,6 +64,8 @@ namespace gr {
        *                    e.g., "010101010111000100"
        */
       virtual bool set_access_code(const std::string &access_code) = 0;
+      virtual void set_threshold(int threshold) = 0;
+      virtual void set_tagname(const std::string &tagname) = 0;
     };
 
   } /* namespace digital */

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -73,6 +73,8 @@ namespace gr {
     correlate_access_code_tag_bb_impl::set_access_code(
         const std::string &access_code)
     {
+      gr::thread::scoped_lock l(d_mutex_access_code);
+
       d_len = access_code.length();	// # of bytes in string
       if(d_len > 64)
         return false;
@@ -96,6 +98,8 @@ namespace gr {
 					    gr_vector_const_void_star &input_items,
 					    gr_vector_void_star &output_items)
     {
+      gr::thread::scoped_lock l(d_mutex_access_code);
+
       const unsigned char *in = (const unsigned char*)input_items[0];
       unsigned char *out = (unsigned char*)output_items[0];
 

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.h
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.h
@@ -42,6 +42,8 @@ namespace gr {
 
       pmt::pmt_t d_key, d_me; //d_key is the tag name, d_me is the block name + unique ID
 
+      gr::thread::mutex d_mutex_access_code;
+
     public:
       correlate_access_code_tag_bb_impl(const std::string &access_code,
 					int threshold,
@@ -53,6 +55,8 @@ namespace gr {
 	       gr_vector_void_star &output_items);
 
       bool set_access_code(const std::string &access_code);
+      void set_threshold(int threshold) { d_threshold = threshold; };
+      void set_tagname(const std::string &tag_name) { d_key = pmt::string_to_symbol(tag_name); };
     };
 
   } /* namespace digital */

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -74,6 +74,8 @@ namespace gr {
     correlate_access_code_tag_ff_impl::set_access_code(
         const std::string &access_code)
     {
+      gr::thread::scoped_lock l(d_mutex_access_code);
+
       d_len = access_code.length();	// # of bytes in string
       if(d_len > 64)
         return false;
@@ -97,6 +99,8 @@ namespace gr {
 					    gr_vector_const_void_star &input_items,
 					    gr_vector_void_star &output_items)
     {
+      gr::thread::scoped_lock l(d_mutex_access_code);
+
       const float *in = (const float*)input_items[0];
       float *out = (float*)output_items[0];
 

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.h
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.h
@@ -42,6 +42,8 @@ namespace gr {
 
       pmt::pmt_t d_key, d_me; //d_key is the tag name, d_me is the block name + unique ID
 
+      gr::thread::mutex d_mutex_access_code;
+
     public:
       correlate_access_code_tag_ff_impl(const std::string &access_code,
 					int threshold,
@@ -53,6 +55,8 @@ namespace gr {
 	       gr_vector_void_star &output_items);
 
       bool set_access_code(const std::string &access_code);
+      void set_threshold(int threshold) { d_threshold = threshold; };
+      void set_tagname(const std::string &tag_name) { d_key = pmt::string_to_symbol(tag_name); };
     };
 
   } /* namespace digital */


### PR DESCRIPTION
Added callbacks to the correlate_access_code_tag_xx block and fixed a minor bug with the block tree for gr_digital related to the same block (it had the earlier _bb suffix in the block tree XML).