### PR TITLE
blocks: QA: correct conditions for CTRLPORT tests removal

### DIFF
--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -44,14 +44,15 @@ if(ENABLE_TESTING)
   include(GrTest)
   file(GLOB py_qa_test_files "qa_*.py")
 
-  # Force out the controlport QA tests if we have no backends to use.
-  if(CTRLPORT_BACKENDS EQUAL 0)
+  # Force out the controlport QA tests if CTRLPORT is not enabled or
+  # if it is enabled but we have no backends to use.
+  if(NOT ENABLE_GR_CTRLPORT OR CTRLPORT_BACKENDS EQUAL 0)
     list(REMOVE_ITEM py_qa_test_files
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_cpp_py_binding.py
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_cpp_py_binding_set.py
       ${CMAKE_CURRENT_SOURCE_DIR}/qa_ctrlport_probes.py
       )
-  endif(CTRLPORT_BACKENDS EQUAL 0)
+  endif(NOT ENABLE_GR_CTRLPORT OR CTRLPORT_BACKENDS EQUAL 0)
 
   foreach(py_qa_test_file ${py_qa_test_files})
     get_filename_component(py_qa_test_name ${py_qa_test_file} NAME_WE)


### PR DESCRIPTION
Related to https://github.com/gnuradio/gnuradio/pull/1728 , but this one fixes just the conditions for CTRLPORT tests removal, and nothing more. Nice and simple!