### PR TITLE
Add non-interned string PMT type 'pmt_string'

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -154,6 +154,26 @@ PMT_API pmt_t intern(const std::string &s);
  */
 PMT_API const std::string symbol_to_string(const pmt_t& sym);
 
+
+/*
+ * ------------------------------------------------------------------------
+ *                 Non-interned strings
+ * ------------------------------------------------------------------------
+ */
+
+//! Return true if obj is a non-interned string PMT, else false.
+PMT_API bool is_string(const pmt_t& p);
+
+/*!
+ * Return an interned or non-interned string PMT containing the given string.
+ */
+PMT_API pmt_t from_string(std::string str, bool interned=false);
+
+/*!
+ * If \p is a string PMT (interned or non-interned), return the contained string
+ */
+PMT_API std::string to_string(const pmt_t& p);
+
 /*
  * ------------------------------------------------------------------------
  *           Numbers: we support integer, real and complex

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -161,18 +161,19 @@ PMT_API const std::string symbol_to_string(const pmt_t& sym);
  * ------------------------------------------------------------------------
  */
 
-//! Return true if obj is a non-interned string PMT, else false.
+//! Return true if obj is a string PMT, else false.
 PMT_API bool is_string(const pmt_t& p);
 
 /*!
- * Return an interned or non-interned string PMT containing the given string.
+ * Return a string PMT containing the given string - if the string is already in the
+ * symbol table, the PMT will be interned, otherwise it will be non-interned.
  */
-PMT_API pmt_t from_string(std::string str, bool interned=false);
+PMT_API pmt_t from_string(const std::string &str);
 
 /*!
  * If \p is a string PMT (interned or non-interned), return the contained string
  */
-PMT_API std::string to_string(const pmt_t& p);
+PMT_API const std::string to_string(const pmt_t& p);
 
 /*
  * ------------------------------------------------------------------------

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -24,6 +24,7 @@
 #define INCLUDED_PMT_H
 
 #include <pmt/api.h>
+#include <gnuradio/attributes.h>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/any.hpp>
@@ -139,6 +140,7 @@ PMT_API bool to_bool(pmt_t val);
  */
 
 //! Return true if obj is a symbol, else false.
