### PR TITLE
Style and indentation cleanup for YAML blocks (WIP)

### DIFF
--- a/gr-blocks/grc/blocks_burst_tagger.block.yml
+++ b/gr-blocks/grc/blocks_burst_tagger.block.yml
@@ -43,8 +43,10 @@ outputs:
 
 templates:
     imports: from gnuradio import blocks
-    make: "blocks.burst_tagger(${type.size})\nself.${id}.set_true_tag(${true_key},${true_value})\n\
-        self.${id}.set_false_tag(${false_key},${false_value})\n\t"
+    make: |-
+        blocks.burst_tagger(${type.size})
+        self.${id}.set_true_tag(${true_key},${true_value})
+        self.${id}.set_false_tag(${false_key},${false_value})
     callbacks:
     - set_true_tag(${true_key},${true_value})
     - set_false_tag(${false_key},${false_value})

--- a/gr-blocks/grc/blocks_stream_to_vector_decimator.block.yml
+++ b/gr-blocks/grc/blocks_stream_to_vector_decimator.block.yml
@@ -38,8 +38,12 @@ asserts:
 
 templates:
     imports: from gnuradio import blocks
-    make: "blocks.stream_to_vector_decimator(\n\titem_size=${type.size},\n\tsample_rate=${sample_rate},\n\
-        \tvec_rate=${vec_rate},\n\tvec_len=${vlen},\n)"
+    make: |-
+        blocks.stream_to_vector_decimator(
+            item_size=${type.size},
+            sample_rate=${sample_rate},
+            vec_rate=${vec_rate},
+            vec_len=${vlen})
     callbacks:
     - set_sample_rate(${sample_rate})
     - set_vec_rate(${vec_rate})

--- a/gr-blocks/grc/blocks_tag_debug.block.yml
+++ b/gr-blocks/grc/blocks_tag_debug.block.yml
@@ -46,7 +46,9 @@ asserts:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.tag_debug(${type.size}*${vlen}, ${name}, ${filter}); self.${id}.set_display(${display})
+    make: |-
+        blocks.tag_debug(${type.size}*${vlen}, ${name}, ${filter})
+        self.${id}.set_display(${display})
     callbacks:
     - set_display(${display})
 

--- a/gr-blocks/grc/blocks_transcendental.block.yml
+++ b/gr-blocks/grc/blocks_transcendental.block.yml
@@ -25,6 +25,6 @@ outputs:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.transcendental(${name}, "$type")
+    make: blocks.transcendental(${name}, "${type}")
 
 file_format: 1

--- a/gr-blocks/grc/xmlrpc_client.block.yml
+++ b/gr-blocks/grc/xmlrpc_client.block.yml
@@ -20,7 +20,7 @@ parameters:
 
 templates:
     imports: import xmlrpclib
-    make: xmlrpclib.Server('http://$(addr):$(port)')
+    make: xmlrpclib.Server('http://${addr}:${port}')
     callbacks:
     - ${callback}(${variable})
 

--- a/gr-channels/grc/channels_cfo_model.block.yml
+++ b/gr-channels/grc/channels_cfo_model.block.yml
@@ -34,8 +34,7 @@ templates:
                 ${srate},
                 ${stdev},
                 ${maxdev},
-                ${seed}
-        )
+                ${seed})
     callbacks:
     - set_std_dev(${stdev})
     - set_max_dev(${maxdev})

--- a/gr-channels/grc/channels_channel_model.block.yml
+++ b/gr-channels/grc/channels_channel_model.block.yml
@@ -44,9 +44,14 @@ templates:
     imports: |-
         from gnuradio import channels
         from gnuradio.filter import firdes
-    make: "channels.channel_model(\n\tnoise_voltage=${noise_voltage},\n\tfrequency_offset=${freq_offset},\n\
-        \tepsilon=${epsilon},\n\ttaps=${taps},\n\tnoise_seed=${seed},\n\tblock_tags=${block_tags}\n\
-        )"
+    make: |-
+        channels.channel_model(
+            noise_voltage=${noise_voltage},
+            frequency_offset=${freq_offset},
+            epsilon=${epsilon},
+            taps=${taps},
+            noise_seed=${seed},
+            block_tags=${block_tags})
     callbacks:
     - set_noise_voltage(${noise_voltage})
     - set_frequency_offset(${freq_offset})

--- a/gr-channels/grc/channels_channel_model2.block.yml
+++ b/gr-channels/grc/channels_channel_model2.block.yml
@@ -46,8 +46,13 @@ templates:
     imports: |-
         from gnuradio import channels
         from gnuradio.filter import firdes
-    make: "channels.channel_model2(\n\tnoise_voltage=${noise_voltage},\n\tepsilon=${epsilon},\n\
-        \ttaps=${taps},\n\tnoise_seed=${seed},\n\tblock_tags=${block_tags}\n)"
+    make: |-
+        channels.channel_model2(
+            noise_voltage=${noise_voltage},
+            epsilon=${epsilon},
+            taps=${taps},
+            noise_seed=${seed},
+            block_tags=${block_tags})
     callbacks:
     - set_noise_voltage(${noise_voltage})
     - set_taps(${taps})

--- a/gr-channels/grc/channels_dynamic_channel_model.block.yml
+++ b/gr-channels/grc/channels_dynamic_channel_model.block.yml
@@ -73,9 +73,22 @@ outputs:
 
 templates:
     imports: from gnuradio import channels
-    make: channels.dynamic_channel_model( ${samp_rate}, ${sro_stdev}, ${sro_maxdev},
-        ${cfo_stdev}, ${cfo_maxdev}, ${N}, ${fD}, ${LOS}, ${K}, ${delays}, ${mags},
-        ${ntaps}, ${noise_amp}, ${seed} )
+    make: |-
+        channels.dynamic_channel_model(
+            ${samp_rate}, 
+            ${sro_stdev}, 
+            ${sro_maxdev},
+            ${cfo_stdev}, 
+            ${cfo_maxdev}, 
+            ${N}, 
+            ${fD}, 
+            ${LOS}, 
+            ${K}, 
+            ${delays}, 
+            ${mags},
+            ${ntaps}, 
+            ${noise_amp}, 
+            ${seed})
     callbacks:
     - set_samp_rate(${samp_rate})
     - set_sro_dev_std(${sro_stdev})

--- a/gr-channels/grc/channels_sro_model.block.yml
+++ b/gr-channels/grc/channels_sro_model.block.yml
@@ -34,8 +34,7 @@ templates:
                 ${srate},
                 ${stdev},
                 ${maxdev},
-                ${seed}
-        )
+                ${seed})
     callbacks:
     - set_std_dev(${stdev})
     - set_max_dev(${maxdev})

--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -42,31 +42,17 @@ value: ${ digital.constellation_calcdist(const_points, sym_map, rot_sym, dims) i
 
 templates:
     imports: from gnuradio import digital
-    var_make: '
-
+    var_make: |-
         % if str(type) == "calcdist":
-
         self.${id} = ${id} = digital.constellation_calcdist(${const_points}, ${sym_map},
         ${rot_sym}, ${dims}).base()
-
         % else:
-
         self.${id} = ${id} = digital.constellation_${type}().base()
-
         % endif
-
-
-        % if str(soft_dec_lut).lower() == ''"auto"'' or str(soft_dec_lut).lower()
-        == "''auto''":
-
+        % if str(soft_dec_lut).lower() == ''"auto"'' or str(soft_dec_lut).lower() == "''auto''":
         self.${id}.gen_soft_dec_lut(${precision})
-
         % elif str(soft_dec_lut) != ''None'':
-
         self.${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision})
-
         % endif
