### PR TITLE
gr-utils: modtool template to use float32 as default for python block signatures

### DIFF
--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -349,12 +349,12 @@ import numpy
 #if $blocktype == 'source'
 #set $inputsig = 'None'
 #else
-#set $inputsig = '[<+numpy.float+>]'
+#set $inputsig = '[<+numpy.float32+>]'
 #end if
 #if $blocktype == 'sink'
 #set $outputsig = 'None'
 #else
-#set $outputsig = '[<+numpy.float+>]'
+#set $outputsig = '[<+numpy.float32+>]'
 #end if
 #else
 #if $blocktype == 'source'


### PR DESCRIPTION
Very minor; gr_modtool template uses 'numpy.float' which defaults to numpy.float64 (double) in python 2 and 3 instead of 'numpy.float32' which is single precision and what is much more common for GR.