### PR TITLE
Fix #1678: Avoid creation of same blockname

### DIFF
--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -72,6 +72,18 @@ class ModToolAdd(ModTool):
     def setup(self, options, args):
         ModTool.setup(self, options, args)
 
+        if self._info['blockname'] is None:
+            if len(args) >= 2:
+                self._info['blockname'] = args[1]
+            else:
+                self._info['blockname'] = raw_input("Enter name of block/code (without module name prefix): ")
+        if os.path.isfile("./lib/"+self._info['blockname']+"_impl.cc") or os.path.isfile("./python/"+self._info['blockname']+".py"):
+            raise ModToolException('The given blockname already exists!')
+        if not re.match('[a-zA-Z0-9_]+', self._info['blockname']):
+            raise ModToolException('Invalid block name.')
+        print "Block/code identifier: " + self._info['blockname']
+        self._info['fullblockname'] = self._info['modname'] + '_' + self._info['blockname']
+
         self._info['blocktype'] = options.block_type
         if self._info['blocktype'] is None:
             # Print list out of blocktypes to user for reference
@@ -97,16 +109,7 @@ class ModToolAdd(ModTool):
         if ((self._skip_subdirs['lib'] and self._info['lang'] == 'cpp')
              or (self._skip_subdirs['python'] and self._info['lang'] == 'python')):
             raise ModToolException('Missing or skipping relevant subdir.')
-
-        if self._info['blockname'] is None:
-            if len(args) >= 2:
-                self._info['blockname'] = args[1]
-            else:
-                self._info['blockname'] = raw_input("Enter name of block/code (without module name prefix): ")
-        if not re.match('[a-zA-Z0-9_]+', self._info['blockname']):
-            raise ModToolException('Invalid block name.')
-        print "Block/code identifier: " + self._info['blockname']
-        self._info['fullblockname'] = self._info['modname'] + '_' + self._info['blockname']
+ 
         if not options.license_file:
             self._info['copyrightholder'] = options.copyright
             if self._info['copyrightholder'] is None:


### PR DESCRIPTION
To avoid creation of same blockname, we can check whether the corresponding block file exists in lib or python directory or not. If the corresponding file, eg: `square_ff_impl.cc` exists in the lib directory, we give a ModToolException that `The corresponding blockname already exists!`