### PR TITLE
Remove catch statements from thread_body_wrapper.h

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
@@ -38,20 +38,42 @@ namespace gr {
     private:
       F d_f;
       std::string d_name;
+      bool d_catch_exceptions;
 
     public:
-      explicit thread_body_wrapper(F f, const std::string &name="")
-        : d_f(f), d_name(name) {}
+      explicit thread_body_wrapper(F f, const std::string &name="",
+                                   bool catch_exceptions=true)
+        : d_f(f), d_name(name), d_catch_exceptions(catch_exceptions) {}
 
       void operator()()
       {
         mask_signals();
 
-        try {
-          d_f();
-        }
-        catch(boost::thread_interrupted const &)
-        {
+        if(d_catch_exceptions) {
+          try {
+            d_f();
+          }
+          catch(boost::thread_interrupted const &)
+          {
+          }
+          catch(std::exception const &e)
+          {
+            std::cerr << "thread[" << d_name << "]: "
+                      << e.what() << std::endl;
+          }
+          catch(...)
+          {
+            std::cerr << "thread[" << d_name << "]: "
+                      << "caught unrecognized exception\n";
+          }
+
+        } else {
+          try {
+            d_f();
+          }
+          catch(boost::thread_interrupted const &)
+          {
+          }
         }
       }
     };

--- a/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
@@ -51,18 +51,8 @@ namespace gr {
           d_f();
         }
         catch(boost::thread_interrupted const &)
-          {
-          }
-        catch(std::exception const &e)
-          {
-            std::cerr << "thread[" << d_name << "]: "
-                      << e.what() << std::endl;
-          }
-        catch(...)
-          {
-            std::cerr << "thread[" << d_name << "]: "
-                      << "caught unrecognized exception\n";
-          }
+        {
+        }
       }
     };
 

--- a/gnuradio-runtime/include/gnuradio/top_block.h
+++ b/gnuradio-runtime/include/gnuradio/top_block.h
@@ -30,7 +30,7 @@ namespace gr {
 
   class top_block_impl;
 
-  GR_RUNTIME_API top_block_sptr make_top_block(const std::string &name);
+  GR_RUNTIME_API top_block_sptr make_top_block(const std::string &name, bool catch_exceptions=true);
 
   /*!
    *\brief Top-level hierarchical block representing a flowgraph
@@ -40,12 +40,12 @@ namespace gr {
   {
   private:
     friend GR_RUNTIME_API top_block_sptr
-      make_top_block(const std::string &name);
+      make_top_block(const std::string &name, bool catch_exceptions);
 
     top_block_impl *d_impl;
 
   protected:
-    top_block(const std::string &name);
+    top_block(const std::string &name, bool catch_exceptions=true);
 
   public:
     ~top_block();

--- a/gnuradio-runtime/lib/scheduler.cc
+++ b/gnuradio-runtime/lib/scheduler.cc
@@ -28,7 +28,8 @@
 namespace gr {
 
   scheduler::scheduler(flat_flowgraph_sptr ffg,
-                       int max_noutput_items)
+                       int max_noutput_items,
+                       bool catch_exceptions)
   {
   }
 

--- a/gnuradio-runtime/lib/scheduler.h
+++ b/gnuradio-runtime/lib/scheduler.h
@@ -48,7 +48,7 @@ namespace gr {
      * The scheduler will continue running until all blocks
      * report that they are done or the stop method is called.
      */
-    scheduler(flat_flowgraph_sptr ffg, int max_noutput_items);
+    scheduler(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions);
 
     virtual ~scheduler();
 

--- a/gnuradio-runtime/lib/scheduler_sts.cc
+++ b/gnuradio-runtime/lib/scheduler_sts.cc
@@ -44,13 +44,13 @@ namespace gr {
   };
 
   scheduler_sptr
-  scheduler_sts::make(flat_flowgraph_sptr ffg, int max_noutput_items)
+  scheduler_sts::make(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions)
   {
-    return scheduler_sptr(new scheduler_sts(ffg, max_noutput_items));
+    return scheduler_sptr(new scheduler_sts(ffg, max_noutput_items, catch_exceptions));
   }
 
-  scheduler_sts::scheduler_sts(flat_flowgraph_sptr ffg, int max_noutput_items)
-    : scheduler(ffg, max_noutput_items)
+  scheduler_sts::scheduler_sts(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions)
+    : scheduler(ffg, max_noutput_items, catch_exceptions)
   {
     // Split the flattened flow graph into discrete partitions, each
     // of which is topologically sorted.
@@ -66,7 +66,7 @@ namespace gr {
       block_vector_t blocks = flat_flowgraph::make_block_vector(*p);
       d_threads.create_thread(
         gr::thread::thread_body_wrapper<sts_container>(sts_container(blocks),
-						  "single-threaded-scheduler"));
+						  "single-threaded-scheduler", catch_exceptions));
     }
   }
 

