### PR TITLE
Modtool: Fix python version incompatibility

### DIFF
--- a/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
@@ -139,7 +139,7 @@ find_package(Doxygen)
 # caps such as FILTER or FFT) and change the version to the minimum
 # API compatible version required.
 set(GR_REQUIRED_COMPONENTS RUNTIME)
-find_package(Gnuradio "3.7.2" REQUIRED)
+find_package(Gnuradio "3.8" REQUIRED)
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 include(GrVersion)
 
@@ -147,7 +147,7 @@ include(GrVersion)
 # Setup doxygen option
 ########################################################################
 if(DOXYGEN_FOUND)
-	option(ENABLE_DOXYGEN "Build docs using Doxygen" ON)
+	option(ENABLE_DOXYGEN "Build docs using Doxygen" OFF)
 else(DOXYGEN_FOUND)
 	option(ENABLE_DOXYGEN "Build docs using Doxygen" OFF)
 endif(DOXYGEN_FOUND)

--- a/gr-utils/python/modtool/templates/gr-newmod/cmake/Modules/GrPython.cmake
+++ b/gr-utils/python/modtool/templates/gr-newmod/cmake/Modules/GrPython.cmake
@@ -38,11 +38,11 @@ else(PYTHON_EXECUTABLE)
 
     #use the built-in find script
     set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
-    find_package(PythonInterp 2)
+    find_package(PythonInterp 3)
 
     #and if that fails use the find program routine
     if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7)
+        find_program(PYTHON_EXECUTABLE NAMES python3 python3.4 python3.5 python3.6)
         if(PYTHON_EXECUTABLE)
             set(PYTHONINTERP_FOUND TRUE)
         endif(PYTHON_EXECUTABLE)
@@ -51,7 +51,7 @@ else(PYTHON_EXECUTABLE)
 endif(PYTHON_EXECUTABLE)
 
 if (CMAKE_CROSSCOMPILING)
-    set(QA_PYTHON_EXECUTABLE "/usr/bin/python")
+    set(QA_PYTHON_EXECUTABLE "/usr/bin/python3")
 else (CMAKE_CROSSCOMPILING)
     set(QA_PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE})
 endif(CMAKE_CROSSCOMPILING)

--- a/gr-utils/python/modtool/templates/gr-newmod/cmake/Modules/GrSwig.cmake
+++ b/gr-utils/python/modtool/templates/gr-newmod/cmake/Modules/GrSwig.cmake
@@ -117,7 +117,7 @@ macro(GR_SWIG_MAKE name)
     endif()
 
     #append additional include directories
-    find_package(PythonLibs 2)
+    find_package(PythonLibs 3)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_PATH}) #deprecated name (now dirs)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
 

--- a/gr-utils/python/modtool/templates/gr-newmod/swig/CMakeLists.txt
+++ b/gr-utils/python/modtool/templates/gr-newmod/swig/CMakeLists.txt
@@ -30,7 +30,7 @@ endif(NOT howto_sources)
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)
-find_package(PythonLibs 2)
+find_package(PythonLibs 3)
 if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
     return()
 endif()

--- a/gr-utils/python/modtool/templates/templates.py
+++ b/gr-utils/python/modtool/templates/templates.py
@@ -527,7 +527,7 @@ ${str_to_python_comment(license)}
 from gnuradio import gr, gr_unittest
 from gnuradio import blocks
 % if lang == 'cpp':
-from . import ${modname}_swig as ${modname}
+import ${modname}_swig as ${modname}
 % else:
 from .${blockname} import ${blockname}
 % endif


### PR DESCRIPTION
Replaced Python2 by Python3 in the modtool templates.
-> We can change that to `python` for version independent compatibility I guess including `find_program(PYTHON_EXECUTABLE NAMES python python3 python3.6 python2 python2.7)` in `GrPython.cmake`.

-> The doxygen still not works.