### PR TITLE
Add threshold to plateau and S&C OFDM sync

### DIFF
--- a/gr-blocks/grc/blocks_plateau_detector_fb.xml
+++ b/gr-blocks/grc/blocks_plateau_detector_fb.xml
@@ -4,6 +4,7 @@
   <key>blocks_plateau_detector_fb</key>
   <import>from gnuradio import blocks</import>
   <make>blocks.plateau_detector_fb($max_len, $threshold)</make>
+  <callback>set_threshold($threshold)</callback>
   <param>
     <name>Max. plateau length</name>
     <key>max_len</key>

--- a/gr-blocks/include/gnuradio/blocks/plateau_detector_fb.h
+++ b/gr-blocks/include/gnuradio/blocks/plateau_detector_fb.h
@@ -61,6 +61,9 @@ namespace gr {
 	* \param threshold Anything above this value is considered a plateau
 	*/
        static sptr make(int max_len, float threshold=0.9);
+
+       virtual void set_threshold(float threshold) = 0;
+       virtual float threshold() const = 0;
     };
 
   } // namespace blocks

--- a/gr-blocks/lib/plateau_detector_fb_impl.cc
+++ b/gr-blocks/lib/plateau_detector_fb_impl.cc
@@ -86,6 +86,16 @@ namespace gr {
       return i;
     }
 
+    void plateau_detector_fb_impl::set_threshold(float threshold)
+    {
+      d_threshold = threshold;
+    }
+
+    float plateau_detector_fb_impl::threshold() const
+    {
+      return d_threshold;
+    }
+
   } /* namespace blocks */
 } /* namespace gr */
 

--- a/gr-blocks/lib/plateau_detector_fb_impl.cc
+++ b/gr-blocks/lib/plateau_detector_fb_impl.cc
@@ -61,6 +61,9 @@ namespace gr {
                       gr_vector_const_void_star &input_items,
                       gr_vector_void_star &output_items)
     {
+      // thread-safe protection from ::set_threshold
+      gr::thread::scoped_lock l (d_setlock);
+
       const float *in = (const float *) input_items[0];
       unsigned char *out = (unsigned char *) output_items[0];
       int flank_start;
@@ -88,6 +91,8 @@ namespace gr {
 
     void plateau_detector_fb_impl::set_threshold(float threshold)
     {
+      // thread-safe protection from ::set_threshold
+      gr::thread::scoped_lock l (d_setlock);
       d_threshold = threshold;
     }
 

--- a/gr-blocks/lib/plateau_detector_fb_impl.h
+++ b/gr-blocks/lib/plateau_detector_fb_impl.h
@@ -44,6 +44,9 @@ class plateau_detector_fb_impl : public plateau_detector_fb
                       gr_vector_int &ninput_items,
                       gr_vector_const_void_star &input_items,
                       gr_vector_void_star &output_items);
+
+  virtual void set_threshold(float threshold);
+  virtual float threshold() const;
 };
 
   } // namespace blocks

--- a/gr-digital/grc/digital_ofdm_sync_sc_cfb.xml
+++ b/gr-digital/grc/digital_ofdm_sync_sc_cfb.xml
@@ -3,7 +3,8 @@
   <name>Schmidl &amp; Cox OFDM synch.</name>
   <key>digital_ofdm_sync_sc_cfb</key>
   <import>from gnuradio import digital</import>
-  <make>digital.ofdm_sync_sc_cfb($fft_len, $cp_len, $use_even_carriers)</make>
+  <make>digital.ofdm_sync_sc_cfb($fft_len, $cp_len, $use_even_carriers, $threshold)</make>
+  <callback>set_threshold($threshold)</callback>
   <param>
     <name>FFT length</name>
     <key>fft_len</key>
@@ -29,6 +30,14 @@
 		  <key>True</key>
 	  </option>
   </param>
+  <param>
+    <name>Threshold</name>
+    <key>threshold</key>
+    <value>0.9</value>
+    <type>real</type>
+  </param>
+  <check>$fft_len &gt; 0</check>
+  <check>$cp_len &gt;= 0</check>
   <sink>
     <name>in</name>
     <type>complex</type>

--- a/gr-digital/include/gnuradio/digital/ofdm_sync_sc_cfb.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_sync_sc_cfb.h
@@ -71,8 +71,13 @@ namespace gr {
        *  \param use_even_carriers If true, the carriers in the sync preamble are occupied such
        *                     that the even carriers are used (0, 2, 4, ...). If you use all
        *                     carriers, that would include the DC carrier, so be careful.
+       *  \param threshold detection threshold. Default is 0.9.
        */
-      static sptr make(int fft_len, int cp_len, bool use_even_carriers=false);
+      static sptr make(int fft_len, int cp_len, bool use_even_carriers=false,
+                       float threshold=0.9);
+
+      virtual void set_threshold(float threshold) = 0;
+      virtual float threshold() const = 0;
     };
 
   } // namespace digital

--- a/gr-digital/lib/ofdm_sync_sc_cfb_impl.h
+++ b/gr-digital/lib/ofdm_sync_sc_cfb_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_DIGITAL_OFDM_SYNC_SC_CFB_IMPL_H
 
 #include <gnuradio/digital/ofdm_sync_sc_cfb.h>
+#include <gnuradio/blocks/plateau_detector_fb.h>
 
 namespace gr {
   namespace digital {
@@ -31,8 +32,15 @@ namespace gr {
     class ofdm_sync_sc_cfb_impl : public ofdm_sync_sc_cfb
     {
      public:
-      ofdm_sync_sc_cfb_impl(int fft_len, int cp_len, bool use_even_carriers);
+      ofdm_sync_sc_cfb_impl(int fft_len, int cp_len, bool use_even_carriers, float threshold);
       ~ofdm_sync_sc_cfb_impl();
+
+      virtual void set_threshold(float threshold);
+      virtual float threshold() const;
+
+     private:
+      gr::blocks::plateau_detector_fb::sptr d_plateau_detector;
+
     };
 
   } // namespace digital


### PR DESCRIPTION
Adding a threshold callback and set / get allows more dynamic use of the S&C OFDM sync block. With a default threshold of 0.9, the S&C OFDM sync block has a lower noise threshold than the header or payload (e.g., if encoded using FEC). These changes allow selection of the mid-level threshold (e.g., 0.5) such that FEC can be used with benefits. In my testing, the GRC blocks are backward compatible with the current ones, as they set default values for the threshold and otherwise change nothing.