### PR TITLE
Widen the id column in the variable editor.

### DIFF
--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -116,7 +116,7 @@ class VariableEditor(Gtk.VBox):
         id_column.set_resizable(True)
         id_column.set_max_width(Utils.scale_scalar(300))
         id_column.set_min_width(Utils.scale_scalar(80))
-        id_column.set_fixed_width(Utils.scale_scalar(100))
+        id_column.set_fixed_width(Utils.scale_scalar(120))
         id_column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
         id_column.set_cell_data_func(self.id_cell, self.set_properties)
         self.id_column = id_column


### PR DESCRIPTION
The "Id" column in GRC's variable editor is a bit too narrow. I've increased the default width so that the `samp_rate` variable is fully visible in a new flowgraph.

Before:
![screenshot from 2018-09-25 08-26-54](https://user-images.githubusercontent.com/583749/46014441-3e27e300-c09d-11e8-8b3a-d70a551c4261.png)

After:
![screenshot from 2018-09-25 08-25-44](https://user-images.githubusercontent.com/583749/46014443-408a3d00-c09d-11e8-9f36-209989d00bca.png)
