### PR TITLE
cmake: don't cache thrift found

### DIFF
--- a/cmake/Modules/targetConfig.cmake.in
+++ b/cmake/Modules/targetConfig.cmake.in
@@ -21,6 +21,6 @@ include(CMakeFindDependencyMacro)
 
 set(target_deps "@TARGET_DEPENDENCIES@")
 foreach(dep IN LISTS target_deps)
-    find_dependency(${dep})
+    find_package(${dep})
 endforeach()
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGET@Targets.cmake")


### PR DESCRIPTION
If GNU Radio is compiled with Thrift, cmake fails in OOTs in all but the first run. AFAIS, Thirft libraries and paths are cached but not the target (not sure if this is possible at all). So cmake fails with

```
CMake Error at lib/CMakeLists.txt:36 (add_library):
  Target "gnuradio-foo" links to target "Thrift::thrift" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```