### PR TITLE
Fix invalid escape sequences.

### DIFF
--- a/docs/doxygen/other/doxypy.py
+++ b/docs/doxygen/other/doxypy.py
@@ -97,22 +97,22 @@ class Doxypy(object):
     def __init__(self):
         string_prefixes = "[uU]?[rR]?"
 
-        self.start_single_comment_re = re.compile("^\s*%s(''')" % string_prefixes)
-        self.end_single_comment_re = re.compile("(''')\s*$")
+        self.start_single_comment_re = re.compile(r"^\s*%s(''')" % string_prefixes)
+        self.end_single_comment_re = re.compile(r"(''')\s*$")
 
-        self.start_double_comment_re = re.compile("^\s*%s(\"\"\")" % string_prefixes)
-        self.end_double_comment_re = re.compile("(\"\"\")\s*$")
+        self.start_double_comment_re = re.compile(r'^\s*%s(""")' % string_prefixes)
+        self.end_double_comment_re = re.compile(r'(""")\s*$')
 
-        self.single_comment_re = re.compile("^\s*%s(''').*(''')\s*$" % string_prefixes)
-        self.double_comment_re = re.compile("^\s*%s(\"\"\").*(\"\"\")\s*$" % string_prefixes)
+        self.single_comment_re = re.compile(r"^\s*%s(''').*(''')\s*$" % string_prefixes)
+        self.double_comment_re = re.compile(r'^\s*%s(""").*(""")\s*$' % string_prefixes)
 
-        self.defclass_re = re.compile("^(\s*)(def .+:|class .+:)")
-        self.empty_re = re.compile("^\s*$")
-        self.hashline_re = re.compile("^\s*#.*$")
-        self.importline_re = re.compile("^\s*(import |from .+ import)")
+        self.defclass_re = re.compile(r"^(\s*)(def .+:|class .+:)")
+        self.empty_re = re.compile(r"^\s*$")
+        self.hashline_re = re.compile(r"^\s*#.*$")
+        self.importline_re = re.compile(r"^\s*(import |from .+ import)")
 
-        self.multiline_defclass_start_re = re.compile("^(\s*)(def|class)(\s.*)?$")
-        self.multiline_defclass_end_re = re.compile(":\s*$")
+        self.multiline_defclass_start_re = re.compile(r"^(\s*)(def|class)(\s.*)?$")
+        self.multiline_defclass_end_re = re.compile(r":\s*$")
 
         ## Transition list format
         #  ["FROM", "TO", condition, action]

--- a/docs/sphinx/hieroglyph/test/test_comments.py
+++ b/docs/sphinx/hieroglyph/test/test_comments.py
@@ -269,7 +269,7 @@ All of the source sequence will be consumed.
                         u'    A Record which has a named attribute for each of the keyword arguments.',
                         u'']
 
-        expected = """A convenience factory for creating Records.
+        expected = r"""A convenience factory for creating Records.
 
 :param \*\*kwargs: Each keyword argument will be used to initialise an
    attribute with the same name as the argument and the given
