### PR TITLE
cmake: add CMake Overloads file and use it at the top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ set(EXPORT_FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake)
 file(WRITE ${EXPORT_FILE}) #blank the file (subdirs will append)
 
 ########################################################################
+# Incorporate CMake function/macros overloading.
+########################################################################
+
+include(CMakeOverloads)
+
+########################################################################
 # Compiler specific setup
 ########################################################################
 include(GrMiscUtils) #compiler flag check

--- a/cmake/Modules/CMakeOverloads.cmake
+++ b/cmake/Modules/CMakeOverloads.cmake
@@ -1,0 +1,70 @@
+# Copyright 2017 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+
+########################################################################
+# This file contains functions that override those provided by CMake.
+# We do this to allow for more generic use of these functions than as
+# provided by CMake.
+########################################################################
+
+if(DEFINED __INCLUDED_CMAKE_OVERLOADS)
+  return()
+endif()
+set(__INCLUDED_CMAKE_OVERLOADS TRUE)
+
+# overload INCLUDE_DIRECTORIES to be a little smarter
+#
+# NOTE: moving all include directories to either BEFORE (internal to
+# source or build) or AFTER (external to source or build) will work in
+# general. The primary time it could fail is when include ordering is
+# required to find a specific version of a header when multiple of the
+# same name are available in the various include directories. This
+# situation seems like it's unlikely, so we ignore it here.
+
+macro(INCLUDE_DIRECTORIES)
+  # for each provided include directory ...
+  foreach(inc_dir ${ARGN})
+
+    # is this dir the literal string "BEFORE" or "AFTER"?
+    string(FIND ${inc_dir} BEFORE IS_BEFORE)
+    string(FIND ${inc_dir} AFTER IS_AFTER)
+    if(${IS_BEFORE} EQUAL 0 OR ${IS_AFTER} EQUAL 0)
+      # yes: ignore it
+      continue()
+    endif()
+
+    # get absolute path of this include directory
+    get_filename_component(inc_dir_abs ${inc_dir} ABSOLUTE)
+
+    # is this include directory located within the SOURCE or BUILD?
+    string(FIND ${inc_dir_abs} ${CMAKE_SOURCE_DIR} IS_IN_SOURCE)
+    string(FIND ${inc_dir_abs} ${CMAKE_BINARY_DIR} IS_IN_BINARY)
+    if(${IS_IN_SOURCE} EQUAL 0 OR ${IS_IN_BINARY} EQUAL 0)
+      # yes: local SOURCE or BINARY; internal.
+      # call the overloaded INCLUDE_DIRECTORIES,
+      # prepending this internal directory.
+      _include_directories(BEFORE ${inc_dir_abs})
+    else()
+      # no: not SOURCE or BUILD; must be external.
+      # call the overloaded INCLUDE_DIRECTORIES,
+      # appending this external directory.
+      _include_directories(AFTER ${inc_dir_abs})
+    endif()
+  endforeach()
+endmacro(INCLUDE_DIRECTORIES)

--- a/cmake/Modules/CMakeOverloads.cmake
+++ b/cmake/Modules/CMakeOverloads.cmake
@@ -44,27 +44,26 @@ macro(INCLUDE_DIRECTORIES)
     # is this dir the literal string "BEFORE" or "AFTER"?
     string(FIND ${inc_dir} BEFORE IS_BEFORE)
     string(FIND ${inc_dir} AFTER IS_AFTER)
-    if(${IS_BEFORE} EQUAL 0 OR ${IS_AFTER} EQUAL 0)
-      # yes: ignore it
-      continue()
-    endif()
+    if(NOT ${IS_BEFORE} EQUAL 0 AND NOT ${IS_AFTER} EQUAL 0)
 
-    # get absolute path of this include directory
-    get_filename_component(inc_dir_abs ${inc_dir} ABSOLUTE)
+      # not "BEFORE" or "AFTER"; a real directory.
+      # get absolute path of this include directory
+      get_filename_component(inc_dir_abs ${inc_dir} ABSOLUTE)
 
-    # is this include directory located within the SOURCE or BUILD?
-    string(FIND ${inc_dir_abs} ${CMAKE_SOURCE_DIR} IS_IN_SOURCE)
-    string(FIND ${inc_dir_abs} ${CMAKE_BINARY_DIR} IS_IN_BINARY)
-    if(${IS_IN_SOURCE} EQUAL 0 OR ${IS_IN_BINARY} EQUAL 0)
-      # yes: local SOURCE or BINARY; internal.
-      # call the overloaded INCLUDE_DIRECTORIES,
-      # prepending this internal directory.
-      _include_directories(BEFORE ${inc_dir_abs})
-    else()
-      # no: not SOURCE or BUILD; must be external.
-      # call the overloaded INCLUDE_DIRECTORIES,
-      # appending this external directory.
-      _include_directories(AFTER ${inc_dir_abs})
+      # is this include directory located within the SOURCE or BUILD?
+      string(FIND ${inc_dir_abs} ${CMAKE_SOURCE_DIR} IS_IN_SOURCE)
+      string(FIND ${inc_dir_abs} ${CMAKE_BINARY_DIR} IS_IN_BINARY)
+      if(${IS_IN_SOURCE} EQUAL 0 OR ${IS_IN_BINARY} EQUAL 0)
+        # yes: local SOURCE or BINARY; internal.
+        # call the overloaded INCLUDE_DIRECTORIES,
+        # prepending this internal directory.
+        _include_directories(BEFORE ${inc_dir_abs})
+      else()
+        # no: not SOURCE or BUILD; must be external.
+        # call the overloaded INCLUDE_DIRECTORIES,
+        # appending this external directory.
+        _include_directories(AFTER ${inc_dir_abs})
+      endif()
     endif()
   endforeach()
 endmacro(INCLUDE_DIRECTORIES)


### PR DESCRIPTION
[This PR is clean for me on maint, master, and next. It needs to be
tested thoroughly, as it overloads a critical CMake function! - MLD]

For now, the CMakeOverloads file just overloads the CMake function
"include_directories", to make it a little smarter. When parsing the
provided directories, the overloaded macro now checks to see whether
each directory is in the SOURCE or BUILD, or neither. If so, then the
directory is added BEFORE others, and if not, then AFTER. The keywords
BEFORE and AFTER are ignored. In this manner, all internal directories
will come before external directories, which allows builds to work
even if a prior version of GNU Radio is already installed into the
CMAKE_INSTALL_PREFIX (e.g., as is often found when building from
source, such as in MacPorts).

By adding this macro at the top-level CMakeLists.txt file, it
overloads all uses of "include_directories" in any subdirectory.

As noted in the file: Moving all include directories to either BEFORE
(internal to source or build) or AFTER (external to source or build)
will work in general. The primary time it could fail is when include
ordering is required to find a specific version of a header when
multiple of the same name are available in the various include
directories. This situation would be poor header naming practice, and
is unlikely to occur in real life. As it does not occur in GNU Radio,
so we ignore it.