-
-        '
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_modulator.block.yml
+++ b/gr-digital/grc/digital_constellation_modulator.block.yml
@@ -46,13 +46,12 @@ templates:
     imports: from gnuradio import digital
     make: |-
         digital.generic_mod(
-          constellation=${constellation},
-          differential=${differential},
-          samples_per_symbol=${samples_per_symbol},
-          pre_diff_code=True,
-          excess_bw=${excess_bw},
-          verbose=${verbose},
-          log=${log},
-          )
+            constellation=${constellation},
+            differential=${differential},
+            samples_per_symbol=${samples_per_symbol},
+            pre_diff_code=True,
+            excess_bw=${excess_bw},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_rect.block.yml
+++ b/gr-digital/grc/digital_constellation_rect.block.yml
@@ -46,20 +46,13 @@ value: ${ digital.constellation_rect(const_points, sym_map, rot_sym, real_sect, 
 
 templates:
     imports: from gnuradio import digital
-    var_make: 'self.${id} = ${id} = digital.constellation_rect(${const_points}, ${sym_map},
+    var_make: |-
+        self.${id} = ${id} = digital.constellation_rect(${const_points}, ${sym_map},
         ${rot_sym}, ${real_sect}, ${imag_sect}, ${w_real_sect}, ${w_imag_sect}).base()
-
-        % if str(soft_dec_lut).lower() == ''"auto"'' or str(soft_dec_lut).lower()
-        == "''auto''":
-
+        % if str(soft_dec_lut).lower() == ''"auto"'' or str(soft_dec_lut).lower() == "''auto''":
         self.${id}.gen_soft_dec_lut(${precision})
-
         % elif str(soft_dec_lut) != ''None'':
-
         self.${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision})
-
         % endif
-
-        '
 
 file_format: 1

--- a/gr-digital/grc/digital_dxpsk_demod.block.yml
+++ b/gr-digital/grc/digital_dxpsk_demod.block.yml
@@ -64,10 +64,16 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.${type}_demod(\n\tsamples_per_symbol=${samples_per_symbol},\n\t\
-        excess_bw=${excess_bw},\n\tfreq_bw=${freq_bw},\n\tphase_bw=${phase_bw},\n\t\
-        timing_bw=${timing_bw},\n\tmod_code=${mod_code},\n\tverbose=${verbose},\n\t\
-        log=${log}\n)"
+    make: |-
+        digital.${type}_demod(
+            samples_per_symbol=${samples_per_symbol},
+            excess_bw=${excess_bw},
+            freq_bw=${freq_bw},
+            phase_bw=${phase_bw},
+            timing_bw=${timing_bw},
+            mod_code=${mod_code},
+            verbose=${verbose},
+            log=${log})
     callbacks:
     - clock_recov.set_loop_bandwidth(${phase_bw})
     - time_recov.set_loop_bandwidth(${timing_bw})

--- a/gr-digital/grc/digital_dxpsk_mod.block.yml
+++ b/gr-digital/grc/digital_dxpsk_mod.block.yml
@@ -46,7 +46,12 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.${type}_mod(\n\tsamples_per_symbol=${samples_per_symbol},\n\texcess_bw=${excess_bw},\n\
-        \tmod_code=${mod_code},\n\tverbose=${verbose},\n\tlog=${log})\n\t"
+    make: |-
+        digital.${type}_mod(
+            samples_per_symbol=${samples_per_symbol},
+            excess_bw=${excess_bw},
+            mod_code=${mod_code},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_gfsk_demod.block.yml
+++ b/gr-digital/grc/digital_gfsk_demod.block.yml
@@ -51,8 +51,15 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.gfsk_demod(\n\tsamples_per_symbol=${samples_per_symbol},\n\tsensitivity=${sensitivity},\n\
-        \tgain_mu=${gain_mu},\n\tmu=${mu},\n\tomega_relative_limit=${omega_relative_limit},\n\
-        \tfreq_error=${freq_error},\n\tverbose=${verbose},\n\tlog=${log},\n)"
+    make: |-
+        digital.gfsk_demod(
+            samples_per_symbol=${samples_per_symbol},
+            sensitivity=${sensitivity},
+            gain_mu=${gain_mu},
+            mu=${mu},
+            omega_relative_limit=${omega_relative_limit},
+            freq_error=${freq_error},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_gfsk_mod.block.yml
+++ b/gr-digital/grc/digital_gfsk_mod.block.yml
@@ -39,7 +39,12 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.gfsk_mod(\n\tsamples_per_symbol=${samples_per_symbol},\n\tsensitivity=${sensitivity},\n\
-        \tbt=${bt},\n\tverbose=${verbose},\n\tlog=${log},\n)"
+    make: |-
+        digital.gfsk_mod(
+            samples_per_symbol=${samples_per_symbol},
+            sensitivity=${sensitivity},
+            bt=${bt},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_gmsk_demod.block.yml
+++ b/gr-digital/grc/digital_gmsk_demod.block.yml
@@ -47,8 +47,13 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.gmsk_demod(\n\tsamples_per_symbol=${samples_per_symbol},\n\tgain_mu=${gain_mu},\n\
-        \tmu=${mu},\n\tomega_relative_limit=${omega_relative_limit},\n\tfreq_error=${freq_error},\n\
-        \tverbose=${verbose},\n\tlog=${log},\n)"
+    make: |-
+        digital.gmsk_demod(
+            samples_per_symbol=${samples_per_symbol},
+            gain_mu=${gain_mu},
+            mu=${mu},
+            omega_relative_limit=${omega_relative_limit},
+            freq_error=${freq_error},
+            verbose=${verbose},log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_gmsk_mod.block.yml
+++ b/gr-digital/grc/digital_gmsk_mod.block.yml
@@ -35,7 +35,11 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.gmsk_mod(\n\tsamples_per_symbol=${samples_per_symbol},\n\tbt=${bt},\n\
-        \tverbose=${verbose},\n\tlog=${log},\n)"
+    make: |-
+        digital.gmsk_mod(
+            samples_per_symbol=${samples_per_symbol},
+            bt=${bt},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_header_payload_demux.block.yml
+++ b/gr-digital/grc/digital_header_payload_demux.block.yml
@@ -76,10 +76,18 @@ outputs:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.header_payload_demux(\n\t  ${header_len},\n\t  ${items_per_symbol},\n\
-        \t  ${guard_interval},\n\t  ${length_tag_key},\n\t  ${trigger_tag_key},\n\t\
-        \  ${output_symbols},\n\t  ${type.itemsize},\n\t  ${timing_tag_key},\n   \
-        \       ${samp_rate},\n          ${special_tags},\n          ${header_padding},\n\
-        \    )"
+    make: |-
+        digital.header_payload_demux(
+            ${header_len},
+            ${items_per_symbol},
+            ${guard_interval},
+            ${length_tag_key},
+            ${trigger_tag_key},
+            ${output_symbols},
+            ${type.itemsize},
+            ${timing_tag_key},
+            ${samp_rate},
+            ${special_tags},
+            ${header_padding})
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_rx.block.yml
+++ b/gr-digital/grc/digital_ofdm_rx.block.yml
@@ -83,13 +83,29 @@ asserts:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.ofdm_rx(\n\t  fft_len=${fft_len}, cp_len=${cp_len},\n\t  frame_length_tag_key='frame_'+${packet_len_key},\n\
-        \t  packet_length_tag_key=${packet_len_key},\n\t  % if occupied_carriers:\n\
-        \t  occupied_carriers=${occupied_carriers},\n\t  % endif\n\t  % if pilot_carriers:\n\
-        \t  pilot_carriers=${pilot_carriers},\n\t  % endif\n\t  % if pilot_symbols:\n\
-        \t  pilot_symbols=${pilot_symbols},\n\t  % endif\n\t  % if sync_word1:\n\t\
-        \  sync_word1=${sync_word1},\n\t  % endif\n\t  % if sync_word2:\n\t  sync_word2=${sync_word2},\n\
-        \t  % endif\n\t  bps_header=${header_mod.bps},\n\t  bps_payload=${payload_mod.bps},\n\
-        \t  debug_log=${log},\n\t  scramble_bits=${scramble_bits}\n\t )"
+    make: |-
+        digital.ofdm_rx(
+            fft_len=${fft_len}, cp_len=${cp_len},
+            frame_length_tag_key='frame_'+${packet_len_key},
+            packet_length_tag_key=${packet_len_key},
+            % if occupied_carriers:
+            occupied_carriers=${occupied_carriers},
+            % endif
+            % if pilot_carriers:
+            pilot_carriers=${pilot_carriers},
+            % endif
+            % if pilot_symbols:
+            pilot_symbols=${pilot_symbols},
+            % endif
+            % if sync_word1:
+            sync_word1=${sync_word1},
+            % endif
+            % if sync_word2:
+            sync_word2=${sync_word2},
+            % endif
+            bps_header=${header_mod.bps},
+            bps_payload=${payload_mod.bps},
+            debug_log=${log},
+            scramble_bits=${scramble_bits})
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_tx.block.yml
+++ b/gr-digital/grc/digital_ofdm_tx.block.yml
@@ -88,13 +88,30 @@ asserts:
 
 templates:
     imports: from gnuradio import digital
-    make: "digital.ofdm_tx(\n\t  fft_len=${fft_len}, cp_len=${cp_len},\n\t  packet_length_tag_key=${packet_len_key},\n\
-        \t  % if occupied_carriers:\n\t  occupied_carriers=${occupied_carriers},\n\
-        \t  % endif\n\t  % if pilot_carriers:\n\t  pilot_carriers=${pilot_carriers},\n\
-        \t  % endif\n\t  % if pilot_carriers:\n\t  pilot_symbols=${pilot_symbols},\n\
-        \t  % endif\n\t  % if sync_word1:\n\t  sync_word1=${sync_word1},\n\t  % endif\n\
-        \t  % if sync_word2:\n\t  sync_word2=${sync_word2},\n\t  % endif\n\t  bps_header=${header_mod.bps},\n\
-        \t  bps_payload=${payload_mod.bps},\n\t  rolloff=${rolloff},\n\t  debug_log=${log},\n\
-        \t  scramble_bits=${scramble_bits}\n\t )"
+    make: |-
+        digital.ofdm_tx(
+            fft_len=${fft_len}, 
+            cp_len=${cp_len},
+            packet_length_tag_key=${packet_len_key},
+            % if occupied_carriers:
+            occupied_carriers=${occupied_carriers},
+            % endif
+            % if pilot_carriers:
+            pilot_carriers=${pilot_carriers},
+            % endif
+            % if pilot_carriers:
+            pilot_symbols=${pilot_symbols},
+            % endif
+            % if sync_word1:
+            sync_word1=${sync_word1},
+            % endif
+            % if sync_word2:
+            sync_word2=${sync_word2},
+            % endif
+            bps_header=${header_mod.bps},
+            bps_payload=${payload_mod.bps},
+            rolloff=${rolloff}, 
+            debug_log=${log},
+            scramble_bits=${scramble_bits})
 
 file_format: 1

--- a/gr-digital/grc/digital_psk_demod.block.yml
+++ b/gr-digital/grc/digital_psk_demod.block.yml
@@ -65,15 +65,14 @@ templates:
     imports: from gnuradio import digital
     make: |-
         digital.psk.psk_demod(
-          constellation_points=${constellation_points},
-          differential=${differential},
-          samples_per_symbol=${samples_per_symbol},
-          excess_bw=${excess_bw},
-          phase_bw=${phase_bw},
-          timing_bw=${timing_bw},
-          mod_code=${mod_code},
-          verbose=${verbose},
-          log=${log},
-          )
+            constellation_points=${constellation_points},
+            differential=${differential},
+            samples_per_symbol=${samples_per_symbol},
+            excess_bw=${excess_bw},
+            phase_bw=${phase_bw},
+            timing_bw=${timing_bw},
+            mod_code=${mod_code},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_psk_mod.block.yml
+++ b/gr-digital/grc/digital_psk_mod.block.yml
@@ -53,13 +53,12 @@ templates:
     imports: from gnuradio import digital
     make: |-
         digital.psk.psk_mod(
-          constellation_points=${constellation_points},
-          mod_code=${mod_code},
-          differential=${differential},
-          samples_per_symbol=${samples_per_symbol},
-          excess_bw=${excess_bw},
-          verbose=${verbose},
-          log=${log},
-          )
+            constellation_points=${constellation_points},
+            mod_code=${mod_code},
+            differential=${differential},
+            samples_per_symbol=${samples_per_symbol},
+            excess_bw=${excess_bw},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_qam_demod.block.yml
+++ b/gr-digital/grc/digital_qam_demod.block.yml
@@ -65,16 +65,15 @@ templates:
     imports: from gnuradio import digital
     make: |-
         digital.qam.qam_demod(
-          constellation_points=${constellation_points},
-          differential=${differential},
-          samples_per_symbol=${samples_per_symbol},
-          excess_bw=${excess_bw},
-          freq_bw=${freq_bw},
-          timing_bw=${timing_bw},
-          phase_bw=${phase_bw},
-          mod_code=${mod_code},
-          verbose=${verbose},
-          log=${log},
-          )
+            constellation_points=${constellation_points},
+            differential=${differential},
+            samples_per_symbol=${samples_per_symbol},
+            excess_bw=${excess_bw},
+            freq_bw=${freq_bw},
+            timing_bw=${timing_bw},
+            phase_bw=${phase_bw},
+            mod_code=${mod_code},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_qam_mod.block.yml
+++ b/gr-digital/grc/digital_qam_mod.block.yml
@@ -53,13 +53,12 @@ templates:
     imports: from gnuradio import digital
     make: |-
         digital.qam.qam_mod(
-          constellation_points=${constellation_points},
-          mod_code=${mod_code},
-          differential=${differential},
-          samples_per_symbol=${samples_per_symbol},
-          excess_bw=${excess_bw},
-          verbose=${verbose},
-          log=${log},
-          )
+            constellation_points=${constellation_points},
+            mod_code=${mod_code},
+            differential=${differential},
+            samples_per_symbol=${samples_per_symbol},
+            excess_bw=${excess_bw},
+            verbose=${verbose},
+            log=${log})
 
 file_format: 1

--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -97,9 +97,19 @@ templates:
     imports: |-
         from gnuradio import digital
         from gnuradio import filter
-    make: digital.symbol_sync_${type}(${ted_type}, ${sps}, ${loop_bw}, ${damping},
-        ${ted_gain}, ${max_dev}, ${osps}, ${constellation}, ${resamp_type}, ${nfilters},
-        ${pfb_mf_taps})
+    make: |-
+        digital.symbol_sync_${type}(
+            ${ted_type}, 
+            ${sps}, 
+            ${loop_bw}, 
+            ${damping},
+            ${ted_gain}, 
+            ${max_dev}, 
+            ${osps}, 
+            ${constellation}, 
+            ${resamp_type}, 
+            ${nfilters},
+            ${pfb_mf_taps})
     callbacks:
     - set_loop_bandwidth(${loop_bw})
     - set_damping_factor(${damping})

--- a/gr-digital/grc/variable_header_format_default.block.yml
+++ b/gr-digital/grc/variable_header_format_default.block.yml
@@ -18,8 +18,13 @@ value: ${ digital.header_format_default(access_code, threshold, bps) }
 
 templates:
     imports: from gnuradio import digital
-    var_make: "\n% if int(access_code)==0 #:\nself.${id} = ${id} = digital.header_format_default(digital.packet_utils.default_access_code,\
-        \ ${threshold}, ${bps})\n% else:\nself.${id} = ${id} = digital.header_format_default(${access_code},\
-        \ ${threshold}, ${bps})\n% endif\n  "
+    var_make: |-
+        % if int(access_code)==0:
+        self.${id} = ${id} = digital.header_format_default(digital.packet_utils.default_access_code,\
+        ${threshold}, ${bps})
+        % else:
+        self.${id} = ${id} = digital.header_format_default(${access_code},\
+        ${threshold}, ${bps})
+        % endif
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvb_bbheader_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_bbheader_bb.block.yml
@@ -143,12 +143,33 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvb_bbheader_bb(${standard.val}, \n% if str(standard) == 'STANDARD_DVBT2':\n\
-        ${framesize1.val}, \n% else:\n${framesize2.val}, \n% endif\n% if str(standard)\
-        \ == 'STANDARD_DVBT2':\n% if str(framesize1) == 'FECFRAME_NORMAL':\n${rate1.val},\
-        \ \n% else:\n${rate2.val}, \n% endif\n% else:\n% if str(framesize2) == 'FECFRAME_NORMAL':\n\
-        ${rate3.val}, \n% elif str(framesize2) == 'FECFRAME_MEDIUM':\n${rate4.val},\
-        \ \n% else:\n${rate5.val}, \n% endif\n% endif\n${rolloff.val}, ${mode.val},\
-        \ ${inband.val}, ${fecblocks}, ${tsrate})"
+    make: |-
+        dtv.dvb_bbheader_bb(
+        ${standard.val},
+        % if str(standard) == 'STANDARD_DVBT2':
+        ${framesize1.val},
+        % else:
+        ${framesize2.val},
+        % endif
+        % if str(standard) == 'STANDARD_DVBT2':
+        % if str(framesize1) == 'FECFRAME_NORMAL':
+        ${rate1.val},
+        % else:
+        ${rate2.val},
+        % endif
+        % else:
+        % if str(framesize2) == 'FECFRAME_NORMAL':
+        ${rate3.val},
+        % elif str(framesize2) == 'FECFRAME_MEDIUM':
+        ${rate4.val},
+        % else:
+        ${rate5.val},
+        % endif
+        % endif
+        ${rolloff.val},
+        ${mode.val},
+        ${inband.val},
+        ${fecblocks},
+        ${tsrate})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvb_bbscrambler_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_bbscrambler_bb.block.yml
@@ -108,11 +108,29 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvb_bbscrambler_bb(${standard.val}, \n% if str(standard) == 'STANDARD_DVBT2':\n\
-        ${framesize1.val}, \n% else:\n${framesize2.val}, \n% endif\n% if str(standard)\
-        \ == 'STANDARD_DVBT2':\n% if str(framesize1) == 'FECFRAME_NORMAL':\n${rate1.val}\n\
-        % else:\n${rate2.val}\n% endif\n% else:\n% if str(framesize2) == 'FECFRAME_NORMAL':\n\
-        ${rate3.val}\n% elif str(framesize2) == 'FECFRAME_MEDIUM':\n${rate4.val}\n\
-        % else:\n${rate5.val}\n% endif\n% endif\n)"
+    make: |-
+        dtv.dvb_bbscrambler_bb(
+            ${standard.val},
+            % if str(standard) == 'STANDARD_DVBT2':
+            ${framesize1.val},
+            % else:
+            ${framesize2.val},
+            % endif
+            % if str(standard) == 'STANDARD_DVBT2':
+            % if str(framesize1) == 'FECFRAME_NORMAL':
+            ${rate1.val}
+            % else:
+            ${rate2.val}
+            % endif
+            % else:
+            % if str(framesize2) == 'FECFRAME_NORMAL':
+            ${rate3.val}
+            % elif str(framesize2) == 'FECFRAME_MEDIUM':
+            ${rate4.val}
+            % else:
+            ${rate5.val}
+            % endif
+            % endif
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvb_bch_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_bch_bb.block.yml
@@ -108,11 +108,29 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvb_bch_bb(${standard.val}, \n% if str(standard) == 'STANDARD_DVBT2':\n\
-        ${framesize1.val}, \n% else:\n${framesize2.val}, \n% endif\n% if str(standard)\
-        \ == 'STANDARD_DVBT2':\n% if str(framesize1) == 'FECFRAME_NORMAL':\n${rate1.val}\n\
-        % else:\n${rate2.val}\n% endif\n% else:\n% if str(framesize2) == 'FECFRAME_NORMAL':\n\
-        ${rate3.val}\n% elif str(framesize2) == 'FECFRAME_MEDIUM':\n${rate4.val}\n\
-        % else:\n${rate5.val}\n% endif\n% endif\n)"
+    make: |-
+        dtv.dvb_bch_bb(
+            ${standard.val},
+            % if str(standard) == 'STANDARD_DVBT2':
+            ${framesize1.val},
+            % else:
+            ${framesize2.val},
+            % endif
+            % if str(standard) == 'STANDARD_DVBT2':
+            % if str(framesize1) == 'FECFRAME_NORMAL':
+            ${rate1.val}
+            % else:
+            ${rate2.val}
+            % endif
+            % else:
+            % if str(framesize2) == 'FECFRAME_NORMAL':
+            ${rate3.val}
+            % elif str(framesize2) == 'FECFRAME_MEDIUM':
+            ${rate4.val}
+            % else:
+            ${rate5.val}
+            % endif
+            % endif
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvb_ldpc_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_ldpc_bb.block.yml
@@ -116,11 +116,29 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvb_ldpc_bb(${standard.val}, \n% if str(standard) == 'STANDARD_DVBT2':\n\
-        ${framesize1.val}, \n% else:\n${framesize2.val}, \n% endif\n% if str(standard)\
-        \ == 'STANDARD_DVBT2':\n% if str(framesize1) == 'FECFRAME_NORMAL':\n${rate1.val},\
-        \ \n% else:\n${rate2.val}, \n% endif\n% else:\n% if str(framesize2) == 'FECFRAME_NORMAL':\n\
-        ${rate3.val}, \n% elif str(framesize2) == 'FECFRAME_MEDIUM':\n${rate4.val},\
-        \ \n% else:\n${rate5.val}, \n% endif\n% endif\n${constellation.val})"
+    make: |-
+        dtv.dvb_ldpc_bb(
+            ${standard.val},
+            if str(standard) == 'STANDARD_DVBT2':
+            ${framesize1.val},
+            % else:
+            ${framesize2.val},
+            % endif
+            % if str(standard) == 'STANDARD_DVBT2':
+            % if str(framesize1) == 'FECFRAME_NORMAL':
+            ${rate1.val},
+            % else:
+            ${rate2.val},
+            % endif
+            % else:
+            % if str(framesize2) == 'FECFRAME_NORMAL':
+            ${rate3.val},
+            % elif str(framesize2) == 'FECFRAME_MEDIUM':
+            ${rate4.val},
+            % else:
+            ${rate5.val},
+            % endif
+            % endif
+            ${constellation.val})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbs2_interleaver_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvbs2_interleaver_bb.block.yml
@@ -79,8 +79,16 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbs2_interleaver_bb(${framesize.val}, \n% if str(framesize) == 'FECFRAME_NORMAL':\n\
-        ${rate1.val}, \n% elif str(framesize) == 'FECFRAME_MEDIUM':\n${rate2.val},\
-        \ \n% else:\n${rate3.val}, \n% endif\n${constellation.val})"
+    make: |-
+        dtv.dvbs2_interleaver_bb(
+            ${framesize.val},
+            % if str(framesize) == 'FECFRAME_NORMAL':
+            ${rate1.val},
+            % elif str(framesize) == 'FECFRAME_MEDIUM':
+            ${rate2.val},
+            % else:
+            ${rate3.val},
+            % endif
+            ${constellation.val})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbs2_modulator_bc.block.yml
+++ b/gr-dtv/grc/dtv_dvbs2_modulator_bc.block.yml
@@ -95,8 +95,17 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbs2_modulator_bc(${framesize.val},\n% if str(framesize) == 'FECFRAME_NORMAL':\n\
-        ${rate1.val}, \n% elif str(framesize) == 'FECFRAME_MEDIUM':\n${rate2.val},\
-        \ \n% else:\n${rate3.val}, \n% endif\n${constellation.val}, ${interpolation.val})"
+    make: |-
+        dtv.dvbs2_modulator_bc(
+            ${framesize.val},
+            % if str(framesize) == 'FECFRAME_NORMAL':
+            ${rate1.val},
+            % elif str(framesize) == 'FECFRAME_MEDIUM':
+            ${rate2.val},
+            % else:
+            ${rate3.val},
+            % endif
+            ${constellation.val},
+            ${interpolation.val})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbs2_physical_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbs2_physical_cc.block.yml
@@ -90,9 +90,18 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbs2_physical_cc(${framesize.val}, \n% if str(framesize) == 'FECFRAME_NORMAL':\n\
-        ${rate1.val}, \n% elif str(framesize) == 'FECFRAME_MEDIUM':\n${rate2.val},\
-        \ \n% else:\n${rate3.val}, \n% endif\n${constellation.val}, ${pilots.val},\
-        \ ${goldcode})"
+    make: |-
+        dtv.dvbs2_physical_cc(
+            ${framesize.val},
+            % if str(framesize) == 'FECFRAME_NORMAL':
+            ${rate1.val},
+            % elif str(framesize) == 'FECFRAME_MEDIUM':
+            ${rate2.val},
+            % else:
+            ${rate3.val},
+            % endif
+            ${constellation.val},
+            ${pilots.val},
+            ${goldcode})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt2_framemapper_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_framemapper_cc.block.yml
@@ -190,14 +190,43 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbt2_framemapper_cc(${framesize.val}, ${rate.val}, ${constellation.val},\
-        \ ${rotation.val}, ${fecblocks}, ${tiblocks}, ${carriermode.val}, \n% if str(version)\
-        \ == 'VERSION_111':\n${fftsize1.val}, \n% else:\n% if str(preamble2) == 'PREAMBLE_T2_SISO'\
-        \ or str(preamble2) == 'PREAMBLE_T2_MISO':\n${fftsize1.val}, \n% else:\n${fftsize2.val},\
-        \ \n% endif\n% endif\n${guardinterval.val}, ${l1constellation.val}, ${pilotpattern.val},\
-        \ ${t2frames}, ${numdatasyms}, \n% if str(version) == 'VERSION_111':\n${paprmode1.val},\
-        \ \n% else:\n${paprmode2.val}, \n% endif\n${version.val}, \n% if str(version)\
-        \ == 'VERSION_111':\n${preamble1.val}, \n% else:\n${preamble2.val}, \n% endif\n\
-        ${inputmode.val}, ${reservedbiasbits.val}, ${l1scrambled.val}, ${inband.val})"
+    make: |-
+        dtv.dvbt2_framemapper_cc(
+            ${framesize.val},
+            ${rate.val},
+            ${constellation.val},
+            ${rotation.val},
+            ${fecblocks},
+            ${tiblocks},
+            ${carriermode.val},
+            % if str(version) == 'VERSION_111':
+            ${fftsize1.val},
+            % else:
+            % if str(preamble2) == 'PREAMBLE_T2_SISO' or str(preamble2) == 'PREAMBLE_T2_MISO':
+            ${fftsize1.val},
+            % else:
+            ${fftsize2.val},
+            % endif
+            % endif
+            ${guardinterval.val},
+            ${l1constellation.val},
+            ${pilotpattern.val},
+            ${t2frames},
+            ${numdatasyms},
+            % if str(version) == 'VERSION_111':
+            ${paprmode1.val},
+            % else:
+            ${paprmode2.val},
+            % endif
+            ${version.val},
+            % if str(version) == 'VERSION_111':
+            ${preamble1.val},
+            % else:
+            ${preamble2.val},
+            % endif
+            ${inputmode.val},
+            ${reservedbiasbits.val},
+            ${l1scrambled.val},
+            ${inband.val})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt2_freqinterleaver_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_freqinterleaver_cc.block.yml
@@ -95,10 +95,24 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbt2_freqinterleaver_cc(${carriermode.val}, ${fftsize.val}, ${pilotpattern.val},\
-        \ ${guardinterval.val}, ${numdatasyms}, \n% if str(version) == 'VERSION_111':\n\
-        ${paprmode1.val}, \n% else:\n${paprmode2.val}, \n% endif\n${version.val},\
-        \ \n% if str(version) == 'VERSION_111':\n${preamble1.val}\n% else:\n${preamble2.val}\n\
-        % endif\n)"
+    make: |-
+        dtv.dvbt2_freqinterleaver_cc(
+            ${carriermode.val},
+            ${fftsize.val},
+            ${pilotpattern.val},
+            ${guardinterval.val},
+            ${numdatasyms},
+            % if str(version) == 'VERSION_111':
+            ${paprmode1.val},
+            % else:
+            ${paprmode2.val},
+            % endif
+            ${version.val},
+            % if str(version) == 'VERSION_111':
+            ${preamble1.val}
+            % else:
+            ${preamble2.val}
+            % endif
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt2_miso_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_miso_cc.block.yml
@@ -79,8 +79,18 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbt2_miso_cc(${carriermode.val}, ${fftsize.val}, ${pilotpattern.val},\
-        \ ${guardinterval.val}, ${numdatasyms}, \n% if str(version) == 'VERSION_111':\n\
-        ${paprmode1.val}, \n% else:\n${paprmode2.val}, \n% endif\n)"
+    make: |-
+        dtv.dvbt2_miso_cc(
+            ${carriermode.val},
+            ${fftsize.val},
+            ${pilotpattern.val},
+            ${guardinterval.val},
+            ${numdatasyms},
+            % if str(version) == 'VERSION_111':
+            ${paprmode1.val}
+            % else:
+            ${paprmode2.val}
+            % endif
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt2_p1insertion_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_p1insertion_cc.block.yml
@@ -96,11 +96,27 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbt2_p1insertion_cc(${carriermode.val}, \n% if str(version) == 'VERSION_111':\n\
-        ${fftsize1.val}, \n% else:\n% if str(preamble2) == 'PREAMBLE_T2_SISO' or str(preamble2)\
-        \ == 'PREAMBLE_T2_MISO':\n${fftsize1.val}, \n% else:\n${fftsize2.val}, \n\
-        % endif\n% endif\n${guardinterval.val}, ${numdatasyms}, \n% if str(version)\
-        \ == 'VERSION_111':\n${preamble1.val}, \n% else:\n${preamble2.val}, \n% endif\n\
-        ${showlevels.val}, ${vclip})"
+    make: |-
+        dtv.dvbt2_p1insertion_cc(
+            ${carriermode.val},
+            % if str(version) == 'VERSION_111':
+            ${fftsize1.val},
+            % else:
+            % if str(preamble2) == 'PREAMBLE_T2_SISO' or str(preamble2) == 'PREAMBLE_T2_MISO':
+            ${fftsize1.val},
+            % else:
+            ${fftsize2.val},
+            % endif
+            % endif
+            ${guardinterval.val},
+            ${numdatasyms},
+            % if str(version) == 'VERSION_111':
+            ${preamble1.val},
+            % else:
+            ${preamble2.val},
+            % endif
+            ${showlevels.val},
+            ${vclip}
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt2_paprtr_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_paprtr_cc.block.yml
@@ -97,9 +97,22 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbt2_paprtr_cc(${carriermode.val}, ${fftsize.val}, ${pilotpattern.val},\
-        \ ${guardinterval.val}, ${numdatasyms}, \n% if str(version) == 'VERSION_111':\n\
-        ${paprmode1.val}, \n% else:\n${paprmode2.val}, \n% endif\n${version.val},\
-        \ ${vclip}, ${iterations}, ${fftsize.vlength})"
+    make: |-
+        dtv.dvbt2_paprtr_cc(
+            ${carriermode.val},
+            ${fftsize.val},
+            ${pilotpattern.val},
+            ${guardinterval.val},
+            ${numdatasyms},
+            % if str(version) == 'VERSION_111':
+            ${paprmode1.val},
+            % else:
+            ${paprmode2.val},
+            % endif
+            ${version.val},
+            ${vclip},
+            ${iterations},
+            ${fftsize.vlength}
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt2_pilotgenerator_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_pilotgenerator_cc.block.yml
@@ -128,10 +128,28 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: "dtv.dvbt2_pilotgenerator_cc(${carriermode.val}, ${fftsize.val}, ${pilotpattern.val},\
-        \ ${guardinterval.val}, ${numdatasyms}, \n% if str(version) == 'VERSION_111':\n\
-        ${paprmode1.val}, \n% else:\n${paprmode2.val}, \n% endif\n${version.val},\
-        \ \n% if str(version) == 'VERSION_111':\n${preamble1.val}, \n% else:\n${preamble2.val},\
-        \ \n% endif\n${misogroup.val}, ${equalization.val}, ${bandwidth.val}, ${fftsize.vlength})"
+    make: |-
+        dtv.dvbt2_pilotgenerator_cc(
+            ${carriermode.val},
+            ${fftsize.val},
+            ${pilotpattern.val},
+            ${guardinterval.val},
+            ${numdatasyms},
+            % if str(version) == 'VERSION_111':
+            ${paprmode1.val},
+            % else:
+            ${paprmode2.val},
+            % endif
+            ${version.val},
+            % if str(version) == 'VERSION_111':
+            ${preamble1.val},
+            % else:
+            ${preamble2.val},
+            % endif
+            ${misogroup.val},
+            ${equalization.val},
+            ${bandwidth.val},
+            ${fftsize.vlength}
+            )
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_demod_reference_signals.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_demod_reference_signals.block.yml
@@ -78,9 +78,18 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: dtv.dvbt_demod_reference_signals(${type.size}, ${transmission_mode.fft_length},
-        ${transmission_mode.payload_length}, ${constellation.val}, ${hierarchy.val},
-        ${code_rate_hp.val}, ${code_rate_lp.val}, ${guard_interval.val}, ${transmission_mode.val},
-        ${include_cell_id.val}, ${cell_id})
+    make: |-
+        dtv.dvbt_demod_reference_signals(
+            ${type.size},
+            ${transmission_mode.fft_length},
+            ${transmission_mode.payload_length},
+            ${constellation.val},
+            ${hierarchy.val},
+            ${code_rate_hp.val},
+            ${code_rate_lp.val},
+            ${guard_interval.val},
+            ${transmission_mode.val},
+            ${include_cell_id.val},
+            ${cell_id})
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_reference_signals.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_reference_signals.block.yml
@@ -78,9 +78,18 @@ outputs:
 
 templates:
     imports: from gnuradio import dtv
-    make: dtv.dvbt_reference_signals(${type.size}, ${transmission_mode.payload_length},
-        ${transmission_mode.fft_length}, ${constellation.val}, ${hierarchy.val}, ${code_rate_hp.val},
-        ${code_rate_lp.val}, ${guard_interval.val}, ${transmission_mode.val}, ${include_cell_id.val},
-        ${cell_id})
+    make: |-
+        dtv.dvbt_reference_signals(
+            ${type.size},
+            ${transmission_mode.payload_length},
+            ${transmission_mode.fft_length},
+            ${constellation.val},
+            ${hierarchy.val},
+            ${code_rate_hp.val},
+            ${code_rate_lp.val},
+            ${guard_interval.val},
+            ${transmission_mode.val},
+            ${include_cell_id.val},
+            ${cell_id})
 
 file_format: 1

--- a/gr-fec/grc/fec_bercurve_generator.block.yml
+++ b/gr-fec/grc/fec_bercurve_generator.block.yml
@@ -44,10 +44,15 @@ templates:
     imports: |-
         from gnuradio import fec
         import numpy
-    make: "fec.bercurve_generator(\n\t${encoder_list}, \\#size\n\t${decoder_list},\
-        \ \\#name\n\t${esno}, \\#range of esnos\n\t${samp_rate}, \\#throttle\n   \
-        \     ${threadtype}, \\#threading mode\n\t${puncpat}, \\#puncture pattern\n\
-        \        ${seed} \\# noise gen. seed\n)\n  "
+    make: |-
+        fec.bercurve_generator(
+            ${encoder_list}, #size
+            ${decoder_list}, #name
+            ${esno}, #range of esnos
+            ${samp_rate}, #throttle
+            ${threadtype}, #threading mode
+            ${puncpat}, #puncture pattern
+            ${seed}) # noise gen. seed
 
 documentation: |-
     Note that this block tries to launch many parallel codes to run simultaneously. Thus, it requires that the definitions for each encoder and decoder (specified in the "Encoder list" and "Decoder list") be configured with a parallelism > 0. If the parallelism for one of the encoder or decoder definition blocks is configured to 0, you will likely see an error like:

--- a/gr-fec/grc/ldpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/ldpc_decoder_def_list.block.yml
@@ -37,11 +37,14 @@ value: ${ value }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.ldpc_decoder.make(${file},\
-        \ ${sigma}, ${max_iter}); \n% elif int(ndim)==1 #:\nself.${id} = ${id} = map(\
-        \ (lambda a: fec.ldpc_decoder.make(${file}, ${sigma}, ${max_iter})), range(0,${dim1})\
-        \ ); \n% else:\nself.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.ldpc_decoder.make(${file},\
-        \ ${sigma}, ${max_iter})), range(0,${dim2}) ) ), range(0,${dim1})); \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.ldpc_decoder.make(${file}, ${sigma}, ${max_iter})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda a: fec.ldpc_decoder.make(${file}, ${sigma}, ${max_iter})), range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.ldpc_decoder.make(${file}, ${sigma}, ${max_iter})), range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 documentation: |-
     This is a soft-decision decoder that uses belief propagation (also known as message passing) that is described at:

--- a/gr-fec/grc/ldpc_encoder_def_list.block.yml
+++ b/gr-fec/grc/ldpc_encoder_def_list.block.yml
@@ -29,10 +29,13 @@ value: ${ fec.ldpc_encoder_make(file) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.ldpc_encoder_make(${file});\
-        \ \n% elif int(ndim)==1 #:\nself.${id} = ${id} = map( (lambda a: fec.ldpc_encoder_make(${file})),\
-        \ range(0,${dim1}) ); \n% else:\nself.${id} = ${id} = map( (lambda b: map(\
-        \ ( lambda a: fec.ldpc_encoder_make(${file})), range(0,${dim2}) ) ), range(0,${dim1}));\
-        \ \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.ldpc_encoder_make(${file})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda a: fec.ldpc_encoder_make(${file})), range(0,${dim1}) )
+        % else:
+        self.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.ldpc_encoder_make(${file})), range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 file_format: 1

--- a/gr-fec/grc/tpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_decoder_def_list.block.yml
@@ -60,14 +60,14 @@ value: ${ value }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.tpc_decoder_make(${row_poly},\
-        \ ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type});\
-        \ \n% elif int(ndim)==1 #:\nself.${id} = ${id} = map( (lambda a: fec.tpc_decoder_make(${row_poly},\
-        \ ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})),\
-        \ range(0,${dim1}) ); \n% else:\nself.${id} = ${id} = map( (lambda b: map(\
-        \ ( lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol},\
-        \ ${bval}, ${qval}, ${max_iter}, ${decoder_type})), range(0,${dim2}) ) ),\
-        \ range(0,${dim1})); \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})), range(0,${dim1}) )
+        % else:
+        self.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})), range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 documentation: |-
     This instantiates a 1-dim array or 2-dim array fo Turbo Product Encoders (TPC).

