### PR TITLE
[gr-blocks] improve moving_average unit test

### DIFF
--- a/gr-blocks/python/blocks/qa_moving_average.py
+++ b/gr-blocks/python/blocks/qa_moving_average.py
@@ -45,6 +45,10 @@ class test_moving_average(gr_unittest.TestCase):
     def tearDown(self):
         self.tb = None
 
+    # These tests will always pass and are therefore useless. 100 random numbers [-1,1) are
+    # getting summed up and scaled with 0.001. Then, an assertion verifies a result near 0,
+    # which is the case even if the block is malfunctioning.
+
     def test_01(self):
         tb = self.tb
 
@@ -86,6 +90,67 @@ class test_moving_average(gr_unittest.TestCase):
 
         # make sure result is close to zero
         self.assertComplexTuplesAlmostEqual(expected_result, dst_data, 1)
+
+    # This tests implement own moving average to verify correct behaviour of the block
+
+    def test_03(self):
+        tb = self.tb
+
+        N = 10000  # number of samples
+        history = 100  # num of samples to average
+        data = make_random_float_tuple(N, 1)  # generate random data
+
+        #  pythonic MA filter
+        data_padded = (history-1)*[0.0]+list(data)  # history  
+        expected_result = []
+        moving_sum = sum(data_padded[:history-1])
+        for i in range(N):
+            moving_sum += data_padded[i+history-1]
+            expected_result.append(moving_sum)
+            moving_sum -= data_padded[i]
+
+        src = blocks.vector_source_f(data, False)
+        op  = blocks.moving_average_ff(history, 1)
+        dst = blocks.vector_sink_f()
+        
+        tb.connect(src, op)
+        tb.connect(op, dst)
+        tb.run()
+    
+        dst_data = dst.data()
+
+        # make sure result is close to zero
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 4)
+
+    def test_04(self):
+        tb = self.tb
+
+        N = 10000  # number of samples
+        history = 100  # num of samples to average
+        data = make_random_complex_tuple(N, 1)  # generate random data
+
+        #  pythonic MA filter
+        data_padded = (history-1)*[0.0+1j*0.0]+list(data)  # history  
+        expected_result = []
+        moving_sum = sum(data_padded[:history-1])
+        for i in range(N):
+            moving_sum += data_padded[i+history-1]
+            expected_result.append(moving_sum)
+            moving_sum -= data_padded[i]
+
+        src = blocks.vector_source_c(data, False)
+        op  = blocks.moving_average_cc(history, 1)
+        dst = blocks.vector_sink_c()
+        
+        tb.connect(src, op)
+        tb.connect(op, dst)
+        tb.run()
+    
+        dst_data = dst.data()
+
+        # make sure result is close to zero
+        self.assertComplexTuplesAlmostEqual(expected_result, dst_data, 4)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_moving_average, "test_moving_average.xml")


### PR DESCRIPTION
This adresses #1461 . The unit test of the moving_average block was not sufficient. 100 random numbers between [-1, 1) were summed up and then scaled with 0.001. If the result was near 0, the case was passed, which should always be the case (even when the block is malfunctioning).

I added two test cases and implemented a pythonic MA filter to check the correct behaviour of the block.