### PR TITLE
gr-analog: fixed analog_random_source bug

### DIFF
--- a/gr-analog/grc/analog_random_source_x.block.yml
+++ b/gr-analog/grc/analog_random_source_x.block.yml
@@ -37,11 +37,15 @@ templates:
         from gnuradio import blocks
         import numpy
     make: blocks.vector_source_${type.fcn}(list(map(int, numpy.random.randint(${min}, ${max},
-        ${num_samps})), ${repeat}))
+        ${num_samps}))), ${repeat})
 
 documentation: |-
     Generate num samples of random numbers of [min, max). Repeat samples if specified.
 
     Ex: With min=0 and max=2, the sequence 01110101... will be generated.
+    
+    This block wraps Vector Source, i.e. it creates a vector source using a vector filled with values returned from calling np.random.randint(min, max, num_samps) once
 
+    If you would like a traditional random number generator, use Random Uniform Source instead
+    
 file_format: 1


### PR DESCRIPTION
A bug was introduced in recently merged PR #2095, the ending parenthesis was put in the wrong spot.  I also added a little bit of documentation while I was at it, making sure people know this block isn't really a block but is a wrapper for Vector Source. 

If anyone has some time (@btashton perhaps), it might be worth checking the other files modified in #2095 to see if any other ending parenthesis were put in the wrong spot.