### PR TITLE
grc: introduce flag 'show_id' to show block id

### DIFF
--- a/gr-blocks/grc/blocks_tag_object.block.yml
+++ b/gr-blocks/grc/blocks_tag_object.block.yml
@@ -1,6 +1,6 @@
 id: variable_tag_object
 label: Tag Object
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: offset

--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -1,7 +1,7 @@
 id: variable_constellation
 label: Constellation Object
 category: Modulators
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: type

--- a/gr-digital/grc/digital_constellation_rect.block.yml
+++ b/gr-digital/grc/digital_constellation_rect.block.yml
@@ -1,7 +1,7 @@
 id: variable_constellation_rect
 label: Constellation Rect. Object
 category: Modulators
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: sym_map

--- a/gr-digital/grc/digital_modulate_vector.block.yml
+++ b/gr-digital/grc/digital_modulate_vector.block.yml
@@ -1,7 +1,7 @@
 id: variable_modulate_vector
 label: Modulate Vector
 category: Modulators
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: mod

--- a/gr-digital/grc/variable_header_format_default.block.yml
+++ b/gr-digital/grc/variable_header_format_default.block.yml
@@ -1,6 +1,6 @@
 id: variable_header_format_default
 label: Default Header Format Obj.
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: access_code

--- a/gr-fec/grc/ldpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/ldpc_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_decoder_def
 label: LDPC Decoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/ldpc_encoder_def_list.block.yml
+++ b/gr-fec/grc/ldpc_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_encoder_def
 label: LDPC Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/tpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_tpc_decoder_def
 label: TPC Decoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/tpc_encoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_tpc_encoder_def
 label: TPC Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_cc_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_cc_decoder_def
 label: CC Decoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_cc_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_cc_encoder_def
 label: CC Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_ccsds_encoder_def
 label: CCSDS Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_dummy_decoder_def
 label: Dummy Decoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_dummy_encoder_def
 label: Dummy Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_ldpc_G_matrix_object.block.yml
+++ b/gr-fec/grc/variable_ldpc_G_matrix_object.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_G_matrix_def
 label: LDPC Generator Matrix
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_H_matrix_object.block.yml
+++ b/gr-fec/grc/variable_ldpc_H_matrix_object.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_H_matrix_def
 label: LDPC Parity Check Matrix
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_bit_flip_decoder.block.yml
+++ b/gr-fec/grc/variable_ldpc_bit_flip_decoder.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_bit_flip_decoder_def
 label: LDPC Bit Flip Decoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_encoder_G.block.yml
+++ b/gr-fec/grc/variable_ldpc_encoder_G.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_encoder_G_def
 label: LDPC Encoder Definition (via Generator)
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_ldpc_encoder_H.block.yml
+++ b/gr-fec/grc/variable_ldpc_encoder_H.block.yml
@@ -1,5 +1,6 @@
 id: variable_ldpc_encoder_H_def
 label: LDPC Encoder Definition (via Parity Check)
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_polar_code_configurator.block.yml
+++ b/gr-fec/grc/variable_polar_code_configurator.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_code_configurator
 label: POLAR code Configurator
+flags: [ show_id ]
 
 parameters:
 -   id: channel

--- a/gr-fec/grc/variable_polar_decoder_sc.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_decoder_sc_def
 label: POLAR Decoder SC Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_polar_decoder_sc_list.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_decoder_sc_list_def
 label: POLAR Decoder SC List Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_polar_decoder_sc_systematic.block.yml
+++ b/gr-fec/grc/variable_polar_decoder_sc_systematic.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_decoder_sc_systematic_def
 label: systematic POLAR Decoder SC Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_polar_encoder.block.yml
+++ b/gr-fec/grc/variable_polar_encoder.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_encoder_def
 label: POLAR Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: is_packed

--- a/gr-fec/grc/variable_polar_encoder_systematic.block.yml
+++ b/gr-fec/grc/variable_polar_encoder_systematic.block.yml
@@ -1,5 +1,6 @@
 id: variable_polar_encoder_systematic_def
 label: systematic POLAR Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_decoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_repetition_decoder_def
 label: Repetition Decoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: value

--- a/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_repetition_encoder_def_list.block.yml
@@ -1,5 +1,6 @@
 id: variable_repetition_encoder_def
 label: Repetition Encoder Definition
+flags: [ show_id ]
 
 parameters:
 -   id: ndim

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_band_pass_filter_taps
 label: Band-pass Filter Taps
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: type

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_band_reject_filter_taps
 label: Band-reject Filter Taps
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: gain

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_high_pass_filter_taps
 label: High-pass Filter Taps
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: gain

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_low_pass_filter_taps
 label: Low-pass Filter Taps
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: gain

