### PR TITLE
add missing includes to headers + reorder qtgui includes

### DIFF
--- a/gr-blocks/lib/stream_pdu_base.h
+++ b/gr-blocks/lib/stream_pdu_base.h
@@ -24,6 +24,7 @@
 #define INCLUDED_STREAM_PDU_BASE_H
 
 #include <gnuradio/thread/thread.h>
+#include <gnuradio/basic_block.h>
 #include <pmt/pmt.h>
 
 class basic_block;

--- a/gr-fec/include/gnuradio/fec/polar_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_common.h
@@ -25,6 +25,7 @@
 #define INCLUDED_FEC_POLAR_COMMON_H
 
 #include <gnuradio/fec/api.h>
+#include <vector>
 
 // Forward declaration for those objects. SWIG doesn't like them to be #include'd.
 namespace gr {

--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -24,6 +24,7 @@
 #define SPECTRUM_GUI_CLASS_CPP
 
 #include <gnuradio/qtgui/SpectrumGUIClass.h>
+
 //Added by qt3to4:
 #include <QEvent>
 #include <volk/volk.h>

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -21,6 +21,7 @@
  */
 
 #include "ber_sink_b_impl.h"
+
 #include <boost/math/special_functions/erf.hpp>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>

--- a/gr-qtgui/lib/ber_sink_b_impl.h
+++ b/gr-qtgui/lib/ber_sink_b_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_BER_SINK_B_IMPL_H
 
 #include <gnuradio/qtgui/ber_sink_b.h>
+
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/constellationdisplayform.h>
 

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -25,6 +25,7 @@
 #endif
 
 #include "const_sink_c_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <string.h>

--- a/gr-qtgui/lib/const_sink_c_impl.h
+++ b/gr-qtgui/lib/const_sink_c_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_CONST_SINK_C_IMPL_H
 
 #include <gnuradio/qtgui/const_sink_c.h>
+
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/constellationdisplayform.h>
 

--- a/gr-qtgui/lib/constellationdisplayform.cc
+++ b/gr-qtgui/lib/constellationdisplayform.cc
@@ -20,9 +20,10 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include <gnuradio/qtgui/constellationdisplayform.h>
+
 #include <cmath>
 #include <QMessageBox>
-#include <gnuradio/qtgui/constellationdisplayform.h>
 #include <iostream>
 
 ConstellationDisplayForm::ConstellationDisplayForm(int nplots, QWidget* parent)

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -21,6 +21,7 @@
  */
 
 #include <gnuradio/qtgui/displayform.h>
+
 #include <iostream>
 #include <QPixmap>
 #include <QFileDialog>

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -25,9 +25,11 @@
 #endif
 
 #include "edit_box_msg_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/qtgui/utils.h>
+
 #include <boost/lexical_cast.hpp>
 
 namespace gr {

--- a/gr-qtgui/lib/edit_box_msg_impl.h
+++ b/gr-qtgui/lib/edit_box_msg_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_EDIT_BOX_MSG_IMPL_H
 
 #include <gnuradio/qtgui/edit_box_msg.h>
+
 #include <QGroupBox>
 #include <QVBoxLayout>
 #include <QHBoxLayout>

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -25,11 +25,14 @@
 #endif
 
 #include "freq_sink_c_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_FREQ_SINK_C_IMPL_H
 
 #include <gnuradio/qtgui/freq_sink_c.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -25,11 +25,14 @@
 #endif
 
 #include "freq_sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_FREQ_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/freq_sink_f.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -21,6 +21,7 @@
  */
 
 #include <gnuradio/qtgui/freqcontrolpanel.h>
+
 #include <cmath>
 
 FreqControlPanel::FreqControlPanel(FreqDisplayForm *form)

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -20,10 +20,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include <gnuradio/qtgui/freqdisplayform.h>
+
 #include <cmath>
 #include <QMessageBox>
 #include <QSpacerItem>
-#include <gnuradio/qtgui/freqdisplayform.h>
 #include <gnuradio/qtgui/freqcontrolpanel.h>
 #include <iostream>
 

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -25,11 +25,14 @@
 #endif
 
 #include "histogram_sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/histogram_sink_f_impl.h
+++ b/gr-qtgui/lib/histogram_sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_HISTOGRAM_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/histogram_sink_f.h>
+
 #include <gnuradio/qtgui/histogramdisplayform.h>
 #include <gnuradio/high_res_timer.h>
 

--- a/gr-qtgui/lib/histogramdisplayform.cc
+++ b/gr-qtgui/lib/histogramdisplayform.cc
@@ -20,9 +20,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include <cmath>
-#include <QMessageBox>
 #include <gnuradio/qtgui/histogramdisplayform.h>
+
+#include <QMessageBox>
+
+#include <cmath>
 #include <iostream>
 
 HistogramDisplayForm::HistogramDisplayForm(int nplots, QWidget* parent)

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -25,11 +25,14 @@
 #endif
 
 #include "number_sink_impl.h"
+
 #include <gnuradio/io_signature.h>
-#include <string.h>
-#include <volk/volk.h>
 #include <gnuradio/fft/fft.h>
+
+#include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 #include <cmath>
 
 #ifdef _MSC_VER

--- a/gr-qtgui/lib/number_sink_impl.h
+++ b/gr-qtgui/lib/number_sink_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_NUMBER_SINK_IMPL_H
 
 #include <gnuradio/qtgui/number_sink.h>
+
 #include <gnuradio/qtgui/numberdisplayform.h>
 #include <gnuradio/filter/single_pole_iir.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -20,12 +20,14 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include <cmath>
+#include <gnuradio/qtgui/numberdisplayform.h>
+
+#include <qwt_color_map.h>
 #include <QMessageBox>
 #include <QFileDialog>
-#include <gnuradio/qtgui/numberdisplayform.h>
+
+#include <cmath>
 #include <iostream>
-#include <qwt_color_map.h>
 
 NumberDisplayForm::NumberDisplayForm(int nplots, gr::qtgui::graph_t type,
                                      QWidget* parent)

--- a/gr-qtgui/lib/plot_raster.cc
+++ b/gr-qtgui/lib/plot_raster.cc
@@ -20,14 +20,16 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include <iostream>
+#include <gnuradio/qtgui/plot_raster.h>
+
 #include <qimage.h>
 #include <qpen.h>
 #include <qpainter.h>
 #include "qwt_painter.h"
 #include "qwt_scale_map.h"
 #include "qwt_color_map.h"
-#include <gnuradio/qtgui/plot_raster.h>
+
+#include <iostream>
 
 #if QWT_VERSION < 0x060000
 #include "qwt_double_interval.h"

--- a/gr-qtgui/lib/plot_waterfall.cc
+++ b/gr-qtgui/lib/plot_waterfall.cc
@@ -20,13 +20,14 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include <gnuradio/qtgui/plot_waterfall.h>
+
 #include <qimage.h>
 #include <qpen.h>
 #include <qpainter.h>
 #include "qwt_painter.h"
 #include "qwt_scale_map.h"
 #include "qwt_color_map.h"
-#include <gnuradio/qtgui/plot_waterfall.h>
 
 #if QWT_VERSION < 0x060000
 #include "qwt_double_interval.h"

--- a/gr-qtgui/lib/qtgui_util.cc
+++ b/gr-qtgui/lib/qtgui_util.cc
@@ -21,7 +21,9 @@
  */
 
 #include <gnuradio/qtgui/utils.h>
+
 #include <gnuradio/prefs.h>
+
 #include <QDebug>
 #include <QFile>
 #include <QCoreApplication>

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -25,10 +25,13 @@
 #endif
 
 #include "sink_c_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/sink_c_impl.h
+++ b/gr-qtgui/lib/sink_c_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2008,2009,2011,2012,2014 Free Software Foundation, Inc.
+ * Copyright 2008,2009,2011,2012,2014,2018 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_SINK_C_IMPL_H
 
 #include <gnuradio/qtgui/sink_c.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -25,10 +25,13 @@
 #endif
 
 #include "sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/sink_f_impl.h
+++ b/gr-qtgui/lib/sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/sink_f.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/spectrumdisplayform.cc
+++ b/gr-qtgui/lib/spectrumdisplayform.cc
@@ -19,12 +19,14 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
+#include <gnuradio/qtgui/spectrumdisplayform.h>
 
-#include <cmath>
+#include <gnuradio/qtgui/qtgui_types.h>
+
 #include <QColorDialog>
 #include <QMessageBox>
-#include <gnuradio/qtgui/spectrumdisplayform.h>
-#include <gnuradio/qtgui/qtgui_types.h>
+
+#include <cmath>
 
 SpectrumDisplayForm::SpectrumDisplayForm(QWidget* parent)
   : QWidget(parent)

--- a/gr-qtgui/lib/timeRasterGlobalData.cc
+++ b/gr-qtgui/lib/timeRasterGlobalData.cc
@@ -24,6 +24,7 @@
 #define TIMERASTER_GLOBAL_DATA_CPP
 
 #include <gnuradio/qtgui/timeRasterGlobalData.h>
+
 #include <cstdio>
 #include <cmath>
 #include <iostream>

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -25,10 +25,13 @@
 #endif
 
 #include "time_raster_sink_b_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/time_raster_sink_b_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_TIME_RASTER_SINK_B_IMPL_H
 
 #include <gnuradio/qtgui/time_raster_sink_b.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -25,10 +25,13 @@
 #endif
 
 #include "time_raster_sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/time_raster_sink_f_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_TIME_RASTER_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/time_raster_sink_f.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -25,12 +25,15 @@
 #endif
 
 #include "time_sink_c_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
-#include <volk/volk.h>
 #include <gnuradio/fft/fft.h>
+
+#include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/time_sink_c_impl.h
+++ b/gr-qtgui/lib/time_sink_c_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_TIME_SINK_C_IMPL_H
 
 #include <gnuradio/qtgui/time_sink_c.h>
+
 #include <gnuradio/qtgui/timedisplayform.h>
 #include <gnuradio/high_res_timer.h>
 

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -25,14 +25,17 @@
 #endif
 
 #include "time_sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
-#include <volk/volk.h>
 #include <gnuradio/fft/fft.h>
+
+#include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/time_sink_f_impl.h
+++ b/gr-qtgui/lib/time_sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_TIME_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/time_sink_f.h>
+
 #include <gnuradio/qtgui/timedisplayform.h>
 #include <gnuradio/high_res_timer.h>
 

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -19,13 +19,15 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
+#include <gnuradio/qtgui/timecontrolpanel.h>
 
-#include <cmath>
+#include <gnuradio/qtgui/timedisplayform.h>
+
 #include <QMessageBox>
 #include <QSpacerItem>
 #include <QGroupBox>
-#include <gnuradio/qtgui/timedisplayform.h>
-#include <gnuradio/qtgui/timecontrolpanel.h>
+
+#include <cmath>
 #include <iostream>
 
 

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -20,10 +20,12 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include <cmath>
+#include <gnuradio/qtgui/timerasterdisplayform.h>
+
 #include <QColorDialog>
 #include <QMessageBox>
-#include <gnuradio/qtgui/timerasterdisplayform.h>
+
+#include <cmath>
 #include <iostream>
 
 TimeRasterDisplayForm::TimeRasterDisplayForm(int nplots,

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -25,11 +25,14 @@
 #endif
 
 #include "vector_sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
 #include <qwt_symbol.h>
+
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/vector_sink_f_impl.h
+++ b/gr-qtgui/lib/vector_sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_VECTOR_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/vector_sink_f.h>
+
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/vectordisplayform.h>
 

--- a/gr-qtgui/lib/vectordisplayform.cc
+++ b/gr-qtgui/lib/vectordisplayform.cc
@@ -20,9 +20,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include <cmath>
-#include <QMessageBox>
 #include <gnuradio/qtgui/vectordisplayform.h>
+
+#include <QMessageBox>
+
+#include <cmath>
 #include <iostream>
 
 VectorDisplayForm::VectorDisplayForm(int nplots, QWidget* parent)

--- a/gr-qtgui/lib/waterfallGlobalData.cc
+++ b/gr-qtgui/lib/waterfallGlobalData.cc
@@ -24,6 +24,7 @@
 #define WATERFALL_GLOBAL_DATA_CPP
 
 #include <gnuradio/qtgui/waterfallGlobalData.h>
+
 #include <cstdio>
 
 WaterfallData::WaterfallData(const double minimumFrequency,

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -25,12 +25,15 @@
 #endif
 
 #include "waterfall_sink_c_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
 #include <qwt_symbol.h>
+
 #include <iostream>
+#include <string.h>
 
 namespace gr {
   namespace qtgui {

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_WATERFALL_SINK_C_IMPL_H
 
 #include <gnuradio/qtgui/waterfall_sink_c.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -25,10 +25,13 @@
 #endif
 
 #include "waterfall_sink_f_impl.h"
+
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <string.h>
+
 #include <volk/volk.h>
+
+#include <string.h>
 #include <iostream>
 
 namespace gr {

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_QTGUI_WATERFALL_SINK_F_IMPL_H
 
 #include <gnuradio/qtgui/waterfall_sink_f.h>
+
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/high_res_timer.h>

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -20,10 +20,12 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include <cmath>
+#include <gnuradio/qtgui/waterfalldisplayform.h>
+
 #include <QColorDialog>
 #include <QMessageBox>
-#include <gnuradio/qtgui/waterfalldisplayform.h>
+
+#include <cmath>
 #include <iostream>
 
 WaterfallDisplayForm::WaterfallDisplayForm(int nplots, QWidget* parent)


### PR DESCRIPTION
Add includes which are missing and will be detected upon correct reordering of includes in implementation files.