### PR TITLE
socket_pdu_impl: garbage collect closed tcp_connections

### DIFF
--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -184,6 +184,15 @@ namespace gr {
     socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection, const boost::system::error_code& error)
     {
       if (!error) {
+        // Garbage collect closed sockets
+        std::vector<tcp_connection::sptr>::iterator it = d_tcp_connections.begin();
+        while(it != d_tcp_connections.end()) {
+          if (! (**it).socket().is_open())
+            it = d_tcp_connections.erase(it);
+          else
+            ++it;
+        }
+
         new_connection->start(this);
         d_tcp_connections.push_back(new_connection);
         start_tcp_accept();

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -102,6 +102,10 @@ namespace gr {
             boost::asio::placeholders::error,
             boost::asio::placeholders::bytes_transferred));
       }
+      else {
+        d_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+        d_socket.close();
+      }
     }
   } /* namespace blocks */
 }/* namespace gr */


### PR DESCRIPTION
This patch addresses two problems. First tcp_connections were not being
closed, leading to a bug report about socket exhaustion [1]. Second,
socket_pdu_impl tracks tcp_connections in a vector so that it can
broadcast outgoing data to clients. Items in this vector were never
freed.

This patch does a shutdown and close on the tcp_connection when there
is a read failure (signaling a socket close). On each new accept, the
tcp_connection list in socket_pdu_impl is scanned for closed connections,
which are then removed.

Possible improvements:
- Make sure the read error is eof.
- Check sends as well as reads.

More direct signalling could be done between tcp_connection and
socket_pdu_impl, but that would require an API change. No change
is required, here.

[1] https://github.com/gnuradio/gnuradio/issues/1568