### PR TITLE
ModTool: Relative imports in python templates

### DIFF
--- a/gr-utils/python/modtool/gr-newmod/python/__init__.py
+++ b/gr-utils/python/modtool/gr-newmod/python/__init__.py
@@ -27,7 +27,7 @@ from __future__ import unicode_literals
 # import swig generated symbols into the howto namespace
 try:
 	# this might fail if the module is python-only
-	from howto_swig import *
+	from .howto_swig import *
 except ImportError:
 	pass
 

--- a/gr-utils/python/modtool/gr-newmod/swig/howto_swig.i
+++ b/gr-utils/python/modtool/gr-newmod/swig/howto_swig.i
@@ -2,7 +2,7 @@
 
 #define HOWTO_API
 
-%include "gnuradio.i"			// the common stuff
+%include "gnuradio.i"           // the common stuff
 
 //load generated python docstrings
 %include "howto_swig_doc.i"

--- a/gr-utils/python/modtool/modtool_add.py
+++ b/gr-utils/python/modtool/modtool_add.py
@@ -295,7 +295,7 @@ class ModToolAdd(ModTool):
         self._write_tpl('block_python', self._info['pydir'], fname_py)
         append_re_line_sequence(self._file['pyinit'],
                                 '(^from.*import.*\n|# import any pure.*\n)',
-                                'from %s import %s' % (self._info['blockname'], self._info['blockname']))
+                                'from .%s import %s' % (self._info['blockname'], self._info['blockname']))
         self.scm.mark_files_updated((self._file['pyinit'],))
         if self._skip_cmakefiles:
             return

--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -505,9 +505,9 @@ ${str_to_python_comment(license)}
 from gnuradio import gr, gr_unittest
 from gnuradio import blocks
 % if lang == 'cpp':
-import ${modname}_swig as ${modname}
+from . import ${modname}_swig as ${modname}
 % else:
-from ${blockname} import ${blockname}
+from .${blockname} import ${blockname}
 % endif
 
 class qa_${blockname} (gr_unittest.TestCase):


### PR DESCRIPTION
In my opinion, imports should be relative in python scripts.