### PR TITLE
runtime: prefs: parse user config even if sys conf dir isn't a directory

### DIFF
--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -67,16 +67,15 @@ namespace gr {
     std::vector<std::string> fnames;
 
     fs::path dir = prefsdir();
-    if(!fs::is_directory(dir))
-      return fnames;
-
-    fs::directory_iterator diritr(dir);
-    while(diritr != fs::directory_iterator()) {
-      fs::path p = *diritr++;
-      if(p.extension() == ".conf")
-        fnames.push_back(p.string());
+    if(fs::is_directory(dir)) {
+      fs::directory_iterator diritr(dir);
+      while(diritr != fs::directory_iterator()) {
+        fs::path p = *diritr++;
+        if(p.extension() == ".conf")
+          fnames.push_back(p.string());
+      }
+      std::sort(fnames.begin(), fnames.end());
     }
-    std::sort(fnames.begin(), fnames.end());
 
     // Find if there is a ~/.gnuradio/config.conf file and add this to
     // the end of the file list to override any preferences in the


### PR DESCRIPTION
This comes from helping a user on the mailing list (hi there, Gary),
who's been having severe problems with the Windows audio source; told
him to configure GNU Radio to use portaudio instead. He did - but GR
ignored his config file. Turned out that the hardcoded path to the
system config dir (set at built) doesn't match how it was installed on
Windows, and that prefs don't even try the user confs if they can't find
that directory. Fixed that.