### PR TITLE
grc: Fix Python Module block

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -103,7 +103,7 @@ class FlowGraph(Element):
         """Iterate over custom code block ID and Source"""
         for block in self.iter_enabled_blocks():
             if block.key == 'epy_module':
-                yield block.name, block.params[1].get_value()
+                yield block.name, block.params['source_code'].get_value()
 
     def iter_enabled_blocks(self):
         """

--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -26,6 +26,7 @@ from ._templates import MakoTemplates
 from .. import utils
 from ..base import Element
 
+from ._build import _build_params as build_core_params
 
 DEFAULT_CODE = '''\
 """
@@ -229,7 +230,7 @@ class EPyModule(Block):
         to set parameters of other blocks in your flowgraph.
     """)}
 
-    parameters_data = [dict(
+    parameters = [dict(
         label='Code',
         id='source_code',
         dtype='_multiline_python_external',
@@ -240,3 +241,7 @@ class EPyModule(Block):
     templates = MakoTemplates(
         imports='import ${ id }  # embedded python module',
     )
+
+    def __init__(self, flow_graph, **kwargs):
+        self.parameters_data = build_core_params(self.parameters, False, False, self.flags, self.key)
+        super(EPyModule, self).__init__(flow_graph, **kwargs)

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -201,9 +201,9 @@ class TopBlockGenerator(object):
         for block in blocks:
             make = block.templates.render('make')
             if not (block.is_variable or block.is_virtual_or_pad):
-                make = 'self.' + block.name + ' = ' + make
-            if make:
-                blocks_make.append((block, make))
+                if make:
+                    make = 'self.' + block.name + ' = ' + make
+                    blocks_make.append((block, make))
         return blocks_make
 
     def _callbacks(self):


### PR DESCRIPTION
Fixes the Python Module mentioned in https://github.com/gnuradio/gnuradio/issues/2039.

**Edit:** Just noticed some warnings from the file chooser dialog. Don't have time to fix these tonight though.
```
/usr/local/lib/python3.7/dist-packages/gnuradio/grc/gui/Dialogs.py:362: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "title, parent, action, buttons" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  transient_for=parent
/usr/local/lib/python3.7/dist-packages/gnuradio/grc/gui/Dialogs.py:362: PyGTKDeprecationWarning: The "buttons" argument must be a Gtk.ButtonsType enum value. Please use the "add_buttons" method for adding buttons. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  transient_for=parent
/usr/lib/python3.7/site-packages/gi/overrides/Gtk.py:571: PyGTKDeprecationWarning: The keyword(s) "parent" have been deprecated in favor of "transient_for" respectively. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self._init(*args, **new_kwargs)
```