### PR TITLE
grc: added url to wiki page for each block in docs tab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ set(MSVC_MIN_VERSION "1800")
 # Enable generation of compile_commands.json for code completion engines
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Set wiki block docs url prefix used in grc-docs.conf (block name gets appended to end of this string)
+set(GRC_DOCS_URL_PREFIX "https://wiki.gnuradio.org/index.php/")
+
 ########################################################################
 # Configure CMake policies
 ########################################################################

--- a/grc/00-grc-docs.conf.in
+++ b/grc/00-grc-docs.conf.in
@@ -1,0 +1,4 @@
+# This should link to the wiki page-per-block documentation, when the block label (e.g., FFT) is appended to the end of the string
+
+[grc-docs]
+wiki_block_docs_url_prefix = @GRC_DOCS_URL_PREFIX@

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -101,7 +101,7 @@ GR_REGISTER_COMPONENT("gnuradio-companion" ENABLE_GRC
 if(ENABLE_GRC)
 
 ########################################################################
-# Create and install the grc conf file
+# Create and install the grc and grc-docs conf file
 ########################################################################
 file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/${GRC_BLOCKS_DIR} blocksdir)
 if(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
@@ -129,6 +129,16 @@ configure_file(
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/grc.conf
+    DESTINATION ${GR_PREFSDIR}
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/00-grc-docs.conf.in
+    ${CMAKE_CURRENT_BINARY_DIR}/00-grc-docs.conf
+@ONLY)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/00-grc-docs.conf
     DESTINATION ${GR_PREFSDIR}
 )
 

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -97,6 +97,10 @@ class Config(CoreConfig):
         return self._gr_prefs.get_string('grc', 'xterm_executable', 'xterm')
 
     @property
+    def wiki_block_docs_url_prefix(self):
+        return self._gr_prefs.get_string('grc-docs', 'wiki_block_docs_url_prefix', '')
+
+    @property
     def default_canvas_size(self):
         try:  # ugly, but matches current code style
             raw = self._gr_prefs.get_string('grc', 'canvas_default_size', '1280, 1024')

--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -57,6 +57,7 @@ class PropsDialog(Gtk.Dialog):
 
         self._block = block
         self._hash = 0
+        self._config = parent.config
 
         vpaned = Gtk.VPaned()
         self.vbox.pack_start(vpaned, True, True, 0)
@@ -210,6 +211,12 @@ class PropsDialog(Gtk.Dialog):
         buf = self._docs_text_display.get_buffer()
         buf.delete(buf.get_start_iter(), buf.get_end_iter())
         pos = buf.get_end_iter()
+
+        # Add link to wiki page for this block, at the top
+        note = "Wiki Page for this Block: "
+        prefix = self._config.wiki_block_docs_url_prefix
+        suffix = self._block.label.replace(" ", "_")
+        buf.insert(pos, note + prefix + suffix + '\n\n')
 
         docstrings = self._block.documentation.copy()
         if not docstrings:


### PR DESCRIPTION
Here's an example of what it looks like.  Note that it's NOT a hyperlink, unfortunately adding a link to a Gtk TextView isn't straightforward, you have to create a tag within the text, then attach an event to that tag, and create the mouse click event.  For now the user will just have to copy/paste the URL (leaves less room for vulnerabilities anyway). 

<a href="https://ibb.co/L5sXJY3"><img src="https://i.ibb.co/X8Gr3jq/Screenshot-from-2019-07-15-15-34-39.png" alt="Screenshot-from-2019-07-15-15-34-39" border="0" /></a>