### PR TITLE
Fix system port for python blocks

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -310,7 +310,11 @@ protected:
 
     bool has_msg_handler(pmt::pmt_t which_port)
     {
-        return (d_msg_handlers_feval.find(which_port) != d_msg_handlers_feval.end());
+        if (d_msg_handlers_feval.find(which_port) != d_msg_handlers_feval.end()) {
+            return true;
+        } else {
+            return gr::basic_block::has_msg_handler(which_port);
+        }
     }
 
     void dispatch_msg(pmt::pmt_t which_port, pmt::pmt_t msg)

--- a/gr-blocks/python/blocks/qa_python_message_passing.py
+++ b/gr-blocks/python/blocks/qa_python_message_passing.py
@@ -103,13 +103,7 @@ class test_python_message_passing(gr_unittest.TestCase):
         self.assertEqual('in_port' in pmt.to_python(msg_cons.message_ports_in()), True)
 
         # Run to verify message passing
-        self.tb.start()
-
-        # Wait for all messages to be sent
-        while msg_gen.msg_ctr < num_msgs:
-            time.sleep(0.5)
-        self.tb.stop()
-        self.tb.wait()
+        self.tb.run()
 
         # Verify that the message consumer got all the messages
         self.assertEqual(num_msgs, len(msg_cons.msg_list))


### PR DESCRIPTION
I looked into #2207. I'm not 100% sure what's going on under the hood, but it looks wrong to access member variables of a block in a different thread and wait for some random time in the hope that the block finishes.
I think with the 3.8 scheduler it should be possible to shutdown the flowgraph cleanly, i.e., the producer sends a `done` message to the system port of the consumer once it finishes.
With the current implementation that didn't work, since the consumer is Python block and the block gateway shadowed the system port. (It only checked the Python message handlers.)
I was not able to trigger the bug locally, but I think if the QA is still flaky, we might have an actual problem.