### PR TITLE
Fix wrong package name

### DIFF
--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -154,5 +154,5 @@ endif(MSVC)
 
 
 if(BUILD_SHARED_LIBS)
-  GR_LIBRARY_FOO(gnuradio-qtgui QWT Qt5Widgets FFTW3f)
+  GR_LIBRARY_FOO(gnuradio-qtgui Qwt Qt5Widgets FFTW3f)
 endif()


### PR DESCRIPTION
The package is named **Qwt** not QWT.
So find_package(Qwt REQUIRED)  leads to
CMake Error at /usr/share/cmake-3.13/Modules/CMakeFindDependencyMacro.cmake:48 (find_package):
  By not providing "FindQWT.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "QWT", but
  CMake did not find one.

  Could not find a package configuration file provided by "QWT" with any of
  the following names:

    QWTConfig.cmake
    qwt-config.cmake

As the module is named FindQwt.cmake in gnuradio/cmake/Modules this patch fixes this issue.