### PR TITLE
rebased #2598: grc: add busports back into 3.8

### DIFF
--- a/gr-blocks/grc/blocks_null_sink.block.yml
+++ b/gr-blocks/grc/blocks_null_sink.block.yml
@@ -21,7 +21,7 @@ parameters:
     dtype: int
     default: '1'
     hide: part
--   id: bus_conns
+-   id: bus_structure_sink
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'

--- a/gr-blocks/grc/blocks_null_source.block.yml
+++ b/gr-blocks/grc/blocks_null_source.block.yml
@@ -21,7 +21,7 @@ parameters:
     dtype: int
     default: '1'
     hide: part
--   id: bus_conns
+-   id: bus_structure_source
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'

--- a/gr-fec/examples/ber_curve_gen.grc
+++ b/gr-fec/examples/ber_curve_gen.grc
@@ -1,2414 +1,498 @@
-<?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.8'?>
-<flow_graph>
-  <timestamp>Tue May 13 19:32:00 2014</timestamp>
-  <block>
-    <key>options</key>
-    <param>
-      <key>author</key>
-      <value></value>
-    </param>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>category</key>
-      <value>Custom</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>description</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 11)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>generate_options</key>
-      <value>qt_gui</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>ber_curve_gen</value>
-    </param>
-    <param>
-      <key>max_nouts</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>realtime_scheduling</key>
-      <value></value>
-    </param>
-    <param>
-      <key>run_options</key>
-      <value>prompt</value>
-    </param>
-    <param>
-      <key>run</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>thread_safe_setters</key>
-      <value></value>
-    </param>
-    <param>
-      <key>title</key>
-      <value></value>
-    </param>
-    <param>
-      <key>window_size</key>
-      <value>2000,2000</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_cc_decoder_def</key>
-    <param>
-      <key>padding</key>
-      <value>False</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>k</key>
-      <value>k</value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>state_end</key>
-      <value>-1</value>
-    </param>
-    <param>
-      <key>framebits</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 659)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>dec_cc</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>polys</key>
-      <value>polys</value>
-    </param>
-    <param>
-      <key>rate</key>
-      <value>rate</value>
-    </param>
-    <param>
-      <key>state_start</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>mode</key>
-      <value>fec.CC_STREAMING</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_dummy_decoder_def</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>framebits</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(424, 771)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>dec_dummy</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_ldpc_decoder_def</key>
-    <param>
-      <key>file</key>
-      <value>gr.prefix() + "/share/gnuradio/fec/ldpc/271.127.3.112"</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(608, 739)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>dec_ldpc</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>max_iter</key>
-      <value>50</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>sigma</key>
-      <value>0.5</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_repetition_decoder_def</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>framebits</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(216, 739)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>dec_rep</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>rep</key>
-      <value>3</value>
-    </param>
-    <param>
-      <key>prob</key>
-      <value>0.5</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_tpc_decoder_def</key>
-    <param>
-      <key>bval</key>
-      <value>9</value>
-    </param>
-    <param>
-      <key>col_poly</key>
-      <value>[43]</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decoder_type</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(776, 659)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>dec_tpc</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>kcol</key>
-      <value>6</value>
-    </param>
-    <param>
-      <key>krow</key>
-      <value>26</value>
-    </param>
-    <param>
-      <key>max_iter</key>
-      <value>6</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>qval</key>
-      <value>3</value>
-    </param>
-    <param>
-      <key>row_poly</key>
-      <value>[3]</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_cc_encoder_def</key>
-    <param>
-      <key>padding</key>
-      <value>False</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>k</key>
-      <value>k</value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>framebits</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 451)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>enc_cc</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>polys</key>
-      <value>polys</value>
-    </param>
-    <param>
-      <key>rate</key>
-      <value>rate</value>
-    </param>
-    <param>
-      <key>state_start</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>mode</key>
-      <value>fec.CC_STREAMING</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_dummy_encoder_def</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>framebits</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(424, 659)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>enc_dummy</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_ldpc_encoder_def</key>
-    <param>
-      <key>file</key>
-      <value>gr.prefix() + "/share/gnuradio/fec/ldpc/271.127.3.112"</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(608, 627)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>enc_ldpc</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_repetition_encoder_def</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>framebits</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(216, 603)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>enc_rep</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>rep</key>
-      <value>3</value>
-    </param>
-  </block>
-  <block>
-    <key>variable_tpc_encoder_def</key>
-    <param>
-      <key>bval</key>
-      <value>9</value>
-    </param>
-    <param>
-      <key>col_poly</key>
-      <value>[43]</value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>dim1</key>
-      <value>len(esno_0)</value>
-    </param>
-    <param>
-      <key>dim2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(776, 467)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>enc_tpc</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>"ok"</value>
-    </param>
-    <param>
-      <key>kcol</key>
-      <value>6</value>
-    </param>
-    <param>
-      <key>krow</key>
-      <value>26</value>
-    </param>
-    <param>
-      <key>ndim</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>qval</key>
-      <value>3</value>
-    </param>
-    <param>
-      <key>row_poly</key>
-      <value>[3]</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 139)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>esno_0</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>numpy.arange(0, 8, .5) </value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(112, 75)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>framebits</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>4096</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 379)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>k</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>7</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(80, 379)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>polys</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>[79, 109]</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 315)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>rate</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>2</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 75)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>samp_rate_0</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>35000000</value>
-    </param>
-  </block>
-  <block>
-    <key>fec_bercurve_generator</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decoder_list</key>
-      <value>dec_cc</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>encoder_list</key>
-      <value>enc_cc</value>
-    </param>
-    <param>
-      <key>esno</key>
-      <value>esno_0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(248, 203)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>fec_bercurve_generator_0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>seed</key>
-      <value>-100</value>
-    </param>
-    <param>
-      <key>puncpat</key>
-      <value>'11'</value>
-    </param>
-    <param>
-      <key>samp_rate</key>
-      <value>samp_rate_0</value>
-    </param>
-    <param>
-      <key>threadtype</key>
-      <value>"capillary"</value>
-    </param>
-    <bus_source>1</bus_source>
-  </block>
-  <block>
-    <key>fec_bercurve_generator</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decoder_list</key>
-      <value>dec_rep</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>encoder_list</key>
-      <value>enc_rep</value>
-    </param>
-    <param>
-      <key>esno</key>
-      <value>esno_0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(248, 107)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>fec_bercurve_generator_0_0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>seed</key>
-      <value>-100</value>
-    </param>
-    <param>
-      <key>puncpat</key>
-      <value>'11'</value>
-    </param>
-    <param>
-      <key>samp_rate</key>
-      <value>samp_rate_0</value>
-    </param>
-    <param>
-      <key>threadtype</key>
-      <value>"capillary"</value>
-    </param>
-    <bus_source>1</bus_source>
-  </block>
-  <block>
-    <key>fec_bercurve_generator</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decoder_list</key>
-      <value>dec_dummy</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>encoder_list</key>
-      <value>enc_dummy</value>
-    </param>
-    <param>
-      <key>esno</key>
-      <value>esno_0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(248, 11)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>fec_bercurve_generator_0_0_0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>seed</key>
-      <value>-100</value>
-    </param>
-    <param>
-      <key>puncpat</key>
-      <value>'11'</value>
-    </param>
-    <param>
-      <key>samp_rate</key>
-      <value>samp_rate_0</value>
-    </param>
-    <param>
-      <key>threadtype</key>
-      <value>"capillary"</value>
-    </param>
-    <bus_source>1</bus_source>
-  </block>
-  <block>
-    <key>fec_bercurve_generator</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decoder_list</key>
-      <value>dec_ldpc</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>encoder_list</key>
-      <value>enc_ldpc</value>
-    </param>
-    <param>
-      <key>esno</key>
-      <value>esno_0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(248, 299)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>fec_bercurve_generator_0_1</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>seed</key>
-      <value>-100</value>
-    </param>
-    <param>
-      <key>puncpat</key>
-      <value>'11'</value>
-    </param>
-    <param>
-      <key>samp_rate</key>
-      <value>samp_rate_0</value>
-    </param>
-    <param>
-      <key>threadtype</key>
-      <value>"capillary"</value>
-    </param>
-    <bus_source>1</bus_source>
-  </block>
-  <block>
-    <key>fec_bercurve_generator</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decoder_list</key>
-      <value>dec_tpc</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>encoder_list</key>
-      <value>enc_tpc</value>
-    </param>
-    <param>
-      <key>esno</key>
-      <value>esno_0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(248, 395)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>fec_bercurve_generator_0_1_0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>seed</key>
-      <value>-100</value>
-    </param>
-    <param>
-      <key>puncpat</key>
-      <value>'11'</value>
-    </param>
-    <param>
-      <key>samp_rate</key>
-      <value>samp_rate_0</value>
-    </param>
-    <param>
-      <key>threadtype</key>
-      <value>"capillary"</value>
-    </param>
-    <bus_source>1</bus_source>
-  </block>
-  <block>
-    <key>qtgui_bercurve_sink</key>
-    <param>
-      <key>berlimit</key>
-      <value>-10</value>
-    </param>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>curvenames</key>
-      <value>[]</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(696, 15)</value>
-    </param>
-    <param>
-      <key>gui_hint</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>qtgui_bercurve_sink_0</value>
-    </param>
-    <param>
-      <key>alpha1</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>color1</key>
-      <value>"blue"</value>
-    </param>
-    <param>
-      <key>label1</key>
-      <value>None</value>
-    </param>
-    <param>
-      <key>marker1</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style1</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>width1</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>alpha10</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color10</key>
-      <value>"red"</value>
-    </param>
-    <param>
-      <key>label10</key>
-      <value></value>
-    </param>
-    <param>
-      <key>marker10</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style10</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>width10</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>alpha2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>color2</key>
-      <value>"red"</value>
-    </param>
-    <param>
-      <key>label2</key>
-      <value>Rep. (Rate=3)</value>
-    </param>
-    <param>
-      <key>marker2</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>style2</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>width2</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>alpha3</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>color3</key>
-      <value>"magenta"</value>
-    </param>
-    <param>
-      <key>label3</key>
-      <value>CC (K=7, Rate=2)</value>
-    </param>
-    <param>
-      <key>marker3</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style3</key>
-      <value>5</value>
-    </param>
-    <param>
-      <key>width3</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>alpha4</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color4</key>
-      <value>"dark red"</value>
-    </param>
-    <param>
-      <key>label4</key>
-      <value>LDPC</value>
-    </param>
-    <param>
-      <key>marker4</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style4</key>
-      <value>5</value>
-    </param>
-    <param>
-      <key>width4</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>alpha5</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color5</key>
-      <value>"Dark Blue"</value>
-    </param>
-    <param>
-      <key>label5</key>
-      <value>TPC</value>
-    </param>
-    <param>
-      <key>marker5</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style5</key>
-      <value>4</value>
-    </param>
-    <param>
-      <key>width5</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>alpha6</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color6</key>
-      <value>"red"</value>
-    </param>
-    <param>
-      <key>label6</key>
-      <value></value>
-    </param>
-    <param>
-      <key>marker6</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style6</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>width6</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>alpha7</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color7</key>
-      <value>"red"</value>
-    </param>
-    <param>
-      <key>label7</key>
-      <value></value>
-    </param>
-    <param>
-      <key>marker7</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style7</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>width7</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>alpha8</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color8</key>
-      <value>"red"</value>
-    </param>
-    <param>
-      <key>label8</key>
-      <value></value>
-    </param>
-    <param>
-      <key>marker8</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style8</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>width8</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>alpha9</key>
-      <value>1.0</value>
-    </param>
-    <param>
-      <key>color9</key>
-      <value>"red"</value>
-    </param>
-    <param>
-      <key>label9</key>
-      <value></value>
-    </param>
-    <param>
-      <key>marker9</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>style9</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>width9</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>berminerrors</key>
-      <value>1000</value>
-    </param>
-    <param>
-      <key>num_curves</key>
-      <value>5</value>
-    </param>
-    <param>
-      <key>update_time</key>
-      <value>0.10</value>
-    </param>
-    <param>
-      <key>ymax</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>ymin</key>
-      <value>-10</value>
-    </param>
-    <param>
-      <key>esno</key>
-      <value>esno_0</value>
-    </param>
-    <bus_sink>1</bus_sink>
-  </block>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>32</source_key>
-    <sink_key>162</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>64</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>1</source_key>
-    <sink_key>65</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>10</source_key>
-    <sink_key>74</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>11</source_key>
-    <sink_key>75</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>12</source_key>
-    <sink_key>76</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>13</source_key>
-    <sink_key>77</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>14</source_key>
-    <sink_key>78</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>15</source_key>
-    <sink_key>79</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>16</source_key>
-    <sink_key>80</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>17</source_key>
-    <sink_key>81</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>18</source_key>
-    <sink_key>82</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>19</source_key>
-    <sink_key>83</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>2</source_key>
-    <sink_key>66</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>20</source_key>
-    <sink_key>84</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>21</source_key>
-    <sink_key>85</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>22</source_key>
-    <sink_key>86</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>23</source_key>
-    <sink_key>87</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>24</source_key>
-    <sink_key>88</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>25</source_key>
-    <sink_key>89</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>26</source_key>
-    <sink_key>90</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>27</source_key>
-    <sink_key>91</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>28</source_key>
-    <sink_key>92</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>29</source_key>
-    <sink_key>93</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>3</source_key>
-    <sink_key>67</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>30</source_key>
-    <sink_key>94</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>31</source_key>
-    <sink_key>95</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>4</source_key>
-    <sink_key>68</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>5</source_key>
-    <sink_key>69</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>6</source_key>
-    <sink_key>70</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>7</source_key>
-    <sink_key>71</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>8</source_key>
-    <sink_key>72</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>9</source_key>
-    <sink_key>73</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>32</source_key>
-    <sink_key>161</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>32</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>1</source_key>
-    <sink_key>33</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>10</source_key>
-    <sink_key>42</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>11</source_key>
-    <sink_key>43</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>12</source_key>
-    <sink_key>44</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>13</source_key>
-    <sink_key>45</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>14</source_key>
-    <sink_key>46</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>15</source_key>
-    <sink_key>47</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>16</source_key>
-    <sink_key>48</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>17</source_key>
-    <sink_key>49</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>18</source_key>
-    <sink_key>50</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>19</source_key>
-    <sink_key>51</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>2</source_key>
-    <sink_key>34</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>20</source_key>
-    <sink_key>52</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>21</source_key>
-    <sink_key>53</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>22</source_key>
-    <sink_key>54</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>23</source_key>
-    <sink_key>55</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>24</source_key>
-    <sink_key>56</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>25</source_key>
-    <sink_key>57</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>26</source_key>
-    <sink_key>58</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>27</source_key>
-    <sink_key>59</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>28</source_key>
-    <sink_key>60</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>29</source_key>
-    <sink_key>61</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>3</source_key>
-    <sink_key>35</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>30</source_key>
-    <sink_key>62</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>31</source_key>
-    <sink_key>63</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>4</source_key>
-    <sink_key>36</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>5</source_key>
-    <sink_key>37</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>6</source_key>
-    <sink_key>38</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>7</source_key>
-    <sink_key>39</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>8</source_key>
-    <sink_key>40</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>9</source_key>
-    <sink_key>41</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>32</source_key>
-    <sink_key>160</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>1</source_key>
-    <sink_key>1</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>10</source_key>
-    <sink_key>10</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>11</source_key>
-    <sink_key>11</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>12</source_key>
-    <sink_key>12</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>13</source_key>
-    <sink_key>13</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>14</source_key>
-    <sink_key>14</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>15</source_key>
-    <sink_key>15</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>16</source_key>
-    <sink_key>16</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>17</source_key>
-    <sink_key>17</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>18</source_key>
-    <sink_key>18</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>19</source_key>
-    <sink_key>19</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>2</source_key>
-    <sink_key>2</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>20</source_key>
-    <sink_key>20</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>21</source_key>
-    <sink_key>21</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>22</source_key>
-    <sink_key>22</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>23</source_key>
-    <sink_key>23</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>24</source_key>
-    <sink_key>24</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>25</source_key>
-    <sink_key>25</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>26</source_key>
-    <sink_key>26</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>27</source_key>
-    <sink_key>27</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>28</source_key>
-    <sink_key>28</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>29</source_key>
-    <sink_key>29</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>3</source_key>
-    <sink_key>3</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>30</source_key>
-    <sink_key>30</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>31</source_key>
-    <sink_key>31</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>4</source_key>
-    <sink_key>4</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>5</source_key>
-    <sink_key>5</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>6</source_key>
-    <sink_key>6</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>7</source_key>
-    <sink_key>7</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>8</source_key>
-    <sink_key>8</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_0_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>9</source_key>
-    <sink_key>9</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>32</source_key>
-    <sink_key>163</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>96</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>1</source_key>
-    <sink_key>97</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>10</source_key>
-    <sink_key>106</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>11</source_key>
-    <sink_key>107</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>12</source_key>
-    <sink_key>108</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>13</source_key>
-    <sink_key>109</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>14</source_key>
-    <sink_key>110</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>15</source_key>
-    <sink_key>111</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>16</source_key>
-    <sink_key>112</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>17</source_key>
-    <sink_key>113</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>18</source_key>
-    <sink_key>114</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>19</source_key>
-    <sink_key>115</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>2</source_key>
-    <sink_key>98</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>20</source_key>
-    <sink_key>116</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>21</source_key>
-    <sink_key>117</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>22</source_key>
-    <sink_key>118</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>23</source_key>
-    <sink_key>119</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>24</source_key>
-    <sink_key>120</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>25</source_key>
-    <sink_key>121</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>26</source_key>
-    <sink_key>122</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>27</source_key>
-    <sink_key>123</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>28</source_key>
-    <sink_key>124</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>29</source_key>
-    <sink_key>125</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>3</source_key>
-    <sink_key>99</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>30</source_key>
-    <sink_key>126</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>31</source_key>
-    <sink_key>127</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>4</source_key>
-    <sink_key>100</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>5</source_key>
-    <sink_key>101</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>6</source_key>
-    <sink_key>102</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>7</source_key>
-    <sink_key>103</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>8</source_key>
-    <sink_key>104</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>9</source_key>
-    <sink_key>105</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>32</source_key>
-    <sink_key>164</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>128</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>1</source_key>
-    <sink_key>129</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>10</source_key>
-    <sink_key>138</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>11</source_key>
-    <sink_key>139</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>12</source_key>
-    <sink_key>140</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>13</source_key>
-    <sink_key>141</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>14</source_key>
-    <sink_key>142</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>15</source_key>
-    <sink_key>143</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>16</source_key>
-    <sink_key>144</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>17</source_key>
-    <sink_key>145</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>18</source_key>
-    <sink_key>146</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>19</source_key>
-    <sink_key>147</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>2</source_key>
-    <sink_key>130</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>20</source_key>
-    <sink_key>148</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>21</source_key>
-    <sink_key>149</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>22</source_key>
-    <sink_key>150</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>23</source_key>
-    <sink_key>151</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>24</source_key>
-    <sink_key>152</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>25</source_key>
-    <sink_key>153</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>26</source_key>
-    <sink_key>154</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>27</source_key>
-    <sink_key>155</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>28</source_key>
-    <sink_key>156</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>29</source_key>
-    <sink_key>157</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>3</source_key>
-    <sink_key>131</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>30</source_key>
-    <sink_key>158</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>31</source_key>
-    <sink_key>159</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>4</source_key>
-    <sink_key>132</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>5</source_key>
-    <sink_key>133</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>6</source_key>
-    <sink_key>134</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>7</source_key>
-    <sink_key>135</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>8</source_key>
-    <sink_key>136</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>fec_bercurve_generator_0_1_0</source_block_id>
-    <sink_block_id>qtgui_bercurve_sink_0</sink_block_id>
-    <source_key>9</source_key>
-    <sink_key>137</sink_key>
-  </connection>
-</flow_graph>
+options:
+  parameters:
+    author: ''
+    category: Custom
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: ber_curve_gen
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ''
+    window_size: 2000,2000
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 11]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: esno_0
+  id: variable
+  parameters:
+    comment: ''
+    value: 'numpy.arange(0, 8, .5) '
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 139]
+    rotation: 0
+    state: enabled
+- name: framebits
+  id: variable
+  parameters:
+    comment: ''
+    value: '4096'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [112, 75]
+    rotation: 0
+    state: enabled
+- name: k
+  id: variable
+  parameters:
+    comment: ''
+    value: '7'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 379]
+    rotation: 0
+    state: enabled
+- name: polys
+  id: variable
+  parameters:
+    comment: ''
+    value: '[79, 109]'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [80, 379]
+    rotation: 0
+    state: enabled
+- name: rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '2'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 315]
+    rotation: 0
+    state: enabled
+- name: samp_rate_0
+  id: variable
+  parameters:
+    comment: ''
+    value: '35000000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 75]
+    rotation: 0
+    state: enabled
+- name: dec_cc
+  id: variable_cc_decoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    framebits: framebits
+    k: k
+    mode: fec.CC_STREAMING
+    ndim: '2'
+    padding: 'False'
+    polys: polys
+    rate: rate
+    state_end: '-1'
+    state_start: '0'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 659]
+    rotation: 0
+    state: enabled
+- name: dec_dummy
+  id: variable_dummy_decoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    framebits: framebits
+    ndim: '2'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [424, 771]
+    rotation: 0
+    state: enabled
+- name: dec_ldpc
+  id: variable_ldpc_decoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    file: gr.prefix() + "/share/gnuradio/fec/ldpc/271.127.3.112"
+    max_iter: '50'
+    ndim: '2'
+    sigma: '0.5'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [608, 739]
+    rotation: 0
+    state: enabled
+- name: dec_rep
+  id: variable_repetition_decoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    framebits: framebits
+    ndim: '2'
+    prob: '0.5'
+    rep: '3'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [216, 739]
+    rotation: 0
+    state: enabled
+- name: dec_tpc
+  id: variable_tpc_decoder_def
+  parameters:
+    bval: '9'
+    col_poly: '[43]'
+    comment: ''
+    decoder_type: '1'
+    dim1: len(esno_0)
+    dim2: '1'
+    kcol: '6'
+    krow: '26'
+    max_iter: '6'
+    ndim: '2'
+    qval: '3'
+    row_poly: '[3]'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [776, 659]
+    rotation: 0
+    state: enabled
+- name: enc_cc
+  id: variable_cc_encoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    framebits: framebits
+    k: k
+    mode: fec.CC_STREAMING
+    ndim: '2'
+    padding: 'False'
+    polys: polys
+    rate: rate
+    state_start: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 451]
+    rotation: 0
+    state: enabled
+- name: enc_dummy
+  id: variable_dummy_encoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    framebits: framebits
+    ndim: '2'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [424, 659]
+    rotation: 0
+    state: enabled
+- name: enc_ldpc
+  id: variable_ldpc_encoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    file: gr.prefix() + "/share/gnuradio/fec/ldpc/271.127.3.112"
+    ndim: '2'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [608, 627]
+    rotation: 0
+    state: enabled
+- name: enc_rep
+  id: variable_repetition_encoder_def
+  parameters:
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    framebits: framebits
+    ndim: '2'
+    rep: '3'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [216, 603]
+    rotation: 0
+    state: enabled
+- name: enc_tpc
+  id: variable_tpc_encoder_def
+  parameters:
+    bval: '9'
+    col_poly: '[43]'
+    comment: ''
+    dim1: len(esno_0)
+    dim2: '1'
+    kcol: '6'
+    krow: '26'
+    ndim: '2'
+    qval: '3'
+    row_poly: '[3]'
+    value: '"ok"'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [776, 467]
+    rotation: 0
+    state: enabled
+
+- name: fec_bercurve_generator_0
+  id: fec_bercurve_generator
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decoder_list: dec_cc
+    encoder_list: enc_cc
+    esno: esno_0
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    puncpat: '''11'''
+    samp_rate: samp_rate_0
+    seed: '-100'
+    threadtype: '"capillary"'
+  states:
+    bus_sink: false
+    bus_source: true
+    bus_structure: null
+    coordinate: [248, 212.0]
+    rotation: 0
+    state: enabled
+- name: fec_bercurve_generator_0_0
+  id: fec_bercurve_generator
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decoder_list: dec_rep
+    encoder_list: enc_rep
+    esno: esno_0
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    puncpat: '''11'''
+    samp_rate: samp_rate_0
+    seed: '-100'
+    threadtype: '"capillary"'
+  states:
+    bus_sink: false
+    bus_source: true
+    bus_structure: null
+    coordinate: [248, 116.0]
+    rotation: 0
+    state: enabled
+- name: fec_bercurve_generator_0_0_0
+  id: fec_bercurve_generator
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decoder_list: dec_dummy
+    encoder_list: enc_dummy
+    esno: esno_0
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    puncpat: '''11'''
+    samp_rate: samp_rate_0
+    seed: '-100'
+    threadtype: '"capillary"'
+  states:
+    bus_sink: false
+    bus_source: true
+    bus_structure: null
+    coordinate: [248, 12.0]
+    rotation: 0
+    state: enabled
+- name: fec_bercurve_generator_0_1
+  id: fec_bercurve_generator
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decoder_list: dec_ldpc
+    encoder_list: enc_ldpc
+    esno: esno_0
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    puncpat: '''11'''
+    samp_rate: samp_rate_0
+    seed: '-100'
+    threadtype: '"capillary"'
+  states:
+    bus_sink: false
+    bus_source: true
+    bus_structure: null
+    coordinate: [248, 332.0]
+    rotation: 0
+    state: enabled
+- name: fec_bercurve_generator_0_1_0
+  id: fec_bercurve_generator
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decoder_list: dec_tpc
+    encoder_list: enc_tpc
+    esno: esno_0
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    puncpat: '''11'''
+    samp_rate: samp_rate_0
+    seed: '-100'
+    threadtype: '"capillary"'
+  states:
+    bus_sink: false
+    bus_source: true
+    bus_structure: null
+    coordinate: [248, 460.0]
+    rotation: 0
+    state: enabled
+- name: qtgui_bercurve_sink_0
+  id: qtgui_bercurve_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1'
+    alpha10: '1.0'
+    alpha2: '1'
+    alpha3: '1'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    berlimit: '-10'
+    berminerrors: '1000'
+    bus_structure_sink: list(map(lambda b:list(map(lambda a:b * len(esno) * 2 + a,
+      range(len(esno)*2))), range(num_curves)))
+    color1: '"blue"'
+    color10: '"red"'
+    color2: '"red"'
+    color3: '"magenta"'
+    color4: '"dark red"'
+    color5: '"Dark Blue"'
+    color6: '"red"'
+    color7: '"red"'
+    color8: '"red"'
+    color9: '"red"'
+    comment: ''
+    curvenames: '[]'
+    esno: esno_0
+    gui_hint: ''
+    label1: None
+    label10: ''
+    label2: Rep. (Rate=3)
+    label3: CC (K=7, Rate=2)
+    label4: LDPC
+    label5: TPC
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    marker1: '0'
+    marker10: '0'
+    marker2: '1'
+    marker3: '0'
+    marker4: '0'
+    marker5: '0'
+    marker6: '0'
+    marker7: '0'
+    marker8: '0'
+    marker9: '0'
+    num_curves: '5'
+    style1: '1'
+    style10: '0'
+    style2: '2'
+    style3: '5'
+    style4: '5'
+    style5: '4'
+    style6: '0'
+    style7: '0'
+    style8: '0'
+    style9: '0'
+    update_time: '0.10'
+    width1: '2'
+    width10: '1'
+    width2: '2'
+    width3: '2'
+    width4: '2'
+    width5: '2'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    ymax: '0'
+    ymin: '-10'
+  states:
+    bus_sink: true
+    bus_source: false
+    bus_structure: null
+    coordinate: [696, 15]
+    rotation: 0
+    state: enabled
+
+connections:
+- [fec_bercurve_generator_0, '32', qtgui_bercurve_sink_0, '162']
+- [fec_bercurve_generator_0_0, '32', qtgui_bercurve_sink_0, '161']
+- [fec_bercurve_generator_0_0_0, '32', qtgui_bercurve_sink_0, '160']
+- [fec_bercurve_generator_0_1, '32', qtgui_bercurve_sink_0, '163']
+- [fec_bercurve_generator_0_1_0, '32', qtgui_bercurve_sink_0, '164']
+
+metadata:
+  file_format: 1

