### PR TITLE
grc: function_probe_block extra quotes with block_id

### DIFF
--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -5,15 +5,15 @@ flags: [ python ]
 parameters:
 -   id: block_id
     label: Block ID
-    dtype: string
+    dtype: id
     default: my_block_0
 -   id: function_name
     label: Function Name
-    dtype: string
+    dtype: name
     default: get_number
 -   id: function_args
     label: Function Args
-    dtype: string
+    dtype: raw
     hide: ${ ('none' if function_args else 'part') }
 -   id: poll_rate
     label: Poll Rate (Hz)

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -61,7 +61,7 @@ PARAM_TYPE_NAMES = {
     'complex_vector', 'real_vector', 'float_vector', 'int_vector',
     'hex', 'string', 'bool',
     'file_open', 'file_save', '_multiline', '_multiline_python_external',
-    'id', 'stream_id',
+    'id', 'stream_id','name',
     'gui_hint',
     'import',
 }

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -68,6 +68,17 @@ def validate_block_id(param):
     return value
 
 
+@validates('name')
+def validate_name(param):
+    # Name of a function that will be generated literally not as a string
+    value = param.value
+    # Can python use this as a variable?
+    if not re.match(r'^[a-z|A-Z]\w*$', value):
+        raise ValidateError('ID "{}" must begin with a letter and may contain letters, numbers, '
+                            'and underscores.'.format(value))
+    return value
+
+
 @validates('stream_id')
 def validate_stream_id(param):
     value = param.value

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -208,7 +208,7 @@ class Param(Element):
         #########################
         # ID and Enum types (not evaled)
         #########################
-        if dtype in ('id', 'stream_id') or self.is_enum():
+        if dtype in ('id', 'stream_id','name') or self.is_enum():
             if self.options.attributes:
                 expr = attributed_str(expr)
                 for key, value in self.options.attributes[expr].items():


### PR DESCRIPTION
The inherent problem is that extra quotes are added when generating the python file - not sure if this is the best solution, but it wasn't clear how to make some string dtypes handled differently than others.  The 'block_id' can be handled as an 'id' dtype because it references another block.  The function name is slightly different, so I added a 'name' dtype with less restrictions than the 'id' dtype.  Please recommend a different solution if this is not preferable.

Due to the way stringify_flag is called, the block_id,
function_name and function_args are all given extra
quotes which cause issues when generating the python source

change/add new dtypes for function_probe

Fixes #1783