### PR TITLE
grc: Expose qt time sink stem plot option

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.xml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.xml
@@ -29,6 +29,7 @@ self.$(id).enable_autoscale($autoscale)
 self.$(id).enable_grid($grid)
 self.$(id).enable_axis_labels($axislabels)
 self.$(id).enable_control_panel($ctrlpanel)
+self.$(id).enable_stem_plot($stemplot)
 
 if not $legend:
   self.$(id).disable_legend()
@@ -367,6 +368,23 @@ $(gui_hint()($win))</make>
     <name>Axis Labels</name>
     <key>axislabels</key>
     <value>True</value>
+    <type>enum</type>
+    <hide>part</hide>
+    <option>
+      <name>Yes</name>
+      <key>True</key>
+    </option>
+    <option>
+      <name>No</name>
+      <key>False</key>
+    </option>
+    <tab>Config</tab>
+  </param>
+
+  <param>
+    <name>Stem Plot</name>
+    <key>stemplot</key>
+    <value>False</value>
     <type>enum</type>
     <hide>part</hide>
     <option>


### PR DESCRIPTION
Stem plots are available in the qt time sink already but not exposed through GRC. This adds a simple control.

I'm not sure if the control is better placed on the main tab or in config. Additionally there is a behavior difference between using this control and the middle click context menu option. The middle click both sets the plot type to stem and changes the point marker to circle. I can add the conditional behavior in the xml to override the marker type if stem is true, but since that is overriding the user's settings I wanted to ask for an opinion before doing that.

Current PR behavior:
![no_circle](https://user-images.githubusercontent.com/253888/32704823-e0b9331e-c803-11e7-87fa-ff3a894577ff.png)

Usual context menu result (marker overridden to circle):
![screenshot from 2017-11-12 23-47-11](https://user-images.githubusercontent.com/253888/32704824-e89460fe-c803-11e7-9052-58b6d1fe07f6.png)

