### PR TITLE
grc: Un-hide option_attributes from rest of parameters

### DIFF
--- a/grc/core/blocks/virtual.py
+++ b/grc/core/blocks/virtual.py
@@ -45,7 +45,7 @@ class VirtualSink(Block):
         self.inputs_data = _build_ports(self.inputs, 'sink') if self.inputs else []
         self.outputs_data = _build_ports(self.outputs, 'source') if self.outputs else []
         self.parameters_data = _build_params(self.parameters or [],
-                                bool(self.inputs), bool(self.outputs), self.flags)
+                                bool(self.inputs), bool(self.outputs), self.flags, self.key)
 
         super(VirtualSink, self).__init__(parent, **kwargs)
         self.params['id'].hide = 'all'
@@ -78,7 +78,7 @@ class VirtualSource(Block):
         self.inputs_data = _build_ports(self.inputs, 'sink') if self.inputs else []
         self.outputs_data = _build_ports(self.outputs, 'source') if self.outputs else []
         self.parameters_data = _build_params(self.parameters or [],
-                                bool(self.inputs), bool(self.outputs), self.flags)
+                                bool(self.inputs), bool(self.outputs), self.flags, self.key)
 
         super(VirtualSource, self).__init__(parent, **kwargs)
         self.params['id'].hide = 'all'

--- a/grc/core/io/yaml.py
+++ b/grc/core/io/yaml.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 import six
 import yaml
 
+from ..params.param import attributed_str
 
 class GRCDumper(yaml.SafeDumper):
     @classmethod
@@ -79,6 +80,7 @@ GRCDumper.add_representer(ListFlowing, GRCDumper.represent_list_flowing)
 GRCDumper.add_representer(tuple, GRCDumper.represent_list)
 GRCDumper.add_representer(MultiLineString, GRCDumper.represent_ml_string)
 GRCDumper.add_representer(yaml.nodes.ScalarNode, lambda r, n: n)
+GRCDumper.add_representer(attributed_str, GRCDumper.represent_str)
 
 
 def dump(data, stream=None, **kwargs):

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -97,6 +97,9 @@ def validate_scalar(param):
 def validate_vector(param):
     # todo: check vector types
 
+    if param.get_evaluated() is None:
+        raise ValidateError('Expression {!r} is invalid for type{!r}.'.format(param.get_evaluated(), param.dtype))
+
     valid_types = Constants.PARAM_TYPE_MAP[param.dtype.split('_', 1)[0]]
     if not all(isinstance(item, valid_types) for item in param.get_evaluated()):
         raise ValidateError('Expression {!r} is invalid for type {!r}.'.format(

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -31,6 +31,7 @@ from ..utils.descriptors import Evaluated, EvaluatedEnum, setup_names
 from . import dtypes
 from .template_arg import TemplateArg
 
+attributed_str = type('attributed_str', (str,), {})
 
 @setup_names
 class Param(Element):
@@ -178,6 +179,10 @@ class Param(Element):
         # ID and Enum types (not evaled)
         #########################
         if dtype in ('id', 'stream_id') or self.is_enum():
+            if self.options.attributes:
+                expr = attributed_str(expr)
+                for key, value in self.options.attributes[expr].items():
+                    setattr(expr, key, value)
             return expr
 
         #########################


### PR DESCRIPTION
Following the discussion from https://github.com/gnuradio/gnuradio/issues/1912 and [this gist](https://gist.github.com/haakov/fb381bf3de1dd6a02b697c9d92d7dae5).

This fixes the problem with a lot of blocks having some of their parameters handled as `raw` while the parameter's `dtype` is in fact dependent on the block's chosen type. This happened because the namespace didn't contain the `option_attributes` when evaluating the block. 

I've given this fix its own PR because I'm only 90% sure this doesn't break anything.