### PR TITLE
Fix compiler warnings about unsigned / signed comparisons

### DIFF
--- a/gr-blocks/lib/integrate_impl.cc
+++ b/gr-blocks/lib/integrate_impl.cc
@@ -58,11 +58,11 @@ namespace gr {
       T *out = (T *)output_items[0];
 
       for (int i = 0; i < noutput_items; i++) {
-        for (int j = 0; j < d_vlen; ++j) {
+        for (unsigned int j = 0; j < d_vlen; ++j) {
           out[i*d_vlen + j] = (T)0;
         }
         for (int j = 0; j < d_decim; j++) {
-          for (int k = 0; k < d_vlen; ++k) {
+          for (unsigned int k = 0; k < d_vlen; ++k) {
             out[i*d_vlen + k] += in[i*d_decim*d_vlen + j*d_vlen + k];
           }
         }

--- a/gr-blocks/lib/vector_sink_impl.cc
+++ b/gr-blocks/lib/vector_sink_impl.cc
@@ -94,7 +94,7 @@ namespace gr {
       // can't touch this (as long as work() is working, the accessors shall not
       // read the data
       gr::thread::scoped_lock guard(d_data_mutex);
-      for(int i = 0; i < noutput_items * d_vlen; i++)
+      for(unsigned int i = 0; i < noutput_items * d_vlen; i++)
         d_data.push_back (iptr[i]);
       std::vector<tag_t> tags;
       this->get_tags_in_range(tags, 0, this->nitems_read(0), this->nitems_read(0) + noutput_items);

--- a/gr-digital/lib/crc32_bb_impl.cc
+++ b/gr-digital/lib/crc32_bb_impl.cc
@@ -108,7 +108,7 @@ namespace gr {
           }
         }
         else{
-          for(int i=0; i < d_crc_length; i++){
+          for(unsigned int i=0; i < d_crc_length; i++){
             if(((crc >> i) & 0x1) != *(in + packet_length - d_crc_length + i)) { // Drop package
               return 0;
             }
@@ -122,7 +122,7 @@ namespace gr {
           memcpy((void *) (out + packet_length), &crc, d_crc_length); // FIXME big-endian/little-endian, this might be wrong
         }
         else {
-          for (int i = 0; i < d_crc_length; i++) { // unpack CRC and store in buffer
+          for (unsigned int i = 0; i < d_crc_length; i++) { // unpack CRC and store in buffer
             d_buffer[i] = (crc >> i) & 0x1;
           }
           memcpy((void *) (out + packet_length), (void *) &d_buffer[0], d_crc_length);

--- a/gr-digital/lib/crc32_bb_impl.h
+++ b/gr-digital/lib/crc32_bb_impl.h
@@ -35,7 +35,7 @@ namespace gr {
       bool d_check;
       bool d_packed;
       boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true>    d_crc_impl;
-      int d_crc_length;
+      unsigned int d_crc_length;
       std::vector<char> d_buffer;
       unsigned int calculate_crc32(const unsigned char* in, size_t packet_length);
 

--- a/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.cc
@@ -1113,7 +1113,7 @@ namespace gr {
           break;
       }
       fstep = fs / vlength;
-      for (int i = 0; i < vlength / 2; i++) {
+      for (unsigned int i = 0; i < vlength / 2; i++) {
         x = GR_M_PI * f / fs;
         if (i == 0) {
           sinc = 1.0;
@@ -1127,7 +1127,7 @@ namespace gr {
         f = f + fstep;
       }
       sincrms = std::sqrt(sincrms / (vlength / 2));
-      for (int i = 0; i < vlength; i++) {
+      for (unsigned int i = 0; i < vlength; i++) {
         inverse_sinc[i] *= sincrms;
       }
       equalization_enable = equalization;

--- a/gr-fec/lib/polar_common.cc
+++ b/gr-fec/lib/polar_common.cc
@@ -111,7 +111,7 @@ namespace gr {
         std::copy(d_frozen_bit_values.begin(), d_frozen_bit_values.end(), d_volk_frozen_bits);
         std::fill(d_volk_frozen_bits + d_frozen_bit_values.size(), d_volk_frozen_bits + nfrozen, 0);
 
-        int nfbit = 0;
+        unsigned int nfbit = 0;
         for(int i = 0; i < block_size(); i++){
           unsigned char m = 0x00;
           if(nfbit < d_frozen_bit_positions.size() && d_frozen_bit_positions[nfbit] == i){

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -127,7 +127,7 @@ namespace gr {
     bool
     time_sink_c_impl::check_topology(int ninputs, int noutputs)
     {
-      return 2*ninputs == d_nconnections;
+      return (unsigned int) (2*ninputs) == d_nconnections;
     }
 
     void

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -122,7 +122,7 @@ namespace gr {
     bool
     time_sink_f_impl::check_topology(int ninputs, int noutputs)
     {
-      return ninputs == d_nconnections;
+      return (unsigned int)(ninputs) == d_nconnections;
     }
 
     void

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -113,13 +113,13 @@ namespace gr {
       std::vector<int> tmp(d_K);
       unsigned char *bytes = reinterpret_cast<unsigned char*>(&tmp[0]);
 
-      for(unsigned int i = 0; i < d_K; i += 8) {
+      for(int i = 0; i < d_K; i += 8) {
               *(reinterpret_cast<uint64_t*>(bytes + i)) = xoroshiro128p_next(rng_state);
       }
       if(d_K % 8) {
               uint64_t randval = xoroshiro128p_next(rng_state);
               unsigned char *valptr = reinterpret_cast<unsigned char*>(&randval);
-              for(unsigned int idx = (d_K / 8)*8; idx < d_K; ++idx) {
+              for(int idx = (d_K / 8)*8; idx < d_K; ++idx) {
                       bytes[idx] = *valptr++;
               }
       }


### PR DESCRIPTION
See #2120
Fixing compiler warnings, excluding volk. In submodule volk there exist more warnings. 