### PR TITLE
Don't use hard-coded path constants.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,12 +309,20 @@ endif(ENABLE_PERFORMANCE_COUNTERS)
 ########################################################################
 # Variables replaced when configuring the package config files
 ########################################################################
-file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
-file(TO_NATIVE_PATH "\${prefix}"                        exec_prefix)
-file(TO_NATIVE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
-file(TO_NATIVE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
-file(TO_NATIVE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
-file(TO_NATIVE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
+file(TO_CMAKE_PATH "\${prefix}"                        exec_prefix)
+file(TO_CMAKE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
+file(TO_CMAKE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
+file(TO_CMAKE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
+file(TO_CMAKE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+
+if(WIN32)
+    file(RELATIVE_PATH prefix_relative_to_lib "${prefix}/${GR_RUNTIME_DIR}" "${prefix}")
+else(WIN32)
+    file(RELATIVE_PATH prefix_relative_to_lib "${prefix}/${GR_LIBRARY_DIR}" "${prefix}")
+endif(WIN32)
+file(RELATIVE_PATH SYSCONFDIR_relative_to_prefix "${prefix}" "${SYSCONFDIR}")
+file(RELATIVE_PATH GR_PREFSDIR_relative_to_prefix "${prefix}" "${GR_PREFSDIR}")
 
 ########################################################################
 # On Apple only, set install name and use rpath correctly, if not already set

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -30,10 +30,6 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
 message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
-#double escape for windows backslash path separators
-string(REPLACE "\\" "\\\\" prefix "${prefix}")
-string(REPLACE "\\" "\\\\" SYSCONFDIR "${SYSCONFDIR}")
-string(REPLACE "\\" "\\\\" GR_PREFSDIR "${GR_PREFSDIR}")
 
 
 #########################################################################

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -26,6 +26,8 @@
 
 #include <stdlib.h>
 #include <gnuradio/constants.h>
+#include <boost/dll/config.hpp>
+#include <boost/dll/runtime_symbol_info.hpp>
 
 namespace gr {
 
@@ -36,33 +38,33 @@ namespace gr {
     const char *prefix = getenv("GR_PREFIX");
     if (prefix != NULL) return prefix;
 
-    return "@prefix@";
+    boost::dll::fs::path prefix_rel_lib = "@prefix_relative_to_lib@";
+    boost::dll::fs::path gr_runtime_lib_path = boost::dll::this_line_location();
+    boost::dll::fs::path prefix_path =
+        gr_runtime_lib_path.remove_filename() / prefix_rel_lib;
+    return prefix_path.lexically_normal().string();
   }
 
   const std::string
   sysconfdir()
   {
-    //Provide the sysconfdir in terms of prefix()
-    //when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL)
-    {
-      return prefix() + "/@GR_CONF_DIR@";
-    }
+    boost::dll::fs::path sysconfdir_rel_prefix =
+        "@SYSCONFDIR_relative_to_prefix@";
+    boost::dll::fs::path prefix_path = prefix();
+    boost::dll::fs::path sysconfdir_path = prefix_path / sysconfdir_rel_prefix;
 
-    return "@SYSCONFDIR@";
+    return sysconfdir_path.lexically_normal().string();
   }
 
   const std::string
   prefsdir()
   {
-    //Provide the prefsdir in terms of sysconfdir()
-    //when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL)
-    {
-      return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
-    }
+    boost::dll::fs::path prefsdir_rel_prefix =
+        "@GR_PREFSDIR_relative_to_prefix@";
+    boost::dll::fs::path prefix_path = prefix();
+    boost::dll::fs::path prefsdir_path = prefix_path / prefsdir_rel_prefix;
 
-    return "@GR_PREFSDIR@";
+    return prefsdir_path.lexically_normal().string();
   }
 
   const std::string


### PR DESCRIPTION
Re-submission of #2656 with proper includes that should fix build on buildbot.

This replaces the path constants for the prefix, system configuration,
and preferences directories with a runtime prefix lookup based on the
gnuradio-runtime library location and relative paths from that.

Also use cmake-style paths instead of native paths for substitution to
avoid unescaped character problems. For relocatable prefix string
replacement, conda always substitutes in forward-slash paths anyway, so
it's just easier to use them from the start.