### PR TITLE
uhd: Fix GRC bindings (gain, freq...)

### DIFF
--- a/gr-uhd/grc/CMakeLists.txt
+++ b/gr-uhd/grc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2011 Free Software Foundation, Inc.
+# Copyright 2011,2018 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #


### PR DESCRIPTION
The YML file generated during CMake was simply not correct. Frequency,
gain, etc. weren't propagated properly to the underlying C++ object.

Fixes #2221.