### PR TITLE
runtime: replace compile-time debugging option by GR_LOG_DEBUG()

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -153,6 +153,7 @@ namespace gr {
      * and never changes during the life of the block.
      */
     std::string symbol_name() const { return d_symbol_name; }
+    std::string identifier() const { return this->name() + "(" + std::to_string(this->unique_id()) + ")"; }
 
     gr::io_signature::sptr input_signature() const  { return d_input_signature; }
     gr::io_signature::sptr output_signature() const { return d_output_signature; }
@@ -392,7 +393,7 @@ namespace gr {
 
   inline std::ostream &operator << (std::ostream &os, basic_block_sptr basic_block)
   {
-    os << basic_block->name() << "(" << basic_block->unique_id() << ")";
+    os << basic_block->identifier();
     return os;
   }
 

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -897,6 +897,8 @@ namespace gr {
 	*/
    void clear_finished(){ d_finished = false; }
 
+   std::string identifier() const;
+
   };
 
   typedef std::vector<block_sptr> block_vector_t;

--- a/gnuradio-runtime/include/gnuradio/flowgraph.h
+++ b/gnuradio-runtime/include/gnuradio/flowgraph.h
@@ -45,8 +45,11 @@ namespace gr {
     endpoint(basic_block_sptr block, int port) { d_basic_block = block; d_port = port; }
     basic_block_sptr block() const { return d_basic_block; }
     int port() const { return d_port; }
+    std::string identifier() const {
+      return d_basic_block->alias() + ":" + std::to_string(d_port);
+    };
 
-    bool operator==(const endpoint &other) const;
+    bool operator==(const endpoint& other) const;
   };
 
   inline bool endpoint::operator==(const endpoint &other) const
@@ -71,6 +74,9 @@ namespace gr {
     pmt::pmt_t port() const { return d_port; }
     bool is_hier() const { return d_is_hier; }
     void set_hier(bool h) { d_is_hier = h; }
+    std::string identifier() const {
+      return d_basic_block->alias() + ":" + pmt::symbol_to_string(d_port);
+    }
 
     bool operator==(const msg_endpoint &other) const;
   };
@@ -99,6 +105,7 @@ namespace gr {
 
     const endpoint &src() const { return d_src; }
     const endpoint &dst() const { return d_dst; }
+    std::string identifier() const { return d_src.identifier() + "->" + d_dst.identifier(); }
 
   private:
     endpoint d_src;
@@ -123,6 +130,7 @@ namespace gr {
 
     const msg_endpoint &src() const { return d_src; }
     const msg_endpoint &dst() const { return d_dst; }
+    std::string identifier() const { return d_src.identifier() + "->" + d_dst.identifier(); }
 
   private:
     msg_endpoint d_src;
@@ -286,28 +294,28 @@ namespace gr {
   inline std::ostream&
   operator <<(std::ostream &os, const endpoint endp)
   {
-    os << endp.block()->alias() << ":" << endp.port();
+    os << endp.identifier();
     return os;
   }
 
   inline std::ostream&
   operator <<(std::ostream &os, const edge edge)
   {
-    os << edge.src() << "->" << edge.dst();
+    os << edge.identifier();
     return os;
   }
 
   inline std::ostream&
   operator <<(std::ostream &os, const msg_endpoint endp)
   {
-    os << endp.block()->alias() << ":" << pmt::symbol_to_string(endp.port());
+    os << endp.identifier();
     return os;
   }
 
   inline std::ostream&
   operator <<(std::ostream &os, const msg_edge edge)
   {
-    os << edge.src() << "->" << edge.dst();
+    os << edge.identifier();
     return os;
   }
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -903,10 +903,14 @@ namespace gr {
 #endif /* defined(GR_CTRLPORT) && defined(GR_PERFORMANCE_COUNTERS) */
   }
 
+  std::string block::identifier() const {
+    return d_name + "(" + std::to_string(d_unique_id) + ")";
+  }
+
   std::ostream&
   operator << (std::ostream& os, const block *m)
   {
-    os << "<block " << m->name() << " (" << m->unique_id() << ")>";
+    os << "<block " << m->identifier() << ">";
     return os;
   }
 


### PR DESCRIPTION
Add identifier() calls to flowgraph components to return a string with a human
readable string to reuse in both: the std::ostream overload and the logging system.