--- a/gr-fec/grc/tpc_encoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_encoder_def_list.block.yml
@@ -50,13 +50,14 @@ value: ${ value }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.tpc_encoder_make(${row_poly},\
-        \ ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}); \n% elif int(ndim)==1\
-        \ #:\nself.${id} = ${id} = map( (lambda a: fec.tpc_encoder_make(${row_poly},\
-        \ ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval})), range(0,${dim1}) ); \n\
-        % else:\nself.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.tpc_encoder_make(${row_poly},\
-        \ ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval})), range(0,${dim2}) ) ),\
-        \ range(0,${dim1})); \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.tpc_encoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda a: fec.tpc_encoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval})), range(0,${dim1}) )
+        % else:
+        self.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.tpc_encoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval})), range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 documentation: |-
     This instantiates a 1-dim array or 2-dim array fo Turbo Product Encoders (TPC).

--- a/gr-fec/grc/variable_cc_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_decoder_def_list.block.yml
@@ -62,14 +62,19 @@ value: ${ fec.cc_decoder.make(framebits, k, rate, polys, state_start, state_end,
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.cc_decoder.make(${framebits},\
-        \ ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding})\n\
-        % elif int(ndim)==1 #:\nself.${id} = ${id} = map( (lambda a: fec.cc_decoder.make(${framebits},\
-        \ ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding})),\
-        \ range(0,${dim1}) ); \n% else:\nself.${id} = ${id} = map( (lambda b: map(\
-        \ ( lambda a: fec.cc_decoder.make(${framebits}, ${k}, ${rate}, ${polys}, ${state_start},\
-        \ ${state_end}, ${mode}, ${padding})), range(0,${dim2}) ) ), range(0,${dim1}));\
-        \ \n% endif\n    "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.cc_decoder.make(${framebits},\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding})\
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda a: fec.cc_decoder.make(${framebits},\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${state_end}, ${mode}, ${padding})),\
+        range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map( (lambda b: map(\
+        ( lambda a: fec.cc_decoder.make(${framebits}, ${k}, ${rate}, ${polys}, ${state_start},\
+        ${state_end}, ${mode}, ${padding})), range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 documentation: ""
 

