### PR TITLE
Update links to https://www.gnuradio.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build](https://shield.lwan.ws/img/p5UKbS/weekly_runner)](https://ci.gnuradio.org/buildbot/#/)
 ![Version](https://img.shields.io/github/tag/gnuradio/gnuradio.svg)
 [![AUR](https://img.shields.io/aur/license/yaourt.svg)](https://github.com/gnuradio/gnuradio/blob/master/COPYING) 
-[![Docs](https://img.shields.io/badge/docs-doxygen-orange.svg)](https://gnuradio.org/doc/doxygen/)
+[![Docs](https://img.shields.io/badge/docs-doxygen-orange.svg)](https://www.gnuradio.org/doc/doxygen/)
 
 GNU Radio is a free & open-source software development toolkit that 
 provides signal processing blocks to implement software radios. It can 
@@ -15,7 +15,7 @@ environment. It is widely used in hobbyist, academic, and commercial
 environments to support both wireless communications research and real-world 
 radio systems.
 
-Please visit the GNU Radio website at https://gnuradio.org/ and the 
+Please visit the GNU Radio website at https://www.gnuradio.org/ and the 
 wiki at https://wiki.gnuradio.org/. Bugs and feature requests are 
 tracked on GitHub's [Issue Tracker](https://github.com/gnuradio/gnuradio/issues). 
 If you have questions about GNU Radio, please search the **discuss-gnuradio** 
@@ -72,11 +72,11 @@ instructions are duplicated below.
 
 ### Manual Source Build
 Complete build instructions are detailed in the 
-[GNU Radio Build Guide](https://gnuradio.org/doc/doxygen/build_guide.html). 
+[GNU Radio Build Guide](https://www.gnuradio.org/doc/doxygen/build_guide.html). 
 Abbreviated instructions are duplicated below.
 
 1. Ensure that you have satisfied the external dependencies, see 
-[GNU Radio Dependencies](https://gnuradio.org/doc/doxygen/build_guide.html).
+[GNU Radio Dependencies](https://www.gnuradio.org/doc/doxygen/build_guide.html).
 
 2. Checkout the latest code:
     ```

--- a/docs/doxygen/other/main_page.dox
+++ b/docs/doxygen/other/main_page.dox
@@ -14,11 +14,11 @@
 <H1> Welcome to GNU Radio! </H1>
 
 For details about GNU Radio and using it, please see the
-<a href="http://gnuradio.org" target="_blank"><b>main project page</b></a>.
+<a href="https://www.gnuradio.org/" target="_blank"><b>main project page</b></a>.
 
 Other information about the project and discussion about GNU Radio,
 software radio, and communication theory in general can be found at
-the <a href="http://www.gnuradio.org/blog" target="_blank"><b>GNU Radio blog</b></a>.
+the <a href="https://www.gnuradio.org/blog/" target="_blank"><b>GNU Radio blog</b></a>.
 
 This manual is split into two parts: A usage manual and a reference. The usage manual
 deals with concepts of GNU Radio, introductions, how to build GNU Radio etc.

--- a/docs/doxygen/other/usage.dox
+++ b/docs/doxygen/other/usage.dox
@@ -9,7 +9,7 @@
 
 /*! \page page_usage Usage Manual
 
-Note: Once built, check out <a href="http://gnuradio.org" target="_blank">gnuradio.org</a> for
+Note: Once built, check out <a href="https://www.gnuradio.org/" target="_blank">gnuradio.org</a> for
 more tutorials on using the software system and examples.
 
 <b>Getting Started</b>

--- a/gr-digital/examples/packet/README
+++ b/gr-digital/examples/packet/README
@@ -1,3 +1,3 @@
 See the Packet Communications page in the GNU Radio manual.
 
-http://gnuradio.org/doc/doxygen
+https://www.gnuradio.org/doc/doxygen/

--- a/gr-trellis/examples/python/README
+++ b/gr-trellis/examples/python/README
@@ -1,6 +1,6 @@
 Here we have several test programs for use with the gr-trellis implementation.
 Documentation can be found in
-http://gnuradio.org/doc/doxygen/group__trellis__coding__blk.html
+https://www.gnuradio.org/doc/doxygen/group__trellis__coding__blk.html
 
 fsm_files is a directory with some FSM definitions
 

--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -27,7 +27,7 @@ from . import Constants
 class Config(object):
     name = 'GNU Radio Companion (no gui)'
     license = __doc__.strip()
-    website = 'http://gnuradio.org'
+    website = 'https://www.gnuradio.org/'
 
     hier_block_lib_dir = os.environ.get('GRC_HIER_PATH', Constants.DEFAULT_HIER_BLOCK_LIB_DIR)
 


### PR DESCRIPTION
Since the canonical website address is now https://www.gnuradio.org/ I've updated all the links, adding `www.` where necessary and upgrading `http` to `https`.