### PR TITLE
cmake: use gnu${CMAKE_C_STANDARD} for cmake version < 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ ENDIF()
 
 # if cmake version is < 3.1, explicitly set C standard to use.
 IF(${CMAKE_VERSION} VERSION_LESS "3.1")
-    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c${CMAKE_C_STANDARD}")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu${CMAKE_C_STANDARD}")
 ENDIF()
 
 ########################################################################


### PR DESCRIPTION
closes #1565