### PR TITLE
Cosmetic change to additive_scrambler_bb_impl.cc

### DIFF
--- a/gr-digital/lib/additive_scrambler_bb_impl.cc
+++ b/gr-digital/lib/additive_scrambler_bb_impl.cc
@@ -100,7 +100,7 @@ namespace gr {
 	  int reset_pos = tags[i].offset - nitems_read(0);
 	  if (reset_pos < reset_index && reset_pos > last_reset_index) {
 	    reset_index = reset_pos;
-	  };
+	  }
 	}
       } else {
 	if (last_reset_index == -1) {


### PR DESCRIPTION
There was a stray semicolon (line #103) on the closing brace of an if-block. Just an extra null statement after the if, so not a functional change.