### PR TITLE
Give the GRC GUI a better default configuration.

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -455,7 +455,8 @@ TOGGLE_CONSOLE_WINDOW = actions.register("win.toggle_console_window",
     label='Show _Console Panel',
     tooltip='Toggle visibility of the console',
     keypresses=["<Ctrl>r"],
-    preference_name='console_window_visible'
+    preference_name='console_window_visible',
+    default=True
 )
 # TODO: Might be able to convert this to a Gio.PropertyAction eventually.
 #       actions would need to be defined in the correct class and not globally
@@ -463,7 +464,8 @@ TOGGLE_BLOCKS_WINDOW = actions.register("win.toggle_blocks_window",
     label='Show _Block Tree Panel',
     tooltip='Toggle visibility of the block tree widget',
     keypresses=["<Ctrl>b"],
-    preference_name='blocks_window_visible'
+    preference_name='blocks_window_visible',
+    default=True
 )
 TOGGLE_SCROLL_LOCK = actions.register("win.console.scroll_lock",
     label='Console Scroll _Lock',

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -134,8 +134,8 @@ class Config(CoreConfig):
     def main_window_size(self, size=None):
         if size is None:
             size = [None, None]
-        w = self.entry('main_window_width', size[0], default=1)
-        h = self.entry('main_window_height', size[1], default=1)
+        w = self.entry('main_window_width', size[0], default=800)
+        h = self.entry('main_window_height', size[1], default=600)
         return w, h
 
     def file_open(self, filename=None):


### PR DESCRIPTION
If `~/.gnuradio/grc.conf` is not present when GRC starts, it will open in a tiny window:

![screenshot from 2018-09-21 09-31-07](https://user-images.githubusercontent.com/583749/45893992-eed27180-bd81-11e8-9fd9-22812108e8a9.png)

Once that window is expanded, the block tree panel and console panel are hidden:

![screenshot from 2018-09-21 09-31-38](https://user-images.githubusercontent.com/583749/45893999-f560e900-bd81-11e8-9274-c4b4afeec15f.png)

In this PR, I've changed the defaults so that a new user would begin with the GUI in a more usable state:

![screenshot from 2018-09-21 09-37-12](https://user-images.githubusercontent.com/583749/45894060-27724b00-bd82-11e8-91f3-b7b8cd7c71ca.png)
