### PR TITLE
cmake: qwt: Only allow qwt-qt5 as a library name

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -33,7 +33,7 @@ find_path(QWT_INCLUDE_DIRS
 )
 
 find_library (QWT_LIBRARIES
-  NAMES qwt6-${QWT_QT_VERSION} qwt-${QWT_QT_VERSION} qwt6 qwt qwt5 qwtd5
+  NAMES qwt6-${QWT_QT_VERSION} qwt-${QWT_QT_VERSION}
   HINTS
   ${PC_QWT_LIBDIR}
   ${CMAKE_INSTALL_PREFIX}/lib


### PR DESCRIPTION
The only way to be sure that FindQwt.cmake is finding the Qt5 version
of Qwt is to either
- limit the name to qwt-qt5 or
- have the user specify it when running CMake.

The latter is unimpeded by this change. However, by default, it'll now
skip libqwt.so on Fedora and Ubuntu systems, which is actually only
a valid library when using Qt4, not Qt5.

Fixes #2027.