### PR TITLE
gengen replacement: fix for not installed header files

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -25,6 +25,7 @@ install(FILES
     add_blk.h
     add_const_v.h
     and_blk.h
+    and_const.h
     api.h
     argmax.h
     control_loop.h
@@ -73,6 +74,7 @@ install(FILES
     char_to_short.h
     check_lfsr_32k_s.h
     complex_to_interleaved_short.h
+    complex_to_interleaved_char.h
     complex_to_float.h
     complex_to_magphase.h
     complex_to_imag.h

--- a/gr-filter/include/gnuradio/filter/CMakeLists.txt
+++ b/gr-filter/include/gnuradio/filter/CMakeLists.txt
@@ -24,10 +24,12 @@ install(FILES
     api.h
     firdes.h
     fir_filter.h
+    fir_filter_blk.h
     fir_filter_with_buffer.h
     fft_filter.h
     iir_filter.h
     interpolator_taps.h
+    interp_fir_filter.h
     mmse_fir_interpolator_cc.h
     mmse_fir_interpolator_ff.h
     mmse_interp_differentiator_cc.h


### PR DESCRIPTION
Some header files are not being installed, seems they were forgotten during gengen replacement, here: https://github.com/gnuradio/gnuradio/commit/1043222e0de551f00683a1cc9060f194adc4fc85 and https://github.com/gnuradio/gnuradio/commit/7588f103b9e75eea56d241868d161d0f04f3fd79

Perhaps @noc0lour will be able to tell quickly if this is correct.

I noticed this when fixing gqrx to compile against latest master.