### PR TITLE
Restore ability to use absolute thresholding with corr_est

### DIFF
--- a/gr-digital/grc/digital_corr_est_cc.xml
+++ b/gr-digital/grc/digital_corr_est_cc.xml
@@ -32,6 +32,20 @@
     <type>float</type>
   </param>
 
+  <param>
+    <name>Threshold Method</name>
+    <key>threshold_method</key>
+    <type>enum</type>
+    <option>
+      <name>Absolute</name>
+      <key>digital.corr_est_cc.THRESHOLD_ABSOLUTE</key>
+    </option>
+    <option>
+      <name>Dynamic</name>
+      <key>digital.corr_est_cc.THRESHOLD_DYNAMIC</key>
+    </option>
+  </param>
+
   <sink>
     <name>in</name>
     <type>complex</type>

--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -87,20 +87,28 @@ namespace gr {
     public:
       typedef boost::shared_ptr<corr_est_cc> sptr;
 
+      enum tm_type {
+        THRESHOLD_DYNAMIC,
+        THRESHOLD_ABSOLUTE,
+      };
+
       /*!
        * Make a block that correlates against the \p symbols vector
        * and outputs a phase and symbol timing estimate.
        *
-       * \param symbols    Set of symbols to correlate against (e.g., a
-       *                   sync word).
-       * \param sps        Samples per symbol
-       * \param mark_delay tag marking delay in samples after the
-       *                   corr_start tag
-       * \param threshold  Threshold of correlator, relative to a 100%
-       *                   correlation (1.0). Default is 0.9.
+       * \param symbols           Set of symbols to correlate against (e.g., a
+       *                          sync word).
+       * \param sps               Samples per symbol
+       * \param mark_delay        tag marking delay in samples after the
+       *                          corr_start tag
+       * \param threshold         Threshold of correlator, relative to a 100%
+       *                          correlation (1.0). Default is 0.9.
+       * \param threshold_method  Method for computing threshold.
+       *
        */
       static sptr make(const std::vector<gr_complex> &symbols,
-                       float sps, unsigned int mark_delay, float threshold=0.9);
+                       float sps, unsigned int mark_delay, float threshold=0.9,
+                       tm_type threshold_method=THRESHOLD_ABSOLUTE);
 
       virtual std::vector<gr_complex> symbols() const = 0;
       virtual void set_symbols(const std::vector<gr_complex> &symbols) = 0;

--- a/gr-digital/lib/corr_est_cc_impl.h
+++ b/gr-digital/lib/corr_est_cc_impl.h
@@ -47,13 +47,16 @@ namespace gr {
       float d_scale;
       float d_pfa; // probability of false alarm
 
+      tm_type d_threshold_method;
+
       void _set_mark_delay(unsigned int mark_delay);
       void _set_threshold(float threshold);
 
     public:
       corr_est_cc_impl(const std::vector<gr_complex> &symbols,
                        float sps, unsigned int mark_delay,
-                       float threshold=0.9);
+                       float threshold=0.9,
+                       tm_type threshold_method=THRESHOLD_ABSOLUTE);
       ~corr_est_cc_impl();
 
       std::vector<gr_complex> symbols() const;


### PR DESCRIPTION
This extends the corr_est block to take a threshold method as an argument.

* THRESHOLD_ABSOLUTE restores the previous function of this block.
* THRESHOLD_DYNAMIC provides the outlier detection algorithm that was later added.

This should resolve #1207 