### PR TITLE
Fixed wrong coefficient in Taylor series; cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 - CMake: using regex to match compiler against "Clang" now enables correct build on OS X
 #### GRC
 - Fixed GRC bug which broke WX and Qt (by altering the template code), in multiple (less than awesome) steps
+#### gr-analog
+- `fmdet_cf`'s derivative coefficients were wrong.
 #### gr-blocks
 - `float_array_to_int`: int32 limits were wrongly hardcoded. 
 - Fixed the undefined behaviour happening in `float_to_complex` when accessing the second input_items element in the single-input case

--- a/gr-analog/lib/fmdet_cf_impl.cc
+++ b/gr-analog/lib/fmdet_cf_impl.cc
@@ -31,8 +31,6 @@
 namespace gr {
   namespace analog {
 
-#define M_TWOPI (2*M_PI)
-
     fmdet_cf::sptr
     fmdet_cf::make(float samplerate, float freq_low,
 		   float freq_high, float scl)
@@ -46,26 +44,13 @@ namespace gr {
       : sync_block("fmdet_cf",
 		      io_signature::make(1, 1, sizeof(gr_complex)),
 		      io_signature::make(1, 1, sizeof(float))),
-	d_S1(0.1), d_S2(0.1),
-	d_S3(0.1), d_S4(0.1)
+        d_S1(0.1), d_S2(0.1),
+        d_S3(0.1), d_S4(0.1)
     {
-      //const float h[] = { 0.003118678733, -0.012139843428,  0.027270898036,
-      //			 -0.051318579352,  0.090406910552, -0.162926865366,
-      //			  0.361885392563,  0.000000000000, -0.361885392563,
-      //			  0.162926865366, -0.090406910552,  0.051318579352,
-      //			 -0.027270898036,  0.012139843428, -0.003118678733};
-
-      //std::vector<float> taps(15);
-
       d_freq = 0;
       d_freqhi = freq_high;
       d_freqlo = freq_low;
       set_scale(scl);
-
-      //for(int i = 0; i < 15; i++) {
-      //taps[i] = h[i];
-      //}
-      //  d_filter = gr_fir_util::create_gr_fir_ccf(taps);
     }
 
     fmdet_cf_impl::~fmdet_cf_impl()
@@ -95,28 +80,26 @@ namespace gr {
     {
       const gr_complex *iptr = (gr_complex*)input_items[0];
       float *optr = (float*)output_items[0];
-      //const gr_complex *scaleiptr = (gr_complex*)input_items[0];
 
       int size = noutput_items;
 
       gr_complex Sdot, S0;
       gr_complex S1=d_S1, S2=d_S2, S3=d_S3, S4=d_S4;
-      float d_8 = 8.0;
 
       while(size-- > 0) {
-	S0 = *iptr++;
+        S0 = *iptr++;
 
-	Sdot = d_scl * (-S0+d_8*S1-d_8*S2+S4);
+        Sdot = d_scl * (-S0 + 8.f*S1 - 8.f*S3 + S4);
 
-	d_freq = (S2.real()*Sdot.imag()-S2.imag()*Sdot.real()) /
-	  (S2.real()*S2.real()+S2.imag()*S2.imag());
+        d_freq = (S2.real()*Sdot.imag() - S2.imag()*Sdot.real()) /
+                 (S2.real()*S2.real() + S2.imag()*S2.imag());
 
-	S4 = S3;
-	S3 = S2;
-	S2 = S1;
-	S1 = S0;
+        S4 = S3;
+        S3 = S2;
+        S2 = S1;
+        S1 = S0;
 
-	*optr++ = d_freq-d_bias;
+        *optr++ = d_freq-d_bias;
       }
       d_S1 = S1;
       d_S2 = S2;


### PR DESCRIPTION
To even edit this file, indents had to be sanitized a bit. Also,
commented-out code was removed. Also, 8.f is a constand and not really
longer than `d_8`.

This is the first in two changes necessary for #1817. The other would be
adding a unit test that is *slightly* more holistic than just doing a
single-tone frequency detection.

Note that there's much about this code that could be refactored,
starting with Sdot being a FIR-filtered version of the input.