### PR TITLE
python: Do not use bare except, specify exception instead

### DIFF
--- a/gnuradio-runtime/examples/mp-sched/wfm_rcv_pll_to_wav.py
+++ b/gnuradio-runtime/examples/mp-sched/wfm_rcv_pll_to_wav.py
@@ -88,11 +88,6 @@ class wfm_rx_block (gr.top_block):
         self.connect (self.src, chan_filt, self.guts)
         self.connect ((self.guts, 0), self.volume_control_l, (sink, 0))
         self.connect ((self.guts, 1), self.volume_control_r, (sink, 1))
-        try:
-          self.guts.stereo_carrier_pll_recovery.squelch_enable(True)
-        except:
-          pass
-          #print "FYI: This implementation of the stereo_carrier_pll_recovery has no squelch implementation yet"
 
         if args.volume is None:
             g = self.volume_range()
@@ -101,12 +96,6 @@ class wfm_rx_block (gr.top_block):
         # set initial values
 
         self.set_vol(args.volume)
-        try:
-          self.guts.stereo_carrier_pll_recovery.set_lock_threshold(args.squelch)
-        except:
-          pass
-          #print "FYI: This implementation of the stereo_carrier_pll_recovery has no squelch implementation yet"
-
 
     def set_vol (self, vol):
         g = self.volume_range()

--- a/gnuradio-runtime/python/gnuradio/ctrlport/GNURadioControlPortClient.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/GNURadioControlPortClient.py
@@ -30,6 +30,15 @@ is currently the only supported transport.
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from gnuradio.ctrlport.RPCConnection import RPCMethods
+try:
+    from gnuradio.ctrlport.RPCConnectionThrift import RPCConnectionThrift
+    from thrift.transport.TTransport import TTransportException
+except ImportError:
+    # Thrift support not provided we should remove it from RPCMethods
+    pass
+
+
 """
 GNURadioControlPortClient is the main class for creating a GNU Radio
 ControlPort client application for all transports.
@@ -112,9 +121,7 @@ class GNURadioControlPortClient(object):
 
         self.client = None
 
-        from gnuradio.ctrlport.RPCConnection import RPCMethods
         if rpcmethod in RPCMethods:
-            from gnuradio.ctrlport.RPCConnectionThrift import RPCConnectionThrift
             if rpcmethod == 'thrift':
                 #print("making RPCConnectionThrift")
                 self.client = RPCConnectionThrift(host, port)

--- a/gnuradio-runtime/python/gnuradio/ctrlport/monitor.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/monitor.py
@@ -33,15 +33,12 @@ class monitor(object):
         self.tool = tool
         atexit.register(self.shutdown)
 
-        try:
-            # setup export prefs
-            gr.prefs().singleton().set_bool("ControlPort","on",True);
-            if(tool == "gr-perf-monitorx"):
-                gr.prefs().singleton().set_bool("ControlPort","edges_list",True);
-                gr.prefs().singleton().set_bool("PerfCounters","on",True);
-                gr.prefs().singleton().set_bool("PerfCounters","export",True);
-        except:
-            print("no support for gr.prefs setting")
+        # setup export prefs
+        gr.prefs().singleton().set_bool("ControlPort","on",True);
+        if(tool == "gr-perf-monitorx"):
+            gr.prefs().singleton().set_bool("ControlPort","edges_list",True);
+            gr.prefs().singleton().set_bool("PerfCounters","on",True);
+            gr.prefs().singleton().set_bool("PerfCounters","export",True);
 
     def __del__(self):
         if(self.started):
@@ -57,7 +54,7 @@ class monitor(object):
             print("running: %s"%(str(cmd)))
             self.proc = subprocess.Popen(cmd);
             self.started = True
-        except:
+        except (ValueError, OSError):
             self.proc = None
             print("failed to to start ControlPort Monitor on specified port")
 

--- a/gnuradio-runtime/python/gnuradio/eng_arg.py
+++ b/gnuradio-runtime/python/gnuradio/eng_arg.py
@@ -34,7 +34,7 @@ def intx(string):
     """
     try:
         return int(string, 0)
