### PR TITLE
grc: fix for GRC's block hotkeys

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -311,35 +311,43 @@ BLOCK_ROTATE_CCW = actions.register("win.block_rotate_ccw",
     label='Rotate Counterclockwise',
     tooltip='Rotate the selected blocks 90 degrees to the left',
     icon_name='object-rotate-left',
+    keypresses=["Left"],
 )
 BLOCK_ROTATE_CW = actions.register("win.block_rotate",
     label='Rotate Clockwise',
     tooltip='Rotate the selected blocks 90 degrees to the right',
     icon_name='object-rotate-right',
+    keypresses=["Right"],
 )
 BLOCK_VALIGN_TOP = actions.register("win.block_align_top",
     label='Vertical Align Top',
     tooltip='Align tops of selected blocks',
+    keypresses=["<Shift>t"],
 )
 BLOCK_VALIGN_MIDDLE = actions.register("win.block_align_middle",
     label='Vertical Align Middle',
     tooltip='Align centers of selected blocks vertically',
+    keypresses=["<Shift>m"],
 )
 BLOCK_VALIGN_BOTTOM = actions.register("win.block_align_bottom",
     label='Vertical Align Bottom',
     tooltip='Align bottoms of selected blocks',
+    keypresses=["<Shift>b"],
 )
 BLOCK_HALIGN_LEFT = actions.register("win.block_align_left",
     label='Horizontal Align Left',
     tooltip='Align left edges of blocks selected blocks',
+    keypresses=["<Shift>l"],
 )
 BLOCK_HALIGN_CENTER = actions.register("win.block_align_center",
     label='Horizontal Align Center',
     tooltip='Align centers of selected blocks horizontally',
+    keypresses=["<Shift>c"],
 )
 BLOCK_HALIGN_RIGHT = actions.register("win.block_align_right",
     label='Horizontal Align Right',
     tooltip='Align right edges of selected blocks',
+    keypresses=["<Shift>r"],
 )
 BLOCK_ALIGNMENTS = [
     BLOCK_VALIGN_TOP,
@@ -354,21 +362,25 @@ BLOCK_PARAM_MODIFY = actions.register("win.block_modify",
     label='_Properties',
     tooltip='Modify params for the selected block',
     icon_name='document-properties',
+    keypresses=["Return"],
 )
 BLOCK_ENABLE = actions.register("win.block_enable",
     label='E_nable',
     tooltip='Enable the selected blocks',
     icon_name='network-wired',
+    keypresses=["e"],
 )
 BLOCK_DISABLE = actions.register("win.block_disable",
     label='D_isable',
     tooltip='Disable the selected blocks',
     icon_name='network-wired-disconnected',
+    keypresses=["d"],
 )
 BLOCK_BYPASS = actions.register("win.block_bypass",
     label='_Bypass',
     tooltip='Bypass the selected block',
     icon_name='media-seek-forward',
+    keypresses=["b"],
 )
 TOGGLE_SNAP_TO_GRID = actions.register("win.snap_to_grid",
     label='_Snap to grid',
@@ -429,6 +441,7 @@ BLOCK_CREATE_HIER = actions.register("win.block_create_hier",
     label='C_reate Hier',
     tooltip='Create hier block from selected blocks',
     icon_name='document-new',
+    keypresses=["c"],
 )
 BLOCK_CUT = actions.register("win.block_cut",
     label='Cu_t',
@@ -514,10 +527,18 @@ FLOW_GRAPH_SCREEN_CAPTURE = actions.register("app.flowgraph.screen_capture",
     icon_name='printer',
     keypresses=["<Ctrl>p"],
 )
-PORT_CONTROLLER_DEC = actions.register("win.port_controller_dec")
-PORT_CONTROLLER_INC = actions.register("win.port_controller_inc")
-BLOCK_INC_TYPE = actions.register("win.block_inc_type")
-BLOCK_DEC_TYPE = actions.register("win.block_dec_type")
+PORT_CONTROLLER_DEC = actions.register("win.port_controller_dec",
+    keypresses=["KP_Subtract", "minus"],
+)
+PORT_CONTROLLER_INC = actions.register("win.port_controller_inc",
+    keypresses=["KP_Add", "plus"],
+)
+BLOCK_INC_TYPE = actions.register("win.block_inc_type",
+    keypresses=["Down"],
+)
+BLOCK_DEC_TYPE = actions.register("win.block_dec_type",
+    keypresses=["Up"],
+)
 RELOAD_BLOCKS = actions.register("app.reload_blocks",
     label='Reload _Blocks',
     tooltip='Reload Blocks',

--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -71,7 +71,6 @@ class DrawingArea(Gtk.DrawingArea):
         # This may not be the correct place to be handling the user events
         # Should this be in the page instead?
         # Or should more of the page functionality move here?
-        self.connect('key_press_event', self._handle_key_press)
 
         # setup drag and drop
         self.drag_dest_set(Gtk.DestDefaults.ALL, [], Gdk.DragAction.COPY)
@@ -91,29 +90,6 @@ class DrawingArea(Gtk.DrawingArea):
         # todo: fix
 #        self.set_flags(Gtk.CAN_FOCUS)  # self.set_can_focus(True)
 #        self.connect('focus-out-event', self._handle_focus_lost_event)
-
-        # Setup a map of the accelerator keys to the action to trigger
-        self.accels = {
-            Gtk.accelerator_parse('d'): Actions.BLOCK_DISABLE,
-            Gtk.accelerator_parse('e'): Actions.BLOCK_ENABLE,
-            Gtk.accelerator_parse('b'): Actions.BLOCK_BYPASS,
-            Gtk.accelerator_parse('c'): Actions.BLOCK_CREATE_HIER,
-            Gtk.accelerator_parse('Up'): Actions.BLOCK_DEC_TYPE,
-            Gtk.accelerator_parse('Down'): Actions.BLOCK_INC_TYPE,
-            Gtk.accelerator_parse('Left'): Actions.BLOCK_ROTATE_CCW,
-            Gtk.accelerator_parse('Right'): Actions.BLOCK_ROTATE_CW,
-            Gtk.accelerator_parse('minus'): Actions.PORT_CONTROLLER_DEC,
-            Gtk.accelerator_parse('plus'): Actions.PORT_CONTROLLER_INC,
-            Gtk.accelerator_parse('Add'): Actions.PORT_CONTROLLER_INC,
-            Gtk.accelerator_parse('Subtract'): Actions.PORT_CONTROLLER_DEC,
-            Gtk.accelerator_parse('Return'): Actions.BLOCK_PARAM_MODIFY,
-            Gtk.accelerator_parse('<Shift>t'): Actions.BLOCK_VALIGN_TOP,
-            Gtk.accelerator_parse('<Shift>m'): Actions.BLOCK_VALIGN_MIDDLE,
-            Gtk.accelerator_parse('<Shift>b'): Actions.BLOCK_VALIGN_BOTTOM,
-            Gtk.accelerator_parse('<Shift>l'): Actions.BLOCK_HALIGN_LEFT,
-            Gtk.accelerator_parse('<Shift>c'): Actions.BLOCK_HALIGN_CENTER,
-            Gtk.accelerator_parse('<Shift>r'): Actions.BLOCK_HALIGN_RIGHT,
-        }
 
 
     ##########################################################################
@@ -186,21 +162,6 @@ class DrawingArea(Gtk.DrawingArea):
         self._flow_graph.handle_mouse_motion(
             coordinate=self._translate_event_coords(event),
         )
-
-    def _handle_key_press(self, widget, event):
-        """
-        Handle specific keypresses when the drawing area has focus that
-        triggers actions by the user.
-        """
-        key = event.keyval
-        mod = event.state
-
-        try:
-            action = self.accels[(key, mod)]
-            action()
-            return True
-        except KeyError:
-            return False
 
     def _update_size(self):
         w, h = self._flow_graph.get_extents()[2:]

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -345,7 +345,7 @@ class Block(CoreBlock, Drawable):
         Returns:
             true for change
         """
-        type_templates = ' '.join(p._type for p in self.params.values())
+        type_templates = ' '.join(p.dtype for p in self.params.values()) + ' '
         type_templates += ' '.join(p.get_raw('dtype') for p in (self.sinks + self.sources))
         type_param = None
         for key, param in six.iteritems(self.params):


### PR DESCRIPTION
PR for Issue #2346  
Currently, none of the hotkeys worked, which is fixed in this PR except for the two of them,
'Up': Actions.BLOCK_DEC_TYPE,
'Down': Actions.BLOCK_INC_TYPE.

I got the following error while fixing them
```
  File "/home/aruroxx31/GNURadioGsoc/gsoc/lib/python3.6/dist-packages/gnuradio/grc/gui/Application.py", line 427, in _handle_action
    if flow_graph.type_controller_modify_selected(-1):
  File "/home/aruroxx31/GNURadioGsoc/gsoc/lib/python3.6/dist-packages/gnuradio/grc/gui/canvas/flowgraph.py", line 319, in type_controller_modify_selected
    return any(sb.type_controller_modify(direction) for sb in self.selected_blocks())
  File "/home/aruroxx31/GNURadioGsoc/gsoc/lib/python3.6/dist-packages/gnuradio/grc/gui/canvas/flowgraph.py", line 319, in <genexpr>
    return any(sb.type_controller_modify(direction) for sb in self.selected_blocks())
  File "/home/aruroxx31/GNURadioGsoc/gsoc/lib/python3.6/dist-packages/gnuradio/grc/gui/canvas/block.py", line 348, in type_controller_modify
    type_templates = ' '.join(p._type for p in self.params.values())
  File "/home/aruroxx31/GNURadioGsoc/gsoc/lib/python3.6/dist-packages/gnuradio/grc/gui/canvas/block.py", line 348, in <genexpr>
    type_templates = ' '.join(p._type for p in self.params.values())
AttributeError: 'Param' object has no attribute '_type'
```

This PR doesn't include fix for these both keys