### PR TITLE
gr-zeromq: Remove VLA from last_endpoint()

### DIFF
--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -57,8 +57,8 @@ namespace gr {
     std::string
     base_impl::last_endpoint()
     {
-      size_t addr_len = 256;
-      char addr[addr_len];
+      char addr[256];
+      size_t addr_len = sizeof(addr);
       d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
       return std::string(addr, addr_len-1);
     }

--- a/gr-zeromq/lib/pub_msg_sink_impl.h
+++ b/gr-zeromq/lib/pub_msg_sink_impl.h
@@ -42,8 +42,8 @@ namespace gr {
 
       void handler(pmt::pmt_t msg);
       std::string last_endpoint() override {
-        size_t addr_len = 256;
-        char addr[addr_len];
+        char addr[256];
+        size_t addr_len = sizeof(addr);
         d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len-1);
       }

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -50,8 +50,8 @@ namespace gr {
       bool stop();
 
       std::string last_endpoint() override {
-        size_t addr_len = 256;
-        char addr[addr_len];
+        char addr[256];
+        size_t addr_len = sizeof(addr);
         d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len-1);
       }

--- a/gr-zeromq/lib/push_msg_sink_impl.h
+++ b/gr-zeromq/lib/push_msg_sink_impl.h
@@ -42,8 +42,8 @@ namespace gr {
 
       void handler(pmt::pmt_t msg);
       std::string last_endpoint() override {
-        size_t addr_len = 256;
-        char addr[addr_len];
+        char addr[256];
+        size_t addr_len = sizeof(addr);
         d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len-1);
       }

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -50,8 +50,8 @@ namespace gr {
       bool stop();
 
       std::string last_endpoint() override {
-        size_t addr_len = 256;
-        char addr[addr_len];
+        char addr[256];
+        size_t addr_len = sizeof(addr);
         d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len-1);
       }

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -50,8 +50,8 @@ namespace gr {
       bool stop();
 
       std::string last_endpoint() override {
-        size_t addr_len = 256;
-        char addr[addr_len];
+        char addr[256];
+        size_t addr_len = sizeof(addr);
         d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len-1);
       }

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -50,8 +50,8 @@ namespace gr {
       bool stop();
 
       std::string last_endpoint() override {
-        size_t addr_len = 256;
-        char addr[addr_len];
+        char addr[256];
+        size_t addr_len = sizeof(addr);
         d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len-1);
       }


### PR DESCRIPTION
The zeromq code as a whole code repeats itself a lot, but changing that would mean creating some new base classes and doing quite a bit of restructuring that I am not very comfortable doing.   This should remove the variable length array that is not allowed by MSVC.