### PR TITLE
GRC: Fix color for input box in parameter widget with dtype raw

### DIFF
--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -41,7 +41,7 @@ style_provider.load_from_data(b"""
     #dtype_string          { background-color: #CC66CC; }
     #dtype_id              { background-color: #DDDDDD; }
     #dtype_stream_id       { background-color: #DDDDDD; }
-    #dtype_raw             { background-color: #FFFFFF; }
+    #dtype_raw             { background-color: #23272A; }
 
     #enum_custom           { background-color: #EEEEEE; }
 """)


### PR DESCRIPTION
Fix for issue #2374 
Changed the input color from `#FFFFFF` (white)  to `#A9A9A9` (dark grey)