### PR TITLE
Add missing includes which will fail after reformat

### DIFF
--- a/gr-trellis/include/gnuradio/trellis/interleaver.h
+++ b/gr-trellis/include/gnuradio/trellis/interleaver.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/trellis/api.h>
 #include <vector>
+#include <string>
 
 namespace gr {
   namespace trellis {

--- a/gr-uhd/lib/gr_uhd_common.h
+++ b/gr-uhd/lib/gr_uhd_common.h
@@ -23,6 +23,7 @@
 #ifndef INCLUDED_GR_UHD_COMMON_H
 #define INCLUDED_GR_UHD_COMMON_H
 
+#include <uhd/stream.hpp>
 #include <uhd/version.hpp>
 #include <boost/format.hpp>
 #include <stdexcept>


### PR DESCRIPTION
Includes in files depending on these headers will
be reordered after reformatting.
This change adds the missing includes before that
happens.