### PR TITLE
Modtool Converter: support mod names w/ underscores

### DIFF
--- a/gr-utils/python/modtool/cli/update.py
+++ b/gr-utils/python/modtool/cli/update.py
@@ -47,8 +47,8 @@ def get_blockname(self):
     """ Returns the blockname for block to be updated """
     if self.info['complete']:
         return
+    block_candidates = get_xml_candidates()
     if self.info['blockname'] is None:
-        block_candidates = get_xml_candidates()
         with SequenceCompleter(block_candidates):
             self.info['blockname'] = cli_input('Which block do you wish to update? : ')
     if not self.info['blockname'] or self.info['blockname'].isspace():

--- a/gr-utils/python/modtool/core/update.py
+++ b/gr-utils/python/modtool/core/update.py
@@ -31,6 +31,7 @@ import logging
 
 from gnuradio.grc.converter import Converter
 from .base import ModTool, ModToolException
+from ..tools import get_modname
 
 logger = logging.getLogger(__name__)
 
@@ -39,9 +40,10 @@ def get_xml_candidates():
     """ Returns a list of XML candidates for update """
     xml_candidates = []
     xml_files = [x for x in glob.glob1("grc", "*.xml")]
+    mod_name = get_modname()
     for candidate in xml_files:
         candidate = os.path.splitext(candidate)[0]
-        candidate = candidate.split("_", 1)[-1]
+        candidate = candidate.split(mod_name + "_", 1)[-1]
         xml_candidates.append(candidate)
     return xml_candidates
 


### PR DESCRIPTION
When using the converter with gr-ieee802-15-4 (its modtool name is ieee802_15_4) the converter splits the file names of the GRC bindings after the first underscore. The change should split after the first underscore following the module name.

Also, I think `block_candidates` are not assigned when giving the block name directly on the command line.