### PR TITLE
grc: prevent scrolling to top of canvas

### DIFF
--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -119,7 +119,12 @@ class DrawingArea(Gtk.DrawingArea):
         """
         Forward button click information to the flow graph.
         """
-        self.grab_focus()
+        # The following line causes the canvas to reset position to 0,0
+        #  when changing focus from the console or block search back to 
+        #  the canvas
+        #  Removing this line leaves the canvas alone when focus changes
+        # self.grab_focus()
+
         self.ctrl_mask = event.get_state() & Gdk.ModifierType.CONTROL_MASK
         self.mod1_mask = event.get_state() & Gdk.ModifierType.MOD1_MASK
         self.button_state[event.button] = True


### PR DESCRIPTION
GRC was scrolling to the top of the canvas when clicking into the console or search tree then back into the canvas. The view reset to the top left.

Commented out one line in _handle_mouse_button_press in DrawingArea.py -
makes the problem go away.  Need some additional testing to verify this won't cause any other negative side effects.  

Fixes #2660