### PR TITLE
grc: make cache dumping compatible across Py2/Py3

### DIFF
--- a/grc/core/cache.py
+++ b/grc/core/cache.py
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 from io import open
 import json
@@ -73,8 +73,9 @@ class Cache(object):
             return
 
         logger.info('Saving %d entries to json cache', len(self.cache))
+        # Dumping to binary file is only supported for Python3 >= 3.6
         with open(self.cache_file, 'w', encoding='utf8') as cache_file:
-            json.dump(self.cache, cache_file)
+            cache_file.write(json.dumps(self.cache, ensure_ascii=False))
 
     def prune(self):
         for filename in (set(self.cache) - self._accessed_items):


### PR DESCRIPTION
A previous change made GRC incompatible with Python2
If we want to only support Python3 greater or equal Python3.6 I could even revert 
the previous change since Python3 only support binary file mode for json.dump since Python3.6