### PR TITLE
uhd: Remove references to clock_config_t

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2015 Free Software Foundation, Inc.
+ * Copyright 2015,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -484,16 +484,6 @@ namespace gr {
       virtual void set_user_register(const uint8_t addr,
                                      const uint32_t data,
                                      size_t mboard = 0) = 0;
-
-      /*!
-       * Set the clock configuration.
-       *
-       * DEPRECATED for set_time/clock_source.
-       * \param clock_config the new configuration
-       * \param mboard the motherboard index 0 to M-1
-       */
-      virtual void set_clock_config(const ::uhd::clock_config_t &clock_config,
-                                    size_t mboard = 0) = 0;
 
       /*!
        * Set the time source for the USRP device.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2015-2016 Free Software Foundation, Inc.
+ * Copyright 2015-2016,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -295,13 +295,6 @@ std::vector<std::string>
 usrp_block_impl::get_mboard_sensor_names(size_t mboard)
 {
   return _dev->get_mboard_sensor_names(mboard);
-}
-
-void
-usrp_block_impl::set_clock_config(const ::uhd::clock_config_t &clock_config,
-                                 size_t mboard)
-{
-  return _dev->set_clock_config(clock_config, mboard);
 }
 
 void

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2015-2016 Free Software Foundation, Inc.
+ * Copyright 2015-2016,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -71,7 +71,6 @@ namespace gr {
       size_t get_num_mboards();
 
       // Setters
-      void set_clock_config(const ::uhd::clock_config_t &clock_config, size_t mboard);
       void set_time_source(const std::string &source, const size_t mboard);
       void set_clock_source(const std::string &source, const size_t mboard);
       void set_clock_rate(double rate, size_t mboard);

--- a/gr-uhd/swig/uhd_swig.i
+++ b/gr-uhd/swig/uhd_swig.i
@@ -109,8 +109,6 @@
 
 %include <uhd/types/stream_cmd.hpp>
 
-%include <uhd/types/clock_config.hpp>
-
 %include <uhd/types/metadata.hpp>
 
 %template(device_addr_vector_t) std::vector<uhd::device_addr_t>;


### PR DESCRIPTION
This extends 87af011b, where we removed other deprecated types.
clock_config_t should have been removed then (same reason: It's
deprecated forever in UHD, and no longer available in the upcoming UHD 4.0).