### PR TITLE
Adopt PDU input port naming to yml description

### DIFF
--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -68,8 +68,8 @@ namespace gr {
       d_index = 0;
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&const_sink_c_impl::handle_pdus, this, _1));
 
       for(int i = 0; i < d_nconnections; i++) {

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -88,8 +88,8 @@ namespace gr {
                       boost::bind(&freq_sink_c_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&freq_sink_c_impl::handle_pdus, this, _1));
 
       d_main_gui = NULL;

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -88,8 +88,8 @@ namespace gr {
                       boost::bind(&freq_sink_f_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&freq_sink_f_impl::handle_pdus, this, _1));
 
       d_main_gui = NULL;

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -73,8 +73,8 @@ namespace gr {
       d_index = 0;
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&histogram_sink_f_impl::handle_pdus, this, _1));
 
       // +1 for the PDU buffer

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -83,8 +83,8 @@ namespace gr {
       d_index = 0;
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&time_raster_sink_b_impl::handle_pdus, this, _1));
 
       d_scale = 1.0f;

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -83,8 +83,8 @@ namespace gr {
       d_index = 0;
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&time_raster_sink_f_impl::handle_pdus, this, _1));
 
       d_icols = static_cast<int>(ceil(d_cols));

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -74,8 +74,8 @@ namespace gr {
       d_main_gui = NULL;
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&time_sink_c_impl::handle_pdus, this, _1));
 
       // +2 for the PDU message buffers

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -74,8 +74,8 @@ namespace gr {
       d_main_gui = NULL;
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&time_sink_f_impl::handle_pdus, this, _1));
 
       // +1 for the PDU buffer

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -126,8 +126,8 @@ namespace gr {
                       boost::bind(&waterfall_sink_c_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&waterfall_sink_c_impl::handle_pdus, this, _1));
     }
 

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -122,8 +122,8 @@ namespace gr {
                       boost::bind(&waterfall_sink_f_impl::handle_set_freq, this, _1));
 
       // setup PDU handling input port
-      message_port_register_in(pmt::mp("in"));
-      set_msg_handler(pmt::mp("in"),
+      message_port_register_in(pmt::mp("in0"));
+      set_msg_handler(pmt::mp("in0"),
                       boost::bind(&waterfall_sink_f_impl::handle_pdus, this, _1));
     }
 


### PR DESCRIPTION
In #2518 and #2528 invalid port names are reported.
This patch adopts the message stream input port names to the yml description which handles the port definition by the multiplicity parameter.

With this fix the qtgui_message_inputs example from the example gr-qtgui/examples directory runs without errors