### PR TITLE
zeromq: fixes to allow building using CPPZMQ 4.3.1 as well as prior

### DIFF
--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2016 Free Software Foundation, Inc.
+ * Copyright 2016,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -105,7 +105,11 @@ namespace gr {
       }
 
       /* Send */
+#if USE_NEW_CPPZMQ_SEND_RECV
+      d_socket->send(msg, zmq::send_flags::none);
+#else
       d_socket->send(msg);
+#endif
 
       /* Report back */
       return in_nitems;
@@ -186,7 +190,11 @@ namespace gr {
       d_consumed_bytes = 0;
 
       /* Get the message */
+#if USE_NEW_CPPZMQ_SEND_RECV
+      d_socket->recv(d_msg);
+#else
       d_socket->recv(&d_msg);
+#endif
 
       /* Parse header from the first (or only) message of a multi-part message */
       if (d_pass_tags && !more)

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2016 Free Software Foundation, Inc.
+ * Copyright 2016,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -23,9 +23,8 @@
 #ifndef INCLUDED_ZEROMQ_BASE_IMPL_H
 #define INCLUDED_ZEROMQ_BASE_IMPL_H
 
-#include <zmq.hpp>
-
 #include <gnuradio/sync_block.h>
+#include "zmq_common_impl.h"
 
 namespace gr {
   namespace zeromq {

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -97,7 +97,11 @@ namespace gr {
 
           // Receive data
           zmq::message_t msg;
+#if USE_NEW_CPPZMQ_SEND_RECV
+          d_socket->recv(msg);
+#else
           d_socket->recv(&msg);
+#endif
 
           std::string buf(static_cast<char*>(msg.data()), msg.size());
           std::stringbuf sb(buf);

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_PULL_MSG_SOURCE_IMPL_H
 
 #include <gnuradio/zeromq/pull_msg_source.h>
-#include <zmq.hpp>
+#include "zmq_common_impl.h"
 
 namespace gr {
   namespace zeromq {

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -99,7 +99,11 @@ namespace gr {
 
             // receive data request
             zmq::message_t request;
+#if USE_NEW_CPPZMQ_SEND_RECV
+            d_socket->recv(request);
+#else
             d_socket->recv(&request);
+#endif
 
             int req_output_items = *(static_cast<int*>(request.data()));
             if(req_output_items != 1)

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_REP_MSG_SINK_IMPL_H
 
 #include <gnuradio/zeromq/rep_msg_sink.h>
-#include <zmq.hpp>
+#include "zmq_common_impl.h"
 
 namespace gr {
   namespace zeromq {

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -71,7 +71,11 @@ namespace gr {
 
         /* Get and parse the request */
         zmq::message_t request;
+#if USE_NEW_CPPZMQ_SEND_RECV
+        d_socket->recv(request);
+#else
         d_socket->recv(&request);
+#endif
 
         int nitems_send = noutput_items - done;
         if (request.size() >= sizeof(uint32_t))

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -99,7 +99,11 @@ namespace gr {
           int nmsg = 1;
           zmq::message_t request(sizeof(int));
           memcpy((void *) request.data (), &nmsg, sizeof(int));
+#if USE_NEW_CPPZMQ_SEND_RECV
+          d_socket->send(request, zmq::send_flags::none);
+#else
           d_socket->send(request);
+#endif
         }
 
         zmq::pollitem_t items[] = { { static_cast<void *>(*d_socket), 0, ZMQ_POLLIN, 0 } };
@@ -109,7 +113,11 @@ namespace gr {
         if (items[0].revents & ZMQ_POLLIN) {
           // Receive data
           zmq::message_t msg;
+#if USE_NEW_CPPZMQ_SEND_RECV
+          d_socket->recv(msg);
+#else
           d_socket->recv(&msg);
+#endif
 
           std::string buf(static_cast<char*>(msg.data()), msg.size());
           std::stringbuf sb(buf);

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_REQ_MSG_SOURCE_IMPL_H
 
 #include <gnuradio/zeromq/req_msg_source.h>
-#include <zmq.hpp>
+#include "zmq_common_impl.h"
 
 namespace gr {
   namespace zeromq {

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -96,8 +96,11 @@ namespace gr {
 
           // Receive data
           zmq::message_t msg;
+#if USE_NEW_CPPZMQ_SEND_RECV
+          d_socket->recv(msg);
+#else
           d_socket->recv(&msg);
-
+#endif
           std::string buf(static_cast<char*>(msg.data()), msg.size());
           std::stringbuf sb(buf);
           pmt::pmt_t m = pmt::deserialize(sb);

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014 Free Software Foundation, Inc.
+ * Copyright 2013,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -24,7 +24,7 @@
 #define INCLUDED_ZEROMQ_SUB_MSG_SOURCE_IMPL_H
 
 #include <gnuradio/zeromq/sub_msg_source.h>
-#include "zmq.hpp"
+#include "zmq_common_impl.h"
 
 namespace gr {
   namespace zeromq {

--- a/gr-zeromq/lib/zmq_common_impl.h
+++ b/gr-zeromq/lib/zmq_common_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2013,2014,2019 Free Software Foundation, Inc.
+ * Copyright 2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio.
  *
@@ -20,27 +20,15 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef INCLUDED_ZEROMQ_REP_SINK_IMPL_H
-#define INCLUDED_ZEROMQ_REP_SINK_IMPL_H
+#ifndef INCLUDED_ZEROMQ_ZMQ_COMMON_IMPL_H
+#define INCLUDED_ZEROMQ_ZMQ_COMMON_IMPL_H
 
-#include <gnuradio/zeromq/rep_sink.h>
-#include "base_impl.h"
+#include <zmq.hpp>
 
-namespace gr {
-  namespace zeromq {
+#if defined (CPPZMQ_VERSION) && defined (ZMQ_MAKE_VERSION) && CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+#define USE_NEW_CPPZMQ_SEND_RECV 1
+#else
+#define USE_NEW_CPPZMQ_SEND_RECV 0
+#endif
 
-    class rep_sink_impl : public rep_sink, public base_sink_impl
-    {
-    public:
-      rep_sink_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
-
-      int work(int noutput_items,
-               gr_vector_const_void_star &input_items,
-               gr_vector_void_star &output_items);
-      std::string last_endpoint() override {return base_sink_impl::last_endpoint();}
-    };
-
-  } // namespace zeromq
-} // namespace gr
-
-#endif /* INCLUDED_ZEROMQ_REP_SINK_IMPL_H */
+#endif /* INCLUDED_ZEROMQ_ZMQ_COMMON_IMPL_H */


### PR DESCRIPTION
ZMQ deprecated some prototypes of "recv" and "send" in some version prior to 4.3.1. The "recv" one has been removed in 4.3.1 and thus generates an error since no valid prototype exists in the way we're trying to call "recv". This fix updates our usage of both calls to work with the "new" and "old" ways, depending on the ZMQ version. Move the ZMQ inclusion and a macro determine which version to use into a common header.

I'm not 100% sure this is the correct solution, but it works (for me on OSX) and is relatively straight forward to understand.