### PR TITLE
Using correct signal in freqdisplayform.cc

### DIFF
--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -180,7 +180,7 @@ FreqDisplayForm::setupControlPanel()
           d_controlpanel, SLOT(toggleGrid(bool)));
   connect(d_axislabelsmenu, SIGNAL(triggered(bool)),
           d_controlpanel, SLOT(toggleAxisLabels(bool)));
-  connect(d_sizemenu, SIGNAL(whichTrigger(unsigned int)),
+  connect(d_sizemenu, SIGNAL(whichTrigger(int)),
 	  d_controlpanel, SLOT(toggleFFTSize(int)));
   connect(d_winmenu, SIGNAL(whichTrigger(gr::filter::firdes::win_type)),
 	  d_controlpanel, SLOT(toggleFFTWindow(gr::filter::firdes::win_type)));


### PR DESCRIPTION
Running gr-filter/examples/filter_taps.grc
leads to
QObject::connect: No such signal FFTSizeMenu::whichTrigger(unsigned int)

This proposed change fixes this issue