### PR TITLE
swig: fix numpy int conversion on py3k

### DIFF
--- a/gnuradio-runtime/swig/gnuradio.i
+++ b/gnuradio-runtime/swig/gnuradio.i
@@ -83,6 +83,7 @@
 
 %begin %{
 #define SWIG_PYTHON_2_UNICODE
+#define SWIG_PYTHON_CAST_MODE
 %}
 
 #ifdef SWIGPYTHON


### PR DESCRIPTION
In Python2 numpy derives from the built-in fixed width integer type. In Py3k the integer type is variable width and thus NumPy does not derive its fixed-width types from it. 
As a result the numpy objects don't pass the PyLong_Check() necessary for conversion from Python to C/C++. 

Enabling SWIG_PYTHON_CAST_MODE enables casting by adding this code fragment: 
```
%#ifdef SWIG_PYTHON_CAST_MODE
  {
    int dispatch = 0;
    long v = PyInt_AsLong(obj);
    if (!PyErr_Occurred()) {
      if (val) *val = v;
      return SWIG_AddCast(SWIG_OK);
    } else {
      PyErr_Clear();
    }
    if (!dispatch) {
      double d;
      int res = SWIG_AddCast(SWIG_AsVal(double)(obj,&d));
      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
	if (val) *val = (long)(d);
	return res;
      }
    }
  }
%#endif
```

Withouth further investigation of sideeffects this skips the PyLong_Check by just using the PyInt_AsLong cast opportunistically on the given Python Object. Which should be ok since it checks for PyErr_Occurred() afterwards.