### PR TITLE
SWIG: Output SWIG source being parsed file during build

### DIFF
--- a/cmake/Modules/UseSWIG.cmake
+++ b/cmake/Modules/UseSWIG.cmake
@@ -434,7 +434,7 @@ function(SWIG_ADD_SOURCE_TO_MODULE name outfiles infile)
     MAIN_DEPENDENCY "${swig_source_file_fullname}"
     DEPENDS ${swig_dependencies}
     IMPLICIT_DEPENDS CXX "${swig_source_file_fullname}"
-    COMMENT "Swig source"
+    COMMENT "Swig source ${infile}"
     COMMAND_EXPAND_LISTS)
   set_source_files_properties("${swig_generated_file_fullname}" ${swig_extra_generated_files}
     PROPERTIES GENERATED 1)


### PR DESCRIPTION
This is mainly beauty. It does come in handy when one fiddles with the
SWIGs too much and needs to figure out which .i broke.