### PR TITLE
blocks: fix multiply matrix complex set_A

### DIFF
--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -102,7 +102,7 @@ namespace gr {
             return;
           }
           for (size_t k = 0; k < pmt::length(row); k++) {
-            new_A[i][k] = pmt::to_double(pmt::is_vector(row) ? pmt::vector_ref(row, k) : pmt::tuple_ref(row, k));
+            new_A[i][k] = pmt::to_complex(pmt::is_vector(row) ? pmt::vector_ref(row, k) : pmt::tuple_ref(row, k));
           }
         } else if (pmt::is_c32vector(row)) {
           size_t row_len = 0;


### PR DESCRIPTION
The multiply_matrix_cc block was converting the values from the set
matrix to double when new_A matrix was expecting complex.  Convert the
PMT to complex instead.

Without this fix, sending complex matrices to the multiply matrix block results in an exception