### PR TITLE
gr-video-sdl: Fixed typo in cmake (MSVC only)

### DIFF
--- a/gr-video-sdl/lib/CMakeLists.txt
+++ b/gr-video-sdl/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ IF(MSVC)
         ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-video-sdl.rc
     @ONLY)
 
-    target_sources(gnuradio-videos-sdl PRIVATE
+    target_sources(gnuradio-video-sdl PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-video-sdl.rc
     )
 ENDIF(MSVC)


### PR DESCRIPTION
Fixes minor typo in cmake file that only impacts MSVC