### PR TITLE
Fixed out-of-bound vector acces in PMT (maint-3.7 edition)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/pycallback_object.h
+++ b/gnuradio-runtime/include/gnuradio/pycallback_object.h
@@ -46,13 +46,13 @@ public:
 template<>
 pmt::pmt_t pmt_assist<std::vector<float> >::make(std::vector<float> _val)
 {
-  return pmt::init_f32vector(_val.size(), &_val[0]);
+  return pmt::init_f32vector(_val.size(), _val);
 }
 
 template<>
 pmt::pmt_t pmt_assist<std::vector<gr_complex> >::make(std::vector<gr_complex> _val)
 {
-  return pmt::init_c32vector(_val.size(), &_val[0]);
+  return pmt::init_c32vector(_val.size(), _val);
 }
 
 template <class myType> class pycallback_object

--- a/gnuradio-runtime/lib/pmt/unv_template.cc.t
+++ b/gnuradio-runtime/lib/pmt/unv_template.cc.t
@@ -21,7 +21,8 @@ pmt_@TAG@vector::pmt_@TAG@vector(size_t k, @TYPE@ fill)
 pmt_@TAG@vector::pmt_@TAG@vector(size_t k, const @TYPE@ *data)
   : d_v(k)
 {
-  memcpy( &d_v[0], data, k * sizeof(@TYPE@) );
+  if(k)
+    memcpy( &d_v[0], data, k * sizeof(@TYPE@) );
 }
 
 @TYPE@
@@ -44,28 +45,28 @@ const @TYPE@ *
 pmt_@TAG@vector::elements(size_t &len)
 {
   len = length();
-  return &d_v[0];
+  return len ?  &d_v[0] : NULL;
 }
 
 @TYPE@ *
 pmt_@TAG@vector::writable_elements(size_t &len)
 {
   len = length();
-  return &d_v[0];
+  return len ? &d_v[0] : NULL;
 }
 
 const void*
 pmt_@TAG@vector::uniform_elements(size_t &len)
 {
   len = length() * sizeof(@TYPE@);
-  return &d_v[0];
+  return len ? &d_v[0] : NULL;
 }
 
 void*
 pmt_@TAG@vector::uniform_writable_elements(size_t &len)
 {
   len = length() * sizeof(@TYPE@);
-  return &d_v[0];
+  return len ? (&d_v[0]) : NULL;
 }
 
 bool
@@ -89,8 +90,10 @@ init_@TAG@vector(size_t k, const @TYPE@ *data)
 pmt_t
 init_@TAG@vector(size_t k, const std::vector< @TYPE@ > &data)
 {
-
-  return pmt_t(new pmt_@TAG@vector(k, &data[0]));
+  if(k) {
+    return pmt_t(new pmt_@TAG@vector(k, &data[0]));
+  }
+  return pmt_t(new pmt_@TAG@vector(k, static_cast< @TYPE@ >(0))); // fills an empty vector with 0
 }
 
 @TYPE@


### PR DESCRIPTION
adresses cases where initialization of uvec happened with empty
`std::vector`, as well as when getting the address of the first element
of an empty uvec, lead to undefined behaviour through doing `vec[0]` for
empty `vec`.

This commit, unlike the similar commit of the same message, uses `NULL`
in case of `nullptr` (maint-3.7 doesn't require C++11).