### PR TITLE
grc: Added switch widget for bool typed params

### DIFF
--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -230,6 +230,23 @@ class EnumParam(InputParam):
     def set_tooltip_text(self, text):
         self._input.set_tooltip_text(text)
 
+class BoolParam(InputParam):
+    """Provide a switch button for Bool types."""
+
+    def __init__(self, *args, **kwargs):
+        InputParam.__init__(self, *args, **kwargs)
+        self._input = Gtk.Switch()
+        self._input.connect('state-set', self._apply_change)
+        self._input.connect('state-set', self._editing_callback)
+        self.pack_start(self._input, False, False, 0)
+        value = self.param.get_value()
+        self._input.set_active(eval(value))
+
+    def get_text(self):
+        return self._input.get_active()
+
+    def set_tooltip_text(self, text):
+        self._input.set_tooltip_text(text)
 
 class EnumEntryParam(InputParam):
     """Provide an entry box and drop down menu for Raw Enum types."""

--- a/grc/gui/canvas/param.py
+++ b/grc/gui/canvas/param.py
@@ -46,6 +46,9 @@ class Param(CoreParam):
         elif dtype == 'enum':
             input_widget_cls = ParamWidgets.EnumParam
 
+        elif dtype == 'bool':
+            input_widget_cls = ParamWidgets.BoolParam
+
         elif self.options:
             input_widget_cls = ParamWidgets.EnumEntryParam
 


### PR DESCRIPTION
Following the discussion in https://github.com/gnuradio/gnuradio/pull/1849, this PR introduces a switch widget for bool typed parameters. This is intended to replace enums with `True` and `False` options.