### PR TITLE
fft: Fix GRC bindings

### DIFF
--- a/gr-channels/grc/channels_channel_model.block.yml
+++ b/gr-channels/grc/channels_channel_model.block.yml
@@ -28,9 +28,7 @@ parameters:
     default: 'False'
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
-    option_attributes:
-        hide_block: ['', part]
-    hide: ${ block_tags.hide_block }
+    hide: ${ 'none' if block_tags == 'False' else 'part' }
 
 inputs:
 -   domain: stream

--- a/gr-fft/grc/fft_fft_vxx.block.yml
+++ b/gr-fft/grc/fft_fft_vxx.block.yml
@@ -6,14 +6,11 @@ parameters:
     label: Input Type
     dtype: enum
     options: [complex, float]
-    option_attributes:
-        hide_shift: ['', all]
     hide: part
 -   id: fft_size
     label: FFT Size
     dtype: int
     default: '1024'
-    hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: forward
     label: Forward/Reverse
     dtype: enum
@@ -28,7 +25,7 @@ parameters:
     dtype: enum
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
-    hide: ${ type.hide_shift }
+    hide: ${ 'all' if type == 'float' else 'none' }
 -   id: nthreads
     label: Num. Threads
     dtype: int


### PR DESCRIPTION
- 'hide' attribute for fftshift was supposed to default to on for real
  mode. It now really does.
- The actual FFT block doesn't have a vlen parameter, and it was causing
  havok in the GRC bindings. It's now removed.