### PR TITLE
grc: prevent yaml parser errors from crashing grc

### DIFF
--- a/gr-utils/python/modtool/templates/templates.py
+++ b/gr-utils/python/modtool/templates/templates.py
@@ -550,11 +550,11 @@ templates:
   imports: import ${modname}
   make: ${modname}.${blockname}(${strip_arg_types_grc(arglist)})
 
-<!-- Make one 'parameters' list entry for every Parameter you want settable from the GUI.
-     Sub-entries of dictionary:
-     * id (makes the value accessible as \$keyname, e.g. in the make entry)
-     * label
-     * dtype -->
+#  Make one 'parameters' list entry for every Parameter you want settable from the GUI.
+#     Sub-entries of dictionary:
+#     * id (makes the value accessible as \$keyname, e.g. in the make entry)
+#     * label
+#     * dtype 
 parameters:
 - id: ...
   label: ...
@@ -563,26 +563,26 @@ parameters:
   label: ...
   dtype: ...
 
-<!-- Make one 'inputs' list entry per input. Sub-entries of dictionary:
-     * label (an identifier for the GUI)
-     * domain
-     * dtype
-     * vlen
-     * optional (set to 1 for optional inputs) -->
+#  Make one 'inputs' list entry per input. Sub-entries of dictionary:
+#      * label (an identifier for the GUI)
+#      * domain
+#      * dtype
+#      * vlen
+#      * optional (set to 1 for optional inputs) 
 inputs:
 - label: ...
   domain: ...
   dtype: ...
   vlen: ...
 
-<!-- Make one 'outputs' list entry per output. Sub-entries of dictionary:
-     * label (an identifier for the GUI)
-     * dtype
-     * vlen
-     * optional (set to 1 for optional inputs) -->
+#  Make one 'outputs' list entry per output. Sub-entries of dictionary:
+#      * label (an identifier for the GUI)
+#      * dtype
+#      * vlen
+#      * optional (set to 1 for optional inputs) 
 - label: ...
   domain: ...
-  dtype: !-- e.g. int, float, complex, byte, short, xxx_vector, ...--
+  dtype: ... #!-- e.g. int, float, complex, byte, short, xxx_vector, ...--
 
 file_format: 1
 '''

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -151,7 +151,6 @@ class Platform(Element):
 
         with Cache(Constants.CACHE_FILE) as cache:
             for file_path in self._iter_files_in_block_path(path):
-                data = cache.get_or_load(file_path)
 
                 if file_path.endswith('.block.yml'):
                     loader = self.load_block_description
@@ -167,6 +166,7 @@ class Platform(Element):
 
                 try:
                     checker = schema_checker.Validator(scheme)
+                    data = cache.get_or_load(file_path)
                     passed = checker.run(data)
                     for msg in checker.messages:
                         logger.warning('{:<40s} {}'.format(os.path.basename(file_path), msg))


### PR DESCRIPTION
Moves the yaml file load inside the try block as recommended by @haakov 

Allows grc to open up when there is a bad yml file in an OOT

Fixes #2668