### PR TITLE
gr-qtgui: 3.8- fixed time sink error

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -516,7 +516,7 @@ templates:
 
         self.${id}.set_y_label(${ylabel}, ${yunit})
 
-        self.${id}.enable_tags(-1, ${entags})
+        self.${id}.enable_tags(0, ${entags})
         self.${id}.set_trigger_mode(${tr_mode}, ${tr_slope}, ${tr_level}, ${tr_delay}, ${tr_chan}, ${tr_tag})
         self.${id}.enable_autoscale(${autoscale})
         self.${id}.enable_grid(${grid})


### PR DESCRIPTION
Recent commit 1f857d30d5d73576070d70ad785cba3d505b2a73 changed variable "which" to be unsigned, so the default can't be -1.  I set it to 0, seems to work...