### PR TITLE
Code improvements through clang-tidy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,9 @@
+---
+Checks:          '-*,misc-throw-by-value-catch-by-reference,'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 ---
-Checks:          '-*,misc-throw-by-value-catch-by-reference,'
+Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert'
+# Not in here: modernize-use-emplace, since that basically broke all things it touched
 WarningsAsErrors: ''
-HeaderFilterRegex: ''
+HeaderFilterRegex: '\.(cc|c|cpp|h|hpp)$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert'
+Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert,readability-container-size-empty'
 # Not in here: modernize-use-emplace, since that basically broke all things it touched
 WarningsAsErrors: ''
 HeaderFilterRegex: '\.(cc|c|cpp|h|hpp)$'

--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (vm.size() == 0 || vm.count("help")) {
+    if (vm.empty() || vm.count("help")) {
         std::cout << desc << std::endl;
         return 1;
     }

--- a/gnuradio-runtime/include/gnuradio/tag_checker.h
+++ b/gnuradio-runtime/include/gnuradio/tag_checker.h
@@ -41,7 +41,7 @@ public:
     {
         d_tags = tags;
         std::sort(d_tags.begin(), d_tags.end(), &gr::tag_t::offset_compare);
-        if (d_tags.size() > 0) {
+        if (!d_tags.empty()) {
             d_has_next_tag = true;
             d_next_tag = tags[0];
         }

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -667,26 +667,26 @@ void block::setup_pc_rpc()
     d_pc_rpc_set = true;
 #if defined(GR_CTRLPORT) && defined(GR_PERFORMANCE_COUNTERS)
 #include <gnuradio/rpcregisterhelpers.h>
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_trigger<block>(alias(),
                                              "reset_perf_counters",
                                              &block::reset_perf_counters,
                                              "Reset the Performance Counters",
-                                             RPC_PRIVLVL_MIN)));
+                                             RPC_PRIVLVL_MIN));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, float>(alias(),
-                                                              "noutput_items",
-                                                              &block::pc_noutput_items,
-                                                              pmt::mp(0),
-                                                              pmt::mp(32768),
-                                                              pmt::mp(0),
-                                                              "",
-                                                              "noutput items",
-                                                              RPC_PRIVLVL_MIN,
-                                                              DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<block, float>(alias(),
+                                                "noutput_items",
+                                                &block::pc_noutput_items,
+                                                pmt::mp(0),
+                                                pmt::mp(32768),
+                                                pmt::mp(0),
+                                                "",
+                                                "noutput items",
+                                                RPC_PRIVLVL_MIN,
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<block, float>(alias(),
                                                 "avg noutput_items",
                                                 &block::pc_noutput_items_avg,
@@ -696,9 +696,9 @@ void block::setup_pc_rpc()
                                                 "",
                                                 "Average noutput items",
                                                 RPC_PRIVLVL_MIN,
-                                                DISPTIME | DISPOPTSTRIP)));
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<block, float>(alias(),
                                                 "var noutput_items",
                                                 &block::pc_noutput_items_var,
@@ -708,45 +708,45 @@ void block::setup_pc_rpc()
                                                 "",
                                                 "Var. noutput items",
                                                 RPC_PRIVLVL_MIN,
-                                                DISPTIME | DISPOPTSTRIP)));
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, float>(alias(),
-                                                              "nproduced",
-                                                              &block::pc_nproduced,
-                                                              pmt::mp(0),
-                                                              pmt::mp(32768),
-                                                              pmt::mp(0),
-                                                              "",
-                                                              "items produced",
-                                                              RPC_PRIVLVL_MIN,
-                                                              DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<block, float>(alias(),
+                                                "nproduced",
+                                                &block::pc_nproduced,
+                                                pmt::mp(0),
+                                                pmt::mp(32768),
+                                                pmt::mp(0),
+                                                "",
+                                                "items produced",
+                                                RPC_PRIVLVL_MIN,
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, float>(alias(),
-                                                              "avg nproduced",
-                                                              &block::pc_nproduced_avg,
-                                                              pmt::mp(0),
-                                                              pmt::mp(32768),
-                                                              pmt::mp(0),
-                                                              "",
-                                                              "Average items produced",
-                                                              RPC_PRIVLVL_MIN,
-                                                              DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<block, float>(alias(),
+                                                "avg nproduced",
+                                                &block::pc_nproduced_avg,
+                                                pmt::mp(0),
+                                                pmt::mp(32768),
+                                                pmt::mp(0),
+                                                "",
+                                                "Average items produced",
+                                                RPC_PRIVLVL_MIN,
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, float>(alias(),
-                                                              "var nproduced",
-                                                              &block::pc_nproduced_var,
-                                                              pmt::mp(0),
-                                                              pmt::mp(32768),
-                                                              pmt::mp(0),
-                                                              "",
-                                                              "Var. items produced",
-                                                              RPC_PRIVLVL_MIN,
-                                                              DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<block, float>(alias(),
+                                                "var nproduced",
+                                                &block::pc_nproduced_var,
+                                                pmt::mp(0),
+                                                pmt::mp(32768),
+                                                pmt::mp(0),
+                                                "",
+                                                "Var. items produced",
+                                                RPC_PRIVLVL_MIN,
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<block, float>(alias(),
                                                 "work time",
                                                 &block::pc_work_time,
@@ -756,9 +756,9 @@ void block::setup_pc_rpc()
                                                 "",
                                                 "clock cycles in call to work",
                                                 RPC_PRIVLVL_MIN,
-                                                DISPTIME | DISPOPTSTRIP)));
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<block, float>(alias(),
                                                 "avg work time",
                                                 &block::pc_work_time_avg,
@@ -768,9 +768,9 @@ void block::setup_pc_rpc()
                                                 "",
                                                 "Average clock cycles in call to work",
                                                 RPC_PRIVLVL_MIN,
-                                                DISPTIME | DISPOPTSTRIP)));
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<block, float>(alias(),
                                                 "var work time",
                                                 &block::pc_work_time_var,
@@ -780,9 +780,9 @@ void block::setup_pc_rpc()
                                                 "",
                                                 "Var. clock cycles in call to work",
                                                 RPC_PRIVLVL_MIN,
-                                                DISPTIME | DISPOPTSTRIP)));
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<block, float>(alias(),
                                                 "total work time",
                                                 &block::pc_work_time_total,
@@ -792,9 +792,9 @@ void block::setup_pc_rpc()
                                                 "",
                                                 "Total clock cycles in calls to work",
                                                 RPC_PRIVLVL_MIN,
-                                                DISPTIME | DISPOPTSTRIP)));
+                                                DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(new rpcbasic_register_get<block, float>(
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, float>(
         alias(),
         "avg throughput",
         &block::pc_throughput_avg,
@@ -804,85 +804,79 @@ void block::setup_pc_rpc()
         "items/s",
         "Average items throughput in call to work",
         RPC_PRIVLVL_MIN,
-        DISPTIME | DISPOPTSTRIP)));
+        DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, std::vector<float>>(
-            alias(),
-            "input \% full",
-            &block::pc_input_buffers_full,
-            pmt::make_f32vector(0, 0),
-            pmt::make_f32vector(0, 1),
-            pmt::make_f32vector(0, 0),
-            "",
-            "how full input buffers are",
-            RPC_PRIVLVL_MIN,
-            DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, std::vector<float>>(
+        alias(),
+        "input \% full",
+        &block::pc_input_buffers_full,
+        pmt::make_f32vector(0, 0),
+        pmt::make_f32vector(0, 1),
+        pmt::make_f32vector(0, 0),
+        "",
+        "how full input buffers are",
+        RPC_PRIVLVL_MIN,
+        DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, std::vector<float>>(
-            alias(),
-            "avg input \% full",
-            &block::pc_input_buffers_full_avg,
-            pmt::make_f32vector(0, 0),
-            pmt::make_f32vector(0, 1),
-            pmt::make_f32vector(0, 0),
-            "",
-            "Average of how full input buffers are",
-            RPC_PRIVLVL_MIN,
-            DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, std::vector<float>>(
+        alias(),
+        "avg input \% full",
+        &block::pc_input_buffers_full_avg,
+        pmt::make_f32vector(0, 0),
+        pmt::make_f32vector(0, 1),
+        pmt::make_f32vector(0, 0),
+        "",
+        "Average of how full input buffers are",
+        RPC_PRIVLVL_MIN,
+        DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, std::vector<float>>(
-            alias(),
-            "var input \% full",
-            &block::pc_input_buffers_full_var,
-            pmt::make_f32vector(0, 0),
-            pmt::make_f32vector(0, 1),
-            pmt::make_f32vector(0, 0),
-            "",
-            "Var. of how full input buffers are",
-            RPC_PRIVLVL_MIN,
-            DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, std::vector<float>>(
+        alias(),
+        "var input \% full",
+        &block::pc_input_buffers_full_var,
+        pmt::make_f32vector(0, 0),
+        pmt::make_f32vector(0, 1),
+        pmt::make_f32vector(0, 0),
+        "",
+        "Var. of how full input buffers are",
+        RPC_PRIVLVL_MIN,
+        DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, std::vector<float>>(
-            alias(),
-            "output \% full",
-            &block::pc_output_buffers_full,
-            pmt::make_f32vector(0, 0),
-            pmt::make_f32vector(0, 1),
-            pmt::make_f32vector(0, 0),
-            "",
-            "how full output buffers are",
-            RPC_PRIVLVL_MIN,
-            DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, std::vector<float>>(
+        alias(),
+        "output \% full",
+        &block::pc_output_buffers_full,
+        pmt::make_f32vector(0, 0),
+        pmt::make_f32vector(0, 1),
+        pmt::make_f32vector(0, 0),
+        "",
+        "how full output buffers are",
+        RPC_PRIVLVL_MIN,
+        DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, std::vector<float>>(
-            alias(),
-            "avg output \% full",
-            &block::pc_output_buffers_full_avg,
-            pmt::make_f32vector(0, 0),
-            pmt::make_f32vector(0, 1),
-            pmt::make_f32vector(0, 0),
-            "",
-            "Average of how full output buffers are",
-            RPC_PRIVLVL_MIN,
-            DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, std::vector<float>>(
+        alias(),
+        "avg output \% full",
+        &block::pc_output_buffers_full_avg,
+        pmt::make_f32vector(0, 0),
+        pmt::make_f32vector(0, 1),
+        pmt::make_f32vector(0, 0),
+        "",
+        "Average of how full output buffers are",
+        RPC_PRIVLVL_MIN,
+        DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<block, std::vector<float>>(
-            alias(),
-            "var output \% full",
-            &block::pc_output_buffers_full_var,
-            pmt::make_f32vector(0, 0),
-            pmt::make_f32vector(0, 1),
-            pmt::make_f32vector(0, 0),
-            "",
-            "Var. of how full output buffers are",
-            RPC_PRIVLVL_MIN,
-            DISPTIME | DISPOPTSTRIP)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<block, std::vector<float>>(
+        alias(),
+        "var output \% full",
+        &block::pc_output_buffers_full_var,
+        pmt::make_f32vector(0, 0),
+        pmt::make_f32vector(0, 1),
+        pmt::make_f32vector(0, 0),
+        "",
+        "Var. of how full output buffers are",
+        RPC_PRIVLVL_MIN,
+        DISPTIME | DISPOPTSTRIP));
 #endif /* defined(GR_CTRLPORT) && defined(GR_PERFORMANCE_COUNTERS) */
 }
 

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -124,10 +124,11 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
             d->get_tags_in_range(
                 rtags, i, start_nitems_read[i], d->nitems_read(i), block_id);
 
-            if (rtags.size() == 0)
+            if (rtags.empty()) {
                 continue;
+            }
 
-            if (out_buf.size() == 0) {
+            if (out_buf.empty()) {
                 out_buf.reserve(d->noutputs());
                 for (int o = 0; o < d->noutputs(); o++)
                     out_buf.push_back(d->output(o));
@@ -176,8 +177,9 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
                 d->get_tags_in_range(
                     rtags, i, start_nitems_read[i], d->nitems_read(i), block_id);
 
-                if (rtags.size() == 0)
+                if (rtags.empty()) {
                     continue;
+                }
 
                 out_buf = d->output(i);
 

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -328,7 +328,7 @@ std::vector<basic_block_vector_t> flowgraph::partition()
     basic_block_vector_t blocks = calc_used_blocks();
     basic_block_vector_t graph;
 
-    while (blocks.size() > 0) {
+    while (!blocks.empty()) {
         graph = calc_reachable_blocks(blocks[0], blocks);
         assert(graph.size());
         result.push_back(topological_sort(graph));
@@ -432,7 +432,7 @@ basic_block_vector_t flowgraph::sort_sources_first(basic_block_vector_t& blocks)
 
 bool flowgraph::source_p(basic_block_sptr block)
 {
-    return (calc_upstream_edges(block).size() == 0);
+    return calc_upstream_edges(block).empty();
 }
 
 void flowgraph::topological_dfs_visit(basic_block_sptr block,

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -171,9 +171,10 @@ int hier_block2::max_output_buffer(size_t port)
 void hier_block2::set_max_output_buffer(int max_output_buffer)
 {
     if (output_signature()->max_streams() > 0) {
-        if (d_detail->d_max_output_buffer.size() == 0)
+        if (d_detail->d_max_output_buffer.empty()) {
             throw std::length_error("hier_block2::set_max_output_buffer(int): out_sig "
                                     "greater than zero, buff_vect isn't");
+        }
         for (int idx = 0; idx < output_signature()->max_streams(); idx++) {
             d_detail->d_max_output_buffer[idx] = max_output_buffer;
         }
@@ -182,10 +183,10 @@ void hier_block2::set_max_output_buffer(int max_output_buffer)
 
 void hier_block2::set_max_output_buffer(size_t port, int max_output_buffer)
 {
-    if (port >= d_detail->d_max_output_buffer.size())
+    if (port >= d_detail->d_max_output_buffer.size()) {
         throw std::invalid_argument(
             "hier_block2::set_max_output_buffer(size_t,int): port out of range.");
-    else {
+    } else {
         d_detail->d_max_output_buffer[port] = max_output_buffer;
     }
 }
@@ -201,9 +202,10 @@ int hier_block2::min_output_buffer(size_t port)
 void hier_block2::set_min_output_buffer(int min_output_buffer)
 {
     if (output_signature()->max_streams() > 0) {
-        if (d_detail->d_min_output_buffer.size() == 0)
+        if (d_detail->d_min_output_buffer.empty()) {
             throw std::length_error("hier_block2::set_min_output_buffer(int): out_sig "
                                     "greater than zero, buff_vect isn't");
+        }
         for (int idx = 0; idx < output_signature()->max_streams(); idx++) {
             d_detail->d_min_output_buffer[idx] = min_output_buffer;
         }
@@ -222,8 +224,9 @@ void hier_block2::set_min_output_buffer(size_t port, int min_output_buffer)
 
 bool hier_block2::all_min_output_buffer_p(void)
 {
-    if (!d_detail->d_min_output_buffer.size())
+    if (d_detail->d_min_output_buffer.empty()) {
         return false;
+    }
     for (size_t idx = 1; idx < d_detail->d_min_output_buffer.size(); idx++) {
         if (d_detail->d_min_output_buffer[0] != d_detail->d_min_output_buffer[idx])
             return false;
@@ -232,7 +235,7 @@ bool hier_block2::all_min_output_buffer_p(void)
 }
 bool hier_block2::all_max_output_buffer_p(void)
 {
-    if (!d_detail->d_max_output_buffer.size())
+    if (d_detail->d_max_output_buffer.empty())
         return false;
     for (size_t idx = 1; idx < d_detail->d_max_output_buffer.size(); idx++) {
         if (d_detail->d_max_output_buffer[0] != d_detail->d_max_output_buffer[idx])

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -288,7 +288,7 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
         }
     }
 
-    if (edges.size() == 0) {
+    if (edges.empty()) {
         std::stringstream msg;
         msg << "cannot disconnect block " << block << ", not found";
         throw std::invalid_argument(msg.str());
@@ -784,7 +784,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     // Now add the list of connected input blocks
     std::stringstream msg;
     for (unsigned int i = 0; i < d_inputs.size(); i++) {
-        if (d_inputs[i].size() == 0) {
+        if (d_inputs[i].empty()) {
             msg << "In hierarchical block " << d_owner->name() << ", input " << i
                 << " is not connected internally";
             throw std::runtime_error(msg.str());

--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -79,8 +79,9 @@ io_signature::io_signature(int min_streams,
     if (min_streams < 0 || (max_streams != IO_INFINITE && max_streams < min_streams))
         throw std::invalid_argument("gr::io_signature(1)");
 
-    if (sizeof_stream_items.size() < 1)
+    if (sizeof_stream_items.empty()) {
         throw std::invalid_argument("gr::io_signature(2)");
+    }
 
     for (size_t i = 0; i < sizeof_stream_items.size(); i++) {
         if (max_streams != 0 && sizeof_stream_items[i] < 1)

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -157,7 +157,7 @@ logger_ptr logger_get_logger(std::string name)
 
 bool logger_load_config(const std::string& config_filename)
 {
-    if (config_filename.size() != 0) {
+    if (!config_filename.empty()) {
         try {
             log4cpp::PropertyConfigurator::configure(config_filename);
             return true;
@@ -343,7 +343,7 @@ bool configure_default_loggers(gr::logger_ptr& l,
     GR_LOG_GETLOGGER(LOG, "gr_log." + name);
     GR_LOG_SET_LEVEL(LOG, log_level);
 
-    if (log_file.size() > 0) {
+    if (!log_file.empty()) {
         if (log_file == "stdout") {
             GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
         } else if (log_file == "stderr") {
@@ -356,7 +356,7 @@ bool configure_default_loggers(gr::logger_ptr& l,
 
     GR_LOG_GETLOGGER(DLOG, "gr_log_debug." + name);
     GR_LOG_SET_LEVEL(DLOG, debug_level);
-    if (debug_file.size() > 0) {
+    if (!debug_file.empty()) {
         if (debug_file == "stdout") {
             GR_LOG_SET_CONSOLE_APPENDER(DLOG, "stdout", "gr::debug :%p: %c{1} - %m%n");
         } else if (debug_file == "stderr") {
@@ -376,7 +376,7 @@ bool update_logger_alias(const std::string& name, const std::string& alias)
     std::string debug_file = p->get_string("LOG", "debug_file", "");
 
     GR_LOG_GETLOGGER(LOG, "gr_log." + name);
-    if (log_file.size() > 0) {
+    if (!log_file.empty()) {
         if (log_file == "stdout") {
             boost::format str("gr::log :%%p: %1% - %%m%%n");
             GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", boost::str(str % alias));

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -243,7 +243,7 @@ bool prefs::get_bool(const std::string& section,
 {
     if (has_option(section, option)) {
         std::string str = get_string(section, option, "");
-        if (str == "") {
+        if (str.empty()) {
             return default_val;
         }
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
@@ -281,7 +281,7 @@ long prefs::get_long(const std::string& section,
 {
     if (has_option(section, option)) {
         std::string str = get_string(section, option, "");
-        if (str == "") {
+        if (str.empty()) {
             return default_val;
         }
         std::stringstream sstr(str);
@@ -316,7 +316,7 @@ double prefs::get_double(const std::string& section,
 {
     if (has_option(section, option)) {
         std::string str = get_string(section, option, "");
-        if (str == "") {
+        if (str.empty()) {
             return default_val;
         }
         std::stringstream sstr(str);

--- a/gnuradio-runtime/lib/top_block.cc
+++ b/gnuradio-runtime/lib/top_block.cc
@@ -109,14 +109,14 @@ void top_block::setup_rpc()
         return;
 
     // Triggers
-    d_rpc_vars.push_back(rpcbasic_sptr(new rpcbasic_register_trigger<top_block>(
-        alias(), "stop", &top_block::stop, "Stop the flowgraph", RPC_PRIVLVL_MIN)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_trigger<top_block>(
+        alias(), "stop", &top_block::stop, "Stop the flowgraph", RPC_PRIVLVL_MIN));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(new rpcbasic_register_trigger<top_block>(
-        alias(), "lock", &top_block::lock, "Lock the flowgraph", RPC_PRIVLVL_MIN)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_trigger<top_block>(
+        alias(), "lock", &top_block::lock, "Lock the flowgraph", RPC_PRIVLVL_MIN));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(new rpcbasic_register_trigger<top_block>(
-        alias(), "unlock", &top_block::unlock, "Unock the flowgraph", RPC_PRIVLVL_MIN)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_trigger<top_block>(
+        alias(), "unlock", &top_block::unlock, "Unock the flowgraph", RPC_PRIVLVL_MIN));
 
     // Getters
     add_rpc_variable(rpcbasic_sptr(

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -68,7 +68,7 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
     GR_LOG_GETLOGGER(LOG, "gr_log.tpb_thread_body");
     GR_LOG_SET_LEVEL(LOG, log_level);
     GR_CONFIG_LOGGER(config_file);
-    if (log_file.size() > 0) {
+    if (!log_file.empty()) {
         if (log_file == "stdout") {
             GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
         } else if (log_file == "stderr") {
@@ -79,7 +79,7 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
     }
 
     // Set thread affinity if it was set before fg was started.
-    if (block->processor_affinity().size() > 0) {
+    if (!block->processor_affinity().empty()) {
         gr::thread::thread_bind_to_processor(d->thread, block->processor_affinity());
     }
 

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.cc
@@ -116,7 +116,7 @@ void ctrlport_probe2_b_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
     int len = static_cast<int>(d_len);
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_b, std::vector<signed char>>(
             alias(),
             d_id.c_str(),
@@ -127,9 +127,9 @@ void ctrlport_probe2_b_impl::setup_rpc()
             "volts",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            d_disp_mask)));
+            d_disp_mask));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_b, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_b::length,
@@ -139,9 +139,9 @@ void ctrlport_probe2_b_impl::setup_rpc()
                                                           "samples",
                                                           "get vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_set<ctrlport_probe2_b, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_b::set_length,
@@ -151,7 +151,7 @@ void ctrlport_probe2_b_impl::setup_rpc()
                                                           "samples",
                                                           "set vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.cc
@@ -116,7 +116,7 @@ void ctrlport_probe2_c_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
     int len = static_cast<int>(d_len);
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_c, std::vector<std::complex<float>>>(
             alias(),
             d_id.c_str(),
@@ -127,9 +127,9 @@ void ctrlport_probe2_c_impl::setup_rpc()
             "volts",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            d_disp_mask | DISPOPTCPLX)));
+            d_disp_mask | DISPOPTCPLX));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_c, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_c::length,
@@ -139,9 +139,9 @@ void ctrlport_probe2_c_impl::setup_rpc()
                                                           "samples",
                                                           "get vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_set<ctrlport_probe2_c, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_c::set_length,
@@ -151,7 +151,7 @@ void ctrlport_probe2_c_impl::setup_rpc()
                                                           "samples",
                                                           "set vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.cc
@@ -116,8 +116,8 @@ void ctrlport_probe2_f_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
     int len = static_cast<int>(d_len);
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<ctrlport_probe2_f, std::vector<float>>(
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<ctrlport_probe2_f, std::vector<float>>(
             alias(),
             d_id.c_str(),
             &ctrlport_probe2_f::get,
@@ -130,9 +130,9 @@ void ctrlport_probe2_f_impl::setup_rpc()
             "volts",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            d_disp_mask)));
+            d_disp_mask));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_f, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_f::length,
@@ -142,9 +142,9 @@ void ctrlport_probe2_f_impl::setup_rpc()
                                                           "samples",
                                                           "get vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_set<ctrlport_probe2_f, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_f::set_length,
@@ -154,7 +154,7 @@ void ctrlport_probe2_f_impl::setup_rpc()
                                                           "samples",
                                                           "set vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.cc
@@ -115,8 +115,8 @@ void ctrlport_probe2_i_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
     int len = static_cast<int>(d_len);
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<ctrlport_probe2_i, std::vector<int>>(
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<ctrlport_probe2_i, std::vector<int>>(
             alias(),
             d_id.c_str(),
             &ctrlport_probe2_i::get,
@@ -126,9 +126,9 @@ void ctrlport_probe2_i_impl::setup_rpc()
             "volts",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            d_disp_mask)));
+            d_disp_mask));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_i, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_i::length,
@@ -138,9 +138,9 @@ void ctrlport_probe2_i_impl::setup_rpc()
                                                           "samples",
                                                           "get vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_set<ctrlport_probe2_i, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_i::set_length,
@@ -150,7 +150,7 @@ void ctrlport_probe2_i_impl::setup_rpc()
                                                           "samples",
                                                           "set vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.cc
@@ -115,8 +115,8 @@ void ctrlport_probe2_s_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
     int len = static_cast<int>(d_len);
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<ctrlport_probe2_s, std::vector<short>>(
+    d_rpc_vars.emplace_back(
+        new rpcbasic_register_get<ctrlport_probe2_s, std::vector<short>>(
             alias(),
             d_id.c_str(),
             &ctrlport_probe2_s::get,
@@ -126,9 +126,9 @@ void ctrlport_probe2_s_impl::setup_rpc()
             "volts",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            d_disp_mask)));
+            d_disp_mask));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe2_s, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_s::length,
@@ -138,9 +138,9 @@ void ctrlport_probe2_s_impl::setup_rpc()
                                                           "samples",
                                                           "get vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_set<ctrlport_probe2_s, int>(alias(),
                                                           "length",
                                                           &ctrlport_probe2_s::set_length,
@@ -150,7 +150,7 @@ void ctrlport_probe2_s_impl::setup_rpc()
                                                           "samples",
                                                           "set vector length",
                                                           RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+                                                          DISPNULL));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/ctrlport_probe_c_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe_c_impl.cc
@@ -81,7 +81,7 @@ int ctrlport_probe_c_impl::work(int noutput_items,
 void ctrlport_probe_c_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe_c, std::vector<std::complex<float>>>(
             alias(),
             d_id.c_str(),
@@ -92,7 +92,7 @@ void ctrlport_probe_c_impl::setup_rpc()
             "volts",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            DISPXY | DISPOPTSCATTER)));
+            DISPXY | DISPOPTSCATTER));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -258,7 +258,7 @@ bool file_meta_source_impl::open(const std::string& filename,
     bool ret = true;
     if (d_state == STATE_DETACHED) {
         std::string s;
-        if (hdr_filename == "")
+        if (hdr_filename.empty())
             s = filename + ".hdr";
         else
             s = hdr_filename;

--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -212,7 +212,7 @@ typename multiply_matrix<T>::sptr
 multiply_matrix<T>::make(std::vector<std::vector<T>> A,
                          gr::block::tag_propagation_policy_t tag_propagation_policy)
 {
-    if (A.empty() || A[0].size() == 0) {
+    if (A.empty() || A[0].empty()) {
         throw std::invalid_argument("matrix A has invalid dimensions.");
     }
     return gnuradio::get_initial_sptr(

--- a/gr-blocks/lib/nop_impl.cc
+++ b/gr-blocks/lib/nop_impl.cc
@@ -69,19 +69,18 @@ int nop_impl::general_work(int noutput_items,
 void nop_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
-    d_rpc_vars.push_back(
-        rpcbasic_sptr(new rpcbasic_register_get<nop, int>(alias(),
-                                                          "test",
-                                                          &nop::ctrlport_test,
-                                                          pmt::mp(-256),
-                                                          pmt::mp(255),
-                                                          pmt::mp(0),
-                                                          "",
-                                                          "Simple testing variable",
-                                                          RPC_PRIVLVL_MIN,
-                                                          DISPNULL)));
+    d_rpc_vars.emplace_back(new rpcbasic_register_get<nop, int>(alias(),
+                                                                "test",
+                                                                &nop::ctrlport_test,
+                                                                pmt::mp(-256),
+                                                                pmt::mp(255),
+                                                                pmt::mp(0),
+                                                                "",
+                                                                "Simple testing variable",
+                                                                RPC_PRIVLVL_MIN,
+                                                                DISPNULL));
 
-    d_rpc_vars.push_back(
+    d_rpc_vars.emplace_back(
         rpcbasic_sptr(new rpcbasic_register_set<nop, int>(alias(),
                                                           "test",
                                                           &nop::set_ctrlport_test,

--- a/gr-blocks/lib/qa_gr_flowgraph.cc
+++ b/gr-blocks/lib/qa_gr_flowgraph.cc
@@ -269,8 +269,8 @@ BOOST_AUTO_TEST_CASE(t15_clear)
 
     fg->clear();
 
-    BOOST_REQUIRE(fg->edges().size() == 0);
-    BOOST_REQUIRE(fg->calc_used_blocks().size() == 0);
+    BOOST_REQUIRE(fg->edges().empty());
+    BOOST_REQUIRE(fg->calc_used_blocks().empty());
 }
 
 BOOST_AUTO_TEST_CASE(t16_partition)

--- a/gr-blocks/lib/tag_debug_impl.cc
+++ b/gr-blocks/lib/tag_debug_impl.cc
@@ -71,7 +71,7 @@ void tag_debug_impl::set_display(bool d) { d_display = d; }
 
 void tag_debug_impl::set_key_filter(const std::string& key_filter)
 {
-    if (key_filter == "")
+    if (key_filter.empty())
         d_filter = pmt::PMT_NIL;
     else
         d_filter = pmt::intern(key_filter);
@@ -104,7 +104,7 @@ int tag_debug_impl::work(int noutput_items,
         else
             get_tags_in_range(d_tags, i, abs_N, end_N, d_filter);
 
-        if (d_tags.size() > 0) {
+        if (!d_tags.empty()) {
             toprint = true;
         }
 

--- a/gr-blocks/lib/tag_gate_impl.cc
+++ b/gr-blocks/lib/tag_gate_impl.cc
@@ -64,7 +64,7 @@ void tag_gate_impl::set_propagation(bool propagate_tags)
 
 void tag_gate_impl::set_single_key(const std::string& single_key)
 {
-    if (single_key == "") {
+    if (single_key.empty()) {
         d_single_key = pmt::PMT_NIL;
         d_single_key_set = false;
     } else {

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -94,7 +94,7 @@ int tagged_file_sink_impl::work(int noutput_items,
     // Look for a time tag and initialize d_timeval.
     std::vector<tag_t> time_tags_outer;
     get_tags_in_range(time_tags_outer, 0, start_N, end_N, tkey);
-    if (time_tags_outer.size() > 0) {
+    if (!time_tags_outer.empty()) {
         const tag_t tag = time_tags_outer[0];
         uint64_t offset = tag.offset;
         pmt::pmt_t time = tag.value;
@@ -122,7 +122,7 @@ int tagged_file_sink_impl::work(int noutput_items,
                     std::vector<tag_t> time_tags;
                     // get_tags_in_range(time_tags, 0, d_last_N, N, gr_tags::key_time);
                     get_tags_in_range(time_tags, 0, d_last_N, N, tkey);
-                    if (time_tags.size() > 0) {
+                    if (!time_tags.empty()) {
                         const tag_t tag = time_tags[time_tags.size() - 1];
 
                         uint64_t time_nitems = tag.offset;

--- a/gr-blocks/lib/tagged_stream_align_impl.cc
+++ b/gr-blocks/lib/tagged_stream_align_impl.cc
@@ -72,7 +72,7 @@ int tagged_stream_align_impl::general_work(int noutput_items,
     } else {
         get_tags_in_range(
             tags, 0, nitems_read(0), nitems_read(0) + ninput_items[0], d_lengthtag);
-        if (tags.size() > 0) {
+        if (!tags.empty()) {
             d_have_sync = true;
             consume_each(tags[0].offset - nitems_read(0));
         } else {

--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -116,7 +116,7 @@ int throttle_impl::work(int noutput_items,
 void throttle_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<throttle, double>(alias(),
                                                     "sample_rate",
                                                     &throttle::sample_rate,
@@ -126,9 +126,9 @@ void throttle_impl::setup_rpc()
                                                     "Hz",
                                                     "Sample Rate",
                                                     RPC_PRIVLVL_MIN,
-                                                    DISPTIME | DISPOPTSTRIP)));
+                                                    DISPTIME | DISPOPTSTRIP));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_set<throttle, double>(alias(),
                                                     "sample_rate",
                                                     &throttle::set_sample_rate,
@@ -138,7 +138,7 @@ void throttle_impl::setup_rpc()
                                                     "Hz",
                                                     "Sample Rate",
                                                     RPC_PRIVLVL_MIN,
-                                                    DISPTIME | DISPOPTSTRIP)));
+                                                    DISPTIME | DISPOPTSTRIP));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-blocks/lib/udp_sink_impl.cc
+++ b/gr-blocks/lib/udp_sink_impl.cc
@@ -70,7 +70,7 @@ void udp_sink_impl::connect(const std::string& host, int port)
         disconnect();
 
     std::string s_port = (boost::format("%d") % port).str();
-    if (host.size() > 0) {
+    if (!host.empty()) {
         boost::asio::ip::udp::resolver resolver(d_io_service);
         boost::asio::ip::udp::resolver::query query(
             host, s_port, boost::asio::ip::resolver_query_base::passive);

--- a/gr-blocks/lib/udp_source_impl.cc
+++ b/gr-blocks/lib/udp_source_impl.cc
@@ -84,7 +84,7 @@ void udp_source_impl::connect(const std::string& host, int port)
     std::string s_port;
     s_port = (boost::format("%d") % d_port).str();
 
-    if (host.size() > 0) {
+    if (!host.empty()) {
         boost::asio::ip::udp::resolver resolver(d_io_service);
         boost::asio::ip::udp::resolver::query query(
             d_host, s_port, boost::asio::ip::resolver_query_base::passive);

--- a/gr-blocks/lib/vector_source_impl.cc
+++ b/gr-blocks/lib/vector_source_impl.cc
@@ -57,7 +57,7 @@ vector_source_impl<T>::vector_source_impl(const std::vector<T>& data,
       d_vlen(vlen),
       d_tags(tags)
 {
-    if (tags.size() == 0) {
+    if (tags.empty()) {
         d_settags = 0;
     } else {
         d_settags = 1;
@@ -79,7 +79,7 @@ void vector_source_impl<T>::set_data(const std::vector<T>& data,
     d_data = data;
     d_tags = tags;
     rewind();
-    if (tags.size() == 0) {
+    if (tags.empty()) {
         d_settags = false;
     } else {
         d_settags = true;

--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -69,7 +69,7 @@ constellation::constellation(std::vector<gr_complex> constell,
             d_constellation[i] = d_constellation[i] * d_scalefactor;
         }
     }
-    if (pre_diff_code.size() == 0)
+    if (pre_diff_code.empty())
         d_apply_pre_diff_code = false;
     else if (pre_diff_code.size() != constsize)
         throw std::runtime_error(
@@ -307,7 +307,7 @@ void constellation::set_soft_dec_lut(const std::vector<std::vector<float>>& soft
     d_lut_scale = powf(2.0, static_cast<float>(precision));
 }
 
-bool constellation::has_soft_dec_lut() { return d_soft_dec_lut.size() > 0; }
+bool constellation::has_soft_dec_lut() { return !d_soft_dec_lut.empty(); }
 
 std::vector<std::vector<float>> constellation::soft_dec_lut() { return d_soft_dec_lut; }
 

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -180,7 +180,7 @@ int costas_loop_cc_impl::work(int noutput_items,
                       pmt::intern("phase_est"));
 
     for (int i = 0; i < noutput_items; i++) {
-        if (tags.size() > 0) {
+        if (!tags.empty()) {
             if (tags[0].offset - nitems_read(0) == (size_t)i) {
                 d_phase = (float)pmt::to_double(tags[0].value);
                 tags.erase(tags.begin());

--- a/gr-digital/lib/hdlc_framer_pb_impl.cc
+++ b/gr-digital/lib/hdlc_framer_pb_impl.cc
@@ -114,7 +114,7 @@ int hdlc_framer_pb_impl::work(int noutput_items,
     // partial packets., but if we're to preserve tag boundaries
     // this is much, much simpler.
     int oidx = 0;
-    while (d_leftovers.size() > 0) {
+    while (!d_leftovers.empty()) {
         if ((size_t)noutput_items < (oidx + d_leftovers[0].size()))
             return oidx;
         memcpy(out + oidx, &d_leftovers[0][0], d_leftovers[0].size());

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -133,7 +133,7 @@ int msk_timing_recovery_cc_impl::general_work(int noutput_items,
 
     while (oidx < noutput_items && iidx < ninp) {
         // check to see if there's a tag to reset the timing estimate
-        if (tags.size() > 0) {
+        if (!tags.empty()) {
             int offset = tags[0].offset - nitems_read(0);
             if ((offset >= iidx) && (offset < (iidx + d_sps))) {
                 float center = (float)pmt::to_double(tags[0].value);

--- a/gr-digital/lib/ofdm_chanest_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_chanest_vcvc_impl.cc
@@ -60,8 +60,8 @@ ofdm_chanest_vcvc_impl::ofdm_chanest_vcvc_impl(
       d_n_data_syms(n_data_symbols),
       d_n_sync_syms(1),
       d_eq_noise_red_len(eq_noise_red_len),
-      d_ref_sym((sync_symbol2.size() && !force_one_sync_symbol) ? sync_symbol2
-                                                                : sync_symbol1),
+      d_ref_sym((!sync_symbol2.empty() && !force_one_sync_symbol) ? sync_symbol2
+                                                                  : sync_symbol1),
       d_corr_v(sync_symbol2),
       d_known_symbol_diffs(0, 0),
       d_new_symbol_diffs(0, 0),
@@ -84,7 +84,7 @@ ofdm_chanest_vcvc_impl::ofdm_chanest_vcvc_impl(
     }
 
     // Sanity checks
-    if (sync_symbol2.size()) {
+    if (!sync_symbol2.empty()) {
         if (sync_symbol1.size() != sync_symbol2.size()) {
             throw std::invalid_argument("sync symbols must have equal length.");
         }
@@ -149,7 +149,7 @@ int ofdm_chanest_vcvc_impl::get_carr_offset(const gr_complex* sync_sym1,
                                             const gr_complex* sync_sym2)
 {
     int carr_offset = 0;
-    if (d_corr_v.size()) {
+    if (!d_corr_v.empty()) {
         // Use Schmidl & Cox method
         float Bg_max = 0;
         // g here is 2g in the paper

--- a/gr-digital/lib/ofdm_equalizer_base.cc
+++ b/gr-digital/lib/ofdm_equalizer_base.cc
@@ -57,7 +57,7 @@ ofdm_equalizer_1d_pilots::ofdm_equalizer_1d_pilots(
     if (input_is_shifted) {
         fft_shift_width = fft_len / 2;
     }
-    if (!occupied_carriers.size()) {
+    if (occupied_carriers.empty()) {
         std::fill(d_occupied_carriers.begin(), d_occupied_carriers.end(), true);
     } else {
         for (unsigned i = 0; i < occupied_carriers.size(); i++) {
@@ -73,7 +73,7 @@ ofdm_equalizer_1d_pilots::ofdm_equalizer_1d_pilots(
             }
         }
     }
-    if (pilot_carriers.size()) {
+    if (!pilot_carriers.empty()) {
         for (unsigned i = 0; i < pilot_carriers.size(); i++) {
             if (pilot_carriers[i].size() != pilot_symbols[i].size()) {
                 throw std::invalid_argument("pilot carriers and -symbols do not match.");

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -68,7 +68,7 @@ pfb_clock_sync_ccf_impl::pfb_clock_sync_ccf_impl(double sps,
       d_error(0),
       d_out_idx(0)
 {
-    if (taps.size() == 0)
+    if (taps.empty())
         throw std::runtime_error("pfb_clock_sync_ccf: please specify a filter.\n");
 
     // Let scheduler adjust our relative_rate.
@@ -382,7 +382,7 @@ int pfb_clock_sync_ccf_impl::general_work(int noutput_items,
 
     // produce output as long as we can and there are enough input samples
     while (i < noutput_items) {
-        if (tags.size() > 0) {
+        if (!tags.empty()) {
             size_t offset = tags[0].offset - nitems_read(0);
             if ((offset >= (size_t)count) && (offset < (size_t)(count + d_sps))) {
                 float center = (float)pmt::to_double(tags[0].value);

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -65,7 +65,7 @@ pfb_clock_sync_fff_impl::pfb_clock_sync_fff_impl(double sps,
       d_error(0),
       d_out_idx(0)
 {
-    if (taps.size() == 0)
+    if (taps.empty())
         throw std::runtime_error("pfb_clock_sync_fff: please specify a filter.\n");
 
     // Let scheduler adjust our relative_rate.

--- a/gr-digital/lib/timing_error_detector.cc
+++ b/gr-digital/lib/timing_error_detector.cc
@@ -232,11 +232,9 @@ void timing_error_detector::sync_reset()
     d_input_derivative.assign(d_error_depth, gr_complex(0.0f, 0.0f));
 
     if (d_constellation) {
-        std::deque<gr_complex>::iterator it;
-        d_decision.clear();
-        for (it = d_input.begin(); it != d_input.end(); ++it)
-            d_decision.push_back(gr_complex(0.0f, 0.0f));
-        // d_decision.push_back(slice(*it));
+        d_decision.assign(d_input.size(), gr_complex(0.0f, 0.0f));
+        // for (it = d_input.begin(); it != d_input.end(); ++it)
+        //   d_decision.push_back(slice(*it));
     }
 
     sync_reset_input_clock();

--- a/gr-dtv/lib/dvbt/dvbt_convolutional_deinterleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_convolutional_deinterleaver_impl.cc
@@ -110,7 +110,7 @@ int dvbt_convolutional_deinterleaver_impl::general_work(
                             nread + (noutput_items * d_I * d_blocks),
                             pmt::string_to_symbol("superframe_start"));
 
-    if (tags.size()) {
+    if (!tags.empty()) {
         if (tags[0].offset - nread) {
             consume_each(tags[0].offset - nread);
             return (0);

--- a/gr-dtv/lib/dvbt/dvbt_demod_reference_signals_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_demod_reference_signals_impl.cc
@@ -116,7 +116,7 @@ int dvbt_demod_reference_signals_impl::is_sync_start(int nitems)
     this->get_tags_in_range(
         tags, 0, nread, nread + nitems, pmt::string_to_symbol("sync_start"));
 
-    return tags.size() ? 1 : 0;
+    return !tags.empty() ? 1 : 0;
 }
 
 int dvbt_demod_reference_signals_impl::general_work(

--- a/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
@@ -644,7 +644,7 @@ int dvbt_viterbi_decoder_impl::general_work(int noutput_items,
                                 nread + (nblocks * d_nsymbols),
                                 pmt::string_to_symbol("superframe_start"));
 
-        if (tags.size()) {
+        if (!tags.empty()) {
             d_init = 0;
 
 #ifdef DTV_SSE2

--- a/gr-fec/lib/conv_bit_corr_bb_impl.h
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.h
@@ -64,7 +64,7 @@ private:
     std::vector<int> get_corr()
     {
         std::vector<int> bits;
-        if (d_correlator.size() < 1) {
+        if (d_correlator.empty()) {
             return bits;
         }
         for (size_t i = 0; i < d_correlator[0].size(); i++) {

--- a/gr-fec/lib/generic_decoder.cc
+++ b/gr-fec/lib/generic_decoder.cc
@@ -45,7 +45,7 @@ generic_decoder::generic_decoder(std::string name)
 
     GR_LOG_GETLOGGER(LOG, "gr_log." + alias());
     GR_LOG_SET_LEVEL(LOG, log_level);
-    if (log_file.size() > 0) {
+    if (!log_file.empty()) {
         if (log_file == "stdout") {
             GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
         } else if (log_file == "stderr") {

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -45,7 +45,7 @@ generic_encoder::generic_encoder(std::string name)
 
     GR_LOG_GETLOGGER(LOG, "gr_log." + alias());
     GR_LOG_SET_LEVEL(LOG, log_level);
-    if (log_file.size() > 0) {
+    if (!log_file.empty()) {
         if (log_file == "stdout") {
             GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
         } else if (log_file == "stderr") {

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -137,7 +137,7 @@ void ctrlport_probe_psd_impl::setup_rpc()
 {
 #ifdef GR_CTRLPORT
     int len = static_cast<int>(d_len);
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe_psd, std::vector<std::complex<float>>>(
             alias(),
             d_id.c_str(),
@@ -148,9 +148,9 @@ void ctrlport_probe_psd_impl::setup_rpc()
             "dB",
             d_desc.c_str(),
             RPC_PRIVLVL_MIN,
-            DISPXY | DISPOPTSCATTER)));
+            DISPXY | DISPOPTSCATTER));
 
-    d_rpc_vars.push_back(rpcbasic_sptr(
+    d_rpc_vars.emplace_back(
         new rpcbasic_register_get<ctrlport_probe_psd, int>(alias(),
                                                            "length",
                                                            &ctrlport_probe_psd::length,
@@ -160,13 +160,13 @@ void ctrlport_probe_psd_impl::setup_rpc()
                                                            "samples",
                                                            "get vector length",
                                                            RPC_PRIVLVL_MIN,
-                                                           DISPNULL)));
+                                                           DISPNULL));
 
-//      d_rpc_vars.push_back(
-//        rpcbasic_sptr(new rpcbasic_register_set<ctrlport_probe_psd, int>(
+//      d_rpc_vars.emplace_back(
+//        new rpcbasic_register_set<ctrlport_probe_psd, int>(
 //          alias(), "length", &ctrlport_probe_psd::set_length,
 //          pmt::mp(1), pmt::mp(10*len), pmt::mp(len),
-//          "samples", "set vector length", RPC_PRIVLVL_MIN, DISPNULL)));
+//          "samples", "set vector length", RPC_PRIVLVL_MIN, DISPNULL));
 #endif /* GR_CTRLPORT */
 }
 

--- a/gr-fft/lib/fft_vcc_fftw.cc
+++ b/gr-fft/lib/fft_vcc_fftw.cc
@@ -67,7 +67,7 @@ int fft_vcc_fftw::nthreads() const { return d_fft->nthreads(); }
 
 bool fft_vcc_fftw::set_window(const std::vector<float>& window)
 {
-    if (window.size() == 0 || window.size() == d_fft_size) {
+    if (window.empty() || window.size() == d_fft_size) {
         d_window = window;
         return true;
     } else
@@ -89,7 +89,7 @@ int fft_vcc_fftw::work(int noutput_items,
     while (count++ < noutput_items) {
 
         // copy input into optimally aligned buffer
-        if (d_window.size()) {
+        if (!d_window.empty()) {
             gr_complex* dst = d_fft->get_inbuf();
             if (!d_forward && d_shift) {
                 unsigned int offset = (!d_forward && d_shift) ? (d_fft_size / 2) : 0;

--- a/gr-fft/lib/fft_vfc_fftw.cc
+++ b/gr-fft/lib/fft_vfc_fftw.cc
@@ -62,7 +62,7 @@ int fft_vfc_fftw::nthreads() const { return d_fft->nthreads(); }
 
 bool fft_vfc_fftw::set_window(const std::vector<float>& window)
 {
-    if (window.size() == 0 || window.size() == d_fft_size) {
+    if (window.empty() || window.size() == d_fft_size) {
         d_window = window;
         return true;
     } else
@@ -83,7 +83,7 @@ int fft_vfc_fftw::work(int noutput_items,
     while (count++ < noutput_items) {
 
         // copy input into optimally aligned buffer
-        if (d_window.size()) {
+        if (!d_window.empty()) {
             gr_complex* dst = d_fft->get_inbuf();
             for (unsigned int i = 0; i < d_fft_size; i++) // apply window
                 dst[i] = in[i] * d_window[i];

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -168,7 +168,7 @@ int fft_filter_fff::filter(int nitems, const float* input, float* output)
         dec_ctr = (j - d_nsamples);
 
         // stash the tail
-        if (d_tail.size()) {
+        if (!d_tail.empty()) {
             memcpy(&d_tail[0],
                    d_invfft->get_outbuf() + d_nsamples,
                    tailsize() * sizeof(float));
@@ -315,7 +315,7 @@ int fft_filter_ccc::filter(int nitems, const gr_complex* input, gr_complex* outp
         dec_ctr = (j - d_nsamples);
 
         // stash the tail
-        if (d_tail.size()) {
+        if (!d_tail.empty()) {
             memcpy(&d_tail[0],
                    d_invfft->get_outbuf() + d_nsamples,
                    tailsize() * sizeof(gr_complex));
@@ -464,7 +464,7 @@ int fft_filter_ccf::filter(int nitems, const gr_complex* input, gr_complex* outp
         dec_ctr = (j - d_nsamples);
 
         // stash the tail
-        if (d_tail.size()) {
+        if (!d_tail.empty()) {
             memcpy(&d_tail[0],
                    d_invfft->get_outbuf() + d_nsamples,
                    tailsize() * sizeof(gr_complex));

--- a/gr-filter/lib/interp_fir_filter_impl.cc
+++ b/gr-filter/lib/interp_fir_filter_impl.cc
@@ -55,7 +55,7 @@ interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::interp_fir_filter_impl(
         throw std::out_of_range("interp_fir_filter_impl: interpolation must be > 0\n");
     }
 
-    if (taps.size() == 0) {
+    if (taps.empty()) {
         throw std::runtime_error("interp_fir_filter_impl: no filter taps provided.\n");
     }
 

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.cc
@@ -125,7 +125,7 @@ void pfb_channelizer_ccf_impl::set_channel_map(const std::vector<int>& map)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    if (map.size() > 0) {
+    if (!map.empty()) {
         unsigned int max = (unsigned int)*std::max_element(map.begin(), map.end());
         if (max >= d_nfilts) {
             throw std::invalid_argument(

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -213,7 +213,7 @@ void pfb_synthesizer_ccf_impl::set_channel_map(const std::vector<int>& map)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    if (map.size() > 0) {
+    if (!map.empty()) {
         int max = *std::max_element(map.begin(), map.end());
         int min = *std::min_element(map.begin(), map.end());
         if ((max >= static_cast<int>(d_twox * d_numchans)) || (min < 0)) {

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -821,7 +821,7 @@ std::vector<double> pm_remez(int order,
     for (int i = 0; i < numbands; i++)
         weight[i] = 1.0;
 
-    if (arg_weight.size() != 0) {
+    if (!arg_weight.empty()) {
         if ((int)arg_weight.size() != numbands)
             punt("gr_remez: need one weight for each band [=length(band)/2]");
         for (int i = 0; i < numbands; i++)

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -260,7 +260,7 @@ void TimeDomainDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
             // Plot and attach any new tags found.
             // First test if this was a complex input where real/imag get
             // split here into two stream.
-            if (tags.size() > 0) {
+            if (!tags.empty()) {
                 bool cmplx = false;
                 unsigned int mult = d_nplots / tags.size();
                 if (mult == 2)

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -109,7 +109,7 @@ ber_sink_b_impl::ber_sink_b_impl(std::vector<float> esnos,
 
     if (curvenames.size() == (unsigned int)curves) {
         for (int j = 0; j < curves; j++) {
-            if (curvenames[j] != "") {
+            if (!curvenames[j].empty()) {
                 set_line_label(j, curvenames[j]);
             }
         }

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -138,7 +138,7 @@ void const_sink_c_impl::initialize()
     d_main_gui = new ConstellationDisplayForm(numplots, d_parent);
     d_main_gui->setNPoints(d_size);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -364,7 +364,7 @@ void const_sink_c_impl::_test_trigger_tags(int nitems)
     uint64_t nr = nitems_read(d_trigger_channel);
     std::vector<gr::tag_t> tags;
     get_tags_in_range(tags, d_trigger_channel, nr, nr + nitems, d_trigger_tag_key);
-    if (tags.size() > 0) {
+    if (!tags.empty()) {
         d_triggered = true;
         trigger_index = tags[0].offset - nr;
         d_start = d_index + trigger_index;

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -106,7 +106,7 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
             d_key->setFixedWidth(width);
 
             // Verify that a default key has been set or emit an error
-            if (key.size() == 0) {
+            if (key.empty()) {
                 throw std::runtime_error(
                     "When using static + pair mode, please set a default key.");
             }
@@ -118,7 +118,7 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
     }
 
     d_label = NULL;
-    if (label != "") {
+    if (!label.empty()) {
         d_label = new QLabel(QString(label.c_str()));
         d_vlayout->addWidget(d_label);
     }

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -492,7 +492,7 @@ void edit_box_msg_impl::edit_finished()
             if (conv_ok) {
                 if (even) {
                     im = t;
-                    xv.push_back(gr_complex(re, im));
+                    xv.emplace_back(re, im);
                     even = false;
                 } else {
                     re = t;

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -171,7 +171,7 @@ void freq_sink_c_impl::initialize()
     set_fft_size(d_fftsize);
     set_frequency_range(d_center_freq, d_bandwidth);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     set_output_multiple(d_fftsize);
@@ -387,7 +387,7 @@ void freq_sink_c_impl::_reset()
 
 void freq_sink_c_impl::fft(float* data_out, const gr_complex* data_in, int size)
 {
-    if (d_window.size()) {
+    if (!d_window.empty()) {
         volk_32fc_32f_multiply_32fc(d_fft->get_inbuf(), data_in, &d_window.front(), size);
     } else {
         memcpy(d_fft->get_inbuf(), data_in, sizeof(gr_complex) * size);
@@ -529,7 +529,7 @@ void freq_sink_c_impl::_test_trigger_tags(int start, int nitems)
     std::vector<gr::tag_t> tags;
     get_tags_in_range(
         tags, d_trigger_channel, nr + start, nr + start + nitems, d_trigger_tag_key);
-    if (tags.size() > 0) {
+    if (!tags.empty()) {
         d_triggered = true;
         d_index = tags[0].offset - nr;
         d_trigger_count = 0;

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -172,7 +172,7 @@ void freq_sink_f_impl::initialize()
     set_fft_size(d_fftsize);
     set_frequency_range(d_center_freq, d_bandwidth);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     set_output_multiple(d_fftsize);
@@ -394,7 +394,7 @@ void freq_sink_f_impl::fft(float* data_out, const float* data_in, int size)
     for (int i = 0; i < size; i++)
         dst[i] = data_in[i];
 
-    if (d_window.size()) {
+    if (!d_window.empty()) {
         volk_32fc_32f_multiply_32fc(d_fft->get_inbuf(), dst, &d_window.front(), size);
     }
 
@@ -533,7 +533,7 @@ void freq_sink_f_impl::_test_trigger_tags(int start, int nitems)
     std::vector<gr::tag_t> tags;
     get_tags_in_range(
         tags, d_trigger_channel, nr + start, nr + start + nitems, d_trigger_tag_key);
-    if (tags.size() > 0) {
+    if (!tags.empty()) {
         d_triggered = true;
         d_index = tags[0].offset - nr;
         d_trigger_count = 0;

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -423,7 +423,7 @@ void FreqDisplayForm::updateTrigger(gr::qtgui::trigger_mode mode)
     }
 
     // if tag mode, popup tag key box to set
-    if ((d_trig_tag_key == "") && (d_trig_mode == gr::qtgui::TRIG_MODE_TAG))
+    if ((d_trig_tag_key.empty()) && (d_trig_mode == gr::qtgui::TRIG_MODE_TAG))
         d_tr_tag_key_act->activate(QAction::Trigger);
 
     emit signalReplot();

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -137,7 +137,7 @@ void histogram_sink_f_impl::initialize()
     d_main_gui->setNPoints(d_size);
     d_main_gui->setXaxis(d_xmin, d_xmax);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -40,7 +40,7 @@ NumberDisplayForm::NumberDisplayForm(int nplots, gr::qtgui::graph_t type, QWidge
         d_min.push_back(+1e32);
         d_max.push_back(-1e32);
         d_label.push_back(new QLabel(QString("Data %1").arg(i)));
-        d_unit.push_back("");
+        d_unit.emplace_back("");
         d_factor.push_back(1);
         d_text_box.push_back(new QLabel(QString("0")));
 

--- a/gr-qtgui/lib/qtgui_util.cc
+++ b/gr-qtgui/lib/qtgui_util.cc
@@ -104,7 +104,7 @@ QwtPickerMachine* QwtDblClickPlotPicker::stateMachine(int n) const
 void check_set_qss(QApplication* app)
 {
     std::string qssfile = gr::prefs::singleton()->get_string("qtgui", "qss", "");
-    if (qssfile.size() > 0) {
+    if (!qssfile.empty()) {
         QString sstext = get_qt_style_sheet(QString(qssfile.c_str()));
         app->setStyleSheet(sstext);
     }

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -238,7 +238,7 @@ void sink_c_impl::set_update_time(double t)
 
 void sink_c_impl::fft(float* data_out, const gr_complex* data_in, int size)
 {
-    if (d_window.size()) {
+    if (!d_window.empty()) {
         volk_32fc_32f_multiply_32fc(d_fft->get_inbuf(), data_in, &d_window.front(), size);
     } else {
         memcpy(d_fft->get_inbuf(), data_in, sizeof(gr_complex) * size);

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -228,7 +228,7 @@ void sink_f_impl::set_update_time(double t)
 
 void sink_f_impl::fft(float* data_out, const float* data_in, int size)
 {
-    if (d_window.size()) {
+    if (!d_window.empty()) {
         gr_complex* dst = d_fft->get_inbuf();
         for (int i = 0; i < size; i++) // apply window
             dst[i] = data_in[i] * d_window[i];

--- a/gr-qtgui/lib/spectrumdisplayform.cc
+++ b/gr-qtgui/lib/spectrumdisplayform.cc
@@ -484,7 +484,7 @@ void SpectrumDisplayForm::setAverageCount(const int newCount)
 void SpectrumDisplayForm::_averageHistory(const double* newBuffer)
 {
     if (_numRealDataPoints > 0) {
-        if (_historyVector->size() > 0) {
+        if (!_historyVector->empty()) {
             memcpy(_historyVector->operator[](_historyEntry),
                    newBuffer,
                    _numRealDataPoints * sizeof(double));

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -146,7 +146,7 @@ void time_raster_sink_b_impl::initialize()
     d_main_gui =
         new TimeRasterDisplayForm(numplots, d_samp_rate, d_rows, d_cols, 1, d_parent);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -297,7 +297,7 @@ double time_raster_sink_b_impl::num_cols() { return d_main_gui->numCols(); }
 
 void time_raster_sink_b_impl::set_multiplier(const std::vector<float>& mult)
 {
-    if (mult.size() == 0) {
+    if (mult.empty()) {
         for (int i = 0; i < d_nconnections + 1; i++) {
             d_mult[i] = 1.0f;
         }
@@ -317,7 +317,7 @@ void time_raster_sink_b_impl::set_multiplier(const std::vector<float>& mult)
 
 void time_raster_sink_b_impl::set_offset(const std::vector<float>& offset)
 {
-    if (offset.size() == 0) {
+    if (offset.empty()) {
         for (int i = 0; i < d_nconnections + 1; i++) {
             d_offset[i] = 0.0f;
         }

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -144,7 +144,7 @@ void time_raster_sink_f_impl::initialize()
     d_main_gui =
         new TimeRasterDisplayForm(numplots, d_samp_rate, d_rows, d_cols, 1, d_parent);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -300,7 +300,7 @@ double time_raster_sink_f_impl::num_cols() { return d_main_gui->numCols(); }
 
 void time_raster_sink_f_impl::set_multiplier(const std::vector<float>& mult)
 {
-    if (mult.size() == 0) {
+    if (mult.empty()) {
         for (int i = 0; i < d_nconnections; i++) {
             d_mult[i] = 1.0f;
         }
@@ -316,7 +316,7 @@ void time_raster_sink_f_impl::set_multiplier(const std::vector<float>& mult)
 
 void time_raster_sink_f_impl::set_offset(const std::vector<float>& offset)
 {
-    if (offset.size() == 0) {
+    if (offset.empty()) {
         for (int i = 0; i < d_nconnections; i++) {
             d_offset[i] = 0.0f;
         }

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -151,7 +151,7 @@ void time_sink_c_impl::initialize()
     d_main_gui->setNPoints(d_size);
     d_main_gui->setSampleRate(d_samp_rate);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -496,7 +496,7 @@ void time_sink_c_impl::_test_trigger_tags(int nitems)
     std::vector<gr::tag_t> tags;
     get_tags_in_range(
         tags, d_trigger_channel / 2, nr, nr + nitems + 1, d_trigger_tag_key);
-    if (tags.size() > 0) {
+    if (!tags.empty()) {
         trigger_index = tags[0].offset - nr;
         int start = d_index + trigger_index - d_trigger_delay - 1;
         if (start >= 0) {

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -147,7 +147,7 @@ void time_sink_f_impl::initialize()
     d_main_gui->setNPoints(d_size);
     d_main_gui->setSampleRate(d_samp_rate);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -489,7 +489,7 @@ void time_sink_f_impl::_test_trigger_tags(int nitems)
     uint64_t nr = nitems_read(d_trigger_channel);
     std::vector<gr::tag_t> tags;
     get_tags_in_range(tags, d_trigger_channel, nr, nr + nitems + 1, d_trigger_tag_key);
-    if (tags.size() > 0) {
+    if (!tags.empty()) {
         trigger_index = tags[0].offset - nr;
         int start = d_index + trigger_index - d_trigger_delay - 1;
         if (start >= 0) {

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -376,7 +376,7 @@ void TimeDisplayForm::updateTrigger(gr::qtgui::trigger_mode mode)
     }
 
     // if tag mode, popup tag key box to set
-    if ((d_trig_tag_key == "") && (d_trig_mode == gr::qtgui::TRIG_MODE_TAG))
+    if ((d_trig_tag_key.empty()) && (d_trig_mode == gr::qtgui::TRIG_MODE_TAG))
         d_tr_tag_key_act->activate(QAction::Trigger);
 
     emit signalReplot();

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -182,7 +182,7 @@ void waterfall_sink_c_impl::initialize()
     set_fft_size(d_fftsize);
     set_frequency_range(d_center_freq, d_bandwidth);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -318,7 +318,7 @@ void waterfall_sink_c_impl::disable_legend() { d_main_gui->disableLegend(); }
 
 void waterfall_sink_c_impl::fft(float* data_out, const gr_complex* data_in, int size)
 {
-    if (d_window.size()) {
+    if (!d_window.empty()) {
         volk_32fc_32f_multiply_32fc(d_fft->get_inbuf(), data_in, &d_window.front(), size);
     } else {
         memcpy(d_fft->get_inbuf(), data_in, sizeof(gr_complex) * size);

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -181,7 +181,7 @@ void waterfall_sink_f_impl::initialize()
     set_fft_size(d_fftsize);
     set_frequency_range(d_center_freq, d_bandwidth);
 
-    if (d_name.size() > 0)
+    if (!d_name.empty())
         set_title(d_name);
 
     // initialize update time to 10 times a second
@@ -327,7 +327,7 @@ void waterfall_sink_f_impl::fft(float* data_out, const float* data_in, int size)
     for (int i = 0; i < size; i++)
         dst[i] = data_in[i];
 
-    if (d_window.size()) {
+    if (!d_window.empty()) {
         volk_32fc_32f_multiply_32fc(d_fft->get_inbuf(), dst, &d_window.front(), size);
     }
 


### PR DESCRIPTION
Requesting a pull to gnuradio:master from marcusmueller:clang-tidy_foundation

Write a message for this pull request. The first block
of text is the title and the rest is the description.

   This is C++11: you can convert

```
   std::vector<complextype> vec; vec.push_back(complextype(foo, bar, baz));
```

   by

```
   std::vector<complextype> vec; vec.emplace_back(foo, bar, baz);
```

   which saves one unnecessary copy (and imho can be more concise for long types).

   This mostly happened in rpc code.

   The automated clang-tidy check failed miserably, so most of this was done
   by hand.