### PR TITLE
python gateway: permit a variable number of ports

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/__init__.py
+++ b/gnuradio-runtime/python/gnuradio/gr/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2003-2012 Free Software Foundation, Inc.
+# Copyright 2003-2012, 2018 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -44,7 +44,7 @@ from exceptions import *
 from top_block import *
 from hier_block2 import *
 from tag_utils import *
-from gateway import basic_block, sync_block, decim_block, interp_block
+from gateway import basic_block, sync_block, decim_block, interp_block, py_io_signature
 
 # Force the preference database to be initialized
 prefs = prefs.singleton

--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -100,7 +100,7 @@ class py_io_signature(object):
     def port_types(self, nports):
         ntypes = len(self.__types)
         if ntypes == 0:
-            return []
+            return ()
         if nports <= ntypes:
             return self.__types[:nports]
         return self.__types + [self.__types[-1]]*(nports-ntypes)
@@ -112,9 +112,9 @@ class gateway_block(object):
 
     def __init__(self, name, in_sig, out_sig, work_type, factor):
 
-        # Normalize the many Python ways of saying 'nothing' to '[]'
-        in_sig = in_sig or []
-        out_sig = out_sig or []
+        # Normalize the many Python ways of saying 'nothing' to '()'
+        in_sig = in_sig or ()
+        out_sig = out_sig or ()
 
         # Backward compatibility: array of type strings -> py_io_signature
         if type(in_sig) is py_io_signature:

--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -81,6 +81,19 @@ class msg_handler(gr.feval_p):
 # io_signature for Python
 ########################################################################
 class py_io_signature(object):
+    """Describes the type/number of ports for block input or output.
+
+    Args:
+
+    min_ports (int): mininum number of connected ports.
+
+    max_ports (int): maximum number of connected ports. -1 indicates
+    no limit.
+
+    type_list (list[str]): numpy type names for each port. If the
+    number of connected ports is greater than the number of types
+    provided, the last type in the list is repeated.
+    """
 
     # Minimum and maximum number of ports, and a list of numpy types.
     def __init__(self, min_ports, max_ports, type_list):
@@ -249,6 +262,17 @@ class gateway_block(object):
 # Wrappers for the user to inherit from
 ########################################################################
 class basic_block(gateway_block):
+    """Args:
+    name (str): block name
+
+    in_sig (gr.py_io_signature): input port signature
+
+    out_sig (gr.py_io_signature): output port signature
+
+    For backward compatibility, a sequence of numpy type names is also
+    accepted as an io signature.
+
+    """
     def __init__(self, name, in_sig, out_sig):
         gateway_block.__init__(self,
             name=name,
@@ -259,6 +283,17 @@ class basic_block(gateway_block):
         )
 
 class sync_block(gateway_block):
+    """
+    Args:
+    name (str): block name
+
+    in_sig (gr.py_io_signature): input port signature
+
+    out_sig (gr.py_io_signature): output port signature
+
+    For backward compatibility, a sequence of numpy type names is also
+    accepted as an io signature.
+    """
     def __init__(self, name, in_sig, out_sig):
         gateway_block.__init__(self,
             name=name,
@@ -269,6 +304,17 @@ class sync_block(gateway_block):
         )
 
 class decim_block(gateway_block):
+    """
+    Args:
+    name (str): block name
+
+    in_sig (gr.py_io_signature): input port signature
+
+    out_sig (gr.py_io_signature): output port signature
+
+    For backward compatibility, a sequence of numpy type names is also
+    accepted as an io signature.
+    """
     def __init__(self, name, in_sig, out_sig, decim):
         gateway_block.__init__(self,
             name=name,
@@ -279,6 +325,17 @@ class decim_block(gateway_block):
         )
 
 class interp_block(gateway_block):