@@ -382,7 +382,7 @@ All of the source sequence will be consumed.
             A Record which has a named attribute for each of the keyword arguments.
         """
 
-        expected = """A convenience factory for creating Records.
+        expected = r"""A convenience factory for creating Records.
 
         :param \*\*kwargs: Each keyword argument will be used to initialise an
             attribute with the same name as the argument and the given
@@ -584,4 +584,3 @@ All of the source sequence will be consumed.
 
         source_lines = source.splitlines()
         self.assertRaises(HieroglyphError, lambda: parse_hieroglyph_text(source_lines))
-

--- a/gnuradio-runtime/python/gnuradio/ctrlport/monitor.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/monitor.py
@@ -51,8 +51,8 @@ class monitor(object):
         print("monitor::endpoints() = %s" % (gr.rpcmanager_get().endpoints()))
         try:
             cmd = map(lambda a: [self.tool,
-                                 re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)",a).group(1),
-                                 re.search("-p (\d+)",a).group(1)],
+                                 re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)",a).group(1),
+                                 re.search(r"-p (\d+)",a).group(1)],
                       gr.rpcmanager_get().endpoints())[0]
             print("running: %s"%(str(cmd)))
             self.proc = subprocess.Popen(cmd);

--- a/gr-blocks/python/blocks/qa_cpp_py_binding.py
+++ b/gr-blocks/python/blocks/qa_cpp_py_binding.py
@@ -153,8 +153,8 @@ class test_cpp_py_binding(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint

--- a/gr-blocks/python/blocks/qa_cpp_py_binding_set.py
+++ b/gr-blocks/python/blocks/qa_cpp_py_binding_set.py
@@ -120,8 +120,8 @@ class test_cpp_py_binding_set(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint

--- a/gr-blocks/python/blocks/qa_ctrlport_probes.py
+++ b/gr-blocks/python/blocks/qa_ctrlport_probes.py
@@ -58,8 +58,8 @@ class test_ctrlport_probes(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
@@ -99,8 +99,8 @@ class test_ctrlport_probes(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
@@ -139,8 +139,8 @@ class test_ctrlport_probes(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
@@ -180,8 +180,8 @@ class test_ctrlport_probes(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
@@ -220,8 +220,8 @@ class test_ctrlport_probes(gr_unittest.TestCase):
 
         # Get available endpoint
         ep = gr.rpcmanager_get().endpoints()[0]
-        hostname = re.search("-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
-        portnum = re.search("-p (\d+)", ep).group(1)
+        hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
+        portnum = re.search(r"-p (\d+)", ep).group(1)
         argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint

--- a/gr-digital/python/digital/qam_constellations.py
+++ b/gr-digital/python/digital/qam_constellations.py
@@ -73,7 +73,7 @@ rotations are based off of.
 For 16QAM:
  - n = 4
  - (2^n)*(n!) = 384
- - k \in [0x0, 0xF]
+ - k \\in [0x0, 0xF]
  - pi = 0, 1, 2, 3
         0, 1, 3, 2
         0, 2, 1, 3

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -2094,19 +2094,19 @@ class gr_plot_filter(QtGui.QMainWindow):
             if (row[0] == "restype"):
                 restype = row[1]
             elif(row[0] == "taps"):
-                testcpx = re.findall("[+-]?\d+\.*\d*[Ee]?[-+]?\d+j", row[1])
+                testcpx = re.findall(r"[+-]?\d+\.*\d*[Ee]?[-+]?\d+j", row[1])
                 if(len(testcpx) > 0): # it's a complex
                     taps = [complex(r) for r in row[1:]]
                 else:
                     taps = [float(r) for r in row[1:]]
             elif(row[0] == "b" or row[0] == "a"):
-                testcpx = re.findall("[+-]?\d+\.*\d*[Ee]?[-+]?\d+j", row[1])
+                testcpx = re.findall(r"[+-]?\d+\.*\d*[Ee]?[-+]?\d+j", row[1])
                 if(len(testcpx) > 0): # it's a complex
                     b_a[row[0]] = [complex(r) for r in row[1:]]
                 else:
                     b_a[row[0]]= [float(r) for r in row[1:]]
             else:
-                testcpx = re.findall("[+-]?\d+\.*\d*[Ee]?[-+]?\d+j", row[1])
+                testcpx = re.findall(r"[+-]?\d+\.*\d*[Ee]?[-+]?\d+j", row[1])
                 if(len(testcpx) > 0): # it's a complex
                     params[row[0]] = complex(row[1])
                 else: # assume it's a float

--- a/gr-utils/python/modtool/cmakefile_editor.py
+++ b/gr-utils/python/modtool/cmakefile_editor.py
@@ -35,7 +35,7 @@ class CMakeFileEditor(object):
 
     def append_value(self, entry, value, to_ignore_start='', to_ignore_end=''):
         """ Add a value to an entry. """
-        regexp = re.compile('(%s\(%s[^()]*?)\s*?(\s?%s)\)' % (entry, to_ignore_start, to_ignore_end),
+        regexp = re.compile(r'(%s\(%s[^()]*?)\s*?(\s?%s)\)' % (entry, to_ignore_start, to_ignore_end),
                             re.MULTILINE)
         substi = r'\1' + self.separator + value + r'\2)'
         (self.cfile, nsubs) = regexp.subn(substi, self.cfile, count=1)
@@ -80,7 +80,7 @@ class CMakeFileEditor(object):
 
     def delete_entry(self, entry, value_pattern=''):
         """Remove an entry from the current buffer."""
-        regexp = '%s\s*\([^()]*%s[^()]*\)[^\n]*\n' % (entry, value_pattern)
+        regexp = r'%s\s*\([^()]*%s[^()]*\)[^\n]*\n' % (entry, value_pattern)
         regexp = re.compile(regexp, re.MULTILINE)
         (self.cfile, nsubs) = re.subn(regexp, '', self.cfile, count=1)
         return nsubs
@@ -98,7 +98,7 @@ class CMakeFileEditor(object):
         on lines that aren't comments """
         filenames = []
         reg = re.compile(regex)
-        fname_re = re.compile('[a-zA-Z]\w+\.\w{1,5}$')
+        fname_re = re.compile(r'[a-zA-Z]\w+\.\w{1,5}$')
         for line in self.cfile.splitlines():
             if len(line.strip()) == 0 or line.strip()[0] == '#':
                 continue
