### PR TITLE
GRC: loading flow graphs now leads to connections, again

### DIFF
--- a/grc/converter/flow_graph.py
+++ b/grc/converter/flow_graph.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Free Software Foundation, Inc.
+# Copyright 2017,2018 Free Software Foundation, Inc.
 # This file is part of GNU Radio
 #
 # GNU Radio Companion is free software; you can redistribute it and/or
@@ -112,9 +112,9 @@ def convert_connection(data):
     snk_port_id = data.findtext('sink_key')
 
     if src_port_id.isdigit():
-        src_port_id = 'out' + src_port_id
+        src_port_id = src_port_id
     if snk_port_id.isdigit():
-        snk_port_id = 'in' + snk_port_id
+        snk_port_id = snk_port_id
 
     return yaml.ListFlowing([src_blk_id, src_port_id, snk_blk_id, snk_port_id])
 


### PR DESCRIPTION
This reverts a renaming experiment.
Due to conflicting naming of ports, connections couldn't be made.

This patch was done based on 100% pure Koslowski wisdom and under his
adult supervision.

This fixes #2023.