### PR TITLE
Convert tabs to spaces and fix syntax errors.

### DIFF
--- a/gnuradio-runtime/examples/mp-sched/affinity_set.py
+++ b/gnuradio-runtime/examples/mp-sched/affinity_set.py
@@ -21,30 +21,30 @@ class affinity_set(gr.top_block):
         gr.top_block.__init__(self, "Affinity Set Test")
 
         ##################################################
-	# Variables
-	##################################################
-	self.samp_rate = samp_rate = 32000
+        # Variables
+        ##################################################
+        self.samp_rate = samp_rate = 32000
 
-	##################################################
-	# Blocks
-	##################################################
+        ##################################################
+        # Blocks
+        ##################################################
         vec_len = 1
-	self.blocks_throttle_0 = blocks.throttle(gr.sizeof_gr_complex*vec_len, samp_rate)
-	self.blocks_null_source_0 = blocks.null_source(gr.sizeof_gr_complex*vec_len)
-	self.blocks_null_sink_0 = blocks.null_sink(gr.sizeof_gr_complex*vec_len)
-	self.filter_filt_0 = filter.fir_filter_ccc(1, 40000*[0.2+0.3j,])
-	self.filter_filt_1 = filter.fir_filter_ccc(1, 40000*[0.2+0.3j,])
+        self.blocks_throttle_0 = blocks.throttle(gr.sizeof_gr_complex*vec_len, samp_rate)
+        self.blocks_null_source_0 = blocks.null_source(gr.sizeof_gr_complex*vec_len)
+        self.blocks_null_sink_0 = blocks.null_sink(gr.sizeof_gr_complex*vec_len)
+        self.filter_filt_0 = filter.fir_filter_ccc(1, 40000*[0.2+0.3j,])
+        self.filter_filt_1 = filter.fir_filter_ccc(1, 40000*[0.2+0.3j,])
 
-	self.filter_filt_0.set_processor_affinity([0,])
-	self.filter_filt_1.set_processor_affinity([0,1])
+        self.filter_filt_0.set_processor_affinity([0,])
+        self.filter_filt_1.set_processor_affinity([0,1])
 
-	##################################################
-	# Connections
-	##################################################
-	self.connect((self.blocks_null_source_0, 0), (self.blocks_throttle_0, 0))
-	self.connect((self.blocks_throttle_0, 0), (self.filter_filt_0, 0))
-	self.connect((self.filter_filt_0, 0), (self.filter_filt_1, 0))
-	self.connect((self.filter_filt_1, 0), (self.blocks_null_sink_0, 0))
+        ##################################################
+        # Connections
+        ##################################################
+        self.connect((self.blocks_null_source_0, 0), (self.blocks_throttle_0, 0))
+        self.connect((self.blocks_throttle_0, 0), (self.filter_filt_0, 0))
+        self.connect((self.filter_filt_0, 0), (self.filter_filt_1, 0))
+        self.connect((self.filter_filt_1, 0), (self.blocks_null_sink_0, 0))
 
     def get_samp_rate(self):
         return self.samp_rate
@@ -60,15 +60,15 @@ if __name__ == '__main__':
 
     while(1):
         ret = input('Enter a new Core # or Press Enter to quit: ')
-	if(len(ret) == 0):
+        if(len(ret) == 0):
             tb.stop()
-	    sys.exit(0)
+            sys.exit(0)
         elif(ret.lower() == "none"):
             tb.filter_filt_0.unset_processor_affinity()
-	else:
+        else:
             try:
                 n = int(ret)
-	    except ValueError:
+            except ValueError:
                 print("Invalid number")
-	    else:
+            else:
                 tb.filter_filt_0.set_processor_affinity([n,])

--- a/gr-audio/examples/python/spectrum_inversion.py
+++ b/gr-audio/examples/python/spectrum_inversion.py
@@ -50,13 +50,13 @@ class my_top_block(gr.top_block):
         src = audio.source (sample_rate, args.audio_input)
         dst = audio.sink (sample_rate, args.audio_output)
 
-	vec1 = [1, -1]
-	vsource = blocks.vector_source_f(vec1, True)
-	multiply = blocks.multiply_ff()
+        vec1 = [1, -1]
+        vsource = blocks.vector_source_f(vec1, True)
+        multiply = blocks.multiply_ff()
 
-	self.connect(src, (multiply, 0))
-	self.connect(vsource, (multiply, 1))
-	self.connect(multiply, dst)
+        self.connect(src, (multiply, 0))
+        self.connect(vsource, (multiply, 1))
+        self.connect(multiply, dst)
 
 
 if __name__ == '__main__':

--- a/gr-digital/examples/narrowband/digital_bert_rx.py
+++ b/gr-digital/examples/narrowband/digital_bert_rx.py
@@ -200,9 +200,9 @@ def get_options(demods):
 
 
 if __name__ == "__main__":
