### PR TITLE
ctrlport: Remove superfluous 'import exceptions'

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/GNURadioControlPortClient.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/GNURadioControlPortClient.py
@@ -30,8 +30,6 @@ is currently the only supported transport.
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import exceptions
-
 """
 GNURadioControlPortClient is the main class for creating a GNU Radio
 ControlPort client application for all transports.
@@ -131,4 +129,4 @@ class GNURadioControlPortClient(object):
                     blockingcallback()
         else:
             print(("Unsupported RPC method: ", rpcmethod))
-            raise exceptions.ValueError()
+            raise ValueError()

--- a/gnuradio-runtime/python/gnuradio/ctrlport/RPCConnection.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/RPCConnection.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #
 # Copyright 2015 Free Software Foundation, Inc.
 #
@@ -18,9 +17,6 @@ from __future__ import unicode_literals
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-
-import exceptions
-
 """
 RPCMethods is a dictionary listing RPC transports currently supported
 by this client.
@@ -30,6 +26,8 @@ Args:
     excluded_args: function arguments that are NOT to be added to the dictionary (sequence of strings)
     options: result of command argument parsing (optparse.Values)
 """
+
+from __future__ import unicode_literals
 
 RPCMethods = {'thrift': 'Apache Thrift',
              #'ice': 'Zeroc ICE'
@@ -95,25 +93,25 @@ class RPCConnection(object):
         return self.port
 
     def newConnection(self, host=None, port=None):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def properties(self, *args):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def getKnobs(self, *args):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def getRe(self,*args):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def postMessage(self,*args):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def setKnobs(self,*args):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def shutdown(self):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()
 
     def printProperties(self, props):
-        raise exceptions.NotImplementedError()
+        raise NotImplementedError()


### PR DESCRIPTION
It's not needed, not even with Python 2.7. It will fail with Python 3,
though.