### PR TITLE
Update param.py

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -359,7 +359,10 @@ class Param(Element):
         # Code Generation
         if tab:
             validate_tab()
-            layout = '{tab}_grid_layout_{index}'.format(tab=tab, index=index)
+            if pos =='':
+                layout = '{tab}_layout_{index}'.format(tab=tab, index=index)
+            else:
+                layout = '{tab}_grid_layout_{index}'.format(tab=tab, index=index)
         else:
             layout = 'top_grid_layout'
 


### PR DESCRIPTION
grc 3.8 should treat
    window@index or
    window@index :i,j,k,l
different like grc 3.7 does.