### PR TITLE
runtime: fix logger_ptr to always be a pointer

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h.in
+++ b/gnuradio-runtime/include/gnuradio/logger.h.in
@@ -64,7 +64,7 @@ typedef unsigned short mode_t;
 
 namespace gr {
   //#warning GR logging Enabled and using std::cout
-  typedef std::string logger_ptr;
+  typedef void* logger_ptr;
 } /* namespace gr */
 
 #define GR_LOG_DECLARE_LOGPTR(logger)


### PR DESCRIPTION
Addresses issue #1383, where if GR and an OOT are built with logging
enabled but GR is build using log4cpp and the OOT is build without it,
then gr_block will be of different size & freeing it can result in
heap corruption.

This fix mades all of the logger_ptr typedefs an actual pointer, which
should always be the same size and hence gr_block will always be the
same size no matter what logging option is selected.

[Unlike PR #1398, which fixed a bunch of logger-related issues, this one is just for the logger_ptr issue #1383. I'm splitting off this fix from the rest, since there is a better way to handle some parts of logging along with include ordering fixes & this issue just needs to be fixed.]