### PR TITLE
qa_fastnoise: split testcases and test for reproducibility

### DIFF
--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -73,9 +73,12 @@ namespace gr {
   void
   random::reseed(unsigned int seed)
   {
-    if(seed==0) d_seed = static_cast<unsigned int>(std::time(0));
-    else d_seed = seed;
-    d_rng->seed(d_seed);
+    d_seed = seed;
+    if (d_seed == 0){
+      d_rng->seed();
+    } else {
+      d_rng->seed(d_seed);
+    }
     // reinstantiate generators. Otherwise reseed doesn't take effect.
     delete d_generator;
     d_generator = new boost::variate_generator<boost::mt19937&, boost::uniform_real<float> > (*d_rng,*d_uniform); // create number generator in [0,1) from boost.random

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -141,9 +141,12 @@ namespace gr {
   float
   random::laplacian()
   {
-    float z = ran1()-0.5;
-    if(z>0) return -logf(1-2*z);
-    else return logf(1+2*z);
+    float z = ran1();
+    if (z > 0.5){
+      return -logf(2*(1-z));
+    }else{
+      return logf(2*z);
+    }
   }
 
   /*

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -141,14 +141,12 @@ namespace gr {
   float
   random::laplacian()
   {
-    float z = ran1();
-    if (z > 0.5){
-      return -logf(2*(1-z));
-    }else{
-      return logf(2*z);
-    }
+          float z = ran1();
+          if (z > 0.5f){
+                  return -logf(2.0f * (1.0f - z) );
+          }
+          return logf(2 * z);
   }
-
   /*
    * Copied from The KC7WW / OH2BNS Channel Simulator
    * FIXME Need to check how good this is at some point

--- a/gr-analog/include/gnuradio/analog/fastnoise_source_X.h.t
+++ b/gr-analog/include/gnuradio/analog/fastnoise_source_X.h.t
@@ -29,6 +29,8 @@
 #include <gnuradio/analog/noise_type.h>
 #include <gnuradio/sync_block.h>
 
+#include <vector>
+
 namespace gr {
   namespace analog {
 
@@ -62,6 +64,7 @@ namespace gr {
 		       long seed = 0, long samples=1024*16);
       virtual @TYPE@ sample() = 0;
       virtual @TYPE@ sample_unbiased() = 0;
+      virtual const std::vector<@TYPE@>& samples() const = 0;
 
       /*!
        * Set the noise type. Nominally from the

--- a/gr-analog/lib/fastnoise_source_X_impl.cc.t
+++ b/gr-analog/lib/fastnoise_source_X_impl.cc.t
@@ -163,5 +163,9 @@ namespace gr {
 #endif
     }
 
+    const std::vector<@TYPE@>& @IMPL_NAME@::samples() const
+    {
+            return d_samples;
+    }
   } /* namespace analog */
 } /* namespace gr */

--- a/gr-analog/lib/fastnoise_source_X_impl.h.t
+++ b/gr-analog/lib/fastnoise_source_X_impl.h.t
@@ -50,6 +50,7 @@ namespace gr {
       void set_type(noise_type_t type);
       void set_amplitude(float ampl);
       void generate();
+      const std::vector<@TYPE@>& samples() const { return d_samples; };
 
       noise_type_t type() const { return d_type; }
       float amplitude() const { return d_ampl; }

--- a/gr-analog/lib/fastnoise_source_X_impl.h.t
+++ b/gr-analog/lib/fastnoise_source_X_impl.h.t
@@ -50,7 +50,7 @@ namespace gr {
       void set_type(noise_type_t type);
       void set_amplitude(float ampl);
       void generate();
-      const std::vector<@TYPE@>& samples() const { return d_samples; };
+      const std::vector<@TYPE@>& samples() const;
 
       noise_type_t type() const { return d_type; }
       float amplitude() const { return d_ampl; }

--- a/gr-analog/python/analog/qa_fastnoise.py
+++ b/gr-analog/python/analog/qa_fastnoise.py
@@ -30,7 +30,7 @@ class test_fastnoise_source(gr_unittest.TestCase):
 
         self.num = 2**22
         self.num_items = 10**6
-        self.default_args = {"samples": self.num, "seed": 43, "ampl": 1}
+        self.default_args = {"samples": self.num, "seed": int(43), "ampl": 1}
 
     def tearDown (self):
         pass
@@ -102,13 +102,14 @@ class test_fastnoise_source(gr_unittest.TestCase):
         self.assertAlmostEqual(data.imag.mean(), 0, places=2)
         self.assertAlmostEqual(data.imag.var(), 0.5, places=2)
 
-    def test_002_reproducibility(self):
+    def test_002_real_uniform_reproducibility(self):
         data1 = self.run_test_real(analog.GR_UNIFORM)
         data2 = self.run_test_real(analog.GR_UNIFORM)
 
         # It's pseudoramdo thus must be equal
         self.assertTrue(numpy.array_equal(data1, data2))
 
+    def test_002_real_gaussian_reproducibility(self):
         data1 = self.run_test_real(analog.GR_GAUSSIAN)
         data2 = self.run_test_real(analog.GR_GAUSSIAN)
 

--- a/gr-analog/python/analog/qa_fastnoise.py
+++ b/gr-analog/python/analog/qa_fastnoise.py
@@ -30,7 +30,7 @@ class test_fastnoise_source(gr_unittest.TestCase):
 
         self.num = 2**22
         self.num_items = 10**6
-        self.default_args = {"samples": self.num, "seed": int(43), "ampl": 1}
+        self.default_args = {"samples": self.num, "seed": 43, "ampl": 1}
 
     def tearDown (self):
         pass
@@ -115,5 +115,25 @@ class test_fastnoise_source(gr_unittest.TestCase):
 
         self.assertTrue(numpy.array_equal(data1, data2))
 
+    def test_003_real_uniform_pool(self):
+        src = analog.fastnoise_source_f(type=analog.GR_UNIFORM, **self.default_args)
+        src2 = analog.fastnoise_source_f(type=analog.GR_UNIFORM, **self.default_args)
+        self.assertTrue(numpy.array_equal(numpy.array(src.samples()), numpy.array(src2.samples())))
+    def test_003_real_gaussian_pool(self):
+        src = analog.fastnoise_source_f(type=analog.GR_GAUSSIAN, **self.default_args)
+        src2 = analog.fastnoise_source_f(type=analog.GR_GAUSSIAN, **self.default_args)
+        self.assertTrue(numpy.array_equal(numpy.array(src.samples()), numpy.array(src2.samples())))
+    def test_003_cmplx_gaussian_pool(self):
+        src = analog.fastnoise_source_c(type=analog.GR_GAUSSIAN, **self.default_args)
+        src2 = analog.fastnoise_source_c(type=analog.GR_GAUSSIAN, **self.default_args)
+        self.assertTrue(numpy.array_equal(numpy.array(src.samples()), numpy.array(src2.samples())))
+    def test_003_cmplx_uniform_pool(self):
+        src = analog.fastnoise_source_c(type=analog.GR_UNIFORM, **self.default_args)
+        src2 = analog.fastnoise_source_c(type=analog.GR_UNIFORM, **self.default_args)
+        self.assertTrue(numpy.array_equal(numpy.array(src.samples()), numpy.array(src2.samples())))
+    def test_003_real_laplacian_pool(self):
+        src = analog.fastnoise_source_f(type=analog.GR_LAPLACIAN, **self.default_args)
+        src2 = analog.fastnoise_source_f(type=analog.GR_LAPLACIAN, **self.default_args)
+        self.assertTrue(numpy.array_equal(numpy.array(src.samples()), numpy.array(src2.samples())))
 if __name__ == '__main__':
     gr_unittest.run(test_fastnoise_source, "test_fastnoise_source.xml")


### PR DESCRIPTION
The unittests were quite hard to comprehend. Splitting in subcases based on 
the PDF to test failures are easier to interpret. (If something changes)

Also adding a reproducibility testcase which compares the vector of samples of two runs
with the same seed. 
Which must result in the same samples if generated on the same machine (due to different FPUs).

The current implementation sometimes yields slightly different results even if run on the same machine.