### PR TITLE
gr-filter: Add more filter reset methods

### DIFF
--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -134,6 +134,11 @@ namespace gr {
 	 * \param output  The result of the filter operation
 	 */
 	int filter(int nitems, const float *input, float *output);
+
+        /*!
+         * \brief Reset filter to initial (zero) state.
+         */
+        void reset();
       };
 
 
@@ -239,6 +244,11 @@ namespace gr {
 	 * \param output  The result of the filter operation
 	 */
 	int filter(int nitems, const gr_complex *input, gr_complex *output);
+
+        /*!
+         * \brief Reset filter to initial (zero) state.
+         */
+        void reset();
       };
 
 
@@ -355,6 +365,11 @@ namespace gr {
 	 * \param output  The result of the filter operation
 	 */
 	int filter(int nitems, const gr_complex *input, gr_complex *output);
+
+        /*!
+         * \brief Reset filter to initial (zero) state.
+         */
+        void reset();
       };
 
     } /* namespace kernel */

--- a/gr-filter/include/gnuradio/filter/fft_filter_ccc.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter_ccc.h
@@ -81,6 +81,11 @@ namespace gr {
        * \brief Get number of threads being used.
        */
       virtual int nthreads() const = 0;
+
+      /*!
+       * \brief Reset filter to initial (zero) state.
+       */
+      virtual void reset() = 0;
     };
 
   } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/fft_filter_ccf.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter_ccf.h
@@ -81,6 +81,11 @@ namespace gr {
        * \brief Get number of threads being used.
        */
       virtual int nthreads() const = 0;
+
+      /*!
+       * \brief Reset filter to initial (zero) state.
+       */
+      virtual void reset() = 0;
     };
 
   } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/fft_filter_fff.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter_fff.h
@@ -81,6 +81,11 @@ namespace gr {
        * \brief Get number of threads being used.
        */
       virtual int nthreads() const = 0;
+
+      /*!
+       * \brief Reset filter to initial (zero) state.
+       */
+      virtual void reset() = 0;
     };
 
   } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/single_pole_iir_filter_cc.h
+++ b/gr-filter/include/gnuradio/filter/single_pole_iir_filter_cc.h
@@ -71,6 +71,8 @@ namespace gr {
       static sptr make(double alpha, unsigned int vlen=1);
 
       virtual void set_taps(double alpha) = 0;
+
+      virtual void reset() = 0;
     };
 
   } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/single_pole_iir_filter_ff.h
+++ b/gr-filter/include/gnuradio/filter/single_pole_iir_filter_ff.h
@@ -71,6 +71,8 @@ namespace gr {
       static sptr make(double alpha, unsigned int vlen=1);
 
       virtual void set_taps (double alpha) = 0;
+
+      virtual void reset() = 0;
     };
 
   } /* namespace filter */

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -188,6 +188,12 @@ namespace gr {
 	return nitems;
       }
 
+      void
+      fft_filter_fff::reset()
+      {
+        std::fill(d_tail.begin(), d_tail.end(), 0);
+      }
+
 
       /**************************************************************/
 
@@ -343,6 +349,12 @@ namespace gr {
 	}
 
 	return nitems;
+      }
+
+      void
+      fft_filter_ccc::reset()
+      {
+        std::fill(d_tail.begin(), d_tail.end(), 0);
       }
 
 
@@ -506,6 +518,12 @@ namespace gr {
 	}
 
 	return nitems;
+      }
+
+      void
+      fft_filter_ccf::reset()
+      {
+        std::fill(d_tail.begin(), d_tail.end(), 0);
       }
 
 

--- a/gr-filter/lib/fft_filter_ccc_impl.cc
+++ b/gr-filter/lib/fft_filter_ccc_impl.cc
@@ -94,6 +94,12 @@ namespace gr {
 	return 0;
     }
 
