### PR TITLE
Fix alloc-dealloc-mismatches

### DIFF
--- a/gr-blocks/lib/tcp_server_sink_impl.h
+++ b/gr-blocks/lib/tcp_server_sink_impl.h
@@ -43,7 +43,7 @@ namespace gr {
       std::set<boost::asio::ip::tcp::socket *> d_sockets;
       boost::asio::ip::tcp::acceptor d_acceptor;
 
-      boost::shared_ptr<uint8_t> d_buf;
+      boost::shared_ptr<uint8_t[]> d_buf;
       enum {
           BUF_SIZE = 256 * 1024,
       };

--- a/gr-filter/lib/pfb_decimator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.cc
@@ -98,7 +98,7 @@ namespace gr {
 
     pfb_decimator_ccf_impl::~pfb_decimator_ccf_impl()
     {
-      delete d_rotator;
+      delete[] d_rotator;
     }
 
     void


### PR DESCRIPTION
The `d_rotator` member of `pfb_decimator_ccf_impl` is allocated with `new[]`
but deallocated with `delete`. It should instead be deallocated with
`delete[]`.

The `d_buf` member of `tcp_server_sink_impl` is currently typed as a shared
pointer to a `uint8_t` but should be a shared pointer to a `uint8_t[]`.

Fixes: #2247 
Fixes: #2249 