### PR TITLE
zeromq: adds test delay to allow sub to init prior to data send

### DIFF
--- a/gr-zeromq/python/zeromq/qa_zeromq_sub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_sub.py
@@ -50,7 +50,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
         self.tb.connect(zeromq_sub_source, sink)
 
         self.tb.start()
-        time.sleep(0.25)
+        time.sleep(0.05)
         self.pub_socket.send(src_data.tostring())
         time.sleep(0.25)
         self.tb.stop()
@@ -68,7 +68,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
         self.tb.connect(zeromq_sub_source, sink)
 
         self.tb.start()
-        time.sleep(0.25)
+        time.sleep(0.05)
         self.pub_socket.send_multipart(src_data)
         time.sleep(0.25)
         self.tb.stop()

--- a/gr-zeromq/python/zeromq/qa_zeromq_sub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_sub.py
@@ -50,6 +50,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
         self.tb.connect(zeromq_sub_source, sink)
 
         self.tb.start()
+        time.sleep(0.25)
         self.pub_socket.send(src_data.tostring())
         time.sleep(0.25)
         self.tb.stop()
@@ -67,6 +68,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
         self.tb.connect(zeromq_sub_source, sink)
 
         self.tb.start()
+        time.sleep(0.25)
         self.pub_socket.send_multipart(src_data)
         time.sleep(0.25)
         self.tb.stop()


### PR DESCRIPTION
This should only affect testing.

In this test, immediately after tb.start() is called asynchronously, the publisher sends the data stream.  If the flowgraph has not yet had time to initialize the subscriber, no data will be received.  So this adds a .25 second delay to ensure that works.

While this caused test fails on Win64, I assume this issue would cause test fails on Linux builds as well.