### PR TITLE
cmake: Enable CMAKE_EXPORT_COMPILE_COMMANDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ set(CLANG_MIN_VERSION "3.4.0")
 set(APPLECLANG_MIN_VERSION "500")
 set(MSVC_MIN_VERSION "1800")
 
+# Enable generation of compile_commands.json for code completion engines
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 ########################################################################
 # Configure CMake policies
 ########################################################################

--- a/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
@@ -49,6 +49,9 @@ set(VERSION_INFO_MAINT_VERSION git)
 
 cmake_policy(SET CMP0011 NEW)
 
+# Enable generation of compile_commands.json for code completion engines
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 ########################################################################
 # Compiler specific setup
 ########################################################################


### PR DESCRIPTION
When CMAKE_EXPORT_COMPILE_COMMANDS is ON, a file compile_commands.json
will be created in the build directory that enables code completion
engines to find all include directories and provide a very comprehensive
auto completion experience without any manual IDE configuration.

A nice example for this is the VS Code extension cpptools that is
developed by Microsoft. Of course this is not limited to VS Code and
works with other engines such as YouCompleteMe as well.