### PR TITLE
ControlPort QA

### DIFF
--- a/gnuradio-runtime/include/gnuradio/pycallback_object.h
+++ b/gnuradio-runtime/include/gnuradio/pycallback_object.h
@@ -161,7 +161,11 @@ private:
 template <>
 std::string pycallback_object<std::string>::pyCast(PyObject* obj)
 {
+#if PY_MAJOR_VERSION >= 3
+    return std::string(PyUnicode_AsUTF8(obj));
+#else
     return std::string(PyString_AsString(obj));
+#endif
 }
 
 template <>

--- a/gr-blocks/python/blocks/qa_cpp_py_binding.py
+++ b/gr-blocks/python/blocks/qa_cpp_py_binding.py
@@ -155,11 +155,10 @@ class test_cpp_py_binding(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         # Get all exported knobs

--- a/gr-blocks/python/blocks/qa_cpp_py_binding_set.py
+++ b/gr-blocks/python/blocks/qa_cpp_py_binding_set.py
@@ -122,11 +122,10 @@ class test_cpp_py_binding_set(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         self.tb.start()

--- a/gr-blocks/python/blocks/qa_ctrlport_probes.py
+++ b/gr-blocks/python/blocks/qa_ctrlport_probes.py
@@ -60,11 +60,10 @@ class test_ctrlport_probes(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         # Get all exported knobs
@@ -101,11 +100,10 @@ class test_ctrlport_probes(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         # Get all exported knobs
@@ -141,11 +139,10 @@ class test_ctrlport_probes(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         # Get all exported knobs
@@ -182,11 +179,10 @@ class test_ctrlport_probes(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         # Get all exported knobs
@@ -222,11 +218,10 @@ class test_ctrlport_probes(gr_unittest.TestCase):
         ep = gr.rpcmanager_get().endpoints()[0]
         hostname = re.search(r"-h (\S+|\d+\.\d+\.\d+\.\d+)", ep).group(1)
         portnum = re.search(r"-p (\d+)", ep).group(1)
-        argv = [None, hostname, portnum]
 
         # Initialize a simple ControlPort client from endpoint
         from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
-        radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+        radiosys = GNURadioControlPortClient(hostname, portnum, rpcmethod='thrift')
         radio = radiosys.client
 
         # Get all exported knobs


### PR DESCRIPTION
I forgot to port the ControlPort QA test to the new API.
I also noticed that the tests throw an exception with Python3 as RPC calls for strings use Python2 string conversion. This patch would switch to Python3 conversion but breaks Python2 compatibility. Not sure if there is a better solution... On the other hand `RPC_get_string` is only used in unit tests, so maybe it's *good enough*? 