### PR TITLE
gr-zeromq: Add last_endpoint function to zmq source and sink blocks

### DIFF
--- a/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
@@ -52,6 +52,11 @@ namespace gr {
        * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
        */
       static sptr make(char *address, int timeout=100);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -57,6 +57,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
@@ -50,6 +50,11 @@ namespace gr {
        *
        */
       static sptr make(char *address, int timeout=100);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -54,6 +54,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
@@ -52,6 +52,11 @@ namespace gr {
        *
        */
       static sptr make(char *address, int timeout=100);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -58,6 +58,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
@@ -52,6 +52,11 @@ namespace gr {
        *
        */
       static sptr make(char *address, int timeout=100);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -56,6 +56,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
@@ -50,6 +50,11 @@ namespace gr {
        *
        */
       static sptr make(char *address, int timeout=100);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -54,6 +54,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
@@ -50,6 +50,11 @@ namespace gr {
        *
        */
       static sptr make(char *address, int timeout=100);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -54,6 +54,11 @@ namespace gr {
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
                        int timeout=100, bool pass_tags=false, int hwm=-1);
+
+      /*!
+       * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.
+       */
+      virtual std::string last_endpoint() = 0;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -54,6 +54,15 @@ namespace gr {
         delete d_context;
     }
 
+    std::string
+    base_impl::last_endpoint()
+    {
+      size_t addr_len = 256;
+      char addr[addr_len];
+      d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+      return std::string(addr, addr_len-1);
+    }
+
 
     base_sink_impl::base_sink_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
         : base_impl(type, itemsize, vlen, timeout, pass_tags)

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -37,6 +37,7 @@ namespace gr {
       virtual ~base_impl();
 
     protected:
+      std::string last_endpoint();
       zmq::context_t  *d_context;
       zmq::socket_t   *d_socket;
       size_t          d_vsize;

--- a/gr-zeromq/lib/pub_msg_sink_impl.h
+++ b/gr-zeromq/lib/pub_msg_sink_impl.h
@@ -41,6 +41,12 @@ namespace gr {
       ~pub_msg_sink_impl();
 
       void handler(pmt::pmt_t msg);
+      std::string last_endpoint() override {
+        size_t addr_len = 256;
+        char addr[addr_len];
+        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        return std::string(addr, addr_len-1);
+      }
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pub_sink_impl.h
+++ b/gr-zeromq/lib/pub_sink_impl.h
@@ -39,6 +39,7 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+      std::string last_endpoint() override {return base_sink_impl::last_endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -48,6 +48,13 @@ namespace gr {
 
       bool start();
       bool stop();
+
+      std::string last_endpoint() override {
+        size_t addr_len = 256;
+        char addr[addr_len];
+        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        return std::string(addr, addr_len-1);
+      }
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pull_source_impl.h
+++ b/gr-zeromq/lib/pull_source_impl.h
@@ -39,6 +39,7 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+      std::string last_endpoint() override {return base_source_impl::last_endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/push_msg_sink_impl.h
+++ b/gr-zeromq/lib/push_msg_sink_impl.h
@@ -41,6 +41,12 @@ namespace gr {
       ~push_msg_sink_impl();
 
       void handler(pmt::pmt_t msg);
+      std::string last_endpoint() override {
+        size_t addr_len = 256;
+        char addr[addr_len];
+        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        return std::string(addr, addr_len-1);
+      }
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/push_sink_impl.h
+++ b/gr-zeromq/lib/push_sink_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string last_endpoint() override {return base_sink_impl::last_endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -48,6 +48,13 @@ namespace gr {
 
       bool start();
       bool stop();
+
+      std::string last_endpoint() override {
+        size_t addr_len = 256;
+        char addr[addr_len];
+        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        return std::string(addr, addr_len-1);
+      }
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/rep_sink_impl.h
+++ b/gr-zeromq/lib/rep_sink_impl.h
@@ -39,6 +39,7 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+      std::string last_endpoint() override {return base_sink_impl::last_endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -48,6 +48,13 @@ namespace gr {
 
       bool start();
       bool stop();
+
+      std::string last_endpoint() override {
+        size_t addr_len = 256;
+        char addr[addr_len];
+        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        return std::string(addr, addr_len-1);
+      }
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/req_source_impl.h
+++ b/gr-zeromq/lib/req_source_impl.h
@@ -40,6 +40,7 @@ namespace gr {
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
 
+      std::string last_endpoint() override {return base_source_impl::last_endpoint();}
     private:
       bool d_req_pending;
     };

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -48,6 +48,13 @@ namespace gr {
 
       bool start();
       bool stop();
+
+      std::string last_endpoint() override {
+        size_t addr_len = 256;
+        char addr[addr_len];
+        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        return std::string(addr, addr_len-1);
+      }
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/sub_source_impl.h
+++ b/gr-zeromq/lib/sub_source_impl.h
@@ -39,6 +39,8 @@ namespace gr {
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,
                gr_vector_void_star &output_items);
+
+      std::string last_endpoint() override {return base_source_impl::last_endpoint();}
     };
 
   } // namespace zeromq

--- a/gr-zeromq/python/zeromq/qa_zeromq_pub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pub.py
@@ -40,10 +40,11 @@ class qa_zeromq_pub (gr_unittest.TestCase):
         self.rx_data = None
         src_data = list(range(vlen))*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5555")
+        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:0")
+        address = zeromq_pub_sink.last_endpoint()
         self.tb.connect(src, zeromq_pub_sink)
         self.probe_manager = zeromq.probe_manager()
-        self.probe_manager.add_socket("tcp://127.0.0.1:5555", 'float32', self.recv_data)
+        self.probe_manager.add_socket(address, 'float32', self.recv_data)
         zmq_pull_t = threading.Thread(target=self.probe_manager.watcher)
         zmq_pull_t.daemon = True
         zmq_pull_t.start()

--- a/gr-zeromq/python/zeromq/qa_zeromq_pubsub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pubsub.py
@@ -40,8 +40,9 @@ class qa_zeromq_pubsub (gr_unittest.TestCase):
         vlen = 10
         src_data = list(range(vlen))*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5556", 0)
-        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5556", 0)
+        zeromq_pub_sink = zeromq.pub_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:0", 0)
+        address = zeromq_pub_sink.last_endpoint()
+        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, address, 0)
         sink = blocks.vector_sink_f(vlen)
         self.send_tb.connect(src, zeromq_pub_sink)
         self.recv_tb.connect(zeromq_sub_source, sink)

--- a/gr-zeromq/python/zeromq/qa_zeromq_pushpull.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pushpull.py
@@ -38,8 +38,9 @@ class qa_zeromq_pushpull (gr_unittest.TestCase):
         vlen = 10
         src_data = list(range(vlen))*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_push_sink = zeromq.push_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5557")
-        zeromq_pull_source = zeromq.pull_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5557", 0)
+        zeromq_push_sink = zeromq.push_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:0")
+        address = zeromq_push_sink.last_endpoint()
+        zeromq_pull_source = zeromq.pull_source(gr.sizeof_float, vlen, address, 0)
         sink = blocks.vector_sink_f(vlen)
         self.send_tb.connect(src, zeromq_push_sink)
         self.recv_tb.connect(zeromq_pull_source, sink)

--- a/gr-zeromq/python/zeromq/qa_zeromq_reqrep.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_reqrep.py
@@ -41,8 +41,9 @@ class qa_zeromq_reqrep (gr_unittest.TestCase):
         vlen = 10
         src_data = list(range(vlen))*100
         src = blocks.vector_source_f(src_data, False, vlen)
-        zeromq_rep_sink = zeromq.rep_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:5558", 0)
-        zeromq_req_source = zeromq.req_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5558", 0)
+        zeromq_rep_sink = zeromq.rep_sink(gr.sizeof_float, vlen, "tcp://127.0.0.1:0", 0)
+        address = zeromq_rep_sink.last_endpoint()
+        zeromq_req_source = zeromq.req_source(gr.sizeof_float, vlen, address, 0)
         sink = blocks.vector_sink_f(vlen)
         self.send_tb.connect(src, zeromq_rep_sink)
         self.recv_tb.connect(zeromq_req_source, sink)

--- a/gr-zeromq/python/zeromq/qa_zeromq_sub.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_sub.py
@@ -35,7 +35,8 @@ class qa_zeromq_sub (gr_unittest.TestCase):
         self.tb = gr.top_block ()
         self.zmq_context = zmq.Context()
         self.pub_socket = self.zmq_context.socket(zmq.PUB)
-        self.pub_socket.bind("tcp://127.0.0.1:5559")
+        self.pub_socket.bind("tcp://127.0.0.1:0")
+        self._address = self.pub_socket.getsockopt(zmq.LAST_ENDPOINT).decode()
 
     def tearDown (self):
         self.pub_socket.close()
@@ -45,7 +46,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
     def test_001 (self):
         vlen = 10
         src_data = numpy.array(list(range(vlen))*100, 'float32')
-        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5559")
+        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, self._address)
         sink = blocks.vector_sink_f(vlen)
         self.tb.connect(zeromq_sub_source, sink)
 
@@ -63,7 +64,7 @@ class qa_zeromq_sub (gr_unittest.TestCase):
         # Construct multipart source data to publish
         raw_data = [numpy.array(range(vlen), 'float32')*100, numpy.array(range(vlen, 2*vlen), 'float32')*100]
         src_data = [a.tostring() for a in raw_data]
-        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, "tcp://127.0.0.1:5559")
+        zeromq_sub_source = zeromq.sub_source(gr.sizeof_float, vlen, self._address)
         sink = blocks.vector_sink_f(vlen)
         self.tb.connect(zeromq_sub_source, sink)
 


### PR DESCRIPTION
This adds a `last_endpoint()` function to the zeromq blocks to allow reading out the address bound to the socket.  This lets us supply an address like `tcp://127.0.0.1:0` and have the OS sort out the port. The ZMQ tests all use this, so multiple copies of a test can run at the same time.

> The ZMQ_LAST_ENDPOINT option shall retrieve the last endpoint bound for TCP and IPC transports. The returned value will be a string in the form of a ZMQ DSN. Note that if the TCP host is INADDR_ANY, indicated by a *, then the returned address will be 0.0.0.0 (for IPv4). 

I added this to the source and sink blocks, although it is most useful to blocks that are performing a bind rather than a connect.

This should resolve #2124