### PR TITLE
Boost 1.67 compatibility

### DIFF
--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -91,7 +91,7 @@ namespace gr {
     void message_strobe_impl::run()
     {
       while(!d_finished) {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(d_period_ms));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(static_cast<long>(d_period_ms)));
         if(d_finished) {
           return;
         }

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -110,7 +110,7 @@ namespace gr {
     void message_strobe_random_impl::run()
     {
       while(!d_finished) {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(std::max(0.0f,next_delay())));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(static_cast<long>(std::max(0.0f,next_delay()))));
         if(d_finished) {
           return;
         }

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -196,7 +196,7 @@ bool usrp_block_impl::_wait_for_locked_sensor(
 
   while (true) {
     if ((not first_lock_time.is_not_a_date_time()) and
-        (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(LOCK_TIMEOUT)))) {
+        (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT))))) {
       break;
     }
 
@@ -207,7 +207,7 @@ bool usrp_block_impl::_wait_for_locked_sensor(
     else {
       first_lock_time = boost::system_time(); //reset to 'not a date time'
 
-      if (boost::get_system_time() > (start + boost::posix_time::seconds(LOCK_TIMEOUT))){
+      if (boost::get_system_time() > (start + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT)))){
         return false;
       }
     }


### PR DESCRIPTION
Fix regression due to https://github.com/boostorg/date_time/commit/f9f2aaf5216c.

`uhd` may be fixing these in some other way. See https://github.com/EttusResearch/uhd/pull/170#issuecomment-381749132.