### PR TITLE
fix: purge boost/math/special_functions/erf.hpp

### DIFF
--- a/gr-analog/lib/cpm.cc
+++ b/gr-analog/lib/cpm.cc
@@ -24,13 +24,10 @@
 #include "config.h"
 #endif
 
+#include <gnuradio/analog/cpm.h>
 #include <cmath>
 #include <cfloat>
-#include <gnuradio/analog/cpm.h>
 
-//gives us erf on compilers without it
-#include <boost/math/special_functions/erf.hpp>
-namespace bm = boost::math;
 
 namespace gr {
   namespace analog {
@@ -183,8 +180,8 @@ namespace gr {
       double alpha = 5.336446256636997 * bt;
       for(unsigned i = 0; i < samples_per_sym * L; i++) {
 	double k =  i - Ls/2; // Causal to acausal
-	taps_d[i] = (bm::erf(alpha * (k / samples_per_sym + 0.5)) -
-		     bm::erf(alpha * (k / samples_per_sym - 0.5)))
+        taps_d[i] = (erf(alpha * (k / samples_per_sym + 0.5)) -
+                     erf(alpha * (k / samples_per_sym - 0.5)))
 	  * 0.5 / samples_per_sym;
 	taps[i] = (float) taps_d[i];
       }

--- a/gr-analog/lib/cpm.cc
+++ b/gr-analog/lib/cpm.cc
@@ -36,14 +36,14 @@ namespace gr {
 #  define M_TWOPI (2*M_PI)
 #endif
 
-    //! Normalised sinc function, sinc(x)=sin(pi*x)/pi*x
+    //! Normalised sinc function, sinc(x)=std::sin(pi*x)/pi*x
     inline double
     sinc(double x)
     {
       if(x == 0) {
 	return 1.0;
       }
-      return sin(M_PI * x) / (M_PI * x);
+      return std::sin(M_PI * x) / (M_PI * x);
     }
 
 
@@ -53,7 +53,7 @@ namespace gr {
     {
       std::vector<float> taps(samples_per_sym * L, 1.0/L/samples_per_sym);
       for(unsigned i = 0; i < samples_per_sym * L; i++) {
-	taps[i] *= 1 - cos(M_TWOPI * i / L / samples_per_sym);
+	taps[i] *= 1 - std::cos(M_TWOPI * i / L / samples_per_sym);
       }
 
       return taps;
@@ -64,7 +64,7 @@ namespace gr {
      *
      * L-SRC has a time-continuous phase response function of
      *
-     * g(t) = 1/LT * sinc(2t/LT) * cos(beta * 2pi t / LT) / (1 - (4beta / LT * t)^2)
+     * g(t) = 1/LT * sinc(2t/LT) * std::cos(beta * 2pi t / LT) / (1 - (4beta / LT * t)^2)
      *
      * which is the Fourier transform of a cos-rolloff function with rolloff
      * beta, and looks like a sinc-function, multiplied with a rolloff term.
@@ -72,7 +72,7 @@ namespace gr {
      * zero crossings.
      * The time-discrete IR is thus
      *
-     * g(k) = 1/Ls * sinc(2k/Ls) * cos(beta * pi k / Ls) / (1 - (4beta / Ls * k)^2)
+     * g(k) = 1/Ls * sinc(2k/Ls) * std::cos(beta * pi k / Ls) / (1 - (4beta / Ls * k)^2)
      * where k = 0...Ls-1
      * and s = samples per symbol.
      */
@@ -97,7 +97,7 @@ namespace gr {
 	}
 	else {
 	  double tmp = 4.0 * beta * k / Ls;
-	  taps_d[i] *= cos(beta * M_TWOPI * k / Ls) / (1 - tmp * tmp);
+	  taps_d[i] *= std::cos(beta * M_TWOPI * k / Ls) / (1 - tmp * tmp);
 	}
 	sum += taps_d[i];
       }
@@ -125,7 +125,7 @@ namespace gr {
 
       const double pi2_24 = 0.411233516712057; // pi^2/24
       double f = M_PI * k / sps;
-      return sinc(k/sps) - pi2_24 * (2 * sin(f) - 2*f*cos(f) - f*f*sin(f)) / (f*f*f);
+      return sinc(k/sps) - pi2_24 * (2 * std::sin(f) - 2*f*std::cos(f) - f*f*std::sin(f)) / (f*f*f);
     }
 
     //! Taps for TFM CPM (Tamed frequency modulation)
@@ -180,8 +180,8 @@ namespace gr {
       double alpha = 5.336446256636997 * bt;
       for(unsigned i = 0; i < samples_per_sym * L; i++) {
 	double k =  i - Ls/2; // Causal to acausal
-        taps_d[i] = (erf(alpha * (k / samples_per_sym + 0.5)) -
-                     erf(alpha * (k / samples_per_sym - 0.5)))
+  taps_d[i] = (std::erf(alpha * (k / samples_per_sym + 0.5)) -
+               std::erf(alpha * (k / samples_per_sym - 0.5)))
 	  * 0.5 / samples_per_sym;
 	taps[i] = (float) taps_d[i];
       }

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -22,11 +22,11 @@
 
 #include "ber_sink_b_impl.h"
 
-#include <boost/math/special_functions/erf.hpp>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <gnuradio/fft/fft.h>
 #include <volk/volk.h>
+#include <cmath>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -91,7 +91,7 @@ namespace gr {
       for(size_t i = 0; i < esnos.size(); i++) {
         double e = pow(10.0, esnos[i]/10.0);
         d_esno_buffers[curves][i] = esnos[i];
-        d_ber_buffers[curves][i] = log10(0.5*boost::math::erfc(sqrt(e)));
+        d_ber_buffers[curves][i] = log10(0.5*erfc(sqrt(e)));
       }
 
 

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -91,7 +91,7 @@ namespace gr {
       for(size_t i = 0; i < esnos.size(); i++) {
         double e = pow(10.0, esnos[i]/10.0);
         d_esno_buffers[curves][i] = esnos[i];
-        d_ber_buffers[curves][i] = log10(0.5*erfc(sqrt(e)));
+        d_ber_buffers[curves][i] = std::log10(0.5*std::erf(std::sqrt(e)));
       }
 
 
@@ -337,7 +337,7 @@ namespace gr {
           if(d_total_errors[j * d_nconnections + i] >= d_ber_min_errors) {
             done++;
           }
-          else if(log10(((double)d_ber_min_errors)/(d_total[j * d_nconnections + i] * 8.0)) < d_ber_limit) {
+          else if(std::log10(((double)d_ber_min_errors)/(d_total[j * d_nconnections + i] * 8.0)) < d_ber_limit) {
             maxed++;
           }
         }
@@ -355,7 +355,7 @@ namespace gr {
       for(unsigned int i = 0; i < ninput_items.size(); i += 2) {
 
         if((d_total_errors[i >> 1] < d_ber_min_errors) && \
-           (log10(((double)d_ber_min_errors)/(d_total[i >> 1] * 8.0)) >= d_ber_limit)) {
+           (std::log10(((double)d_ber_min_errors)/(d_total[i >> 1] * 8.0)) >= d_ber_limit)) {
 
           int items = ninput_items[i] <= ninput_items[i+1] ? ninput_items[i] : ninput_items[i+1];
 
@@ -371,7 +371,7 @@ namespace gr {
 
             d_total[i >> 1] += items;
 
-            ber = log10(((double)d_total_errors[i >> 1])/(d_total[i >> 1] * 8.0));
+            ber = std::log10(((double)d_total_errors[i >> 1])/(d_total[i >> 1] * 8.0));
             d_ber_buffers[i/(d_nconnections * 2)][(i%(d_nconnections * 2)) >> 1] = ber;
 
           }
@@ -382,7 +382,7 @@ namespace gr {
             GR_LOG_INFO(d_logger, boost::format("    %1% over %2%  -->  %3%") \
                         % d_total_errors[i >> 1] % (d_total[i >> 1] * 8) % ber);
           }
-          else if(log10(((double)d_ber_min_errors)/(d_total[i >> 1] * 8.0)) < d_ber_limit) {
+          else if(std::log10(((double)d_ber_min_errors)/(d_total[i >> 1] * 8.0)) < d_ber_limit) {
             GR_LOG_INFO(d_logger, "BER Limit Reached");
             d_ber_buffers[i/(d_nconnections * 2)][(i%(d_nconnections * 2)) >> 1] = d_ber_limit;
             d_total_errors[i >> 1] = d_ber_min_errors + 1;


### PR DESCRIPTION
`boost/math/special_functions/erf.hpp` causes compile errors. Also, it is only used for two functions `erf` and `erfc`. Both functions are available in `cmath`. Including this boost header back in 2012 might have fixed an issue, but now it causes huge trouble. A 1500+ line compile error with:
`/usr/include/boost/math/special_functions/detail/erf_inv.hpp:355:50: error: invalid suffix Q on floating constant
             boost::math::erfc_inv(static_cast<T>(BOOST_MATH_BIG_CONSTANT(T, 64, 1e-900)), Policy());`