### PR TITLE
Backport: Fix Boost 1.67 linking issues

### DIFF
--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -320,7 +320,11 @@ if(ENABLE_TESTING)
 
   add_executable(test-gr-blocks ${test_gr_blocks_sources})
 
-  list(APPEND GR_TEST_TARGET_DEPS test-gr-blocks gnuradio-blocks)
+  list(APPEND GR_TEST_TARGET_DEPS test-gr-blocks gnuradio-blocks
+    ${Boost_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CPPUNIT_LIBRARIES}
+  )
 
   target_link_libraries(
     test-gr-blocks

--- a/gr-uhd/examples/c++/CMakeLists.txt
+++ b/gr-uhd/examples/c++/CMakeLists.txt
@@ -35,7 +35,7 @@ link_directories(${Boost_LIBRARY_DIRS})
 # Build executable
 ########################################################################
 add_executable(tags_demo tags_demo.cc)
-target_link_libraries(tags_demo gnuradio-uhd)
+target_link_libraries(tags_demo gnuradio-uhd ${CMAKE_THREAD_LIBS_INIT})
 
 INSTALL(TARGETS
     tags_demo


### PR DESCRIPTION
Fixes "undefined reference to `pthread_condattr_setclock'"