### PR TITLE
gr-fec: remove erf redefinition in metrics.c

### DIFF
--- a/gr-fec/lib/viterbi/CMakeLists.txt
+++ b/gr-fec/lib/viterbi/CMakeLists.txt
@@ -28,19 +28,6 @@ set(viterbi_sources
 )
 
 ########################################################################
-# define missing erf function with C linkage (hack for metrics.c)
-########################################################################
-if(MSVC)
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/boost_math_erf.cc "
-#include <boost/math/special_functions/erf.hpp>
-extern \"C\" double erf(double x){
-    return boost::math::erf(x);
-}
-")
-list(APPEND viterbi_sources ${CMAKE_CURRENT_BINARY_DIR}/boost_math_erf.cc)
-endif(MSVC)
-
-########################################################################
 # Append gnuradio-runtime library sources
 ########################################################################
 SET_SOURCE_FILES_PROPERTIES( ${viterbi_sources} PROPERTIES LANGUAGE CXX )

--- a/gr-fec/lib/viterbi/metrics.c
+++ b/gr-fec/lib/viterbi/metrics.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 1995 Phil Karn, KA9Q
- * Copyright 2008 Free Software Foundation, Inc.
+ * Copyright 2008,2018 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -41,11 +41,8 @@
 
 #include<gnuradio/math.h>
 
-#include <stdlib.h>
-#include <math.h>
-
-//declare erf in case it was missing in math.h and provided for by the build system
-extern double erf(double x);
+#include <cstdlib>
+#include <cmath>
 
 /* Normal function integrated from -Inf to x. Range: 0-1 */
 #define	normal(x)	(0.5 + 0.5*erf((x)/GR_M_SQRT2))


### PR DESCRIPTION
As `erf` is required in <cmath> since C++11