### PR TITLE
grc: Fixed the "Show Msg Ports" option

### DIFF
--- a/gr-blocks/grc/blocks_copy.block.yml
+++ b/gr-blocks/grc/blocks_copy.block.yml
@@ -23,7 +23,7 @@ parameters:
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: showports
     label: Show Msg Ports
-    dtype: enum
+    dtype: bool
     default: 'True'
     options: ['False', 'True']
     option_labels: ['Yes', 'No']

--- a/gr-digital/grc/digital_constellation_receiver_cb.block.yml
+++ b/gr-digital/grc/digital_constellation_receiver_cb.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: real
 -   id: showports
     label: Show Msg Ports
-    dtype: enum
+    dtype: bool
     default: 'True'
     options: ['False', 'True']
     option_labels: ['Yes', 'No']

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -103,7 +103,7 @@ parameters:
     hide: part
 -   id: showports
     label: Show Msg Ports
-    dtype: enum
+    dtype: bool
     default: 'True'
     options: ['False', 'True']
     option_labels: ['Yes', 'No']

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -85,7 +85,7 @@ parameters:
     hide: part
 -   id: showports
     label: Show Msg Ports
-    dtype: enum
+    dtype: bool
     default: 'True'
     options: ['False', 'True']
     option_labels: ['Yes', 'No']

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -93,7 +93,7 @@ parameters:
     hide: part
 -   id: showports
     label: Show Msg Ports
-    dtype: enum
+    dtype: bool
     default: 'True'
     options: ['False', 'True']
     option_labels: ['Yes', 'No']

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -79,7 +79,7 @@ parameters:
     hide: part
 -   id: showports
     label: Show Msg Ports
-    dtype: enum
+    dtype: bool
     default: 'True'
     options: ['False', 'True']
     option_labels: ['Yes', 'No']

--- a/grc/core/ports/port.py
+++ b/grc/core/ports/port.py
@@ -39,7 +39,7 @@ class Port(Element):
     optional = EvaluatedFlag()
 
     def __init__(self, parent, direction, id, label='', domain=Constants.DEFAULT_DOMAIN, dtype='',
-                 vlen='', multiplicity=1, optional=False, hide='', **_):
+                 vlen='', multiplicity=1, optional=False, hide=False, **_):
         """Make a new port from nested data."""
         Element.__init__(self, parent)
 


### PR DESCRIPTION
6 of the blocks in the block tree have the ability to hide their message ports. Without this fix, the message ports are shown regardless of the "Show Msg Ports" option.