### PR TITLE
backport: digital: qa_packet_format fix conditionals to wait for messages

### DIFF
--- a/gr-digital/python/digital/qa_packet_format.py
+++ b/gr-digital/python/digital/qa_packet_format.py
@@ -55,7 +55,7 @@ class test_packet_format_fb(gr_unittest.TestCase):
         formatter.to_basic_block()._post(port, msg)
 
         self.tb.start()
-        while (snk_hdr.num_messages() < 1) and (snk_pld.num_messages() < 1):
+        while (snk_hdr.num_messages() < 1) or (snk_pld.num_messages() < 1):
             time.sleep(0.1)
         self.tb.stop()
         self.tb.wait()
@@ -106,7 +106,7 @@ class test_packet_format_fb(gr_unittest.TestCase):
         self.tb.msg_connect(parser_4bps, 'info', snk_hdr_4bps, 'store')
 
         self.tb.start()
-        while (snk_hdr_1bps.num_messages() < 1) and (snk_hdr_4bps.num_messages() < 1):
+        while (snk_hdr_1bps.num_messages() < 1) or (snk_hdr_4bps.num_messages() < 1):
             time.sleep(0.1)
         self.tb.stop()
         self.tb.wait()
@@ -148,7 +148,7 @@ class test_packet_format_fb(gr_unittest.TestCase):
         formatter.to_basic_block()._post(port, msg)
 
         self.tb.start()
-        while (snk_hdr.num_messages() < 1) and (snk_pld.num_messages() < 1):
+        while (snk_hdr.num_messages() < 1) or (snk_pld.num_messages() < 1):
             time.sleep(0.1)
         self.tb.stop()
         self.tb.wait()


### PR DESCRIPTION
This backports #1830 to 3.7