### PR TITLE
gr-blocks: use libvolk to speed up nlog10_ff block

### DIFF
--- a/gr-blocks/lib/nlog10_ff_impl.cc
+++ b/gr-blocks/lib/nlog10_ff_impl.cc
@@ -27,6 +27,7 @@
 #include "nlog10_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
+#include <limits>
 
 namespace gr {
   namespace blocks {
@@ -40,7 +41,8 @@ namespace gr {
       : sync_block("nlog10_ff",
 		      io_signature::make (1, 1, sizeof(float)*vlen),
 		      io_signature::make (1, 1, sizeof(float)*vlen)),
-        d_n_log2_10(n/log2f(10.0f)), d_vlen(vlen), d_k(k)
+        d_n_log2_10(n/log2f(10.0f)), d_float_min(std::numeric_limits<float>::min()),
+        d_vlen(vlen), d_k(k)
     {
       const int alignment_multiple =
         volk_get_alignment() / sizeof(float);
@@ -69,7 +71,7 @@ namespace gr {
       int noi = noutput_items * d_vlen;
 
       for (int i = 0; i < noi; i++) {
-          out[i] = in[i] + 1e-18;
+          out[i] = in[i] + d_float_min;
       }
 
       volk_32f_log2_32f(out, out, noi);

--- a/gr-blocks/lib/nlog10_ff_impl.cc
+++ b/gr-blocks/lib/nlog10_ff_impl.cc
@@ -68,13 +68,9 @@ namespace gr {
       float *out = (float *) output_items[0];
       int noi = noutput_items * d_vlen;
 
-      volk_32f_log2_32f(out, in, noi);
-      volk_32f_s32f_multiply_32f(out, out, d_prefactor, noi);
-      if(d_k != 0.0f) {
-        for(int i = 0; i < noi; ++i) {
-          out[i] += d_k;
-        }
-      }
+      for (int i = 0; i < noi; i++)
+        out[i] = n * log10f(std::max(in[i], (float) 1e-18)) + k;
+
       return noutput_items;
     }
 

--- a/gr-blocks/lib/nlog10_ff_impl.cc
+++ b/gr-blocks/lib/nlog10_ff_impl.cc
@@ -48,18 +48,6 @@ namespace gr {
       set_alignment(std::max(1,alignment_multiple));
     }
 
-    void
-    nlog10_ff_impl::setk(float k)
-    {
-      d_k = k;
-    }
-
-    void
-    nlog10_ff_impl::setn(float n)
-    {
-      d_prefactor = n / log2f(10.0f);
-    }
-
     int
     nlog10_ff_impl::work(int noutput_items,
 			      gr_vector_const_void_star &input_items,

--- a/gr-blocks/lib/nlog10_ff_impl.cc
+++ b/gr-blocks/lib/nlog10_ff_impl.cc
@@ -40,7 +40,7 @@ namespace gr {
       : sync_block("nlog10_ff",
 		      io_signature::make (1, 1, sizeof(float)*vlen),
 		      io_signature::make (1, 1, sizeof(float)*vlen)),
-        d_n(n), d_vlen(vlen), d_k(k)
+        d_n_log2_10(n/log2f(10.0f)), d_vlen(vlen), d_k(k)
     {
       const int alignment_multiple =
         volk_get_alignment() / sizeof(float);
@@ -68,15 +68,15 @@ namespace gr {
       float *out = (float *) output_items[0];
       int noi = noutput_items * d_vlen;
 
-      volk_32f_log2_32f(out, in, noi);
-      volk_32f_s32f_multiply_32f(out, out, n/log2f(10.0f), noi);
-      if (k != 0.0f) {
+      for (int i = 0; i < noi; i++) {
+          out[i] = in[i] + 1e-18;
+      }
+
+      volk_32f_log2_32f(out, out, noi);
+      volk_32f_s32f_multiply_32f(out, out, d_n_log2_10, noi);
+      if (d_k != 0.0f) {
         for (int i = 0; i < noi; i++) {
-          out[i] += k + 1e-18;
-        }
-      } else {
-        for (int i = 0; i < noi; i++) {
-          out[i] += 1e-18;
+          out[i] += d_k;
         }
       }
 

--- a/gr-blocks/lib/nlog10_ff_impl.h
+++ b/gr-blocks/lib/nlog10_ff_impl.h
@@ -36,8 +36,6 @@ namespace gr {
 
     public:
       nlog10_ff_impl(float n, size_t vlen, float k);
-      void setn(float n);
-      void setk(float k);
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,

--- a/gr-blocks/lib/nlog10_ff_impl.h
+++ b/gr-blocks/lib/nlog10_ff_impl.h
@@ -31,9 +31,8 @@ namespace gr {
     class BLOCKS_API nlog10_ff_impl : public nlog10_ff
     {
       float  d_n_log2_10;
-      float  d_float_min;
+      float  d_10_k_n;
       size_t d_vlen;
-      float  d_k;
 
     public:
       nlog10_ff_impl(float n, size_t vlen, float k);

--- a/gr-blocks/lib/nlog10_ff_impl.h
+++ b/gr-blocks/lib/nlog10_ff_impl.h
@@ -31,6 +31,7 @@ namespace gr {
     class BLOCKS_API nlog10_ff_impl : public nlog10_ff
     {
       float  d_n_log2_10;
+      float  d_float_min;
       size_t d_vlen;
       float  d_k;
 

--- a/gr-blocks/lib/nlog10_ff_impl.h
+++ b/gr-blocks/lib/nlog10_ff_impl.h
@@ -30,7 +30,7 @@ namespace gr {
 
     class BLOCKS_API nlog10_ff_impl : public nlog10_ff
     {
-      float  d_prefactor;
+      float  d_n_log2_10;
       size_t d_vlen;
       float  d_k;
 


### PR DESCRIPTION
Using libvolk instead of the C double precision `log10()` is faster by about an order of magnitude.