### PR TITLE
modtool: fix modtool tests for missing pylint dependency

### DIFF
--- a/gr-utils/python/modtool/core/base.py
+++ b/gr-utils/python/modtool/core/base.py
@@ -29,7 +29,22 @@ import re
 import glob
 import logging
 import itertools
-from types import SimpleNamespace
+
+try:
+    from types import SimpleNamespace
+except:
+    # Py2.7 doesn't have SimpleNamespace, soooo use what Py3 docs say is roughly equivalent
+    class SimpleNamespace:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        def __repr__(self):
+            keys = sorted(self.__dict__)
+            items = ("{}={!r}".format(k, self.__dict__[k]) for k in keys)
+            return "{}({})".format(type(self).__name__, ", ".join(items))
+
+        def __eq__(self, other):
+            return self.__dict__ == other.__dict__
 
 from gnuradio import gr
 from ..tools import get_modname, SCMRepoFactory

--- a/gr-utils/python/modtool/core/base.py
+++ b/gr-utils/python/modtool/core/base.py
@@ -33,7 +33,6 @@ from types import SimpleNamespace
 
 from gnuradio import gr
 from ..tools import get_modname, SCMRepoFactory
-from ..cli import setup_cli_logger
 
 logger = logging.getLogger('gnuradio.modtool')
 
@@ -90,6 +89,7 @@ class ModTool(object):
             self.info['yes'] = True
         else:
             self.info['yes'] = kwargs.get('yes', False)
+            from ..cli import setup_cli_logger
             setup_cli_logger(logger)
 
         if not type(self).__name__ in ['ModToolInfo', 'ModToolNewModule']:

--- a/gr-utils/python/modtool/core/disable.py
+++ b/gr-utils/python/modtool/core/disable.py
@@ -29,7 +29,6 @@ import re
 import sys
 import logging
 
-from ..cli import cli_input
 from ..tools import CMakeFileEditor
 from .base import ModTool, ModToolException
 
@@ -131,6 +130,8 @@ class ModToolDisable(ModTool):
         # This portion will be covered by the CLI
         if not self.cli:
             self.validate()
