### PR TITLE
blocks: remove unused class member

### DIFF
--- a/gr-blocks/lib/annotator_alltoall_impl.cc
+++ b/gr-blocks/lib/annotator_alltoall_impl.cc
@@ -45,7 +45,7 @@ namespace gr {
       : sync_block("annotator_alltoall",
                       io_signature::make(1, -1, sizeof_stream_item),
                       io_signature::make(1, -1, sizeof_stream_item)),
-        d_itemsize(sizeof_stream_item), d_when((uint64_t)when)
+                      d_when((uint64_t)when)
     {
       set_tag_propagation_policy(TPP_ALL_TO_ALL);
 

--- a/gr-blocks/lib/annotator_alltoall_impl.h
+++ b/gr-blocks/lib/annotator_alltoall_impl.h
@@ -31,7 +31,6 @@ namespace gr {
     class annotator_alltoall_impl : public annotator_alltoall
     {
     private:
-      size_t d_itemsize;
       uint64_t d_when;
       uint64_t d_tag_counter;
       std::vector<tag_t> d_stored_tags;


### PR DESCRIPTION
In gr-blocks/annotator_alltoall.[h/cc]: class member d_itemsize was unused. Thus, it was removed as part of code clean-up.

This fixes #1623 .