### PR TITLE
gr_modtool: Fix for parameter wrap in cli inputs

### DIFF
--- a/gr-utils/python/modtool/cli/add.py
+++ b/gr-utils/python/modtool/cli/add.py
@@ -127,7 +127,7 @@ def get_copyrightholder(self):
 def get_arglist(self):
     """ Get the argument list of the block to be added """
     if self.info['arglist'] is not None:
-        self.info['arglist'] = cli_input('Enter valid argument list, including default arguments: ')
+        self.info['arglist'] = click.prompt(click.style('Enter valid argument list, including default arguments: \n', fg='cyan'), prompt_suffix='')
 
 def get_py_qa(self):
     """ Get a boolean value for addition of py_qa """

--- a/gr-utils/python/modtool/core/info.py
+++ b/gr-utils/python/modtool/core/info.py
@@ -119,7 +119,7 @@ class ModToolInfo(ModTool):
                     inc_dirs += line.replace('GNURADIO_RUNTIME_INCLUDE_DIRS:{}='.format(path_or_internal), '').strip().split(';')
         except IOError:
             pass
-        if (not inc_dirs or inc_dirs.isspace) and self._suggested_dirs is not None:
+        if not inc_dirs and self._suggested_dirs is not None:
             inc_dirs = [os.path.normpath(path) for path in self._suggested_dirs.split(':') if os.path.isdir(path)]
         return inc_dirs
 


### PR DESCRIPTION
cli `input()` replaced by `click.prompt()`, and parameters are now asked to be given in new line, thus fixing text wrap.