### PR TITLE
Replace rand() by gr::random() (maint-3.7 branch)

### DIFF
--- a/gr-digital/lib/ofdm_mapper_bcv_impl.cc
+++ b/gr-digital/lib/ofdm_mapper_bcv_impl.cc
@@ -59,7 +59,8 @@ namespace gr {
 	d_bit_offset(0),
 	d_pending_flag(0),
 	d_resid(0),
-	d_nresid(0)
+	d_nresid(0),
+	d_rnd_sym(gr::random(1765399812, 0, constellation.size()))
     {
       GR_LOG_WARN(d_logger, "The gr::digital::ofdm_mapper_bcv block has been deprecated.");
 
@@ -134,7 +135,7 @@ namespace gr {
 
     int ofdm_mapper_bcv_impl::randsym()
     {
-      return (rand() % d_constellation.size());
+      return (d_rnd_sym.ran_int());
     }
 
     int

--- a/gr-digital/lib/ofdm_mapper_bcv_impl.h
+++ b/gr-digital/lib/ofdm_mapper_bcv_impl.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/digital/ofdm_mapper_bcv.h>
 #include <gnuradio/message.h>
+#include <gnuradio/random.h>
 #include <vector>
 
 namespace gr {
@@ -33,6 +34,8 @@ namespace gr {
     class ofdm_mapper_bcv_impl : public ofdm_mapper_bcv
     {
     private:
+      /* NOTE: d_rand_sym.set_integer_limits(0, new_const.size()) must be called
+       * if set_constellation() is ever added */
       std::vector<gr_complex> d_constellation;
       msg_queue::sptr d_msgq;
       message::sptr   d_msg;
@@ -52,6 +55,7 @@ namespace gr {
 
       std::vector<int> d_subcarrier_map;
 
+      gr::random d_rnd_sym;
       int randsym();
 
     public:

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -21,12 +21,14 @@
  */
 
 #include <cstdlib>
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <string>
 #include <fstream>
 #include <stdexcept>
 #include <cmath>
+#include <gnuradio/random.h>
 #include <gnuradio/trellis/quicksort_index.h>
 #include <gnuradio/trellis/interleaver.h>
 
@@ -107,12 +109,11 @@ namespace gr {
       d_INTER.resize(d_K);
       d_DEINTER.resize(d_K);
 
-      if(seed>=0)
-	srand((unsigned int)seed);
+      gr::random rnd_int(seed, 0, INT_MAX);
       std::vector<int> tmp(d_K);
       for(int i=0;i<d_K;i++) {
 	d_INTER[i]=i;
-	tmp[i] = rand();
+	tmp[i] = rnd_int.ran_int();
       }
       quicksort_index <int> (tmp,d_INTER,0,d_K-1);
 


### PR DESCRIPTION
This is the last pull request to fix issue #1841. Changes in gr-digital and gr-trellis can be considered as API changes: User-visible behavior is modified. However, no code modifications in GNU Radio or OOT modules are required (as far as I can tell).