### PR TITLE
gr-blocks: fix fast multiply block to allow vector input

### DIFF
--- a/gr-blocks/grc/blocks_multiply_const_xx.xml
+++ b/gr-blocks/grc/blocks_multiply_const_xx.xml
@@ -19,25 +19,25 @@
 			<name>Complex</name>
 			<key>complex</key>
 			<opt>fcn:cc</opt>
-      <opt>const_type:complex</opt>
+			<opt>const_type:complex</opt>
 		</option>
 		<option>
 			<name>Float</name>
 			<key>float</key>
 			<opt>fcn:ff</opt>
-      <opt>const_type:float</opt>
+			<opt>const_type:float</opt>
 		</option>
 		<option>
 			<name>Int</name>
 			<key>int</key>
 			<opt>fcn:ii</opt>
-      <opt>const_type:int</opt>
+			<opt>const_type:int</opt>
 		</option>
 		<option>
 			<name>Short</name>
 			<key>short</key>
 			<opt>fcn:ss</opt>
-      <opt>const_type:int</opt>
+			<opt>const_type:int</opt>
 		</option>
 	</param>
 	<param>

--- a/gr-blocks/grc/blocks_multiply_const_xx.xml
+++ b/gr-blocks/grc/blocks_multiply_const_xx.xml
@@ -19,28 +19,32 @@
 			<name>Complex</name>
 			<key>complex</key>
 			<opt>fcn:cc</opt>
+      <opt>const_type:complex</opt>
 		</option>
 		<option>
 			<name>Float</name>
 			<key>float</key>
 			<opt>fcn:ff</opt>
+      <opt>const_type:float</opt>
 		</option>
 		<option>
 			<name>Int</name>
 			<key>int</key>
 			<opt>fcn:ii</opt>
+      <opt>const_type:int</opt>
 		</option>
 		<option>
 			<name>Short</name>
 			<key>short</key>
 			<opt>fcn:ss</opt>
+      <opt>const_type:int</opt>
 		</option>
 	</param>
 	<param>
 		<name>Constant</name>
 		<key>const</key>
 		<value>0</value>
-		<type>$type</type>
+		<type>$(type.const_type)</type>
 	</param>
 	<param>
 		<name>Vec Length</name>

--- a/gr-blocks/grc/blocks_multiply_const_xx.xml
+++ b/gr-blocks/grc/blocks_multiply_const_xx.xml
@@ -9,7 +9,7 @@
 	<name>Fast Multiply Const</name>
 	<key>blocks_multiply_const_xx</key>
 	<import>from gnuradio import blocks</import>
-	<make>blocks.multiply_const_$(type.fcn)($const)</make>
+	<make>blocks.multiply_const_$(type.fcn)($const, $vlen)</make>
 	<callback>set_k($const)</callback>
 	<param>
 		<name>IO Type</name>

--- a/gr-blocks/include/gnuradio/blocks/multiply_const_XX.h.t
+++ b/gr-blocks/include/gnuradio/blocks/multiply_const_XX.h.t
@@ -46,8 +46,9 @@ namespace gr {
       /*!
        * \brief Create an instance of @NAME@
        * \param k multiplicative constant
+       * \param vlen number of items in vector
        */
-      static sptr make(@O_TYPE@ k);
+      static sptr make(@O_TYPE@ k, size_t vlen=1);
 
       /*!
        * \brief Return multiplicative constant

--- a/gr-blocks/lib/multiply_const_XX_impl.cc.t
+++ b/gr-blocks/lib/multiply_const_XX_impl.cc.t
@@ -34,7 +34,7 @@ namespace gr {
 
     @NAME@::sptr @NAME@::make(@O_TYPE@ k, size_t vlen)
     {
-        return gnuradio::get_initial_sptr(new @NAME_IMPL@(k, vlen));
+      return gnuradio::get_initial_sptr(new @NAME_IMPL@(k, vlen));
     }
 
     @NAME_IMPL@::@NAME_IMPL@(@O_TYPE@ k, size_t vlen)

--- a/gr-blocks/lib/multiply_const_XX_impl.cc.t
+++ b/gr-blocks/lib/multiply_const_XX_impl.cc.t
@@ -32,16 +32,17 @@
 namespace gr {
   namespace blocks {
 
-    @NAME@::sptr @NAME@::make(@O_TYPE@ k)
+    @NAME@::sptr @NAME@::make(@O_TYPE@ k, size_t vlen)
     {
-      return gnuradio::get_initial_sptr(new @NAME_IMPL@(k));
+        return gnuradio::get_initial_sptr(new @NAME_IMPL@(k, vlen));
     }
 
-    @NAME_IMPL@::@NAME_IMPL@(@O_TYPE@ k)
+    @NAME_IMPL@::@NAME_IMPL@(@O_TYPE@ k, size_t vlen)
       : sync_block ("@NAME@",
-		       io_signature::make (1, 1, sizeof (@I_TYPE@)),
-		       io_signature::make (1, 1, sizeof (@O_TYPE@))),
-      d_k(k)
+		       io_signature::make (1, 1, sizeof (@I_TYPE@)*vlen),
+		       io_signature::make (1, 1, sizeof (@O_TYPE@)*vlen)),
+      d_k(k),
+      d_vlen(vlen)
     {
     }
 
@@ -53,7 +54,7 @@ namespace gr {
       @I_TYPE@ *iptr = (@I_TYPE@ *) input_items[0];
       @O_TYPE@ *optr = (@O_TYPE@ *) output_items[0];
 
-      int size = noutput_items;
+      int size = noutput_items*d_vlen;
 
       while (size >= 8){
 	*optr++ = *iptr++ * d_k;

--- a/gr-blocks/lib/multiply_const_XX_impl.h.t
+++ b/gr-blocks/lib/multiply_const_XX_impl.h.t
@@ -33,9 +33,10 @@ namespace gr {
     class BLOCKS_API @NAME_IMPL@ : public @NAME@
     {
       @O_TYPE@ d_k;
+      size_t d_vlen;
 
     public:
-      @NAME_IMPL@(@O_TYPE@ k);
+      @NAME_IMPL@(@O_TYPE@ k, size_t vlen);
 
       @O_TYPE@ k() const { return d_k; }
       void set_k(@O_TYPE@ k) { d_k = k; }


### PR DESCRIPTION
This block ignored the 'Vec Length' parameter and when trying to actually input a vector and set the 'Vec Length' accordingly it'd complain "ValueError: itemsize mismatch: multiply_const_cc0:0 using 8, complex_to_mag_squared0:0 using 8192".