### PR TITLE
Use gnuradio icon if available

### DIFF
--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -72,10 +72,13 @@ class MainWindow(Gtk.ApplicationWindow):
         self.add(vbox)
 
         icon_theme = Gtk.IconTheme.get_default()
-        icon = icon_theme.lookup_icon("gnuradio-grc", 48, 0)
+        icon = icon_theme.load_icon("gnuradio-grc", 48, 0)
         if not icon:
-            # Set window icon
+            # Set default window icon
             self.set_icon_from_file(os.path.dirname(os.path.abspath(__file__)) + "/icon.png")
+        else :
+            # Use gnuradio icon
+            self.set_icon(icon)
 
         # Create the menu bar and toolbar
         generate_modes = platform.get_generate_options()


### PR DESCRIPTION
The existence of a gnuradio ( theme ) icon is checked, but if found not set.
So try to load the icon and if found set it.