### PR TITLE
Add message input port to qtgui_time_sink

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -815,7 +815,12 @@ inputs:
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
     optional: true
-
+    hide: ${ (type.startswith('msg') ) }
+-   domain: message
+    id: in
+    optional: true
+    hide: ${ (not type.startswith('msg') ) } 
+    
 templates:
     imports: |-
         from PyQt5 import Qt


### PR DESCRIPTION
The qtgui time sink can act as message sink. But as the definition of a message port is missing, the code generated by grc is wrong and fails to run. See #2518 
This patch adds a message port definition