### PR TITLE
Reduce peak memory usage of Octave function read_cshort_binary

### DIFF
--- a/gr-utils/octave/read_cshort_binary.m
+++ b/gr-utils/octave/read_cshort_binary.m
@@ -42,5 +42,8 @@ function cv = read_cshort_binary (filename, count)
   else
     v = fread (f, count, 'short');
     fclose (f);
-    cv = v(1:2:end)+v(2:2:end)*j;
+    v_r = v(1:2:end);
+    v_i = v(2:2:end)*j;
+    clear v;
+    cv = v_r+v_i;
   end


### PR DESCRIPTION
Hi,

I was trying to read rather large complex<int16> recordings with **gr-utils/octave/read_cshort_binary.m** under _Ubuntu 18.04.2 LTS_ with a version of Octave 6.0.0 built from sources just today (18MAR2019) (_HG ID for this build is "1771bed38482"_), on a computer with:  _MemTotal: 32694812 kB_.

I kept getting memory overflows and Octave was quitting with the error message: 'octave exited with signal 6'.

I realized that, on the contrary, **gr-utils/octave/read_short_binary.m** _was_ able to read the same data which allowed me to play with the data, and I eventually managed to reduce the memory highest-water mark in the '...cshort...' function when compared to the peak usage induced by current code:

`cv = v(1:2:end)+v(2:2:end)*j;`

I'm copying a few logs below to give a more accurate idea of the amounts of data involved. With the change I'm suggesting, there is no memory overflow when calling ' **read_cshort_binary** ' and I'm able to load and work with the data.

I am submitting this pull request in case it could help anyone facing the same issue.

Thank you.

----

**Octave logs showing in detail how the suggested change manages to stay within the memory limits:**

```
>> addpath('~/sdr/gnuradio/gr-utils/octave/');
>> dat = read_short_binary('~/sdr/recordings/lbuc100/20190305/recorded-data-20190305-143055_samples');
>> dat_r=dat(1:2:end);
>> dat_i=dat(2:2:end)*j;
>> whos
Variables visible from the current scope:

variables in scope: top scope

   Attr Name            Size                     Bytes  Class
   ==== ====            ====                     =====  =====
        dat    1199833088x1                 9598664704  double
   c    dat_i   599916544x1                 9598664704  double
        dat_r   599916544x1                 4799332352  double

Total is 2399666176 elements using 23996661760 bytes

>> clear dat;
>> dat=dat_r+dat_i;
>> whos
Variables visible from the current scope:

variables in scope: top scope

   Attr Name           Size                     Bytes  Class
   ==== ====           ====                     =====  =====
   c    dat    599916544x1                 9598664704  double
   c    dat_i  599916544x1                 9598664704  double
        dat_r  599916544x1                 4799332352  double

Total is 1799749632 elements using 23996661760 bytes
```

----

**Commit message**

Attempts to read large amounts of data with 'read_cshort_binary' may
make Octave 6.0.0 overflow and exit with the message:
'octave exited with signal 6'.
The purpose of this change is to use more sparingly memory in order
to avoid overflowing in cases where the computer *does* have enough
memory to perform the desired operation.