### PR TITLE
gr-uhd 3.8- fixes some of the many bugs in usrp yaml

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -41,8 +41,8 @@ parameters:
 -   id: stream_args
     label: Stream args
     dtype: string
-    options: [peak=0.003906]
-    option_labels: [peak=0.003906]
+    options: [none, peak=0.003906]
+    option_labels: [Default, peak=0.003906]
     hide: ${'$'}{ 'none' if stream_args else 'part'}
 -   id: stream_chans
     label: Stream channels
@@ -68,15 +68,15 @@ parameters:
 -   id: clock_rate
     label: Clock Rate (Hz)
     dtype: real
-    default: '0.0'
-    options: ['0.0', 200e6, 184.32e6, 120e6, 30.72e6]
+    default: 0e0
+    options: [0e0, 200e6, 184.32e6, 120e6, 30.72e6]
     option_labels: [Default, 200 MHz, 184.32 MHz, 120 MHz, 30.72 MHz]
     hide: ${'$'}{ 'none' if clock_rate else 'part' }
 -   id: num_mboards
     label: Num Mboards
     dtype: int
-    default: '1'
-    options: ['1', '2', '3', '4', '5', '6', '7', '8']
+    default: 1
+    options: [1, 2, 3, 4, 5, 6, 7, 8]
     hide: part
 % for m in range(max_mboards):
 -   id: clock_source${m}
@@ -105,6 +105,7 @@ parameters:
 -   id: samp_rate
     label: Smp rate (Sps)
     dtype: real
+    default: samp_rate
 ${params}
 
 
@@ -149,7 +150,7 @@ templates:
                 ${'$'}{len_tag_name},
                 ${'%'} endif
         )
-        ${'%'} if clock_rate:
+        ${'%'} if clock_rate():
         self.${'$'}{id}.set_clock_rate(${'$'}{clock_rate}, uhd.ALL_MBOARDS)
         ${'%'} endif
         self.${'$'}{id}.set_samp_rate(${'$'}{samp_rate})
@@ -265,7 +266,7 @@ PARAMS_TMPL = """
 -   id: norm_gain${n}
     label: 'Ch${n}: Gain Type'
     category: RF Options
-    dtype: bool
+    dtype: string
     default: 'False'
     options: ['False', 'True']
     option_labels: [Absolute (dB), Normalized]
@@ -277,6 +278,7 @@ PARAMS_TMPL = """
 % if sourk == 'source':
     options: [TX/RX, RX2, RX1]
     option_labels: [TX/RX, RX2, RX1]
+    default: RX2
 % else:
     options: [TX/RX]
     option_labels: [TX/RX]


### PR DESCRIPTION
Even with these fixes there is still a major block of code missing from this new yaml, and it's the code that tunes and sets the gain, etc.  Here is the old xml version of the block of code I'm referring to:

```
#for $n in range($max_nchan)
\#if \$nchan() > $n
self.\$(id).set_center_freq(\$center_freq$(n), $n)
\#if \$norm_gain${n}()
self.\$(id).set_normalized_gain(\$gain$(n), $n)
\#else
self.\$(id).set_gain(\$gain$(n), $n)
\#end if
	\#if \$ant$(n)()
self.\$(id).set_antenna(\$ant$(n), $n)
	\#end if
	\#if \$bw$(n)()
self.\$(id).set_bandwidth(\$bw$(n), $n)
	\#end if
#if $sourk == 'source'
	\#if \$lo_export$(n)() and not \$hide_lo_controls()
self.\$(id).set_lo_export_enabled(\$lo_export$(n), uhd.ALL_LOS, $n)
	\#end if
    \#if \$lo_source$(n)() and not \$hide_lo_controls()
self.\$(id).set_lo_source(\$lo_source$(n), uhd.ALL_LOS, $n)
	\#end if
	\#if \$dc_offs_enb$(n)()
self.\$(id).set_auto_dc_offset(\$dc_offs_enb$(n), $n)
	\#end if
	\#if \$iq_imbal_enb$(n)()
self.\$(id).set_auto_iq_balance(\$iq_imbal_enb$(n), $n)
	\#end if
#end if
\#end if
#end for
```