### PR TITLE
rebased PR for #2560 (unescaped shell paths)

### DIFF
--- a/cmake/Modules/GrTest.cmake
+++ b/cmake/Modules/GrTest.cmake
@@ -22,6 +22,14 @@ if(DEFINED __INCLUDED_GR_TEST_CMAKE)
 endif()
 set(__INCLUDED_GR_TEST_CMAKE TRUE)
 
+
+function (GR_CONVERT_QUOTED_STRING path_str quoted_path)
+    file(TO_NATIVE_PATH "${path_str}" path_str)
+    string(CONCAT path_str "\"" ${path_str} "\"")
+    string(REPLACE "\\ " " " path_str ${path_str})
+    set(${quoted_path} "${path_str}" PARENT_SCOPE)
+endfunction()
+
 ########################################################################
 # Add a unit test and setup the environment for a unit test.
 # Takes the same arguments as the ADD_TEST function.
@@ -59,9 +67,10 @@ function(GR_ADD_TEST test_name)
         endforeach(pydir)
     endif(WIN32)
 
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR} srcdir)
-    file(TO_NATIVE_PATH "${GR_TEST_LIBRARY_DIRS}" libpath) #ok to use on dir list?
-    file(TO_NATIVE_PATH "${GR_TEST_PYTHON_DIRS}" pypath) #ok to use on dir list?
+    GR_CONVERT_QUOTED_STRING("${CMAKE_CURRENT_BINARY_DIR}" bindir)
+    GR_CONVERT_QUOTED_STRING("${CMAKE_CURRENT_SOURCE_DIR}" srcdir)
+    GR_CONVERT_QUOTED_STRING("${GR_TEST_LIBRARY_DIRS}" libpath)
+    GR_CONVERT_QUOTED_STRING("${GR_TEST_PYTHON_DIRS}" pypath)
 
     set(environs "VOLK_GENERIC=1" "GR_DONT_LOAD_PREFS=1" "srcdir=${srcdir}"
         "GR_CONF_CONTROLPORT_ON=False")
@@ -79,7 +88,7 @@ function(GR_ADD_TEST test_name)
             set(LD_PATH_VAR "DYLD_LIBRARY_PATH")
         endif()
 
-        set(binpath "${CMAKE_CURRENT_BINARY_DIR}:$PATH")
+        set(binpath "${bindir}:$PATH")
         list(APPEND libpath "$${LD_PATH_VAR}")
         list(APPEND pypath "$PYTHONPATH")
 

--- a/gr-utils/python/modtool/core/add.py
+++ b/gr-utils/python/modtool/core/add.py
@@ -160,6 +160,7 @@ class ModToolAdd(ModTool):
         if self.skip_cmakefiles:
             return
         try:
+            #TODO: The following statement adds the C++ QA Test at the wrong part of the CMakeLists.txt
             append_re_line_sequence(self._file['cmlib'],
                                     '\$\{CMAKE_CURRENT_SOURCE_DIR\}/qa_%s.cc.*\n' % self.info['modname'],
                                     '    ${CMAKE_CURRENT_SOURCE_DIR}/qa_%s.cc' % self.info['blockname'])
@@ -260,7 +261,7 @@ class ModToolAdd(ModTool):
         logger.info("Editing {}/CMakeLists.txt...".format(self.info['pydir']))
         with open(self._file['cmpython'], 'a') as f:
             f.write(
-                'GR_ADD_TEST(qa_%s ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/%s)\n' % \
+                'GR_ADD_TEST(qa_%s ${PYTHON_EXECUTABLE} \\\"${CMAKE_CURRENT_SOURCE_DIR}\\\"/%s)\n' % \
                 (self.info['blockname'], fname_py_qa))
         self.scm.mark_files_updated((self._file['cmpython'],))
 

--- a/gr-utils/python/modtool/templates/gr-newmod/docs/doxygen/Doxyfile.in
+++ b/gr-utils/python/modtool/templates/gr-newmod/docs/doxygen/Doxyfile.in
@@ -654,8 +654,8 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = @top_srcdir@ \
-                         @top_builddir@
+INPUT                  = "@top_srcdir@" \
+                         "@top_builddir@"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -790,7 +790,7 @@ INPUT_FILTER           =
 # info on how filters are used. If FILTER_PATTERNS is empty or if
 # non of the patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        = *.py=@top_srcdir@/doc/doxygen/other/doxypy.py
+FILTER_PATTERNS        = *.py="@top_srcdir@"/doc/doxygen/other/doxypy.py
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will be used to filter the input files when producing source

--- a/gr-utils/python/modtool/templates/gr-newmod/docs/doxygen/Doxyfile.swig_doc.in
+++ b/gr-utils/python/modtool/templates/gr-newmod/docs/doxygen/Doxyfile.swig_doc.in
@@ -54,7 +54,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @OUTPUT_DIRECTORY@
+OUTPUT_DIRECTORY       = "@OUTPUT_DIRECTORY@"
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output


### PR DESCRIPTION
This rebases #2560 against current master.

This is also necessary for CI reasons, since CI broadly failed with mormj's original PR.

modtool: Make path strings in qa shell scripts quoted

Required changes in GrTest.cmake and modtool
Intended to fix the case where user has space in their
path to their OOT Module

Fixes #2443