### PR TITLE
runtime: declare d_logger only if actually using logging with log4cpp via macros

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h.in
+++ b/gnuradio-runtime/include/gnuradio/logger.h.in
@@ -763,7 +763,8 @@ namespace gr {
   {
   private:
     /*! \brief logger pointer to logger associated wiith this wrapper class */
-    logger_ptr d_logger;
+    GR_LOG_DECLARE_LOGPTR(d_logger);
+
   public:
     /*!
      * \brief constructor Provide name of logger to associate with this class


### PR DESCRIPTION
If logging with log4cpp is not enabled, then this variable is not used and thus causes warnings with some compilers / settings. Simple tweak to fix these warnings as well as help the code make more sense via using the already-in-place macro to declare it.