-    print ("Warning: this example in its current shape is deprecated and
+    print ("""Warning: this example in its current shape is deprecated and
             will be removed or fundamentally reworked in a coming GNU Radio
-            release.")
+            release.""")
     demods = digital.modulation_utils.type_1_demods()
 
     (options, args) = get_options(demods)

--- a/gr-digital/examples/narrowband/digital_bert_tx.py
+++ b/gr-digital/examples/narrowband/digital_bert_tx.py
@@ -43,9 +43,9 @@ class bert_transmit(gr.hier_block2):
         gr.hier_block2.__init__(self, "bert_transmit",
                                 gr.io_signature(0, 0, 0),                    # Output signature
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex)) # Input signature
-        
-        # Create BERT data bit stream	
-	self._bits = blocks.vector_source_b([1,], True)      # Infinite stream of ones
+
+        # Create BERT data bit stream
+        self._bits = blocks.vector_source_b([1,], True)      # Infinite stream of ones
         self._scrambler = digital.scrambler_bb(0x8A, 0x7F, 7) # CCSDS 7-bit scrambler
 
         self._mod = digital.generic_mod(constellation, differential,
@@ -60,15 +60,15 @@ class bert_transmit(gr.hier_block2):
 
 class tx_psk_block(gr.top_block):
     def __init__(self, mod, options):
-	gr.top_block.__init__(self, "tx_mpsk")
+        gr.top_block.__init__(self, "tx_mpsk")
 
         self._modulator_class = mod
 
         # Get mod_kwargs
         mod_kwargs = self._modulator_class.extract_kwargs_from_options(options)
-        
+
         # transmitter
-	self._modulator = self._modulator_class(**mod_kwargs)
+        self._modulator = self._modulator_class(**mod_kwargs)
 
         if(options.tx_freq is not None):
             symbol_rate = options.bitrate / self._modulator.bits_per_symbol()
@@ -78,13 +78,13 @@ class tx_psk_block(gr.top_block):
                                          options.spec,
                                          options.antenna, options.verbose)
             options.samples_per_symbol = self._sink._sps
-            
+
         elif(options.to_file is not None):
             self._sink = blocks.file_sink(gr.sizeof_gr_complex, options.to_file)
         else:
             self._sink = blocks.null_sink(gr.sizeof_gr_complex)
-            
-            
+
+
         self._transmitter = bert_transmit(self._modulator._constellation,
                                           options.samples_per_symbol,
                                           options.differential,
@@ -94,7 +94,7 @@ class tx_psk_block(gr.top_block):
                                           log=options.log)
 
         self.amp = blocks.multiply_const_cc(options.amplitude)
-	self.connect(self._transmitter, self.amp, self._sink)
+        self.connect(self._transmitter, self.amp, self._sink)
 
 
 def get_options(mods):
@@ -120,22 +120,22 @@ def get_options(mods):
 
     for mod in list(mods.values()):
         mod.add_options(parser)
-		      
+
     (options, args) = parser.parse_args()
     if len(args) != 0:
         parser.print_help()
         sys.exit(1)
-	
+
     return (options, args)
 
 if __name__ == "__main__":
-    print ("Warning: this example in its current shape is deprecated and
+    print ("""Warning: this example in its current shape is deprecated and
             will be removed or fundamentally reworked in a coming GNU Radio
-            release.")
+            release.""")
     mods = digital.modulation_utils.type_1_mods()
 
     (options, args) = get_options(mods)
-    
+
     mod = mods[options.modulation]
     tb = tx_psk_block(mod, options)
 

--- a/gr-digital/examples/ofdm/receive_path.py
+++ b/gr-digital/examples/ofdm/receive_path.py
@@ -1,24 +1,24 @@
 from __future__ import unicode_literals
 #
 # Copyright 2005,2006,2011 Free Software Foundation, Inc.
-# 
+#
 # This file is part of GNU Radio
-# 
+#
 # GNU Radio is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # GNU Radio is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with GNU Radio; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-# 
+#
 
 from gnuradio import gr
 from gnuradio import eng_notation
@@ -35,9 +35,9 @@ import sys
 class receive_path(gr.hier_block2):
     def __init__(self, rx_callback, options):
 
-	gr.hier_block2.__init__(self, "receive_path",
-				gr.io_signature(1, 1, gr.sizeof_gr_complex),
-				gr.io_signature(0, 0, 0))
+        gr.hier_block2.__init__(self, "receive_path",
+                                gr.io_signature(1, 1, gr.sizeof_gr_complex),
+                                gr.io_signature(0, 0, 0))
 
 
         options = copy.copy(options)    # make a copy so we can destructively modify
@@ -61,7 +61,7 @@ class receive_path(gr.hier_block2):
         # Display some information about the setup
         if self._verbose:
             self._print_verbage()
-        
+
     def carrier_sensed(self):
         """
         Return True if we think carrier is present.


### PR DESCRIPTION
Scanning Python code for deprecation warnings turned up a bunch of "Sorry: TabError: inconsistent use of tabs and spaces in indentation" and a couple "SyntaxError: EOL while scanning string literal". I've fixed those here. Together with #2047 this fixes all the deprecation warnings and errors identified by the following command:

```
find . -name "*.py" | grep -v "^./build/" | grep -v "^./volk/" | xargs python3 -Wd -m py_compile
```