### PR TITLE
grc/cppgen: Hide linking parameter

### DIFF
--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -41,7 +41,7 @@ parameters:
     default: dynamic
     options: [dynamic, static]
     option_labels: [ Dynamic, Static ]
-    hide: ${ ('part' if output_language == 'cpp' else 'all') }
+    hide: 'all'
 -   id: gen_cmake
     label: Generate CMakeLists.txt
     dtype: enum


### PR DESCRIPTION
Hide the option to generate statically linked C++ code until building GNU Radio with - DENABLE_STATIC_LIBS=ON works again. (Unless someone already fixed it, unfortunately I didn't have time to test it) 