--- a/gr-filter/grc/variable_rrc_filter_taps.block.yml
+++ b/gr-filter/grc/variable_rrc_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_rrc_filter_taps
 label: RRC Filter Taps
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: gain

--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_check_box
 label: QT GUI Check Box
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_chooser
 label: QT GUI Chooser
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_entry
 label: QT GUI Entry
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_label.block.yml
+++ b/gr-qtgui/grc/qtgui_label.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_label
 label: QT GUI Label
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_push_button.block.yml
+++ b/gr-qtgui/grc/qtgui_push_button.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_push_button
 label: QT GUI Push Button
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: label

--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_range
 label: QT GUI Range
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: label

--- a/grc/blocks/parameter.block.yml
+++ b/grc/blocks/parameter.block.yml
@@ -1,6 +1,6 @@
 id: parameter
 label: Parameter
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: label

--- a/grc/blocks/variable.block.yml
+++ b/grc/blocks/variable.block.yml
@@ -1,6 +1,6 @@
 id: variable
 label: Variable
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: value

--- a/grc/blocks/variable_config.block.yml
+++ b/grc/blocks/variable_config.block.yml
@@ -1,6 +1,6 @@
 id: variable_config
 label: Variable Config
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: value

--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -1,6 +1,6 @@
 id: variable_function_probe
 label: Function Probe
-flags: [ python ]
+flags: [ show_id, python ]
 
 parameters:
 -   id: block_id

--- a/grc/blocks/variable_struct.block.yml.py
+++ b/grc/blocks/variable_struct.block.yml.py
@@ -5,6 +5,7 @@ MAX_NUM_FIELDS = 20
 HEADER = """\
 id: variable_struct
 label: Struct Variable
+flags: [ show_id ]
 
 parameters:
 """

--- a/grc/converter/block.py
+++ b/grc/converter/block.py
@@ -84,7 +84,10 @@ def convert_block_xml(node):
     data['id'] = block_id
     data['label'] = node.findtext('name') or no_value
     data['category'] = node.findtext('category') or no_value
-    data['flags'] = node.findtext('flags') or no_value
+    data['flags'] = [n.text for n in node.findall('flags')]
+    data['flags'] += ['show_id'] if block_id.startswith('variable') else []
+    if not data['flags']:
+        data['flags'] = no_value
 
     data['parameters'] = [convert_param_xml(param_node, converter.to_python_dec)
                           for param_node in node.iterfind('param')] or no_value

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -325,7 +325,7 @@ class FlowGraph(Element):
             a nested data odict
         """
         def block_order(b):
-            return not b.key.startswith('variable'), b.name  # todo: vars still first ?!?
+            return not b.is_variable, b.name  # todo: vars still first ?!?
 
         data = collections.OrderedDict()
         data['options'] = self._options_block.export_data()

--- a/grc/core/blocks/_build.py
+++ b/grc/core/blocks/_build.py
@@ -103,7 +103,10 @@ def build_params(params_raw, have_inputs, have_outputs, flags, block_id):
     def add_param(**data):
         params.append(data)
 
-    add_param(id='id', name='ID', dtype='id', hide='part')
+    if flags.SHOW_ID in flags:
+        add_param(id='id', name='ID', dtype='id', hide='none')
+    else:
+        add_param(id='id', name='ID', dtype='id', hide='all')
 
     if not flags.not_dsp:
         add_param(id='alias', name='Block Alias', dtype='string',

--- a/grc/core/blocks/_flags.py
+++ b/grc/core/blocks/_flags.py
@@ -27,6 +27,7 @@ class Flags(object):
     NEED_QT_GUI = 'need_qt_gui'
     DEPRECATED = 'deprecated'
     NOT_DSP = 'not_dsp'
+    SHOW_ID = 'show_id'
     HAS_PYTHON = 'python'
     HAS_CPP = 'cpp'
 

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -77,7 +77,7 @@ class Block(Element):
             (data['id'], param_factory(parent=self, **data))
             for data in self.parameters_data
         )
-        if self.key == 'options' or self.is_variable:
+        if self.key == 'options':
             self.params['id'].hide = 'part'
 
         self.sinks = [port_factory(parent=self, **params) for params in self.inputs_data]

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -191,7 +191,7 @@ class VariableEditor(Gtk.VBox):
                 self.set_tooltip_text(error_message[-1])
             else:
                 # Evaluate and show the value (if it is a variable)
-                if block.key == "variable":
+                if block.is_variable:
                     evaluated = str(block.params['value'].evaluate())
                     self.set_tooltip_text(evaluated)
         # Always set the text value.


### PR DESCRIPTION
This is supposed to address #2235 by introducing a flag `show_id` to show the block ID in GRC. This is useful for variables and parameters, but maybe other blocks too.