### PR TITLE
Add support for serializing PMTs containing longs outside of 32-bit range

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt-serial-tags.scm
+++ b/gnuradio-runtime/lib/pmt/pmt-serial-tags.scm
@@ -35,6 +35,7 @@
 (define pst-uniform-vector	#x0a)
 (define pst-uint64	#x0b)
 (define pst-tuple	#x0c)
+(define pst-int64	#x0d)
 
 ;; u8, s8, u16, s16, u32, s32, u64, s64, f32, f64, c32, c64
 ;;

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -24,6 +24,7 @@
 #endif
 
 #include <vector>
+#include <limits>
 #include <pmt/pmt.h>
 #include "pmt_int.h"
 #include "pmt/pmt_serial_tags.h"
@@ -286,7 +287,7 @@ serialize(pmt_t obj, std::streambuf &sb)
     else {
       if(is_integer(obj)) {
         long i = to_long(obj);
-        if((sizeof(long) > 4) && ((i < -2147483647 || i > 2147483647))) {
+        if((sizeof(long) > 4) && ((i < std::numeric_limits<std::int32_t>::min() || i > std::numeric_limits<std::int32_t>::max()))) {
           // Serializing as 4 bytes won't work for this value, serialize as 8 bytes
           ok = serialize_untagged_u8(PST_INT64, sb);
           ok &= serialize_untagged_u64(i, sb);

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -25,6 +25,9 @@ import pmt
 
 class test_pmt(unittest.TestCase):
 
+    MAXINT32 = (2**31)-1
+    MININT32 = (-MAXINT32)-1
+
     def test01(self):
         a = pmt.intern("a")
         b = pmt.from_double(123765)
@@ -101,6 +104,72 @@ class test_pmt(unittest.TestCase):
         s = pmt.serialize_str(v)
         d = pmt.deserialize_str(s)
         self.assertTrue(pmt.equal(v, d))
+
+    def test13(self):
+        const = self.MAXINT32
+        x_pmt = pmt.from_long(const)
+        s = pmt.serialize_str(x_pmt)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(x_pmt, deser))
+        self.assertEqual(const, pmt.to_long(deser))
+
+    def test14(self):
+        const = self.MAXINT32 - 1
+        x_pmt = pmt.from_long(const)
+        s = pmt.serialize_str(x_pmt)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(x_pmt, deser))
+        self.assertEqual(const,pmt.to_long(deser))
+
+    def test15(self):
+        const = self.MAXINT32 + 1
+        x_pmt = pmt.from_long(const)
+        s = pmt.serialize_str(x_pmt)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(x_pmt, deser))
+        x_long = pmt.to_long(deser)
+        self.assertEqual(const, x_long)
+
+    def test16(self):
+        const = self.MININT32
+        x_pmt = pmt.from_long(const)
+        s = pmt.serialize_str(x_pmt)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(x_pmt, deser))
+
+    def test17(self):
+        const = self.MININT32 + 1
+        x_pmt = pmt.from_long(const)
+        s = pmt.serialize_str(x_pmt)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(x_pmt, deser))
+        x_long = pmt.to_long(deser)
+        self.assertEqual(const, x_long)
+
+    def test18(self):
+        const = self.MININT32 - 1
+        x_pmt = pmt.from_long(const)
+        s = pmt.serialize_str(x_pmt)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(x_pmt, deser))
+        x_long = pmt.to_long(deser)
+        self.assertEqual(const, x_long)
+
+    def test19(self):
+        max_key = pmt.intern("MAX")
+        _max = pmt.from_long(self.MAXINT32)
+        min_key = pmt.intern("MIN")
+        _min = pmt.from_long(self.MININT32)
+        d = pmt.make_dict()
+        d = pmt.dict_add(d, max_key, _max)
+        d = pmt.dict_add(d, min_key, _min)
+        s = pmt.serialize_str(d)
+        deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.equal(d, deser))
+        p_dict = pmt.to_python(deser)
+        self.assertEqual(self.MAXINT32, p_dict["MAX"])
+        self.assertEqual(self.MININT32, p_dict["MIN"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, there is a limitation in PMT serialization and deserialization which prevents the serialization of PMT longs which are outside of the expressible range of a 32-bit signed int. This PR removes that limitation, by adding a new PST (PMT serial tag) for signed 64-bit ints.

This change retains partial backwards compatibility: PMTs which are serialized by older versions of GNU Radio will be deserialized correctly by this version, but if a PMT containing a large 64-bit int is serialized by this version, it will not be deserializeable by older versions.