### PR TITLE
cmake: fix install dir of runtime_swig

### DIFF
--- a/gnuradio-runtime/swig/CMakeLists.txt
+++ b/gnuradio-runtime/swig/CMakeLists.txt
@@ -62,7 +62,7 @@ GR_SWIG_MAKE(runtime_swig runtime_swig.i)
 install(
   TARGETS runtime_swig
   EXPORT runtime_swig-export
-  DESTINATION ${GR_PYTHON_RELATIVE}/gnuradio/gr
+  DESTINATION ${GR_PYTHON_DIR}/gnuradio/gr
   )
 
 include(GrPython)


### PR DESCRIPTION
subject says it all. simple and easy. Toby will have to figure out how to work around this change!