### PR TITLE
clang-tidy: do performance-* enhancements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,55 @@
+---
+Checks:          '-*,performance-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:    
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-copy-initialization.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           ''
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+...
+

--- a/cmake/msvc/sys/time.h
+++ b/cmake/msvc/sys/time.h
@@ -5,7 +5,7 @@
 #ifndef _MSC_SYS_TIME_H_
 #define _MSC_SYS_TIME_H_
 
-#include < time.h >
+#include <time.h>
 
 #if _MSC_VER < 1900
 struct timespec {

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -32,6 +32,8 @@
 #include <mpirxx.h>
 #else
 #include <gmpxx.h>
+
+#include <utility>
 #endif
 
 namespace gr {
@@ -709,7 +711,7 @@ public:
     /*!
      * \brief the system message handler
      */
-    void system_handler(pmt::pmt_t msg);
+    void system_handler(const pmt::pmt_t& msg);
 
     /*!
      * \brief Set the logger's output level.
@@ -766,7 +768,7 @@ protected:
     block(void) {} // allows pure virtual interface sub-classes
     block(const std::string& name,
           gr::io_signature::sptr input_signature,
-          gr::io_signature::sptr output_signature);
+          const gr::io_signature::sptr& output_signature);
 
     void set_fixed_rate(bool fixed_rate) { d_fixed_rate = fixed_rate; }
 
@@ -949,7 +951,7 @@ protected:
 
 public:
     block_detail_sptr detail() const { return d_detail; }
-    void set_detail(block_detail_sptr detail) { d_detail = detail; }
+    void set_detail(block_detail_sptr detail) { d_detail = std::move(detail); }
 
     /*! \brief Tell msg neighbors we are finished
      */
@@ -965,7 +967,7 @@ public:
 typedef std::vector<block_sptr> block_vector_t;
 typedef std::vector<block_sptr>::iterator block_viter_t;
 
-inline block_sptr cast_to_block_sptr(basic_block_sptr p)
+inline block_sptr cast_to_block_sptr(const basic_block_sptr& p)
 {
     return boost::dynamic_pointer_cast<block, basic_block>(p);
 }

--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -27,6 +27,8 @@
 #include <gnuradio/block.h>
 #include <gnuradio/feval.h>
 
+#include <utility>
+
 namespace gr {
 
 /*!
@@ -263,39 +265,39 @@ public:
     /* Message passing interface */
     void block__message_port_register_in(pmt::pmt_t port_id)
     {
-        gr::basic_block::message_port_register_in(port_id);
+        gr::basic_block::message_port_register_in(std::move(port_id));
     }
 
     void block__message_port_register_out(pmt::pmt_t port_id)
     {
-        gr::basic_block::message_port_register_out(port_id);
+        gr::basic_block::message_port_register_out(std::move(port_id));
     }
 
     void block__message_port_pub(pmt::pmt_t port_id, pmt::pmt_t msg)
     {
-        gr::basic_block::message_port_pub(port_id, msg);
+        gr::basic_block::message_port_pub(std::move(port_id), std::move(msg));
     }
 
     void block__message_port_sub(pmt::pmt_t port_id, pmt::pmt_t target)
     {
-        gr::basic_block::message_port_sub(port_id, target);
+        gr::basic_block::message_port_sub(std::move(port_id), std::move(target));
     }
 
     void block__message_port_unsub(pmt::pmt_t port_id, pmt::pmt_t target)
     {
-        gr::basic_block::message_port_unsub(port_id, target);
+        gr::basic_block::message_port_unsub(std::move(port_id), std::move(target));
     }
 
     pmt::pmt_t block__message_subscribers(pmt::pmt_t which_port)
     {
-        return gr::basic_block::message_subscribers(which_port);
+        return gr::basic_block::message_subscribers(std::move(which_port));
     }
 
     pmt::pmt_t block__message_ports_in() { return gr::basic_block::message_ports_in(); }
 
     pmt::pmt_t block__message_ports_out() { return gr::basic_block::message_ports_out(); }
 
-    void set_msg_handler_feval(pmt::pmt_t which_port, gr::feval_p* msg_handler)
+    void set_msg_handler_feval(const pmt::pmt_t& which_port, gr::feval_p* msg_handler)
     {
         if (msg_queue.find(which_port) == msg_queue.end()) {
             throw std::runtime_error(

--- a/gnuradio-runtime/include/gnuradio/block_registry.h
+++ b/gnuradio-runtime/include/gnuradio/block_registry.h
@@ -43,14 +43,14 @@ public:
     void block_unregister(basic_block* block);
 
     std::string register_symbolic_name(basic_block* block);
-    void register_symbolic_name(basic_block* block, std::string name);
-    void update_symbolic_name(basic_block* block, std::string name);
+    void register_symbolic_name(basic_block* block, const std::string& name);
+    void update_symbolic_name(basic_block* block, const std::string& name);
 
-    basic_block_sptr block_lookup(pmt::pmt_t symbol);
+    basic_block_sptr block_lookup(const pmt::pmt_t& symbol);
 
-    void register_primitive(std::string blk, gr::block* ref);
-    void unregister_primitive(std::string blk);
-    void notify_blk(std::string blk);
+    void register_primitive(const std::string& blk, gr::block* ref);
+    void unregister_primitive(const std::string& blk);
+    void notify_blk(const std::string& blk);
 
 private:
     // typedef std::map< long, basic_block_sptr >   blocksubmap_t;

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -154,7 +154,7 @@ private:
     friend GR_RUNTIME_API buffer_sptr make_buffer(int nitems,
                                                   size_t sizeof_item,
                                                   block_sptr link);
-    friend GR_RUNTIME_API buffer_reader_sptr buffer_add_reader(buffer_sptr buf,
+    friend GR_RUNTIME_API buffer_reader_sptr buffer_add_reader(const buffer_sptr& buf,
                                                                int nzero_preload,
                                                                block_sptr link,
                                                                int delay);
@@ -220,7 +220,7 @@ private:
      * dependent boundary.  This is typically the system page size, but
      * under MS windows is 64KB.
      */
-    buffer(int nitems, size_t sizeof_item, block_sptr link);
+    buffer(int nitems, size_t sizeof_item, const block_sptr& link);
 
     /*!
      * \brief disassociate \p reader from this buffer
@@ -235,7 +235,7 @@ private:
  * \param link is the block that reads from the buffer using this gr::buffer_reader.
  * \param delay Optional setting to declare the buffer's sample delay.
  */
-GR_RUNTIME_API buffer_reader_sptr buffer_add_reader(buffer_sptr buf,
+GR_RUNTIME_API buffer_reader_sptr buffer_add_reader(const buffer_sptr& buf,
                                                     int nzero_preload,
                                                     block_sptr link = block_sptr(),
                                                     int delay = 0);
@@ -339,7 +339,7 @@ public:
 
 private:
     friend class buffer;
-    friend GR_RUNTIME_API buffer_reader_sptr buffer_add_reader(buffer_sptr buf,
+    friend GR_RUNTIME_API buffer_reader_sptr buffer_add_reader(const buffer_sptr& buf,
                                                                int nzero_preload,
                                                                block_sptr link,
                                                                int delay);
@@ -351,7 +351,9 @@ private:
     unsigned d_attr_delay;         // sample delay attribute for tag propagation
 
     //! constructor is private.  Use gr::buffer::add_reader to create instances
-    buffer_reader(buffer_sptr buffer, unsigned int read_index, block_sptr link);
+    buffer_reader(const buffer_sptr& buffer,
+                  unsigned int read_index,
+                  const block_sptr& link);
 };
 
 //! returns # of buffer_readers currently allocated

--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -112,21 +112,21 @@ public:
      * subscription
      */
     void msg_connect(basic_block_sptr src,
-                     pmt::pmt_t srcport,
+                     const pmt::pmt_t& srcport,
                      basic_block_sptr dst,
                      pmt::pmt_t dstport);
     void msg_connect(basic_block_sptr src,
-                     std::string srcport,
+                     const std::string& srcport,
                      basic_block_sptr dst,
-                     std::string dstport);
+                     const std::string& dstport);
     void msg_disconnect(basic_block_sptr src,
-                        pmt::pmt_t srcport,
+                        const pmt::pmt_t& srcport,
                         basic_block_sptr dst,
                         pmt::pmt_t dstport);
     void msg_disconnect(basic_block_sptr src,
-                        std::string srcport,
+                        const std::string& srcport,
                         basic_block_sptr dst,
-                        std::string dstport);
+                        const std::string& dstport);
 
     /*!
      * \brief Remove a gr-block or hierarchical block from the
@@ -237,7 +237,7 @@ public:
     pmt::pmt_t hier_message_ports_in;
     pmt::pmt_t hier_message_ports_out;
 
-    void message_port_register_hier_in(pmt::pmt_t port_id)
+    void message_port_register_hier_in(const pmt::pmt_t& port_id)
     {
         if (pmt::list_has(hier_message_ports_in, port_id))
             throw std::invalid_argument(
@@ -248,7 +248,7 @@ public:
         hier_message_ports_in = pmt::list_add(hier_message_ports_in, port_id);
     }
 
-    void message_port_register_hier_out(pmt::pmt_t port_id)
+    void message_port_register_hier_out(const pmt::pmt_t& port_id)
     {
         if (pmt::list_has(hier_message_ports_out, port_id))
             throw std::invalid_argument(
@@ -327,9 +327,9 @@ public:
 /*!
  * \brief Return hierarchical block's flow graph represented in dot language
  */
-GR_RUNTIME_API std::string dot_graph(hier_block2_sptr hierblock2);
+GR_RUNTIME_API std::string dot_graph(const hier_block2_sptr& hierblock2);
 
-inline hier_block2_sptr cast_to_hier_block2_sptr(basic_block_sptr block)
+inline hier_block2_sptr cast_to_hier_block2_sptr(const basic_block_sptr& block)
 {
     return boost::dynamic_pointer_cast<hier_block2, basic_block>(block);
 }

--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -361,7 +361,10 @@ private:
 
     std::string get_config4rpc() { return filename; }
 
-    void set_config4rpc(std::string set) { printf("Set string was:%s\n", set.c_str()); }
+    void set_config4rpc(const std::string& set)
+    {
+        printf("Set string was:%s\n", set.c_str());
+    }
 
     /*! \brief destructor stops watch thread before exits */
     ~logger_config() { stop_watch(); }
@@ -393,7 +396,7 @@ public:
  *
  * \param name Name of the logger for which a pointer is requested
  */
-GR_RUNTIME_API logger_ptr logger_get_logger(std::string name);
+GR_RUNTIME_API logger_ptr logger_get_logger(const std::string& name);
 
 /*!
  * \brief Load logger's configuration file.
@@ -530,8 +533,9 @@ GR_RUNTIME_API void logger_set_appender(logger_ptr logger, std::string appender)
  * \param target Std target to write 'cout' or 'cerr' (default is cout)
  * \param pattern Formatting pattern for log messages
  */
-GR_RUNTIME_API void
-logger_add_console_appender(logger_ptr logger, std::string target, std::string pattern);
+GR_RUNTIME_API void logger_add_console_appender(logger_ptr logger,
+                                                const std::string& target,
+                                                const std::string& pattern);
 
 /*!
  * \brief Sets a new console appender to a given logger after
@@ -556,9 +560,9 @@ logger_set_console_appender(logger_ptr logger, std::string target, std::string p
  * \param pattern Formatting pattern for log messages
  */
 GR_RUNTIME_API void logger_add_file_appender(logger_ptr logger,
-                                             std::string filename,
+                                             const std::string& filename,
                                              bool append,
-                                             std::string pattern);
+                                             const std::string& pattern);
 
 /*!
  * \brief Set a file appender to a given logger. To add another file
@@ -588,12 +592,12 @@ GR_RUNTIME_API void logger_set_file_appender(logger_ptr logger,
  * \param pattern Formatting pattern for log messages
  */
 GR_RUNTIME_API void logger_add_rollingfile_appender(logger_ptr logger,
-                                                    std::string filename,
+                                                    const std::string& filename,
                                                     size_t filesize,
                                                     int bkup_index,
                                                     bool append,
                                                     mode_t mode,
-                                                    std::string pattern);
+                                                    const std::string& pattern);
 
 /*!
  * \brief Add rolling file appender to a given logger
@@ -635,45 +639,51 @@ public:
 
     // Wrappers for logging macros
     /*! \brief inline function, wrapper to set the logger level */
-    void set_level(std::string level) { GR_LOG_SET_LEVEL(d_logger, level); }
+    void set_level(const std::string& level) { GR_LOG_SET_LEVEL(d_logger, level); }
 
     /*! \brief inline function, wrapper to get the logger level */
     void get_level(std::string& level) { GR_LOG_GET_LEVEL(d_logger, level); }
 
     /*! \brief inline function, wrapper for LOG4CPP_DEBUG for DEBUG message */
-    void debug(std::string msg) { GR_LOG_DEBUG(d_logger, msg); };
+    void debug(const std::string& msg) { GR_LOG_DEBUG(d_logger, msg); };
 
     /*! \brief inline function, wrapper for LOG4CPP_INFO for INFO message */
-    void info(std::string msg) { GR_LOG_INFO(d_logger, msg); }
+    void info(const std::string& msg) { GR_LOG_INFO(d_logger, msg); }
 
     /*! \brief inline function, wrapper for NOTICE message */
-    void notice(std::string msg) { GR_LOG_NOTICE(d_logger, msg); }
+    void notice(const std::string& msg) { GR_LOG_NOTICE(d_logger, msg); }
 
     /*! \brief inline function, wrapper for LOG4CPP_WARN for WARN message */
-    void warn(std::string msg) { GR_LOG_WARN(d_logger, msg); }
+    void warn(const std::string& msg) { GR_LOG_WARN(d_logger, msg); }
 
     /*! \brief inline function, wrapper for LOG4CPP_ERROR for ERROR message */
-    void error(std::string msg) { GR_LOG_ERROR(d_logger, msg); }
+    void error(const std::string& msg) { GR_LOG_ERROR(d_logger, msg); }
 
     /*! \brief inline function, wrapper for NOTICE message */
-    void crit(std::string msg) { GR_LOG_CRIT(d_logger, msg); }
+    void crit(const std::string& msg) { GR_LOG_CRIT(d_logger, msg); }
 
     /*! \brief inline function, wrapper for ALERT message */
-    void alert(std::string msg) { GR_LOG_ALERT(d_logger, msg); }
+    void alert(const std::string& msg) { GR_LOG_ALERT(d_logger, msg); }
 
     /*! \brief inline function, wrapper for FATAL message */
-    void fatal(std::string msg) { GR_LOG_FATAL(d_logger, msg); }
+    void fatal(const std::string& msg) { GR_LOG_FATAL(d_logger, msg); }
 
     /*! \brief inline function, wrapper for EMERG message */
-    void emerg(std::string msg) { GR_LOG_EMERG(d_logger, msg); }
+    void emerg(const std::string& msg) { GR_LOG_EMERG(d_logger, msg); }
 
     /*! \brief inline function, wrapper for LOG4CPP_ASSERT for conditional ERROR message
      */
-    void errorIF(bool cond, std::string msg) { GR_LOG_ERRORIF(d_logger, cond, msg); }
+    void errorIF(bool cond, const std::string& msg)
+    {
+        GR_LOG_ERRORIF(d_logger, cond, msg);
+    }
 
     /*! \brief inline function, wrapper for LOG4CPP_ASSERT for conditional ERROR message
      */
-    void log_assert(bool cond, std::string msg) { GR_LOG_ASSERT(d_logger, cond, msg); }
+    void log_assert(bool cond, const std::string& msg)
+    {
+        GR_LOG_ASSERT(d_logger, cond, msg);
+    }
 
     /*! \brief inline function, Method to add console appender to logger */
     void add_console_appender(std::string target, std::string pattern)
@@ -722,7 +732,7 @@ public:
  * \param watch_period Seconds to wait between checking for changes in conf file.
  *        Watch_period defaults to 0 in which case the file is not watched for changes
  */
-GR_RUNTIME_API void gr_logger_config(const std::string config_filename,
+GR_RUNTIME_API void gr_logger_config(const std::string& config_filename,
                                      unsigned int watch_period = 0);
 
 /*!
@@ -749,7 +759,7 @@ namespace gr {
  * automatically in gr::block.
  */
 GR_RUNTIME_API bool
-configure_default_loggers(gr::logger_ptr& l, gr::logger_ptr& d, const std::string name);
+configure_default_loggers(gr::logger_ptr& l, gr::logger_ptr& d, const std::string& name);
 
 GR_RUNTIME_API bool update_logger_alias(const std::string& name,
                                         const std::string& alias);

--- a/gnuradio-runtime/include/gnuradio/message.h
+++ b/gnuradio-runtime/include/gnuradio/message.h
@@ -65,7 +65,7 @@ public:
      */
     static sptr make(long type = 0, double arg1 = 0, double arg2 = 0, size_t length = 0);
 
-    static sptr make_from_string(const std::string s,
+    static sptr make_from_string(const std::string& s,
                                  long type = 0,
                                  double arg1 = 0,
                                  double arg2 = 0);

--- a/gnuradio-runtime/include/gnuradio/messages/msg_passing.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_passing.h
@@ -46,8 +46,9 @@ namespace messages {
  *
  * \returns msg
  */
-static inline pmt::pmt_t
-send(msg_accepter_sptr accepter, const pmt::pmt_t& which_port, const pmt::pmt_t& msg)
+static inline pmt::pmt_t send(const msg_accepter_sptr& accepter,
+                              const pmt::pmt_t& which_port,
+                              const pmt::pmt_t& msg)
 {
     accepter->post(which_port, msg);
     return msg;
@@ -108,7 +109,7 @@ send(msg_accepter& accepter, const pmt::pmt_t& which_port, const pmt::pmt_t& msg
  * \returns msg
  */
 static inline pmt::pmt_t
-send(pmt::pmt_t accepter, const pmt::pmt_t& which_port, const pmt::pmt_t& msg)
+send(const pmt::pmt_t& accepter, const pmt::pmt_t& which_port, const pmt::pmt_t& msg)
 {
     return send(pmt::msg_accepter_ref(accepter), which_port, msg);
 }

--- a/gnuradio-runtime/include/gnuradio/messages/msg_queue.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_queue.h
@@ -59,7 +59,7 @@ public:
      *
      * Block if queue if full.
      */
-    void insert_tail(pmt::pmt_t msg);
+    void insert_tail(const pmt::pmt_t& msg);
 
     /*!
      * \brief Delete message from head of queue and return it.

--- a/gnuradio-runtime/include/gnuradio/msg_queue.h
+++ b/gnuradio-runtime/include/gnuradio/msg_queue.h
@@ -60,7 +60,7 @@ public:
      *
      * Block if queue if full.
      */
-    void insert_tail(message::sptr msg);
+    void insert_tail(const message::sptr& msg);
 
     /*!
      * \brief Delete message from head of queue and return it.

--- a/gnuradio-runtime/include/gnuradio/pycallback_object.h
+++ b/gnuradio-runtime/include/gnuradio/pycallback_object.h
@@ -24,6 +24,7 @@
 #include <pythread.h>
 #include <boost/format.hpp>
 #include <iostream>
+#include <utility>
 
 enum pyport_t { PYPORT_STRING, PYPORT_FLOAT };
 
@@ -63,21 +64,21 @@ public:
                       myType deflt,
                       DisplayType dtype)
         : d_callback(NULL),
-          d_functionbase(functionbase),
-          d_units(units),
-          d_desc(desc),
+          d_functionbase(std::move(functionbase)),
+          d_units(std::move(units)),
+          d_desc(std::move(desc)),
           d_min(min),
           d_max(max),
           d_deflt(deflt),
           d_dtype(dtype),
-          d_name(name),
+          d_name(std::move(name)),
           d_id(pycallback_object_count++)
     {
         d_callback = NULL;
         setup_rpc();
     }
 
-    void add_rpc_variable(rpcbasic_sptr s) { d_rpc_vars.push_back(s); }
+    void add_rpc_variable(const rpcbasic_sptr& s) { d_rpc_vars.push_back(s); }
 
     myType get()
     {

--- a/gnuradio-runtime/include/gnuradio/rpccallbackregister_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpccallbackregister_base.h
@@ -71,9 +71,9 @@ struct callbackregister_base {
                         const std::string& units_,
                         const DisplayType display_,
                         const std::string& desc_,
-                        const pmt::pmt_t min_,
-                        const pmt::pmt_t max_,
-                        const pmt::pmt_t def)
+                        const pmt::pmt_t& min_,
+                        const pmt::pmt_t& max_,
+                        const pmt::pmt_t& def)
             : priv(priv_),
               units(units_),
               description(desc_),

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 // Fixes circular dependency issue before including block_registry.h
 class rpcbasic_base;
@@ -217,7 +218,7 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, const pmt::pmt_t& msg)
     {
         (void)which_port;
         (void)msg;
@@ -238,11 +239,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, char>::_source->*rpcextractor_base<T, char>::_func)(
-            static_cast<char>(pmt::to_long(msg)));
+            static_cast<char>(pmt::to_long(std::move(msg))));
     }
 };
 
@@ -259,11 +260,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, short>::_source->*rpcextractor_base<T, short>::_func)(
-            static_cast<short>(pmt::to_long(msg)));
+            static_cast<short>(pmt::to_long(std::move(msg))));
     }
 };
 
@@ -280,11 +281,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, double>::_source->*rpcextractor_base<T, double>::_func)(
-            pmt::to_double(msg));
+            pmt::to_double(std::move(msg)));
     }
 };
 
@@ -301,11 +302,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, float>::_source->*rpcextractor_base<T, float>::_func)(
-            pmt::to_double(msg));
+            pmt::to_double(std::move(msg)));
     }
 };
 
@@ -322,11 +323,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, long>::_source->*rpcextractor_base<T, long>::_func)(
-            pmt::to_long(msg));
+            pmt::to_long(std::move(msg)));
     }
 };
 
@@ -343,11 +344,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, int>::_source->*rpcextractor_base<T, int>::_func)(
-            pmt::to_long(msg));
+            pmt::to_long(std::move(msg)));
     }
 };
 
@@ -364,11 +365,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, bool>::_source->*rpcextractor_base<T, bool>::_func)(
-            pmt::to_bool(msg));
+            pmt::to_bool(std::move(msg)));
     }
 };
 
@@ -386,10 +387,11 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
-        std::complex<float> k = static_cast<std::complex<float>>(pmt::to_complex(msg));
+        std::complex<float> k =
+            static_cast<std::complex<float>>(pmt::to_complex(std::move(msg)));
         (rpcextractor_base<T, std::complex<float>>::_source
              ->*rpcextractor_base<T, std::complex<float>>::_func)(k);
     }
@@ -409,11 +411,12 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, pmt::pmt_t msg)
     {
         (void)which_port;
         (rpcextractor_base<T, std::complex<double>>::_source
-             ->*rpcextractor_base<T, std::complex<double>>::_func)(pmt::to_complex(msg));
+             ->*rpcextractor_base<T, std::complex<double>>::_func)(
+            pmt::to_complex(std::move(msg)));
     }
 };
 
@@ -431,7 +434,7 @@ public:
         ;
     }
 
-    void post(pmt::pmt_t which_port, pmt::pmt_t msg)
+    void post(const pmt::pmt_t& which_port, const pmt::pmt_t& msg)
     {
         (void)which_port;
         (rpcextractor_base<T, std::string>::_source
@@ -927,11 +930,11 @@ struct rpcbasic_register_set : public rpcbasic_base {
     priv_lvl_t privilege_level() const { return d_minpriv; }
     DisplayType default_display() const { return d_display; }
 
-    void set_min(pmt::pmt_t p) { d_min = p; }
-    void set_max(pmt::pmt_t p) { d_max = p; }
-    void set_def(pmt::pmt_t p) { d_def = p; }
-    void units(std::string u) { d_units = u; }
-    void description(std::string d) { d_desc = d; }
+    void set_min(const pmt::pmt_t& p) { d_min = p; }
+    void set_max(const pmt::pmt_t& p) { d_max = p; }
+    void set_def(const pmt::pmt_t& p) { d_def = p; }
+    void units(const std::string& u) { d_units = u; }
+    void description(const std::string& d) { d_desc = d; }
     void privilege_level(priv_lvl_t p) { d_minpriv = p; }
     void default_display(DisplayType d) { d_display = d; }
 
@@ -1067,7 +1070,7 @@ struct rpcbasic_register_trigger : public rpcbasic_base {
     std::string description() const { return d_desc; }
     priv_lvl_t privilege_level() const { return d_minpriv; }
 
-    void description(std::string d) { d_desc = d; }
+    void description(const std::string& d) { d_desc = d; }
     void privilege_level(priv_lvl_t p) { d_minpriv = p; }
 
 private:
@@ -1346,11 +1349,11 @@ public:
     priv_lvl_t privilege_level() const { return d_minpriv; }
     DisplayType default_display() const { return d_display; }
 
-    void set_min(pmt::pmt_t p) { d_min = p; }
-    void set_max(pmt::pmt_t p) { d_max = p; }
-    void set_def(pmt::pmt_t p) { d_def = p; }
-    void units(std::string u) { d_units = u; }
-    void description(std::string d) { d_desc = d; }
+    void set_min(const pmt::pmt_t& p) { d_min = p; }
+    void set_max(const pmt::pmt_t& p) { d_max = p; }
+    void set_def(const pmt::pmt_t& p) { d_def = p; }
+    void units(const std::string& u) { d_units = u; }
+    void description(const std::string& d) { d_desc = d; }
     void privilege_level(priv_lvl_t p) { d_minpriv = p; }
     void default_display(DisplayType d) { d_display = d; }
 
@@ -1665,8 +1668,8 @@ public:
     priv_lvl_t privilege_level() const { return d_minpriv; }
     DisplayType default_display() const { return d_display; }
 
-    void units(std::string u) { d_units = u; }
-    void description(std::string d) { d_desc = d; }
+    void units(const std::string& u) { d_units = u; }
+    void description(const std::string& d) { d_desc = d; }
     void privilege_level(priv_lvl_t p) { d_minpriv = p; }
     void default_display(DisplayType d) { d_display = d; }
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_aggregator.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_aggregator.h
@@ -44,7 +44,7 @@ public:
     void registerHandlerCallback(const std::string& id, const handlerCallback_t callback);
     void unregisterHandlerCallback(const std::string& id);
 
-    void registerServer(rpcmanager_base::rpcserver_booter_base_sptr server);
+    void registerServer(const rpcmanager_base::rpcserver_booter_base_sptr& server);
 
     const std::string& type();
 

--- a/gnuradio-runtime/include/gnuradio/tagged_stream_block.h
+++ b/gnuradio-runtime/include/gnuradio/tagged_stream_block.h
@@ -46,7 +46,7 @@ protected:
     std::string d_length_tag_key_str;
     tagged_stream_block(void) {} // allows pure virtual interface sub-classes
     tagged_stream_block(const std::string& name,
-                        gr::io_signature::sptr input_signature,
+                        const gr::io_signature::sptr& input_signature,
                         gr::io_signature::sptr output_signature,
                         const std::string& length_tag_key);
 

--- a/gnuradio-runtime/include/gnuradio/top_block.h
+++ b/gnuradio-runtime/include/gnuradio/top_block.h
@@ -142,7 +142,7 @@ public:
     void setup_rpc();
 };
 
-inline top_block_sptr cast_to_top_block_sptr(basic_block_sptr block)
+inline top_block_sptr cast_to_top_block_sptr(const basic_block_sptr& block)
 {
     return boost::dynamic_pointer_cast<top_block, basic_block>(block);
 }

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -147,20 +147,20 @@ PMT_API pmt_t get_PMT_EOF();
  */
 
 //! Return true if obj is \#t or \#f, else return false.
-PMT_API bool is_bool(pmt_t obj);
+PMT_API bool is_bool(const pmt_t& obj);
 
 //! Return false if obj is \#f, else return true.
-PMT_API bool is_true(pmt_t obj);
+PMT_API bool is_true(const pmt_t& obj);
 
 //! Return true if obj is \#f, else return true.
-PMT_API bool is_false(pmt_t obj);
+PMT_API bool is_false(const pmt_t& obj);
 
 //! Return \#f is val is false, else return \#t.
 PMT_API pmt_t from_bool(bool val);
 
 //! Return true if val is pmt::True, return false when val is pmt::PMT_F,
 // else raise wrong_type exception.
-PMT_API bool to_bool(pmt_t val);
+PMT_API bool to_bool(const pmt_t& val);
 
 /*
  * ------------------------------------------------------------------------
@@ -191,7 +191,7 @@ PMT_API const std::string symbol_to_string(const pmt_t& sym);
  */
 
 //! Return true if obj is any kind of number, else false.
-PMT_API bool is_number(pmt_t obj);
+PMT_API bool is_number(const pmt_t& obj);
 
 /*
  * ------------------------------------------------------------------------
@@ -200,7 +200,7 @@ PMT_API bool is_number(pmt_t obj);
  */
 
 //! Return true if \p x is an integer number, else false
-PMT_API bool is_integer(pmt_t x);
+PMT_API bool is_integer(const pmt_t& x);
 
 //! Return the pmt value that represents the integer \p x.
 PMT_API pmt_t from_long(long x);
@@ -212,7 +212,7 @@ PMT_API pmt_t from_long(long x);
  * return that integer.  Else raise an exception, either wrong_type
  * when x is not an exact integer, or out_of_range when it doesn't fit.
  */
-PMT_API long to_long(pmt_t x);
+PMT_API long to_long(const pmt_t& x);
 
 /*
  * ------------------------------------------------------------------------
@@ -221,7 +221,7 @@ PMT_API long to_long(pmt_t x);
  */
 
 //! Return true if \p x is an uint64 number, else false
-PMT_API bool is_uint64(pmt_t x);
+PMT_API bool is_uint64(const pmt_t& x);
 
 //! Return the pmt value that represents the uint64 \p x.
 PMT_API pmt_t from_uint64(uint64_t x);
@@ -233,7 +233,7 @@ PMT_API pmt_t from_uint64(uint64_t x);
  * return that uint64.  Else raise an exception, either wrong_type
  * when x is not an exact uint64, or out_of_range when it doesn't fit.
  */
-PMT_API uint64_t to_uint64(pmt_t x);
+PMT_API uint64_t to_uint64(const pmt_t& x);
 
 /*
  * ------------------------------------------------------------------------
@@ -244,7 +244,7 @@ PMT_API uint64_t to_uint64(pmt_t x);
 /*
  * \brief Return true if \p obj is a real number, else false.
  */
-PMT_API bool is_real(pmt_t obj);
+PMT_API bool is_real(const pmt_t& obj);
 
 //! Return the pmt value that represents double \p x.
 PMT_API pmt_t from_double(double x);
@@ -257,7 +257,7 @@ PMT_API pmt_t from_float(float x);
  * as a double.  The argument \p val must be a real or integer, otherwise
  * a wrong_type exception is raised.
  */
-PMT_API double to_double(pmt_t x);
+PMT_API double to_double(const pmt_t& x);
 
 /*!
  * \brief Convert pmt to float if possible.
@@ -277,7 +277,7 @@ PMT_API float to_float(pmt_t x);
 /*!
  * \brief return true if \p obj is a complex number, false otherwise.
  */
-PMT_API bool is_complex(pmt_t obj);
+PMT_API bool is_complex(const pmt_t& obj);
 
 //! Return a complex number constructed of the given real and imaginary parts.
 PMT_API pmt_t make_rectangular(double re, double im);
@@ -298,7 +298,7 @@ PMT_API pmt_t pmt_from_complex(const std::complex<double>& z);
  * If \p z is complex, real or integer, return the closest complex<double>.
  * Otherwise, raise the wrong_type exception.
  */
-PMT_API std::complex<double> to_complex(pmt_t z);
+PMT_API std::complex<double> to_complex(const pmt_t& z);
 
 /*
  * ------------------------------------------------------------------------
@@ -322,17 +322,17 @@ PMT_API pmt_t car(const pmt_t& pair);
 PMT_API pmt_t cdr(const pmt_t& pair);
 
 //! Stores \p value in the car field of \p pair.
-PMT_API void set_car(pmt_t pair, pmt_t value);
+PMT_API void set_car(const pmt_t& pair, pmt_t value);
 
 //! Stores \p value in the cdr field of \p pair.
-PMT_API void set_cdr(pmt_t pair, pmt_t value);
+PMT_API void set_cdr(const pmt_t& pair, pmt_t value);
 
-PMT_API pmt_t caar(pmt_t pair);
-PMT_API pmt_t cadr(pmt_t pair);
-PMT_API pmt_t cdar(pmt_t pair);
-PMT_API pmt_t cddr(pmt_t pair);
-PMT_API pmt_t caddr(pmt_t pair);
-PMT_API pmt_t cadddr(pmt_t pair);
+PMT_API pmt_t caar(const pmt_t& pair);
+PMT_API pmt_t cadr(const pmt_t& pair);
+PMT_API pmt_t cdar(const pmt_t& pair);
+PMT_API pmt_t cddr(const pmt_t& pair);
+PMT_API pmt_t caddr(const pmt_t& pair);
+PMT_API pmt_t cadddr(const pmt_t& pair);
 
 /*
  * ------------------------------------------------------------------------
@@ -345,7 +345,7 @@ PMT_API pmt_t cadddr(pmt_t pair);
  */
 
 //! Return true if \p x is a tuple, otherwise false.
-PMT_API bool is_tuple(pmt_t x);
+PMT_API bool is_tuple(const pmt_t& x);
 
 PMT_API pmt_t make_tuple();
 PMT_API pmt_t make_tuple(const pmt_t& e0);
@@ -418,7 +418,7 @@ PMT_API pmt_t tuple_ref(const pmt_t& tuple, size_t k);
  */
 
 //! Return true if \p x is a vector, otherwise false.
-PMT_API bool is_vector(pmt_t x);
+PMT_API bool is_vector(const pmt_t& x);
 
 //! Make a vector of length \p k, with initial values set to \p fill
 PMT_API pmt_t make_vector(size_t k, pmt_t fill);
@@ -427,13 +427,13 @@ PMT_API pmt_t make_vector(size_t k, pmt_t fill);
  * Return the contents of position \p k of \p vector.
  * \p k must be a valid index of \p vector.
  */
-PMT_API pmt_t vector_ref(pmt_t vector, size_t k);
+PMT_API pmt_t vector_ref(const pmt_t& vector, size_t k);
 
 //! Store \p obj in position \p k.
-PMT_API void vector_set(pmt_t vector, size_t k, pmt_t obj);
+PMT_API void vector_set(const pmt_t& vector, size_t k, pmt_t obj);
 
 //! Store \p fill in every position of \p vector
-PMT_API void vector_fill(pmt_t vector, pmt_t fill);
+PMT_API void vector_fill(const pmt_t& vector, pmt_t fill);
 
 /*
  * ------------------------------------------------------------------------
@@ -490,23 +490,23 @@ PMT_API size_t blob_length(pmt_t blob);
  */
 
 //! true if \p x is any kind of uniform numeric vector
-PMT_API bool is_uniform_vector(pmt_t x);
+PMT_API bool is_uniform_vector(const pmt_t& x);
 
-PMT_API bool is_u8vector(pmt_t x);
-PMT_API bool is_s8vector(pmt_t x);
-PMT_API bool is_u16vector(pmt_t x);
-PMT_API bool is_s16vector(pmt_t x);
-PMT_API bool is_u32vector(pmt_t x);
-PMT_API bool is_s32vector(pmt_t x);
-PMT_API bool is_u64vector(pmt_t x);
-PMT_API bool is_s64vector(pmt_t x);
-PMT_API bool is_f32vector(pmt_t x);
-PMT_API bool is_f64vector(pmt_t x);
-PMT_API bool is_c32vector(pmt_t x);
-PMT_API bool is_c64vector(pmt_t x);
+PMT_API bool is_u8vector(const pmt_t& x);
+PMT_API bool is_s8vector(const pmt_t& x);
+PMT_API bool is_u16vector(const pmt_t& x);
+PMT_API bool is_s16vector(const pmt_t& x);
+PMT_API bool is_u32vector(const pmt_t& x);
+PMT_API bool is_s32vector(const pmt_t& x);
+PMT_API bool is_u64vector(const pmt_t& x);
+PMT_API bool is_s64vector(const pmt_t& x);
+PMT_API bool is_f32vector(const pmt_t& x);
+PMT_API bool is_f64vector(const pmt_t& x);
+PMT_API bool is_c32vector(const pmt_t& x);
+PMT_API bool is_c64vector(const pmt_t& x);
 
 //! item size in bytes if \p x is any kind of uniform numeric vector
-PMT_API size_t uniform_vector_itemsize(pmt_t x);
+PMT_API size_t uniform_vector_itemsize(const pmt_t& x);
 
 PMT_API pmt_t make_u8vector(size_t k, uint8_t fill);
 PMT_API pmt_t make_s8vector(size_t k, int8_t fill);
@@ -546,65 +546,75 @@ PMT_API pmt_t init_c32vector(size_t k, const std::vector<std::complex<float>>& d
 PMT_API pmt_t init_c64vector(size_t k, const std::complex<double>* data);
 PMT_API pmt_t init_c64vector(size_t k, const std::vector<std::complex<double>>& data);
 
-PMT_API uint8_t u8vector_ref(pmt_t v, size_t k);
-PMT_API int8_t s8vector_ref(pmt_t v, size_t k);
-PMT_API uint16_t u16vector_ref(pmt_t v, size_t k);
-PMT_API int16_t s16vector_ref(pmt_t v, size_t k);
-PMT_API uint32_t u32vector_ref(pmt_t v, size_t k);
-PMT_API int32_t s32vector_ref(pmt_t v, size_t k);
-PMT_API uint64_t u64vector_ref(pmt_t v, size_t k);
-PMT_API int64_t s64vector_ref(pmt_t v, size_t k);
-PMT_API float f32vector_ref(pmt_t v, size_t k);
-PMT_API double f64vector_ref(pmt_t v, size_t k);
-PMT_API std::complex<float> c32vector_ref(pmt_t v, size_t k);
-PMT_API std::complex<double> c64vector_ref(pmt_t v, size_t k);
+PMT_API uint8_t u8vector_ref(const pmt_t& v, size_t k);
+PMT_API int8_t s8vector_ref(const pmt_t& v, size_t k);
+PMT_API uint16_t u16vector_ref(const pmt_t& v, size_t k);
+PMT_API int16_t s16vector_ref(const pmt_t& v, size_t k);
+PMT_API uint32_t u32vector_ref(const pmt_t& v, size_t k);
+PMT_API int32_t s32vector_ref(const pmt_t& v, size_t k);
+PMT_API uint64_t u64vector_ref(const pmt_t& v, size_t k);
+PMT_API int64_t s64vector_ref(const pmt_t& v, size_t k);
+PMT_API float f32vector_ref(const pmt_t& v, size_t k);
+PMT_API double f64vector_ref(const pmt_t& v, size_t k);
+PMT_API std::complex<float> c32vector_ref(const pmt_t& v, size_t k);
+PMT_API std::complex<double> c64vector_ref(const pmt_t& v, size_t k);
 
-PMT_API void u8vector_set(pmt_t v, size_t k, uint8_t x); //< v[k] = x
-PMT_API void s8vector_set(pmt_t v, size_t k, int8_t x);
-PMT_API void u16vector_set(pmt_t v, size_t k, uint16_t x);
-PMT_API void s16vector_set(pmt_t v, size_t k, int16_t x);
-PMT_API void u32vector_set(pmt_t v, size_t k, uint32_t x);
-PMT_API void s32vector_set(pmt_t v, size_t k, int32_t x);
-PMT_API void u64vector_set(pmt_t v, size_t k, uint64_t x);
-PMT_API void s64vector_set(pmt_t v, size_t k, int64_t x);
-PMT_API void f32vector_set(pmt_t v, size_t k, float x);
-PMT_API void f64vector_set(pmt_t v, size_t k, double x);
-PMT_API void c32vector_set(pmt_t v, size_t k, std::complex<float> x);
-PMT_API void c64vector_set(pmt_t v, size_t k, std::complex<double> x);
+PMT_API void u8vector_set(const pmt_t& v, size_t k, uint8_t x); //< v[k] = x
+PMT_API void s8vector_set(const pmt_t& v, size_t k, int8_t x);
+PMT_API void u16vector_set(const pmt_t& v, size_t k, uint16_t x);
+PMT_API void s16vector_set(const pmt_t& v, size_t k, int16_t x);
+PMT_API void u32vector_set(const pmt_t& v, size_t k, uint32_t x);
+PMT_API void s32vector_set(const pmt_t& v, size_t k, int32_t x);
+PMT_API void u64vector_set(const pmt_t& v, size_t k, uint64_t x);
+PMT_API void s64vector_set(const pmt_t& v, size_t k, int64_t x);
+PMT_API void f32vector_set(const pmt_t& v, size_t k, float x);
+PMT_API void f64vector_set(const pmt_t& v, size_t k, double x);
+PMT_API void c32vector_set(const pmt_t& v, size_t k, std::complex<float> x);
+PMT_API void c64vector_set(const pmt_t& v, size_t k, std::complex<double> x);
 
 // Return const pointers to the elements
 
 PMT_API const void*
-uniform_vector_elements(pmt_t v, size_t& len); //< works with any; len is in bytes
+uniform_vector_elements(const pmt_t& v, size_t& len); //< works with any; len is in bytes
 
-PMT_API const uint8_t* u8vector_elements(pmt_t v, size_t& len);   //< len is in elements
-PMT_API const int8_t* s8vector_elements(pmt_t v, size_t& len);    //< len is in elements
-PMT_API const uint16_t* u16vector_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API const int16_t* s16vector_elements(pmt_t v, size_t& len);  //< len is in elements
-PMT_API const uint32_t* u32vector_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API const int32_t* s32vector_elements(pmt_t v, size_t& len);  //< len is in elements
-PMT_API const uint64_t* u64vector_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API const int64_t* s64vector_elements(pmt_t v, size_t& len);  //< len is in elements
-PMT_API const float* f32vector_elements(pmt_t v, size_t& len);    //< len is in elements
-PMT_API const double* f64vector_elements(pmt_t v, size_t& len);   //< len is in elements
-PMT_API const std::complex<float>* c32vector_elements(pmt_t v,
+PMT_API const uint8_t* u8vector_elements(const pmt_t& v,
+                                         size_t& len); //< len is in elements
+PMT_API const int8_t* s8vector_elements(const pmt_t& v,
+                                        size_t& len); //< len is in elements
+PMT_API const uint16_t* u16vector_elements(const pmt_t& v,
+                                           size_t& len); //< len is in elements
+PMT_API const int16_t* s16vector_elements(const pmt_t& v,
+                                          size_t& len); //< len is in elements
+PMT_API const uint32_t* u32vector_elements(const pmt_t& v,
+                                           size_t& len); //< len is in elements
+PMT_API const int32_t* s32vector_elements(const pmt_t& v,
+                                          size_t& len); //< len is in elements
+PMT_API const uint64_t* u64vector_elements(const pmt_t& v,
+                                           size_t& len); //< len is in elements
+PMT_API const int64_t* s64vector_elements(const pmt_t& v,
+                                          size_t& len); //< len is in elements
+PMT_API const float* f32vector_elements(const pmt_t& v,
+                                        size_t& len); //< len is in elements
+PMT_API const double* f64vector_elements(const pmt_t& v,
+                                         size_t& len); //< len is in elements
+PMT_API const std::complex<float>* c32vector_elements(const pmt_t& v,
                                                       size_t& len); //< len is in elements
 PMT_API const std::complex<double>*
-c64vector_elements(pmt_t v, size_t& len); //< len is in elements
+c64vector_elements(const pmt_t& v, size_t& len); //< len is in elements
 
 // len is in elements
-PMT_API const std::vector<uint8_t> u8vector_elements(pmt_t v);
-PMT_API const std::vector<int8_t> s8vector_elements(pmt_t v);
-PMT_API const std::vector<uint16_t> u16vector_elements(pmt_t v);
-PMT_API const std::vector<int16_t> s16vector_elements(pmt_t v);
-PMT_API const std::vector<uint32_t> u32vector_elements(pmt_t v);
-PMT_API const std::vector<int32_t> s32vector_elements(pmt_t v);
-PMT_API const std::vector<uint64_t> u64vector_elements(pmt_t v);
-PMT_API const std::vector<int64_t> s64vector_elements(pmt_t v);
-PMT_API const std::vector<float> f32vector_elements(pmt_t v);
-PMT_API const std::vector<double> f64vector_elements(pmt_t v);
-PMT_API const std::vector<std::complex<float>> c32vector_elements(pmt_t v);
-PMT_API const std::vector<std::complex<double>> c64vector_elements(pmt_t v);
+PMT_API const std::vector<uint8_t> u8vector_elements(const pmt_t& v);
+PMT_API const std::vector<int8_t> s8vector_elements(const pmt_t& v);
+PMT_API const std::vector<uint16_t> u16vector_elements(const pmt_t& v);
+PMT_API const std::vector<int16_t> s16vector_elements(const pmt_t& v);
+PMT_API const std::vector<uint32_t> u32vector_elements(const pmt_t& v);
+PMT_API const std::vector<int32_t> s32vector_elements(const pmt_t& v);
+PMT_API const std::vector<uint64_t> u64vector_elements(const pmt_t& v);
+PMT_API const std::vector<int64_t> s64vector_elements(const pmt_t& v);
+PMT_API const std::vector<float> f32vector_elements(const pmt_t& v);
+PMT_API const std::vector<double> f64vector_elements(const pmt_t& v);
+PMT_API const std::vector<std::complex<float>> c32vector_elements(const pmt_t& v);
+PMT_API const std::vector<std::complex<double>> c64vector_elements(const pmt_t& v);
 
 // len is in elements
 PMT_API const std::vector<uint8_t> pmt_u8vector_elements(pmt_t v);
@@ -623,26 +633,33 @@ PMT_API const std::vector<std::complex<double>> pmt_c64vector_elements(pmt_t v);
 // Return non-const pointers to the elements
 
 PMT_API void*
-uniform_vector_writable_elements(pmt_t v,
+uniform_vector_writable_elements(const pmt_t& v,
                                  size_t& len); //< works with any; len is in bytes
 
-PMT_API uint8_t* u8vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API int8_t* s8vector_writable_elements(pmt_t v, size_t& len);  //< len is in elements
-PMT_API uint16_t* u16vector_writable_elements(pmt_t v,
-                                              size_t& len);         //< len is in elements
-PMT_API int16_t* s16vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API uint32_t* u32vector_writable_elements(pmt_t v,
-                                              size_t& len);         //< len is in elements
-PMT_API int32_t* s32vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API uint64_t* u64vector_writable_elements(pmt_t v,
-                                              size_t& len);         //< len is in elements
-PMT_API int64_t* s64vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
-PMT_API float* f32vector_writable_elements(pmt_t v, size_t& len);   //< len is in elements
-PMT_API double* f64vector_writable_elements(pmt_t v, size_t& len);  //< len is in elements
+PMT_API uint8_t* u8vector_writable_elements(const pmt_t& v,
+                                            size_t& len); //< len is in elements
+PMT_API int8_t* s8vector_writable_elements(const pmt_t& v,
+                                           size_t& len); //< len is in elements
+PMT_API uint16_t* u16vector_writable_elements(const pmt_t& v,
+                                              size_t& len); //< len is in elements
+PMT_API int16_t* s16vector_writable_elements(const pmt_t& v,
+                                             size_t& len); //< len is in elements
+PMT_API uint32_t* u32vector_writable_elements(const pmt_t& v,
+                                              size_t& len); //< len is in elements
+PMT_API int32_t* s32vector_writable_elements(const pmt_t& v,
+                                             size_t& len); //< len is in elements
+PMT_API uint64_t* u64vector_writable_elements(const pmt_t& v,
+                                              size_t& len); //< len is in elements
+PMT_API int64_t* s64vector_writable_elements(const pmt_t& v,
+                                             size_t& len); //< len is in elements
+PMT_API float* f32vector_writable_elements(const pmt_t& v,
+                                           size_t& len); //< len is in elements
+PMT_API double* f64vector_writable_elements(const pmt_t& v,
+                                            size_t& len); //< len is in elements
 PMT_API std::complex<float>*
-c32vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
+c32vector_writable_elements(const pmt_t& v, size_t& len); //< len is in elements
 PMT_API std::complex<double>*
-c64vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
+c64vector_writable_elements(const pmt_t& v, size_t& len); //< len is in elements
 
 /*
  * ------------------------------------------------------------------------
@@ -676,13 +693,13 @@ PMT_API pmt_t dict_ref(const pmt_t& dict, const pmt_t& key, const pmt_t& not_fou
 PMT_API pmt_t dict_items(pmt_t dict);
 
 //! Return list of keys
-PMT_API pmt_t dict_keys(pmt_t dict);
+PMT_API pmt_t dict_keys(const pmt_t& dict);
 
 //! Return a new dictionary \p dict1 with k=>v pairs from \p dict2 added.
 PMT_API pmt_t dict_update(const pmt_t& dict1, const pmt_t& dict2);
 
 //! Return list of values
-PMT_API pmt_t dict_values(pmt_t dict);
+PMT_API pmt_t dict_values(const pmt_t& dict);
 
 /*
  * ------------------------------------------------------------------------
@@ -694,16 +711,16 @@ PMT_API pmt_t dict_values(pmt_t dict);
  */
 
 //! Return true if \p obj is an any
-PMT_API bool is_any(pmt_t obj);
+PMT_API bool is_any(const pmt_t& obj);
 
 //! make an any
 PMT_API pmt_t make_any(const boost::any& any);
 
 //! Return underlying boost::any
-PMT_API boost::any any_ref(pmt_t obj);
+PMT_API boost::any any_ref(const pmt_t& obj);
 
 //! Store \p any in \p obj
-PMT_API void any_set(pmt_t obj, const boost::any& any);
+PMT_API void any_set(const pmt_t& obj, const boost::any& any);
 
 
 /*
@@ -715,7 +732,7 @@ PMT_API void any_set(pmt_t obj, const boost::any& any);
 PMT_API bool is_msg_accepter(const pmt_t& obj);
 
 //! make a msg_accepter
-PMT_API pmt_t make_msg_accepter(boost::shared_ptr<gr::messages::msg_accepter> ma);
+PMT_API pmt_t make_msg_accepter(const boost::shared_ptr<gr::messages::msg_accepter>& ma);
 
 //! Return underlying msg_accepter
 PMT_API boost::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t& obj);
@@ -765,7 +782,7 @@ PMT_API size_t length(const pmt_t& v);
  * in \p alist has \p obj as its car then \#f is returned.
  * Uses pmt::eq to compare \p obj with car fields of the pairs in \p alist.
  */
-PMT_API pmt_t assq(pmt_t obj, pmt_t alist);
+PMT_API pmt_t assq(const pmt_t& obj, pmt_t alist);
 
 /*!
  * \brief Find the first pair in \p alist whose car field is \p obj
@@ -775,7 +792,7 @@ PMT_API pmt_t assq(pmt_t obj, pmt_t alist);
  * in \p alist has \p obj as its car then \#f is returned.
  * Uses pmt::eqv to compare \p obj with car fields of the pairs in \p alist.
  */
-PMT_API pmt_t assv(pmt_t obj, pmt_t alist);
+PMT_API pmt_t assv(const pmt_t& obj, pmt_t alist);
 
 /*!
  * \brief Find the first pair in \p alist whose car field is \p obj
@@ -785,7 +802,7 @@ PMT_API pmt_t assv(pmt_t obj, pmt_t alist);
  * in \p alist has \p obj as its car then \#f is returned.
  * Uses pmt::equal to compare \p obj with car fields of the pairs in \p alist.
  */
-PMT_API pmt_t assoc(pmt_t obj, pmt_t alist);
+PMT_API pmt_t assoc(const pmt_t& obj, pmt_t alist);
 
 /*!
  * \brief Apply \p proc element-wise to the elements of list and returns
@@ -801,7 +818,7 @@ PMT_API pmt_t map(pmt_t proc(const pmt_t&), pmt_t list);
  *
  * \p list must be a proper list.
  */
-PMT_API pmt_t reverse(pmt_t list);
+PMT_API pmt_t reverse(const pmt_t& list);
 
 /*!
  * \brief destructively reverse \p list.
@@ -813,7 +830,10 @@ PMT_API pmt_t reverse_x(pmt_t list);
 /*!
  * \brief (acons x y a) == (cons (cons x y) a)
  */
-inline static pmt_t acons(pmt_t x, pmt_t y, pmt_t a) { return cons(cons(x, y), a); }
+inline static pmt_t acons(const pmt_t& x, const pmt_t& y, const pmt_t& a)
+{
+    return cons(cons(x, y), a);
+}
 
 /*!
  * \brief locates \p nth element of \n list where the car is the 'zeroth' element.
@@ -831,27 +851,27 @@ PMT_API pmt_t nthcdr(size_t n, pmt_t list);
  * If \p obj does not occur in \p list, then \#f is returned.
  * pmt::memq use pmt::eq to compare \p obj with the elements of \p list.
  */
-PMT_API pmt_t memq(pmt_t obj, pmt_t list);
+PMT_API pmt_t memq(const pmt_t& obj, pmt_t list);
 
 /*!
  * \brief Return the first sublist of \p list whose car is \p obj.
  * If \p obj does not occur in \p list, then \#f is returned.
  * pmt::memv use pmt::eqv to compare \p obj with the elements of \p list.
  */
-PMT_API pmt_t memv(pmt_t obj, pmt_t list);
+PMT_API pmt_t memv(const pmt_t& obj, pmt_t list);
 
 /*!
  * \brief Return the first sublist of \p list whose car is \p obj.
  * If \p obj does not occur in \p list, then \#f is returned.
  * pmt::member use pmt::equal to compare \p obj with the elements of \p list.
  */
-PMT_API pmt_t member(pmt_t obj, pmt_t list);
+PMT_API pmt_t member(const pmt_t& obj, pmt_t list);
 
 /*!
  * \brief Return true if every element of \p list1 appears in \p list2, and false
  * otherwise. Comparisons are done with pmt::eqv.
  */
-PMT_API bool subsetp(pmt_t list1, pmt_t list2);
+PMT_API bool subsetp(pmt_t list1, const pmt_t& list2);
 
 /*!
  * \brief Return a list of length 1 containing \p x1
@@ -903,7 +923,7 @@ PMT_API pmt_t list_rm(pmt_t list, const pmt_t& item);
 /*!
  * \brief Return bool of \p list contains \p item
  */
-PMT_API bool list_has(pmt_t list, const pmt_t& item);
+PMT_API bool list_has(const pmt_t& list, const pmt_t& item);
 
 
 /*
@@ -913,7 +933,7 @@ PMT_API bool list_has(pmt_t list, const pmt_t& item);
  */
 
 //! return true if obj is the EOF object, otherwise return false.
-PMT_API bool is_eof_object(pmt_t obj);
+PMT_API bool is_eof_object(const pmt_t& obj);
 
 /*!
  * read converts external representations of pmt objects into the
@@ -935,7 +955,7 @@ PMT_API pmt_t read(std::istream& port);
 /*!
  * Write a written representation of \p obj to the given \p port.
  */
-PMT_API void write(pmt_t obj, std::ostream& port);
+PMT_API void write(const pmt_t& obj, std::ostream& port);
 
 /*!
  * Return a string representation of \p obj.
@@ -978,7 +998,7 @@ PMT_API std::string serialize_str(pmt_t obj);
 /*!
  * \brief Provide a simple string generating interface to pmt's deserialize function
  */
-PMT_API pmt_t deserialize_str(std::string str);
+PMT_API pmt_t deserialize_str(const std::string& str);
 
 /*!
  * \brief Provide a comparator function object to allow pmt use in stl types

--- a/gnuradio-runtime/include/pmt/pmt_sugar.h
+++ b/gnuradio-runtime/include/pmt/pmt_sugar.h
@@ -29,6 +29,8 @@
 
 #include <gnuradio/messages/msg_accepter.h>
 
+#include <utility>
+
 namespace pmt {
 
 //! Make pmt symbol
@@ -67,7 +69,7 @@ static inline pmt_t mp(std::complex<float> z)
 //! Make pmt msg_accepter
 static inline pmt_t mp(boost::shared_ptr<gr::messages::msg_accepter> ma)
 {
-    return make_msg_accepter(ma);
+    return make_msg_accepter(std::move(ma));
 }
 
 //! Make pmt Binary Large Object (BLOB)

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -31,13 +31,14 @@
 #include <gnuradio/prefs.h>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 
 block::block(const std::string& name,
              io_signature::sptr input_signature,
-             io_signature::sptr output_signature)
-    : basic_block(name, input_signature, output_signature),
+             const io_signature::sptr& output_signature)
+    : basic_block(name, std::move(input_signature), output_signature),
       d_output_multiple(1),
       d_output_multiple_set(false),
       d_unaligned(0),
@@ -606,7 +607,7 @@ void block::reset_perf_counters()
 }
 
 
-void block::system_handler(pmt::pmt_t msg)
+void block::system_handler(const pmt::pmt_t& msg)
 {
     // std::cout << "system_handler " << msg << "\n";
     pmt::pmt_t op = pmt::car(msg);

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -27,6 +27,7 @@
 #include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
 #include <iostream>
+#include <utility>
 
 namespace gr {
 
@@ -75,7 +76,7 @@ void block_detail::set_input(unsigned int which, buffer_reader_sptr reader)
     if (which >= d_ninputs)
         throw std::invalid_argument("block_detail::set_input");
 
-    d_input[which] = reader;
+    d_input[which] = std::move(reader);
 }
 
 void block_detail::set_output(unsigned int which, buffer_sptr buffer)
@@ -83,7 +84,7 @@ void block_detail::set_output(unsigned int which, buffer_sptr buffer)
     if (which >= d_noutputs)
         throw std::invalid_argument("block_detail::set_output");
 
-    d_output[which] = buffer;
+    d_output[which] = std::move(buffer);
 }
 
 block_detail_sptr make_block_detail(unsigned int ninputs, unsigned int noutputs)

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -35,6 +35,7 @@
 #include <boost/thread.hpp>
 #include <iostream>
 #include <limits>
+#include <utility>
 
 namespace gr {
 
@@ -223,7 +224,7 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
 }
 
 block_executor::block_executor(block_sptr block, int max_noutput_items)
-    : d_block(block), d_log(0), d_max_noutput_items(max_noutput_items)
+    : d_block(std::move(block)), d_log(0), d_max_noutput_items(max_noutput_items)
 {
     if (ENABLE_LOGGING) {
         std::string name = str(boost::format("sst-%03d.log") % which_scheduler++);

--- a/gnuradio-runtime/lib/block_gateway_impl.cc
+++ b/gnuradio-runtime/lib/block_gateway_impl.cc
@@ -23,6 +23,7 @@
 #include <gnuradio/io_signature.h>
 #include <boost/bind.hpp>
 #include <iostream>
+#include <utility>
 
 namespace gr {
 
@@ -46,8 +47,8 @@ block_gateway::sptr block_gateway::make(feval_ll* handler,
                                         const block_gw_work_type work_type,
                                         const unsigned factor)
 {
-    return block_gateway::sptr(
-        new block_gateway_impl(handler, name, in_sig, out_sig, work_type, factor));
+    return block_gateway::sptr(new block_gateway_impl(
+        handler, name, std::move(in_sig), std::move(out_sig), work_type, factor));
 }
 
 block_gateway_impl::block_gateway_impl(feval_ll* handler,
@@ -56,7 +57,9 @@ block_gateway_impl::block_gateway_impl(feval_ll* handler,
                                        gr::io_signature::sptr out_sig,
                                        const block_gw_work_type work_type,
                                        const unsigned factor)
-    : block(name, in_sig, out_sig), _handler(handler), _work_type(work_type)
+    : block(name, std::move(in_sig), std::move(out_sig)),
+      _handler(handler),
+      _work_type(work_type)
 {
     switch (_work_type) {
     case GR_BLOCK_GW_WORK_GENERAL:

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -72,7 +72,7 @@ std::string block_registry::register_symbolic_name(basic_block* block)
     return ss.str();
 }
 
-void block_registry::register_symbolic_name(basic_block* block, std::string name)
+void block_registry::register_symbolic_name(basic_block* block, const std::string& name)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
@@ -82,7 +82,7 @@ void block_registry::register_symbolic_name(basic_block* block, std::string name
     d_ref_map = pmt::dict_add(d_ref_map, pmt::intern(name), pmt::make_any(block));
 }
 
-void block_registry::update_symbolic_name(basic_block* block, std::string name)
+void block_registry::update_symbolic_name(basic_block* block, const std::string& name)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
@@ -101,7 +101,7 @@ void block_registry::update_symbolic_name(basic_block* block, std::string name)
     d_ref_map = pmt::dict_add(d_ref_map, pmt::intern(name), pmt::make_any(block));
 }
 
-basic_block_sptr block_registry::block_lookup(pmt::pmt_t symbol)
+basic_block_sptr block_registry::block_lookup(const pmt::pmt_t& symbol)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
@@ -113,21 +113,21 @@ basic_block_sptr block_registry::block_lookup(pmt::pmt_t symbol)
     return blk->shared_from_this();
 }
 
-void block_registry::register_primitive(std::string blk, block* ref)
+void block_registry::register_primitive(const std::string& blk, block* ref)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
     primitive_map[blk] = ref;
 }
 
-void block_registry::unregister_primitive(std::string blk)
+void block_registry::unregister_primitive(const std::string& blk)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
     primitive_map.erase(primitive_map.find(blk));
 }
 
-void block_registry::notify_blk(std::string blk)
+void block_registry::notify_blk(const std::string& blk)
 {
     gr::thread::scoped_lock guard(d_mutex);
 

--- a/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
+++ b/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
@@ -92,7 +92,7 @@ void rpcserver_aggregator::unregisterHandlerCallback(const std::string& id)
 
 
 void rpcserver_aggregator::registerServer(
-    rpcmanager_base::rpcserver_booter_base_sptr server)
+    const rpcmanager_base::rpcserver_booter_base_sptr& server)
 {
     std::vector<std::string>::iterator it(std::find(
         d_registeredServers.begin(), d_registeredServers.end(), server->type()));

--- a/gnuradio-runtime/lib/feval.cc
+++ b/gnuradio-runtime/lib/feval.cc
@@ -26,6 +26,8 @@
 
 #include <gnuradio/feval.h>
 
+#include <utility>
+
 namespace gr {
 
 feval_dd::~feval_dd() {}
@@ -70,7 +72,7 @@ void feval_p::eval(pmt::pmt_t x)
     // nop
 }
 
-void feval_p::calleval(pmt::pmt_t x) { eval(x); }
+void feval_p::calleval(pmt::pmt_t x) { eval(std::move(x)); }
 
 /*
  * Trivial examples showing C++ (transparently) calling Python

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -81,7 +81,7 @@ void flat_flowgraph::setup_connections()
     }
 }
 
-block_detail_sptr flat_flowgraph::allocate_block_detail(basic_block_sptr block)
+block_detail_sptr flat_flowgraph::allocate_block_detail(const basic_block_sptr& block)
 {
     int ninputs = calc_used_ports(block, true).size();
     int noutputs = calc_used_ports(block, false).size();
@@ -119,7 +119,7 @@ block_detail_sptr flat_flowgraph::allocate_block_detail(basic_block_sptr block)
     return detail;
 }
 
-buffer_sptr flat_flowgraph::allocate_buffer(basic_block_sptr block, int port)
+buffer_sptr flat_flowgraph::allocate_buffer(const basic_block_sptr& block, int port)
 {
     block_sptr grblock = cast_to_block_sptr(block);
     if (!grblock)
@@ -188,7 +188,7 @@ buffer_sptr flat_flowgraph::allocate_buffer(basic_block_sptr block, int port)
     return b;
 }
 
-void flat_flowgraph::connect_block_inputs(basic_block_sptr block)
+void flat_flowgraph::connect_block_inputs(const basic_block_sptr& block)
 {
     block_sptr grblock = cast_to_block_sptr(block);
     if (!grblock)
@@ -223,7 +223,7 @@ void flat_flowgraph::connect_block_inputs(basic_block_sptr block)
     }
 }
 
-void flat_flowgraph::merge_connections(flat_flowgraph_sptr old_ffg)
+void flat_flowgraph::merge_connections(const flat_flowgraph_sptr& old_ffg)
 {
     // Allocate block details if needed.  Only new blocks that aren't pruned out
     // by flattening will need one; existing blocks still in the new flowgraph will
@@ -335,7 +335,7 @@ void flat_flowgraph::merge_connections(flat_flowgraph_sptr old_ffg)
     }
 }
 
-void flat_flowgraph::setup_buffer_alignment(block_sptr block)
+void flat_flowgraph::setup_buffer_alignment(const block_sptr& block)
 {
     const int alignment = volk_get_alignment();
     for (int i = 0; i < block->detail()->ninputs(); i++) {

--- a/gnuradio-runtime/lib/flat_flowgraph.h
+++ b/gnuradio-runtime/lib/flat_flowgraph.h
@@ -51,7 +51,7 @@ public:
     void setup_connections();
 
     // Merge applicable connections from existing flat flowgraph
-    void merge_connections(flat_flowgraph_sptr sfg);
+    void merge_connections(const flat_flowgraph_sptr& sfg);
 
     // Return a string list of edges
     std::string edge_list();
@@ -90,9 +90,9 @@ public:
 private:
     flat_flowgraph();
 
-    block_detail_sptr allocate_block_detail(basic_block_sptr block);
-    buffer_sptr allocate_buffer(basic_block_sptr block, int port);
-    void connect_block_inputs(basic_block_sptr block);
+    block_detail_sptr allocate_block_detail(const basic_block_sptr& block);
+    buffer_sptr allocate_buffer(const basic_block_sptr& block, int port);
+    void connect_block_inputs(const basic_block_sptr& block);
 
     /* When reusing a flowgraph's blocks, this call makes sure all of
      * the buffer's are aligned at the machine's alignment boundary
@@ -101,7 +101,7 @@ private:
      * Called from both setup_connections and merge_connections for
      * start and restarts.
      */
-    void setup_buffer_alignment(block_sptr block);
+    void setup_buffer_alignment(const block_sptr& block);
 
     gr::logger_ptr d_logger;
     gr::logger_ptr d_debug_logger;

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -29,6 +29,7 @@
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
 #include <iostream>
+#include <utility>
 
 namespace gr {
 
@@ -39,13 +40,13 @@ hier_block2_sptr make_hier_block2(const std::string& name,
                                   gr::io_signature::sptr output_signature)
 {
     return gnuradio::get_initial_sptr(
-        new hier_block2(name, input_signature, output_signature));
+        new hier_block2(name, std::move(input_signature), std::move(output_signature)));
 }
 
 hier_block2::hier_block2(const std::string& name,
                          gr::io_signature::sptr input_signature,
                          gr::io_signature::sptr output_signature)
-    : basic_block(name, input_signature, output_signature),
+    : basic_block(name, std::move(input_signature), std::move(output_signature)),
       d_detail(new hier_block2_detail(this)),
       hier_message_ports_in(pmt::PMT_NIL),
       hier_message_ports_out(pmt::PMT_NIL)
@@ -68,62 +69,67 @@ hier_block2_sptr hier_block2::to_hier_block2()
     return cast_to_hier_block2_sptr(shared_from_this());
 }
 
-void hier_block2::connect(basic_block_sptr block) { d_detail->connect(block); }
+void hier_block2::connect(basic_block_sptr block) { d_detail->connect(std::move(block)); }
 
 void hier_block2::connect(basic_block_sptr src,
                           int src_port,
                           basic_block_sptr dst,
                           int dst_port)
 {
-    d_detail->connect(src, src_port, dst, dst_port);
+    d_detail->connect(std::move(src), src_port, std::move(dst), dst_port);
 }
 
 void hier_block2::msg_connect(basic_block_sptr src,
-                              pmt::pmt_t srcport,
+                              const pmt::pmt_t& srcport,
                               basic_block_sptr dst,
                               pmt::pmt_t dstport)
 {
     if (!pmt::is_symbol(srcport)) {
         throw std::runtime_error("bad port id");
     }
-    d_detail->msg_connect(src, srcport, dst, dstport);
+    d_detail->msg_connect(std::move(src), srcport, std::move(dst), std::move(dstport));
 }
 
 void hier_block2::msg_connect(basic_block_sptr src,
-                              std::string srcport,
+                              const std::string& srcport,
                               basic_block_sptr dst,
-                              std::string dstport)
+                              const std::string& dstport)
 {
-    d_detail->msg_connect(src, pmt::mp(srcport), dst, pmt::mp(dstport));
+    d_detail->msg_connect(
+        std::move(src), pmt::mp(srcport), std::move(dst), pmt::mp(dstport));
 }
 
 void hier_block2::msg_disconnect(basic_block_sptr src,
-                                 pmt::pmt_t srcport,
+                                 const pmt::pmt_t& srcport,
                                  basic_block_sptr dst,
                                  pmt::pmt_t dstport)
 {
     if (!pmt::is_symbol(srcport)) {
         throw std::runtime_error("bad port id");
     }
-    d_detail->msg_disconnect(src, srcport, dst, dstport);
+    d_detail->msg_disconnect(std::move(src), srcport, std::move(dst), std::move(dstport));
 }
 
 void hier_block2::msg_disconnect(basic_block_sptr src,
-                                 std::string srcport,
+                                 const std::string& srcport,
                                  basic_block_sptr dst,
-                                 std::string dstport)
+                                 const std::string& dstport)
 {
-    d_detail->msg_disconnect(src, pmt::mp(srcport), dst, pmt::mp(dstport));
+    d_detail->msg_disconnect(
+        std::move(src), pmt::mp(srcport), std::move(dst), pmt::mp(dstport));
 }
 
-void hier_block2::disconnect(basic_block_sptr block) { d_detail->disconnect(block); }
+void hier_block2::disconnect(basic_block_sptr block)
+{
+    d_detail->disconnect(std::move(block));
+}
 
 void hier_block2::disconnect(basic_block_sptr src,
                              int src_port,
                              basic_block_sptr dst,
                              int dst_port)
 {
-    d_detail->disconnect(src, src_port, dst, dst_port);
+    d_detail->disconnect(std::move(src), src_port, std::move(dst), dst_port);
 }
 
 void hier_block2::disconnect_all() { d_detail->disconnect_all(); }
@@ -155,7 +161,7 @@ void hier_block2::set_log_level(std::string level) { d_detail->set_log_level(lev
 
 std::string hier_block2::log_level() { return d_detail->log_level(); }
 
-std::string dot_graph(hier_block2_sptr hierblock2)
+std::string dot_graph(const hier_block2_sptr& hierblock2)
 {
     return dot_graph_fg(hierblock2->flatten());
 }

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -64,7 +64,7 @@ hier_block2_detail::~hier_block2_detail()
     d_owner = 0; // Don't use delete, we didn't allocate
 }
 
-void hier_block2_detail::connect(basic_block_sptr block)
+void hier_block2_detail::connect(const basic_block_sptr& block)
 {
     std::stringstream msg;
 
@@ -93,9 +93,9 @@ void hier_block2_detail::connect(basic_block_sptr block)
     d_blocks.push_back(block);
 }
 
-void hier_block2_detail::connect(basic_block_sptr src,
+void hier_block2_detail::connect(const basic_block_sptr& src,
                                  int src_port,
-                                 basic_block_sptr dst,
+                                 const basic_block_sptr& dst,
                                  int dst_port)
 {
     std::stringstream msg;
@@ -257,7 +257,7 @@ void hier_block2_detail::msg_disconnect(basic_block_sptr src,
     src->message_port_unsub(srcport, pmt::cons(dst->alias_pmt(), dstport));
 }
 
-void hier_block2_detail::disconnect(basic_block_sptr block)
+void hier_block2_detail::disconnect(const basic_block_sptr& block)
 {
     // Check on singleton list
     for (basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
@@ -300,9 +300,9 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
     }
 }
 
-void hier_block2_detail::disconnect(basic_block_sptr src,
+void hier_block2_detail::disconnect(const basic_block_sptr& src,
                                     int src_port,
-                                    basic_block_sptr dst,
+                                    const basic_block_sptr& dst,
                                     int dst_port)
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -367,7 +367,9 @@ void hier_block2_detail::refresh_io_signature()
     }
 }
 
-void hier_block2_detail::connect_input(int my_port, int port, basic_block_sptr block)
+void hier_block2_detail::connect_input(int my_port,
+                                       int port,
+                                       const basic_block_sptr& block)
 {
     std::stringstream msg;
 
@@ -390,7 +392,9 @@ void hier_block2_detail::connect_input(int my_port, int port, basic_block_sptr b
     endps.push_back(endp);
 }
 
-void hier_block2_detail::connect_output(int my_port, int port, basic_block_sptr block)
+void hier_block2_detail::connect_output(int my_port,
+                                        int port,
+                                        const basic_block_sptr& block)
 {
     std::stringstream msg;
 
@@ -410,7 +414,9 @@ void hier_block2_detail::connect_output(int my_port, int port, basic_block_sptr 
     d_outputs[my_port] = endpoint(block, port);
 }
 
-void hier_block2_detail::disconnect_input(int my_port, int port, basic_block_sptr block)
+void hier_block2_detail::disconnect_input(int my_port,
+                                          int port,
+                                          const basic_block_sptr& block)
 {
     std::stringstream msg;
 
@@ -433,7 +439,9 @@ void hier_block2_detail::disconnect_input(int my_port, int port, basic_block_spt
     endps.erase(p);
 }
 
-void hier_block2_detail::disconnect_output(int my_port, int port, basic_block_sptr block)
+void hier_block2_detail::disconnect_output(int my_port,
+                                           int port,
+                                           const basic_block_sptr& block)
 {
     std::stringstream msg;
 
@@ -549,7 +557,7 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
     throw std::runtime_error(msg.str());
 }
 
-void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
+void hier_block2_detail::flatten_aux(const flat_flowgraph_sptr& sfg) const
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
         std::cout << " ** Flattening " << d_owner->name()
@@ -936,7 +944,7 @@ std::vector<int> hier_block2_detail::processor_affinity()
     return tmp[0]->processor_affinity();
 }
 
-void hier_block2_detail::set_log_level(std::string level)
+void hier_block2_detail::set_log_level(const std::string& level)
 {
     basic_block_vector_t tmp = d_fg->calc_used_blocks();
     for (basic_block_viter_t p = tmp.begin(); p != tmp.end(); p++) {

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -39,8 +39,11 @@ public:
     hier_block2_detail(hier_block2* owner);
     ~hier_block2_detail();
 
-    void connect(basic_block_sptr block);
-    void connect(basic_block_sptr src, int src_port, basic_block_sptr dst, int dst_port);
+    void connect(const basic_block_sptr& block);
+    void connect(const basic_block_sptr& src,
+                 int src_port,
+                 const basic_block_sptr& dst,
+                 int dst_port);
     void msg_connect(basic_block_sptr src,
                      pmt::pmt_t srcport,
                      basic_block_sptr dst,
@@ -49,18 +52,21 @@ public:
                         pmt::pmt_t srcport,
                         basic_block_sptr dst,
                         pmt::pmt_t dstport);
-    void disconnect(basic_block_sptr block);
-    void disconnect(basic_block_sptr, int src_port, basic_block_sptr, int dst_port);
+    void disconnect(const basic_block_sptr& block);
+    void disconnect(const basic_block_sptr&,
+                    int src_port,
+                    const basic_block_sptr&,
+                    int dst_port);
     void disconnect_all();
     void lock();
     void unlock();
-    void flatten_aux(flat_flowgraph_sptr sfg) const;
+    void flatten_aux(const flat_flowgraph_sptr& sfg) const;
 
     void set_processor_affinity(const std::vector<int>& mask);
     void unset_processor_affinity();
     std::vector<int> processor_affinity();
 
-    void set_log_level(std::string level);
+    void set_log_level(const std::string& level);
     std::string log_level();
 
     // Track output buffer min/max settings
@@ -78,10 +84,10 @@ private:
     basic_block_vector_t d_blocks;
 
     void refresh_io_signature();
-    void connect_input(int my_port, int port, basic_block_sptr block);
-    void connect_output(int my_port, int port, basic_block_sptr block);
-    void disconnect_input(int my_port, int port, basic_block_sptr block);
-    void disconnect_output(int my_port, int port, basic_block_sptr block);
+    void connect_input(int my_port, int port, const basic_block_sptr& block);
+    void connect_output(int my_port, int port, const basic_block_sptr& block);
+    void disconnect_input(int my_port, int port, const basic_block_sptr& block);
+    void disconnect_output(int my_port, int port, const basic_block_sptr& block);
 
     endpoint_vector_t resolve_port(int port, bool is_input);
     endpoint_vector_t resolve_endpoint(const endpoint& endp, bool is_input) const;

--- a/gnuradio-runtime/lib/math/qa_fast_atan2f.cc
+++ b/gnuradio-runtime/lib/math/qa_fast_atan2f.cc
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(t1)
         for (float j = -N / 2; i < N / 2; i++) {
             float x = i / 10.0;
             float y = j / 10.0;
-            c_atan2 = atan2(y, x);
+            c_atan2 = std::atan2(y, x);
 
             gr_atan2f = gr::fast_atan2f(y, x);
 
@@ -66,13 +66,13 @@ BOOST_AUTO_TEST_CASE(t2)
     /* Test x as INF */
     x = inf;
     y = 0;
-    c_atan2 = atan2(y, x);
+    c_atan2 = std::atan2(y, x);
     gr_atan2f = gr::fast_atan2f(y, x);
     BOOST_CHECK_CLOSE(c_atan2, gr_atan2f, 0.0);
 
     x = -inf;
     y = 0;
-    c_atan2 = atan2(y, x);
+    c_atan2 = std::atan2(y, x);
     gr_atan2f = gr::fast_atan2f(y, x);
     BOOST_CHECK_CLOSE(c_atan2, gr_atan2f, 0.0);
 
@@ -80,13 +80,13 @@ BOOST_AUTO_TEST_CASE(t2)
     /* Test y as INF */
     x = 0;
     y = inf;
-    c_atan2 = atan2(y, x);
+    c_atan2 = std::atan2(y, x);
     gr_atan2f = gr::fast_atan2f(y, x);
     BOOST_CHECK_CLOSE(c_atan2, gr_atan2f, 0.0);
 
     x = 0;
     y = -inf;
-    c_atan2 = atan2(y, x);
+    c_atan2 = std::atan2(y, x);
     gr_atan2f = gr::fast_atan2f(y, x);
     BOOST_CHECK_CLOSE(c_atan2, gr_atan2f, 0.0);
 

--- a/gnuradio-runtime/lib/message.cc
+++ b/gnuradio-runtime/lib/message.cc
@@ -38,7 +38,7 @@ message::sptr message::make(long type, double arg1, double arg2, size_t length)
 }
 
 message::sptr
-message::make_from_string(const std::string s, long type, double arg1, double arg2)
+message::make_from_string(const std::string& s, long type, double arg1, double arg2)
 {
     message::sptr m = message::make(type, arg1, arg2, s.size());
     memcpy(m->msg(), s.data(), s.size());

--- a/gnuradio-runtime/lib/messages/msg_accepter_msgq.cc
+++ b/gnuradio-runtime/lib/messages/msg_accepter_msgq.cc
@@ -25,17 +25,21 @@
 
 #include <gnuradio/messages/msg_accepter_msgq.h>
 
+#include <utility>
+
 namespace gr {
 namespace messages {
 
-msg_accepter_msgq::msg_accepter_msgq(msg_queue_sptr msgq) : d_msg_queue(msgq) {}
+msg_accepter_msgq::msg_accepter_msgq(msg_queue_sptr msgq) : d_msg_queue(std::move(msgq))
+{
+}
 
 msg_accepter_msgq::~msg_accepter_msgq()
 {
     // NOP, required as virtual destructor
 }
 
-void msg_accepter_msgq::post(pmt::pmt_t msg) { d_msg_queue->insert_tail(msg); }
+void msg_accepter_msgq::post(pmt::pmt_t msg) { d_msg_queue->insert_tail(std::move(msg)); }
 
 } /* namespace messages */
 } /* namespace gr */

--- a/gnuradio-runtime/lib/messages/msg_queue.cc
+++ b/gnuradio-runtime/lib/messages/msg_queue.cc
@@ -39,7 +39,7 @@ msg_queue::msg_queue(unsigned int limit) : d_limit(limit) {}
 
 msg_queue::~msg_queue() { flush(); }
 
-void msg_queue::insert_tail(pmt::pmt_t msg)
+void msg_queue::insert_tail(const pmt::pmt_t& msg)
 {
     gr::thread::scoped_lock guard(d_mutex);
 

--- a/gnuradio-runtime/lib/msg_queue.cc
+++ b/gnuradio-runtime/lib/msg_queue.cc
@@ -44,7 +44,7 @@ msg_queue::msg_queue(unsigned int limit)
 
 msg_queue::~msg_queue() { flush(); }
 
-void msg_queue::insert_tail(message::sptr msg)
+void msg_queue::insert_tail(const message::sptr& msg)
 {
     if (msg->d_next)
         throw std::invalid_argument("gr::msg_queue::insert_tail: msg already in queue");

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -30,6 +30,7 @@
 #include <pmt/pmt_pool.h>
 #include <stdio.h>
 #include <string.h>
+#include <utility>
 #include <vector>
 
 namespace pmt {
@@ -44,22 +45,22 @@ pmt_base::~pmt_base()
 ////////////////////////////////////////////////////////////////////////////
 
 exception::exception(const std::string& msg, pmt_t obj)
-    : logic_error(msg + ": " + write_string(obj))
+    : logic_error(msg + ": " + write_string(std::move(obj)))
 {
 }
 
 wrong_type::wrong_type(const std::string& msg, pmt_t obj)
-    : exception(msg + ": wrong_type ", obj)
+    : exception(msg + ": wrong_type ", std::move(obj))
 {
 }
 
 out_of_range::out_of_range(const std::string& msg, pmt_t obj)
-    : exception(msg + ": out of range ", obj)
+    : exception(msg + ": out of range ", std::move(obj))
 {
 }
 
 notimplemented::notimplemented(const std::string& msg, pmt_t obj)
-    : exception(msg + ": notimplemented ", obj)
+    : exception(msg + ": notimplemented ", std::move(obj))
 {
 }
 
@@ -67,28 +68,34 @@ notimplemented::notimplemented(const std::string& msg, pmt_t obj)
 //                          Dynamic Casts
 ////////////////////////////////////////////////////////////////////////////
 
-static pmt_symbol* _symbol(pmt_t x) { return dynamic_cast<pmt_symbol*>(x.get()); }
+static pmt_symbol* _symbol(const pmt_t& x) { return dynamic_cast<pmt_symbol*>(x.get()); }
 
-static pmt_integer* _integer(pmt_t x) { return dynamic_cast<pmt_integer*>(x.get()); }
+static pmt_integer* _integer(const pmt_t& x)
+{
+    return dynamic_cast<pmt_integer*>(x.get());
+}
 
-static pmt_uint64* _uint64(pmt_t x) { return dynamic_cast<pmt_uint64*>(x.get()); }
+static pmt_uint64* _uint64(const pmt_t& x) { return dynamic_cast<pmt_uint64*>(x.get()); }
 
-static pmt_real* _real(pmt_t x) { return dynamic_cast<pmt_real*>(x.get()); }
+static pmt_real* _real(const pmt_t& x) { return dynamic_cast<pmt_real*>(x.get()); }
 
-static pmt_complex* _complex(pmt_t x) { return dynamic_cast<pmt_complex*>(x.get()); }
+static pmt_complex* _complex(const pmt_t& x)
+{
+    return dynamic_cast<pmt_complex*>(x.get());
+}
 
-static pmt_pair* _pair(pmt_t x) { return dynamic_cast<pmt_pair*>(x.get()); }
+static pmt_pair* _pair(const pmt_t& x) { return dynamic_cast<pmt_pair*>(x.get()); }
 
-static pmt_vector* _vector(pmt_t x) { return dynamic_cast<pmt_vector*>(x.get()); }
+static pmt_vector* _vector(const pmt_t& x) { return dynamic_cast<pmt_vector*>(x.get()); }
 
-static pmt_tuple* _tuple(pmt_t x) { return dynamic_cast<pmt_tuple*>(x.get()); }
+static pmt_tuple* _tuple(const pmt_t& x) { return dynamic_cast<pmt_tuple*>(x.get()); }
 
-static pmt_uniform_vector* _uniform_vector(pmt_t x)
+static pmt_uniform_vector* _uniform_vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_uniform_vector*>(x.get());
 }
 
-static pmt_any* _any(pmt_t x) { return dynamic_cast<pmt_any*>(x.get()); }
+static pmt_any* _any(const pmt_t& x) { return dynamic_cast<pmt_any*>(x.get()); }
 
 ////////////////////////////////////////////////////////////////////////////
 //                           Globals
@@ -124,15 +131,15 @@ pmt_t get_PMT_EOF()
 
 pmt_bool::pmt_bool() {}
 
-bool is_true(pmt_t obj) { return obj != PMT_F; }
+bool is_true(const pmt_t& obj) { return obj != PMT_F; }
 
-bool is_false(pmt_t obj) { return obj == PMT_F; }
+bool is_false(const pmt_t& obj) { return obj == PMT_F; }
 
-bool is_bool(pmt_t obj) { return obj->is_bool(); }
+bool is_bool(const pmt_t& obj) { return obj->is_bool(); }
 
 pmt_t from_bool(bool val) { return val ? PMT_T : PMT_F; }
 
-bool to_bool(pmt_t val)
+bool to_bool(const pmt_t& val)
 {
     if (val == PMT_T)
         return true;
@@ -221,7 +228,7 @@ const std::string symbol_to_string(const pmt_t& sym)
 //                             Number
 ////////////////////////////////////////////////////////////////////////////
 
-bool is_number(pmt_t x) { return x->is_number(); }
+bool is_number(const pmt_t& x) { return x->is_number(); }
 
 ////////////////////////////////////////////////////////////////////////////
 //                             Integer
@@ -229,12 +236,12 @@ bool is_number(pmt_t x) { return x->is_number(); }
 
 pmt_integer::pmt_integer(long value) : d_value(value) {}
 
-bool is_integer(pmt_t x) { return x->is_integer(); }
+bool is_integer(const pmt_t& x) { return x->is_integer(); }
 
 
 pmt_t from_long(long x) { return pmt_t(new pmt_integer(x)); }
 
-long to_long(pmt_t x)
+long to_long(const pmt_t& x)
 {
     pmt_integer* i = dynamic_cast<pmt_integer*>(x.get());
     if (i)
@@ -249,12 +256,12 @@ long to_long(pmt_t x)
 
 pmt_uint64::pmt_uint64(uint64_t value) : d_value(value) {}
 
-bool is_uint64(pmt_t x) { return x->is_uint64(); }
+bool is_uint64(const pmt_t& x) { return x->is_uint64(); }
 
 
 pmt_t from_uint64(uint64_t x) { return pmt_t(new pmt_uint64(x)); }
 
-uint64_t to_uint64(pmt_t x)
+uint64_t to_uint64(const pmt_t& x)
 {
     if (x->is_uint64())
         return _uint64(x)->value();
@@ -273,13 +280,13 @@ uint64_t to_uint64(pmt_t x)
 
 pmt_real::pmt_real(double value) : d_value(value) {}
 
-bool is_real(pmt_t x) { return x->is_real(); }
+bool is_real(const pmt_t& x) { return x->is_real(); }
 
 pmt_t from_double(double x) { return pmt_t(new pmt_real(x)); }
 
 pmt_t from_float(float x) { return pmt_t(new pmt_real(x)); }
 
-double to_double(pmt_t x)
+double to_double(const pmt_t& x)
 {
     if (x->is_real())
         return _real(x)->value();
@@ -289,7 +296,7 @@ double to_double(pmt_t x)
     throw wrong_type("pmt_to_double", x);
 }
 
-float to_float(pmt_t x) { return float(to_double(x)); }
+float to_float(pmt_t x) { return float(to_double(std::move(x))); }
 
 ////////////////////////////////////////////////////////////////////////////
 //                              Complex
@@ -297,7 +304,7 @@ float to_float(pmt_t x) { return float(to_double(x)); }
 
 pmt_complex::pmt_complex(std::complex<double> value) : d_value(value) {}
 
-bool is_complex(pmt_t x) { return x->is_complex(); }
+bool is_complex(const pmt_t& x) { return x->is_complex(); }
 
 pmt_t make_rectangular(double re, double im) { return from_complex(re, im); }
 
@@ -310,7 +317,7 @@ pmt_t pmt_from_complex(double re, double im)
 
 pmt_t from_complex(const std::complex<double>& z) { return pmt_t(new pmt_complex(z)); }
 
-std::complex<double> to_complex(pmt_t x)
+std::complex<double> to_complex(const pmt_t& x)
 {
     if (x->is_complex())
         return _complex(x)->value();
@@ -353,18 +360,18 @@ pmt_t cdr(const pmt_t& pair)
     throw wrong_type("pmt_cdr", pair);
 }
 
-void set_car(pmt_t pair, pmt_t obj)
+void set_car(const pmt_t& pair, pmt_t obj)
 {
     if (pair->is_pair())
-        _pair(pair)->set_car(obj);
+        _pair(pair)->set_car(std::move(obj));
     else
         throw wrong_type("pmt_set_car", pair);
 }
 
-void set_cdr(pmt_t pair, pmt_t obj)
+void set_cdr(const pmt_t& pair, pmt_t obj)
 {
     if (pair->is_pair())
-        _pair(pair)->set_cdr(obj);
+        _pair(pair)->set_cdr(std::move(obj));
     else
         throw wrong_type("pmt_set_cdr", pair);
 }
@@ -373,7 +380,7 @@ void set_cdr(pmt_t pair, pmt_t obj)
 //                             Vectors
 ////////////////////////////////////////////////////////////////////////////
 
-pmt_vector::pmt_vector(size_t len, pmt_t fill) : d_v(len)
+pmt_vector::pmt_vector(size_t len, const pmt_t& fill) : d_v(len)
 {
     for (size_t i = 0; i < len; i++)
         d_v[i] = fill;
@@ -390,38 +397,41 @@ void pmt_vector::set(size_t k, pmt_t obj)
 {
     if (k >= length())
         throw out_of_range("pmt_vector_set", from_long(k));
-    d_v[k] = obj;
+    d_v[k] = std::move(obj);
 }
 
-void pmt_vector::fill(pmt_t obj)
+void pmt_vector::fill(const pmt_t& obj)
 {
     for (size_t i = 0; i < length(); i++)
         d_v[i] = obj;
 }
 
-bool is_vector(pmt_t obj) { return obj->is_vector(); }
+bool is_vector(const pmt_t& obj) { return obj->is_vector(); }
 
-pmt_t make_vector(size_t k, pmt_t fill) { return pmt_t(new pmt_vector(k, fill)); }
+pmt_t make_vector(size_t k, pmt_t fill)
+{
+    return pmt_t(new pmt_vector(k, std::move(fill)));
+}
 
-pmt_t vector_ref(pmt_t vector, size_t k)
+pmt_t vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_vector())
         throw wrong_type("pmt_vector_ref", vector);
     return _vector(vector)->ref(k);
 }
 
-void vector_set(pmt_t vector, size_t k, pmt_t obj)
+void vector_set(const pmt_t& vector, size_t k, pmt_t obj)
 {
     if (!vector->is_vector())
         throw wrong_type("pmt_vector_set", vector);
-    _vector(vector)->set(k, obj);
+    _vector(vector)->set(k, std::move(obj));
 }
 
-void vector_fill(pmt_t vector, pmt_t obj)
+void vector_fill(const pmt_t& vector, pmt_t obj)
 {
     if (!vector->is_vector())
         throw wrong_type("pmt_vector_set", vector);
-    _vector(vector)->fill(obj);
+    _vector(vector)->fill(std::move(obj));
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -437,7 +447,7 @@ pmt_t pmt_tuple::ref(size_t k) const
     return d_v[k];
 }
 
-bool is_tuple(pmt_t obj) { return obj->is_tuple(); }
+bool is_tuple(const pmt_t& obj) { return obj->is_tuple(); }
 
 pmt_t tuple_ref(const pmt_t& tuple, size_t k)
 {
@@ -634,23 +644,23 @@ pmt_t to_tuple(const pmt_t& x)
 //                       Uniform Numeric Vectors
 ////////////////////////////////////////////////////////////////////////////
 
-bool is_uniform_vector(pmt_t x) { return x->is_uniform_vector(); }
+bool is_uniform_vector(const pmt_t& x) { return x->is_uniform_vector(); }
 
-size_t uniform_vector_itemsize(pmt_t vector)
+size_t uniform_vector_itemsize(const pmt_t& vector)
 {
     if (!vector->is_uniform_vector())
         throw wrong_type("pmt_uniform_vector_itemsize", vector);
     return _uniform_vector(vector)->itemsize();
 }
 
-const void* uniform_vector_elements(pmt_t vector, size_t& len)
+const void* uniform_vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_uniform_vector())
         throw wrong_type("pmt_uniform_vector_elements", vector);
     return _uniform_vector(vector)->uniform_elements(len);
 }
 
-void* uniform_vector_writable_elements(pmt_t vector, size_t& len)
+void* uniform_vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_uniform_vector())
         throw wrong_type("pmt_uniform_vector_writable_elements", vector);
@@ -730,7 +740,7 @@ pmt_t dict_items(pmt_t dict)
     return dict; // equivalent to dict in the a-list case
 }
 
-pmt_t dict_keys(pmt_t dict)
+pmt_t dict_keys(const pmt_t& dict)
 {
     if (!is_dict(dict))
         throw wrong_type("pmt_dict_keys", dict);
@@ -738,7 +748,7 @@ pmt_t dict_keys(pmt_t dict)
     return map(car, dict);
 }
 
-pmt_t dict_values(pmt_t dict)
+pmt_t dict_values(const pmt_t& dict)
 {
     if (!is_dict(dict))
         throw wrong_type("pmt_dict_keys", dict);
@@ -752,18 +762,18 @@ pmt_t dict_values(pmt_t dict)
 
 pmt_any::pmt_any(const boost::any& any) : d_any(any) {}
 
-bool is_any(pmt_t obj) { return obj->is_any(); }
+bool is_any(const pmt_t& obj) { return obj->is_any(); }
 
 pmt_t make_any(const boost::any& any) { return pmt_t(new pmt_any(any)); }
 
-boost::any any_ref(pmt_t obj)
+boost::any any_ref(const pmt_t& obj)
 {
     if (!obj->is_any())
         throw wrong_type("pmt_any_ref", obj);
     return _any(obj)->ref();
 }
 
-void any_set(pmt_t obj, const boost::any& any)
+void any_set(const pmt_t& obj, const boost::any& any)
 {
     if (!obj->is_any())
         throw wrong_type("pmt_any_set", obj);
@@ -784,7 +794,10 @@ bool is_msg_accepter(const pmt_t& obj)
 }
 
 //! make a msg_accepter
-pmt_t make_msg_accepter(gr::messages::msg_accepter_sptr ma) { return make_any(ma); }
+pmt_t make_msg_accepter(const gr::messages::msg_accepter_sptr& ma)
+{
+    return make_any(ma);
+}
 
 //! Return underlying msg_accepter
 gr::messages::msg_accepter_sptr msg_accepter_ref(const pmt_t& obj)
@@ -801,7 +814,7 @@ gr::messages::msg_accepter_sptr msg_accepter_ref(const pmt_t& obj)
 //             Binary Large Object -- currently a u8vector
 ////////////////////////////////////////////////////////////////////////////
 
-bool is_blob(pmt_t x) { return is_u8vector(x); }
+bool is_blob(pmt_t x) { return is_u8vector(std::move(x)); }
 
 pmt_t make_blob(const void* buf, size_t len_in_bytes)
 {
@@ -811,13 +824,13 @@ pmt_t make_blob(const void* buf, size_t len_in_bytes)
 const void* blob_data(pmt_t blob)
 {
     size_t len;
-    return uniform_vector_elements(blob, len);
+    return uniform_vector_elements(std::move(blob), len);
 }
 
 size_t blob_length(pmt_t blob)
 {
     size_t len;
-    uniform_vector_elements(blob, len);
+    uniform_vector_elements(std::move(blob), len);
     return len;
 }
 
@@ -935,7 +948,7 @@ size_t length(const pmt_t& x)
     throw wrong_type("pmt_length", x);
 }
 
-pmt_t assq(pmt_t obj, pmt_t alist)
+pmt_t assq(const pmt_t& obj, pmt_t alist)
 {
     while (is_pair(alist)) {
         pmt_t p = car(alist);
@@ -950,7 +963,7 @@ pmt_t assq(pmt_t obj, pmt_t alist)
     return PMT_F;
 }
 
-pmt_t assv(pmt_t obj, pmt_t alist)
+pmt_t assv(const pmt_t& obj, pmt_t alist)
 {
     while (is_pair(alist)) {
         pmt_t p = car(alist);
@@ -966,7 +979,7 @@ pmt_t assv(pmt_t obj, pmt_t alist)
 }
 
 
-pmt_t assoc(pmt_t obj, pmt_t alist)
+pmt_t assoc(const pmt_t& obj, pmt_t alist)
 {
     while (is_pair(alist)) {
         pmt_t p = car(alist);
@@ -993,7 +1006,7 @@ pmt_t map(pmt_t proc(const pmt_t&), pmt_t list)
     return reverse_x(r);
 }
 
-pmt_t reverse(pmt_t listx)
+pmt_t reverse(const pmt_t& listx)
 {
     pmt_t list = listx;
     pmt_t r = PMT_NIL;
@@ -1011,12 +1024,12 @@ pmt_t reverse(pmt_t listx)
 pmt_t reverse_x(pmt_t list)
 {
     // FIXME do it destructively
-    return reverse(list);
+    return reverse(std::move(list));
 }
 
 pmt_t nth(size_t n, pmt_t list)
 {
-    pmt_t t = nthcdr(n, list);
+    pmt_t t = nthcdr(n, std::move(list));
     if (is_pair(t))
         return car(t);
     else
@@ -1042,7 +1055,7 @@ pmt_t nthcdr(size_t n, pmt_t list)
     return list;
 }
 
-pmt_t memq(pmt_t obj, pmt_t list)
+pmt_t memq(const pmt_t& obj, pmt_t list)
 {
     while (is_pair(list)) {
         if (eq(obj, car(list)))
@@ -1052,7 +1065,7 @@ pmt_t memq(pmt_t obj, pmt_t list)
     return PMT_F;
 }
 
-pmt_t memv(pmt_t obj, pmt_t list)
+pmt_t memv(const pmt_t& obj, pmt_t list)
 {
     while (is_pair(list)) {
         if (eqv(obj, car(list)))
@@ -1062,7 +1075,7 @@ pmt_t memv(pmt_t obj, pmt_t list)
     return PMT_F;
 }
 
-pmt_t member(pmt_t obj, pmt_t list)
+pmt_t member(const pmt_t& obj, pmt_t list)
 {
     while (is_pair(list)) {
         if (equal(obj, car(list)))
@@ -1072,7 +1085,7 @@ pmt_t member(pmt_t obj, pmt_t list)
     return PMT_F;
 }
 
-bool subsetp(pmt_t list1, pmt_t list2)
+bool subsetp(pmt_t list1, const pmt_t& list2)
 {
     while (is_pair(list1)) {
         pmt_t p = car(list1);
@@ -1115,7 +1128,7 @@ pmt_t list6(const pmt_t& x1,
 
 pmt_t list_add(pmt_t list, const pmt_t& item)
 {
-    return reverse(cons(item, reverse(list)));
+    return reverse(cons(item, reverse(std::move(list))));
 }
 
 pmt_t list_rm(pmt_t list, const pmt_t& item)
@@ -1133,7 +1146,7 @@ pmt_t list_rm(pmt_t list, const pmt_t& item)
     }
 }
 
-bool list_has(pmt_t list, const pmt_t& item)
+bool list_has(const pmt_t& list, const pmt_t& item)
 {
     if (is_pair(list)) {
         pmt_t left = car(list);
@@ -1148,19 +1161,19 @@ bool list_has(pmt_t list, const pmt_t& item)
     }
 }
 
-pmt_t caar(pmt_t pair) { return (car(car(pair))); }
+pmt_t caar(const pmt_t& pair) { return (car(car(pair))); }
 
-pmt_t cadr(pmt_t pair) { return car(cdr(pair)); }
+pmt_t cadr(const pmt_t& pair) { return car(cdr(pair)); }
 
-pmt_t cdar(pmt_t pair) { return cdr(car(pair)); }
+pmt_t cdar(const pmt_t& pair) { return cdr(car(pair)); }
 
-pmt_t cddr(pmt_t pair) { return cdr(cdr(pair)); }
+pmt_t cddr(const pmt_t& pair) { return cdr(cdr(pair)); }
 
-pmt_t caddr(pmt_t pair) { return car(cdr(cdr(pair))); }
+pmt_t caddr(const pmt_t& pair) { return car(cdr(cdr(pair))); }
 
-pmt_t cadddr(pmt_t pair) { return car(cdr(cdr(cdr(pair)))); }
+pmt_t cadddr(const pmt_t& pair) { return car(cdr(cdr(cdr(pair)))); }
 
-bool is_eof_object(pmt_t obj) { return eq(obj, PMT_EOF); }
+bool is_eof_object(const pmt_t& obj) { return eq(obj, PMT_EOF); }
 
 void dump_sizeof()
 {

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -26,6 +26,7 @@
 #include <boost/atomic.hpp>
 #include <boost/utility.hpp>
 #include <boost/version.hpp>
+#include <utility>
 
 /*
  * EVERYTHING IN THIS FILE IS PRIVATE TO THE IMPLEMENTATION!
@@ -59,7 +60,7 @@ public:
     const std::string name() { return d_name; }
 
     pmt_t next() { return d_next; } // symbol table link
-    void set_next(pmt_t next) { d_next = next; }
+    void set_next(pmt_t next) { d_next = std::move(next); }
 };
 
 class pmt_integer : public pmt_base
@@ -136,8 +137,8 @@ public:
     pmt_t car() const { return d_car; }
     pmt_t cdr() const { return d_cdr; }
 
-    void set_car(pmt_t car) { d_car = car; }
-    void set_cdr(pmt_t cdr) { d_cdr = cdr; }
+    void set_car(pmt_t car) { d_car = std::move(car); }
+    void set_cdr(pmt_t cdr) { d_cdr = std::move(cdr); }
 };
 
 class pmt_vector : public pmt_base
@@ -145,13 +146,13 @@ class pmt_vector : public pmt_base
     std::vector<pmt_t> d_v;
 
 public:
-    pmt_vector(size_t len, pmt_t fill);
+    pmt_vector(size_t len, const pmt_t& fill);
     //~pmt_vector();
 
     bool is_vector() const { return true; }
     pmt_t ref(size_t k) const;
     void set(size_t k, pmt_t obj);
-    void fill(pmt_t fill);
+    void fill(const pmt_t& fill);
     size_t length() const { return d_v.size(); }
 
     pmt_t _ref(size_t k) const { return d_v[k]; }
@@ -170,7 +171,7 @@ public:
     size_t length() const { return d_v.size(); }
 
     pmt_t _ref(size_t k) const { return d_v[k]; }
-    void _set(size_t k, pmt_t v) { d_v[k] = v; }
+    void _set(size_t k, pmt_t v) { d_v[k] = std::move(v); }
 };
 
 class pmt_any : public pmt_base

--- a/gnuradio-runtime/lib/pmt/pmt_io.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_io.cc
@@ -27,6 +27,7 @@
 #include <pmt/pmt.h>
 #include <iostream>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 namespace pmt {
@@ -49,7 +50,7 @@ static void write_list_tail(pmt_t obj, std::ostream& port)
     }
 }
 
-void write(pmt_t obj, std::ostream& port)
+void write(const pmt_t& obj, std::ostream& port)
 {
     if (is_bool(obj)) {
         if (is_true(obj))
@@ -117,14 +118,14 @@ void write(pmt_t obj, std::ostream& port)
 
 std::ostream& operator<<(std::ostream& os, pmt_t obj)
 {
-    write(obj, os);
+    write(std::move(obj), os);
     return os;
 }
 
 std::string write_string(pmt_t obj)
 {
     std::ostringstream s;
-    s << obj;
+    s << std::move(obj);
     return s.str();
 }
 
@@ -135,7 +136,7 @@ pmt_t read(std::istream& port)
 
 void serialize(pmt_t obj, std::ostream& sink)
 {
-    throw notimplemented("notimplemented: pmt::serialize", obj);
+    throw notimplemented("notimplemented: pmt::serialize", std::move(obj));
 }
 
 /*!
@@ -149,4 +150,4 @@ pmt_t deserialize(std::istream& source)
 } /* namespace pmt */
 
 
-void pmt::print(pmt_t v) { std::cout << write_string(v) << std::endl; }
+void pmt::print(pmt_t v) { std::cout << write_string(std::move(v)) << std::endl; }

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -27,6 +27,7 @@
 #include "pmt_int.h"
 #include <pmt/pmt.h>
 #include <limits>
+#include <utility>
 #include <vector>
 
 namespace pmt {
@@ -743,7 +744,7 @@ error:
 std::string serialize_str(pmt_t obj)
 {
     std::stringbuf sb;
-    serialize(obj, sb);
+    serialize(std::move(obj), sb);
     return sb.str();
 }
 
@@ -751,7 +752,7 @@ std::string serialize_str(pmt_t obj)
 /*
  * provide a simple string accessor to the deserialized pmt form
  */
-pmt_t deserialize_str(std::string s)
+pmt_t deserialize_str(const std::string& s)
 {
     std::stringbuf sb(s);
     return deserialize(sb);

--- a/gnuradio-runtime/lib/pmt/pmt_unv.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_unv.cc
@@ -37,7 +37,10 @@
 
 namespace pmt {
 
-static pmt_u8vector* _u8vector(pmt_t x) { return dynamic_cast<pmt_u8vector*>(x.get()); }
+static pmt_u8vector* _u8vector(const pmt_t& x)
+{
+    return dynamic_cast<pmt_u8vector*>(x.get());
+}
 
 
 pmt_u8vector::pmt_u8vector(size_t k, uint8_t fill) : d_v(k)
@@ -90,7 +93,7 @@ void* pmt_u8vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_u8vector(pmt_t obj) { return obj->is_u8vector(); }
+bool is_u8vector(const pmt_t& obj) { return obj->is_u8vector(); }
 
 pmt_t make_u8vector(size_t k, uint8_t fill) { return pmt_t(new pmt_u8vector(k, fill)); }
 
@@ -108,28 +111,28 @@ pmt_t init_u8vector(size_t k, const std::vector<uint8_t>& data)
         new pmt_u8vector(k, static_cast<uint8_t>(0))); // fills an empty vector with 0
 }
 
-uint8_t u8vector_ref(pmt_t vector, size_t k)
+uint8_t u8vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_u8vector())
         throw wrong_type("pmt_u8vector_ref", vector);
     return _u8vector(vector)->ref(k);
 }
 
-void u8vector_set(pmt_t vector, size_t k, uint8_t obj)
+void u8vector_set(const pmt_t& vector, size_t k, uint8_t obj)
 {
     if (!vector->is_u8vector())
         throw wrong_type("pmt_u8vector_set", vector);
     _u8vector(vector)->set(k, obj);
 }
 
-const uint8_t* u8vector_elements(pmt_t vector, size_t& len)
+const uint8_t* u8vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u8vector())
         throw wrong_type("pmt_u8vector_elements", vector);
     return _u8vector(vector)->elements(len);
 }
 
-const std::vector<uint8_t> u8vector_elements(pmt_t vector)
+const std::vector<uint8_t> u8vector_elements(const pmt_t& vector)
 {
     if (!vector->is_u8vector())
         throw wrong_type("pmt_u8vector_elements", vector);
@@ -140,7 +143,7 @@ const std::vector<uint8_t> u8vector_elements(pmt_t vector)
 }
 
 
-uint8_t* u8vector_writable_elements(pmt_t vector, size_t& len)
+uint8_t* u8vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u8vector())
         throw wrong_type("pmt_u8vector_writable_elements", vector);
@@ -159,7 +162,10 @@ const std::string pmt_u8vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_s8vector* _s8vector(pmt_t x) { return dynamic_cast<pmt_s8vector*>(x.get()); }
+static pmt_s8vector* _s8vector(const pmt_t& x)
+{
+    return dynamic_cast<pmt_s8vector*>(x.get());
+}
 
 
 pmt_s8vector::pmt_s8vector(size_t k, int8_t fill) : d_v(k)
@@ -212,7 +218,7 @@ void* pmt_s8vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_s8vector(pmt_t obj) { return obj->is_s8vector(); }
+bool is_s8vector(const pmt_t& obj) { return obj->is_s8vector(); }
 
 pmt_t make_s8vector(size_t k, int8_t fill) { return pmt_t(new pmt_s8vector(k, fill)); }
 
@@ -230,28 +236,28 @@ pmt_t init_s8vector(size_t k, const std::vector<int8_t>& data)
         new pmt_s8vector(k, static_cast<int8_t>(0))); // fills an empty vector with 0
 }
 
-int8_t s8vector_ref(pmt_t vector, size_t k)
+int8_t s8vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_s8vector())
         throw wrong_type("pmt_s8vector_ref", vector);
     return _s8vector(vector)->ref(k);
 }
 
-void s8vector_set(pmt_t vector, size_t k, int8_t obj)
+void s8vector_set(const pmt_t& vector, size_t k, int8_t obj)
 {
     if (!vector->is_s8vector())
         throw wrong_type("pmt_s8vector_set", vector);
     _s8vector(vector)->set(k, obj);
 }
 
-const int8_t* s8vector_elements(pmt_t vector, size_t& len)
+const int8_t* s8vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s8vector())
         throw wrong_type("pmt_s8vector_elements", vector);
     return _s8vector(vector)->elements(len);
 }
 
-const std::vector<int8_t> s8vector_elements(pmt_t vector)
+const std::vector<int8_t> s8vector_elements(const pmt_t& vector)
 {
     if (!vector->is_s8vector())
         throw wrong_type("pmt_s8vector_elements", vector);
@@ -262,7 +268,7 @@ const std::vector<int8_t> s8vector_elements(pmt_t vector)
 }
 
 
-int8_t* s8vector_writable_elements(pmt_t vector, size_t& len)
+int8_t* s8vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s8vector())
         throw wrong_type("pmt_s8vector_writable_elements", vector);
@@ -281,7 +287,7 @@ const std::string pmt_s8vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_u16vector* _u16vector(pmt_t x)
+static pmt_u16vector* _u16vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_u16vector*>(x.get());
 }
@@ -337,7 +343,7 @@ void* pmt_u16vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_u16vector(pmt_t obj) { return obj->is_u16vector(); }
+bool is_u16vector(const pmt_t& obj) { return obj->is_u16vector(); }
 
 pmt_t make_u16vector(size_t k, uint16_t fill)
 {
@@ -358,28 +364,28 @@ pmt_t init_u16vector(size_t k, const std::vector<uint16_t>& data)
         new pmt_u16vector(k, static_cast<uint16_t>(0))); // fills an empty vector with 0
 }
 
-uint16_t u16vector_ref(pmt_t vector, size_t k)
+uint16_t u16vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_u16vector())
         throw wrong_type("pmt_u16vector_ref", vector);
     return _u16vector(vector)->ref(k);
 }
 
-void u16vector_set(pmt_t vector, size_t k, uint16_t obj)
+void u16vector_set(const pmt_t& vector, size_t k, uint16_t obj)
 {
     if (!vector->is_u16vector())
         throw wrong_type("pmt_u16vector_set", vector);
     _u16vector(vector)->set(k, obj);
 }
 
-const uint16_t* u16vector_elements(pmt_t vector, size_t& len)
+const uint16_t* u16vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u16vector())
         throw wrong_type("pmt_u16vector_elements", vector);
     return _u16vector(vector)->elements(len);
 }
 
-const std::vector<uint16_t> u16vector_elements(pmt_t vector)
+const std::vector<uint16_t> u16vector_elements(const pmt_t& vector)
 {
     if (!vector->is_u16vector())
         throw wrong_type("pmt_u16vector_elements", vector);
@@ -390,7 +396,7 @@ const std::vector<uint16_t> u16vector_elements(pmt_t vector)
 }
 
 
-uint16_t* u16vector_writable_elements(pmt_t vector, size_t& len)
+uint16_t* u16vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u16vector())
         throw wrong_type("pmt_u16vector_writable_elements", vector);
@@ -409,7 +415,7 @@ const std::string pmt_u16vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_s16vector* _s16vector(pmt_t x)
+static pmt_s16vector* _s16vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_s16vector*>(x.get());
 }
@@ -465,7 +471,7 @@ void* pmt_s16vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_s16vector(pmt_t obj) { return obj->is_s16vector(); }
+bool is_s16vector(const pmt_t& obj) { return obj->is_s16vector(); }
 
 pmt_t make_s16vector(size_t k, int16_t fill) { return pmt_t(new pmt_s16vector(k, fill)); }
 
@@ -483,28 +489,28 @@ pmt_t init_s16vector(size_t k, const std::vector<int16_t>& data)
         new pmt_s16vector(k, static_cast<int16_t>(0))); // fills an empty vector with 0
 }
 
-int16_t s16vector_ref(pmt_t vector, size_t k)
+int16_t s16vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_s16vector())
         throw wrong_type("pmt_s16vector_ref", vector);
     return _s16vector(vector)->ref(k);
 }
 
-void s16vector_set(pmt_t vector, size_t k, int16_t obj)
+void s16vector_set(const pmt_t& vector, size_t k, int16_t obj)
 {
     if (!vector->is_s16vector())
         throw wrong_type("pmt_s16vector_set", vector);
     _s16vector(vector)->set(k, obj);
 }
 
-const int16_t* s16vector_elements(pmt_t vector, size_t& len)
+const int16_t* s16vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s16vector())
         throw wrong_type("pmt_s16vector_elements", vector);
     return _s16vector(vector)->elements(len);
 }
 
-const std::vector<int16_t> s16vector_elements(pmt_t vector)
+const std::vector<int16_t> s16vector_elements(const pmt_t& vector)
 {
     if (!vector->is_s16vector())
         throw wrong_type("pmt_s16vector_elements", vector);
@@ -515,7 +521,7 @@ const std::vector<int16_t> s16vector_elements(pmt_t vector)
 }
 
 
-int16_t* s16vector_writable_elements(pmt_t vector, size_t& len)
+int16_t* s16vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s16vector())
         throw wrong_type("pmt_s16vector_writable_elements", vector);
@@ -534,7 +540,7 @@ const std::string pmt_s16vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_u32vector* _u32vector(pmt_t x)
+static pmt_u32vector* _u32vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_u32vector*>(x.get());
 }
@@ -590,7 +596,7 @@ void* pmt_u32vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_u32vector(pmt_t obj) { return obj->is_u32vector(); }
+bool is_u32vector(const pmt_t& obj) { return obj->is_u32vector(); }
 
 pmt_t make_u32vector(size_t k, uint32_t fill)
 {
@@ -611,28 +617,28 @@ pmt_t init_u32vector(size_t k, const std::vector<uint32_t>& data)
         new pmt_u32vector(k, static_cast<uint32_t>(0))); // fills an empty vector with 0
 }
 
-uint32_t u32vector_ref(pmt_t vector, size_t k)
+uint32_t u32vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_u32vector())
         throw wrong_type("pmt_u32vector_ref", vector);
     return _u32vector(vector)->ref(k);
 }
 
-void u32vector_set(pmt_t vector, size_t k, uint32_t obj)
+void u32vector_set(const pmt_t& vector, size_t k, uint32_t obj)
 {
     if (!vector->is_u32vector())
         throw wrong_type("pmt_u32vector_set", vector);
     _u32vector(vector)->set(k, obj);
 }
 
-const uint32_t* u32vector_elements(pmt_t vector, size_t& len)
+const uint32_t* u32vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u32vector())
         throw wrong_type("pmt_u32vector_elements", vector);
     return _u32vector(vector)->elements(len);
 }
 
-const std::vector<uint32_t> u32vector_elements(pmt_t vector)
+const std::vector<uint32_t> u32vector_elements(const pmt_t& vector)
 {
     if (!vector->is_u32vector())
         throw wrong_type("pmt_u32vector_elements", vector);
@@ -643,7 +649,7 @@ const std::vector<uint32_t> u32vector_elements(pmt_t vector)
 }
 
 
-uint32_t* u32vector_writable_elements(pmt_t vector, size_t& len)
+uint32_t* u32vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u32vector())
         throw wrong_type("pmt_u32vector_writable_elements", vector);
@@ -662,7 +668,7 @@ const std::string pmt_u32vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_s32vector* _s32vector(pmt_t x)
+static pmt_s32vector* _s32vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_s32vector*>(x.get());
 }
@@ -718,7 +724,7 @@ void* pmt_s32vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_s32vector(pmt_t obj) { return obj->is_s32vector(); }
+bool is_s32vector(const pmt_t& obj) { return obj->is_s32vector(); }
 
 pmt_t make_s32vector(size_t k, int32_t fill) { return pmt_t(new pmt_s32vector(k, fill)); }
 
@@ -736,28 +742,28 @@ pmt_t init_s32vector(size_t k, const std::vector<int32_t>& data)
         new pmt_s32vector(k, static_cast<int32_t>(0))); // fills an empty vector with 0
 }
 
-int32_t s32vector_ref(pmt_t vector, size_t k)
+int32_t s32vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_s32vector())
         throw wrong_type("pmt_s32vector_ref", vector);
     return _s32vector(vector)->ref(k);
 }
 
-void s32vector_set(pmt_t vector, size_t k, int32_t obj)
+void s32vector_set(const pmt_t& vector, size_t k, int32_t obj)
 {
     if (!vector->is_s32vector())
         throw wrong_type("pmt_s32vector_set", vector);
     _s32vector(vector)->set(k, obj);
 }
 
-const int32_t* s32vector_elements(pmt_t vector, size_t& len)
+const int32_t* s32vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s32vector())
         throw wrong_type("pmt_s32vector_elements", vector);
     return _s32vector(vector)->elements(len);
 }
 
-const std::vector<int32_t> s32vector_elements(pmt_t vector)
+const std::vector<int32_t> s32vector_elements(const pmt_t& vector)
 {
     if (!vector->is_s32vector())
         throw wrong_type("pmt_s32vector_elements", vector);
@@ -768,7 +774,7 @@ const std::vector<int32_t> s32vector_elements(pmt_t vector)
 }
 
 
-int32_t* s32vector_writable_elements(pmt_t vector, size_t& len)
+int32_t* s32vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s32vector())
         throw wrong_type("pmt_s32vector_writable_elements", vector);
@@ -787,7 +793,7 @@ const std::string pmt_s32vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_u64vector* _u64vector(pmt_t x)
+static pmt_u64vector* _u64vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_u64vector*>(x.get());
 }
@@ -843,7 +849,7 @@ void* pmt_u64vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_u64vector(pmt_t obj) { return obj->is_u64vector(); }
+bool is_u64vector(const pmt_t& obj) { return obj->is_u64vector(); }
 
 pmt_t make_u64vector(size_t k, uint64_t fill)
 {
@@ -864,28 +870,28 @@ pmt_t init_u64vector(size_t k, const std::vector<uint64_t>& data)
         new pmt_u64vector(k, static_cast<uint64_t>(0))); // fills an empty vector with 0
 }
 
-uint64_t u64vector_ref(pmt_t vector, size_t k)
+uint64_t u64vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_u64vector())
         throw wrong_type("pmt_u64vector_ref", vector);
     return _u64vector(vector)->ref(k);
 }
 
-void u64vector_set(pmt_t vector, size_t k, uint64_t obj)
+void u64vector_set(const pmt_t& vector, size_t k, uint64_t obj)
 {
     if (!vector->is_u64vector())
         throw wrong_type("pmt_u64vector_set", vector);
     _u64vector(vector)->set(k, obj);
 }
 
-const uint64_t* u64vector_elements(pmt_t vector, size_t& len)
+const uint64_t* u64vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u64vector())
         throw wrong_type("pmt_u64vector_elements", vector);
     return _u64vector(vector)->elements(len);
 }
 
-const std::vector<uint64_t> u64vector_elements(pmt_t vector)
+const std::vector<uint64_t> u64vector_elements(const pmt_t& vector)
 {
     if (!vector->is_u64vector())
         throw wrong_type("pmt_u64vector_elements", vector);
@@ -896,7 +902,7 @@ const std::vector<uint64_t> u64vector_elements(pmt_t vector)
 }
 
 
-uint64_t* u64vector_writable_elements(pmt_t vector, size_t& len)
+uint64_t* u64vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_u64vector())
         throw wrong_type("pmt_u64vector_writable_elements", vector);
@@ -915,7 +921,7 @@ const std::string pmt_u64vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_s64vector* _s64vector(pmt_t x)
+static pmt_s64vector* _s64vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_s64vector*>(x.get());
 }
@@ -971,7 +977,7 @@ void* pmt_s64vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_s64vector(pmt_t obj) { return obj->is_s64vector(); }
+bool is_s64vector(const pmt_t& obj) { return obj->is_s64vector(); }
 
 pmt_t make_s64vector(size_t k, int64_t fill) { return pmt_t(new pmt_s64vector(k, fill)); }
 
@@ -989,28 +995,28 @@ pmt_t init_s64vector(size_t k, const std::vector<int64_t>& data)
         new pmt_s64vector(k, static_cast<int64_t>(0))); // fills an empty vector with 0
 }
 
-int64_t s64vector_ref(pmt_t vector, size_t k)
+int64_t s64vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_s64vector())
         throw wrong_type("pmt_s64vector_ref", vector);
     return _s64vector(vector)->ref(k);
 }
 
-void s64vector_set(pmt_t vector, size_t k, int64_t obj)
+void s64vector_set(const pmt_t& vector, size_t k, int64_t obj)
 {
     if (!vector->is_s64vector())
         throw wrong_type("pmt_s64vector_set", vector);
     _s64vector(vector)->set(k, obj);
 }
 
-const int64_t* s64vector_elements(pmt_t vector, size_t& len)
+const int64_t* s64vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s64vector())
         throw wrong_type("pmt_s64vector_elements", vector);
     return _s64vector(vector)->elements(len);
 }
 
-const std::vector<int64_t> s64vector_elements(pmt_t vector)
+const std::vector<int64_t> s64vector_elements(const pmt_t& vector)
 {
     if (!vector->is_s64vector())
         throw wrong_type("pmt_s64vector_elements", vector);
@@ -1021,7 +1027,7 @@ const std::vector<int64_t> s64vector_elements(pmt_t vector)
 }
 
 
-int64_t* s64vector_writable_elements(pmt_t vector, size_t& len)
+int64_t* s64vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_s64vector())
         throw wrong_type("pmt_s64vector_writable_elements", vector);
@@ -1040,7 +1046,7 @@ const std::string pmt_s64vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_f32vector* _f32vector(pmt_t x)
+static pmt_f32vector* _f32vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_f32vector*>(x.get());
 }
@@ -1096,7 +1102,7 @@ void* pmt_f32vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_f32vector(pmt_t obj) { return obj->is_f32vector(); }
+bool is_f32vector(const pmt_t& obj) { return obj->is_f32vector(); }
 
 pmt_t make_f32vector(size_t k, float fill) { return pmt_t(new pmt_f32vector(k, fill)); }
 
@@ -1114,28 +1120,28 @@ pmt_t init_f32vector(size_t k, const std::vector<float>& data)
         new pmt_f32vector(k, static_cast<float>(0))); // fills an empty vector with 0
 }
 
-float f32vector_ref(pmt_t vector, size_t k)
+float f32vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_f32vector())
         throw wrong_type("pmt_f32vector_ref", vector);
     return _f32vector(vector)->ref(k);
 }
 
-void f32vector_set(pmt_t vector, size_t k, float obj)
+void f32vector_set(const pmt_t& vector, size_t k, float obj)
 {
     if (!vector->is_f32vector())
         throw wrong_type("pmt_f32vector_set", vector);
     _f32vector(vector)->set(k, obj);
 }
 
-const float* f32vector_elements(pmt_t vector, size_t& len)
+const float* f32vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_f32vector())
         throw wrong_type("pmt_f32vector_elements", vector);
     return _f32vector(vector)->elements(len);
 }
 
-const std::vector<float> f32vector_elements(pmt_t vector)
+const std::vector<float> f32vector_elements(const pmt_t& vector)
 {
     if (!vector->is_f32vector())
         throw wrong_type("pmt_f32vector_elements", vector);
@@ -1146,7 +1152,7 @@ const std::vector<float> f32vector_elements(pmt_t vector)
 }
 
 
-float* f32vector_writable_elements(pmt_t vector, size_t& len)
+float* f32vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_f32vector())
         throw wrong_type("pmt_f32vector_writable_elements", vector);
@@ -1165,7 +1171,7 @@ const std::string pmt_f32vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_f64vector* _f64vector(pmt_t x)
+static pmt_f64vector* _f64vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_f64vector*>(x.get());
 }
@@ -1221,7 +1227,7 @@ void* pmt_f64vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_f64vector(pmt_t obj) { return obj->is_f64vector(); }
+bool is_f64vector(const pmt_t& obj) { return obj->is_f64vector(); }
 
 pmt_t make_f64vector(size_t k, double fill) { return pmt_t(new pmt_f64vector(k, fill)); }
 
@@ -1239,28 +1245,28 @@ pmt_t init_f64vector(size_t k, const std::vector<double>& data)
         new pmt_f64vector(k, static_cast<double>(0))); // fills an empty vector with 0
 }
 
-double f64vector_ref(pmt_t vector, size_t k)
+double f64vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_f64vector())
         throw wrong_type("pmt_f64vector_ref", vector);
     return _f64vector(vector)->ref(k);
 }
 
-void f64vector_set(pmt_t vector, size_t k, double obj)
+void f64vector_set(const pmt_t& vector, size_t k, double obj)
 {
     if (!vector->is_f64vector())
         throw wrong_type("pmt_f64vector_set", vector);
     _f64vector(vector)->set(k, obj);
 }
 
-const double* f64vector_elements(pmt_t vector, size_t& len)
+const double* f64vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_f64vector())
         throw wrong_type("pmt_f64vector_elements", vector);
     return _f64vector(vector)->elements(len);
 }
 
-const std::vector<double> f64vector_elements(pmt_t vector)
+const std::vector<double> f64vector_elements(const pmt_t& vector)
 {
     if (!vector->is_f64vector())
         throw wrong_type("pmt_f64vector_elements", vector);
@@ -1271,7 +1277,7 @@ const std::vector<double> f64vector_elements(pmt_t vector)
 }
 
 
-double* f64vector_writable_elements(pmt_t vector, size_t& len)
+double* f64vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_f64vector())
         throw wrong_type("pmt_f64vector_writable_elements", vector);
@@ -1290,7 +1296,7 @@ const std::string pmt_f64vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_c32vector* _c32vector(pmt_t x)
+static pmt_c32vector* _c32vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_c32vector*>(x.get());
 }
@@ -1346,7 +1352,7 @@ void* pmt_c32vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_c32vector(pmt_t obj) { return obj->is_c32vector(); }
+bool is_c32vector(const pmt_t& obj) { return obj->is_c32vector(); }
 
 pmt_t make_c32vector(size_t k, std::complex<float> fill)
 {
@@ -1367,28 +1373,28 @@ pmt_t init_c32vector(size_t k, const std::vector<std::complex<float>>& data)
         k, static_cast<std::complex<float>>(0))); // fills an empty vector with 0
 }
 
-std::complex<float> c32vector_ref(pmt_t vector, size_t k)
+std::complex<float> c32vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_c32vector())
         throw wrong_type("pmt_c32vector_ref", vector);
     return _c32vector(vector)->ref(k);
 }
 
-void c32vector_set(pmt_t vector, size_t k, std::complex<float> obj)
+void c32vector_set(const pmt_t& vector, size_t k, std::complex<float> obj)
 {
     if (!vector->is_c32vector())
         throw wrong_type("pmt_c32vector_set", vector);
     _c32vector(vector)->set(k, obj);
 }
 
-const std::complex<float>* c32vector_elements(pmt_t vector, size_t& len)
+const std::complex<float>* c32vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_c32vector())
         throw wrong_type("pmt_c32vector_elements", vector);
     return _c32vector(vector)->elements(len);
 }
 
-const std::vector<std::complex<float>> c32vector_elements(pmt_t vector)
+const std::vector<std::complex<float>> c32vector_elements(const pmt_t& vector)
 {
     if (!vector->is_c32vector())
         throw wrong_type("pmt_c32vector_elements", vector);
@@ -1399,7 +1405,7 @@ const std::vector<std::complex<float>> c32vector_elements(pmt_t vector)
 }
 
 
-std::complex<float>* c32vector_writable_elements(pmt_t vector, size_t& len)
+std::complex<float>* c32vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_c32vector())
         throw wrong_type("pmt_c32vector_writable_elements", vector);
@@ -1418,7 +1424,7 @@ const std::string pmt_c32vector::string_ref(size_t k) const
 
 namespace pmt {
 
-static pmt_c64vector* _c64vector(pmt_t x)
+static pmt_c64vector* _c64vector(const pmt_t& x)
 {
     return dynamic_cast<pmt_c64vector*>(x.get());
 }
@@ -1474,7 +1480,7 @@ void* pmt_c64vector::uniform_writable_elements(size_t& len)
     return len ? (&d_v[0]) : nullptr;
 }
 
-bool is_c64vector(pmt_t obj) { return obj->is_c64vector(); }
+bool is_c64vector(const pmt_t& obj) { return obj->is_c64vector(); }
 
 pmt_t make_c64vector(size_t k, std::complex<double> fill)
 {
@@ -1495,28 +1501,28 @@ pmt_t init_c64vector(size_t k, const std::vector<std::complex<double>>& data)
         k, static_cast<std::complex<double>>(0))); // fills an empty vector with 0
 }
 
-std::complex<double> c64vector_ref(pmt_t vector, size_t k)
+std::complex<double> c64vector_ref(const pmt_t& vector, size_t k)
 {
     if (!vector->is_c64vector())
         throw wrong_type("pmt_c64vector_ref", vector);
     return _c64vector(vector)->ref(k);
 }
 
-void c64vector_set(pmt_t vector, size_t k, std::complex<double> obj)
+void c64vector_set(const pmt_t& vector, size_t k, std::complex<double> obj)
 {
     if (!vector->is_c64vector())
         throw wrong_type("pmt_c64vector_set", vector);
     _c64vector(vector)->set(k, obj);
 }
 
-const std::complex<double>* c64vector_elements(pmt_t vector, size_t& len)
+const std::complex<double>* c64vector_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_c64vector())
         throw wrong_type("pmt_c64vector_elements", vector);
     return _c64vector(vector)->elements(len);
 }
 
-const std::vector<std::complex<double>> c64vector_elements(pmt_t vector)
+const std::vector<std::complex<double>> c64vector_elements(const pmt_t& vector)
 {
     if (!vector->is_c64vector())
         throw wrong_type("pmt_c64vector_elements", vector);
@@ -1527,7 +1533,7 @@ const std::vector<std::complex<double>> c64vector_elements(pmt_t vector)
 }
 
 
-std::complex<double>* c64vector_writable_elements(pmt_t vector, size_t& len)
+std::complex<double>* c64vector_writable_elements(const pmt_t& vector, size_t& len)
 {
     if (!vector->is_c64vector())
         throw wrong_type("pmt_c64vector_writable_elements", vector);

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(test_vectors)
         BOOST_CHECK_EQUAL(s0, pmt::vector_ref(v1, i));
 }
 
-static void check_tuple(size_t len, const std::vector<pmt::pmt_t>& s, pmt::pmt_t t)
+static void check_tuple(size_t len, const std::vector<pmt::pmt_t>& s, const pmt::pmt_t& t)
 {
     BOOST_CHECK_EQUAL(true, pmt::is_tuple(t));
     BOOST_CHECK_EQUAL(len, pmt::length(t));

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -93,7 +93,7 @@ void prefs::_read_files(const std::vector<std::string>& filenames)
                     po::parse_config_file(infile, po::options_description(), true);
                 BOOST_FOREACH (po::basic_option<char_t> o, (parsed.options)) {
                     std::string okey = o.string_key;
-                    size_t pos = okey.find(".");
+                    size_t pos = okey.find('.');
                     std::string section, key;
                     if (pos != std::string::npos) {
                         section = okey.substr(0, pos);

--- a/gnuradio-runtime/lib/scheduler.cc
+++ b/gnuradio-runtime/lib/scheduler.cc
@@ -27,7 +27,7 @@
 
 namespace gr {
 
-scheduler::scheduler(flat_flowgraph_sptr ffg, int max_noutput_items) {}
+scheduler::scheduler(const flat_flowgraph_sptr& ffg, int max_noutput_items) {}
 
 scheduler::~scheduler() {}
 

--- a/gnuradio-runtime/lib/scheduler.h
+++ b/gnuradio-runtime/lib/scheduler.h
@@ -48,7 +48,7 @@ public:
      * The scheduler will continue running until all blocks
      * report that they are done or the stop method is called.
      */
-    scheduler(flat_flowgraph_sptr ffg, int max_noutput_items);
+    scheduler(const flat_flowgraph_sptr& ffg, int max_noutput_items);
 
     virtual ~scheduler();
 

--- a/gnuradio-runtime/lib/scheduler_tpb.cc
+++ b/gnuradio-runtime/lib/scheduler_tpb.cc
@@ -28,6 +28,7 @@
 #include <gnuradio/thread/thread_body_wrapper.h>
 #include <boost/make_shared.hpp>
 #include <sstream>
+#include <utility>
 
 namespace gr {
 
@@ -41,7 +42,9 @@ public:
     tpb_container(block_sptr block,
                   int max_noutput_items,
                   thread::barrier_sptr start_sync)
-        : d_block(block), d_max_noutput_items(max_noutput_items), d_start_sync(start_sync)
+        : d_block(std::move(block)),
+          d_max_noutput_items(max_noutput_items),
+          d_start_sync(std::move(start_sync))
     {
     }
 
@@ -53,10 +56,10 @@ public:
 
 scheduler_sptr scheduler_tpb::make(flat_flowgraph_sptr ffg, int max_noutput_items)
 {
-    return scheduler_sptr(new scheduler_tpb(ffg, max_noutput_items));
+    return scheduler_sptr(new scheduler_tpb(std::move(ffg), max_noutput_items));
 }
 
-scheduler_tpb::scheduler_tpb(flat_flowgraph_sptr ffg, int max_noutput_items)
+scheduler_tpb::scheduler_tpb(const flat_flowgraph_sptr& ffg, int max_noutput_items)
     : scheduler(ffg, max_noutput_items)
 {
     int block_max_noutput_items;

--- a/gnuradio-runtime/lib/scheduler_tpb.h
+++ b/gnuradio-runtime/lib/scheduler_tpb.h
@@ -42,7 +42,7 @@ protected:
      * The scheduler will continue running until all blocks until they
      * report that they are done or the stop method is called.
      */
-    scheduler_tpb(flat_flowgraph_sptr ffg, int max_noutput_items);
+    scheduler_tpb(const flat_flowgraph_sptr& ffg, int max_noutput_items);
 
 public:
     static scheduler_sptr make(flat_flowgraph_sptr ffg, int max_noutput_items = 100000);

--- a/gnuradio-runtime/lib/sync_block.cc
+++ b/gnuradio-runtime/lib/sync_block.cc
@@ -26,12 +26,14 @@
 
 #include <gnuradio/sync_block.h>
 
+#include <utility>
+
 namespace gr {
 
 sync_block::sync_block(const std::string& name,
                        io_signature::sptr input_signature,
                        io_signature::sptr output_signature)
-    : block(name, input_signature, output_signature)
+    : block(name, std::move(input_signature), std::move(output_signature))
 {
     set_fixed_rate(true);
 }

--- a/gnuradio-runtime/lib/sync_decimator.cc
+++ b/gnuradio-runtime/lib/sync_decimator.cc
@@ -26,13 +26,15 @@
 
 #include <gnuradio/sync_decimator.h>
 
+#include <utility>
+
 namespace gr {
 
 sync_decimator::sync_decimator(const std::string& name,
                                io_signature::sptr input_signature,
                                io_signature::sptr output_signature,
                                unsigned decimation)
-    : sync_block(name, input_signature, output_signature)
+    : sync_block(name, std::move(input_signature), std::move(output_signature))
 {
     set_decimation(decimation);
 }

--- a/gnuradio-runtime/lib/sync_interpolator.cc
+++ b/gnuradio-runtime/lib/sync_interpolator.cc
@@ -26,13 +26,15 @@
 
 #include <gnuradio/sync_interpolator.h>
 
+#include <utility>
+
 namespace gr {
 
 sync_interpolator::sync_interpolator(const std::string& name,
                                      io_signature::sptr input_signature,
                                      io_signature::sptr output_signature,
                                      unsigned interpolation)
-    : sync_block(name, input_signature, output_signature)
+    : sync_block(name, std::move(input_signature), std::move(output_signature))
 {
     set_interpolation(interpolation);
 }

--- a/gnuradio-runtime/lib/tagged_stream_block.cc
+++ b/gnuradio-runtime/lib/tagged_stream_block.cc
@@ -26,14 +26,15 @@
 
 #include <gnuradio/tagged_stream_block.h>
 #include <boost/format.hpp>
+#include <utility>
 
 namespace gr {
 
 tagged_stream_block::tagged_stream_block(const std::string& name,
-                                         io_signature::sptr input_signature,
+                                         const io_signature::sptr& input_signature,
                                          io_signature::sptr output_signature,
                                          const std::string& length_tag_key)
-    : block(name, input_signature, output_signature),
+    : block(name, input_signature, std::move(output_signature)),
       d_length_tag_key(pmt::string_to_symbol(length_tag_key)),
       d_n_input_items_reqd(input_signature->min_streams(), 0),
       d_length_tag_key_str(length_tag_key)

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 
@@ -72,7 +73,7 @@ static scheduler_sptr make_scheduler(flat_flowgraph_sptr ffg, int max_noutput_it
             }
         }
     }
-    return factory(ffg, max_noutput_items);
+    return factory(std::move(ffg), max_noutput_items);
 }
 
 top_block_impl::top_block_impl(top_block* owner)

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -32,8 +32,8 @@
 
 namespace gr {
 
-tpb_thread_body::tpb_thread_body(block_sptr block,
-                                 gr::thread::barrier_sptr start_sync,
+tpb_thread_body::tpb_thread_body(const block_sptr& block,
+                                 const gr::thread::barrier_sptr& start_sync,
                                  int max_noutput_items)
     : d_exec(block, max_noutput_items)
 {

--- a/gnuradio-runtime/lib/tpb_thread_body.h
+++ b/gnuradio-runtime/lib/tpb_thread_body.h
@@ -41,8 +41,8 @@ class GR_RUNTIME_API tpb_thread_body
     block_executor d_exec;
 
 public:
-    tpb_thread_body(block_sptr block,
-                    thread::barrier_sptr start_sync,
+    tpb_thread_body(const block_sptr& block,
+                    const thread::barrier_sptr& start_sync,
                     int max_noutput_items = 100000);
     ~tpb_thread_body();
 };

--- a/gr-analog/lib/ctcss_squelch_ff_impl.cc
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.cc
@@ -26,6 +26,8 @@
 
 #include "ctcss_squelch_ff_impl.h"
 
+#include <cmath>
+
 namespace gr {
 namespace analog {
 
@@ -132,9 +134,9 @@ void ctcss_squelch_ff_impl::update_state(const float& in)
     float rounder = 100000;
     float d_out_l, d_out_c, d_out_r;
     if (d_goertzel_c->ready()) {
-        d_out_l = floor(rounder * abs(d_goertzel_l->output())) / rounder;
-        d_out_c = floor(rounder * abs(d_goertzel_c->output())) / rounder;
-        d_out_r = floor(rounder * abs(d_goertzel_r->output())) / rounder;
+        d_out_l = std::floor(rounder * abs(d_goertzel_l->output())) / rounder;
+        d_out_c = std::floor(rounder * abs(d_goertzel_c->output())) / rounder;
+        d_out_r = std::floor(rounder * abs(d_goertzel_r->output())) / rounder;
 
         // printf("d_out_l=%f d_out_c=%f d_out_r=%f\n", d_out_l, d_out_c, d_out_r);
         d_mute = (d_out_c < d_level || d_out_c < d_out_l || d_out_c < d_out_r);

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -76,7 +76,7 @@ sig_source_impl<T>::~sig_source_impl()
 }
 
 template <class T>
-void sig_source_impl<T>::set_frequency_msg(pmt::pmt_t msg)
+void sig_source_impl<T>::set_frequency_msg(const pmt::pmt_t& msg)
 {
     // Accepts either a number that is assumed to be the new
     // frequency or a key:value pair message where the key must be

--- a/gr-analog/lib/sig_source_impl.h
+++ b/gr-analog/lib/sig_source_impl.h
@@ -64,7 +64,7 @@ public:
 
     void set_sampling_freq(double sampling_freq);
     void set_waveform(gr_waveform_t waveform);
-    void set_frequency_msg(pmt::pmt_t msg);
+    void set_frequency_msg(const pmt::pmt_t& msg);
     void set_frequency(double frequency);
     void set_amplitude(double ampl);
     void set_offset(T offset);

--- a/gr-audio/include/gnuradio/audio/sink.h
+++ b/gr-audio/include/gnuradio/audio/sink.h
@@ -53,7 +53,7 @@ public:
      * \endxmlonly
      */
     static sptr
-    make(int sampling_rate, const std::string device_name = "", bool ok_to_block = true);
+    make(int sampling_rate, const std::string& device_name = "", bool ok_to_block = true);
 };
 
 } /* namespace audio */

--- a/gr-audio/include/gnuradio/audio/source.h
+++ b/gr-audio/include/gnuradio/audio/source.h
@@ -53,7 +53,7 @@ public:
      * \endxmlonly
      */
     static sptr
-    make(int sampling_rate, const std::string device_name = "", bool ok_to_block = true);
+    make(int sampling_rate, const std::string& device_name = "", bool ok_to_block = true);
 };
 
 } /* namespace audio */

--- a/gr-audio/lib/alsa/alsa_sink.cc
+++ b/gr-audio/lib/alsa/alsa_sink.cc
@@ -71,7 +71,7 @@ static int default_nperiods()
 
 // ----------------------------------------------------------------
 
-alsa_sink::alsa_sink(int sampling_rate, const std::string device_name, bool ok_to_block)
+alsa_sink::alsa_sink(int sampling_rate, const std::string& device_name, bool ok_to_block)
     : sync_block(
           "audio_alsa_sink", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
       d_sampling_rate(sampling_rate),

--- a/gr-audio/lib/alsa/alsa_sink.h
+++ b/gr-audio/lib/alsa/alsa_sink.h
@@ -74,7 +74,7 @@ class alsa_sink : public sink
     void bail(const char* msg, int err);
 
 public:
-    alsa_sink(int sampling_rate, const std::string device_name, bool ok_to_block);
+    alsa_sink(int sampling_rate, const std::string& device_name, bool ok_to_block);
     ~alsa_sink();
 
     bool check_topology(int ninputs, int noutputs);

--- a/gr-audio/lib/alsa/alsa_source.cc
+++ b/gr-audio/lib/alsa/alsa_source.cc
@@ -72,7 +72,7 @@ static int default_nperiods()
 // ----------------------------------------------------------------
 
 alsa_source::alsa_source(int sampling_rate,
-                         const std::string device_name,
+                         const std::string& device_name,
                          bool ok_to_block)
     : sync_block(
           "audio_alsa_source", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),

--- a/gr-audio/lib/alsa/alsa_source.h
+++ b/gr-audio/lib/alsa/alsa_source.h
@@ -77,7 +77,7 @@ class alsa_source : public source
     void bail(const char* msg, int err);
 
 public:
-    alsa_source(int sampling_rate, const std::string device_name, bool ok_to_block);
+    alsa_source(int sampling_rate, const std::string& device_name, bool ok_to_block);
     ~alsa_source();
 
     bool check_topology(int ninputs, int noutputs);

--- a/gr-audio/lib/audio_registry.cc
+++ b/gr-audio/lib/audio_registry.cc
@@ -151,7 +151,7 @@ static void do_arch_warning(const std::string& arch)
 }
 
 source::sptr
-source::make(int sampling_rate, const std::string device_name, bool ok_to_block)
+source::make(int sampling_rate, const std::string& device_name, bool ok_to_block)
 {
     gr::logger_ptr logger, debug_logger;
     configure_default_loggers(logger, debug_logger, "audio source");
@@ -175,7 +175,7 @@ source::make(int sampling_rate, const std::string device_name, bool ok_to_block)
     return entry.source(sampling_rate, device_name, ok_to_block);
 }
 
-sink::sptr sink::make(int sampling_rate, const std::string device_name, bool ok_to_block)
+sink::sptr sink::make(int sampling_rate, const std::string& device_name, bool ok_to_block)
 {
     gr::logger_ptr logger, debug_logger;
     configure_default_loggers(logger, debug_logger, "audio source");

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -94,7 +94,7 @@ int jack_sink_process(jack_nframes_t nframes, void* arg)
 
 // ----------------------------------------------------------------
 
-jack_sink::jack_sink(int sampling_rate, const std::string device_name, bool ok_to_block)
+jack_sink::jack_sink(int sampling_rate, const std::string& device_name, bool ok_to_block)
     : sync_block(
           "audio_jack_sink", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
       d_sampling_rate(sampling_rate),

--- a/gr-audio/lib/jack/jack_sink.h
+++ b/gr-audio/lib/jack/jack_sink.h
@@ -70,7 +70,7 @@ class jack_sink : public sink
     void bail(const char* msg, int err);
 
 public:
-    jack_sink(int sampling_rate, const std::string device_name, bool ok_to_block);
+    jack_sink(int sampling_rate, const std::string& device_name, bool ok_to_block);
     ~jack_sink();
 
     bool check_topology(int ninputs, int noutputs);

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -95,7 +95,7 @@ int jack_source_process(jack_nframes_t nframes, void* arg)
 // ----------------------------------------------------------------
 
 jack_source::jack_source(int sampling_rate,
-                         const std::string device_name,
+                         const std::string& device_name,
                          bool ok_to_block)
     : sync_block(
           "audio_jack_source", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),

--- a/gr-audio/lib/jack/jack_source.h
+++ b/gr-audio/lib/jack/jack_source.h
@@ -70,7 +70,7 @@ class jack_source : public source
     void bail(const char* msg, int err);
 
 public:
-    jack_source(int sampling_rate, const std::string device_name, bool ok_to_block);
+    jack_source(int sampling_rate, const std::string& device_name, bool ok_to_block);
     ~jack_source();
 
     bool check_topology(int ninputs, int noutputs);

--- a/gr-audio/lib/oss/oss_sink.cc
+++ b/gr-audio/lib/oss/oss_sink.cc
@@ -53,7 +53,7 @@ static std::string default_device_name()
         "audio_oss", "default_output_device", "/dev/dsp");
 }
 
-oss_sink::oss_sink(int sampling_rate, const std::string device_name, bool ok_to_block)
+oss_sink::oss_sink(int sampling_rate, const std::string& device_name, bool ok_to_block)
     : sync_block("audio_oss_sink",
                  io_signature::make(1, 2, sizeof(float)),
                  io_signature::make(0, 0, 0)),

--- a/gr-audio/lib/oss/oss_sink.h
+++ b/gr-audio/lib/oss/oss_sink.h
@@ -46,7 +46,7 @@ class oss_sink : public sink
 
 public:
     oss_sink(int sampling_rate,
-             const std::string device_name = "",
+             const std::string& device_name = "",
              bool ok_to_block = true);
     ~oss_sink();
 

--- a/gr-audio/lib/oss/oss_source.cc
+++ b/gr-audio/lib/oss/oss_source.cc
@@ -53,7 +53,9 @@ static std::string default_device_name()
         "audio_oss", "default_input_device", "/dev/dsp");
 }
 
-oss_source::oss_source(int sampling_rate, const std::string device_name, bool ok_to_block)
+oss_source::oss_source(int sampling_rate,
+                       const std::string& device_name,
+                       bool ok_to_block)
     : sync_block("audio_oss_source",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 2, sizeof(float))),

--- a/gr-audio/lib/oss/oss_source.h
+++ b/gr-audio/lib/oss/oss_source.h
@@ -46,7 +46,7 @@ class oss_source : public source
 
 public:
     oss_source(int sampling_rate,
-               const std::string device_name = "",
+               const std::string& device_name = "",
                bool ok_to_block = true);
 
     ~oss_source();

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -138,7 +138,7 @@ int portaudio_sink_callback(const void* inputBuffer,
 // ----------------------------------------------------------------
 
 portaudio_sink::portaudio_sink(int sampling_rate,
-                               const std::string device_name,
+                               const std::string& device_name,
                                bool ok_to_block)
     : sync_block("audio_portaudio_sink",
                  io_signature::make(0, 0, 0),

--- a/gr-audio/lib/portaudio/portaudio_sink.h
+++ b/gr-audio/lib/portaudio/portaudio_sink.h
@@ -71,7 +71,7 @@ class portaudio_sink : public sink
     void create_ringbuffer();
 
 public:
-    portaudio_sink(int sampling_rate, const std::string device_name, bool ok_to_block);
+    portaudio_sink(int sampling_rate, const std::string& device_name, bool ok_to_block);
 
     ~portaudio_sink();
 

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -138,7 +138,7 @@ int portaudio_source_callback(const void* inputBuffer,
 // ----------------------------------------------------------------
 
 portaudio_source::portaudio_source(int sampling_rate,
-                                   const std::string device_name,
+                                   const std::string& device_name,
                                    bool ok_to_block)
     : sync_block("audio_portaudio_source",
                  io_signature::make(0, 0, 0),

--- a/gr-audio/lib/portaudio/portaudio_source.h
+++ b/gr-audio/lib/portaudio/portaudio_source.h
@@ -70,7 +70,7 @@ class portaudio_source : public source
     void create_ringbuffer();
 
 public:
-    portaudio_source(int sampling_rate, const std::string device_name, bool ok_to_block);
+    portaudio_source(int sampling_rate, const std::string& device_name, bool ok_to_block);
 
     ~portaudio_source();
 

--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -69,7 +69,7 @@ static std::string default_device_name()
 }
 
 windows_sink::windows_sink(int sampling_freq,
-                           const std::string device_name,
+                           const std::string& device_name,
                            bool ok_to_block)
     : sync_block("audio_windows_sink",
                  io_signature::make(1, 2, sizeof(float)),

--- a/gr-audio/lib/windows/windows_sink.h
+++ b/gr-audio/lib/windows/windows_sink.h
@@ -64,7 +64,7 @@ protected:
     UINT find_device(std::string szDeviceName);
 
 public:
-    windows_sink(int sampling_freq, const std::string device_name, bool ok_to_block);
+    windows_sink(int sampling_freq, const std::string& device_name, bool ok_to_block);
     ~windows_sink();
 
     int work(int noutput_items,

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -70,7 +70,7 @@ static std::string default_device_name()
     return (default_device == "default" ? "WAVE_MAPPER" : default_device);
 }
 
-windows_source::windows_source(int sampling_freq, const std::string device_name)
+windows_source::windows_source(int sampling_freq, const std::string& device_name)
     : sync_block("audio_windows_source",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(float))),

--- a/gr-audio/lib/windows/windows_source.h
+++ b/gr-audio/lib/windows/windows_source.h
@@ -64,7 +64,7 @@ protected:
     boost::lockfree::spsc_queue<LPWAVEHDR> buffer_queue{ 100 };
 
 public:
-    windows_source(int sampling_freq, const std::string device_name = "");
+    windows_source(int sampling_freq, const std::string& device_name = "");
     ~windows_source();
 
     int work(int noutput_items,

--- a/gr-blocks/include/gnuradio/blocks/pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu.h
@@ -35,9 +35,9 @@ enum vector_type { byte_t, float_t, complex_t };
 
 BLOCKS_API const pmt::pmt_t pdu_port_id();
 BLOCKS_API size_t itemsize(vector_type type);
-BLOCKS_API bool type_matches(vector_type type, pmt::pmt_t v);
+BLOCKS_API bool type_matches(vector_type type, const pmt::pmt_t& v);
 BLOCKS_API pmt::pmt_t make_pdu_vector(vector_type type, const uint8_t* buf, size_t items);
-BLOCKS_API vector_type type_from_pmt(pmt::pmt_t vector);
+BLOCKS_API vector_type type_from_pmt(const pmt::pmt_t& vector);
 
 } /* namespace pdu */
 } /* namespace blocks */

--- a/gr-blocks/lib/bin_statistics_f_impl.cc
+++ b/gr-blocks/lib/bin_statistics_f_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <string.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
@@ -38,7 +40,7 @@ bin_statistics_f::sptr bin_statistics_f::make(unsigned int vlen,
                                               size_t dwell_delay)
 {
     return gnuradio::get_initial_sptr(
-        new bin_statistics_f_impl(vlen, msgq, tune, tune_delay, dwell_delay));
+        new bin_statistics_f_impl(vlen, std::move(msgq), tune, tune_delay, dwell_delay));
 }
 
 bin_statistics_f_impl::bin_statistics_f_impl(unsigned int vlen,
@@ -50,7 +52,7 @@ bin_statistics_f_impl::bin_statistics_f_impl(unsigned int vlen,
                  io_signature::make(1, 1, sizeof(float) * vlen),
                  io_signature::make(0, 0, 0)),
       d_vlen(vlen),
-      d_msgq(msgq),
+      d_msgq(std::move(msgq)),
       d_tune(tune),
       d_tune_delay(tune_delay),
       d_dwell_delay(dwell_delay),

--- a/gr-blocks/lib/copy_impl.cc
+++ b/gr-blocks/lib/copy_impl.cc
@@ -49,7 +49,7 @@ copy_impl::copy_impl(size_t itemsize)
 
 copy_impl::~copy_impl() {}
 
-void copy_impl::handle_enable(pmt::pmt_t msg)
+void copy_impl::handle_enable(const pmt::pmt_t& msg)
 {
     if (pmt::is_bool(msg)) {
         bool en = pmt::to_bool(msg);

--- a/gr-blocks/lib/copy_impl.h
+++ b/gr-blocks/lib/copy_impl.h
@@ -41,7 +41,7 @@ public:
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
     bool check_topology(int ninputs, int noutputs);
 
-    void handle_enable(pmt::pmt_t msg);
+    void handle_enable(const pmt::pmt_t& msg);
 
     void setup_rpc();
 

--- a/gr-blocks/lib/file_meta_sink_impl.h
+++ b/gr-blocks/lib/file_meta_sink_impl.h
@@ -53,7 +53,7 @@ private:
 
 protected:
     void write_header(FILE* fp, pmt_t header, pmt_t extra);
-    void update_header(pmt_t key, pmt_t value);
+    void update_header(const pmt_t& key, pmt_t value);
     void update_last_header();
     void update_last_header_inline();
     void update_last_header_detached();
@@ -70,7 +70,7 @@ public:
                         gr_file_types type = GR_FILE_FLOAT,
                         bool complex = true,
                         size_t max_segment_size = 1000000,
-                        pmt::pmt_t extra_dict = pmt::make_dict(),
+                        const pmt::pmt_t& extra_dict = pmt::make_dict(),
                         bool detached_header = false);
     ~file_meta_sink_impl();
 

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -174,7 +174,7 @@ bool file_meta_source_impl::read_header(pmt::pmt_t& hdr, pmt::pmt_t& extras)
     return true;
 }
 
-void file_meta_source_impl::parse_header(pmt::pmt_t hdr,
+void file_meta_source_impl::parse_header(const pmt::pmt_t& hdr,
                                          uint64_t offset,
                                          std::vector<tag_t>& tags)
 {
@@ -231,7 +231,7 @@ void file_meta_source_impl::parse_header(pmt::pmt_t hdr,
     }
 }
 
-void file_meta_source_impl::parse_extras(pmt::pmt_t extras,
+void file_meta_source_impl::parse_extras(const pmt::pmt_t& extras,
                                          uint64_t offset,
                                          std::vector<tag_t>& tags)
 {

--- a/gr-blocks/lib/file_meta_source_impl.h
+++ b/gr-blocks/lib/file_meta_source_impl.h
@@ -56,8 +56,8 @@ private:
 protected:
     bool _open(FILE** fp, const char* filename);
     bool read_header(pmt_t& hdr, pmt_t& extras);
-    void parse_header(pmt_t hdr, uint64_t offset, std::vector<tag_t>& tags);
-    void parse_extras(pmt_t extras, uint64_t offset, std::vector<tag_t>& tags);
+    void parse_header(const pmt_t& hdr, uint64_t offset, std::vector<tag_t>& tags);
+    void parse_extras(const pmt_t& extras, uint64_t offset, std::vector<tag_t>& tags);
 
 public:
     file_meta_source_impl(const std::string& filename,

--- a/gr-blocks/lib/magphase_to_complex_impl.cc
+++ b/gr-blocks/lib/magphase_to_complex_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 
+#include <cmath>
+
 namespace gr {
 namespace blocks {
 
@@ -55,7 +57,7 @@ int magphase_to_complex_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     for (size_t j = 0; j < noutput_items * d_vlen; j++)
-        out[j] = gr_complex(mag[j] * cos(phase[j]), mag[j] * sin(phase[j]));
+        out[j] = gr_complex(mag[j] * std::cos(phase[j]), mag[j] * std::sin(phase[j]));
 
     return noutput_items;
 }

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -28,6 +28,7 @@
 #include <gnuradio/io_signature.h>
 #include <cstdio>
 #include <iostream>
+#include <utility>
 
 namespace gr {
 namespace blocks {
@@ -40,17 +41,17 @@ message_debug::sptr message_debug::make()
 void message_debug_impl::print(pmt::pmt_t msg)
 {
     std::cout << "******* MESSAGE DEBUG PRINT ********\n";
-    pmt::print(msg);
+    pmt::print(std::move(msg));
     std::cout << "************************************\n";
 }
 
-void message_debug_impl::store(pmt::pmt_t msg)
+void message_debug_impl::store(const pmt::pmt_t& msg)
 {
     gr::thread::scoped_lock guard(d_mutex);
     d_messages.push_back(msg);
 }
 
-void message_debug_impl::print_pdu(pmt::pmt_t pdu)
+void message_debug_impl::print_pdu(const pmt::pmt_t& pdu)
 {
     pmt::pmt_t meta = pmt::car(pdu);
     pmt::pmt_t vector = pmt::cdr(pdu);

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -56,7 +56,7 @@ private:
      *
      * \param pdu A PDU message passed from the scheduler's message handling.
      */
-    void print_pdu(pmt::pmt_t pdu);
+    void print_pdu(const pmt::pmt_t& pdu);
 
     /*!
      * \brief Messages received in this port are stored in a vector.
@@ -69,7 +69,7 @@ private:
      *
      * \param msg A pmt message passed from the scheduler's message handling.
      */
-    void store(pmt::pmt_t msg);
+    void store(const pmt::pmt_t& msg);
 
     gr::thread::mutex d_mutex;
     std::vector<pmt::pmt_t> d_messages;

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -34,20 +34,21 @@
 #include <cstdio>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace blocks {
 
 message_strobe::sptr message_strobe::make(pmt::pmt_t msg, long period_ms)
 {
-    return gnuradio::get_initial_sptr(new message_strobe_impl(msg, period_ms));
+    return gnuradio::get_initial_sptr(new message_strobe_impl(std::move(msg), period_ms));
 }
 
 message_strobe_impl::message_strobe_impl(pmt::pmt_t msg, long period_ms)
     : block("message_strobe", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
       d_finished(false),
       d_period_ms(period_ms),
-      d_msg(msg),
+      d_msg(std::move(msg)),
       d_port(pmt::mp("strobe"))
 {
     message_port_register_out(d_port);

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -34,6 +34,7 @@
 #include <cstdio>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace blocks {
@@ -45,7 +46,7 @@ message_strobe_random::make(pmt::pmt_t msg,
                             float std_ms)
 {
     return gnuradio::get_initial_sptr(
-        new message_strobe_random_impl(msg, dist, mean_ms, std_ms));
+        new message_strobe_random_impl(std::move(msg), dist, mean_ms, std_ms));
 }
 
 
@@ -61,7 +62,7 @@ message_strobe_random_impl::message_strobe_random_impl(
       d_mean_ms(mean_ms),
       d_std_ms(std_ms),
       d_dist(dist),
-      d_msg(msg),
+      d_msg(std::move(msg)),
       d_rng(),
       d_port(pmt::mp("strobe"))
 {

--- a/gr-blocks/lib/mute_impl.h
+++ b/gr-blocks/lib/mute_impl.h
@@ -26,6 +26,8 @@
 
 #include <gnuradio/blocks/mute.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
@@ -41,7 +43,7 @@ public:
 
     bool mute() const { return d_mute; }
     void set_mute(bool mute) { d_mute = mute; }
-    void set_mute_pmt(pmt::pmt_t msg) { set_mute(pmt::to_bool(msg)); }
+    void set_mute_pmt(pmt::pmt_t msg) { set_mute(pmt::to_bool(std::move(msg))); }
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-blocks/lib/nop_impl.cc
+++ b/gr-blocks/lib/nop_impl.cc
@@ -52,7 +52,7 @@ nop_impl::~nop_impl() {}
 
 // Trivial message handler that just counts them.
 // (N.B., This feature is used in qa_set_msg_handler)
-void nop_impl::count_received_msgs(pmt::pmt_t msg) { d_nmsgs_recvd++; }
+void nop_impl::count_received_msgs(const pmt::pmt_t& msg) { d_nmsgs_recvd++; }
 
 int nop_impl::general_work(int noutput_items,
                            gr_vector_int& ninput_items,

--- a/gr-blocks/lib/nop_impl.h
+++ b/gr-blocks/lib/nop_impl.h
@@ -35,7 +35,7 @@ protected:
     int d_ctrlport_test;
 
     // Method that just counts any received messages.
-    void count_received_msgs(pmt::pmt_t msg);
+    void count_received_msgs(const pmt::pmt_t& msg);
 
 public:
     nop_impl(size_t sizeof_stream_item);

--- a/gr-blocks/lib/patterned_interleaver_impl.cc
+++ b/gr-blocks/lib/patterned_interleaver_impl.cc
@@ -27,17 +27,20 @@
 #include "patterned_interleaver_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
 patterned_interleaver::sptr patterned_interleaver::make(size_t itemsize,
                                                         std::vector<int> pattern)
 {
-    return gnuradio::get_initial_sptr(new patterned_interleaver_impl(itemsize, pattern));
+    return gnuradio::get_initial_sptr(
+        new patterned_interleaver_impl(itemsize, std::move(pattern)));
 }
 
 patterned_interleaver_impl::patterned_interleaver_impl(size_t itemsize,
-                                                       std::vector<int> pattern)
+                                                       const std::vector<int>& pattern)
     : block("patterned_interleaver",
             io_signature::make(
                 pattern_max(pattern) + 1, pattern_max(pattern) + 1, itemsize),

--- a/gr-blocks/lib/patterned_interleaver_impl.h
+++ b/gr-blocks/lib/patterned_interleaver_impl.h
@@ -32,7 +32,7 @@ namespace blocks {
 class BLOCKS_API patterned_interleaver_impl : public patterned_interleaver
 {
 public:
-    patterned_interleaver_impl(size_t itemsize, std::vector<int> pattern);
+    patterned_interleaver_impl(size_t itemsize, const std::vector<int>& pattern);
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-blocks/lib/pdu.cc
+++ b/gr-blocks/lib/pdu.cc
@@ -50,7 +50,7 @@ size_t itemsize(vector_type type)
     }
 }
 
-bool type_matches(vector_type type, pmt::pmt_t v)
+bool type_matches(vector_type type, const pmt::pmt_t& v)
 {
     switch (type) {
     case byte_t:
@@ -78,7 +78,7 @@ pmt::pmt_t make_pdu_vector(vector_type type, const uint8_t* buf, size_t items)
     }
 }
 
-vector_type type_from_pmt(pmt::pmt_t vector)
+vector_type type_from_pmt(const pmt::pmt_t& vector)
 {
     if (pmt::is_u8vector(vector))
         return byte_t;

--- a/gr-blocks/lib/pdu_filter_impl.cc
+++ b/gr-blocks/lib/pdu_filter_impl.cc
@@ -28,18 +28,21 @@
 #include <gnuradio/blocks/pdu.h>
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
 pdu_filter::sptr pdu_filter::make(pmt::pmt_t k, pmt::pmt_t v, bool invert)
 {
-    return gnuradio::get_initial_sptr(new pdu_filter_impl(k, v, invert));
+    return gnuradio::get_initial_sptr(
+        new pdu_filter_impl(std::move(k), std::move(v), invert));
 }
 
 pdu_filter_impl::pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert)
     : block("pdu_filter", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
-      d_k(k),
-      d_v(v),
+      d_k(std::move(k)),
+      d_v(std::move(v)),
       d_invert(invert)
 {
     message_port_register_out(pdu::pdu_port_id());
@@ -48,7 +51,7 @@ pdu_filter_impl::pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert)
                     boost::bind(&pdu_filter_impl::handle_msg, this, _1));
 }
 
-void pdu_filter_impl::handle_msg(pmt::pmt_t pdu)
+void pdu_filter_impl::handle_msg(const pmt::pmt_t& pdu)
 {
     pmt::pmt_t meta = pmt::car(pdu);
     bool output = d_invert;

--- a/gr-blocks/lib/pdu_filter_impl.h
+++ b/gr-blocks/lib/pdu_filter_impl.h
@@ -37,7 +37,7 @@ private:
 
 public:
     pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert);
-    void handle_msg(pmt::pmt_t msg);
+    void handle_msg(const pmt::pmt_t& msg);
     void set_key(pmt::pmt_t key) { d_k = key; };
     void set_val(pmt::pmt_t val) { d_v = val; };
     void set_inversion(bool invert) { d_invert = invert; };

--- a/gr-blocks/lib/pdu_remove_impl.cc
+++ b/gr-blocks/lib/pdu_remove_impl.cc
@@ -28,17 +28,19 @@
 #include <gnuradio/blocks/pdu.h>
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
 pdu_remove::sptr pdu_remove::make(pmt::pmt_t k)
 {
-    return gnuradio::get_initial_sptr(new pdu_remove_impl(k));
+    return gnuradio::get_initial_sptr(new pdu_remove_impl(std::move(k)));
 }
 
 pdu_remove_impl::pdu_remove_impl(pmt::pmt_t k)
     : block("pdu_remove", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
-      d_k(k)
+      d_k(std::move(k))
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
@@ -46,7 +48,7 @@ pdu_remove_impl::pdu_remove_impl(pmt::pmt_t k)
                     boost::bind(&pdu_remove_impl::handle_msg, this, _1));
 }
 
-void pdu_remove_impl::handle_msg(pmt::pmt_t pdu)
+void pdu_remove_impl::handle_msg(const pmt::pmt_t& pdu)
 {
     // add the field and publish
     pmt::pmt_t meta = pmt::car(pdu);

--- a/gr-blocks/lib/pdu_remove_impl.h
+++ b/gr-blocks/lib/pdu_remove_impl.h
@@ -35,7 +35,7 @@ private:
 
 public:
     pdu_remove_impl(pmt::pmt_t k);
-    void handle_msg(pmt::pmt_t msg);
+    void handle_msg(const pmt::pmt_t& msg);
     void set_key(pmt::pmt_t key) { d_k = key; };
 };
 

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -28,25 +28,27 @@
 #include <gnuradio/blocks/pdu.h>
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
 pdu_set::sptr pdu_set::make(pmt::pmt_t k, pmt::pmt_t v)
 {
-    return gnuradio::get_initial_sptr(new pdu_set_impl(k, v));
+    return gnuradio::get_initial_sptr(new pdu_set_impl(std::move(k), std::move(v)));
 }
 
 pdu_set_impl::pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v)
     : block("pdu_set", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
-      d_k(k),
-      d_v(v)
+      d_k(std::move(k)),
+      d_v(std::move(v))
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(), boost::bind(&pdu_set_impl::handle_msg, this, _1));
 }
 
-void pdu_set_impl::handle_msg(pmt::pmt_t pdu)
+void pdu_set_impl::handle_msg(const pmt::pmt_t& pdu)
 {
     // add the field and publish
     pmt::pmt_t meta = pmt::car(pdu);

--- a/gr-blocks/lib/pdu_set_impl.h
+++ b/gr-blocks/lib/pdu_set_impl.h
@@ -36,7 +36,7 @@ private:
 
 public:
     pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v);
-    void handle_msg(pmt::pmt_t msg);
+    void handle_msg(const pmt::pmt_t& msg);
     void set_key(pmt::pmt_t key) { d_k = key; };
     void set_val(pmt::pmt_t val) { d_v = val; };
 };

--- a/gr-blocks/lib/qa_block_tags.cc
+++ b/gr-blocks/lib/qa_block_tags.cc
@@ -33,6 +33,7 @@
 #include <gnuradio/blocks/null_source.h>
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
+#include <utility>
 
 
 // ----------------------------------------------------------------
@@ -50,9 +51,9 @@ gr::tag_t make_tag(uint64_t offset, pmt::pmt_t key, pmt::pmt_t value, pmt::pmt_t
 {
     gr::tag_t result;
     result.offset = offset;
-    result.key = key;
-    result.value = value;
-    result.srcid = srcid;
+    result.key = std::move(key);
+    result.value = std::move(value);
+    result.srcid = std::move(srcid);
     return result;
 }
 

--- a/gr-blocks/lib/random_pdu_impl.h
+++ b/gr-blocks/lib/random_pdu_impl.h
@@ -49,7 +49,7 @@ public:
 
     bool start();
     void output_random();
-    void generate_pdu(pmt::pmt_t msg) { output_random(); }
+    void generate_pdu(const pmt::pmt_t& msg) { output_random(); }
     void generate_pdu() { output_random(); }
 };
 

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -48,7 +48,7 @@ repeat_impl::repeat_impl(size_t itemsize, int interp)
                     boost::bind(&repeat_impl::msg_set_interpolation, this, _1));
 }
 
-void repeat_impl::msg_set_interpolation(pmt::pmt_t msg)
+void repeat_impl::msg_set_interpolation(const pmt::pmt_t& msg)
 {
     // Dynamization by Kevin McQuiggin:
     d_interp = pmt::to_long(pmt::cdr(msg));

--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -45,7 +45,7 @@ public:
              gr_vector_void_star& output_items);
 
 private:
-    void msg_set_interpolation(pmt::pmt_t msg);
+    void msg_set_interpolation(const pmt::pmt_t& msg);
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -28,6 +28,7 @@
 #include <gnuradio/io_signature.h>
 #include <string.h>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace blocks {
@@ -53,7 +54,8 @@ selector_impl::selector_impl(size_t itemsize,
       d_num_outputs(0)
 {
     message_port_register_in(pmt::mp("en"));
-    set_msg_handler(pmt::mp("en"), [this](pmt::pmt_t msg) { this->handle_enable(msg); });
+    set_msg_handler(pmt::mp("en"),
+                    [this](pmt::pmt_t msg) { this->handle_enable(std::move(msg)); });
 
     // TODO: add message ports for input_index and output_index
 }
@@ -78,7 +80,7 @@ void selector_impl::set_output_index(unsigned int output_index)
         throw std::out_of_range("output_index must be < noutputs");
 }
 
-void selector_impl::handle_enable(pmt::pmt_t msg)
+void selector_impl::handle_enable(const pmt::pmt_t& msg)
 {
     if (pmt::is_bool(msg)) {
         bool en = pmt::to_bool(msg);

--- a/gr-blocks/lib/selector_impl.h
+++ b/gr-blocks/lib/selector_impl.h
@@ -47,7 +47,7 @@ public:
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
     bool check_topology(int ninputs, int noutputs);
     void setup_rpc();
-    void handle_enable(pmt::pmt_t msg);
+    void handle_enable(const pmt::pmt_t& msg);
     void set_enabled(bool enable)
     {
         gr::thread::scoped_lock l(d_mutex);

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -29,6 +29,8 @@
 #include <gnuradio/blocks/pdu.h>
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
@@ -38,13 +40,13 @@ socket_pdu::sptr socket_pdu::make(std::string type,
                                   int MTU /*= 10000*/,
                                   bool tcp_no_delay /*= false*/)
 {
-    return gnuradio::get_initial_sptr(
-        new socket_pdu_impl(type, addr, port, MTU, tcp_no_delay));
+    return gnuradio::get_initial_sptr(new socket_pdu_impl(
+        std::move(type), std::move(addr), std::move(port), MTU, tcp_no_delay));
 }
 
-socket_pdu_impl::socket_pdu_impl(std::string type,
-                                 std::string addr,
-                                 std::string port,
+socket_pdu_impl::socket_pdu_impl(const std::string& type,
+                                 const std::string& addr,
+                                 const std::string& port,
                                  int MTU /*= 10000*/,
                                  bool tcp_no_delay /*= false*/)
     : block("socket_pdu", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
@@ -201,14 +203,14 @@ void socket_pdu_impl::start_tcp_accept()
                                              boost::asio::placeholders::error));
 }
 
-void socket_pdu_impl::tcp_server_send(pmt::pmt_t msg)
+void socket_pdu_impl::tcp_server_send(const pmt::pmt_t& msg)
 {
     pmt::pmt_t vector = pmt::cdr(msg);
     for (size_t i = 0; i < d_tcp_connections.size(); i++)
         d_tcp_connections[i]->send(vector);
 }
 
-void socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection,
+void socket_pdu_impl::handle_tcp_accept(const tcp_connection::sptr& new_connection,
                                         const boost::system::error_code& error)
 {
     if (!error) {
@@ -228,7 +230,7 @@ void socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection,
         std::cout << error << std::endl;
 }
 
-void socket_pdu_impl::tcp_client_send(pmt::pmt_t msg)
+void socket_pdu_impl::tcp_client_send(const pmt::pmt_t& msg)
 {
     pmt::pmt_t vector = pmt::cdr(msg);
     size_t len = pmt::blob_length(vector);
@@ -242,7 +244,7 @@ void socket_pdu_impl::tcp_client_send(pmt::pmt_t msg)
     }
 }
 
-void socket_pdu_impl::udp_send(pmt::pmt_t msg)
+void socket_pdu_impl::udp_send(const pmt::pmt_t& msg)
 {
     if (d_udp_endpoint_other.address().to_string() == "0.0.0.0")
         return;

--- a/gr-blocks/lib/socket_pdu_impl.h
+++ b/gr-blocks/lib/socket_pdu_impl.h
@@ -48,13 +48,13 @@ private:
     // TCP server specific
     boost::shared_ptr<boost::asio::ip::tcp::acceptor> d_acceptor_tcp;
     void start_tcp_accept();
-    void tcp_server_send(pmt::pmt_t msg);
-    void handle_tcp_accept(tcp_connection::sptr new_connection,
+    void tcp_server_send(const pmt::pmt_t& msg);
+    void handle_tcp_accept(const tcp_connection::sptr& new_connection,
                            const boost::system::error_code& error);
 
     // TCP client specific
     boost::shared_ptr<boost::asio::ip::tcp::socket> d_tcp_socket;
-    void tcp_client_send(pmt::pmt_t msg);
+    void tcp_client_send(const pmt::pmt_t& msg);
 
     // UDP specific
     boost::asio::ip::udp::endpoint d_udp_endpoint;
@@ -62,12 +62,12 @@ private:
     boost::shared_ptr<boost::asio::ip::udp::socket> d_udp_socket;
     void handle_udp_read(const boost::system::error_code& error,
                          size_t bytes_transferred);
-    void udp_send(pmt::pmt_t msg);
+    void udp_send(const pmt::pmt_t& msg);
 
 public:
-    socket_pdu_impl(std::string type,
-                    std::string addr,
-                    std::string port,
+    socket_pdu_impl(const std::string& type,
+                    const std::string& addr,
+                    const std::string& port,
                     int MTU = 10000,
                     bool tcp_no_delay = false);
     ~socket_pdu_impl();

--- a/gr-blocks/lib/stream_pdu_base.cc
+++ b/gr-blocks/lib/stream_pdu_base.cc
@@ -36,6 +36,7 @@
 #include <gnuradio/basic_block.h>
 #include <gnuradio/blocks/pdu.h>
 #include <boost/format.hpp>
+#include <utility>
 
 static const long timeout_us = 100 * 1000; // 100ms
 
@@ -53,7 +54,7 @@ stream_pdu_base::~stream_pdu_base() { stop_rxthread(); }
 void stream_pdu_base::start_rxthread(basic_block* blk, pmt::pmt_t port)
 {
     d_blk = blk;
-    d_port = port;
+    d_port = std::move(port);
     d_thread = gr::thread::thread(boost::bind(&stream_pdu_base::run, this));
     d_started = true;
 }
@@ -101,7 +102,7 @@ bool stream_pdu_base::wait_ready()
     return ::select(d_fd + 1, &rset, NULL, NULL, &tv) > 0;
 }
 
-void stream_pdu_base::send(pmt::pmt_t msg)
+void stream_pdu_base::send(const pmt::pmt_t& msg)
 {
     pmt::pmt_t vector = pmt::cdr(msg);
     size_t offset(0);

--- a/gr-blocks/lib/stream_pdu_base.h
+++ b/gr-blocks/lib/stream_pdu_base.h
@@ -49,7 +49,7 @@ protected:
     basic_block* d_blk;
 
     void run();
-    void send(pmt::pmt_t msg);
+    void send(const pmt::pmt_t& msg);
     bool wait_ready();
     void start_rxthread(basic_block* blk, pmt::pmt_t rxport);
     void stop_rxthread();

--- a/gr-blocks/lib/tagged_stream_multiply_length_impl.h
+++ b/gr-blocks/lib/tagged_stream_multiply_length_impl.h
@@ -24,6 +24,7 @@
 #define INCLUDED_TAGGED_STREAM_MULTIPLY_LENGTH_IMPL_H
 
 #include <gnuradio/blocks/tagged_stream_multiply_length.h>
+#include <utility>
 #include <vector>
 
 namespace gr {
@@ -49,7 +50,7 @@ public:
 
     void set_scalar(double scalar) { d_scalar = scalar; }
 
-    void set_scalar_pmt(pmt::pmt_t msg) { set_scalar(pmt::to_double(msg)); }
+    void set_scalar_pmt(pmt::pmt_t msg) { set_scalar(pmt::to_double(std::move(msg))); }
 };
 
 } // namespace blocks

--- a/gr-blocks/lib/tags_strobe_impl.cc
+++ b/gr-blocks/lib/tags_strobe_impl.cc
@@ -34,6 +34,7 @@
 #include <cstdio>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace blocks {
@@ -43,8 +44,8 @@ tags_strobe::sptr tags_strobe::make(size_t sizeof_stream_item,
                                     uint64_t nsamps,
                                     pmt::pmt_t key)
 {
-    return gnuradio::get_initial_sptr(
-        new tags_strobe_impl(sizeof_stream_item, value, nsamps, key));
+    return gnuradio::get_initial_sptr(new tags_strobe_impl(
+        sizeof_stream_item, std::move(value), nsamps, std::move(key)));
 }
 
 tags_strobe_impl::tags_strobe_impl(size_t sizeof_stream_item,
@@ -59,8 +60,8 @@ tags_strobe_impl::tags_strobe_impl(size_t sizeof_stream_item,
     d_tag.offset = 0;
     d_tag.key = pmt::intern("strobe");
     d_tag.srcid = alias_pmt();
-    set_value(value);
-    set_key(key);
+    set_value(std::move(value));
+    set_key(std::move(key));
     set_nsamps(nsamps);
     d_offset = 0;
 }

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -52,7 +52,7 @@ tcp_connection::tcp_connection(boost::asio::io_service& io_service,
     }
 }
 
-void tcp_connection::send(pmt::pmt_t vector)
+void tcp_connection::send(const pmt::pmt_t& vector)
 {
     size_t len = pmt::blob_length(vector);
 

--- a/gr-blocks/lib/tcp_connection.h
+++ b/gr-blocks/lib/tcp_connection.h
@@ -55,9 +55,9 @@ public:
     boost::asio::ip::tcp::socket& socket() { return d_socket; };
 
     void start(gr::basic_block* block);
-    void send(pmt::pmt_t vector);
+    void send(const pmt::pmt_t& vector);
     void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-    void handle_write(boost::shared_ptr<char[]> txbuf,
+    void handle_write(const boost::shared_ptr<char[]>& txbuf,
                       const boost::system::error_code& error,
                       size_t bytes_transferred)
     {

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -28,6 +28,7 @@
 #include <gnuradio/blocks/pdu.h>
 #include <gnuradio/io_signature.h>
 #include <boost/format.hpp>
+#include <utility>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -45,7 +46,8 @@ namespace blocks {
 tuntap_pdu::sptr tuntap_pdu::make(std::string dev, int MTU, bool istunflag)
 {
 #if (defined(linux) || defined(__linux) || defined(__linux__))
-    return gnuradio::get_initial_sptr(new tuntap_pdu_impl(dev, MTU, istunflag));
+    return gnuradio::get_initial_sptr(
+        new tuntap_pdu_impl(std::move(dev), MTU, istunflag));
 #else
     throw std::runtime_error("tuntap_pdu not implemented on this platform");
 #endif

--- a/gr-blocks/lib/vector_map_impl.cc
+++ b/gr-blocks/lib/vector_map_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <string.h>
 
+#include <utility>
+
 namespace gr {
 namespace blocks {
 
@@ -54,12 +56,14 @@ vector_map::sptr vector_map::make(size_t item_size,
                                   std::vector<size_t> in_vlens,
                                   std::vector<std::vector<std::vector<size_t>>> mapping)
 {
-    return gnuradio::get_initial_sptr(new vector_map_impl(item_size, in_vlens, mapping));
+    return gnuradio::get_initial_sptr(
+        new vector_map_impl(item_size, std::move(in_vlens), std::move(mapping)));
 }
 
-vector_map_impl::vector_map_impl(size_t item_size,
-                                 std::vector<size_t> in_vlens,
-                                 std::vector<std::vector<std::vector<size_t>>> mapping)
+vector_map_impl::vector_map_impl(
+    size_t item_size,
+    const std::vector<size_t>& in_vlens,
+    const std::vector<std::vector<std::vector<size_t>>>& mapping)
     : sync_block(
           "vector_map",
           io_signature::makev(

--- a/gr-blocks/lib/vector_map_impl.h
+++ b/gr-blocks/lib/vector_map_impl.h
@@ -39,8 +39,8 @@ private:
 
 public:
     vector_map_impl(size_t item_size,
-                    std::vector<size_t> in_vlens,
-                    std::vector<std::vector<std::vector<size_t>>> mapping);
+                    const std::vector<size_t>& in_vlens,
+                    const std::vector<std::vector<std::vector<size_t>>>& mapping);
     ~vector_map_impl();
 
     void set_mapping(std::vector<std::vector<std::vector<size_t>>> mapping);

--- a/gr-blocks/tests/benchmark_nco.cc
+++ b/gr-blocks/tests/benchmark_nco.cc
@@ -114,12 +114,12 @@ void basic_sincos_vec(float* x, float* y)
 {
     gr::blocks::nco<float, float> nco;
 
-    nco.set_freq(2 * GR_M_PI / FREQ);
+    gr::nco.set_freq(2 * GR_M_PI / FREQ);
 
     for (int i = 0; i < ITERATIONS / BLOCK_SIZE; i++) {
         for (int j = 0; j < BLOCK_SIZE; j++) {
-            nco.sincos(&x[2 * j + 1], &x[2 * j]);
-            nco.step();
+            gr::nco.sincos(&x[2 * j + 1], &x[2 * j]);
+            gr::nco.step();
         }
     }
 }
@@ -128,7 +128,7 @@ void native_sincos_vec(float* x, float* y)
 {
     gr::blocks::nco<float, float> nco;
 
-    nco.set_freq(2 * GR_M_PI / FREQ);
+    gr::nco.set_freq(2 * GR_M_PI / FREQ);
 
     for (int i = 0; i < ITERATIONS / BLOCK_SIZE; i++) {
         nco.sincos((gr_complex*)x, BLOCK_SIZE);

--- a/gr-channels/lib/dynamic_channel_model_impl.cc
+++ b/gr-channels/lib/dynamic_channel_model_impl.cc
@@ -23,6 +23,7 @@
 #include "dynamic_channel_model_impl.h"
 #include <gnuradio/io_signature.h>
 #include <iostream>
+#include <utility>
 
 namespace gr {
 namespace channels {
@@ -51,8 +52,8 @@ dynamic_channel_model::sptr dynamic_channel_model::make(double samp_rate,
                                                                      doppler_freq,
                                                                      LOS_model,
                                                                      K,
-                                                                     delays,
-                                                                     mags,
+                                                                     std::move(delays),
+                                                                     std::move(mags),
                                                                      ntaps_mpath,
                                                                      noise_amp,
                                                                      noise_seed));
@@ -84,8 +85,14 @@ dynamic_channel_model_impl::dynamic_channel_model_impl(double samp_rate,
         channels::sro_model::make(samp_rate, sro_std_dev, sro_max_dev, noise_seed);
     d_cfo_model =
         channels::cfo_model::make(samp_rate, cfo_std_dev, cfo_max_dev, noise_seed);
-    d_fader = channels::selective_fading_model::make(
-        N, doppler_freq / samp_rate, LOS_model, K, noise_seed, delays, mags, ntaps_mpath);
+    d_fader = channels::selective_fading_model::make(N,
+                                                     doppler_freq / samp_rate,
+                                                     LOS_model,
+                                                     K,
+                                                     noise_seed,
+                                                     std::move(delays),
+                                                     std::move(mags),
+                                                     ntaps_mpath);
 
     connect(self(), 0, d_sro_model, 0);
     connect(d_sro_model, 0, d_cfo_model, 0);

--- a/gr-channels/lib/selective_fading_model2_impl.cc
+++ b/gr-channels/lib/selective_fading_model2_impl.cc
@@ -31,6 +31,7 @@
 #include <boost/random.hpp>
 
 #include <iostream>
+#include <utility>
 
 
 // FASTSINCOS:  0 = slow native,  1 = gr::fxpt impl,  2 = sincostable.h
@@ -52,8 +53,17 @@ selective_fading_model2::make(unsigned int N,
                               std::vector<float> mags,
                               int ntaps)
 {
-    return gnuradio::get_initial_sptr(new selective_fading_model2_impl(
-        N, fDTs, LOS, K, seed, delays, delays_std, delays_maxdev, mags, ntaps));
+    return gnuradio::get_initial_sptr(
+        new selective_fading_model2_impl(N,
+                                         fDTs,
+                                         LOS,
+                                         K,
+                                         seed,
+                                         std::move(delays),
+                                         std::move(delays_std),
+                                         std::move(delays_maxdev),
+                                         std::move(mags),
+                                         ntaps));
 }
 
 // Block constructor
@@ -63,10 +73,10 @@ selective_fading_model2_impl::selective_fading_model2_impl(
     bool LOS,
     float K,
     int seed,
-    std::vector<float> delays,
-    std::vector<float> delays_std,
-    std::vector<float> delays_maxdev,
-    std::vector<float> mags,
+    const std::vector<float>& delays,
+    const std::vector<float>& delays_std,
+    const std::vector<float>& delays_maxdev,
+    const std::vector<float>& mags,
     int ntaps)
     : sync_block("selective_fading_model2",
                  io_signature::make(1, 1, sizeof(gr_complex)),

--- a/gr-channels/lib/selective_fading_model2_impl.h
+++ b/gr-channels/lib/selective_fading_model2_impl.h
@@ -58,10 +58,10 @@ public:
                                  bool LOS,
                                  float K,
                                  int seed,
-                                 std::vector<float> delays,
-                                 std::vector<float> delay_std,
-                                 std::vector<float> delay_maxdev,
-                                 std::vector<float> mags,
+                                 const std::vector<float>& delays,
+                                 const std::vector<float>& delay_std,
+                                 const std::vector<float>& delay_maxdev,
+                                 const std::vector<float>& mags,
                                  int ntaps);
     ~selective_fading_model2_impl();
     void setup_rpc();

--- a/gr-channels/lib/selective_fading_model_impl.cc
+++ b/gr-channels/lib/selective_fading_model_impl.cc
@@ -31,6 +31,7 @@
 #include <boost/random.hpp>
 
 #include <iostream>
+#include <utility>
 
 
 // FASTSINCOS:  0 = slow native,  1 = gr::fxpt impl,  2 = sincostable.h
@@ -49,8 +50,8 @@ selective_fading_model::sptr selective_fading_model::make(unsigned int N,
                                                           std::vector<float> mags,
                                                           int ntaps)
 {
-    return gnuradio::get_initial_sptr(
-        new selective_fading_model_impl(N, fDTs, LOS, K, seed, delays, mags, ntaps));
+    return gnuradio::get_initial_sptr(new selective_fading_model_impl(
+        N, fDTs, LOS, K, seed, std::move(delays), std::move(mags), ntaps));
 }
 
 // Block constructor
@@ -59,8 +60,8 @@ selective_fading_model_impl::selective_fading_model_impl(unsigned int N,
                                                          bool LOS,
                                                          float K,
                                                          int seed,
-                                                         std::vector<float> delays,
-                                                         std::vector<float> mags,
+                                                         const std::vector<float>& delays,
+                                                         const std::vector<float>& mags,
                                                          int ntaps)
     : sync_block("selective_fading_model",
                  io_signature::make(1, 1, sizeof(gr_complex)),

--- a/gr-channels/lib/selective_fading_model_impl.h
+++ b/gr-channels/lib/selective_fading_model_impl.h
@@ -51,8 +51,8 @@ public:
                                 bool LOS,
                                 float K,
                                 int seed,
-                                std::vector<float> delays,
-                                std::vector<float> mags,
+                                const std::vector<float>& delays,
+                                const std::vector<float>& mags,
                                 int ntaps);
     ~selective_fading_model_impl();
     void setup_rpc();

--- a/gr-channels/lib/sro_model_impl.cc
+++ b/gr-channels/lib/sro_model_impl.cc
@@ -26,6 +26,7 @@
 
 #include "sro_model_impl.h"
 #include <gnuradio/io_signature.h>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {
@@ -69,8 +70,8 @@ void sro_model_impl::forecast(int noutput_items, gr_vector_int& ninput_items_req
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
         ninput_items_required[i] =
-            (int)ceil((noutput_items * (d_mu_inc + d_max_dev_hz / d_samp_rate)) +
-                      d_interp->ntaps());
+            (int)std::ceil((noutput_items * (d_mu_inc + d_max_dev_hz / d_samp_rate)) +
+                           d_interp->ntaps());
     }
 }
 

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -63,7 +63,7 @@ class DIGITAL_API constellation : public boost::enable_shared_from_this<constell
 {
 public:
     constellation(std::vector<gr_complex> constell,
-                  std::vector<int> pre_diff_code,
+                  const std::vector<int>& pre_diff_code,
                   unsigned int rotational_symmetry,
                   unsigned int dimensionality,
                   bool normalize_points = true);
@@ -470,7 +470,7 @@ protected:
 
     unsigned int calc_sector_value(unsigned int sector);
 
-    constellation_psk(std::vector<gr_complex> constell,
+    constellation_psk(const std::vector<gr_complex>& constell,
                       std::vector<int> pre_diff_code,
                       unsigned int n_sectors);
 };

--- a/gr-digital/include/gnuradio/digital/crc32.h
+++ b/gr-digital/include/gnuradio/digital/crc32.h
@@ -43,11 +43,11 @@ namespace digital {
 DIGITAL_API unsigned int
 update_crc32(unsigned int crc, const unsigned char* buf, size_t len);
 
-DIGITAL_API unsigned int update_crc32(unsigned int crc, const std::string buf);
+DIGITAL_API unsigned int update_crc32(unsigned int crc, const std::string& buf);
 
 DIGITAL_API unsigned int crc32(const unsigned char* buf, size_t len);
 
-DIGITAL_API unsigned int crc32(const std::string buf);
+DIGITAL_API unsigned int crc32(const std::string& buf);
 
 } /* namespace digital */
 } /* namespace gr */

--- a/gr-digital/include/gnuradio/digital/hdlc_framer_pb.h
+++ b/gr-digital/include/gnuradio/digital/hdlc_framer_pb.h
@@ -55,7 +55,7 @@ public:
      *
      * \param frame_tag_name: The tag to add to the first sample of each frame.
      */
-    static sptr make(const std::string frame_tag_name);
+    static sptr make(const std::string& frame_tag_name);
 };
 
 } // namespace digital

--- a/gr-digital/include/gnuradio/digital/modulate_vector.h
+++ b/gr-digital/include/gnuradio/digital/modulate_vector.h
@@ -59,9 +59,9 @@ namespace digital {
  * before using this function.
  *
  */
-DIGITAL_API std::vector<gr_complex> modulate_vector_bc(basic_block_sptr modulator,
-                                                       std::vector<uint8_t> data,
-                                                       std::vector<float> taps);
+DIGITAL_API std::vector<gr_complex> modulate_vector_bc(const basic_block_sptr& modulator,
+                                                       const std::vector<uint8_t>& data,
+                                                       const std::vector<float>& taps);
 
 } /* namespace digital */
 } /* namespace gr */

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -28,6 +28,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <gnuradio/prefs.h>
+#include <cmath>
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
@@ -83,7 +84,7 @@ void clock_recovery_mm_cc_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_omega) + d_interp->ntaps()) + FUDGE;
+            (int)std::ceil((noutput_items * d_omega) + d_interp->ntaps()) + FUDGE;
 }
 
 gr_complex clock_recovery_mm_cc_impl::slicer_0deg(gr_complex sample)
@@ -160,8 +161,8 @@ int clock_recovery_mm_cc_impl::general_work(int noutput_items,
                 d_omega_mid + gr::branchless_clip(d_omega - d_omega_mid, d_omega_lim);
 
             d_mu = d_mu + d_omega + d_gain_mu * mm_val;
-            ii += (int)floor(d_mu);
-            d_mu -= floor(d_mu);
+            ii += (int)std::floor(d_mu);
+            d_mu -= std::floor(d_mu);
 
             // write the error signal to the second output
             foptr[oo - 1] = mm_val;
@@ -195,8 +196,8 @@ int clock_recovery_mm_cc_impl::general_work(int noutput_items,
                 d_omega_mid + gr::branchless_clip(d_omega - d_omega_mid, d_omega_lim);
 
             d_mu = d_mu + d_omega + d_gain_mu * mm_val;
-            ii += (int)floor(d_mu);
-            d_mu -= floor(d_mu);
+            ii += (int)std::floor(d_mu);
+            d_mu -= std::floor(d_mu);
 
             if (d_verbose) {
                 std::stringstream tmp;

--- a/gr-digital/lib/clock_recovery_mm_ff_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_ff_impl.cc
@@ -27,6 +27,7 @@
 #include "clock_recovery_mm_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {
@@ -69,7 +70,7 @@ void clock_recovery_mm_ff_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_omega) + d_interp->ntaps());
+            (int)std::ceil((noutput_items * d_omega) + d_interp->ntaps());
 }
 
 static inline float slice(float x) { return x < 0 ? -1.0F : 1.0F; }
@@ -104,8 +105,8 @@ int clock_recovery_mm_ff_impl::general_work(int noutput_items,
         d_omega = d_omega_mid + gr::branchless_clip(d_omega - d_omega_mid, d_omega_lim);
         d_mu = d_mu + d_omega + d_gain_mu * mm_val;
 
-        ii += (int)floor(d_mu);
-        d_mu = d_mu - floor(d_mu);
+        ii += (int)std::floor(d_mu);
+        d_mu = d_mu - std::floor(d_mu);
         oo++;
     }
 

--- a/gr-digital/lib/constellation_decoder_cb_impl.cc
+++ b/gr-digital/lib/constellation_decoder_cb_impl.cc
@@ -27,17 +27,20 @@
 #include "constellation_decoder_cb_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace digital {
 
 constellation_decoder_cb::sptr
 constellation_decoder_cb::make(constellation_sptr constellation)
 {
-    return gnuradio::get_initial_sptr(new constellation_decoder_cb_impl(constellation));
+    return gnuradio::get_initial_sptr(
+        new constellation_decoder_cb_impl(std::move(constellation)));
 }
 
 constellation_decoder_cb_impl::constellation_decoder_cb_impl(
-    constellation_sptr constellation)
+    const constellation_sptr& constellation)
     : block("constellation_decoder_cb",
             io_signature::make(1, 1, sizeof(gr_complex)),
             io_signature::make(1, 1, sizeof(unsigned char))),

--- a/gr-digital/lib/constellation_decoder_cb_impl.h
+++ b/gr-digital/lib/constellation_decoder_cb_impl.h
@@ -35,7 +35,7 @@ private:
     unsigned int d_dim;
 
 public:
-    constellation_decoder_cb_impl(constellation_sptr constellation);
+    constellation_decoder_cb_impl(const constellation_sptr& constellation);
     ~constellation_decoder_cb_impl();
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -30,6 +30,7 @@
 #include <gnuradio/math.h>
 #include <gnuradio/tag_checker.h>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace digital {
@@ -41,7 +42,7 @@ constellation_receiver_cb::sptr constellation_receiver_cb::make(
     constellation_sptr constell, float loop_bw, float fmin, float fmax)
 {
     return gnuradio::get_initial_sptr(
-        new constellation_receiver_cb_impl(constell, loop_bw, fmin, fmax));
+        new constellation_receiver_cb_impl(std::move(constell), loop_bw, fmin, fmax));
 }
 
 static int ios[] = {
@@ -54,7 +55,7 @@ constellation_receiver_cb_impl::constellation_receiver_cb_impl(
             io_signature::make(1, 1, sizeof(gr_complex)),
             io_signature::makev(1, 5, iosig)),
       blocks::control_loop(loop_bw, fmax, fmin),
-      d_constellation(constellation)
+      d_constellation(std::move(constellation))
 {
     if (d_constellation->dimensionality() != 1)
         throw std::runtime_error(
@@ -99,7 +100,7 @@ void constellation_receiver_cb_impl::set_phase_freq(float phase, float freq)
 }
 
 void constellation_receiver_cb_impl::handle_set_constellation(
-    pmt::pmt_t constellation_pmt)
+    const pmt::pmt_t& constellation_pmt)
 {
     if (pmt::is_any(constellation_pmt)) {
         boost::any constellation_any = pmt::any_ref(constellation_pmt);
@@ -109,7 +110,7 @@ void constellation_receiver_cb_impl::handle_set_constellation(
     }
 }
 
-void constellation_receiver_cb_impl::handle_rotate_phase(pmt::pmt_t rotation)
+void constellation_receiver_cb_impl::handle_rotate_phase(const pmt::pmt_t& rotation)
 {
     if (pmt::is_real(rotation)) {
         double phase = pmt::to_double(rotation);
@@ -119,7 +120,7 @@ void constellation_receiver_cb_impl::handle_rotate_phase(pmt::pmt_t rotation)
 
 void constellation_receiver_cb_impl::set_constellation(constellation_sptr constellation)
 {
-    d_constellation = constellation;
+    d_constellation = std::move(constellation);
 }
 
 int constellation_receiver_cb_impl::general_work(int noutput_items,

--- a/gr-digital/lib/constellation_receiver_cb_impl.h
+++ b/gr-digital/lib/constellation_receiver_cb_impl.h
@@ -63,7 +63,7 @@ private:
      * constellation_pmt is a pmt_any; constellation objects have
      * an as_pmt function that can be used for this purpose.
      */
-    void handle_set_constellation(pmt::pmt_t constellation_pmt);
+    void handle_set_constellation(const pmt::pmt_t& constellation_pmt);
 
     /*!
      * Message handler port to update the phase of the rotator. The
@@ -71,7 +71,7 @@ private:
      * to the current phase. So we can rotate the constellation by
      * 90 degress by passing a value of pmt::from_double(GR_M_PI/2).
      */
-    void handle_rotate_phase(pmt::pmt_t rotation);
+    void handle_rotate_phase(const pmt::pmt_t& rotation);
 
     //! Set the constellation used.
     //! Typically used when we receive a tag with a value for this.

--- a/gr-digital/lib/constellation_soft_decoder_cf_impl.cc
+++ b/gr-digital/lib/constellation_soft_decoder_cf_impl.cc
@@ -27,6 +27,8 @@
 #include "constellation_soft_decoder_cf_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace digital {
 
@@ -34,11 +36,11 @@ constellation_soft_decoder_cf::sptr
 constellation_soft_decoder_cf::make(constellation_sptr constellation)
 {
     return gnuradio::get_initial_sptr(
-        new constellation_soft_decoder_cf_impl(constellation));
+        new constellation_soft_decoder_cf_impl(std::move(constellation)));
 }
 
 constellation_soft_decoder_cf_impl::constellation_soft_decoder_cf_impl(
-    constellation_sptr constellation)
+    const constellation_sptr& constellation)
     : sync_interpolator("constellation_soft_decoder_cf",
                         io_signature::make(1, 1, sizeof(gr_complex)),
                         io_signature::make(1, 1, sizeof(float)),

--- a/gr-digital/lib/constellation_soft_decoder_cf_impl.h
+++ b/gr-digital/lib/constellation_soft_decoder_cf_impl.h
@@ -36,7 +36,7 @@ private:
     int d_bps;
 
 public:
-    constellation_soft_decoder_cf_impl(constellation_sptr constellation);
+    constellation_soft_decoder_cf_impl(const constellation_sptr& constellation);
     ~constellation_soft_decoder_cf_impl();
 
     int work(int noutput_items,

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -152,7 +152,7 @@ float costas_loop_cc_impl::phase_detector_snr_2(gr_complex sample) const
 
 float costas_loop_cc_impl::error() const { return d_error; }
 
-void costas_loop_cc_impl::handle_set_noise(pmt::pmt_t msg)
+void costas_loop_cc_impl::handle_set_noise(const pmt::pmt_t& msg)
 {
     if (pmt::is_real(msg)) {
         d_noise = pmt::to_double(msg);

--- a/gr-digital/lib/costas_loop_cc_impl.h
+++ b/gr-digital/lib/costas_loop_cc_impl.h
@@ -94,7 +94,7 @@ public:
 
     float error() const;
 
-    void handle_set_noise(pmt::pmt_t msg);
+    void handle_set_noise(const pmt::pmt_t& msg);
 
     void setup_rpc();
 

--- a/gr-digital/lib/crc32.cc
+++ b/gr-digital/lib/crc32.cc
@@ -91,7 +91,7 @@ unsigned int update_crc32(unsigned int crc, const unsigned char* data, size_t le
     return crc;
 }
 
-unsigned int update_crc32(unsigned int crc, const std::string s)
+unsigned int update_crc32(unsigned int crc, const std::string& s)
 {
     return update_crc32(crc, (const unsigned char*)s.data(), s.size());
 }
@@ -101,7 +101,7 @@ unsigned int crc32(const unsigned char* buf, size_t len)
     return update_crc32(0xffffffff, buf, len) ^ 0xffffffff;
 }
 
-unsigned int crc32(const std::string s)
+unsigned int crc32(const std::string& s)
 {
     return crc32((const unsigned char*)s.data(), s.size());
 }

--- a/gr-digital/lib/crc32_async_bb_impl.cc
+++ b/gr-digital/lib/crc32_async_bb_impl.cc
@@ -55,7 +55,7 @@ crc32_async_bb_impl::crc32_async_bb_impl(bool check)
 
 crc32_async_bb_impl::~crc32_async_bb_impl() {}
 
-void crc32_async_bb_impl::calc(pmt::pmt_t msg)
+void crc32_async_bb_impl::calc(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));
@@ -83,7 +83,7 @@ void crc32_async_bb_impl::calc(pmt::pmt_t msg)
     volk_free(bytes_out);
 }
 
-void crc32_async_bb_impl::check(pmt::pmt_t msg)
+void crc32_async_bb_impl::check(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));

--- a/gr-digital/lib/crc32_async_bb_impl.h
+++ b/gr-digital/lib/crc32_async_bb_impl.h
@@ -37,8 +37,8 @@ private:
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;
 
-    void calc(pmt::pmt_t msg);
-    void check(pmt::pmt_t msg);
+    void calc(const pmt::pmt_t& msg);
+    void check(const pmt::pmt_t& msg);
 
 public:
     crc32_async_bb_impl(bool check);

--- a/gr-digital/lib/fll_band_edge_cc_impl.cc
+++ b/gr-digital/lib/fll_band_edge_cc_impl.cc
@@ -27,6 +27,7 @@
 #include "fll_band_edge_cc_impl.h"
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
+#include <cmath>
 #include <cstdio>
 
 namespace gr {
@@ -144,7 +145,7 @@ void fll_band_edge_cc_impl::design_filter(float samps_per_sym,
                                           float rolloff,
                                           int filter_size)
 {
-    int M = rint(filter_size / samps_per_sym);
+    int M = std::rint(filter_size / samps_per_sym);
     float power = 0;
 
     // Create the baseband filter by adding two sincs together

--- a/gr-digital/lib/framer_sink_1_impl.cc
+++ b/gr-digital/lib/framer_sink_1_impl.cc
@@ -28,6 +28,7 @@
 #include <gnuradio/io_signature.h>
 #include <cstdio>
 #include <string>
+#include <utility>
 
 namespace gr {
 namespace digital {
@@ -70,14 +71,14 @@ inline void framer_sink_1_impl::enter_have_header(int payload_len, int whitener_
 
 framer_sink_1::sptr framer_sink_1::make(msg_queue::sptr target_queue)
 {
-    return gnuradio::get_initial_sptr(new framer_sink_1_impl(target_queue));
+    return gnuradio::get_initial_sptr(new framer_sink_1_impl(std::move(target_queue)));
 }
 
 framer_sink_1_impl::framer_sink_1_impl(msg_queue::sptr target_queue)
     : sync_block("framer_sink_1",
                  io_signature::make(1, 1, sizeof(unsigned char)),
                  io_signature::make(0, 0, 0)),
-      d_target_queue(target_queue)
+      d_target_queue(std::move(target_queue))
 {
     enter_search();
 }

--- a/gr-digital/lib/hdlc_framer_pb_impl.cc
+++ b/gr-digital/lib/hdlc_framer_pb_impl.cc
@@ -32,7 +32,7 @@
 namespace gr {
 namespace digital {
 
-hdlc_framer_pb::sptr hdlc_framer_pb::make(const std::string frame_tag_name)
+hdlc_framer_pb::sptr hdlc_framer_pb::make(const std::string& frame_tag_name)
 {
     return gnuradio::get_initial_sptr(new hdlc_framer_pb_impl(frame_tag_name));
 }
@@ -40,7 +40,7 @@ hdlc_framer_pb::sptr hdlc_framer_pb::make(const std::string frame_tag_name)
 /*
  * The private constructor
  */
-hdlc_framer_pb_impl::hdlc_framer_pb_impl(const std::string frame_tag_name)
+hdlc_framer_pb_impl::hdlc_framer_pb_impl(const std::string& frame_tag_name)
     : gr::sync_block("hdlc_framer_pb",
                      gr::io_signature::make(0, 0, 0),
                      gr::io_signature::make(1, 1, sizeof(unsigned char))),

--- a/gr-digital/lib/hdlc_framer_pb_impl.h
+++ b/gr-digital/lib/hdlc_framer_pb_impl.h
@@ -41,7 +41,7 @@ private:
     const pmt::pmt_t d_port;
 
 public:
-    hdlc_framer_pb_impl(const std::string frame_tag_name);
+    hdlc_framer_pb_impl(const std::string& frame_tag_name);
     ~hdlc_framer_pb_impl();
 
     // Where all the action really happens

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -39,7 +39,7 @@ const pmt::pmt_t header_payload_demux_impl::msg_port_id()
 
 //! Returns a PMT time tuple (uint seconds, double fraction) as the sum of
 //  another PMT time tuple and a time diff in seconds.
-pmt::pmt_t _update_pmt_time(pmt::pmt_t old_time, double time_difference)
+pmt::pmt_t _update_pmt_time(const pmt::pmt_t& old_time, double time_difference)
 {
     double diff_seconds;
     double diff_frac = modf(time_difference, &diff_seconds);
@@ -404,7 +404,7 @@ int header_payload_demux_impl::find_trigger_signal(int skip_items,
 } /* find_trigger_signal() */
 
 
-void header_payload_demux_impl::parse_header_data_msg(pmt::pmt_t header_data)
+void header_payload_demux_impl::parse_header_data_msg(const pmt::pmt_t& header_data)
 {
     d_payload_tag_keys.clear();
     d_payload_tag_values.clear();

--- a/gr-digital/lib/header_payload_demux_impl.h
+++ b/gr-digital/lib/header_payload_demux_impl.h
@@ -73,7 +73,7 @@ private:
 
     //! Message handler: Reads the result from the header demod and sets length tag (and
     //! other tags)
-    void parse_header_data_msg(pmt::pmt_t header_data);
+    void parse_header_data_msg(const pmt::pmt_t& header_data);
 
     //! Helper function that returns true if a trigger signal is detected.
     //  Searches input 1 (if active), then the tags. Returns the offset in the input

--- a/gr-digital/lib/interpolating_resampler.cc
+++ b/gr-digital/lib/interpolating_resampler.cc
@@ -26,6 +26,7 @@
 
 #include "interpolating_resampler.h"
 #include <gnuradio/math.h>
+#include <cmath>
 #include <deque>
 #include <stdexcept>
 
@@ -295,7 +296,7 @@ interp_resampler_pfb_no_mf_cc::~interp_resampler_pfb_no_mf_cc()
 gr_complex interp_resampler_pfb_no_mf_cc::interpolate(const gr_complex input[],
                                                       float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_no_mf_cc: mu is not "
@@ -307,7 +308,7 @@ gr_complex interp_resampler_pfb_no_mf_cc::interpolate(const gr_complex input[],
 gr_complex interp_resampler_pfb_no_mf_cc::differentiate(const gr_complex input[],
                                                         float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_no_mf_cc: mu is not "
@@ -379,7 +380,7 @@ interp_resampler_pfb_no_mf_ff::~interp_resampler_pfb_no_mf_ff()
 
 float interp_resampler_pfb_no_mf_ff::interpolate(const float input[], float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_no_mf_ff: mu is not "
@@ -390,7 +391,7 @@ float interp_resampler_pfb_no_mf_ff::interpolate(const float input[], float mu) 
 
 float interp_resampler_pfb_no_mf_ff::differentiate(const float input[], float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_no_mf_ff: mu is not "
@@ -532,7 +533,7 @@ interp_resampler_pfb_mf_ccf::~interp_resampler_pfb_mf_ccf()
 gr_complex interp_resampler_pfb_mf_ccf::interpolate(const gr_complex input[],
                                                     float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_mf_ccf: mu is not "
@@ -544,7 +545,7 @@ gr_complex interp_resampler_pfb_mf_ccf::interpolate(const gr_complex input[],
 gr_complex interp_resampler_pfb_mf_ccf::differentiate(const gr_complex input[],
                                                       float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_mf_ccf: mu is not "
@@ -685,7 +686,7 @@ interp_resampler_pfb_mf_fff::~interp_resampler_pfb_mf_fff()
 
 float interp_resampler_pfb_mf_fff::interpolate(const float input[], float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_mf_fff: mu is not "
@@ -696,7 +697,7 @@ float interp_resampler_pfb_mf_fff::interpolate(const float input[], float mu) co
 
 float interp_resampler_pfb_mf_fff::differentiate(const float input[], float mu) const
 {
-    int arm = static_cast<int>(rint(mu * d_nfilters));
+    int arm = static_cast<int>(std::rint(mu * d_nfilters));
 
     if (arm < 0 || arm > d_nfilters)
         throw std::runtime_error("interp_resampler_pfb_mf_fff: mu is not "

--- a/gr-digital/lib/lms_dd_equalizer_cc_impl.cc
+++ b/gr-digital/lib/lms_dd_equalizer_cc_impl.cc
@@ -29,6 +29,8 @@
 #include <gnuradio/misc.h>
 #include <volk/volk.h>
 
+#include <utility>
+
 namespace gr {
 namespace digital {
 
@@ -38,7 +40,7 @@ lms_dd_equalizer_cc::sptr
 lms_dd_equalizer_cc::make(int num_taps, float mu, int sps, constellation_sptr cnst)
 {
     return gnuradio::get_initial_sptr(
-        new lms_dd_equalizer_cc_impl(num_taps, mu, sps, cnst));
+        new lms_dd_equalizer_cc_impl(num_taps, mu, sps, std::move(cnst)));
 }
 
 lms_dd_equalizer_cc_impl::lms_dd_equalizer_cc_impl(int num_taps,
@@ -52,7 +54,7 @@ lms_dd_equalizer_cc_impl::lms_dd_equalizer_cc_impl(int num_taps,
       fir_filter_ccc(sps, std::vector<gr_complex>(num_taps, gr_complex(0, 0))),
       d_new_taps(num_taps, gr_complex(0, 0)),
       d_updated(false),
-      d_cnst(cnst)
+      d_cnst(std::move(cnst))
 {
     set_gain(mu);
     if (num_taps > 0)

--- a/gr-digital/lib/modulate_vector.cc
+++ b/gr-digital/lib/modulate_vector.cc
@@ -48,9 +48,9 @@
 
 namespace gr {
 namespace digital {
-std::vector<gr_complex> modulate_vector_bc(basic_block_sptr modulator,
-                                           std::vector<uint8_t> data,
-                                           std::vector<float> taps)
+std::vector<gr_complex> modulate_vector_bc(const basic_block_sptr& modulator,
+                                           const std::vector<uint8_t>& data,
+                                           const std::vector<float>& taps)
 {
     blocks::vector_source_b::sptr vector_src = blocks::vector_source_b::make(data);
     filter::fir_filter_ccf::sptr filter = filter::fir_filter_ccf::make(1, taps);

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -29,6 +29,8 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 
+#include <cmath>
+
 namespace gr {
 namespace digital {
 
@@ -204,8 +206,8 @@ int msk_timing_recovery_cc_impl::general_work(int noutput_items,
 
         // update interpolator twice per symbol
         d_mu += d_omega;
-        iidx += (int)floor(d_mu);
-        d_mu -= floor(d_mu);
+        iidx += (int)std::floor(d_mu);
+        d_mu -= std::floor(d_mu);
     }
 
     consume_each(iidx);

--- a/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 
+#include <utility>
+
 static const pmt::pmt_t CARR_OFFSET_KEY = pmt::mp("ofdm_sync_carr_offset");
 static const pmt::pmt_t CHAN_TAPS_KEY = pmt::mp("ofdm_sync_chan_taps");
 
@@ -42,11 +44,11 @@ ofdm_frame_equalizer_vcvc::make(ofdm_equalizer_base::sptr equalizer,
                                 int fixed_frame_len)
 {
     return gnuradio::get_initial_sptr(new ofdm_frame_equalizer_vcvc_impl(
-        equalizer, cp_len, tsb_key, propagate_channel_state, fixed_frame_len));
+        std::move(equalizer), cp_len, tsb_key, propagate_channel_state, fixed_frame_len));
 }
 
 ofdm_frame_equalizer_vcvc_impl::ofdm_frame_equalizer_vcvc_impl(
-    ofdm_equalizer_base::sptr equalizer,
+    const ofdm_equalizer_base::sptr& equalizer,
     int cp_len,
     const std::string& tsb_key,
     bool propagate_channel_state,

--- a/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.h
+++ b/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.h
@@ -42,7 +42,7 @@ protected:
                            gr_vector_int& n_input_items_reqd);
 
 public:
-    ofdm_frame_equalizer_vcvc_impl(ofdm_equalizer_base::sptr equalizer,
+    ofdm_frame_equalizer_vcvc_impl(const ofdm_equalizer_base::sptr& equalizer,
                                    int cp_len,
                                    const std::string& len_tag_key,
                                    bool propagate_channel_state,

--- a/gr-digital/lib/packet_sink_impl.cc
+++ b/gr-digital/lib/packet_sink_impl.cc
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <cstdio>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace digital {
@@ -79,7 +80,7 @@ packet_sink::sptr packet_sink::make(const std::vector<unsigned char>& sync_vecto
                                     int threshold)
 {
     return gnuradio::get_initial_sptr(
-        new packet_sink_impl(sync_vector, target_queue, threshold));
+        new packet_sink_impl(sync_vector, std::move(target_queue), threshold));
 }
 
 packet_sink_impl::packet_sink_impl(const std::vector<unsigned char>& sync_vector,
@@ -88,7 +89,7 @@ packet_sink_impl::packet_sink_impl(const std::vector<unsigned char>& sync_vector
     : sync_block("packet_sink",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(0, 0, 0)),
-      d_target_queue(target_queue),
+      d_target_queue(std::move(target_queue)),
       d_threshold(threshold == -1 ? DEFAULT_THRESHOLD : threshold)
 {
     d_sync_vector = 0;

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -335,6 +335,7 @@ std::vector<std::vector<float>> pfb_clock_sync_ccf_impl::diff_taps() const
 std::vector<float> pfb_clock_sync_ccf_impl::channel_taps(int channel) const
 {
     std::vector<float> taps;
+    taps.reserve(d_taps_per_filter);
     for (int i = 0; i < d_taps_per_filter; i++) {
         taps.push_back(d_taps[channel][i]);
     }
@@ -344,6 +345,7 @@ std::vector<float> pfb_clock_sync_ccf_impl::channel_taps(int channel) const
 std::vector<float> pfb_clock_sync_ccf_impl::diff_channel_taps(int channel) const
 {
     std::vector<float> taps;
+    taps.reserve(d_taps_per_filter);
     for (int i = 0; i < d_taps_per_filter; i++) {
         taps.push_back(d_dtaps[channel][i]);
     }

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -85,9 +85,9 @@ pfb_clock_sync_fff_impl::pfb_clock_sync_fff_impl(double sps,
     // set it here to the fractional difference based on the initial phaes
     d_k = init_phase;
     d_rate = (sps - floor(sps)) * (double)d_nfilters;
-    d_rate_i = (int)floor(d_rate);
+    d_rate_i = (int)std::floor(d_rate);
     d_rate_f = d_rate - (float)d_rate_i;
-    d_filtnum = (int)floor(d_k);
+    d_filtnum = (int)std::floor(d_k);
 
     d_filters = std::vector<kernel::fir_filter_fff*>(d_nfilters);
     d_diff_filters = std::vector<kernel::fir_filter_fff*>(d_nfilters);
@@ -320,6 +320,7 @@ std::vector<std::vector<float>> pfb_clock_sync_fff_impl::diff_taps() const
 std::vector<float> pfb_clock_sync_fff_impl::channel_taps(int channel) const
 {
     std::vector<float> taps;
+    taps.reserve(d_taps_per_filter);
     for (int i = 0; i < d_taps_per_filter; i++) {
         taps.push_back(d_taps[channel][i]);
     }
@@ -329,6 +330,7 @@ std::vector<float> pfb_clock_sync_fff_impl::channel_taps(int channel) const
 std::vector<float> pfb_clock_sync_fff_impl::diff_channel_taps(int channel) const
 {
     std::vector<float> taps;
+    taps.reserve(d_taps_per_filter);
     for (int i = 0; i < d_taps_per_filter; i++) {
         taps.push_back(d_dtaps[channel][i]);
     }
@@ -364,7 +366,7 @@ int pfb_clock_sync_fff_impl::general_work(int noutput_items,
     // produce output as long as we can and there are enough input samples
     while (i < noutput_items) {
         while (d_out_idx < d_osps) {
-            d_filtnum = (int)floor(d_k);
+            d_filtnum = (int)std::floor(d_k);
 
             // Keep the current filter number in [0, d_nfilters]
             // If we've run beyond the last filter, wrap around and go to next sample

--- a/gr-digital/lib/protocol_formatter_async_impl.cc
+++ b/gr-digital/lib/protocol_formatter_async_impl.cc
@@ -60,7 +60,7 @@ protocol_formatter_async_impl::protocol_formatter_async_impl(
 
 protocol_formatter_async_impl::~protocol_formatter_async_impl() {}
 
-void protocol_formatter_async_impl::append(pmt::pmt_t msg)
+void protocol_formatter_async_impl::append(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));

--- a/gr-digital/lib/protocol_formatter_async_impl.h
+++ b/gr-digital/lib/protocol_formatter_async_impl.h
@@ -36,7 +36,7 @@ private:
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_hdr_port, d_pld_port;
 
-    void append(pmt::pmt_t msg);
+    void append(const pmt::pmt_t& msg);
 
 public:
     protocol_formatter_async_impl(const header_format_base::sptr& format);

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -29,6 +29,7 @@
 #include <gnuradio/math.h>
 #include <boost/math/common_factor.hpp>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace digital {
@@ -52,7 +53,7 @@ symbol_sync_cc::sptr symbol_sync_cc::make(enum ted_type detector_type,
                                                               ted_gain,
                                                               max_deviation,
                                                               osps,
-                                                              slicer,
+                                                              std::move(slicer),
                                                               interp_type,
                                                               n_filters,
                                                               taps));
@@ -105,7 +106,7 @@ symbol_sync_cc_impl::symbol_sync_cc_impl(enum ted_type detector_type,
         throw std::out_of_range("output samples per symbol must be > 0");
 
     // Timing Error Detector
-    d_ted = timing_error_detector::make(detector_type, slicer);
+    d_ted = timing_error_detector::make(detector_type, std::move(slicer));
     if (d_ted == NULL)
         throw std::runtime_error("unable to create timing_error_detector");
 

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -29,6 +29,7 @@
 #include <gnuradio/math.h>
 #include <boost/math/common_factor.hpp>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace digital {
@@ -52,7 +53,7 @@ symbol_sync_ff::sptr symbol_sync_ff::make(enum ted_type detector_type,
                                                               ted_gain,
                                                               max_deviation,
                                                               osps,
-                                                              slicer,
+                                                              std::move(slicer),
                                                               interp_type,
                                                               n_filters,
                                                               taps));
@@ -105,7 +106,7 @@ symbol_sync_ff_impl::symbol_sync_ff_impl(enum ted_type detector_type,
         throw std::out_of_range("output samples per symbol must be > 0");
 
     // Timing Error Detector
-    d_ted = timing_error_detector::make(detector_type, slicer);
+    d_ted = timing_error_detector::make(detector_type, std::move(slicer));
     if (d_ted == NULL)
         throw std::runtime_error("unable to create timing_error_detector");
 

--- a/gr-digital/lib/timing_error_detector.cc
+++ b/gr-digital/lib/timing_error_detector.cc
@@ -27,12 +27,13 @@
 #include "timing_error_detector.h"
 #include <gnuradio/math.h>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace digital {
 
-timing_error_detector* timing_error_detector::make(enum ted_type type,
-                                                   constellation_sptr constellation)
+timing_error_detector*
+timing_error_detector::make(enum ted_type type, const constellation_sptr& constellation)
 {
     timing_error_detector* ret = NULL;
     switch (type) {
@@ -77,7 +78,7 @@ timing_error_detector::timing_error_detector(enum ted_type type,
                                              bool needs_lookahead,
                                              bool needs_derivative,
                                              constellation_sptr constellation)
-    : d_constellation(constellation),
+    : d_constellation(std::move(constellation)),
       d_error(0.0f),
       d_prev_error(0.0f),
       d_inputs_per_symbol(inputs_per_symbol),

--- a/gr-digital/lib/timing_error_detector.h
+++ b/gr-digital/lib/timing_error_detector.h
@@ -27,6 +27,7 @@
 #include <gnuradio/digital/timing_error_detector_type.h>
 #include <gnuradio/gr_complex.h>
 #include <deque>
+#include <utility>
 
 namespace gr {
 namespace digital {
@@ -63,7 +64,8 @@ public:
      *                      algorithms
      */
     static timing_error_detector*
-    make(enum ted_type type, constellation_sptr constellation = constellation_sptr());
+    make(enum ted_type type,
+         const constellation_sptr& constellation = constellation_sptr());
 
     virtual ~timing_error_detector(){};
 
@@ -241,7 +243,8 @@ public:
      * \param constellation A constellation to be used as a decision slicer
      */
     ted_mueller_and_muller(constellation_sptr constellation)
-        : timing_error_detector(TED_MUELLER_AND_MULLER, 1, 2, false, false, constellation)
+        : timing_error_detector(
+              TED_MUELLER_AND_MULLER, 1, 2, false, false, std::move(constellation))
     {
     }
     ~ted_mueller_and_muller(){};
@@ -279,7 +282,7 @@ public:
      */
     ted_mod_mueller_and_muller(constellation_sptr constellation)
         : timing_error_detector(
-              TED_MOD_MUELLER_AND_MULLER, 1, 3, false, false, constellation)
+              TED_MOD_MUELLER_AND_MULLER, 1, 3, false, false, std::move(constellation))
     {
     }
     ~ted_mod_mueller_and_muller(){};
@@ -306,7 +309,8 @@ public:
      * \param constellation A constellation to be used as a decision slicer
      */
     ted_zero_crossing(constellation_sptr constellation)
-        : timing_error_detector(TED_ZERO_CROSSING, 2, 3, false, false, constellation)
+        : timing_error_detector(
+              TED_ZERO_CROSSING, 2, 3, false, false, std::move(constellation))
     {
     }
     ~ted_zero_crossing(){};

--- a/gr-dtv/lib/dvbt2/dvbt2_cellinterleaver_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_cellinterleaver_cc_impl.cc
@@ -25,6 +25,8 @@
 #include "dvbt2_cellinterleaver_cc_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <cmath>
+
 namespace gr {
 namespace dtv {
 
@@ -170,8 +172,8 @@ dvbt2_cellinterleaver_cc_impl::dvbt2_cellinterleaver_cc_impl(
         numBigTIBlocks = 0;
         numSmallTIBlocks = fecblocks;
     } else {
-        FECBlocksPerSmallTIBlock = floor(((float)fecblocks) / ((float)tiblocks));
-        FECBlocksPerBigTIBlock = ceil(((float)fecblocks) / ((float)tiblocks));
+        FECBlocksPerSmallTIBlock = std::floor(((float)fecblocks) / ((float)tiblocks));
+        FECBlocksPerBigTIBlock = std::ceil(((float)fecblocks) / ((float)tiblocks));
         numBigTIBlocks = fecblocks % tiblocks;
         numSmallTIBlocks = tiblocks - numBigTIBlocks;
     }

--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -25,6 +25,7 @@
 #include "dvbt2_framemapper_cc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <algorithm>
+#include <cmath>
 
 namespace gr {
 namespace dtv {
@@ -872,10 +873,10 @@ dvbt2_framemapper_cc_impl::dvbt2_framemapper_cc_impl(
     N_punc_temp = (6 * (KBCH_1_2 - KSIG_POST)) / 5;
     N_post_temp = KSIG_POST + NBCH_PARITY + 9000 - N_punc_temp;
     if (N_P2 == 1) {
-        N_post = ceil((float)N_post_temp / (2 * (float)eta_mod)) * 2 * eta_mod;
+        N_post = std::ceil((float)N_post_temp / (2 * (float)eta_mod)) * 2 * eta_mod;
     } else {
-        N_post =
-            ceil((float)N_post_temp / ((float)eta_mod * (float)N_P2)) * eta_mod * N_P2;
+        N_post = std::ceil((float)N_post_temp / ((float)eta_mod * (float)N_P2)) *
+                 eta_mod * N_P2;
     }
     N_punc = N_punc_temp - (N_post - N_post_temp);
     l1preinit->l1_post_size = N_post / eta_mod;

--- a/gr-fec/include/gnuradio/fec/awgn_bp.h
+++ b/gr-fec/include/gnuradio/fec/awgn_bp.h
@@ -50,7 +50,7 @@ public:
     awgn_bp(){};
 
     //! A constructor for given GF2Mat and sigma
-    awgn_bp(const GF2Mat X, float sgma);
+    awgn_bp(const GF2Mat& X, float sgma);
 
     //! A constructor for given alist and sigma
     awgn_bp(alist _list, float sgma);
@@ -125,7 +125,7 @@ public:
      * \param niterations The number of message passing iterations
      *        done to decode this codeword.
      */
-    std::vector<char> decode(std::vector<float> rx_word, int* niterations);
+    std::vector<char> decode(const std::vector<float>& rx_word, int* niterations);
 
 private:
     //! The number of check nodes in the tanner-graph

--- a/gr-fec/include/gnuradio/fec/cldpc.h
+++ b/gr-fec/include/gnuradio/fec/cldpc.h
@@ -39,10 +39,10 @@ public:
     cldpc(){};
 
     //! Constructs the LDPC class from given GF2mat X
-    cldpc(const GF2Mat X);
+    cldpc(const GF2Mat& X);
 
     //! Constructs the class from the given alist _list
-    cldpc(const alist _list);
+    cldpc(const alist& _list);
 
     //! Prints the variable permute
     void print_permute();
@@ -78,13 +78,13 @@ public:
     int get_N();
 
     //! Returns the syndrome for a given vector "in"
-    std::vector<char> syndrome(const std::vector<char> in);
+    std::vector<char> syndrome(const std::vector<char>& in);
 
     //! Returns true if "in" is a codeword, else false
-    bool is_codeword(const std::vector<char> in);
+    bool is_codeword(const std::vector<char>& in);
 
     //! Set the variable _list
-    void set_alist(const alist _list);
+    void set_alist(const alist& _list);
 
     //! Obtain systematic bits from "in"
     std::vector<char> get_systematic_bits(std::vector<char> in);

--- a/gr-fec/include/gnuradio/fec/fec_mtrx.h
+++ b/gr-fec/include/gnuradio/fec/fec_mtrx.h
@@ -64,8 +64,8 @@ typedef boost::shared_ptr<fec_mtrx> fec_mtrx_sptr;
  *                 format is described at:
  *                 http://www.inference.phy.cam.ac.uk/mackay/codes/alist.html
  */
-FEC_API matrix_sptr read_matrix_from_file(const std::string filename);
-FEC_API void write_matrix_to_file(const std::string filename, matrix_sptr M);
+FEC_API matrix_sptr read_matrix_from_file(const std::string& filename);
+FEC_API void write_matrix_to_file(const std::string& filename, const matrix_sptr& M);
 
 /*!
  * \brief Takes a parity check matrix (H) and returns the
@@ -80,7 +80,7 @@ FEC_API void write_matrix_to_file(const std::string filename, matrix_sptr M);
  *              using read_matrix_from_file with a given alist
  *              file format.
  */
-FEC_API matrix_sptr generate_G_transpose(matrix_sptr H_obj);
+FEC_API matrix_sptr generate_G_transpose(const matrix_sptr& H_obj);
 
 /*!
  * \brief Takes a parity check matrix (H) and returns the
@@ -95,7 +95,7 @@ FEC_API matrix_sptr generate_G_transpose(matrix_sptr H_obj);
  *              using read_matrix_from_file with a given alist
  *              file format.
  */
-FEC_API matrix_sptr generate_G(matrix_sptr H_obj);
+FEC_API matrix_sptr generate_G(const matrix_sptr& H_obj);
 
 /*!
  * \brief Takes a generator matrix (G) and returns the
@@ -105,7 +105,7 @@ FEC_API matrix_sptr generate_G(matrix_sptr H_obj);
  *              using read_matrix_from_file with a given alist
  *              file format.
  */
-FEC_API matrix_sptr generate_H(matrix_sptr G_obj);
+FEC_API matrix_sptr generate_H(const matrix_sptr& G_obj);
 
 /*!
  * \brief Takes a matrix and prints it to screen.
@@ -115,7 +115,7 @@ FEC_API matrix_sptr generate_H(matrix_sptr G_obj);
  *        copy-and-pasted directly into a numpy.matrix(~) call
  *        in Python.
  */
-FEC_API void print_matrix(const matrix_sptr M, bool numpy = false);
+FEC_API void print_matrix(const matrix_sptr& M, bool numpy = false);
 
 /*!
  * \brief Base class for FEC matrix objects.

--- a/gr-fec/include/gnuradio/fec/generic_decoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_decoder.h
@@ -222,28 +222,29 @@ public:
 };
 
 /*! see generic_decoder::get_output_size() */
-FEC_API int get_decoder_output_size(generic_decoder::sptr my_decoder);
+FEC_API int get_decoder_output_size(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_input_size() */
-FEC_API int get_decoder_input_size(generic_decoder::sptr my_decoder);
+FEC_API int get_decoder_input_size(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_shift() */
-FEC_API float get_shift(generic_decoder::sptr my_decoder);
+FEC_API float get_shift(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_history() */
-FEC_API int get_history(generic_decoder::sptr my_decoder);
+FEC_API int get_history(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_input_item_size() */
-FEC_API int get_decoder_input_item_size(generic_decoder::sptr my_decoder);
+FEC_API int get_decoder_input_item_size(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_output_item_size() */
-FEC_API int get_decoder_output_item_size(generic_decoder::sptr my_decoder);
+FEC_API int get_decoder_output_item_size(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_input_conversion() */
-FEC_API const char* get_decoder_input_conversion(generic_decoder::sptr my_decoder);
+FEC_API const char* get_decoder_input_conversion(const generic_decoder::sptr& my_decoder);
 
 /*! see generic_decoder::get_output_conversion() */
-FEC_API const char* get_decoder_output_conversion(generic_decoder::sptr my_decoder);
+FEC_API const char*
+get_decoder_output_conversion(const generic_decoder::sptr& my_decoder);
 
 } /* namespace fec */
 } /* namespace gr */

--- a/gr-fec/include/gnuradio/fec/generic_encoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_encoder.h
@@ -134,16 +134,17 @@ public:
 };
 
 /*! see generic_encoder::get_output_size() */
-FEC_API int get_encoder_output_size(generic_encoder::sptr my_encoder);
+FEC_API int get_encoder_output_size(const generic_encoder::sptr& my_encoder);
 
 /*! see generic_encoder::get_input_size() */
-FEC_API int get_encoder_input_size(generic_encoder::sptr my_encoder);
+FEC_API int get_encoder_input_size(const generic_encoder::sptr& my_encoder);
 
 /*! see generic_encoder::get_input_conversion() */
-FEC_API const char* get_encoder_input_conversion(generic_encoder::sptr my_encoder);
+FEC_API const char* get_encoder_input_conversion(const generic_encoder::sptr& my_encoder);
 
 /*! see generic_encoder::get_output_conversion() */
-FEC_API const char* get_encoder_output_conversion(generic_encoder::sptr my_encoder);
+FEC_API const char*
+get_encoder_output_conversion(const generic_encoder::sptr& my_encoder);
 
 
 } /* namespace fec */

--- a/gr-fec/include/gnuradio/fec/gf2vec.h
+++ b/gr-fec/include/gnuradio/fec/gf2vec.h
@@ -48,7 +48,7 @@ public:
     int size();
 
     //! Resets the vector with the given input
-    void set_vec(const std::vector<char>);
+    void set_vec(const std::vector<char>&);
 
     //! Access the ith element
     char& operator[](int i);

--- a/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
@@ -68,7 +68,7 @@ public:
      *                 format is described at:
      *                 http://www.inference.phy.cam.ac.uk/mackay/codes/alist.html
      */
-    static sptr make(const std::string filename);
+    static sptr make(const std::string& filename);
 
     //! Encode \p inbuffer with LDPC H matrix into \p outbuffer.
     virtual void encode(unsigned char* outbuffer,

--- a/gr-fec/include/gnuradio/fec/ldpc_H_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_H_matrix.h
@@ -64,7 +64,7 @@ public:
      *            algorithm. It is equal to the number of rows in
      *            submatrices E, C and D.
      */
-    static sptr make(const std::string filename, unsigned int gap);
+    static sptr make(const std::string& filename, unsigned int gap);
 
     //! Encode \p inbuffer with LDPC H matrix into \p outbuffer.
     virtual void encode(unsigned char* outbuffer,

--- a/gr-fec/include/gnuradio/fec/ldpc_bit_flip_decoder.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_bit_flip_decoder.h
@@ -65,7 +65,7 @@ public:
      *        testing. May be increased for possibly better
      *        performance, but may slow things down.
      */
-    static generic_decoder::sptr make(const fec_mtrx_sptr mtrx_obj,
+    static generic_decoder::sptr make(const fec_mtrx_sptr& mtrx_obj,
                                       unsigned int max_iter = 100);
 
     /*!

--- a/gr-fec/include/gnuradio/fec/ldpc_gen_mtrx_encoder.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_gen_mtrx_encoder.h
@@ -53,7 +53,7 @@ public:
      * \param G_obj The ldpc_G_matrix object to use for
      *              encoding.
      */
-    static generic_encoder::sptr make(const code::ldpc_G_matrix::sptr G_obj);
+    static generic_encoder::sptr make(const code::ldpc_G_matrix::sptr& G_obj);
 
     /*!
      * \brief  Sets the uncoded frame size to \p frame_size.

--- a/gr-fec/include/gnuradio/fec/ldpc_par_mtrx_encoder.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_par_mtrx_encoder.h
@@ -37,7 +37,7 @@ class FEC_API ldpc_par_mtrx_encoder : virtual public generic_encoder
 {
 public:
     static generic_encoder::sptr make(std::string alist_file, unsigned int gap = 0);
-    static generic_encoder::sptr make_H(const code::ldpc_H_matrix::sptr H_obj);
+    static generic_encoder::sptr make_H(const code::ldpc_H_matrix::sptr& H_obj);
 
     virtual double rate() = 0;
     virtual bool set_frame_size(unsigned int frame_size) = 0;

--- a/gr-fec/include/gnuradio/fec/tpc_common.h
+++ b/gr-fec/include/gnuradio/fec/tpc_common.h
@@ -41,7 +41,7 @@ public:
                             std::vector<std::vector<int>>& nextStates);
     static void
     precomputeStateTransitionMatrix_RSCPoly(int numStates,
-                                            std::vector<int> g,
+                                            const std::vector<int>& g,
                                             int KK,
                                             int nn,
                                             std::vector<std::vector<int>>& output,

--- a/gr-fec/include/gnuradio/fec/tpc_decoder.h
+++ b/gr-fec/include/gnuradio/fec/tpc_decoder.h
@@ -139,7 +139,7 @@ class FEC_API tpc_decoder : public generic_decoder
 
     // Computes the branch metric used for decoding, returning a metric between the
     // hypothetical symbol and received vector
-    float gamma(const std::vector<float> rec_array, const int symbol);
+    float gamma(const std::vector<float>& rec_array, const int symbol);
 
     float (tpc_decoder::*max_star)(const float, const float);
 

--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -29,6 +29,8 @@
 #include <stdio.h>
 #include <volk/volk.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -36,7 +38,7 @@ async_decoder::sptr
 async_decoder::make(generic_decoder::sptr my_decoder, bool packed, bool rev_pack, int mtu)
 {
     return gnuradio::get_initial_sptr(
-        new async_decoder_impl(my_decoder, packed, rev_pack, mtu));
+        new async_decoder_impl(std::move(my_decoder), packed, rev_pack, mtu));
 }
 
 async_decoder_impl::async_decoder_impl(generic_decoder::sptr my_decoder,
@@ -48,7 +50,7 @@ async_decoder_impl::async_decoder_impl(generic_decoder::sptr my_decoder,
     d_in_port = pmt::mp("in");
     d_out_port = pmt::mp("out");
 
-    d_decoder = my_decoder;
+    d_decoder = std::move(my_decoder);
 
     if (d_decoder->get_history() > 0) {
         throw std::runtime_error("async_decoder deploment does not support decoders with "
@@ -101,7 +103,7 @@ async_decoder_impl::~async_decoder_impl()
     }
 }
 
-void async_decoder_impl::decode_unpacked(pmt::pmt_t msg)
+void async_decoder_impl::decode_unpacked(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));
@@ -170,7 +172,7 @@ void async_decoder_impl::decode_unpacked(pmt::pmt_t msg)
     message_port_pub(d_out_port, pmt::cons(meta, outvec));
 }
 
-void async_decoder_impl::decode_packed(pmt::pmt_t msg)
+void async_decoder_impl::decode_packed(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));

--- a/gr-fec/lib/async_decoder_impl.h
+++ b/gr-fec/lib/async_decoder_impl.h
@@ -48,8 +48,8 @@ private:
     int8_t* d_tmp_u8;
     uint8_t* d_bits_out;
 
-    void decode_packed(pmt::pmt_t msg);
-    void decode_unpacked(pmt::pmt_t msg);
+    void decode_packed(const pmt::pmt_t& msg);
+    void decode_unpacked(const pmt::pmt_t& msg);
 
 public:
     async_decoder_impl(generic_decoder::sptr my_decoder,

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -29,6 +29,8 @@
 #include <stdio.h>
 #include <volk/volk.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -39,7 +41,7 @@ async_encoder::sptr async_encoder::make(generic_encoder::sptr my_encoder,
                                         int mtu)
 {
     return gnuradio::get_initial_sptr(
-        new async_encoder_impl(my_encoder, packed, rev_unpack, rev_pack, mtu));
+        new async_encoder_impl(std::move(my_encoder), packed, rev_unpack, rev_pack, mtu));
 }
 
 async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
@@ -52,7 +54,7 @@ async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
     d_in_port = pmt::mp("in");
     d_out_port = pmt::mp("out");
 
-    d_encoder = my_encoder;
+    d_encoder = std::move(my_encoder);
 
     d_packed = packed;
     d_rev_unpack = rev_unpack;
@@ -103,7 +105,7 @@ async_encoder_impl::~async_encoder_impl()
     }
 }
 
-void async_encoder_impl::encode_unpacked(pmt::pmt_t msg)
+void async_encoder_impl::encode_unpacked(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));
@@ -153,7 +155,7 @@ void async_encoder_impl::encode_unpacked(pmt::pmt_t msg)
     message_port_pub(d_out_port, msg_pair);
 }
 
-void async_encoder_impl::encode_packed(pmt::pmt_t msg)
+void async_encoder_impl::encode_packed(const pmt::pmt_t& msg)
 {
     // extract input pdu
     pmt::pmt_t meta(pmt::car(msg));

--- a/gr-fec/lib/async_encoder_impl.h
+++ b/gr-fec/lib/async_encoder_impl.h
@@ -49,8 +49,8 @@ private:
     uint8_t* d_bits_in;
     uint8_t* d_bits_out;
 
-    void encode_packed(pmt::pmt_t msg);
-    void encode_unpacked(pmt::pmt_t msg);
+    void encode_packed(const pmt::pmt_t& msg);
+    void encode_unpacked(const pmt::pmt_t& msg);
 
 public:
     async_encoder_impl(generic_encoder::sptr my_encoder,

--- a/gr-fec/lib/awgn_bp.cc
+++ b/gr-fec/lib/awgn_bp.cc
@@ -22,7 +22,11 @@
 
 #include <gnuradio/fec/awgn_bp.h>
 
-awgn_bp::awgn_bp(const GF2Mat X, float sgma)
+#include <cmath>
+
+#include <utility>
+
+awgn_bp::awgn_bp(const GF2Mat& X, float sgma)
 {
     H = X;
     M = H.get_M();
@@ -90,7 +94,7 @@ void awgn_bp::rx_lr_calc(std::vector<float> codeword)
     float y;
     for (int i = 0; i < N; i++) {
         y = codeword[i];
-        rx_lr[i] = exp((-1 * y) / (2 * sigma * sigma));
+        rx_lr[i] = std::exp((-1 * y) / (2 * sigma * sigma));
     }
 }
 
@@ -177,7 +181,7 @@ std::vector<char> awgn_bp::get_syndrome(std::vector<char> codeword)
     std::vector<char> synd;
     synd.resize(N - K);
     GF2Vec in_bvec;
-    in_bvec.set_vec(codeword);
+    in_bvec.set_vec(std::move(codeword));
     for (int i = 0; i < N - K; i++) {
         synd[i] = H[i] * in_bvec;
     }
@@ -199,7 +203,7 @@ std::vector<char> awgn_bp::get_syndrome()
 bool awgn_bp::is_codeword(std::vector<char> codeword)
 {
     std::vector<char> synd;
-    synd = get_syndrome(codeword);
+    synd = get_syndrome(std::move(codeword));
     bool is_code;
     is_code = true;
     for (int i = 0; i < N - K; i++) {
@@ -228,7 +232,7 @@ void awgn_bp::set_max_iterations(int k) { max_iterations = k; }
 
 int awgn_bp::get_max_iterations() { return max_iterations; }
 
-std::vector<char> awgn_bp::decode(std::vector<float> rx_word, int* niteration)
+std::vector<char> awgn_bp::decode(const std::vector<float>& rx_word, int* niteration)
 {
     *niteration = 0;
     compute_init_estimate(rx_word);

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -30,6 +30,7 @@
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 namespace gr {
@@ -46,7 +47,7 @@ generic_decoder::sptr cc_decoder::make(int frame_size,
                                        bool padded)
 {
     return generic_decoder::sptr(new cc_decoder_impl(
-        frame_size, k, rate, polys, start_state, end_state, mode, padded));
+        frame_size, k, rate, std::move(polys), start_state, end_state, mode, padded));
 }
 
 cc_decoder_impl::cc_decoder_impl(int frame_size,
@@ -60,7 +61,7 @@ cc_decoder_impl::cc_decoder_impl(int frame_size,
     : generic_decoder("cc_decoder"),
       d_k(k),
       d_rate(rate),
-      d_polys(polys),
+      d_polys(std::move(polys)),
       d_mode(mode),
       d_padding(0),
       d_start_state_chaining(start_state),

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -33,6 +33,7 @@
 #include <volk/volk_typedefs.h>
 #include <boost/assign/list_of.hpp>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 namespace gr {
@@ -47,8 +48,8 @@ generic_encoder::sptr cc_encoder::make(int frame_size,
                                        cc_mode_t mode,
                                        bool padded)
 {
-    return generic_encoder::sptr(
-        new cc_encoder_impl(frame_size, k, rate, polys, start_state, mode, padded));
+    return generic_encoder::sptr(new cc_encoder_impl(
+        frame_size, k, rate, std::move(polys), start_state, mode, padded));
 }
 
 cc_encoder_impl::cc_encoder_impl(int frame_size,
@@ -61,7 +62,7 @@ cc_encoder_impl::cc_encoder_impl(int frame_size,
     : generic_encoder("cc_encoder"),
       d_rate(rate),
       d_k(k),
-      d_polys(polys),
+      d_polys(std::move(polys)),
       d_start_state(start_state),
       d_mode(mode),
       d_padding(0)

--- a/gr-fec/lib/cldpc.cc
+++ b/gr-fec/lib/cldpc.cc
@@ -23,7 +23,7 @@
 #include <gnuradio/fec/cldpc.h>
 #include <stdexcept>
 
-cldpc::cldpc(const GF2Mat X)
+cldpc::cldpc(const GF2Mat& X)
 {
     H = X;
     M = H.get_M();
@@ -32,7 +32,7 @@ cldpc::cldpc(const GF2Mat X)
     K = N - rank_H;
 }
 
-cldpc::cldpc(const alist _list)
+cldpc::cldpc(const alist& _list)
 {
     H = GF2Mat(_list);
     M = H.get_M();
@@ -41,7 +41,7 @@ cldpc::cldpc(const alist _list)
     K = N - rank_H;
 }
 
-void cldpc::set_alist(const alist _list)
+void cldpc::set_alist(const alist& _list)
 {
     H = GF2Mat(_list);
     M = H.get_M();
@@ -70,7 +70,7 @@ void cldpc::print_permute()
     std::cout << "\n";
 }
 
-std::vector<char> cldpc::syndrome(const std::vector<char> in)
+std::vector<char> cldpc::syndrome(const std::vector<char>& in)
 {
     std::vector<char> synd;
     synd.resize(rank_H);
@@ -82,7 +82,7 @@ std::vector<char> cldpc::syndrome(const std::vector<char> in)
     return synd;
 }
 
-bool cldpc::is_codeword(const std::vector<char> in)
+bool cldpc::is_codeword(const std::vector<char>& in)
 {
     std::vector<char> synd;
     synd = syndrome(in);

--- a/gr-fec/lib/conv_bit_corr_bb_impl.cc
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.cc
@@ -29,6 +29,8 @@
 #include <gnuradio/messages/msg_passing.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -39,8 +41,8 @@ conv_bit_corr_bb::sptr conv_bit_corr_bb::make(std::vector<unsigned long long> co
                                               int flush,
                                               float thresh)
 {
-    return gnuradio::get_initial_sptr(
-        new conv_bit_corr_bb_impl(correlator, corr_sym, corr_len, cut, flush, thresh));
+    return gnuradio::get_initial_sptr(new conv_bit_corr_bb_impl(
+        std::move(correlator), corr_sym, corr_len, cut, flush, thresh));
 }
 
 conv_bit_corr_bb_impl::conv_bit_corr_bb_impl(std::vector<unsigned long long> correlator,
@@ -116,7 +118,7 @@ conv_bit_corr_bb_impl::conv_bit_corr_bb_impl(std::vector<unsigned long long> cor
 
 conv_bit_corr_bb_impl::~conv_bit_corr_bb_impl() {}
 
-void conv_bit_corr_bb_impl::catch_msg(pmt::pmt_t msg)
+void conv_bit_corr_bb_impl::catch_msg(const pmt::pmt_t& msg)
 {
     // stub code
     d_msgrecv++;

--- a/gr-fec/lib/conv_bit_corr_bb_impl.h
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.h
@@ -85,7 +85,7 @@ public:
                           float thresh);
     ~conv_bit_corr_bb_impl();
 
-    void catch_msg(pmt::pmt_t msg);
+    void catch_msg(const pmt::pmt_t& msg);
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-fec/lib/decode_ccsds_27_fb_impl.cc
+++ b/gr-fec/lib/decode_ccsds_27_fb_impl.cc
@@ -27,6 +27,8 @@
 #include "decode_ccsds_27_fb_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <cmath>
+
 namespace gr {
 namespace fec {
 
@@ -65,7 +67,7 @@ int decode_ccsds_27_fb_impl::work(int noutput_items,
             sample = 255.0;
         else if (sample < 0.0)
             sample = 0.0;
-        unsigned char sym = (unsigned char)(floor(sample));
+        unsigned char sym = (unsigned char)(std::floor(sample));
 
         d_viterbi_in[d_count % 4] = sym;
         if ((d_count % 4) == 3) {

--- a/gr-fec/lib/decoder_impl.cc
+++ b/gr-fec/lib/decoder_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -36,10 +38,10 @@ decoder::sptr decoder::make(generic_decoder::sptr my_decoder,
                             size_t output_item_size)
 {
     return gnuradio::get_initial_sptr(
-        new decoder_impl(my_decoder, input_item_size, output_item_size));
+        new decoder_impl(std::move(my_decoder), input_item_size, output_item_size));
 }
 
-decoder_impl::decoder_impl(generic_decoder::sptr my_decoder,
+decoder_impl::decoder_impl(const generic_decoder::sptr& my_decoder,
                            size_t input_item_size,
                            size_t output_item_size)
     : block("fec_decoder",

--- a/gr-fec/lib/decoder_impl.h
+++ b/gr-fec/lib/decoder_impl.h
@@ -36,7 +36,7 @@ private:
     size_t d_output_item_size;
 
 public:
-    decoder_impl(generic_decoder::sptr my_decoder,
+    decoder_impl(const generic_decoder::sptr& my_decoder,
                  size_t input_item_size,
                  size_t output_item_size);
 

--- a/gr-fec/lib/encoder_impl.cc
+++ b/gr-fec/lib/encoder_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -36,10 +38,10 @@ encoder::sptr encoder::make(generic_encoder::sptr my_encoder,
                             size_t output_item_size)
 {
     return gnuradio::get_initial_sptr(
-        new encoder_impl(my_encoder, input_item_size, output_item_size));
+        new encoder_impl(std::move(my_encoder), input_item_size, output_item_size));
 }
 
-encoder_impl::encoder_impl(generic_encoder::sptr my_encoder,
+encoder_impl::encoder_impl(const generic_encoder::sptr& my_encoder,
                            size_t input_item_size,
                            size_t output_item_size)
     : block("fec_encoder",

--- a/gr-fec/lib/encoder_impl.h
+++ b/gr-fec/lib/encoder_impl.h
@@ -38,7 +38,7 @@ private:
     size_t d_output_size;
 
 public:
-    encoder_impl(generic_encoder::sptr my_encoder,
+    encoder_impl(const generic_encoder::sptr& my_encoder,
                  size_t input_item_size,
                  size_t output_item_size);
     ~encoder_impl();

--- a/gr-fec/lib/fec_mtrx_impl.cc
+++ b/gr-fec/lib/fec_mtrx_impl.cc
@@ -40,7 +40,7 @@ namespace code {
 void matrix_free(matrix* x) { gsl_matrix_free((gsl_matrix*)x); }
 
 
-matrix_sptr read_matrix_from_file(const std::string filename)
+matrix_sptr read_matrix_from_file(const std::string& filename)
 {
     std::ifstream inputFile;
     unsigned int ncols, nrows;
@@ -96,7 +96,7 @@ matrix_sptr read_matrix_from_file(const std::string filename)
     return H;
 }
 
-void write_matrix_to_file(const std::string filename, matrix_sptr M)
+void write_matrix_to_file(const std::string& filename, const matrix_sptr& M)
 {
     std::ofstream outputfile;
 
@@ -158,7 +158,7 @@ void write_matrix_to_file(const std::string filename, matrix_sptr M)
     outputfile.close();
 }
 
-matrix_sptr generate_G_transpose(matrix_sptr H_obj)
+matrix_sptr generate_G_transpose(const matrix_sptr& H_obj)
 {
     unsigned int k = H_obj->size1;
     unsigned int n = H_obj->size2;
@@ -197,7 +197,7 @@ matrix_sptr generate_G_transpose(matrix_sptr H_obj)
     return G;
 }
 
-matrix_sptr generate_G(matrix_sptr H_obj)
+matrix_sptr generate_G(const matrix_sptr& H_obj)
 {
     matrix_sptr G_trans = generate_G_transpose(H_obj);
 
@@ -211,7 +211,7 @@ matrix_sptr generate_G(matrix_sptr H_obj)
     return Gret;
 }
 
-matrix_sptr generate_H(matrix_sptr G_obj)
+matrix_sptr generate_H(const matrix_sptr& G_obj)
 {
     unsigned int row_index, col_index;
 
@@ -258,7 +258,7 @@ matrix_sptr generate_H(matrix_sptr G_obj)
 }
 
 
-void print_matrix(const matrix_sptr M, bool numpy)
+void print_matrix(const matrix_sptr& M, bool numpy)
 {
     if (!numpy) {
         for (size_t i = 0; i < M->size1; i++) {

--- a/gr-fec/lib/generic_decoder.cc
+++ b/gr-fec/lib/generic_decoder.cc
@@ -28,12 +28,14 @@
 #include <gnuradio/prefs.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
 generic_decoder::generic_decoder(std::string name)
 {
-    d_name = name;
+    d_name = std::move(name);
     my_id = base_unique_id++;
 
     prefs* p = prefs::singleton();
@@ -78,36 +80,42 @@ int generic_decoder::unique_id() { return my_id; }
 /*******************************************************
  * Static functions
  ******************************************************/
-int get_decoder_output_size(generic_decoder::sptr my_decoder)
+int get_decoder_output_size(const generic_decoder::sptr& my_decoder)
 {
     return my_decoder->get_output_size();
 }
 
-int get_history(generic_decoder::sptr my_decoder) { return my_decoder->get_history(); }
+int get_history(const generic_decoder::sptr& my_decoder)
+{
+    return my_decoder->get_history();
+}
 
-int get_decoder_input_size(generic_decoder::sptr my_decoder)
+int get_decoder_input_size(const generic_decoder::sptr& my_decoder)
 {
     return my_decoder->get_input_size();
 }
 
-int get_decoder_output_item_size(generic_decoder::sptr my_decoder)
+int get_decoder_output_item_size(const generic_decoder::sptr& my_decoder)
 {
     return my_decoder->get_output_item_size();
 }
 
-int get_decoder_input_item_size(generic_decoder::sptr my_decoder)
+int get_decoder_input_item_size(const generic_decoder::sptr& my_decoder)
 {
     return my_decoder->get_input_item_size();
 }
 
-float get_shift(generic_decoder::sptr my_decoder) { return my_decoder->get_shift(); }
+float get_shift(const generic_decoder::sptr& my_decoder)
+{
+    return my_decoder->get_shift();
+}
 
-const char* get_decoder_input_conversion(generic_decoder::sptr my_decoder)
+const char* get_decoder_input_conversion(const generic_decoder::sptr& my_decoder)
 {
     return my_decoder->get_input_conversion();
 }
 
-const char* get_decoder_output_conversion(generic_decoder::sptr my_decoder)
+const char* get_decoder_output_conversion(const generic_decoder::sptr& my_decoder)
 {
     return my_decoder->get_output_conversion();
 }

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -28,12 +28,14 @@
 #include <gnuradio/prefs.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
 generic_encoder::generic_encoder(std::string name)
 {
-    d_name = name;
+    d_name = std::move(name);
     my_id = base_unique_id++;
 
     prefs* p = prefs::singleton();
@@ -70,22 +72,22 @@ int generic_encoder::unique_id() { return my_id; }
 /*******************************************************
  * Static functions
  ******************************************************/
-int get_encoder_output_size(generic_encoder::sptr my_encoder)
+int get_encoder_output_size(const generic_encoder::sptr& my_encoder)
 {
     return my_encoder->get_output_size();
 }
 
-int get_encoder_input_size(generic_encoder::sptr my_encoder)
+int get_encoder_input_size(const generic_encoder::sptr& my_encoder)
 {
     return my_encoder->get_input_size();
 }
 
-const char* get_encoder_input_conversion(generic_encoder::sptr my_encoder)
+const char* get_encoder_input_conversion(const generic_encoder::sptr& my_encoder)
 {
     return my_encoder->get_input_conversion();
 }
 
-const char* get_encoder_output_conversion(generic_encoder::sptr my_encoder)
+const char* get_encoder_output_conversion(const generic_encoder::sptr& my_encoder)
 {
     return my_encoder->get_output_conversion();
 }

--- a/gr-fec/lib/gf2vec.cc
+++ b/gr-fec/lib/gf2vec.cc
@@ -25,7 +25,7 @@
 
 GF2Vec::GF2Vec(int size) { vec.resize(size); }
 
-void GF2Vec::set_vec(const std::vector<char> in) { vec = in; }
+void GF2Vec::set_vec(const std::vector<char>& in) { vec = in; }
 
 std::vector<char> GF2Vec::get_vec() { return vec; }
 

--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -32,12 +32,12 @@ namespace gr {
 namespace fec {
 namespace code {
 
-ldpc_G_matrix::sptr ldpc_G_matrix::make(const std::string filename)
+ldpc_G_matrix::sptr ldpc_G_matrix::make(const std::string& filename)
 {
     return ldpc_G_matrix::sptr(new ldpc_G_matrix_impl(filename));
 }
 
-ldpc_G_matrix_impl::ldpc_G_matrix_impl(const std::string filename) : fec_mtrx_impl()
+ldpc_G_matrix_impl::ldpc_G_matrix_impl(const std::string& filename) : fec_mtrx_impl()
 {
     configure_default_loggers(d_logger, d_debug_logger, "ldpc_G_matrix");
 

--- a/gr-fec/lib/ldpc_G_matrix_impl.h
+++ b/gr-fec/lib/ldpc_G_matrix_impl.h
@@ -70,7 +70,7 @@ private:
     gr::logger_ptr d_debug_logger;
 
 public:
-    ldpc_G_matrix_impl(const std::string filename);
+    ldpc_G_matrix_impl(const std::string& filename);
 
     void encode(unsigned char* outbuffer, const unsigned char* inbuffer) const;
 

--- a/gr-fec/lib/ldpc_H_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_H_matrix_impl.cc
@@ -33,12 +33,12 @@ namespace gr {
 namespace fec {
 namespace code {
 
-ldpc_H_matrix::sptr ldpc_H_matrix::make(const std::string filename, unsigned int gap)
+ldpc_H_matrix::sptr ldpc_H_matrix::make(const std::string& filename, unsigned int gap)
 {
     return ldpc_H_matrix::sptr(new ldpc_H_matrix_impl(filename, gap));
 }
 
-ldpc_H_matrix_impl::ldpc_H_matrix_impl(const std::string filename, unsigned int gap)
+ldpc_H_matrix_impl::ldpc_H_matrix_impl(const std::string& filename, unsigned int gap)
     : fec_mtrx_impl()
 {
     matrix_sptr x = read_matrix_from_file(filename);

--- a/gr-fec/lib/ldpc_H_matrix_impl.h
+++ b/gr-fec/lib/ldpc_H_matrix_impl.h
@@ -85,7 +85,7 @@ public:
      *            algorithm. It is equal to the number of rows in
      *            submatrices E, C and D.
      */
-    ldpc_H_matrix_impl(const std::string filename, unsigned int gap);
+    ldpc_H_matrix_impl(const std::string& filename, unsigned int gap);
 
     //! Encode \p inbuffer with LDPC H matrix into \p outbuffer.
     void encode(unsigned char* outbuffer, const unsigned char* inbuffer) const;

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
@@ -34,13 +34,13 @@ namespace gr {
 namespace fec {
 namespace code {
 
-generic_decoder::sptr ldpc_bit_flip_decoder::make(const fec_mtrx_sptr mtrx_obj,
+generic_decoder::sptr ldpc_bit_flip_decoder::make(const fec_mtrx_sptr& mtrx_obj,
                                                   unsigned int max_iter)
 {
     return generic_decoder::sptr(new ldpc_bit_flip_decoder_impl(mtrx_obj, max_iter));
 }
 
-ldpc_bit_flip_decoder_impl::ldpc_bit_flip_decoder_impl(const fec_mtrx_sptr mtrx_obj,
+ldpc_bit_flip_decoder_impl::ldpc_bit_flip_decoder_impl(const fec_mtrx_sptr& mtrx_obj,
                                                        unsigned int max_iter)
     : generic_decoder("ldpc_bit_flip_decoder")
 {

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.h
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.h
@@ -45,7 +45,8 @@ private:
     unsigned int d_max_iterations;
 
 public:
-    ldpc_bit_flip_decoder_impl(const fec_mtrx_sptr mtrx_obj, unsigned int max_iter = 100);
+    ldpc_bit_flip_decoder_impl(const fec_mtrx_sptr& mtrx_obj,
+                               unsigned int max_iter = 100);
     ~ldpc_bit_flip_decoder_impl();
 
     void generic_work(void* inbuffer, void* outbuffer);

--- a/gr-fec/lib/ldpc_decoder.cc
+++ b/gr-fec/lib/ldpc_decoder.cc
@@ -30,6 +30,7 @@
 #include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
 #include <sstream>
+#include <utility>
 #include <vector>
 
 
@@ -39,7 +40,8 @@ namespace fec {
 generic_decoder::sptr
 ldpc_decoder::make(std::string alist_file, float sigma, int max_iterations)
 {
-    return generic_decoder::sptr(new ldpc_decoder(alist_file, sigma, max_iterations));
+    return generic_decoder::sptr(
+        new ldpc_decoder(std::move(alist_file), sigma, max_iterations));
 }
 
 ldpc_decoder::ldpc_decoder(std::string alist_file, float sigma, int max_iterations)

--- a/gr-fec/lib/ldpc_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_encoder_impl.cc
@@ -27,13 +27,14 @@
 #include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
 #include <sstream>
+#include <utility>
 
 namespace gr {
 namespace fec {
 
 generic_encoder::sptr ldpc_encoder::make(std::string alist_file)
 {
-    return generic_encoder::sptr(new ldpc_encoder_impl(alist_file));
+    return generic_encoder::sptr(new ldpc_encoder_impl(std::move(alist_file)));
 }
 
 ldpc_encoder_impl::ldpc_encoder_impl(std::string alist_file)

--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
@@ -29,12 +29,12 @@ namespace gr {
 namespace fec {
 namespace code {
 
-generic_encoder::sptr ldpc_gen_mtrx_encoder::make(const ldpc_G_matrix::sptr G_obj)
+generic_encoder::sptr ldpc_gen_mtrx_encoder::make(const ldpc_G_matrix::sptr& G_obj)
 {
     return generic_encoder::sptr(new ldpc_gen_mtrx_encoder_impl(G_obj));
 }
 
-ldpc_gen_mtrx_encoder_impl::ldpc_gen_mtrx_encoder_impl(const ldpc_G_matrix::sptr G_obj)
+ldpc_gen_mtrx_encoder_impl::ldpc_gen_mtrx_encoder_impl(const ldpc_G_matrix::sptr& G_obj)
     : generic_encoder("ldpc_gen_mtrx_encoder")
 {
     // Generator matrix to use for encoding

--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.h
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.h
@@ -50,7 +50,7 @@ private:
     ldpc_G_matrix::sptr d_G;
 
 public:
-    ldpc_gen_mtrx_encoder_impl(const ldpc_G_matrix::sptr G_obj);
+    ldpc_gen_mtrx_encoder_impl(const ldpc_G_matrix::sptr& G_obj);
     ~ldpc_gen_mtrx_encoder_impl();
 
     bool set_frame_size(unsigned int frame_size);

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -28,6 +28,7 @@
 #include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
 #include <sstream>
+#include <utility>
 #include <vector>
 
 namespace gr {
@@ -37,17 +38,19 @@ namespace code {
 generic_encoder::sptr ldpc_par_mtrx_encoder::make(std::string alist_file,
                                                   unsigned int gap)
 {
-    code::ldpc_H_matrix::sptr H_obj = code::ldpc_H_matrix::make(alist_file, gap);
+    code::ldpc_H_matrix::sptr H_obj =
+        code::ldpc_H_matrix::make(std::move(alist_file), gap);
     return make_H(H_obj);
 }
 
-generic_encoder::sptr ldpc_par_mtrx_encoder::make_H(const code::ldpc_H_matrix::sptr H_obj)
+generic_encoder::sptr
+ldpc_par_mtrx_encoder::make_H(const code::ldpc_H_matrix::sptr& H_obj)
 {
     return generic_encoder::sptr(new ldpc_par_mtrx_encoder_impl(H_obj));
 }
 
 ldpc_par_mtrx_encoder_impl::ldpc_par_mtrx_encoder_impl(
-    const code::ldpc_H_matrix::sptr H_obj)
+    const code::ldpc_H_matrix::sptr& H_obj)
     : generic_encoder("ldpc_par_mtrx_encoder")
 {
     // LDPC parity check matrix to use for encoding

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.h
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.h
@@ -48,7 +48,7 @@ private:
     code::ldpc_H_matrix::sptr d_H;
 
 public:
-    ldpc_par_mtrx_encoder_impl(const code::ldpc_H_matrix::sptr H_obj);
+    ldpc_par_mtrx_encoder_impl(const code::ldpc_H_matrix::sptr& H_obj);
     ~ldpc_par_mtrx_encoder_impl();
 
     double rate();

--- a/gr-fec/lib/polar_common.cc
+++ b/gr-fec/lib/polar_common.cc
@@ -34,6 +34,7 @@
 #include <cmath>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace gr {
@@ -44,10 +45,10 @@ polar_common::polar_common(int block_size,
                            int num_info_bits,
                            std::vector<int> frozen_bit_positions,
                            std::vector<char> frozen_bit_values)
-    : d_frozen_bit_positions(frozen_bit_positions),
-      d_frozen_bit_values(frozen_bit_values),
+    : d_frozen_bit_positions(std::move(frozen_bit_positions)),
+      d_frozen_bit_values(std::move(frozen_bit_values)),
       d_block_size(block_size),
-      d_block_power((int)log2(float(block_size))),
+      d_block_power((int)std::log2(float(block_size))),
       d_num_info_bits(num_info_bits)
 {
     if (pow(2, d_block_power) != d_block_size) {

--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -28,7 +28,9 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 
+#include <cmath>
 #include <cstdio>
+#include <utility>
 
 namespace gr {
 namespace fec {
@@ -40,7 +42,10 @@ polar_decoder_common::polar_decoder_common(int block_size,
                                            int num_info_bits,
                                            std::vector<int> frozen_bit_positions,
                                            std::vector<char> frozen_bit_values)
-    : polar_common(block_size, num_info_bits, frozen_bit_positions, frozen_bit_values),
+    : polar_common(block_size,
+                   num_info_bits,
+                   std::move(frozen_bit_positions),
+                   std::move(frozen_bit_values)),
       d_frozen_bit_counter(0)
 {
 }
@@ -59,7 +64,8 @@ void polar_decoder_common::initialize_decoder(unsigned char* u,
 
 float polar_decoder_common::llr_odd(const float la, const float lb) const
 {
-    return copysignf(1.0f, la) * copysignf(1.0f, lb) * std::min(fabs(la), fabs(lb));
+    return copysignf(1.0f, la) * copysignf(1.0f, lb) *
+           std::min(std::fabs(la), std::fabs(lb));
 }
 
 float polar_decoder_common::llr_even(const float la,

--- a/gr-fec/lib/polar_decoder_sc.cc
+++ b/gr-fec/lib/polar_decoder_sc.cc
@@ -30,6 +30,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <utility>
 
 namespace gr {
 namespace fec {
@@ -40,16 +41,20 @@ generic_decoder::sptr polar_decoder_sc::make(int block_size,
                                              std::vector<int> frozen_bit_positions,
                                              std::vector<char> frozen_bit_values)
 {
-    return generic_decoder::sptr(new polar_decoder_sc(
-        block_size, num_info_bits, frozen_bit_positions, frozen_bit_values));
+    return generic_decoder::sptr(new polar_decoder_sc(block_size,
+                                                      num_info_bits,
+                                                      std::move(frozen_bit_positions),
+                                                      std::move(frozen_bit_values)));
 }
 
 polar_decoder_sc::polar_decoder_sc(int block_size,
                                    int num_info_bits,
                                    std::vector<int> frozen_bit_positions,
                                    std::vector<char> frozen_bit_values)
-    : polar_decoder_common(
-          block_size, num_info_bits, frozen_bit_positions, frozen_bit_values)
+    : polar_decoder_common(block_size,
+                           num_info_bits,
+                           std::move(frozen_bit_positions),
+                           std::move(frozen_bit_values))
 {
     d_llr_vec = (float*)volk_malloc(sizeof(float) * block_size * (block_power() + 1),
                                     volk_get_alignment());

--- a/gr-fec/lib/polar_decoder_sc_list.cc
+++ b/gr-fec/lib/polar_decoder_sc_list.cc
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 namespace gr {
 namespace fec {
@@ -42,11 +43,12 @@ generic_decoder::sptr polar_decoder_sc_list::make(int max_list_size,
                                                   std::vector<int> frozen_bit_positions,
                                                   std::vector<char> frozen_bit_values)
 {
-    return generic_decoder::sptr(new polar_decoder_sc_list(max_list_size,
-                                                           block_size,
-                                                           num_info_bits,
-                                                           frozen_bit_positions,
-                                                           frozen_bit_values));
+    return generic_decoder::sptr(
+        new polar_decoder_sc_list(max_list_size,
+                                  block_size,
+                                  num_info_bits,
+                                  std::move(frozen_bit_positions),
+                                  std::move(frozen_bit_values)));
 }
 
 polar_decoder_sc_list::polar_decoder_sc_list(int max_list_size,
@@ -54,8 +56,10 @@ polar_decoder_sc_list::polar_decoder_sc_list(int max_list_size,
                                              int num_info_bits,
                                              std::vector<int> frozen_bit_positions,
                                              std::vector<char> frozen_bit_values)
-    : polar_decoder_common(
-          block_size, num_info_bits, frozen_bit_positions, frozen_bit_values)
+    : polar_decoder_common(block_size,
+                           num_info_bits,
+                           std::move(frozen_bit_positions),
+                           std::move(frozen_bit_values))
 {
     d_scl = new polar::scl_list(max_list_size, block_size, block_power());
 }

--- a/gr-fec/lib/polar_decoder_sc_systematic.cc
+++ b/gr-fec/lib/polar_decoder_sc_systematic.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 namespace code {
@@ -35,14 +37,14 @@ namespace code {
 generic_decoder::sptr polar_decoder_sc_systematic::make(
     int block_size, int num_info_bits, std::vector<int> frozen_bit_positions)
 {
-    return generic_decoder::sptr(
-        new polar_decoder_sc_systematic(block_size, num_info_bits, frozen_bit_positions));
+    return generic_decoder::sptr(new polar_decoder_sc_systematic(
+        block_size, num_info_bits, std::move(frozen_bit_positions)));
 }
 
 polar_decoder_sc_systematic::polar_decoder_sc_systematic(
     int block_size, int num_info_bits, std::vector<int> frozen_bit_positions)
     : polar_decoder_common(
-          block_size, num_info_bits, frozen_bit_positions, std::vector<char>())
+          block_size, num_info_bits, std::move(frozen_bit_positions), std::vector<char>())
 {
     d_llr_vec = (float*)volk_malloc(sizeof(float) * block_size * (block_power() + 1),
                                     volk_get_alignment());

--- a/gr-fec/lib/polar_encoder_systematic.cc
+++ b/gr-fec/lib/polar_encoder_systematic.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 namespace code {
@@ -35,14 +37,15 @@ namespace code {
 generic_encoder::sptr polar_encoder_systematic::make(
     int block_size, int num_info_bits, std::vector<int> frozen_bit_positions)
 {
-    return generic_encoder::sptr(
-        new polar_encoder_systematic(block_size, num_info_bits, frozen_bit_positions));
+    return generic_encoder::sptr(new polar_encoder_systematic(
+        block_size, num_info_bits, std::move(frozen_bit_positions)));
 }
 
 polar_encoder_systematic::polar_encoder_systematic(int block_size,
                                                    int num_info_bits,
                                                    std::vector<int> frozen_bit_positions)
-    : polar_common(block_size, num_info_bits, frozen_bit_positions, std::vector<char>())
+    : polar_common(
+          block_size, num_info_bits, std::move(frozen_bit_positions), std::vector<char>())
 {
     d_volk_syst_intermediate = (unsigned char*)volk_malloc(
         sizeof(unsigned char) * block_size, volk_get_alignment());

--- a/gr-fec/lib/scl_list.cc
+++ b/gr-fec/lib/scl_list.cc
@@ -23,6 +23,7 @@
 #include "scl_list.h"
 #include <volk/volk.h>
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 
@@ -158,7 +159,7 @@ float scl_list::update_path_metric(const float last_pm,
         //        if(ui == (unsigned char) (0.5 * 1 - copysignf(1.0f, llr))){
         return last_pm;
     }
-    return last_pm + fabs(llr);
+    return last_pm + std::fabs(llr);
 }
 
 void scl_list::set_frozen_bit(const unsigned char frozen_bit, const int bit_pos)

--- a/gr-fec/lib/tagged_decoder_impl.cc
+++ b/gr-fec/lib/tagged_decoder_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -38,7 +40,7 @@ tagged_decoder::sptr tagged_decoder::make(generic_decoder::sptr my_decoder,
                                           int mtu)
 {
     return gnuradio::get_initial_sptr(new tagged_decoder_impl(
-        my_decoder, input_item_size, output_item_size, lengthtagname, mtu));
+        std::move(my_decoder), input_item_size, output_item_size, lengthtagname, mtu));
 }
 
 tagged_decoder_impl::tagged_decoder_impl(generic_decoder::sptr my_decoder,
@@ -52,7 +54,7 @@ tagged_decoder_impl::tagged_decoder_impl(generic_decoder::sptr my_decoder,
                           lengthtagname),
       d_mtu(mtu)
 {
-    d_decoder = my_decoder;
+    d_decoder = std::move(my_decoder);
     d_decoder->set_frame_size(d_mtu * 8);
 
     set_relative_rate(d_decoder->rate());

--- a/gr-fec/lib/tagged_encoder_impl.cc
+++ b/gr-fec/lib/tagged_encoder_impl.cc
@@ -28,6 +28,8 @@
 #include <gnuradio/io_signature.h>
 #include <stdio.h>
 
+#include <utility>
+
 namespace gr {
 namespace fec {
 
@@ -38,7 +40,7 @@ tagged_encoder::sptr tagged_encoder::make(generic_encoder::sptr my_encoder,
                                           int mtu)
 {
     return gnuradio::get_initial_sptr(new tagged_encoder_impl(
-        my_encoder, input_item_size, output_item_size, lengthtagname, mtu));
+        std::move(my_encoder), input_item_size, output_item_size, lengthtagname, mtu));
 }
 
 tagged_encoder_impl::tagged_encoder_impl(generic_encoder::sptr my_encoder,
@@ -52,7 +54,7 @@ tagged_encoder_impl::tagged_encoder_impl(generic_encoder::sptr my_encoder,
                           lengthtagname),
       d_mtu(mtu)
 {
-    d_encoder = my_encoder;
+    d_encoder = std::move(my_encoder);
 
     d_encoder->set_frame_size(d_mtu * 8);
     set_relative_rate(d_encoder->rate());

--- a/gr-fec/lib/tpc_common.cc
+++ b/gr-fec/lib/tpc_common.cc
@@ -69,7 +69,7 @@ void tpc_common::rsc_enc_bit(int input,
 
 void tpc_common::precomputeStateTransitionMatrix_RSCPoly(
     int numStates,
-    std::vector<int> g,
+    const std::vector<int>& g,
     int KK,
     int nn,
     std::vector<std::vector<int>>& output,

--- a/gr-fec/lib/tpc_decoder.cc
+++ b/gr-fec/lib/tpc_decoder.cc
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <boost/assign/list_of.hpp>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <string.h>  // for memcpy
@@ -47,8 +48,14 @@ generic_decoder::sptr tpc_decoder::make(std::vector<int> row_polys,
                                         int max_iter,
                                         int decoder_type)
 {
-    return generic_decoder::sptr(new tpc_decoder(
-        row_polys, col_polys, krow, kcol, bval, qval, max_iter, decoder_type));
+    return generic_decoder::sptr(new tpc_decoder(std::move(row_polys),
+                                                 std::move(col_polys),
+                                                 krow,
+                                                 kcol,
+                                                 bval,
+                                                 qval,
+                                                 max_iter,
+                                                 decoder_type));
 }
 
 tpc_decoder::tpc_decoder(std::vector<int> row_polys,
@@ -60,8 +67,8 @@ tpc_decoder::tpc_decoder(std::vector<int> row_polys,
                          int max_iter,
                          int decoder_type)
     : generic_decoder("tpc_decoder"),
-      d_rowpolys(row_polys),
-      d_colpolys(col_polys),
+      d_rowpolys(std::move(row_polys)),
+      d_colpolys(std::move(col_polys)),
       d_krow(krow),
       d_kcol(kcol),
       d_bval(bval),
@@ -790,7 +797,7 @@ float tpc_decoder::log_map_cfunction_correction(const float delta1, const float 
     }
 }
 
-float tpc_decoder::gamma(const std::vector<float> rx_array, const int symbol)
+float tpc_decoder::gamma(const std::vector<float>& rx_array, const int symbol)
 {
     float rm = 0;
     int ii;

--- a/gr-fec/lib/tpc_encoder.cc
+++ b/gr-fec/lib/tpc_encoder.cc
@@ -29,6 +29,7 @@
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <string.h>  // for memcpy
@@ -43,8 +44,8 @@ generic_encoder::sptr tpc_encoder::make(std::vector<int> row_polys,
                                         int bval,
                                         int qval)
 {
-    return generic_encoder::sptr(
-        new tpc_encoder(row_polys, col_polys, krow, kcol, bval, qval));
+    return generic_encoder::sptr(new tpc_encoder(
+        std::move(row_polys), std::move(col_polys), krow, kcol, bval, qval));
 }
 
 tpc_encoder::tpc_encoder(std::vector<int> row_polys,
@@ -53,8 +54,8 @@ tpc_encoder::tpc_encoder(std::vector<int> row_polys,
                          int kcol,
                          int bval,
                          int qval)
-    : d_rowpolys(row_polys),
-      d_colpolys(col_polys),
+    : d_rowpolys(std::move(row_polys)),
+      d_colpolys(std::move(col_polys)),
       d_krow(krow),
       d_kcol(kcol),
       d_bval(bval),

--- a/gr-fec/lib/viterbi/decode.cc
+++ b/gr-fec/lib/viterbi/decode.cc
@@ -47,7 +47,7 @@ int main()
     float RATE = 0.5;
     float ebn0 = 12.0;
     float esn0 = RATE * pow(10.0, ebn0 / 10);
-    gen_met(mettab, amp, esn0, 0.0, 4);
+    gr::fec::gen_met(mettab, amp, esn0, 0.0, 4);
 
     // Initialize decoder state
     struct gr::fec::viterbi_state state0[64];

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -27,6 +27,8 @@
 #include "ctrlport_probe_psd_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <cmath>
+
 namespace gr {
 namespace fft {
 
@@ -86,7 +88,8 @@ std::vector<gr_complex> ctrlport_probe_psd_impl::get()
     for (size_t i = 0; i < d_len; i++) {
         size_t idx = (i + d_len / 2) % d_len;
         float x = i / (d_len - 1.0f) - 0.5;
-        buf_copy[i] = gr_complex(x, 10 * log10((out[idx] * std::conj(out[idx])).real()));
+        buf_copy[i] =
+            gr_complex(x, 10 * std::log10((out[idx] * std::conj(out[idx])).real()));
     }
     mutex_buffer.unlock();
     return buf_copy;

--- a/gr-filter/include/gnuradio/filter/pm_remez.h
+++ b/gr-filter/include/gnuradio/filter/pm_remez.h
@@ -61,7 +61,7 @@ FILTER_API std::vector<double> pm_remez(int order,
                                         const std::vector<double>& bands,
                                         const std::vector<double>& ampl,
                                         const std::vector<double>& error_weight,
-                                        const std::string filter_type = "bandpass",
+                                        const std::string& filter_type = "bandpass",
                                         int grid_density = 16) noexcept(false);
 
 } /* namespace filter */

--- a/gr-filter/lib/firdes.cc
+++ b/gr-filter/lib/firdes.cc
@@ -26,6 +26,7 @@
 
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/math.h>
+#include <cmath>
 #include <stdexcept>
 
 using std::vector;
@@ -355,7 +356,7 @@ firdes::complex_band_pass_2(double gain,
         phase = -freq / 2.0 * ((1 + 2 * lptaps.size()) >> 1);
 
     for (unsigned int i = 0; i < lptaps.size(); i++) {
-        *optr++ = gr_complex(*iptr * cos(phase), *iptr * sin(phase));
+        *optr++ = gr_complex(*iptr * std::cos(phase), *iptr * std::sin(phase));
         iptr++, phase += freq;
     }
 
@@ -399,7 +400,7 @@ firdes::complex_band_pass(double gain,
         phase = -freq / 2.0 * ((1 + 2 * lptaps.size()) >> 1);
 
     for (unsigned int i = 0; i < lptaps.size(); i++) {
-        *optr++ = gr_complex(*iptr * cos(phase), *iptr * sin(phase));
+        *optr++ = gr_complex(*iptr * std::cos(phase), *iptr * std::sin(phase));
         iptr++, phase += freq;
     }
 
@@ -523,7 +524,7 @@ vector<float> firdes::hilbert(unsigned int ntaps, win_type windowtype, double be
             taps[h + i] = taps[h - i] = 0;
     }
 
-    gain = 2 * fabs(gain);
+    gain = 2 * std::fabs(gain);
     for (unsigned int i = 0; i < ntaps; i++)
         taps[i] /= gain;
     return taps;

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.cc
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.cc
@@ -132,7 +132,7 @@ std::vector<TAP_T> freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::taps() cons
 
 template <class IN_T, class OUT_T, class TAP_T>
 void freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::handle_set_center_freq(
-    pmt::pmt_t msg)
+    const pmt::pmt_t& msg)
 {
     if (pmt::is_dict(msg) && pmt::dict_has_key(msg, pmt::intern("freq"))) {
         pmt::pmt_t x = pmt::dict_ref(msg, pmt::intern("freq"), pmt::PMT_NIL);

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.h
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.h
@@ -58,7 +58,7 @@ public:
     void set_taps(const std::vector<TAP_T>& taps);
     std::vector<TAP_T> taps() const;
 
-    void handle_set_center_freq(pmt::pmt_t msg);
+    void handle_set_center_freq(const pmt::pmt_t& msg);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-filter/lib/mmse_fir_interpolator_cc.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_cc.cc
@@ -26,6 +26,7 @@
 
 #include <gnuradio/filter/interpolator_taps.h>
 #include <gnuradio/filter/mmse_fir_interpolator_cc.h>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {
@@ -53,7 +54,7 @@ unsigned mmse_fir_interpolator_cc::nsteps() const { return NSTEPS; }
 
 gr_complex mmse_fir_interpolator_cc::interpolate(const gr_complex input[], float mu) const
 {
-    int imu = (int)rint(mu * NSTEPS);
+    int imu = (int)std::rint(mu * NSTEPS);
 
     if ((imu < 0) || (imu > NSTEPS)) {
         throw std::runtime_error("mmse_fir_interpolator_cc: imu out of bounds.\n");

--- a/gr-filter/lib/mmse_fir_interpolator_ff.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_ff.cc
@@ -26,6 +26,7 @@
 
 #include <gnuradio/filter/interpolator_taps.h>
 #include <gnuradio/filter/mmse_fir_interpolator_ff.h>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {
@@ -53,7 +54,7 @@ unsigned mmse_fir_interpolator_ff::nsteps() const { return NSTEPS; }
 
 float mmse_fir_interpolator_ff::interpolate(const float input[], float mu) const
 {
-    int imu = (int)rint(mu * NSTEPS);
+    int imu = (int)std::rint(mu * NSTEPS);
 
     if ((imu < 0) || (imu > NSTEPS)) {
         throw std::runtime_error("mmse_fir_interpolator_ff: imu out of bounds.\n");

--- a/gr-filter/lib/mmse_interp_differentiator_cc.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_cc.cc
@@ -26,6 +26,7 @@
 
 #include "gnuradio/filter/interp_differentiator_taps.h"
 #include <gnuradio/filter/mmse_interp_differentiator_cc.h>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {
@@ -54,7 +55,7 @@ unsigned mmse_interp_differentiator_cc::nsteps() const { return DNSTEPS; }
 gr_complex mmse_interp_differentiator_cc::differentiate(const gr_complex input[],
                                                         float mu) const
 {
-    int imu = (int)rint(mu * DNSTEPS);
+    int imu = (int)std::rint(mu * DNSTEPS);
 
     if ((imu < 0) || (imu > DNSTEPS)) {
         throw std::runtime_error("mmse_interp_differentiator_cc: imu out of bounds.\n");

--- a/gr-filter/lib/mmse_interp_differentiator_ff.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_ff.cc
@@ -26,6 +26,7 @@
 
 #include "gnuradio/filter/interp_differentiator_taps.h"
 #include <gnuradio/filter/mmse_interp_differentiator_ff.h>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {
@@ -53,7 +54,7 @@ unsigned mmse_interp_differentiator_ff::nsteps() const { return DNSTEPS; }
 
 float mmse_interp_differentiator_ff::differentiate(const float input[], float mu) const
 {
-    int imu = (int)rint(mu * DNSTEPS);
+    int imu = (int)std::rint(mu * DNSTEPS);
 
     if ((imu < 0) || (imu > DNSTEPS)) {
         throw std::runtime_error("mmse_interp_differentiator_ff: imu out of bounds.\n");

--- a/gr-filter/lib/mmse_resampler_cc_impl.cc
+++ b/gr-filter/lib/mmse_resampler_cc_impl.cc
@@ -58,7 +58,7 @@ mmse_resampler_cc_impl::mmse_resampler_cc_impl(float phase_shift, float resamp_r
 
 mmse_resampler_cc_impl::~mmse_resampler_cc_impl() { delete d_resamp; }
 
-void mmse_resampler_cc_impl::handle_msg(pmt::pmt_t msg)
+void mmse_resampler_cc_impl::handle_msg(const pmt::pmt_t& msg)
 {
     if (!pmt::is_dict(msg))
         return;

--- a/gr-filter/lib/mmse_resampler_cc_impl.h
+++ b/gr-filter/lib/mmse_resampler_cc_impl.h
@@ -40,7 +40,7 @@ public:
     mmse_resampler_cc_impl(float phase_shift, float resamp_ratio);
     ~mmse_resampler_cc_impl();
 
-    void handle_msg(pmt::pmt_t msg);
+    void handle_msg(const pmt::pmt_t& msg);
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
     int general_work(int noutput_items,

--- a/gr-filter/lib/mmse_resampler_ff_impl.cc
+++ b/gr-filter/lib/mmse_resampler_ff_impl.cc
@@ -59,7 +59,7 @@ mmse_resampler_ff_impl::mmse_resampler_ff_impl(float phase_shift, float resamp_r
 
 mmse_resampler_ff_impl::~mmse_resampler_ff_impl() { delete d_resamp; }
 
-void mmse_resampler_ff_impl::handle_msg(pmt::pmt_t msg)
+void mmse_resampler_ff_impl::handle_msg(const pmt::pmt_t& msg)
 {
     if (!pmt::is_dict(msg))
         return;

--- a/gr-filter/lib/mmse_resampler_ff_impl.h
+++ b/gr-filter/lib/mmse_resampler_ff_impl.h
@@ -40,7 +40,7 @@ public:
     mmse_resampler_ff_impl(float phase_shift, float resamp_ratio);
     ~mmse_resampler_ff_impl();
 
-    void handle_msg(pmt::pmt_t msg);
+    void handle_msg(const pmt::pmt_t& msg);
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
     int general_work(int noutput_items,

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -775,7 +775,7 @@ static int remez(double h[],
 //
 //////////////////////////////////////////////////////////////////////////////
 
-static void punt(const std::string msg)
+static void punt(const std::string& msg)
 {
     std::cerr << msg << '\n';
     throw std::runtime_error(msg);
@@ -785,7 +785,7 @@ std::vector<double> pm_remez(int order,
                              const std::vector<double>& arg_bands,
                              const std::vector<double>& arg_response,
                              const std::vector<double>& arg_weight,
-                             const std::string filter_type,
+                             const std::string& filter_type,
                              int grid_density) noexcept(false)
 {
     int numtaps = order + 1;

--- a/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
@@ -40,8 +40,8 @@ public:
     ConstellationDisplayPlot(int nplots, QWidget*);
     virtual ~ConstellationDisplayPlot();
 
-    void plotNewData(const std::vector<double*> realDataPoints,
-                     const std::vector<double*> imagDataPoints,
+    void plotNewData(const std::vector<double*>& realDataPoints,
+                     const std::vector<double*>& imagDataPoints,
                      const int64_t numDataPoints,
                      const double timeInterval);
 

--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -261,8 +261,8 @@ public slots:
     void setMarkerAlpha8(int);
     void setMarkerAlpha9(int);
 
-    void setZoomerColor(QColor c);
-    void setPaletteColor(QColor c);
+    void setZoomerColor(const QColor& c);
+    void setPaletteColor(const QColor& c);
     void setAxisLabelFontSize(int axisId, int fs);
     void setYaxisLabelFontSize(int fs);
     void setXaxisLabelFontSize(int fs);

--- a/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
@@ -69,7 +69,7 @@ public:
     double getStartFrequency() const;
     double getStopFrequency() const;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<double*>& dataPoints,
                      const int64_t numDataPoints,
                      const double noiseFloorAmplitude,
                      const double peakFrequency,
@@ -90,8 +90,8 @@ public:
     double getYMin() const;
     double getYMax() const;
 
-    void setTraceColour(QColor);
-    void setBGColour(QColor c);
+    void setTraceColour(const QColor&);
+    void setBGColour(const QColor& c);
     void showCFMarker(const bool);
 
     const bool getMaxFFTVisible() const;
@@ -110,16 +110,16 @@ public:
 public slots:
     void setMaxFFTVisible(const bool);
     void setMinFFTVisible(const bool);
-    void setMinFFTColor(QColor c);
-    void setMaxFFTColor(QColor c);
-    void setMarkerLowerIntensityColor(QColor c);
+    void setMinFFTColor(const QColor& c);
+    void setMaxFFTColor(const QColor& c);
+    void setMarkerLowerIntensityColor(const QColor& c);
     void setMarkerLowerIntensityVisible(bool visible);
-    void setMarkerUpperIntensityColor(QColor c);
+    void setMarkerUpperIntensityColor(const QColor& c);
     void setMarkerUpperIntensityVisible(bool visible);
-    void setMarkerPeakAmplitudeColor(QColor c);
+    void setMarkerPeakAmplitudeColor(const QColor& c);
     void setMarkerNoiseFloorAmplitudeVisible(bool visible);
-    void setMarkerNoiseFloorAmplitudeColor(QColor c);
-    void setMarkerCFColor(QColor c);
+    void setMarkerNoiseFloorAmplitudeColor(const QColor& c);
+    void setMarkerCFColor(const QColor& c);
 
     void setLowerIntensityLevel(const double);
     void setUpperIntensityLevel(const double);

--- a/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
@@ -40,7 +40,7 @@ public:
     HistogramDisplayPlot(unsigned int nplots, QWidget*);
     virtual ~HistogramDisplayPlot();
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<double*>& dataPoints,
                      const uint64_t numDataPoints,
                      const double timeInterval);
 

--- a/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
+++ b/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
@@ -59,7 +59,7 @@ public:
                             const bool waterfall = true,
                             const bool time = true,
                             const bool constellation = true);
-    void setDisplayTitle(const std::string);
+    void setDisplayTitle(const std::string&);
 
     bool getWindowOpenFlag();
     void setWindowOpenFlag(const bool);

--- a/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
@@ -47,7 +47,7 @@ public:
     TimeDomainDisplayPlot(int nplots, QWidget*);
     virtual ~TimeDomainDisplayPlot();
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<double*>& dataPoints,
                      const int64_t numDataPoints,
                      const double timeInterval,
                      const std::vector<std::vector<gr::tag_t>>& tags =

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -73,7 +73,8 @@ public:
                            const double units,
                            const std::string& strunits);
 
-    void plotNewData(const std::vector<double*> dataPoints, const uint64_t numDataPoints);
+    void plotNewData(const std::vector<double*>& dataPoints,
+                     const uint64_t numDataPoints);
 
     void plotNewData(const double* dataPoints, const uint64_t numDataPoints);
 
@@ -84,7 +85,7 @@ public:
     int getIntensityColorMapType(unsigned int) const;
     int getIntensityColorMapType1() const;
     void
-    setIntensityColorMapType(const unsigned int, const int, const QColor, const QColor);
+    setIntensityColorMapType(const unsigned int, const int, const QColor&, const QColor&);
     void setIntensityColorMapType1(int);
     int getColorMapTitleFontSize() const;
     void setColorMapTitleFontSize(int tfs);

--- a/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
@@ -59,7 +59,7 @@ public:
 
     void setXAxisValues(const double start, const double step = 1.0);
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<double*>& dataPoints,
                      const int64_t numDataPoints,
                      const double refLevel,
                      const double timeInterval);
@@ -79,8 +79,8 @@ public:
     void setXAxisUnit(const QString& unit);
     void setYAxisUnit(const QString& unit);
 
-    void setTraceColour(QColor);
-    void setBGColour(QColor c);
+    void setTraceColour(const QColor&);
+    void setBGColour(const QColor& c);
 
     const bool getMaxVecVisible() const;
     const bool getMinVecVisible() const;
@@ -96,14 +96,14 @@ public:
 public slots:
     void setMaxVecVisible(const bool);
     void setMinVecVisible(const bool);
-    void setMinVecColor(QColor c);
-    void setMaxVecColor(QColor c);
-    void setMarkerLowerIntensityColor(QColor c);
+    void setMinVecColor(const QColor& c);
+    void setMaxVecColor(const QColor& c);
+    void setMarkerLowerIntensityColor(const QColor& c);
     void setMarkerLowerIntensityVisible(bool visible);
-    void setMarkerUpperIntensityColor(QColor c);
+    void setMarkerUpperIntensityColor(const QColor& c);
     void setMarkerUpperIntensityVisible(bool visible);
     void setMarkerRefLevelAmplitudeVisible(bool visible);
-    void setMarkerRefLevelAmplitudeColor(QColor c);
+    void setMarkerRefLevelAmplitudeColor(const QColor& c);
 
     void setLowerIntensityLevel(const double);
     void setUpperIntensityLevel(const double);

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -68,7 +68,7 @@ public:
     double getStartFrequency() const;
     double getStopFrequency() const;
 
-    void plotNewData(const std::vector<double*> dataPoints,
+    void plotNewData(const std::vector<double*>& dataPoints,
                      const int64_t numDataPoints,
                      const double timePerFFT,
                      const gr::high_res_timer_type timestamp,
@@ -101,7 +101,7 @@ public:
 
 public slots:
     void
-    setIntensityColorMapType(const unsigned int, const int, const QColor, const QColor);
+    setIntensityColorMapType(const unsigned int, const int, const QColor&, const QColor&);
     void setIntensityColorMapType1(int);
     void setColorMapTitleFontSize(int tfs);
     void setUserDefinedLowIntensityColor(QColor);

--- a/gr-qtgui/include/gnuradio/qtgui/constellationdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/constellationdisplayform.h
@@ -64,10 +64,10 @@ public slots:
     void updateTrigger(gr::qtgui::trigger_mode mode);
     void setTriggerMode(gr::qtgui::trigger_mode mode);
     void setTriggerSlope(gr::qtgui::trigger_slope slope);
-    void setTriggerLevel(QString s);
+    void setTriggerLevel(const QString& s);
     void setTriggerLevel(float level);
     void setTriggerChannel(int chan);
-    void setTriggerTagKey(QString s);
+    void setTriggerTagKey(const QString& s);
     void setTriggerTagKey(const std::string& s);
 
 private slots:

--- a/gr-qtgui/include/gnuradio/qtgui/form_menus.h
+++ b/gr-qtgui/include/gnuradio/qtgui/form_menus.h
@@ -506,7 +506,7 @@ public:
 
     void setValidator(QValidator* v) { d_text->setValidator(v); }
 
-    void setDiagText(QString text) { d_text->setText(text); }
+    void setDiagText(const QString& text) { d_text->setText(text); }
 
 signals:
     void whichTrigger(const QString& text);
@@ -534,7 +534,7 @@ class OtherDualAction : public QAction
     Q_OBJECT
 
 public:
-    OtherDualAction(QString label0, QString label1, QWidget* parent)
+    OtherDualAction(const QString& label0, const QString& label1, QWidget* parent)
         : QAction("Other", parent)
     {
         d_diag = new QDialog(parent);
@@ -1444,7 +1444,7 @@ class PopupMenu : public QAction
     Q_OBJECT
 
 public:
-    PopupMenu(QString desc, QWidget* parent) : QAction(desc, parent)
+    PopupMenu(const QString& desc, QWidget* parent) : QAction(desc, parent)
     {
         d_diag = new QDialog(parent);
         d_diag->setWindowTitle(desc);
@@ -1468,7 +1468,7 @@ public:
 
     ~PopupMenu() {}
 
-    void setText(QString s) { d_text->setText(s); }
+    void setText(const QString& s) { d_text->setText(s); }
 
 signals:
     void whichTrigger(const QString data);
@@ -1497,7 +1497,7 @@ class ItemFloatAct : public QAction
     Q_OBJECT
 
 public:
-    ItemFloatAct(unsigned int which, QString title, QWidget* parent)
+    ItemFloatAct(unsigned int which, const QString& title, QWidget* parent)
         : QAction(title, parent), d_which(which)
     {
         d_diag = new QDialog(parent);

--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -86,10 +86,10 @@ public slots:
     // Trigger slots
     void updateTrigger(gr::qtgui::trigger_mode mode);
     void setTriggerMode(gr::qtgui::trigger_mode mode);
-    void setTriggerLevel(QString s);
+    void setTriggerLevel(const QString& s);
     void setTriggerLevel(float level);
     void setTriggerChannel(int chan);
-    void setTriggerTagKey(QString s);
+    void setTriggerTagKey(const QString& s);
     void setTriggerTagKey(const std::string& s);
 
     void setupControlPanel(bool en);

--- a/gr-qtgui/include/gnuradio/qtgui/numberdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/numberdisplayform.h
@@ -62,13 +62,13 @@ public slots:
     void setStop();
     void setGraphType(const gr::qtgui::graph_t type);
     void setColor(unsigned int which, const QColor& min, const QColor& max);
-    void setColorMin(unsigned int which, QString min);
-    void setColorMax(unsigned int which, QString max);
+    void setColorMin(unsigned int which, const QString& min);
+    void setColorMax(unsigned int which, const QString& max);
     void setLabel(unsigned int which, const std::string& label);
-    void setLabel(unsigned int which, QString label);
+    void setLabel(unsigned int which, const QString& label);
     void setAverage(const float avg);
     void setUpdateTime(const float time);
-    void setUpdateTime(QString time);
+    void setUpdateTime(const QString& time);
     void saveFigure();
     void setScale(unsigned int which, int min, int max);
     void setScaleMin(unsigned int which, int min);

--- a/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
+++ b/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
@@ -208,7 +208,10 @@ public:
 class ColorMap_UserDefined : public QwtLinearColorMap
 {
 public:
-    ColorMap_UserDefined(QColor low, QColor high) : QwtLinearColorMap(low, high) {}
+    ColorMap_UserDefined(const QColor& low, const QColor& high)
+        : QwtLinearColorMap(low, high)
+    {
+    }
 };
 
 #endif // QTGUI_TYPES_H

--- a/gr-qtgui/include/gnuradio/qtgui/spectrumUpdateEvents.h
+++ b/gr-qtgui/include/gnuradio/qtgui/spectrumUpdateEvents.h
@@ -121,9 +121,9 @@ private:
 class TimeUpdateEvent : public QEvent
 {
 public:
-    TimeUpdateEvent(const std::vector<double*> timeDomainPoints,
+    TimeUpdateEvent(const std::vector<double*>& timeDomainPoints,
                     const uint64_t numTimeDomainDataPoints,
-                    const std::vector<std::vector<gr::tag_t>> tags);
+                    const std::vector<std::vector<gr::tag_t>>& tags);
 
     ~TimeUpdateEvent();
 
@@ -151,7 +151,7 @@ private:
 class FreqUpdateEvent : public QEvent
 {
 public:
-    FreqUpdateEvent(const std::vector<double*> dataPoints, const uint64_t numDataPoints);
+    FreqUpdateEvent(const std::vector<double*>& dataPoints, const uint64_t numDataPoints);
 
     ~FreqUpdateEvent();
 
@@ -190,8 +190,8 @@ private:
 class QTGUI_API ConstUpdateEvent : public QEvent
 {
 public:
-    ConstUpdateEvent(const std::vector<double*> realDataPoints,
-                     const std::vector<double*> imagDataPoints,
+    ConstUpdateEvent(const std::vector<double*>& realDataPoints,
+                     const std::vector<double*>& imagDataPoints,
                      const uint64_t numDataPoints);
 
     ~ConstUpdateEvent();
@@ -219,7 +219,7 @@ private:
 class WaterfallUpdateEvent : public QEvent
 {
 public:
-    WaterfallUpdateEvent(const std::vector<double*> dataPoints,
+    WaterfallUpdateEvent(const std::vector<double*>& dataPoints,
                          const uint64_t numDataPoints,
                          const gr::high_res_timer_type dataTimestamp);
 
@@ -250,7 +250,7 @@ private:
 class TimeRasterUpdateEvent : public QEvent
 {
 public:
-    TimeRasterUpdateEvent(const std::vector<double*> dataPoints,
+    TimeRasterUpdateEvent(const std::vector<double*>& dataPoints,
                           const uint64_t numDataPoints);
     ~TimeRasterUpdateEvent();
 
@@ -292,7 +292,7 @@ private:
 class HistogramUpdateEvent : public QEvent
 {
 public:
-    HistogramUpdateEvent(const std::vector<double*> points, const uint64_t npoints);
+    HistogramUpdateEvent(const std::vector<double*>& points, const uint64_t npoints);
 
     ~HistogramUpdateEvent();
 
@@ -342,7 +342,7 @@ public:
 class NumberUpdateEvent : public QEvent
 {
 public:
-    NumberUpdateEvent(const std::vector<float> samples);
+    NumberUpdateEvent(const std::vector<float>& samples);
     ~NumberUpdateEvent();
 
     int which() const;

--- a/gr-qtgui/include/gnuradio/qtgui/timedisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timedisplayform.h
@@ -72,12 +72,12 @@ public slots:
     void updateTrigger(gr::qtgui::trigger_mode mode);
     void setTriggerMode(gr::qtgui::trigger_mode mode);
     void setTriggerSlope(gr::qtgui::trigger_slope slope);
-    void setTriggerLevel(QString s);
+    void setTriggerLevel(const QString& s);
     void setTriggerLevel(float level);
-    void setTriggerDelay(QString s);
+    void setTriggerDelay(const QString& s);
     void setTriggerDelay(float delay);
     void setTriggerChannel(int chan);
-    void setTriggerTagKey(QString s);
+    void setTriggerTagKey(const QString& s);
     void setTriggerTagKey(const std::string& s);
 
     void setupControlPanel(bool en);

--- a/gr-qtgui/include/gnuradio/qtgui/timerasterdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timerasterdisplayform.h
@@ -64,8 +64,8 @@ public slots:
     void setNumRows(double rows);
     void setNumCols(double cols);
 
-    void setNumRows(QString rows);
-    void setNumCols(QString cols);
+    void setNumRows(const QString& rows);
+    void setNumCols(const QString& cols);
 
     void setSampleRate(const double samprate);
     void setSampleRate(const QString& rate);
@@ -76,8 +76,8 @@ public slots:
 
     void setColorMap(unsigned int which,
                      const int newType,
-                     const QColor lowColor = QColor("white"),
-                     const QColor highColor = QColor("white"));
+                     const QColor& lowColor = QColor("white"),
+                     const QColor& highColor = QColor("white"));
 
     void setAlpha(unsigned int which, unsigned int alpha);
 

--- a/gr-qtgui/include/gnuradio/qtgui/utils.h
+++ b/gr-qtgui/include/gnuradio/qtgui/utils.h
@@ -36,7 +36,7 @@
  * the qApplication. The QSS file is typically retrieved using the
  * [qtgui] qss=\<filename\> section of the preferences files.
  */
-QTGUI_API QString get_qt_style_sheet(QString filename);
+QTGUI_API QString get_qt_style_sheet(const QString& filename);
 
 class QTGUI_API QwtDblClickPlotPicker : public QwtPlotPicker
 {

--- a/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
@@ -65,7 +65,7 @@ public:
 
 public slots:
     void customEvent(QEvent* e);
-    void setTimeTitle(const std::string);
+    void setTimeTitle(const std::string&);
     void setSampleRate(const QString& samprate);
     void setFFTSize(const int);
     void setFFTAverage(const float);
@@ -81,8 +81,8 @@ public slots:
 
     void setColorMap(unsigned int which,
                      const int newType,
-                     const QColor lowColor = QColor("white"),
-                     const QColor highColor = QColor("white"));
+                     const QColor& lowColor = QColor("white"),
+                     const QColor& highColor = QColor("white"));
 
     void autoScale(bool en = false);
     void setPlotPosHalf(bool half);

--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
+++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
@@ -163,8 +163,8 @@ void ConstellationDisplayPlot::set_pen_size(int size)
 void ConstellationDisplayPlot::replot() { QwtPlot::replot(); }
 
 
-void ConstellationDisplayPlot::plotNewData(const std::vector<double*> realDataPoints,
-                                           const std::vector<double*> imagDataPoints,
+void ConstellationDisplayPlot::plotNewData(const std::vector<double*>& realDataPoints,
+                                           const std::vector<double*>& imagDataPoints,
                                            const int64_t numDataPoints,
                                            const double timeInterval)
 {

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -203,7 +203,7 @@ SETUPLINE(7, 6)
 SETUPLINE(8, 7)
 SETUPLINE(9, 8)
 
-void DisplayPlot::setZoomerColor(QColor c)
+void DisplayPlot::setZoomerColor(const QColor& c)
 {
     d_zoomer->setRubberBandPen(c);
     d_zoomer->setTrackerPen(c);
@@ -211,7 +211,7 @@ void DisplayPlot::setZoomerColor(QColor c)
 
 QColor DisplayPlot::getZoomerColor() const { return d_zoomer->rubberBandPen().color(); }
 
-void DisplayPlot::setPaletteColor(QColor c)
+void DisplayPlot::setPaletteColor(const QColor& c)
 {
     QPalette palette;
     palette.setColor(canvas()->backgroundRole(), c);

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -333,7 +333,7 @@ void FrequencyDisplayPlot::replot()
     QwtPlot::replot();
 }
 
-void FrequencyDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void FrequencyDisplayPlot::plotNewData(const std::vector<double*>& dataPoints,
                                        const int64_t numDataPoints,
                                        const double noiseFloorAmplitude,
                                        const double peakFrequency,
@@ -524,9 +524,12 @@ void FrequencyDisplayPlot::setUpperIntensityLevel(const double upperIntensityLev
     d_upper_intensity_marker->setYValue(upperIntensityLevel);
 }
 
-void FrequencyDisplayPlot::setTraceColour(QColor c) { d_plot_curve[0]->setPen(QPen(c)); }
+void FrequencyDisplayPlot::setTraceColour(const QColor& c)
+{
+    d_plot_curve[0]->setPen(QPen(c));
+}
 
-void FrequencyDisplayPlot::setBGColour(QColor c)
+void FrequencyDisplayPlot::setBGColour(const QColor& c)
 {
     QPalette palette;
     palette.setColor(canvas()->backgroundRole(), c);
@@ -567,14 +570,14 @@ void FrequencyDisplayPlot::setYLabel(const std::string& label, const std::string
     setAxisTitle(QwtPlot::yLeft, QString(l.c_str()));
 }
 
-void FrequencyDisplayPlot::setMinFFTColor(QColor c)
+void FrequencyDisplayPlot::setMinFFTColor(const QColor& c)
 {
     d_min_fft_color = c;
     d_min_fft_plot_curve->setPen(QPen(c));
 }
 const QColor FrequencyDisplayPlot::getMinFFTColor() const { return d_min_fft_color; }
 
-void FrequencyDisplayPlot::setMaxFFTColor(QColor c)
+void FrequencyDisplayPlot::setMaxFFTColor(const QColor& c)
 {
     d_max_fft_color = c;
     d_max_fft_plot_curve->setPen(QPen(c));
@@ -582,7 +585,7 @@ void FrequencyDisplayPlot::setMaxFFTColor(QColor c)
 
 const QColor FrequencyDisplayPlot::getMaxFFTColor() const { return d_max_fft_color; }
 
-void FrequencyDisplayPlot::setMarkerLowerIntensityColor(QColor c)
+void FrequencyDisplayPlot::setMarkerLowerIntensityColor(const QColor& c)
 {
     d_marker_lower_intensity_color = c;
     d_lower_intensity_marker->setLinePen(QPen(c));
@@ -605,7 +608,7 @@ const bool FrequencyDisplayPlot::getMarkerLowerIntensityVisible() const
     return d_marker_lower_intensity_visible;
 }
 
-void FrequencyDisplayPlot::setMarkerUpperIntensityColor(QColor c)
+void FrequencyDisplayPlot::setMarkerUpperIntensityColor(const QColor& c)
 {
     d_marker_upper_intensity_color = c;
     d_upper_intensity_marker->setLinePen(QPen(c, 0, Qt::DotLine));
@@ -630,7 +633,7 @@ const bool FrequencyDisplayPlot::getMarkerUpperIntensityVisible() const
     return d_marker_upper_intensity_visible;
 }
 
-void FrequencyDisplayPlot::setMarkerPeakAmplitudeColor(QColor c)
+void FrequencyDisplayPlot::setMarkerPeakAmplitudeColor(const QColor& c)
 {
     d_marker_peak_amplitude_color = c;
     d_marker_peak_amplitude->setLinePen(QPen(c));
@@ -650,7 +653,7 @@ const QColor FrequencyDisplayPlot::getMarkerPeakAmplitudeColor() const
     return d_marker_peak_amplitude_color;
 }
 
-void FrequencyDisplayPlot::setMarkerNoiseFloorAmplitudeColor(QColor c)
+void FrequencyDisplayPlot::setMarkerNoiseFloorAmplitudeColor(const QColor& c)
 {
     d_marker_noise_floor_amplitude_color = c;
     d_marker_noise_floor_amplitude->setLinePen(QPen(c, 0, Qt::DotLine));
@@ -675,7 +678,7 @@ const bool FrequencyDisplayPlot::getMarkerNoiseFloorAmplitudeVisible() const
     return d_marker_noise_floor_amplitude_visible;
 }
 
-void FrequencyDisplayPlot::setMarkerCFColor(QColor c)
+void FrequencyDisplayPlot::setMarkerCFColor(const QColor& c)
 {
     d_marker_cf_color = c;
     d_marker_cf->setLinePen(QPen(c, 0, Qt::DotLine));

--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -184,7 +184,7 @@ HistogramDisplayPlot::~HistogramDisplayPlot()
 
 void HistogramDisplayPlot::replot() { QwtPlot::replot(); }
 
-void HistogramDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void HistogramDisplayPlot::plotNewData(const std::vector<double*>& dataPoints,
                                        const uint64_t numDataPoints,
                                        const double timeInterval)
 {

--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -153,7 +153,7 @@ void SpectrumGUIClass::reset()
     // ResetPendingGUIUpdateEvents();
 }
 
-void SpectrumGUIClass::setDisplayTitle(const std::string newString)
+void SpectrumGUIClass::setDisplayTitle(const std::string& newString)
 {
     _title.assign(newString);
 

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -31,6 +31,7 @@
 #include <QColor>
 #include <cmath>
 #include <iostream>
+#include <utility>
 
 class TimePrecisionClass
 {
@@ -212,7 +213,7 @@ TimeDomainDisplayPlot::~TimeDomainDisplayPlot()
 
 void TimeDomainDisplayPlot::replot() { QwtPlot::replot(); }
 
-void TimeDomainDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void TimeDomainDisplayPlot::plotNewData(const std::vector<double*>& dataPoints,
                                         const int64_t numDataPoints,
                                         const double timeInterval,
                                         const std::vector<std::vector<gr::tag_t>>& tags)
@@ -582,11 +583,11 @@ const Qt::BrushStyle TimeDomainDisplayPlot::getTagBackgroundStyle()
     return d_tag_background_style;
 }
 
-void TimeDomainDisplayPlot::setTagTextColor(QColor c) { d_tag_text_color = c; }
+void TimeDomainDisplayPlot::setTagTextColor(QColor c) { d_tag_text_color = std::move(c); }
 
 void TimeDomainDisplayPlot::setTagBackgroundColor(QColor c)
 {
-    d_tag_background_color = c;
+    d_tag_background_color = std::move(c);
 }
 
 void TimeDomainDisplayPlot::setTagBackgroundStyle(Qt::BrushStyle b)

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -340,7 +340,7 @@ void TimeRasterDisplayPlot::setPlotDimensions(const double rows,
     }
 }
 
-void TimeRasterDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void TimeRasterDisplayPlot::plotNewData(const std::vector<double*>& dataPoints,
                                         const uint64_t numDataPoints)
 {
     if (!d_stop) {
@@ -450,8 +450,8 @@ void TimeRasterDisplayPlot::setColorMapTitleFontSize(int tfs)
 
 void TimeRasterDisplayPlot::setIntensityColorMapType(const unsigned int which,
                                                      const int newType,
-                                                     const QColor lowColor,
-                                                     const QColor highColor)
+                                                     const QColor& lowColor,
+                                                     const QColor& highColor)
 {
     if (which >= d_color_map_type.size())
         throw std::runtime_error(

--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -296,7 +296,7 @@ void VectorDisplayPlot::replot()
     QwtPlot::replot();
 }
 
-void VectorDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void VectorDisplayPlot::plotNewData(const std::vector<double*>& dataPoints,
                                     const int64_t numDataPoints,
                                     const double refLevel,
                                     const double timeInterval)
@@ -438,9 +438,12 @@ void VectorDisplayPlot::setUpperIntensityLevel(const double upperIntensityLevel)
     d_upper_intensity_marker->setYValue(upperIntensityLevel);
 }
 
-void VectorDisplayPlot::setTraceColour(QColor c) { d_plot_curve[0]->setPen(QPen(c)); }
+void VectorDisplayPlot::setTraceColour(const QColor& c)
+{
+    d_plot_curve[0]->setPen(QPen(c));
+}
 
-void VectorDisplayPlot::setBGColour(QColor c)
+void VectorDisplayPlot::setBGColour(const QColor& c)
 {
     QPalette palette;
     palette.setColor(canvas()->backgroundRole(), c);
@@ -461,7 +464,7 @@ void VectorDisplayPlot::onPickerPointSelected6(const QPointF& p)
     emit plotPointSelected(point);
 }
 
-void VectorDisplayPlot::setMinVecColor(QColor c)
+void VectorDisplayPlot::setMinVecColor(const QColor& c)
 {
     d_min_vec_color = c;
     d_min_vec_plot_curve->setPen(QPen(c));
@@ -469,7 +472,7 @@ void VectorDisplayPlot::setMinVecColor(QColor c)
 
 const QColor VectorDisplayPlot::getMinVecColor() const { return d_min_vec_color; }
 
-void VectorDisplayPlot::setMaxVecColor(QColor c)
+void VectorDisplayPlot::setMaxVecColor(const QColor& c)
 {
     d_max_vec_color = c;
     d_max_vec_plot_curve->setPen(QPen(c));
@@ -477,7 +480,7 @@ void VectorDisplayPlot::setMaxVecColor(QColor c)
 
 const QColor VectorDisplayPlot::getMaxVecColor() const { return d_max_vec_color; }
 
-void VectorDisplayPlot::setMarkerLowerIntensityColor(QColor c)
+void VectorDisplayPlot::setMarkerLowerIntensityColor(const QColor& c)
 {
     d_marker_lower_intensity_color = c;
     d_lower_intensity_marker->setLinePen(QPen(c));
@@ -500,7 +503,7 @@ const bool VectorDisplayPlot::getMarkerLowerIntensityVisible() const
     return d_marker_lower_intensity_visible;
 }
 
-void VectorDisplayPlot::setMarkerUpperIntensityColor(QColor c)
+void VectorDisplayPlot::setMarkerUpperIntensityColor(const QColor& c)
 {
     d_marker_upper_intensity_color = c;
     d_upper_intensity_marker->setLinePen(QPen(c, 0, Qt::DotLine));
@@ -525,7 +528,7 @@ const bool VectorDisplayPlot::getMarkerUpperIntensityVisible() const
     return d_marker_upper_intensity_visible;
 }
 
-void VectorDisplayPlot::setMarkerRefLevelAmplitudeColor(QColor c)
+void VectorDisplayPlot::setMarkerRefLevelAmplitudeColor(const QColor& c)
 {
     d_marker_ref_level_color = c;
     d_marker_ref_level->setLinePen(QPen(c, 0, Qt::DotLine));

--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -44,6 +44,7 @@
 namespace pt = boost::posix_time;
 
 #include <QDebug>
+#include <utility>
 
 /***********************************************************************
  * Text scale widget to provide Y (time) axis text
@@ -253,7 +254,7 @@ double WaterfallDisplayPlot::getStartFrequency() const { return d_start_frequenc
 
 double WaterfallDisplayPlot::getStopFrequency() const { return d_stop_frequency; }
 
-void WaterfallDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
+void WaterfallDisplayPlot::plotNewData(const std::vector<double*>& dataPoints,
                                        const int64_t numDataPoints,
                                        const double timePerFFT,
                                        const gr::high_res_timer_type timestamp,
@@ -443,8 +444,8 @@ int WaterfallDisplayPlot::getIntensityColorMapType(unsigned int which) const
 
 void WaterfallDisplayPlot::setIntensityColorMapType(const unsigned int which,
                                                     const int newType,
-                                                    const QColor lowColor,
-                                                    const QColor highColor)
+                                                    const QColor& lowColor,
+                                                    const QColor& highColor)
 {
     if ((d_intensity_color_map_type[which] != newType) ||
         ((newType == INTENSITY_COLOR_MAP_TYPE_USER_DEFINED) &&
@@ -546,7 +547,7 @@ int WaterfallDisplayPlot::getIntensityColorMapType1() const
 
 void WaterfallDisplayPlot::setUserDefinedLowIntensityColor(QColor c)
 {
-    d_user_defined_low_intensity_color = c;
+    d_user_defined_low_intensity_color = std::move(c);
 }
 
 const QColor WaterfallDisplayPlot::getUserDefinedLowIntensityColor() const
@@ -556,7 +557,7 @@ const QColor WaterfallDisplayPlot::getUserDefinedLowIntensityColor() const
 
 void WaterfallDisplayPlot::setUserDefinedHighIntensityColor(QColor c)
 {
-    d_user_defined_high_intensity_color = c;
+    d_user_defined_high_intensity_color = std::move(c);
 }
 
 const QColor WaterfallDisplayPlot::getUserDefinedHighIntensityColor() const

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -27,6 +27,7 @@
 #include <gnuradio/math.h>
 #include <volk/volk.h>
 #include <cmath>
+#include <utility>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -42,8 +43,12 @@ ber_sink_b::sptr ber_sink_b::make(std::vector<float> esnos,
                                   std::vector<std::string> curvenames,
                                   QWidget* parent)
 {
-    return gnuradio::get_initial_sptr(new ber_sink_b_impl(
-        esnos, curves, ber_min_errors, ber_limit, curvenames, parent));
+    return gnuradio::get_initial_sptr(new ber_sink_b_impl(std::move(esnos),
+                                                          curves,
+                                                          ber_min_errors,
+                                                          ber_limit,
+                                                          std::move(curvenames),
+                                                          parent));
 }
 
 ber_sink_b_impl::ber_sink_b_impl(std::vector<float> esnos,

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -479,7 +479,7 @@ int const_sink_c_impl::work(int noutput_items,
     return nitems;
 }
 
-void const_sink_c_impl::handle_pdus(pmt::pmt_t msg)
+void const_sink_c_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len = 0;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/const_sink_c_impl.h
+++ b/gr-qtgui/lib/const_sink_c_impl.h
@@ -69,7 +69,7 @@ private:
     bool _test_trigger_slope(const gr_complex* in) const;
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     const_sink_c_impl(int size,

--- a/gr-qtgui/lib/constellationdisplayform.cc
+++ b/gr-qtgui/lib/constellationdisplayform.cc
@@ -189,7 +189,10 @@ gr::qtgui::trigger_slope ConstellationDisplayForm::getTriggerSlope() const
     return d_trig_slope;
 }
 
-void ConstellationDisplayForm::setTriggerLevel(QString s) { d_trig_level = s.toFloat(); }
+void ConstellationDisplayForm::setTriggerLevel(const QString& s)
+{
+    d_trig_level = s.toFloat();
+}
 
 void ConstellationDisplayForm::setTriggerLevel(float level)
 {
@@ -207,7 +210,7 @@ void ConstellationDisplayForm::setTriggerChannel(int channel)
 
 int ConstellationDisplayForm::getTriggerChannel() const { return d_trig_channel; }
 
-void ConstellationDisplayForm::setTriggerTagKey(QString s)
+void ConstellationDisplayForm::setTriggerTagKey(const QString& s)
 {
     d_trig_tag_key = s.toStdString();
 }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -484,7 +484,7 @@ void freq_sink_c_impl::check_clicked()
     }
 }
 
-void freq_sink_c_impl::handle_set_freq(pmt::pmt_t msg)
+void freq_sink_c_impl::handle_set_freq(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -496,7 +496,7 @@ void freq_sink_c_impl::handle_set_freq(pmt::pmt_t msg)
     }
 }
 
-void freq_sink_c_impl::handle_set_bw(pmt::pmt_t msg)
+void freq_sink_c_impl::handle_set_bw(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -623,7 +623,7 @@ int freq_sink_c_impl::work(int noutput_items,
 }
 
 
-void freq_sink_c_impl::handle_pdus(pmt::pmt_t msg)
+void freq_sink_c_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -77,14 +77,14 @@ private:
 
     // Handles message input port for setting new bandwidth
     // The message is a PMT pair (intern('bw'), double(bw))
-    void handle_set_bw(pmt::pmt_t msg);
+    void handle_set_bw(const pmt::pmt_t& msg);
 
     // Handles message input port for setting new center frequency.
     // The message is a PMT pair (intern('freq'), double(frequency)).
-    void handle_set_freq(pmt::pmt_t msg);
+    void handle_set_freq(const pmt::pmt_t& msg);
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
     // Members used for triggering scope
     trigger_mode d_trigger_mode;

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -488,7 +488,7 @@ void freq_sink_f_impl::check_clicked()
     }
 }
 
-void freq_sink_f_impl::handle_set_freq(pmt::pmt_t msg)
+void freq_sink_f_impl::handle_set_freq(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -500,7 +500,7 @@ void freq_sink_f_impl::handle_set_freq(pmt::pmt_t msg)
     }
 }
 
-void freq_sink_f_impl::handle_set_bw(pmt::pmt_t msg)
+void freq_sink_f_impl::handle_set_bw(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -626,7 +626,7 @@ int freq_sink_f_impl::work(int noutput_items,
     return noutput_items;
 }
 
-void freq_sink_f_impl::handle_pdus(pmt::pmt_t msg)
+void freq_sink_f_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -77,14 +77,14 @@ private:
 
     // Handles message input port for setting new bandwidth
     // The message is a PMT pair (intern('bw'), double(bw))
-    void handle_set_bw(pmt::pmt_t msg);
+    void handle_set_bw(const pmt::pmt_t& msg);
 
     // Handles message input port for setting new center frequency.
     // The message is a PMT pair (intern('freq'), double(frequency)).
-    void handle_set_freq(pmt::pmt_t msg);
+    void handle_set_freq(const pmt::pmt_t& msg);
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
     // Members used for triggering scope
     trigger_mode d_trigger_mode;

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -432,7 +432,7 @@ void FreqDisplayForm::updateTrigger(gr::qtgui::trigger_mode mode)
 
 gr::qtgui::trigger_mode FreqDisplayForm::getTriggerMode() const { return d_trig_mode; }
 
-void FreqDisplayForm::setTriggerLevel(QString s)
+void FreqDisplayForm::setTriggerLevel(const QString& s)
 {
     d_trig_level = s.toFloat();
 
@@ -468,7 +468,10 @@ void FreqDisplayForm::setTriggerChannel(int channel)
 
 int FreqDisplayForm::getTriggerChannel() const { return d_trig_channel; }
 
-void FreqDisplayForm::setTriggerTagKey(QString s) { d_trig_tag_key = s.toStdString(); }
+void FreqDisplayForm::setTriggerTagKey(const QString& s)
+{
+    d_trig_tag_key = s.toStdString();
+}
 
 void FreqDisplayForm::setTriggerTagKey(const std::string& key)
 {

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -358,7 +358,7 @@ int histogram_sink_f_impl::work(int noutput_items,
     return j;
 }
 
-void histogram_sink_f_impl::handle_pdus(pmt::pmt_t msg)
+void histogram_sink_f_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/histogram_sink_f_impl.h
+++ b/gr-qtgui/lib/histogram_sink_f_impl.h
@@ -56,7 +56,7 @@ private:
     void npoints_resize();
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     histogram_sink_f_impl(int size,

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -323,12 +323,12 @@ void NumberDisplayForm::setColor(unsigned int which, const QColor& min, const QC
 #endif /* QWT_VERSION < 0x060000 */
 }
 
-void NumberDisplayForm::setColorMin(unsigned int which, QString min)
+void NumberDisplayForm::setColorMin(unsigned int which, const QString& min)
 {
     setColor(which, QColor(min), colorMax(which));
 }
 
-void NumberDisplayForm::setColorMax(unsigned int which, QString max)
+void NumberDisplayForm::setColorMax(unsigned int which, const QString& max)
 {
     setColor(which, colorMin(which), QColor(max));
 }
@@ -338,7 +338,7 @@ void NumberDisplayForm::setLabel(unsigned int which, const std::string& label)
     d_label[which]->setText(label.c_str());
 }
 
-void NumberDisplayForm::setLabel(unsigned int which, QString label)
+void NumberDisplayForm::setLabel(unsigned int which, const QString& label)
 {
     d_label[which]->setText(label);
 }
@@ -347,7 +347,10 @@ void NumberDisplayForm::setAverage(const float avg) { d_avg = avg; }
 
 void NumberDisplayForm::setUpdateTime(const float time) { d_update_time = time; }
 
-void NumberDisplayForm::setUpdateTime(QString time) { setUpdateTime(time.toFloat()); }
+void NumberDisplayForm::setUpdateTime(const QString& time)
+{
+    setUpdateTime(time.toFloat());
+}
 
 void NumberDisplayForm::setScale(unsigned int which, int min, int max)
 {

--- a/gr-qtgui/lib/qtgui_util.cc
+++ b/gr-qtgui/lib/qtgui_util.cc
@@ -29,7 +29,7 @@
 #include <QDebug>
 #include <QFile>
 
-QString get_qt_style_sheet(QString filename)
+QString get_qt_style_sheet(const QString& filename)
 {
     QString sstext;
     QFile ss(filename);

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -303,7 +303,7 @@ void sink_c_impl::check_clicked()
     }
 }
 
-void sink_c_impl::handle_set_freq(pmt::pmt_t msg)
+void sink_c_impl::handle_set_freq(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);

--- a/gr-qtgui/lib/sink_c_impl.h
+++ b/gr-qtgui/lib/sink_c_impl.h
@@ -75,7 +75,7 @@ private:
 
     // Handles message input port for setting new center frequency.
     // The message is a PMT pair (intern('freq'), double(frequency)).
-    void handle_set_freq(pmt::pmt_t msg);
+    void handle_set_freq(const pmt::pmt_t& msg);
 
 public:
     sink_c_impl(int fftsize,

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -297,7 +297,7 @@ void sink_f_impl::check_clicked()
     }
 }
 
-void sink_f_impl::handle_set_freq(pmt::pmt_t msg)
+void sink_f_impl::handle_set_freq(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);

--- a/gr-qtgui/lib/sink_f_impl.h
+++ b/gr-qtgui/lib/sink_f_impl.h
@@ -73,7 +73,7 @@ private:
 
     // Handles message input port for setting new center frequency.
     // The message is a PMT pair (intern('freq'), double(frequency)).
-    void handle_set_freq(pmt::pmt_t msg);
+    void handle_set_freq(const pmt::pmt_t& msg);
 
 public:
     sink_f_impl(int fftsize,

--- a/gr-qtgui/lib/spectrumUpdateEvents.cc
+++ b/gr-qtgui/lib/spectrumUpdateEvents.cc
@@ -162,9 +162,9 @@ double SpectrumFrequencyRangeEvent::GetStopFrequency() const { return _stopFrequ
 /***************************************************************************/
 
 
-TimeUpdateEvent::TimeUpdateEvent(const std::vector<double*> timeDomainPoints,
+TimeUpdateEvent::TimeUpdateEvent(const std::vector<double*>& timeDomainPoints,
                                  const uint64_t numTimeDomainDataPoints,
-                                 const std::vector<std::vector<gr::tag_t>> tags)
+                                 const std::vector<std::vector<gr::tag_t>>& tags)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
 {
     if (numTimeDomainDataPoints < 1) {
@@ -211,7 +211,7 @@ const std::vector<std::vector<gr::tag_t>> TimeUpdateEvent::getTags() const
 /***************************************************************************/
 
 
-FreqUpdateEvent::FreqUpdateEvent(const std::vector<double*> dataPoints,
+FreqUpdateEvent::FreqUpdateEvent(const std::vector<double*>& dataPoints,
                                  const uint64_t numDataPoints)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
 {
@@ -259,8 +259,8 @@ double SetFreqEvent::getBandwidth() const { return _bandwidth; }
 /***************************************************************************/
 
 
-ConstUpdateEvent::ConstUpdateEvent(const std::vector<double*> realDataPoints,
-                                   const std::vector<double*> imagDataPoints,
+ConstUpdateEvent::ConstUpdateEvent(const std::vector<double*>& realDataPoints,
+                                   const std::vector<double*>& imagDataPoints,
                                    const uint64_t numDataPoints)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
 {
@@ -307,7 +307,7 @@ uint64_t ConstUpdateEvent::getNumDataPoints() const { return _numDataPoints; }
 /***************************************************************************/
 
 
-WaterfallUpdateEvent::WaterfallUpdateEvent(const std::vector<double*> dataPoints,
+WaterfallUpdateEvent::WaterfallUpdateEvent(const std::vector<double*>& dataPoints,
                                            const uint64_t numDataPoints,
                                            const gr::high_res_timer_type dataTimestamp)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
@@ -349,7 +349,7 @@ gr::high_res_timer_type WaterfallUpdateEvent::getDataTimestamp() const
 /***************************************************************************/
 
 
-TimeRasterUpdateEvent::TimeRasterUpdateEvent(const std::vector<double*> dataPoints,
+TimeRasterUpdateEvent::TimeRasterUpdateEvent(const std::vector<double*>& dataPoints,
                                              const uint64_t numDataPoints)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
 {
@@ -397,7 +397,7 @@ double TimeRasterSetSize::nCols() const { return _ncols; }
 /***************************************************************************/
 
 
-HistogramUpdateEvent::HistogramUpdateEvent(const std::vector<double*> points,
+HistogramUpdateEvent::HistogramUpdateEvent(const std::vector<double*>& points,
                                            const uint64_t npoints)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
 {
@@ -441,7 +441,7 @@ bool HistogramSetAccumulator::getAccumulator() const { return _en; }
 /***************************************************************************/
 
 
-NumberUpdateEvent::NumberUpdateEvent(const std::vector<float> samples)
+NumberUpdateEvent::NumberUpdateEvent(const std::vector<float>& samples)
     : QEvent(QEvent::Type(SpectrumUpdateEventType))
 {
     _samples = samples;

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -421,7 +421,7 @@ int time_raster_sink_b_impl::work(int noutput_items,
 }
 
 
-void time_raster_sink_b_impl::handle_pdus(pmt::pmt_t msg)
+void time_raster_sink_b_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/time_raster_sink_b_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.h
@@ -64,7 +64,7 @@ private:
     void _ncols_resize();
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     time_raster_sink_b_impl(double samp_rate,

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -414,7 +414,7 @@ int time_raster_sink_f_impl::work(int noutput_items,
     return j;
 }
 
-void time_raster_sink_f_impl::handle_pdus(pmt::pmt_t msg)
+void time_raster_sink_f_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/time_raster_sink_f_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.h
@@ -63,7 +63,7 @@ private:
     void _ncols_resize();
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     time_raster_sink_f_impl(double samp_rate,

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -624,7 +624,7 @@ int time_sink_c_impl::work(int noutput_items,
     return nitems;
 }
 
-void time_sink_c_impl::handle_pdus(pmt::pmt_t msg)
+void time_sink_c_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/time_sink_c_impl.h
+++ b/gr-qtgui/lib/time_sink_c_impl.h
@@ -76,7 +76,7 @@ private:
     bool _test_trigger_slope(const gr_complex* in) const;
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     time_sink_c_impl(int size,

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -613,7 +613,7 @@ int time_sink_f_impl::work(int noutput_items,
     return nitems;
 }
 
-void time_sink_f_impl::handle_pdus(pmt::pmt_t msg)
+void time_sink_f_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     pmt::pmt_t dict, samples;

--- a/gr-qtgui/lib/time_sink_f_impl.h
+++ b/gr-qtgui/lib/time_sink_f_impl.h
@@ -74,7 +74,7 @@ private:
     bool _test_trigger_slope(const float* in) const;
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     time_sink_f_impl(int size,

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -396,7 +396,7 @@ void TimeDisplayForm::setTriggerSlope(gr::qtgui::trigger_slope slope)
 
 gr::qtgui::trigger_slope TimeDisplayForm::getTriggerSlope() const { return d_trig_slope; }
 
-void TimeDisplayForm::setTriggerLevel(QString s)
+void TimeDisplayForm::setTriggerLevel(const QString& s)
 {
     d_trig_level = s.toFloat();
 
@@ -423,7 +423,7 @@ void TimeDisplayForm::setTriggerLevel(float level)
 
 float TimeDisplayForm::getTriggerLevel() const { return d_trig_level; }
 
-void TimeDisplayForm::setTriggerDelay(QString s)
+void TimeDisplayForm::setTriggerDelay(const QString& s)
 {
     d_trig_delay = s.toFloat();
 
@@ -460,7 +460,7 @@ void TimeDisplayForm::setTriggerChannel(int channel)
 
 int TimeDisplayForm::getTriggerChannel() const { return d_trig_channel; }
 
-void TimeDisplayForm::setTriggerTagKey(QString s)
+void TimeDisplayForm::setTriggerTagKey(const QString& s)
 {
     d_trig_tag_key = s.toStdString();
 

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -194,7 +194,7 @@ void TimeRasterDisplayForm::setNumRows(double rows)
     getPlot()->replot();
 }
 
-void TimeRasterDisplayForm::setNumRows(QString rows)
+void TimeRasterDisplayForm::setNumRows(const QString& rows)
 {
     getPlot()->setNumRows(rows.toDouble());
     getPlot()->replot();
@@ -206,7 +206,7 @@ void TimeRasterDisplayForm::setNumCols(double cols)
     getPlot()->replot();
 }
 
-void TimeRasterDisplayForm::setNumCols(QString cols)
+void TimeRasterDisplayForm::setNumCols(const QString& cols)
 {
     getPlot()->setNumCols(cols.toDouble());
     getPlot()->replot();
@@ -226,8 +226,8 @@ void TimeRasterDisplayForm::setSampleRate(const QString& rate)
 
 void TimeRasterDisplayForm::setColorMap(unsigned int which,
                                         const int newType,
-                                        const QColor lowColor,
-                                        const QColor highColor)
+                                        const QColor& lowColor,
+                                        const QColor& highColor)
 {
     getPlot()->setIntensityColorMapType(which, newType, lowColor, highColor);
     getPlot()->replot();

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -418,7 +418,7 @@ void waterfall_sink_c_impl::check_clicked()
     }
 }
 
-void waterfall_sink_c_impl::handle_set_freq(pmt::pmt_t msg)
+void waterfall_sink_c_impl::handle_set_freq(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -430,7 +430,7 @@ void waterfall_sink_c_impl::handle_set_freq(pmt::pmt_t msg)
     }
 }
 
-void waterfall_sink_c_impl::handle_set_bw(pmt::pmt_t msg)
+void waterfall_sink_c_impl::handle_set_bw(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -500,7 +500,7 @@ int waterfall_sink_c_impl::work(int noutput_items,
     return j;
 }
 
-void waterfall_sink_c_impl::handle_pdus(pmt::pmt_t msg)
+void waterfall_sink_c_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     size_t start = 0;

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -80,14 +80,14 @@ private:
 
     // Handles message input port for setting new bandwidth
     // The message is a PMT pair (intern('bw'), double(bw))
-    void handle_set_bw(pmt::pmt_t msg);
+    void handle_set_bw(const pmt::pmt_t& msg);
 
     // Handles message input port for setting new center frequency.
     // The message is a PMT pair (intern('freq'), double(frequency)).
-    void handle_set_freq(pmt::pmt_t msg);
+    void handle_set_freq(const pmt::pmt_t& msg);
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     waterfall_sink_c_impl(int size,

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -425,7 +425,7 @@ void waterfall_sink_f_impl::check_clicked()
     }
 }
 
-void waterfall_sink_f_impl::handle_set_freq(pmt::pmt_t msg)
+void waterfall_sink_f_impl::handle_set_freq(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -437,7 +437,7 @@ void waterfall_sink_f_impl::handle_set_freq(pmt::pmt_t msg)
     }
 }
 
-void waterfall_sink_f_impl::handle_set_bw(pmt::pmt_t msg)
+void waterfall_sink_f_impl::handle_set_bw(const pmt::pmt_t& msg)
 {
     if (pmt::is_pair(msg)) {
         pmt::pmt_t x = pmt::cdr(msg);
@@ -507,7 +507,7 @@ int waterfall_sink_f_impl::work(int noutput_items,
     return j;
 }
 
-void waterfall_sink_f_impl::handle_pdus(pmt::pmt_t msg)
+void waterfall_sink_f_impl::handle_pdus(const pmt::pmt_t& msg)
 {
     size_t len;
     size_t start = 0;

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -80,14 +80,14 @@ private:
 
     // Handles message input port for setting new bandwidth
     // The message is a PMT pair (intern('bw'), double(bw))
-    void handle_set_bw(pmt::pmt_t msg);
+    void handle_set_bw(const pmt::pmt_t& msg);
 
     // Handles message input port for setting new center frequency.
     // The message is a PMT pair (intern('freq'), double(frequency)).
-    void handle_set_freq(pmt::pmt_t msg);
+    void handle_set_freq(const pmt::pmt_t& msg);
 
     // Handles message input port for displaying PDU samples.
-    void handle_pdus(pmt::pmt_t msg);
+    void handle_pdus(const pmt::pmt_t& msg);
 
 public:
     waterfall_sink_f_impl(int size,

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -235,8 +235,8 @@ void WaterfallDisplayForm::setFrequencyRange(const double centerfreq,
 
 void WaterfallDisplayForm::setColorMap(unsigned int which,
                                        const int newType,
-                                       const QColor lowColor,
-                                       const QColor highColor)
+                                       const QColor& lowColor,
+                                       const QColor& highColor)
 {
     getPlot()->setIntensityColorMapType(which, newType, lowColor, highColor);
     getPlot()->replot();
@@ -301,7 +301,7 @@ bool WaterfallDisplayForm::checkClicked()
     }
 }
 
-void WaterfallDisplayForm::setTimeTitle(const std::string title)
+void WaterfallDisplayForm::setTimeTitle(const std::string& title)
 {
     getPlot()->setAxisTitle(QwtPlot::yLeft, title.c_str());
 }

--- a/gr-trellis/include/gnuradio/trellis/fsm.h
+++ b/gr-trellis/include/gnuradio/trellis/fsm.h
@@ -189,14 +189,14 @@ public:
      * \param filename         filename
      * \param number_stages    ????
      */
-    void write_trellis_svg(std::string filename, int number_stages);
+    void write_trellis_svg(const std::string& filename, int number_stages);
 
     /*!
      * \brief Write the FSMS to a file.
      *
      * \param filename   filename
      */
-    void write_fsm_txt(std::string filename);
+    void write_fsm_txt(const std::string& filename);
 };
 
 } /* namespace trellis */

--- a/gr-trellis/include/gnuradio/trellis/interleaver.h
+++ b/gr-trellis/include/gnuradio/trellis/interleaver.h
@@ -50,7 +50,7 @@ public:
     unsigned int K() const { return d_K; }
     const std::vector<int>& INTER() const { return d_INTER; }
     const std::vector<int>& DEINTER() const { return d_DEINTER; }
-    void write_interleaver_txt(std::string filename);
+    void write_interleaver_txt(const std::string& filename);
 };
 
 } /* namespace trellis */

--- a/gr-trellis/lib/constellation_metrics_cf_impl.cc
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.cc
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <iostream>
 #include <stdexcept>
+#include <utility>
 
 namespace gr {
 namespace trellis {
@@ -38,11 +39,11 @@ constellation_metrics_cf::make(digital::constellation_sptr constellation,
                                digital::trellis_metric_type_t TYPE)
 {
     return gnuradio::get_initial_sptr(
-        new constellation_metrics_cf_impl(constellation, TYPE));
+        new constellation_metrics_cf_impl(std::move(constellation), TYPE));
 }
 
 constellation_metrics_cf_impl::constellation_metrics_cf_impl(
-    digital::constellation_sptr constellation, digital::trellis_metric_type_t TYPE)
+    const digital::constellation_sptr& constellation, digital::trellis_metric_type_t TYPE)
     : block("constellation_metrics_cf",
             io_signature::make(1, -1, sizeof(gr_complex)),
             io_signature::make(1, -1, sizeof(float))),

--- a/gr-trellis/lib/constellation_metrics_cf_impl.h
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.h
@@ -38,7 +38,7 @@ private:
     unsigned int d_D;
 
 public:
-    constellation_metrics_cf_impl(digital::constellation_sptr constellation,
+    constellation_metrics_cf_impl(const digital::constellation_sptr& constellation,
                                   digital::trellis_metric_type_t TYPE);
     ~constellation_metrics_cf_impl();
 

--- a/gr-trellis/lib/core_algorithms.cc
+++ b/gr-trellis/lib/core_algorithms.cc
@@ -22,6 +22,7 @@
 
 #include <gnuradio/trellis/calc_metric.h>
 #include <gnuradio/trellis/core_algorithms.h>
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -35,7 +36,7 @@ float min(float a, float b) { return a <= b ? a : b; }
 
 float min_star(float a, float b)
 {
-    return (a <= b ? a : b) - log(1 + exp(a <= b ? a - b : b - a));
+    return (a <= b ? a : b) - log(1 + std::exp(a <= b ? a - b : b - a));
 }
 
 template <class T>

--- a/gr-trellis/lib/fsm.cc
+++ b/gr-trellis/lib/fsm.cc
@@ -484,7 +484,7 @@ bool fsm::find_es(int es)
 //######################################################################
 //#  generate trellis representation of FSM as an SVG file
 //######################################################################
-void fsm::write_trellis_svg(std::string filename, int number_stages)
+void fsm::write_trellis_svg(const std::string& filename, int number_stages)
 {
     std::ofstream trellis_fname(filename.c_str());
     if (!trellis_fname) {
@@ -574,7 +574,7 @@ void fsm::write_trellis_svg(std::string filename, int number_stages)
 //# Write trellis specification to a text file,
 //# in the same format used when reading FSM files
 //######################################################################
-void fsm::write_fsm_txt(std::string filename)
+void fsm::write_fsm_txt(const std::string& filename)
 {
     std::ofstream trellis_fname(filename.c_str());
     if (!trellis_fname) {

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -144,7 +144,7 @@ interleaver::interleaver(unsigned int K, int seed)
 //# list of space separated K integers from 0 to K-1 in appropriate order
 //# optional comments
 //######################################################################
-void interleaver::write_interleaver_txt(std::string filename)
+void interleaver::write_interleaver_txt(const std::string& filename)
 {
     std::ofstream interleaver_fname(filename.c_str());
     if (!interleaver_fname) {

--- a/gr-uhd/include/gnuradio/uhd/amsg_source.h
+++ b/gr-uhd/include/gnuradio/uhd/amsg_source.h
@@ -57,7 +57,7 @@ public:
      * Convert a raw asynchronous message to an asynchronous metadata object.
      * \return The asynchronous metadata object.
      */
-    static ::uhd::async_metadata_t msg_to_async_metadata_t(const message::sptr msg);
+    static ::uhd::async_metadata_t msg_to_async_metadata_t(const message::sptr& msg);
 };
 
 } /* namespace uhd */

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -22,6 +22,7 @@
 
 #include "usrp_block_impl.h"
 #include <boost/make_shared.hpp>
+#include <utility>
 
 using namespace gr::uhd;
 
@@ -33,7 +34,7 @@ const double usrp_block_impl::LOCK_TIMEOUT = 1.5;
 usrp_block::usrp_block(const std::string& name,
                        gr::io_signature::sptr input_signature,
                        gr::io_signature::sptr output_signature)
-    : sync_block(name, input_signature, output_signature)
+    : sync_block(name, std::move(input_signature), std::move(output_signature))
 {
     // nop
 }
@@ -179,7 +180,7 @@ void usrp_block_impl::_update_stream_args(const ::uhd::stream_args_t& stream_arg
 
 bool usrp_block_impl::_wait_for_locked_sensor(std::vector<std::string> sensor_names,
                                               const std::string& sensor_name,
-                                              get_sensor_fn_t get_sensor_fn)
+                                              const get_sensor_fn_t& get_sensor_fn)
 {
     if (std::find(sensor_names.begin(), sensor_names.end(), sensor_name) ==
         sensor_names.end())
@@ -274,7 +275,8 @@ bool usrp_block_impl::_check_mboard_sensors_locked()
     return clocks_locked;
 }
 
-void usrp_block_impl::_set_center_freq_from_internals_allchans(pmt::pmt_t direction)
+void usrp_block_impl::_set_center_freq_from_internals_allchans(
+    const pmt::pmt_t& direction)
 {
     while (_chans_to_tune.any()) {
         // This resets() bits, so this loop should not run indefinitely
@@ -562,7 +564,7 @@ void usrp_block_impl::dispatch_msg_cmd_handler(const pmt::pmt_t& cmd,
 void usrp_block_impl::register_msg_cmd_handler(const pmt::pmt_t& cmd,
                                                cmd_handler_t handler)
 {
-    _msg_cmd_handlers[cmd] = handler;
+    _msg_cmd_handlers[cmd] = std::move(handler);
 }
 
 void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req, int chan)

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -153,7 +153,7 @@ protected:
      */
     bool _wait_for_locked_sensor(std::vector<std::string> sensor_names,
                                  const std::string& sensor_name,
-                                 get_sensor_fn_t get_sensor_fn);
+                                 const get_sensor_fn_t& get_sensor_fn);
 
     //! Helper function for msg_handler_command:
     // - Extracts command and the command value from the command PMT
@@ -205,7 +205,7 @@ protected:
     _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction) = 0;
 
     //! Calls _set_center_freq_from_internals() on all channels
-    void _set_center_freq_from_internals_allchans(pmt::pmt_t direction);
+    void _set_center_freq_from_internals_allchans(const pmt::pmt_t& direction);
 
     /**********************************************************************
      * Members

--- a/gr-vocoder/include/gnuradio/vocoder/freedv_tx_ss.h
+++ b/gr-vocoder/include/gnuradio/vocoder/freedv_tx_ss.h
@@ -52,7 +52,7 @@ public:
      * \param interleave_frames FreeDV 700D mode number of frames to average error
      */
     static sptr make(int mode = freedv_api::MODE_1600,
-                     const std::string msg_txt = "GNU Radio",
+                     const std::string& msg_txt = "GNU Radio",
                      int interleave_frames = 1);
 };
 

--- a/gr-vocoder/lib/freedv_tx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.cc
@@ -53,14 +53,14 @@ namespace gr {
 namespace vocoder {
 
 freedv_tx_ss::sptr
-freedv_tx_ss::make(int mode, const std::string msg_txt, int interleave_frames)
+freedv_tx_ss::make(int mode, const std::string& msg_txt, int interleave_frames)
 {
     return gnuradio::get_initial_sptr(
         new freedv_tx_ss_impl(mode, msg_txt, interleave_frames));
 }
 
 freedv_tx_ss_impl::freedv_tx_ss_impl(int mode,
-                                     const std::string msg_txt,
+                                     const std::string& msg_txt,
                                      int interleave_frames)
     : sync_block("vocoder_freedv_tx_ss",
                  io_signature::make(1, 1, sizeof(short)),

--- a/gr-vocoder/lib/freedv_tx_ss_impl.h
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.h
@@ -63,7 +63,7 @@ private:
     struct CODEC2* d_c2;
 
 public:
-    freedv_tx_ss_impl(int mode, const std::string txt_msg, int interleave_frames);
+    freedv_tx_ss_impl(int mode, const std::string& txt_msg, int interleave_frames);
     ~freedv_tx_ss_impl();
 
     void set_clip(bool val);

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -28,6 +28,8 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace zeromq {
 
@@ -68,7 +70,7 @@ pub_msg_sink_impl::~pub_msg_sink_impl()
 void pub_msg_sink_impl::handler(pmt::pmt_t msg)
 {
     std::stringbuf sb("");
-    pmt::serialize(msg, sb);
+    pmt::serialize(std::move(msg), sb);
     std::string s = sb.str();
     zmq::message_t zmsg(s.size());
 

--- a/gr-zeromq/lib/push_msg_sink_impl.cc
+++ b/gr-zeromq/lib/push_msg_sink_impl.cc
@@ -28,6 +28,8 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 
+#include <utility>
+
 namespace gr {
 namespace zeromq {
 
@@ -70,7 +72,7 @@ push_msg_sink_impl::~push_msg_sink_impl()
 void push_msg_sink_impl::handler(pmt::pmt_t msg)
 {
     std::stringbuf sb("");
-    pmt::serialize(msg, sb);
+    pmt::serialize(std::move(msg), sb);
     std::string s = sb.str();
     zmq::message_t zmsg(s.size());
 

--- a/tools/clang-tidy-subtree.sh
+++ b/tools/clang-tidy-subtree.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/zsh
+
+files=$(git ls-files "$@")
+cpp_files=$(echo ${files}|grep -E '\.(cpp|hpp|c|cc|h)$')
+
+clang-tidy -fix-errors -header-filter=.\* -p build/


### PR DESCRIPTION
This boils down to three main categories:

* using const references where e.g. passing a smart pointer by value
 would be expensive
* using `std::move` on smart pointers not used afterwards
* use `<cmath>` `std::function` where possible, avoiding unnecessary
 `float`->`double` promotion

This basically affects most usage of `pmt_t`, since that's a smart pointer
type (which unfortunately is hidden and leads to frequent memory leaks on
the python/C++ interface).