### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -166,7 +166,8 @@ namespace gr {
 
 
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) || \
-  defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
+  defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
+  defined(__NetBSD__)
 
 namespace gr {
   namespace thread {

--- a/gr-vocoder/lib/CMakeLists.txt
+++ b/gr-vocoder/lib/CMakeLists.txt
@@ -104,6 +104,9 @@ endif(LIBGSM_LIBRARIES)
 
 add_library(gnuradio-vocoder SHARED ${gr_vocoder_sources})
 target_link_libraries(gnuradio-vocoder ${vocoder_libs})
+if(LIBGSM_INCLUDE_DIR)
+    target_include_directories(gnuradio-vocoder PUBLIC ${LIBGSM_INCLUDE_DIR})
+endif(LIBGSM_INCLUDE_DIR)
 GR_LIBRARY_FOO(gnuradio-vocoder)
 
 if(ENABLE_STATIC_LIBS)

--- a/gr-vocoder/lib/gsm_fr_decode_ps_impl.h
+++ b/gr-vocoder/lib/gsm_fr_decode_ps_impl.h
@@ -26,7 +26,7 @@
 #include <gnuradio/vocoder/gsm_fr_decode_ps.h>
 
 extern "C"{
-#include "gsm/gsm.h"
+#include "gsm.h"
 }
 
 namespace gr {

--- a/gr-vocoder/lib/gsm_fr_encode_sp_impl.h
+++ b/gr-vocoder/lib/gsm_fr_encode_sp_impl.h
@@ -26,7 +26,7 @@
 #include <gnuradio/vocoder/gsm_fr_encode_sp.h>
 
 extern "C"{
-#include "gsm/gsm.h"
+#include "gsm.h"
 }
 
 namespace gr {


### PR DESCRIPTION
There was an #ifdef missing in lib/thread/thread.c and in gr-vocoder
the include directive for gsm.h contains a gsm/ prefix.
The cmake FindGSM.cmake looks for **/include/ and **/include/gsm
anyways.