### PR TITLE
cmake: Bump required thrift version to 0.10.0

### DIFF
--- a/cmake/Modules/FindThrift.cmake
+++ b/cmake/Modules/FindThrift.cmake
@@ -1,7 +1,7 @@
 INCLUDE(FindPkgConfig)
 PKG_CHECK_MODULES(PC_THRIFT thrift)
 
-set(THRIFT_REQ_VERSION "0.9.2")
+set(THRIFT_REQ_VERSION "0.10.0")
 
 # If pkg-config found Thrift and it doesn't meet our version
 # requirement, warn and exit -- does not cause an error; just doesn't

--- a/docs/doxygen/other/ctrlport.dox
+++ b/docs/doxygen/other/ctrlport.dox
@@ -65,7 +65,7 @@ Thrift project.
 
 \subsection ctrlport_thrift Apache Thrift
 
-Current version support: >= 0.9.2
+Current version support: >= 0.10.0
 
 Apache Thrift is a middleware layer that defines interfaces of a
 program using its own Thrift language. GNU Radio's interface file is:
@@ -77,7 +77,7 @@ also defines a set of data structure Knobs to allow us to pass any
 type of data over the interfaces.
 
 To use Thrift in ControlPort requires a minimum Thrift version of
-0.9.0. If a Thrift version greater than or equal to this version is
+0.10.0. If a Thrift version greater than or equal to this version is
 not found, the Thrift backend to ControlPort will not be installed,
 through ControlPort itself still will be. During cmake configuration
 time, it prints out information about finding Thrift and requires:


### PR DESCRIPTION
For profiling with ControlPort GNU Radio uses features/components from thrift 0.10.0