@@ -141,6 +141,5 @@ class CMakeFileEditor(object):
 
     def check_for_glob(self, globstr):
         """ Returns true if a glob as in globstr is found in the cmake file """
-        glob_re = r'GLOB\s[a-z_]+\s"%s"' % globstr.replace('*', '\*')
+        glob_re = r'GLOB\s[a-z_]+\s"%s"' % globstr.replace('*', r'\*')
         return re.search(glob_re, self.cfile, flags=re.MULTILINE|re.IGNORECASE) is not None
-

--- a/gr-utils/python/modtool/modtool_disable.py
+++ b/gr-utils/python/modtool/modtool_disable.py
@@ -117,7 +117,7 @@ class ModToolDisable(ModTool):
             blockname = os.path.splitext(fname[len(self._info['modname'])+1:])[0]
             if self._info['version'] in ('37', '38'):
                 blockname = os.path.splitext(fname)[0]
-            swigfile = re.sub('(%include\s+"'+fname+'")', r'//\1', swigfile)
+            swigfile = re.sub(r'(%include\s+"'+fname+r'")', r'//\1', swigfile)
             print("Changing %s..." % self._file['swig'])
             swigfile = re.sub('(GR_SWIG_BLOCK_MAGIC2?.+'+blockname+'.+;)', r'//\1', swigfile)
             open(self._file['swig'], 'w').write(swigfile)
@@ -163,4 +163,3 @@ class ModToolDisable(ModTool):
             cmake.write()
             self.scm.mark_files_updated((os.path.join(subdir, 'CMakeLists.txt'),))
         print("Careful: 'gr_modtool disable' does not resolve dependencies.")
-

--- a/gr-utils/python/modtool/parser_cc_block.py
+++ b/gr-utils/python/modtool/parser_cc_block.py
@@ -53,7 +53,7 @@ class ParserCCBlock(object):
                    }
         def _typestr_to_iotype(typestr):
             """ Convert a type string (e.g. sizeof(int) * vlen) to the type (e.g. 'int'). """
-            type_match = re.search('sizeof\s*\(([^)]*)\)', typestr)
+            type_match = re.search(r'sizeof\s*\(([^)]*)\)', typestr)
             if type_match is None:
                 return self.type_trans('char')
             return self.type_trans(type_match.group(1))
@@ -76,10 +76,10 @@ class ParserCCBlock(object):
             elif len(vlen_parts) > 1:
                 return '*'.join(vlen_parts).strip()
         iosig = {}
-        iosig_regex = '(?P<incall>gr::io_signature::make[23v]?)\s*\(\s*(?P<inmin>[^,]+),\s*(?P<inmax>[^,]+),' + \
-                      '\s*(?P<intype>(\([^\)]*\)|[^)])+)\),\s*' + \
-                      '(?P<outcall>gr::io_signature::make[23v]?)\s*\(\s*(?P<outmin>[^,]+),\s*(?P<outmax>[^,]+),' + \
-                      '\s*(?P<outtype>(\([^\)]*\)|[^)])+)\)'
+        iosig_regex = r'(?P<incall>gr::io_signature::make[23v]?)\s*\(\s*(?P<inmin>[^,]+),\s*(?P<inmax>[^,]+),' + \
+                      r'\s*(?P<intype>(\([^\)]*\)|[^)])+)\),\s*' + \
+                      r'(?P<outcall>gr::io_signature::make[23v]?)\s*\(\s*(?P<outmin>[^,]+),\s*(?P<outmax>[^,]+),' + \
+                      r'\s*(?P<outtype>(\([^\)]*\)|[^)])+)\)'
         iosig_match = re.compile(iosig_regex, re.MULTILINE).search(self.code_cc)
         try:
             iosig['in'] = _figure_out_iotype_and_vlen(iosig_match.group('incall'),
@@ -210,9 +210,9 @@ class ParserCCBlock(object):
             return param_list
         # Go, go, go!
         if self.version in ('37', '38'):
-            make_regex = 'static\s+sptr\s+make\s*'
+            make_regex = r'static\s+sptr\s+make\s*'
         else:
-            make_regex = '(?<=_API)\s+\w+_sptr\s+\w+_make_\w+\s*'
+            make_regex = r'(?<=_API)\s+\w+_sptr\s+\w+_make_\w+\s*'
         make_match = re.compile(make_regex, re.MULTILINE).search(self.code_h)
         try:
             params_list = _scan_param_list(make_match.end(0))
@@ -226,4 +226,3 @@ class ParserCCBlock(object):
                            'default': plist[2],
                            'in_constructor': True})
         return params
-

