### PR TITLE
Some still missing SLOT/SIGNALS signed <-> unsigned fixes

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/timerasterdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timerasterdisplayform.h
@@ -80,7 +80,7 @@ public slots:
 		   const QColor lowColor=QColor("white"),
 		   const QColor highColor=QColor("white"));
 
-  void setAlpha(unsigned int which, int alpha);
+  void setAlpha(unsigned int which, unsigned int alpha);
 
   void autoScale(bool en=false);
 

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -180,7 +180,7 @@ FreqDisplayForm::setupControlPanel()
           d_controlpanel, SLOT(toggleGrid(bool)));
   connect(d_axislabelsmenu, SIGNAL(triggered(bool)),
           d_controlpanel, SLOT(toggleAxisLabels(bool)));
-  connect(d_sizemenu, SIGNAL(whichTrigger(int)),
+  connect(d_sizemenu, SIGNAL(whichTrigger(unsigned int)),
 	  d_controlpanel, SLOT(toggleFFTSize(int)));
   connect(d_winmenu, SIGNAL(whichTrigger(gr::filter::firdes::win_type)),
 	  d_controlpanel, SLOT(toggleFFTWindow(gr::filter::firdes::win_type)));

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -100,20 +100,20 @@ NumberDisplayForm::NumberDisplayForm(int nplots, gr::qtgui::graph_t type,
   // Menu items for each number line
   for(unsigned int i = 0; i < d_nplots; ++i) {
     d_label_act.push_back(new LineTitleAction(i, this));
-    connect(d_label_act[i], SIGNAL(whichTrigger(int, const QString&)),
-	    this, SLOT(setLabel(int, const QString&)));
+    connect(d_label_act[i], SIGNAL(whichTrigger( unsigned int, const QString&)),
+	    this, SLOT(setLabel(unsigned int, const QString&)));
 
     d_label_menu.push_back(new QMenu(tr(""), this));
     d_label_menu[i]->addAction(d_label_act[i]);
 
     d_color_menu.push_back(new NumberColorMapMenu(i, this));
-    connect(d_color_menu[i], SIGNAL(whichTrigger(int, const QColor&, const QColor&)),
-            this, SLOT(setColor(int, const QColor&, const QColor&)));
+    connect(d_color_menu[i], SIGNAL(whichTrigger(unsigned int, const QColor&, const QColor&)),
+            this, SLOT(setColor(unsigned int, const QColor&, const QColor&)));
     d_label_menu[i]->addMenu(d_color_menu[i]);
 
     d_factor_act.push_back(new ItemFloatAct(i, "Factor", this));
-    connect(d_factor_act[i], SIGNAL(whichTrigger(int, float)),
-            this, SLOT(setFactor(int, float)));
+    connect(d_factor_act[i], SIGNAL(whichTrigger(unsigned int, float)),
+            this, SLOT(setFactor(unsigned int, float)));
     d_label_menu[i]->addAction(d_factor_act[i]);
 
     d_menu->addMenu(d_label_menu[i]);

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -64,18 +64,18 @@ TimeRasterDisplayForm::TimeRasterDisplayForm(int nplots,
   // Now create our own menus
   for(int i = 0; i < nplots; i++) {
     d_line_title_act.push_back(new LineTitleAction(i, this));
-    connect(d_line_title_act[i], SIGNAL(whichTrigger(int, const QString&)),
-	    this, SLOT(setLineLabel(int, const QString&)));
+    connect(d_line_title_act[i], SIGNAL(whichTrigger(unsigned int, const QString&)),
+	    this, SLOT(setLineLabel(unsigned int, const QString&)));
     d_lines_menu[i]->addAction(d_line_title_act[i]);
 
     ColorMapMenu *colormap = new ColorMapMenu(i, this);
-    connect(colormap, SIGNAL(whichTrigger(int, const int, const QColor&, const QColor&)),
-	    this, SLOT(setColorMap(int, const int, const QColor&, const QColor&)));
+    connect(colormap, SIGNAL(whichTrigger(unsigned int, const int, const QColor&, const QColor&)),
+	    this, SLOT(setColorMap(unsigned int, const int, const QColor&, const QColor&)));
     d_lines_menu[i]->addMenu(colormap);
 
     d_marker_alpha_menu.push_back(new MarkerAlphaMenu(i, this));
-    connect(d_marker_alpha_menu[i], SIGNAL(whichTrigger(int, int)),
-	    this, SLOT(setAlpha(int, int)));
+    connect(d_marker_alpha_menu[i], SIGNAL(whichTrigger(unsigned int,unsigned int)),
+	    this, SLOT(setAlpha(unsigned int,unsigned int)));
     d_lines_menu[i]->addMenu(d_marker_alpha_menu[i]);
   }
 
@@ -248,7 +248,7 @@ TimeRasterDisplayForm::setColorMap(unsigned int which,
 }
 
 void
-TimeRasterDisplayForm::setAlpha(unsigned int which, int alpha)
+TimeRasterDisplayForm::setAlpha(unsigned int which,unsigned  int alpha)
 {
   getPlot()->setAlpha(which, alpha);
   getPlot()->replot();


### PR DESCRIPTION
In d19c96111 some SLOT/SIGNALS fixes were left out.
Some SIGNALS kept int as parameter. This wasn't changed here.
Only signals and slot parameters were adapted.