### PR TITLE
fix incorrect CPPUNIT inclusion

### DIFF
--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -317,7 +317,6 @@ if(ENABLE_TESTING)
   list(APPEND GR_TEST_TARGET_DEPS gnuradio-blocks
     ${Boost_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${CPPUNIT_LIBRARIES}
   )
 
   foreach(qa_file ${test_gr_blocks_sources})


### PR DESCRIPTION
My mistake by incorrectly solving a merge conflict; luckily, no harm is done: without CPPUNIT being looked for, the cmake variable resolves to nothingness without notice.