### PR TITLE
blocks: reserve memory in vector_sink constructor

### DIFF
--- a/gr-blocks/grc/blocks_vector_sink_x.xml
+++ b/gr-blocks/grc/blocks_vector_sink_x.xml
@@ -8,7 +8,7 @@
 	<name>Vector Sink</name>
 	<key>blocks_vector_sink_x</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.vector_sink_$(type.fcn)($vlen, $min_items)</make>
+	<make>blocks.vector_sink_$(type.fcn)($vlen, $reserve_items)</make>
 	<param>
 		<name>Input Type</name>
 		<key>type</key>
@@ -47,7 +47,7 @@
 	</param>
 	<param>
 		<name>Minimum data items</name>
-		<key>min_items</key>
+		<key>reserve_items</key>
 		<value>100</value>
 		<type>int</type>
 	</param>

--- a/gr-blocks/grc/blocks_vector_sink_x.xml
+++ b/gr-blocks/grc/blocks_vector_sink_x.xml
@@ -46,9 +46,9 @@
 		<type>int</type>
 	</param>
 	<param>
-		<name>Minimum data items</name>
+		<name>Reserve memory for items</name>
 		<key>reserve_items</key>
-		<value>100</value>
+		<value>1024</value>
 		<type>int</type>
 	</param>
 	<check>$vlen &gt; 0</check>

--- a/gr-blocks/grc/blocks_vector_sink_x.xml
+++ b/gr-blocks/grc/blocks_vector_sink_x.xml
@@ -8,7 +8,7 @@
 	<name>Vector Sink</name>
 	<key>blocks_vector_sink_x</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.vector_sink_$(type.fcn)($vlen)</make>
+	<make>blocks.vector_sink_$(type.fcn)($vlen, $min_items)</make>
 	<param>
 		<name>Input Type</name>
 		<key>type</key>
@@ -43,6 +43,12 @@
 		<name>Vec Length</name>
 		<key>vlen</key>
 		<value>1</value>
+		<type>int</type>
+	</param>
+	<param>
+		<name>Minimum data items</name>
+		<key>min_items</key>
+		<value>100</value>
 		<type>int</type>
 	</param>
 	<check>$vlen &gt; 0</check>

--- a/gr-blocks/include/gnuradio/blocks/vector_sink_X.h.t
+++ b/gr-blocks/include/gnuradio/blocks/vector_sink_X.h.t
@@ -41,7 +41,7 @@ namespace gr {
       // gr::blocks::@NAME@::sptr
       typedef boost::shared_ptr<@NAME@> sptr;
 
-      static sptr make(const int vlen = 1, const int min_items = 100);
+      static sptr make(const int vlen = 1, const int reserve_items = 1024);
 
       //! Clear the data and tags containers.
       virtual void reset() = 0;

--- a/gr-blocks/include/gnuradio/blocks/vector_sink_X.h.t
+++ b/gr-blocks/include/gnuradio/blocks/vector_sink_X.h.t
@@ -41,7 +41,7 @@ namespace gr {
       // gr::blocks::@NAME@::sptr
       typedef boost::shared_ptr<@NAME@> sptr;
 
-      static sptr make(int vlen = 1);
+      static sptr make(const int vlen = 1, const int min_items = 100);
 
       //! Clear the data and tags containers.
       virtual void reset() = 0;

--- a/gr-blocks/lib/vector_sink_X_impl.cc.t
+++ b/gr-blocks/lib/vector_sink_X_impl.cc.t
@@ -36,20 +36,20 @@ namespace gr {
   namespace blocks {
 
     @NAME@::sptr
-    @BASE_NAME@::make(const int vlen, const int min_items)
+    @BASE_NAME@::make(const int vlen, const int reserve_items)
     {
       return gnuradio::get_initial_sptr
-        (new @NAME_IMPL@(vlen, min_items));
+        (new @NAME_IMPL@(vlen, reserve_items));
     }
 
-    @NAME_IMPL@::@NAME_IMPL@(const int vlen, const int min_items)
+    @NAME_IMPL@::@NAME_IMPL@(const int vlen, const int reserve_items)
     : sync_block("@NAME@",
                     io_signature::make(1, 1, sizeof(@TYPE@) * vlen),
                     io_signature::make(0, 0, 0)),
     d_vlen(vlen)
     {
       gr::thread::scoped_lock guard(d_data_mutex);
-      d_data.reserve(d_vlen * min_items);
+      d_data.reserve(d_vlen * reserve_items);
     }
 
     @NAME_IMPL@::~@NAME_IMPL@()

--- a/gr-blocks/lib/vector_sink_X_impl.cc.t
+++ b/gr-blocks/lib/vector_sink_X_impl.cc.t
@@ -36,18 +36,20 @@ namespace gr {
   namespace blocks {
 
     @NAME@::sptr
-    @BASE_NAME@::make(int vlen)
+    @BASE_NAME@::make(const int vlen, const int min_items)
     {
       return gnuradio::get_initial_sptr
-        (new @NAME_IMPL@(vlen));
+        (new @NAME_IMPL@(vlen, min_items));
     }
 
-    @NAME_IMPL@::@NAME_IMPL@(int vlen)
+    @NAME_IMPL@::@NAME_IMPL@(const int vlen, const int min_items)
     : sync_block("@NAME@",
                     io_signature::make(1, 1, sizeof(@TYPE@) * vlen),
                     io_signature::make(0, 0, 0)),
     d_vlen(vlen)
     {
+      gr::thread::scoped_lock guard(d_data_mutex);
+      d_data.reserve(d_vlen * min_items);
     }
 
     @NAME_IMPL@::~@NAME_IMPL@()

--- a/gr-blocks/lib/vector_sink_X_impl.h.t
+++ b/gr-blocks/lib/vector_sink_X_impl.h.t
@@ -40,7 +40,7 @@ namespace gr {
       int d_vlen;
 
     public:
-      @NAME_IMPL@(const int vlen, const int min_items);
+      @NAME_IMPL@(const int vlen, const int reserve_items);
       ~@NAME_IMPL@();
 
       void reset();

--- a/gr-blocks/lib/vector_sink_X_impl.h.t
+++ b/gr-blocks/lib/vector_sink_X_impl.h.t
@@ -40,7 +40,7 @@ namespace gr {
       int d_vlen;
 
     public:
-      @NAME_IMPL@(int vlen);
+      @NAME_IMPL@(const int vlen, const int min_items);
       ~@NAME_IMPL@();
 
       void reset();


### PR DESCRIPTION
Might bring some performance benefits. Changes public interface to vector_sink.