### PR TITLE
grc fails to build hier2 block with message pad

### DIFF
--- a/grc/core/generator/hier_block.py
+++ b/grc/core/generator/hier_block.py
@@ -99,7 +99,7 @@ class HierBlockGenerator(TopBlockGenerator):
             for port in get_hier_block_io(self._flow_graph, direction):
                 p = collections.OrderedDict()
                 if port.domain == Constants.GR_MESSAGE_DOMAIN:
-                    p['id'] = port.id
+                    p['id'] = port.key
                 p['label'] = port.parent.params['label'].value
                 if port.domain != Constants.DEFAULT_DOMAIN:
                     p['domain'] = port.domain


### PR DESCRIPTION
Generate Error: 'Port' object has no attribute 'id'
>>> Failure
Traceback (most recent call last):
  File "/usr/local/gnuradio/lib/python3.6/dist-packages/gnuradio/grc/gui/Application.py", line 697, in _handle_action
    generator.write()
  File "/usr/local/gnuradio/lib/python3.6/dist-packages/gnuradio/grc/core/generator/hier_block.py", line 39, in write
    data = yaml.dump(self._build_block_n_from_flow_graph_io())
  File "/usr/local/gnuradio/lib/python3.6/dist-packages/gnuradio/grc/core/generator/hier_block.py", line 102, in _build_block_n_from_flow_graph_io
    p['id'] = port.id
AttributeError: 'Port' object has no attribute 'id'