### PR TITLE
cmake: fix CTRLPORT includes and testing

### DIFF
--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -44,7 +44,7 @@ configure_file(
 list(APPEND gnuradio_runtime_sources ${CMAKE_CURRENT_BINARY_DIR}/constants.cc)
 
 ########################################################################
-# Setup the include and linker paths
+# Setup globally used include paths
 ########################################################################
 include_directories(${GNURADIO_RUNTIME_INCLUDE_DIRS}
                     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -52,12 +52,6 @@ include_directories(${GNURADIO_RUNTIME_INCLUDE_DIRS}
                     ${Boost_INCLUDE_DIRS}
                     ${MPLIB_INCLUDE_DIRS}
 )
-
-if(ENABLE_CTRLPORT_THRIFT)
-    list(APPEND include_directories
-        ${THRIFT_INCLUDE_DIRS}
-    )
-endif(ENABLE_CTRLPORT_THRIFT)
 
 ########################################################################
 # Include subdirs rather to populate to the sources lists.
@@ -67,6 +61,13 @@ GR_INCLUDE_SUBDIRECTORY(messages)
 GR_INCLUDE_SUBDIRECTORY(thread)
 GR_INCLUDE_SUBDIRECTORY(math)
 GR_INCLUDE_SUBDIRECTORY(controlport)
+
+########################################################################
+# Setup CTRLPORT include path, if using
+########################################################################
+if(ENABLE_CTRLPORT_THRIFT)
+    include_directories(${THRIFT_INCLUDE_DIRS})
+endif(ENABLE_CTRLPORT_THRIFT)
 
 ########################################################################
 # Setup library

--- a/gnuradio-runtime/lib/controlport/CMakeLists.txt
+++ b/gnuradio-runtime/lib/controlport/CMakeLists.txt
@@ -17,15 +17,18 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-if(ENABLE_GR_CTRLPORT)
-
 # Keep track of the number of backends ControlPort supports
 SET(CTRLPORT_BACKENDS 0)
+
+if(ENABLE_GR_CTRLPORT)
 
 # Add definition so we can compile in ControlPort to the blocks.
 add_definitions(-DGR_CTRLPORT)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 list(APPEND gnuradio_ctrlport_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/rpcmanager.cc
@@ -33,7 +36,6 @@ list(APPEND gnuradio_ctrlport_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/rpcserver_booter_aggregator.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/rpcserver_selector.cc
 )
-
 
 OPTION(ENABLE_CTRLPORT_THRIFT "Enable ControlPort Thrift support" ON)
 
@@ -88,17 +90,10 @@ install(
 
 endif(THRIFT_FOUND)
 endif(ENABLE_CTRLPORT_THRIFT)
-
-########################################################################
-# Add controlport stuff to gnuradio-runtime
-########################################################################
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+endif(ENABLE_GR_CTRLPORT)
 
 # Save the number of backends for testing against later
 set(
   CTRLPORT_BACKENDS ${CTRLPORT_BACKENDS}
   CACHE INTERNAL "Number of ControlPort backends available"
 )
-
-endif(ENABLE_GR_CTRLPORT)

--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -45,13 +45,13 @@ if(ENABLE_TESTING)
   file(GLOB py_qa_test_files "qa_*.py")
 
   # Force out the controlport QA tests if we have no backends to use.
-  if(CTRLPORT_BACKENDS EQUAL 0)
+  if(NOT ENABLE_GR_CTRLPORT)
     list(REMOVE_ITEM py_qa_test_files
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_cpp_py_binding.py
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_cpp_py_binding_set.py
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_ctrlport_probes.py
       )
-  endif(CTRLPORT_BACKENDS EQUAL 0)
+  endif(NOT ENABLE_GR_CTRLPORT)
 
   foreach(py_qa_test_file ${py_qa_test_files})
     get_filename_component(py_qa_test_name ${py_qa_test_file} NAME_WE)


### PR DESCRIPTION
Currently, CTRLPORT_BACKENDS is not declared if ENABLE_GR_CTRLPORT is FALSE, so testing this variable makes no sense. All testing in gr-* is done using ENABLE_GR_CTRLPORT, so move to that in gr-blocks.

That said, having CTRLPORT_BACKENDS set to 0 could be useful, so rearrange CTRLPORT determination to set this variable correctly.

If ENABLE_CTRLPORT_THRIFT, then correctly use include_directories for header directories, -after- CTRLPORT is determined, not before. We can also combine some of these declarations to simplify the code.