### PR TITLE
gr-digital: Install example symbol_sync_test_float_ted_gain.m file

### DIFF
--- a/gr-digital/examples/CMakeLists.txt
+++ b/gr-digital/examples/CMakeLists.txt
@@ -90,6 +90,7 @@ install(
     demod/gfsk_loopback.grc
     demod/symbol_sync_test_complex.grc
     demod/symbol_sync_test_float.grc
+    demod/symbol_sync_test_float_ted_gain.m
     demod/test_corr_and_sync.grc
     demod/test_corr_est.grc
     demod/uhd_corr_and_sync_tx.grc


### PR DESCRIPTION
Add the example symbol_sync_test_float_ted_gain.m file to the gr-digital/examples/CMakeLists.txt file for installation.  Not doing this was an oversight, when the file was first added.