### PR TITLE
gr-blocks: use libvolk to speed up nlog10_ff block

### DIFF
--- a/gr-blocks/lib/nlog10_ff_impl.h
+++ b/gr-blocks/lib/nlog10_ff_impl.h
@@ -30,14 +30,12 @@ namespace gr {
 
     class BLOCKS_API nlog10_ff_impl : public nlog10_ff
     {
-      float  d_prefactor;
+      float  d_n_log2_10;
+      float  d_10_k_n;
       size_t d_vlen;
-      float  d_k;
 
     public:
       nlog10_ff_impl(float n, size_t vlen, float k);
-      void setn(float n);
-      void setk(float k);
 
       int work(int noutput_items,
 	       gr_vector_const_void_star &input_items,


### PR DESCRIPTION
This results in an order of magnitude improvement for the throughput.

Reviewed-By: Marcus Müller <marcus@hostalia.de>
Reviewed-By: Martin Braun <martin.braun@ettus.com>