--- a/gnuradio-runtime/lib/scheduler_sts.h
+++ b/gnuradio-runtime/lib/scheduler_sts.h
@@ -42,11 +42,12 @@ namespace gr {
      * The scheduler will continue running until all blocks until they
      * report that they are done or the stop method is called.
      */
-    scheduler_sts(flat_flowgraph_sptr ffg, int max_noutput_items);
+    scheduler_sts(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions);
 
   public:
     static scheduler_sptr make(flat_flowgraph_sptr ffg,
-                               int max_noutput_items);
+                               int max_noutput_items,
+                               bool catch_exceptions);
 
     ~scheduler_sts();
 

--- a/gnuradio-runtime/lib/scheduler_tpb.cc
+++ b/gnuradio-runtime/lib/scheduler_tpb.cc
@@ -48,14 +48,15 @@ namespace gr {
   };
 
   scheduler_sptr
-  scheduler_tpb::make(flat_flowgraph_sptr ffg, int max_noutput_items)
+  scheduler_tpb::make(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions)
   {
-    return scheduler_sptr(new scheduler_tpb(ffg, max_noutput_items));
+    return scheduler_sptr(new scheduler_tpb(ffg, max_noutput_items, catch_exceptions));
   }
 
   scheduler_tpb::scheduler_tpb(flat_flowgraph_sptr ffg,
-                               int max_noutput_items)
-    : scheduler(ffg, max_noutput_items)
+                               int max_noutput_items,
+                               bool catch_exceptions)
+    : scheduler(ffg, max_noutput_items, catch_exceptions)
   {
     int block_max_noutput_items;
 
@@ -91,7 +92,8 @@ namespace gr {
       }
       d_threads.create_thread(thread::thread_body_wrapper<tpb_container>(
           tpb_container(blocks[i], block_max_noutput_items, start_sync),
-          name.str()));
+          name.str(),
+          catch_exceptions));
     }
     start_sync->wait();
   }

--- a/gnuradio-runtime/lib/scheduler_tpb.h
+++ b/gnuradio-runtime/lib/scheduler_tpb.h
@@ -42,11 +42,12 @@ namespace gr {
      * The scheduler will continue running until all blocks until they
      * report that they are done or the stop method is called.
      */
-    scheduler_tpb(flat_flowgraph_sptr ffg, int max_noutput_items);
+    scheduler_tpb(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions);
 
   public:
     static scheduler_sptr make(flat_flowgraph_sptr ffg,
-                               int max_noutput_items=100000);
+                               int max_noutput_items=100000,
+                               bool catch_exceptions=true);
 
     ~scheduler_tpb();
 

