### PR TITLE
Test: adds swig dirs to python tests to allow ctest to run on win builds

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -44,6 +44,11 @@ if(ENABLE_TESTING)
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gruel/src/python
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig		
+    ${CMAKE_BINARY_DIR}/gr-filter/swig		
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
     )
   include(GrTest)
   file(GLOB py_qa_test_files "qa_*.py")

--- a/gnuradio-runtime/python/pmt/CMakeLists.txt
+++ b/gnuradio-runtime/python/pmt/CMakeLists.txt
@@ -40,6 +40,7 @@ foreach(py_qa_test_file ${py_qa_test_files})
     set(GR_TEST_PYTHON_DIRS
         ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
         ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig
+        ${CMAKE_BINARY_DIR}/gnuradio-blocks/swig		
     )
     set(GR_TEST_TARGET_DEPS gnuradio-runtime)
     GR_ADD_TEST(${py_qa_test_name} ${QA_PYTHON_EXECUTABLE} ${PYTHON_DASH_B} ${py_qa_test_file})

--- a/gr-analog/python/analog/CMakeLists.txt
+++ b/gr-analog/python/analog/CMakeLists.txt
@@ -48,6 +48,11 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig		
     )
 
   include(GrTest)

--- a/gr-atsc/python/atsc/CMakeLists.txt
+++ b/gr-atsc/python/atsc/CMakeLists.txt
@@ -52,6 +52,9 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig
+    ${CMAKE_BINARY_DIR}/gr-atsc/swig	
     )
 
   include(GrTest)

--- a/gr-audio/python/audio/CMakeLists.txt
+++ b/gr-audio/python/audio/CMakeLists.txt
@@ -36,6 +36,7 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
     )
 
   include(GrTest)

--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -38,6 +38,8 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig
     )
 
   include(GrTest)

--- a/gr-channels/python/channels/CMakeLists.txt
+++ b/gr-channels/python/channels/CMakeLists.txt
@@ -45,6 +45,12 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-channels/swig
     )
 
   include(GrTest)

--- a/gr-comedi/python/comedi/CMakeLists.txt
+++ b/gr-comedi/python/comedi/CMakeLists.txt
@@ -38,6 +38,7 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
     )
 
   include(GrTest)

--- a/gr-digital/python/digital/CMakeLists.txt
+++ b/gr-digital/python/digital/CMakeLists.txt
@@ -74,6 +74,13 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-channels/swig	
+    ${CMAKE_BINARY_DIR}/gr-digital/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig		
+    ${CMAKE_BINARY_DIR}/gr-analog/swig		
     )
 
   include(GrTest)

--- a/gr-dtv/python/dtv/CMakeLists.txt
+++ b/gr-dtv/python/dtv/CMakeLists.txt
@@ -39,6 +39,12 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-dtv/swig	
     )
 
   include(GrTest)

--- a/gr-fcd/python/fcd/CMakeLists.txt
+++ b/gr-fcd/python/fcd/CMakeLists.txt
@@ -36,6 +36,8 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-fcd/swig		
     )
 
   include(GrTest)

--- a/gr-fec/python/fec/CMakeLists.txt
+++ b/gr-fec/python/fec/CMakeLists.txt
@@ -47,10 +47,16 @@ add_subdirectory(polar)
 if(ENABLE_TESTING)
 
 list(APPEND GR_TEST_PYTHON_DIRS
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/python 
     ${CMAKE_BINARY_DIR}/gr-fec/python
     ${CMAKE_BINARY_DIR}/gr-fec/swig
     ${CMAKE_BINARY_DIR}/gr-blocks/python
     ${CMAKE_BINARY_DIR}/gr-blocks/swig
+    ${CMAKE_BINARY_DIR}/gr-fft/swig
+    ${CMAKE_BINARY_DIR}/gr-analog/swig
+    ${CMAKE_BINARY_DIR}/gr-digital/swig
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
 )
 
 list(APPEND GR_TEST_TARGET_DEPS gnuradio-fec)

