### PR TITLE
uhd: fix freq_hopping example - missing 'time'

### DIFF
--- a/gr-uhd/examples/python/freq_hopping.py
+++ b/gr-uhd/examples/python/freq_hopping.py
@@ -109,6 +109,10 @@ class FrequencyHopperSrc(gr.hier_block2):
         gain_tag.value = pmt.to_pmt({'gain': tx_gain})
         tag_list = [gain_tag,]
         for i in xrange(len(self.hop_sequence)):
+            time = pmt.cons(
+                    pmt.from_uint64(int(base_time + i * hop_time+0.01)),
+                    pmt.from_double((base_time + i * hop_time+0.01) % 1),
+            )
             tune_tag = gr.tag_t()
             tune_tag.offset = i * burst_length
             if i > 0 and post_tuning and not dsp_tuning: # TODO dsp_tuning should also be able to do post_tuning
@@ -116,9 +120,11 @@ class FrequencyHopperSrc(gr.hier_block2):
             if dsp_tuning:
                 tune_tag.key = pmt.string_to_symbol('tx_command')
                 tune_tag.value = pmt.to_pmt({'lo_freq': base_freq, 'dsp_freq': base_freq - self.hop_sequence[i]})
+                tune_tag.value = pmt.dict_add(tune_tag.value, pmt.intern("time"),time)
             else:
-                tune_tag.key = pmt.string_to_symbol('tx_freq')
-                tune_tag.value = pmt.to_pmt(self.hop_sequence[i])
+                tune_tag.key = pmt.string_to_symbol('tx_command')
+                tune_tag.value = pmt.to_pmt({'freq': self.hop_sequence[i]})
+                tune_tag.value = pmt.dict_add(tune_tag.value, pmt.intern('time'), time)
             tag_list.append(tune_tag)
             length_tag = gr.tag_t()
             length_tag.offset = i * burst_length
@@ -129,8 +135,8 @@ class FrequencyHopperSrc(gr.hier_block2):
             time_tag.offset = i * burst_length
             time_tag.key = pmt.string_to_symbol('tx_time')
             time_tag.value = pmt.make_tuple(
-                    pmt.from_uint64(int(base_time + i * hop_time)),
-                    pmt.from_double((base_time + i * hop_time) % 1),
+                    pmt.car(time),
+                    pmt.cdr(time)
             )
             tag_list.append(time_tag)
         tag_source = blocks.vector_source_c((1.0,) * n_samples_total, repeat=False, tags=tag_list)
@@ -217,4 +223,3 @@ if __name__ == '__main__':
         main()
     except KeyboardInterrupt:
         pass
-


### PR DESCRIPTION
Freq_hopping example wasn't working correctly. Symptom of it was that frequency changes were happening in random moments. The reason was that time of execution of tune commands wasn't specified and so they were executed as non-timed commands.

The fix was to add missing 'time' specified as pmt.cons to 'tx_command' tag value.

In case of of full tuning (dsp_tuning == false) a bit more changes were needed. 'tx_freq' tag can't be executed as timed command at all, so I changed it to 'tx_command' with 'freq' element and also added missing 'time'.

I found out about the issue but credit of fixing it by adding 'time' element to 'tx_command' tag value goes to Sylvain Munaut, as this change was suggested by him.