+    void
+    fft_filter_ccc_impl::reset()
+    {
+      d_filter->reset();
+    }
+
     int
     fft_filter_ccc_impl::work(int noutput_items,
 			      gr_vector_const_void_star &input_items,

--- a/gr-filter/lib/fft_filter_ccc_impl.h
+++ b/gr-filter/lib/fft_filter_ccc_impl.h
@@ -50,6 +50,8 @@ namespace gr {
       void set_nthreads(int n);
       int nthreads() const;
 
+      void reset();
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);

--- a/gr-filter/lib/fft_filter_ccf_impl.cc
+++ b/gr-filter/lib/fft_filter_ccf_impl.cc
@@ -96,6 +96,12 @@ namespace gr {
 	return 0;
     }
 
+    void
+    fft_filter_ccf_impl::reset()
+    {
+      d_filter->reset();
+    }
+
     int
     fft_filter_ccf_impl::work(int noutput_items,
 			      gr_vector_const_void_star &input_items,

--- a/gr-filter/lib/fft_filter_ccf_impl.h
+++ b/gr-filter/lib/fft_filter_ccf_impl.h
@@ -51,6 +51,8 @@ namespace gr {
       void set_nthreads(int n);
       int nthreads() const;
 
+      void reset();
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);

--- a/gr-filter/lib/fft_filter_fff_impl.cc
+++ b/gr-filter/lib/fft_filter_fff_impl.cc
@@ -95,6 +95,12 @@ namespace gr {
 	return 0;
     }
 
+    void
+    fft_filter_fff_impl::reset()
+    {
+      d_filter->reset();
+    }
+
     int
     fft_filter_fff_impl::work(int noutput_items,
 			      gr_vector_const_void_star &input_items,

--- a/gr-filter/lib/fft_filter_fff_impl.h
+++ b/gr-filter/lib/fft_filter_fff_impl.h
@@ -50,6 +50,8 @@ namespace gr {
       void set_nthreads(int n);
       int nthreads() const;
 
+      void reset();
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);

--- a/gr-filter/lib/single_pole_iir_filter_cc_impl.cc
+++ b/gr-filter/lib/single_pole_iir_filter_cc_impl.cc
@@ -60,6 +60,14 @@ namespace gr {
       }
     }
 
+    void
+    single_pole_iir_filter_cc_impl::reset()
+    {
+      for(unsigned int i = 0; i < d_vlen; i++) {
+        d_iir[i].reset();
+      }
+    }
+
     int
     single_pole_iir_filter_cc_impl::work(int noutput_items,
 					 gr_vector_const_void_star &input_items,

--- a/gr-filter/lib/single_pole_iir_filter_cc_impl.h
+++ b/gr-filter/lib/single_pole_iir_filter_cc_impl.h
@@ -44,6 +44,8 @@ namespace gr {
 
       void set_taps(double alpha);
 
+      void reset();
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);

--- a/gr-filter/lib/single_pole_iir_filter_ff_impl.cc
+++ b/gr-filter/lib/single_pole_iir_filter_ff_impl.cc
@@ -59,6 +59,14 @@ namespace gr {
       }
     }
 
+    void
+    single_pole_iir_filter_ff_impl::reset()
+    {
+      for(unsigned int i = 0; i < d_vlen; i++) {
+        d_iir[i].reset();
+      }
+    }
+
     int
     single_pole_iir_filter_ff_impl::work(int noutput_items,
 					 gr_vector_const_void_star &input_items,

--- a/gr-filter/lib/single_pole_iir_filter_ff_impl.h
+++ b/gr-filter/lib/single_pole_iir_filter_ff_impl.h
@@ -43,6 +43,8 @@ namespace gr {
 
       void set_taps(double alpha);
 
+      void reset();
+
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,
 	       gr_vector_void_star &output_items);

--- a/gr-filter/python/filter/qa_fft_filter.py
+++ b/gr-filter/python/filter/qa_fft_filter.py
@@ -218,6 +218,28 @@ class test_fft_filter(gr_unittest.TestCase):
 
             self.assert_fft_ok2(expected_result, result_data)
 
+    def test_ccc_007(self):
+        # Test reset
+	tb = gr.top_block()
+        src_data = (2,2,2,2)
+        taps = (1,1)
+        src = blocks.vector_source_c(src_data)
+        op = filter.fft_filter_ccc(1, taps)
+        dst = blocks.vector_sink_c()
+        tb.connect(src, op, dst)
+        tb.run()
+        op.reset()
+        src.set_data((0,0,0,0))
+        tb.run()
+        result_data = dst.data()
+
+        # Make sure we have a hard falling edge instead of smoothed
+        expected_result = (2,4,4,0,0,0)
+
+        #print 'expected:', expected_result
+        #print 'results: ', result_data
+        self.assertComplexTuplesAlmostEqual (expected_result, result_data, 5)
+
     # ----------------------------------------------------------------
     # test _ccf version
     # ----------------------------------------------------------------
@@ -336,6 +358,28 @@ class test_fft_filter(gr_unittest.TestCase):
 	    result_data = dst.data()
 
             self.assert_fft_ok2(expected_result, result_data)
+
+    def test_ccf_007(self):
+        # Test reset
+	tb = gr.top_block()
+        src_data = (2,2,2,2)
+        taps = (1,1)
+        src = blocks.vector_source_c(src_data)
+        op = filter.fft_filter_ccf(1, taps)
+        dst = blocks.vector_sink_c()
+        tb.connect(src, op, dst)
+        tb.run()
+        op.reset()
+        src.set_data((0,0,0,0))
+        tb.run()
+        result_data = dst.data()
+
+        # Make sure we have a hard falling edge instead of smoothed
+        expected_result = (2,4,4,0,0,0)
+
+        #print 'expected:', expected_result
+        #print 'results: ', result_data
+        self.assertComplexTuplesAlmostEqual (expected_result, result_data, 5)
 
     # ----------------------------------------------------------------
     # test _fff version
@@ -480,6 +524,28 @@ class test_fft_filter(gr_unittest.TestCase):
             result_data = dst.data()
 
             self.assert_fft_float_ok2(expected_result, result_data)
+
+    def test_fff_008(self):
+        # Test reset
+	tb = gr.top_block()
+        src_data = (2,2,2,2)
+        taps = (1,1)
+        src = blocks.vector_source_f(src_data)
+        op = filter.fft_filter_fff(1, taps)
+        dst = blocks.vector_sink_f()
+        tb.connect(src, op, dst)
+        tb.run()
+        op.reset()
+        src.set_data((0,0,0,0))
+        tb.run()
+        result_data = dst.data()
+
+        # Make sure we have a hard falling edge instead of smoothed
+        expected_result = (2,4,4,0,0,0)
+
+        #print 'expected:', expected_result
+        #print 'results: ', result_data
+        self.assertComplexTuplesAlmostEqual (expected_result, result_data, 5)
 
     def test_fff_get0(self):
         random.seed(0)

--- a/gr-filter/python/filter/qa_single_pole_iir.py
+++ b/gr-filter/python/filter/qa_single_pole_iir.py
@@ -66,6 +66,22 @@ class test_single_pole_iir_filter(gr_unittest.TestCase):
         result_data = dst.data()
         self.assertFloatTuplesAlmostEqual(expected_result, result_data, 3)
 
+    def test_ff_004(self):
+        # Test reset
+        src_data  = (1000, 1000, 1000)
+        src = blocks.vector_source_f(src_data)
+        op = filter.single_pole_iir_filter_ff(0.5)
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        op.reset()
+        src.set_data((0, 0))
+        self.tb.run()
+        result_data = dst.data()
+        # Ensure that we have a hard edge instead of smooth
+        expected_result = (500, 750, 875, 0, 0)
+        self.assertFloatTuplesAlmostEqual(expected_result, result_data, 3)
+
     def test_cc_001(self):
         src_data = (0+0j, 1000+1000j, 2000+2000j, 3000+3000j, 4000+4000j, 5000+5000j)
         expected_result = src_data
@@ -107,6 +123,22 @@ class test_single_pole_iir_filter(gr_unittest.TestCase):
         self.tb.run()
         result_data = dst.data()
         self.assertComplexTuplesAlmostEqual(expected_result, result_data, 3)
+
+    def test_cc_004(self):
+        # Test reset
+        src_data = (1000+1000j, 1000+1000j, 1000+1000j)
+        src = blocks.vector_source_c(src_data)
+        op = filter.single_pole_iir_filter_cc(0.5)
+        dst = blocks.vector_sink_c()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        op.reset()
+        src.set_data((0+0j, 0+0j))
+        self.tb.run()
+        result_data = dst.data()
+        # Ensure that we have a hard edge instead of smooth
+        expected_result = (500+500j, 750+750j, 875+875j, 0+0j, 0+0j)
+        self.assertComplexTuplesAlmostEqual(expected_result, result_data)
 
 if __name__ == '__main__':
     gr_unittest.run(test_single_pole_iir_filter, "test_single_pole_iir_filter.xml")


### PR DESCRIPTION
This adds ``reset()`` methods to zero the state of various filters. At this point it includes reset methods on both kernels and blocks for FFT filters and single-pole IIR filters, with tests. I'd like to add more filter types before this is merged, but wanted to open a pull request early in case there's feedback.

Related to #1442.