### PR TITLE
QA test for complex sinusoid

### DIFF
--- a/gr-analog/python/analog/qa_sig_source.py
+++ b/gr-analog/python/analog/qa_sig_source.py
@@ -82,6 +82,20 @@ class test_sig_source(gr_unittest.TestCase):
         dst_data = dst1.data()
         self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
 
+    def test_cosine_c(self):
+        tb = self.tb
+        sqrt2 = math.sqrt(2) / 2
+        sqrt2j = 1j * math.sqrt(2) / 2
+        expected_result = (1, sqrt2 + sqrt2j, 1j, -sqrt2 + sqrt2j, -1, -sqrt2 - sqrt2j, -1j, sqrt2 - sqrt2j, 1)
+        src1 = analog.sig_source_c(8, analog.GR_COS_WAVE, 1.0, 1.0)
+        op = blocks.head(gr.sizeof_gr_complex, 9)
+        dst1 = blocks.vector_sink_c()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
     def test_sqr_c(self):
         tb = self.tb			#arg6 is a bit before -PI/2
         expected_result = (1j, 1j, 0, 0, 1, 1, 1+0j, 1+1j, 1j)


### PR DESCRIPTION
There were no unit tests for sig_source_c for the sinusoidal case.  This pull request adds a unit test for a complex sinusoid. 

The original motivation was that I had incorrectly assumed that setting the waveform of a complex signal to GR_COS_WAVE and GR_SIN_WAVE would yield different results.  I had assumed that setting the waveform to GR_SIN_WAVE would have created a complex signal that was 3pi/2 radians phase shifted.  I reviewed the unit tests because I thought that there was something wrong; I think there should be at least a runtime note that GR_COS_WAVE and GR_SIN_WAVE produce the same behaviour in the complex case.  

My goal was to have two complex signals that were out of phase.  I may open up an issue (and potentially send a pull request) regarding setting the phase of a signal source. 