### PR TITLE
uhd: Parametrize recv timeout and single-packet option

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_source.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_source.h
@@ -131,6 +131,33 @@ namespace gr {
        */
       virtual void issue_stream_cmd(const ::uhd::stream_cmd_t &cmd) = 0;
 
+      /*! Configure the timeout value on the UHD recv() call
+       *
+       * This is an advanced use parameter. Changing the timeout value affects
+       * the latency of this block; a high timeout value can be more optimal
+       * for high-throughput applications (e.g., 1 second) and setting it to
+       * zero will have the best latency. Changing the timeout value may also
+       * be useful for custom FPGA modifications, where traffic might not be
+       * continuously streaming.
+       * For specialized high-performance use cases, twiddling these knobs may
+       * improve performance, but changes are not generally applicable.
+       *
+       * Note that UHD's recv() call may block until the timeout is over, which
+       * means this block might also block for up to the timeout value.
+       *
+       * \param timeout Timeout parameter in seconds. Cf. the UHD manual for
+       *                uhd::rx_streamer::recv() for more details. A lower
+       *                value will mean lower latency, but higher CPU load.
+       * \param one_packet If true, only receive one packet at a time. Cf. the
+       *                   UHD manual for uhd::rx_streamer::recv() for more
+       *                   details. A value of true will mean lower latency,
+       *                   but higher CPU load.
+       */
+      virtual void set_recv_timeout(
+          const double timeout,
+          const bool one_packet=true
+      ) = 0;
+
       /*!
        * Returns identifying information about this USRP's configuration.
        * Returns motherboard ID, name, and serial.

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -71,6 +71,7 @@ namespace gr {
                     args_to_io_sig(stream_args)),
       usrp_block_impl(device_addr, stream_args, ""),
       _recv_timeout(0.1), // seconds
+      _recv_one_packet(true),
       _tag_now(false),
       _issue_stream_cmd_on_start(issue_stream_cmd_on_start)
     {
@@ -489,6 +490,15 @@ namespace gr {
         _tag_now = true;
     }
 
+    void
+    usrp_source_impl::set_recv_timeout(
+            const double timeout,
+            const bool one_packet
+    ) {
+        _recv_timeout = timeout;
+        _recv_one_packet = one_packet;
+    }
+
     bool
     usrp_source_impl::start(void)
     {
@@ -625,7 +635,7 @@ namespace gr {
           noutput_items,
           _metadata,
           _recv_timeout,
-          true /* one packet -> minimize latency */
+          _recv_one_packet
       );
 #else
       size_t num_samps = _dev->get_device()->recv

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -107,6 +107,7 @@ namespace gr {
       double set_lo_freq(double freq, const std::string &name, size_t chan);
 
       void issue_stream_cmd(const ::uhd::stream_cmd_t &cmd);
+      void set_recv_timeout(const double timeout, const bool one_packet);
       void flush(void);
       bool start(void);
       bool stop(void);
@@ -126,7 +127,10 @@ namespace gr {
 #ifdef GR_UHD_USE_STREAM_API
       ::uhd::rx_streamer::sptr _rx_stream;
       size_t _samps_per_packet;
+      //! Timeout value for UHD's recv() call. Lower values mean lower latency.
       double _recv_timeout;
+      //! one_packet value for UHD's recv() call. 'true' is lower latency.
+      bool _recv_one_packet;
 #endif
       bool _tag_now;
       ::uhd::rx_metadata_t _metadata;


### PR DESCRIPTION
usrp_source currently hard-codes timeout values. For high-performance
applications, it might be desirable to control the details of the call
to uhd::rx_streamer::recv(), which is now enabled.

Defaults are unchanged.