### PR TITLE
grc: Generating a flowgraph with no gui requires to import sys, too

### DIFF
--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -134,10 +134,10 @@ templates:
     imports: |-
         from gnuradio import gr
         from gnuradio.filter import firdes
+        import sys
         import signal
         % if generate_options == 'qt_gui':
         from PyQt5 import Qt
-        import sys
         % endif
         % if generate_options == 'bokeh_gui':
         import time


### PR DESCRIPTION
If a flowgraph without  a gui is generated, this piece of code is generated

https://github.com/gnuradio/gnuradio/blob/cff05c36dfc3908c3933773ac789959050fae45e/grc/core/generator/flow_graph.py.mako#L417

But at the moment sys only will be imported if qt_gui is selected