### PR TITLE
blocks: Fix add and multiply const blocks GRC bindings

### DIFF
--- a/gr-blocks/grc/blocks_add_const_vxx.block.yml
+++ b/gr-blocks/grc/blocks_add_const_vxx.block.yml
@@ -7,12 +7,13 @@ parameters:
     dtype: enum
     options: [complex, float, int, short]
     option_attributes:
-        const_type: [complex_vector, real_vector, int_vector, int_vector]
+        vconst_type: [complex_vector, real_vector, int_vector, int_vector]
+        const_type:  [complex, real, int, int]
         fcn: [cc, ff, ii, ss]
     hide: part
 -   id: const
     label: Constant
-    dtype: ${ type.const_type }
+    dtype: ${ type.const_type if vlen == 1 else type.vconst_type }
     default: '0'
 -   id: vlen
     label: Vec Length
@@ -31,12 +32,12 @@ outputs:
     vlen: ${ vlen }
 
 asserts:
-- ${ len(const) == vlen }
 - ${ vlen > 0 }
+- ${ (vlen > 1 and len(const) == vlen) or (vlen == 1) }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.add_const_v${type.fcn}(${const})
+    make: blocks.add_const_${ 'v' if context.get('vlen')() > 1 else '' }${type.fcn}(${const})
     callbacks:
     - set_k(${const})
 

--- a/gr-blocks/grc/blocks_multiply_const_vxx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_const_vxx.block.yml
@@ -7,13 +7,14 @@ parameters:
     dtype: enum
     options: [complex, float, int, short]
     option_attributes:
-        const_type: [complex_vector, real_vector, int_vector, int_vector]
+        vconst_type: [complex_vector, real_vector, int_vector, int_vector]
+        const_type:  [complex, real, int, int]
         fcn: [cc, ff, ii, ss]
     hide: part
 -   id: const
     label: Constant
-    dtype: ${ type.const_type }
-    default: '0'
+    dtype: ${ type.const_type if vlen == 1 else type.vconst_type }
+    default: '1'
 -   id: vlen
     label: Vec Length
     dtype: int
@@ -31,12 +32,12 @@ outputs:
     vlen: ${ vlen }
 
 asserts:
-- ${ len(const) == vlen }
 - ${ vlen > 0 }
+- ${ (vlen > 1 and len(const) == vlen) or (vlen == 1) }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.multiply_const_v${type.fcn}(${const})
+    make: blocks.multiply_const_${ 'v' if context.get('vlen')() > 1 else '' }${type.fcn}(${const})
     callbacks:
     - set_k(${const})
 


### PR DESCRIPTION
The 'add' and 'multiply' const blocks have different implementations in
C++ for vector- and scalar use cases. In GRC, there was only one type of
bindings. This commit fixes the switching between the vector- and scalar
versions. It also fixes the assertion error that would require users to
specify scalars as vectors of length one.