### PR TITLE
grc: Added the Delete key as a way to delete blocks and connections

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -302,6 +302,7 @@ ELEMENT_DELETE = actions.register("win.delete",
     label='_Delete',
     tooltip='Delete the selected blocks',
     icon_name='edit-delete',
+    keypresses=["Delete"],
 )
 BLOCK_MOVE = actions.register("win.block_move")
 BLOCK_ROTATE_CCW = actions.register("win.block_rotate_ccw",


### PR DESCRIPTION
This feature was present in the `master` branch. I suppose we'd like to keep it?