### PR TITLE
fixup! cmake: Only go into grc/ subdirs when ENABLE_GRC=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,7 @@ add_definitions(${MPLIB_DEFINITIONS})
 ########################################################################
 add_subdirectory(docs)
 add_subdirectory(gnuradio-runtime)
+add_subdirectory(grc)
 add_subdirectory(gr-blocks)
 add_subdirectory(gr-fec)
 add_subdirectory(gr-fft)
@@ -492,7 +493,6 @@ add_subdirectory(gr-video-sdl)
 add_subdirectory(gr-vocoder)
 add_subdirectory(gr-wavelet)
 add_subdirectory(gr-zeromq)
-add_subdirectory(grc)
 
 # Defining GR_CTRLPORT for gnuradio/config.h
 if(ENABLE_GR_CTRLPORT)


### PR DESCRIPTION
The grc subdir was parsed last, making ENABLE_GRC appear false in all
components, thus disabling blocks.

Fixes #2259.