### PR TITLE
polar_sc: Fix vector out of bound accesses

### DIFF
--- a/gr-fec/lib/polar_common.cc
+++ b/gr-fec/lib/polar_common.cc
@@ -108,14 +108,13 @@ namespace gr {
         d_volk_temp = (unsigned char*) volk_malloc(sizeof(unsigned char) * block_size(), volk_get_alignment());
         d_volk_frozen_bit_mask = (unsigned char*) volk_malloc(sizeof(unsigned char) * block_size(), volk_get_alignment());
         d_volk_frozen_bits = (unsigned char*) volk_malloc(sizeof(unsigned char) * nfrozen, volk_get_alignment());
-        for(int i = 0; i < nfrozen; i++){
-          d_volk_frozen_bits[i] = d_frozen_bit_values[i];
-        }
+        std::copy(d_frozen_bit_values.begin(), d_frozen_bit_values.end(), d_volk_frozen_bits);
+        std::fill(d_volk_frozen_bits + d_frozen_bit_values.size(), d_volk_frozen_bits + nfrozen, 0);
 
         int nfbit = 0;
         for(int i = 0; i < block_size(); i++){
           unsigned char m = 0x00;
-          if(d_frozen_bit_positions[nfbit] == i){
+          if(nfbit < d_frozen_bit_positions.size() && d_frozen_bit_positions[nfbit] == i){
             m = 0xFF;
             nfbit++;
           }


### PR DESCRIPTION
Unlike most of the other #1774-triggered fixes, this actually was an
effect of reading from unitialized memory. I'm surprised this worked as
intended!

Needs content-wise review from @jdemel!