### PR TITLE
grc: Evaluate gtk icon in generated code instead of template compile …

### DIFF
--- a/grc/core/generator/flow_graph.tmpl
+++ b/grc/core/generator/flow_graph.tmpl
@@ -78,18 +78,17 @@ $imp
 #set $class_name = $flow_graph.get_option('id')
 #set $param_str = ', '.join(['self'] + ['%s=%s'%(param.get_id(), param.get_make()) for param in $parameters])
 #if $generate_options == 'wx_gui'
-    #import gtk
-    #set $icon = gtk.IconTheme().lookup_icon('gnuradio-grc', 32, 0)
+import gtk
 
 
 class $(class_name)(grc_wxgui.top_block_gui):
 
     def __init__($param_str):
         grc_wxgui.top_block_gui.__init__(self, title="$title")
-    #if $icon
-        _icon_path = "$icon.get_filename()"
-        self.SetIcon(wx.Icon(_icon_path, wx.BITMAP_TYPE_ANY))
-    #end if
+        icon = gtk.IconTheme().lookup_icon('gnuradio-grc', 32, 0)
+        if icon
+            _icon_path = icon.get_filename()
+            self.SetIcon(wx.Icon(_icon_path, wx.BITMAP_TYPE_ANY))
 #elif $generate_options == 'qt_gui'
 from gnuradio import qtgui
 

--- a/grc/core/generator/flow_graph.tmpl
+++ b/grc/core/generator/flow_graph.tmpl
@@ -86,7 +86,7 @@ class $(class_name)(grc_wxgui.top_block_gui):
     def __init__($param_str):
         grc_wxgui.top_block_gui.__init__(self, title="$title")
         icon = gtk.IconTheme().lookup_icon('gnuradio-grc', 32, 0)
-        if icon
+        if icon:
             _icon_path = icon.get_filename()
             self.SetIcon(wx.Icon(_icon_path, wx.BITMAP_TYPE_ANY))
 #elif $generate_options == 'qt_gui'


### PR DESCRIPTION
…ve so it is only written when gui is enabled.

A cheetah `#import` statement causes the import to be placed at the top of the generated module, not at the location of the statement. This means that even when `nogui` is specified, flow graphs have an unnecessary dependency on `gtk` existing when compiling the Cheetah template. So instead of evaluating `icon` during template compilation, it evaluates it at runtime so the code is only run when `generate_options == wx_gui`. This seems like a good idea either way since it means the generated file could be moved to another computer which may not have the icon available.