--- a/gr-fec/grc/variable_cc_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_encoder_def_list.block.yml
@@ -53,13 +53,18 @@ value: ${ fec.cc_encoder_make(framebits, k, rate, polys, state_start, mode, padd
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.cc_encoder_make(${framebits},\
-        \ ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})\n% elif int(ndim)==1\
-        \ #:\nself.${id} = ${id} = map( (lambda a: fec.cc_encoder_make(${framebits},\
-        \ ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})), range(0,${dim1})\
-        \ ); \n% else:\nself.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.cc_encoder_make(${framebits},\
-        \ ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})), range(0,${dim2})\
-        \ ) ), range(0,${dim1})); \n% endif\n    "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.cc_encoder_make(${framebits},\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda a: fec.cc_encoder_make(${framebits},\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})), range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.cc_encoder_make(${framebits},\
+        ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})), range(0,${dim2})\) ), 
+        range(0,${dim1}))
+        % endif
 
 documentation: ""
 

--- a/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
@@ -34,12 +34,19 @@ value: ${ fec.ccsds_encoder_make(framebits, state_start, mode) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.ccsds_encoder_make(${framebits},\
-        \ ${state_start}, ${mode})\n% elif int(ndim)==1 #:\nself.${id} = ${id} = map(\
-        \ (lambda a: fec.ccsds_encoder_make(${framebits}, ${state_start}, ${mode})),\
-        \ range(0,${dim1}) ); \n% else:\nself.${id} = ${id} = map( (lambda b: map(\
-        \ ( lambda a: fec.ccsds_encoder_make(${framebits}, ${state_start}, ${mode})),\
-        \ range(0,${dim2}) ) ), range(0,${dim1})); \n% endif\n    "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.ccsds_encoder_make(${framebits},\
+        ${state_start}, ${mode})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map(\
+        (lambda a: fec.ccsds_encoder_make(${framebits}, ${state_start}, ${mode})),\
+        range(0,${dim1}) )
+        % else:
+        self.${id} = ${id} = map( (lambda b: map(\
+        ( lambda a: fec.ccsds_encoder_make(${framebits}, ${state_start}, ${mode})),\
+        range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 documentation: ""
 

--- a/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
@@ -29,11 +29,16 @@ value: ${ fec.dummy_decoder.make(framebits) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.dummy_decoder.make(${framebits})\n\
-        % elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.dummy_decoder.make(${framebits})),\
-        \ range(0,${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.dummy_decoder.make(${framebits})), range(0,${dim2}))), range(0,${dim1}))\
-        \ \n% endif\n    "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.dummy_decoder.make(${framebits}) \
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.dummy_decoder.make(${framebits})),\
+        range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.dummy_decoder.make(${framebits})), range(0,${dim2}))), range(0,${dim1}))\
+        % endif
 
 documentation: ""
 

--- a/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
@@ -25,11 +25,16 @@ value: ${ fec.dummy_encoder_make(framebits) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.dummy_encoder_make(${framebits})\n\
-        % elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.dummy_encoder_make(${framebits})),\
-        \ range(0,${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.dummy_encoder_make(${framebits})), range(0,${dim2}))), range(0,${dim1}))\
-        \ \n% endif\n    "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.dummy_encoder_make(${framebits})\
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.dummy_encoder_make(${framebits})),\
+        range(0,${dim1})) 
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.dummy_encoder_make(${framebits})), range(0,${dim2}))), range(0,${dim1}))\
+        % endif
 
 documentation: ""
 

