### PR TITLE
clang-tidy: Throw exceptions by value, catch by reference

### DIFF
--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -231,9 +231,8 @@ void block_detail::set_processor_affinity(const std::vector<int>& mask)
     if (threaded) {
         try {
             gr::thread::thread_bind_to_processor(thread, mask);
-        } catch (std::runtime_error e) {
+        } catch (std::runtime_error& e) {
             std::cerr << "set_processor_affinity: invalid mask." << std::endl;
-            ;
         }
     }
 }

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -110,7 +110,7 @@ void prefs::_read_files(const std::vector<std::string>& filenames)
                     std::string value = o.value[0];
                     d_config_map[section][key] = value;
                 }
-            } catch (std::exception e) {
+            } catch (std::exception& e) {
                 std::cerr << "WARNING: Config file '" << fname
                           << "' failed to parse:" << std::endl;
                 std::cerr << e.what() << std::endl;

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -238,7 +238,7 @@ bool usrp_block_impl::_unpack_chan_command(std::string& command,
         } else {
             return false;
         }
-    } catch (pmt::wrong_type w) {
+    } catch (pmt::wrong_type& w) {
         return false;
     }
     return true;


### PR DESCRIPTION
Exceptions should be thrown by value and caught by reference.
Closes #2708