### PR TITLE
Add 'Watch End Tag' option to 'ZeroMQ Pull Source' block

### DIFF
--- a/gr-zeromq/grc/zeromq_pull_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_source.block.yml
@@ -29,6 +29,13 @@ parameters:
     default: 'False'
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
+-   id: watch_end_tag
+    label: Watch End Tag
+    dtype: enum
+    default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: ${ ('all' if str(pass_tags) == 'False' else 'none') }
 -   id: hwm
     label: High Watermark
     dtype: int
@@ -43,6 +50,6 @@ outputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.pull_source(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm})
+        ${hwm}, ${watch_end_tag})
 
 file_format: 1

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -51,9 +51,10 @@ namespace gr {
        * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
        * \param pass_tags Whether source will look for and deserialize tags.
        * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
+       * \param watch_end_tag Whether to end with WORK_DONE after writing an item tagged "end" to output
        */
       static sptr make(size_t itemsize, size_t vlen, char *address,
-                       int timeout=100, bool pass_tags=false, int hwm=-1);
+                       int timeout=100, bool pass_tags=false, int hwm=-1, bool watch_end_tag=false);
 
       /*!
        * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -56,7 +56,7 @@ namespace gr {
     class base_source_impl : public base_impl
     {
     public:
-      base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
+      base_source_impl(int type, size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm, bool watch_end_tag);
 
     protected:
       zmq::message_t d_msg;
@@ -67,6 +67,12 @@ namespace gr {
       bool has_pending();
       int  flush_pending(void *out_buf, const int out_nitems, const uint64_t out_offset);
       bool load_message(bool wait);
+      bool work_done();
+
+    private:
+      bool d_watch_end_tag;
+      bool d_terminate;
+      uint64_t d_end_offset;
     };
 
   } // namespace zeromq

--- a/gr-zeromq/lib/pull_source_impl.cc
+++ b/gr-zeromq/lib/pull_source_impl.cc
@@ -32,17 +32,17 @@ namespace gr {
   namespace zeromq {
 
     pull_source::sptr
-    pull_source::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
+    pull_source::make(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm, bool watch_end_tag)
     {
       return gnuradio::get_initial_sptr
-        (new pull_source_impl(itemsize, vlen, address, timeout, pass_tags, hwm));
+        (new pull_source_impl(itemsize, vlen, address, timeout, pass_tags, hwm, watch_end_tag));
     }
 
-    pull_source_impl::pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm)
+    pull_source_impl::pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm, bool watch_end_tag)
       : gr::sync_block("pull_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
-        base_source_impl(ZMQ_PULL, itemsize, vlen, address, timeout, pass_tags, hwm)
+        base_source_impl(ZMQ_PULL, itemsize, vlen, address, timeout, pass_tags, hwm, watch_end_tag)
     {
       /* All is delegated */
     }
@@ -79,7 +79,7 @@ namespace gr {
         }
       }
 
-      return done;
+      return work_done() ? WORK_DONE : done;
     }
 
   } /* namespace zeromq */

--- a/gr-zeromq/lib/pull_source_impl.h
+++ b/gr-zeromq/lib/pull_source_impl.h
@@ -34,7 +34,7 @@ namespace gr {
     class pull_source_impl : public pull_source, public base_source_impl
     {
     public:
-      pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm);
+      pull_source_impl(size_t itemsize, size_t vlen, char *address, int timeout, bool pass_tags, int hwm, bool watch_end_tag);
 
       int work(int noutput_items,
                gr_vector_const_void_star &input_items,

--- a/gr-zeromq/lib/req_source_impl.cc
+++ b/gr-zeromq/lib/req_source_impl.cc
@@ -42,7 +42,7 @@ namespace gr {
       : gr::sync_block("req_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
-        base_source_impl(ZMQ_REQ, itemsize, vlen, address, timeout, pass_tags, hwm),
+        base_source_impl(ZMQ_REQ, itemsize, vlen, address, timeout, pass_tags, hwm, false),
         d_req_pending(false)
     {
       /* All is delegated */

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -42,7 +42,7 @@ namespace gr {
       : gr::sync_block("sub_source",
                        gr::io_signature::make(0, 0, 0),
                        gr::io_signature::make(1, 1, itemsize * vlen)),
-        base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm)
+        base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm, false)
     {
       /* Subscribe */
       d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);


### PR DESCRIPTION
### The Problem
A flow-graph that acquires input from a **ZeroMQ Pull Source** block, remains running and there is no way to tell it to exit if there is no incoming data remaining, other than to kill it by a parent process.

### Purpose
Complete and gently exit a running flow-graph that acquires data from a **ZeroMQ pull source** block.

### How I solved it
If **Pass Tags** option of the **ZeroMQ Pull Source** GRC block is set, a **Watch End Tag** option will appear, that if enabled, watches incoming data for an item that is tagged with `"end"` key. The block will `return WORK_DONE` in its `work` function when all items before (and including) that tagged item is written to output port.