+        else:
+            from ..cli import cli_input
         # List of special rules: 0: subdir, 1: filename re match, 2: callback
         special_treatments = (
                 ('python', r'qa.+py$', _handle_py_qa),

--- a/gr-utils/python/modtool/core/newmod.py
+++ b/gr-utils/python/modtool/core/newmod.py
@@ -54,7 +54,7 @@ class ModToolNewModule(ModTool):
 
     def validate(self):
         """ Validates the arguments """
-        if self.info['modname'] is None:
+        if not self.info['modname']:
             raise ModToolException('Module name not specified.')
         if not re.match('[a-zA-Z0-9_]+$', self.info['modname']):
             raise ModToolException('Invalid module name.')
@@ -65,7 +65,7 @@ class ModToolNewModule(ModTool):
         else:
             raise ModToolException('The given directory exists.')
         if not os.path.isdir(self.srcdir):
-            raise ModToolException('Could not find gr-newmod source dir.')
+            raise ModToolException('Could not find gr-newmod source dir \'' + self.srcdir + '\'')
 
     def run(self):
         """

--- a/gr-utils/python/modtool/core/rm.py
+++ b/gr-utils/python/modtool/core/rm.py
@@ -31,7 +31,6 @@ import glob
 import logging
 
 from ..tools import remove_pattern_from_file, CMakeFileEditor
-from ..cli import cli_input
 from .base import ModTool, ModToolException
 
 logger = logging.getLogger(__name__)
@@ -57,6 +56,8 @@ class ModToolRemove(ModTool):
         # This portion will be covered by the CLI
         if not self.cli:
             self.validate()
+        else:
+            from ..cli import cli_input
         def _remove_cc_test_case(filename=None, ed=None):
             """ Special function that removes the occurrences of a qa*.cc file
             from the CMakeLists.txt. """

--- a/gr-utils/python/modtool/core/update.py
+++ b/gr-utils/python/modtool/core/update.py
@@ -29,7 +29,6 @@ import re
 import glob
 import logging
 
-from gnuradio.grc.converter import Converter
 from .base import ModTool, ModToolException
 from ..tools import get_modname
 
@@ -73,6 +72,7 @@ class ModToolUpdate(ModTool):
             raise ModToolException("The XML bindings does not exists!")
 
     def run(self):
+        from gnuradio.grc.converter import Converter
         if not self.cli:
             self.validate()
         logger.warning("Warning: This is an experimental feature. Please verify the bindings.")

--- a/gr-utils/python/modtool/tests/CMakeLists.txt
+++ b/gr-utils/python/modtool/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Free Software Foundation, Inc.
+# Copyright 2019 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -19,9 +19,25 @@
 
 include(GrPython)
 
-GR_PYTHON_INSTALL(FILES
-    __init__.py
-    test_modtool.py
-    DESTINATION ${GR_PYTHON_DIR}/gnuradio/modtool/tests
-)
+########################################################################
+# Handle the unit tests
+########################################################################
+if(ENABLE_TESTING)
 
+  set(GR_TEST_TARGET_DEPS "")
+  set(GR_TEST_LIBRARY_DIRS "")
+  set(GR_TEST_PYTHON_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/python
+    ${CMAKE_BINARY_DIR}/gnuradio-runtime/swig
+    )
+
+  include(GrTest)
+  file(GLOB py_qa_test_files "test_*.py")
+
+  foreach(py_qa_test_file ${py_qa_test_files})
+    get_filename_component(py_qa_test_name ${py_qa_test_file} NAME_WE)
+    GR_ADD_TEST(${py_qa_test_name} ${QA_PYTHON_EXECUTABLE} -B ${py_qa_test_file})
+  endforeach(py_qa_test_file)
+
+endif(ENABLE_TESTING)

--- a/gr-utils/python/modtool/tests/test_modtool.py
+++ b/gr-utils/python/modtool/tests/test_modtool.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Free Software Foundation, Inc.
+# Copyright 2018, 2019 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -35,7 +35,13 @@ try:
 except:
     skip_pylint_test = True
 
-from gnuradio.modtool.core import *
+from modtool.core import ModToolNewModule
+from modtool.core import ModToolAdd
+from modtool.core import ModToolDisable
+from modtool.core import ModToolException
+from modtool.core import ModToolMakeYAML
+from modtool.core import ModToolRename
+from modtool.core import ModToolRemove
 
 class TestModToolCore(unittest.TestCase):
     """ The tests for the modtool core """
@@ -43,6 +49,7 @@ class TestModToolCore(unittest.TestCase):
         super(TestModToolCore, self).__init__(*args, **kwargs)
         self.f_add = False
         self.f_newmod = False
+        self.srcdir = path.abspath(path.join(path.dirname(path.realpath(__file__)),  '../templates/gr-newmod'))
 
     @classmethod
     def setUpClass(cls):
@@ -58,7 +65,9 @@ class TestModToolCore(unittest.TestCase):
         """ create a new module and block before every test """
         try:
             warnings.simplefilter("ignore", ResourceWarning)
-            args = {'module_name':'howto', 'directory': self.test_dir}
+            args = {'module_name':'howto',
+                    'directory': self.test_dir,
+                    'srcdir': self.srcdir}
             ModToolNewModule(**args).run()
         except (TypeError, ModToolException):
             self.f_newmod = True
@@ -83,8 +92,8 @@ class TestModToolCore(unittest.TestCase):
     def test_newmod(self):
         """ Tests for the API function newmod """
         ## Tests for proper exceptions ##
-        test_dict = {}
-        test_dict['directory'] = self.test_dir
+        test_dict = { 'directory': self.test_dir,
+                      'srcdir': self.srcdir}
         # module name not specified
         self.assertRaises(ModToolException, ModToolNewModule(**test_dict).run)
         test_dict['module_name'] = 'howto'
@@ -108,9 +117,10 @@ class TestModToolCore(unittest.TestCase):
         self.assertTrue(path.exists(path.join(module_dir, 'CMakeLists.txt')))
 
         ## The check for object instantiation ##
-        test_obj = ModToolNewModule()
+        test_obj = ModToolNewModule(srcdir = self.srcdir)
         # module name not specified
-        self.assertRaises(ModToolException, test_obj.run)
+        with self.assertRaises(ModToolException) as context_manager:
+            test_obj.run()
         test_obj.info['modname'] = 'howto'
         test_obj.directory = self.test_dir
         # directory already exists

--- a/gr-utils/python/modtool/tests/test_modtool.py
+++ b/gr-utils/python/modtool/tests/test_modtool.py
@@ -64,7 +64,11 @@ class TestModToolCore(unittest.TestCase):
     def setUp(self):
         """ create a new module and block before every test """
         try:
-            warnings.simplefilter("ignore", ResourceWarning)
+            try:
+                warnings.simplefilter("ignore", ResourceWarning)
+            except (NameError):
+                # Python2 , Python3 < 3.2 don't know ResourceWarning
+                pass
             args = {'module_name':'howto',
                     'directory': self.test_dir,
                     'srcdir': self.srcdir}

--- a/gr-utils/python/modtool/tools/util_functions.py
+++ b/gr-utils/python/modtool/tools/util_functions.py
@@ -99,7 +99,7 @@ def strip_arg_types(string):
     string = strip_default_values(string)
     return ", ".join(
                 [part.strip().split(' ')[-1] for part in string.split(',')]
-            ).translate(str.maketrans('','','*&'))
+            ).replace('*','').replace('&','')
 
 def strip_arg_types_grc(string):
     """" Strip the argument types from a list of arguments for GRC make tag.


### PR DESCRIPTION
gr-modtool tests depend on `pylint`, so earlier modtool tests failed in case of the missing dependency (pylint) which has been fixed in this PR. :)