### PR TITLE
Unbreak boost 1.67. Constrain the delay in message_strobe

### DIFF
--- a/gr-blocks/grc/blocks_message_strobe.block.yml
+++ b/gr-blocks/grc/blocks_message_strobe.block.yml
@@ -8,7 +8,7 @@ parameters:
     default: pmt.intern("TEST")
 -   id: period
     label: Period (ms)
-    dtype: real
+    dtype: int
     default: '1000'
 
 inputs:

--- a/gr-blocks/include/gnuradio/blocks/message_strobe.h
+++ b/gr-blocks/include/gnuradio/blocks/message_strobe.h
@@ -51,7 +51,7 @@ namespace gr {
        * \param period_ms the time period in milliseconds in which to
        *                  send \p msg.
        */
-      static sptr make(pmt::pmt_t msg, float period_ms);
+      static sptr make(pmt::pmt_t msg, long period_ms);
 
       /*!
        * Reset the message being sent.
@@ -68,12 +68,12 @@ namespace gr {
        * Reset the sending interval.
        * \param period_ms the time period in milliseconds.
        */
-      virtual void set_period(float period_ms) = 0;
+      virtual void set_period(long period_ms) = 0;
 
       /*!
        * Get the time interval of the strobe.
        */
-      virtual float period() const = 0;
+      virtual long period() const = 0;
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -39,13 +39,13 @@ namespace gr {
   namespace blocks {
 
     message_strobe::sptr
-    message_strobe::make(pmt::pmt_t msg, float period_ms)
+    message_strobe::make(pmt::pmt_t msg, long period_ms)
     {
       return gnuradio::get_initial_sptr
         (new message_strobe_impl(msg, period_ms));
     }
 
-    message_strobe_impl::message_strobe_impl(pmt::pmt_t msg, float period_ms)
+    message_strobe_impl::message_strobe_impl(pmt::pmt_t msg, long period_ms)
       : block("message_strobe",
               io_signature::make(0, 0, 0),
               io_signature::make(0, 0, 0)),

--- a/gr-blocks/lib/message_strobe_impl.h
+++ b/gr-blocks/lib/message_strobe_impl.h
@@ -33,19 +33,19 @@ namespace gr {
     private:
       boost::shared_ptr<gr::thread::thread> d_thread;
       bool d_finished;
-      float d_period_ms;
+      long d_period_ms;
       pmt::pmt_t d_msg;
 
       void run();
 
     public:
-      message_strobe_impl(pmt::pmt_t msg, float period_ms);
+      message_strobe_impl(pmt::pmt_t msg, long period_ms);
       ~message_strobe_impl();
 
       void set_msg(pmt::pmt_t msg) { d_msg = msg; }
       pmt::pmt_t msg() const { return d_msg; }
-      void set_period(float period_ms) { d_period_ms = period_ms; }
-      float period() const { return d_period_ms; }
+      void set_period(long period_ms) { d_period_ms = period_ms; }
+      long period() const { return d_period_ms; }
 
       // Overloading these to start and stop the internal thread that
       // periodically produces the message.

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -69,15 +69,15 @@ namespace gr {
                       boost::bind(&message_strobe_random_impl::set_msg, this, _1));
     }
 
-    float message_strobe_random_impl::next_delay(){
+    long message_strobe_random_impl::next_delay(){
         switch(d_dist){
             case STROBE_POISSON:
                 //return d_variate_poisson->operator()();
-                return d_variate_poisson->operator()();
+                return static_cast<long>(d_variate_poisson->operator()());
             case STROBE_GAUSSIAN:
-                return d_variate_normal->operator()();
+                return static_cast<long>(d_variate_normal->operator()());
             case STROBE_UNIFORM:
-                return d_variate_uniform->operator()();
+                return static_cast<long>(d_variate_uniform->operator()());
             default:
                 throw std::runtime_error("message_strobe_random_impl::d_distribution is very unhappy with you");
         }
@@ -108,7 +108,7 @@ namespace gr {
     void message_strobe_random_impl::run()
     {
       while(!d_finished) {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(std::max(0.0f,next_delay())));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(std::max(0L, next_delay())));
         if(d_finished) {
           return;
         }

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -43,7 +43,7 @@ namespace gr {
       message_strobe_random_distribution_t d_dist;
       pmt::pmt_t d_msg;
       void run();
-      float next_delay();
+      long next_delay();
 
       boost::mt19937 d_rng;
       boost::shared_ptr< boost::variate_generator <boost::mt19937, boost::poisson_distribution<> > > d_variate_poisson;

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -129,7 +129,7 @@ bool usrp_block_impl::_wait_for_locked_sensor(
 
   while (true) {
     if ((not first_lock_time.is_not_a_date_time()) and
-        (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(LOCK_TIMEOUT)))) {
+        (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT))))) {
       break;
     }
 
@@ -140,7 +140,7 @@ bool usrp_block_impl::_wait_for_locked_sensor(
     else {
       first_lock_time = boost::system_time(); //reset to 'not a date time'
 
-      if (boost::get_system_time() > (start + boost::posix_time::seconds(LOCK_TIMEOUT))){
+      if (boost::get_system_time() > (start + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT)))) {
         return false;
       }
     }


### PR DESCRIPTION
Apply the fixes contained in master to next in order to unbreak boost 1.67 by static_casting the delay values to long. As suggested before, change the API of message_strobe such that only integer milliseconds can be specified. 

I'm not sure whether constraining the parameters of the delay distributions in message_strobe_random to integer values would be a good idea. This PR leaves the delay distribution values as floats and only rounds the random delays to integer millisecond values.