### PR TITLE
modtool: SequenceCompleter has default [] sequence

### DIFF
--- a/gr-utils/python/modtool/util_functions.py
+++ b/gr-utils/python/modtool/util_functions.py
@@ -150,9 +150,12 @@ class SequenceCompleter(object):
     """ A simple completer function wrapper to be used with readline, e.g.
     option_iterable = ("search", "seek", "destroy")
     readline.set_completer(SequenceCompleter(option_iterable).completefunc)
+
+    Typical usage is with the `with` statement. Restores the previous completer
+    at exit, thus nestable.
     """
 
-    def __init__(self, sequence):
+    def __init__(self, sequence=[]):
         self._seq = sequence
         self._tmp_matches = []
 

--- a/gr-utils/python/modtool/util_functions.py
+++ b/gr-utils/python/modtool/util_functions.py
@@ -155,8 +155,8 @@ class SequenceCompleter(object):
     at exit, thus nestable.
     """
 
-    def __init__(self, sequence=[]):
-        self._seq = sequence
+    def __init__(self, sequence=None):
+        self._seq = sequence or []
         self._tmp_matches = []
 
     def completefunc(self, text, state):


### PR DESCRIPTION
Fixes #1602, where SequenceCompleter was called from `gr_modtool rm`
without any argument.

Note that the longer-term goal is still to amend the `rm` statement's
code to prepare a good list of candidates instead of reducing the usage
of SequenceCompleter to just enabling readline editing capabilities.