### PR TITLE
Trying to merge @michaelld's PR

### DIFF
--- a/gnuradio-runtime/lib/controlport/CMakeLists.txt
+++ b/gnuradio-runtime/lib/controlport/CMakeLists.txt
@@ -17,15 +17,18 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-if(ENABLE_GR_CTRLPORT)
-
 # Keep track of the number of backends ControlPort supports
 SET(CTRLPORT_BACKENDS 0)
+
+if(ENABLE_GR_CTRLPORT)
 
 # Add definition so we can compile in ControlPort to the blocks.
 add_definitions(-DGR_CTRLPORT)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 list(APPEND gnuradio_ctrlport_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/rpcmanager.cc
@@ -33,7 +36,6 @@ list(APPEND gnuradio_ctrlport_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/rpcserver_booter_aggregator.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/rpcserver_selector.cc
 )
-
 
 OPTION(ENABLE_CTRLPORT_THRIFT "Enable ControlPort Thrift support" ON)
 
@@ -89,17 +91,10 @@ install(
 
 endif(THRIFT_FOUND)
 endif(ENABLE_CTRLPORT_THRIFT)
-
-########################################################################
-# Add controlport stuff to gnuradio-runtime
-########################################################################
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+endif(ENABLE_GR_CTRLPORT)
 
 # Save the number of backends for testing against later
 set(
   CTRLPORT_BACKENDS ${CTRLPORT_BACKENDS}
   CACHE INTERNAL "Number of ControlPort backends available"
 )
-
-endif(ENABLE_GR_CTRLPORT)

--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -46,13 +46,13 @@ if(ENABLE_TESTING)
   file(GLOB py_qa_test_files "qa_*.py")
 
   # Force out the controlport QA tests if we have no backends to use.
-  if(CTRLPORT_BACKENDS EQUAL 0)
+  if(NOT ENABLE_GR_CTRLPORT)
     list(REMOVE_ITEM py_qa_test_files
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_cpp_py_binding.py
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_cpp_py_binding_set.py
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_ctrlport_probes.py
       )
-  endif(CTRLPORT_BACKENDS EQUAL 0)
+  endif(NOT ENABLE_GR_CTRLPORT)
 
   foreach(py_qa_test_file ${py_qa_test_files})
     get_filename_component(py_qa_test_name ${py_qa_test_file} NAME_WE)


### PR DESCRIPTION
cmake: fix CTRLPORT includes and testing

Currently, CTRLPORT_BACKENDS is not declared if ENABLE_GR_CTRLPORT is FALSE, so testing this variable makes no sense. All testing in gr-* is done using ENABLE_GR_CTRLPORT, so move to that in gr-blocks.

That said, having CTRLPORT_BACKENDS set to 0 could be useful, so rearrange CTRLPORT determination to set this variable correctly.

If ENABLE_CTRLPORT_THRIFT, then correctly use include_directories for header directories, -after- CTRLPORT is determined, not before. We can also combine some of these declarations to simplify the code.