### PR TITLE
uhd: Create compatibility layer for future UHD versions

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/CMakeLists.txt
+++ b/gr-uhd/include/gnuradio/uhd/CMakeLists.txt
@@ -22,6 +22,8 @@
 ########################################################################
 install(FILES
     api.h
+    clock_config.hpp
+    io_type.hpp
     usrp_block.h
     usrp_source.h
     usrp_sink.h

--- a/gr-uhd/include/gnuradio/uhd/clock_config.hpp
+++ b/gr-uhd/include/gnuradio/uhd/clock_config.hpp
@@ -1,0 +1,72 @@
+//
+// Copyright 2010-2011 Ettus Research LLC
+// Copyright 2018 Ettus Research, a National Instruments Company
+// Copyright 2019 Ettus Research, a National Instruments Company
+// Copyright 2019 Free Software Foundation, Inc.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#ifndef INCLUDED_UHD_TYPES_CLOCK_CONFIG_HPP
+#define INCLUDED_UHD_TYPES_CLOCK_CONFIG_HPP
+
+#include <uhd/config.hpp>
+
+namespace uhd {
+
+/*!  The DEPRECATED Clock configuration settings:
+ *
+ * This is a copy from the UHD, for backward compatibility. UHD has deprecated
+ * this structure in UHD 4.0. Older versions of UHD still have it, but it won't
+ * be modified any more.
+ */
+struct clock_config_t
+{
+    //------ simple usage --------//
+    clock_config_t(void):
+        ref_source(REF_INT),
+        pps_source(PPS_SMA),
+        pps_polarity(PPS_POS)
+    {
+        /* NOP */
+    }
+
+    //! A convenience function to create an external clock configuration
+    static clock_config_t external(void){
+        clock_config_t clock_config;
+        clock_config.ref_source = clock_config_t::REF_SMA;
+        clock_config.pps_source = clock_config_t::PPS_SMA;
+        clock_config.pps_polarity = clock_config_t::PPS_POS;
+        return clock_config;
+    }
+
+    //! A convenience function to create an internal clock configuration
+    static clock_config_t internal(void){
+        clock_config_t clock_config;
+        clock_config.ref_source = clock_config_t::REF_INT;
+        clock_config.pps_source = clock_config_t::PPS_SMA;
+        clock_config.pps_polarity = clock_config_t::PPS_POS;
+        return clock_config;
+    }
+
+    //------ advanced usage --------//
+    enum ref_source_t {
+        REF_AUTO = int('a'), // automatic (device specific)
+        REF_INT  = int('i'), // internal reference
+        REF_SMA  = int('s'), // external sma port
+        REF_MIMO = int('m') // reference from mimo cable
+    } ref_source;
+    enum pps_source_t {
+        PPS_INT  = int('i'), // there is no internal
+        PPS_SMA  = int('s'), // external sma port
+        PPS_MIMO = int('m') // time sync from mimo cable
+    } pps_source;
+    enum pps_polarity_t {
+        PPS_NEG = int('n'), // negative edge
+        PPS_POS = int('p') // positive edge
+    } pps_polarity;
+};
+
+} // namespace uhd
+
+#endif /* INCLUDED_UHD_TYPES_CLOCK_CONFIG_HPP */

--- a/gr-uhd/include/gnuradio/uhd/io_type.hpp
+++ b/gr-uhd/include/gnuradio/uhd/io_type.hpp
@@ -1,0 +1,75 @@
+//
+// Copyright 2010-2011 Ettus Research LLC
+// Copyright 2018 Ettus Research, a National Instruments Company
+// Copyright 2019 Free Software Foundation, Inc.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+#ifndef INCLUDED_UHD_TYPES_IO_TYPE_HPP
+#define INCLUDED_UHD_TYPES_IO_TYPE_HPP
+
+#include <uhd/config.hpp>
+
+namespace uhd {
+
+/* The DEPRECATED Input/Output configuration struct
+ *
+ * This is a copy from the UHD, for backward compatibility. UHD has deprecated
+ * this structure in UHD 4.0. Older versions of UHD still have it, but it won't
+ * be modified any more.
+ */
+class io_type_t
+{
+public:
+    /*!
+     * Built in IO types known to the system.
+     */
+    enum tid_t {
+        //! Custom type (technically unsupported by implementation)
+        CUSTOM_TYPE = int('?'),
+        //! Complex floating point (64-bit floats) range [-1.0, +1.0]
+        COMPLEX_FLOAT64 = int('d'),
+        //! Complex floating point (32-bit floats) range [-1.0, +1.0]
+        COMPLEX_FLOAT32 = int('f'),
+        //! Complex signed integer (16-bit integers) range [-32768, +32767]
+        COMPLEX_INT16 = int('s'),
+        //! Complex signed integer (8-bit integers) range [-128, 127]
+        COMPLEX_INT8 = int('b')
+    };
+
+    /*!
+     * The size of this io type in bytes.
+     */
+    const size_t size;
+
+    /*!
+     * The type id of this io type.
+     * Good for using with switch statements.
+     */
+    const tid_t tid;
+
+    /*!
+     * Create an io type from a built-in type id.
+     * \param tid a type id known to the system
+     */
+    io_type_t(tid_t tid) : size(tid == COMPLEX_FLOAT64 ? sizeof(std::complex<double>) :
+            tid == COMPLEX_FLOAT32 ? sizeof(std::complex<float>) :
+            tid == COMPLEX_INT16 ? sizeof(std::complex<int16_t>) :
+            sizeof(std::complex<int8_t>)),
+        tid(tid)
+    {
+        // nop
+    }
+
+    /*!
+     * Create an io type from attributes.
+     * The tid will be set to custom.
+     * \param size the size in bytes
+     */
+    io_type_t(size_t size) : size(size), tid(CUSTOM_TYPE) {}
+};
+
+} // namespace uhd
+
+#endif /* INCLUDED_UHD_TYPES_IO_TYPE_HPP */

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -27,6 +27,11 @@
 #include <gnuradio/sync_block.h>
 #include <uhd/usrp/multi_usrp.hpp>
 
+// This needs to come after multi_usrp.hpp, because we want to use the UHD
+// version of clock_config if it exists:
+#include <gnuradio/uhd/clock_config.hpp>
+#include <gnuradio/uhd/io_type.hpp>
+
 namespace gr {
   namespace uhd {
 

--- a/gr-uhd/swig/uhd_swig.i
+++ b/gr-uhd/swig/uhd_swig.i
@@ -79,7 +79,7 @@
 
 %include <uhd/types/device_addr.hpp>
 
-%include <uhd/types/io_type.hpp>
+%include "gnuradio/uhd/io_type.hpp"
 
 %template(range_vector_t) std::vector<uhd::range_t>; //define before range
 %include <uhd/types/ranges.hpp>
@@ -87,8 +87,6 @@
 %include <uhd/types/tune_request.hpp>
 
 %include <uhd/types/tune_result.hpp>
-
-%include <uhd/types/io_type.hpp>
 
 %include <uhd/types/time_spec.hpp>
 
@@ -113,7 +111,7 @@
 
 %include <uhd/types/stream_cmd.hpp>
 
-%include <uhd/types/clock_config.hpp>
+%include "gnuradio/uhd/clock_config.hpp"
 
 %include <uhd/types/metadata.hpp>
 


### PR DESCRIPTION
clock_config_t and io_type_t are UHD types that have been flagged as
deprecated, in some cases since 2012. UHD 4.0 will finally remove those
types.

In order to stay compatible with future versions of UHD without breaking
the GNU Radio APIs on this API-stable branch, we add the types directly
into GNU Radio. The implementation is such that the UHD version will be
used if available, and the GNU Radio version will be used otherwise.