### PR TITLE
trellis interleaver: made table size unsigned int

### DIFF
--- a/gr-trellis/include/gnuradio/trellis/interleaver.h
+++ b/gr-trellis/include/gnuradio/trellis/interleaver.h
@@ -37,17 +37,17 @@ namespace gr {
     class TRELLIS_API interleaver
     {
     private:
-      int d_K;
+      unsigned int d_K;
       std::vector<int> d_INTER;
       std::vector<int> d_DEINTER;
 
     public:
       interleaver();
       interleaver(const interleaver & INTERLEAVER);
-      interleaver(int K, const std::vector<int> & INTER);
+      interleaver(unsigned int K, const std::vector<int> & INTER);
       interleaver(const char *name);
-      interleaver(int K, int seed);
-      int K () const { return d_K; }
+      interleaver(unsigned int K, int seed);
+      unsigned int K () const { return d_K; }
       const std::vector<int> & INTER() const { return d_INTER; }
       const std::vector<int> & DEINTER() const { return d_DEINTER; }
       void write_interleaver_txt(std::string filename);

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -48,14 +48,14 @@ namespace gr {
       d_DEINTER=INTERLEAVER.DEINTER();
     }
 
-    interleaver::interleaver(int K, const std::vector<int> &INTER)
+    interleaver::interleaver(unsigned int K, const std::vector<int> &INTER)
     {
       d_K=K;
       d_INTER=INTER;
       d_DEINTER.resize(d_K);
 
       // generate DEINTER table
-      for(int i=0;i<d_K;i++) {
+      for(unsigned int i = 0; i < d_K; i++) {
 	d_DEINTER[d_INTER[i]]=i;
       }
     }
@@ -84,16 +84,17 @@ namespace gr {
       d_INTER.resize(d_K);
       d_DEINTER.resize(d_K);
 
-      for(int i=0;i<d_K;i++) {
-	if(fscanf(interleaverfile,"%d",&(d_INTER[i])) == EOF) {
-	  if(ferror(interleaverfile) != 0)
-	    throw std::runtime_error("interleaver::interleaver(const char *name): file read error\n");
-	}
+      for (unsigned int i = 0; i < d_K; i++) {
+          if (fscanf(interleaverfile, "%d", &(d_INTER[i])) == EOF) {
+              if (ferror(interleaverfile) != 0)
+                  throw std::runtime_error(
+                      "interleaver::interleaver(const char *name): file read error\n");
+          }
       }
 
       // generate DEINTER table
-      for(int i=0;i<d_K;i++) {
-	d_DEINTER[d_INTER[i]]=i;
+      for (unsigned int i = 0; i < d_K; i++) {
+          d_DEINTER[d_INTER[i]] = i;
       }
 
       fclose(interleaverfile);
@@ -102,7 +103,7 @@ namespace gr {
     //######################################################################
     //# Generate a random interleaver
     //######################################################################
-    interleaver::interleaver(int K, int seed)
+    interleaver::interleaver(unsigned int K, int seed)
     {
       d_K=K;
       d_INTER.resize(d_K);
@@ -113,23 +114,23 @@ namespace gr {
       std::vector<int> tmp(d_K);
       unsigned char *bytes = reinterpret_cast<unsigned char*>(&tmp[0]);
 
-      for(int i = 0; i < d_K; i += 8) {
+      for(unsigned int i = 0; i < d_K; i += 8) {
               *(reinterpret_cast<uint64_t*>(bytes + i)) = xoroshiro128p_next(rng_state);
       }
       if(d_K % 8) {
               uint64_t randval = xoroshiro128p_next(rng_state);
               unsigned char *valptr = reinterpret_cast<unsigned char*>(&randval);
-              for(int idx = (d_K / 8)*8; idx < d_K; ++idx) {
+              for(unsigned int idx = (d_K / 8)*8; idx < d_K; ++idx) {
                       bytes[idx] = *valptr++;
               }
       }
-      for(int i=0;i<d_K;i++) {
-              d_INTER[i]=i;
+      for (unsigned int i = 0; i < d_K; i++) {
+          d_INTER[i] = i;
       }
       quicksort_index <int> (tmp,d_INTER,0,d_K-1);
 
       // generate DEINTER table
-      for(int i=0;i<d_K;i++) {
+      for(unsigned int i=0;i<d_K;i++) {
               d_DEINTER[d_INTER[i]]=i;
       }
     }
@@ -151,7 +152,7 @@ namespace gr {
       }
       interleaver_fname << d_K << std::endl;
       interleaver_fname << std::endl;
-      for(int i=0;i<d_K;i++)
+      for(unsigned int i=0;i<d_K;i++)
 	interleaver_fname << d_INTER[i] << ' ';
       interleaver_fname << std::endl;
       interleaver_fname.close();


### PR DESCRIPTION
This complements the excellent work of #2198.

This is part of the ongoing effort to avoid signedness confusion.

It completes df4e7a85263eb523395ce6bef0b2e7769bd63465 in that it at
least strives to handle sizes consistently in interleaver.cc.

Of course, the returned vectors still contain signed ints where there
should be unsigned ints, but the trellis core_algorithms.cc code is
convoluted enough to warrant carefulness when touching, so this part of
the API was kept.