### PR TITLE
grc: Add missing keys to schema checker to avoid warnings

### DIFF
--- a/grc/core/schema_checker/block.py
+++ b/grc/core/schema_checker/block.py
@@ -31,6 +31,7 @@ PORT_SCHEME = expand(
 TEMPLATES_SCHEME = expand(
     imports=str_,
     var_make=str_,
+    var_value=str_,
     make=str_,
     callbacks=list,
 )
@@ -50,6 +51,7 @@ BLOCK_SCHEME = expand(
     templates=Spec(types=dict, required=False, item_scheme=TEMPLATES_SCHEME),
 
     documentation=str_,
+    grc_source=str_,
 
     file_format=Spec(types=int, required=True, item_scheme=None),
 


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/2101