### PR TITLE
Removing calls to PMT::mp("string") at run time wherever possible

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -684,6 +684,8 @@ namespace gr {
     bool                  d_update_rate;           // should sched update rel rate?
     bool d_finished;    // true if msg ports think we are finished
 
+    static const pmt::pmt_t d_pmt_done;
+
   protected:
     block(void) {} // allows pure virtual interface sub-classes
     block(const std::string &name,
@@ -860,6 +862,10 @@ namespace gr {
 
     // These are really only for internal use, but leaving them public avoids
     // having to work up an ever-varying list of friend GR_RUNTIME_APIs
+
+    /*! PMT Symbol of the system port, `pmt::mp("system")`
+     */
+    static const pmt::pmt_t d_system_port;
 
   public:
     block_detail_sptr detail() const { return d_detail; }

--- a/gr-blocks/include/gnuradio/blocks/pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu.h
@@ -27,12 +27,11 @@
 #include <gnuradio/gr_complex.h>
 #include <pmt/pmt.h>
 
-#define PDU_PORT_ID    pmt::mp("pdus")
 
 namespace gr {
   namespace blocks {
     namespace pdu {
-
+      static const pmt::pmt_t s_pdu_port_id = pmt::mp("pdus");
       enum vector_type { byte_t, float_t, complex_t };
 
       BLOCKS_API size_t itemsize(vector_type type);

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -51,9 +51,10 @@ namespace gr {
               io_signature::make(0, 0, 0)),
         d_finished(false),
         d_period_ms(period_ms),
-        d_msg(msg)
+        d_msg(msg),
+        d_port(pmt::mp("strobe"))
     {
-      message_port_register_out(pmt::mp("strobe"));
+      message_port_register_out(d_port);
 
       message_port_register_in(pmt::mp("set_msg"));
       set_msg_handler(pmt::mp("set_msg"),
@@ -95,7 +96,7 @@ namespace gr {
           return;
         }
 
-        message_port_pub(pmt::mp("strobe"), d_msg);
+        message_port_pub(d_port, d_msg);
       }
     }
 

--- a/gr-blocks/lib/message_strobe_impl.h
+++ b/gr-blocks/lib/message_strobe_impl.h
@@ -35,6 +35,7 @@ namespace gr {
       bool d_finished;
       float d_period_ms;
       pmt::pmt_t d_msg;
+      const pmt::pmt_t d_port;
 
       void run();
 

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -45,6 +45,7 @@ namespace gr {
         (new message_strobe_random_impl(msg, dist, mean_ms, std_ms));
     }
 
+
     message_strobe_random_impl::message_strobe_random_impl(pmt::pmt_t msg, message_strobe_random_distribution_t dist, float mean_ms, float std_ms)
       : block("message_strobe_random",
                  io_signature::make(0, 0, 0),
@@ -54,13 +55,14 @@ namespace gr {
         d_std_ms(std_ms),
         d_dist(dist),
         d_msg(msg),
-        d_rng()
+        d_rng(),
+        d_port(pmt::mp("strobe"))
     {
       // allocate RNGs
       update_dist();
 
       // set up ports
-      message_port_register_out(pmt::mp("strobe"));
+      message_port_register_out(d_port);
       d_thread = boost::shared_ptr<gr::thread::thread>
         (new gr::thread::thread(boost::bind(&message_strobe_random_impl::run, this)));
 
@@ -113,7 +115,7 @@ namespace gr {
           return;
         }
 
-        message_port_pub(pmt::mp("strobe"), d_msg);
+        message_port_pub(d_port, d_msg);
       }
     }
 

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -50,6 +50,8 @@ namespace gr {
       boost::shared_ptr< boost::variate_generator <boost::mt19937, boost::normal_distribution<> > > d_variate_normal;
       boost::shared_ptr< boost::variate_generator <boost::mt19937, boost::uniform_real<> > > d_variate_uniform;
 
+      const pmt::pmt_t d_port;
+
       void update_dist();
 
     public:

--- a/gr-blocks/lib/pdu_filter_impl.cc
+++ b/gr-blocks/lib/pdu_filter_impl.cc
@@ -43,9 +43,9 @@ namespace gr {
 		 io_signature::make (0, 0, 0)),
     d_k(k), d_v(v), d_invert(invert)
     {
-      message_port_register_out(pmt::mp("pdus"));
-      message_port_register_in(pmt::mp("pdus"));
-      set_msg_handler(pmt::mp("pdus"), boost::bind(&pdu_filter_impl::handle_msg, this, _1));
+      message_port_register_out(pdu::s_pdu_port_id);
+      message_port_register_in(pdu::s_pdu_port_id);
+      set_msg_handler(pdu::s_pdu_port_id, boost::bind(&pdu_filter_impl::handle_msg, this, _1));
     }
 
     void
@@ -63,7 +63,7 @@ namespace gr {
 
       // if all tests pass, propagate the pdu
       if(output){
-        message_port_pub(pmt::mp("pdus"), pdu);
+        message_port_pub(pdu::s_pdu_port_id, pdu);
         }
     }
 

--- a/gr-blocks/lib/pdu_remove_impl.cc
+++ b/gr-blocks/lib/pdu_remove_impl.cc
@@ -43,9 +43,9 @@ namespace gr {
 		 io_signature::make (0, 0, 0)),
     d_k(k)
     {
-      message_port_register_out(pmt::mp("pdus"));
-      message_port_register_in(pmt::mp("pdus"));
-      set_msg_handler(pmt::mp("pdus"), boost::bind(&pdu_remove_impl::handle_msg, this, _1));
+      message_port_register_out(pdu::s_pdu_port_id);
+      message_port_register_in(pdu::s_pdu_port_id);
+      set_msg_handler(pdu::s_pdu_port_id, boost::bind(&pdu_remove_impl::handle_msg, this, _1));
     }
 
     void
@@ -59,7 +59,7 @@ namespace gr {
         throw std::runtime_error("pdu_remove received non PDU input");
         }
       meta = pmt::dict_delete(meta, d_k);
-      message_port_pub(pmt::mp("pdus"), pmt::cons(meta, pmt::cdr(pdu)));
+      message_port_pub(pdu::s_pdu_port_id, pmt::cons(meta, pmt::cdr(pdu)));
     }
 
   } /* namespace blocks */

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -41,11 +41,11 @@ namespace gr {
       :	block("pdu_set",
 		 io_signature::make (0, 0, 0),
 		 io_signature::make (0, 0, 0)),
-    d_k(k), d_v(v)
+        d_k(k), d_v(v)
     {
-      message_port_register_out(pmt::mp("pdus"));
-      message_port_register_in(pmt::mp("pdus"));
-      set_msg_handler(pmt::mp("pdus"), boost::bind(&pdu_set_impl::handle_msg, this, _1));
+      message_port_register_out(pdu::s_pdu_port_id);
+      message_port_register_in(pdu::s_pdu_port_id);
+      set_msg_handler(pdu::s_pdu_port_id, boost::bind(&pdu_set_impl::handle_msg, this, _1));
     }
 
     void
@@ -59,7 +59,7 @@ namespace gr {
         throw std::runtime_error("pdu_set received non PDU input");
         }
       meta = pmt::dict_add(meta, d_k, d_v);
-      message_port_pub(pmt::mp("pdus"), pmt::cons(meta, pmt::cdr(pdu)));
+      message_port_pub(pdu::s_pdu_port_id, pmt::cons(meta, pmt::cdr(pdu)));
     }
 
   } /* namespace blocks */

--- a/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
@@ -46,7 +46,7 @@ namespace gr {
         d_type(type),
         d_curr_len(0)
     {
-      message_port_register_in(PDU_PORT_ID);
+      message_port_register_in(pdu::s_pdu_port_id);
     }
 
     int pdu_to_tagged_stream_impl::calculate_output_stream_length(const gr_vector_int &)
@@ -55,7 +55,7 @@ namespace gr {
           /* FIXME: This blocking call is far from ideal but is the best we
 	   *        can do at the moment
 	   */
-        pmt::pmt_t msg(delete_head_blocking(PDU_PORT_ID, 100));
+        pmt::pmt_t msg(delete_head_blocking(pdu::s_pdu_port_id, 100));
         if (msg.get() == NULL) {
           return 0;
         }

--- a/gr-blocks/lib/probe_rate_impl.cc
+++ b/gr-blocks/lib/probe_rate_impl.cc
@@ -46,9 +46,12 @@ namespace gr {
         d_avg(0),
         d_min_update_time(update_rate_ms),
         d_lastthru(0),
-        d_itemsize(itemsize)
+        d_itemsize(itemsize),
+        d_port(pmt::mp("rate")),
+        d_dict_avg(pmt::mp("rate_avg")),
+        d_dict_now(pmt::mp("rate_now"))
         {
-            message_port_register_out(pmt::mp("rate"));
+            message_port_register_out(d_port);
         }
 
     probe_rate_impl::~probe_rate_impl(){}
@@ -70,9 +73,9 @@ namespace gr {
                 d_avg = rate_this_update*d_alpha + d_avg*d_beta;
             }
             pmt::pmt_t d = pmt::make_dict();
-            d = pmt::dict_add(d, pmt::mp("rate_avg"), pmt::mp(d_avg));
-            d = pmt::dict_add(d, pmt::mp("rate_now"), pmt::mp(rate_this_update));
-            message_port_pub(pmt::mp("rate"), pmt::cons(d, pmt::PMT_NIL));
+            d = pmt::dict_add(d, d_dict_avg, pmt::mp(d_avg));
+            d = pmt::dict_add(d, d_dict_now, pmt::mp(rate_this_update));
+            message_port_pub(d_port, pmt::cons(d, pmt::PMT_NIL));
         }
         return noutput_items;
       }

--- a/gr-blocks/lib/probe_rate_impl.h
+++ b/gr-blocks/lib/probe_rate_impl.h
@@ -38,6 +38,9 @@ namespace gr {
       size_t d_itemsize;
       void setup_rpc();
 
+      const pmt::pmt_t d_port;
+      const pmt::pmt_t d_dict_avg, d_dict_now;
+
     public:
       probe_rate_impl(size_t itemsize, double update_rate_ms, double alpha = 0.0001);
       ~probe_rate_impl();

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -48,7 +48,7 @@ namespace gr {
     d_mask(byte_mask),
     d_length_modulo(length_modulo)
     {
-      message_port_register_out(PDU_PORT_ID);
+      message_port_register_out(pdu::s_pdu_port_id);
       message_port_register_in(pmt::mp("generate"));
       set_msg_handler(pmt::mp("generate"), boost::bind(&random_pdu_impl::generate_pdu, this, _1));
       if(length_modulo < 1)
@@ -80,7 +80,7 @@ namespace gr {
       pmt::pmt_t vecpmt(pmt::make_blob(&vec[0], len));
       pmt::pmt_t pdu(pmt::cons(pmt::PMT_NIL, vecpmt));
 
-      message_port_pub(PDU_PORT_ID, pdu);
+      message_port_pub(pdu::s_pdu_port_id, pdu);
     }
 
   } /* namespace blocks */

--- a/gr-blocks/lib/tagged_stream_to_pdu_impl.cc
+++ b/gr-blocks/lib/tagged_stream_to_pdu_impl.cc
@@ -45,7 +45,7 @@ namespace gr {
 	d_pdu_meta(pmt::PMT_NIL),
 	d_pdu_vector(pmt::PMT_NIL)
     {
-      message_port_register_out(PDU_PORT_ID);
+      message_port_register_out(pdu::s_pdu_port_id);
     }
 
     int
@@ -71,7 +71,7 @@ namespace gr {
 
       // Send msg
       pmt::pmt_t msg = pmt::cons(d_pdu_meta, d_pdu_vector);
-      message_port_pub(PDU_PORT_ID, msg);
+      message_port_pub(pdu::s_pdu_port_id, msg);
 
       return ninput_items[0];
     }

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -94,7 +94,7 @@ namespace gr {
           pmt::pmt_t vector = pmt::init_u8vector(bytes_transferred, (const uint8_t*)&d_buf[0]);
           pmt::pmt_t pdu = pmt::cons(pmt::PMT_NIL, vector);
 
-          d_block->message_port_pub(PDU_PORT_ID, pdu);
+          d_block->message_port_pub(pdu::s_pdu_port_id, pdu);
         }
 
         d_socket.async_read_some(boost::asio::buffer(d_buf),

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -92,12 +92,12 @@ namespace gr {
         ) % dev % dev << std::endl;
 
       // set up output message port
-      message_port_register_out(PDU_PORT_ID);
-      start_rxthread(this, PDU_PORT_ID);
+      message_port_register_out(pdu::s_pdu_port_id);
+      start_rxthread(this, pdu::s_pdu_port_id);
 
       // set up input message port
-      message_port_register_in(PDU_PORT_ID);
-      set_msg_handler(PDU_PORT_ID, boost::bind(&tuntap_pdu_impl::send, this, _1));
+      message_port_register_in(pdu::s_pdu_port_id);
+      set_msg_handler(pdu::s_pdu_port_id, boost::bind(&tuntap_pdu_impl::send, this, _1));
     }
 
     int

--- a/gr-digital/lib/hdlc_deframer_bp_impl.cc
+++ b/gr-digital/lib/hdlc_deframer_bp_impl.cc
@@ -48,10 +48,11 @@ namespace gr {
               gr::io_signature::make(1, 1, sizeof(unsigned char)),
               gr::io_signature::make(0, 0, 0)),
         d_length_min(length_min),
-        d_length_max(length_max)
+        d_length_max(length_max),
+        d_port(pmt::mp("out"))
     {
         set_output_multiple(length_max*2);
-        message_port_register_out(pmt::mp("out"));
+        message_port_register_out(d_port);
         d_bytectr=0;
         d_bitctr=0;
         d_ones=0;
@@ -101,7 +102,7 @@ namespace gr {
                         if (crc==calc_crc) {
                             pmt::pmt_t pdu(pmt::cons(pmt::PMT_NIL,
                                                      pmt::make_blob(d_pktbuf, len)));
-                            message_port_pub(pmt::mp("out"), pdu);
+                            message_port_pub(d_port, pdu);
                         }
                         else {
                         }

--- a/gr-digital/lib/hdlc_deframer_bp_impl.h
+++ b/gr-digital/lib/hdlc_deframer_bp_impl.h
@@ -38,6 +38,8 @@ namespace gr {
         size_t d_bitctr;
         unsigned char *d_pktbuf;
 
+        const pmt::pmt_t d_port;
+
         unsigned int crc_ccitt(unsigned char *data, size_t len);
 
      public:

--- a/gr-digital/lib/hdlc_framer_pb_impl.cc
+++ b/gr-digital/lib/hdlc_framer_pb_impl.cc
@@ -45,9 +45,10 @@ namespace gr {
     hdlc_framer_pb_impl::hdlc_framer_pb_impl(const std::string frame_tag_name)
       : gr::sync_block("hdlc_framer_pb",
               gr::io_signature::make(0, 0, 0),
-              gr::io_signature::make(1, 1, sizeof(unsigned char)))
+              gr::io_signature::make(1, 1, sizeof(unsigned char))),
+      d_port(pmt::mp("in"))
     {
-        message_port_register_in(pmt::mp("in"));
+        message_port_register_in(d_port);
         d_frame_tag = pmt::string_to_symbol(frame_tag_name);
         std::stringstream str;
         str << name() << unique_id();
@@ -129,7 +130,7 @@ namespace gr {
         }
 
         //get PDU
-        pmt::pmt_t msg(delete_head_nowait(pmt::mp("in")));
+        pmt::pmt_t msg(delete_head_nowait(d_port));
         if(msg.get() == NULL) return oidx;
 
         pmt::pmt_t len(pmt::car(msg)); //TODO for non-mult-8 nbits

--- a/gr-digital/lib/hdlc_framer_pb_impl.h
+++ b/gr-digital/lib/hdlc_framer_pb_impl.h
@@ -38,6 +38,8 @@ namespace gr {
         std::vector<unsigned char> unpack(std::vector<unsigned char> &pkt);
         void stuff(std::vector<unsigned char> &pkt);
 
+        const pmt::pmt_t d_port;
+
      public:
       hdlc_framer_pb_impl(const std::string frame_tag_name);
       ~hdlc_framer_pb_impl();

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -31,6 +31,8 @@
 namespace gr {
   namespace digital {
 
+    const pmt::pmt_t header_payload_demux_impl::s_msg_port_id = pmt::mp("header_data");
+
     //! Returns a PMT time tuple (uint seconds, double fraction) as the sum of
     //  another PMT time tuple and a time diff in seconds.
     pmt::pmt_t _update_pmt_time(
@@ -59,8 +61,6 @@ namespace gr {
       PORT_INPUTDATA = 0,
       PORT_TRIGGER = 1
     };
-
-#define msg_port_id pmt::mp("header_data")
 
     header_payload_demux::sptr
     header_payload_demux::make(
@@ -149,8 +149,8 @@ namespace gr {
         );
       }
       set_tag_propagation_policy(TPP_DONT);
-      message_port_register_in(msg_port_id);
-      set_msg_handler(msg_port_id, boost::bind(&header_payload_demux_impl::parse_header_data_msg, this, _1));
+      message_port_register_in(s_msg_port_id);
+      set_msg_handler(s_msg_port_id, boost::bind(&header_payload_demux_impl::parse_header_data_msg, this, _1));
       for (size_t i = 0; i < special_tags.size(); i++) {
         d_special_tags.push_back(pmt::string_to_symbol(special_tags[i]));
         d_special_tags_last_value.push_back(pmt::PMT_NIL);

--- a/gr-digital/lib/header_payload_demux_impl.h
+++ b/gr-digital/lib/header_payload_demux_impl.h
@@ -55,6 +55,8 @@ namespace gr {
       std::vector<pmt::pmt_t> d_special_tags; //!< List of special tags
       std::vector<pmt::pmt_t> d_special_tags_last_value; //!< The current value of the special tags
 
+      static const pmt::pmt_t s_msg_port_id; //!< Message Port Id
+
       // Helper functions to make the state machine more readable
 
       //! Checks if there are enough items on the inputs and enough space on the output buffers to copy \p n_symbols symbols

--- a/gr-digital/lib/packet_headerparser_b_impl.cc
+++ b/gr-digital/lib/packet_headerparser_b_impl.cc
@@ -27,8 +27,6 @@
 #include <gnuradio/io_signature.h>
 #include "packet_headerparser_b_impl.h"
 
-#define msg_port_id     pmt::mp("header_data")
-
 namespace gr {
   namespace digital {
 
@@ -51,9 +49,10 @@ namespace gr {
       : sync_block("packet_headerparser_b",
 		      io_signature::make(1, 1, sizeof (unsigned char)),
 		      io_signature::make(0, 0, 0)),
-      d_header_formatter(header_formatter)
+        d_header_formatter(header_formatter),
+        d_port(pmt::mp("header_data"))
     {
-      message_port_register_out(msg_port_id);
+      message_port_register_out(d_port);
       set_output_multiple(header_formatter->header_len());
     }
 
@@ -81,13 +80,13 @@ namespace gr {
 
       if (!d_header_formatter->header_parser(in, tags)) {
 	GR_LOG_INFO(d_logger, boost::format("Detected an invalid packet at item %1%") % nitems_read(0));
-	message_port_pub(msg_port_id, pmt::PMT_F);
+	message_port_pub(d_port, pmt::PMT_F);
       } else {
 	pmt::pmt_t dict(pmt::make_dict());
 	for (unsigned i = 0; i < tags.size(); i++) {
 	  dict = pmt::dict_add(dict, tags[i].key, tags[i].value);
 	}
-	message_port_pub(msg_port_id, dict);
+	message_port_pub(d_port, dict);
       }
 
       return d_header_formatter->header_len();

--- a/gr-digital/lib/packet_headerparser_b_impl.h
+++ b/gr-digital/lib/packet_headerparser_b_impl.h
@@ -32,6 +32,8 @@ namespace gr {
     private:
       packet_header_default::sptr d_header_formatter;
 
+      const pmt::pmt_t d_port;
+
     public:
       packet_headerparser_b_impl(const gr::digital::packet_header_default::sptr &header_formatter);
       ~packet_headerparser_b_impl();

--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -170,7 +170,8 @@ namespace gr {
         }
       }
 
-      meta = pmt::dict_add(meta, pmt::mp("iterations"), pmt::mp(d_decoder->get_iterations()) );
+      static const pmt::pmt_t iterations_key = pmt::mp("iterations");
+      meta = pmt::dict_add(meta, iterations_key, pmt::mp(d_decoder->get_iterations()) );
       message_port_pub(d_out_port, pmt::cons(meta, outvec));
     }
 

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -51,7 +51,8 @@ namespace gr {
       : block("edit_box_msg",
               io_signature::make(0, 0, 0),
               io_signature::make(0, 0, 0)),
-        QObject(parent)
+        QObject(parent),
+        d_port(pmt::mp("msg"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -156,7 +157,7 @@ namespace gr {
 
       d_msg = pmt::PMT_NIL;
 
-      message_port_register_out(pmt::mp("msg"));
+      message_port_register_out(d_port);
       message_port_register_in(pmt::mp("val"));
 
       set_msg_handler(pmt::mp("val"),
@@ -404,7 +405,7 @@ namespace gr {
 
       // Emit the new message to pass updates downstream.
       // Loops are prevented by the early exit if d_msg == val.
-      message_port_pub(pmt::mp("msg"), d_msg);
+      message_port_pub(d_port, d_msg);
     }
 
     void
@@ -560,7 +561,7 @@ namespace gr {
         d_msg = pmt::cons(pmt::intern(key), d_msg);
       }
 
-      message_port_pub(pmt::mp("msg"), d_msg);
+      message_port_pub(d_port, d_msg);
     }
 
   } /* namespace qtgui */

--- a/gr-qtgui/lib/edit_box_msg_impl.h
+++ b/gr-qtgui/lib/edit_box_msg_impl.h
@@ -55,6 +55,7 @@ namespace gr {
       QComboBox *d_type_box;
 
       pmt::pmt_t d_msg;
+      const pmt::pmt_t d_port;
 
     public:
       edit_box_msg_impl(gr::qtgui::data_type_t type,

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -58,8 +58,9 @@ namespace gr {
                    io_signature::make(0, 0, 0)),
 	d_fftsize(fftsize), d_fftavg(1.0),
 	d_wintype((filter::firdes::win_type)(wintype)),
-	d_center_freq(fc), d_bandwidth(bw), d_name(name),
-	d_nconnections(nconnections), d_parent(parent)
+  d_center_freq(fc), d_bandwidth(bw), d_name(name),
+  d_nconnections(nconnections), d_parent(parent),
+  d_port(pmt::mp("freq"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -71,9 +72,9 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp("freq"));
-      message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
+      message_port_register_out(d_port);
+      message_port_register_in(d_port);
+      set_msg_handler(d_port,
                       boost::bind(&freq_sink_c_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
@@ -585,8 +586,8 @@ namespace gr {
     {
       if(d_main_gui->checkClicked()) {
         double freq = d_main_gui->getClickedFreq();
-        message_port_pub(pmt::mp("freq"),
-                         pmt::cons(pmt::mp("freq"),
+        message_port_pub(d_port,
+                         pmt::cons(d_port,
                                    pmt::from_double(freq)));
       }
     }

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -47,6 +47,8 @@ namespace gr {
       std::string d_name;
       int d_nconnections;
 
+      const pmt::pmt_t d_port;
+
       bool d_shift;
       fft::fft_complex *d_fft;
 

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -59,7 +59,8 @@ namespace gr {
 	d_fftsize(fftsize), d_fftavg(1.0),
 	d_wintype((filter::firdes::win_type)(wintype)),
 	d_center_freq(fc), d_bandwidth(bw), d_name(name),
-	d_nconnections(nconnections), d_parent(parent)
+  d_nconnections(nconnections), d_parent(parent),
+  d_port(pmt::mp("freq"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -71,9 +72,9 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp("freq"));
-      message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
+      message_port_register_out(d_port);
+      message_port_register_in(d_port);
+      set_msg_handler(d_port,
                       boost::bind(&freq_sink_f_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
@@ -590,8 +591,8 @@ namespace gr {
     {
       if(d_main_gui->checkClicked()) {
         double freq = d_main_gui->getClickedFreq();
-        message_port_pub(pmt::mp("freq"),
-                         pmt::cons(pmt::mp("freq"),
+        message_port_pub(d_port,
+                         pmt::cons(d_port,
                                    pmt::from_double(freq)));
       }
     }

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -47,6 +47,8 @@ namespace gr {
       std::string d_name;
       int d_nconnections;
 
+      const pmt::pmt_t d_port;
+
       bool d_shift;
       fft::fft_complex *d_fft;
 

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -63,7 +63,8 @@ namespace gr {
 	d_center_freq(fc), d_bandwidth(bw), d_name(name),
 	d_plotfreq(plotfreq), d_plotwaterfall(plotwaterfall),
 	d_plottime(plottime), d_plotconst(plotconst),
-	d_parent(parent)
+  d_parent(parent),
+  d_port(pmt::mp("freq"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -75,9 +76,9 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp("freq"));
-      message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
+      message_port_register_out(d_port);
+      message_port_register_in(d_port);
+      set_msg_handler(d_port,
                       boost::bind(&sink_c_impl::handle_set_freq, this, _1));
 
       d_main_gui = NULL;
@@ -328,8 +329,8 @@ namespace gr {
     {
       if(d_main_gui->checkClicked()) {
         double freq = d_main_gui->getClickedFreq();
-        message_port_pub(pmt::mp("freq"),
-                         pmt::cons(pmt::mp("freq"),
+        message_port_pub(d_port,
+                         pmt::cons(d_port,
                                    pmt::from_double(freq)));
       }
     }

--- a/gr-qtgui/lib/sink_c_impl.h
+++ b/gr-qtgui/lib/sink_c_impl.h
@@ -48,6 +48,8 @@ namespace gr {
       gr::high_res_timer_type  d_last_update;
       bool d_update_active;
 
+      const pmt::pmt_t d_port;
+
       bool d_shift;
       fft::fft_complex *d_fft;
 

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -63,7 +63,8 @@ namespace gr {
 	d_center_freq(fc), d_bandwidth(bw), d_name(name),
 	d_plotfreq(plotfreq), d_plotwaterfall(plotwaterfall),
 	d_plottime(plottime), d_plotconst(plotconst),
-	d_parent(parent)
+  d_parent(parent),
+  d_port(pmt::mp("freq"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -75,9 +76,9 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp("freq"));
-      message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
+      message_port_register_out(d_port);
+      message_port_register_in(d_port);
+      set_msg_handler(d_port,
                       boost::bind(&sink_f_impl::handle_set_freq, this, _1));
 
       d_main_gui = NULL;
@@ -323,8 +324,8 @@ namespace gr {
     {
       if(d_main_gui->checkClicked()) {
         double freq = d_main_gui->getClickedFreq();
-        message_port_pub(pmt::mp("freq"),
-                         pmt::cons(pmt::mp("freq"),
+        message_port_pub(d_port,
+                         pmt::cons(d_port,
                                    pmt::from_double(freq)));
       }
     }

--- a/gr-qtgui/lib/sink_f_impl.h
+++ b/gr-qtgui/lib/sink_f_impl.h
@@ -46,6 +46,8 @@ namespace gr {
       double d_bandwidth;
       std::string d_name;
 
+      const pmt::pmt_t d_port;
+
       bool d_shift;
       fft::fft_complex *d_fft;
 

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -53,7 +53,8 @@ namespace gr {
                    io_signature::make(0, nconnections, sizeof(gr_complex)),
                    io_signature::make(0, 0, 0)),
 	d_size(size), d_buffer_size(2*size), d_samp_rate(samp_rate), d_name(name),
-	d_nconnections(2*nconnections), d_parent(parent)
+  d_nconnections(2*nconnections), d_parent(parent),
+  d_tag_key(pmt::mp("tags"))
     {
       if(nconnections > 12)
         throw std::runtime_error("time_sink_c only supports up to 12 inputs");
@@ -719,9 +720,9 @@ namespace gr {
 
       // add tag info if it is present in metadata
       if(pmt::is_dict(dict)){
-        if(pmt::dict_has_key(dict, pmt::mp("tags"))){
+        if(pmt::dict_has_key(dict, d_tag_key)){
             d_tags.clear();
-            pmt::pmt_t tags = pmt::dict_ref(dict, pmt::mp("tags"), pmt::PMT_NIL);
+            pmt::pmt_t tags = pmt::dict_ref(dict, d_tag_key, pmt::PMT_NIL);
             int len = pmt::length(tags);
             for(int i=0; i<len; i++){
                 // get tag info from list
@@ -729,7 +730,7 @@ namespace gr {
                 int tagval = pmt::to_long(pmt::tuple_ref(tup,0));
                 pmt::pmt_t k = pmt::tuple_ref(tup,1);
                 pmt::pmt_t v = pmt::tuple_ref(tup,2);
-                
+
                 // add the tag
                 t[0].push_back( gr::tag_t() );
                 t[0][t[0].size()-1].offset = tagval;

--- a/gr-qtgui/lib/time_sink_c_impl.h
+++ b/gr-qtgui/lib/time_sink_c_impl.h
@@ -40,6 +40,8 @@ namespace gr {
       std::string d_name;
       int d_nconnections;
 
+      const pmt::pmt_t d_tag_key;
+
       int d_index, d_start, d_end;
       std::vector<gr_complex*> d_cbuffers;
       std::vector<double*> d_buffers;

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -77,8 +77,9 @@ namespace gr {
         d_vecavg(1.0),
         d_name(name),
         d_nconnections(nconnections),
-        d_msg_key("x"),
-        d_parent(parent)
+        d_msg(pmt::mp("x")),
+        d_parent(parent),
+        d_port(pmt::mp(MSG_PORT_OUT_XVAL))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -90,7 +91,7 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp(MSG_PORT_OUT_XVAL));
+      message_port_register_out(d_port);
 
       d_main_gui = NULL;
 
@@ -397,8 +398,8 @@ namespace gr {
       if(d_main_gui->checkClicked()) {
         double xval = d_main_gui->getClickedXVal();
         message_port_pub(
-            pmt::mp(MSG_PORT_OUT_XVAL),
-            pmt::cons(pmt::mp(d_msg_key), pmt::from_double(xval))
+                         d_port,
+                         pmt::cons(d_msg, pmt::from_double(xval))
         );
       }
     }

--- a/gr-qtgui/lib/vector_sink_f_impl.h
+++ b/gr-qtgui/lib/vector_sink_f_impl.h
@@ -46,7 +46,9 @@ namespace gr {
 
       std::string d_name; //!< Initial title of the plot
       int d_nconnections; //!< Number of connected streaming ports on input
-      std::string d_msg_key; //!< Key of outgoing messages
+
+      const pmt::pmt_t d_port;
+      const pmt::pmt_t d_msg; //< Key of outgoing messages
 
       std::vector<double*> d_magbufs;
 

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -60,7 +60,8 @@ namespace gr {
 	d_fftsize(fftsize), d_fftavg(1.0),
 	d_wintype((filter::firdes::win_type)(wintype)),
 	d_center_freq(fc), d_bandwidth(bw), d_name(name),
-	d_nconnections(nconnections), d_nrows(200), d_parent(parent)
+  d_nconnections(nconnections), d_nrows(200), d_parent(parent),
+  d_port(pmt::mp("freq"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -106,9 +107,9 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp("freq"));
-      message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
+      message_port_register_out(d_port);
+      message_port_register_in(d_port);
+      set_msg_handler(d_port,
                       boost::bind(&waterfall_sink_c_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
@@ -485,8 +486,8 @@ namespace gr {
     {
       if(d_main_gui->checkClicked()) {
         double freq = d_main_gui->getClickedFreq();
-        message_port_pub(pmt::mp("freq"),
-                         pmt::cons(pmt::mp("freq"),
+        message_port_pub(d_port,
+                         pmt::cons(d_port,
                                    pmt::from_double(freq)));
       }
     }

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -49,6 +49,8 @@ namespace gr {
       int d_nconnections;
       int d_nrows;
 
+      const pmt::pmt_t d_port;
+
       bool d_shift;
       fft::fft_complex *d_fft;
 

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -60,7 +60,8 @@ namespace gr {
 	d_wintype((filter::firdes::win_type)(wintype)),
 	d_center_freq(fc), d_bandwidth(bw), d_name(name),
 	d_nconnections(nconnections), d_nrows(200),
-        d_parent(parent)
+        d_parent(parent),
+        d_port(pmt::mp("freq"))
     {
       // Required now for Qt; argc must be greater than 0 and argv
       // must have at least one valid character. Must be valid through
@@ -106,9 +107,9 @@ namespace gr {
 
       // setup output message port to post frequency when display is
       // double-clicked
-      message_port_register_out(pmt::mp("freq"));
-      message_port_register_in(pmt::mp("freq"));
-      set_msg_handler(pmt::mp("freq"),
+      message_port_register_out(d_port);
+      message_port_register_in(d_port);
+      set_msg_handler(d_port,
                       boost::bind(&waterfall_sink_f_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
@@ -493,8 +494,8 @@ namespace gr {
     {
       if(d_main_gui->checkClicked()) {
         double freq = d_main_gui->getClickedFreq();
-        message_port_pub(pmt::mp("freq"),
-                         pmt::cons(pmt::mp("freq"),
+        message_port_pub(d_port,
+                         pmt::cons(d_port,
                                    pmt::from_double(freq)));
       }
     }

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -49,6 +49,8 @@ namespace gr {
       int d_nconnections;
       int d_nrows;
 
+      const pmt::pmt_t d_port;
+
       bool d_shift;
       fft::fft_complex *d_fft;
 

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -41,6 +41,8 @@ const pmt::pmt_t CMD_MBOARD_KEY = pmt::mp("mboard");
 const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("antenna");
 const pmt::pmt_t CMD_DIRECTION_KEY = pmt::mp("direction");
 
+const pmt::pmt_t ANT_DIRECTION_RX = pmt::mp("RX");
+const pmt::pmt_t ANT_DIRECTION_TX = pmt::mp("TX");
 
 /**********************************************************************
  * Structors
@@ -471,7 +473,7 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     pmt::pmt_t new_msg = pmt::make_dict();
     new_msg = pmt::dict_add(new_msg, pmt::tuple_ref(msg, 0), pmt::tuple_ref(msg, 1));
     if (pmt::length(msg) == 3) {
-      new_msg = pmt::dict_add(new_msg, pmt::mp("chan"), pmt::tuple_ref(msg, 2));
+      new_msg = pmt::dict_add(new_msg, CMD_CHAN_KEY, pmt::tuple_ref(msg, 2));
     }
     GR_LOG_WARN(d_debug_logger, boost::format("Using legacy message format (tuples): %s") % msg);
     return msg_handler_command(new_msg);

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -36,6 +36,24 @@ namespace gr {
       static const size_t ALL_MBOARDS = ::uhd::usrp::multi_usrp::ALL_MBOARDS;
       static const size_t ALL_CHANS = ::uhd::usrp::multi_usrp::ALL_CHANS;
       static const std::string ALL_GAINS = ::uhd::usrp::multi_usrp::ALL_GAINS;
+
+      static const pmt::pmt_t CMD_CHAN_KEY;
+      static const pmt::pmt_t CMD_GAIN_KEY;
+      static const pmt::pmt_t CMD_FREQ_KEY;
+      static const pmt::pmt_t CMD_LO_OFFSET_KEY;
+      static const pmt::pmt_t CMD_TUNE_KEY;
+      static const pmt::pmt_t CMD_LO_FREQ_KEY;
+      static const pmt::pmt_t CMD_DSP_FREQ_KEY;
+      static const pmt::pmt_t CMD_RATE_KEY;
+      static const pmt::pmt_t CMD_BANDWIDTH_KEY;
+      static const pmt::pmt_t CMD_TIME_KEY;
+      static const pmt::pmt_t CMD_MBOARD_KEY;
+      static const pmt::pmt_t CMD_ANTENNA_KEY;
+      static const pmt::pmt_t CMD_DIRECTION_KEY;
+
+
+      static const pmt::pmt_t ANT_DIRECTION_RX;
+      static const pmt::pmt_t ANT_DIRECTION_TX;
 #ifdef UHD_USRP_MULTI_USRP_LO_CONFIG_API
       static const std::string ALL_LOS = ::uhd::usrp::multi_usrp::ALL_LOS;
 #else

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -139,7 +139,7 @@ namespace gr {
     usrp_sink_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
     {
       _chans_to_tune.reset(chan);
-      if (pmt::eqv(direction, pmt::mp("RX"))) {
+      if (pmt::eqv(direction, ANT_DIRECTION_RX)) {
         // TODO: what happens if the RX device is not instantiated? Catch error?
         return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
       } else {
@@ -518,14 +518,14 @@ namespace gr {
           // If it's on the first sample, immediately do the tune:
           GR_LOG_DEBUG(d_debug_logger, boost::format("Received tx_freq on start of burst."));
           pmt::pmt_t freq_cmd = pmt::make_dict();
-          freq_cmd = pmt::dict_add(freq_cmd, pmt::mp("freq"), value);
+          freq_cmd = pmt::dict_add(freq_cmd, CMD_FREQ_KEY, value);
           msg_handler_command(freq_cmd);
         }
         else if(pmt::equal(key, FREQ_KEY)) {
           // If it's not on the first sample, queue this command and only tx until here:
           GR_LOG_DEBUG(d_debug_logger, boost::format("Received tx_freq mid-burst."));
           pmt::pmt_t freq_cmd = pmt::make_dict();
-          freq_cmd = pmt::dict_add(freq_cmd, pmt::mp("freq"), value);
+          freq_cmd = pmt::dict_add(freq_cmd, CMD_FREQ_KEY, value);
           commands_in_burst.push_back(freq_cmd);
           max_count = my_tag_count + 1;
           in_burst_cmd_offset = my_tag_count;

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -154,7 +154,7 @@ namespace gr {
     usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
     {
       _chans_to_tune.reset(chan);
-      if (pmt::eqv(direction, pmt::mp("TX"))) {
+      if (pmt::eqv(direction, ANT_DIRECTION_TX)) {
         // TODO: what happens if the TX device is not instantiated? Catch error?
         return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
       } else {

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -44,7 +44,8 @@ namespace gr {
       : gr::block("pull_msg_source",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+      d_timeout(timeout),
+      d_port(pmt::mp("out"))
     {
       int major, minor, patch;
       zmq::version (&major, &minor, &patch);
@@ -60,7 +61,7 @@ namespace gr {
       d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
       d_socket->connect (address);
 
-      message_port_register_out(pmt::mp("out"));
+      message_port_register_out(d_port);
     }
 
     pull_msg_source_impl::~pull_msg_source_impl()
@@ -101,7 +102,7 @@ namespace gr {
           std::string buf(static_cast<char*>(msg.data()), msg.size());
           std::stringbuf sb(buf);
           pmt::pmt_t m = pmt::deserialize(sb);
-          message_port_pub(pmt::mp("out"), m);
+          message_port_pub(d_port, m);
 
         } else {
           boost::this_thread::sleep(boost::posix_time::microseconds(100));

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -36,6 +36,7 @@ namespace gr {
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
       boost::thread   *d_thread;
+      const pmt::pmt_t d_port;
 
       void readloop();
 

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -38,6 +38,8 @@ namespace gr {
       boost::thread   *d_thread;
       bool            d_finished;
 
+      const pmt::pmt_t d_port;
+
       void            readloop();
 
     public:

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -44,7 +44,8 @@ namespace gr {
       : gr::block("req_msg_source",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+      d_timeout(timeout),
+      d_port(pmt::mp("out"))
     {
       int major, minor, patch;
       zmq::version(&major, &minor, &patch);
@@ -60,7 +61,7 @@ namespace gr {
       d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
       d_socket->connect (address);
 
-      message_port_register_out(pmt::mp("out"));
+      message_port_register_out(d_port);
     }
 
     req_msg_source_impl::~req_msg_source_impl()
@@ -113,7 +114,7 @@ namespace gr {
           std::string buf(static_cast<char*>(msg.data()), msg.size());
           std::stringbuf sb(buf);
           pmt::pmt_t m = pmt::deserialize(sb);
-          message_port_pub(pmt::mp("out"), m);
+          message_port_pub(d_port, m);
 
         } else {
           boost::this_thread::sleep(boost::posix_time::microseconds(100));

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -36,6 +36,7 @@ namespace gr {
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
       boost::thread   *d_thread;
+      const pmt::pmt_t d_port;
 
       void readloop();
 

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -44,7 +44,8 @@ namespace gr {
       : gr::block("sub_msg_source",
                   gr::io_signature::make(0, 0, 0),
                   gr::io_signature::make(0, 0, 0)),
-        d_timeout(timeout)
+      d_timeout(timeout),
+      d_port(pmt::mp("out"))
     {
       int major, minor, patch;
       zmq::version(&major, &minor, &patch);
@@ -59,7 +60,7 @@ namespace gr {
       d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
       d_socket->connect (address);
 
-      message_port_register_out(pmt::mp("out"));
+      message_port_register_out(d_port);
     }
 
     sub_msg_source_impl::~sub_msg_source_impl()
@@ -101,7 +102,7 @@ namespace gr {
           std::stringbuf sb(buf);
           pmt::pmt_t m = pmt::deserialize(sb);
 
-          message_port_pub(pmt::mp("out"), m);
+          message_port_pub(d_port, m);
         } else {
           boost::this_thread::sleep(boost::posix_time::microseconds(100));
         }

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -36,6 +36,7 @@ namespace gr {
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
       boost::thread   *d_thread;
+      const pmt::pmt_t d_port;
 
       void readloop();
 


### PR DESCRIPTION
typical usage:

     message_port_pub(pmt::mp("out_port"), …)

which is bad, as it implies hashing of a string, allocation of memory,
deallocation, finding the hashed string in the table of interned strings and
returning a unique pointer (which for reasons of PMT awesomeness isn't even
unique) to the interned port name.

Replacing all these port name ad hoc ::mp() calls by reusing one, private, port
name member. When feasible, even static const.

PMT::intern is a sometimes less-than-optimal implementation, but things like
`#define`s that put `pmt::mp("string")` where people thought they were actually
using a constant is straight out harmful.