### PR TITLE
grc: Add optional parameter to pad_* blocks description

### DIFF
--- a/grc/blocks/pad_sink.block.yml
+++ b/grc/blocks/pad_sink.block.yml
@@ -38,6 +38,8 @@ inputs:
     dtype: ${ type }
     vlen: ${ vlen }
     multiplicity: ${ num_streams }
+    optional: ${optional}
+
 
 asserts:
 - ${ vlen > 0 }

--- a/grc/blocks/pad_source.block.yml
+++ b/grc/blocks/pad_source.block.yml
@@ -38,6 +38,8 @@ outputs:
     dtype: ${ type }
     vlen: ${ vlen }
     multiplicity: ${ num_streams }
+    optional: ${optional}
+
 
 asserts:
 - ${ vlen > 0 }


### PR DESCRIPTION
Pad sink/sources blocks may be optional, so connections in the calling flowgraph may not be required.
But at the moment setting optional to yes in the pad property window has no effect. The pad block is alwas required.
This is due to an error in the yml description of pad* blocks.

This fixes #2098