### PR TITLE
gr-fec: Fix the POLAR Encoder Definition block

### DIFF
--- a/gr-fec/grc/variable_polar_encoder.block.yml
+++ b/gr-fec/grc/variable_polar_encoder.block.yml
@@ -4,10 +4,8 @@ label: POLAR Encoder Definition
 parameters:
 -   id: is_packed
     label: Packed Bits
-    dtype: enum
+    dtype: bool
     default: 'False'
-    options: ['False', 'True']
-    option_labels: ['No', 'Yes']
 -   id: ndim
     label: Parallelism
     dtype: enum


### PR DESCRIPTION
See https://github.com/gnuradio/gnuradio/issues/2260.