### PR TITLE
Fix sign-compare warning in pdu_t_tagged_stream_impl.

### DIFF
--- a/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/pdu_to_tagged_stream_impl.cc
@@ -82,7 +82,7 @@ namespace gr {
 
       // work() should only be called if the current PDU fits entirely
       // into the output buffer.
-      assert(noutput_items >= d_curr_len);
+      assert(noutput_items >= 0 && (unsigned int) noutput_items >= d_curr_len);
 
       // Copy vector output
       size_t nout = d_curr_len;


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/2120 except warnings in `volk` using gcc 8.3.0 on 64-bit linux.