### PR TITLE
sig_source: Added phase parameter to signal source block

### DIFF
--- a/gr-analog/include/gnuradio/analog/sig_source_X.h.t
+++ b/gr-analog/include/gnuradio/analog/sig_source_X.h.t
@@ -54,19 +54,21 @@ namespace gr {
       static sptr make(double sampling_freq,
 		       gr::analog::gr_waveform_t waveform,
 		       double wave_freq,
-		       double ampl, @TYPE@ offset = 0);
+		       double ampl, @TYPE@ offset = 0, double phase = 0);
 
       virtual double sampling_freq() const = 0;
       virtual gr::analog::gr_waveform_t waveform() const = 0;
       virtual double frequency() const = 0;
       virtual double amplitude() const = 0;
       virtual @TYPE@ offset() const = 0;
+      virtual double phase() const = 0;
 
       virtual void set_sampling_freq(double sampling_freq) = 0;
       virtual void set_waveform(gr::analog::gr_waveform_t waveform) = 0;
       virtual void set_frequency(double frequency) = 0;
       virtual void set_amplitude(double ampl) = 0;
       virtual void set_offset(@TYPE@ offset) = 0;
+      virtual void set_phase(double phase) = 0;
     };
 
   } /* namespace analog */

--- a/gr-analog/lib/sig_source_X_impl.cc.t
+++ b/gr-analog/lib/sig_source_X_impl.cc.t
@@ -38,21 +38,22 @@ namespace gr {
 
     @BASE_NAME@::sptr
     @BASE_NAME@::make(double sampling_freq, gr_waveform_t waveform,
-		      double frequency, double ampl, @TYPE@ offset)
+		      double frequency, double ampl, @TYPE@ offset, double phase)
     {
       return gnuradio::get_initial_sptr
-	(new @IMPL_NAME@(sampling_freq, waveform, frequency, ampl, offset));
+	(new @IMPL_NAME@(sampling_freq, waveform, frequency, ampl, offset, phase));
     }
 
     @IMPL_NAME@::@IMPL_NAME@(double sampling_freq, gr_waveform_t waveform,
-			     double frequency, double ampl, @TYPE@ offset)
+			     double frequency, double ampl, @TYPE@ offset, double phase)
     : sync_block("@BASE_NAME@",
 		    io_signature::make(0, 0, 0),
 		    io_signature::make(1, 1, sizeof(@TYPE@))),
       d_sampling_freq(sampling_freq), d_waveform(waveform),
-      d_frequency(frequency), d_ampl(ampl), d_offset(offset)
+      d_frequency(frequency), d_ampl(ampl), d_offset(offset), d_phase(phase)
     {
       set_frequency(frequency);
+      set_phase(phase);
 
       message_port_register_in(pmt::mp("freq"));
       set_msg_handler(pmt::mp("freq"), boost::bind(&@IMPL_NAME@::set_frequency_msg, this, _1));
@@ -274,6 +275,13 @@ namespace gr {
     @NAME@::set_amplitude(double ampl)
     {
       d_ampl = ampl;
+    }
+
+    void
+    @NAME@::set_phase(double phase)
+    {
+      d_phase = phase;
+      d_nco.set_phase(phase);
     }
 
     void

--- a/gr-analog/lib/sig_source_X_impl.h.t
+++ b/gr-analog/lib/sig_source_X_impl.h.t
@@ -41,10 +41,11 @@ namespace gr {
       double		d_ampl;
       @TYPE@		d_offset;
       gr::fxpt_nco	d_nco;
+      double            d_phase;
 
     public:
       @IMPL_NAME@(double sampling_freq, gr_waveform_t waveform,
-		  double wave_freq, double ampl, @TYPE@ offset = 0);
+		  double wave_freq, double ampl, @TYPE@ offset = 0, double phase = 0);
       ~@IMPL_NAME@();
 
       virtual int work(int noutput_items,
@@ -56,6 +57,7 @@ namespace gr {
       double frequency() const { return d_frequency; }
       double amplitude() const { return d_ampl; }
       @TYPE@ offset() const { return d_offset; }
+      double phase() const { return d_phase; }
 
       void set_sampling_freq(double sampling_freq);
       void set_waveform(gr_waveform_t waveform);
@@ -63,6 +65,7 @@ namespace gr {
       void set_frequency(double frequency);
       void set_amplitude(double ampl);
       void set_offset(@TYPE@ offset);
+      void set_phase(double phase);
     };
 
   } /* namespace analog */


### PR DESCRIPTION
This pull request will add the phase parameter to the sig_source block. This parameter allows setting of different phases across sig_source blocks.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>