### PR TITLE
grc: Simplify py2/3 logic for new_module

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, print_function
 import collections
 import itertools
 import sys
+import types
 from operator import methodcaller, attrgetter
 
 from . import Messages, blocks
@@ -27,16 +28,6 @@ from .Constants import FLOW_GRAPH_FILE_FORMAT_VERSION
 from .base import Element
 from .utils import expr_utils
 from .utils.backports import shlex
-
-
-if sys.version_info[0] < 3:
-    import imp
-    def _new_module_helper(name):
-        return imp.new_module(name)
-else:
-    import types
-    def _new_module_helper(name):
-        return types.ModuleType(name)
 
 
 class FlowGraph(Element):
@@ -201,7 +192,7 @@ class FlowGraph(Element):
 
         for id, expr in self.get_python_modules():
             try:
-                module = _new_module_helper(id)
+                module = types.ModuleType(id)
                 exec(expr, module.__dict__)
                 namespace[id] = module
             except:


### PR DESCRIPTION
Turns out we can use types.ModuleType in python2 as well so we can remove all of the logic using the imp module.  Based on conversation at #2135