### PR TITLE
Making enable/disable and parameter Spectrum width work

### DIFF
--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -418,8 +418,9 @@ templates:
         self.${id}.enable_grid(${grid})
         self.${id}.enable_axis_labels(${axislabels})
 
-        if not ${legend}:
-            self.${id}.disable_legend()
+        % if legend == "False":
+        self.${id}.disable_legend()
+        % endif
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -414,11 +414,13 @@ templates:
         self.${id}.enable_axis_labels(${axislabels})
         self.${id}.enable_control_panel(${ctrlpanel})
 
-        if not ${legend}:
-            self.${id}.disable_legend()
+        % if legend == "False":
+        self.${id}.disable_legend()
+        % endif
 
-        if ${type} == "float" or ${type} == "msg_float":
-            self.${id}.set_plot_pos_half(not ${freqhalf})
+        % if type == "float" or type == "msg_float":
+        self.${id}.set_plot_pos_half(not ${freqhalf})
+        % endif 
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -384,8 +384,9 @@ templates:
         self.${id}.enable_grid(${grid})
         self.${id}.enable_axis_labels(${axislabels})
 
-        if not ${legend}:
-          self.${id}.disable_legend()
+        % if legend == "False":
+        self.${id}.disable_legend()
+        % endif
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -516,7 +516,7 @@ templates:
 
         self.${id}.set_y_label(${ylabel}, ${yunit})
 
-        self.${id}.enable_tags(-1, ${entags})
+        self.${id}.enable_tags(${entags})
         self.${id}.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_delay}, ${tr_chan}, ${tr_tag})
         self.${id}.enable_autoscale(${autoscale})
         self.${id}.enable_grid(${grid})
@@ -524,8 +524,9 @@ templates:
         self.${id}.enable_control_panel(${ctrlpanel})
         self.${id}.enable_stem_plot(${stemplot})
 
-        if not ${legend}:
-            self.${id}.disable_legend()
+        % if legend == "False":
+        self.${id}.disable_legend()
+        % endif
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
@@ -548,6 +549,17 @@ templates:
                     self.${id}.set_line_label(i, "Re{{Data {0}}}".format(i/2))
                 else:
                     self.${id}.set_line_label(i, "Im{{Data {0}}}".format(i/2))
+            else:
+                self.${id}.set_line_label(i, labels[i])
+            self.${id}.set_line_width(i, widths[i])
+            self.${id}.set_line_color(i, colors[i])
+            self.${id}.set_line_style(i, styles[i])
+            self.${id}.set_line_marker(i, markers[i])
+            self.${id}.set_line_alpha(i, alphas[i])
+        % else:
+        for i in range(${1 if type.startswith('msg') else int(nconnections)}):
+            if len(labels[i]) == 0:
+                self.${id}.set_line_label(i, "Data {0}".format(i))
             else:
                 self.${id}.set_line_label(i, labels[i])
             self.${id}.set_line_width(i, widths[i])

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -269,11 +269,13 @@ templates:
         self.${id}.enable_grid(${grid})
         self.${id}.enable_axis_labels(${axislabels})
 
-        if not ${legend}:
-            self.${id}.disable_legend()
+        % if legend == "False":
+        self.${id}.disable_legend()
+        % endif
 
-        if "${type}" == "float" or "${type}" == "msg_float":
-            self.${id}.set_plot_pos_half(not ${freqhalf})
+        % if type == "float" or type == "msg_float":
+        self.${id}.set_plot_pos_half(not ${freqhalf})
+        % endif 
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
                   ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]


### PR DESCRIPTION
Legend settings and spectrum witdh settings for input type *float are not handled correctly.
This is fixed here.
The multiple reported error in qt time sink 'enable_tags'
( https://github.com/gnuradio/gnuradio/issues/2013 , https://github.com/gnuradio/gnuradio/pull/2032 )

is fixed, too.

To make these blocks properly work the following prs should be merged, too:

qtgui: Change the signals and slots to unsigned as well https://github.com/gnuradio/gnuradio/pull/2018
grc: Un-hide option_attributes from rest of parameters https://github.com/gnuradio/gnuradio/pull/1925