### PR TITLE
Qt Waterfall YAML: remove setters for absent properties

### DIFF
--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -252,8 +252,6 @@ templates:
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
-    - set_title(${which}, ${title})
-    - set_color(${which}, ${color})
     - set_intensity_range(${int_min}, ${int_max})
     make: |-
         <%


### PR DESCRIPTION
Building a waterfall sink fails with:

    Generate Error: (NameError('Undefined',), ['set_frequency_range(${fc}, ${bw})', 'set_update_time(${update_time})', 'set_title(${which}, 
    ${title})', 'set_color(${which}, ${color})', 'set_intensity_range(${int_min}, ${int_max})'])

as there does not exist a title nor a color value entry.