### PR TITLE
grc: saving epy_module/epy_block code at block path if block is hierarchical

### DIFF
--- a/grc/core/generator/Generator.py
+++ b/grc/core/generator/Generator.py
@@ -272,6 +272,7 @@ class HierBlockGenerator(TopBlockGenerator):
             os.mkdir(hier_block_lib_dir)
 
         self._mode = HIER_BLOCK_FILE_MODE
+        self._dirname = hier_block_lib_dir
         self.file_path = os.path.join(hier_block_lib_dir, self._flow_graph.get_option('id') + '.py')
         self._file_path_xml = self.file_path + '.xml'
 


### PR DESCRIPTION
Code which is generated from Python module/blocks in hierarchical block flow graphs will be saved at the block path, fixes #1709 