### PR TITLE
dtv: Fix scrambler and BCH encoder for MEDIUM size frames.

### DIFF
--- a/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_bbscrambler_bb_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /* 
- * Copyright 2015 Free Software Foundation, Inc.
+ * Copyright 2015,2019 Free Software Foundation, Inc.
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,9 @@ namespace gr {
     {
      private:
       int kbch;
+      int frame_size;
       unsigned char bb_randomise[FRAME_SIZE_NORMAL];
+      uint32_t* bb_randomize32;
       uint64_t* bb_randomize64;
       void init_bb_randomiser(void);
 

--- a/gr-dtv/lib/dvb/dvb_bch_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_bch_bb_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /* 
- * Copyright 2015,2016 Free Software Foundation, Inc.
+ * Copyright 2015,2016,2019 Free Software Foundation, Inc.
  * 
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,12 +36,15 @@ namespace gr {
       unsigned int kbch;
       unsigned int nbch;
       unsigned int bch_code;
+      unsigned int frame_size;
 
       std::bitset<MAX_BCH_PARITY_BITS> crc_table[256];
+      std::bitset<MAX_BCH_PARITY_BITS> crc_medium_table[16];
       unsigned int num_parity_bits;
       std::bitset<MAX_BCH_PARITY_BITS> polynome;
 
       void calculate_crc_table();
+      void calculate_medium_crc_table();
       int poly_mult(const int*, int, const int*, int, int*);
       void bch_poly_build_tables(void);
 


### PR DESCRIPTION
DVB-S2X VL-SNR MEDIUM size frames are not divisible by 8.