### PR TITLE
Remove remaining usage of dict.iteritems

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -403,7 +403,7 @@ class DataTableBuffers(DataTable):
 
         else:
             if(self._sort):
-                sorted_fullness = sorted(blockport_fullness.iteritems(),
+                sorted_fullness = sorted(blockport_fullness.items(),
                                          key=operator.itemgetter(1))
                 self._keymap = map(operator.itemgetter(0), sorted_fullness)
             else:
@@ -457,7 +457,7 @@ class DataTableRuntimes(DataTable):
 
         else:
             if(self._sort):
-                sorted_work = sorted(work_times.iteritems(), key=operator.itemgetter(1))
+                sorted_work = sorted(work_times.items(), key=operator.itemgetter(1))
                 self._keymap = map(operator.itemgetter(0), sorted_work)
             else:
                 if self._keymap:

--- a/grc/tests/resources/file3.block.yml
+++ b/grc/tests/resources/file3.block.yml
@@ -50,7 +50,7 @@ templates:
         %>
         ${win} = Qt.QCheckBox(${label})
         self._${id}_choices = {True: ${true}, False: ${false}}
-        self._${id}_choices_inv = dict((v,k) for k,v in self._${id}_choices.iteritems())
+        self._${id}_choices_inv = {${true}: True, ${false}: False}
         self._${id}_callback = lambda i: Qt.QMetaObject.invokeMethod(${win}, "setChecked", Qt.Q_ARG("bool", self._${id}_choices_inv[i]))
         self._${id}_callback(self.${id})
         ${win}.stateChanged.connect(lambda i: self.set_${id}(self._${id}_choices[bool(i)]))


### PR DESCRIPTION
Remove remaining usage of `dict.iteritems` in Gnuradio. `dict.iteritems` is no longer present in Python3, so we have to move to `dict.items` (supported in both Py2k and Py3k), or do something else. The two remaining cases I found were:
- gr-perf-monitorx: replaced with `dict.items()`. Correct me if I'm wrong, but in this case, the dictionaries will have entries for each buffer. That doesn't seem very large to me, so our performance shouldn't be degraded. Additionally, we also call `sorted()` on the `dict.items()`, which converts it into a list, so we're paying for the conversion anyway.
- file3.block.yml: honestly, I wasn't entirely sure where this is used; my commit message may be off-base there. The line that was using `dict.iteritems` was constructing a dictionary mapping Boolean values, so we can just manually create it instead and keep things simple.

Fixes Gnuradio/Gnuradio#2142