### PR TITLE
cmake: fix finding Python packages

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -93,12 +93,12 @@ endmacro(GR_PYTHON_CHECK_MODULE)
 ########################################################################
 if(NOT DEFINED GR_PYTHON_DIR)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
-import os
-import sys
-if os.name == 'posix':
-    print(os.path.join('lib', 'python' + sys.version[:3], 'dist-packages'))
-if os.name == 'nt':
-    print(os.path.join('Lib', 'site-packages'))
+try:
+    from site import getsitepackages
+    print(getsitepackages()[0])
+except ImportError:
+    from distutils.sysconfig import get_python_lib
+    print(get_python_lib(prefix=''))
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 endif()

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -98,7 +98,7 @@ try:
     print(getsitepackages()[0])
 except ImportError:
     from distutils.sysconfig import get_python_lib
-    print(get_python_lib(prefix=''))
+    print(get_python_lib())
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 endif()


### PR DESCRIPTION
Removes the hard-coded 'dist-packages' because it's Debian specific and leads to problems on distributions which use 'site-packages' (e.g. Arch and Gentoo). This commit still retains the current behavior in virtual environments without 'getsitepackages'.

This fixes #2006 and is an alternative to #2019.