### PR TITLE
Short documentation for some GRC blocks

### DIFF
--- a/gr-blocks/grc/blocks_moving_average_xx.xml
+++ b/gr-blocks/grc/blocks_moving_average_xx.xml
@@ -74,4 +74,31 @@
 		<type>$type</type>
 		<vlen>$vlen</vlen>
 	</source>
+	<doc>
+Computes a moving average of the input:
+Output[i] = scale * sum(input[i-length: i])
+
+In its default parameters, the block actually computes a moving sum.
+
+Length:
+The size of the moving average window to used.
+
+Scale:
+Factor to scale the sum of the last (Length) samples.
+To get an actual moving average, the scale should then be set to 1/Length.
+
+Max Iter:
+The maximum number of samples the block will treat in one call of its work function.
+
+vlen:
+Used if the input samples are vectors and correspond to the length of those vectors.
+When operating on vectors, the average is done using only the numbers from the same vector index
+Output[i][vector_index] = scale * sum(Input[i-length: i][vector_index])
+
+
+Implementation file:
+gr-blocks/lib/moving_average_XX_impl.cc.t
+GRC file:
+gr-blocks/grc/blocks_moving_average_xx.xml
+	</doc>
 </block>

--- a/gr-blocks/grc/blocks_nlog10_ff.xml
+++ b/gr-blocks/grc/blocks_nlog10_ff.xml
@@ -39,4 +39,19 @@
 		<type>float</type>
 		<vlen>$vlen</vlen>
 	</source>
+    <doc>
+        Computes this formula on each input sample:
+output = n*log10(input) + k
+
+Actual formula is output = n*log10( max(input, 1e-18) ) + k to ensure things do not break when input <= 0.
+
+vlen is used if the input samples are a vector and corresponds to the length of that vector. The formula is applied independently on each vector element.
+
+There is no get or set function for the parameters so they are not dynamically accessible.
+
+Implementation file:
+gr-blocks/lib/nlog10_ff_impl.cc
+GRC file:
+gr-blocks/grc/blocks_nlog10_ff.xml
+    </doc>
 </block>

--- a/gr-blocks/grc/blocks_null_sink.xml
+++ b/gr-blocks/grc/blocks_null_sink.xml
@@ -67,5 +67,21 @@
 		<nports>$num_inputs</nports>
 	</sink>
         <bus_structure_sink>$bus_conns</bus_structure_sink>
-</block>
 
+<doc>
+A nice way to bin your samples:
+This block simply consumes samples from its input without doing anything.
+
+Vec Length:
+Vector length of the incoming data streams. The streams must have the same vector length.
+
+Bus Connections:
+
+
+
+Implementation file:
+gr-blocks/lib/null_sink_impl.cc
+GRC file:
+gr-blocks/grc/blocks_null_sink.xml
+</doc>
+</block>

--- a/gr-blocks/grc/blocks_null_source.xml
+++ b/gr-blocks/grc/blocks_null_source.xml
@@ -67,4 +67,15 @@
 		<nports>$num_outputs</nports>
 	</source>
         <bus_structure_source>$bus_conns</bus_structure_source>
+	<doc>
+Output zeros as needed.
+
+Vec Length:
+Vector length of the output data streams. The streams will have the same vector length.
+
+Implementation file:
+gr-blocks/lib/null_source_impl.cc
+GRC file:
+gr-blocks/grc/blocks_null_source.xml
+	</doc>
 </block>

--- a/gr-blocks/grc/blocks_threshold_ff.xml
+++ b/gr-blocks/grc/blocks_threshold_ff.xml
@@ -37,4 +37,24 @@
 		<name>out</name>
 		<type>float</type>
 	</source>
+	<doc>
+Output a 1 or zero based on a threshold value.
+
+Test the incoming signal against a threshold. If the signal
+excedes the High value, it will change its output to 1, and if the signal
+falls below the Low value, it will change its output to 0.
+
+Dynamically reacts to changes in the High and Low variables.
+
+Get/Set functions:
+lo(), set_lo(float) to access the Low parameter
+hi(), set_hi(floar) to access the High parameter
+last_state(), set_last_state(float) to access the value that is being output.
+
+
+Implementation file:
+gr-blocks/lib/threshold_ff_impl.cc
+GRC file:
+gr-blocks/grc/blocks_threshold_ff.xml
+	</doc>
 </block>

--- a/gr-blocks/grc/blocks_throttle.xml
+++ b/gr-blocks/grc/blocks_throttle.xml
@@ -71,4 +71,24 @@
 		<type>$type</type>
 		<vlen>$vlen</vlen>
 	</source>
+	<doc>
+Limits the average sample rate to a maximum rate.
+
+Sample Rate:
+Maximum average sample rate wanted.
+
+Ignore rx_rate tag:
+If set to False, the block will set its sample rate to the value of recieved tags with the key rx_rate. It will ignore other tags.
+
+vlen:
+vlen (for Vector length) is useful if the input samples are vectors and it corresponds to the length of that vector.
+
+The sample_rate() and get_sample_rate() functions are available to interact with the sample rate parameter dynamically. (but not the other parameters)
+A Controlport interface is also available to get and set the sample rate value.
+
+Implementation file:
+gr-blocks/lib/throttle_impl.cc
+GRC file:
+gr-blocks/grc/blocks_throttle.xml
+	</doc>
 </block>


### PR DESCRIPTION
I've begun adding a doc to the grc xml block files so I don't need to always search through the codebase for implementation details to understand what a block does with its parameters.

I started with some really simple blocks that I was using at the moment since I needed to go through their source code anyways to use them.

I will certainly add more blocks later as I get to use them. Should I do a pull request for each separate block or as batches?

The philosophy I decided to follow was to do a short description of what the block does, then the effect of the parameters and finally the path to the source file because It's always a pain to search through the different modules for the source file that doesn't always have the same name as the block.

If you have some advice on the formalism I should use to doc the blocks, or anything, I'll take it.