### PR TITLE
qtgui: fix QT Gui Entry emitting signal when changed

### DIFF
--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -45,7 +45,7 @@ templates:
         self._${id}_line_edit = Qt.QLineEdit(str(self.${id}))
         self._${id}_tool_bar.addWidget(self._${id}_line_edit)
         self._${id}_line_edit.returnPressed.connect(
-            lambda: self.set_${id}(${type.conv}(str(self._${id}_line_edit.text().toAscii()))))
+            lambda: self.set_${id}(${type.conv}(str(self._${id}_line_edit.text()))))
         ${gui_hint() % win}
 
 cpp_templates:


### PR DESCRIPTION
Was calling toAscii on the text edit which was removed in QT5