### PR TITLE
Replace dict.iteritems() with dict.items()

### DIFF
--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -48,7 +48,7 @@ templates:
         %>
         ${win} = Qt.QCheckBox(${(label if (len(label) - 2 > 0) else repr(id))})
         self._${id}_choices = {True: ${true}, False: ${false}}
-        self._${id}_choices_inv = dict((v,k) for k,v in self._${id}_choices.iteritems())
+        self._${id}_choices_inv = dict((v,k) for k,v in self._${id}_choices.items())
         self._${id}_callback = lambda i: Qt.QMetaObject.invokeMethod(${win}, "setChecked", Qt.Q_ARG("bool", self._${id}_choices_inv[i]))
         self._${id}_callback(self.${id})
         ${win}.stateChanged.connect(lambda i: self.set_${id}(self._${id}_choices[bool(i)]))


### PR DESCRIPTION
dict.iteritems() is not implemented in python3; dict.items() in python3 has the same function as dict.iteritems() in python2. This preserves backward and forward compatibility at the cost of possible higher memory usage in python2.