### PR TITLE
fix broken gr-uhd command tags

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -27,23 +27,6 @@ using namespace gr::uhd;
 
 const double usrp_block_impl::LOCK_TIMEOUT = 1.5;
 
-const pmt::pmt_t CMD_CHAN_KEY = pmt::mp("chan");
-const pmt::pmt_t CMD_GAIN_KEY = pmt::mp("gain");
-const pmt::pmt_t CMD_FREQ_KEY = pmt::mp("freq");
-const pmt::pmt_t CMD_LO_OFFSET_KEY = pmt::mp("lo_offset");
-const pmt::pmt_t CMD_TUNE_KEY = pmt::mp("tune");
-const pmt::pmt_t CMD_LO_FREQ_KEY = pmt::mp("lo_freq");
-const pmt::pmt_t CMD_DSP_FREQ_KEY = pmt::mp("dsp_freq");
-const pmt::pmt_t CMD_RATE_KEY = pmt::mp("rate");
-const pmt::pmt_t CMD_BANDWIDTH_KEY = pmt::mp("bandwidth");
-const pmt::pmt_t CMD_TIME_KEY = pmt::mp("time");
-const pmt::pmt_t CMD_MBOARD_KEY = pmt::mp("mboard");
-const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("antenna");
-const pmt::pmt_t CMD_DIRECTION_KEY = pmt::mp("direction");
-
-const pmt::pmt_t ANT_DIRECTION_RX = pmt::mp("RX");
-const pmt::pmt_t ANT_DIRECTION_TX = pmt::mp("TX");
-
 /**********************************************************************
  * Structors
  *********************************************************************/

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -37,23 +37,23 @@ namespace gr {
       static const size_t ALL_CHANS = ::uhd::usrp::multi_usrp::ALL_CHANS;
       static const std::string ALL_GAINS = ::uhd::usrp::multi_usrp::ALL_GAINS;
 
-      static const pmt::pmt_t CMD_CHAN_KEY;
-      static const pmt::pmt_t CMD_GAIN_KEY;
-      static const pmt::pmt_t CMD_FREQ_KEY;
-      static const pmt::pmt_t CMD_LO_OFFSET_KEY;
-      static const pmt::pmt_t CMD_TUNE_KEY;
-      static const pmt::pmt_t CMD_LO_FREQ_KEY;
-      static const pmt::pmt_t CMD_DSP_FREQ_KEY;
-      static const pmt::pmt_t CMD_RATE_KEY;
-      static const pmt::pmt_t CMD_BANDWIDTH_KEY;
-      static const pmt::pmt_t CMD_TIME_KEY;
-      static const pmt::pmt_t CMD_MBOARD_KEY;
-      static const pmt::pmt_t CMD_ANTENNA_KEY;
-      static const pmt::pmt_t CMD_DIRECTION_KEY;
+      static const pmt::pmt_t CMD_CHAN_KEY = pmt::mp("chan");
+      static const pmt::pmt_t CMD_GAIN_KEY = pmt::mp("gain");
+      static const pmt::pmt_t CMD_FREQ_KEY = pmt::mp("freq");
+      static const pmt::pmt_t CMD_LO_OFFSET_KEY = pmt::mp("lo_offset");
+      static const pmt::pmt_t CMD_TUNE_KEY = pmt::mp("tune");
+      static const pmt::pmt_t CMD_LO_FREQ_KEY = pmt::mp("lo_freq");
+      static const pmt::pmt_t CMD_DSP_FREQ_KEY = pmt::mp("dsp_freq");
+      static const pmt::pmt_t CMD_RATE_KEY = pmt::mp("rate");
+      static const pmt::pmt_t CMD_BANDWIDTH_KEY = pmt::mp("bandwidth");
+      static const pmt::pmt_t CMD_TIME_KEY = pmt::mp("time");
+      static const pmt::pmt_t CMD_MBOARD_KEY = pmt::mp("mboard");
+      static const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("antenna");
+      static const pmt::pmt_t CMD_DIRECTION_KEY = pmt::mp("direction");
 
+      static const pmt::pmt_t ANT_DIRECTION_RX = pmt::mp("RX");
+      static const pmt::pmt_t ANT_DIRECTION_TX = pmt::mp("TX");
 
-      static const pmt::pmt_t ANT_DIRECTION_RX;
-      static const pmt::pmt_t ANT_DIRECTION_TX;
 #ifdef UHD_USRP_MULTI_USRP_LO_CONFIG_API
       static const std::string ALL_LOS = ::uhd::usrp::multi_usrp::ALL_LOS;
 #else


### PR DESCRIPTION
These constant pmt variables are not initialized when included from the header file.  I figure they can be initialized in the header file itself.  This corresponds to the bug in issue #1688.