### PR TITLE
grc: Correctly building dummy block

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -371,7 +371,7 @@ class FlowGraph(Element):
             )
 
             if isinstance(block, blocks.DummyBlock):
-                print('Block id "%s" not found' % block_id)
+                block.add_error_message('Block id "{}" not found.'.format(block_id))
 
             block.import_data(**block_data)
 

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -370,9 +370,6 @@ class FlowGraph(Element):
                 self.new_block(block_id='_dummy', missing_block_id=block_id, **block_data)
             )
 
-            if isinstance(block, blocks.DummyBlock):
-                block.add_error_message('Block id "{}" not found.'.format(block_id))
-
             block.import_data(**block_data)
 
         self.rewrite()  # evaluate stuff like nports before adding connections
@@ -417,6 +414,14 @@ class FlowGraph(Element):
                 'Connection between {}({}) and {}({}) could not be made.\n\t{}'.format(
                     src_blk_id, src_port_id, snk_blk_id, snk_port_id, e))
             had_connect_errors = True
+
+        for block in self.blocks:
+            if block.is_dummy_block :
+                block.rewrite()      # Make ports visible
+                # Flowgraph errors depending on disabled blocks are not displayed
+                # in ther error dialog box
+                # So put a messsage into the Property window of the dummy block
+                block.add_error_message('Block id "{}" not found.'.format(block.key))
 
         self.rewrite()  # global rewrite
         return had_connect_errors

--- a/grc/core/blocks/dummy.py
+++ b/grc/core/blocks/dummy.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 
 from . import Block, register_build_in
 
+from ._build import _build_params, _build_ports
 
 @register_build_in
 class DummyBlock(Block):
@@ -28,9 +29,12 @@ class DummyBlock(Block):
     label = 'Missing Block'
     key = '_dummy'
 
-    def __init__(self, parent, missing_block_id, parameters, **_):
+    def __init__(self, parent, missing_block_id, parameters,**kwargs):
+
         self.key = missing_block_id
+        self.parameters_data = _build_params([kwargs],False, False,self.flags, self.key)
         super(DummyBlock, self).__init__(parent=parent)
+        del self.params[self.key] # Remove missing keys from parameter list
 
         param_factory = self.parent_platform.make_param
         for param_id in parameters:
@@ -42,7 +46,7 @@ class DummyBlock(Block):
     @property
     def enabled(self):
         return False
-
+        
     def add_missing_port(self, port_id, direction):
         port = self.parent_platform.make_port(
             parent=self, direction=direction, id=port_id, name='?', dtype='',
@@ -51,4 +55,6 @@ class DummyBlock(Block):
             self.sources.append(port)
         else:
             self.sinks.append(port)
+        self.rewrite()     # Make port visible
+        self.validate()    # Generate appropriate error messages     
         return port

--- a/grc/core/blocks/dummy.py
+++ b/grc/core/blocks/dummy.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 
 from . import Block, register_build_in
 
-from ._build import _build_params, _build_ports
+from ._build import _build_params as build_core_params
 
 @register_build_in
 class DummyBlock(Block):
@@ -29,12 +29,11 @@ class DummyBlock(Block):
     label = 'Missing Block'
     key = '_dummy'
 
-    def __init__(self, parent, missing_block_id, parameters,**kwargs):
+    def __init__(self, parent, missing_block_id, parameters,**_):
 
         self.key = missing_block_id
-        self.parameters_data = _build_params([kwargs],False, False,self.flags, self.key)
+        self.parameters_data = build_core_params([],False, False,self.flags, self.key)
         super(DummyBlock, self).__init__(parent=parent)
-        del self.params[self.key] # Remove missing keys from parameter list
 
         param_factory = self.parent_platform.make_param
         for param_id in parameters:
@@ -46,7 +45,7 @@ class DummyBlock(Block):
     @property
     def enabled(self):
         return False
-        
+
     def add_missing_port(self, port_id, direction):
         port = self.parent_platform.make_port(
             parent=self, direction=direction, id=port_id, name='?', dtype='',
@@ -55,6 +54,4 @@ class DummyBlock(Block):
             self.sources.append(port)
         else:
             self.sinks.append(port)
-        self.rewrite()     # Make port visible
-        self.validate()    # Generate appropriate error messages     
         return port


### PR DESCRIPTION
Flowgraphs referencing unknown blocks fail to build and display as the dummy block that should be build instead of the missing block misses some parameters.

This fixes #2160 