### PR TITLE
modtool: restore rm functionality

### DIFF
--- a/gr-utils/python/modtool/core/rm.py
+++ b/gr-utils/python/modtool/core/rm.py
@@ -137,6 +137,8 @@ class ModToolRemove(ModTool):
                         may contain references to the globbed files
         cmakeedit_func - If the CMakeLists.txt needs special editing, use this
         """
+        if self.cli:
+            from ..cli import cli_input
         # 1. Create a filtered list
         files = []
         for g in globs:
@@ -155,7 +157,7 @@ class ModToolRemove(ModTool):
         yes = self.info['yes']
         for f in files_filt:
             b = os.path.basename(f)
-            if not yes:
+            if not yes and self.cli:
                 ans = cli_input("Really delete {}? [Y/n/a/q]: ".format(f)).lower().strip()
                 if ans == 'a':
                     yes = True


### PR DESCRIPTION
Add import for cli_input as the cli is called in rm.py
I suspect that this should be pulled out into cli/rm.py but we'll stick
with the low risk fix for now, to be refactored later

Fixes #2652