### PR TITLE
gr_modtool: python QA code for C++ blocks will attempt non swig module import

### DIFF
--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -494,7 +494,10 @@ ${str_to_python_comment($license)}
 from gnuradio import gr, gr_unittest
 from gnuradio import blocks
 #if $lang == 'cpp'
-import ${modname}_swig as ${modname}
+try:
+    import ${modname}_swig as ${modname}
+except ImportError:
+    import ${modname} as ${modname}
 #else
 from ${blockname} import ${blockname}
 #end if
@@ -782,4 +785,3 @@ add_executable($basename $filename)
 target_link_libraries($basename gnuradio-$modname \${Boost_LIBRARIES})
 GR_ADD_TEST($basename $basename)
 """
-


### PR DESCRIPTION
Change allows python QA code for C++ blocks to attempt to import the module directly if import of module_swig fails. This allows for running the QA code explicitly which is helpful for non-build time tests (and efficient writing of QA code): `python qa_my_cpp_block.py`