### PR TITLE
GRC: enable displaying of variable IDs

### DIFF
--- a/gr-blocks/grc/blocks_tag_object.block.yml
+++ b/gr-blocks/grc/blocks_tag_object.block.yml
@@ -1,5 +1,6 @@
 id: variable_tag_object
 label: Tag Object
+flags: variable
 
 parameters:
 -   id: offset

--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -1,5 +1,6 @@
 id: variable_constellation
 label: Constellation Object
+flags: variable
 category: Modulators
 
 parameters:

--- a/gr-digital/grc/digital_constellation_rect.block.yml
+++ b/gr-digital/grc/digital_constellation_rect.block.yml
@@ -1,5 +1,6 @@
 id: variable_constellation_rect
 label: Constellation Rect. Object
+flags: variable
 category: Modulators
 
 parameters:

--- a/gr-digital/grc/digital_modulate_vector.block.yml
+++ b/gr-digital/grc/digital_modulate_vector.block.yml
@@ -1,5 +1,6 @@
 id: variable_modulate_vector
 label: Modulate Vector
+flags: variable
 category: Modulators
 
 parameters:

--- a/gr-digital/grc/variable_header_format_default.block.yml
+++ b/gr-digital/grc/variable_header_format_default.block.yml
@@ -1,5 +1,6 @@
 id: variable_header_format_default
 label: Default Header Format Obj.
+flags: variable
 
 parameters:
 -   id: access_code

--- a/gr-fec/grc/ldpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/ldpc_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_decoder_def
 label: LDPC Decoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/ldpc_encoder_def_list.block.yml
+++ b/gr-fec/grc/ldpc_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_encoder_def
 label: LDPC Encoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/tpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_tpc_decoder_def
 label: TPC Decoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/tpc_encoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_tpc_encoder_def
 label: TPC Encoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_cc_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_cc_decoder_def
 label: CC Decoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_cc_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_cc_encoder_def
 label: CC Encoder Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_ccsds_encoder_def
 label: CCSDS Encoder Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_dummy_decoder_def
 label: Dummy Decoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_dummy_encoder_def
 label: Dummy Encoder Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_ldpc_G_matrix_object.block.yml
+++ b/gr-fec/grc/variable_ldpc_G_matrix_object.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_G_matrix_def
 label: LDPC Generator Matrix
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_H_matrix_object.block.yml
+++ b/gr-fec/grc/variable_ldpc_H_matrix_object.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_H_matrix_def
 label: LDPC Parity Check Matrix
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_bit_flip_decoder.block.yml
+++ b/gr-fec/grc/variable_ldpc_bit_flip_decoder.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_bit_flip_decoder_def
 label: LDPC Bit Flip Decoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_encoder_G.block.yml
+++ b/gr-fec/grc/variable_ldpc_encoder_G.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_encoder_G_def
 label: LDPC Encoder Definition (via Generator)
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_encoder_H.block.yml
+++ b/gr-fec/grc/variable_ldpc_encoder_H.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_encoder_H_def
 label: LDPC Encoder Definition (via Parity Check)
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_polar_code_configurator.block.yml
+++ b/gr-fec/grc/variable_polar_code_configurator.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_code_configurator
 label: POLAR code Configurator
+flags: variable
 
 parameters:
 -   id: channel

--- a/gr-fec/grc/variable_polar_decoder_sc.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_decoder_sc_def
 label: POLAR Decoder SC Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_polar_decoder_sc_list.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_decoder_sc_list_def
 label: POLAR Decoder SC List Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_polar_decoder_sc_systematic.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc_systematic.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_decoder_sc_systematic_def
 label: systematic POLAR Decoder SC Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_polar_encoder.block.yml
+++ b/gr-fec/grc/variable_polar_encoder.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_encoder_def
 label: POLAR Encoder Definition
+flags: variable
 
 parameters:
 -   id: is_packed

--- a/gr-fec/grc/variable_polar_encoder_systematic.block.yml
+++ b/gr-fec/grc/variable_polar_encoder_systematic.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_encoder_systematic_def
 label: systematic POLAR Encoder Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_repetition_decoder_def
 label: Repetition Decoder Definition
+flags: variable
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_repetition_encoder_def
 label: Repetition Encoder Definition
