### PR TITLE
Remove calls to random()

### DIFF
--- a/gr-atsc/lib/qa_atsci_fake_single_viterbi.cc
+++ b/gr-atsc/lib/qa_atsci_fake_single_viterbi.cc
@@ -36,8 +36,6 @@ static const int NTRIALS     =   50;
 static const int MAXERRORS   =   10;
 static const int NN          =  200;
 
-static const int MAXDIBIT    = 3;
-
 static gr::random rndm;
 
 void
@@ -82,14 +80,14 @@ qa_atsci_fake_single_viterbi::t0 ()
 
   // printf ("  Delay is %d.\n", delay);
 
-  srandom (27);		// reproducible sequence of "random" values
+  gr::random rnd_dibit(3961094692, 0, 4);
 
   for (int nt = 0; nt < NTRIALS; nt++){
 
     // load block with random data and encode
 
     for (i = 0; i < (blocklen-delay); i++)
-      in[i] = random () & MAXDIBIT;
+      in[i] = rnd_dibit.ran_int();
     for (     ; i < blocklen; i++)
       in[i] = 0;		/* To empty the delay buffers */
 

--- a/gr-atsc/lib/qa_atsci_reed_solomon.cc
+++ b/gr-atsc/lib/qa_atsci_reed_solomon.cc
@@ -45,7 +45,7 @@ qa_atsci_reed_solomon::t0_reed_solomon ()
   atsc_mpeg_packet_no_sync	out;
   gr::random rnd_byte(3311823649, 0, 256);
   gr::random rnd_err(1594472664, 1, 256); // Error must not be 0.
-  gr::random rnd_err_loc(957498807, 0, NN + 1);
+  gr::random rnd_err_loc(957498807, 0, NN);
   int			  derrors;
   int			  errlocs[NN];
   int			  errval;

--- a/gr-atsc/lib/qa_atsci_reed_solomon.cc
+++ b/gr-atsc/lib/qa_atsci_reed_solomon.cc
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <gnuradio/atsc/reed_solomon_impl.h>
+#include <gnuradio/random.h>
 #include "qa_atsci_reed_solomon.h"
 #include <string.h>
 
@@ -42,6 +43,9 @@ qa_atsci_reed_solomon::t0_reed_solomon ()
   atsc_mpeg_packet_no_sync	in;
   atsc_mpeg_packet_rs_encoded  	enc;
   atsc_mpeg_packet_no_sync	out;
+  gr::random rnd_byte(3311823649, 0, 256);
+  gr::random rnd_err(1594472664, 1, 256); // Error must not be 0.
+  gr::random rnd_err_loc(957498807, 0, NN + 1);
   int			  derrors;
   int			  errlocs[NN];
   int			  errval;
@@ -56,7 +60,7 @@ qa_atsci_reed_solomon::t0_reed_solomon ()
       // load block with random data and encode
 
       for (int i = 0; i < ATSC_MPEG_DATA_LENGTH; i++)
-	in.data[i] = random () & 0xff;
+	in.data[i] = rnd_byte.ran_int();
 
       rs.encode (enc, in);
 
@@ -64,12 +68,10 @@ qa_atsci_reed_solomon::t0_reed_solomon ()
 
       for (int i = 0; i < errors; i++){
 
-	do {
-	  errval = random () & 0xff;
-	} while (errval == 0);	// error value must be non-zero
+	  errval = rnd_err.ran_int();
 
 	do {
-	  errloc = random () % NN;
+	  errloc = rnd_err_loc.ran_int();
 	} while (errlocs[errloc] != 0);		// must not choose the same location twice
 
 	errlocs[errloc] = 1;

--- a/gr-atsc/lib/qa_atsci_single_viterbi.cc
+++ b/gr-atsc/lib/qa_atsci_single_viterbi.cc
@@ -37,8 +37,6 @@ static const int NTRIALS     =   50;
 static const int MAXERRORS   =   10;
 static const int NN          =  200;
 
-static const int MAXDIBIT    = 3;
-
 static gr::random rndm;
 
 void
@@ -79,14 +77,14 @@ qa_atsci_single_viterbi::t0 ()
 
   // printf ("  Delay is %d.\n", delay);
 
-  srandom (27);		// reproducible sequence of "random" values
+  gr::random rnd_dibit(3489051638, 0, 4);
 
   for (int nt = 0; nt < NTRIALS; nt++){
 
     // load block with random data and encode
 
     for (i = 0; i < (blocklen-delay); i++)
-      in[i] = random () & MAXDIBIT;
+      in[i] = rnd_dibit.ran_int();
     for (     ; i < blocklen; i++)
       in[i] = 0;		/* To empty the delay buffers */
 
@@ -157,7 +155,8 @@ qa_atsci_single_viterbi::t1 ()
 
   // printf ("  Delay is %d.\n", delay);
 
-  srandom (1);		// reproducible sequence of "random" values
+  gr::random rnd_dibit(3153023792, 0, 4);
+  gr::random rnd_err_loc(1136465838, 0, NN + 1);
 
   for (int nt = 0; nt < NTRIALS; nt++){
 
@@ -167,7 +166,7 @@ qa_atsci_single_viterbi::t1 ()
       // load block with random data and encode
 
       for (i = 0; i < (blocklen-delay); i++)
-	in[i] = random () & MAXDIBIT;
+	in[i] = rnd_dibit.ran_int();
       for (     ; i < blocklen; i++)
 	in[i] = 0;		/* To empty the delay buffers */
 
@@ -192,10 +191,13 @@ qa_atsci_single_viterbi::t1 ()
 
       for (int j = 0; j < errors; j++){
 
+	/*
 	do {
 	  // errval = random () & 3;  // FIXME:  1;   // FIXME: MAXSYM;
 	  errval = random () & 1;  // FIXME:  1;   // FIXME: MAXSYM;
 	} while (errval == 0);	// error value must be non-zero
+	*/
+	errval = 1;
 
 	// Don't insert errors in the first delay slot, since we
 	// don't have valid history to correct them.  Also, don't
@@ -204,7 +206,7 @@ qa_atsci_single_viterbi::t1 ()
 	// the same location twice when inserting an error.
 
 	do {
-	  errloc = random () % NN;
+	  errloc = rnd_err_loc.ran_int();
 	} while (errloc < delay || errlocs[errloc] != 0
 		 || (errloc > 0 && errlocs[errloc-1] != 0)
 		 || (errloc > 1 && errlocs[errloc-2] != 0)

--- a/gr-atsc/lib/qa_atsci_single_viterbi.cc
+++ b/gr-atsc/lib/qa_atsci_single_viterbi.cc
@@ -156,7 +156,7 @@ qa_atsci_single_viterbi::t1 ()
   // printf ("  Delay is %d.\n", delay);
 
   gr::random rnd_dibit(3153023792, 0, 4);
-  gr::random rnd_err_loc(1136465838, 0, NN + 1);
+  gr::random rnd_err_loc(1136465838, 0, NN);
 
   for (int nt = 0; nt < NTRIALS; nt++){
 

--- a/gr-filter/lib/qa_fir_filter_with_buffer.cc
+++ b/gr-filter/lib/qa_fir_filter_with_buffer.cc
@@ -122,7 +122,6 @@ namespace gr {
 	o_type   *actual_output = (float*)volk_malloc(OUTPUT_LEN*sizeof(float), align);
 	tap_type *taps = (float*)volk_malloc(MAX_TAPS*sizeof(float), align);
 
-	srandom(0);	// we want reproducibility
 	memset(dline, 0, INPUT_LEN*sizeof(i_type));
 
 	for(int n = 0; n <= MAX_TAPS; n++) {
@@ -238,7 +237,6 @@ namespace gr {
 	o_type   *actual_output = (gr_complex*)volk_malloc(OUTPUT_LEN*sizeof(gr_complex), align);
 	tap_type *taps = (gr_complex*)volk_malloc(MAX_TAPS*sizeof(gr_complex), align);
 
-	srandom(0);	// we want reproducibility
 	memset(dline, 0, INPUT_LEN*sizeof(i_type));
 
 	for(int n = 0; n <= MAX_TAPS; n++) {
@@ -354,7 +352,6 @@ namespace gr {
 	o_type   *actual_output = (gr_complex*)volk_malloc(OUTPUT_LEN*sizeof(gr_complex), align);
 	tap_type *taps = (float*)volk_malloc(MAX_TAPS*sizeof(float), align);
 
-	srandom(0);	// we want reproducibility
 	memset(dline, 0, INPUT_LEN*sizeof(i_type));
 
 	for(int n = 0; n <= MAX_TAPS; n++) {


### PR DESCRIPTION
This partly resolves [1]. For maint-3.7 branch.

Note: `git grep -n -E "\<s?random\>[ \t]*\(" -- "*.cc" "*.c" "*.h"` still finds usages of random() in comments. One exception is `gr-fec/lib/reed-solomon/exercise.c`. This file is used to generate a QA test (gr_fec_rstest) which is a standalone executable. The test does not contain any multithreaded code, i.e. usage of random() should by OK.

[1] https://github.com/gnuradio/gnuradio/issues/1841