### PR TITLE
CMake: MSVC fixes for 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,8 @@ IF(MSVC)
     IF(MSVC_VERSION LESS "${MSVC_MIN_VERSION}")
         MESSAGE(FATAL_ERROR "MSVC Versions < minimum version ${MSVC_MIN_VERSION}")
     ENDIF()
+    SET(cmake_c_compiler_version ${MSVC_VERSION})
+    SET(cmake_cxx_compiler_version ${MSVC_VERSION})
 ELSE()
     execute_process(COMMAND ${CMAKE_C_COMPILER} --version
             OUTPUT_VARIABLE cmake_c_compiler_version)

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -142,7 +142,19 @@ GR_PYTHON_INSTALL(
 )
 
 GR_PYTHON_INSTALL(
-    DIRECTORY core gui converter
+    DIRECTORY core
+    DESTINATION "${GR_PYTHON_DIR}/gnuradio/grc"
+    FILES_MATCHING REGEX "\\.(py|dtd|grc|tmpl|png|mako)$"
+)
+
+GR_PYTHON_INSTALL(
+    DIRECTORY gui
+    DESTINATION "${GR_PYTHON_DIR}/gnuradio/grc"
+    FILES_MATCHING REGEX "\\.(py|dtd|grc|tmpl|png|mako)$"
+)
+
+GR_PYTHON_INSTALL(
+    DIRECTORY converter
     DESTINATION "${GR_PYTHON_DIR}/gnuradio/grc"
     FILES_MATCHING REGEX "\\.(py|dtd|grc|tmpl|png|mako)$"
 )


### PR DESCRIPTION
Two minor fixes for 3.8 to build on windows.
First just sets a compiler version, will error out later if the variable is empty

Second deals with the 8191 character limitation for command lines on windows by doing in 3 commands what could be otherwise done in one.