### PR TITLE
Fix CMake Error "VOLK required but not found."

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Abbreviated instructions are duplicated below.
 
 2. Checkout the latest code:
     ```
-    $ git clone https://github.com/gnuradio/gnuradio.git
+    $ git clone --recursive https://github.com/gnuradio/gnuradio.git
     ```
 
 3. Build with CMake:


### PR DESCRIPTION
When manually building from source:
CMake Error at CMakeLists.txt:420 (message):
  VOLK required but not found.