### PR TITLE
qtgui: Remove remaining problematic callbacks from sinks (next)

### DIFF
--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -398,10 +398,7 @@ templates:
         from gnuradio import qtgui
         import sip
     callbacks:
-    - set_resize(${width}, ${height})
     - set_update_time(${update_time})
-    - set_title(${which}, ${title})
-    - set_color(${which}, ${color})
     - self.${id}.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_chan},
         ${tr_tag})
     make: |-

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -363,8 +363,6 @@ templates:
         import sip
     callbacks:
     - set_update_time(${update_time})
-    - set_title(${which}, ${title})
-    - set_color(${which}, ${color})
     - set_bins(${bins})
     - set_x_axis(${xmin}, ${xmax})
     make: |-

--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -221,8 +221,6 @@ templates:
     - set_multiplier(${mult})
     - set_offset(${offset})
     - set_update_time(${update_time})
-    - set_title(${which}, ${title})
-    - set_color(${which}, ${color})
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -497,8 +497,6 @@ templates:
     callbacks:
     - set_time_domain_axis(${min}, ${max})
     - set_update_time(${update_time})
-    - set_title(${which}, ${title})
-    - set_color(${which}, ${color})
     - set_y_axis(${ymin}, ${ymax})
     - set_samp_rate(${srate})
     - self.${id}.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_delay},

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -297,8 +297,6 @@ templates:
         import sip
     callbacks:
     - set_update_time(${update_time})
-    - set_title(${title})
-    - set_color(${which}, ${color})
     - set_x_axis(${x_start}, ${x_step})
     - set_y_axis(${ymin}, ${ymax})
     - set_ref_level(${ref_level})


### PR DESCRIPTION
This is really just https://github.com/gnuradio/gnuradio/pull/1969 for the remaining QT sinks that have this problem.