### PR TITLE
Issue #1974:  Unnecessary delay in selective fading model

### DIFF
--- a/gr-channels/lib/selective_fading_model_impl.cc
+++ b/gr-channels/lib/selective_fading_model_impl.cc
@@ -63,7 +63,7 @@ namespace gr {
 
         // set up tap history
         if(ntaps < 1){ throw std::runtime_error("ntaps must be >= 1"); }
-        set_history(1+ntaps);
+        set_history(ntaps);
         d_taps.resize(ntaps, gr_complex(0,0));
     }
 


### PR DESCRIPTION
Backport from master branch
Reduce set_history from ntaps+1 to ntaps as an extra delay is introduced

Fixes #1974 