### PR TITLE
CMake: Fixes error when both debug and release python libs installed

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -54,10 +54,20 @@ set(PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE} CACHE FILEPATH "python interpreter")
 set(QA_PYTHON_EXECUTABLE ${QA_PYTHON_EXECUTABLE} CACHE FILEPATH "python interpreter for QA tests")
 
 add_library(Python::Python INTERFACE IMPORTED)
-set_target_properties(Python::Python PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
-  INTERFACE_LINK_LIBRARIES "${PYTHON_LIBRARIES}"
-  )
+# Need to handle special cases where both debug and release
+# libraries are available (in form of debug;A;optimized;B) in PYTHON_LIBRARIES
+if(PYTHON_LIBRARY_DEBUG AND PYTHON_LIBRARY_RELEASE)
+    set_target_properties(Python::Python PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "$<$<NOT:$<CONFIG:Debug>>:${PYTHON_LIBRARY_RELEASE}>;$<$<CONFIG:Debug>:${PYTHON_LIBRARY_DEBUG}>"
+      )
+else()
+    set_target_properties(Python::Python PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${PYTHON_LIBRARIES}"
+      )
+endif()
+
 
 ########################################################################
 # Check for the existence of a python module:


### PR DESCRIPTION
If both debug/release versions are present, cmake will failed with an error about the "optimized" keyword, essentially we have to pick a version when using the INTERFACE_LINK_LIBRARIES property.

So this does a quick check for that case, and links to Debug if Debug, and Release if anything else.  
