### PR TITLE
runtime: circumvent long long, uint64_t problems on 32-bit archs

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -194,13 +194,16 @@ namespace gr {
   void
   block::set_relative_rate(uint64_t interpolation, uint64_t decimation)
   {
+    mpz_class interp, decim;
     if (interpolation < 1)
       throw std::invalid_argument("block::set_relative_rate: interpolation rate cannot be 0");
 
     if (decimation < 1)
       throw std::invalid_argument("block::set_relative_rate: decimation rate cannot be 0");
 
-    d_mp_relative_rate = mpq_class(interpolation, decimation);
+    mpz_import(interp.get_mpz_t(), 1, 1, sizeof(interpolation), 0, 0, &interpolation);
+    mpz_import(decim.get_mpz_t(), 1, 1, sizeof(decimation), 0, 0, &decimation);
+    d_mp_relative_rate = interp / decim;
     d_mp_relative_rate.canonicalize();
     d_relative_rate = d_mp_relative_rate.get_d();
   }

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -203,7 +203,7 @@ namespace gr {
 
     mpz_import(interp.get_mpz_t(), 1, 1, sizeof(interpolation), 0, 0, &interpolation);
     mpz_import(decim.get_mpz_t(), 1, 1, sizeof(decimation), 0, 0, &decimation);
-    d_mp_relative_rate = interp / decim;
+    d_mp_relative_rate = mpz_class(interp, decim);
     d_mp_relative_rate.canonicalize();
     d_relative_rate = d_mp_relative_rate.get_d();
   }

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -146,7 +146,8 @@ namespace gr {
           mpz_class offset;
           for(t = rtags.begin(); t != rtags.end(); t++) {
             tag_t new_tag = *t;
-            offset = new_tag.offset * mp_rrate + one_half;
+            mpz_import(offset.get_mpz_t(), 1, 1, sizeof(new_tag.offset), 0, 0, &new_tag.offset);
+            offset *= mp_rrate + one_half;
             new_tag.offset = offset.get_ui();
             for(int o = 0; o < d->noutputs(); o++)
               out_buf[o]->add_item_tag(new_tag);
@@ -188,7 +189,8 @@ namespace gr {
             mpz_class offset;
             for(t = rtags.begin(); t != rtags.end(); t++) {
               tag_t new_tag = *t;
-              offset = new_tag.offset * mp_rrate + one_half;
+              mpz_import(offset.get_mpz_t(), 1, 1, sizeof(new_tag.offset), 0, 0, &new_tag.offset);
+              offset *= mp_rrate + one_half;
               new_tag.offset = offset.get_ui();
               out_buf->add_item_tag(new_tag);
             }


### PR DESCRIPTION
C++ bindings for MPIR/GMP don't provide conversion for uint64_t, also known
as "long long" on 32-bit architectures.

Using the underlying (GMP/MPIR) C library directly allows usage of these types.