### PR TITLE
[WIP] uhd: Control of frequency and gain in both directions at the same moment

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -159,7 +159,7 @@ namespace gr {
        * \param gain the gain in dB
        * \param chan the channel index 0 to N-1
        */
-      virtual void set_gain(double gain, size_t chan = 0) = 0;
+      virtual void set_gain(double gain, size_t chan = 0, pmt::pmt_t direction = pmt::PMT_NIL) = 0;
 
       /*!
        * Set the named gain on the dboard.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -640,15 +640,21 @@ void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t &lo_offset, int cha
 
 void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t &gain_, int chan, const pmt::pmt_t &msg)
 {
+  //See if a direction was specified
+  pmt::pmt_t direction = pmt::dict_ref(
+      msg, cmd_direction_key(),
+      pmt::PMT_NIL // Anything except "TX" or "RX will default to the messaged block direction"
+  );
+
   double gain = pmt::to_double(gain_);
   if (chan == -1) {
     for (size_t i = 0; i < _nchan; i++) {
-      set_gain(gain, i);
+      set_gain(gain, i, direction);
     }
     return;
   }
 
-  set_gain(gain, chan);
+  set_gain(gain, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t &ant, int chan, const pmt::pmt_t &msg)

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -142,7 +142,7 @@ namespace gr {
       void _update_stream_args(const ::uhd::stream_args_t &stream_args_);
 
       // should be const, doesn't work though 'cause missing operator=() for tune_request_t
-      void _update_curr_tune_req(::uhd::tune_request_t &tune_req, int chan);
+      void _update_curr_tune_req(::uhd::tune_request_t &tune_req, int chan, pmt::pmt_t direction = pmt::PMT_NIL);
 
       /*! \brief Wait until a timeout or a sensor returns 'locked'.
        *
@@ -208,7 +208,7 @@ namespace gr {
       virtual ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction) = 0;
 
       //! Calls _set_center_freq_from_internals() on all channels
-      void _set_center_freq_from_internals_allchans(pmt::pmt_t direction);
+      void _set_center_freq_from_internals_allchans();
 
       /**********************************************************************
        * Members
@@ -227,8 +227,10 @@ namespace gr {
       std::vector<pmt::pmt_t> _pending_cmds;
       //! Shadows the last value we told the USRP to tune to for every channel
       // (this is not necessarily the true value the USRP is currently tuned to!).
-      std::vector< ::uhd::tune_request_t > _curr_tune_req;
-      boost::dynamic_bitset<> _chans_to_tune;
+      std::vector< ::uhd::tune_request_t > _curr_tx_tune_req;
+      std::vector< ::uhd::tune_request_t > _curr_rx_tune_req;
+      boost::dynamic_bitset<> _tx_chans_to_tune;
+      boost::dynamic_bitset<> _rx_chans_to_tune;
 
       //! Stores the individual command handlers
       ::uhd::dict<pmt::pmt_t, cmd_handler_t> _msg_cmd_handlers;

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -141,10 +141,15 @@ namespace gr {
     }
 
     void
-    usrp_sink_impl::set_gain(double gain, size_t chan)
+    usrp_sink_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
     {
-      chan = _stream_args.channels[chan];
-      return _dev->set_tx_gain(gain, chan);
+      if (pmt::eqv(direction, ant_direction_rx())) {
+        chan = _stream_args.channels[chan];
+        return _dev->set_rx_gain(gain, chan);
+      } else {
+        chan = _stream_args.channels[chan];
+        return _dev->set_tx_gain(gain, chan);
+      }
     }
 
     void

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -109,7 +109,7 @@ namespace gr {
     usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request,
                                     size_t chan)
     {
-      _curr_tune_req[chan] = tune_request;
+      _curr_tx_tune_req[chan] = tune_request;
       chan = _stream_args.channels[chan];
       return _dev->set_tx_freq(tune_request, chan);
     }
@@ -117,12 +117,13 @@ namespace gr {
     ::uhd::tune_result_t
     usrp_sink_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
     {
-      _chans_to_tune.reset(chan);
       if (pmt::eqv(direction, ant_direction_rx())) {
         // TODO: what happens if the RX device is not instantiated? Catch error?
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _rx_chans_to_tune.reset(chan);
+        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
       } else {
-        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _tx_chans_to_tune.reset(chan);
+        return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
       }
     }
 

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -94,7 +94,7 @@ namespace gr {
       void set_samp_rate(double rate);
       ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan);
-      void set_gain(double gain, size_t chan);
+      void set_gain(double gain, size_t chan, pmt::pmt_t direction);
       void set_gain(double gain, const std::string &name, size_t chan);
       void set_normalized_gain(double gain, size_t chan);
       void set_antenna(const std::string &ant, size_t chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -146,7 +146,7 @@ namespace gr {
     }
 
     void
-    usrp_source_impl::set_gain(double gain, size_t chan)
+    usrp_source_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
     {
       chan = _stream_args.channels[chan];
       return _dev->set_rx_gain(gain, chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -122,12 +122,13 @@ namespace gr {
     ::uhd::tune_result_t
     usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
     {
-      _chans_to_tune.reset(chan);
       if (pmt::eqv(direction, ant_direction_tx())) {
         // TODO: what happens if the TX device is not instantiated? Catch error?
-        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _tx_chans_to_tune.reset(chan);
+        return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
       } else {
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _rx_chans_to_tune.reset(chan);
+        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
       }
     }
 

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -81,7 +81,7 @@ namespace gr {
       void set_samp_rate(double rate);
       ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan);
-      void set_gain(double gain, size_t chan);
+      void set_gain(double gain, size_t chan = 0, pmt::pmt_t direction = pmt::PMT_NIL);
       void set_gain(double gain, const std::string &name, size_t chan);
       void set_normalized_gain(double gain, size_t chan);
       void set_antenna(const std::string &ant, size_t chan);


### PR DESCRIPTION
Over a year ago mrjacobagilbert added "direction" key which can be used together with "freq" or "tune" keys of "tx_command" to control frequency in both directions with use of gr-uhd source or sink block and their command ports or tag processing capabilities: https://github.com/gnuradio/gnuradio/commit/cfb6e49e33d7f664268000e312367d091a60b9c3.

This is a great idea.

However underlying code was still not 100% ready for this, as it is impossible to control Rx and Tx freqs at the same time. This is because there is single vector for storing frequencies, shared by both Tx and Rx: https://github.com/gnuradio/gnuradio/blame/master/gr-uhd/lib/usrp_block_impl.cc#L648

Few months ago I prepared patches adding such capability for frequencies and gains, but I wasn't 100% happy with the code - especially the fact that I added repeating checks for direction pmt in each affected function that sets frequency.

Anyway it's very usable for me, so maybe others would want to make use of such capability as well. This is more work-in-progress pull request, so I'm open to any suggestions how to improve this commits before merging.

It probably would be also great to have ability to control other things in both directions i.e. why not (most importantly) gains, bw, rate and antenna? Maybe the code of uhd blocks should be restructured a bit to support this without bloating it too much the way I did.

If this pull request will be successful I would be happy to add the same improvement in maint-3.7 branch. 