### PR TITLE
cmake: check for python module click as dependency of modtool

### DIFF
--- a/gr-utils/python/modtool/CMakeLists.txt
+++ b/gr-utils/python/modtool/CMakeLists.txt
@@ -19,6 +19,18 @@
 
 include(GrPython)
 
+GR_PYTHON_CHECK_MODULE_RAW(
+  "click"
+  "import click; import click_plugins"
+  CLICK_FOUND
+  )
+
+if(NOT CMAKE_CROSSCOMPILING)
+  if(NOT CLICK_FOUND)
+    message(FATAL_ERROR "Python module click is required for gr-modtool")
+  endif()
+endif()
+
 GR_PYTHON_INSTALL(FILES
     __init__.py
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/modtool


### PR DESCRIPTION
Previously cmake did not check if click is installed as it is a runtime
requirement. If CMAKE_CROSSCOMPILING is set the module checking is
skipped.

Closes #2292