### PR TITLE
grc: Added local namespace to eval() for var_value (next)

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -230,7 +230,7 @@ class FlowGraph(Element):
         if namespace is not None:
             return eval(expr, namespace, local_namespace)
         else:
-            return self._eval_cache.setdefault(expr, eval(expr, self.namespace))
+            return self._eval_cache.setdefault(expr, eval(expr, self.namespace, local_namespace))
 
     ##############################################
     # Add/remove stuff


### PR DESCRIPTION
Some variable blocks, like the filter taps, have more advanced `value`s than the 
good old `value: ${ value }`. One example: https://github.com/gnuradio/gnuradio/blob/201afd9a330adda44fcde41a36efce20f5a0b46d/gr-filter/grc/variable_band_reject_filter_taps.block.yml#L33-L34

This doesn't work, GRC refuses to generate, complaining that `gain` and the other variables are not defined. I'm not sure if this breaks anything, but this PR fixes the problem.

Please note that some variable blocks, like the Band Pass filter, will still not work since the `value` is depending on the `type`'s `option_attributes`, discussed in https://github.com/gnuradio/gnuradio/pull/1925.

@skoslowski, I'd appreciate your feedback on this :)