### PR TITLE
qtgui: Change the signals and slots to unsigned as well

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/displayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/displayform.h
@@ -64,10 +64,10 @@ public slots:
   void setTitle(const QString &title);
   void setLineLabel(unsigned int which, const QString &label);
   void setLineColor(unsigned int which, const QString &color);
-  void setLineWidth(unsigned int which, int width);
+  void setLineWidth(unsigned int which, unsigned int width);
   void setLineStyle(unsigned int which, Qt::PenStyle style);
   void setLineMarker(unsigned int which, QwtSymbol::Style style);
-  void setMarkerAlpha(unsigned int which, int alpha);
+  void setMarkerAlpha(unsigned int which, unsigned int alpha);
 
   QString title();
   QString lineLabel(unsigned int which);

--- a/gr-qtgui/include/gnuradio/qtgui/form_menus.h
+++ b/gr-qtgui/include/gnuradio/qtgui/form_menus.h
@@ -184,7 +184,7 @@ public:
   }
 
 signals:
-  void whichTrigger(unsigned int which, int width);
+  void whichTrigger(unsigned int which, unsigned int width);
 
 public slots:
   void getOne()   { emit whichTrigger(d_which, 1); }
@@ -423,7 +423,7 @@ public:
   }
 
 signals:
-  void whichTrigger(unsigned int which, int);
+  void whichTrigger(unsigned int which, unsigned int);
 
 public slots:
   void getNone()   { emit whichTrigger(d_which, 255); }

--- a/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
@@ -79,7 +79,7 @@ public slots:
   void setMaxIntensity(const QString &m);
   void setMinIntensity(const QString &m);
 
-  void setAlpha(unsigned int which, int alpha);
+  void setAlpha(unsigned int which, unsigned int alpha);
 
   void setColorMap(unsigned int which,
 		   const int newType,

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -76,32 +76,32 @@ DisplayForm::DisplayForm(int nplots, QWidget* parent)
     d_line_marker_menu.push_back(new LineMarkerMenu(i, this));
     d_marker_alpha_menu.push_back(new MarkerAlphaMenu(i, this));
 
-    connect(d_line_title_act[i], SIGNAL(whichTrigger(int, const QString&)),
-	    this, SLOT(setLineLabel(int, const QString&)));
+    connect(d_line_title_act[i], SIGNAL(whichTrigger(unsigned int, const QString&)),
+	    this, SLOT(setLineLabel(unsigned int, const QString&)));
 
     for(int j = 0; j < d_line_color_menu[i]->getNumActions(); j++) {
-      connect(d_line_color_menu[i], SIGNAL(whichTrigger(int, const QString&)),
-	      this, SLOT(setLineColor(int, const QString&)));
+      connect(d_line_color_menu[i], SIGNAL(whichTrigger(unsigned int, const QString&)),
+	      this, SLOT(setLineColor(unsigned int, const QString&)));
     }
 
     for(int j = 0; j < d_line_width_menu[i]->getNumActions(); j++) {
-      connect(d_line_width_menu[i], SIGNAL(whichTrigger(int, int)),
-	      this, SLOT(setLineWidth(int, int)));
+      connect(d_line_width_menu[i], SIGNAL(whichTrigger(unsigned int, unsigned int)),
+	      this, SLOT(setLineWidth(unsigned int, unsigned int)));
     }
 
     for(int j = 0; j < d_line_style_menu[i]->getNumActions(); j++) {
-      connect(d_line_style_menu[i], SIGNAL(whichTrigger(int, Qt::PenStyle)),
-	      this, SLOT(setLineStyle(int, Qt::PenStyle)));
+      connect(d_line_style_menu[i], SIGNAL(whichTrigger(unsigned int, Qt::PenStyle)),
+	      this, SLOT(setLineStyle(unsigned int, Qt::PenStyle)));
     }
 
     for(int j = 0; j < d_line_marker_menu[i]->getNumActions(); j++) {
-      connect(d_line_marker_menu[i], SIGNAL(whichTrigger(int, QwtSymbol::Style)),
-	      this, SLOT(setLineMarker(int, QwtSymbol::Style)));
+      connect(d_line_marker_menu[i], SIGNAL(whichTrigger(unsigned int, QwtSymbol::Style)),
+	      this, SLOT(setLineMarker(unsigned int, QwtSymbol::Style)));
     }
 
     for(int j = 0; j < d_marker_alpha_menu[i]->getNumActions(); j++) {
-      connect(d_marker_alpha_menu[i], SIGNAL(whichTrigger(int, int)),
-	      this, SLOT(setMarkerAlpha(int, int)));
+      connect(d_marker_alpha_menu[i], SIGNAL(whichTrigger(unsigned int, unsigned int)),
+	      this, SLOT(setMarkerAlpha(unsigned int, unsigned int)));
     }
 
     d_lines_menu.push_back(new QMenu(tr(""), this));
@@ -233,7 +233,7 @@ DisplayForm::setLineColor(unsigned int which, const QString &color)
 }
 
 void
-DisplayForm::setLineWidth(unsigned int which, int width)
+DisplayForm::setLineWidth(unsigned int which, unsigned int width)
 {
   d_display_plot->setLineWidth(which, width);
   d_display_plot->replot();
@@ -254,7 +254,7 @@ DisplayForm::setLineMarker(unsigned int which, QwtSymbol::Style marker)
 }
 
 void
-DisplayForm::setMarkerAlpha(unsigned int which, int alpha)
+DisplayForm::setMarkerAlpha(unsigned int which, unsigned int alpha)
 {
   d_display_plot->setMarkerAlpha(which, alpha);
   d_display_plot->replot();

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -66,13 +66,13 @@ WaterfallDisplayForm::WaterfallDisplayForm(int nplots, QWidget* parent)
   // Now create our own menus
   for(int i = 0; i < nplots; i++) {
     ColorMapMenu *colormap = new ColorMapMenu(i, this);
-    connect(colormap, SIGNAL(whichTrigger(int, const int, const QColor&, const QColor&)),
-	    this, SLOT(setColorMap(int, const int, const QColor&, const QColor&)));
+    connect(colormap, SIGNAL(whichTrigger(unsigned int, const int, const QColor&, const QColor&)),
+	    this, SLOT(setColorMap(unsigned int, const int, const QColor&, const QColor&)));
     d_lines_menu[i]->addMenu(colormap);
 
     d_marker_alpha_menu.push_back(new MarkerAlphaMenu(i, this));
-    connect(d_marker_alpha_menu[i], SIGNAL(whichTrigger(int, int)),
-	    this, SLOT(setAlpha(int, int)));
+    connect(d_marker_alpha_menu[i], SIGNAL(whichTrigger(unsigned int, unsigned int)),
+	    this, SLOT(setAlpha(unsigned int, unsigned int)));
     d_lines_menu[i]->addMenu(d_marker_alpha_menu[i]);
   }
 
@@ -257,7 +257,7 @@ WaterfallDisplayForm::setColorMap(unsigned int which,
 }
 
 void
-WaterfallDisplayForm::setAlpha(unsigned int which, int alpha)
+WaterfallDisplayForm::setAlpha(unsigned int which, unsigned int alpha)
 {
   getPlot()->setAlpha(which, alpha);
   getPlot()->replot();
@@ -364,4 +364,3 @@ WaterfallDisplayForm::setUpdateTime(double t)
    // This is the case when plotting using gr_spectrogram_plot
    d_time_per_fft = t;
 }
-


### PR DESCRIPTION
In 1f857d30d5d73576070d70ad785cba3d505b2a73 no Qt signals were changed to the new unsigned indices so no GUI elements work...