### PR TITLE
grc: introduce flag 'show_id' to show block id

### DIFF
--- a/grc/blocks/parameter.block.yml
+++ b/grc/blocks/parameter.block.yml
@@ -1,6 +1,6 @@
 id: parameter
 label: Parameter
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: label

--- a/grc/blocks/variable.block.yml
+++ b/grc/blocks/variable.block.yml
@@ -1,6 +1,6 @@
 id: variable
 label: Variable
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: value

--- a/grc/blocks/variable_config.block.yml
+++ b/grc/blocks/variable_config.block.yml
@@ -1,6 +1,6 @@
 id: variable_config
 label: Variable Config
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: value

--- a/grc/blocks/variable_struct.block.yml.py
+++ b/grc/blocks/variable_struct.block.yml.py
@@ -5,6 +5,7 @@ MAX_NUM_FIELDS = 20
 HEADER = """\
 id: variable_struct
 label: Struct Variable
+flags: [ show_id ]
 
 parameters:
 """

--- a/grc/core/blocks/_build.py
+++ b/grc/core/blocks/_build.py
@@ -103,7 +103,10 @@ def build_params(params_raw, have_inputs, have_outputs, flags, block_id):
     def add_param(**data):
         params.append(data)
 
-    add_param(id='id', name='ID', dtype='id', hide='part')
+    if flags.SHOW_ID in flags:
+        add_param(id='id', name='ID', dtype='id', hide='none')
+    else:
+        add_param(id='id', name='ID', dtype='id', hide='all')
 
     if not flags.not_dsp:
         add_param(id='alias', name='Block Alias', dtype='string',

--- a/grc/core/blocks/_flags.py
+++ b/grc/core/blocks/_flags.py
@@ -27,6 +27,7 @@ class Flags(object):
     NEED_QT_GUI = 'need_qt_gui'
     DEPRECATED = 'deprecated'
     NOT_DSP = 'not_dsp'
+    SHOW_ID = 'show_id'
     HAS_PYTHON = 'python'
     HAS_CPP = 'cpp'
 

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -77,7 +77,7 @@ class Block(Element):
             (data['id'], param_factory(parent=self, **data))
             for data in self.parameters_data
         )
-        if self.key == 'options' or self.is_variable:
+        if self.key == 'options':
             self.params['id'].hide = 'part'
 
         self.sinks = [port_factory(parent=self, **params) for params in self.inputs_data]


### PR DESCRIPTION
This is supposed to address https://github.com/gnuradio/gnuradio/issues/2235 by introducing a flag `show_id` to show the block ID in GRC's main canvas. This is useful for variables and parameters but maybe other blocks too. So maybe a flag is better than a list or a regex on the block ID.