### PR TITLE
uhd: grc: Don't set antenna if no value is given

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -175,7 +175,9 @@ templates:
         ${'%'} else:
         self.${'$'}{id}.set_gain(${'$'}{${'gain' + str(n)}}, ${n})
         ${'%'} endif
+        ${'%'} if context.get('ant${n}')():
         self.${'$'}{id}.set_antenna(${'$'}{${'ant' + str(n)}}, ${n})
+        ${'%'} endif
         ${'%'} if context.get('bw${n}')():
         self.${'$'}{id}.set_bandwidth(${'$'}{${'bw' + str(n)}}, ${n})
         ${'%'} endif


### PR DESCRIPTION
For some attributes in the GRC bindings, we'd skip the setters at make()
time when no value was given. This also adds this behaviour for the
antenna.