### PR TITLE
3.9. OOT needs to rely on 3.9

### DIFF
--- a/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
@@ -85,7 +85,7 @@ ENDIF()
 ########################################################################
 # Install directories
 ########################################################################
-find_package(Gnuradio "3.8" REQUIRED)
+find_package(Gnuradio "3.9" REQUIRED)
 include(GrVersion)
 
 include(GrPlatform) #define LIB_SUFFIX


### PR DESCRIPTION
It would be advantageous to not hard-code this, but that requires the
templates to be CMake-time configured.