### PR TITLE
.gitignore: ignore build*/ instead of just build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 *.pyc
 *.pyo
-build/
+build*/


### PR DESCRIPTION
This is a convenience edit, so that one can have multiple separate build
directories in one source tree, for example to test Py2 and Py3 in
parallel and compare build results.