### PR TITLE
qtgui: restore enums/defaults for QT GUI Time Sink

### DIFF
--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -1,6 +1,5 @@
 id: qtgui_time_sink_x
 label: QT GUI Time Sink
-flags: [ python ]
 
 parameters:
 -   id: type
@@ -163,6 +162,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width1
     label: Line 1 Width
     default: 1
@@ -172,9 +172,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color1
     label: Line 1 Color
-    dtype: string
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
     default: 'blue'
     hide: ${ ('part' if (
             int(nconnections) >= 1
@@ -182,9 +185,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style1
     label: Line 1 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     hide: ${ ('part' if (
             int(nconnections) >= 1
@@ -192,16 +198,20 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker1
     label: Line 1 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     hide: ${ ('part' if (
             int(nconnections) >= 1
             or (type == "complex" and int(nconnections) >= 1)
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha1
     label: Line 1 Alpha
     dtype: real
@@ -212,6 +222,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label2
     label: Line 2 Label
@@ -224,6 +235,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width2
     label: Line 2 Width
     default: 1
@@ -234,10 +246,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color2
     label: Line 2 Color
-    dtype: string
-    default: 'green'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'red'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 2
@@ -245,9 +260,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style2
     label: Line 2 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -256,10 +274,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker2
     label: Line 2 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 2
@@ -267,6 +288,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha2
     label: Line 2 Alpha
     dtype: real
@@ -278,6 +300,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label3
     label: Line 3 Label
@@ -290,6 +313,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width3
     label: Line 3 Width
     default: 1
@@ -300,10 +324,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color3
     label: Line 3 Color
-    dtype: string
-    default: 'black'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'green'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 3
@@ -311,9 +338,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style3
     label: Line 3 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -322,10 +352,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker3
     label: Line 3 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 3
@@ -333,6 +366,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha3
     label: Line 3 Alpha
     dtype: real
@@ -344,6 +378,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label4
     label: Line 4 Label
@@ -356,6 +391,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width4
     label: Line 4 Width
     default: 1
@@ -366,10 +402,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color4
     label: Line 4 Color
-    dtype: string
-    default: 'cyan'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'black'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 4
@@ -377,9 +416,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style4
     label: Line 4 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -388,10 +430,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker4
     label: Line 4 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 4
@@ -399,6 +444,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha4
     label: Line 4 Alpha
     dtype: real
@@ -410,6 +456,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label5
     label: Line 5 Label
@@ -422,6 +469,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width5
     label: Line 5 Width
     default: 1
@@ -432,10 +480,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color5
     label: Line 5 Color
-    dtype: string
-    default: 'magenta'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'cyan'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 5
@@ -443,9 +494,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style5
     label: Line 5 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -454,10 +508,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker5
     label: Line 5 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 5
@@ -465,6 +522,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha5
     label: Line 5 Alpha
     dtype: real
@@ -476,6 +534,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label6
     label: Line 6 Label
@@ -488,6 +547,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width6
     label: Line 6 Width
     default: 1
@@ -498,10 +558,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color6
     label: Line 6 Color
-    dtype: string
-    default: 'yellow'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'magenta'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 6
@@ -509,9 +572,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style6
     label: Line 6 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -520,10 +586,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker6
     label: Line 6 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 6
@@ -531,6 +600,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha6
     label: Line 6 Alpha
     dtype: real
@@ -542,6 +612,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label7
     label: Line 7 Label
@@ -554,6 +625,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width7
     label: Line 7 Width
     default: 1
@@ -564,10 +636,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color7
     label: Line 7 Color
-    dtype: string
-    default: 'dark red'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'yellow'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 7
@@ -575,9 +650,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style7
     label: Line 7 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -586,10 +664,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker7
     label: Line 7 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 7
@@ -597,6 +678,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha7
     label: Line 7 Alpha
     dtype: real
@@ -608,6 +690,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label8
     label: Line 8 Label
@@ -620,6 +703,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width8
     label: Line 8 Width
     default: 1
@@ -630,10 +714,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color8
     label: Line 8 Color
-    dtype: string
-    default: 'dark green'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'dark red'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 8
@@ -641,9 +728,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style8
     label: Line 8 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -652,10 +742,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker8
     label: Line 8 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 8
@@ -663,6 +756,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha8
     label: Line 8 Alpha
     dtype: real
@@ -674,6 +768,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label9
     label: Line 9 Label
@@ -686,6 +781,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width9
     label: Line 9 Width
     default: 1
@@ -696,10 +792,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color9
     label: Line 9 Color
-    dtype: string
-    default: 'Dark Blue'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'dark green'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 9
@@ -707,9 +806,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style9
     label: Line 9 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -718,10 +820,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker9
     label: Line 9 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 9
@@ -729,6 +834,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha9
     label: Line 9 Alpha
     dtype: real
@@ -740,6 +846,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 -   id: label10
     label: Line 10 Label
@@ -752,6 +859,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: width10
     label: Line 10 Width
     default: 1
@@ -762,10 +870,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: color10
     label: Line 10 Color
-    dtype: string
-    default: 'blue'
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
+    default: 'dark blue'
     base_key: color1
     hide: ${ ('part' if (
             int(nconnections) >= 10
@@ -773,9 +884,12 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: style10
     label: Line 10 Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${ ('part' if (
@@ -784,10 +898,13 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: marker10
     label: Line 10 Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${ ('part' if (
             int(nconnections) >= 10
@@ -795,6 +912,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 -   id: alpha10
     label: Line 10 Alpha
     dtype: real
@@ -806,6 +924,7 @@ parameters:
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }
+    category: Config
 
 asserts:
 - ${nconnections <= (5 if type == 'complex' else 10)}
@@ -860,8 +979,8 @@ templates:
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
         widths = [${width1}, ${width2}, ${width3}, ${width4}, ${width5},
             ${width6}, ${width7}, ${width8}, ${width9}, ${width10}]
-        colors = [${color1}, ${color2}, ${color3}, ${color4}, ${color5},
-            ${color6}, ${color7}, ${color8}, ${color9}, ${color10}]
+        colors = ['${color1}', '${color2}', '${color3}', '${color4}', '${color5}',
+            '${color6}', '${color7}', '${color8}', '${color9}', '${color10}']
         alphas = [${alpha1}, ${alpha2}, ${alpha3}, ${alpha4}, ${alpha5},
             ${alpha6}, ${alpha7}, ${alpha8}, ${alpha9}, ${alpha10}]
         styles = [${style1}, ${style2}, ${style3}, ${style4}, ${style5},

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -170,6 +170,7 @@ LINE_PARAMS = """
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }}
+    category: Config
 -   id: width{i}
     label: Line {i} Width
     default: 1
@@ -180,9 +181,12 @@ LINE_PARAMS = """
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }}
+    category: Config
 -   id: color{i}
     label: Line {i} Color
-    dtype: string
+    dtype: enum
+    options: ['blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow', 'dark red', 'dark green', 'dark blue']
+    option_labels: ['Blue', 'Red', 'Green', 'Black', 'Cyan', 'Magenta', 'Yellow', 'Dark Red', 'Dark Green', 'Dark Blue']
     default: '{i_color}'
     base_key: color1
     hide: ${{ ('part' if (
@@ -191,9 +195,12 @@ LINE_PARAMS = """
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }}
+    category: Config
 -   id: style{i}
     label: Line {i} Style
-    dtype: int
+    dtype: enum
+    options: ['1','2','3','4','5','0']
+    option_labels: ['Solid','Dash','Dots','Dash-Dot','Dash-Dot-Dot']
     default: 1
     base_key: style1
     hide: ${{ ('part' if (
@@ -202,10 +209,13 @@ LINE_PARAMS = """
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }}
+    category: Config
 -   id: marker{i}
     label: Line {i} Marker
-    dtype: int
-    default: 1
+    dtype: enum
+    options: ['-1','0','1','2','3','4','5','6','7','8','9']
+    option_labels: ['None','Circle','Rectangle','Diamond','Triangle','Down Triangle','Left Triangle','Right Triangle','Cross','X-Cross']
+    default: -1
     base_key: marker1
     hide: ${{ ('part' if (
             int(nconnections) >= {i}
@@ -213,6 +223,7 @@ LINE_PARAMS = """
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }}
+    category: Config
 -   id: alpha{i}
     label: Line {i} Alpha
     dtype: real
@@ -224,6 +235,7 @@ LINE_PARAMS = """
             or (type == "msg_complex")) and (not type == "msg_float")
         else 'all')
         }}
+    category: Config
 """
 
 EVERYTHING_AFTER_PARAMS = """
@@ -280,8 +292,8 @@ templates:
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
         widths = [${width1}, ${width2}, ${width3}, ${width4}, ${width5},
             ${width6}, ${width7}, ${width8}, ${width9}, ${width10}]
-        colors = [${color1}, ${color2}, ${color3}, ${color4}, ${color5},
-            ${color6}, ${color7}, ${color8}, ${color9}, ${color10}]
+        colors = ['${color1}', '${color2}', '${color3}', '${color4}', '${color5}',
+            '${color6}', '${color7}', '${color8}', '${color9}', '${color10}']
         alphas = [${alpha1}, ${alpha2}, ${alpha3}, ${alpha4}, ${alpha5},
             ${alpha6}, ${alpha7}, ${alpha8}, ${alpha9}, ${alpha10}]
         styles = [${style1}, ${style2}, ${style3}, ${style4}, ${style5},
@@ -330,7 +342,7 @@ def make_yml():
     """Return the YML file as a string"""
     default_colors = [
         'blue', 'red', 'green', 'black', 'cyan', 'magenta', 'yellow',
-        'dark red', 'dark green', 'Dark Blue'
+        'dark red', 'dark green', 'dark blue'
     ]
     line_params_1 = LINE_PARAMS.format(i=1, i_cplx=1, i_color=default_colors[0])
     line_params_1 = re.sub(r'    base_key:.*\n', '', line_params_1)
@@ -338,7 +350,7 @@ def make_yml():
         LINE_PARAMS.format(
             i=i,
             i_cplx=int(math.ceil(float(i)/2)),
-            i_color=default_colors[i % len(default_colors)],
+            i_color=default_colors[(i-1) % len(default_colors)],
         )
         for i in range(2, 11)
     ])


### PR DESCRIPTION
Somewhere along the line, the QT Gui Time sink lost enums in .grc going to yml.  Also some of the 3.8 color and marker defaults were not ideal, though probably need for discussion here - resets to 3.7 color/marker defaults.  The enums I think are necessary for usability.

- moves the line style parameters to the Config Tab
- fixes issue with green becoming the second color

![image](https://user-images.githubusercontent.com/34754695/61899453-7aa8b300-aee9-11e9-8cb4-ac317ccbdf18.png)
