### PR TITLE
Update selective_fading_model_impl.cc

### DIFF
--- a/gr-channels/lib/selective_fading_model_impl.cc
+++ b/gr-channels/lib/selective_fading_model_impl.cc
@@ -103,7 +103,7 @@ namespace gr {
                 //gr_complex ff_H(d_faders[j]->next_sample());
                 for(size_t k=0; k<d_taps.size(); k++){
                     float dist = k-d_delays[j];
-                    float interpmag = d_sintable.sinc(2*M_PI*dist);
+                    float interpmag = d_sintable.sinc(M_PI*dist);
                     d_taps[k] += ff_H * interpmag * d_mags[j];
                 }
             }


### PR DESCRIPTION
The multiplication by 2 in the sinc() function argument appears to be a mistake. It, for example, results in signal paths with a delay of 0.5 sample time being completely ignored.

https://en.wikipedia.org/wiki/Sinc_function

The same change may be required in 'selective_fading_model2_impl.cc'.