### PR TITLE
qa: Use random.seed(0) everywhere import random is used

### DIFF
--- a/gr-blocks/python/blocks/qa_keep_m_in_n.py
+++ b/gr-blocks/python/blocks/qa_keep_m_in_n.py
@@ -29,7 +29,7 @@ import random
 class test_keep_m_in_n(gr_unittest.TestCase):
 
     def setUp(self):
-        pass
+        random.seed(0)
 
     def tearDown(self):
         pass

--- a/gr-blocks/python/blocks/qa_pack_k_bits.py
+++ b/gr-blocks/python/blocks/qa_pack_k_bits.py
@@ -28,6 +28,7 @@ from gnuradio import gr, gr_unittest, blocks
 class test_pack(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-blocks/python/blocks/qa_packed_to_unpacked.py
+++ b/gr-blocks/python/blocks/qa_packed_to_unpacked.py
@@ -28,6 +28,7 @@ import random
 class test_packing(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block ()
 
     def tearDown(self):

--- a/gr-blocks/python/blocks/qa_repack_bits_bb.py
+++ b/gr-blocks/python/blocks/qa_repack_bits_bb.py
@@ -28,6 +28,7 @@ import pmt
 class qa_repack_bits_bb (gr_unittest.TestCase):
 
     def setUp (self):
+        random.seed(0)
         self.tb = gr.top_block ()
         self.tsb_key = "length"
 

--- a/gr-blocks/python/blocks/qa_socket_pdu.py
+++ b/gr-blocks/python/blocks/qa_socket_pdu.py
@@ -29,6 +29,7 @@ import time
 class qa_socket_pdu (gr_unittest.TestCase):
 
     def setUp (self):
+        random.seed(0)
         self.tb = gr.top_block ()
 
     def tearDown (self):

--- a/gr-blocks/python/blocks/qa_unpack_k_bits.py
+++ b/gr-blocks/python/blocks/qa_unpack_k_bits.py
@@ -28,6 +28,7 @@ import random
 class test_unpack(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block ()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_binary_slicer_fb.py
+++ b/gr-digital/python/digital/qa_binary_slicer_fb.py
@@ -28,6 +28,7 @@ from gnuradio import gr, gr_unittest, digital, blocks
 class test_binary_slicer_fb(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_clock_recovery_mm.py
+++ b/gr-digital/python/digital/qa_clock_recovery_mm.py
@@ -29,6 +29,7 @@ from gnuradio import gr, gr_unittest, digital, blocks
 class test_clock_recovery_mm(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -171,6 +171,7 @@ class test_constellation(gr_unittest.TestCase):
     src_length = 256
 
     def setUp(self):
+        random.seed(0)
         # Generate a list of random bits.
         self.src_data = tuple([random.randint(0,1) for i in range(0, self.src_length)])
 

--- a/gr-digital/python/digital/qa_constellation_receiver.py
+++ b/gr-digital/python/digital/qa_constellation_receiver.py
@@ -89,6 +89,9 @@ class test_constellation_receiver(gr_unittest.TestCase):
     max_data_length = DATA_LENGTH * 6
     max_num_samples = 1000
 
+    def setUp(self):
+        random.seed(0)
+
     def test_basic(self):
         """
         Tests a bunch of different constellations by using generic

--- a/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
+++ b/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
@@ -28,6 +28,7 @@ from numpy import random, vectorize
 class test_constellation_soft_decoder(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_costas_loop_cc.py
+++ b/gr-digital/python/digital/qa_costas_loop_cc.py
@@ -31,6 +31,7 @@ from gnuradio.digital import psk
 class test_costas_loop_cc(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_crc32.py
+++ b/gr-digital/python/digital/qa_crc32.py
@@ -21,7 +21,6 @@
 # 
 
 
-import random
 import cmath
 
 from gnuradio import gr, gr_unittest, digital

--- a/gr-digital/python/digital/qa_diff_encoder.py
+++ b/gr-digital/python/digital/qa_diff_encoder.py
@@ -35,6 +35,7 @@ def make_random_int_tuple(L, min, max):
 class test_diff_encoder(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_fll_band_edge.py
+++ b/gr-digital/python/digital/qa_fll_band_edge.py
@@ -30,6 +30,7 @@ from gnuradio import gr, gr_unittest, digital, filter, blocks, analog
 class test_fll_band_edge_cc(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
+++ b/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
@@ -45,6 +45,7 @@ def rand_range(min_val, max_val):
 class qa_ofdm_chanest_vcvc (gr_unittest.TestCase):
 
     def setUp (self):
+        random.seed(0)
         self.tb = gr.top_block ()
 
     def tearDown (self):

--- a/gr-digital/python/digital/qa_ofdm_txrx.py
+++ b/gr-digital/python/digital/qa_ofdm_txrx.py
@@ -67,6 +67,7 @@ class ofdm_rx_fg (gr.top_block):
 class test_ofdm_txrx (gr_unittest.TestCase):
 
     def setUp (self):
+        random.seed(0)
         self.tb = gr.top_block ()
 
     def tearDown (self):

--- a/gr-digital/python/digital/qa_packet_headerparser_b.py
+++ b/gr-digital/python/digital/qa_packet_headerparser_b.py
@@ -30,6 +30,7 @@ import pmt
 class qa_packet_headerparser_b (gr_unittest.TestCase):
 
     def setUp (self):
+        random.seed(0)
         self.tb = gr.top_block ()
 
     def tearDown (self):

--- a/gr-digital/python/digital/qa_pfb_clock_sync.py
+++ b/gr-digital/python/digital/qa_pfb_clock_sync.py
@@ -31,6 +31,7 @@ from gnuradio import gr, gr_unittest, filter, digital, blocks
 class test_pfb_clock_sync(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):

--- a/gr-filter/python/filter/qa_fft_filter.py
+++ b/gr-filter/python/filter/qa_fft_filter.py
@@ -89,7 +89,7 @@ def print_complex(x):
 class test_fft_filter(gr_unittest.TestCase):
 
     def setUp(self):
-        pass
+        random.seed(0)
 
     def tearDown(self):
         pass

--- a/gr-filter/python/filter/qa_filterbank.py
+++ b/gr-filter/python/filter/qa_filterbank.py
@@ -43,6 +43,7 @@ def convolution(A, B):
 class test_filterbank_vcvcf(gr_unittest.TestCase):
 
     def setUp(self):
+        random.seed(0)
         self.tb = gr.top_block()
 
     def tearDown(self):


### PR DESCRIPTION
This affects all Python-based unit tests which use the Python random
module. If they do, this change adds random.seed(0) to every setUp()
call, so that all QA runs are reproducible.