### PR TITLE
runtime swig: correct the destination for runtime_swigTargets.cmake

### DIFF
--- a/gnuradio-runtime/swig/CMakeLists.txt
+++ b/gnuradio-runtime/swig/CMakeLists.txt
@@ -74,7 +74,7 @@ GR_PYTHON_INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/runtime_swig.py
 install(EXPORT runtime_swig-export
   FILE runtime_swigTargets.cmake
   NAMESPACE gnuradio::
-  DESTINATION ${GR_LIBRARY_DIR}/cmake/gnuradio
+  DESTINATION ${GR_CMAKE_DIR}
 )
 
 install(


### PR DESCRIPTION
This destination matches that from GrMiscUtils. Nice and simple tweak.