### PR TITLE
modtool: add 3.8 version for info command

### DIFF
--- a/gr-utils/python/modtool/core/info.py
+++ b/gr-utils/python/modtool/core/info.py
@@ -57,6 +57,8 @@ class ModToolInfo(ModTool):
                 os.path.isdir(os.path.join('include', 'gnuradio', mod_info['modname']))
                 ):
             self.info['version'] = '37'
+        if not os.path.isfile(os.path.join('cmake', 'Modules', 'FindCppUnit.cmake')):
+            self.info['version'] = '38'
         mod_info['version'] = self.info['version']
         if 'is_component' in list(self.info.keys()) and self.info['is_component']:
             mod_info['is_component'] = True


### PR DESCRIPTION
Add version information detection to the part of the code being called by gr_modtool info

fixes #2403 