### PR TITLE
Typo

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -322,7 +322,7 @@ def show_types(parent):
 def show_missing_xterm(parent, xterm):
     markup = textwrap.dedent("""\
         The xterm executable {0!r} is missing.
-        You can change this setting in your gnurado.conf, in section [grc], 'xterm_executable'.
+        You can change this setting in your gnuradio.conf, in section [grc], 'xterm_executable'.
         \n\
         (This message is shown only once)\
     """).format(xterm)


### PR DESCRIPTION
repro:
"execute" button, without xterm executable available, produces dialog with typo
<img width="421" alt="gnuradio-typo" src="https://user-images.githubusercontent.com/150244/62906539-2a30b280-bd3d-11e9-91cb-847539bb6048.png">
