### PR TITLE
runtime: address floating point roundoff concerns in num_to_str() in …

### DIFF
--- a/gnuradio-runtime/python/gnuradio/eng_notation.py
+++ b/gnuradio-runtime/python/gnuradio/eng_notation.py
@@ -36,29 +36,30 @@ scale_factor['p'] = 1e-12
 scale_factor['f'] = 1e-15
 scale_factor['a'] = 1e-18
 
-def num_to_str (n):
+def num_to_str (n, precision=6):
     '''Convert a number to a string in engineering notation.  E.g., 5e-9 -> 5n'''
     m = abs(n)
+    format_spec = '%.' + repr(int(precision)) + 'g'
     if m >= 1e9:
-        return "%gG" % (n * 1e-9)
+        return '%sG' % float(format_spec % (n * 1e-9))
     elif m >= 1e6:
-        return "%gM" % (n * 1e-6)
+        return '%sM' % float(format_spec % (n * 1e-6))
     elif m >= 1e3:
-        return "%gk" % (n * 1e-3)
+        return '%sk' % float(format_spec % (n * 1e-3))
     elif m >= 1:
-        return "%g" % (n)
+        return '%s' % float(format_spec % (n))
     elif m >= 1e-3:
-        return "%gm" % (n * 1e3)
+        return '%sm' % float(format_spec % (n * 1e3))
     elif m >= 1e-6:
-        return "%gu" % (n * 1e6)        # where's that mu when you need it (unicode?)
+        return '%su' % float(format_spec % (n * 1e6))
     elif m >= 1e-9:
-        return "%gn" % (n * 1e9)
+        return '%sn' % float(format_spec % (n * 1e9))
     elif m >= 1e-12:
-        return "%gp" % (n * 1e12)
+        return '%sp' % float(format_spec % (n * 1e12))
     elif m >= 1e-15:
-        return "%gf" % (n * 1e15)
+        return '%sf' % float(format_spec % (n * 1e15))
     else:
-        return "%g" % (n)
+        return '%s' % float(format_spec % (n))
 
 
 def str_to_num (value):


### PR DESCRIPTION
…eng_notation - attempt 2

This PR addresses Issue #1523 and will ensure the eng_notation module does not cause added floating point roundoff. This is a follow-on to PR #1525 that does not change the default behavior.

Before:
```
eng_notation.num_to_str(11234123412.12341234)
'11.2341G'
```

After:
```
>>> eng_notation.num_to_str(11234123412.12341234)
'11.2341G'
>>> eng_notation.num_to_str(11234123412.12341234, 10)
'11.23412341G'
>>> eng_notation.num_to_str(1234123412.12341234, 1)
'10.0G'
```

Using `String.format()` was discussed, however this caused undesirable results for some values and precisions:

```
>>> eng_notation.num_to_str(11234123412.12341234,1)
'1e+01G'
``` 