### PR TITLE
grc: Use yaml.safe_load() instead of yaml.load()

### DIFF
--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -232,7 +232,7 @@ class CppTopBlockGenerator(TopBlockGenerator):
             make = block.cpp_templates.render('make')
             declarations = block.cpp_templates.render('declarations')
             if translations:
-                translations = yaml.load(translations)
+                translations = yaml.safe_load(translations)
             else:
                 translations = {}
             translations.update(

--- a/grc/tests/test_yaml_checker.py
+++ b/grc/tests/test_yaml_checker.py
@@ -74,7 +74,7 @@ def test_extra_keys():
 
 def test_checker():
     checker = Validator(BLOCK_SCHEME)
-    data = yaml.load(BLOCK1)
+    data = yaml.safe_load(BLOCK1)
     passed = checker.run(data)
     if not passed:
         print()


### PR DESCRIPTION
yaml.load() has been deprecated: https://msg.pyyaml.org/load

This PR gets rid of the following warning:
`YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.`