### PR TITLE
Force to update all affected elements

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -542,8 +542,12 @@ class Application(Gtk.Application):
                 while response == Gtk.ResponseType.APPLY:  # rerun the dialog if Apply was hit
                     response = self.dialog.run()
                     if response in (Gtk.ResponseType.APPLY, Gtk.ResponseType.ACCEPT):
-                        flow_graph_update()
                         page.state_cache.save_new_state(flow_graph.export_data())
+                        ### Following  lines force an complete update of io ports
+                        n = page.state_cache.get_current_state()
+                        flow_graph.import_data(n)
+                        flow_graph_update()
+
                         page.saved = False
                     else:  # restore the current state
                         n = page.state_cache.get_current_state()


### PR DESCRIPTION
On a parameter change of block , the block will not be updated correctly.

Example:
     Open a new Flowgraph tab.
     Add an  math add block. The default of the io ports is complex.
     Open the property dialog and change the type of the io ports from complex to float and select OK.
     Only the first input and the output port change from 'complex' to 'float'. The second input port remains 'complex'.
     The only way to change the type of the second input port is to reopen the property dialog and select quit !!!!
     Now the second port has the correct type.

The proposed change fixes this issue. But I'm not sure if there isn't a more elegant way to handle this issue.