### PR TITLE
Fix memset clearing non-trivial type gr_complex warnings in gcc-8

### DIFF
--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2010,2013,2018 Free Software Foundation, Inc.
+ * Copyright 2004,2010,2013,2018,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -28,6 +28,7 @@
 #include "mute_impl.h"
 #include <gnuradio/io_signature.h>
 #include <string.h>
+#include <algorithm>
 
 namespace gr {
 namespace blocks {
@@ -66,7 +67,7 @@ int mute_impl<T>::work(int noutput_items,
     int size = noutput_items;
 
     if (d_mute) {
-        memset(optr, 0, noutput_items * sizeof(T));
+        std::fill_n(optr, noutput_items, 0);
     } else {
         while (size >= 8) {
             *optr++ = *iptr++;

--- a/gr-digital/lib/burst_shaper_impl.cc
+++ b/gr-digital/lib/burst_shaper_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2015,2018 Free Software Foundation, Inc.
+ * Copyright 2015,2018,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -28,6 +28,7 @@
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 #include <boost/format.hpp>
+#include <algorithm>
 
 namespace gr {
 namespace digital {
@@ -220,7 +221,7 @@ template <class T>
 void burst_shaper_impl<T>::write_padding(T*& dst, int& nwritten, int nspace)
 {
     int nprocess = std::min(d_limit - d_index, nspace);
-    std::memset(dst, 0x00, nprocess * sizeof(T));
+    std::fill_n(dst, nprocess, 0x00);
     dst += nprocess;
     nwritten += nprocess;
     d_index += nprocess;

--- a/gr-filter/lib/fir_filter.cc
+++ b/gr-filter/lib/fir_filter.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2004,2010,2012,2018 Free Software Foundation, Inc.
+ * Copyright 2004,2010,2012,2018,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -80,7 +80,7 @@ void fir_filter<IN_T, OUT_T, TAP_T>::set_taps(const std::vector<TAP_T>& taps)
     for (int i = 0; i < d_naligned; i++) {
         d_aligned_taps[i] =
             (TAP_T*)volk_malloc((d_ntaps + d_naligned - 1) * sizeof(TAP_T), d_align);
-        memset(d_aligned_taps[i], 0, sizeof(TAP_T) * (d_ntaps + d_naligned - 1));
+        std::fill_n(d_aligned_taps[i], d_ntaps + d_naligned - 1, 0);
         for (unsigned int j = 0; j < d_ntaps; j++)
             d_aligned_taps[i][i + j] = d_taps[j];
     }

--- a/gr-filter/lib/fir_filter_with_buffer.cc
+++ b/gr-filter/lib/fir_filter_with_buffer.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2010,2012 Free Software Foundation, Inc.
+ * Copyright 2010,2012,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -242,7 +242,7 @@ void fir_filter_with_buffer_ccc::set_taps(const std::vector<gr_complex>& taps)
     // allocated space.
     d_buffer_ptr = (gr_complex*)volk_malloc(
         (2 * (d_ntaps + d_naligned)) * sizeof(gr_complex), d_align);
-    memset(d_buffer_ptr, 0, 2 * (d_ntaps + d_naligned) * sizeof(gr_complex));
+    std::fill_n(d_buffer_ptr, 2 * (d_ntaps + d_naligned), 0);
     d_buffer = d_buffer_ptr + d_naligned;
 
     // Allocate aligned taps
@@ -250,7 +250,7 @@ void fir_filter_with_buffer_ccc::set_taps(const std::vector<gr_complex>& taps)
     for (int i = 0; i < d_naligned; i++) {
         d_aligned_taps[i] = (gr_complex*)volk_malloc(
             (d_ntaps + d_naligned - 1) * sizeof(gr_complex), d_align);
-        memset(d_aligned_taps[i], 0, sizeof(gr_complex) * (d_ntaps + d_naligned - 1));
+        std::fill_n(d_aligned_taps[i], d_ntaps + d_naligned - 1, 0);
         for (unsigned int j = 0; j < d_ntaps; j++)
             d_aligned_taps[i][i + j] = d_taps[j];
     }
@@ -386,7 +386,7 @@ void fir_filter_with_buffer_ccf::set_taps(const std::vector<float>& taps)
     // allocated space.
     d_buffer_ptr = (gr_complex*)volk_malloc(
         (2 * (d_ntaps + d_naligned)) * sizeof(gr_complex), d_align);
-    memset(d_buffer_ptr, 0, 2 * (d_ntaps + d_naligned) * sizeof(gr_complex));
+    std::fill_n(d_buffer_ptr, 2 * (d_ntaps + d_naligned), 0);
     d_buffer = d_buffer_ptr + d_naligned;
 
     // Allocate aligned taps

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2010,2012,2014 Free Software Foundation, Inc.
+ * Copyright 2010,2012,2014,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -27,6 +27,7 @@
 #include "pfb_synthesizer_ccf_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cstdio>
+#include <algorithm>
 
 namespace gr {
 namespace filter {
@@ -72,7 +73,7 @@ pfb_synthesizer_ccf_impl::pfb_synthesizer_ccf_impl(unsigned int numchans,
 
     // Create the IFFT to handle the input channel rotations
     d_fft = new fft::fft_complex(d_twox * d_numchans, false);
-    memset(d_fft->get_inbuf(), 0, d_twox * d_numchans * sizeof(gr_complex));
+    std::fill_n(d_fft->get_inbuf(), d_twox * d_numchans, 0);
 
     set_output_multiple(d_numchans);
 }
@@ -223,7 +224,7 @@ void pfb_synthesizer_ccf_impl::set_channel_map(const std::vector<int>& map)
         d_channel_map = map;
 
         // Zero out fft buffer so that unused channels are always 0
-        memset(d_fft->get_inbuf(), 0, d_twox * d_numchans * sizeof(gr_complex));
+        std::fill_n(d_fft->get_inbuf(), d_twox * d_numchans, 0);
     }
 }
 

--- a/gr-filter/lib/qa_fir_filter_with_buffer.cc
+++ b/gr-filter/lib/qa_fir_filter_with_buffer.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2010,2012 Free Software Foundation, Inc.
+ * Copyright 2010,2012,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -32,6 +32,7 @@
 #include <boost/test/unit_test.hpp>
 #include <cmath>
 #include <cstring>
+#include <algorithm>
 
 using std::vector;
 
@@ -201,7 +202,7 @@ void test_decimate(unsigned int decimate)
         (gr_complex*)volk_malloc(OUTPUT_LEN * sizeof(gr_complex), align);
     tap_type* taps = (gr_complex*)volk_malloc(MAX_TAPS * sizeof(gr_complex), align);
 
-    memset(dline, 0, INPUT_LEN * sizeof(i_type));
+    std::fill_n(dline, INPUT_LEN, 0);
 
     for (int n = 0; n <= MAX_TAPS; n++) {
         for (int ol = 0; ol <= OUTPUT_LEN; ol++) {
@@ -211,7 +212,7 @@ void test_decimate(unsigned int decimate)
             random_complex(taps, MAX_TAPS);
 
             // compute expected output values
-            memset(dline, 0, INPUT_LEN * sizeof(i_type));
+            std::fill_n(dline, INPUT_LEN, 0);
             for (int o = 0; o < (int)(ol / decimate); o++) {
                 // use an actual delay line for this test
                 for (int dd = 0; dd < (int)decimate; dd++) {
@@ -228,7 +229,7 @@ void test_decimate(unsigned int decimate)
                 new kernel::fir_filter_with_buffer_ccc(f1_taps);
 
             // zero the output, then do the filtering
-            memset(actual_output, 0, OUTPUT_LEN * sizeof(o_type));
+            std::fill_n(actual_output, OUTPUT_LEN, 0);
             f1->filterNdec(actual_output, input, ol / decimate, decimate);
 
             // check results
@@ -302,7 +303,7 @@ void test_decimate(unsigned int decimate)
         (gr_complex*)volk_malloc(OUTPUT_LEN * sizeof(gr_complex), align);
     tap_type* taps = (float*)volk_malloc(MAX_TAPS * sizeof(float), align);
 
-    memset(dline, 0, INPUT_LEN * sizeof(i_type));
+    std::fill_n(dline, INPUT_LEN, 0);
 
     for (int n = 0; n <= MAX_TAPS; n++) {
         for (int ol = 0; ol <= OUTPUT_LEN; ol++) {
@@ -312,7 +313,7 @@ void test_decimate(unsigned int decimate)
             random_floats(taps, MAX_TAPS);
 
             // compute expected output values
-            memset(dline, 0, INPUT_LEN * sizeof(i_type));
+            std::fill_n(dline, INPUT_LEN, 0);
             for (int o = 0; o < (int)(ol / decimate); o++) {
                 // use an actual delay line for this test
                 for (int dd = 0; dd < (int)decimate; dd++) {
@@ -329,7 +330,7 @@ void test_decimate(unsigned int decimate)
                 new kernel::fir_filter_with_buffer_ccf(f1_taps);
 
             // zero the output, then do the filtering
-            memset(actual_output, 0, OUTPUT_LEN * sizeof(gr_complex));
+            std::fill_n(actual_output, OUTPUT_LEN, 0);
             f1->filterNdec(actual_output, input, ol / decimate, decimate);
 
             // check results

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2014-2015 Free Software Foundation, Inc.
+ * Copyright 2012,2014-2015,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -33,6 +33,7 @@
 #include <volk/volk.h>
 
 #include <string.h>
+#include <algorithm>
 
 namespace gr {
 namespace qtgui {
@@ -111,7 +112,7 @@ freq_sink_c_impl::freq_sink_c_impl(int fftsize,
         d_magbufs.push_back(
             (double*)volk_malloc(d_fftsize * sizeof(double), volk_get_alignment()));
 
-        memset(d_residbufs[i], 0, d_fftsize * sizeof(gr_complex));
+        std::fill_n(d_residbufs[i], d_fftsize, 0);
         memset(d_magbufs[i], 0, d_fftsize * sizeof(double));
     }
 
@@ -119,7 +120,7 @@ freq_sink_c_impl::freq_sink_c_impl(int fftsize,
         (gr_complex*)volk_malloc(d_fftsize * sizeof(gr_complex), volk_get_alignment()));
     d_pdu_magbuf = (double*)volk_malloc(d_fftsize * sizeof(double), volk_get_alignment());
     d_magbufs.push_back(d_pdu_magbuf);
-    memset(d_residbufs[d_nconnections], 0, d_fftsize * sizeof(gr_complex));
+    std::fill_n(d_residbufs[d_nconnections], d_fftsize, 0);
     memset(d_pdu_magbuf, 0, d_fftsize * sizeof(double));
 
     buildwindow();
@@ -442,7 +443,7 @@ bool freq_sink_c_impl::fftresize()
             d_magbufs[i] =
                 (double*)volk_malloc(newfftsize * sizeof(double), volk_get_alignment());
 
-            memset(d_residbufs[i], 0, newfftsize * sizeof(gr_complex));
+            std::fill_n(d_residbufs[i], newfftsize, 0);
             memset(d_magbufs[i], 0, newfftsize * sizeof(double));
         }
 
@@ -672,7 +673,7 @@ void freq_sink_c_impl::handle_pdus(pmt::pmt_t msg)
         size_t max = std::min(d_fftsize, static_cast<int>(len));
         for (int n = 0; n < nffts; n++) {
             // Clear in case (max-min) < d_fftsize
-            memset(d_residbufs[d_nconnections], 0x00, sizeof(gr_complex) * d_fftsize);
+            std::fill_n(d_residbufs[d_nconnections], d_fftsize, 0x00);
 
             // Copy in as much of the input samples as we can
             memcpy(

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2011-2013,2015 Free Software Foundation, Inc.
+ * Copyright 2011-2013,2015,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -34,6 +34,7 @@
 #include <volk/volk.h>
 
 #include <string.h>
+#include <algorithm>
 
 namespace gr {
 namespace qtgui {
@@ -92,7 +93,7 @@ time_sink_c_impl::time_sink_c_impl(int size,
     for (unsigned int n = 0; n < d_nconnections / 2; n++) {
         d_cbuffers.push_back((gr_complex*)volk_malloc(d_buffer_size * sizeof(gr_complex),
                                                       volk_get_alignment()));
-        memset(d_cbuffers[n], 0, d_buffer_size * sizeof(gr_complex));
+        std::fill_n(d_cbuffers[n], d_buffer_size, 0);
     }
 
     // Set alignment properties for VOLK
@@ -323,7 +324,7 @@ void time_sink_c_impl::set_nsamps(const int newsize)
             volk_free(d_cbuffers[n]);
             d_cbuffers[n] = (gr_complex*)volk_malloc(d_buffer_size * sizeof(gr_complex),
                                                      volk_get_alignment());
-            memset(d_cbuffers[n], 0, d_buffer_size * sizeof(gr_complex));
+            std::fill_n(d_cbuffers[n], d_buffer_size, 0);
         }
 
         // If delay was set beyond the new boundary, pull it back.

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2014-2015 Free Software Foundation, Inc.
+ * Copyright 2012,2014-2015,2019 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -34,6 +34,7 @@
 
 #include <string.h>
 #include <iostream>
+#include <algorithm>
 
 namespace gr {
 namespace qtgui {
@@ -98,7 +99,7 @@ waterfall_sink_c_impl::waterfall_sink_c_impl(int fftsize,
                                                        volk_get_alignment()));
         d_magbufs.push_back(
             (double*)volk_malloc(d_fftsize * sizeof(double), volk_get_alignment()));
-        memset(d_residbufs[i], 0, d_fftsize * sizeof(gr_complex));
+        std::fill_n(d_residbufs[i], d_fftsize, 0);
         memset(d_magbufs[i], 0, d_fftsize * sizeof(double));
     }
 
@@ -108,7 +109,7 @@ waterfall_sink_c_impl::waterfall_sink_c_impl(int fftsize,
         (double*)volk_malloc(d_fftsize * sizeof(double) * d_nrows, volk_get_alignment());
     d_magbufs.push_back(d_pdu_magbuf);
     memset(d_pdu_magbuf, 0, d_fftsize * sizeof(double) * d_nrows);
-    memset(d_residbufs[d_nconnections], 0, d_fftsize * sizeof(gr_complex));
+    std::fill_n(d_residbufs[d_nconnections], d_fftsize, 0);
 
     buildwindow();
 
@@ -371,7 +372,7 @@ void waterfall_sink_c_impl::fftresize()
             d_magbufs[i] =
                 (double*)volk_malloc(newfftsize * sizeof(double), volk_get_alignment());
 
-            memset(d_residbufs[i], 0, newfftsize * sizeof(gr_complex));
+            std::fill_n(d_residbufs[i], newfftsize, 0);
             memset(d_magbufs[i], 0, newfftsize * sizeof(double));
         }
 
@@ -385,7 +386,7 @@ void waterfall_sink_c_impl::fftresize()
         d_pdu_magbuf = (double*)volk_malloc(newfftsize * sizeof(double) * d_nrows,
                                             volk_get_alignment());
         d_magbufs[d_nconnections] = d_pdu_magbuf;
-        memset(d_residbufs[d_nconnections], 0, newfftsize * sizeof(gr_complex));
+        std::fill_n(d_residbufs[d_nconnections], newfftsize, 0);
         memset(d_pdu_magbuf, 0, newfftsize * sizeof(double) * d_nrows);
 
         // Set new fft size and reset buffer index
@@ -558,7 +559,7 @@ void waterfall_sink_c_impl::handle_pdus(pmt::pmt_t msg)
         size_t max = std::min(d_fftsize, static_cast<int>(len));
         for (size_t i = 0; j < d_nrows; i += stride) {
             // Clear residbufs if len < d_fftsize
-            memset(d_residbufs[d_nconnections], 0x00, sizeof(gr_complex) * d_fftsize);
+            std::fill_n(d_residbufs[d_nconnections], d_fftsize, 0x00);
 
             // Copy in as much of the input samples as we can
             memcpy(


### PR DESCRIPTION
Fixes #2743 by casting pointers passed to `memset` to `void*`.