### PR TITLE
grc: Attempt to fix test_expr_utils

### DIFF
--- a/grc/core/utils/expr_utils.py
+++ b/grc/core/utils/expr_utils.py
@@ -92,7 +92,7 @@ def sort_objects2(objects, id_getter, expr_getter, check_circular=True):
 
     def dependent_ids(obj):
         deps = dependencies(expr_getter(obj))
-        return [id_ if id_ in deps else None for id_ in known_ids]
+        return [id_ if id_ in deps else '' for id_ in known_ids]
 
     objects = sorted(objects, key=dependent_ids)
 


### PR DESCRIPTION
This fixes the failing test, but I haven't had time to investigate if this causes any side effects yet.

Cause:
None is less than everything in Python 2, but not in Python 3: https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons