### PR TITLE
Execute generated freedesktop install script

### DIFF
--- a/grc/scripts/freedesktop/CMakeLists.txt
+++ b/grc/scripts/freedesktop/CMakeLists.txt
@@ -66,5 +66,9 @@ if(UNIX AND HAVE_XDG_UTILS)
     install(
         PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/grc_setup_freedesktop
         DESTINATION ${GR_PKG_LIBEXEC_DIR}
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    )
+    install (
+        CODE "execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/${GR_PKG_LIBEXEC_DIR}/grc_setup_freedesktop install)" 
     )
 endif(UNIX AND HAVE_XDG_UTILS)


### PR DESCRIPTION
At the moment an install script for the freedesktop icons is generated but not executed, so the icons are missing. This sometimes leads to missing icons or even errors . ( See #2536 )

Executing the generated freedesktop installaition script will fix this problem.