### PR TITLE
rescale constellation points only if max(abs(points))>1

### DIFF
--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -66,7 +66,8 @@ namespace gr {
       constellation(std::vector<gr_complex> constell,
 		    std::vector<int> pre_diff_code,
 		    unsigned int rotational_symmetry,
-		    unsigned int dimensionality);
+		    unsigned int dimensionality,
+		    bool normalize_points=true);
       constellation();
       virtual ~constellation();
 
@@ -253,11 +254,13 @@ namespace gr {
        *                      coding) (order of list matches constell)
        * \param rotational_symmetry Number of rotations around unit circle that have the same representation.
        * \param dimensionality Number of dimensions to the constellation.
+       * \param normalize_points Normalize constellation points to mean(abs(points))=1 (default is true)
        */
       static sptr make(std::vector<gr_complex> constell,
 		       std::vector<int> pre_diff_code,
 		       unsigned int rotational_symmetry,
-		       unsigned int dimensionality);
+		       unsigned int dimensionality,
+		       bool normalize_points=true);
 
       unsigned int decision_maker(const gr_complex *sample);
       // void calc_metric(gr_complex *sample, float *metric, trellis_metric_type_t type);
@@ -268,7 +271,8 @@ namespace gr {
       constellation_calcdist(std::vector<gr_complex> constell,
 			     std::vector<int> pre_diff_code,
 			     unsigned int rotational_symmetry,
-			     unsigned int dimensionality);
+			     unsigned int dimensionality,
+			     bool nomalize_points=true);
     };
 
 

--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -43,7 +43,8 @@ namespace gr {
     constellation::constellation(std::vector<gr_complex> constell,
                                  std::vector<int> pre_diff_code,
                                  unsigned int rotational_symmetry,
-                                 unsigned int dimensionality
+                                 unsigned int dimensionality,
+				 bool normalize_points
     ) :
       d_constellation(constell),
       d_pre_diff_code(pre_diff_code),
@@ -56,16 +57,18 @@ namespace gr {
       d_lut_precision(0),
       d_lut_scale(0)
     {
-      // Scale constellation points so that average magnitude is 1.
-      float summed_mag = 0;
       unsigned int constsize = d_constellation.size();
-      for (unsigned int i=0; i<constsize; i++) {
-        gr_complex c = d_constellation[i];
-        summed_mag += sqrt(c.real()*c.real() + c.imag()*c.imag());
-      }
-      d_scalefactor = constsize/summed_mag;
-      for (unsigned int i=0; i<constsize; i++) {
-        d_constellation[i] = d_constellation[i]*d_scalefactor;
+      if (normalize_points) {
+	// Scale constellation points so that average magnitude is 1.
+	float summed_mag = 0;
+	for (unsigned int i=0; i<constsize; i++) {
+	  gr_complex c = d_constellation[i];
+	  summed_mag += sqrt(c.real()*c.real() + c.imag()*c.imag());
+	}
+	d_scalefactor = constsize/summed_mag;
+	for (unsigned int i=0; i<constsize; i++) {
+	  d_constellation[i] = d_constellation[i]*d_scalefactor;
+	}
       }
       if(pre_diff_code.size() == 0)
         d_apply_pre_diff_code = false;
@@ -406,19 +409,21 @@ namespace gr {
     constellation_calcdist::make(std::vector<gr_complex> constell,
                                  std::vector<int> pre_diff_code,
                                  unsigned int rotational_symmetry,
-                                 unsigned int dimensionality)
+                                 unsigned int dimensionality,
+				 bool normalize_points)
     {
       return constellation_calcdist::sptr(
         new constellation_calcdist(constell, pre_diff_code,
-                                   rotational_symmetry, dimensionality));
+                                   rotational_symmetry, dimensionality, normalize_points));
     }
 
     constellation_calcdist::constellation_calcdist(
       std::vector<gr_complex> constell,
       std::vector<int> pre_diff_code,
       unsigned int rotational_symmetry,
-      unsigned int dimensionality)
-      : constellation(constell, pre_diff_code, rotational_symmetry, dimensionality)
+      unsigned int dimensionality,
+      bool normalize_points)
+      : constellation(constell, pre_diff_code, rotational_symmetry, dimensionality, normalize_points)
     {}
 
     // Chooses points base on shortest distance.


### PR DESCRIPTION
This is needed for QAM constellations which are used, _e.g._, on HF and have max(abs(points))<=1.

If such QAM constellations are normalized to have average magnitude 1, the channel equalizer gets disturbed when switching from 8-PSK to QAM modulation and vice versa.

<img width="448" alt="qam32" src="https://user-images.githubusercontent.com/7550829/48569452-0e10f980-e902-11e8-801e-bebe3759b9db.png">
