### PR TITLE
docs: Properly excape backslashes in swig docstrings

### DIFF
--- a/docs/doxygen/swig_doc.py
+++ b/docs/doxygen/swig_doc.py
@@ -80,11 +80,13 @@ class Block2(object):
 
 def utoascii(text):
     """
-    Convert unicode text into ascii and escape quotes.
+    Convert unicode text into ascii and escape quotes and backslashes.
     """
     if text is None:
         return ''
     out = text.encode('ascii', 'replace')
+    # swig will require us to replace blackslash with 4 backslashes
+    out = out.replace(b'\\', b'\\\\\\\\')
     out = out.replace(b'"', b'\\"').decode('ascii')
     return str(out)
 


### PR DESCRIPTION
Fixes #2097 

Latex equations like this are in the header files:
`y[n] - \sum_{k=1}^{M} a_k y[n-k] = \sum_{k=0}^{N} b_k x[n-k]`
This does not get escaped properly when swig generates it from the interface file.  To help swig we need to give it 4 backslashes, 2 backslashes will still get reduced to a single backslash.

  