### PR TITLE
Add UHD multi_usrp filter APIs to gr-uhd

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -561,6 +561,39 @@ namespace gr {
           const size_t mboard = 0
       ) = 0;
 
+     /*!
+      * Enumerate the available filters in the signal path.
+      * \param search_mask
+      * \parblock
+      * Select only certain filter names by specifying this search mask.
+      *
+      * E.g. if search mask is set to "rx_frontends/A" only filter names including that string will be returned.
+      * \endparblock
+      * \return a vector of strings representing the selected filter names.
+      */
+      virtual std::vector<std::string> get_filter_names(
+          const std::string &search_mask = ""
+      ) = 0;
+
+     /*!
+      * Write back a filter obtained by get_filter() to the signal path.
+      * This filter can be a modified version of the originally returned one.
+      * The information about Rx or Tx is contained in the path parameter.
+      * \param path the name of the filter as returned from get_filter_names().
+      * \param filter the filter_info_base::sptr of the filter object to be written
+      */
+      virtual void set_filter(
+          const std::string &path, ::uhd::filter_info_base::sptr filter
+      ) = 0;
+
+     /*!
+      * Return the filter object for the given name.
+      * @param path the name of the filter as returned from get_filter_names()
+      * @return the filter object
+      */
+      virtual ::uhd::filter_info_base::sptr get_filter(
+          const std::string &path
+      ) = 0;
     };
 
   } /* namespace uhd */

--- a/gr-uhd/lib/CMakeLists.txt
+++ b/gr-uhd/lib/CMakeLists.txt
@@ -77,6 +77,10 @@ add_library(gnuradio-uhd SHARED ${gr_uhd_sources})
 target_link_libraries(gnuradio-uhd ${uhd_libs})
 GR_LIBRARY_FOO(gnuradio-uhd RUNTIME_COMPONENT "uhd_runtime" DEVEL_COMPONENT "uhd_devel")
 
