### PR TITLE
grc: Fix missing default code in python block and python module

### DIFF
--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -85,7 +85,7 @@ class EPyBlock(Block):
         label='Code',
         id='_source_code',
         dtype='_multiline_python_external',
-        value=DEFAULT_CODE,
+        default=DEFAULT_CODE,
         hide='part',
     )]
     inputs_data = []
@@ -233,7 +233,7 @@ class EPyModule(Block):
         label='Code',
         id='source_code',
         dtype='_multiline_python_external',
-        value='# this module will be imported in the into your flowgraph',
+        default='# this module will be imported in the into your flowgraph',
         hide='part',
     )]
 


### PR DESCRIPTION
Fix for the missing default code in python block and python module. For more look here: #2039.
Please review if the key should be changed to 'default' or stay as 'value' and the change should be done elsewhere.