+flags: variable
 
 parameters:
 -   id: ndim

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -1,5 +1,6 @@
 id: variable_band_pass_filter_taps
 label: Band-pass Filter Taps
+flags: variable
 
 parameters:
 -   id: type

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -1,5 +1,6 @@
 id: variable_band_reject_filter_taps
 label: Band-reject Filter Taps
+flags: variable
 
 parameters:
 -   id: gain

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -1,5 +1,6 @@
 id: variable_high_pass_filter_taps
 label: High-pass Filter Taps
+flags: variable
 
 parameters:
 -   id: gain

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -1,5 +1,6 @@
 id: variable_low_pass_filter_taps
 label: Low-pass Filter Taps
+flags: variable
 
 parameters:
 -   id: gain

--- a/gr-filter/grc/variable_rrc_filter_taps.block.yml
+++ b/gr-filter/grc/variable_rrc_filter_taps.block.yml
@@ -1,5 +1,6 @@
 id: variable_rrc_filter_taps
 label: RRC Filter Taps
+flags: variable
 
 parameters:
 -   id: gain

--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_check_box
 label: QT GUI Check Box
+flags: variable
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_chooser
 label: QT GUI Chooser
+flags: variable
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_entry
 label: QT GUI Entry
+flags: variable
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_label.block.yml
+++ b/gr-qtgui/grc/qtgui_label.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_label
 label: QT GUI Label
+flags: variable
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_push_button.block.yml
+++ b/gr-qtgui/grc/qtgui_push_button.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_push_button
 label: QT GUI Push Button
+flags: variable
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_range
 label: QT GUI Range
+flags: variable
 
 parameters:
 -   id: label

--- a/grc/blocks/parameter.block.yml
+++ b/grc/blocks/parameter.block.yml
@@ -1,5 +1,6 @@
 id: parameter
 label: Parameter
+flags: variable
 
 parameters:
 -   id: label

--- a/grc/blocks/variable.block.yml
+++ b/grc/blocks/variable.block.yml
@@ -1,5 +1,6 @@
 id: variable
 label: Variable
+flags: variable
 
 parameters:
 -   id: value

--- a/grc/blocks/variable_config.block.yml
+++ b/grc/blocks/variable_config.block.yml
@@ -1,5 +1,6 @@
 id: variable_config
 label: Variable Config
+flags: variable
 
 parameters:
 -   id: value

--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -1,5 +1,6 @@
 id: variable_function_probe
 label: Function Probe
+flags: variable
 
 parameters:
 -   id: block_id

--- a/grc/blocks/variable_struct.block.yml.py
+++ b/grc/blocks/variable_struct.block.yml.py
@@ -5,6 +5,7 @@ MAX_NUM_FIELDS = 20
 HEADER = """\
 id: variable_struct
 label: Struct Variable
+flags: variable
 
 parameters:
 """

--- a/grc/converter/block.py
+++ b/grc/converter/block.py
@@ -84,7 +84,10 @@ def convert_block_xml(node):
     data['id'] = block_id
     data['label'] = node.findtext('name') or no_value
     data['category'] = node.findtext('category') or no_value
-    data['flags'] = node.findtext('flags') or no_value
+    data['flags'] = [n.text for n in node.findall('flags')]
+    data['flags'] += ['variable'] if block_id.startswith('variable') else []
+    if not data['flags']:
+        data['flags'] = no_value
 
     data['parameters'] = [convert_param_xml(param_node, converter.to_python_dec)
                           for param_node in node.iterfind('param')] or no_value