+    """
+    Args:
+    name (str): block name
+
+    in_sig (gr.py_io_signature): input port signature
+
+    out_sig (gr.py_io_signature): output port signature
+
+    For backward compatibility, a sequence of numpy type names is also
+    accepted as an io signature.
+    """
     def __init__(self, name, in_sig, out_sig, interp):
         gateway_block.__init__(self,
             name=name,

--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -167,13 +167,13 @@ class gateway_block(object):
                     self.__message.general_work_args_input_items[i],
                     in_types[i],
                     self.__message.general_work_args_ninput_items[i]
-                ) for i in xrange(ninputs)],
+                ) for i in range(ninputs)],
 
                 output_items=[pointer_to_ndarray(
                     self.__message.general_work_args_output_items[i],
                     out_types[i],
                     self.__message.general_work_args_noutput_items
-                ) for i in xrange(noutputs)],
+                ) for i in range(noutputs)],
             )
 
         elif self.__message.action == gr.block_gw_message_type.ACTION_WORK:
@@ -188,13 +188,13 @@ class gateway_block(object):
                     self.__message.work_args_input_items[i],
                     in_types[i],
                     self.__message.work_args_ninput_items
-                ) for i in xrange(ninputs)],
+                ) for i in range(ninputs)],
 
                 output_items=[pointer_to_ndarray(
                     self.__message.work_args_output_items[i],
                     out_types[i],
                     self.__message.work_args_noutput_items
-                ) for i in xrange(noutputs)],
+                ) for i in range(noutputs)],
             )
 
         elif self.__message.action == gr.block_gw_message_type.ACTION_FORECAST:


### PR DESCRIPTION
Here is an initial cut at allowing Python blocks to have a variable number of ports. Backward compatibility is maintained by checking the type of io args passed to the constructor. The test program below shows how this works. A new py_io_signature class is used. This class is similar to io_signature, but keeps track of the numpy type for each port.

Performance is within 5% of the previous version.

```
-----
EXAMPLE OF USAGE (implements multi-port add block)
-----

#!/usr/bin/env python

from gnuradio import gr, blocks
import numpy as np

# Set this to test py_io_signature
NEW=1

class TestBasic(gr.basic_block):

    def __init__(self):

        # Using py_io_signature, variable number of inputs, fixed number of outputs
        if NEW:
            gr.basic_block.__init__(self, "Test",
                                    gr.py_io_signature(2,-1, ['float32', 'float32']),
                                    gr.py_io_signature(1, 1, ['float32']))

        # Backward compatible, fixed number of I/O ports
        else:
            gr.basic_block.__init__(self, "Test", ['float32', 'float32'], ['float32'])

    def general_work(self, input_items, output_items):
        n = len(output_items[0])
        output_items[0][:] = input_items[0][:n]
        for i in range(1,len(input_items)):
            output_items[0][:] += input_items[i][:n]

        self.consume_each(n)
        return n

class TestSync(gr.sync_block):

    def __init__(self):

        # Using py_io_signature, variable number of inputs, fixed number of outputs
        if NEW:
            gr.sync_block.__init__(self, "Test",
                                   gr.py_io_signature(2,-1, ['float32', 'float32']),
                                   gr.py_io_signature(1, 1, ['float32']))

        # Backward compatible, fixed number of I/O ports
        else:
            gr.sync_block.__init__(self, "Test", ['float32', 'float32'], ['float32'])

    def work(self, input_items, output_items):
        n = len(output_items[0])
        output_items[0][:] = input_items[0][:n]
        for i in range(1,len(input_items)):
            output_items[0][:] += input_items[i][:n]

        self.consume_each(n)
        return n

###
## MAIN
#
tb = gr.top_block()
src = blocks.vector_source_f(range(1000), repeat=True)
head = blocks.head(4, 100000000)
dst = blocks.null_sink(4)
test = TestBasic()
tb.connect(src, (test,0))
tb.connect(src, (test,1))

# Add more ports at run time
if NEW:
    tb.connect(src, (test,2))
    tb.connect(src, (test,3))
    tb.connect(src, (test,4))

tb.connect(test, head, dst)
tb.run()
```