### PR TITLE
Use site-packages vs dist-packages for python libs

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -96,7 +96,7 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
 import os
 import sys
 if os.name == 'posix':
-    print(os.path.join('lib', 'python' + sys.version[:3], 'dist-packages'))
+    print(os.path.join('lib', 'python' + sys.version[:3], 'site-packages'))
 if os.name == 'nt':
     print(os.path.join('Lib', 'site-packages'))
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Fixes #2006

This also helps on non-debian packaging.