### PR TITLE
Replace scipy/pylab where numpy/pyplot is sufficient

### DIFF
--- a/docs/doxygen/other/pfb_intro.dox
+++ b/docs/doxygen/other/pfb_intro.dox
@@ -96,7 +96,7 @@ Hz. The code then plots the PSD of the original signal to see the
 signals in the origina spectrum and then makes 9 plots for each of the
 channels.
 
-NOTE: you need the Scipy and Matplotlib Python modules installed to
+NOTE: you need the Matplotlib Python module installed to
 run this example.
 
 \include gr-filter/examples/channelize.py

--- a/gnuradio-runtime/examples/volk_benchmark/volk_test_funcs.py
+++ b/gnuradio-runtime/examples/volk_benchmark/volk_test_funcs.py
@@ -5,12 +5,7 @@ from __future__ import unicode_literals
 from gnuradio import gr
 from gnuradio import blocks
 import math, sys, os, time
-
-try:
-    import scipy
-except ImportError:
-    sys.stderr.write("Unable to import Scipy (www.scipy.org)\n")
-    sys.exit(1)
+import numpy
 
 try:
     import sqlite3
@@ -165,8 +160,8 @@ def format_results(kernel, times):
     '''
     res = dict()
     res["kernel"] = kernel
-    res["avg"] = scipy.mean(times)
-    res["var"] = scipy.var(times)
+    res["avg"] = numpy.mean(times)
+    res["var"] = numpy.var(times)
     res["max"] = max(times)
     res["min"] = min(times)
     return res

--- a/gr-analog/examples/fmtest.py
+++ b/gr-analog/examples/fmtest.py
@@ -29,12 +29,7 @@ from gnuradio import filter
 from gnuradio import analog
 from gnuradio import channels
 import sys, math, time
-
-try:
-    import numpy
-except ImportError:
-    print("Error: Program requires numpy (see: www.scipy.org).")
-    sys.exit(1)
+import numpy
 
 try:
     import pylab

--- a/gr-analog/examples/fmtest.py
+++ b/gr-analog/examples/fmtest.py
@@ -31,10 +31,9 @@ from gnuradio import channels
 import sys, math, time
 
 try:
-    import scipy
-    from scipy import fftpack
+    import numpy
 except ImportError:
-    print("Error: Program requires scipy (see: www.scipy.org).")
+    print("Error: Program requires numpy (see: www.scipy.org).")
     sys.exit(1)
 
 try:
@@ -147,7 +146,7 @@ def main():
         Ne = 100000
 
         fftlen = 8192
-        winfunc = scipy.blackman
+        winfunc = numpy.blackman
 
         # Plot transmitted signal
         fs = fm._if_rate
@@ -158,8 +157,8 @@ def main():
         X,freq = sp1_f.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                            window = lambda d: d*winfunc(fftlen),
                            visible=False)
-        X_in = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_in = scipy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
+        X_in = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_in = numpy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
         p1_f = sp1_f.plot(f_in, X_in, "b")
         sp1_f.set_xlim([min(f_in), max(f_in)+1])
         sp1_f.set_ylim([-120.0, 20.0])
@@ -171,16 +170,16 @@ def main():
         Ts = 1.0 / fs
         Tmax = len(d)*Ts
 
-        t_in = scipy.arange(0, Tmax, Ts)
-        x_in = scipy.array(d)
+        t_in = numpy.arange(0, Tmax, Ts)
+        x_in = numpy.array(d)
         sp1_t = fig1.add_subplot(2, 1, 2)
         p1_t = sp1_t.plot(t_in, x_in.real, "b-o")
         #p1_t = sp1_t.plot(t_in, x_in.imag, "r-o")
         sp1_t.set_ylim([-5, 5])
 
         # Set up the number of rows and columns for plotting the subfigures
-        Ncols = int(scipy.floor(scipy.sqrt(fm.num_rx_channels())))
-        Nrows = int(scipy.floor(fm.num_rx_channels() / Ncols))
+        Ncols = int(numpy.floor(numpy.sqrt(fm.num_rx_channels())))
+        Nrows = int(numpy.floor(fm.num_rx_channels() / Ncols))
         if(fm.num_rx_channels() % Ncols != 0):
             Nrows += 1
 
@@ -197,10 +196,10 @@ def main():
             X,freq = sp2_f.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs_o,
                                window = lambda d: d*winfunc(fftlen),
                                visible=False)
-            #X_o = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-            X_o = 10.0*scipy.log10(abs(X))
-            #f_o = scipy.arange(-fs_o/2.0, fs_o/2.0, fs_o/float(X_o.size))
-            f_o = scipy.arange(0, fs_o / 2.0, fs_o/2.0/float(X_o.size))
+            #X_o = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+            X_o = 10.0*numpy.log10(abs(X))
+            #f_o = numpy.arange(-fs_o/2.0, fs_o/2.0, fs_o/float(X_o.size))
+            f_o = numpy.arange(0, fs_o / 2.0, fs_o/2.0/float(X_o.size))
             p2_f = sp2_f.plot(f_o, X_o, "b")
             sp2_f.set_xlim([min(f_o), max(f_o)+0.1])
             sp2_f.set_ylim([-120.0, 20.0])
@@ -213,9 +212,9 @@ def main():
 
             Ts = 1.0 / fs_o
             Tmax = len(d)*Ts
-            t_o = scipy.arange(0, Tmax, Ts)
+            t_o = numpy.arange(0, Tmax, Ts)
 
-            x_t = scipy.array(d)
+            x_t = numpy.array(d)
             sp2_t = fig3.add_subplot(Nrows, Ncols, 1+i)
             p2_t = sp2_t.plot(t_o, x_t.real, "b")
             p2_t = sp2_t.plot(t_o, x_t.imag, "r")

--- a/gr-blocks/examples/tags/test_file_tags.py
+++ b/gr-blocks/examples/tags/test_file_tags.py
@@ -27,14 +27,8 @@ from gnuradio import gr
 from gnuradio import blocks
 import sys
 
-try:
-    import scipy
-except ImportError:
-    print("Error: Program requires scipy (see: www.scipy.org).")
-    sys.exit(1)
-
 def main():
-    data = scipy.arange(0, 32000, 1).tolist()
+    data = numpy.arange(0, 32000, 1).tolist()
     trig = 100*[0,] + 100*[1,]
 
     src = blocks.vector_source_s(data, True)

--- a/gr-blocks/examples/tags/test_file_tags.py
+++ b/gr-blocks/examples/tags/test_file_tags.py
@@ -26,6 +26,7 @@ from __future__ import unicode_literals
 from gnuradio import gr
 from gnuradio import blocks
 import sys
+import numpy
 
 def main():
     data = numpy.arange(0, 32000, 1).tolist()

--- a/gr-blocks/examples/tags/test_tag_prop.grc
+++ b/gr-blocks/examples/tags/test_tag_prop.grc
@@ -301,7 +301,7 @@
     </param>
     <param>
       <key>vector</key>
-      <value>scipy.arange(-1, 1, 0.01)</value>
+      <value>numpy.arange(-1, 1, 0.01)</value>
     </param>
   </block>
   <block>
@@ -360,7 +360,7 @@
     </param>
     <param>
       <key>vector</key>
-      <value>scipy.arange(-1, 1, 0.1)</value>
+      <value>numpy.arange(-1, 1, 0.1)</value>
     </param>
   </block>
   <block>
@@ -387,11 +387,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>import_scipy</value>
+      <value>import_numpy</value>
     </param>
     <param>
       <key>import</key>
-      <value>import scipy</value>
+      <value>import numpy</value>
     </param>
   </block>
   <block>

--- a/gr-digital/examples/berawgn.py
+++ b/gr-digital/examples/berawgn.py
@@ -51,9 +51,9 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import pylab
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
+    print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
 # Best to choose powers of 10
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     print("Simulating...")
     ber_simu   = [simulate_ber(x) for x in EbN0_range]
 
-    f = pylab.figure()
+    f = pyplot.figure()
     s = f.add_subplot(1,1,1)
     s.semilogy(EbN0_range, ber_theory, 'g-.', label="Theoretical")
     s.semilogy(EbN0_range, ber_simu, 'b-o', label="Simulated")
@@ -138,4 +138,4 @@ if __name__ == "__main__":
     s.set_ylabel('BER')
     s.legend()
     s.grid()
-    pylab.show()
+    pyplot.show()

--- a/gr-digital/examples/demod/test_corr_est.grc
+++ b/gr-digital/examples/demod/test_corr_est.grc
@@ -638,11 +638,11 @@
     </param>
     <param>
       <key>start</key>
-      <value>-2*scipy.pi</value>
+      <value>-2*numpy.pi</value>
     </param>
     <param>
       <key>stop</key>
-      <value>2*scipy.pi</value>
+      <value>2*numpy.pi</value>
     </param>
     <param>
       <key>step</key>
@@ -2661,7 +2661,7 @@
     </param>
     <param>
       <key>import</key>
-      <value>import scipy</value>
+      <value>import numpy</value>
     </param>
     <param>
       <key>alias</key>

--- a/gr-digital/examples/example_costas.py
+++ b/gr-digital/examples/example_costas.py
@@ -31,17 +31,12 @@ from gnuradio import eng_notation
 from gnuradio.eng_arg import eng_float, intx
 from argparse import ArgumentParser
 import sys
+import numpy
 
 try:
-    import scipy
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import scipy (http://www.scipy.org/)")
-    sys.exit(1)
-
-try:
-    import pylab
-except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
+    print("Error: could not import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
 class example_costas(gr.top_block):
@@ -51,8 +46,8 @@ class example_costas(gr.top_block):
         rrc_taps = filter.firdes.root_raised_cosine(
             sps, sps, 1.0, rolloff, ntaps)
 
-        data = 2.0*scipy.random.randint(0, 2, N) - 1.0
-        data = scipy.exp(1j*poffset) * data
+        data = 2.0*numpy.random.randint(0, 2, N) - 1.0
+        data = numpy.exp(1j*poffset) * data
 
         self.src = blocks.vector_source_c(data.tolist(), False)
         self.rrc = filter.interp_fir_filter_ccf(sps, rrc_taps)
@@ -75,7 +70,7 @@ def main():
                       help="Set the samples per symbol [default=%(default)r]")
     parser.add_argument("-r", "--rolloff", type=eng_float, default=0.35,
                       help="Set the rolloff factor [default=%(default)r]")
-    parser.add_argument("-W", "--bandwidth", type=eng_float, default=2*scipy.pi/100.0,
+    parser.add_argument("-W", "--bandwidth", type=eng_float, default=2*numpy.pi/100.0,
                       help="Set the loop bandwidth [default=%(default)r]")
     parser.add_argument("-n", "--ntaps", type=int, default=45,
                       help="Set the number of taps in the filters [default=%(default)r]")
@@ -98,16 +93,16 @@ def main():
                          args.foffset, args.toffset, args.poffset)
     put.run()
 
-    data_src = scipy.array(put.vsnk_src.data())
+    data_src = numpy.array(put.vsnk_src.data())
 
     # Convert the FLL's LO frequency from rads/sec to Hz
-    data_frq = scipy.array(put.vsnk_frq.data()) / (2.0*scipy.pi)
+    data_frq = numpy.array(put.vsnk_frq.data()) / (2.0*numpy.pi)
 
     # adjust this to align with the data.
-    data_cst = scipy.array(3*[0,]+list(put.vsnk_cst.data()))
+    data_cst = numpy.array(3*[0,]+list(put.vsnk_cst.data()))
 
     # Plot the Costas loop's LO frequency
-    f1 = pylab.figure(1, figsize=(12,10), facecolor='w')
+    f1 = pyplot.figure(1, figsize=(12,10), facecolor='w')
     s1 = f1.add_subplot(2,2,1)
     s1.plot(data_frq)
     s1.set_title("Costas LO")
@@ -133,7 +128,7 @@ def main():
     s4.set_xlabel("Samples")
     s4.set_ylabel("Real Part of Signals")
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     try:

--- a/gr-digital/examples/example_fll.py
+++ b/gr-digital/examples/example_fll.py
@@ -31,17 +31,12 @@ from gnuradio import eng_notation
 from gnuradio.eng_arg import eng_float, intx
 from argparse import ArgumentParser
 import sys
+import numpy
 
 try:
-    import scipy
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import scipy (http://www.scipy.org/)")
-    sys.exit(1)
-
-try:
-    import pylab
-except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
+    print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
 class example_fll(gr.top_block):
@@ -51,8 +46,8 @@ class example_fll(gr.top_block):
         rrc_taps = filter.firdes.root_raised_cosine(
             sps, sps, 1.0, rolloff, ntaps)
 
-        data = 2.0*scipy.random.randint(0, 2, N) - 1.0
-        data = scipy.exp(1j*poffset) * data
+        data = 2.0*numpy.random.randint(0, 2, N) - 1.0
+        data = numpy.exp(1j*poffset) * data
 
         self.src = blocks.vector_source_c(data.tolist(), False)
         self.rrc = filter.interp_fir_filter_ccf(sps, rrc_taps)
@@ -79,7 +74,7 @@ def main():
                       help="Set the samples per symbol [default=%(default)r]")
     parser.add_argument("-r", "--rolloff", type=eng_float, default=0.35,
                       help="Set the rolloff factor [default=%(default)r]")
-    parser.add_argument("-W", "--bandwidth", type=eng_float, default=2*scipy.pi/100.0,
+    parser.add_argument("-W", "--bandwidth", type=eng_float, default=2*numpy.pi/100.0,
                       help="Set the loop bandwidth [default=%(default)r]")
     parser.add_argument("-n", "--ntaps", type=int, default=45,
                       help="Set the number of taps in the filters [default=%(default)r]")
@@ -102,18 +97,18 @@ def main():
                       args.foffset, args.toffset, args.poffset)
     put.run()
 
-    data_src = scipy.array(put.vsnk_src.data())
-    data_err = scipy.array(put.vsnk_err.data())
+    data_src = numpy.array(put.vsnk_src.data())
+    data_err = numpy.array(put.vsnk_err.data())
 
     # Convert the FLL's LO frequency from rads/sec to Hz
-    data_frq = scipy.array(put.vsnk_frq.data()) / (2.0*scipy.pi)
+    data_frq = numpy.array(put.vsnk_frq.data()) / (2.0*numpy.pi)
 
     # adjust this to align with the data. There are 2 filters of
     # ntaps long and the channel introduces another 4 sample delay.
-    data_fll = scipy.array(put.vsnk_fll.data()[2*args.ntaps-4:])
+    data_fll = numpy.array(put.vsnk_fll.data()[2*args.ntaps-4:])
 
     # Plot the FLL's LO frequency
-    f1 = pylab.figure(1, figsize=(12,10))
+    f1 = pyplot.figure(1, figsize=(12,10))
     s1 = f1.add_subplot(2,2,1)
     s1.plot(data_frq)
     s1.set_title("FLL LO")
@@ -143,7 +138,7 @@ def main():
     s4.set_xlabel("Samples")
     s4.set_ylabel("Real Part of Signals")
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     try:

--- a/gr-digital/examples/example_timing.py
+++ b/gr-digital/examples/example_timing.py
@@ -31,20 +31,15 @@ from gnuradio import eng_notation
 from gnuradio.eng_arg import eng_float, intx
 from argparse import ArgumentParser
 import sys
+import numpy
 
 try:
-    import scipy
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import scipy (http://www.scipy.org/)")
+    print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
-try:
-    import pylab
-except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
-    sys.exit(1)
-
-from scipy import fftpack
+from numpy.fft import fftpack
 
 class example_timing(gr.top_block):
     def __init__(self, N, sps, rolloff, ntaps, bw, noise,
@@ -59,8 +54,8 @@ class example_timing(gr.top_block):
         rrc_taps_rx = filter.firdes.root_raised_cosine(
             nfilts, sps*nfilts, 1.0, rolloff, ntaps*nfilts)
 
-        data = 2.0*scipy.random.randint(0, 2, N) - 1.0
-        data = scipy.exp(1j*poffset) * data
+        data = 2.0*numpy.random.randint(0, 2, N) - 1.0
+        data = numpy.exp(1j*poffset) * data
 
         self.src = blocks.vector_source_c(data.tolist(), False)
         self.rrc = filter.interp_fir_filter_ccf(sps, rrc_taps)
@@ -73,7 +68,7 @@ class example_timing(gr.top_block):
             self.taps = self.clk.taps()
             self.dtaps = self.clk.diff_taps()
 
-            self.delay = int(scipy.ceil(((len(rrc_taps)-1)//2 +
+            self.delay = int(numpy.ceil(((len(rrc_taps)-1)//2 +
                                          (len(self.taps[0])-1)//2 )//float(sps))) + 1
 
             self.vsnk_err = blocks.vector_sink_f()
@@ -112,7 +107,7 @@ def main():
                       help="Set the samples per symbol [default=%(default)r]")
     parser.add_argument("-r", "--rolloff", type=eng_float, default=0.35,
                       help="Set the rolloff factor [default=%(default)r]")
-    parser.add_argument("-W", "--bandwidth", type=eng_float, default=2*scipy.pi/100.0,
+    parser.add_argument("-W", "--bandwidth", type=eng_float, default=2*numpy.pi/100.0,
                       help="Set the loop bandwidth (PFB) or gain (M&M) [default=%(default)r]")
     parser.add_argument("-n", "--ntaps", type=int, default=45,
                       help="Set the number of taps in the filters [default=%(default)r]")
@@ -139,14 +134,14 @@ def main():
     put.run()
 
     if args.mode == 0:
-        data_src = scipy.array(put.vsnk_src.data()[20:])
-        data_clk = scipy.array(put.vsnk_clk.data()[20:])
+        data_src = numpy.array(put.vsnk_src.data()[20:])
+        data_clk = numpy.array(put.vsnk_clk.data()[20:])
 
-        data_err = scipy.array(put.vsnk_err.data()[20:])
-        data_rat = scipy.array(put.vsnk_rat.data()[20:])
-        data_phs = scipy.array(put.vsnk_phs.data()[20:])
+        data_err = numpy.array(put.vsnk_err.data()[20:])
+        data_rat = numpy.array(put.vsnk_rat.data()[20:])
+        data_phs = numpy.array(put.vsnk_phs.data()[20:])
 
-        f1 = pylab.figure(1, figsize=(12,10), facecolor='w')
+        f1 = pyplot.figure(1, figsize=(12,10), facecolor='w')
 
         # Plot the IQ symbols
         s1 = f1.add_subplot(2,2,1)
@@ -190,28 +185,28 @@ def main():
         diff_taps = put.dtaps
         ntaps = len(diff_taps[0])
         nfilts = len(diff_taps)
-        t = scipy.arange(0, ntaps*nfilts)
+        t = numpy.arange(0, ntaps*nfilts)
 
-        f3 = pylab.figure(3, figsize=(12,10), facecolor='w')
+        f3 = pyplot.figure(3, figsize=(12,10), facecolor='w')
         s31 = f3.add_subplot(2,1,1)
         s32 = f3.add_subplot(2,1,2)
         s31.set_title("Differential Filters")
         s32.set_title("FFT of Differential Filters")
 
         for i,d in enumerate(diff_taps):
-            D = 20.0*scipy.log10(1e-20+abs(fftpack.fftshift(fftpack.fft(d, 10000))))
+            D = 20.0*numpy.log10(1e-20+abs(numpy.fft.fftshift(fftpack.fft(d, 10000))))
             s31.plot(t[i::nfilts].real, d, "-o")
             s32.plot(D)
         s32.set_ylim([-120, 10])
 
     # If testing the M&M clock recovery loop
     else:
-        data_src = scipy.array(put.vsnk_src.data()[20:])
-        data_clk = scipy.array(put.vsnk_clk.data()[20:])
+        data_src = numpy.array(put.vsnk_src.data()[20:])
+        data_clk = numpy.array(put.vsnk_clk.data()[20:])
 
-        data_err = scipy.array(put.vsnk_err.data()[20:])
+        data_err = numpy.array(put.vsnk_err.data()[20:])
 
-        f1 = pylab.figure(1, figsize=(12,10), facecolor='w')
+        f1 = pyplot.figure(1, figsize=(12,10), facecolor='w')
 
         # Plot the IQ symbols
         s1 = f1.add_subplot(2,2,1)
@@ -239,7 +234,7 @@ def main():
         s3.set_xlabel("Samples")
         s3.set_ylabel("Error")
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     try:

--- a/gr-digital/examples/snr_estimators.py
+++ b/gr-digital/examples/snr_estimators.py
@@ -34,7 +34,7 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import pylab
+    from matplotlib import pyplot
 except ImportError:
     print("Error: Program requires Matplotlib (matplotlib.sourceforge.net).")
     sys.exit(1)
@@ -183,7 +183,7 @@ def main():
 
         snr_gr.append(gr_snr.snr())
 
-    f1 = pylab.figure(1)
+    f1 = pyplot.figure(1)
     s1 = f1.add_subplot(1,1,1)
     s1.plot(SNR_dB, snr_known, "k-o", linewidth=2, label="Known")
     s1.plot(SNR_dB, snr_python, "b-o", linewidth=2, label="Python")
@@ -194,11 +194,11 @@ def main():
     s1.set_ylabel('Estimated SNR')
     s1.legend()
 
-    f2 = pylab.figure(2)
+    f2 = pyplot.figure(2)
     s2 = f2.add_subplot(1,1,1)
     s2.plot(yy.real, yy.imag, 'o')
 
-    pylab.show()
+    pyplot.show()
 
 
 if __name__ == "__main__":

--- a/gr-digital/python/digital/test_soft_decisions.py
+++ b/gr-digital/python/digital/test_soft_decisions.py
@@ -25,7 +25,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import numpy, pylab, sys
+import numpy, sys
+from matplotlib import pyplot
 from gnuradio import digital
 from .soft_dec_lut_gen import soft_dec_table, calc_soft_dec_from_table, calc_soft_dec
 from .psk_constellations import psk_4_0, psk_4_1, psk_4_2, psk_4_3, psk_4_4, psk_4_5, psk_4_6, psk_4_7, sd_psk_4_0, sd_psk_4_1, sd_psk_4_2, sd_psk_4_3, sd_psk_4_4, sd_psk_4_5, sd_psk_4_6, sd_psk_4_7
@@ -126,7 +127,7 @@ if __name__ == "__main__":
     print("C++ Table calc:              ", (y_cpp_table))
     print("C++ Raw calc:                ", (y_cpp_raw_calc))
 
-    fig = pylab.figure(1)
+    fig = pyplot.figure(1)
     sp1 = fig.add_subplot(1,1,1)
     sp1.plot([c.real for c in constel],
              [c.imag for c in constel], 'bo')
@@ -137,4 +138,4 @@ if __name__ == "__main__":
     for i,c in enumerate(constel):
         sp1.text(1.2*c.real, 1.2*c.imag, bin(code[i])[2:].zfill(fill),
                  ha='center', va='center', size=18)
-    pylab.show()
+    pyplot.show()

--- a/gr-dtv/examples/atsc_ctrlport_monitor.py
+++ b/gr-dtv/examples/atsc_ctrlport_monitor.py
@@ -28,8 +28,8 @@ matplotlib.use("QT4Agg")
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-import scipy
-from scipy import fftpack
+import numpy
+from numpy.fft import fftpack
 
 """
 If a host is running the ATSC receiver chain with ControlPort
@@ -51,7 +51,7 @@ class atsc_ctrlport_monitor(object):
 
         vt_init_key = 'dtv_atsc_viterbi_decoder0::decoder_metrics'
         data = self.radio.getKnobs([vt_init_key])[vt_init_key]
-        init_metric = scipy.mean(data.value)
+        init_metric = numpy.mean(data.value)
         self._viterbi_metric = 100*[init_metric,]
 
         table_col_labels = ('Num Packets', 'Error Rate', 'Packet Error Rate',
@@ -102,7 +102,7 @@ class atsc_ctrlport_monitor(object):
             vt_decoder_metrics = data[vt_metrics_key]
             snr_est = data[snr_key]
 
-            vt_decoder_metrics = scipy.mean(vt_decoder_metrics.value)
+            vt_decoder_metrics = numpy.mean(vt_decoder_metrics.value)
             self._viterbi_metric.pop()
             self._viterbi_metric.insert(0, vt_decoder_metrics)
 
@@ -117,9 +117,9 @@ class atsc_ctrlport_monitor(object):
         self._sp0.set_ylim(min(eqdata.value), max(eqdata.value))
 
         fs = 6.25e6
-        freq = scipy.linspace(-fs / 2, fs / 2, 10000)
-        H = fftpack.fftshift(fftpack.fft(eqdata.value, 10000))
-        HdB = 20.0*scipy.log10(abs(H))
+        freq = numpy.linspace(-fs / 2, fs / 2, 10000)
+        H = numpy.fft.fftshift(fftpack.fft(eqdata.value, 10000))
+        HdB = 20.0*numpy.log10(abs(H))
         psd.set_ydata(HdB)
         psd.set_xdata(freq)
         self._sp1.set_xlim(0, fs / 2)
@@ -139,7 +139,7 @@ class atsc_ctrlport_monitor(object):
         table._cells[(1,0)]._text.set_text("{0}".format(rs_num_packets.value))
         table._cells[(1,1)]._text.set_text("{0:.2g}".format(ber))
         table._cells[(1,2)]._text.set_text("{0:.2g}".format(per))
-        table._cells[(1,3)]._text.set_text("{0:.1f}".format(scipy.mean(self._viterbi_metric)))
+        table._cells[(1,3)]._text.set_text("{0:.1f}".format(numpy.mean(self._viterbi_metric)))
         table._cells[(1,4)]._text.set_text("{0:.4f}".format(snr_est.value[0]))
 
         return (taps, psd, syms, table)

--- a/gr-filter/examples/channelize.py
+++ b/gr-filter/examples/channelize.py
@@ -27,18 +27,12 @@ from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
 import sys, time
+import numpy
 
 try:
     from gnuradio import analog
 except ImportError:
     sys.stderr.write("Error: Program requires gr-analog.\n")
-    sys.exit(1)
-
-try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
     sys.exit(1)
 
 try:
@@ -63,7 +57,7 @@ class pfb_top_block(gr.top_block):
                                               window=filter.firdes.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
-        tpc = scipy.ceil(float(len(self._taps)) / float(self._M))
+        tpc = numpy.ceil(float(len(self._taps)) / float(self._M))
         print("Number of taps:     ", len(self._taps))
         print("Number of channels: ", self._M)
         print("Taps per channel:   ", tpc)
@@ -119,7 +113,7 @@ def main():
         Ne = 10000
 
         fftlen = 8192
-        winfunc = scipy.blackman
+        winfunc = numpy.blackman
         fs = tb._ifs
 
         # Plot the input signal on its own figure
@@ -129,8 +123,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_in = 10.0*scipy.log10(abs(X))
-        f_in = scipy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
+        X_in = 10.0*numpy.log10(abs(X))
+        f_in = numpy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
         pin_f = spin_f.plot(f_in, X_in, "b")
         spin_f.set_xlim([min(f_in), max(f_in)+1])
         spin_f.set_ylim([-200.0, 50.0])
@@ -143,8 +137,8 @@ def main():
         Ts = 1.0 / fs
         Tmax = len(d)*Ts
 
-        t_in = scipy.arange(0, Tmax, Ts)
-        x_in = scipy.array(d)
+        t_in = numpy.arange(0, Tmax, Ts)
+        x_in = numpy.array(d)
         spin_t = fig_in.add_subplot(2, 1, 2)
         pin_t = spin_t.plot(t_in, x_in.real, "b")
         pin_t = spin_t.plot(t_in, x_in.imag, "r")
@@ -152,8 +146,8 @@ def main():
         spin_t.set_xlabel("Time (s)")
         spin_t.set_ylabel("Amplitude")
 
-        Ncols = int(scipy.floor(scipy.sqrt(tb._M)))
-        Nrows = int(scipy.floor(tb._M / Ncols))
+        Ncols = int(numpy.floor(numpy.sqrt(tb._M)))
+        Nrows = int(numpy.floor(tb._M / Ncols))
         if(tb._M % Ncols != 0):
             Nrows += 1
 
@@ -172,8 +166,8 @@ def main():
             X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs_o,
                               window = lambda d: d*winfunc(fftlen),
                               scale_by_freq=True)
-            X_o = 10.0*scipy.log10(abs(X))
-            f_o = scipy.arange(-fs_o / 2.0, fs_o / 2.0, fs_o / float(X_o.size))
+            X_o = 10.0*numpy.log10(abs(X))
+            f_o = numpy.arange(-fs_o / 2.0, fs_o / 2.0, fs_o / float(X_o.size))
             p2_f = sp1_f.plot(f_o, X_o, "b")
             sp1_f.set_xlim([min(f_o), max(f_o)+1])
             sp1_f.set_ylim([-200.0, 50.0])
@@ -182,8 +176,8 @@ def main():
             sp1_f.set_xlabel("Frequency (Hz)")
             sp1_f.set_ylabel("Power (dBW)")
 
-            x_o = scipy.array(d)
-            t_o = scipy.arange(0, Tmax_o, Ts_o)
+            x_o = numpy.array(d)
+            t_o = numpy.arange(0, Tmax_o, Ts_o)
             sp2_o = fig2.add_subplot(Nrows, Ncols, 1+i)
             p2_o = sp2_o.plot(t_o, x_o.real, "b")
             p2_o = sp2_o.plot(t_o, x_o.imag, "r")

--- a/gr-filter/examples/chirp_channelize.py
+++ b/gr-filter/examples/chirp_channelize.py
@@ -27,18 +27,12 @@ from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
 import sys, time
+import numpy
 
 try:
     from gnuradio import analog
 except ImportError:
     sys.stderr.write("Error: Program requires gr-analog.\n")
-    sys.exit(1)
-
-try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
     sys.exit(1)
 
 try:
@@ -62,7 +56,7 @@ class pfb_top_block(gr.top_block):
                                               window=filter.firdes.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
-        tpc = scipy.ceil(float(len(self._taps)) / float(self._M))
+        tpc = numpy.ceil(float(len(self._taps)) / float(self._M))
         print("Number of taps:     ", len(self._taps))
         print("Number of channels: ", self._M)
         print("Taps per channel:   ", tpc)
@@ -72,7 +66,7 @@ class pfb_top_block(gr.top_block):
             self.vco_input = analog.sig_source_f(self._fs, analog.GR_SIN_WAVE, 0.25, 110)
         else:
             amp = 100
-            data = scipy.arange(0, amp, amp / float(self._N))
+            data = numpy.arange(0, amp, amp / float(self._N))
             self.vco_input = blocks.vector_source_f(data, False)
 
         # Build a VCO controlled by either the sinusoid or single chirp tone
@@ -119,7 +113,7 @@ def main():
         Ne = 20000
 
         fftlen = 8192
-        winfunc = scipy.blackman
+        winfunc = numpy.blackman
         fs = tb._fs
 
         # Plot the input signal on its own figure
@@ -129,8 +123,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_in = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_in = scipy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
+        X_in = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_in = numpy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
         pin_f = spin_f.plot(f_in, X_in, "b")
         spin_f.set_xlim([min(f_in), max(f_in)+1])
         spin_f.set_ylim([-200.0, 50.0])
@@ -143,8 +137,8 @@ def main():
         Ts = 1.0 / fs
         Tmax = len(d)*Ts
 
-        t_in = scipy.arange(0, Tmax, Ts)
-        x_in = scipy.array(d)
+        t_in = numpy.arange(0, Tmax, Ts)
+        x_in = numpy.array(d)
         spin_t = fig_in.add_subplot(2, 1, 2)
         pin_t = spin_t.plot(t_in, x_in.real, "b")
         pin_t = spin_t.plot(t_in, x_in.imag, "r")
@@ -152,8 +146,8 @@ def main():
         spin_t.set_xlabel("Time (s)")
         spin_t.set_ylabel("Amplitude")
 
-        Ncols = int(scipy.floor(scipy.sqrt(tb._M)))
-        Nrows = int(scipy.floor(tb._M / Ncols))
+        Ncols = int(numpy.floor(numpy.sqrt(tb._M)))
+        Nrows = int(numpy.floor(tb._M / Ncols))
         if(tb._M % Ncols != 0):
             Nrows += 1
 
@@ -172,7 +166,7 @@ def main():
             X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs_o,
                               window = lambda d: d*winfunc(fftlen),
                               scale_by_freq=True)
-            X_o = 10.0*scipy.log10(abs(X))
+            X_o = 10.0*numpy.log10(abs(X))
             f_o = freq
             p2_f = sp1_f.plot(f_o, X_o, "b")
             sp1_f.set_xlim([min(f_o), max(f_o)+1])
@@ -182,8 +176,8 @@ def main():
             sp1_f.set_xlabel("Frequency (Hz)")
             sp1_f.set_ylabel("Power (dBW)")
 
-            x_o = scipy.array(d)
-            t_o = scipy.arange(0, Tmax_o, Ts_o)
+            x_o = numpy.array(d)
+            t_o = numpy.arange(0, Tmax_o, Ts_o)
             sp2_o = fig2.add_subplot(Nrows, Ncols, 1+i)
             p2_o = sp2_o.plot(t_o, x_o.real, "b")
             p2_o = sp2_o.plot(t_o, x_o.imag, "r")

--- a/gr-filter/examples/decimate.py
+++ b/gr-filter/examples/decimate.py
@@ -27,6 +27,7 @@ from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
 import sys, time
+import numpy
 
 try:
     from gnuradio import analog
@@ -34,16 +35,10 @@ except ImportError:
     sys.stderr.write("Error: Program requires gr-analog.\n")
     sys.exit(1)
 
-try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
-    sys.exit(1)
 
 try:
-    import pylab
-    from pylab import mlab
+    from matplotlib import pyplot
+    from matplotlib import pyplot as mlab
 except ImportError:
     sys.stderr.write("Error: Program requires matplotlib (see: matplotlib.sourceforge.net).\n")
     sys.exit(1)
@@ -63,7 +58,7 @@ class pfb_top_block(gr.top_block):
                                               window=filter.firdes.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
-        tpc = scipy.ceil(float(len(self._taps)) / float(self._decim))
+        tpc = numpy.ceil(float(len(self._taps)) / float(self._decim))
         print("Number of taps:     ", len(self._taps))
         print("Number of filters:  ", self._decim)
         print("Taps per channel:   ", tpc)
@@ -106,14 +101,14 @@ def main():
     print("Run time: %f" % (tend - tstart))
 
     if 1:
-        fig1 = pylab.figure(1, figsize=(16,9))
-        fig2 = pylab.figure(2, figsize=(16,9))
+        fig1 = pyplot.figure(1, figsize=(16,9))
+        fig2 = pyplot.figure(2, figsize=(16,9))
 
         Ns = 10000
         Ne = 10000
 
         fftlen = 8192
-        winfunc = scipy.blackman
+        winfunc = numpy.blackman
         fs = tb._fs
 
         # Plot the input to the decimator
@@ -124,8 +119,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_in = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_in = scipy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
+        X_in = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_in = numpy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
         p1_f = sp1_f.plot(f_in, X_in, "b")
         sp1_f.set_xlim([min(f_in), max(f_in)+1])
         sp1_f.set_ylim([-200.0, 50.0])
@@ -137,8 +132,8 @@ def main():
         Ts = 1.0 / fs
         Tmax = len(d)*Ts
 
-        t_in = scipy.arange(0, Tmax, Ts)
-        x_in = scipy.array(d)
+        t_in = numpy.arange(0, Tmax, Ts)
+        x_in = numpy.array(d)
         sp1_t = fig1.add_subplot(2, 1, 2)
         p1_t = sp1_t.plot(t_in, x_in.real, "b")
         p1_t = sp1_t.plot(t_in, x_in.imag, "r")
@@ -156,8 +151,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs_o,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_o = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_o = scipy.arange(-fs_o / 2.0, fs_o / 2.0, fs_o / float(X_o.size))
+        X_o = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_o = numpy.arange(-fs_o / 2.0, fs_o / 2.0, fs_o / float(X_o.size))
         p2_f = sp2_f.plot(f_o, X_o, "b")
         sp2_f.set_xlim([min(f_o), max(f_o)+1])
         sp2_f.set_ylim([-200.0, 50.0])
@@ -170,8 +165,8 @@ def main():
         Ts_o = 1.0 / fs_o
         Tmax_o = len(d)*Ts_o
 
-        x_o = scipy.array(d)
-        t_o = scipy.arange(0, Tmax_o, Ts_o)
+        x_o = numpy.array(d)
+        t_o = numpy.arange(0, Tmax_o, Ts_o)
         sp2_t = fig2.add_subplot(2, 1, 2)
         p2_t = sp2_t.plot(t_o, x_o.real, "b-o")
         p2_t = sp2_t.plot(t_o, x_o.imag, "r-o")
@@ -180,7 +175,7 @@ def main():
         sp2_t.set_xlabel("Time (s)")
         sp2_t.set_ylabel("Amplitude")
 
-        pylab.show()
+        pyplot.show()
 
 
 if __name__ == "__main__":

--- a/gr-filter/examples/fft_filter_ccc.py
+++ b/gr-filter/examples/fft_filter_ccc.py
@@ -30,17 +30,12 @@ from gnuradio import eng_notation
 from gnuradio.eng_arg import eng_float, intx
 from argparse import ArgumentParser
 import sys
+import numpy
 
 try:
-    import scipy
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import scipy (http://www.scipy.org/)")
-    sys.exit(1)
-
-try:
-    import pylab
-except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
+    print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
 class example_fft_filter_ccc(gr.top_block):
@@ -97,24 +92,24 @@ def main():
                                  args.decimation)
     put.run()
 
-    data_src = scipy.array(put.vsnk_src.data())
-    data_snk = scipy.array(put.vsnk_out.data())
+    data_src = numpy.array(put.vsnk_src.data())
+    data_snk = numpy.array(put.vsnk_out.data())
 
     # Plot the signals PSDs
     nfft = 1024
-    f1 = pylab.figure(1, figsize=(12,10))
+    f1 = pyplot.figure(1, figsize=(12,10))
     s1 = f1.add_subplot(1,1,1)
     s1.psd(data_src, NFFT=nfft, noverlap=nfft / 4,
            Fs=args.samplerate)
     s1.psd(data_snk, NFFT=nfft, noverlap=nfft / 4,
            Fs=args.samplerate)
 
-    f2 = pylab.figure(2, figsize=(12,10))
+    f2 = pyplot.figure(2, figsize=(12,10))
     s2 = f2.add_subplot(1,1,1)
     s2.plot(data_src)
     s2.plot(data_snk.real, 'g')
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     try:

--- a/gr-filter/examples/fir_filter_ccc.py
+++ b/gr-filter/examples/fir_filter_ccc.py
@@ -30,17 +30,12 @@ from gnuradio import eng_notation
 from gnuradio.eng_arg import eng_float, intx
 from argparse import ArgumentParser
 import sys
+import numpy
 
 try:
-    import scipy
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import scipy (http://www.scipy.org/)")
-    sys.exit(1)
-
-try:
-    import pylab
-except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
+    print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
 class example_fir_filter_ccc(gr.top_block):
@@ -91,24 +86,24 @@ def main():
                                  args.decimation)
     put.run()
 
-    data_src = scipy.array(put.vsnk_src.data())
-    data_snk = scipy.array(put.vsnk_out.data())
+    data_src = numpy.array(put.vsnk_src.data())
+    data_snk = numpy.array(put.vsnk_out.data())
 
     # Plot the signals PSDs
     nfft = 1024
-    f1 = pylab.figure(1, figsize=(12,10))
+    f1 = pyplot.figure(1, figsize=(12,10))
     s1 = f1.add_subplot(1,1,1)
     s1.psd(data_src, NFFT=nfft, noverlap=nfft / 4,
            Fs=args.samplerate)
     s1.psd(data_snk, NFFT=nfft, noverlap=nfft / 4,
            Fs=args.samplerate)
 
-    f2 = pylab.figure(2, figsize=(12,10))
+    f2 = pyplot.figure(2, figsize=(12,10))
     s2 = f2.add_subplot(1,1,1)
     s2.plot(data_src)
     s2.plot(data_snk.real, 'g')
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     try:

--- a/gr-filter/examples/fir_filter_fff.py
+++ b/gr-filter/examples/fir_filter_fff.py
@@ -30,17 +30,12 @@ from gnuradio import eng_notation
 from gnuradio.eng_arg import eng_float, intx
 from argparse import ArgumentParser
 import sys
+import numpy
 
 try:
-    import scipy
+    from matplotlib import pyplot
 except ImportError:
-    print("Error: could not import scipy (http://www.scipy.org/)")
-    sys.exit(1)
-
-try:
-    import pylab
-except ImportError:
-    print("Error: could not import pylab (http://matplotlib.sourceforge.net/)")
+    print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
 class example_fir_filter_fff(gr.top_block):
@@ -91,24 +86,24 @@ def main():
                                  args.decimation)
     put.run()
 
-    data_src = scipy.array(put.vsnk_src.data())
-    data_snk = scipy.array(put.vsnk_out.data())
+    data_src = numpy.array(put.vsnk_src.data())
+    data_snk = numpy.array(put.vsnk_out.data())
 
     # Plot the signals PSDs
     nfft = 1024
-    f1 = pylab.figure(1, figsize=(12,10))
+    f1 = pyplot.figure(1, figsize=(12,10))
     s1 = f1.add_subplot(1,1,1)
     s1.psd(data_src, NFFT=nfft, noverlap=nfft / 4,
            Fs=args.samplerate)
     s1.psd(data_snk, NFFT=nfft, noverlap=nfft / 4,
            Fs=args.samplerate)
 
-    f2 = pylab.figure(2, figsize=(12,10))
+    f2 = pyplot.figure(2, figsize=(12,10))
     s2 = f2.add_subplot(1,1,1)
     s2.plot(data_src)
     s2.plot(data_snk.real, 'g')
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     try:

--- a/gr-filter/examples/interpolate.py
+++ b/gr-filter/examples/interpolate.py
@@ -27,18 +27,12 @@ from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
 import sys, time
+import numpy
 
 try:
     from gnuradio import analog
 except ImportError:
     sys.stderr.write("Error: Program requires gr-analog.\n")
-    sys.exit(1)
-
-try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
     sys.exit(1)
 
 try:
@@ -82,7 +76,7 @@ class pfb_top_block(gr.top_block):
                                                window=filter.firdes.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
-        tpc = scipy.ceil(float(len(self._taps)) / float(self._interp))
+        tpc = numpy.ceil(float(len(self._taps)) / float(self._interp))
         print("Number of taps:     ", len(self._taps))
         print("Number of filters:  ", self._interp)
         print("Taps per channel:   ", tpc)
@@ -136,7 +130,7 @@ def main():
         Ne = 10000
 
         fftlen = 8192
-        winfunc = scipy.blackman
+        winfunc = numpy.blackman
 
         # Plot input signal
         fs = tb._fs
@@ -147,8 +141,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_in = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_in = scipy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
+        X_in = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_in = numpy.arange(-fs / 2.0, fs / 2.0, fs / float(X_in.size))
         p1_f = sp1_f.plot(f_in, X_in, "b")
         sp1_f.set_xlim([min(f_in), max(f_in)+1])
         sp1_f.set_ylim([-200.0, 50.0])
@@ -161,8 +155,8 @@ def main():
         Ts = 1.0 / fs
         Tmax = len(d)*Ts
 
-        t_in = scipy.arange(0, Tmax, Ts)
-        x_in = scipy.array(d)
+        t_in = numpy.arange(0, Tmax, Ts)
+        x_in = numpy.array(d)
         sp1_t = fig1.add_subplot(2, 1, 2)
         p1_t = sp1_t.plot(t_in, x_in.real, "b-o")
         #p1_t = sp1_t.plot(t_in, x_in.imag, "r-o")
@@ -181,8 +175,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_o = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_o = scipy.arange(-fs_int / 2.0, fs_int / 2.0, fs_int / float(X_o.size))
+        X_o = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_o = numpy.arange(-fs_int / 2.0, fs_int / 2.0, fs_int / float(X_o.size))
         p2_f = sp2_f.plot(f_o, X_o, "b")
         sp2_f.set_xlim([min(f_o), max(f_o)+1])
         sp2_f.set_ylim([-200.0, 50.0])
@@ -194,8 +188,8 @@ def main():
         Ts_int = 1.0 / fs_int
         Tmax = len(d)*Ts_int
 
-        t_o = scipy.arange(0, Tmax, Ts_int)
-        x_o1 = scipy.array(d)
+        t_o = numpy.arange(0, Tmax, Ts_int)
+        x_o1 = numpy.array(d)
         sp2_t = fig2.add_subplot(2, 1, 2)
         p2_t = sp2_t.plot(t_o, x_o1.real, "b-o")
         #p2_t = sp2_t.plot(t_o, x_o.imag, "r-o")
@@ -214,8 +208,8 @@ def main():
         X,freq = mlab.psd(d, NFFT=fftlen, noverlap=fftlen / 4, Fs=fs,
                           window = lambda d: d*winfunc(fftlen),
                           scale_by_freq=True)
-        X_o = 10.0*scipy.log10(abs(fftpack.fftshift(X)))
-        f_o = scipy.arange(-fs_aint / 2.0, fs_aint / 2.0, fs_aint / float(X_o.size))
+        X_o = 10.0*numpy.log10(abs(numpy.fft.fftshift(X)))
+        f_o = numpy.arange(-fs_aint / 2.0, fs_aint / 2.0, fs_aint / float(X_o.size))
         p3_f = sp3_f.plot(f_o, X_o, "b")
         sp3_f.set_xlim([min(f_o), max(f_o)+1])
         sp3_f.set_ylim([-200.0, 50.0])
@@ -227,8 +221,8 @@ def main():
         Ts_aint = 1.0 / fs_aint
         Tmax = len(d)*Ts_aint
 
-        t_o = scipy.arange(0, Tmax, Ts_aint)
-        x_o2 = scipy.array(d)
+        t_o = numpy.arange(0, Tmax, Ts_aint)
+        x_o2 = numpy.array(d)
         sp3_f = fig3.add_subplot(2, 1, 2)
         p3_f = sp3_f.plot(t_o, x_o2.real, "b-o")
         p3_f = sp3_f.plot(t_o, x_o1.real, "m-o")

--- a/gr-filter/examples/reconstruction.py
+++ b/gr-filter/examples/reconstruction.py
@@ -27,6 +27,7 @@ from gnuradio import gr, digital
 from gnuradio import filter
 from gnuradio import blocks
 import sys
+import numpy
 
 try:
     from gnuradio import channels
@@ -35,14 +36,7 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    print("Error: Program requires scipy (see: www.scipy.org).")
-    sys.exit(1)
-
-try:
-    import pylab
+    from matplotlib import pyplot
 except ImportError:
     print("Error: Program requires matplotlib (see: matplotlib.sourceforge.net).")
     sys.exit(1)
@@ -53,7 +47,7 @@ def main():
     N = 10000
     fs = 2000.0
     Ts = 1.0 / fs
-    t = scipy.arange(0, N*Ts, Ts)
+    t = numpy.arange(0, N*Ts, Ts)
 
     # When playing with the number of channels, be careful about the filter
     # specs and the channel map of the synthesizer set below.
@@ -70,10 +64,10 @@ def main():
 
     # Create a modulated signal
     npwr = 0.01
-    data = scipy.random.randint(0, 256, N)
+    data = numpy.random.randint(0, 256, N)
     rrc_taps = filter.firdes.root_raised_cosine(1, 2, 1, 0.35, 41)
 
-    src = blocks.vector_source_b(data.astype(scipy.uint8).tolist(), False)
+    src = blocks.vector_source_b(data.astype(numpy.uint8).tolist(), False)
     mod = digital.bpsk_mod(samples_per_symbol=2)
     chan = channels.channel_model(npwr)
     rrc = filter.fft_filter_ccc(1, rrc_taps)
@@ -107,13 +101,13 @@ def main():
     tb.connect(synthesizer, snk)
     tb.run()
 
-    sin  = scipy.array(src_snk.data()[1000:])
-    sout = scipy.array(snk.data()[1000:])
+    sin  = numpy.array(src_snk.data()[1000:])
+    sout = numpy.array(snk.data()[1000:])
 
 
     # Plot original signal
     fs_in = nchans*fs
-    f1 = pylab.figure(1, figsize=(16,12), facecolor='w')
+    f1 = pyplot.figure(1, figsize=(16,12), facecolor='w')
     s11 = f1.add_subplot(2,2,1)
     s11.psd(sin, NFFT=fftlen, Fs=fs_in)
     s11.set_title("PSD of Original Signal")
@@ -133,10 +127,10 @@ def main():
     s13.set_ylim([-2, 2])
 
     # Plot channels
-    nrows = int(scipy.sqrt(nchans))
-    ncols = int(scipy.ceil(float(nchans) / float(nrows)))
+    nrows = int(numpy.sqrt(nchans))
+    ncols = int(numpy.ceil(float(nchans) / float(nrows)))
 
-    f2 = pylab.figure(2, figsize=(16,12), facecolor='w')
+    f2 = pyplot.figure(2, figsize=(16,12), facecolor='w')
     for n in range(nchans):
         s = f2.add_subplot(nrows, ncols, n+1)
         s.psd(vsnk[n].data(), NFFT=fftlen, Fs=fs_in)
@@ -145,7 +139,7 @@ def main():
 
     # Plot reconstructed signal
     fs_out = 2*nchans*fs
-    f3 = pylab.figure(3, figsize=(16,12), facecolor='w')
+    f3 = pyplot.figure(3, figsize=(16,12), facecolor='w')
     s31 = f3.add_subplot(2,2,1)
     s31.psd(sout, NFFT=fftlen, Fs=fs_out)
     s31.set_title("PSD of Reconstructed Signal")
@@ -164,7 +158,7 @@ def main():
     s33.set_xlim([-2, 2])
     s33.set_ylim([-2, 2])
 
-    pylab.show()
+    pyplot.show()
 
 
 if __name__ == "__main__":

--- a/gr-filter/examples/resampler.py
+++ b/gr-filter/examples/resampler.py
@@ -27,6 +27,7 @@ from gnuradio import gr
 from gnuradio import filter
 from gnuradio import blocks
 import sys
+import numpy
 
 try:
     from gnuradio import analog
@@ -35,13 +36,7 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
-    sys.exit(1)
-
-try:
-    import pylab
+    from matplotlib import pyplot
 except ImportError:
     sys.stderr.write("Error: Program requires matplotlib (see: matplotlib.sourceforge.net).\n")
     sys.exit(1)
@@ -91,7 +86,7 @@ def main():
 
     # Plot PSD of signals
     nfftsize = 2048
-    fig1 = pylab.figure(1, figsize=(10,10), facecolor="w")
+    fig1 = pyplot.figure(1, figsize=(10,10), facecolor="w")
     sp1 = fig1.add_subplot(2,1,1)
     sp1.psd(tb.snk_in.data(), NFFT=nfftsize,
             noverlap=nfftsize / 4, Fs = fs_in)
@@ -112,10 +107,10 @@ def main():
     # Plot signals in time
     Ts_in = 1.0 / fs_in
     Ts_out = 1.0 / fs_out
-    t_in = scipy.arange(0, len(tb.snk_in.data())*Ts_in, Ts_in)
-    t_out = scipy.arange(0, len(tb.snk_0.data())*Ts_out, Ts_out)
+    t_in = numpy.arange(0, len(tb.snk_in.data())*Ts_in, Ts_in)
+    t_out = numpy.arange(0, len(tb.snk_0.data())*Ts_out, Ts_out)
 
-    fig2 = pylab.figure(2, figsize=(10,10), facecolor="w")
+    fig2 = pyplot.figure(2, figsize=(10,10), facecolor="w")
     sp21 = fig2.add_subplot(2,1,1)
     sp21.plot(t_in, tb.snk_in.data())
     sp21.set_title(("Input Signal at f_s=%.2f kHz" % (fs_in / 1000.0)))
@@ -131,7 +126,7 @@ def main():
     sp22.set_xlim([t_out[r * 100], t_out[r * 200]])
     sp22.legend()
 
-    pylab.show()
+    pyplot.show()
 
 if __name__ == "__main__":
     main()

--- a/gr-filter/examples/synth_filter.py
+++ b/gr-filter/examples/synth_filter.py
@@ -27,6 +27,7 @@ from gnuradio import gr
 from gnuradio import filter
 from gnuradio import blocks
 import sys
+import numpy
 
 try:
     from gnuradio import analog
@@ -35,13 +36,7 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
-    sys.exit(1)
-
-try:
-    import pylab
+    from matplotlib import pyplot
 except ImportError:
     sys.stderr.write("Error: Program requires matplotlib (see: matplotlib.sourceforge.net).\n")
     sys.exit(1)
@@ -76,20 +71,20 @@ def main():
     tb.run()
 
     if 1:
-        f1 = pylab.figure(1)
+        f1 = pyplot.figure(1)
         s1 = f1.add_subplot(1,1,1)
         s1.plot(snk.data()[1000:])
 
         fftlen = 2048
-        f2 = pylab.figure(2)
+        f2 = pyplot.figure(2)
         s2 = f2.add_subplot(1,1,1)
-        winfunc = scipy.blackman
+        winfunc = numpy.blackman
         s2.psd(snk.data()[10000:], NFFT=fftlen,
                Fs = nchans*fs,
                noverlap=fftlen / 4,
                window = lambda d: d*winfunc(fftlen))
 
-        pylab.show()
+        pyplot.show()
 
 if __name__ == "__main__":
     main()

--- a/gr-filter/examples/synth_to_chan.py
+++ b/gr-filter/examples/synth_to_chan.py
@@ -27,6 +27,7 @@ from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
 import sys
+import numpy
 
 try:
     from gnuradio import analog
@@ -35,13 +36,7 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    sys.stderr.write("Error: Program requires scipy (see: www.scipy.org).\n")
-    sys.exit(1)
-
-try:
-    import pylab
+    from matplotlib import pyplot
 except ImportError:
     sys.stderr.write("Error: Program requires matplotlib (see: matplotlib.sourceforge.net).\n")
     sys.exit(1)
@@ -97,16 +92,16 @@ def main():
         channel = 1
         data = snk[channel].data()[1000:]
 
-        f1 = pylab.figure(1)
+        f1 = pyplot.figure(1)
         s1 = f1.add_subplot(1,1,1)
         s1.plot(data[10000:10200] )
         s1.set_title(("Output Signal from Channel %d" % channel))
 
         fftlen = 2048
-        winfunc = scipy.blackman
-        #winfunc = scipy.hamming
+        winfunc = numpy.blackman
+        #winfunc = numpy.hamming
 
-        f2 = pylab.figure(2)
+        f2 = pyplot.figure(2)
         s2 = f2.add_subplot(1,1,1)
         s2.psd(data, NFFT=fftlen,
                Fs = nchans*fs,
@@ -114,7 +109,7 @@ def main():
                window = lambda d: d*winfunc(fftlen))
         s2.set_title(("Output PSD from Channel %d" % channel))
 
-        f3 = pylab.figure(3)
+        f3 = pyplot.figure(3)
         s3 = f3.add_subplot(1,1,1)
         s3.psd(snk_synth.data()[1000:], NFFT=fftlen,
                Fs = nchans*fs,
@@ -122,7 +117,7 @@ def main():
                window = lambda d: d*winfunc(fftlen))
         s3.set_title("Output of Synthesis Filter")
 
-        pylab.show()
+        pyplot.show()
 
 if __name__ == "__main__":
     main()

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -31,8 +31,9 @@ from optparse import OptionParser
 from gnuradio import filter
 
 try:
-    import scipy
-    from scipy import fftpack, poly1d, signal
+    import numpy
+    from numpy.fft import fftpack
+    from scipy import poly1d, signal
 except ImportError:
     print("Please install SciPy to run this script (http://www.scipy.org/)")
     raise SystemExit(1)
@@ -106,7 +107,7 @@ class gr_plot_filter(QtGui.QMainWindow):
             if ind != -1:
                 self.gui.fselectComboBox.removeItem(ind)
         elif restype == "fir":
-            ind = self.gui.fselectComboBox.findText("IIR(scipy)")
+            ind = self.gui.fselectComboBox.findText("IIR(numpy)")
             if ind != -1:
                 self.gui.fselectComboBox.removeItem(ind)
 
@@ -702,7 +703,7 @@ class gr_plot_filter(QtGui.QMainWindow):
             self.gui.mttapsPush.setEnabled(True)
             self.gui.addpolePush.setEnabled(False)
             self.gui.maddpolePush.setEnabled(False)
-        elif(ftype == "IIR(scipy)"):
+        elif(ftype == "IIR(numpy)"):
             self.gui.filterDesignTypeComboBox.hide()
             self.gui.globalParamsBox.hide()
             self.gui.filterTypeComboBox.hide()
@@ -872,7 +873,7 @@ class gr_plot_filter(QtGui.QMainWindow):
             self.b, self.a=[],[]
             if(ret):
                 self.design_fir(ftype, fs, gain, winstr)
-        elif (fsel == "IIR(scipy)"):
+        elif (fsel == "IIR(numpy)"):
             with warnings.catch_warnings(record=True) as w:
                 # Cause all warnings to always be triggered.
                 warnings.simplefilter("always")
@@ -1047,10 +1048,10 @@ class gr_plot_filter(QtGui.QMainWindow):
     def iir_plot_all(self,z,p,k):
         self.b,self.a = signal.zpk2tf(z,p,k)
         w,h = signal.freqz(self.b,self.a)
-        self.fftdB = 20 * scipy.log10 (abs(h))
+        self.fftdB = 20 * numpy.log10 (abs(h))
         self.freq = w / max(w)
-        self.fftDeg = scipy.unwrap(scipy.arctan2(scipy.imag(h),scipy.real(h)))
-        self.groupDelay = -scipy.diff(self.fftDeg)
+        self.fftDeg = numpy.unwrap(numpy.arctan2(numpy.imag(h),numpy.real(h)))
+        self.groupDelay = -numpy.diff(self.fftDeg)
         self.phaseDelay = -self.fftDeg[1:] / self.freq[1:]
         if self.gridview:
             self.set_mfmagresponse()
@@ -1083,28 +1084,28 @@ class gr_plot_filter(QtGui.QMainWindow):
     def get_fft(self, fs, taps, Npts):
         Ts = 1.0 / fs
         fftpts = fftpack.fft(taps, Npts)
-        self.freq = scipy.arange(0, fs, 1.0 / (Npts*Ts))
+        self.freq = numpy.arange(0, fs, 1.0 / (Npts*Ts))
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.fftdB = 20.0*scipy.log10(abs(fftpts))
+            self.fftdB = 20.0*numpy.log10(abs(fftpts))
             if any(self.fftdB == float('-inf')):
                 sys.stderr.write('Filter design failed (taking log10 of 0).\n')
-                self.fftdB = scipy.zeros([len(fftpts)])
+                self.fftdB = numpy.zeros([len(fftpts)])
 
-        self.fftDeg = scipy.unwrap(scipy.angle(fftpts))
-        self.groupDelay = -scipy.diff(self.fftDeg)
+        self.fftDeg = numpy.unwrap(numpy.angle(fftpts))
+        self.groupDelay = -numpy.diff(self.fftDeg)
         self.phaseDelay = -self.fftDeg[1:] / self.freq[1:]
 
     def update_time_curves(self):
         ntaps = len(self.taps)
         if(ntaps > 0):
-            if(type(self.taps[0]) == scipy.complex128):
-                self.rcurve.setData(scipy.arange(ntaps), self.taps.real)
-                self.icurve.setData(scipy.arange(ntaps), self.taps.imag)
+            if(type(self.taps[0]) == numpy.complex128):
+                self.rcurve.setData(numpy.arange(ntaps), self.taps.real)
+                self.icurve.setData(numpy.arange(ntaps), self.taps.imag)
                 ymax = 1.5 * max(max(self.taps.real),max(self.taps.imag))
                 ymin = 1.5 * min(min(self.taps.real),min(self.taps.imag))
             else:
-                self.rcurve.setData(scipy.arange(ntaps), self.taps)
+                self.rcurve.setData(numpy.arange(ntaps), self.taps)
                 self.icurve.setData([],[]);
                 ymax = 1.5 * max(self.taps)
                 ymin = 1.5 * min(self.taps)
@@ -1141,13 +1142,13 @@ class gr_plot_filter(QtGui.QMainWindow):
                 ntaps=50
             else:
                 stepres=self.step_response(self.taps)
-            if(type(stepres[0]) == scipy.complex128):
-                self.steprescurve.setData(scipy.arange(ntaps), stepres.real)
-                self.steprescurve_i.setData(scipy.arange(ntaps), stepres.imag)
+            if(type(stepres[0]) == numpy.complex128):
+                self.steprescurve.setData(numpy.arange(ntaps), stepres.real)
+                self.steprescurve_i.setData(numpy.arange(ntaps), stepres.imag)
                 symax = 1.5 * max(max(stepres.real),max(stepres.imag))
                 symin = 1.5 * min(min(stepres.real),min(stepres.imag))
             else:
-                self.steprescurve.setData(scipy.arange(ntaps), stepres)
+                self.steprescurve.setData(numpy.arange(ntaps), stepres)
                 self.steprescurve_i.setData([],[])
                 symax = 1.5 * max(stepres)
                 symin = 1.5 * min(stepres)
@@ -1184,13 +1185,13 @@ class gr_plot_filter(QtGui.QMainWindow):
                 ntaps=50
             else:
                 impres=self.impulse_response(self.taps)
-            if(type(impres[0]) == scipy.complex128):
-                self.imprescurve.setData(scipy.arange(ntaps), impres.real)
-                self.imprescurve_i.setData(scipy.arange(ntaps), impres.imag)
+            if(type(impres[0]) == numpy.complex128):
+                self.imprescurve.setData(numpy.arange(ntaps), impres.real)
+                self.imprescurve_i.setData(numpy.arange(ntaps), impres.imag)
                 iymax = 1.5 * max(max(impres.real),max(impres.imag))
                 iymin = 1.5 * min(min(impres.real),min(impres.imag))
             else:
-                self.imprescurve.setData(scipy.arange(ntaps), impres)
+                self.imprescurve.setData(numpy.arange(ntaps), impres)
                 self.imprescurve_i.setData([],[])
                 iymax = 1.5 * max(impres)
                 iymin = 1.5 * min(impres)
@@ -1700,7 +1701,7 @@ class gr_plot_filter(QtGui.QMainWindow):
 
     def update_fft(self, taps, params):
         self.params = params
-        self.taps = scipy.array(taps)
+        self.taps = numpy.array(taps)
         self.get_fft(self.params["fs"], self.taps, self.nfftpts)
 
     def set_mfoverlay(self):
@@ -1837,7 +1838,7 @@ class gr_plot_filter(QtGui.QMainWindow):
         else:
             plot = self.gui.freqPlot
 
-        if (self.gui.actionIdeal_Band.isChecked() == 0 or fsel == "IIR(scipy)"):
+        if (self.gui.actionIdeal_Band.isChecked() == 0 or fsel == "IIR(numpy)"):
             self.idbanditems.detach_allidealcurves(plot)
         elif(self.params):
             ftype = str(self.gui.filterTypeComboBox.currentText().toAscii())
@@ -2021,9 +2022,9 @@ class gr_plot_filter(QtGui.QMainWindow):
         l = len(b)
         if self.iir:
             l = 50
-        impulse = scipy.repeat(0.,l)
+        impulse = numpy.repeat(0.,l)
         impulse[0] =1.
-        x = scipy.arange(0,l)
+        x = numpy.arange(0,l)
         response = signal.lfilter(b,a,impulse)
         return response
 
@@ -2031,11 +2032,11 @@ class gr_plot_filter(QtGui.QMainWindow):
         l = len(b)
         if self.iir:
             l = 50
-        impulse = scipy.repeat(0.,l)
+        impulse = numpy.repeat(0.,l)
         impulse[0] =1.
-        x = scipy.arange(0,l)
+        x = numpy.arange(0,l)
         response = signal.lfilter(b,a,impulse)
-        step = scipy.cumsum(response)
+        step = numpy.cumsum(response)
         return step
 
     def update_fcoeff(self):
@@ -2270,7 +2271,7 @@ class gr_plot_filter(QtGui.QMainWindow):
 
     def draw_plots(self, taps, params):
         self.params = params
-        self.taps = scipy.array(taps)
+        self.taps = numpy.array(taps)
         if self.params:
             self.get_fft(self.params["fs"], self.taps, self.nfftpts)
             self.update_time_curves()

--- a/gr-filter/python/filter/gui/idealbanditems.py
+++ b/gr-filter/python/filter/gui/idealbanditems.py
@@ -24,7 +24,7 @@ from __future__ import unicode_literals
 
 from PyQt4 import QtGui, QtCore, Qt
 import PyQt4.Qwt5 as Qwt
-import scipy
+import numpy
 
 class IdealBandItems(object):
     def __init__(self):
@@ -46,11 +46,11 @@ class IdealBandItems(object):
             if (ftype == "Low Pass"):
                 self.detach_unwantedcurves(plot)
                 x=[0, self.params["pbend"]]
-                y=[20.0*scipy.log10(self.params["gain"])]*2
+                y=[20.0*numpy.log10(self.params["gain"])]*2
                 self.idealbandhcurves[0].setData(x, y)
 
                 x=[self.params["pbend"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[0].setData(x, y)
 
@@ -66,11 +66,11 @@ class IdealBandItems(object):
             elif ftype == "High Pass":
                 self.detach_unwantedcurves(plot)
                 x=[self.params["pbstart"],self.params["fs"] / 2.0]
-                y=[20.0*scipy.log10(self.params["gain"])]*2
+                y=[20.0*numpy.log10(self.params["gain"])]*2
                 self.idealbandhcurves[0].setData(x, y)
 
                 x=[self.params["pbstart"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[0].setData(x, y)
 
@@ -99,35 +99,35 @@ class IdealBandItems(object):
                 self.idealbandvcurves[1].setData(x, y)
 
                 x=[0,self.params["sbstart"]-self.params["tb"]]
-                y=[20.0*scipy.log10(self.params["gain"])]*2
+                y=[20.0*numpy.log10(self.params["gain"])]*2
                 self.idealbandhcurves[1].setData(x, y)
 
                 x=[self.params["sbstart"]-self.params["tb"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[2].setData(x, y)
 
                 x=[self.params["sbend"]+self.params["tb"],self.params["fs"] / 2.0]
-                y=[20.0*scipy.log10(self.params["gain"])]*2
+                y=[20.0*numpy.log10(self.params["gain"])]*2
                 self.idealbandhcurves[2].setData(x, y)
 
                 x=[self.params["sbend"]+self.params["tb"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[3].setData(x, y)
 
             elif ftype == "Band Pass":
                 x=[self.params["pbstart"],self.params["pbend"]]
-                y=[20.0*scipy.log10(self.params["gain"])]*2
+                y=[20.0*numpy.log10(self.params["gain"])]*2
                 self.idealbandhcurves[0].setData(x, y)
 
                 x=[self.params["pbstart"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[0].setData(x, y)
 
                 x=[self.params["pbend"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[1].setData(x, y)
 
@@ -151,16 +151,16 @@ class IdealBandItems(object):
 
             elif ftype == "Complex Band Pass":
                 x=[self.params["pbstart"],self.params["pbend"]]
-                y=[20.0*scipy.log10(self.params["gain"])]*2
+                y=[20.0*numpy.log10(self.params["gain"])]*2
                 self.idealbandhcurves[0].setData(x, y)
 
                 x=[self.params["pbstart"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[0].setData(x, y)
 
                 x=[self.params["pbend"]]*2
-                y=[20.0*scipy.log10(self.params["gain"]),
+                y=[20.0*numpy.log10(self.params["gain"]),
                    plot.axisScaleDiv(Qwt.QwtPlot.yLeft).lowerBound()]
                 self.idealbandvcurves[1].setData(x, y)
 

--- a/gr-qtgui/apps/gr_constellation_plot
+++ b/gr-qtgui/apps/gr_constellation_plot
@@ -37,12 +37,6 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    print("Error: Scipy required (www.scipy.org).")
-    sys.exit(1)
-
-try:
     from gnuradio.qtgui.plot_constellation_form import *
     from gnuradio.qtgui.plot_base import *
 except ImportError:

--- a/gr-qtgui/apps/gr_psd_plot_b
+++ b/gr-qtgui/apps/gr_psd_plot_b
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_psd_base as plot_base

--- a/gr-qtgui/apps/gr_psd_plot_c
+++ b/gr-qtgui/apps/gr_psd_plot_c
@@ -23,7 +23,6 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_psd_base as plot_base

--- a/gr-qtgui/apps/gr_psd_plot_f
+++ b/gr-qtgui/apps/gr_psd_plot_f
@@ -23,7 +23,6 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_psd_base as plot_base

--- a/gr-qtgui/apps/gr_psd_plot_i
+++ b/gr-qtgui/apps/gr_psd_plot_i
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_psd_base as plot_base

--- a/gr-qtgui/apps/gr_psd_plot_s
+++ b/gr-qtgui/apps/gr_psd_plot_s
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_psd_base as plot_base

--- a/gr-qtgui/apps/gr_spectrogram_plot
+++ b/gr-qtgui/apps/gr_spectrogram_plot
@@ -25,7 +25,6 @@ from gnuradio import blocks
 from gnuradio import filter
 import pmt
 from gnuradio.blocks import parse_file_metadata
-import scipy
 import sys
 import os
 

--- a/gr-qtgui/apps/gr_spectrogram_plot_b
+++ b/gr-qtgui/apps/gr_spectrogram_plot_b
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_spectrogram_base as plot_base

--- a/gr-qtgui/apps/gr_spectrogram_plot_c
+++ b/gr-qtgui/apps/gr_spectrogram_plot_c
@@ -23,7 +23,6 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_spectrogram_base as plot_base

--- a/gr-qtgui/apps/gr_spectrogram_plot_f
+++ b/gr-qtgui/apps/gr_spectrogram_plot_f
@@ -23,7 +23,6 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_spectrogram_base as plot_base

--- a/gr-qtgui/apps/gr_spectrogram_plot_i
+++ b/gr-qtgui/apps/gr_spectrogram_plot_i
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_spectrogram_base as plot_base

--- a/gr-qtgui/apps/gr_spectrogram_plot_s
+++ b/gr-qtgui/apps/gr_spectrogram_plot_s
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import filter
-import scipy
 
 try:
     import gnuradio.qtgui.plot_spectrogram_base as plot_base

--- a/gr-qtgui/apps/gr_time_plot_b
+++ b/gr-qtgui/apps/gr_time_plot_b
@@ -21,7 +21,6 @@
 #
 
 from gnuradio import gr
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_base as plot_base

--- a/gr-qtgui/apps/gr_time_plot_c
+++ b/gr-qtgui/apps/gr_time_plot_c
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import blocks
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_base as plot_base

--- a/gr-qtgui/apps/gr_time_plot_f
+++ b/gr-qtgui/apps/gr_time_plot_f
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import blocks
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_base as plot_base

--- a/gr-qtgui/apps/gr_time_plot_i
+++ b/gr-qtgui/apps/gr_time_plot_i
@@ -21,7 +21,6 @@
 #
 
 from gnuradio import gr
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_base as plot_base

--- a/gr-qtgui/apps/gr_time_plot_s
+++ b/gr-qtgui/apps/gr_time_plot_s
@@ -21,7 +21,6 @@
 #
 
 from gnuradio import gr
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_base as plot_base

--- a/gr-qtgui/apps/gr_time_raster_b
+++ b/gr-qtgui/apps/gr_time_raster_b
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import blocks
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_raster_base as plot_base

--- a/gr-qtgui/apps/gr_time_raster_f
+++ b/gr-qtgui/apps/gr_time_raster_f
@@ -22,7 +22,6 @@
 
 from gnuradio import gr
 from gnuradio import blocks
-import scipy
 
 try:
     import gnuradio.qtgui.plot_time_raster_base as plot_base

--- a/gr-qtgui/apps/plot_base.py
+++ b/gr-qtgui/apps/plot_base.py
@@ -37,11 +37,7 @@ except ImportError:
     print("Error: Program requires PyQt4 and gr-qtgui.")
     sys.exit(1)
 
-try:
-    import scipy
-except ImportError:
-    print("Error: Scipy required (www.scipy.org).")
-    sys.exit(1)
+import numpy
 
 try:
     from gnuradio.qtgui.plot_constellation_form import *
@@ -60,7 +56,7 @@ def read_samples(filename, start, in_size, min_size, dtype, dtype_size):
     # Read in_size number of samples from file
     fhandle = open(filename, 'r')
     fhandle.seek(start*dtype_size, 0)
-    data = scipy.fromfile(fhandle, dtype=dtype, count=in_size)
+    data = numpy.fromfile(fhandle, dtype=dtype, count=in_size)
     data_min = 1.1*data.min()
     data_max = 1.1*data.max()
     data = data.tolist()
@@ -80,31 +76,31 @@ def read_samples(filename, start, in_size, min_size, dtype, dtype_size):
 
 def read_samples_f(filename, start, in_size, min_size=0):
     return read_samples(filename, start, in_size, min_size,
-                        scipy.float32, gr.sizeof_float)
+                        numpy.float32, gr.sizeof_float)
 
 def read_samples_i(filename, start, in_size, min_size=0):
     return read_samples(filename, start, in_size, min_size,
-                        scipy.int32, gr.sizeof_int)
+                        numpy.int32, gr.sizeof_int)
 
 def read_samples_s(filename, start, in_size, min_size=0):
     return read_samples(filename, start, in_size, min_size,
-                        scipy.int16, gr.sizeof_short)
+                        numpy.int16, gr.sizeof_short)
 
 def read_samples_b(filename, start, in_size, min_size=0):
     d,mn,mx = read_samples(filename, start, in_size, min_size,
-                           scipy.int8, gr.sizeof_char)
+                           numpy.int8, gr.sizeof_char)
 
     # Bit of a hack since we want to read the data as signed ints, but
     # the blocks.vector_source_b will only accept unsigned. We read in as
     # signed, do our min/max and things on that, then convert here.
-    d = scipy.array(d, dtype=scipy.uint8).tolist()
+    d = numpy.array(d, dtype=numpy.uint8).tolist()
     return d,mn,mx
 
 def read_samples_c(filename, start, in_size, min_size=0):
     # Complex samples are handled differently
     fhandle = open(filename, 'r')
     fhandle.seek(start*gr.sizeof_gr_complex, 0)
-    data = scipy.fromfile(fhandle, dtype=scipy.complex64, count=in_size)
+    data = numpy.fromfile(fhandle, dtype=numpy.complex64, count=in_size)
     data_min = 1.1*float(min(data.real.min(), data.imag.min()))
     data_max = 1.1*float(max(data.real.max(), data.imag.max()))
     data = data.tolist()

--- a/gr-qtgui/apps/plot_psd_base.py
+++ b/gr-qtgui/apps/plot_psd_base.py
@@ -37,12 +37,6 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    print("Error: Scipy required (www.scipy.org).")
-    sys.exit(1)
-
-try:
     from gnuradio.qtgui.plot_form import *
     from gnuradio.qtgui.plot_base import *
 except ImportError:

--- a/gr-qtgui/apps/plot_spectrogram_base.py
+++ b/gr-qtgui/apps/plot_spectrogram_base.py
@@ -38,12 +38,6 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    print("Error: Scipy required (www.scipy.org).")
-    sys.exit(1)
-
-try:
     from gnuradio.qtgui.plot_form import *
     from gnuradio.qtgui.plot_base import *
 except ImportError:

--- a/gr-qtgui/apps/plot_time_base.py
+++ b/gr-qtgui/apps/plot_time_base.py
@@ -37,12 +37,6 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    print("Error: Scipy required (www.scipy.org).")
-    sys.exit(1)
-
-try:
     from gnuradio.qtgui.plot_form import *
     from gnuradio.qtgui.plot_base import *
 except ImportError:

--- a/gr-qtgui/apps/plot_time_raster_base.py
+++ b/gr-qtgui/apps/plot_time_raster_base.py
@@ -37,12 +37,6 @@ except ImportError:
     sys.exit(1)
 
 try:
-    import scipy
-except ImportError:
-    print("Error: Scipy required (www.scipy.org).")
-    sys.exit(1)
-
-try:
     from gnuradio.qtgui.plot_form import *
     from gnuradio.qtgui.plot_base import *
 except ImportError:

--- a/gr-qtgui/examples/qtgui_tags_viewing.grc
+++ b/gr-qtgui/examples/qtgui_tags_viewing.grc
@@ -989,7 +989,7 @@
     </param>
     <param>
       <key>import</key>
-      <value>import scipy</value>
+      <value>import numpy</value>
     </param>
   </block>
   <block>

--- a/gr-utils/python/utils/gr_plot_char
+++ b/gr-utils/python/utils/gr_plot_char
@@ -22,14 +22,10 @@
 
 from __future__ import print_function
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
-
 from argparse import ArgumentParser
 from gnuradio.plot_data import plot_data
+
+import numpy
 
 def main():
     description = "Takes a GNU Radio byte/char binary file and displays the samples versus time. You can set the block size to specify how many points to read in at a time and the start position in the file. By default, the system assumes a sample rate of 1, so in time, each sample is plotted versus the sample number. To set a true time axis, set the sample rate (-R or --sample-rate) to the sample rate used when capturing the samples."
@@ -46,7 +42,7 @@ def main():
 
     args = parser.parse_args()
 
-    datatype = scipy.int8
+    datatype = numpy.int8
     dc = plot_data(datatype, args.files, args)
 
 if __name__ == "__main__":

--- a/gr-utils/python/utils/gr_plot_const
+++ b/gr-utils/python/utils/gr_plot_const
@@ -22,11 +22,7 @@
 
 from __future__ import print_function
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
+import numpy
 
 try:
     from pylab import *
@@ -44,7 +40,7 @@ class draw_constellation:
         self.start = options.start
         self.sample_rate = options.sample_rate
 
-        self.datatype = scipy.complex64
+        self.datatype = numpy.complex64
         self.sizeof_data = self.datatype().nbytes    # number of bytes per sample in file
 
         self.axis_font_size = 16
@@ -83,17 +79,17 @@ class draw_constellation:
     def get_data(self):
         self.text_file_pos.set_text("File Position: %d" % (self.hfile.tell()//self.sizeof_data))
         try:
-            iq = scipy.fromfile(self.hfile, dtype=self.datatype, count=self.block_length)
+            iq = numpy.fromfile(self.hfile, dtype=self.datatype, count=self.block_length)
         except MemoryError:
             print("End of File")
         else:
-            # retesting length here as newer version of scipy does not throw a MemoryError, just
+            # retesting length here as newer version of numpy does not throw a MemoryError, just
             # returns a zero-length array
             if(len(iq) > 0):
-                self.reals = scipy.array([r.real for r in iq])
-                self.imags = scipy.array([i.imag for i in iq])
+                self.reals = numpy.array([r.real for r in iq])
+                self.imags = numpy.array([i.imag for i in iq])
 
-                self.time = scipy.array([i*(1/self.sample_rate) for i in range(len(self.reals))])
+                self.time = numpy.array([i*(1/self.sample_rate) for i in range(len(self.reals))])
                 return True
             else:
                 print("End of File")
@@ -145,8 +141,8 @@ class draw_constellation:
         draw()
 
     def zoom(self, event):
-        newxlim = scipy.array(self.sp_iq.get_xlim())
-        curxlim = scipy.array(self.xlim)
+        newxlim = numpy.array(self.sp_iq.get_xlim())
+        curxlim = numpy.array(self.xlim)
         if(newxlim[0] != curxlim[0] or newxlim[1] != curxlim[1]):
             self.xlim = newxlim
             r = self.reals[int(ceil(self.xlim[0])) : int(ceil(self.xlim[1]))]

--- a/gr-utils/python/utils/gr_plot_float
+++ b/gr-utils/python/utils/gr_plot_float
@@ -22,11 +22,7 @@
 
 from __future__ import print_function
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
+import numpy
 
 from argparse import ArgumentParser
 from gnuradio.plot_data import plot_data
@@ -46,7 +42,7 @@ def main():
 
     args = parser.parse_args()
 
-    datatype=scipy.float32
+    datatype=numpy.float32
     dc = plot_data(datatype, args.file, args)
 
 if __name__ == "__main__":

--- a/gr-utils/python/utils/gr_plot_int
+++ b/gr-utils/python/utils/gr_plot_int
@@ -20,14 +20,10 @@
 # Boston, MA 02110-1301, USA.
 #
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
-
 from argparse import ArgumentParser
 from gnuradio.plot_data import plot_data
+
+import numpy
 
 def main():
     description = "Takes a GNU Radio integer binary file and displays the samples versus time. You can set the block size to specify how many points to read in at a time and the start position in the file. By default, the system assumes a sample rate of 1, so in time, each sample is plotted versus the sample number. To set a true time axis, set the sample rate (-R or --sample-rate) to the sample rate used when capturing the samples."
@@ -44,7 +40,7 @@ def main():
 
     args = parser.parse_args()
 
-    datatype=scipy.int32
+    datatype=numpy.int32
     dc = plot_data(datatype, args.file, args)
 
 if __name__ == "__main__":

--- a/gr-utils/python/utils/gr_plot_iq
+++ b/gr-utils/python/utils/gr_plot_iq
@@ -22,11 +22,7 @@
 
 from __future__ import print_function
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
+import numpy
 
 try:
     from pylab import *
@@ -43,7 +39,7 @@ class draw_iq:
         self.start = options.start
         self.sample_rate = options.sample_rate
 
-        self.datatype = scipy.complex64
+        self.datatype = numpy.complex64
         self.sizeof_data = self.datatype().nbytes    # number of bytes per sample in file
 
         self.axis_font_size = 16
@@ -81,13 +77,13 @@ class draw_iq:
     def get_data(self):
         self.text_file_pos.set_text("File Position: %d" % (self.hfile.tell()//self.sizeof_data))
         try:
-            self.iq = scipy.fromfile(self.hfile, dtype=self.datatype, count=self.block_length)
+            self.iq = numpy.fromfile(self.hfile, dtype=self.datatype, count=self.block_length)
         except MemoryError:
             print("End of File")
         else:
-            self.reals = scipy.array([r.real for r in self.iq])
-            self.imags = scipy.array([i.imag for i in self.iq])
-            self.time = scipy.array([i*(1/self.sample_rate) for i in range(len(self.reals))])
+            self.reals = numpy.array([r.real for r in self.iq])
+            self.imags = numpy.array([i.imag for i in self.iq])
+            self.time = numpy.array([i*(1/self.sample_rate) for i in range(len(self.reals))])
 
     def make_plots(self):
         # if specified on the command-line, set file pointer

--- a/gr-utils/python/utils/gr_plot_qt
+++ b/gr-utils/python/utils/gr_plot_qt
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
-
-try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
+import numpy
 
 try:
     from matplotlib import mlab
@@ -42,7 +36,7 @@ class SpectrogramData(Qwt.QwtRasterData):
 
     def __init__(self, f, t):
         Qwt.QwtArrayData.__init__(self, Qt.QRectF(0, 0, 0, 0))
-        self.sp = scipy.array([[0], [0]])
+        self.sp = numpy.array([[0], [0]])
 
     def set_data(self, xfreq, ytime, data):
         self.sp = data
@@ -84,9 +78,9 @@ class gr_plot_qt(QtGui.QMainWindow):
         self.sample_rate = options.sample_rate
         self.psdfftsize = options.psd_size
         self.specfftsize = options.spec_size
-        self.winfunc = scipy.blackman
+        self.winfunc = numpy.blackman
         self.sizeof_data = 8
-        self.datatype = scipy.complex64
+        self.datatype = numpy.complex64
         self.pen_width = 1
         self.iq = list()
         self.time = list()
@@ -328,7 +322,7 @@ class gr_plot_qt(QtGui.QMainWindow):
             self.hfile.seek(start*self.sizeof_data, os.SEEK_SET)
             self.position = start
             try:
-                iq = scipy.fromfile(self.hfile, dtype=self.datatype,
+                iq = numpy.fromfile(self.hfile, dtype=self.datatype,
                                     count=end-start)
 
                 if(len(iq) < (end-start)):
@@ -355,7 +349,7 @@ class gr_plot_qt(QtGui.QMainWindow):
                                 window=winpoints,
                                 scale_by_freq=False)
 
-        self.iq_psd = 10.0*scipy.log10(abs(fftpack.fftshift(iq_psd)))
+        self.iq_psd = 10.0*numpy.log10(abs(numpy.fft.fftshift(iq_psd)))
         self.freq = freq - self.sample_rate/2.0
 
     def get_specgram(self):
@@ -366,7 +360,7 @@ class gr_plot_qt(QtGui.QMainWindow):
                                       window=winpoints,
                                       scale_by_freq=False)
 
-        self.iq_spec = 10.0*scipy.log10(abs(iq_spec))
+        self.iq_spec = 10.0*numpy.log10(abs(iq_spec))
         self.spec_f = f
         self.spec_t = t
 

--- a/gr-utils/python/utils/gr_plot_short
+++ b/gr-utils/python/utils/gr_plot_short
@@ -22,14 +22,10 @@
 
 from __future__ import print_function
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
-
 from argparse import ArgumentParser
 from gnuradio.plot_data import plot_data
+
+import numpy
 
 def main():
     description = "Takes a GNU Radio short integer binary file and displays the samples versus time. You can set the block size to specify how many points to read in at a time and the start position in the file. By default, the system assumes a sample rate of 1, so in time, each sample is plotted versus the sample number. To set a true time axis, set the sample rate (-R or --sample-rate) to the sample rate used when capturing the samples."
@@ -46,7 +42,7 @@ def main():
 
     args = parser.parse_args()
 
-    datatype=scipy.int16
+    datatype=numpy.int16
     dc = plot_data(datatype, args.files, args)
 
 if __name__ == "__main__":

--- a/gr-utils/python/utils/plot_data.py
+++ b/gr-utils/python/utils/plot_data.py
@@ -26,18 +26,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-try:
-    import scipy
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
-
-try:
-    from pylab import *
-except ImportError:
-    print("Please install Matplotlib to run this script (http://matplotlib.sourceforge.net/)")
-    raise SystemExit(1)
-
+import numpy
 
 class plot_data(object):
     def __init__(self, datatype, filenames, options):
@@ -88,12 +77,12 @@ class plot_data(object):
     def get_data(self, hfile):
         self.text_file_pos.set_text("File Position: %d" % (hfile.tell()//self.sizeof_data))
         try:
-            f = scipy.fromfile(hfile, dtype=self.datatype, count=self.block_length)
+            f = numpy.fromfile(hfile, dtype=self.datatype, count=self.block_length)
         except MemoryError:
             print("End of File")
         else:
-            self.f = scipy.array(f)
-            self.time = scipy.array([i*(1 / self.sample_rate) for i in range(len(self.f))])
+            self.f = numpy.array(f)
+            self.time = numpy.array([i*(1 / self.sample_rate) for i in range(len(self.f))])
 
     def make_plots(self):
         self.sp_f = self.fig.add_subplot(2,1,1, position=[0.075, 0.2, 0.875, 0.6])

--- a/gr-utils/python/utils/plot_fft_base.py
+++ b/gr-utils/python/utils/plot_fft_base.py
@@ -24,12 +24,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-try:
-    import scipy
-    from scipy import fftpack
-except ImportError:
-    print("Please install SciPy to run this script (http://www.scipy.org/)")
-    raise SystemExit(1)
+import numpy
+from numpy.fft import fftpack
 
 try:
     from pylab import *
@@ -46,7 +42,7 @@ class plot_fft_base(object):
         self.start = options.start
         self.sample_rate = options.sample_rate
 
-        self.datatype = getattr(scipy, datatype)
+        self.datatype = numpy.complex64
         self.sizeof_data = self.datatype().nbytes    # number of bytes per sample in file
 
         self.axis_font_size = 16
@@ -86,22 +82,22 @@ class plot_fft_base(object):
         self.position = self.hfile.tell() / self.sizeof_data
         self.text_file_pos.set_text("File Position: %d" % (self.position))
         try:
-            self.iq = scipy.fromfile(self.hfile, dtype=self.datatype, count=self.block_length)
+            self.iq = numpy.fromfile(self.hfile, dtype=self.datatype, count=self.block_length)
         except MemoryError:
             print("End of File")
         else:
             self.iq_fft = self.dofft(self.iq)
 
             tstep = 1.0 / self.sample_rate
-            #self.time = scipy.array([tstep*(self.position + i) for i in range(len(self.iq))])
-            self.time = scipy.array([tstep*(i) for i in range(len(self.iq))])
+            #self.time = numpy.array([tstep*(self.position + i) for i in range(len(self.iq))])
+            self.time = numpy.array([tstep*(i) for i in range(len(self.iq))])
 
             self.freq = self.calc_freq(self.time, self.sample_rate)
 
     def dofft(self, iq):
         N = len(iq)
-        iq_fft = scipy.fftpack.fftshift(scipy.fft(iq))       # fft and shift axis
-        iq_fft = 20*scipy.log10(abs((iq_fft+1e-15) / N)) # convert to decibels, adjust power
+        iq_fft = numpy.fft.fftshift(fftpack.fft(iq))       # fft and shift axis
+        iq_fft = 20*numpy.log10(abs((iq_fft+1e-15) / N)) # convert to decibels, adjust power
         # adding 1e-15 (-300 dB) to protect against value errors if an item in iq_fft is 0
         return iq_fft
 
@@ -109,7 +105,7 @@ class plot_fft_base(object):
         N = len(time)
         Fs = 1.0 / (time.max( - time.min()))
         Fn = 0.5 * sample_rate
-        freq = scipy.array([-Fn + i*Fs for i in range(N)])
+        freq = numpy.array([-Fn + i*Fs for i in range(N)])
         return freq
 
     def make_plots(self):
@@ -161,8 +157,8 @@ class plot_fft_base(object):
         draw()
 
     def zoom(self, event):
-        newxlim = scipy.array(self.sp_iq.get_xlim())
-        curxlim = scipy.array(self.xlim)
+        newxlim = numpy.array(self.sp_iq.get_xlim())
+        curxlim = numpy.array(self.xlim)
         if(newxlim[0] != curxlim[0] or newxlim[1] != curxlim[1]):
             self.xlim = newxlim
             #xmin = max(0, int(ceil(self.sample_rate*(self.xlim[0] - self.position))))


### PR DESCRIPTION
This should reduce the number of times users are prompted to install
pylab || scipy when they'd actually get away with functionality fully
contained in numpy and matplotlib.

This only solves the obvious cases. There's some usage of `pylab.mlab`
that would need more than 20s of consideration.