### PR TITLE
Add missing header file (fir_filter_blk.h)

### DIFF
--- a/gr-filter/include/gnuradio/filter/CMakeLists.txt
+++ b/gr-filter/include/gnuradio/filter/CMakeLists.txt
@@ -24,6 +24,7 @@ install(FILES
     api.h
     firdes.h
     fir_filter.h
+    fir_filter_blk.h
     fir_filter_with_buffer.h
     fft_filter.h
     iir_filter.h


### PR DESCRIPTION
Install the missing header ```fir_filter_blk.h```, so other modules using these blocks can be easily updated.