### PR TITLE
gr-uhd: Solution for out of order message based timed commands for transceivers

### DIFF
--- a/gr-uhd/doc/uhd.dox
+++ b/gr-uhd/doc/uhd.dox
@@ -93,6 +93,7 @@ Command name | Value Type   | Description
 `tune`       | tune_request | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.
 `lo_freq`    | double       | For fully manual tuning: Set the LO frequency (RF frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
 `dsp_freq`   | double       | For fully manual tuning: Set the DSP frequency (CORDIC frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
+`direction`  | string       | Used for timed transceiver tuning to ensure tuning order is maintained. Values other than 'TX' or 'RX' will be ignored.
 `rate`       | double       | See usrp_block::set_samp_rate(). *Always* affects all channels.
 `bandwidth`  | double       | See usrp_block::set_bandwidth(). Defaults to all channels.
 `time`       | timestamp    | Sets a command time. See usrp_block::set_command_time(). A value of PMT_NIL will clear the command time.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -39,6 +39,7 @@ const pmt::pmt_t CMD_BANDWIDTH_KEY = pmt::mp("bandwidth");
 const pmt::pmt_t CMD_TIME_KEY = pmt::mp("time");
 const pmt::pmt_t CMD_MBOARD_KEY = pmt::mp("mboard");
 const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("antenna");
+const pmt::pmt_t CMD_DIRECTION_KEY = pmt::mp("direction");
 
 
 /**********************************************************************
@@ -209,11 +210,11 @@ bool usrp_block_impl::_check_mboard_sensors_locked()
 }
 
 void
-usrp_block_impl::_set_center_freq_from_internals_allchans()
+usrp_block_impl::_set_center_freq_from_internals_allchans(pmt::pmt_t direction)
 {
   while (_chans_to_tune.any()) {
     // This resets() bits, so this loop should not run indefinitely
-    _set_center_freq_from_internals(_chans_to_tune.find_first());
+    _set_center_freq_from_internals(_chans_to_tune.find_first(), direction);
   }
 }
 
@@ -539,8 +540,14 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     }
   }
 
-  /// 4) Check if we need to re-tune
-  _set_center_freq_from_internals_allchans();
+  /// 4) See if a direction was specified
+  pmt::pmt_t direction = pmt::dict_ref(
+      msg, CMD_DIRECTION_KEY,
+      pmt::PMT_NIL // Anything except "TX" or "RX will default to the messaged block direction"
+  );
+
+  /// 5) Check if we need to re-tune
+  _set_center_freq_from_internals_allchans(direction);
 }
 
 
@@ -699,4 +706,3 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t &dspfreq, int chan, 
 
   _update_curr_tune_req(new_tune_request, chan);
 }
-

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -29,13 +29,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/bind.hpp>
 
-#define SET_CENTER_FREQ_FROM_INTERNALS(usrp_class, tune_method) \
-    ::uhd::tune_result_t \
-    usrp_class::_set_center_freq_from_internals(size_t chan) \
-    { \
-      _chans_to_tune.reset(chan); \
-      return _dev->tune_method(_curr_tune_req[chan], _stream_args.channels[chan]); \
-    }
 
 namespace gr {
   namespace uhd {
@@ -213,10 +206,10 @@ namespace gr {
       }
 
       //! Like set_center_freq(), but uses _curr_freq and _curr_lo_offset
-      virtual ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan) = 0;
+      virtual ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction) = 0;
 
       //! Calls _set_center_freq_from_internals() on all channels
-      void _set_center_freq_from_internals_allchans();
+      void _set_center_freq_from_internals_allchans(pmt::pmt_t direction);
 
       /**********************************************************************
        * Members
@@ -247,4 +240,3 @@ namespace gr {
 } /* namespace gr */
 
 #endif /* INCLUDED_GR_UHD_BLOCK_IMPL_H */
-

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -135,7 +135,17 @@ namespace gr {
       return _dev->set_tx_freq(tune_request, chan);
     }
 
-    SET_CENTER_FREQ_FROM_INTERNALS(usrp_sink_impl, set_tx_freq);
+    ::uhd::tune_result_t
+    usrp_sink_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
+    {
+      _chans_to_tune.reset(chan);
+      if (pmt::eqv(direction, pmt::mp("RX"))) {
+        // TODO: what happens if the RX device is not instantiated? Catch error?
+        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+      } else {
+        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+      }
+    }
 
     double
     usrp_sink_impl::get_center_freq(size_t chan)

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -107,7 +107,7 @@ namespace gr {
 
     private:
       //! Like set_center_freq(), but uses _curr_freq and _curr_lo_offset
-      ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan);
+      ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction);
 
 #ifdef GR_UHD_USE_STREAM_API
       ::uhd::tx_streamer::sptr _tx_stream;

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -149,7 +149,17 @@ namespace gr {
       return res;
     }
 
-    SET_CENTER_FREQ_FROM_INTERNALS(usrp_source_impl, set_rx_freq);
+    ::uhd::tune_result_t
+    usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
+    {
+      _chans_to_tune.reset(chan);
+      if (pmt::eqv(direction, pmt::mp("TX"))) {
+        // TODO: what happens if the TX device is not instantiated? Catch error?
+        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+      } else {
+        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+      }
+    }
 
     double
     usrp_source_impl::get_center_freq(size_t chan)
@@ -534,7 +544,7 @@ namespace gr {
           _rx_stream->recv(outputs, nbytes/bpi, _metadata, 0.0);
         else
           // no rx streamer -- nothing to flush
-          break; 
+          break;
 #else
         _dev->get_device()->recv
           (outputs, nbytes/_type->size, _metadata, *_type,

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -120,7 +120,7 @@ namespace gr {
 
     private:
       //! Like set_center_freq(), but uses _curr_freq and _curr_lo_offset
-      ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan);
+      ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction);
       void _cmd_handler_tag(const pmt::pmt_t &tag);
 
 #ifdef GR_UHD_USE_STREAM_API


### PR DESCRIPTION
This PR addresses issue #1199.

Issue Summary: Currently, UHD timed tuning commands are issued to the direction (RX or TX) corresponding to the block (Source / Sink respectively) they are issued to. In a transceiver application, this can cause tune commands to end up out-of-order as messages are asynchronous.

This change:

1. Removes the macro function definition used for message based tuning and explicitly instantiates the method in each of the source / sink blocks.
2. Adds an optional ‘direction’ command (PMT symbol ‘TX’ or ‘RX’) to the UHD message command dictionary which allows the sink block to tune the RX path or source block to tune TX path. This value is now an argument to the tuning function mentioned in 1.
3. Updates doxygen for the new ‘direction’ command.

If no ‘direction’ command is supplied, it will default to the block issued to (source -> RX, sink -> TX) like normal. Values other than ’TX’ and ‘RX’ do nothing. In the event a TX block is not in the flowgraph, a TX tune sent to the RX block will still be issued to no effect (no checking is done...someone should look at this and make sure it's OK). It could alternatively be made to throw an error if desired though I do not see a clear way to determine if a TX/RX device exists.
