### PR TITLE
README: Add repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Version](https://img.shields.io/github/tag/gnuradio/gnuradio.svg)
 [![AUR](https://img.shields.io/aur/license/yaourt.svg)](https://github.com/gnuradio/gnuradio/blob/master/COPYING) 
 [![Docs](https://img.shields.io/badge/docs-doxygen-orange.svg)](https://www.gnuradio.org/doc/doxygen/)
+[![Packaging status](https://repology.org/badge/tiny-repos/gnuradio.svg)](https://repology.org/project/gnuradio/badges)
 
 GNU Radio is a free & open-source software development toolkit that 
 provides signal processing blocks to implement software radios. It can 


### PR DESCRIPTION
Repology shows what repositories a package is available in. For space purposes the small badge is appropriate here. Example:
[![Packaging status](https://repology.org/badge/tiny-repos/gnuradio.svg)](https://repology.org/project/gnuradio/badges)

But in other contexts the full badge is more informative. Example:  
[![Packaging status](https://repology.org/badge/vertical-allrepos/gnuradio.svg?header=gnuradio)](https://repology.org/project/gnuradio/versions)

Preview the PR at: https://github.com/luzpaz/gnuradio/blob/repology/README.md