--- a/gr-fft/python/fft/CMakeLists.txt
+++ b/gr-fft/python/fft/CMakeLists.txt
@@ -36,6 +36,9 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig		
+    ${CMAKE_BINARY_DIR}/gr-fft/swig		
     )
   include(GrTest)
   file(GLOB py_qa_test_files "qa_*.py")

--- a/gr-filter/python/filter/CMakeLists.txt
+++ b/gr-filter/python/filter/CMakeLists.txt
@@ -41,6 +41,11 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig		
     )
 
   include(GrTest)

--- a/gr-noaa/python/noaa/CMakeLists.txt
+++ b/gr-noaa/python/noaa/CMakeLists.txt
@@ -38,6 +38,8 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-noaa/swig	
     )
 
   include(GrTest)

--- a/gr-pager/python/pager/CMakeLists.txt
+++ b/gr-pager/python/pager/CMakeLists.txt
@@ -38,6 +38,12 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-pager/swig	
     )
 
   include(GrTest)

--- a/gr-qtgui/python/qtgui/CMakeLists.txt
+++ b/gr-qtgui/python/qtgui/CMakeLists.txt
@@ -37,6 +37,8 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-qtgui/swig
     )
 
   include(GrTest)

--- a/gr-trellis/python/trellis/CMakeLists.txt
+++ b/gr-trellis/python/trellis/CMakeLists.txt
@@ -39,6 +39,13 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-digital/swig	
+    ${CMAKE_BINARY_DIR}/gr-trellis/swig	
     )
 
   include(GrTest)

--- a/gr-uhd/python/uhd/CMakeLists.txt
+++ b/gr-uhd/python/uhd/CMakeLists.txt
@@ -37,6 +37,8 @@ if(ENABLE_TESTING)
 list(APPEND GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gr-uhd/python
     ${CMAKE_BINARY_DIR}/gr-uhd/swig
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/python 	
 )
 
 list(APPEND GR_TEST_TARGET_DEPS gnuradio-uhd)

--- a/gr-video-sdl/python/video_sdl/CMakeLists.txt
+++ b/gr-video-sdl/python/video_sdl/CMakeLists.txt
@@ -38,6 +38,8 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-video-sdl/swig
     )
 
   include(GrTest)

--- a/gr-vocoder/python/vocoder/CMakeLists.txt
+++ b/gr-vocoder/python/vocoder/CMakeLists.txt
@@ -39,6 +39,11 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-vocoder/swig	
     )
 
   include(GrTest)

--- a/gr-wavelet/python/wavelet/CMakeLists.txt
+++ b/gr-wavelet/python/wavelet/CMakeLists.txt
@@ -36,6 +36,12 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-filter/swig	
+    ${CMAKE_BINARY_DIR}/gr-fft/swig	
+    ${CMAKE_BINARY_DIR}/gr-analog/swig	
+    ${CMAKE_BINARY_DIR}/gr-wavelet/swig	
     )
 
   include(GrTest)

--- a/gr-zeromq/python/zeromq/CMakeLists.txt
+++ b/gr-zeromq/python/zeromq/CMakeLists.txt
@@ -45,6 +45,9 @@ if(ENABLE_TESTING)
   set(GR_TEST_LIBRARY_DIRS "")
   set(GR_TEST_PYTHON_DIRS
     ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig	
+    ${CMAKE_BINARY_DIR}/gr-blocks/swig	
+    ${CMAKE_BINARY_DIR}/gr-zeromq/swig	
   )
 
   include(GrTest)


### PR DESCRIPTION
Running unit tests on windows has previously required running tests individually because the dependencies are not set up correctly for the build structure.

This adds the appropriate directories and allows ctest to run within the run_gr.bat environment.

Only affects test environment, and while Linux may not require the additional paths, I don't think they'll be hurt by them either.