### PR TITLE
Fix typo that creates build issues from GR dependencies

### DIFF
--- a/cmake/Modules/FindLOG4CPP.cmake
+++ b/cmake/Modules/FindLOG4CPP.cmake
@@ -48,7 +48,7 @@ else ()
 endif ()
 
 
-if (LOG4CPP_FOUND AND NOT TARGET log4cpp::log4cpp)
+if (LOG4CPP_FOUND AND NOT TARGET Log4cpp::log4cpp)
   add_library(Log4Cpp::log4cpp INTERFACE IMPORTED)
   set_target_properties(Log4Cpp::log4cpp PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${LOG4CPP_INCLUDE_DIRS}"


### PR DESCRIPTION
I'm not sure whether it is intentional or not, but it seems a typo in `cmake/Modules/FindLOG4CPP.cmake` creates build error for applications that depends on GR CMake module to build, `e.g.` with [gr-osmosdr](https://osmocom.org/projects/osmosdr)

    CMake Error at /usr/local/lib/cmake/gnuradio/FindLOG4CPP.cmake:52 (add_library):
      add_library cannot create imported target "Log4Cpp::log4cpp" because
      another target with the same name already exists.
    Call Stack (most recent call first):
      /usr/local/Cellar/cmake/3.15.2/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
      /usr/local/lib/cmake/gnuradio/GnuradioConfig.cmake:25 (find_dependency)
      CMakeLists.txt:184 (find_package)

