### PR TITLE
Updated to Thrift 0.11.0 for Controlport support ( issue #2089 )

### DIFF
--- a/cmake/Modules/FindTHRIFT.cmake
+++ b/cmake/Modules/FindTHRIFT.cmake
@@ -1,7 +1,7 @@
 INCLUDE(FindPkgConfig)
 PKG_CHECK_MODULES(PC_THRIFT thrift)
 
-set(THRIFT_REQ_VERSION "0.9.2")
+set(THRIFT_REQ_VERSION "0.11.0")
 
 # If pkg-config found Thrift and it doesn't meet our version
 # requirement, warn and exit -- does not cause an error; just doesn't

--- a/docs/doxygen/other/build_guide.dox.in
+++ b/docs/doxygen/other/build_guide.dox.in
@@ -107,7 +107,7 @@ process, and each is its own dependency.
 
 Currently, ControlPort only supports the Apache Thrift backend.
 
-\li thrift       (>= 0.9.2)   https://thrift.apache.org/
+\li thrift       (>= 0.11.0)   https://thrift.apache.org/
 
 To have nice formula formatting in doxygen, you'll need LaTeX; for python docs, sphinx:
 

--- a/docs/doxygen/other/ctrlport.dox
+++ b/docs/doxygen/other/ctrlport.dox
@@ -65,7 +65,7 @@ Thrift project.
 
 \subsection ctrlport_thrift Apache Thrift
 
-Current version support: >= 0.9.2
+Current version support: >= 0.11.0
 
 Apache Thrift is a middleware layer that defines interfaces of a
 program using its own Thrift language. GNU Radio's interface file is:

--- a/gnuradio-runtime/include/gnuradio/rpcmanager_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpcmanager_base.h
@@ -23,7 +23,7 @@
 #ifndef RPCMANAGER_BASE_H
 #define RPCMANAGER_BASE_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class rpcserver_booter_base;
 //class rpcserver_booter_aggregator;
@@ -31,7 +31,7 @@ class rpcserver_booter_base;
 class rpcmanager_base
 {
  public:
-  typedef boost::shared_ptr<rpcserver_booter_base> rpcserver_booter_base_sptr;
+  typedef std::shared_ptr<rpcserver_booter_base> rpcserver_booter_base_sptr;
 
   rpcmanager_base() {;}
   ~rpcmanager_base() {;}

--- a/gnuradio-runtime/include/gnuradio/rpcserver_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_base.h
@@ -23,6 +23,7 @@
 #ifndef RPCSERVER_BASE_H
 #define RPCSERVER_BASE_H
 
+#include <memory>
 #include <gnuradio/rpccallbackregister_base.h>
 
 class rpcserver_base : public virtual callbackregister_base
@@ -42,7 +43,7 @@ public:
 
   virtual void setCurPrivLevel(const priv_lvl_t priv) { cur_priv = priv; }
 
-  typedef boost::shared_ptr<rpcserver_base> rpcserver_base_sptr;
+  typedef std::shared_ptr<rpcserver_base> rpcserver_base_sptr;
 protected:
   priv_lvl_t cur_priv;
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_booter_aggregator.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_booter_aggregator.h
@@ -26,7 +26,6 @@
 #include <gnuradio/api.h>
 #include <gnuradio/rpcserver_booter_base.h>
 #include <gnuradio/rpcserver_aggregator.h>
-#include <boost/shared_ptr.hpp>
 #include <string>
 
 class rpcserver_server;
@@ -50,7 +49,7 @@ class GR_RUNTIME_API rpcserver_booter_aggregator :
 
 private:
   std::string d_type;
-  boost::shared_ptr<rpcserver_aggregator> server;
+  std::shared_ptr<rpcserver_aggregator> server;
 };
 
 #endif /* RPCSERVER_BOOTER_AGGREGATOR */

--- a/gnuradio-runtime/include/gnuradio/thrift_server_template.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_server_template.h
@@ -50,11 +50,11 @@ protected:
   friend class thrift_application_base<TserverBase, TImplClass>;
 
 private:
-  boost::shared_ptr<TserverClass> d_handler;
-  boost::shared_ptr<thrift::TProcessor> d_processor;
-  boost::shared_ptr<thrift::transport::TServerTransport> d_serverTransport;
-  boost::shared_ptr<thrift::transport::TTransportFactory> d_transportFactory;
-  boost::shared_ptr<thrift::protocol::TProtocolFactory> d_protocolFactory;
+  std::shared_ptr<TserverClass> d_handler;
+  std::shared_ptr<thrift::TProcessor> d_processor;
+  std::shared_ptr<thrift::transport::TServerTransport> d_serverTransport;
+  std::shared_ptr<thrift::transport::TTransportFactory> d_transportFactory;
+  std::shared_ptr<thrift::protocol::TProtocolFactory> d_protocolFactory;
   /**
    * Custom TransportFactory that allows you to override the default Thrift buffer size
    * of 512 bytes.
@@ -67,10 +67,10 @@ private:
 
     virtual ~TBufferedTransportFactory() {}
 
-    virtual boost::shared_ptr<thrift::transport::TTransport> getTransport(
-        boost::shared_ptr<thrift::transport::TTransport> trans)
+    virtual std::shared_ptr<thrift::transport::TTransport> getTransport(
+        std::shared_ptr<thrift::transport::TTransport> trans)
     {
-      return boost::shared_ptr<thrift::transport::TTransport>
+      return std::shared_ptr<thrift::transport::TTransport>
         (new thrift::transport::TBufferedTransport(trans, bufferSize));
     }
   private:
@@ -126,11 +126,11 @@ thrift_server_template<TserverBase, TserverClass, TImplClass>::thrift_server_tem
   }
   else {
     //std::cout << "Thrift Multi-threaded server : " << d_nthreads << std::endl;
-    boost::shared_ptr<thrift::concurrency::ThreadManager> threadManager
+    std::shared_ptr<thrift::concurrency::ThreadManager> threadManager
       (thrift::concurrency::ThreadManager::newSimpleThreadManager(nthreads));
 
     threadManager->threadFactory
-      (boost::shared_ptr<thrift::concurrency::PlatformThreadFactory>
+      (std::shared_ptr<thrift::concurrency::PlatformThreadFactory>
        (new thrift::concurrency::PlatformThreadFactory()));
 
     threadManager->start();


### PR DESCRIPTION
Update Controlport to require/support Thrift 0.11.0 ( tested on Debian Buster )
