### PR TITLE
uhd: Add RX1 as default option

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -517,6 +517,10 @@ PARAMS_TMPL = """	<param>
 			<name>RX2</name>
 			<key>RX2</key>
 		</option>
+		<option>
+			<name>RX1</name>
+			<key>RX1</key>
+		</option>
 #end if
 		<tab>RF Options</tab>
 	</param>


### PR DESCRIPTION
GRC bindings for the USRP sink and source suggest some antenna names.
This adds the antenna name RX1 (TwinRX) into the list of antenna name
suggestions.