### PR TITLE
Fix infinite loop when extract_docs worker dies.

### DIFF
--- a/grc/core/utils/extract_docs.py
+++ b/grc/core/utils/extract_docs.py
@@ -199,7 +199,10 @@ class SubprocessLoader(object):
                     raise ValueError('Got wrong auth code')
                 return cmd, args
             except ValueError:
-                continue  # ignore invalid output from worker
+                if self._worker.poll():
+                    raise IOError("Worker died")
+                else:
+                    continue  # ignore invalid output from worker
         else:
             raise IOError("Can't read worker response")
 


### PR DESCRIPTION
If the worker process in extract_docs.py dies (which it currently does on my machine due to a segfault that occurs when `gnuradio.qtgui` is imported), its parent process doesn't realize that and enters into an infinite loop attempting to read its output. This causes 100% CPU utilization and makes GRC very sluggish.

In this PR, I've added a check which raises an `IOError` in the event that the worker process dies. After the change, extract_docs.py works as expected, relaunching the worker process in the event of crash, and eventually giving up after too many crashes occur.