### PR TITLE
Remove "open recent" button from toolbar.

### DIFF
--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -50,8 +50,9 @@ LIST_NAME = [
 
 # The list of actions for the toolbar.
 TOOLBAR_LIST = [
-    [(Actions.FLOW_GRAPH_NEW, 'flow_graph_new_type'), Actions.FLOW_GRAPH_OPEN,
-    (Actions.FLOW_GRAPH_OPEN_RECENT, 'flow_graph_recent'), Actions.FLOW_GRAPH_SAVE, Actions.FLOW_GRAPH_CLOSE],
+    [(Actions.FLOW_GRAPH_NEW, 'flow_graph_new_type'),
+     (Actions.FLOW_GRAPH_OPEN, 'flow_graph_recent'),
+     Actions.FLOW_GRAPH_SAVE, Actions.FLOW_GRAPH_CLOSE],
     [Actions.TOGGLE_FLOW_GRAPH_VAR_EDITOR, Actions.FLOW_GRAPH_SCREEN_CAPTURE],
     [Actions.BLOCK_CUT, Actions.BLOCK_COPY, Actions.BLOCK_PASTE, Actions.ELEMENT_DELETE],
     [Actions.FLOW_GRAPH_UNDO, Actions.FLOW_GRAPH_REDO],


### PR DESCRIPTION
The GRC toolbar has a useless "Open a recently used flowgraph" button. It's greyed out and can't be clicked:

![screenshot from 2018-09-25 08-46-21](https://user-images.githubusercontent.com/583749/46015176-8fd16d00-c09f-11e8-9b7d-f8eac5456104.png)

I've removed this button from the toolbar. This puts the recent files drop-down next to the open button, like it was in GNU Radio 3.7.