### PR TITLE
GRC: fix failing thread run

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -83,7 +83,10 @@ class ExecFlowGraphThread(threading.Thread):
         r = "\n"
         while r:
             GLib.idle_add(Messages.send_verbose_exec, r)
-            r = self.process.stdout.read(1024).decode('utf-8','ignore')
+            r = self.process.stdout.read(1024)
+            if not isinstance(r, str):
+                r = r.decode('utf-8','ignore')
+
         self.process.poll()
         GLib.idle_add(self.done)
 


### PR DESCRIPTION
In Py3k a string decode might trigger an error because it is already a unicode string. This is not the case in Py2k land. Thus, add a check.

This should fix #2078 .