### PR TITLE
[gr-fec] include GSL_LDFLAGS in CMakeLists to avoid linking errors in dependent in-trees

### DIFF
--- a/gr-fec/lib/CMakeLists.txt
+++ b/gr-fec/lib/CMakeLists.txt
@@ -114,7 +114,7 @@ list(APPEND gnuradio_fec_libs
 if(GSL_FOUND)
   include_directories(${GSL_INCLUDE_DIRS})
   link_directories(${GSL_LIBRARY_DIRS})
-  list(APPEND gnuradio_fec_libs ${GSL_LIBRARIES})
+  list(APPEND gnuradio_fec_libs ${GSL_LDFLAGS})
 
   list(APPEND gnuradio_fec_sources
     ldpc_bit_flip_decoder_impl.cc


### PR DESCRIPTION
These changes are required in order to build GR on macOS 10.13 with MacPorts. Also tested on Fedora 25, but further testing e.g. on Ubuntu would be sensible. If these changes are not provided, I get a linker error: `ld: library not found for -lgsl`. @bastibl hope that doesn't interfere with #1247, where you actually deleted this.