--- a/gnuradio-runtime/lib/top_block.cc
+++ b/gnuradio-runtime/lib/top_block.cc
@@ -34,18 +34,18 @@
 
 namespace gr {
   top_block_sptr
-  make_top_block(const std::string &name)
+  make_top_block(const std::string &name, bool catch_exceptions)
   {
     return gnuradio::get_initial_sptr
-      (new top_block(name));
+      (new top_block(name, catch_exceptions));
   }
 
-  top_block::top_block(const std::string &name)
+  top_block::top_block(const std::string &name, bool catch_exceptions)
     : hier_block2(name,
                   io_signature::make(0,0,0),
 		  io_signature::make(0,0,0))
   {
-    d_impl = new top_block_impl(this);
+    d_impl = new top_block_impl(this, catch_exceptions);
   }
 
   top_block::~top_block()

--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -39,7 +39,7 @@ namespace gr {
   class GR_RUNTIME_API top_block_impl
   {
   public:
-    top_block_impl(top_block *owner);
+    top_block_impl(top_block *owner, bool catch_exceptions);
     ~top_block_impl();
 
     // Create and start scheduler threads
@@ -85,6 +85,7 @@ namespace gr {
     bool d_retry_wait;
     boost::condition_variable d_lock_cond;
     int d_max_noutput_items;
+    bool d_catch_exceptions;
 
   private:
     void restart();

--- a/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from gnuradio import gr, gr_unittest, blocks
+from multiprocessing import Process
+import numpy
+
+
+# This block just exists to pass data through and throw an exception
+class except_block(gr.sync_block):
+    def __init__(self, throw_except, except_count=10000):
+        gr.sync_block.__init__(
+            self,
+            name="except_block",
+            in_sig=[numpy.complex64],
+            out_sig=[numpy.complex64],
+        )
+        self.throw_except = throw_except
+        self.except_count = except_count
+        self.count = 0
+
+    def work(self, input_items, output_items):
+        output_items[0][:] = input_items[0]
+        self.count += len(output_items[0])
+        if self.count >= self.except_count:
+            raise RuntimeError("Error in except_block")
+        return len(output_items[0])
+
+
+class test_uncaught_exception(gr_unittest.TestCase):
+
+    def test_exception_throw(self):
+        # Test to ensure that throwing an exception causes the
+        # process running top_block to exit
+
+        def process_func():
+            tb = gr.top_block()
+            # some test data
+            src_data = [complex(x, x + 1) for x in range(65536)]
+            src = blocks.vector_source_c(src_data)
+            src.set_repeat(True)
+
+            e_block_1 = except_block(False)
+            e_block_2 = except_block(True)
+
+            sink_1 = blocks.null_sink(gr.sizeof_gr_complex)
+            sink_2 = blocks.null_sink(gr.sizeof_gr_complex)
+
+            tb.connect(src, e_block_1)
+            tb.connect(src, e_block_2)
+            tb.connect(e_block_1, sink_1)
+            tb.connect(e_block_2, sink_2)
+            tb.run()
+
+        p = Process(target=process_func)
+        p.daemon = True
+        p.start()
+        p.join(1)
+        exit_code = p.exitcode
+        self.assertIsNotNone(
+            exit_code, "exception did not cause flowgraph exit")
+
+if __name__ == '__main__':
+    gr_unittest.run(test_uncaught_exception, "test_uncaught_exception.xml")

--- a/gnuradio-runtime/python/gnuradio/gr/top_block.py
+++ b/gnuradio-runtime/python/gnuradio/gr/top_block.py
@@ -94,12 +94,12 @@ class top_block(hier_block2):
     python subclassing.
     """
 
-    def __init__(self, name="top_block"):
+    def __init__(self, name="top_block", catch_exceptions=True):
         """
         Create a top block with a given name.
         """
         # not calling hier_block2.__init__, we set our own _impl
-        self._impl = top_block_swig(name)
+        self._impl = top_block_swig(name, catch_exceptions)
         self.handle_sigint = True
 
     def start(self, max_noutput_items=10000000):

--- a/gnuradio-runtime/swig/top_block.i
+++ b/gnuradio-runtime/swig/top_block.i
@@ -26,13 +26,13 @@ namespace gr {
   // Hack to have a Python shim implementation of gr.top_block
   // that instantiates one of these and passes through calls
   %rename(top_block_swig) make_top_block;
-  gr::top_block_sptr make_top_block(const std::string name)
+  gr::top_block_sptr make_top_block(const std::string name, bool catch_exceptions)
     throw (std::logic_error);
 
   class top_block : public gr::hier_block2
   {
   private:
-    top_block(const std::string &name);
+    top_block(const std::string &name, bool catch_exceptions=true);
 
   public:
     ~top_block();

--- a/gr-wxgui/grc/top_block_gui.py
+++ b/gr-wxgui/grc/top_block_gui.py
@@ -27,7 +27,8 @@ default_gui_size = (200, 100)
 class top_block_gui(gr.top_block):
 	"""gr top block with wx gui app and grid sizer."""
 
-	def __init__(self, title='', size=default_gui_size):
+	def __init__(self, title='', size=default_gui_size,
+			catch_exceptions=True):
 		"""
 		Initialize the gr top block.
 		Create the wx gui elements.
@@ -38,7 +39,7 @@ class top_block_gui(gr.top_block):
 		    icon: the file path to an icon or None
 		"""
 		#initialize
-		gr.top_block.__init__(self)
+		gr.top_block.__init__(self, catch_exceptions=catch_exceptions)
 		self._size = size
 		#create gui elements
 		self._app = wx.App()

--- a/grc/blocks/options.xml
+++ b/grc/blocks/options.xml
@@ -241,6 +241,22 @@ part#slurp
 		<tab>Advanced</tab>
 	</param>
 	<param>
+		<name>Catch Block Exceptions</name>
+		<key>catch_exceptions</key>
+		<value>1</value>
+		<type>enum</type>
+		<hide>part</hide>
+		<option>
+			<name>Off</name>
+			<key></key>
+		</option>
+		<option>
+			<name>On</name>
+			<key>1</key>
+		</option>
+		<tab>Advanced</tab>
+	</param>
+	<param>
 		<name>Run Command</name>
 		<key>run_command</key>
 		<value>{python} -u {filename}</value>

--- a/grc/core/generator/flow_graph.tmpl
+++ b/grc/core/generator/flow_graph.tmpl
@@ -76,6 +76,7 @@ $imp
 ##  Setup the IO signature (hier block only).
 ########################################################
 #set $class_name = $flow_graph.get_option('id')
+#set $catch_exceptions = bool($flow_graph.get_option('catch_exceptions'))
 #set $param_str = ', '.join(['self'] + ['%s=%s'%(param.get_id(), param.get_make()) for param in $parameters])
 #if $generate_options == 'wx_gui'
     #import gtk
@@ -85,7 +86,7 @@ $imp
 class $(class_name)(grc_wxgui.top_block_gui):
 
     def __init__($param_str):
-        grc_wxgui.top_block_gui.__init__(self, title="$title")
+        grc_wxgui.top_block_gui.__init__(self, title="$title", catch_exceptions=$catch_exceptions)
     #if $icon
         _icon_path = "$icon.get_filename()"
         self.SetIcon(wx.Icon(_icon_path, wx.BITMAP_TYPE_ANY))
@@ -97,7 +98,7 @@ from gnuradio import qtgui
 class $(class_name)(gr.top_block, Qt.QWidget):
 
     def __init__($param_str):
-        gr.top_block.__init__(self, "$title")
+        gr.top_block.__init__(self, "$title", catch_exceptions=$catch_exceptions)
         Qt.QWidget.__init__(self)
         self.setWindowTitle("$title")
         qtgui.util.check_set_qss()
@@ -124,7 +125,7 @@ class $(class_name)(gr.top_block, Qt.QWidget):
 
 class $(class_name)(gr.top_block):
     def __init__(self, doc):
-        gr.top_block.__init__(self, "$title")
+        gr.top_block.__init__(self, "$title", catch_exceptions=$catch_exceptions)
         self.doc = doc
         self.plot_lst = []
         self.widget_lst = []
@@ -134,7 +135,7 @@ class $(class_name)(gr.top_block):
 class $(class_name)(gr.top_block):
 
     def __init__($param_str):
-        gr.top_block.__init__(self, "$title")
+        gr.top_block.__init__(self, "$title", catch_exceptions=$catch_exceptions)
 #elif $generate_options.startswith('hb')
     #set $in_sigs = $flow_graph.get_hier_block_stream_io('in')
     #set $out_sigs = $flow_graph.get_hier_block_stream_io('out')


### PR DESCRIPTION
This commit removes the catch statements from thread_body_wrapper.h. Currently, a single block in a flowgraph may throw an exception and stop functioning, but the only indication
of this to the user is printing the exception's `what()` to stderr. This leaves a zombie flowgraph with at least one block which is nonfunctional, which seems like behavior that is never desirable. As far as I can tell, the only mechanism for recovering from such a state is to lock the flowgraph and manually replace the broken block, which is a difficult pattern to implement.

With this patch, the process will terminate immediately, which I think will make "production" usage of GNU Radio more practical, as it allows for other process management tools like systemd to restart a crashed application.

Additionally, the uncaught exception will call `std::terminate`, which by default will still print the exception's `what()`, so debugging information is not lost. I've got another [PR](https://github.com/gnuradio/gnuradio/pull/1894) following this one that adds a `terminate_handler` to ensure that any exceptions get information about them printed and optionally print a backtrace. 