### PR TITLE
Correctly handle tag offsets in the skiphead block

### DIFF
--- a/gr-blocks/lib/skiphead_impl.h
+++ b/gr-blocks/lib/skiphead_impl.h
@@ -33,6 +33,7 @@ namespace gr {
     private:
       uint64_t d_nitems_to_skip;
       uint64_t d_nitems;           // total items seen
+      std::vector<tag_t> d_tags;
 
     public:
       skiphead_impl(size_t itemsize, uint64_t nitems_to_skip);

--- a/gr-blocks/python/blocks/qa_skiphead.py
+++ b/gr-blocks/python/blocks/qa_skiphead.py
@@ -21,6 +21,19 @@
 #
 
 from gnuradio import gr, gr_unittest, blocks
+import pmt
+import numpy
+
+
+def make_tag(key, value, offset, srcid=None):
+    tag = gr.tag_t()
+    tag.key = pmt.string_to_symbol(key)
+    tag.value = pmt.to_pmt(value)
+    tag.offset = offset
+    if srcid is not None:
+        tag.srcid = pmt.to_pmt(srcid)
+    return tag
+
 
 class test_skiphead(gr_unittest.TestCase):
 
@@ -97,6 +110,19 @@ class test_skiphead(gr_unittest.TestCase):
         dst_data = dst1.data()
         self.assertEqual(expected_result, dst_data)
 
+    def test_skip_tags(self):
+        skip_cnt = 25
+        expected_result = tuple(self.src_data[skip_cnt:])
+
+        src_tags = tuple([make_tag('foo', 'bar', 50, 'src')])
+        src1 = blocks.vector_source_i(self.src_data, tags=src_tags)
+        op = blocks.skiphead(gr.sizeof_int, skip_cnt)
+        dst1 = blocks.vector_sink_i()
+        self.tb.connect(src1, op, dst1)
+        self.tb.run()
+        dst_data = dst1.data()
+        self.assertEqual(expected_result, dst_data)
+        self.assertEqual(dst1.tags()[0].offset, 25, "Tag offset is incorrect")
 
 if __name__ == '__main__':
     gr_unittest.run(test_skiphead, "test_skiphead.xml")

--- a/gr-blocks/python/blocks/qa_skiphead.py
+++ b/gr-blocks/python/blocks/qa_skiphead.py
@@ -114,7 +114,8 @@ class test_skiphead(gr_unittest.TestCase):
         skip_cnt = 25
         expected_result = tuple(self.src_data[skip_cnt:])
 
-        src_tags = tuple([make_tag('foo', 'bar', 50, 'src')])
+        src_tags = tuple([make_tag('foo', 'bar', 1, 'src'),
+                          make_tag('baz', 'qux', 50, 'src')])
         src1 = blocks.vector_source_i(self.src_data, tags=src_tags)
         op = blocks.skiphead(gr.sizeof_int, skip_cnt)
         dst1 = blocks.vector_sink_i()
@@ -123,6 +124,11 @@ class test_skiphead(gr_unittest.TestCase):
         dst_data = dst1.data()
         self.assertEqual(expected_result, dst_data)
         self.assertEqual(dst1.tags()[0].offset, 25, "Tag offset is incorrect")
+        self.assertEqual(len(dst1.tags()), 1, "Wrong number of tags received")
+        self.assertEqual(pmt.to_python(
+            dst1.tags()[0].key), "baz", "Tag key is incorrect")
+        self.assertEqual(pmt.to_python(
+            dst1.tags()[0].value), "qux", "Tag value is incorrect")
 
 if __name__ == '__main__':
     gr_unittest.run(test_skiphead, "test_skiphead.xml")


### PR DESCRIPTION
This PR addresses https://github.com/gnuradio/gnuradio/issues/959. In the current skiphead block, tags have incorrect offsets, this PR adjusts the offsets of all tags that pass through by the number of items skipped to ensure that tags stay correctly aligned. 