### PR TITLE
gr-channels: Fixing the formula behind the IQ_imbal block

### DIFF
--- a/gr-channels/grc/channels_iqbal_gen.xml
+++ b/gr-channels/grc/channels_iqbal_gen.xml
@@ -8,7 +8,7 @@
   <name>IQ Imbalance Generator</name>
   <key>channels_iqbal_gen</key>
   <import>from gnuradio import channels</import>
-  <make>channels.iqbal_gen($mag, $phase)</make>
+  <make>channels.iqbal_gen($mag, $phase, $mode)</make>
   <callback>set_magnitude($mag)</callback>
   <callback>set_phase($phase)</callback>
   <param>
@@ -22,6 +22,20 @@
     <key>phase</key>
     <value>0</value>
     <type>float</type>
+  </param>
+  <param>
+    <name>Origin</name>
+    <key>mode</key>
+    <value>0</value>
+    <type>enum</type>
+		<option>
+			<name>Reciever</name>
+			<key>1</key>
+		</option>
+		<option>
+			<name>Transmitter</name>
+			<key>0</key>
+		</option>
   </param>
   <sink>
     <name>in</name>

--- a/gr-channels/grc/channels_iqbal_gen.xml
+++ b/gr-channels/grc/channels_iqbal_gen.xml
@@ -45,4 +45,35 @@
     <name>out</name>
     <type>complex</type>
   </source>
+  <doc>
+This block implements the single branch IQ imbalance
+transmitter and receiver models.
+
+Developed from source (2014):
+"In-Phase and Quadrature Imbalance: Modeling, Estimation, and Compensation"
+
+    TX Impairment:
+                                      
+                                                        {R}--|Multiply: 10**(mag/20)|--+--|Multiply: cos(pi*degree/180)|--X1
+Input ---|Complex2Float|---|                                                               |--|Multiply: sin(pi*degree/180)|--X2
+                                                        {I}--|   Adder  |
+                                                       X2--|       (+)      |--X3
+
+                          X1--{R}--| Float 2     |--- Output
+                          X3---{I}--| Complex |
+
+    RX Impairment:
+                                      
+                                                        {R}--|Multiply: cos(pi*degree/180)|-------|               |
+Input ---|Complex2Float|---|                                                                                  | Adder |--X1
+                                                         {I}--+--|Multiply: sin(pi*degree/180)|----|     (+)      |
+                                                                 |
+                                                                 +--X2
+
+                        X1--|Multply: 10**(mag/20)|--{R}--| Float 2     |--- Output
+                        X2--------------------------------------------{I}--| Complex |
+
+    (ASCII ART adjusted for GRC viewing)
+
+  </doc>
 </block>

--- a/gr-channels/python/channels/iqbal_gen.py
+++ b/gr-channels/python/channels/iqbal_gen.py
@@ -21,6 +21,29 @@ class iqbal_gen(gr.hier_block2):
         Developed from source (2014):
         "In-Phase and Quadrature Imbalance:
           Modeling, Estimation, and Compensation"
