### PR TITLE
CMake: Reduce Boost Minimum Version from 1.54 to 1.53

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ SET(VERSION_INFO_MAINT_VERSION 0)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:
-set(GR_BOOST_MIN_VERSION "1.54")
+set(GR_BOOST_MIN_VERSION "1.53")
 set(GR_SWIG_MIN_VERSION "3.0.8")
 set(GR_CMAKE_MIN_VERSION "3.5.1")
 set(GR_MAKO_MIN_VERSION "0.4.2")


### PR DESCRIPTION
This is the same version UHD requires; it's also what is available on
CentOS/RHEL 7.6, so this allows building on a wider scale of platforms
without breaking anything observable.