### PR TITLE
uhd: docs: Removed spurious reference to io_type_t

### DIFF
--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -142,10 +142,9 @@ A typical option parser setup for a UHD device looks like
 To use these options to create a UHD source object:
 
 \code
+    stream_args = uhd.stream_args()
     self.u = uhd.usrp_source(device_addr=options.args,
-                             io_type=uhd.io_type.COMPLEX_FLOAT32,
-                             num_channels=1)
-
+                             stream_args)
     self.u.set_samp_rate(options.samp_rate)
 
     # if no gain was specified, use the mid-point in dB


### PR DESCRIPTION
io_type_t was removed a while ago, but there was a reference to it in
the documentation which is now removed.