### PR TITLE
Use raw strings for regexp and docstrings that have desired backslashes

### DIFF
--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -212,8 +212,8 @@ file(WRITE ${CMAKE_BINARY_DIR}/get_swig_deps.py "
 
 import os, sys, re, io
 
-i_include_matcher = re.compile('%(include|import)\\s*[<|\"](.*)[>|\"]')
-h_include_matcher = re.compile('#(include)\\s*[<|\"](.*)[>|\"]')
+i_include_matcher = re.compile(r'%(include|import)\\s*[<|\"](.*)[>|\"]')
+h_include_matcher = re.compile(r'#(include)\\s*[<|\"](.*)[>|\"]')
 include_dirs = sys.argv[2].split(';')
 
 def get_swig_incs(file_path):

--- a/gr-analog/python/analog/fm_emph.py
+++ b/gr-analog/python/analog/fm_emph.py
@@ -29,7 +29,7 @@ import cmath
 
 
 class fm_deemph(gr.hier_block2):
-    """
+    r"""
     FM Deemphasis IIR filter
     
     Args:
@@ -143,7 +143,7 @@ class fm_deemph(gr.hier_block2):
 
 
 class fm_preemph(gr.hier_block2):
-    """
+    r"""
     FM Preemphasis IIR filter.
     
     Args:


### PR DESCRIPTION
Resolves #2121 DeprecationWarning: invalid escape sequence /