### PR TITLE
Adding a CMake option -DENABLE_GLIBCXX_ASSERTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,8 @@ endif(ENABLE_PERFORMANCE_COUNTERS)
 OPTION(ENABLE_STATIC_LIBS "Enable building of static libraries" OFF)
 message(STATUS "Building Static Libraries: ${ENABLE_STATIC_LIBS}")
 
+OPTION(ENABLE_GLIBCXX_ASSERTIONS "GCC/libstdc++ cheap assertions (_GLIBCXX_ASSERTIONS)" OFF)
+
 ########################################################################
 # Variables replaced when configuring the package config files
 ########################################################################

--- a/cmake/Modules/GrPlatform.cmake
+++ b/cmake/Modules/GrPlatform.cmake
@@ -60,3 +60,11 @@ if (CMAKE_INSTALL_LIBDIR MATCHES lib64)
 endif()
 
 set(LIB_SUFFIX ${LIB_SUFFIX} CACHE STRING "lib directory suffix")
+
+########################################################################
+# Allow GNU libstdc++ assertion checks
+########################################################################
+
+if (ENABLE_GLIBCXX_ASSERTIONS)
+  add_definitions(-D_GLIBCXX_ASSERTIONS)
+endif()


### PR DESCRIPTION
This allows setting of the _GLIBCXX_ASSERTIONS macro, which enables
"cheap" runtime checks for things like vector access bounds.

This is related to #1774.

It allows for implementation of https://github.com/gnuradio/gnuradio-buildbot/issues/6

Note that Fedora 28 introduced the aformentioned macro as set-by-default, so that we now see GNU Radio fail in production Fedora maintainer binary packages.