+
+        TX Impairment:
+
+                                  {R}--|Multiply: 10**(mag/20)|--+--|Multiply: cos(pi*degree/180)|--X1
+        Input ---|Complex2Float|---|                             +--|Multiply: sin(pi*degree/180)|--X2
+                                  {I}--|  Adder  |
+                                   X2--|   (+)   |--X3
+
+                          X1--{R}--| Float 2 |--- Output
+                          X3--{I}--| Complex |
+
+        RX Impairment:
+
+                                  {R}--|Multiply: cos(pi*degree/180)|-------|       |
+        Input ---|Complex2Float|---|                                        | Adder |--X1
+                                  {I}--+--|Multiply: sin(pi*degree/180)|----|  (+)  |
+                                       |
+                                       +--X2
+
+                        X1--|Multply: 10**(mag/20)|--{R}--| Float 2 |--- Output
+                        X2---------------------------{I}--| Complex |
+
+        (ASCII ART monospace viewing)
         '''
         gr.hier_block2.__init__(
             self, "IQ Imbalance Generator",

--- a/gr-channels/python/channels/iqbal_gen.py
+++ b/gr-channels/python/channels/iqbal_gen.py
@@ -14,6 +14,14 @@ import math
 class iqbal_gen(gr.hier_block2):
 
     def __init__(self, magnitude=0, phase=0, mode=0):
+        '''
+        This block implements the single branch IQ imbalance
+        transmitter and receiver models.
+
+        Developed from source (2014):
+        "In-Phase and Quadrature Imbalance:
+          Modeling, Estimation, and Compensation"
+        '''
         gr.hier_block2.__init__(
             self, "IQ Imbalance Generator",
             gr.io_signature(1, 1, gr.sizeof_gr_complex*1),

--- a/gr-channels/python/channels/iqbal_gen.py
+++ b/gr-channels/python/channels/iqbal_gen.py
@@ -13,7 +13,7 @@ import math
 
 class iqbal_gen(gr.hier_block2):
 
-    def __init__(self, magnitude=0, phase=0):
+    def __init__(self, magnitude=0, phase=0, mode=0):
         gr.hier_block2.__init__(
             self, "IQ Imbalance Generator",
             gr.io_signature(1, 1, gr.sizeof_gr_complex*1),
@@ -25,29 +25,53 @@ class iqbal_gen(gr.hier_block2):
         ##################################################
         self.magnitude = magnitude
         self.phase = phase
+        self.mode = mode
 
         ##################################################
         # Blocks
         ##################################################
-        self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
-        self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
-        self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
-        self.f2c = blocks.float_to_complex(1)
-        self.c2f = blocks.complex_to_float(1)
-        self.adder = blocks.add_vff(1)
+        if(self.mode):
+            # Receiver Mode
+            self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
+            self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
+            self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
+            self.f2c = blocks.float_to_complex(1)
+            self.c2f = blocks.complex_to_float(1)
+            self.adder = blocks.add_vff(1)
+        else:
+            # Transmitter Mode
+            self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
+            self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
+            self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
+            self.f2c = blocks.float_to_complex(1)
+            self.c2f = blocks.complex_to_float(1)
+            self.adder = blocks.add_vff(1)
 
         ##################################################
         # Connections
         ##################################################
-        self.connect((self, 0), (self.c2f, 0))
-        self.connect((self.c2f, 0), (self.mag, 0))
-        self.connect((self.mag, 0), (self.cos_phase, 0))
-        self.connect((self.cos_phase, 0), (self.f2c, 0))
-        self.connect((self.mag, 0), (self.sin_phase, 0))
-        self.connect((self.sin_phase, 0), (self.adder, 0))
-        self.connect((self.c2f, 1), (self.adder, 1))
-        self.connect((self.adder, 0), (self.f2c, 1))
-        self.connect((self.f2c, 0), (self, 0))
+        if(self.mode):
+            # Receiver Mode
+            self.connect((self, 0), (self.c2f, 0))
+            self.connect((self.c2f, 0), (self.cos_phase, 0))
+            self.connect((self.cos_phase, 0), (self.adder, 0))
+            self.connect((self.c2f, 1), (self.sin_phase, 0))
+            self.connect((self.sin_phase, 0), (self.adder, 1))
+            self.connect((self.adder, 0), (self.mag, 0))
+            self.connect((self.mag, 0), (self.f2c, 0))
+            self.connect((self.c2f, 1), (self.f2c, 1))
+            self.connect((self.f2c, 0), (self, 0))
+        else:
+            # Transmitter Mode
+            self.connect((self, 0), (self.c2f, 0))
+            self.connect((self.c2f, 0), (self.mag, 0))
+            self.connect((self.mag, 0), (self.cos_phase, 0))
+            self.connect((self.cos_phase, 0), (self.f2c, 0))
+            self.connect((self.mag, 0), (self.sin_phase, 0))
+            self.connect((self.sin_phase, 0), (self.adder, 0))
+            self.connect((self.c2f, 1), (self.adder, 1))
+            self.connect((self.adder, 0), (self.f2c, 1))
+            self.connect((self.f2c, 0), (self, 0))
 
 
     # QT sink close method reimplementation

--- a/gr-channels/python/channels/iqbal_gen.py
+++ b/gr-channels/python/channels/iqbal_gen.py
@@ -30,22 +30,13 @@ class iqbal_gen(gr.hier_block2):
         ##################################################
         # Blocks
         ##################################################
-        if(self.mode):
-            # Receiver Mode
-            self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
-            self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
-            self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
-            self.f2c = blocks.float_to_complex(1)
-            self.c2f = blocks.complex_to_float(1)
-            self.adder = blocks.add_vff(1)
-        else:
-            # Transmitter Mode
-            self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
-            self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
-            self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
-            self.f2c = blocks.float_to_complex(1)
-            self.c2f = blocks.complex_to_float(1)
-            self.adder = blocks.add_vff(1)
+        # Same blocks for Transmitter and Receiver
+        self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
+        self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
+        self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
+        self.f2c = blocks.float_to_complex(1)
+        self.c2f = blocks.complex_to_float(1)
+        self.adder = blocks.add_vff(1)
 
         ##################################################
         # Connections

--- a/gr-channels/python/channels/iqbal_gen.py
+++ b/gr-channels/python/channels/iqbal_gen.py
@@ -30,25 +30,27 @@ class iqbal_gen(gr.hier_block2):
         # Blocks
         ##################################################
         self.mag = blocks.multiply_const_vff((math.pow(10,magnitude/20.0), ))
-        self.blocks_multiply_const_vxx_0 = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
-        self.blocks_float_to_complex_0 = blocks.float_to_complex(1)
-        self.blocks_complex_to_float_0 = blocks.complex_to_float(1)
-        self.blocks_add_xx_0 = blocks.add_vff(1)
+        self.sin_phase = blocks.multiply_const_vff((math.sin(phase*math.pi/180.0), ))
+        self.cos_phase = blocks.multiply_const_vff((math.cos(phase*math.pi/180.0), ))
+        self.f2c = blocks.float_to_complex(1)
+        self.c2f = blocks.complex_to_float(1)
+        self.adder = blocks.add_vff(1)
 
         ##################################################
         # Connections
         ##################################################
-        self.connect((self.blocks_float_to_complex_0, 0), (self, 0))
-        self.connect((self, 0), (self.blocks_complex_to_float_0, 0))
-        self.connect((self.blocks_complex_to_float_0, 0), (self.mag, 0))
-        self.connect((self.mag, 0), (self.blocks_float_to_complex_0, 0))
-        self.connect((self.blocks_add_xx_0, 0), (self.blocks_float_to_complex_0, 1))
-        self.connect((self.blocks_multiply_const_vxx_0, 0), (self.blocks_add_xx_0, 0))
-        self.connect((self.blocks_complex_to_float_0, 1), (self.blocks_add_xx_0, 1))
-        self.connect((self.blocks_complex_to_float_0, 0), (self.blocks_multiply_const_vxx_0, 0))
+        self.connect((self, 0), (self.c2f, 0))
+        self.connect((self.c2f, 0), (self.mag, 0))
+        self.connect((self.mag, 0), (self.cos_phase, 0))
+        self.connect((self.cos_phase, 0), (self.f2c, 0))
+        self.connect((self.mag, 0), (self.sin_phase, 0))
+        self.connect((self.sin_phase, 0), (self.adder, 0))
+        self.connect((self.c2f, 1), (self.adder, 1))
+        self.connect((self.adder, 0), (self.f2c, 1))
+        self.connect((self.f2c, 0), (self, 0))
 
 
-# QT sink close method reimplementation
+    # QT sink close method reimplementation
 
     def get_magnitude(self):
         return self.magnitude
@@ -62,6 +64,7 @@ class iqbal_gen(gr.hier_block2):
 
     def set_phase(self, phase):
         self.phase = phase
-        self.blocks_multiply_const_vxx_0.set_k((math.sin(self.phase*math.pi/180.0), ))
+        self.sin_phase.set_k((math.sin(self.phase*math.pi/180.0), ))
+        self.cos_phase.set_k((math.cos(self.phase*math.pi/180.0), ))
 
 


### PR DESCRIPTION
Fixing the formula behind the IQ_imbal block to be true mathematically.
X' = (1+mag_lin)·cos(theta)·real(X) + j·((1+mag_lin)·sin(theta)·real(X) + imag(X))
is the proper equation for handling the IQ imblance purely within the Inphase component.

Previously it was:
X' = (1+mag_lin)·real(X) + j·(sin(theta)·real(X) + imag(X))