### PR TITLE
python: replace unfunctional old_div with functional code

### DIFF
--- a/gnuradio-runtime/lib/math/gen_sine_table.py
+++ b/gnuradio-runtime/lib/math/gen_sine_table.py
@@ -41,7 +41,7 @@ def gen_approx_table (f, nentries, min_x, max_x):
         a = (i * incx) + min_x
         b = ((i + 1) * incx) + min_x
         m = (f(b)-f(a)) / (b-a)
-        c = (3*a+b)*(f(a)-f(b))/(4*(b-a)) + (f(old_div((a+b) / 2) + f(a)),2)
+        c = (3*a+b)*(f(a)-f(b))/(4*(b-a)) + (f((a+b)/2) + f(a))//2
         abs_error = c+m*a-f(a)
         r.append ((m, c, abs_error))
     return r

--- a/gr-digital/examples/example_timing.py
+++ b/gr-digital/examples/example_timing.py
@@ -73,9 +73,8 @@ class example_timing(gr.top_block):
             self.taps = self.clk.taps()
             self.dtaps = self.clk.diff_taps()
 
-            self.delay = int(scipy.ceil((old_div((len(rrc_taps)-1) / 2 +
-                                         (len(self.taps[0])-1) / 2),float(sps)))) + 1
-
+            self.delay = int(scipy.ceil(((len(rrc_taps)-1)//2 +
+                                         (len(self.taps[0])-1)//2 )//float(sps))) + 1
 
             self.vsnk_err = blocks.vector_sink_f()
             self.vsnk_rat = blocks.vector_sink_f()

--- a/gr-digital/python/digital/gmsk.py
+++ b/gr-digital/python/digital/gmsk.py
@@ -93,7 +93,7 @@ class gmsk_mod(gr.hier_block2):
             raise TypeError("samples_per_symbol must be an integer >= 2, is %r" % (samples_per_symbol,))
 
         ntaps = 4 * samples_per_symbol                        # up to 3 bits in filter at once
-        sensitivity = (old_div(pi / 2), samples_per_symbol)        # phase change per bit = pi / 2
+        sensitivity = (pi / 2) / samples_per_symbol        # phase change per bit = pi / 2
 
         # Turn it into NRZ data.
         #self.nrz = digital.bytes_to_syms()
@@ -216,7 +216,7 @@ class gmsk_demod(gr.hier_block2):
         self._gain_omega = .25 * self._gain_mu * self._gain_mu        # critically damped
 
         # Demodulate FM
-        sensitivity = (old_div(pi / 2), samples_per_symbol)
+        sensitivity = (pi / 2) / samples_per_symbol
         self.fmdemod = analog.quadrature_demod_cf(1.0 / sensitivity)
 
         # the clock recovery block tracks the symbol clock and resamples as needed.

--- a/gr-digital/python/digital/ofdm_receiver.py
+++ b/gr-digital/python/digital/ofdm_receiver.py
@@ -69,7 +69,7 @@ class ofdm_receiver(gr.hier_block2):
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex), # Input signature
                                 gr.io_signature2(2, 2, gr.sizeof_gr_complex*occupied_tones, gr.sizeof_char)) # Output signature
 
-        bw = (old_div(float(occupied_tones) / float(fft_length)), 2.0)
+        bw = (float(occupied_tones) / float(fft_length)) / 2.0
         tb = bw*0.08
         chan_coeffs = filter.firdes.low_pass (1.0,                     # gain
                                               1.0,                     # sampling rate

--- a/gr-fec/python/fec/fec_test.py
+++ b/gr-fec/python/fec/fec_test.py
@@ -67,7 +67,7 @@ class fec_test(gr.hier_block2):
                                         ann=None, puncpat=puncpat,
                                         integration_period=10000, rotator=None)
 
-        noise = math.sqrt((10.0**(old_div(-esno / 10.0)),2.0))
+        noise = math.sqrt((10.0**(-esno / 10.0))/2.0)
         #self.fastnoise = analog.fastnoise_source_f(analog.GR_GAUSSIAN, noise, seed, 8192)
         self.fastnoise = analog.noise_source_f(analog.GR_GAUSSIAN, noise, seed)
         self.addnoise = blocks.add_ff(1)

--- a/gr-filter/python/filter/optfir.py
+++ b/gr-filter/python/filter/optfir.py
@@ -185,7 +185,7 @@ def stopband_atten_to_dev (atten_db):
 
 def passband_ripple_to_dev (ripple_db):
     """Convert passband ripple spec expressed in dB to an absolute value"""
-    return (10**(old_div(ripple_db / 20)-1),(10**(ripple_db / 20)+1))
+    return (10**(ripple_db / 20)-1)/(10**(ripple_db / 20)+1)
 
 # ----------------------------------------------------------------
 

--- a/gr-trellis/docs/test_tcm.py
+++ b/gr-trellis/docs/test_tcm.py
@@ -82,8 +82,8 @@ def main(args):
     Es = 0
     for i in range(len(constellation)):
         Es = Es + constellation[i]**2
-    Es = Es / (old_div(len(constellation,dimensionality)))
-    N0=Es / pow(10.0,old_div(esn0_db,10.0)); # noise variance
+    Es = Es / (len(constellation)//dimensionality)
+    N0=Es / pow(10.0,esn0_db/10.0); # noise variance
 
     tot_s=0
     terr_s=0

--- a/gr-trellis/examples/python/test_tcm.py
+++ b/gr-trellis/examples/python/test_tcm.py
@@ -99,8 +99,8 @@ def main():
     Es = 0
     for i in range(len(constellation)):
         Es = Es + constellation[i]**2
-    Es = Es / (old_div(len(constellation,dimensionality)))
-    N0=Es / pow(10.0,old_div(esn0_db,10.0)); # calculate noise variance
+    Es = Es / (len(constellation)//dimensionality)
+    N0=Es / pow(10.0,esn0_db/10.0); # calculate noise variance
 
     tot_b=0 # total number of transmitted bits
     terr_b=0 # total number of bits in error
@@ -112,7 +112,7 @@ def main():
         terr_p=terr_p+(e!=0)
         if ((i+1)%100==0) : # display progress
             print(i+1,terr_p, '%.2e' % ((1.0*terr_p) / (i+1)),tot_b,terr_b, '%.2e' % ((1.0*terr_b) / tot_b))
-	if e!=0:
+        if e!=0:
             print("rep=",i, e)
             for k in range(Kb):
                 if pattern[k]!=0:


### PR DESCRIPTION
a previous change to py3k introduced syntactically incorrect
`old_div` function calls. A replacement with `//` and `/` where applicable is
more appropriate.
Eventually `from __future__ import division` needs to be added as well to have
the "real" division also for integer values in python