### PR TITLE
Adding a CMake option -DENABLE_GLIBCXX_ASSERTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,8 @@ endif(ENABLE_PERFORMANCE_COUNTERS)
 OPTION(ENABLE_STATIC_LIBS "Enable building of static libraries" OFF)
 message(STATUS "Building Static Libraries: ${ENABLE_STATIC_LIBS}")
 
+OPTION(ENABLE_GLIBCXX_ASSERTIONS "GCC/libstdc++ cheap assertions (_GLIBCXX_ASSERTIONS)" OFF)
+
 ########################################################################
 # Variables replaced when configuring the package config files
 ########################################################################

--- a/cmake/Modules/GrPlatform.cmake
+++ b/cmake/Modules/GrPlatform.cmake
@@ -60,3 +60,11 @@ if (CMAKE_INSTALL_LIBDIR MATCHES lib64)
 endif()
 
 set(LIB_SUFFIX ${LIB_SUFFIX} CACHE STRING "lib directory suffix")
+
+########################################################################
+# Allow GNU libstdc++ assertion checks
+########################################################################
+
+if (ENABLE_GLIBCXX_ASSERTIONS)
+  add_definitions(-D_GLIBCXX_ASSERTIONS)
+endif()


### PR DESCRIPTION
Since  #1877 is a error-detection enhancing flag, and especially applies to released version, need this on 3.7.