### PR TITLE
Use enable_tags correctly in time sink template.

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -516,7 +516,7 @@ templates:
 
         self.${id}.set_y_label(${ylabel}, ${yunit})
 
-        self.${id}.enable_tags(0, ${entags})
+        self.${id}.enable_tags(${entags})
         self.${id}.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_delay}, ${tr_chan}, ${tr_tag})
         self.${id}.enable_autoscale(${autoscale})
         self.${id}.enable_grid(${grid})


### PR DESCRIPTION
https://github.com/gnuradio/gnuradio/pull/1983 changed the time sink to use unsigned integers for input numbers. As noted in https://github.com/gnuradio/gnuradio/pull/1983#issuecomment-423720413, the template for the time sink passes in `-1`, which is no longer valid:

https://github.com/gnuradio/gnuradio/blob/d9c981e5137f04a0a226d7b29d5814ecf53b2df2/gr-qtgui/grc/qtgui_time_sink_x.block.yml#L519

To fix this, I've changed the template to use the single-argument version of `enable_tags`, which sets the value for all inputs simultaneously. I imagine this was the intention, since there's only a single "Disp. Tags" drop-down in the block settings, even when "Number of inputs" is greater than 1.