### PR TITLE
grc sometimes generates wrong yml description of  hier2 block

### DIFF
--- a/grc/core/generator/hier_block.py
+++ b/grc/core/generator/hier_block.py
@@ -97,8 +97,6 @@ class HierBlockGenerator(TopBlockGenerator):
             data[direction] = []
             for port in get_hier_block_io(self._flow_graph, direction):
                 p = collections.OrderedDict()
-                if port.domain == Constants.GR_MESSAGE_DOMAIN:
-                    p['id'] = port.key
                 p['label'] = port.parent.params['label'].value
                 if port.domain != Constants.DEFAULT_DOMAIN:
                     p['domain'] = port.domain

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -177,7 +177,6 @@ class Platform(Element):
                 except Exception as error:
                     logger.exception('Error while loading %s', file_path)
                     logger.exception(error)
-                    raise
 
         for key, block in six.iteritems(self.blocks):
             category = self._block_categories.get(key, block.category)


### PR DESCRIPTION
If  a hier2 block contains more than one ( input or output ) message port
grc generates a wrong yml description of this block.

If you restart grc , grc terminates with an error messages is no longer usable.

You can check with the example in

gr-blocks/examples/msg_passing/hier

This example is running in 3.7 without any problems.

The modification in platform.py avoids the termination of grc
if there is an error in the flowgraph to be loaded.

The modification fixes the bug in the generated yml code.

Another proposal to prevent the termination of grc can be found in #2412 . But this pr does not fix the wrong yml code.