### PR TITLE
QtGui: fix 'Show Msg Port' slider

### DIFF
--- a/gr-blocks/grc/blocks_copy.block.yml
+++ b/gr-blocks/grc/blocks_copy.block.yml
@@ -25,9 +25,7 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Yes', 'No']
+    default: 'False'
     hide: part
 
 inputs:
@@ -37,7 +35,7 @@ inputs:
 -   domain: message
     id: en
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 outputs:
 -   domain: stream

--- a/gr-digital/grc/digital_constellation_receiver_cb.block.yml
+++ b/gr-digital/grc/digital_constellation_receiver_cb.block.yml
@@ -17,9 +17,7 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Yes', 'No']
+    default: 'False'
     hide: part
 
 inputs:
@@ -28,11 +26,11 @@ inputs:
 -   domain: message
     id: set_constellation
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 -   domain: message
     id: rotate_phase
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 outputs:
 -   domain: stream

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -105,9 +105,7 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Yes', 'No']
+    default: 'False'
     hide: part
 -   id: tr_mode
     label: Trigger Mode
@@ -374,17 +372,17 @@ inputs:
 -   domain: message
     id: freq
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 -   domain: message
     id: bw
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 outputs:
 -   domain: message
     id: freq
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -81,9 +81,7 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Yes', 'No']
+    default: 'False'
     hide: part
 
 inputs:
@@ -93,13 +91,13 @@ inputs:
 -   domain: message
     id: freq
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 outputs:
 -   domain: message
     id: freq
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -95,9 +95,7 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Yes', 'No']
+    default: 'False'
     hide: part
 -   id: label1
     label: Line 1 Label
@@ -289,7 +287,7 @@ outputs:
 -   domain: message
     id: xval
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -81,9 +81,7 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Yes', 'No']
+    default: 'False'
     hide: part
 -   id: legend
     label: Legend
@@ -236,17 +234,17 @@ inputs:
 -   domain: message
     id: freq
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 -   domain: message
     id: bw
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 outputs:
 -   domain: message
     id: freq
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 templates:
     imports: |-


### PR DESCRIPTION
The slider for 'Show Msg Port' worked the wrong way around. As it actually triggers a 'hide' in the Yaml, I've changed it to 'Hide Msg Port', so the behaviour and default value actually matches what is shown by the slider.