### PR TITLE
gr-qtgui: 3.8- time raster sink: set default values for ncols and nrows

### DIFF
--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -24,10 +24,12 @@ parameters:
 -   id: nrows
     label: Num. Rows
     dtype: int
+    default: 256
     hide: ${ ('all' if type.startswith('msg') else 'none') }
 -   id: ncols
     label: Num. Cols
     dtype: int
+    default: 256
 -   id: grid
     label: Grid
     dtype: enum


### PR DESCRIPTION
Without these defaults set the block errors out when you run the flowgraph