### PR TITLE
docs: sphinx: removed video_sdl blocks so sphinx builds

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -1117,16 +1117,6 @@ UHD Blocks
    gnuradio.uhd.usrp_source
 
 
-Video Blocks
-------------
-
-.. autosummary::
-   :nosignatures:
-
-   gnuradio.video_sdl.sink_s
-   gnuradio.video_sdl.sink_uc
-
-
 
 Waveform Generator Blocks
 -------------------------

--- a/docs/sphinx/source/video_sdl_blocks.rst
+++ b/docs/sphinx/source/video_sdl_blocks.rst
@@ -1,7 +1,0 @@
-gnuradio.video_sdl
-==================
-
-.. automodule:: gnuradio.video_sdl
-
-.. autoblock:: gnuradio.video_sdl.sink_s
-.. autoblock:: gnuradio.video_sdl.sink_uc


### PR DESCRIPTION
Probably other stuff that needs to be cleaned up in the sphinx rst files (e.g. blocks missing), but at least now the sphinx docs will build.  Addresses issue #2118 