### PR TITLE
Added template for message sink port for set_symbol_table in chunks_to_symbols

### DIFF
--- a/gr-digital/grc/digital_chunks_to_symbols.xml
+++ b/gr-digital/grc/digital_chunks_to_symbols.xml
@@ -70,6 +70,11 @@
 		<type>$in_type</type>
 		<nports>$num_ports</nports>
 	</sink>
+	<sink>
+		<name>set_symbol_table</name>
+		<type>message</type>
+        	<optional>1</optional>
+	</sink>
 	<source>
 		<name>out</name>
 		<type>$out_type</type>


### PR DESCRIPTION
chunks_to_symbols_XX_impl.cc.t contains code for a message sink port.  sink port for the same added in the GRC template.