### PR TITLE
Including issue_stream_cmd_on_start in arguments to usrp_source

### DIFF
--- a/gr-uhd/python/uhd/__init__.py
+++ b/gr-uhd/python/uhd/__init__.py
@@ -117,7 +117,7 @@ def _prepare_uhd_swig():
                         if kwargs.has_key(key): kwargs[key] = cast(kwargs[key])
                     except: pass
                 #don't pass kwargs, it confuses swig, map into args list:
-                for key in ('device_addr', 'stream_args', 'io_type', 'num_channels', 'msgq'):
+                for key in ('device_addr', 'stream_args', 'io_type', 'num_channels', 'msgq', 'issue_stream_cmd_on_start'):
                     if kwargs.has_key(key): args.append(kwargs[key])
                 return old_constructor(*args)
             return constructor_interceptor


### PR DESCRIPTION
The static list of parameters passed to the usrp_source swig block in `uhd/__init__.py` does not include issue_stream_cmd_on_start, which is used by the usrp_source block.