### PR TITLE
modtool: Improve GRC YAML template

### DIFF
--- a/gr-utils/python/modtool/templates/templates.py
+++ b/gr-utils/python/modtool/templates/templates.py
@@ -550,11 +550,11 @@ templates:
   imports: import ${modname}
   make: ${modname}.${blockname}(${strip_arg_types_grc(arglist)})
 
-#  Make one 'parameters' list entry for every Parameter you want settable from the GUI.
-#     Sub-entries of dictionary:
+#  Make one 'parameters' list entry for every parameter you want settable from the GUI.
+#     Keys include:
 #     * id (makes the value accessible as \$keyname, e.g. in the make entry)
-#     * label
-#     * dtype 
+#     * label (label shown in the GUI)
+#     * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
 parameters:
 - id: ...
   label: ...
@@ -563,27 +563,29 @@ parameters:
   label: ...
   dtype: ...
 
-#  Make one 'inputs' list entry per input. Sub-entries of dictionary:
+#  Make one 'inputs' list entry per input and one 'outputs' list entry per output.
+#  Keys include:
 #      * label (an identifier for the GUI)
-#      * domain
-#      * dtype
-#      * vlen
-#      * optional (set to 1 for optional inputs) 
+#      * domain (optional - stream or message. Default is stream)
+#      * dtype (e.g. int, float, complex, byte, short, xxx_vector, ...)
+#      * vlen (optional - data stream vector length. Default is 1)
+#      * optional (optional - set to 1 for optional inputs. Default is 0)
 inputs:
 - label: ...
   domain: ...
   dtype: ...
   vlen: ...
+  optional: ...
 
-#  Make one 'outputs' list entry per output. Sub-entries of dictionary:
-#      * label (an identifier for the GUI)
-#      * dtype
-#      * vlen
-#      * optional (set to 1 for optional inputs) 
+outputs:
 - label: ...
   domain: ...
-  dtype: ... #!-- e.g. int, float, complex, byte, short, xxx_vector, ...--
+  dtype: ...
+  vlen: ...
+  optional: ...
 
+#  'file_format' specifies the version of the GRC yml format used in the file
+#  and should usually not be changed.
 file_format: 1
 '''
 


### PR DESCRIPTION
This pull request adds a couple of improvements to the GRC YAML template in gr-modtool:
- Adds a missing "outputs:" key
- Removes redundant documentation
- Removes a couple of trailing whitespaces