--- a/gr-fec/grc/variable_ldpc_bit_flip_decoder.block.yml
+++ b/gr-fec/grc/variable_ldpc_bit_flip_decoder.block.yml
@@ -32,12 +32,19 @@ value: ${ value }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(),\
-        \ ${max_iterations})\n% elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda\
-        \ a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), ${max_iterations})),\
-        \ range(0,${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), ${max_iterations})),\
-        \ range(0,${dim2}))), range(0,${dim1})) \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(),\
+        ${max_iterations})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda\
+        a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), ${max_iterations})),\
+        range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.ldpc_bit_flip_decoder.make(${matrix_object}.get_base_sptr(), ${max_iterations})),\
+        range(0,${dim2}))), range(0,${dim1}))
+        % endif
 
 documentation: |-
     This block creates a LDPC Bit Flip Decoder Definition variable.

--- a/gr-fec/grc/variable_ldpc_encoder_G.block.yml
+++ b/gr-fec/grc/variable_ldpc_encoder_G.block.yml
@@ -28,11 +28,16 @@ value: ${ value }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.ldpc_gen_mtrx_encoder_make(${G})\n\
-        % elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.ldpc_gen_mtrx_encoder_make(${G})),\
-        \ range(0,${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.ldpc_gen_mtrx_encoder_make(${G})), range(0,${dim2}))), range(0,${dim1}))\
-        \ \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.ldpc_gen_mtrx_encoder_make(${G})\
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.ldpc_gen_mtrx_encoder_make(${G})),\
+        range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.ldpc_gen_mtrx_encoder_make(${G})), range(0,${dim2}))), range(0,${dim1}))\
+        % endif
 
 documentation: |-
     Given a generator matrix in systematic form, G = [I|P], where I is the identity matrix and P is the parity submatrix, the information word s is encoded into a codeword x via:

