### PR TITLE
Replacing srandom with XOROSHIRO128+

### DIFF
--- a/gr-digital/lib/qa_header_format.cc
+++ b/gr-digital/lib/qa_header_format.cc
@@ -35,22 +35,34 @@
 #include <stdio.h>
 #include <cmath>
 
+static void xoroshiro_fill_buffer(uint8_t *buffer, unsigned int length, uint64_t seed = 42) {
+  uint64_t rng_state[2];
+  xoroshiro128p_seed(rng_state, seed);
+  uint64_t *data_ptr = reinterpret_cast<uint64_t*>(buffer);
+  for(unsigned int i = 0; i < length / 8; ++i) {
+    *data_ptr = xoroshiro128p_next(rng_state);
+    data_ptr++;
+  }
+  if(length % 8) {
+    uint64_t tmp = xoroshiro128p_next(rng_state);
+    uint8_t *tmpptr = reinterpret_cast<uint8_t*>(&tmp);
+    for(unsigned int counter = length - length % 8; counter < length; ++counter) {
+      buffer[counter] = *tmpptr;
+      ++tmpptr;
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(test_default_format)
 {
   static const int N = 4800; /* multiple of 8 for easy random generation */
-  uint64_t rng_state[2];
   int upper8 = (N >> 8) & 0xFF;
   int lower8 = N & 0xFF;
 
   std::string ac = "1010101010101010"; //0xAAAA
   unsigned char *data = (unsigned char*)volk_malloc(N*sizeof(unsigned char),
                                                     volk_get_alignment());
-  uint64_t *data_ptr = reinterpret_cast<uint64_t*>(data);
-  xoroshiro128p_seed(rng_state, 42);
-  for(unsigned int i = 0; i < N / 8; ++i) {
-          *data_ptr = xoroshiro128p_next(rng_state);
-          data_ptr++;
-  }
+  xoroshiro_fill_buffer(data, N);
   gr::digital::header_format_default::sptr hdr_format;
   hdr_format = gr::digital::header_format_default::make(ac, 0);
 
@@ -93,20 +105,7 @@ BOOST_AUTO_TEST_CASE(test_default_parse)
   unsigned char *bits = (unsigned char*)volk_malloc(nbits*sizeof(unsigned char),
                                                     volk_get_alignment());
 
-  uint64_t rng_state[2];
-  xoroshiro128p_seed(rng_state, 43);
-
-  // Fill bytes with random values
-  for(unsigned int i = 0; i < nbytes; i += 8) {
-          *(reinterpret_cast<uint64_t*>(bytes + i)) = xoroshiro128p_next(rng_state);
-  }
-  if(nbytes % 8) {
-          uint64_t randval = xoroshiro128p_next(rng_state);
-          unsigned char *valptr = reinterpret_cast<unsigned char*>(&randval);
-          for(unsigned int idx = (nbytes / 8)*8; idx < nbytes; ++idx) {
-                  bytes[idx] = *valptr++;
-          }
-  }
+  xoroshiro_fill_buffer(bytes, nbytes);
 
   int index = 0;
   bytes[index+0] = 0xAA;
@@ -151,20 +150,7 @@ BOOST_AUTO_TEST_CASE(test_counter_format)
   std::string ac = "1010101010101010"; //0xAAAA
   unsigned char *data = (unsigned char*)volk_malloc(N*sizeof(unsigned char),
                                                     volk_get_alignment());
-  uint64_t rng_state[2];
-  xoroshiro128p_seed(rng_state, 43);
-
-  // fill data with random values
-  for(unsigned int i = 0; i < N; i += 8) {
-          *(reinterpret_cast<uint64_t*>(data + i)) = xoroshiro128p_next(rng_state);
-  }
-  if(N % 8) {
-          uint64_t randval = xoroshiro128p_next(rng_state);
-          unsigned char *valptr = reinterpret_cast<unsigned char*>(&randval);
-          for(unsigned int idx = (N / 8)*8; idx < N; ++idx) {
-                  data[idx] = *valptr++;
-          }
-  }
+  xoroshiro_fill_buffer(data, N);
 
   uint16_t expected_bps = 2;
   gr::digital::header_format_counter::sptr hdr_format;
@@ -225,21 +211,7 @@ BOOST_AUTO_TEST_CASE(test_counter_parse)
                                                      volk_get_alignment());
   unsigned char *bits = (unsigned char*)volk_malloc(nbits*sizeof(unsigned char),
                                                     volk_get_alignment());
-  uint64_t rng_state[2];
-  xoroshiro128p_seed(rng_state, 43);
-
-  // Fill bytes with random values
-  for(unsigned int i = 0; i < nbytes; i += 8) {
-          *(reinterpret_cast<uint64_t*>(bytes + i)) = xoroshiro128p_next(rng_state);
-  }
-  if(nbytes % 8) {
-          uint64_t randval = xoroshiro128p_next(rng_state);
-          unsigned char *valptr = reinterpret_cast<unsigned char*>(&randval);
-          for(unsigned int idx = (nbytes / 8)*8; idx < nbytes; ++idx) {
-                  bytes[idx] = *valptr++;
-          }
-  }
-
+  xoroshiro_fill_buffer(bytes, nbytes);
   int index = 0;
   bytes[index+0] = 0xAA;
   bytes[index+1] = 0xAA;

--- a/gr-filter/lib/qa_fir_filter_with_buffer.cc
+++ b/gr-filter/lib/qa_fir_filter_with_buffer.cc
@@ -102,7 +102,6 @@ namespace gr {
 	o_type   *actual_output = (float*)volk_malloc(OUTPUT_LEN*sizeof(float), align);
 	tap_type *taps = (float*)volk_malloc(MAX_TAPS*sizeof(float), align);
 
-	srandom(0);	// we want reproducibility
 	memset(dline, 0, INPUT_LEN*sizeof(i_type));
 
 	for(int n = 0; n <= MAX_TAPS; n++) {
@@ -215,7 +214,6 @@ namespace gr {
 	o_type   *actual_output = (gr_complex*)volk_malloc(OUTPUT_LEN*sizeof(gr_complex), align);
 	tap_type *taps = (gr_complex*)volk_malloc(MAX_TAPS*sizeof(gr_complex), align);
 
-	srandom(0);	// we want reproducibility
 	memset(dline, 0, INPUT_LEN*sizeof(i_type));
 
 	for(int n = 0; n <= MAX_TAPS; n++) {
@@ -325,7 +323,6 @@ namespace gr {
 	o_type   *actual_output = (gr_complex*)volk_malloc(OUTPUT_LEN*sizeof(gr_complex), align);
 	tap_type *taps = (float*)volk_malloc(MAX_TAPS*sizeof(float), align);
 
-	srandom(0);	// we want reproducibility
 	memset(dline, 0, INPUT_LEN*sizeof(i_type));
 
 	for(int n = 0; n <= MAX_TAPS; n++) {

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <gnuradio/trellis/quicksort_index.h>
 #include <gnuradio/trellis/interleaver.h>
+#include <gnuradio/xoroshiro128p.h>
 
 namespace gr {
   namespace trellis {
@@ -107,18 +108,29 @@ namespace gr {
       d_INTER.resize(d_K);
       d_DEINTER.resize(d_K);
 
-      if(seed>=0)
-	srand((unsigned int)seed);
+      uint64_t rng_state[2];
+      xoroshiro128p_seed(rng_state, seed);
       std::vector<int> tmp(d_K);
+      unsigned char *bytes = reinterpret_cast<unsigned char*>(&tmp[0]);
+
+      for(unsigned int i = 0; i < d_K; i += 8) {
+              *(reinterpret_cast<uint64_t*>(bytes + i)) = xoroshiro128p_next(rng_state);
+      }
+      if(d_K % 8) {
+              uint64_t randval = xoroshiro128p_next(rng_state);
+              unsigned char *valptr = reinterpret_cast<unsigned char*>(&randval);
+              for(unsigned int idx = (d_K / 8)*8; idx < d_K; ++idx) {
+                      bytes[idx] = *valptr++;
+              }
+      }
       for(int i=0;i<d_K;i++) {
-	d_INTER[i]=i;
-	tmp[i] = rand();
+              d_INTER[i]=i;
       }
       quicksort_index <int> (tmp,d_INTER,0,d_K-1);
 
       // generate DEINTER table
       for(int i=0;i<d_K;i++) {
-	d_DEINTER[d_INTER[i]]=i;
+              d_DEINTER[d_INTER[i]]=i;
       }
     }
 


### PR DESCRIPTION
This is a continuation of the work we did on fastnoise_source. This should especially fix the flaky `qa_header_format`.