### PR TITLE
cmake: remove unused *_generated_swigs syntax

### DIFF
--- a/gr-analog/lib/CMakeLists.txt
+++ b/gr-analog/lib/CMakeLists.txt
@@ -101,7 +101,7 @@ list(APPEND analog_libs
 add_library(gnuradio-analog SHARED ${analog_sources})
 target_link_libraries(gnuradio-analog ${analog_libs})
 GR_LIBRARY_FOO(gnuradio-analog)
-add_dependencies(gnuradio-analog analog_generated_swigs gnuradio-filter)
+add_dependencies(gnuradio-analog gnuradio-filter)
 
 if(ENABLE_STATIC_LIBS)
   add_library(gnuradio-analog_static STATIC ${analog_sources})

--- a/gr-channels/lib/CMakeLists.txt
+++ b/gr-channels/lib/CMakeLists.txt
@@ -79,7 +79,6 @@ add_library(gnuradio-channels SHARED ${channels_sources})
 target_link_libraries(gnuradio-channels ${channels_libs})
 GR_LIBRARY_FOO(gnuradio-channels)
 add_dependencies(gnuradio-channels
-  channels_generated_swigs
   gnuradio-runtime gnuradio-filter gnuradio-analog gnuradio-blocks)
 
 if(ENABLE_STATIC_LIBS)

--- a/gr-digital/lib/CMakeLists.txt
+++ b/gr-digital/lib/CMakeLists.txt
@@ -150,7 +150,6 @@ GR_LIBRARY_FOO(gnuradio-digital)
 
 add_dependencies(
     gnuradio-digital
-    digital_generated_swigs
     gnuradio-runtime
     gnuradio-filter
     gnuradio-analog

--- a/gr-filter/lib/CMakeLists.txt
+++ b/gr-filter/lib/CMakeLists.txt
@@ -115,7 +115,6 @@ add_library(gnuradio-filter SHARED ${filter_sources})
 target_link_libraries(gnuradio-filter ${filter_libs})
 GR_LIBRARY_FOO(gnuradio-filter)
 add_dependencies(gnuradio-filter
-  filter_generated_swigs
   gnuradio-runtime gnuradio-fft)
 
 if(ENABLE_STATIC_LIBS)

--- a/gr-trellis/lib/CMakeLists.txt
+++ b/gr-trellis/lib/CMakeLists.txt
@@ -84,7 +84,6 @@ add_library(gnuradio-trellis SHARED ${trellis_sources})
 target_link_libraries(gnuradio-trellis ${trellis_libs})
 GR_LIBRARY_FOO(gnuradio-trellis)
 add_dependencies(gnuradio-trellis
-  trellis_generated_swigs
   gnuradio-runtime gnuradio-digital)
 
 if(ENABLE_STATIC_LIBS)
@@ -102,7 +101,6 @@ if(ENABLE_STATIC_LIBS)
   add_library(gnuradio-trellis_static STATIC ${trellis_sources})
 
   add_dependencies(gnuradio-trellis_static
-    trellis_generated_swigs
     gnuradio-runtime_static gnuradio-digital_static
     )
 

--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -80,7 +80,6 @@ endif()
 
 GR_LIBRARY_FOO(gnuradio-wavelet)
 add_dependencies(gnuradio-wavelet
-  wavelet_generated_swigs
   gnuradio-runtime)
 
 if(ENABLE_STATIC_LIBS)


### PR DESCRIPTION
these variables are always empty and are leftovers from
removing gengen templates