### PR TITLE
gr-qtgui: time_sink: adds nconnections check to grc and fixes #1317

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.xml
@@ -931,6 +931,8 @@ $(gui_hint()($win))</make>
     <hide>#if ((int($nconnections()) >= 10 or ($type() == "complex" and int($nconnections()) >= 5)) and not $type.t == "message") then 'part' else 'all'#</hide>
   </param>
 
+  <check>$nconnections &lt;= #if $type() == "complex" then 5 else 10#</check>
+
   <sink>
     <name>in</name>
     <type>$type.t</type>

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -170,8 +170,14 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
   colors << QColor(Qt::blue) << QColor(Qt::red) << QColor(Qt::green)
 	 << QColor(Qt::black) << QColor(Qt::cyan) << QColor(Qt::magenta)
 	 << QColor(Qt::yellow) << QColor(Qt::gray) << QColor(Qt::darkRed)
+	 << QColor(Qt::darkGreen) << QColor(Qt::darkBlue) << QColor(Qt::darkGray)
+	 // cycle through all colors again to increase time_sink_f input limit
+	 // from 12 to 24, otherwise you get a segfault
+	 << QColor(Qt::blue) << QColor(Qt::red) << QColor(Qt::green)
+	 << QColor(Qt::black) << QColor(Qt::cyan) << QColor(Qt::magenta)
+	 << QColor(Qt::yellow) << QColor(Qt::gray) << QColor(Qt::darkRed)
 	 << QColor(Qt::darkGreen) << QColor(Qt::darkBlue) << QColor(Qt::darkGray);
-
+	 
   // Setup dataPoints and plot vectors
   // Automatically deleted when parent is deleted
   for(int i = 0; i < d_nplots; i++) {

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -55,6 +55,9 @@ namespace gr {
 	d_size(size), d_buffer_size(2*size), d_samp_rate(samp_rate), d_name(name),
 	d_nconnections(2*nconnections), d_parent(parent)
     {
+      if(nconnections > 12)
+        throw std::runtime_error("time_sink_c only supports up to 12 inputs");
+
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
       // life of the qApplication:

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -57,6 +57,9 @@ namespace gr {
 	d_size(size), d_buffer_size(2*size), d_samp_rate(samp_rate), d_name(name),
 	d_nconnections(nconnections), d_parent(parent)
     {
+      if(nconnections > 24)
+        throw std::runtime_error("time_sink_f only supports up to 24 inputs");
+
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
       // life of the qApplication:


### PR DESCRIPTION
now fixes #1317 and adds a check to grc so that when a user enters more than 5 (complex) or 10 (float) inputs, an error occurs letting them know what is wrong.  The reason for not allowing 24 inputs when using grc is pretty clear if you look at how qtgui_time_sink_x.xml is written, the whole thing should probably be rewritten using for loops.

on a side note, once a PR is closed, is there a way to open it again and add a commit?  I created this new PR because I wasn't sure how to do that or if it was possible.  The old PR was #1321 