### PR TITLE
modtool: c++ qa tests cmake error

### DIFF
--- a/gr-utils/python/modtool/core/add.py
+++ b/gr-utils/python/modtool/core/add.py
@@ -161,8 +161,8 @@ class ModToolAdd(ModTool):
             return
         try:
             append_re_line_sequence(self._file['cmlib'],
-                                    '\$\{CMAKE_CURRENT_SOURCE_DIR\}/qa_%s.cc.*\n' % self.info['modname'],
-                                    '    ${CMAKE_CURRENT_SOURCE_DIR}/qa_%s.cc' % self.info['blockname'])
+                                    'list\(APPEND test_{}_sources.*\n'.format(self.info['modname']),
+                                    'qa_{}.cc'.format(self.info['blockname']))
             append_re_line_sequence(self._file['qalib'],
                                     '#include.*\n',
                                     '#include "{}"'.format(fname_qa_h))


### PR DESCRIPTION
C++ QA tests were not being added to the correct spot in lib/CMakeLists

The default c++ test case does not compile, but that appears to be a different issue:

```
/usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status
lib/CMakeFiles/asdf_qa_foo.cc.dir/build.make:111: recipe for target 'lib/asdf_qa_foo.cc' failed
make[2]: *** [lib/asdf_qa_foo.cc] Error 1
CMakeFiles/Makefile2:174: recipe for target 'lib/CMakeFiles/asdf_qa_foo.cc.dir/all' failed
```

Fixes #2559