--- a/gr-utils/python/modtool/templates.py
+++ b/gr-utils/python/modtool/templates.py
@@ -276,7 +276,7 @@ namespace gr {
 '''
 
 # Block definition header file (for include/)
-Templates['block_def_h'] = '''/* -*- c++ -*- */
+Templates['block_def_h'] = r'''/* -*- c++ -*- */
 ${str_to_fancyc_comment(license)}
 
 #ifndef INCLUDED_${modname.upper()}_${blockname.upper()}_H
@@ -292,7 +292,7 @@ namespace gr {
 
 % if blocktype == 'noblock':
     /*!
-     * \\brief <+description+>
+     * \brief <+description+>
      *
      */
     class ${modname.upper()}_API ${blockname}
@@ -304,7 +304,7 @@ namespace gr {
     };
 % else:
     /*!
-     * \\brief <+description of block+>
+     * \brief <+description of block+>
      * \ingroup ${modname}
      *
      */
@@ -314,7 +314,7 @@ namespace gr {
       typedef boost::shared_ptr<${blockname}> sptr;
 
       /*!
-       * \\brief Return a shared_ptr to a new instance of ${modname}::${blockname}.
+       * \brief Return a shared_ptr to a new instance of ${modname}::${blockname}.
        *
        * To avoid accidental use of raw pointers, ${modname}::${blockname}'s
        * constructor is in a private implementation
@@ -417,7 +417,7 @@ class ${blockname}(${parenttype}):
     def general_work(self, input_items, output_items):
         output_items[0][:] = input_items[0]
         consume(0, len(input_items[0]))
-        \#self.consume_each(len(input_items[0]))
+        \\#self.consume_each(len(input_items[0]))
         return len(output_items[0])
 <% return %>
 % endif
@@ -547,7 +547,7 @@ if __name__ == '__main__':
     gr_unittest.run(qa_${blockname}, "qa_${blockname}.xml")
 '''
 
-Templates['grc_xml'] = '''<?xml version="1.0"?>
+Templates['grc_xml'] = r'''<?xml version="1.0"?>
 <block>
   <name>${blockname}</name>
   <key>${modname}_${blockname}</key>
@@ -724,7 +724,7 @@ ${modname}_${blockname}::work(int noutput_items,
 '''
 
 # Block definition header file (for include/)
-Templates['block_h36'] = '''/* -*- c++ -*- */
+Templates['block_h36'] = r'''/* -*- c++ -*- */
 ${str_to_fancyc_comment(license)}
 
 #ifndef INCLUDED_${modname.upper()}_${blockname.upper()}_H
@@ -749,7 +749,7 @@ typedef boost::shared_ptr<${modname}_${blockname}> ${modname}_${blockname}_sptr;
 ${modname.upper()}_API ${modname}_${blockname}_sptr ${modname}_make_${blockname} (${arglist});
 
 /*!
- * \\brief <+description+>
+ * \brief <+description+>
  * \ingroup ${modname}
  *
  */

--- a/grc/converter/cheetah_converter.py
+++ b/grc/converter/cheetah_converter.py
@@ -247,7 +247,7 @@ class Converter(object):
 
         out = ''.join(out)
         # fix: eval stuff
-        out = re.sub(r'(?P<arg>' + r'|'.join(self.extended) + r')\(\)', '\g<arg>', out)
+        out = re.sub(r'(?P<arg>' + r'|'.join(self.extended) + r')\(\)', r'\g<arg>', out)
 
         self.stats['hard'] += 1
         return spec.type(out)

--- a/tools/template_convert.py
+++ b/tools/template_convert.py
@@ -8,8 +8,8 @@ template_keywords = [
     "GR_EXPAND_X_H", "GR_EXPAND_CC_H", "GR_EXPAND_X_CC_H_IMPL", "GR_EXPAND_X_CC_H"
 ]
 template_regex = re.compile(
-    "^(?P<template_type>" + "|".join(template_keywords) + ")\(" +
-    "(?P<category>\w+)\s+(?P<name>\w+_XX?X?)(_impl)?\s+(?P<types>[\w\s]+)" + "\)$")
+    r"^(?P<template_type>" + "|".join(template_keywords) + r")\(" +
+    r"(?P<category>\w+)\s+(?P<name>\w+_XX?X?)(_impl)?\s+(?P<types>[\w\s]+)" + r"\)$")
 
 cpp_keywords = ["abs", "add", "and", "max", "min" "not" "xor"]
 types = {"s": "std::int16_t", "i": "std::int32_t", "b": "std::uint8_t", "c": "gr_complex", "f": "float"}


### PR DESCRIPTION
Python produces the following warning when processing many of GNU Radio's .py files:

> DeprecationWarning: invalid escape sequence

I've fixed all these, mostly by using raw strings. In a couple cases, it was simpler to stick with an ordinary string and replace `\` with `\\`.

I compared the strings in Python before & after, so these changes shouldn't break anything.