### PR TITLE
grc: Make GRC save blank parameters

### DIFF
--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -348,9 +348,6 @@ class Platform(Element):
         try:
             for d in chain([data['options']], data['blocks']):
                 d['states']['coordinate'] = yaml.ListFlowing(d['states']['coordinate'])
-                for param_id, value in list(d['parameters'].items()):
-                    if value == '':
-                        d['parameters'].pop(param_id)
         except KeyError:
             pass
 


### PR DESCRIPTION
Following the discussion from https://github.com/gnuradio/gnuradio/issues/2229. 

For the time being, GRC discards empty parameters when generating the `.grc` file. This PR alters this behaviour. I haven't tested if this creates any problems yet, but can't think of any off the top of my head. 

It will result in more cluttered `.grc` files though. @skoslowski what are your thoughts on this?