### PR TITLE
grc: embedded python module show_id flag

### DIFF
--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -230,12 +230,15 @@ class EPyModule(Block):
         to set parameters of other blocks in your flowgraph.
     """)}
 
+    epy_flags=Block.flags
+    epy_flags.set(epy_flags.SHOW_ID)
+
     parameters_data = build_params(
         params_raw=[
             dict(label='Code', id='source_code', dtype='_multiline_python_external',
                  default='# this module will be imported in the into your flowgraph',
                  hide='part')
-        ], have_inputs=False, have_outputs=False, flags=Block.flags, block_id=key
+        ], have_inputs=False, have_outputs=False, flags=epy_flags, block_id=key
     )
 
     templates = MakoTemplates(


### PR DESCRIPTION
It is necessary to have access to the show_id flag for a python module
in grc to be able to access it elsewhere.  This adds the flag when the
module object is created in the block library.

![image](https://user-images.githubusercontent.com/34754695/62326817-02a83300-b47d-11e9-9225-3647252ede57.png)