-    except:
+    except (ValueError, TypeError):
         raise argparse.ArgumentTypeError(
             "Invalid integer value: {}".format(string)
         )
@@ -47,7 +47,7 @@ def eng_float(string):
     """
     try:
         return eng_notation.str_to_num(string)
-    except:
+    except (TypeError, ValueError):
         raise argparse.ArgumentTypeError(
             "Invalid engineering notation value: {}".format(string)
         )

--- a/gnuradio-runtime/python/gnuradio/eng_notation.py
+++ b/gnuradio-runtime/python/gnuradio/eng_notation.py
@@ -23,6 +23,9 @@ Display numbers as strings using engineering notation.
 """
 from __future__ import unicode_literals
 
+import six
+
+
 scale_factor = {}
 scale_factor['E'] = 1e18
 scale_factor['P'] = 1e15
@@ -66,11 +69,13 @@ def num_to_str (n, precision=6):
 def str_to_num (value):
     '''Convert a string in engineering notation to a number.  E.g., '15m' -> 15e-3'''
     try:
+        if not isinstance(value, six.string_types):
+            raise TypeError("Value must be a string")
         scale = 1.0
         suffix = value[-1]
         if suffix in scale_factor:
             return float (value[0:-1]) * scale_factor[suffix]
         return float (value)
