### PR TITLE
Change /MP and /bigobj to compile_options for Ninja compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,8 +219,8 @@ if(MSVC)
         -D_CRT_NONSTDC_NO_DEPRECATE
     )
     add_definitions(-DHAVE_CONFIG_H)
-    add_definitions(/MP) #build with multiple processors
-    add_definitions(/bigobj) #allow for larger object files
+    add_compile_options(/MP) #build with multiple processors
+    add_compile_options(/bigobj) #allow for larger object files
 endif(MSVC)
 
 if(WIN32)


### PR DESCRIPTION
The current code fails when using the Ninja build system on Windows due to "/MP" and "/bigobj" being added to the compile definitions. They really are compilation options, and adding them as such in the CMakeLists.txt fixes the build error.

See the [Windows build for my in-development gnuradio conda-forge feedstock](https://dev.azure.com/rvolz/feedstock-builds/_build/results?buildId=50) for an example of the error.