### PR TITLE
next: Fix the fact that, depending on file order, block_tree.xml overrode categories in block files.

### DIFF
--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -1,6 +1,6 @@
 id: variable_constellation
 label: Constellation Object
-category: Modulators
+category: [Core]/Modulators
 
 parameters:
 -   id: type

--- a/gr-digital/grc/digital_constellation_rect.block.yml
+++ b/gr-digital/grc/digital_constellation_rect.block.yml
@@ -1,6 +1,6 @@
 id: variable_constellation_rect
 label: Constellation Rect. Object
-category: Modulators
+category: [Core]/Modulators
 
 parameters:
 -   id: sym_map

--- a/gr-digital/grc/digital_modulate_vector.block.yml
+++ b/gr-digital/grc/digital_modulate_vector.block.yml
@@ -1,6 +1,6 @@
 id: variable_modulate_vector
 label: Modulate Vector
-category: Modulators
+category: [Core]/Modulators
 
 parameters:
 -   id: mod

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -177,7 +177,17 @@ class Platform(Element):
                     raise
 
         for key, block in six.iteritems(self.blocks):
-            category = self._block_categories.get(key, block.category)
+            category = block.category
+            if len(category) == 0:
+                category = self._block_categories.get(key, block.category)
+            elif key in self._block_categories and self._block_categories[key] != category:
+                logger.warning(
+                    'conflicting categories on {:s}:\n\t"{:s}" (block file) vs "{:s}" (block tree)'.format(
+                        key,
+                        '/'.join(category),
+                        '/'.join(self._block_categories[key])
+                    )
+                )
             if not category:
                 continue
             root = category[0]


### PR DESCRIPTION
forward-port of #1869 to python3 and yaml