### PR TITLE
cmake: remove obsolete code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,12 +158,6 @@ ELSE()
     message(warning "C standard could not be set because compiler is not GNU, Clang or MSVC.")
 ENDIF()
 
-# if cmake version is < 3.1, explicitly set C standard to use.
-IF(${CMAKE_VERSION} VERSION_LESS "3.1")
-    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c${CMAKE_C_STANDARD}")
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
-ENDIF()
-
 ########################################################################
 # Environment setup
 ########################################################################


### PR DESCRIPTION
GR 3.8 requires CMake 3.5.1 but it contained a workaround for CMake < 3.1 in its root `CMakeList.txt` file which is now obsolete. Thus, this patch removes the now obsolete workaround.