### PR TITLE
grc: fix gr-fec GRC definitions.

### DIFF
--- a/gr-fec/grc/variable_cc_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_decoder_def_list.block.yml
@@ -48,12 +48,12 @@ parameters:
     default: '-1'
 -   id: mode
     label: Streaming Behavior
-    dtype: enum
-    options: [fec.CC_STREAMING, fec.CC_TERMINATED, fec.CC_TAILBITING, fec.CC_TRUNCATED]
+    dtype: raw
+    options: ['fec.CC_STREAMING', 'fec.CC_TERMINATED', 'fec.CC_TAILBITING', 'fec.CC_TRUNCATED']
     option_labels: [Streaming, Terminated, Tailbiting, Truncated]
 -   id: padding
     label: Byte Padding
-    dtype: enum
+    dtype: bool
     default: 'False'
     options: ['False', 'True']
     option_labels: ['No', 'Yes']

--- a/gr-fec/grc/variable_cc_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_encoder_def_list.block.yml
@@ -39,12 +39,12 @@ parameters:
     default: '0'
 -   id: mode
     label: Streaming Behavior
-    dtype: enum
-    options: [fec.CC_STREAMING, fec.CC_TERMINATED, fec.CC_TAILBITING, fec.CC_TRUNCATED]
+    dtype: raw
+    options: ['fec.CC_STREAMING', 'fec.CC_TERMINATED', 'fec.CC_TAILBITING', 'fec.CC_TRUNCATED']
     option_labels: [Streaming, Terminated, Tailbiting, Truncated]
 -   id: padding
     label: Byte Padding
-    dtype: enum
+    dtype: bool
     default: 'False'
     options: ['False', 'True']
     option_labels: ['No', 'Yes']

--- a/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
@@ -27,8 +27,8 @@ parameters:
     default: '0'
 -   id: mode
     label: Streaming Behavior
-    dtype: enum
-    options: [fec.CC_STREAMING, fec.CC_TERMINATED, fec.CC_TAILBITING, fec.CC_TRUNCATED]
+    dtype: int
+    options: ['fec.CC_STREAMING', 'fec.CC_TERMINATED', 'fec.CC_TAILBITING', 'fec.CC_TRUNCATED']
     option_labels: [Streaming, Terminated, Tailbiting, Truncated]
 value: ${ fec.ccsds_encoder_make(framebits, state_start, mode) }
 

--- a/gr-fec/grc/variable_polar_encoder.block.yml
+++ b/gr-fec/grc/variable_polar_encoder.block.yml
@@ -47,9 +47,9 @@ templates:
         ${num_info_bits}, ${frozen_bit_positions}, ${frozen_bit_values}, ${is_packed})),\
         range(0, ${dim1})))
         % else:
-        self.${id} = ${id} = list(map((lambda b: map((lambda\
-        a: fec.polar_encoder.make(${block_size}, ${num_info_bits}, ${frozen_bit_positions},\
-        ${frozen_bit_values}, ${is_packed})), range(0, ${dim2}))), range(0, ${dim1}))\)
+        self.${id} = ${id} = list(map((lambda b: map((lambda a: \
+        fec.polar_encoder.make(${block_size}, ${num_info_bits}, ${frozen_bit_positions},\
+        ${frozen_bit_values}, ${is_packed})), range(0, ${dim2}))), range(0, ${dim1})))
         % endif
 
 file_format: 1

--- a/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
@@ -42,7 +42,7 @@ templates:
         self.${id} = ${id} = fec.repetition_decoder.make(${framebits},\
         ${rep}, ${prob})
         % elif int(ndim)==1:
-        self.${id} = ${id} = list(map( (lambda\
+        self.${id} = ${id} = list(map( (lambda \
         a: fec.repetition_decoder.make(${framebits}, ${rep}, ${prob})), range(0,${dim1})))
         % else:
         self.${id} = ${id} = list(map( (lambda b: map( ( lambda a: fec.repetition_decoder.make(${framebits},\

--- a/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
@@ -35,7 +35,7 @@ templates:
         self.${id} = ${id} = list(map((lambda a: fec.repetition_encoder_make(${framebits},\
         ${rep})), range(0,${dim1})))
         % else:
-        self.${id} = ${id} = list(map((lambda\
+        self.${id} = ${id} = list(map((lambda \
         b: map((lambda a: fec.repetition_encoder_make(${framebits}, ${rep})), range(0,${dim2}))),\
         range(0,${dim1})))
         % endif


### PR DESCRIPTION
Several FECAPI blocks have issues to generate correct Python code. These problems should be fixed now.

Issues with the  option persist, though. Those must be handled in the encoder/decoder block definitions.

As a side note: basically all examples `.grc` files are still XML definitions which are auto converted. Will those be converted at a later date? Or should they be updated whenever one works on them?

I'd like to add another commit with a few fixes to those files which make them work with Py3k. Mainly, integer vs. float division problems.