### PR TITLE
fixup! Modifying dummy block and error messages

### DIFF
--- a/grc/core/blocks/dummy.py
+++ b/grc/core/blocks/dummy.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 
 from . import Block, register_build_in
 
-from ._build import _build_params as build_core_params
+from ._build import build_params
 
 @register_build_in
 class DummyBlock(Block):
@@ -29,10 +29,9 @@ class DummyBlock(Block):
     label = 'Missing Block'
     key = '_dummy'
 
-    def __init__(self, parent, missing_block_id, parameters,**_):
-
+    def __init__(self, parent, missing_block_id, parameters, **_):
         self.key = missing_block_id
-        self.parameters_data = build_core_params([],False, False,self.flags, self.key)
+        self.parameters_data = build_params([],False, False,self.flags, self.key)
         super(DummyBlock, self).__init__(parent=parent)
 
         param_factory = self.parent_platform.make_param


### PR DESCRIPTION
I accidentally merged an older version of PR https://github.com/gnuradio/gnuradio/pull/2278 while fixing a typo. This fixup brings in the correct changes to dummy.py

I wanted to get a second set of eyes to prevent a second mistake.