--- a/gr-fec/grc/variable_ldpc_encoder_H.block.yml
+++ b/gr-fec/grc/variable_ldpc_encoder_H.block.yml
@@ -28,11 +28,16 @@ value: ${ value }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.ldpc_par_mtrx_encoder_make_H(${H})\n\
-        % elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.ldpc_par_mtrx_encoder_make_H(${H})),\
-        \ range(0,${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.ldpc_par_mtrx_encoder_make_H(${H})), range(0,${dim2}))), range(0,${dim1}))\
-        \ \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.ldpc_par_mtrx_encoder_make_H(${H})\
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.ldpc_par_mtrx_encoder_make_H(${H})),\
+        range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.ldpc_par_mtrx_encoder_make_H(${H})), range(0,${dim2}))), range(0,${dim1}))\
+        % endif
 
 documentation: |-
     This block creates a LDPC Encoder Definition variable.

--- a/gr-fec/grc/variable_polar_decoder_sc.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc.block.yml
@@ -34,12 +34,18 @@ value: ${ fec.polar_decoder_sc.make(block_size, num_info_bits, frozen_bit_positi
 
 templates:
     imports: from gnuradio import fec
-    var_make: "% if int(ndim)==0 #:\nself.${id} = ${id} = fec.polar_decoder_sc.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values}) \n% elif\
-        \ int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.polar_decoder_sc.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})), range(0,\
-        \ ${dim1}) ) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda a:\
-        \ fec.polar_decoder_sc.make(${block_size}, ${num_info_bits}, ${frozen_bit_positions},\
-        \ ${frozen_bit_values})), range(0, ${dim2}))), range(0, ${dim1})) \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.polar_decoder_sc.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.polar_decoder_sc.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})), range(0,\
+        ${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda a:\
+        fec.polar_decoder_sc.make(${block_size}, ${num_info_bits}, ${frozen_bit_positions},\
+        ${frozen_bit_values})), range(0, ${dim2}))), range(0, ${dim1}))
+        % endif
 
 file_format: 1

--- a/gr-fec/grc/variable_polar_decoder_sc_list.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc_list.block.yml
@@ -37,13 +37,19 @@ value: ${ fec.polar_decoder_sc_list.make(max_list_size, block_size, num_info_bit
 
 templates:
     imports: from gnuradio import fec
-    var_make: "% if int(ndim)==0 #:\nself.${id} = ${id} = fec.polar_decoder_sc_list.make(${max_list_size},\
-        \ ${block_size}, ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})\
-        \ \n% elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.polar_decoder_sc_list.make(${max_list_size},\
-        \ ${block_size}, ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})),\
-        \ range(0, ${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.polar_decoder_sc_list.make(${max_list_size}, ${block_size}, ${num_info_bits},\
-        \ ${frozen_bit_positions}, ${frozen_bit_values})), range(0, ${dim2}))), range(0,\
-        \ ${dim1})) \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.polar_decoder_sc_list.make(${max_list_size},\
+        ${block_size}, ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})\
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.polar_decoder_sc_list.make(${max_list_size},\
+        ${block_size}, ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values})),\
+        range(0, ${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.polar_decoder_sc_list.make(${max_list_size}, ${block_size}, ${num_info_bits},\
+        ${frozen_bit_positions}, ${frozen_bit_values})), range(0, ${dim2}))), range(0,\
+        ${dim1}))
+        % endif
 
 file_format: 1

--- a/gr-fec/grc/variable_polar_decoder_sc_systematic.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc_systematic.block.yml
@@ -31,12 +31,16 @@ value: ${ fec.polar_decoder_sc_systematic.make(block_size, num_info_bits, frozen
 
 templates:
     imports: from gnuradio import fec
-    var_make: "% if int(ndim)==0 #:\nself.${id} = ${id} = fec.polar_decoder_sc_systematic.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions}) \n% elif int(ndim)==1 #:\nself.${id}\
-        \ = ${id} = map((lambda a: fec.polar_decoder_sc_systematic.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim1}) ) \n% else:\n\
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.polar_decoder_sc_systematic.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.polar_decoder_sc_systematic.make(${block_size},\
+        \ ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim1}) )
+        % else:
         self.${id} = ${id} = map((lambda b: map((lambda a: fec.polar_decoder_sc_systematic.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim2}))), range(0,\
-        \ ${dim1})) \n% endif"
+        \ ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim2}))), range(0, ${dim1}))
+        % endif
 
 file_format: 1

