### PR TITLE
grc: add python block to misc category

### DIFF
--- a/grc/blocks/grc.tree.yml
+++ b/grc/blocks/grc.tree.yml
@@ -4,6 +4,7 @@
   - pad_sink
   - virtual_source
   - virtual_sink
+  - epy_block
   - epy_module
   - note
   - import


### PR DESCRIPTION
Fixes #2040.

Currently the Python Block doesn't appear in in the block tree panel. This adds it to the Misc category.

/cc @haakov 