### PR TITLE
blocks: make file_source take (u)int64_t for lengths, offsets, not size_t

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/file_source.h
+++ b/gr-blocks/include/gnuradio/blocks/file_source.h
@@ -62,7 +62,7 @@ namespace gr {
        * \param len     produce only items [offset, offset+len)
        */
       static sptr make(size_t itemsize, const char *filename, bool repeat = false,
-                       size_t offset = 0, size_t len = 0);
+                       uint64_t offset = 0, uint64_t len = 0);
 
       /*!
        * \brief seek file to \p seek_point relative to \p whence
@@ -70,7 +70,7 @@ namespace gr {
        * \param seek_point      sample offset in file
        * \param whence  one of SEEK_SET, SEEK_CUR, SEEK_END (man fseek)
        */
-      virtual bool seek(long seek_point, int whence) = 0;
+      virtual bool seek(int64_t seek_point, int whence) = 0;
 
       /*!
        * \brief Opens a new file.
@@ -80,7 +80,7 @@ namespace gr {
        * \param offset  begin this many items into file
        * \param len     produce only items [offset, offset+len)
        */
-      virtual void open(const char *filename, bool repeat, size_t offset = 0, size_t len = 0) = 0;
+      virtual void open(const char *filename, bool repeat, uint64_t offset = 0, uint64_t len = 0) = 0;
 
       /*!
        * \brief Close the file handle.

--- a/gr-blocks/lib/file_source_impl.h
+++ b/gr-blocks/lib/file_source_impl.h
@@ -33,9 +33,9 @@ namespace gr {
     {
     private:
       size_t d_itemsize;
-      size_t d_start_offset_items;
-      size_t d_length_items;
-      size_t d_items_remaining;
+      uint64_t d_start_offset_items;
+      uint64_t d_length_items;
+      uint64_t d_items_remaining;
       FILE *d_fp;
       FILE *d_new_fp;
       bool d_repeat;
@@ -51,11 +51,11 @@ namespace gr {
 
     public:
       file_source_impl(size_t itemsize, const char *filename, bool repeat,
-                       size_t offset, size_t len);
+                       uint64_t offset, uint64_t len);
       ~file_source_impl();
 
-      bool seek(long seek_point, int whence);
-      void open(const char *filename, bool repeat, size_t offset, size_t len);
+      bool seek(int64_t seek_point, int whence);
+      void open(const char *filename, bool repeat, uint64_t offset, uint64_t len);
       void close();
 
       int work(int noutput_items,

--- a/gr-blocks/lib/file_source_impl.h
+++ b/gr-blocks/lib/file_source_impl.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/blocks/file_source.h>
 #include <boost/thread/mutex.hpp>
+#include <fstream>
 
 namespace gr {
   namespace blocks {
@@ -36,8 +37,9 @@ namespace gr {
       uint64_t d_start_offset_items;
       uint64_t d_length_items;
       uint64_t d_items_remaining;
-      FILE *d_fp;
-      FILE *d_new_fp;
+
+      std::ifstream* d_fstream;
+      std::ifstream* d_new_fstream;
       bool d_repeat;
       bool d_updated;
       bool d_file_begin;
@@ -48,6 +50,7 @@ namespace gr {
       pmt::pmt_t _id;
 
       void do_update();
+      void close_conditionally(std::ifstream* fstream);
 
     public:
       file_source_impl(size_t itemsize, const char *filename, bool repeat,


### PR DESCRIPTION
This is meant to address #2245; @drmpeg rightfully complained that it's a bad
idea to use size_t as file length or offset specifier, since that's very
limited in usefulness on 32 bit systems. 

This requires testing by @drmpeg before merging. 

Closes #2245. (presumably. Don't merge if it doesn't allow large offsets)