### PR TITLE
grc:CMakeLists: fix python3.6 min version

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -27,7 +27,7 @@ message(STATUS "")
 GR_PYTHON_CHECK_MODULE_RAW(
     "python2 >= 2.7.6 or python3 >= 3.6.5"
     "import sys; \
-     requirement = (3, 6, 6) if sys.version_info.major >= 3 else (2, 7, 6); \
+     requirement = (3, 6, 5) if sys.version_info.major >= 3 else (2, 7, 6); \
      assert sys.version_info[:3] >= requirement"
     PYTHON_MIN_VER_FOUND
 )


### PR DESCRIPTION
Message about minimal python3 version said : 
python3 >= 3.6.5
but in grc/CMAkeLists.txt requirement variable is set to 3.6.6 if sys.version_info.major >= 3.
This patch fix this typo.