--- a/gr-fec/grc/variable_polar_encoder.block.yml
+++ b/gr-fec/grc/variable_polar_encoder.block.yml
@@ -40,13 +40,18 @@ value: ${ fec.polar_encoder.make(block_size, num_info_bits, frozen_bit_positions
 
 templates:
     imports: from gnuradio import fec
-    var_make: "% if int(ndim)==0 #:\nself.${id} = ${id} = fec.polar_encoder.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values}, ${is_packed})\
-        \ \n% elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.polar_encoder.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values}, ${is_packed})),\
-        \ range(0, ${dim1})) \n% else:\nself.${id} = ${id} = map((lambda b: map((lambda\
-        \ a: fec.polar_encoder.make(${block_size}, ${num_info_bits}, ${frozen_bit_positions},\
-        \ ${frozen_bit_values}, ${is_packed})), range(0, ${dim2}))), range(0, ${dim1}))\
-        \ \n% endif"
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.polar_encoder.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values}, ${is_packed})\
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.polar_encoder.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values}, ${is_packed})),\
+        range(0, ${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda b: map((lambda\
+        a: fec.polar_encoder.make(${block_size}, ${num_info_bits}, ${frozen_bit_positions},\
+        ${frozen_bit_values}, ${is_packed})), range(0, ${dim2}))), range(0, ${dim1}))\
+        % endif
 
 file_format: 1

