### PR TITLE
docs: fixed units of timeout param in all the zmq blocks

### DIFF
--- a/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
@@ -49,7 +49,7 @@ namespace gr {
        * \brief Return a shared_ptr to a new instance of zeromq::pub_msg_sink.
        *
        * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        */
       static sptr make(char *address, int timeout=100);
     };

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -51,7 +51,7 @@ namespace gr {
        * \param itemsize Size of a stream item in bytes.
        * \param vlen Vector length of the input items. Note that one vector is one item.
        * \param address  ZMQ socket address specifier.
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether sink will serialize and pass tags over the link.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */

--- a/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
@@ -46,7 +46,7 @@ namespace gr {
        * \brief Return a shared_ptr to a new instance of gr::zeromq::pull_msg_source.
        *
        * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        *
        */
       static sptr make(char *address, int timeout=100);

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -48,7 +48,7 @@ namespace gr {
        * \param itemsize Size of a stream item in bytes.
        * \param vlen Vector length of the input items. Note that one vector is one item.
        * \param address  ZMQ socket address specifier.
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */

--- a/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
@@ -48,7 +48,7 @@ namespace gr {
        * \brief Return a shared_ptr to a new instance of gr::zeromq::push_msg_sink
        *
        * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        *
        */
       static sptr make(char *address, int timeout=100);

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -52,7 +52,7 @@ namespace gr {
        * \param itemsize Size of a stream item in bytes.
        * \param vlen Vector length of the input items. Note that one vector is one item.
        * \param address  ZMQ socket address specifier.
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether sink will serialize and pass tags over the link.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */

--- a/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
@@ -48,7 +48,7 @@ namespace gr {
        * \brief Return a shared_ptr to a new instance of zeromq::rep_msg_sink.
        *
        * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        *
        */
       static sptr make(char *address, int timeout=100);

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -50,7 +50,7 @@ namespace gr {
        * \param itemsize Size of a stream item in bytes.
        * \param vlen Vector length of the input items. Note that one vector is one item.
        * \param address  ZMQ socket address specifier.
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether sink will serialize and pass tags over the link.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */

--- a/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
@@ -46,7 +46,7 @@ namespace gr {
        * \brief Return a shared_ptr to a new instance of zeromq::req_msg_source.
        *
        * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        *
        */
       static sptr make(char *address, int timeout=100);

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -48,7 +48,7 @@ namespace gr {
        * \param itemsize Size of a stream item in bytes.
        * \param vlen Vector length of the input items. Note that one vector is one item.
        * \param address  ZMQ socket address specifier.
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */

--- a/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
@@ -46,7 +46,7 @@ namespace gr {
        * \brief Return a shared_ptr to a new instance of gr::zeromq::sub_msg_source.
        *
        * \param address  ZMQ socket address specifier
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        *
        */
       static sptr make(char *address, int timeout=100);

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -48,7 +48,7 @@ namespace gr {
        * \param itemsize Size of a stream item in bytes.
        * \param vlen Vector length of the input items. Note that one vector is one item.
        * \param address  ZMQ socket address specifier.
-       * \param timeout  Receive timeout in seconds, default is 100ms, 1us increments.
+       * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
        */


### PR DESCRIPTION
pretty sure it's milliseconds