### PR TITLE
Add missing quotes in themes parameter of option block and fix some depreciation warnings

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -348,7 +348,7 @@ def main(top_block_cls=${class_name}, options=None):
     tb.start(${flow_graph.get_option('max_nouts') or ''})
     % endif
     % if flow_graph.get_option('qt_qss_theme'):
-    tb.setStyleSheetFromFile(${ flow_graph.get_option('qt_qss_theme') })
+    tb.setStyleSheetFromFile("${ flow_graph.get_option('qt_qss_theme') }")
     % endif
     tb.show()
 

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -141,16 +141,16 @@ class TextDisplay(SimpleTextDisplay):
         """Create a popup menu for the scroll lock and clear functions"""
         menu.append(Gtk.SeparatorMenuItem())
 
-        lock = Gtk.CheckMenuItem("Scroll Lock")
+        lock = Gtk.CheckMenuItem(label = "Scroll Lock")
         menu.append(lock)
         lock.set_active(self.scroll_lock)
         lock.connect('activate', self.scroll_back_cb, view)
 
-        save = Gtk.ImageMenuItem(Gtk.STOCK_SAVE)
+        save = Gtk.ImageMenuItem(label = Gtk.STOCK_SAVE)
         menu.append(save)
         save.connect('activate', self.save_cb, view)
 
-        clear = Gtk.ImageMenuItem(Gtk.STOCK_CLEAR)
+        clear = Gtk.ImageMenuItem(label = Gtk.STOCK_CLEAR)
         menu.append(clear)
         clear.connect('activate', self.clear_cb, view)
         menu.show_all()

--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -322,16 +322,16 @@ class FileParam(EntryParam):
         # build the dialog
         if self.param.dtype == 'file_open':
             file_dialog = Gtk.FileChooserDialog(
-                'Open a Data File...', None, Gtk.FileChooserAction.OPEN,
-                ('gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-open', Gtk.ResponseType.OK),
+                title = 'Open a Data File...',action = Gtk.FileChooserAction.OPEN,
                 transient_for=self._transient_for,
             )
+            file_dialog.add_buttons( 'gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-open' , Gtk.ResponseType.OK )
         elif self.param.dtype == 'file_save':
             file_dialog = Gtk.FileChooserDialog(
-                'Save a Data File...', None, Gtk.FileChooserAction.SAVE,
-                ('gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-save', Gtk.ResponseType.OK),
+                title = 'Save a Data File...',action = Gtk.FileChooserAction.SAVE,
                 transient_for=self._transient_for,
             )
+            file_dialog.add_buttons( 'gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-save', Gtk.ResponseType.OK )
             file_dialog.set_do_overwrite_confirmation(True)
             file_dialog.set_current_name(basename)  # show the current filename
         else:


### PR DESCRIPTION
setStyleSheetFromFile requires a string as parameter.
While generating the python code the quotes are missing.
See #2439 