### PR TITLE
Fixing Name error in Dialog.py

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -273,7 +273,7 @@ def show_about(parent, config):
     try:
         ad.set_logo(Gtk.IconTheme().load_icon('gnuradio-grc', 64, 0))
     except GLib.Error:
-        log.debug("Failed to set window logo")
+        Messages.send("Failed to set window logo\n")
 
     #ad.set_comments("")
     ad.set_copyright(config.license.splitlines()[0])


### PR DESCRIPTION
log is undefined in Dialog.py. Use Messages.send instead.
This fixes the Name error described in @ #2536 and now a Message window will be displayed.