### PR TITLE
modtool: Py2 `input` means `eval`; use `raw_input` instead.

### DIFF
--- a/gr-utils/python/modtool/cli/base.py
+++ b/gr-utils/python/modtool/cli/base.py
@@ -122,7 +122,11 @@ def setup_cli_logger(logger):
 
 def cli_input(msg):
     """ Returns enhanced input """
-    return input(click.style(msg, fg='cyan'))
+    if sys.version_info[0] < 3:
+        in_func = raw_input
+    else:
+        in_func = input
+    return in_func(click.style(msg, fg='cyan'))
 
 
 def common_params(func):

--- a/gr-utils/python/modtool/tools/util_functions.py
+++ b/gr-utils/python/modtool/tools/util_functions.py
@@ -143,8 +143,12 @@ def is_number(s):
 def ask_yes_no(question, default):
     """ Asks a binary question. Returns True for yes, False for no.
     default is given as a boolean. """
+    if sys.version_info[0] < 3:
+        in_func = raw_input
+    else:
+        in_func = input
     question += {True: ' [Y/n] ', False: ' [y/N] '}[default]
-    if input(question).lower() != {True: 'n', False: 'y'}[default]:
+    if in_func(question).lower() != {True: 'n', False: 'y'}[default]:
         return default
     else:
         return not default


### PR DESCRIPTION
This only applies to maint-3.8. Thankfully, 3.9 won't be Py2-compatible.