### PR TITLE
Removing unneeded decode

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -83,7 +83,7 @@ class ExecFlowGraphThread(threading.Thread):
         r = "\n"
         while r:
             GLib.idle_add(Messages.send_verbose_exec, r)
-            r = self.process.stdout.read(1024).decode('utf-8','ignore')
+            r = self.process.stdout.read(1024)
         self.process.poll()
         GLib.idle_add(self.done)
 


### PR DESCRIPTION
There was a misunderstanding in [pr 1965]https://github.com/gnuradio/gnuradio/pull/1965l)
No we get:
      File "/usr/local/gnuradio/lib/python3.6/dist-packages/gnuradio/grc/gui/Executor.py", line 86, in run
         r = self.process.stdout.read(1024).decode('utf-8','ignore')
     AttributeError: 'str' object has no attribute 'decode'

self.process.stdout.read is a string object and must not be decoded.

os.read(self.process.stdout.fileno(), 1024) delivers bytes that have to be decoded to strings.

After removing the decode everything works fine.
