### PR TITLE
Fix the fact that, depending on file order, block_tree.xml overrode categories in block files.

### DIFF
--- a/gr-digital/grc/digital_constellation.xml
+++ b/gr-digital/grc/digital_constellation.xml
@@ -7,7 +7,7 @@
 <block>
   <name>Constellation Object</name>
   <key>variable_constellation</key>
-  <category>Modulators</category>
+  <category>[Core]/Modulators</category>
   <import>from gnuradio import digital</import>
   <var_make>
 #if str($type) == "calcdist"

--- a/gr-digital/grc/digital_constellation_rect.xml
+++ b/gr-digital/grc/digital_constellation_rect.xml
@@ -7,7 +7,7 @@
 <block>
   <name>Constellation Rect. Object</name>
   <key>variable_constellation_rect</key>
-  <category>Modulators</category>
+  <category>[Core]/Modulators</category>
   <import>from gnuradio import digital</import>
   <var_make>self.$(id) = $(id) = digital.constellation_rect($const_points, $sym_map, $rot_sym, $real_sect, $imag_sect, $w_real_sect, $w_imag_sect).base()
 #if str($soft_dec_lut).lower() == '"auto"' or str($soft_dec_lut).lower() == "'auto'"

--- a/gr-digital/grc/digital_modulate_vector.xml
+++ b/gr-digital/grc/digital_modulate_vector.xml
@@ -7,7 +7,7 @@
 <block>
   <name>Modulate Vector</name>
   <key>variable_modulate_vector</key>
-  <category>Modulators</category>
+  <category>[Core]/Modulators</category>
   <import>from gnuradio import digital</import>
   <var_make>self.$(id) = $(id) = digital.modulate_vector_bc($mod .to_basic_block(), $data, $taps)</var_make>
   <var_value>digital.modulate_vector_bc($mod .to_basic_block(), $data, $taps)</var_value>

--- a/grc/core/Platform.py
+++ b/grc/core/Platform.py
@@ -158,7 +158,12 @@ class Platform(Element):
 
         # Add blocks to block tree
         for key, block in self.blocks.iteritems():
-            category = self._block_categories.get(key, block.category)
+            category = block.category
+            if len(category) == 0:
+                category = self._block_categories.get(key, block.category)
+            elif key in self._block_categories and self._block_categories[key] != category:
+                print >> sys.stderr, 'conflicting categories on %s:\n\t"%s" (block file) vs "%s" (block tree)' % \
+                (key, '/'.join(category), '/'.join(self._block_categories[key]))
             # Blocks with empty categories are hidden
             if not category:
                 continue

--- a/grc/core/Platform.py
+++ b/grc/core/Platform.py
@@ -159,11 +159,12 @@ class Platform(Element):
         # Add blocks to block tree
         for key, block in self.blocks.iteritems():
             category = block.category
-            if len(category) == 0:
+            if not len(category):
                 category = self._block_categories.get(key, block.category)
-            elif key in self._block_categories and self._block_categories[key] != category:
+            elif category != self._block_categories.get(key, category):
                 print >> sys.stderr, 'conflicting categories on %s:\n\t"%s" (block file) vs "%s" (block tree)' % \
                 (key, '/'.join(category), '/'.join(self._block_categories[key]))
+                category = self._block_categories[key]
             # Blocks with empty categories are hidden
             if not category:
                 continue


### PR DESCRIPTION
Defaults to block file category now; prints a warning on conflict.