### PR TITLE
grc: Introduce sensible defaults

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -49,9 +49,9 @@ class FlowGraph(Element):
             the flow graph object
         """
         Element.__init__(self, parent)
-        self._options_block = self.parent_platform.make_block(self, 'options')
+        self.options_block = self.parent_platform.make_block(self, 'options')
 
-        self.blocks = [self._options_block]
+        self.blocks = [self.options_block]
         self.connections = set()
 
         self._eval_cache = {}
@@ -149,7 +149,7 @@ class FlowGraph(Element):
         Returns:
             the value held by that param
         """
-        return self._options_block.params[key].get_evaluated()
+        return self.options_block.params[key].get_evaluated()
 
     def get_run_command(self, file_path, split=False):
         run_command = self.get_option('run_command')
@@ -264,7 +264,7 @@ class FlowGraph(Element):
             the new block or None if not found
         """
         if block_id == 'options':
-            return self._options_block
+            return self.options_block
         try:
             block = self.parent_platform.make_block(self, block_id, **kwargs)
             self.blocks.append(block)
@@ -303,7 +303,7 @@ class FlowGraph(Element):
         If the element is a block, remove its connections.
         If the element is a connection, just remove the connection.
         """
-        if element is self._options_block:
+        if element is self.options_block:
             return
 
         if element.is_port:
@@ -332,9 +332,9 @@ class FlowGraph(Element):
             return not b.is_variable, b.name  # todo: vars still first ?!?
 
         data = collections.OrderedDict()
-        data['options'] = self._options_block.export_data()
+        data['options'] = self.options_block.export_data()
         data['blocks'] = [b.export_data() for b in sorted(self.blocks, key=block_order)
-                          if b is not self._options_block]
+                          if b is not self.options_block]
         data['connections'] = sorted(c.export_data() for c in self.connections)
         data['metadata'] = {'file_format': FLOW_GRAPH_FILE_FORMAT_VERSION}
         return data
@@ -342,7 +342,7 @@ class FlowGraph(Element):
     def _build_depending_hier_block(self, block_id):
         # we're before the initial fg update(), so no evaluated values!
         # --> use raw value instead
-        path_param = self._options_block.params['hier_block_src_path']
+        path_param = self.options_block.params['hier_block_src_path']
         file_path = self.parent_platform.find_file_in_paths(
             filename=block_id + '.grc',
             paths=path_param.get_value(),
@@ -368,8 +368,8 @@ class FlowGraph(Element):
         file_format = data['metadata']['file_format']
 
         # build the blocks
-        self._options_block.import_data(name='', **data.get('options', {}))
-        self.blocks.append(self._options_block)
+        self.options_block.import_data(name='', **data.get('options', {}))
+        self.blocks.append(self.options_block)
 
         for block_data in data.get('blocks', []):
             block_id = block_data['id']

--- a/grc/core/default_flow_graph.grc
+++ b/grc/core/default_flow_graph.grc
@@ -5,8 +5,8 @@
 
 options:
   parameters:
-    id: 'top_block'
-    title: 'top_block'
+    id: 'default'
+    title: 'Not titled yet'
   states:
     coordinate:
     - 8

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -26,7 +26,7 @@ from .. import Constants
 
 
 # Blacklist certain ids, its not complete, but should help
-ID_BLACKLIST = ['self', 'options', 'gr', 'math', 'firdes'] + dir(builtins)
+ID_BLACKLIST = ['self', 'options', 'gr', 'math', 'firdes', 'default'] + dir(builtins)
 try:
     from gnuradio import gr
     ID_BLACKLIST.extend(attr for attr in dir(gr.top_block()) if not attr.startswith('_'))

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -596,14 +596,14 @@ class Application(Gtk.Application):
             main.new_page()
             args = (GLib.Variant('s', 'qt_gui'),)
             flow_graph = main.current_page.flow_graph
-            flow_graph._options_block.params['generate_options'].set_value(str(args[0])[1:-1])
-            flow_graph._options_block.params['author'].set_value(getuser())
+            flow_graph.options_block.params['generate_options'].set_value(str(args[0])[1:-1])
+            flow_graph.options_block.params['author'].set_value(getuser())
             flow_graph_update(flow_graph)
         elif action == Actions.FLOW_GRAPH_NEW_TYPE:
             main.new_page()
             if args:
                 flow_graph = main.current_page.flow_graph
-                flow_graph._options_block.params['generate_options'].set_value(str(args[0])[1:-1])
+                flow_graph.options_block.params['generate_options'].set_value(str(args[0])[1:-1])
                 flow_graph_update(flow_graph)
         elif action == Actions.FLOW_GRAPH_OPEN:
             file_paths = args[0] if args[0] else FileDialogs.OpenFlowGraph(main, page.file_path).run()
@@ -641,9 +641,9 @@ class Application(Gtk.Application):
             file_path = FileDialogs.SaveFlowGraph(main, page.file_path).run()
 
             if file_path is not None:
-                if flow_graph._options_block.params['id'].get_value() == 'default':
+                if flow_graph.options_block.params['id'].get_value() == 'default':
                     file_name = os.path.basename(file_path).replace(".grc", "")
-                    flow_graph._options_block.params['id'].set_value(file_name)
+                    flow_graph.options_block.params['id'].set_value(file_name)
                     flow_graph_update(flow_graph)
 
                 page.file_path = os.path.abspath(file_path)

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -25,6 +25,7 @@ import os
 import subprocess
 
 from gi.repository import Gtk, Gio, GLib, GObject
+from getpass import getuser
 
 from . import Constants, Dialogs, Actions, Executor, FileDialogs, Utils, Bars
 
@@ -596,6 +597,7 @@ class Application(Gtk.Application):
             args = (GLib.Variant('s', 'qt_gui'),)
             flow_graph = main.current_page.flow_graph
             flow_graph._options_block.params['generate_options'].set_value(str(args[0])[1:-1])
+            flow_graph._options_block.params['author'].set_value(getuser())
             flow_graph_update(flow_graph)
         elif action == Actions.FLOW_GRAPH_NEW_TYPE:
             main.new_page()
@@ -637,7 +639,13 @@ class Application(Gtk.Application):
                     page.saved = False
         elif action == Actions.FLOW_GRAPH_SAVE_AS:
             file_path = FileDialogs.SaveFlowGraph(main, page.file_path).run()
+
             if file_path is not None:
+                if flow_graph._options_block.params['id'].get_value() == 'default':
+                    file_name = os.path.basename(file_path).replace(".grc", "")
+                    flow_graph._options_block.params['id'].set_value(file_name)
+                    flow_graph_update(flow_graph)
+
                 page.file_path = os.path.abspath(file_path)
                 try:
                     self.platform.save_flow_graph(page.file_path, flow_graph)


### PR DESCRIPTION
Defaults as described in: https://github.com/gnuradio/gnuradio/issues/2558

**Bug warning:**
If you
1. create a new flow graph
2. save it without changing the ID (So that the ID is replaced by the file name)
3. open any block's parameter dialog
4. press "Cancel"

the Options block's ID will be reset to `default` again, and you will have to manually change the ID to be allowed to generate code from GRC.

I haven't had time to investigate why, but I believe this bug to be out of scope for this PR and perhaps related to https://github.com/gnuradio/gnuradio/issues/2061