### PR TITLE
[gr-fec] Define GSL_LDFLAGS in MSVC build

### DIFF
--- a/cmake/Modules/FindGSL.cmake
+++ b/cmake/Modules/FindGSL.cmake
@@ -51,6 +51,7 @@ if( WIN32 AND NOT CYGWIN AND NOT MSYS )
     endif( GSL_CBLAS_LIBRARY )
 
     set( GSL_LIBRARIES ${GSL_LIBRARY} ${GSL_CBLAS_LIBRARY} )
+    set( GSL_LDFLAGS ${GSL_LIBRARIES} )
   endif( GSL_INCLUDE_DIRS )
 
   mark_as_advanced(


### PR DESCRIPTION
Pull request #1490 breaks the windows build because GSL_LDFLAGS isn't defined in MSVC windows.  

Assuming the use of GSL_LDFLAGS is needed in Linux instead of the more common XXX_LIBRARIES pattern, this will specifically define GSL_LDFLAGS for WIN32/MSVC builds only.

That allows gr-fec/lib/CMakeText.txt to find the correct libraries and add the dependencies.