### PR TITLE
modtool: Sequence Completer for python3 branch

### DIFF
--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -73,7 +73,6 @@ class ModToolAdd(ModTool):
 
         self._info['blocktype'] = options.block_type
         if self._info['blocktype'] is None:
-            # Print list out of blocktypes to user for reference
             print(str(self._block_types))
             with SequenceCompleter(sorted(self._block_types)):
                 while self._info['blocktype'] not in self._block_types:
@@ -84,7 +83,7 @@ class ModToolAdd(ModTool):
         # Allow user to specify language interactively if not set
         self._info['lang'] = options.lang
         if self._info['lang'] is None:
-            language_candidates = ('cpp', 'python')
+            language_candidates = ('cpp', 'python', 'c++')
             with SequenceCompleter(language_candidates):
                 while self._info['lang'] not in language_candidates:
                     self._info['lang'] = input("Language (python/cpp): ")

--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 import os
 import re
 
-from .util_functions import append_re_line_sequence, ask_yes_no
+from .util_functions import append_re_line_sequence, ask_yes_no, SequenceCompleter
 from .cmakefile_editor import CMakeFileEditor
 from .modtool_base import ModTool, ModToolException
 from .templates import Templates
@@ -73,17 +73,21 @@ class ModToolAdd(ModTool):
 
         self._info['blocktype'] = options.block_type
         if self._info['blocktype'] is None:
-            # Print(list out of blocktypes to user for reference)
+            # Print list out of blocktypes to user for reference
             print(str(self._block_types))
-            while self._info['blocktype'] not in self._block_types:
-                self._info['blocktype'] = input("Enter block type: ")
-                if self._info['blocktype'] not in self._block_types:
-                    print('Must be one of ' + str(self._block_types))
+            with SequenceCompleter(sorted(self._block_types)):
+                while self._info['blocktype'] not in self._block_types:
+                    self._info['blocktype'] = input("Enter block type: ")
+                    if self._info['blocktype'] not in self._block_types:
+                        print('Must be one of ' + str(self._block_types))
+
         # Allow user to specify language interactively if not set
         self._info['lang'] = options.lang
         if self._info['lang'] is None:
-            while self._info['lang'] not in ['c++', 'cpp', 'python']:
-                self._info['lang'] = input("Language (python/cpp): ")
+            language_candidates = ('cpp', 'python')
+            with SequenceCompleter(language_candidates):
+                while self._info['lang'] not in language_candidates:
+                    self._info['lang'] = input("Language (python/cpp): ")
         if self._info['lang'] == 'c++':
             self._info['lang'] = 'cpp'
 

--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -29,7 +29,7 @@ import re
 import sys
 import glob
 
-from .util_functions import remove_pattern_from_file
+from .util_functions import remove_pattern_from_file, SequenceCompleter
 from .modtool_base import ModTool
 from .cmakefile_editor import CMakeFileEditor
 
@@ -52,7 +52,8 @@ class ModToolRemove(ModTool):
         if options.blockname is not None:
             self._info['pattern'] = options.blockname
         else:
-            self._info['pattern'] = input('Which blocks do you want to delete? (Regex): ')
+            with SequenceCompleter():
+                self._info['pattern'] = input('Which blocks do you want to delete? (Regex): ')
         if len(self._info['pattern']) == 0:
             self._info['pattern'] = '.'
 

--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -29,7 +29,7 @@ import re
 import sys
 import glob
 
-from .util_functions import remove_pattern_from_file, SequenceCompleter
+from .util_functions import remove_pattern_from_file
 from .modtool_base import ModTool
 from .cmakefile_editor import CMakeFileEditor
 
@@ -52,8 +52,7 @@ class ModToolRemove(ModTool):
         if options.blockname is not None:
             self._info['pattern'] = options.blockname
         else:
-            with SequenceCompleter():
-                self._info['pattern'] = input('Which blocks do you want to delete? (Regex): ')
+            self._info['pattern'] = input('Which blocks do you want to delete? (Regex): ')
         if len(self._info['pattern']) == 0:
             self._info['pattern'] = '.'
 

--- a/gr-utils/python/modtool/util_functions.py
+++ b/gr-utils/python/modtool/util_functions.py
@@ -152,7 +152,7 @@ class SequenceCompleter(object):
         if not text and state < len(self._seq):
             return self._seq[state]
         if not state:
-            self._tmp_matches = filter(lambda candidate: candidate.startswith(text), self._seq)
+            self._tmp_matches = [candidate for candidate in self._seq if candidate.startswith(text)]
         if state < len(self._tmp_matches):
             return self._tmp_matches[state]
 
@@ -161,5 +161,5 @@ class SequenceCompleter(object):
         readline.set_completer(self.completefunc)
         readline.parse_and_bind("tab: complete")
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         readline.set_completer(self._old_completer)

--- a/gr-utils/python/modtool/util_functions.py
+++ b/gr-utils/python/modtool/util_functions.py
@@ -23,6 +23,7 @@ from __future__ import unicode_literals
 
 import re
 import sys
+import readline
 
 # None of these must depend on other modtool stuff!
 
@@ -136,3 +137,29 @@ def ask_yes_no(question, default):
         return default
     else:
         return not default
+
+class SequenceCompleter(object):
+    """ A simple completer function wrapper to be used with readline, e.g.
+    option_iterable = ("search", "seek", "destroy")
+    readline.set_completer(SequenceCompleter(option_iterable).completefunc)
+    """
+
+    def __init__(self, sequence):
+        self._seq = sequence
+        self._tmp_matches = []
+
+    def completefunc(self, text, state):
+        if not text and state < len(self._seq):
+            return self._seq[state]
+        if not state:
+            self._tmp_matches = filter(lambda candidate: candidate.startswith(text), self._seq)
+        if state < len(self._tmp_matches):
+            return self._tmp_matches[state]
+
+    def __enter__(self):
+        self._old_completer = readline.get_completer()
+        readline.set_completer(self.completefunc)
+        readline.parse_and_bind("tab: complete")
+
+    def __exit__(self):
+        readline.set_completer(self._old_completer)


### PR DESCRIPTION
I have updated the Sequence Completer added by @marcusmueller for python3 compatibility.
Key update: `filter` returns an iterator rather than a list if a list is passed in py3k.