### PR TITLE
OFDM Cyclic prefixer is now safer and more flexible.

### DIFF
--- a/gr-digital/examples/ofdm/tx_ofdm.grc
+++ b/gr-digital/examples/ofdm/tx_ofdm.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.10'?>
+<?grc format='1' created='3.7.12'?>
 <flow_graph>
   <timestamp>Wed Jul  9 15:49:47 2014</timestamp>
   <block>
@@ -30,7 +30,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1, 0)</value>
+      <value>(0, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value>OFDM Tx</value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -93,7 +101,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(181, -1)</value>
+      <value>(184, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -120,7 +128,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(720, 69)</value>
+      <value>(872, 84)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -147,7 +155,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(567, 0)</value>
+      <value>(568, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -174,7 +182,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(352, 0)</value>
+      <value>(352, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -201,7 +209,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(320, 69)</value>
+      <value>(472, 84)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -228,7 +236,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(476, 0)</value>
+      <value>(472, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -255,7 +263,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(734, 0)</value>
+      <value>(736, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -282,7 +290,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(480, 69)</value>
+      <value>(632, 84)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -309,7 +317,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(608, 69)</value>
+      <value>(760, 84)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -336,7 +344,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(898, -1)</value>
+      <value>(904, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -363,7 +371,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(255, 0)</value>
+      <value>(256, 12)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -390,7 +398,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 93)</value>
+      <value>(184, 84)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -417,7 +425,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(152, 93)</value>
+      <value>(328, 84)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -452,7 +460,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(16, 167)</value>
+      <value>(8, 188)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -574,7 +582,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(664, 245)</value>
+      <value>(624, 244)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -633,7 +641,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(896, 157)</value>
+      <value>(872, 172)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -680,7 +688,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(192, 181)</value>
+      <value>(168, 204)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -739,7 +747,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(680, 822)</value>
+      <value>(688, 868)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -790,7 +798,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(376, 692)</value>
+      <value>(376, 684)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -817,6 +825,10 @@
       <value>False</value>
     </param>
     <param>
+      <key>single_key</key>
+      <value>""</value>
+    </param>
+    <param>
       <key>vlen</key>
       <value>1</value>
     </param>
@@ -841,7 +853,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(512, 369)</value>
+      <value>(496, 360)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -967,7 +979,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(192, 801)</value>
+      <value>(208, 844)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1022,7 +1034,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(216, 317)</value>
+      <value>(256, 324)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1081,7 +1093,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(216, 397)</value>
+      <value>(216, 396)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1136,7 +1148,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(432, 182)</value>
+      <value>(384, 196)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1191,7 +1203,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(192, 489)</value>
+      <value>(200, 484)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1237,8 +1249,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>fft_len/4</value>
+      <key>cp_lengths</key>
+      <value>(fft_len/4,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -1253,12 +1265,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>fft_len</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(632, 503)</value>
+      <value>(712, 508)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1269,7 +1281,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value>length_tag_key</value>
     </param>
     <param>
@@ -1313,7 +1325,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(440, 766)</value>
+      <value>(440, 804)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1396,7 +1408,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(656, 157)</value>
+      <value>(624, 172)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1447,7 +1459,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(416, 496)</value>
+      <value>(448, 492)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1494,7 +1506,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1104, 164)</value>
+      <value>(1072, 180)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1557,7 +1569,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(960, 759)</value>
+      <value>(1080, 780)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -1844,7 +1856,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(960, 671)</value>
+      <value>(1080, 668)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -2123,6 +2135,10 @@
       <value>samp_rate</value>
     </param>
     <param>
+      <key>stemplot</key>
+      <value>False</value>
+    </param>
+    <param>
       <key>tr_chan</key>
       <value>0</value>
     </param>
@@ -2183,7 +2199,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(856, 524)</value>
+      <value>(1056, 524)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2210,7 +2226,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(856, 252)</value>
+      <value>(1072, 252)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2237,7 +2253,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(744, 388)</value>
+      <value>(1080, 372)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2264,7 +2280,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(960, 620)</value>
+      <value>(1080, 604)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2291,7 +2307,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(0, 324)</value>
+      <value>(8, 332)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2318,7 +2334,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(0, 404)</value>
+      <value>(8, 404)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2345,7 +2361,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(0, 524)</value>
+      <value>(8, 524)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2372,7 +2388,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(0, 692)</value>
+      <value>(8, 692)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2399,7 +2415,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(0, 836)</value>
+      <value>(8, 884)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/gr-digital/grc/digital_ofdm_cyclic_prefixer.xml
+++ b/gr-digital/grc/digital_ofdm_cyclic_prefixer.xml
@@ -54,7 +54,7 @@
     <key>len_tag_key</key>
     <value>"frame_len"</value>
     <type>string</type>
-    <hide>#if $tagname() == "" then "part" else "none"#</hide>
+    <hide>#if $len_tag_key() == "" then "part" else "none"#</hide>
   </param>
   <sink>
     <name>in</name>

--- a/gr-digital/grc/digital_ofdm_cyclic_prefixer.xml
+++ b/gr-digital/grc/digital_ofdm_cyclic_prefixer.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!--
  Copyright 2011 Free Software Foundation, Inc.
- 
+
  This file is part of GNU Radio
- 
+
  GNU Radio is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 3, or (at your option)
  any later version.
- 
+
  GNU Radio is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with GNU Radio; see the file COPYING.  If not, write to
  the Free Software Foundation, Inc., 51 Franklin Street,
@@ -26,42 +26,43 @@
 ###################################################
  -->
 <block>
-	<name>OFDM Cyclic Prefixer</name>
-	<key>digital_ofdm_cyclic_prefixer</key>
-	<import>from gnuradio import digital</import>
-	<make>digital.ofdm_cyclic_prefixer($input_size, $input_size+$cp_len, $rolloff, $tagname)</make>
-	<param>
-		<name>FFT Length</name>
-		<key>input_size</key>
-		<value>fft_len</value>
-		<type>int</type>
-	</param>
-	<param>
-		<name>CP Length</name>
-		<key>cp_len</key>
-		<value>fft_len/4</value>
-		<type>int</type>
-	</param>
-	<param>
-		<name>Rolloff</name>
-		<key>rolloff</key>
-		<value>0</value>
-		<type>int</type>
-		<hide>#if $rolloff then 'none' else 'part'#</hide>
-	</param>
-	<param>
-		<name>Length Tag Key</name>
-		<key>tagname</key>
-		<value>"frame_len"</value>
-		<type>string</type>
-	</param>
-	<sink>
-		<name>in</name>
-		<type>complex</type>
-		<vlen>$input_size</vlen>
-	</sink>
-	<source>
-		<name>out</name>
-		<type>complex</type>
-	</source>
+  <name>OFDM Cyclic Prefixer</name>
+  <key>digital_ofdm_cyclic_prefixer</key>
+  <import>from gnuradio import digital</import>
+  <make>digital.ofdm_cyclic_prefixer($fft_len, $cp_lengths, $rolloff, $len_tag_key)</make>
+  <param>
+    <name>FFT Length</name>
+    <key>fft_len</key>
+    <value>fft_len</value>
+    <type>int</type>
+  </param>
+  <param>
+    <name>CP Lengths</name>
+    <key>cp_lengths</key>
+    <value>(10,)</value>
+    <type>raw</type>
+  </param>
+  <param>
+    <name>Rolloff</name>
+    <key>rolloff</key>
+    <value>0</value>
+    <type>int</type>
+    <hide>#if $rolloff() == 0 then "part" else "none"#</hide>
+  </param>
+  <param>
+    <name>Length Tag Key</name>
+    <key>len_tag_key</key>
+    <value>"frame_len"</value>
+    <type>string</type>
+    <hide>#if $tagname() == "" then "part" else "none"#</hide>
+  </param>
+  <sink>
+    <name>in</name>
+    <type>complex</type>
+    <vlen>$fft_len</vlen>
+  </sink>
+  <source>
+    <name>out</name>
+    <type>complex</type>
+  </source>
 </block>

--- a/gr-digital/include/gnuradio/digital/ofdm_cyclic_prefixer.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_cyclic_prefixer.h
@@ -49,10 +49,15 @@ namespace gr {
      * Different CP lengths as for instance needed in LTE are supported. This
      * is why one of the inputs is std::vector<int>. After every CP given has
      * been prepended to symbols, each with the length of the IFFT operation,
-     * the mechanism will wrap arround and start over. To give an example, the
+     * the mechanism will wrap around and start over. To give an example, the
      * input tuple for LTE with an FFT length of 2048 would be (160,) +
      * (144,)*6, which is equal to (160, 144, 144, 144, 144, 144, 144). A
      * uniform CP would be indicated by (uniform_cp_length, ).
+     *
+     * This block does some sanity checking: 1. It is not allowed to have a
+     * vector of CP lengths, which are only 0.  2. Not a single CP in the
+     * vector must be longer than the rolloff. 3. Not a single CP is allowed to
+     * be < 0.
      */
 
     class DIGITAL_API ofdm_cyclic_prefixer : virtual public tagged_stream_block
@@ -60,13 +65,27 @@ namespace gr {
      public:
       typedef boost::shared_ptr<ofdm_cyclic_prefixer> sptr;
 
-      /*!
+      /*! \brief Make is overloaded to maintain API backwardscompatibility.
+       *         This will map one CP length to a vector of length 1.
+       * \param input_size IFFT length (i.e. length of the OFDM symbols).
+       * \param output_size FFT length + cyclic prefix length (in samples).
+       * \param rolloff_len Length of the rolloff flank in samples.
+       * \param len_tag_key For framed processing the key of the length tag.
+       */
+      static sptr make
+      (
+        size_t input_size,
+        size_t output_size,
+        int rolloff_len=0,
+        const std::string &len_tag_key=""
+      );
+
+      /*! \brief This interface should be used for new applications.
        * \param fft_len IFFT length (i.e. length of the OFDM symbols).
        * \param cp_lengths CP lengths. Wraps arround after reaching the end.
        * \param rolloff_len Length of the rolloff flank in samples.
        * \param len_tag_key For framed processing the key of the length tag.
        */
-
       static sptr make
       (
         int fft_len,

--- a/gr-digital/include/gnuradio/digital/ofdm_cyclic_prefixer.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_cyclic_prefixer.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/* 
- * Copyright 2013 Free Software Foundation, Inc.
- * 
+/*
+ * Copyright 2013, 2018 Free Software Foundation, Inc.
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -30,7 +30,7 @@ namespace gr {
   namespace digital {
 
     /*!
-     * \brief Adds a cyclic prefix and performs pulse shaping on OFDM symbols.
+     * \brief Adds a cyclic prefix and performs optional pulse shaping on OFDM symbols.
      * \ingroup ofdm_blk
      *
      * \details
@@ -45,28 +45,37 @@ namespace gr {
      *         the pulse shaping.
      *
      * The pulse shape is a raised cosine in the time domain.
+     *
+     * Different CP lengths as for instance needed in LTE are supported. This
+     * is why one of the inputs is std::vector<int>. After every CP given has
+     * been prepended to symbols, each with the length of the IFFT operation,
+     * the mechanism will wrap arround and start over. To give an example, the
+     * input tuple for LTE with an FFT length of 2048 would be (160,) +
+     * (144,)*6, which is equal to (160, 144, 144, 144, 144, 144, 144). A
+     * uniform CP would be indicated by (uniform_cp_length, ).
      */
+
     class DIGITAL_API ofdm_cyclic_prefixer : virtual public tagged_stream_block
     {
      public:
       typedef boost::shared_ptr<ofdm_cyclic_prefixer> sptr;
 
       /*!
-       * \param input_size FFT length (i.e. length of the OFDM symbols)
-       * \param output_size FFT length + cyclic prefix length (in samples)
-       * \param rolloff_len Length of the rolloff flank in samples
-       * \param len_tag_key For framed processing the key of the length tag
+       * \param fft_len IFFT length (i.e. length of the OFDM symbols).
+       * \param cp_lengths CP lengths. Wraps arround after reaching the end.
+       * \param rolloff_len Length of the rolloff flank in samples.
+       * \param len_tag_key For framed processing the key of the length tag.
        */
-      static sptr make(
-	  size_t input_size,
-	  size_t output_size,
-	  int rolloff_len=0,
-	  const std::string &len_tag_key=""
+
+      static sptr make
+      (
+        int fft_len,
+        std::vector<int> cp_lengths,
+        int rolloff_len=0,
+        const std::string &len_tag_key=""
       );
     };
-
   } // namespace digital
 } // namespace gr
 
 #endif /* INCLUDED_DIGITAL_OFDM_CYCLIC_PREFIXER_H */
-

--- a/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
+++ b/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
@@ -142,7 +142,7 @@ namespace gr {
       if(!d_len_tag_key.empty()) {
         symbols_to_read = ninput_items[0];
       } else {
-        symbols_to_read = std::min(noutput_items / d_cp_max, ninput_items[0]);
+        symbols_to_read = std::min(noutput_items / (d_fft_len + d_cp_max), ninput_items[0]);
       }
       noutput_items = 0;
       // 2) Do the cyclic prefixing and, optionally, the pulse shaping.

--- a/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
+++ b/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/* 
- * Copyright 2013 Free Software Foundation, Inc.
- * 
+/*
+ * Copyright 2013, 2018 Free Software Foundation, Inc.
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -31,48 +31,72 @@ namespace gr {
   namespace digital {
 
     ofdm_cyclic_prefixer::sptr
-    ofdm_cyclic_prefixer::make(size_t input_size, size_t output_size, int rolloff_len, const std::string &len_tag_key)
+    ofdm_cyclic_prefixer::make(int fft_len, std::vector<int> cp_lengths, int rolloff_len, const std::string &len_tag_key)
     {
-      return gnuradio::get_initial_sptr (new ofdm_cyclic_prefixer_impl(input_size, output_size, rolloff_len, len_tag_key));
+      return gnuradio::get_initial_sptr(new ofdm_cyclic_prefixer_impl(fft_len, cp_lengths, rolloff_len, len_tag_key));
     }
 
-
-    ofdm_cyclic_prefixer_impl::ofdm_cyclic_prefixer_impl(size_t input_size, size_t output_size, int rolloff_len, const std::string &len_tag_key)
-  : tagged_stream_block ("ofdm_cyclic_prefixer",
-		  io_signature::make (1, 1, input_size*sizeof(gr_complex)),
-		  io_signature::make (1, 1, sizeof(gr_complex)),
-		  len_tag_key),
-	d_fft_len(input_size),
-	d_output_size(output_size),
-	d_cp_size(output_size - input_size),
-	d_rolloff_len(rolloff_len),
-	d_up_flank((rolloff_len ? rolloff_len-1 : 0), 0),
-	d_down_flank((rolloff_len ? rolloff_len-1 : 0), 0),
-	d_delay_line(0, 0)
+    ofdm_cyclic_prefixer_impl::ofdm_cyclic_prefixer_impl(int fft_len, std::vector<int> cp_lengths, int rolloff_len, const std::string &len_tag_key)
+      : gr::tagged_stream_block
+        (
+          "ofdm_cyclic_prefixer",
+          gr::io_signature::make(1, 1, fft_len*sizeof(gr_complex)),
+          gr::io_signature::make(1, 1, sizeof(gr_complex)), len_tag_key
+        ),
+        d_fft_len(fft_len),
+        d_state(0),
+        d_cp_max(0),
+        d_rolloff_len(rolloff_len),
+        d_cp_lengths(cp_lengths),
+        d_up_flank((rolloff_len ? rolloff_len-1 : 0), 0),
+        d_down_flank((rolloff_len ? rolloff_len-1 : 0), 0),
+        d_delay_line(0, 0),
+        d_len_tag_key(len_tag_key)
     {
-      set_relative_rate(d_output_size);
-
-      // Flank of length 1 would just be rectangular
-      if (d_rolloff_len == 1) {
-	d_rolloff_len = 0;
+      for(const int& cp_len : d_cp_lengths) {
+        d_cp_max = std::max(d_cp_max, cp_len);
       }
-      if (d_rolloff_len) {
-	d_delay_line.resize(d_rolloff_len-1, 0);
-	if (rolloff_len > d_cp_size) {
-	  throw std::invalid_argument("cyclic prefixer: rolloff len must smaller than the cyclic prefix.");
-	}
-	// The actual flanks are one sample shorter than d_rolloff_len, because the
-	// first sample of the up- and down flank is always zero and one, respectively
-	for (int i = 1; i < d_rolloff_len; i++) {
-	  d_up_flank[i-1]   = 0.5 * (1 + cos(M_PI * i/rolloff_len - M_PI));
-	  d_down_flank[i-1] = 0.5 * (1 + cos(M_PI * (rolloff_len-i)/rolloff_len - M_PI));
-	}
+      // Sanity
+      for(unsigned i=0; i<d_cp_lengths.size(); i++) {
+        if (d_cp_lengths[i] != 0) {
+          break;
+        }
+        if (i == d_cp_lengths.size()-1) {
+          throw std::invalid_argument(this->alias() + std::string(": It does not make sense to only have one or a couple of CPs with length 0."));
+        }
       }
-
-      if (len_tag_key.empty()) {
-	set_output_multiple(d_output_size);
-      } else {
-	set_tag_propagation_policy(TPP_DONT);
+      if (d_cp_lengths.empty()) {
+        throw std::invalid_argument(this->alias() + std::string(": CP lengths vector can not be empty. Please enter at least (d,) (a single Python tuple) with d being a integer CP length."));
+      }
+      // Give the buffer allcoator and scheduler a hint about the ratio between input and output.
+      set_relative_rate(d_cp_max + d_fft_len);
+      // Flank of length 1 would just be rectangular.
+      if(d_rolloff_len == 1) {
+        throw std::invalid_argument(this->alias() + std::string(": A rolloff length of 1 does not make sense, as it results in a boxcar function."));
+      }
+      if(d_rolloff_len) {
+        d_delay_line.resize(d_rolloff_len-1, 0);
+        // More sanity
+        for(const int& cp_len : d_cp_lengths) {
+          if(d_rolloff_len > cp_len) {
+            throw std::invalid_argument(this->alias() + std::string(": Rolloff length must be smaller than the cyclic prefix."));
+          }
+        }
+        /* The actual flanks are one sample shorter than d_rolloff_len, because the
+           first sample of the up- and down flank is always zero and one, respectively.*/
+        for(int i = 1; i < d_rolloff_len; i++) {
+          d_up_flank[i-1]   = 0.5 * (1 + cos(M_PI * i/rolloff_len - M_PI));
+          d_down_flank[i-1] = 0.5 * (1 + cos(M_PI * (rolloff_len-i)/rolloff_len - M_PI));
+        }
+      }
+      if(d_len_tag_key.empty()) {
+        // noutput_items is set to be a multiple of the largest possible output size.
+        // It is always OK to return less (in case of the shorter CP).
+        set_output_multiple(d_cp_max);
+      }
+      else {
+        // Avoid automatic tag propagation and propagate them manually.
+        set_tag_propagation_policy(TPP_DONT);
       }
     }
 
@@ -80,86 +104,74 @@ namespace gr {
     {
     }
 
-
     int
     ofdm_cyclic_prefixer_impl::calculate_output_stream_length(const gr_vector_int &ninput_items)
     {
-      int nout = ninput_items[0] * d_output_size + d_delay_line.size();
-      return nout;
+      int noutput_items = ninput_items[0] * (d_cp_max + d_fft_len) + ( d_len_tag_key.empty() ? 0 : d_delay_line.size() );
+      return noutput_items;
     }
 
-
-    // Operates in two ways:
-    // - When there's a length tag name specified, operates in packet mode.
-    //   Here, an entire OFDM frame is processed at once. The final OFDM symbol
-    //   is postfixed with the delay line of the pulse shape.
-    //   We manually propagate tags.
-    // - Otherwise, we're in freewheeling mode. Process as many OFDM symbols as
-    //   are space for in the output buffer. The delay line is never flushed.
-    //   Tags are propagated by the scheduler.
     int
-    ofdm_cyclic_prefixer_impl::work (int noutput_items,
-                       gr_vector_int &ninput_items,
-                       gr_vector_const_void_star &input_items,
-                       gr_vector_void_star &output_items)
+    ofdm_cyclic_prefixer_impl::work
+    (
+      int noutput_items,
+      gr_vector_int &ninput_items,
+      gr_vector_const_void_star &input_items,
+      gr_vector_void_star &output_items
+    )
     {
       gr_complex *in = (gr_complex *) input_items[0];
       gr_complex *out = (gr_complex *) output_items[0];
       int symbols_to_read = 0;
-
-      // 1) Figure out if we're in freewheeling or packet mode
-      if (!d_length_tag_key_str.empty()) {
-	symbols_to_read = ninput_items[0];
-	noutput_items = symbols_to_read * d_output_size + d_delay_line.size();
+      // 1) Figure out if we're in freewheeling or packet mode.
+      if(!d_len_tag_key.empty()) {
+        symbols_to_read = ninput_items[0];
       } else {
-	symbols_to_read = std::min(noutput_items / (int) d_output_size, ninput_items[0]);
-	noutput_items = symbols_to_read * d_output_size;
+        symbols_to_read = std::min(noutput_items / d_cp_max, ninput_items[0]);
       }
-
-      // 2) Do the cyclic prefixing and, optionally, the pulse shaping
-      for (int sym_idx = 0; sym_idx < symbols_to_read; sym_idx++) {
-	memcpy((void *)(out + d_cp_size), (void *) in, d_fft_len * sizeof(gr_complex));
-	memcpy((void *) out, (void *) (in + d_fft_len - d_cp_size), d_cp_size * sizeof(gr_complex));
-	if (d_rolloff_len) {
-	  for (int i = 0; i < d_rolloff_len-1; i++) {
-	    out[i] = out[i] * d_up_flank[i] + d_delay_line[i];
-	    d_delay_line[i] = in[i] * d_down_flank[i];
-	  }
-	}
-	in += d_fft_len;
-	out += d_output_size;
+      noutput_items = 0;
+      // 2) Do the cyclic prefixing and, optionally, the pulse shaping.
+      for(int sym_idx = 0; sym_idx < symbols_to_read; sym_idx++) {
+        memcpy(static_cast<void*>(out + d_cp_lengths[d_state]), static_cast<void*>(in), d_fft_len * sizeof(gr_complex));
+        memcpy(static_cast<void*>(out), static_cast<void*>(in + d_fft_len - d_cp_lengths[d_state]), d_cp_lengths[d_state] * sizeof(gr_complex));
+        if(d_rolloff_len) {
+          for(int i = 0; i < d_rolloff_len-1; i++) {
+            out[i] = out[i] * d_up_flank[i] + d_delay_line[i];
+            /* This basically a cyclic suffix, but completely shifted into the next symbol.
+               The data rate does not change. */
+            d_delay_line[i] = in[i] * d_down_flank[i];
+          }
+        }
+        in += d_fft_len;
+        out += d_fft_len + d_cp_lengths[d_state];
+        // Raise the number of noutput_items depending on how long the current output was.
+        noutput_items += d_fft_len + d_cp_lengths[d_state];
+        // Propagate tags.
+        auto last_state = d_state > 0 ? d_state-1 : d_cp_lengths.size()-1;
+        std::vector<tag_t> tags;
+        get_tags_in_range(tags, 0, nitems_read(0) + sym_idx, nitems_read(0) + sym_idx + 1);
+        for(unsigned i = 0; i < tags.size(); i++) {
+          tags[i].offset = ( (tags[i].offset - nitems_read(0)) * (d_fft_len + d_cp_lengths[last_state]) ) + nitems_written(0);
+          add_item_tag(0, tags[i].offset, tags[i].key, tags[i].value);
+        }
+        // Finally switch to next state.
+        ++d_state %= d_cp_lengths.size();
       }
-
-      // 3) If we're in packet mode:
-      //    - flush the delay line, if applicable
-      //    - Propagate tags
-      if (!d_length_tag_key_str.empty()) {
-	if (d_rolloff_len) {
-	  for (unsigned i = 0; i < d_delay_line.size(); i++) {
-	    *out++ = d_delay_line[i];
-	  }
-	  d_delay_line.assign(d_delay_line.size(), 0);
-	}
-	std::vector<tag_t> tags;
-	get_tags_in_range(
-	    tags, 0,
-	    nitems_read(0), nitems_read(0)+symbols_to_read
-	);
-	for (unsigned i = 0; i < tags.size(); i++) {
-	  tags[i].offset = ((tags[i].offset - nitems_read(0)) * d_output_size) + nitems_written(0);
-	  add_item_tag(0,
-	      tags[i].offset,
-	      tags[i].key,
-	      tags[i].value
-	  );
-	}
-      } else {
-	consume_each(symbols_to_read);
+      /* 3) If we're in packet mode:
+            - flush the delay line, if applicable */
+      if(!d_len_tag_key.empty()) {
+        if(d_rolloff_len) {
+          std::memcpy(static_cast<void*>(out), static_cast<void*>(d_delay_line.data()), sizeof(gr_complex)*d_delay_line.size());
+          d_delay_line.assign(d_delay_line.size(), 0);
+          // Make last symbol a bit longer.
+          noutput_items += d_delay_line.size();
+        }
       }
-
+      else {
+        consume_each(symbols_to_read);
+      }
+      // Tell runtime system how many output items we produced.
       return noutput_items;
     }
-
-  } /* namespace digital */
-} /* namespace gr */
-
+  } // namespace digital
+} // namespace gr

--- a/gr-digital/lib/ofdm_cyclic_prefixer_impl.h
+++ b/gr-digital/lib/ofdm_cyclic_prefixer_impl.h
@@ -1,19 +1,19 @@
 /* -*- c++ -*- */
-/* 
- * Copyright 2013 Free Software Foundation, Inc.
- * 
+/*
+ * Copyright 2013, 2018 Free Software Foundation, Inc.
+ *
  * This file is part of GNU Radio
- * 
+ *
  * GNU Radio is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
  * any later version.
- * 
+ *
  * GNU Radio is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Radio; see the file COPYING.  If not, write to
  * the Free Software Foundation, Inc., 51 Franklin Street,
@@ -24,6 +24,7 @@
 #define INCLUDED_DIGITAL_OFDM_CYCLIC_PREFIXER_IMPL_H
 
 #include <gnuradio/digital/ofdm_cyclic_prefixer.h>
+#include <vector>
 
 namespace gr {
   namespace digital {
@@ -31,32 +32,40 @@ namespace gr {
     class ofdm_cyclic_prefixer_impl : public ofdm_cyclic_prefixer
     {
      private:
-      size_t d_fft_len;
-      //! FFT length + CP length in samples
-      size_t d_output_size;
-      //! Length of the cyclic prefix in samples
-      int d_cp_size;
+      //! FFT length
+      int d_fft_len;
+      //!  State, that determines the current output length used.
+      int d_state;
+      //! Variable being initialized with the largest CP.
+      int d_cp_max;
       //! Length of pulse rolloff in samples
       int d_rolloff_len;
+      //! Vector, that holds different CP lengths
+      std::vector<int> d_cp_lengths;
       //! Buffers the up-flank (at the beginning of the cyclic prefix)
       std::vector<float> d_up_flank;
       //! Buffers the down-flank (which trails the symbol)
       std::vector<float> d_down_flank;
+      //! Vector, that holds tail of the predecessor symbol.
       std::vector<gr_complex> d_delay_line; // We do this explicitly to avoid outputting zeroes (i.e. no history!)
+      //! Holds the length tag key.
+      const std::string d_len_tag_key;
 
      protected:
       int calculate_output_stream_length(const gr_vector_int &ninput_items);
 
      public:
-      ofdm_cyclic_prefixer_impl(size_t input_size, size_t output_size, int rolloff_len, const std::string &len_tag_key);
+      ofdm_cyclic_prefixer_impl(int fft_len, std::vector<int> cp_lengths, int rolloff_len, const std::string &len_tag_key);
       ~ofdm_cyclic_prefixer_impl();
 
-      int work(int noutput_items,
-		       gr_vector_int &ninput_items,
-		       gr_vector_const_void_star &input_items,
-		       gr_vector_void_star &output_items);
+      int work
+      (
+        int noutput_items,
+        gr_vector_int &ninput_items,
+	gr_vector_const_void_star &input_items,
+	gr_vector_void_star &output_items
+      );
     };
-
   } // namespace digital
 } // namespace gr
 

--- a/gr-digital/lib/ofdm_cyclic_prefixer_impl.h
+++ b/gr-digital/lib/ofdm_cyclic_prefixer_impl.h
@@ -35,9 +35,11 @@ namespace gr {
       //! FFT length
       int d_fft_len;
       //!  State, that determines the current output length used.
-      int d_state;
+      unsigned d_state;
       //! Variable being initialized with the largest CP.
       int d_cp_max;
+      //! Variable being initialized with the smallest CP.
+      int d_cp_min;
       //! Length of pulse rolloff in samples
       int d_rolloff_len;
       //! Vector, that holds different CP lengths

--- a/gr-digital/python/digital/qa_ofdm_cyclic_prefixer.py
+++ b/gr-digital/python/digital/qa_ofdm_cyclic_prefixer.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 #
-# Copyright 2007,2010,2011,2013,2014 Free Software Foundation, Inc.
-# 
+# Copyright 2007-2018 Free Software Foundation, Inc.
+#
 # This file is part of GNU Radio
-# 
+#
 # GNU Radio is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # GNU Radio is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with GNU Radio; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-# 
+#
 
 from gnuradio import gr, gr_unittest, digital, blocks
 import pmt
@@ -34,11 +34,11 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
     def test_wo_tags_no_rolloff(self):
         " The easiest test: make sure the CP is added correctly. "
         fft_len = 8
-        cp_len = 2
+        cp_lengths = (2,)
         expected_result = (6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
                            6, 7, 0, 1, 2, 3, 4, 5, 6, 7)
         src = blocks.vector_source_c(range(fft_len) * 2, False, fft_len)
-        cp = digital.ofdm_cyclic_prefixer(fft_len, fft_len + cp_len)
+        cp = digital.ofdm_cyclic_prefixer(fft_len, cp_lengths)
         sink = blocks.vector_sink_c()
         self.tb.connect(src, cp, sink)
         self.tb.run()
@@ -47,12 +47,12 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
     def test_wo_tags_2s_rolloff(self):
         " No tags, but have a 2-sample rolloff "
         fft_len = 8
-        cp_len = 2
+        cp_lengths = (2,)
         rolloff = 2
         expected_result = (7.0/2,       8, 1, 2, 3, 4, 5, 6, 7, 8, # 1.0/2
                            7.0/2+1.0/2, 8, 1, 2, 3, 4, 5, 6, 7, 8)
         src = blocks.vector_source_c(range(1, fft_len+1) * 2, False, fft_len)
-        cp = digital.ofdm_cyclic_prefixer(fft_len, fft_len + cp_len, rolloff)
+        cp = digital.ofdm_cyclic_prefixer(fft_len, cp_lengths, rolloff)
         sink = blocks.vector_sink_c()
         self.tb.connect(src, cp, sink)
         self.tb.run()
@@ -61,16 +61,17 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
     def test_with_tags_2s_rolloff(self):
         " With tags and a 2-sample rolloff "
         fft_len = 8
-        cp_len = 2
+        cp_lengths = (2,)
+        rolloff = 2
         tag_name = "ts_last"
         expected_result = (7.0/2,       8, 1, 2, 3, 4, 5, 6, 7, 8, # 1.0/2
                            7.0/2+1.0/2, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1.0/2)
-        tag2 = gr.tag_t()
-        tag2.offset = 1
-        tag2.key = pmt.string_to_symbol("random_tag")
-        tag2.value = pmt.from_long(42)
-        src = blocks.vector_source_c(range(1, fft_len+1) * 2, False, fft_len, (tag2,))
-        cp = digital.ofdm_cyclic_prefixer(fft_len, fft_len + cp_len, 2, tag_name)
+        tag = gr.tag_t()
+        tag.offset = 1
+        tag.key = pmt.string_to_symbol("random_tag")
+        tag.value = pmt.from_long(42)
+        src = blocks.vector_source_c(range(1, fft_len+1) * 2, False, fft_len, (tag,))
+        cp = digital.ofdm_cyclic_prefixer(fft_len, cp_lengths, rolloff, tag_name)
         sink = blocks.tsb_vector_sink_c(tsb_key=tag_name)
         self.tb.connect(src, blocks.stream_to_tagged_stream(gr.sizeof_gr_complex, fft_len, 2, tag_name), cp, sink)
         self.tb.run()
@@ -78,10 +79,77 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
         tags = [gr.tag_to_python(x) for x in sink.tags()]
         tags = sorted([(x.offset, x.key, x.value) for x in tags])
         expected_tags = [
-            (fft_len+cp_len, "random_tag", 42)
+            (fft_len+cp_lengths[0], "random_tag", 42)
         ]
         self.assertEqual(tags, expected_tags)
 
+    def test_wo_tags_no_rolloff_multiple_cps(self):
+        "Test with an interval and different CPs."
+        fft_len = 8
+        cp_lengths = (3, 2, 2)
+        expected_result = ( 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, # 1
+                            6, 7, 0, 1, 2, 3, 4, 5, 6, 7,    # 2
+                            6, 7, 0, 1, 2, 3, 4, 5, 6, 7,    # 3
+                            5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, # 4
+                            6, 7, 0, 1, 2, 3, 4, 5, 6, 7     # 5
+        )
+        src = blocks.vector_source_c(range(fft_len)*5, False, fft_len)
+        cp = digital.ofdm_cyclic_prefixer(fft_len, cp_lengths)
+        sink = blocks.vector_sink_c()
+        self.tb.connect(src, cp, sink)
+        self.tb.run()
+        self.assertEqual(sink.data(), expected_result)
+
+    def test_wo_tags_2s_rolloff_multiple_cps(self):
+        "Test with an interval, rolloff and different CPs."
+        fft_len = 8
+        cp_lengths = (3, 2, 2)
+        rolloff = 2
+        expected_result = ( 6.0/2,7,8,1,2,3,4,5,6,7,8,        #1
+                            7.0/2 + 1.0/2,8,1,2,3,4,5,6,7,8,  #2
+                            7.0/2 + 1.0/2,8,1,2,3,4,5,6,7,8,  #3
+                            6.0/2 + 1.0/2,7,8,1,2,3,4,5,6,7,8,#4
+                            7.0/2 + 1.0/2,8,1,2,3,4,5,6,7,8   #5
+        )
+        src = blocks.vector_source_c(range(1, fft_len+1)*5, False, fft_len)
+        cp = digital.ofdm_cyclic_prefixer(fft_len, cp_lengths, rolloff)
+        sink = blocks.vector_sink_c()
+        self.tb.connect(src, cp, sink)
+        self.tb.run()
+        self.assertEqual(sink.data(), expected_result)
+
+    def test_with_tags_2s_rolloff_multiples_cps(self):
+        "Test with tags, 2-sample rolloff and two CP lengths."
+        fft_len = 8
+        cp_lengths = (3, 2, 2)
+        rolloff = 2
+        tag_name = "ts_last"
+        expected_result = (6.0/2,7,8,1,2,3,4,5,6,7,8,           #1
+                           7.0/2+1.0/2,8,1,2,3,4,5,6,7,8,1.0/2  #Last tail
+        )
+        # First test tag
+        tag0 = gr.tag_t()
+        tag0.offset = 0
+        tag0.key = pmt.string_to_symbol("first_tag")
+        tag0.value = pmt.from_long(24)
+        # Second test tag
+        tag1 = gr.tag_t()
+        tag1.offset = 1
+        tag1.key = pmt.string_to_symbol("second_tag")
+        tag1.value = pmt.from_long(42)
+        src = blocks.vector_source_c(range(1, fft_len+1) * 2, False, fft_len, (tag0, tag1))
+        cp = digital.ofdm_cyclic_prefixer(fft_len, cp_lengths, rolloff, tag_name)
+        sink = blocks.tsb_vector_sink_c(tsb_key=tag_name)
+        self.tb.connect(src, blocks.stream_to_tagged_stream(gr.sizeof_gr_complex, fft_len, 2, tag_name), cp, sink)
+        self.tb.run()
+        self.assertEqual(sink.data()[0], expected_result)
+        tags = [gr.tag_to_python(x) for x in sink.tags()]
+        tags = sorted([(x.offset, x.key, x.value) for x in tags])
+        expected_tags = [
+            (0, "first_tag", 24),
+            (fft_len + cp_lengths[0], "second_tag", 42)
+        ]
+        self.assertEqual(tags, expected_tags)
 
 if __name__ == '__main__':
     gr_unittest.run(test_ofdm_cyclic_prefixer, "test_ofdm_cyclic_prefixer.xml")

--- a/gr-digital/python/digital/qa_ofdm_cyclic_prefixer.py
+++ b/gr-digital/python/digital/qa_ofdm_cyclic_prefixer.py
@@ -84,7 +84,7 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
         self.assertEqual(tags, expected_tags)
 
     def test_wo_tags_no_rolloff_multiple_cps(self):
-        "Test with an interval and different CPs."
+        "Two CP lengths, no rolloff and no tags."
         fft_len = 8
         cp_lengths = (3, 2, 2)
         expected_result = ( 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, # 1
@@ -101,7 +101,7 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
         self.assertEqual(sink.data(), expected_result)
 
     def test_wo_tags_2s_rolloff_multiple_cps(self):
-        "Test with an interval, rolloff and different CPs."
+        "Two CP lengths, 2-sample rolloff and no tags."
         fft_len = 8
         cp_lengths = (3, 2, 2)
         rolloff = 2
@@ -119,7 +119,7 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
         self.assertEqual(sink.data(), expected_result)
 
     def test_with_tags_2s_rolloff_multiples_cps(self):
-        "Test with tags, 2-sample rolloff and two CP lengths."
+        "Two CP lengths, 2-sample rolloff and tags."
         fft_len = 8
         cp_lengths = (3, 2, 2)
         rolloff = 2
@@ -150,6 +150,19 @@ class test_ofdm_cyclic_prefixer (gr_unittest.TestCase):
             (fft_len + cp_lengths[0], "second_tag", 42)
         ]
         self.assertEqual(tags, expected_tags)
+
+    def test_wo_tags_no_rolloff_old_api(self):
+        "Test the old API."
+        fft_len = 8
+        cp_len = 2
+        expected_result = (6, 7, 0, 1, 2, 3, 4, 5, 6, 7,
+                           6, 7, 0, 1, 2, 3, 4, 5, 6, 7)
+        src = blocks.vector_source_c(range(fft_len) * 2, False, fft_len)
+        cp = digital.ofdm_cyclic_prefixer(fft_len, fft_len + cp_len)
+        sink = blocks.vector_sink_c()
+        self.tb.connect(src, cp, sink)
+        self.tb.run()
+        self.assertEqual(sink.data(), expected_result)
 
 if __name__ == '__main__':
     gr_unittest.run(test_ofdm_cyclic_prefixer, "test_ofdm_cyclic_prefixer.xml")

--- a/gr-dtv/examples/dvbt_tx_2k.grc
+++ b/gr-dtv/examples/dvbt_tx_2k.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.11'?>
+<?grc format='1' created='3.7.12'?>
 <flow_graph>
   <timestamp>Thu Jan 16 23:00:58 2014</timestamp>
   <block>
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -327,6 +335,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>64</value>
+      <key>cp_lengths</key>
+      <value>(64,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>2048</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(392, 400)</value>
+      <value>(392, 412)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/dvbt_tx_8k.grc
+++ b/gr-dtv/examples/dvbt_tx_8k.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.11'?>
+<?grc format='1' created='3.7.12'?>
 <flow_graph>
   <timestamp>Thu Jan 16 23:00:58 2014</timestamp>
   <block>
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -327,6 +335,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>256</value>
+      <key>cp_lengths</key>
+      <value>(256,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(392, 400)</value>
+      <value>(360, 412)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g1.grc
+++ b/gr-dtv/examples/germany-g1.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(16384 * 19) / 128</value>
+      <key>cp_lengths</key>
+      <value>((16384 * 19) / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(328, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g10.grc
+++ b/gr-dtv/examples/germany-g10.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(16384 * 19) / 128</value>
+      <key>cp_lengths</key>
+      <value>((16384 * 19) / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(328, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g2.grc
+++ b/gr-dtv/examples/germany-g2.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(16384 * 19) / 128</value>
+      <key>cp_lengths</key>
+      <value>((16384 * 19) / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(328, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g3.grc
+++ b/gr-dtv/examples/germany-g3.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 16</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(328, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g4.grc
+++ b/gr-dtv/examples/germany-g4.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>16384 / 8</value>
+      <key>cp_lengths</key>
+      <value>(16384 / 8,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g5.grc
+++ b/gr-dtv/examples/germany-g5.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(16384 * 19) / 256</value>
+      <key>cp_lengths</key>
+      <value>((16384 * 19) / 256,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g6.grc
+++ b/gr-dtv/examples/germany-g6.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 32</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(320, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g7.grc
+++ b/gr-dtv/examples/germany-g7.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 16</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g8.grc
+++ b/gr-dtv/examples/germany-g8.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 16</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/germany-g9.grc
+++ b/gr-dtv/examples/germany-g9.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(16384 * 19) / 256</value>
+      <key>cp_lengths</key>
+      <value>((16384 * 19) / 256,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv001-cr35.grc
+++ b/gr-dtv/examples/vv001-cr35.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 128</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv003-cr23.grc
+++ b/gr-dtv/examples/vv003-cr23.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 128</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(328, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv004-8kfft.grc
+++ b/gr-dtv/examples/vv004-8kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(8192 * 19) / 256</value>
+      <key>cp_lengths</key>
+      <value>((8192 * 19) / 256,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv005-8kfft.grc
+++ b/gr-dtv/examples/vv005-8kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>8192 / 16</value>
+      <key>cp_lengths</key>
+      <value>(8192 / 16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(336, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv007-16kfft.grc
+++ b/gr-dtv/examples/vv007-16kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>(16384 * 19) / 128</value>
+      <key>cp_lengths</key>
+      <value>((16384 * 19) / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(344, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv008-16kfft.grc
+++ b/gr-dtv/examples/vv008-16kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>16384 / 32</value>
+      <key>cp_lengths</key>
+      <value>(16384 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(344, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv009-4kfft.grc
+++ b/gr-dtv/examples/vv009-4kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>4096 / 32</value>
+      <key>cp_lengths</key>
+      <value>(4096 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>4096</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(328, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv010-2kfft.grc
+++ b/gr-dtv/examples/vv010-2kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>2048 / 8</value>
+      <key>cp_lengths</key>
+      <value>(2048 / 8,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>2048</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(320, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv011-1kfft.grc
+++ b/gr-dtv/examples/vv011-1kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>1024 / 8</value>
+      <key>cp_lengths</key>
+      <value>(1024 / 8,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>1024</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(344, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv012-64qam45.grc
+++ b/gr-dtv/examples/vv012-64qam45.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>8192 / 32</value>
+      <key>cp_lengths</key>
+      <value>(8192 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv013-64qam56.grc
+++ b/gr-dtv/examples/vv013-64qam56.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>8192 / 32</value>
+      <key>cp_lengths</key>
+      <value>(8192 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv014-64qam34.grc
+++ b/gr-dtv/examples/vv014-64qam34.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>8192 / 32</value>
+      <key>cp_lengths</key>
+      <value>(8192 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv015-8kfft.grc
+++ b/gr-dtv/examples/vv015-8kfft.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>8192 / 32</value>
+      <key>cp_lengths</key>
+      <value>(8192 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>8192</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(344, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv016-256qam34.grc
+++ b/gr-dtv/examples/vv016-256qam34.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 128</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv017-paprtr.grc
+++ b/gr-dtv/examples/vv017-paprtr.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 32</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 32,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv018-miso.grc
+++ b/gr-dtv/examples/vv018-miso.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -303,6 +311,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -464,8 +476,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768/16</value>
+      <key>cp_lengths</key>
+      <value>(32768/16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -480,12 +492,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(56, 528)</value>
+      <value>(56, 540)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -496,7 +508,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>
@@ -519,8 +531,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768/16</value>
+      <key>cp_lengths</key>
+      <value>(32768/16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -535,12 +547,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(56, 408)</value>
+      <value>(56, 404)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -551,7 +563,7 @@
       <value>digital_ofdm_cyclic_prefixer_0_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv019-norot.grc
+++ b/gr-dtv/examples/vv019-norot.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 128</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 128,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(344, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv034-dtg016.grc
+++ b/gr-dtv/examples/vv034-dtg016.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>4096 / 16</value>
+      <key>cp_lengths</key>
+      <value>(4096 / 16,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,12 +516,12 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>4096</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(344, 464)</value>
+      <value>(344, 476)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv035-dtg052.grc
+++ b/gr-dtv/examples/vv035-dtg052.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>16384 / 8</value>
+      <key>cp_lengths</key>
+      <value>(16384 / 8,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>16384</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>

--- a/gr-dtv/examples/vv036-dtg091.grc
+++ b/gr-dtv/examples/vv036-dtg091.grc
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -378,6 +386,10 @@
   <block>
     <key>blocks_file_source</key>
     <param>
+      <key>begin_tag</key>
+      <value>pmt.PMT_NIL</value>
+    </param>
+    <param>
       <key>alias</key>
       <value></value>
     </param>
@@ -488,8 +500,8 @@
       <value></value>
     </param>
     <param>
-      <key>cp_len</key>
-      <value>32768 / 8</value>
+      <key>cp_lengths</key>
+      <value>(32768 / 8,)</value>
     </param>
     <param>
       <key>comment</key>
@@ -504,7 +516,7 @@
       <value>True</value>
     </param>
     <param>
-      <key>input_size</key>
+      <key>fft_len</key>
       <value>32768</value>
     </param>
     <param>
@@ -520,7 +532,7 @@
       <value>digital_ofdm_cyclic_prefixer_0</value>
     </param>
     <param>
-      <key>tagname</key>
+      <key>len_tag_key</key>
       <value></value>
     </param>
     <param>


### PR DESCRIPTION
Made a new branch as I messed it up with the old one. @willcode I implemented your suggestion. If the way I solved it now is OK, I will change the other examples, as this commit breaks backward compatibility. The idea with a vector for different CPs required a new signature. However, the tx_ofdm.grc I fixed to demonstrate, that my code is working. New test cases are also provided along with the code. 