### PR TITLE
py3k conv: file_metadata_sink::make now accepts unserialized PMT

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/file_meta_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/file_meta_sink.h
@@ -87,17 +87,20 @@ namespace gr {
        * \param complex (bool): If data stream is complex
        * \param max_segment_size (size_t): Length of a single segment
        *    before the header is repeated (in items).
-       * \param extra_dict (string): a serialized PMT dictionary of extra
-       *    information. Currently not supported.
+       * \param extra_dict: a PMT dictionary of extra
+       *    information.
        * \param detached_header (bool): Set to true to store the header
        *    info in a separate file (named filename.hdr)
        */
-      static sptr make(size_t itemsize, const std::string &filename,
-		       double samp_rate=1, double relative_rate=1,
-		       gr_file_types type=GR_FILE_FLOAT, bool complex=true,
-		       size_t max_segment_size=1000000,
-		       const std::string &extra_dict="",
-		       bool detached_header=false);
+      static sptr make(size_t itemsize,
+                       const std::string &filename,
+                       double samp_rate=1,
+                       double relative_rate=1,
+                       gr_file_types type=GR_FILE_FLOAT,
+                       bool complex=true,
+                       size_t max_segment_size=1000000,
+                       pmt::pmt_t extra_dict=pmt::make_dict(),
+                       bool detached_header=false);
 
       virtual bool open(const std::string &filename) = 0;
       virtual void close() = 0;

--- a/gr-blocks/lib/file_meta_sink_impl.h
+++ b/gr-blocks/lib/file_meta_sink_impl.h
@@ -66,12 +66,14 @@ namespace gr {
       bool _open(FILE **fp, const char *filename);
 
     public:
-      file_meta_sink_impl(size_t itemsize, const std::string &filename,
-			  double samp_rate=1, double relative_rate=1,
-			  gr_file_types type=GR_FILE_FLOAT, bool complex=true,
-			  size_t max_segment_size=1000000,
-			  const std::string &extra_dict="",
-			  bool detached_header=false);
+            file_meta_sink_impl(size_t itemsize, const std::string &filename,
+                                double samp_rate=1,
+                                double relative_rate=1,
+                                gr_file_types type=GR_FILE_FLOAT,
+                                bool complex=true,
+                                size_t max_segment_size=1000000,
+                                pmt::pmt_t extra_dict=pmt::make_dict(),
+                                bool detached_header=false);
       ~file_meta_sink_impl();
 
       bool open(const std::string &filename);

--- a/gr-blocks/python/blocks/qa_file_metadata.py
+++ b/gr-blocks/python/blocks/qa_file_metadata.py
@@ -55,14 +55,13 @@ class test_file_metadata(gr_unittest.TestCase):
         val = pmt.from_double(samp_rate)
         extras = pmt.make_dict()
         extras = pmt.dict_add(extras, key, val)
-        extras_str = pmt.serialize_str(extras)
 
         data = sig_source_c(samp_rate, 1000, 1, N)
         src  = blocks.vector_source_c(data)
         fsnk = blocks.file_meta_sink(gr.sizeof_gr_complex, outfile,
                                      samp_rate, 1,
                                      blocks.GR_FILE_FLOAT, True,
-                                     1000000, extras_str, detached)
+                                     1000000, extras, detached)
         fsnk.set_unbuffered(True)
 
         self.tb.connect(src, fsnk)
@@ -135,14 +134,13 @@ class test_file_metadata(gr_unittest.TestCase):
         val = pmt.from_double(samp_rate)
         extras = pmt.make_dict()
         extras = pmt.dict_add(extras, key, val)
-        extras_str = pmt.serialize_str(extras)
 
         data = sig_source_c(samp_rate, 1000, 1, N)
         src  = blocks.vector_source_c(data)
         fsnk = blocks.file_meta_sink(gr.sizeof_gr_complex, outfile,
                                      samp_rate, 1,
                                      blocks.GR_FILE_FLOAT, True,
-                                     1000000, extras_str, detached)
+                                     1000000, extras, detached)
         fsnk.set_unbuffered(True)
 
         self.tb.connect(src, fsnk)


### PR DESCRIPTION
This was necessitated by #1852