@@ -96,6 +99,8 @@ def convert_block_xml(node):
     data['outputs'] = [convert_port_xml(port_node, converter.to_python_dec)
                        for port_node in node.iterfind('source')] or no_value
     data['value'] = (
+        # old GRC used to treat blocks starting with "variable" specially (magically);
+        # we're now wiser and have "flags: variable" for that
         converter.to_python_dec(node.findtext('var_value')) or
         ('${ value }' if block_id.startswith('variable') else no_value)
     )

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -325,7 +325,7 @@ class FlowGraph(Element):
             a nested data odict
         """
         def block_order(b):
-            return not b.key.startswith('variable'), b.name  # todo: vars still first ?!?
+            return not "variable" in b.flags, b.name  # todo: vars still first ?!?
 
         data = collections.OrderedDict()
         data['options'] = self._options_block.export_data()

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -192,7 +192,7 @@ class Block(Element):
 
     @lazy_property
     def is_variable(self):
-        return bool(self.value)
+        return 'variable' in self.flags or bool(self.value)
 
     @lazy_property
     def is_import(self):

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -175,12 +175,15 @@ class VariableEditor(Gtk.VBox):
         if block:
             if block.key == 'import':
                 value = block.params['imports'].get_value()
-            elif not "variable" in block.flags:
+            elif not block.is_variable:
                 value = "<Open Properties>"
                 sp('editable', False)
                 sp('foreground', '#0D47A1')
-            else:
+            elif 'value' in block.params:
                 value = block.params['value'].get_value()
+            else:
+                value = block.value + " (Open Properties)"
+                sp('editable', False)
 
             # Check if there are errors in the blocks.
             # Show the block error as a tooltip
@@ -191,9 +194,11 @@ class VariableEditor(Gtk.VBox):
                 self.set_tooltip_text(error_message[-1])
             else:
                 # Evaluate and show the value (if it is a variable)
-                if "variable" in block.flags:
-                    evaluated = str(block.params['value'].evaluate())
-                    self.set_tooltip_text(evaluated)
+                if block.is_variable:
+                    if 'value' in block.params:
+                        self.set_tooltip_text(str(block.params['value'].evaluate()))
+                    else:
+                        self.set_tooltip_text(block.value)
         # Always set the text value.
         sp('text', value)
 
@@ -241,7 +246,8 @@ class VariableEditor(Gtk.VBox):
         if block.is_import:
             block.params['import'].set_value(new_text)
         else:
-            block.params['value'].set_value(new_text)
+            if 'value' in block.params:
+                block.params['value'].set_value(new_text)
         Actions.VARIABLE_EDITOR_UPDATE()
 
     def handle_action(self, item, key, event=None):

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -175,7 +175,7 @@ class VariableEditor(Gtk.VBox):
         if block:
             if block.key == 'import':
                 value = block.params['imports'].get_value()
-            elif block.key != "variable":
+            elif not "variable" in block.flags:
                 value = "<Open Properties>"
                 sp('editable', False)
                 sp('foreground', '#0D47A1')
@@ -191,7 +191,7 @@ class VariableEditor(Gtk.VBox):
                 self.set_tooltip_text(error_message[-1])
             else:
                 # Evaluate and show the value (if it is a variable)
-                if block.key == "variable":
+                if "variable" in block.flags:
                     evaluated = str(block.params['value'].evaluate())
                     self.set_tooltip_text(evaluated)
         # Always set the text value.

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -160,12 +160,22 @@ class Block(CoreBlock, Drawable):
             PangoCairo.update_layout(cr, title_layout)
             PangoCairo.update_layout(cr, params_layout)
 
-        title_layout.set_markup(
-            '<span {foreground} font_desc="{font}"><b>{label}</b></span>'.format(
-                foreground='foreground="red"' if not self.is_valid() else '', font=BLOCK_FONT,
-                label=Utils.encode(self.label)
+        if not "variable" in self.flags:
+            title_layout.set_markup(
+                '<span {foreground} font_desc="{font}"><b>{label}</b></span>'.format(
+                    foreground='foreground="red"' if not self.is_valid() else '', font=BLOCK_FONT,
+                    label=Utils.encode(self.label)
+                )
             )
-        )
+        else:
+            title_layout.set_markup(
+                '<span {foreground} font_desc="{font}"><b>{label}:</b> {id}</span>'.format(
+                    foreground='foreground="red"' if not self.is_valid() else '', font=BLOCK_FONT,
+                    label=Utils.encode(self.label),
+                    id=self.name
+                )
+            )
+
         title_width, title_height = title_layout.get_size()
 
         # update the params layout

--- a/grc/tests/resources/file3.block.yml
+++ b/grc/tests/resources/file3.block.yml
@@ -1,5 +1,6 @@
 id: variable_qtgui_check_box
 label: QT GUI Check Box
+flags: variable
 
 parameters:
 -   id: label


### PR DESCRIPTION
This was a regression from GRC 3.7: Variable IDs were no longer
displayed.

This restores that functionality for any block with the flag "variable".

This tags the Variable, Variable Config, Variable Struct, Parameter, and
Function Probe blocks with that particular flag.

Closes #2235.