### PR TITLE
Fix for misc. typos (user and non user-facing)

### DIFF
--- a/cmake/Modules/GrBuildTypes.cmake
+++ b/cmake/Modules/GrBuildTypes.cmake
@@ -50,7 +50,7 @@ list(APPEND AVAIL_BUILDTYPES
 # known build types in AVAIL_BUILDTYPES. If the build type is found,
 # the function exits immediately. If nothing is found by the end of
 # checking all available build types, we exit with an error and list
-# the avialable build types.
+# the available build types.
 ########################################################################
 function(GR_CHECK_BUILD_TYPE settype)
   STRING(TOUPPER ${settype} _settype)

--- a/docs/RELEASE-NOTES-3.7.10.1.md
+++ b/docs/RELEASE-NOTES-3.7.10.1.md
@@ -48,7 +48,7 @@ Fix VL-SNR framing.
 
 ### Digital
 
-Enable update rate in block_recovery_mm blocks to keep tags close to the the proper clock-recovered sample time. Tag offsets will still be off between calls to work, but each work call updates the tag rate.
+Enable update rate in block_recovery_mm blocks to keep tags close to the proper clock-recovered sample time. Tag offsets will still be off between calls to work, but each work call updates the tag rate.
 
 ### Analog
 

--- a/docs/doxygen/other/build_guide.dox.in
+++ b/docs/doxygen/other/build_guide.dox.in
@@ -153,7 +153,7 @@ built or installed.
 
 The -DENABLE_DEFAULT=False can be used to disable all
 components. Individual components can then be selectively turned back
-on. For example, just buidling the VOLK library can be
+on. For example, just building the VOLK library can be
 done with this:
 
 \code

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -177,7 +177,7 @@ namespace gr {
      *
      * WORK_CALLED_PRODUCE is used where not all outputs produce the
      * same number of items. general_work must call produce() for each
-     * output to indicate the numer of items actually produced.
+     * output to indicate the number of items actually produced.
      *
      * WORK_DONE indicates that no more data will be produced by this block.
      *

--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -301,7 +301,7 @@ namespace gr {
       printf("Set string was:%s\n", set.c_str());
     }
 
-    /*! \brief destrcutor stops watch thread before exits */
+    /*! \brief destructor stops watch thread before exits */
     ~logger_config() {
       stop_watch();
     }

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -1452,7 +1452,7 @@ public:
    * \brief Adds the ability to pass a message over ControlPort.
    *
    * \details
-   * This makes any message handler function avialable over
+   * This makes any message handler function available over
    * ControlPort. Since message handlers always take in a single PMT
    * message input, this interface provides a very generic way of
    * setting values in a block in a flowgraph.

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -92,7 +92,7 @@ namespace gr {
     }
   }
 
-  // Method to load the confifuration.  It only loads if the filename
+  // Method to load the configuration.  It only loads if the filename
   // or watch has changed
   void
   logger_config::load_config(std::string filename,unsigned int watch_period)

--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -95,7 +95,7 @@ class py_io_signature(object):
         """
         Args:
 
-        min_ports (int): mininum number of connected ports.
+        min_ports (int): minimum number of connected ports.
 
         max_ports (int): maximum number of connected ports. -1 indicates
         no limit.

--- a/gnuradio-runtime/python/gnuradio/gr/top_block.py
+++ b/gnuradio-runtime/python/gnuradio/gr/top_block.py
@@ -44,7 +44,7 @@ class _top_block_waiter(threading.Thread):
     thread), we create a separate thread that does the blocking wait,
     and then use the thread that called wait to do a slow poll of an
     event queue.  That thread, which is executing "wait" below is
-    interruptable, and if it sees a KeyboardInterrupt, executes a stop
+    interruptible, and if it sees a KeyboardInterrupt, executes a stop
     on the top_block, then goes back to waiting for it to complete.
     This ensures that the unlocked wait that was in progress (in the
     _top_block_waiter thread) can complete, release its mutex and back
@@ -52,7 +52,7 @@ class _top_block_waiter(threading.Thread):
     things occur like leaving the USRP transmitter sending a carrier.
 
     See also top_block.wait (below), which uses this class to implement
-    the interruptable wait.
+    the interruptible wait.
     """
     def __init__(self, tb):
         threading.Thread.__init__(self)

--- a/gnuradio-runtime/python/gnuradio/gru/freqz.py
+++ b/gnuradio-runtime/python/gnuradio/gru/freqz.py
@@ -120,7 +120,7 @@ class poly1d(object):
     p[k] is the coefficient on the kth power of x (backwards from
          sequencing the coefficient array.
 
-    polynomials can be added, substracted, multiplied and divided (returns
+    polynomials can be added, subtracted, multiplied and divided (returns
          quotient and remainder).
     asarray(p) will also give the coefficient array, so polynomials can
          be used in all functions that accept arrays.

--- a/gnuradio-runtime/swig/gnuradio.i
+++ b/gnuradio-runtime/swig/gnuradio.i
@@ -75,7 +75,7 @@
 %include <gnuradio/high_res_timer.h>
 
 ////////////////////////////////////////////////////////////////////////
-// Python 2/3 compatibilty
+// Python 2/3 compatibility
 
 %begin %{
 #define SWIG_PYTHON_2_UNICODE

--- a/gr-blocks/grc/blocks_message_strobe_random.block.yml
+++ b/gr-blocks/grc/blocks_message_strobe_random.block.yml
@@ -46,6 +46,6 @@ documentation: |-
     Please note some peculiarities below:
                 - poisson does not care about your std
                 - gaussian operates as expected
-                - uniform is actually of the range (mean-std, mean+std) - thus we are lieing and it is not actually an std here
+                - uniform is actually of the range (mean-std, mean+std) - thus we are lying and it is not actually an std here
 
 file_format: 1

--- a/gr-blocks/grc/blocks_vector_insert_x.block.yml
+++ b/gr-blocks/grc/blocks_vector_insert_x.block.yml
@@ -45,6 +45,6 @@ documentation: |-
     Periodicity, the length of the periodicity at which the vector should be inserted at the output.
             (i.e. one vector for every N output items)
 
-            Offset sepcifies where in the cycle period we should begin at.
+            Offset specifies where in the cycle period we should begin at.
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/control_loop.h
+++ b/gr-blocks/include/gnuradio/blocks/control_loop.h
@@ -33,7 +33,7 @@ namespace gr {
      *
      * \details
      * This class implements a second order control loop and is
-     * inteded to act as a parent class to blocks which need a control
+     * intended to act as a parent class to blocks which need a control
      * loop (e.g., gr::digital::costas_loop_cc,
      * gr::analog::pll_refout_cc, etc.). It takes in a loop bandwidth
      * as well as a max and min frequency and provides the functions
@@ -326,7 +326,7 @@ namespace gr {
     /*!
      * A look-up table (LUT) tanh calcuation. This function returns an
      * estimate to tanh(x) based on a 256-point LUT between -2 and
-     * 2. If x < -2, it returns -1; if > 2, it retursn 1.
+     * 2. If x < -2, it returns -1; if > 2, it returns 1.
      *
      * This LUT form of the tanh is "hidden" in this code because it
      * is likely too coarse an estimate for any real uses of a

--- a/gr-blocks/include/gnuradio/blocks/tcp_server_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/tcp_server_sink.h
@@ -30,7 +30,7 @@ namespace gr {
   namespace blocks {
 
     /*!
-     * \brief Send stream trought an TCP socket.
+     * \brief Send stream through a TCP socket.
      * \ingroup networking_tools_blk
      *
      * \details

--- a/gr-blocks/lib/udp_source_impl.cc
+++ b/gr-blocks/lib/udp_source_impl.cc
@@ -186,7 +186,7 @@ namespace gr {
 
       // Use async receive_from to get data from UDP buffer and wait
       // on a conditional signal before proceeding. We use this
-      // because the conditional wait is interruptable while a
+      // because the conditional wait is interruptible while a
       // synchronous receive_from is not.
       boost::unique_lock<boost::mutex> lock(d_udp_mutex);
 

--- a/gr-channels/grc/channels_iqbal_gen.block.yml
+++ b/gr-channels/grc/channels_iqbal_gen.block.yml
@@ -56,7 +56,7 @@ documentation: |-
                                                                  |
                                                                  +--X2
 
-                        X1--|Multply: 10**(mag/20)|--{R}--| Float 2     |--- Output
+                        X1--|Multiply: 10**(mag/20)|--{R}--| Float 2     |--- Output
                         X2--------------------------------------------{I}--| Complex |
 
     (ASCII ART adjusted for GRC viewing)

--- a/gr-channels/grc/channels_selective_fading_model2.block.yml
+++ b/gr-channels/grc/channels_selective_fading_model2.block.yml
@@ -86,7 +86,7 @@ documentation: |-
        Compact Rayleigh and Rician fading simulator based on random walk processes
        A. Alimohammad S.F. Fard B.F. Cockburn C. Schlegel
        26th November 2008
-        (Alogrithm III)
+        (Algorithm III)
         ( with a novel addition of time delay tap random walk )
 
       The frequency selective extension of the block roughly implements

--- a/gr-channels/include/gnuradio/channels/dynamic_channel_model.h
+++ b/gr-channels/include/gnuradio/channels/dynamic_channel_model.h
@@ -39,7 +39,7 @@ namespace gr {
      * be used to help evaluate, design, and test various signals,
      * waveforms, and algorithms.
      *
-     * This model allows the user to set up an AWGN noise cource, a
+     * This model allows the user to set up an AWGN noise source, a
      * random walk process to simulate carrier frequency drift, a random
      * walk process to simulate sample rate offset drive, and a frequency
      * selective fading channel response that is either Rayleigh or Ricean

--- a/gr-channels/python/channels/iqbal_gen.py
+++ b/gr-channels/python/channels/iqbal_gen.py
@@ -42,7 +42,7 @@ class iqbal_gen(gr.hier_block2):
                                        |
                                        +--X2
 
-                        X1--|Multply: 10**(mag/20)|--{R}--| Float 2 |--- Output
+                        X1--|Multiply: 10**(mag/20)|--{R}--| Float 2 |--- Output
                         X2---------------------------{I}--| Complex |
 
         (ASCII ART monospace viewing)

--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -71,7 +71,7 @@ namespace gr {
      * know where the actual sync word symbols are located relative to
      * "corr_start", given that some modulations have pulses with
      * intentional ISI.  The user should manually examine the primary
-     * output and the "corr_start" tag postition to determine the
+     * output and the "corr_start" tag position to determine the
      * required tag delay settings for the particular modulation,
      * sync word, and downstream blocks used.
      *

--- a/gr-digital/include/gnuradio/digital/diff_decoder_bb.h
+++ b/gr-digital/include/gnuradio/digital/diff_decoder_bb.h
@@ -44,7 +44,7 @@ namespace gr {
       typedef boost::shared_ptr<diff_decoder_bb> sptr;
       
       /*!
-       * Make a differntial decoder block.
+       * Make a differential decoder block.
        *
        * \param modulus Modulus of code's alphabet
        */

--- a/gr-digital/include/gnuradio/digital/diff_encoder_bb.h
+++ b/gr-digital/include/gnuradio/digital/diff_encoder_bb.h
@@ -44,7 +44,7 @@ namespace gr {
       typedef boost::shared_ptr<diff_encoder_bb> sptr;
 
       /*!
-       * Make a differntial encoder block.
+       * Make a differential encoder block.
        *
        * \param modulus Modulus of code's alphabet
        */

--- a/gr-digital/include/gnuradio/digital/fll_band_edge_cc.h
+++ b/gr-digital/include/gnuradio/digital/fll_band_edge_cc.h
@@ -65,7 +65,7 @@ namespace gr {
      * derivative of a cosine is a sine).  Extend this sine by another
      * quarter wave to make a half wave around the band-edges is
      * equivalent in time to the sum of two sinc functions. The
-     * baseband filter fot the band edges is therefore derived from
+     * baseband filter for the band edges is therefore derived from
      * this sum of sincs. The band edge filters are then just the
      * baseband signal modulated to the correct place in
      * frequency. All of these calculations are done in the

--- a/gr-digital/lib/clock_tracking_loop.h
+++ b/gr-digital/lib/clock_tracking_loop.h
@@ -31,7 +31,7 @@ namespace gr {
      *
      * \details
      * This class implements most of a second order symbol clock
-     * tracking loop and is inteded to act as a parent class to blocks
+     * tracking loop and is intended to act as a parent class to blocks
      * which need a symbol clock tracking loop to determine the optimal
      * instant to sample a received symbol from an input sample
      * stream (i.e. *_clock_recovery* and *_clock_sync* blocks).

--- a/gr-digital/python/digital/digital_voice.py.real
+++ b/gr-digital/python/digital/digital_voice.py.real
@@ -51,7 +51,7 @@ AIR_FRAME_SIZE = 70
 
 class digital_voice_tx(gr.hier_block):
     """
-    Hierarchical block for digital voice tranmission.
+    Hierarchical block for digital voice transmission.
 
     The input is 8kS/sec floating point audio in the range [-1,+1]
     The output is 256kS/sec GMSK modulated complex baseband signal in the range [-1,+1].

--- a/gr-digital/python/digital/ofdm_receiver.py
+++ b/gr-digital/python/digital/ofdm_receiver.py
@@ -45,7 +45,7 @@ class ofdm_receiver(gr.hier_block2):
 
     The receiver performs channel filtering as well as symbol, frequency, and phase synchronization.
     The synchronization routines are available in three flavors: preamble correlator (Schmidl and Cox),
-    modifid preamble correlator with autocorrelation (not yet working), and cyclic prefix correlator
+    modified preamble correlator with autocorrelation (not yet working), and cyclic prefix correlator
     (Van de Beeks).
     """
 

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -37,7 +37,7 @@ tested_mod_codes = (mod_codes.NO_CODE, mod_codes.GRAY_CODE)
 # Second item is a dictionary of arguments for function with lists of
 # possible values.
 # Third item is whether differential encoding should be tested.
-# Fourth item is the name of the argument to constructor that specifices
+# Fourth item is the name of the argument to constructor that specifies
 # whether differential encoding is used.
 
 def twod_constell():

--- a/gr-digital/python/digital/soft_dec_lut_gen.py
+++ b/gr-digital/python/digital/soft_dec_lut_gen.py
@@ -188,7 +188,7 @@ def calc_soft_dec(sample, constel, symbols, npwr=1):
     If known, the noise power of the received sample may be passed in
     to this function as npwr.
 
-    This is an incredibly costly algorthm because it must calculate
+    This is an incredibly costly algorithm because it must calculate
     the Euclidean distance between the sample and all points in the
     constellation to build up its probability
     calculations. Conversely, it should work for any given

--- a/gr-digital/python/digital/utils/gray_code.py
+++ b/gr-digital/python/digital/utils/gray_code.py
@@ -33,7 +33,7 @@ class GrayCodeGenerator(object):
         self.lp2 = 2
         # The next power of two that will be passed through.
         self.np2 = 4
-        # Curent index
+        # Current index
         self.i = 2
 
     def get_gray_code(self, length):

--- a/gr-fec/grc/fec_decoder.block.yml
+++ b/gr-fec/grc/fec_decoder.block.yml
@@ -36,6 +36,6 @@ templates:
     make: fec.decoder(${decoder}, ${itype.size}, ${otype.size})
 
 documentation: |-
-    This is a GNU Radio adaptor for any FEC decoder following the generic_decoder API in the fec module. Input and output are flexible to accomodate decoders that, say, modulate their encoded results into complex or float types.
+    This is a GNU Radio adaptor for any FEC decoder following the generic_decoder API in the fec module. Input and output are flexible to accommodate decoders that, say, modulate their encoded results into complex or float types.
 
 file_format: 1

--- a/gr-fec/grc/fec_encoder.block.yml
+++ b/gr-fec/grc/fec_encoder.block.yml
@@ -36,6 +36,6 @@ templates:
     make: fec.encoder(${encoder}, ${itype.size}, ${otype.size})
 
 documentation: |-
-    This is a GNU Radio adaptor for any FEC encoder following the generic_encoder API in the fec module. Input and output are flexible to accomodate encoders that, say, modulate their encoded results into complex or float types.
+    This is a GNU Radio adaptor for any FEC encoder following the generic_encoder API in the fec module. Input and output are flexible to accommodate encoders that, say, modulate their encoded results into complex or float types.
 
 file_format: 1

--- a/gr-fec/python/fec/polar/polar_channel_construction
+++ b/gr-fec/python/fec/polar/polar_channel_construction
@@ -34,7 +34,7 @@ def setup_parser():
                       default='BEC')
     parser.add_argument("-b", "--blocksize", type=int, dest="block_size",
                       help="specify block size of polar code (default=16)", default=16)
-    parser.add_argument("-s", "--desgin-snr", type=float, dest="design_snr",
+    parser.add_argument("-s", "--design-snr", type=float, dest="design_snr",
                       help="specify design SNR of polar code (default=0.0)", default=0.0)
     parser.add_argument("-k", "--mu", type=int,
                       help="specify block size of polar code (default=2)", default=2)

--- a/gr-filter/apps/gr_filter_design
+++ b/gr-filter/apps/gr_filter_design
@@ -23,5 +23,5 @@
 from gnuradio.filter import filter_design
 import sys
 
-# Call filter desgin main function
+# Call filter design main function
 filter_design.main(sys.argv)

--- a/gr-filter/grc/filter_band_pass_filter.block.yml
+++ b/gr-filter/grc/filter_band_pass_filter.block.yml
@@ -108,6 +108,6 @@ documentation: |-
 
     Sample rate, cutoff frequency, and transition width are in Hertz.
 
-    The beta paramater only applies to the Kaiser window.
+    The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/filter_band_reject_filter.block.yml
+++ b/gr-filter/grc/filter_band_reject_filter.block.yml
@@ -103,6 +103,6 @@ documentation: |-
 
     Sample rate, cutoff frequency, and transition width are in Hertz.
 
-    The beta paramater only applies to the Kaiser window.
+    The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/filter_high_pass_filter.block.yml
+++ b/gr-filter/grc/filter_high_pass_filter.block.yml
@@ -98,6 +98,6 @@ documentation: |-
 
     Sample rate, cutoff frequency, and transition width are in Hertz.
 
-    The beta paramater only applies to the Kaiser window.
+    The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/filter_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_filter.block.yml
@@ -98,6 +98,6 @@ documentation: |-
 
     Sample rate, cutoff frequency, and transition width are in Hertz.
 
-    The beta paramater only applies to the Kaiser window.
+    The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
@@ -84,6 +84,6 @@ documentation: |-
 
     Sample rate, cutoff frequency, and transition width are in Hertz.
 
-    The beta paramater only applies to the Kaiser window.
+    The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -51,6 +51,6 @@ cpp_templates:
 documentation: |-
     This is a convenience wrapper for calling firdes.band_reject().
 
-        The beta paramater only applies to the Kaiser window.
+        The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -47,6 +47,6 @@ cpp_templates:
 documentation: |-
     This variable is a convenience wrapper around a call to firdes.high_pass(...).
 
-        The beta paramater only applies to the Kaiser window.
+        The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -47,6 +47,6 @@ cpp_templates:
 documentation: |-
     This variable is a convenience wrapper around a call to firdes.low_pass(...).
 
-        The beta paramater only applies to the Kaiser window.
+        The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -103,7 +103,7 @@ namespace gr {
     void
     pfb_synthesizer_ccf_impl::set_taps1(const std::vector<float> &taps)
     {
-      // In this partitioning, we do a normal polyphase paritioning by
+      // In this partitioning, we do a normal polyphase partitioning by
       // deinterleaving the taps into each filter:
       //
       // Prototype filter: [t0, t1, t2, t3, t4, t5, t6]

--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -150,7 +150,7 @@ SpectrumGUIClass::reset()
     qApp->postEvent(_spectrumDisplayForm, new SpectrumWindowResetEvent());
   }
   _droppedEntriesCount = 0;
-  // Call the following function the the Spectrum Window Reset Event window
+  // Call the following function from the Spectrum Window Reset Event window
   // ResetPendingGUIUpdateEvents();
 }
 

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -146,7 +146,7 @@ namespace gr {
       // Create time raster plot; as a bit input, we expect to see 1's
       // and 0's from each stream, so we set the maximum intensity
       // (zmax) to the number of connections so after adding the
-      // streams, the max will the the max of 1's from all streams.
+      // streams, the max will be the max of 1's from all streams.
       int numplots = (d_nconnections > 0) ? d_nconnections : 1;
       d_main_gui = new TimeRasterDisplayForm(numplots,
 					     d_samp_rate,

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -120,7 +120,7 @@ class RangeWidget(QtWidgets.QWidget):
             self.notifyChanged = slot
 
         def changed(self, value):
-            """ Handles maping the value to the right range before calling the slot. """
+            """ Handles mapping the value to the right range before calling the slot. """
             val = self.range.map_range(value)
             self.notifyChanged(self.rangeType(val))
 

--- a/gr-uhd/include/gnuradio/uhd/amsg_source.h
+++ b/gr-uhd/include/gnuradio/uhd/amsg_source.h
@@ -55,7 +55,7 @@ namespace gr {
                        msg_queue::sptr msgq);
 
       /*!
-       * Convert a raw asynchronous message to an asynchronous metatdata object.
+       * Convert a raw asynchronous message to an asynchronous metadata object.
        * \return The asynchronous metadata object.
        */
       static ::uhd::async_metadata_t

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -122,7 +122,7 @@ namespace gr {
       ) = 0;
 
       /*!
-       * Tune the the selected channel to the desired center frequency.
+       * Tune the selected channel to the desired center frequency.
        *
        * This is a wrapper around set_center_freq() so that in this case,
        * the user can pass a single frequency in the call instead of

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -549,7 +549,7 @@ namespace gr {
     std::vector<std::vector<std::complex<float> > >
     usrp_source_impl::finite_acquisition_v(const size_t nsamps)
     {
-      //kludgy way to ensure rx streamer exsists
+      //kludgy way to ensure rx streamer exists
       if(!_rx_stream) {
         this->start();
         this->stop();

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -427,7 +427,7 @@ class FlowGraph(Element):
                 block.rewrite()      # Make ports visible
                 # Flowgraph errors depending on disabled blocks are not displayed
                 # in the error dialog box
-                # So put a messsage into the Property window of the dummy block
+                # So put a message into the Property window of the dummy block
                 block.add_error_message('Block id "{}" not found.'.format(block.key))
 
         self.rewrite()  # global rewrite

--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -49,11 +49,11 @@ class Namespace(object):
                  icon_name=None, keypresses=None, preference_name=None, default=None):
         # Check types
         if not isinstance(name, str):
-            raise TypeError("Cannot register fuction: 'name' must be a str")
+            raise TypeError("Cannot register function: 'name' must be a str")
         if parameter and not isinstance(parameter, str):
-            raise TypeError("Cannot register fuction: 'parameter' must be a str")
+            raise TypeError("Cannot register function: 'parameter' must be a str")
         if handler and not callable(handler):
-            raise TypeError("Cannot register fuction: 'handler' must be callable")
+            raise TypeError("Cannot register function: 'handler' must be callable")
 
         # Check if the name has a prefix.
         prefix = None

--- a/grc/gui/FileDialogs.py
+++ b/grc/gui/FileDialogs.py
@@ -176,7 +176,7 @@ class SaveScreenShot(SaveFileDialog):
         Dialogs.MessageDialogWrapper(
             self.parent,
             Gtk.MessageType.ERROR, Gtk.ButtonsType.CLOSE, 'Can not Save!',
-            'File Extention of <b>{filename}</b> not supported!'.format(filename=Utils.encode(filename)),
+            'File Extension of <b>{filename}</b> not supported!'.format(filename=Utils.encode(filename)),
         ).run_and_destroy()
 
     def run(self):

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -419,7 +419,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
             x, y = selected_block.coordinate
             min_x, min_y = min(min_x, x), min(min_y, y)
             max_x, max_y = max(max_x, x), max(max_y, y)
-        #calculate center point of slected blocks
+        #calculate center point of selected blocks
         ctr_x, ctr_y = (max_x + min_x)/2, (max_y + min_y)/2
         #rotate the blocks around the center point
         for selected_block in self.selected_blocks():

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -69,7 +69,7 @@ def callo(args):
 
 class ClangFormat(object):
     """Class encapsulates finding a suitable copy of clang-format,
-    and linting/formating an individual file
+    and linting/formatting an individual file
     """
 
     def __init__(self, path):

--- a/tools/template_convert.py
+++ b/tools/template_convert.py
@@ -24,7 +24,7 @@ def get_real_name(block_definition):
 
 def rewrite_cmakelists(block_definition):
     """
-    Remove gengen template invokations from CMakeLists.txt
+    Remove gengen template invocations from CMakeLists.txt
     """
     with open(
             os.path.join(block_definition.get("path"), "CMakeLists.txt"),


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,sinc,hist,ist,ith,uint,fo -S ./volk`