### PR TITLE
grc: Fix a bug where all variable blocks' make code is ignored when generating flowgraph

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -200,10 +200,10 @@ class TopBlockGenerator(object):
         blocks_make = []
         for block in blocks:
             make = block.templates.render('make')
-            if not (block.is_variable or block.is_virtual_or_pad):
-                if make:
+            if make:
+                if not (block.is_variable or block.is_virtual_or_pad):
                     make = 'self.' + block.name + ' = ' + make
-                    blocks_make.append((block, make))
+                blocks_make.append((block, make))
         return blocks_make
 
     def _callbacks(self):


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/2307, a bug introduced by yours truly while fixing the Python Module block: https://github.com/gnuradio/gnuradio/pull/2296.

Haven't had time to test it yet, but I believe it should be correct now.