--- a/gr-fec/grc/tpc_decoder_def_list.block.yml
+++ b/gr-fec/grc/tpc_decoder_def_list.block.yml
@@ -65,9 +65,11 @@ templates:
         % if int(ndim)==0:
         self.${id} = ${id} = fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})
         % elif int(ndim)==1:
-        self.${id} = ${id} = list(map( (lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})), range(0,${dim1}) ))
+        self.${id} = ${id} = list(map( (lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, \
+        ${max_iter}, ${decoder_type})), range(0,${dim1}) ))
         % else:
-        self.${id} = ${id} = list(map( (lambda b: map( ( lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, ${bval}, ${qval}, ${max_iter}, ${decoder_type})), range(0,${dim2}) ) ), range(0,${dim1})))
+        self.${id} = ${id} = list(map( (lambda b: list(map( ( lambda a: fec.tpc_decoder_make(${row_poly}, ${col_poly}, ${krow}, ${kcol}, \
+        ${bval}, ${qval}, ${max_iter}, ${decoder_type})), range(0,${dim2})))), range(0,${dim1})))
         % endif
 
 documentation: |-

--- a/gr-fec/grc/variable_cc_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_decoder_def_list.block.yml
@@ -72,7 +72,7 @@ templates:
         % else:
         self.${id} = ${id} = list(map( (lambda b: map(\
         ( lambda a: fec.cc_decoder.make(${framebits}, ${k}, ${rate}, ${polys}, ${state_start},\
-        ${state_end}, ${mode}, ${padding})), range(0,${dim2}) ) ), range(0,${dim1})))
+        ${state_end}, ${mode}, ${padding})), range(0,${dim2}) ) ), range(0,${dim1})))\
         % endif
 
 documentation: ""

