### PR TITLE
 Corrected framebits in dec_hdr block.

### DIFF
--- a/gr-digital/examples/packet/uhd_packet_rx.grc
+++ b/gr-digital/examples/packet/uhd_packet_rx.grc
@@ -146,7 +146,7 @@ blocks:
     comment: ''
     dim1: '1'
     dim2: '1'
-    framebits: '8000'
+    framebits: hdr_format.header_nbits()
     ndim: '0'
     value: '"ok"'
   states:

--- a/gr-digital/examples/packet/uhd_packet_rx_tun.grc
+++ b/gr-digital/examples/packet/uhd_packet_rx_tun.grc
@@ -146,7 +146,7 @@ blocks:
     comment: ''
     dim1: '1'
     dim2: '1'
-    framebits: '8000'
+    framebits: hdr_format.header_nbits()
     ndim: '0'
     value: '"ok"'
   states:


### PR DESCRIPTION
The example grc files have an incorrect parameter for framebits in the dec_hdr block. This is correct in packet_loopback_hier.grc. The files uhd_packet_rx.grc and uhd_packet_rx_tun.grc both contained this error since creation. This error causes the blocks to get in sort of a deadlock when receiving the header with the dummy FEC. I tested the blocks replacing the uhd blocks with a ZMQ block and running the TX and RX flowgraphs separately. 