### PR TITLE
cmake: Bump required version for thrift to 0.11.0

### DIFF
--- a/cmake/Modules/FindThrift.cmake
+++ b/cmake/Modules/FindThrift.cmake
@@ -1,7 +1,7 @@
 INCLUDE(FindPkgConfig)
 PKG_CHECK_MODULES(PC_THRIFT thrift)
 
-set(THRIFT_REQ_VERSION "0.9.2")
+set(THRIFT_REQ_VERSION "0.11.0")
 
 # If pkg-config found Thrift and it doesn't meet our version
 # requirement, warn and exit -- does not cause an error; just doesn't


### PR DESCRIPTION
We require TRecursive.py from thrift and that only exists
starting with thrift 0.11.0 onwards.