### PR TITLE
Add GR_PYTHON_RELATIVE to fix issue #2515 with runtime_swigTargets-re…

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -111,6 +111,19 @@ endif()
 file(TO_CMAKE_PATH ${GR_PYTHON_DIR} GR_PYTHON_DIR)
 
 ########################################################################
+# Sets the python relative installation directory GR_PYTHON_RELATIVE
+########################################################################
+if(NOT DEFINED GR_PYTHON_RELATIVE)
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "
+from distutils import sysconfig as sc
+print(sc.get_python_lib(prefix='', plat_specific=True))
+"
+  OUTPUT_VARIABLE GR_PYTHON_RELATIVE  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+endif()
+
+
+########################################################################
 # Create an always-built target with a unique name
 # Usage: GR_UNIQUE_TARGET(<description> <dependencies list>)
 ########################################################################

--- a/gnuradio-runtime/swig/CMakeLists.txt
+++ b/gnuradio-runtime/swig/CMakeLists.txt
@@ -62,7 +62,7 @@ GR_SWIG_MAKE(runtime_swig runtime_swig.i)
 install(
   TARGETS runtime_swig
   EXPORT runtime_swig-export
-  DESTINATION ${GR_PYTHON_DIR}/gnuradio/gr
+  DESTINATION ${GR_PYTHON_RELATIVE}/gnuradio/gr
   )
 
 include(GrPython)
@@ -74,7 +74,7 @@ GR_PYTHON_INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/runtime_swig.py
 install(EXPORT runtime_swig-export
   FILE runtime_swigTargets.cmake
   NAMESPACE gnuradio::
-  DESTINATION ${GR_LIBRARY_DIR}/cmake/gnuradio
+  DESTINATION ${GR_CMAKE_DIR}
 )
 
 install(


### PR DESCRIPTION
…lease.cmake

This commit fixes issue #2515.  A new CMake variable, GR_PYTHON_RELATIVE
is needed to properly create the CMake files used by OOTs when cross
compiling or using sysroot based build systems

see  https://cmake.org/Bug/print_bug_page.php?bug_id=14367  for more
information