### PR TITLE
uhd: Skip restoreGeometry() when no previous settings exist

### DIFF
--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -82,7 +82,9 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self.top_grid_layout = Qt.QGridLayout()
         self.top_layout.addLayout(self.top_grid_layout)
         self.settings = Qt.QSettings("GNU Radio", "uhd_fft")
-        self.restoreGeometry(self.settings.value("geometry"))
+        geo_settings = self.settings.value("geometry")
+        if geo_settings:
+            self.restoreGeometry(self.settings.value("geometry"))
 
         ##################################################
         # Parameters

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -85,7 +85,9 @@ class uhd_siggen_gui(Qt.QWidget):
         self.top_grid_layout = Qt.QGridLayout()
         self.top_layout.addLayout(self.top_grid_layout)
         self.settings = Qt.QSettings("GNU Radio", "uhd_siggen_gui")
-        self.restoreGeometry(self.settings.value("geometry"))
+        geo_settings = self.settings.value("geometry")
+        if geo_settings:
+            self.restoreGeometry(self.settings.value("geometry"))
 
         ##################################################
         # Widgets + Controls


### PR DESCRIPTION
There are cases when the Qt-based apps in gr-uhd would crash because Qt
would try and load previous geometry settings which didn't exist. This
disables applying previous geometry if the setting is empty.