### PR TITLE
make basic_block::alias() const

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -161,17 +161,17 @@ namespace gr {
     /*!
      * True if the block has an alias (see set_block_alias).
      */
-    bool alias_set() { return !d_symbol_alias.empty(); }
+    bool alias_set() const { return !d_symbol_alias.empty(); }
 
     /*!
      * Returns the block's alias as a string.
      */
-    std::string alias(){ return alias_set()?d_symbol_alias:symbol_name(); }
+    std::string alias() const { return alias_set()?d_symbol_alias:symbol_name(); }
 
     /*!
      * Returns the block's alias as PMT.
      */
-    pmt::pmt_t alias_pmt(){ return pmt::intern(alias()); }
+    pmt::pmt_t alias_pmt() const { return pmt::intern(alias()); }
 
     /*!
      * Set's a new alias for the block; also adds an entry into the


### PR DESCRIPTION
`basic_block::alias()` was not const, so I was unable to retrieve the alias of a block if I had only a const reference. This merge request fixes this. It should have no impact on any code.