--- a/gr-fec/grc/variable_cc_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_cc_encoder_def_list.block.yml
@@ -60,9 +60,8 @@ templates:
         self.${id} = ${id} = list(map( (lambda a: fec.cc_encoder_make(${framebits},\
         ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})), range(0,${dim1})))
         % else:
-        self.${id} = ${id} = list(map( (lambda b: map( ( lambda a: fec.cc_encoder_make(${framebits},\
-        ${k}, ${rate}, ${polys}, ${state_start}, ${mode}, ${padding})), range(0,${dim2})\) ), 
-        range(0,${dim1})))
+        self.${id} = ${id} = list(map( (lambda b:list(map( ( lambda a:fec.cc_encoder_make(${framebits}, ${k}, ${rate}, ${polys}, \
+        ${state_start}, ${mode}, ${padding})), range(0,${dim2})))), range(0,${dim1})))
         % endif
 
 documentation: ""

--- a/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_decoder_def_list.block.yml
@@ -37,7 +37,7 @@ templates:
         self.${id} = ${id} = list(map((lambda a: fec.dummy_decoder.make(${framebits})),\
         range(0,${dim1})))
         % else:
-        self.${id} = ${id} = list(map((lambda b: map((lambda\
+        self.${id} = ${id} = list(map((lambda b: map((lambda \
         a: fec.dummy_decoder.make(${framebits})), range(0,${dim2}))), range(0,${dim1})))\
         % endif
 

--- a/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_dummy_encoder_def_list.block.yml
@@ -30,11 +30,12 @@ templates:
         % if int(ndim)==0:
         self.${id} = ${id} = fec.dummy_encoder_make(${framebits})\
         % elif int(ndim)==1:
-        self.${id} = ${id} = list(map((lambda a: fec.dummy_encoder_make(${framebits})),\
+        self.${id} = ${id} = list(map((lambda a:fec.dummy_encoder_make(${framebits})),\
         range(0,${dim1})))
         % else:
-        self.${id} = ${id} = list(map((lambda b: map((lambda\
-        a: fec.dummy_encoder_make(${framebits})), range(0,${dim2}))), range(0,${dim1})))\
+        self.${id} = ${id} = list(map((lambda b:map((lambda a:\
+        fec.dummy_encoder_make(${framebits})),\
+        range(0,${dim2}))), range(0,${dim1})))
         % endif
 
 documentation: ""

--- a/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
+++ b/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
@@ -311,6 +311,10 @@ parameters:
     label: Line 10 Alpha
     base_key: alpha1
     hide: ${ ('part' if int(num_curves) >= 10 else 'all') }
+-   id: bus_structure_sink
+    default: list(map(lambda b:list(map(lambda a:b * len(esno) * 2 + a, range(len(esno)*2))), range(num_curves))) 
+    dtype: raw
+    hide: all
 
 inputs:
 -   domain: stream
@@ -346,7 +350,11 @@ templates:
             ${color6}, ${color7}, ${color8}, ${color9}, ${color10}]
         alphas = [${alpha1}, ${alpha2}, ${alpha3}, ${alpha4}, ${alpha5},
             ${alpha6}, ${alpha7}, ${alpha8}, ${alpha9}, ${alpha10}]
-
+        styles = [${style1}, ${style2}, ${style3}, ${style4}, ${style5},
+            ${style6}, ${style7}, ${style8}, ${style9}, ${style10}]
+        markers = [${marker1}, ${marker2}, ${marker3}, ${marker4}, ${marker5},
+            ${marker6}, ${marker7}, ${marker8}, ${marker9}, ${marker10}]
+            
         for i in range(${num_curves}):
             if len(labels[i]) == 0:
                 self.${id}.set_line_label(i, "Data {0}".format(i))

--- a/grc/blocks/grc.tree.yml
+++ b/grc/blocks/grc.tree.yml
@@ -4,6 +4,10 @@
   - pad_sink
   - virtual_source
   - virtual_sink
+  - bus_sink
+  - bus_source
+  - bus_structure_sink
+  - bus_structure_source
   - epy_block
   - epy_module
   - note

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -284,6 +284,7 @@ class FlowGraph(Element):
         connection = self.parent_platform.Connection(
             parent=self, source=porta, sink=portb)
         self.connections.add(connection)
+            
         return connection
 
     def disconnect(self, *ports):
@@ -377,6 +378,7 @@ class FlowGraph(Element):
 
             block.import_data(**block_data)
 
+        self.rewrite()  # TODO: Figure out why this has to be called twice to populate bus ports correctly
         self.rewrite()  # evaluate stuff like nports before adding connections
 
         # build the connections

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -298,7 +298,28 @@ class TopBlockGenerator(object):
         rendered = []
         for con in sorted(connections, key=by_domain_and_blocks):
             template = templates[con.type]
-            code = template.render(make_port_sig=make_port_sig, source=con.source_port, sink=con.sink_port)
-            rendered.append(code)
+            if con.source_port.dtype != 'bus':
+                code = template.render(make_port_sig=make_port_sig, source=con.source_port, sink=con.sink_port)
+                rendered.append(code)
+            else:
+                # Bus ports need to iterate over the underlying connections and then render
+                # the code for each subconnection
+                porta = con.source_port
+                portb = con.sink_port
+                fg = self._flow_graph
+                             
+                if porta.dtype == 'bus' and portb.dtype == 'bus':
+                    # which bus port is this relative to the bus structure
+                    if len(porta.bus_structure) == len(portb.bus_structure):
+                        for port_num_a,port_num_b in zip(porta.bus_structure,portb.bus_structure):
+                            hidden_porta = porta.parent.sources[port_num_a]
+                            hidden_portb = portb.parent.sinks[port_num_b]
+                            connection = fg.parent_platform.Connection(
+                                parent=self, source=hidden_porta, sink=hidden_portb)
+                            code = template.render(make_port_sig=make_port_sig, source=hidden_porta, sink=hidden_portb)
+                            rendered.append(code)
+                            
+
+            
 
         return rendered

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -802,8 +802,8 @@ class Application(Gtk.Application):
 
         Actions.BLOCK_CREATE_HIER.set_enabled(bool(selected_blocks))
         Actions.OPEN_HIER.set_enabled(bool(selected_blocks))
-        #Actions.BUSSIFY_SOURCES.set_enabled(bool(selected_blocks))
-        #Actions.BUSSIFY_SINKS.set_enabled(bool(selected_blocks))
+        Actions.BUSSIFY_SOURCES.set_enabled(bool(selected_blocks))
+        Actions.BUSSIFY_SINKS.set_enabled(bool(selected_blocks))
         Actions.RELOAD_BLOCKS.enable()
         Actions.FIND_BLOCKS.enable()
 

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -128,16 +128,14 @@ class Block(CoreBlock, Drawable):
             self._area = (0, 0, self.height, self.width)
         self.bounds_from_area(self._area)
 
-        # bussified = self.current_bus_structure['source'], self.current_bus_structure['sink']
-        bussified = False, False
+        bussified = self.current_bus_structure['source'], self.current_bus_structure['sink']
         for ports, has_busses in zip((self.active_sources, self.active_sinks), bussified):
             if not ports:
                 continue
             port_separation = PORT_SEPARATION if not has_busses else ports[0].height + PORT_SPACING
             offset = (self.height - (len(ports) - 1) * port_separation - ports[0].height) / 2
             for port in ports:
-                port.create_shapes()
-
+                port.create_shapes()            
                 port.coordinate = {
                     0: (+self.width, offset),
                     90: (offset, -port.width),
@@ -193,23 +191,20 @@ class Block(CoreBlock, Drawable):
 
         def get_min_height_for_ports(ports):
             min_height = 2 * PORT_BORDER_SEPARATION + len(ports) * PORT_SEPARATION
-            if ports:
-                min_height -= ports[-1].height
+            # If any of the ports are bus ports - make the min height larger
+            if any([p.dtype == 'bus' for p in ports]):
+                min_height = 2 * PORT_BORDER_SEPARATION + sum(
+                    port.height + PORT_SPACING for port in ports if port.dtype == 'bus'
+                    ) - PORT_SPACING
+            
+            else:
+                if ports:
+                    min_height -= ports[-1].height
             return min_height
 
         height = max(height,
                      get_min_height_for_ports(self.active_sinks),
                      get_min_height_for_ports(self.active_sources))
-
-        # def get_min_height_for_bus_ports(ports):
-        #     return 2 * PORT_BORDER_SEPARATION + sum(
-        #         port.height + PORT_SPACING for port in ports if port.dtype == 'bus'
-        #     ) - PORT_SPACING
-        #
-        # if self.current_bus_structure['sink']:
-        #     height = max(height, get_min_height_for_bus_ports(self.active_sinks))
-        # if self.current_bus_structure['source']:
-        #     height = max(height, get_min_height_for_bus_ports(self.active_sources))
 
         self.width, self.height = width, height = Utils.align_to_grid((width, height))
 

--- a/grc/gui/canvas/connection.py
+++ b/grc/gui/canvas/connection.py
@@ -113,7 +113,7 @@ class Connection(CoreConnection, Drawable):
             self._make_path()  # no cr set --> only sets bounding_points for extent
 
     def _make_path(self, cr=None):
-        x_pos, y_pos = self.coordinate  # is source connector coordinate
+        x_pos, y_pos = self.source_port.connector_coordinate_absolute
         # x_start, y_start = self.source_port.get_connector_coordinate()
         x_end, y_end = self.sink_port.connector_coordinate_absolute
 

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -487,7 +487,13 @@ class FlowGraph(CoreFlowgraph, Drawable):
             element.create_labels(cr)
 
     def create_shapes(self):
-        for element in self._elements_to_draw:
+        #TODO - this is a workaround for bus ports not having a proper coordinate
+        # until the shape is drawn.  The workaround is to draw blocks before connections
+
+        for element in filter(lambda x: x.is_block, self._elements_to_draw) :
+            element.create_shapes()
+
+        for element in filter(lambda x: not x.is_block, self._elements_to_draw):
             element.create_shapes()
 
     def _drawables(self):

--- a/grc/gui/canvas/port.py
+++ b/grc/gui/canvas/port.py
@@ -124,17 +124,18 @@ class Port(CorePort, Drawable):
         label_width, label_height = self.label_layout.get_size()
 
         self.width = 2 * Constants.PORT_LABEL_PADDING + label_width / Pango.SCALE
-        self.height = 2 * Constants.PORT_LABEL_PADDING + label_height / Pango.SCALE
+        self.height = (2 * Constants.PORT_LABEL_PADDING + label_height*(3 if self.dtype == 'bus' else 1) ) / Pango.SCALE
         self._label_layout_offsets = [0, Constants.PORT_LABEL_PADDING]
-        # if self.dtype == 'bus':
-        #     self.height += Constants.PORT_EXTRA_BUS_HEIGHT
-        #     self._label_layout_offsets[1] += Constants.PORT_EXTRA_BUS_HEIGHT / 2
+
         self.height += self.height % 2  # uneven height
 
     def draw(self, cr):
         """
         Draw the socket with a label.
         """
+        if self.hidden:
+            return
+
         border_color = self._border_color
         cr.set_line_width(self._line_width_factor * cr.get_line_width())
         cr.translate(*self.coordinate)


### PR DESCRIPTION
@mormj work, just rebased onto origin/master.
<hr>
Bus ports had not been added back in since the refactor of grc
Hopefully this fully enables busports though there are still some
issues with the gr-fec flowgraphs

Fixes #2277