### PR TITLE
grc/cppgen: Use cli-style CMake options

### DIFF
--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -13,7 +13,6 @@
 
 <%
 class_name = flow_graph.get_option('id')
-cmake_opt_list = flow_graph.get_option('cmake_opt').split(";")
 %>\
 
 cmake_minimum_required(VERSION 3.8)
@@ -37,9 +36,9 @@ add_definitions(${'$'}{Qt5Widgets_DEFINITIONS})
 set(CMAKE_AUTOMOC TRUE)
 % endif
 
-% if cmake_opt_list != ['']:
-% for opt in cmake_opt_list:
-set(${opt.split("=")[0].strip()} ${opt.split("=")[1].strip()})
+% if cmake_tuples:
+% for key, val in cmake_tuples:
+set(${key} ${val})
 % endfor
 % endif
 

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -155,6 +155,15 @@ class CppTopBlockGenerator(TopBlockGenerator):
         filename = 'CMakeLists.txt'
         file_path = os.path.join(self.file_path, filename)
 
+        cmake_tuples = []
+        cmake_opt = self._flow_graph.get_option("cmake_opt")
+        cmake_opt = " " + cmake_opt # To make sure we get rid of the "-D"s when splitting
+
+        for opt_string in cmake_opt.split(" -D"):
+            opt_string = opt_string.strip()
+            if opt_string:
+                cmake_tuples.append(tuple(opt_string.split("=")))
+
         output = []
 
         flow_graph_code = cmake_template.render(
@@ -164,6 +173,7 @@ class CppTopBlockGenerator(TopBlockGenerator):
             callbacks=self._callbacks(),
             connections=self._connections(),
             links=self._links(),
+            cmake_tuples=cmake_tuples,
             **self.namespace
         )
         # strip trailing white-space


### PR DESCRIPTION
In other words, use `-DKEY1=VAL1 -DKEY2=VAL2` instead of `KEY1=VAL1; KEY2=VAL2` for the CMake options parameter.

Mentioned here: https://github.com/gnuradio/gnuradio/issues/2613