### PR TITLE
wavfile.cc bugfix

### DIFF
--- a/gr-blocks/lib/wavfile.cc
+++ b/gr-blocks/lib/wavfile.cc
@@ -180,7 +180,7 @@ namespace gr {
     short int
     wav_read_sample(FILE *fp, int bytes_per_sample)
     {
-      int16_t buf_16bit;
+      int16_t buf_16bit = 0;
 
       if(fread(&buf_16bit, bytes_per_sample, 1, fp) != 1) {
 	return 0;


### PR DESCRIPTION

![123](https://user-images.githubusercontent.com/51999383/59768520-2dfc0780-92ad-11e9-969b-1b8380fd5865.png)
'Wav File Source' block in gnuradio reads PCM 8bit wav files incorrectly. It adds random huge DC component. Caused by garbage in high byte of buf_16bit (gnuradio 3.7.13.4)