### PR TITLE
analog: correct errors of automatic conversion script in fm_preemph

### DIFF
--- a/gr-analog/python/analog/fm_emph.py
+++ b/gr-analog/python/analog/fm_emph.py
@@ -289,7 +289,8 @@ class fm_preemph(gr.hier_block2):
         # That isn't what users are going to expect, so adjust with a
         # gain, g, so that H(z = 1) = 1.0 for 0 dB gain at DC.
         w_0dB = 2.0 * math.pi * 0.0
-        g =        abs(1.0 - p1 * cmath.rect(1.0 / -w_0dB), (b0 * abs(1.0 - z1 * cmath.rect(1.0, -w_0dB))))
+        g =        abs(1.0 - p1 * cmath.rect(1.0 / -w_0dB)) \
+            / (b0 * abs(1.0 - z1 * cmath.rect(1.0, -w_0dB)))
 
         btaps = [ g * b0 * 1.0, g * b0 * -z1 ]
         ataps = [          1.0,          -p1 ]


### PR DESCRIPTION
An automatic conversion for python3 mangled the source and introduced a bug.
This commit fixes the conversion bug in fm_preemph. Changeset that lead to this
bug still has to be analyzed further.

Fixes #2286