### PR TITLE
ModTool: Proper check on blockname before renaming

### DIFF
--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -27,11 +27,12 @@ from __future__ import unicode_literals
 import os
 import re
 
-from .util_functions import append_re_line_sequence, ask_yes_no, SequenceCompleter
 from .cmakefile_editor import CMakeFileEditor
 from .modtool_base import ModTool, ModToolException
 from .templates import Templates
 from .code_generator import render_template
+from .util_functions import append_re_line_sequence, ask_yes_no, SequenceCompleter
+
 
 class ModToolAdd(ModTool):
     """ Add block to the out-of-tree module. """
@@ -73,7 +74,6 @@ class ModToolAdd(ModTool):
 
         self._info['blocktype'] = options.block_type
         if self._info['blocktype'] is None:
-            # Print list out of blocktypes to user for reference
             print(str(self._block_types))
             with SequenceCompleter(sorted(self._block_types)):
                 while self._info['blocktype'] not in self._block_types:

--- a/gr-utils/python/modtool/modtool_base.py
+++ b/gr-utils/python/modtool/modtool_base.py
@@ -26,11 +26,31 @@ from __future__ import unicode_literals
 
 import os
 import re
+import glob
+import itertools
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 from gnuradio import gr
 from .util_functions import get_modname
 from .scm import SCMRepoFactory
+
+
+def get_block_candidates():
+    """ Returns a list of all possible blocknames """
+    block_candidates = []
+    cpp_filters = ["*.cc", "*.cpp"]
+    cpp_blocks = []
+    for ftr in cpp_filters:
+        cpp_blocks += [x for x in glob.glob1("lib", ftr) if not (x.startswith('qa_') or
+                       x.startswith('test_'))]
+    python_blocks = [x for x in glob.glob1("python", "*.py") if not (x.startswith('qa_') or
+                     x.startswith('build') or x.startswith('__init__'))]
+    for block in itertools.chain(cpp_blocks, python_blocks):
+        block = os.path.splitext(block)[0]
+        block = block.split('_impl')[0]
+        block_candidates.append(block)
+    return block_candidates
+
 
 class ModToolException(BaseException):
     """ Standard exception for modtool classes. """

--- a/gr-utils/python/modtool/modtool_disable.py
+++ b/gr-utils/python/modtool/modtool_disable.py
@@ -28,8 +28,9 @@ import os
 import re
 import sys
 
-from .modtool_base import ModTool
+from .modtool_base import get_block_candidates, ModTool
 from .cmakefile_editor import CMakeFileEditor
+from .util_functions import SequenceCompleter
 
 
 class ModToolDisable(ModTool):
@@ -50,8 +51,10 @@ class ModToolDisable(ModTool):
         if options.blockname is not None:
             self._info['pattern'] = options.blockname
         else:
-            self._info['pattern'] = input('Which blocks do you want to disable? (Regex): ')
-        if len(self._info['pattern']) == 0:
+            block_candidates = get_block_candidates()
+            with SequenceCompleter(block_candidates):
+                self._info['pattern'] = input('Which blocks do you want to disable? (Regex): ')
+        if not self._info['pattern'] or self._info['pattern'].isspace():
             self._info['pattern'] = '.'
 
     def run(self, options):

--- a/gr-utils/python/modtool/modtool_makexml.py
+++ b/gr-utils/python/modtool/modtool_makexml.py
@@ -28,11 +28,12 @@ import os
 import re
 import glob
 
+from .modtool_base import get_block_candidates
 from .modtool_base import ModTool, ModToolException
 from .parser_cc_block import ParserCCBlock
 from .grc_xml_generator import GRCXMLGenerator
 from .cmakefile_editor import CMakeFileEditor
-from .util_functions import ask_yes_no
+from .util_functions import ask_yes_no, SequenceCompleter
 
 
 class ModToolMakeXML(ModTool):
@@ -58,8 +59,10 @@ class ModToolMakeXML(ModTool):
         if options.blockname is not None:
             self._info['pattern'] = options.blockname
         else:
-            self._info['pattern'] = input('Which blocks do you want to parse? (Regex): ')
-        if len(self._info['pattern']) == 0:
+            block_candidates = get_block_candidates()
+            with SequenceCompleter(block_candidates):
+                self._info['pattern'] = input('Which blocks do you want to parse? (Regex): ')
+        if not self._info['pattern'] or self._info['pattern'].isspace():
             self._info['pattern'] = '.'
 
     def run(self, options):

--- a/gr-utils/python/modtool/modtool_rm.py
+++ b/gr-utils/python/modtool/modtool_rm.py
@@ -29,9 +29,9 @@ import re
 import sys
 import glob
 
-from .util_functions import remove_pattern_from_file, SequenceCompleter
-from .modtool_base import ModTool
+from .modtool_base import get_block_candidates, ModTool
 from .cmakefile_editor import CMakeFileEditor
+from .util_functions import remove_pattern_from_file, SequenceCompleter
 
 
 class ModToolRemove(ModTool):
@@ -52,9 +52,10 @@ class ModToolRemove(ModTool):
         if options.blockname is not None:
             self._info['pattern'] = options.blockname
         else:
-            with SequenceCompleter():
+            block_candidates = get_block_candidates()
+            with SequenceCompleter(block_candidates):
                 self._info['pattern'] = input('Which blocks do you want to delete? (Regex): ')
-        if len(self._info['pattern']) == 0:
+        if not self._info['pattern'] or self._info['pattern'].isspace():
             self._info['pattern'] = '.'
 
     def run(self, options):

--- a/gr-utils/python/modtool/util_functions.py
+++ b/gr-utils/python/modtool/util_functions.py
@@ -153,7 +153,7 @@ class SequenceCompleter(object):
         if not text and state < len(self._seq):
             return self._seq[state]
         if not state:
-            self._tmp_matches = filter(lambda candidate: candidate.startswith(text), self._seq)
+            self._tmp_matches = [candidate for candidate in self._seq if candidate.startswith(text)]
         if state < len(self._tmp_matches):
             return self._tmp_matches[state]
 
@@ -162,5 +162,5 @@ class SequenceCompleter(object):
         readline.set_completer(self.completefunc)
         readline.parse_and_bind("tab: complete")
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         readline.set_completer(self._old_completer)


### PR DESCRIPTION
While renaming the `blockname`, there must be a valid check on the existence of `blockname`. This can be done by traversing the `lib` and `python` directories, getting a list of all `blocknames` and checking if this `blockname` exists. If it does not exists, we can give the user a list of `suggested alternatives` for his ease.
Moreover, this same list of blocknames can be beneficial for the `Sequence Completer`. 
This method of generating the list of `blocknames` is more efficient than the one existing on the `master` branch script `modtool_rm.py` as it is python3 compatible. `filter` returns an object in python 3.
Fixes #1727 