### PR TITLE
runtime: Fix tag propagation

### DIFF
--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -147,7 +147,7 @@ namespace gr {
           for(t = rtags.begin(); t != rtags.end(); t++) {
             tag_t new_tag = *t;
             mpz_import(offset.get_mpz_t(), 1, 1, sizeof(new_tag.offset), 0, 0, &new_tag.offset);
-            offset *= mp_rrate + one_half;
+            offset = offset * mp_rrate + one_half;
             new_tag.offset = offset.get_ui();
             for(int o = 0; o < d->noutputs(); o++)
               out_buf[o]->add_item_tag(new_tag);
@@ -190,7 +190,7 @@ namespace gr {
             for(t = rtags.begin(); t != rtags.end(); t++) {
               tag_t new_tag = *t;
               mpz_import(offset.get_mpz_t(), 1, 1, sizeof(new_tag.offset), 0, 0, &new_tag.offset);
-              offset *= mp_rrate + one_half;
+              offset = offset * mp_rrate + one_half;
               new_tag.offset = offset.get_ui();
               out_buf->add_item_tag(new_tag);
             }


### PR DESCRIPTION
During the fix for long long on 32bit architectures a bug was introduced
which lead to offset being multiplied by (mp_rrate + one_half).

The correct solution is to multiply with mp_rrate and then add one_half.

Fixes #2201