### PR TITLE
runtime: prefs: parse user config even if sys conf dir isn't a directory

### DIFF
--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -67,16 +67,15 @@ namespace gr {
     std::vector<std::string> fnames;
 
     fs::path dir = prefsdir();
-    if(!fs::is_directory(dir))
-      return fnames;
-
-    fs::directory_iterator diritr(dir);
-    while(diritr != fs::directory_iterator()) {
-      fs::path p = *diritr++;
-      if(p.extension() == ".conf")
-        fnames.push_back(p.string());
+    if(fs::is_directory(dir)) {
+      fs::directory_iterator diritr(dir);
+      while(diritr != fs::directory_iterator()) {
+        fs::path p = *diritr++;
+        if(p.extension() == ".conf")
+          fnames.push_back(p.string());
+      }
+      std::sort(fnames.begin(), fnames.end());
     }
-    std::sort(fnames.begin(), fnames.end());
 
     // Find if there is a ~/.gnuradio/config.conf file and add this to
     // the end of the file list to override any preferences in the


### PR DESCRIPTION
This is #2475 for maint-3.7.

Before, this lead to systems where due to missing system paths, a user
couldn't even use their own config file, because GNU Radio didn't even
look for it.