### PR TITLE
cleanup: remove dynamic exception specifications

### DIFF
--- a/gnuradio-runtime/swig/hier_block2.i
+++ b/gnuradio-runtime/swig/hier_block2.i
@@ -34,7 +34,7 @@ namespace gr {
   make_hier_block2(const std::string name,
                    gr::io_signature::sptr input_signature,
                    gr::io_signature::sptr output_signature)
-  throw (std::runtime_error);
+    noexcept(false);
 }
 
 // Rename connect and disconnect so that we can more easily build a
@@ -58,28 +58,28 @@ namespace gr {
     ~hier_block2 ();
 
     void connect(gr::basic_block_sptr block)
-      throw (std::invalid_argument);
+      noexcept(false);
     void connect(gr::basic_block_sptr src, int src_port,
                  gr::basic_block_sptr dst, int dst_port)
-      throw (std::invalid_argument);
+      noexcept(false);
     void msg_connect(gr::basic_block_sptr src, pmt::pmt_t srcport,
                      gr::basic_block_sptr dst, pmt::pmt_t dstport)
-      throw (std::runtime_error);
+      noexcept(false);
     void msg_connect(gr::basic_block_sptr src, std::string srcport,
                      gr::basic_block_sptr dst,  std::string dstport)
-      throw (std::runtime_error);
+      noexcept(false);
     void msg_disconnect(gr::basic_block_sptr src, pmt::pmt_t srcport,
                         gr::basic_block_sptr dst, pmt::pmt_t dstport)
-      throw (std::runtime_error);
+      noexcept(false);
     void msg_disconnect(gr::basic_block_sptr src, std::string srcport,
                         gr::basic_block_sptr dst, std::string dstport)
-      throw (std::runtime_error);
+      noexcept(false);
 
     void disconnect(gr::basic_block_sptr block)
-      throw (std::invalid_argument);
+      noexcept(false);
     void disconnect(gr::basic_block_sptr src, int src_port,
                     gr::basic_block_sptr dst, int dst_port)
-      throw (std::invalid_argument);
+      noexcept(false);
     void disconnect_all();
     void lock();
     void unlock();

--- a/gnuradio-runtime/swig/top_block.i
+++ b/gnuradio-runtime/swig/top_block.i
@@ -37,12 +37,12 @@ namespace gr {
   public:
     ~top_block();
 
-    void start(int max_noutput_items=100000000) throw (std::runtime_error);
+    void start(int max_noutput_items=100000000) noexcept(false);
     void stop();
     //void wait();
     //void run() throw (std::runtime_error);
     void lock();
-    void unlock() throw (std::runtime_error);
+    void unlock() noexcept(false);
     std::string edge_list();
     std::string msg_edge_list();
     void dump();
@@ -57,7 +57,7 @@ namespace gr {
 #ifdef SWIGPYTHON
 
 %inline %{
-void top_block_run_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
+void top_block_run_unlocked(gr::top_block_sptr r) noexcept(false)
 {
     GR_PYTHON_BLOCKING_CODE
     (
@@ -65,7 +65,7 @@ void top_block_run_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
     )
 }
 
-void top_block_start_unlocked(gr::top_block_sptr r, int max_noutput_items) throw (std::runtime_error)
+void top_block_start_unlocked(gr::top_block_sptr r, int max_noutput_items) noexcept(false)
 {
     GR_PYTHON_BLOCKING_CODE
     (
@@ -73,7 +73,7 @@ void top_block_start_unlocked(gr::top_block_sptr r, int max_noutput_items) throw
     )
 }
 
-void top_block_wait_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
+void top_block_wait_unlocked(gr::top_block_sptr r) noexcept(false)
 {
     GR_PYTHON_BLOCKING_CODE
     (
@@ -81,7 +81,7 @@ void top_block_wait_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
     )
 }
 
-void top_block_stop_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
+void top_block_stop_unlocked(gr::top_block_sptr r) noexcept(false)
 {
     GR_PYTHON_BLOCKING_CODE
     (
@@ -89,7 +89,7 @@ void top_block_stop_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
     )
 }
 
-void top_block_unlock_unlocked(gr::top_block_sptr r) throw (std::runtime_error)
+void top_block_unlock_unlocked(gr::top_block_sptr r) noexcept(false)
 {
     GR_PYTHON_BLOCKING_CODE
     (

--- a/gr-audio/lib/alsa/alsa_sink.cc
+++ b/gr-audio/lib/alsa/alsa_sink.cc
@@ -538,7 +538,7 @@ namespace gr {
     }
 
     void
-    alsa_sink::bail(const char *msg, int err) throw (std::runtime_error)
+    alsa_sink::bail(const char *msg, int err)
     {
       output_error_msg(msg, err);
       throw std::runtime_error("audio_alsa_sink");

--- a/gr-audio/lib/alsa/alsa_sink.h
+++ b/gr-audio/lib/alsa/alsa_sink.h
@@ -71,7 +71,7 @@ namespace gr {
       bool d_ok_to_block; // defaults to "true", controls blocking/non-block I/O
 
       void output_error_msg(const char *msg, int err);
-      void bail(const char *msg, int err) throw (std::runtime_error);
+      void bail(const char *msg, int err);
 
     public:
       alsa_sink(int sampling_rate,

--- a/gr-audio/lib/alsa/alsa_source.cc
+++ b/gr-audio/lib/alsa/alsa_source.cc
@@ -503,7 +503,7 @@ namespace gr {
     }
 
     void
-    alsa_source::bail(const char *msg, int err) throw (std::runtime_error)
+    alsa_source::bail(const char *msg, int err)
     {
       output_error_msg(msg, err);
       throw std::runtime_error("audio_alsa_source");

--- a/gr-audio/lib/alsa/alsa_source.h
+++ b/gr-audio/lib/alsa/alsa_source.h
@@ -74,7 +74,7 @@ namespace gr {
       int d_nsuspends;  // count of suspends
 
       void output_error_msg(const char *msg, int err);
-      void bail(const char *msg, int err) throw (std::runtime_error);
+      void bail(const char *msg, int err);
 
     public:
       alsa_source(int sampling_rate,

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -256,7 +256,7 @@ namespace gr {
     }
 
     void
-    jack_sink::bail(const char *msg, int err) throw (std::runtime_error)
+    jack_sink::bail(const char *msg, int err)
     {
       output_error_msg(msg, err);
       throw std::runtime_error("audio_jack_sink");

--- a/gr-audio/lib/jack/jack_sink.h
+++ b/gr-audio/lib/jack/jack_sink.h
@@ -67,7 +67,7 @@ namespace gr {
       int d_nunderuns;    // count of underruns
 
       void output_error_msg(const char *msg, int err);
-      void bail(const char *msg, int err) throw (std::runtime_error);
+      void bail(const char *msg, int err);
 
     public:
       jack_sink(int sampling_rate,

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -256,7 +256,7 @@ namespace gr {
     }
 
     void
-    jack_source::bail(const char *msg, int err) throw (std::runtime_error)
+    jack_source::bail(const char *msg, int err)
     {
       output_error_msg(msg, err);
       throw std::runtime_error("audio_jack_source");

--- a/gr-audio/lib/jack/jack_source.h
+++ b/gr-audio/lib/jack/jack_source.h
@@ -67,7 +67,7 @@ namespace gr {
       int d_noverruns;  // count of overruns
 
       void output_error_msg(const char *msg, int err);
-      void bail(const char *msg, int err) throw (std::runtime_error);
+      void bail(const char *msg, int err);
 
     public:
       jack_source(int sampling_rate,

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -368,7 +368,7 @@ namespace gr {
     }
 
     void
-    portaudio_sink::bail(const char *msg, int err) throw (std::runtime_error)
+    portaudio_sink::bail(const char *msg, int err)
     {
       output_error_msg(msg, err);
       throw std::runtime_error("audio_portaudio_sink");

--- a/gr-audio/lib/portaudio/portaudio_sink.h
+++ b/gr-audio/lib/portaudio/portaudio_sink.h
@@ -67,7 +67,7 @@ namespace gr {
       //gri_logger_sptr d_log;  // handle to non-blocking logging instance
 
       void output_error_msg(const char *msg, int err);
-      void bail(const char *msg, int err) throw (std::runtime_error);
+      void bail(const char *msg, int err);
       void create_ringbuffer();
 
     public:

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -376,7 +376,7 @@ namespace gr {
     }
 
     void
-    portaudio_source::bail(const char *msg, int err) throw (std::runtime_error)
+    portaudio_source::bail(const char *msg, int err)
     {
       output_error_msg(msg, err);
       throw std::runtime_error("audio_portaudio_source");

--- a/gr-audio/lib/portaudio/portaudio_source.h
+++ b/gr-audio/lib/portaudio/portaudio_source.h
@@ -66,7 +66,7 @@ namespace gr {
       int d_noverruns;  // count of overruns
 
       void output_error_msg(const char *msg, int err);
-      void bail(const char *msg, int err) throw (std::runtime_error);
+      void bail(const char *msg, int err);
       void create_ringbuffer();
 
     public:

--- a/gr-blocks/python/blocks/qa_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_hier_block2.py
@@ -71,7 +71,7 @@ class test_hier_block2(gr_unittest.TestCase):
 	nop1 = blocks.nop(gr.sizeof_int)
 	nop2 = blocks.nop(gr.sizeof_int)
 	hblock.connect(nop1, hblock)
-	self.assertRaises(ValueError,
+	self.assertRaises(RuntimeError,
 	    lambda: hblock.connect(nop2, hblock))
 
     def test_006_connect_invalid_src_port_neg(self):
@@ -79,7 +79,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int),
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
-	self.assertRaises(ValueError,
+	self.assertRaises(RuntimeError,
 	    lambda: hblock.connect((hblock, -1), nop1))
 
     def test_005_connect_invalid_src_port_exceeds(self):
@@ -87,7 +87,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int),
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
-	self.assertRaises(ValueError,
+	self.assertRaises(RuntimeError,
 	    lambda: hblock.connect((hblock, 1), nop1))
 
     def test_007_connect_invalid_dst_port_neg(self):
@@ -96,7 +96,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
 	nop2 = blocks.nop(gr.sizeof_int)
-	self.assertRaises(ValueError,
+	self.assertRaises(RuntimeError,
 	    lambda: hblock.connect(nop1, (nop2, -1)))
 
     def test_008_connect_invalid_dst_port_exceeds(self):
@@ -105,7 +105,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.null_sink(gr.sizeof_int)
 	nop2 = blocks.null_sink(gr.sizeof_int)
-	self.assertRaises(ValueError,
+	self.assertRaises(RuntimeError,
 	    lambda: hblock.connect(nop1, (nop2, 1)))
 
     def test_009_check_topology(self):
@@ -141,7 +141,7 @@ class test_hier_block2(gr_unittest.TestCase):
 	nop1 = blocks.nop(gr.sizeof_int)
         nop2 = blocks.nop(gr.sizeof_int)
 	hblock.connect(hblock, nop1)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
             lambda: hblock.disconnect(hblock, nop2))
 
     def test_014_disconnect_input_neg(self):
@@ -150,7 +150,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
 	hblock.connect(hblock, nop1)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
             lambda: hblock.disconnect((hblock, -1), nop1))
 
     def test_015_disconnect_input_exceeds(self):
@@ -159,7 +159,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
 	hblock.connect(hblock, nop1)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
             lambda: hblock.disconnect((hblock, 1), nop1))
 
     def test_016_disconnect_output(self):
@@ -177,7 +177,7 @@ class test_hier_block2(gr_unittest.TestCase):
 	nop1 = blocks.nop(gr.sizeof_int)
         nop2 = blocks.nop(gr.sizeof_int)
 	hblock.connect(nop1, hblock)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
             lambda: hblock.disconnect(nop2, hblock))
 
     def test_018_disconnect_output_neg(self):
@@ -186,7 +186,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
 	hblock.connect(hblock, nop1)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
             lambda: hblock.disconnect(nop1, (hblock, -1)))
 
     def test_019_disconnect_output_exceeds(self):
@@ -195,7 +195,7 @@ class test_hier_block2(gr_unittest.TestCase):
 				gr.io_signature(1,1,gr.sizeof_int))
 	nop1 = blocks.nop(gr.sizeof_int)
 	hblock.connect(nop1, hblock)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
             lambda: hblock.disconnect(nop1, (hblock, 1)))
 
     def test_020_run(self):
@@ -219,7 +219,7 @@ class test_hier_block2(gr_unittest.TestCase):
         blk = gr.hier_block2("block",
                              gr.io_signature(1, 1, 1),
                              gr.io_signature(1, 1, 1))
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
                           lambda: hblock.connect(blk))
 
     def test_023_connect_single_twice(self):
@@ -228,7 +228,7 @@ class test_hier_block2(gr_unittest.TestCase):
                              gr.io_signature(0, 0, 0),
                              gr.io_signature(0, 0, 0))
         hblock.connect(blk)
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
                           lambda: hblock.connect(blk))
 
     def test_024_disconnect_single(self):
@@ -244,7 +244,7 @@ class test_hier_block2(gr_unittest.TestCase):
         blk = gr.hier_block2("block",
                              gr.io_signature(0, 0, 0),
                              gr.io_signature(0, 0, 0))
-        self.assertRaises(ValueError,
+        self.assertRaises(RuntimeError,
                           lambda: hblock.disconnect(blk))
 
     def test_026_run_single(self):

--- a/gr-filter/include/gnuradio/filter/iir_filter.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter.h
@@ -120,7 +120,7 @@ namespace gr {
 	iir_filter(const std::vector<tap_type>& fftaps,
 		   const std::vector<tap_type>& fbtaps,
 		   bool oldstyle=true)
-	  throw (std::invalid_argument)
+    noexcept(false)
 	{
 	  d_oldstyle = oldstyle;
 	  set_taps(fftaps, fbtaps);
@@ -153,7 +153,6 @@ namespace gr {
 	 */
 	void set_taps(const std::vector<tap_type> &fftaps,
 		      const std::vector<tap_type> &fbtaps)
-	  throw (std::invalid_argument)
 	{
 	  d_latest_n = 0;
 	  d_latest_m = 0;

--- a/gr-filter/include/gnuradio/filter/pm_remez.h
+++ b/gr-filter/include/gnuradio/filter/pm_remez.h
@@ -64,7 +64,7 @@ namespace gr {
 	     const std::vector<double> &error_weight,
 	     const std::string filter_type = "bandpass",
 	     int grid_density = 16
-	     ) throw (std::runtime_error);
+             ) noexcept(false);
 
   } /* namespace filter */
 } /* namespace gr */

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -776,7 +776,8 @@ namespace gr {
 	     const std::vector<double> &arg_weight,
 	     const std::string filter_type,
 	     int grid_density
-	     ) throw (std::runtime_error)
+	     )
+      noexcept(false)
     {
       int numtaps = order + 1;
       if(numtaps < 4)


### PR DESCRIPTION
Dynamic exception specifications are deprecated in C++11. Definining function with `noexcept()` is the way to go from C++11 on. `throw()` will be redefined to `noexecept(true)` in C++17.

We only have to define `noexcept(false)` for:
 - destructors
 - {default,copy,move} constructors
 - {copy,move} assignment operators
 - deallocation functions

Otherwise all other functions in C++ are potentially throwing by definition.
I wasn't sure about the swig templates, so I replaced throw(`something`) with noexcept(false) to give swig a hint that those functions are potentially throwing.