### PR TITLE
blocks: random_pdu mask parameter fails under python3

### DIFF
--- a/gr-blocks/grc/blocks_random_pdu.block.yml
+++ b/gr-blocks/grc/blocks_random_pdu.block.yml
@@ -34,6 +34,6 @@ templates:
     imports: |-
         from gnuradio import blocks
         import pmt
-    make: blocks.random_pdu(${minsize}, ${maxsize}, chr(${mask}), ${length_modulo})
+    make: blocks.random_pdu(${minsize}, ${maxsize}, ${mask}, ${length_modulo})
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/random_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/random_pdu.h
@@ -43,7 +43,7 @@ namespace gr {
       /*!
        * \brief Construct a random PDU generator
        */
-      static sptr make(int mintime, int maxtime, char byte_mask = 0xFF, int length_modulo = 1);
+      static sptr make(int mintime, int maxtime, unsigned char byte_mask = 0xFF, int length_modulo = 1);
     };
 
   } /* namespace blocks */

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -32,12 +32,12 @@ namespace gr {
   namespace blocks {
 
     random_pdu::sptr
-    random_pdu::make(int min_items, int max_items, char byte_mask, int length_modulo)
+    random_pdu::make(int min_items, int max_items, unsigned char byte_mask, int length_modulo)
     {
       return gnuradio::get_initial_sptr(new random_pdu_impl(min_items, max_items, byte_mask, length_modulo));
     }
 
-    random_pdu_impl::random_pdu_impl(int min_items, int max_items, char byte_mask, int length_modulo)
+    random_pdu_impl::random_pdu_impl(int min_items, int max_items, unsigned char byte_mask, int length_modulo)
       :	block("random_pdu",
 		 io_signature::make (0, 0, 0),
 		 io_signature::make (0, 0, 0)),

--- a/gr-blocks/lib/random_pdu_impl.h
+++ b/gr-blocks/lib/random_pdu_impl.h
@@ -38,11 +38,11 @@ namespace gr {
       boost::uniform_int<> d_brange;
       boost::variate_generator< boost::mt19937, boost::uniform_int<> > d_rvar; // pdu length
       boost::variate_generator< boost::mt19937, boost::uniform_int<> > d_bvar; // pdu contents
-      char d_mask;
+      unsigned char d_mask;
       int d_length_modulo;
 
     public:
-      random_pdu_impl(int min_items, int max_items, char byte_mask, int length_modulo);
+      random_pdu_impl(int min_items, int max_items, unsigned char byte_mask, int length_modulo);
 
       bool start();
       void output_random();


### PR DESCRIPTION
The use of chr() in the grc file for the mask
creates an invalid input to the random_pdu make
function

1) Change the inputs to unsigned char since this is a mask
2) Remove the chr() from the grc yml

I'm not entirely sure what the purpose of the chr(mask) in
the make function was, but it created invalid input

Instead just pass the bitmask directly

fixes #2557