+if(UHD_VERSION VERSION_GREATER_EQUAL "3.9.0")
+  add_compile_definitions(UHD_USRP_MULTI_FILTER_API)
+endif(UHD_VERSION VERSION_GREATER_EQUAL "3.9.0")
+
 ########################################################################
 # Build static libraries if enabled
 ########################################################################

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -353,7 +353,7 @@ usrp_block_impl::get_gpio_attr(
 std::vector<std::string>
 usrp_block_impl::get_filter_names(const std::string &search_mask)
 {
-#if UHD_USRP_MULTI_FILTER_API
+#ifdef UHD_USRP_MULTI_FILTER_API
     return _dev->get_filter_names(search_mask);
 #else
   throw std::runtime_error("not implemented in this version");
@@ -363,7 +363,7 @@ usrp_block_impl::get_filter_names(const std::string &search_mask)
 ::uhd::filter_info_base::sptr
 usrp_block_impl::get_filter(const std::string &path)
 {
-#if UHD_USRP_MULTI_FILTER_API
+#ifdef UHD_USRP_MULTI_FILTER_API
   return _dev->get_filter(path);
 #else
   throw std::runtime_error("not implemented in this version");
@@ -373,7 +373,7 @@ usrp_block_impl::get_filter(const std::string &path)
 void
 usrp_block_impl::set_filter(const std::string &path, ::uhd::filter_info_base::sptr filter)
 {
-#if UHD_USRP_MULTI_FILTER_API
+#ifdef UHD_USRP_MULTI_FILTER_API
   _dev->set_filter(path, filter);
 #else
   throw std::runtime_error("not implemented in this version");

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -350,6 +350,36 @@ usrp_block_impl::get_gpio_attr(
 #endif
 }
 
+std::vector<std::string>
+usrp_block_impl::get_filter_names(const std::string &search_mask)
+{
+#if UHD_USRP_MULTI_FILTER_API
+    return _dev->get_filter_names(search_mask);
+#else
+  throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::filter_info_base::sptr
+usrp_block_impl::get_filter(const std::string &path)
+{
+#if UHD_USRP_MULTI_FILTER_API
+  return _dev->get_filter(path);
+#else
+  throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+void
+usrp_block_impl::set_filter(const std::string &path, ::uhd::filter_info_base::sptr filter)
+{
+#if UHD_USRP_MULTI_FILTER_API
+  _dev->set_filter(path, filter);
+#else
+  throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void
 usrp_block_impl::set_time_now(const ::uhd::time_spec_t &time_spec,
                              size_t mboard)

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -69,6 +69,8 @@ namespace gr {
           const size_t mboard = 0
       );
       size_t get_num_mboards();
+      std::vector<std::string> get_filter_names (const std::string &search_mask);
+      ::uhd::filter_info_base::sptr get_filter(const std::string &path);
 
       // Setters
       void set_clock_config(const ::uhd::clock_config_t &clock_config, size_t mboard);
@@ -88,6 +90,7 @@ namespace gr {
           const boost::uint32_t mask,
           const size_t mboard
       );
+      void set_filter(const std::string &path, ::uhd::filter_info_base::sptr filter);
 
       // RPC
       void setup_rpc();

--- a/gr-uhd/swig/uhd_swig.i
+++ b/gr-uhd/swig/uhd_swig.i
@@ -119,10 +119,40 @@
 
 %include <uhd/stream.hpp>
 
+%include <uhd/types/filters.hpp>
+
+%include stdint.i
+
+// Used for lists of filter taps
+%template(uhd_vector_int16_t) std::vector<int16_t>;
+
+%template(filter_info_base_sptr) boost::shared_ptr<uhd::filter_info_base>;
+%template(analog_filter_base_stpr) boost::shared_ptr<uhd::analog_filter_base>;
+%template(analog_filter_lp_stpr) boost::shared_ptr<uhd::analog_filter_lp>;
+%template(digital_filter_base_int16_t_sptr) boost::shared_ptr<uhd::digital_filter_base<int16_t>>;
+%template(digital_filter_fir_int16_t_sptr) boost::shared_ptr<uhd::digital_filter_fir<int16_t>>;
+
+%extend uhd::filter_info_base{
+    boost::shared_ptr<uhd::analog_filter_base> to_analog_info_base(boost::shared_ptr<uhd::filter_info_base> ptr) {
+       return boost::dynamic_pointer_cast<uhd::analog_filter_base>(ptr);
+    }
+
+    boost::shared_ptr<uhd::analog_filter_lp> to_analog_filter_lp(boost::shared_ptr<uhd::filter_info_base> ptr) {
+       return boost::dynamic_pointer_cast<uhd::analog_filter_lp>(ptr);
+    }
+
+    boost::shared_ptr<uhd::digital_filter_base<int16_t>> to_digital_filter_base_int16(boost::shared_ptr<uhd::filter_info_base> ptr) {
+       return boost::dynamic_pointer_cast<uhd::digital_filter_base<int16_t>>(ptr);
+    }
+
+    boost::shared_ptr<uhd::digital_filter_fir<int16_t>> to_digital_filter_fir_int16(boost::shared_ptr<uhd::filter_info_base> ptr) {
+       return boost::dynamic_pointer_cast<uhd::digital_filter_fir<int16_t>>(ptr);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////
 // swig dboard_iface for python access
 ////////////////////////////////////////////////////////////////////////
-%include stdint.i
 %include <uhd/types/serial.hpp>
 %include <uhd/usrp/dboard_iface.hpp>
 


### PR DESCRIPTION
This PR will be complete when it provides the ability to list, get, and set all filters supported and used by UHD.

- [x] APIs exposed in C++ USRP Source/Sink blocks
- [x] Add IFDEF protection for UHD versions < 3.9.0
- [x] APIs wrapped into Python

EDIT: Moving these to another issue/PR
- Write a Python example
- Functionality exposed (where useful) in GRC
- Write a GRC example (will be B2xx/E3xx specific)

I'm thinking of adding a text field to the GRC blocks which accepts a Python dictionary with `Filter Path: taps`. This provides a simple way of setting custom filters.

I'm testing the above with a B205mini.

@mbr0wn the SWIG wrapping is a bit clumsy at the moment, but I think it is about as good as it can be, second opinions much appreciated. Also any thoughts on the GRC UI. In a future PR I'd like to add a control port based API for getting and setting the filters but that's "future work".