### PR TITLE
Forward porting Out-Of-Bound access fixes to allow for more precise testing

### DIFF
--- a/gr-blocks/lib/float_to_complex_impl.cc
+++ b/gr-blocks/lib/float_to_complex_impl.cc
@@ -54,8 +54,7 @@ namespace gr {
 				gr_vector_const_void_star &input_items,
 				gr_vector_void_star &output_items)
     {
-      float        *r = (float *)input_items[0];
-      float        *i = (float *)input_items[1];
+      float        *r = (float *) input_items[0];
       gr_complex *out = (gr_complex *) output_items[0];
 
       switch (input_items.size ()){
@@ -65,10 +64,13 @@ namespace gr {
 	break;
 
       case 2:
+      {
 	//for (size_t j = 0; j < noutput_items*d_vlen; j++)
 	//  out[j] = gr_complex (r[j], i[j]);
+        float *i = (float *) input_items[1];
         volk_32f_x2_interleave_32fc(out, r, i, noutput_items*d_vlen);
 	break;
+      }
 
       default:
 	assert (0);

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -29,7 +29,8 @@
 #include <gnuradio/prefs.h>
 #include <gnuradio/math.h>
 #include <stdexcept>
-#include <iostream>
+#include <sstream>
+#include <iomanip>
 
 namespace gr {
   namespace digital {
@@ -211,12 +212,8 @@ namespace gr {
       }
 
       if(ii > 0) {
-	if(ii > ninput_items[0]) {
-	  std::cerr << "clock_recovery_mm_cc: ii > ninput_items[0] ("
-		    << ii << " > " << ninput_items[0] << std::endl;
-	  assert(0);
-	}
-	consume_each(ii);
+        assert(ii <= ninput_items[0]);
+        consume_each(ii);
       }
 
       return oo;

--- a/gr-digital/lib/crc32_bb_impl.cc
+++ b/gr-digital/lib/crc32_bb_impl.cc
@@ -73,7 +73,7 @@ namespace gr {
         if (n_packed_length > d_buffer.size()){
           d_buffer.resize(n_packed_length);
           }
-        d_buffer.clear();
+        std::fill(d_buffer.begin(), d_buffer.begin() + n_packed_length, 0);
         for (size_t bit = 0; bit < packet_length; bit++){
           d_buffer[bit/8] |= (in[bit] << (bit % 8));
         }

--- a/gr-digital/lib/crc32_bb_impl.h
+++ b/gr-digital/lib/crc32_bb_impl.h
@@ -36,7 +36,7 @@ namespace gr {
       bool d_packed;
       boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true>    d_crc_impl;
       int d_crc_length;
-      char *d_unpacked_crc;
+      std::vector<char> d_buffer;
       unsigned int calculate_crc32(const unsigned char* in, size_t packet_length);
 
      public:

--- a/gr-digital/lib/crc32_bb_impl.h
+++ b/gr-digital/lib/crc32_bb_impl.h
@@ -37,6 +37,7 @@ namespace gr {
       boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true>    d_crc_impl;
       int d_crc_length;
       char *d_unpacked_crc;
+      unsigned int calculate_crc32(const unsigned char* in, size_t packet_length);
 
      public:
       crc32_bb_impl(bool check, const std::string& lengthtagname, bool packed);

--- a/gr-fec/lib/polar_common.cc
+++ b/gr-fec/lib/polar_common.cc
@@ -108,14 +108,13 @@ namespace gr {
         d_volk_temp = (unsigned char*) volk_malloc(sizeof(unsigned char) * block_size(), volk_get_alignment());
         d_volk_frozen_bit_mask = (unsigned char*) volk_malloc(sizeof(unsigned char) * block_size(), volk_get_alignment());
         d_volk_frozen_bits = (unsigned char*) volk_malloc(sizeof(unsigned char) * nfrozen, volk_get_alignment());
-        for(int i = 0; i < nfrozen; i++){
-          d_volk_frozen_bits[i] = d_frozen_bit_values[i];
-        }
+        std::copy(d_frozen_bit_values.begin(), d_frozen_bit_values.end(), d_volk_frozen_bits);
+        std::fill(d_volk_frozen_bits + d_frozen_bit_values.size(), d_volk_frozen_bits + nfrozen, 0);
 
         int nfbit = 0;
         for(int i = 0; i < block_size(); i++){
           unsigned char m = 0x00;
-          if(d_frozen_bit_positions[nfbit] == i){
+          if(nfbit < d_frozen_bit_positions.size() && d_frozen_bit_positions[nfbit] == i){
             m = 0xFF;
             nfbit++;
           }

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -181,8 +181,10 @@ namespace gr {
 	  dec_ctr = (j - d_nsamples);
 
 	  // stash the tail
-	  memcpy(&d_tail[0], d_invfft->get_outbuf() + d_nsamples,
-		 tailsize() * sizeof(float));
+    if(d_tail.size()) {
+      memcpy(&d_tail[0], d_invfft->get_outbuf() + d_nsamples,
+             tailsize() * sizeof(float));
+    }
 	}
 
 	return nitems;
@@ -338,8 +340,10 @@ namespace gr {
 	  dec_ctr = (j - d_nsamples);
 
 	  // stash the tail
-	  memcpy(&d_tail[0], d_invfft->get_outbuf() + d_nsamples,
-		 tailsize() * sizeof(gr_complex));
+    if(d_tail.size()) {
+      memcpy(&d_tail[0], d_invfft->get_outbuf() + d_nsamples,
+             tailsize() * sizeof(gr_complex));
+    }
 	}
 
 	return nitems;
@@ -501,8 +505,10 @@ namespace gr {
 	  dec_ctr = (j - d_nsamples);
 
 	  // stash the tail
-	  memcpy(&d_tail[0], d_invfft->get_outbuf() + d_nsamples,
-		 tailsize() * sizeof(gr_complex));
+    if(d_tail.size()) {
+      memcpy(&d_tail[0], d_invfft->get_outbuf() + d_nsamples,
+             tailsize() * sizeof(gr_complex));
+    }
 	}
 
 	return nitems;

--- a/gr-filter/lib/filter_delay_fc_impl.cc
+++ b/gr-filter/lib/filter_delay_fc_impl.cc
@@ -76,7 +76,7 @@ namespace gr {
 			       gr_vector_void_star &output_items)
     {
       float *in0 = (float *)input_items[0];
-      float *in1 = (float *)input_items[1];
+      float *in1;
       gr_complex *out = (gr_complex *)output_items[0];
 
       if(d_update) {
@@ -95,6 +95,7 @@ namespace gr {
 	break;
 
       case 2:
+        in1 = (float *)input_items[1];
 	for(int j = 0; j < noutput_items; j++) {
 	  out[j] = gr_complex(in0[j + d_delay],
 			      d_fir->filter(&in1[j]));


### PR DESCRIPTION
On several systems, `_GLIBCXX_ASSERTIONS` leads to runtime aborts, e.g. when getting the pointer to the second output stream in a block that might be configured to only have one.
This patchset just remedies that.