### PR TITLE
modtool: Allow empty argument list in modtool add

### DIFF
--- a/gr-utils/python/modtool/cli/add.py
+++ b/gr-utils/python/modtool/cli/add.py
@@ -127,7 +127,9 @@ def get_copyrightholder(self):
 def get_arglist(self):
     """ Get the argument list of the block to be added """
     if self.info['arglist'] is not None:
-        self.info['arglist'] = click.prompt(click.style('Enter valid argument list, including default arguments: \n', fg='cyan'), prompt_suffix='')
+        self.info['arglist'] = click.prompt(
+            click.style('Enter valid argument list, including default arguments: \n', fg='cyan'),
+            prompt_suffix='', default='', show_default=False)
 
 def get_py_qa(self):
     """ Get a boolean value for addition of py_qa """

--- a/gr-utils/python/modtool/core/add.py
+++ b/gr-utils/python/modtool/core/add.py
@@ -161,8 +161,8 @@ class ModToolAdd(ModTool):
             return
         try:
             append_re_line_sequence(self._file['cmlib'],
-                                    '\$\{CMAKE_CURRENT_SOURCE_DIR\}/qa_%s.cc.*\n' % self.info['modname'],
-                                    '    ${CMAKE_CURRENT_SOURCE_DIR}/qa_%s.cc' % self.info['blockname'])
+                                    'list\(APPEND test_{}_sources.*\n'.format(self.info['modname']),
+                                    'qa_{}.cc'.format(self.info['blockname']))
             append_re_line_sequence(self._file['qalib'],
                                     '#include.*\n',
                                     '#include "{}"'.format(fname_qa_h))


### PR DESCRIPTION
`gr-modtool add` does not accept an empty argument list. This pull request fixes the problem.