### PR TITLE
gr-filter: Fix a typo in the YAML for Polyphase Channelizer

### DIFF
--- a/gr-filter/grc/filter_pfb_channelizer.block.yml
+++ b/gr-filter/grc/filter_pfb_channelizer.block.yml
@@ -53,7 +53,8 @@ templates:
             ${taps},
             ${osr},
             ${atten})
-        self.${id}.set_channel_map(${ch_map})\nself.${id}.declare_sample_delay(${samp_delay})
+        self.${id}.set_channel_map(${ch_map})
+        self.${id}.declare_sample_delay(${samp_delay})
     callbacks:
     - set_taps(${taps})
     - set_channel_map(${ch_map})


### PR DESCRIPTION
When a Polyphase Channelizer is used in GRC, the generated Python code fails with the following error:
```
  File "./channelizer.py", line 83
    self.pfb_channelizer_ccf_0.set_channel_map([])\nself.pfb_channelizer_ccf_0.declare_sample_delay(0)
                                                                                                     ^
SyntaxError: unexpected character after line continuation character
```
This is due to a typo in the YAML file. I've replaced `\n` with an actual carriage return to fix it.