### PR TITLE
tuntap_pdu: use MTU+14 byte receive buffer for TAP

### DIFF
--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -57,7 +57,7 @@ namespace gr {
       :	block("tuntap_pdu",
 		 io_signature::make (0, 0, 0),
 		 io_signature::make (0, 0, 0)),
-	stream_pdu_base(MTU),
+	stream_pdu_base(istunflag ? MTU : MTU + 14),
 	d_dev(dev),
 	d_istunflag(istunflag)
     {


### PR DESCRIPTION
The MTU for TUN/TAP interfaces is always the IP frame MTU (1500 bytes). Currently the receive buffer is of size MTU both for TUN and TAP, but for TAP it should be MTU+14 to be able to hold the extra Ethernet header. We fix this and allow the reception of MTU sized IP frames through TAP.