### PR TITLE
CMake: remove duplicately installed files

### DIFF
--- a/gnuradio-runtime/swig/CMakeLists.txt
+++ b/gnuradio-runtime/swig/CMakeLists.txt
@@ -87,7 +87,6 @@ install(
     buffer.i
     constants.i
     feval.i
-    gnuradio.i
     gr_ctrlport.i
     gr_extras.i
     gr_intrusive_ptr.i

--- a/gr-analog/include/gnuradio/analog/CMakeLists.txt
+++ b/gr-analog/include/gnuradio/analog/CMakeLists.txt
@@ -23,7 +23,6 @@
 install(FILES
     api.h
     cpm.h
-    noise_type.h
     agc.h
     agc2.h
     noise_type.h

--- a/gr-digital/include/gnuradio/digital/CMakeLists.txt
+++ b/gr-digital/include/gnuradio/digital/CMakeLists.txt
@@ -101,6 +101,5 @@ install(FILES
     symbol_sync_cc.h
     symbol_sync_ff.h
     timing_error_detector_type.h
-    header_payload_demux.h
     DESTINATION ${GR_INCLUDE_DIR}/gnuradio/digital
 )


### PR DESCRIPTION
These subsequently appeared twice in install_manifest.txt, which lead to
warnings/errors on deinstallation.