### PR TITLE
Throwing a std::invalid_argument instead of letting SIGFPE happen for…

### DIFF
--- a/gr-digital/grc/digital_ofdm_carrier_allocator_cvc.xml
+++ b/gr-digital/grc/digital_ofdm_carrier_allocator_cvc.xml
@@ -18,13 +18,13 @@
   <param>
     <name>Pilot Carriers</name>
     <key>pilot_carriers</key>
-    <value>()</value>
+    <value>((),)</value>
     <type>raw</type>
   </param>
   <param>
     <name>Pilot Symbols</name>
     <key>pilot_symbols</key>
-    <value>()</value>
+    <value>((),)</value>
     <type>raw</type>
   </param>
   <param>

--- a/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.cc
+++ b/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013-2018 Free Software Foundation, Inc.
+ * Copyright 2013, 2018 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -74,9 +74,8 @@ namespace gr {
 	d_output_is_shifted(output_is_shifted)
     {
       // Sanity checks
-      // Since C++11: Get pointer to underlying array
       // If that is is null, the input is wrong -> force user to use ((),) in python
-      if (d_occupied_carriers.data() == nullptr) {
+      if (d_occupied_carriers.empty()) {
         throw std::invalid_argument("Occupied carriers must be of type vector of vector i.e. ((),).");
       }
       for (unsigned i = 0; i < d_occupied_carriers.size(); i++) {
@@ -92,7 +91,7 @@ namespace gr {
 	  }
 	}
       }
-      if (d_pilot_carriers.data() == nullptr) {
+      if (d_pilot_carriers.empty()) {
         throw std::invalid_argument("Pilot carriers must be of type vector of vector i.e. ((),).");
       }
       for (unsigned i = 0; i < d_pilot_carriers.size(); i++) {
@@ -108,7 +107,7 @@ namespace gr {
 	  }
 	}
       }
-      if (d_pilot_symbols.data() == nullptr) {
+      if (d_pilot_symbols.empty()) {
         throw std::invalid_argument("Pilot symbols must be of type vector of vector i.e. ((),).");
       }
       for (unsigned i = 0; i < std::max(d_pilot_carriers.size(), d_pilot_symbols.size()); i++) {

--- a/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.cc
+++ b/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.cc
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/* 
- * Copyright 2013 Free Software Foundation, Inc.
- * 
+/*
+ * Copyright 2013-2018 Free Software Foundation, Inc.
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -73,6 +73,12 @@ namespace gr {
 	d_symbols_per_set(0),
 	d_output_is_shifted(output_is_shifted)
     {
+      // Sanity checks
+      // Since C++11: Get pointer to underlying array
+      // If that is is null, the input is wrong -> force user to use ((),) in python
+      if (d_occupied_carriers.data() == nullptr) {
+        throw std::invalid_argument("Occupied carriers must be of type vector of vector i.e. ((),).");
+      }
       for (unsigned i = 0; i < d_occupied_carriers.size(); i++) {
 	for (unsigned j = 0; j < d_occupied_carriers[i].size(); j++) {
 	  if (occupied_carriers[i][j] < 0) {
@@ -86,6 +92,9 @@ namespace gr {
 	  }
 	}
       }
+      if (d_pilot_carriers.data() == nullptr) {
+        throw std::invalid_argument("Pilot carriers must be of type vector of vector i.e. ((),).");
+      }
       for (unsigned i = 0; i < d_pilot_carriers.size(); i++) {
 	for (unsigned j = 0; j < d_pilot_carriers[i].size(); j++) {
 	  if (d_pilot_carriers[i][j] < 0) {
@@ -98,6 +107,9 @@ namespace gr {
 	    d_pilot_carriers[i][j] = (d_pilot_carriers[i][j] + fft_len/2) % fft_len;
 	  }
 	}
+      }
+      if (d_pilot_symbols.data() == nullptr) {
+        throw std::invalid_argument("Pilot symbols must be of type vector of vector i.e. ((),).");
       }
       for (unsigned i = 0; i < std::max(d_pilot_carriers.size(), d_pilot_symbols.size()); i++) {
 	if (d_pilot_carriers[i % d_pilot_carriers.size()].size() != d_pilot_symbols[i % d_pilot_symbols.size()].size()) {
@@ -191,6 +203,6 @@ namespace gr {
       return n_ofdm_symbols + d_sync_words.size();
     }
 
-  } /* namespace digital */
-} /* namespace gr */
+  } // namespace digital
+} // namespace gr
 

--- a/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.h
+++ b/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/*
- * Copyright 2013-2018 Free Software Foundation, Inc.
- *
+/* 
+ * Copyright 2013 Free Software Foundation, Inc.
+ * 
  * This file is part of GNU Radio
- *
+ * 
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- *
+ * 
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,

--- a/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.h
+++ b/gr-digital/lib/ofdm_carrier_allocator_cvc_impl.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/* 
- * Copyright 2013 Free Software Foundation, Inc.
- * 
+/*
+ * Copyright 2013-2018 Free Software Foundation, Inc.
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,

--- a/gr-digital/python/digital/qa_ofdm_carrier_allocator_cvc.py
+++ b/gr-digital/python/digital/qa_ofdm_carrier_allocator_cvc.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
-# Copyright 2012-2014 Free Software Foundation, Inc.
-# 
+# Copyright 2012-2018 Free Software Foundation, Inc.
+#
 # This file is part of GNU Radio
-# 
+#
 # GNU Radio is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # GNU Radio is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with GNU Radio; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-# 
+#
 
 from gnuradio import gr, gr_unittest, digital, blocks
 import pmt
@@ -208,6 +208,32 @@ class qa_digital_carrier_allocator_cvc (gr_unittest.TestCase):
                 self.assertEqual(correct_offsets[key], tag.offset)
         self.assertTrue(all(tags_found.values()))
 
+    @gr_unittest.unittest.skip("Skipping test with wrong input (caused SIGFPE earlier, now throws a simple std::invalid_argument with useful message)")
+    def test_004_t (self):
+        """
+        Provoking exception (earlier SIGFPE).
+        """
+        fft_len = 6
+        tx_symbols = (1, 2, 3)
+        pilot_symbols = ()
+        occupied_carriers = ((-1, 1, 2),)
+        pilot_carriers = ()
+        expected_result = (0, 0, 1, 0, 2, 3)
+        src = blocks.vector_source_c(tx_symbols, False, 1)
+        alloc = digital.ofdm_carrier_allocator_cvc(fft_len,
+                       occupied_carriers,
+                       pilot_carriers,
+                       pilot_symbols, (),
+                       self.tsb_key)
+        sink = blocks.tsb_vector_sink_c(fft_len)
+        self.tb.connect(
+                src,
+                blocks.stream_to_tagged_stream(gr.sizeof_gr_complex, 1, len(tx_symbols), self.tsb_key),
+                alloc,
+                sink
+        )
+        self.tb.run ()
+        self.assertEqual(sink.data()[0], expected_result)
 
 if __name__ == '__main__':
     gr_unittest.run(qa_digital_carrier_allocator_cvc, "qa_digital_carrier_allocator_cvc.xml")


### PR DESCRIPTION
… wrong input in case of the OFDM carrier allocator.

Fixes #1648