### PR TITLE
Corrected framebits in dec_hdr block. 

### DIFF
--- a/gr-digital/examples/packet/uhd_packet_rx.grc
+++ b/gr-digital/examples/packet/uhd_packet_rx.grc
@@ -482,7 +482,7 @@
     </param>
     <param>
       <key>framebits</key>
-      <value>8000</value>
+      <value>hdr_format.header_nbits()</value>
     </param>
     <param>
       <key>_coordinate</key>

--- a/gr-digital/examples/packet/uhd_packet_rx_tun.grc
+++ b/gr-digital/examples/packet/uhd_packet_rx_tun.grc
@@ -482,7 +482,7 @@
     </param>
     <param>
       <key>framebits</key>
-      <value>8000</value>
+      <value>hdr_format.header_nbits()</value>
     </param>
     <param>
       <key>_coordinate</key>


### PR DESCRIPTION
The example grc files have an incorrect parameter for framebits in the dec_hdr block. This is correct in packet_loopback_hier.grc. The files uhd_packet_rx.grc and uhd_packet_rx_tun.grc both contained this error since creation. This error causes the blocks to get in sort of a deadlock when receiving the header with the dummy FEC. I tested the blocks replacing the uhd blocks with a ZMQ block and running the TX and RX flowgraphs separately.