### PR TITLE
Clean up resources allocated by run_worker.

### DIFF
--- a/grc/core/utils/extract_docs.py
+++ b/grc/core/utils/extract_docs.py
@@ -166,7 +166,11 @@ class SubprocessLoader(object):
                 break  # normal termination, return
             finally:
                 if self._worker:
+                    self._worker.stdin.close()
+                    self._worker.stdout.close()
+                    self._worker.stderr.close()
                     self._worker.terminate()
+                    self._worker.wait()
         else:
             print("Warning: docstring loader crashed too often", file=sys.stderr)
         self._thread = None


### PR DESCRIPTION
When GRC is started, a "subprocess is still running" warning appears, and a zombie process remains. This happens because `run_worker` terminates its subprocess, but does not call `wait()`.

https://github.com/gnuradio/gnuradio/blob/007923c64d2505b37dffb8e11cb1e3ecf4e489eb/grc/core/utils/extract_docs.py#L169

Adding a `wait()` call reveals further warnings because `run_worker` does not close the file handles it uses to communicate with the subprocess.

In this PR, I've added `close()` and `wait()` calls to eliminate the warnings.

The issue can also be reproduced by running `extract_docs.py` directly:

```
python3 -Wd grc/core/utils/extract_docs.py
```

