### PR TITLE
pmt: fix for error in pmt::equal() when comparing uniform vectors

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -1163,7 +1163,7 @@ equal(const pmt_t& x, const pmt_t& y)
 	       len_x) == 0)
       return true;
 
-    return true;
+    return false;
   }
 
   // FIXME add other cases here...

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -1158,9 +1158,9 @@ equal(const pmt_t& x, const pmt_t& y)
       return false;
 
     size_t len_x, len_y;
-    if (memcmp(xv->uniform_elements(len_x),
-	       yv->uniform_elements(len_y),
-	       len_x) == 0)
+    const void *x_m = xv->uniform_elements(len_x);
+    const void *y_m = yv->uniform_elements(len_y);
+    if (memcmp(x_m, y_m, len_x) == 0)
       return true;
 
     return false;


### PR DESCRIPTION
PMT uniform vector comparisons with pmt::equal() do not fail for different vector elements provided the vectors are the same size and type:

before:

```
>>> import pmt
>>> uv1 = pmt.init_u8vector(4,[1,2,3,4])
>>> uv2 = pmt.init_u8vector(4,[5,6,7,8])
>>> uv3 = pmt.init_u8vector(4,[5,6,7,8])
>>> pmt.equal(uv1, uv2)
True
>>> pmt.equal(uv2, uv3)
True
```

after:

```
>>> import pmt
>>> uv1 = pmt.init_u8vector(4,[1,2,3,4])
>>> uv2 = pmt.init_u8vector(4,[5,6,7,8])
>>> uv3 = pmt.init_u8vector(4,[5,6,7,8])
>>> pmt.equal(uv1, uv2)
False
>>> pmt.equal(uv2, uv3)
True
```