-    except:
-        raise RuntimeError (
+    except (TypeError, KeyError, ValueError):
+        raise ValueError (
             "Invalid engineering notation value: %r" % (value,))

--- a/gnuradio-runtime/python/gnuradio/eng_option.py
+++ b/gnuradio-runtime/python/gnuradio/eng_option.py
@@ -30,14 +30,14 @@ from . import eng_notation
 def check_eng_float (option, opt, value):
     try:
         return eng_notation.str_to_num(value)
-    except:
+    except (ValueError, TypeError):
         raise OptionValueError (
             "option %s: invalid engineering notation value: %r" % (opt, value))
 
 def check_intx (option, opt, value):
     try:
         return int (value, 0)
-    except:
+    except (ValueError, TypeError):
         raise OptionValueError (
             "option %s: invalid integer value: %r" % (opt, value))
 

--- a/gnuradio-runtime/python/pmt/pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/pmt_to_python.py
@@ -124,7 +124,8 @@ def pmt_to_python(p):
         if pmt_check(p):
             try:
                 return to_python(p)
-            except:
+            except (TypeError, ValueError):
+                # This exception will be handled by the general failure case
                 pass
     raise ValueError("can't convert %s type to pmt (%s)"%(type(p),p))
 

--- a/gr-dtv/examples/atsc_ctrlport_monitor.py
+++ b/gr-dtv/examples/atsc_ctrlport_monitor.py
@@ -27,7 +27,9 @@ import matplotlib
 matplotlib.use("QT4Agg")
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
-from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
+from gnuradio.ctrlport.GNURadioControlPortClient import (
+    GNURadioControlPortClient, TTransportException,
+)
 import numpy
 from numpy.fft import fftpack
 
@@ -106,7 +108,7 @@ class atsc_ctrlport_monitor(object):
             self._viterbi_metric.pop()
             self._viterbi_metric.insert(0, vt_decoder_metrics)
 
-        except:
+        except TTransportException:
             sys.stderr.write("Lost connection, exiting")
             sys.exit(1)
 

--- a/gr-fec/python/fec/LDPC/Generate_LDPC_matrix_functions.py
+++ b/gr-fec/python/fec/LDPC/Generate_LDPC_matrix_functions.py
@@ -65,7 +65,9 @@ def write_alist_file(filename, H, verbose=0):
 
   try:
     myfile = open(filename,'w')
-  except:
+  except EnvironmentError:
+    # This is an api, we should be using a logging interface and not
+    # terminating the application directly.
     sys.stderr.write("Could not open output file '{0}'".format(filename))
     sys.exit(1)
 

--- a/gr-filter/python/filter/qa_fft_filter.py
+++ b/gr-filter/python/filter/qa_fft_filter.py
@@ -409,7 +409,7 @@ class test_fft_filter(gr_unittest.TestCase):
             #print "src_len =", src_len, " ntaps =", ntaps
             try:
                 self.assert_fft_float_ok2(expected_result, result_data, abs_eps=1.0)
-            except:
+            except AssertionError:
                 expected = open('expected', 'w')
                 for x in expected_result:
                     expected.write(repr(x) + '\n')

--- a/gr-qtgui/apps/uhd_display.py
+++ b/gr-qtgui/apps/uhd_display.py
@@ -253,7 +253,7 @@ class my_top_block(gr.top_block):
 
         try:
             self.snk.set_frequency_range(self._freq, self._bandwidth)
-        except:
+        except RuntimeError:
             pass
 
     def set_bandwidth(self, bw):
@@ -262,7 +262,7 @@ class my_top_block(gr.top_block):
 
         try:
             self.snk.set_frequency_range(self._freq, self._bandwidth)
-        except:
+        except RuntimeError:
             pass
 
     def set_amplifier_gain(self, amp):

--- a/gr-uhd/apps/uhd_app.py
+++ b/gr-uhd/apps/uhd_app.py
@@ -85,7 +85,9 @@ class UHDApp(object):
         """
         Return a nice textual description of the USRP we're using.
         """
-        assert tx_or_rx == 'rx' or tx_or_rx == 'tx'
+        if tx_or_rx not in ['rx', 'tx']:
+            raise ValueError("tx_or_rx argument must be one of ['rx', 'tx']")
+
         try:
             info_pp = {}
             if self.prefix is None:
@@ -110,7 +112,7 @@ class UHDApp(object):
             if compact:
                 tpl = COMPACT_TPL
             return tpl.format(**info_pp)
-        except:
+        except Exception:
             return "Can't establish USRP info."
 
     def normalize_sel(self, num_name, arg_name, num, arg):
@@ -351,7 +353,7 @@ class UHDApp(object):
             """
             try:
                 return [int(x.strip()) for x in string.split(",")]
-            except:
+            except ValueError:
                 raise argparse.ArgumentTypeError("Not a comma-separated list: {string}".format(string=string))
         if parser is None:
             parser = argparse.ArgumentParser(

--- a/gr-uhd/python/uhd/__init__.py
+++ b/gr-uhd/python/uhd/__init__.py
@@ -115,10 +115,10 @@ def _prepare_uhd_swig():
                     (0, 'device_addr', device_addr),
                     (1, 'io_type', io_type),
                 ):
-                    try:
-                        if len(args) > index: args[index] = cast(args[index])
-                        if key in kwargs: kwargs[key] = cast(kwargs[key])
-                    except: pass
+                    if len(args) > index:
+                        args[index] = cast(args[index])
+                    if key in kwargs:
+                        kwargs[key] = cast(kwargs[key])
                 #don't pass kwargs, it confuses swig, map into args list:
                 for key in ('device_addr', 'stream_args',
                         'issue_stream_cmd_on_start', 'tsb_tag_name', 'msgq'):

--- a/grc/converter/flow_graph.py
+++ b/grc/converter/flow_graph.py
@@ -128,6 +128,6 @@ def _guess_file_format_1(data):
     try:
         if any(not has_numeric_port_ids(*con) for con in data['connections']):
             return 1
-    except:
+    except (TypeError, KeyError):
         pass
     return 0

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -144,7 +144,7 @@ class Block(Element):
             try:
                 if not self.evaluate(expr):
                     self.add_error_message('Assertion "{}" failed.'.format(expr))
-            except:
+            except Exception:
                 self.add_error_message('Assertion "{}" did not evaluate.'.format(expr))
 
     def _validate_generate_mode_compat(self):

--- a/grc/core/generator/hier_block.py
+++ b/grc/core/generator/hier_block.py
@@ -52,10 +52,9 @@ class HierBlockGenerator(TopBlockGenerator):
 
         with codecs.open(self.file_path_yml, 'w', encoding='utf-8') as fp:
             fp.write(data)
-        try:
-            os.chmod(self.file_path_yml, self._mode)
-        except:
-            pass
+
+        # Windows only supports S_IREAD and S_IWRITE, other flags are ignored
+        os.chmod(self.file_path_yml, self._mode)
 
     def _build_block_n_from_flow_graph_io(self):
         """

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -69,10 +69,7 @@ class TopBlockGenerator(object):
             with codecs.open(filename, 'w', encoding='utf-8') as fp:
                 fp.write(data)
             if filename == self.file_path:
-                try:
-                    os.chmod(filename, self._mode)
-                except:
-                    pass
+                os.chmod(filename, self._mode)
 
     def _build_python_code_from_template(self):
         """
@@ -172,7 +169,8 @@ class TopBlockGenerator(object):
             code = block.templates.render('make').replace(block.name, ' ')
             try:
                 code += block.params['gui_hint'].get_value()  # Newer gui markup w/ qtgui
-            except:
+            except KeyError:
+                # No gui hint
                 pass
             return code
 

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -220,7 +220,7 @@ class Param(Element):
                 value = self.parent_flowgraph.evaluate(expr)
                 if not isinstance(value, str):
                     raise Exception()
-            except:
+            except Exception:
                 self._stringify_flag = True
                 value = str(expr)
             if dtype == '_multiline_python_external':

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -102,9 +102,9 @@ class Config(CoreConfig):
             raw = self._gr_prefs.get_string('grc', 'canvas_default_size', '1280, 1024')
             value = tuple(int(x.strip('() ')) for x in raw.split(','))
             if len(value) != 2 or not all(300 < x < 4096 for x in value):
-                raise Exception()
+                raise ValueError
             return value
-        except:
+        except (ValueError, TypeError):
             print("Error: invalid 'canvas_default_size' setting.", file=sys.stderr)
             return Constants.DEFAULT_CANVAS_SIZE_DEFAULT
 
@@ -114,8 +114,8 @@ class Config(CoreConfig):
             font_size = self._gr_prefs.get_long('grc', 'canvas_font_size',
                                                 Constants.DEFAULT_FONT_SIZE)
             if font_size <= 0:
-                raise Exception()
-        except:
+                raise ValueError
+        except (ValueError, TypeError):
             font_size = Constants.DEFAULT_FONT_SIZE
             print("Error: invalid 'canvas_font_size' setting.", file=sys.stderr)
 

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -21,7 +21,7 @@ import sys
 import textwrap
 from distutils.spawn import find_executable
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GLib
 
 from . import Utils, Actions, Constants
 from ..core import Messages
@@ -272,8 +272,8 @@ def show_about(parent, config):
 
     try:
         ad.set_logo(Gtk.IconTheme().load_icon('gnuradio-grc', 64, 0))
-    except:
-        pass
+    except GLib.Error:
+        log.debug("Failed to set window logo")
 
     #ad.set_comments("")
     ad.set_copyright(config.license.splitlines()[0])

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -368,7 +368,7 @@ class Block(CoreBlock, Drawable):
             new_index = (old_index + direction + len(values)) % len(values)
             type_param.set_value(values[new_index])
             return True
-        except:
+        except IndexError:
             return False
 
     def port_controller_modify(self, direction):
@@ -394,7 +394,8 @@ class Block(CoreBlock, Drawable):
                 if value > 0:
                     param.set_value(value)
                     changed = True
-            except:
+            except ValueError:
+                # Should we be logging something here
                 pass
         return changed
 

--- a/grc/main.py
+++ b/grc/main.py
@@ -48,11 +48,6 @@ def main():
     parser.add_argument('--log', choices=['debug', 'info', 'warning', 'error', 'critical'], default='warning')
     args = parser.parse_args()
 
-    try:
-        Gtk.window_set_default_icon(Gtk.IconTheme().load_icon('gnuradio-grc', 256, 0))
-    except:
-        pass
-
     # Enable logging
     # Note: All other modules need to use the 'grc.<module>' convention
     log = logging.getLogger('grc')


### PR DESCRIPTION
This specifies actual exception types instead of just leaving them as:
```
except:
    pass
```

There is also some very old unused threading code for py23 and py24 that is removed.  The changes around uhd will need a closer look, in some cases it is not clear what the expected Exception that is being passes is (hence why this issue is important).