### PR TITLE
runtime: Fix issue where setup_rpc() is not called for all blocks in a flowgraph

### DIFF
--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -787,13 +787,6 @@ namespace gr {
     std::vector<basic_block_sptr>::const_iterator b;   // Because flatten_aux is const
     for(b = d_blocks.begin(); b != d_blocks.end(); b++) {
       tmp.push_back(*b);
-      // for every block, attempt to setup RPC
-      if(ctrlport_on) {
-        if(!(*b)->is_rpc_set()) {
-          (*b)->setup_rpc();
-          (*b)->rpc_set();
-        }
-      }
     }
 
     // Now add the list of connected input blocks
@@ -900,6 +893,17 @@ namespace gr {
     if(HIER_BLOCK2_DETAIL_DEBUG && is_top_block){
       std::cout << "flatten_aux finished in top_block" << std::endl;
       sfg->dump();
+    }
+
+    // if ctrlport is enabled, call setup RPC for all blocks in the flowgraph
+    if(ctrlport_on) {
+      for(b = blocks.begin(); b != blocks.end(); b++) {
+        if(!(*b)->is_rpc_set()) {
+          (*b)->setup_rpc();
+          (*b)->rpc_set();
+          //std::cout << "\t- setup_rpc was run for block " << (*b)->alias() << std::endl;
+        }
+      }
     }
   }
 

--- a/gr-blocks/examples/ctrlport/simple_copy.grc
+++ b/gr-blocks/examples/ctrlport/simple_copy.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.11'?>
+<?grc format='1' created='3.7.12'?>
 <flow_graph>
   <timestamp>Sat Mar 16 22:03:14 2013</timestamp>
   <block>
@@ -390,48 +390,6 @@ to enable/disablethis block</value>
     <param>
       <key>vlen</key>
       <value>1</value>
-    </param>
-  </block>
-  <block>
-    <key>epy_block</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_io_cache</key>
-      <value>('Null Msg Source', 'blk', [], [], [('fake_output', 'message', 1)], '', [])</value>
-    </param>
-    <param>
-      <key>_source_code</key>
-      <value># Block that doesn't do anything, just used to get a msg input port on another block exposed to ControlPort
-from gnuradio import gr
-import pmt
-class blk(gr.basic_block):
-    def __init__(self): 
-        gr.basic_block.__init__(self,name='Null Msg Source',in_sig=[],out_sig=[])
-        self.message_port_register_out(pmt.intern("fake_output"))
-</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(357, 218)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>epy_block_0</value>
     </param>
   </block>
   <block>
@@ -860,11 +818,5 @@ python simple_copy_controller.py 127.0.0.1 &lt;PORT&gt; true</value>
     <sink_block_id>blocks_add_xx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>epy_block_0</source_block_id>
-    <sink_block_id>blocks_copy_0</sink_block_id>
-    <source_key>fake_output</source_key>
-    <sink_key>en</sink_key>
   </connection>
 </flow_graph>


### PR DESCRIPTION
This PR fixes an issue introduced by PR https://github.com/gnuradio/gnuradio/pull/1119 and referenced in issue https://github.com/gnuradio/gnuradio/issues/1302 related to how setup_rpc() is called for blocks. Originally this was done for the source and destination of each streaming connection, which excluded blocks that message only ports. PR1119 made this work for message ports but broke streaming ports.

This PR moves this to the end of the function that interprets flowgraphs and iterates explicitly over each connected block calling setup_rpc() if it is not setup already. This still does not setup RPC for blocks that are not connected to anything else, which may or may not be an issue.

This also removes the workaround for this bug in PR https://github.com/gnuradio/gnuradio/pull/1324 which is no longer necessary.