### PR TITLE
runtime: expose set_max_noutput_items to python

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -152,6 +152,10 @@ namespace gr {
       return gr::block::set_min_output_buffer(size);
     }
 
+    void block__set_max_noutput_items(int m) {
+      return gr::block::set_max_noutput_items(m);
+    }
+    
     int block__output_multiple(void) const {
       return gr::block::output_multiple();
     }


### PR DESCRIPTION
It looks like set_max_noutput_items was exposed to python via swig, but wasn't actually added in the .h file.  Am I missing something here or was it just never added?  I mean if you were going to call this it would be from the python flowgraph right? 