### PR TITLE
cmake: Don't abort everything when modtool can't find click

### DIFF
--- a/gr-utils/CMakeLists.txt
+++ b/gr-utils/CMakeLists.txt
@@ -24,6 +24,18 @@ include(GrPython)
 
 GR_PYTHON_CHECK_MODULE("Mako >= ${GR_MAKO_MIN_VERSION}" mako "mako.__version__ >= '${GR_MAKO_MIN_VERSION}'" MAKO_FOUND)
 
+GR_PYTHON_CHECK_MODULE_RAW(
+  "click"
+  "import click"
+  CLICK_FOUND
+  )
+
+GR_PYTHON_CHECK_MODULE_RAW(
+  "click-plugins"
+  "import click_plugins"
+  CLICK_PLUGINS_FOUND
+  )
+
 ########################################################################
 # Register component
 ########################################################################
@@ -32,12 +44,23 @@ if(NOT CMAKE_CROSSCOMPILING)
     set(utils_python_deps
         MAKO_FOUND
     )
+    
+    set(utils_modtool_deps
+      CLICK_FOUND
+      CLICK_PLUGINS_FOUND
+    )
 endif(NOT CMAKE_CROSSCOMPILING)
 
 GR_REGISTER_COMPONENT("gr-utils" ENABLE_GR_UTILS
     ENABLE_GNURADIO_RUNTIME
     ENABLE_PYTHON
     ${utils_python_deps}
+)
+
+GR_REGISTER_COMPONENT("gr_modtool" ENABLE_GR_MODTOOL
+    ENABLE_GNURADIO_RUNTIME
+    ENABLE_PYTHON
+    ${utils_modtool_deps}
 )
 
 ########################################################################
@@ -49,6 +72,9 @@ if(ENABLE_GR_UTILS)
 # Add subdirectories
 ########################################################################
 add_subdirectory(python/utils)
+
+if(ENABLE_GR_MODTOOL)
 add_subdirectory(python/modtool)
+endif(ENABLE_GR_MODTOOL)
 
 endif(ENABLE_GR_UTILS)

--- a/gr-utils/python/modtool/CMakeLists.txt
+++ b/gr-utils/python/modtool/CMakeLists.txt
@@ -17,29 +17,6 @@
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
 
-include(GrPython)
-
-GR_PYTHON_CHECK_MODULE_RAW(
-  "click"
-  "import click"
-  CLICK_FOUND
-  )
-
-GR_PYTHON_CHECK_MODULE_RAW(
-  "click-plugins"
-  "import click_plugins"
-  CLICK_PLUGINS_FOUND
-  )
-
-if(NOT CMAKE_CROSSCOMPILING)
-  if(NOT CLICK_FOUND)
-    message(FATAL_ERROR "Python module click is required for gr-modtool")
-  endif()
-  if(NOT CLICK_PLUGINS_FOUND)
-    message(FATAL_ERROR "Python module click-plugins is required for gr-modtool")
-  endif()
-endif()
-
 GR_PYTHON_INSTALL(FILES
     __init__.py
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/modtool


### PR DESCRIPTION
Fix for https://github.com/gnuradio/gnuradio/issues/2646: Modtool is simply disabled if `click` and `click-plugins` can't be found. With this fix, modtool can also be enabled and disabled with `-DENABLE_GR_MODTOOL=ON/OFF` like the top-level modules. Looks like it works to me, but I don't know if this is the best way to do it. @noc0lour thoughts?