### PR TITLE
gr-digital: The usage of 'and', 'or' and 'not' logical statements breaks compilation under MSVC

### DIFF
--- a/gr-digital/lib/clock_tracking_loop.cc
+++ b/gr-digital/lib/clock_tracking_loop.cc
@@ -251,7 +251,7 @@ namespace gr {
     void
     clock_tracking_loop::set_nom_avg_period(float period)
     {
-        if (period < d_min_avg_period or
+        if (period < d_min_avg_period ||
             period > d_max_avg_period   ) {
             d_nom_avg_period = (d_max_avg_period + d_min_avg_period)/2.0f;
         } else {

--- a/gr-digital/lib/interpolating_resampler.cc
+++ b/gr-digital/lib/interpolating_resampler.cc
@@ -282,7 +282,7 @@ namespace gr {
         // N.B. We assume in this class: NSTEPS == DNSTEPS and NTAPS == DNTAPS
 
         // Limit to the maximum number of precomputed MMSE tap sets
-        if (d_nfilters <= 0 or d_nfilters > NSTEPS)
+        if (d_nfilters <= 0 || d_nfilters > NSTEPS)
             d_nfilters = NSTEPS;
 
         // Create our polyphase filter arms for the steps from 0.0 to 1.0 from
@@ -328,7 +328,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_no_mf_cc: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -341,7 +341,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_no_mf_cc: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -376,7 +376,7 @@ namespace gr {
         // N.B. We assume in this class: NSTEPS == DNSTEPS and NTAPS == DNTAPS
 
         // Limit to the maximum number of precomputed MMSE tap sets
-        if (d_nfilters <= 0 or d_nfilters > NSTEPS)
+        if (d_nfilters <= 0 || d_nfilters > NSTEPS)
             d_nfilters = NSTEPS;
 
         // Create our polyphase filter arms for the steps from 0.0 to 1.0 from
@@ -422,7 +422,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_no_mf_ff: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -435,7 +435,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_no_mf_ff: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -498,7 +498,7 @@ namespace gr {
         for (i = 0; i < l; i++) {
             for (j = 0; j < m;  j++) {
                 k = i + j - (m - 1);
-                if (k < 0 or k >= n)
+                if (k < 0 || k >= n)
                     continue;
                 diff_taps[i] += ideal_diff_taps[(m - 1) - j] * taps[k];
             }
@@ -524,7 +524,7 @@ namespace gr {
             mag += fabsf(diff_taps[i]);
         for (i = 0; i < n; i++) {
             diff_taps[i] *= d_nfilters/mag;
-            if (d_derivative and std::isnan(diff_taps[i]))
+            if (d_derivative && std::isnan(diff_taps[i]))
                 throw std::runtime_error("interpolating_resampler_pfb_mf_ccf: "
                                          "NaN error creating derivative filter."
                                         ); 
@@ -555,7 +555,7 @@ namespace gr {
             if (d_filters[i] == NULL)
                 throw std::runtime_error("unable to create fir_filter_ccf");
 
-            if (not d_derivative)
+            if (!d_derivative)
                 continue;
 
             d_diff_taps[i] = std::vector<float>(d_taps_per_filter, 0.0f);
@@ -587,7 +587,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_mf_ccf: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -600,7 +600,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_mf_ccf: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -663,7 +663,7 @@ namespace gr {
         for (i = 0; i < l; i++) {
             for (j = 0; j < m;  j++) {
                 k = i + j - (m - 1);
-                if (k < 0 or k >= n)
+                if (k < 0 || k >= n)
                     continue;
                 diff_taps[i] += ideal_diff_taps[(m - 1) - j] * taps[k];
             }
@@ -689,7 +689,7 @@ namespace gr {
             mag += fabsf(diff_taps[i]);
         for (i = 0; i < n; i++) {
             diff_taps[i] *= d_nfilters/mag;
-            if (d_derivative and std::isnan(diff_taps[i]))
+            if (d_derivative && std::isnan(diff_taps[i]))
                 throw std::runtime_error("interpolating_resampler_pfb_mf_fff: "
                                          "NaN error creating derivative filter."
                                         ); 
@@ -720,7 +720,7 @@ namespace gr {
             if (d_filters[i] == NULL)
                 throw std::runtime_error("unable to create fir_filter_fff");
 
-            if (not d_derivative)
+            if (!d_derivative)
                 continue;
 
             d_diff_taps[i] = std::vector<float>(d_taps_per_filter, 0.0f);
@@ -752,7 +752,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_mf_fff: mu is not "
                                      "in the range [0.0, 1.0]");
 
@@ -765,7 +765,7 @@ namespace gr {
     {
         int arm = static_cast<int>(rint(mu * d_nfilters));
 
-        if (arm < 0 or arm > d_nfilters)
+        if (arm < 0 || arm > d_nfilters)
             throw std::runtime_error("interp_resampler_pfb_mf_fff: mu is not "
                                      "in the range [0.0, 1.0]");
 

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -166,7 +166,7 @@ namespace gr {
                     //samples and throwing off downstream blocks which depend
                     //on proper alignment -- for instance, a decimating FIR
                     //filter.
-//                    if(d_div == 0 and d_osps == 2) oidx++;
+//                    if(d_div == 0 && d_osps == 2) oidx++;
                     tags.erase(tags.begin());
                 }
             }

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -255,8 +255,8 @@ namespace gr {
             if (t->offset < soffset) // tag is in the past of what we care about
                 continue;
 
-            if (not pmt::eq(t->key, d_time_est_key) and  // not a time_est tag
-                not pmt::eq(t->key, d_clock_est_key)   ) // not a clock_est tag
+            if (!pmt::eq(t->key, d_time_est_key) &&  // not a time_est tag
+                !pmt::eq(t->key, d_clock_est_key)   ) // not a clock_est tag
                 continue;
 
             found = true;
@@ -272,7 +272,7 @@ namespace gr {
                 for (t2 = ++t; t2 != d_new_tags.end(); ++t2) {
                     if (t2->offset > t->offset) // search finished
                         break;
-                    if (not pmt::eq(t->key, d_clock_est_key)) // not a clock_est
+                    if (!pmt::eq(t->key, d_clock_est_key)) // not a clock_est
                         continue;
                     // Found a clock_est tag at the same offset
                     tag_offset = t2->offset;
@@ -290,7 +290,7 @@ namespace gr {
                                    pmt::to_double(pmt::tuple_ref(t->value, 1)));
             }
 
-            if (not(timing_offset >= -1.0f and timing_offset <= 1.0f)) {
+            if (!(timing_offset >= -1.0f && timing_offset <= 1.0f)) {
                 // the time_est/clock_est tag's payload is invalid
                 GR_LOG_WARN(d_logger,
                             boost::format("ignoring time_est/clock_est tag with"
@@ -300,13 +300,13 @@ namespace gr {
                 continue;
             }
 
-            if (t->offset == soffset and timing_offset < 0.0f) {
+            if (t->offset == soffset && timing_offset < 0.0f) {
                 // already handled times earlier than this previously
                 found = false;
                 continue;
             }
 
-            if (t->offset == eoffset and timing_offset >= 0.0f) {
+            if (t->offset == eoffset && timing_offset >= 0.0f) {
                 // handle times greater than this later
                 found = false;
                 break;
@@ -341,7 +341,7 @@ namespace gr {
         int i;
         std::vector<tag_t>::iterator t;
         for (t = d_tags.begin();
-             t != d_tags.end() and t->offset <= mid_period_offset;
+             t != d_tags.end() && t->offset <= mid_period_offset;
              t = d_tags.erase(t)) {
             t->offset = output_offset;
             for (i = 0; i < d_noutputs; i++)
@@ -489,7 +489,7 @@ namespace gr {
                     d_interp->differentiate(&in[ii], d_interp->phase_wrapped());
             d_ted->input(interp_output, interp_derivative);
         }
-        if (symbol_clock() and d_ted->needs_lookahead()) {
+        if (symbol_clock() && d_ted->needs_lookahead()) {
             // N.B. symbol_clock() == true implies ted_input_clock() == true
             // N.B. symbol_clock() == true implies output_sample_clock() == true
 

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -255,8 +255,8 @@ namespace gr {
             if (t->offset < soffset) // tag is in the past of what we care about
                 continue;
 
-            if (not pmt::eq(t->key, d_time_est_key) and  // not a time_est tag
-                not pmt::eq(t->key, d_clock_est_key)   ) // not a clock_est tag
+            if (!pmt::eq(t->key, d_time_est_key) &&  // not a time_est tag
+                !pmt::eq(t->key, d_clock_est_key)   ) // not a clock_est tag
                 continue;
 
             found = true;
@@ -272,7 +272,7 @@ namespace gr {
                 for (t2 = ++t; t2 != d_new_tags.end(); ++t2) {
                     if (t2->offset > t->offset) // search finished
                         break;
-                    if (not pmt::eq(t->key, d_clock_est_key)) // not a clock_est
+                    if (!pmt::eq(t->key, d_clock_est_key)) // not a clock_est
                         continue;
                     // Found a clock_est tag at the same offset
                     tag_offset = t2->offset;
@@ -290,7 +290,7 @@ namespace gr {
                                    pmt::to_double(pmt::tuple_ref(t->value, 1)));
             }
 
-            if (not(timing_offset >= -1.0f and timing_offset <= 1.0f)) {
+            if (!(timing_offset >= -1.0f && timing_offset <= 1.0f)) {
                 // the time_est/clock_est tag's payload is invalid
                 GR_LOG_WARN(d_logger,
                             boost::format("ignoring time_est/clock_est tag with"
@@ -300,13 +300,13 @@ namespace gr {
                 continue;
             }
 
-            if (t->offset == soffset and timing_offset < 0.0f) {
+            if (t->offset == soffset && timing_offset < 0.0f) {
                 // already handled times earlier than this previously
                 found = false;
                 continue;
             }
 
-            if (t->offset == eoffset and timing_offset >= 0.0f) {
+            if (t->offset == eoffset && timing_offset >= 0.0f) {
                 // handle times greater than this later
                 found = false;
                 break;
@@ -341,7 +341,7 @@ namespace gr {
         int i;
         std::vector<tag_t>::iterator t;
         for (t = d_tags.begin();
-             t != d_tags.end() and t->offset <= mid_period_offset;
+             t != d_tags.end() && t->offset <= mid_period_offset;
              t = d_tags.erase(t)) {
             t->offset = output_offset;
             for (i = 0; i < d_noutputs; i++)
@@ -489,7 +489,7 @@ namespace gr {
                     d_interp->differentiate(&in[ii], d_interp->phase_wrapped());
             d_ted->input(interp_output, interp_derivative);
         }
-        if (symbol_clock() and d_ted->needs_lookahead()) {
+        if (symbol_clock() && d_ted->needs_lookahead()) {
             // N.B. symbol_clock() == true implies ted_input_clock() == true
             // N.B. symbol_clock() == true implies output_sample_clock() == true
 

--- a/gr-digital/lib/timing_error_detector.cc
+++ b/gr-digital/lib/timing_error_detector.cc
@@ -215,7 +215,7 @@ namespace gr {
     void
     timing_error_detector::revert(bool preserve_error)
     {
-        if (d_input_clock == 0 and preserve_error != true)
+        if (d_input_clock == 0 && preserve_error != true)
             d_error = d_prev_error;
         revert_input_clock();
 


### PR DESCRIPTION
i.e. with Geof Nieboer's scripts.

Replacing them with '&&', '||' and '!' respectively.