### PR TITLE
Moving enum from digital.corr_est_cc to digital

### DIFF
--- a/gr-digital/grc/digital_corr_est_cc.block.yml
+++ b/gr-digital/grc/digital_corr_est_cc.block.yml
@@ -19,7 +19,7 @@ parameters:
 -   id: threshold_method
     label: Threshold Method
     dtype: enum
-    options: [digital.corr_est_cc.THRESHOLD_ABSOLUTE, digital.corr_est_cc.THRESHOLD_DYNAMIC]
+    options: [digital.THRESHOLD_ABSOLUTE, digital.THRESHOLD_DYNAMIC]
     option_labels: [Absolute, Dynamic]
 
 inputs:

--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -82,15 +82,15 @@ namespace gr {
      * _on_Signal_Processing_, Volume 47, No. 9, September 1999
      *
      */
+      typedef enum {
+        THRESHOLD_DYNAMIC,
+        THRESHOLD_ABSOLUTE,
+      } tm_type;
+
     class DIGITAL_API corr_est_cc : virtual public sync_block
     {
     public:
       typedef boost::shared_ptr<corr_est_cc> sptr;
-
-      enum tm_type {
-        THRESHOLD_DYNAMIC,
-        THRESHOLD_ABSOLUTE,
-      };
 
       /*!
        * Make a block that correlates against the \p symbols vector


### PR DESCRIPTION
The generated python code for corr_est_cc fails with

AttributeError: 'function' object has no attribute 'THRESHOLD_ABSOLUTE'

Moving the enum from corr_est_cc to the digital namespace fixes this problem.

See #2470 
With this patch at least the generated code runs.