--- a/gr-fec/grc/variable_polar_encoder_systematic.block.yml
+++ b/gr-fec/grc/variable_polar_encoder_systematic.block.yml
@@ -26,17 +26,20 @@ parameters:
 -   id: frozen_bit_positions
     label: Frozen Bit Positions
     dtype: int_vector
-value: ${ fec.polar_encoder_systematic.make(block_size, num_info_bits, frozen_bit_positions)
-    }
+value: ${ fec.polar_encoder_systematic.make(block_size, num_info_bits, frozen_bit_positions) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "% if int(ndim)==0 #:\nself.${id} = ${id} = fec.polar_encoder_systematic.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions}) \n% elif int(ndim)==1 #:\nself.${id}\
-        \ = ${id} = map((lambda a: fec.polar_encoder_systematic.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim1})) \n% else:\n\
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.polar_encoder_systematic.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.polar_encoder_systematic.make(${block_size},\
+        ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim1}))
+        % else:
         self.${id} = ${id} = map((lambda b: map((lambda a: fec.polar_encoder_systematic.make(${block_size},\
-        \ ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim2}))), range(0,\
-        \ ${dim1})) \n% endif"
+        ${num_info_bits}, ${frozen_bit_positions})), range(0, ${dim2}))), range(0, ${dim1}))
+        % endif
 
 file_format: 1

--- a/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
@@ -37,12 +37,17 @@ value: ${ fec.repetition_decoder.make(framebits, rep, prob) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.repetition_decoder.make(${framebits},\
-        \ ${rep}, ${prob})\n% elif int(ndim)==1 #:\nself.${id} = ${id} = map( (lambda\
-        \ a: fec.repetition_decoder.make(${framebits}, ${rep}, ${prob})), range(0,${dim1})\
-        \ ) \n% else:\nself.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.repetition_decoder.make(${framebits},\
-        \ ${rep}, ${prob})), range(0,${dim2}) ) ), range(0,${dim1})) \n% endif\n \
-        \   "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.repetition_decoder.make(${framebits},\
+        ${rep}, ${prob})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map( (lambda\
+        a: fec.repetition_decoder.make(${framebits}, ${rep}, ${prob})), range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map( (lambda b: map( ( lambda a: fec.repetition_decoder.make(${framebits},\
+        ${rep}, ${prob})), range(0,${dim2}) ) ), range(0,${dim1}))
+        % endif
 
 documentation: ""
 

--- a/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
@@ -28,11 +28,17 @@ value: ${ fec.repetition_encoder_make(framebits, rep) }
 
 templates:
     imports: from gnuradio import fec
-    var_make: "\n% if int(ndim)==0 #:\nself.${id} = ${id} = fec.repetition_encoder_make(${framebits},\
-        \ ${rep})\n% elif int(ndim)==1 #:\nself.${id} = ${id} = map((lambda a: fec.repetition_encoder_make(${framebits},\
-        \ ${rep})), range(0,${dim1})) \n% else:\nself.${id} = ${id} = map((lambda\
-        \ b: map((lambda a: fec.repetition_encoder_make(${framebits}, ${rep})), range(0,${dim2}))),\
-        \ range(0,${dim1})) \n% endif\n    "
+    var_make: |-
+        % if int(ndim)==0:
+        self.${id} = ${id} = fec.repetition_encoder_make(${framebits}, ${rep})
+        % elif int(ndim)==1:
+        self.${id} = ${id} = map((lambda a: fec.repetition_encoder_make(${framebits},\
+        ${rep})), range(0,${dim1}))
+        % else:
+        self.${id} = ${id} = map((lambda\
+        b: map((lambda a: fec.repetition_encoder_make(${framebits}, ${rep})), range(0,${dim2}))),\
+        range(0,${dim1}))
+        % endif
 
 documentation: ""
 

--- a/gr-fft/grc/fft_logpwrfft_x.block.yml
+++ b/gr-fft/grc/fft_logpwrfft_x.block.yml
@@ -48,9 +48,14 @@ outputs:
 
 templates:
     imports: from gnuradio.fft import logpwrfft
-    make: "logpwrfft.logpwrfft_${type.fcn}(\n\tsample_rate=${sample_rate},\n\tfft_size=${fft_size},\n\
-        \tref_scale=${ref_scale},\n\tframe_rate=${frame_rate},\n\tavg_alpha=${avg_alpha},\n\
-        \taverage=${average},\n)"
+    make: |-
+        logpwrfft.logpwrfft_${type.fcn}(
+            sample_rate=${sample_rate},
+            fft_size=${fft_size},
+            ref_scale=${ref_scale},
+            frame_rate=${frame_rate},
+            avg_alpha=${avg_alpha},
+            average=${average})
     callbacks:
     - set_sample_rate(${sample_rate})
     - set_avg_alpha(${avg_alpha})

--- a/gr-filter/grc/filter_band_pass_filter.block.yml
+++ b/gr-filter/grc/filter_band_pass_filter.block.yml
@@ -71,7 +71,7 @@ templates:
     make: |-
         filter.${type}(
             ${ interp if str(type).startswith('interp') else decim },
-            firdes.type.fcn(
+            firdes.${type.fcn}(
                 ${gain},
                 ${samp_rate},
                 ${low_cutoff_freq},

--- a/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
@@ -62,8 +62,17 @@ templates:
         from gnuradio import filter
         from gnuradio.filter import firdes
     make: |-
-        filter.freq_xlating_fir_filter_${type}(${decim}, firdes.low_pass(
-            ${gain}, 2*${samp_rate}, ${cutoff_freq}, ${width}, ${win}, ${beta}), ${center_freq}, ${samp_rate})
+        filter.freq_xlating_fir_filter_${type}(
+            ${decim}, 
+            firdes.low_pass(
+                ${gain}, 
+                2*${samp_rate}, 
+                ${cutoff_freq}, 
+                ${width}, 
+                ${win}, 
+                ${beta}), 
+            ${center_freq}, 
+            ${samp_rate})
     callbacks:
     - set_taps(firdes.low_pass(${gain}, 2*${samp_rate}, ${cutoff_freq}, ${width},
         ${win}, ${beta}))

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -247,7 +247,7 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
             with open(filename) as ss:
                 self.setStyleSheet(ss.read())
         except Exception as e:
-            print >> sys.stderr, e
+            print(e, file=sys.stderr)
     % endif
 % endif
 ##
@@ -334,7 +334,7 @@ def main(top_block_cls=${class_name}, options=None):
     % endif
     % if flow_graph.get_option('realtime_scheduling'):
     if gr.enable_realtime_scheduling() != gr.RT_OK:
-        print "Error: failed to enable real-time scheduling."
+        print("Error: failed to enable real-time scheduling.")
     % endif
     % if generate_options == 'qt_gui':
 

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -156,7 +156,7 @@ class Param(Element):
             try:
                 validator(self)
             except dtypes.ValidateError as e:
-                self.add_error_message(e.message)
+                self.add_error_message(str(e))
 
     def get_evaluated(self):
         return self._evaluated


### PR DESCRIPTION
Contains fixes from recent GitHub issues. Also contains some further cleanup of YAML files, mostly getting rid of `\n` and `\t` from the `make` field. 