### PR TITLE
codec2: only check length of encoded messages in unit test

### DIFF
--- a/gr-vocoder/python/vocoder/qa_codec2_vocoder.py
+++ b/gr-vocoder/python/vocoder/qa_codec2_vocoder.py
@@ -32,21 +32,49 @@ class test_codec2_vocoder (gr_unittest.TestCase):
     def tearDown (self):
         self.tb = None
 
-    def test001_module_load (self):
-        data = 40*(100,200,300,400,500,600,700,800)
-        expected_data = (0, 5, 10, 14, 15, 13, 14, 20, 40, 46, 39, 36, 35, 33, 22, 17, 31, 34, 29, 24, 24, 15, -3, -8, -7, 1, -4, -11, -14, -22, -39, -53, -51, -52, -58, -58, -59, -58, -61, -74, -73, -79, -75, -61, -73, -76, -72, -75, -62, -74, -75, -64, -64, -59, -61, -49, -68, -60, -23, -46, -48, -33, -48, 2, 20, -3, 2, -8, 9, 38, 9, 16, 23, 16, 44, 65, 37, 24, 25, 55, 61, 57, 52, 39, 47, 57, 66, 73, 50, 46, 47, 55, 55, 45, 73, 86, 63, 66, 60, 55, 60, 55, 71, 59, 46, 58, 46, 2, 38, 50, 33, 41, 32, 0, -16, -11, 10, 16, -13, 0, -5, -33, -45, -38, -28, -24, -41, 21, -2, -53, -55, -74, -66, -64, -64, -41, -46, -94, -122, -130, -92, -126, -104, -90, -74, -118, -162, -154, -130, -133, -163, -18, -23, -155, -95, -145, -60, -63, 156, 864, 882, 607, 449, 163, 204, 17, 47, 612, 447, 200, -59, -188, -175, -418, -192, 170, 14, -73, -258, -276, -267, -335, -117, 96, 34, -28, -152, -130, -124, -187, 42, 176, 131, 78, -52, -2, -57, -75, 104, 130, 111, 29, -50, -46, -107, -64, 66, 36, 33, -39, -129, -91, -157, -39, 69, 1, -12, -84, -99, -52, -61, 86, 147, 58, 21, -63, -60, -100, -48, 68, 76, 6, -65, -79, -108, -159, -71, 89, 171, 183, 216, 152, 26, -35, 0, 87, 126, 143, 182, 151, 95, 106, 115, 155, 103, 86, 127, 12, -41, -91, -87, -32, -52, -41, -32, -123, -147, -154, -156, -61, -37, -8, -51, -127, -132, -127, -107, -54, 1, 26, -17, -100, -61, -9, 3, 57, 117, 102, 58, -47, 24, 67, 42, 116, 141, 113, 39, -15, 63, 68, 41, 118, 80, 24, -46, -72, 12, 5, -17, 18, -43, -61, -110, -119, -42, -40, -16, 2, -11, -50)
-
-        src = blocks.vector_source_s(data)
+    def test001_mode_2400_encoder(self):
+        # compresses a
+        # 16-bit 8 kHz (128 kbit/s) PCM stream
+        # to 2400 bit/s
         enc = vocoder.codec2_encode_sp(codec2.MODE_2400)
-        dec = vocoder.codec2_decode_ps(codec2.MODE_2400)
-        snk = blocks.vector_sink_s()
-        self.tb.connect(src, enc, dec, snk)
+        samples_per_frame = enc.relative_rate_d()
+        data = samples_per_frame*(100,200,300,400,500,600,700,800)
+        src = blocks.vector_source_s(data)
+        snk = blocks.vector_sink_b(vlen=48)
+
+        expected_length = ((len(data) * 16)*2400)//128000
+        self.tb.connect(src,enc,snk)
         self.tb.run()
-        actual_result = snk.data()
-        self.assertEqual(expected_data, actual_result)
-        self.tb.disconnect(src, enc, dec, snk)
+        result = snk.data()
+        self.assertEqual(expected_length, len(result))
+
+    def test001_mode_1600_encoder(self):
+        enc = vocoder.codec2_encode_sp(codec2.MODE_1600)
+        samples_per_frame = enc.relative_rate_d()
+        bits_per_frame = enc.output_signature().sizeof_stream_item(0)
+        data = samples_per_frame*(100,200,300,400,500,600,700,800)
+        src = blocks.vector_source_s(data)
+        snk = blocks.vector_sink_b(vlen=bits_per_frame)
+
+        expected_length = ((len(data) * 16)*1600)//128000
+        self.tb.connect(src,enc,snk)
+        self.tb.run()
+        result = snk.data()
+        self.assertEqual(expected_length, len(result))
+
+    def test001_mode_1400_encoder(self):
+        enc = vocoder.codec2_encode_sp(codec2.MODE_1400)
+        samples_per_frame = enc.relative_rate_d()
+        bits_per_frame = enc.output_signature().sizeof_stream_item(0)
+        data = samples_per_frame*(100,200,300,400,500,600,700,800)
+        src = blocks.vector_source_s(data)
+        snk = blocks.vector_sink_b(vlen=bits_per_frame)
+
+        expected_length = ((len(data) * 16)*1400)//128000
+        self.tb.connect(src,enc,snk)
+        self.tb.run()
+        result = snk.data()
+        self.assertEqual(expected_length, len(result))
 
 if __name__ == '__main__':
-    # Note: The Vocoder is stateful, which means this test will produce failure when removing the xml option.
-    # Perhaps this is not the best way to test such a vocoder.
-    gr_unittest.run(test_codec2_vocoder, "test_codec2_vocoder.xml")
+    gr_unittest.run(test_codec2_vocoder)


### PR DESCRIPTION
previously the encoder & decoder pair was tested for a known input to produce a
precomputed output. Which can change with improvements in the codec2 library.
A similar test for the decoder needs to be implemented