### PR TITLE
Fix a few coverity issues

### DIFF
--- a/gnuradio-runtime/lib/qa_buffer.cc
+++ b/gnuradio-runtime/lib/qa_buffer.cc
@@ -256,7 +256,6 @@ t3_body()
     // pick a random reader and read some
 
     int r = (int)(N * random.ran1());
-    BOOST_CHECK(0 <= r && r < N);
 
     int m = reader[r]->items_available();
     int *rp = (int*)reader[r]->read_pointer();

--- a/gr-digital/lib/timing_error_detector.cc
+++ b/gr-digital/lib/timing_error_detector.cc
@@ -256,11 +256,12 @@ namespace gr {
     timing_error_detector::slice(const gr_complex &x)
     {
         unsigned int index;
-        gr_complex z(0.0f, 0.0f);
+        /* Passing a length 1 array is OK since we only accept 1D constellations */
+        gr_complex z[1];
 
         index = d_constellation->decision_maker(&x);
-        d_constellation->map_to_points(index, &z);
-        return z;
+        d_constellation->map_to_points(index, z);
+        return z[0];
     }
 
     /*************************************************************************/


### PR DESCRIPTION
1) Remove uncessary BOOST_CHECK for bounds on ran1()
2) Pass an actual array to map_to_points() function in TED