### PR TITLE
Executor.py: decode stdout as UTF-8

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -83,7 +83,7 @@ class ExecFlowGraphThread(threading.Thread):
         r = "\n"
         while r:
             GLib.idle_add(Messages.send_verbose_exec, r)
-            r = os.read(self.process.stdout.fileno(), 1024)
+            r = self.process.stdout.read(1024).decode('utf-8','ignore')
         self.process.poll()
         GLib.idle_add(self.done)
 


### PR DESCRIPTION
If the executed script sends some ( error ) messages you get a lot of error messages like

    Traceback (most recent call last):
      File "/usr/local/gnuradio/lib/python3.6/dist-packages/gnuradio/grc/core/Messages.py", line 117, in send_verbose_exec
        send(verbose)
       File "/usr/local/gnuradio/lib/python3.6/dist-packages/gnuradio/grc/core/Messages.py", line 52, in send
    messenger(_indent + message)
    TypeError: must be str, not bytes

But you don't find out the reason of this error. The return type of os.read seems to have changed between python 2.7 and python 3.
The decode function fixes this issue and you get valuable messages.