+__GR_ATTR_DEPRECATED
 PMT_API bool is_symbol(const pmt_t& obj);
 
 //! Return the symbol whose name is \p s.

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -92,7 +92,7 @@ namespace gr {
   void
   basic_block::message_port_register_in(pmt::pmt_t port_id)
   {
-    if(!pmt::is_symbol(port_id)) {
+    if(!pmt::is_string(port_id)) {
       throw std::runtime_error("message_port_register_in: bad port id");
     }
     msg_queue[port_id] = msg_queue_t();
@@ -115,7 +115,7 @@ namespace gr {
   void
   basic_block::message_port_register_out(pmt::pmt_t port_id)
   {
-    if(!pmt::is_symbol(port_id)) {
+    if(!pmt::is_string(port_id)) {
       throw std::runtime_error("message_port_register_out: bad port id");
     }
     if(pmt::dict_has_key(d_message_subscribers, port_id)) {

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -192,7 +192,7 @@ namespace gr {
   void
   block_detail::add_item_tag(unsigned int which_output, const tag_t &tag)
   {
-    if(!pmt::is_symbol(tag.key)) {
+    if(!pmt::is_string(tag.key)) {
       throw pmt::wrong_type("block_detail::add_item_tag key", tag.key);
     }
     else {
@@ -204,7 +204,7 @@ namespace gr {
   void
   block_detail::remove_item_tag(unsigned int which_input, const tag_t &tag, long id)
   {
-    if(!pmt::is_symbol(tag.key)) {
+    if(!pmt::is_string(tag.key)) {
       throw pmt::wrong_type("block_detail::add_item_tag key", tag.key);
     }
     else {

--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -34,7 +34,7 @@ rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
     result.value.__set_a_double(pmt::to_double(knob));
     return result;
   }
-  else if(pmt::is_symbol(knob)) {
+  else if(pmt::is_string(knob)) {
     std::string value = pmt::symbol_to_string(knob);
     GNURadio::Knob result;
     result.type = GNURadio::BaseTypes::STRING;

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -91,7 +91,7 @@ namespace gr {
   hier_block2::msg_connect(basic_block_sptr src, pmt::pmt_t srcport,
                            basic_block_sptr dst, pmt::pmt_t dstport)
   {
-    if(!pmt::is_symbol(srcport)) {
+    if(!pmt::is_string(srcport)) {
       throw std::runtime_error("bad port id");
     }
     d_detail->msg_connect(src, srcport, dst, dstport);
@@ -108,7 +108,7 @@ namespace gr {
   hier_block2::msg_disconnect(basic_block_sptr src, pmt::pmt_t srcport,
                               basic_block_sptr dst, pmt::pmt_t dstport)
   {
-    if(!pmt::is_symbol(srcport)) {
+    if(!pmt::is_string(srcport)) {
       throw std::runtime_error("bad port id");
     }
     d_detail->msg_disconnect(src, srcport, dst, dstport);

--- a/gnuradio-runtime/lib/pmt/pmt-serial-tags.scm
+++ b/gnuradio-runtime/lib/pmt/pmt-serial-tags.scm
@@ -36,6 +36,8 @@
 (define pst-uint64	#x0b)
 (define pst-tuple	#x0c)
 
+(define pst-string        #x0d)   ; untagged-int16 n; followed by n bytes of string value
+
 ;; u8, s8, u16, s16, u32, s32, u64, s64, f32, f64, c32, c64
 ;;
 ;;   untagged-uint8  tag

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -285,6 +285,12 @@ hash_string(const std::string &s)
 bool
 is_symbol(const pmt_t& p)
 {
+  return p->is_string();
+}
+
+bool
+is_interned_string(const pmt_t& p)
+{
   return p->is_string() && _string(p)->is_interned();
 }
 

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -262,7 +262,7 @@ get_symbol_hash_table()
   return &s_symbol_hash_table;
 }
 
-pmt_string::pmt_string(const std::string &name) : d_name(name), d_next(NULL) {}
+pmt_string::pmt_string(const std::string &name, bool is_interned) : d_name(name), d_is_interned(is_interned) {}
 
 
 static unsigned int
@@ -310,7 +310,7 @@ string_to_symbol(const std::string &name)
   }
   
   // Nope.  Make a new one.
-  pmt_t sym = pmt_t(new pmt_string(name));
+  pmt_t sym = pmt_t(new pmt_string(name, true));
   _string(sym)->set_next((*get_symbol_hash_table())[hash]);
   (*get_symbol_hash_table())[hash] = sym;
   return sym;
@@ -343,7 +343,7 @@ from_string(const std::string &str)
       return sym;   // Yes.  Return it
   }
 
-  return pmt_t(new pmt_string(str));
+  return pmt_t(new pmt_string(str, false));
 }
 
 const std::string

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -65,6 +65,7 @@ protected:
 public:
   virtual bool is_bool()    const { return false; }
   virtual bool is_symbol()  const { return false; }
+  virtual bool is_string()  const { return false; }
   virtual bool is_number()  const { return false; }
   virtual bool is_integer() const { return false; }
   virtual bool is_uint64()  const { return false; }
@@ -124,6 +125,19 @@ public:
 
   pmt_t next() { return d_next; }		// symbol table link
   void set_next(pmt_t next) { d_next = next; }
+};
+
+class pmt_string : public pmt_base
+{
+  std::string d_value;
+
+public:
+  pmt_string(std::string value);
+  //~pmt_string(){}
+
+  bool is_string() const { return true; }
+  std::string value() { return d_value; }
+
 };
 
 class pmt_integer : public pmt_base

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -109,6 +109,7 @@ public:
   bool is_bool() const { return true; }
 };
 
+bool is_interned_string(const pmt_t& obj);
 
 class pmt_string : public pmt_base
 {

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -64,7 +64,6 @@ protected:
 
 public:
   virtual bool is_bool()    const { return false; }
-  virtual bool is_symbol()  const { return false; }
   virtual bool is_string()  const { return false; }
   virtual bool is_number()  const { return false; }
   virtual bool is_integer() const { return false; }
@@ -111,33 +110,21 @@ public:
 };
 
 
-class pmt_symbol : public pmt_base
+class pmt_string : public pmt_base
 {
   std::string	d_name;
   pmt_t		d_next;
 
 public:
-  pmt_symbol(const std::string &name);
-  //~pmt_symbol(){}
-
-  bool is_symbol() const { return true; }
-  const std::string name() { return d_name; }
-
-  pmt_t next() { return d_next; }		// symbol table link
-  void set_next(pmt_t next) { d_next = next; }
-};
-
-class pmt_string : public pmt_base
-{
-  std::string d_value;
-
-public:
-  pmt_string(std::string value);
+  pmt_string(const std::string &name);
   //~pmt_string(){}
 
   bool is_string() const { return true; }
-  std::string value() { return d_value; }
+  const std::string name() { return d_name; }
+  bool is_interned() { return (d_next != NULL); }
 
+  pmt_t next() { return d_next; }		// symbol table link
+  void set_next(pmt_t next) { d_next = next; }
 };
 
 class pmt_integer : public pmt_base

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -114,14 +114,15 @@ class pmt_string : public pmt_base
 {
   std::string	d_name;
   pmt_t		d_next;
+  bool d_is_interned;
 
 public:
-  pmt_string(const std::string &name);
+  pmt_string(const std::string &name, bool is_interned);
   //~pmt_string(){}
 
   bool is_string() const { return true; }
   const std::string name() { return d_name; }
-  bool is_interned() { return (d_next != NULL); }
+  bool is_interned() { return d_is_interned; }
 
   pmt_t next() { return d_next; }		// symbol table link
   void set_next(pmt_t next) { d_next = next; }

--- a/gnuradio-runtime/lib/pmt/pmt_io.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_io.cc
@@ -60,7 +60,7 @@ write(pmt_t obj, std::ostream &port)
     else
       port << "#f";
   }
-  else if (is_symbol(obj) || is_string(obj)){
+  else if (is_string(obj)){
     port << to_string(obj);
   }
   else if (is_number(obj)){

--- a/gnuradio-runtime/lib/pmt/pmt_io.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_io.cc
@@ -60,8 +60,8 @@ write(pmt_t obj, std::ostream &port)
     else
       port << "#f";
   }
-  else if (is_symbol(obj)){
-    port << symbol_to_string(obj);
+  else if (is_symbol(obj) || is_string(obj)){
+    port << to_string(obj);
   }
   else if (is_number(obj)){
     if (is_integer(obj))

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -256,12 +256,14 @@ serialize(pmt_t obj, std::streambuf &sb)
   if(is_null(obj))
     return serialize_untagged_u8(PST_NULL, sb);
 
-  if(is_symbol(obj) || is_string(obj)) {
+  if(is_string(obj)) {
     const std::string s = to_string(obj);
     size_t len = s.size();
     if (is_symbol(obj)) {
+      // Interned
       ok = serialize_untagged_u8(PST_SYMBOL, sb);
     } else {
+      // Not interned
       ok = serialize_untagged_u8(PST_STRING, sb);
     }
     ok &= serialize_untagged_u16(len, sb);

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -259,7 +259,7 @@ serialize(pmt_t obj, std::streambuf &sb)
   if(is_string(obj)) {
     const std::string s = to_string(obj);
     size_t len = s.size();
-    if (is_symbol(obj)) {
+    if (is_interned_string(obj)) {
       // Interned
       ok = serialize_untagged_u8(PST_SYMBOL, sb);
     } else {

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -256,10 +256,14 @@ serialize(pmt_t obj, std::streambuf &sb)
   if(is_null(obj))
     return serialize_untagged_u8(PST_NULL, sb);
 
-  if(is_symbol(obj)) {
-    const std::string s = symbol_to_string(obj);
+  if(is_symbol(obj) || is_string(obj)) {
+    const std::string s = to_string(obj);
     size_t len = s.size();
-    ok = serialize_untagged_u8(PST_SYMBOL, sb);
+    if (is_symbol(obj)) {
+      ok = serialize_untagged_u8(PST_SYMBOL, sb);
+    } else {
+      ok = serialize_untagged_u8(PST_STRING, sb);
+    }
     ok &= serialize_untagged_u16(len, sb);
     for(size_t i = 0; i < len; i++)
       ok &= serialize_untagged_u8(s[i], sb);
@@ -555,6 +559,16 @@ deserialize(std::streambuf &sb)
     if (sb.sgetn(tmpbuf, u16) != u16)
       goto error;
     return intern(std::string(tmpbuf, u16));
+
+  case PST_STRING:
+    if (!deserialize_untagged_u16(&u16, sb))
+      goto error;
+    if (u16 > sizeof(tmpbuf))
+      throw notimplemented("pmt::deserialize: very long string",
+         PMT_F);
+    if (sb.sgetn(tmpbuf, u16) != u16)
+      goto error;
+    return from_string(std::string(tmpbuf, u16));
 
   case PST_INT32:
     if (!deserialize_untagged_u32(&u32, sb))

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -31,12 +31,12 @@
 void
 qa_pmt_prims::test_symbols()
 {
-  CPPUNIT_ASSERT(!pmt::is_symbol(pmt::PMT_T));
-  CPPUNIT_ASSERT(!pmt::is_symbol(pmt::PMT_F));
+  CPPUNIT_ASSERT(!pmt::is_string(pmt::PMT_T));
+  CPPUNIT_ASSERT(!pmt::is_string(pmt::PMT_F));
   CPPUNIT_ASSERT_THROW(pmt::symbol_to_string(pmt::PMT_F), pmt::wrong_type);
 
   pmt::pmt_t sym1 = pmt::mp("test");
-  CPPUNIT_ASSERT(pmt::is_symbol(sym1));
+  CPPUNIT_ASSERT(pmt::is_string(sym1));
   CPPUNIT_ASSERT_EQUAL(std::string("test"), pmt::symbol_to_string(sym1));
   CPPUNIT_ASSERT(pmt::is_true(sym1));
   CPPUNIT_ASSERT(!pmt::is_false(sym1));
@@ -597,7 +597,7 @@ qa_pmt_prims::test_sets()
 void
 qa_pmt_prims::test_sugar()
 {
-  CPPUNIT_ASSERT(pmt::is_symbol(pmt::mp("my-symbol")));
+  CPPUNIT_ASSERT(pmt::is_string(pmt::mp("my-symbol")));
   CPPUNIT_ASSERT_EQUAL((long) 10, pmt::to_long(pmt::mp(10)));
   CPPUNIT_ASSERT_EQUAL((double) 1e6, pmt::to_double(pmt::mp(1e6)));
   CPPUNIT_ASSERT_EQUAL(std::complex<double>(2, 3),

--- a/gnuradio-runtime/python/pmt/__init__.py
+++ b/gnuradio-runtime/python/pmt/__init__.py
@@ -57,4 +57,3 @@ PMT_EOF = get_PMT_EOF()
 
 from pmt_to_python import pmt_to_python as to_python
 from pmt_to_python import python_to_pmt as to_pmt
-from pmt_to_python import str_noninterned as str_noninterned

--- a/gnuradio-runtime/python/pmt/__init__.py
+++ b/gnuradio-runtime/python/pmt/__init__.py
@@ -57,3 +57,4 @@ PMT_EOF = get_PMT_EOF()
 
 from pmt_to_python import pmt_to_python as to_python
 from pmt_to_python import python_to_pmt as to_pmt
+from pmt_to_python import str_noninterned as str_noninterned

--- a/gnuradio-runtime/python/pmt/pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/pmt_to_python.py
@@ -102,9 +102,20 @@ def uvector_to_numpy(uvector):
 	else:
 		raise ValueError("unsupported uvector data type for conversion to numpy array %s"%(uvector))
 
+class str_noninterned(str): 
+    """
+    A subclass of string used to indicate that this string should not be interned when converted from
+    Python to PMT. 
+    """
+    pass
+
+def pmt_to_str_noninterned(p):
+    return str_noninterned(pmt.to_string(p))
+
 type_mappings = ( #python type, check pmt type, to python, from python
     (None, pmt.is_null, lambda x: None, lambda x: PMT_NIL),
     (bool, pmt.is_bool, pmt.to_bool, pmt.from_bool),
+    (str_noninterned, pmt.is_string, pmt_to_str_noninterned, pmt.from_string),
     (str, pmt.is_symbol, pmt.symbol_to_string, pmt.string_to_symbol),
     (unicode, lambda x: False, None, lambda x: pmt.string_to_symbol(x.encode('utf-8'))),
     (int, pmt.is_integer, pmt.to_long, pmt.from_long),

--- a/gnuradio-runtime/python/pmt/pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/pmt_to_python.py
@@ -102,21 +102,10 @@ def uvector_to_numpy(uvector):
 	else:
 		raise ValueError("unsupported uvector data type for conversion to numpy array %s"%(uvector))
 
-class str_noninterned(str): 
-    """
-    A subclass of string used to indicate that this string should not be interned when converted from
-    Python to PMT. 
-    """
-    pass
-
-def pmt_to_str_noninterned(p):
-    return str_noninterned(pmt.to_string(p))
-
 type_mappings = ( #python type, check pmt type, to python, from python
     (None, pmt.is_null, lambda x: None, lambda x: PMT_NIL),
     (bool, pmt.is_bool, pmt.to_bool, pmt.from_bool),
-    (str_noninterned, pmt.is_string, pmt_to_str_noninterned, pmt.from_string),
-    (str, pmt.is_symbol, pmt.symbol_to_string, pmt.string_to_symbol),
+    (str, pmt.is_string, pmt.to_string, pmt.from_string),
     (unicode, lambda x: False, None, lambda x: pmt.string_to_symbol(x.encode('utf-8'))),
     (int, pmt.is_integer, pmt.to_long, pmt.from_long),
     (long, pmt.is_uint64, lambda x: long(pmt.to_uint64(x)), pmt.from_uint64),
@@ -143,4 +132,6 @@ def python_to_pmt(p):
         if python_type is None:
             if p is None: return from_python(p)
         elif isinstance(p, python_type): return from_python(p)
+        elif isinstance(p, pmt.swig_int_ptr): return p
     raise ValueError("can't convert %s type to pmt (%s)"%(type(p),p))
+

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -101,6 +101,10 @@ namespace pmt{
   pmt_t intern(const std::string &s);
   const std::string symbol_to_string(const pmt_t& sym);
 
+  bool is_string(const pmt_t& p);
+  pmt_t from_string(std::string str, bool interned=false);
+  std::string to_string(const pmt_t& p);
+
   bool is_number(pmt_t obj);
   bool is_integer(pmt_t x);
   pmt_t from_long(long x);

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -102,8 +102,8 @@ namespace pmt{
   const std::string symbol_to_string(const pmt_t& sym);
 
   bool is_string(const pmt_t& p);
-  pmt_t from_string(std::string str, bool interned=false);
-  std::string to_string(const pmt_t& p);
+  pmt_t from_string(const std::string &str);
+  const std::string to_string(const pmt_t& p);
 
   bool is_number(pmt_t obj);
   bool is_integer(pmt_t x);

--- a/gr-blocks/lib/tag_debug_impl.cc
+++ b/gr-blocks/lib/tag_debug_impl.cc
@@ -128,7 +128,7 @@ namespace gr {
           for(d_tags_itr = d_tags.begin(); d_tags_itr != d_tags.end(); d_tags_itr++) {
             sout << std::setw(10) << "Offset: " << d_tags_itr->offset
                  << std::setw(10) << "Source: "
-                 << (pmt::is_symbol(d_tags_itr->srcid) ? pmt::symbol_to_string(d_tags_itr->srcid) : "n/a")
+                 << (pmt::is_string(d_tags_itr->srcid) ? pmt::symbol_to_string(d_tags_itr->srcid) : "n/a")
                  << std::setw(10) << "Key: " << pmt::symbol_to_string(d_tags_itr->key)
                  << std::setw(10) << "Value: ";
             sout << d_tags_itr->value << std::endl;

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -391,7 +391,7 @@ namespace gr {
         }
         break;
       case STRING:
-        if(pmt::is_symbol(val)) {
+        if(pmt::is_string(val)) {
           xs = pmt::symbol_to_string(val);
           d_val->setText(QString(xs.c_str()));
         }


### PR DESCRIPTION
For my application, I use many symbol PMTs (pmt::string_to_symbol, pmt::intern) that are decoded from stream data. These strings are long and unique and they are created frequently, so over time the PMT symbol hash table fills up - old symbols cannot be removed. This causes increasing hash table access times (iterating long linked lists of collisions) and unbounded memory usage growth. 

In this case, it makes more sense to just work with the string itself rather than dealing with string interning. My solution is to add a non-interned PMT string type and appropriate functions to the PMT API - not interfering with the existing pmt_symbol API at all. 

If there are enough applications that could benefit from this functionality, I think it should be added. 

### Usage
C++:
```
// Convert string to non-interned string PMT (2nd arg indicates whether to intern - default is false)
pmt::pmt_t foo_pmt = pmt::from_string("foo", false);

// Convert non-interned string PMT to string
std::string foo_str = pmt::to_string(foo_pmt);
```
Python:
```
# Convert string to non-interned string PMT
# Use string subclass 'str_noninterned' to indicate non-interned string
foo_str = pmt.str_noninterned("foo")
foo_pmt = pmt.to_pmt(foo_str)

# Convert non-interned string PMT to string
foo_str2 = pmt.to_python(foo_pmt)
```