### PR TITLE
Make Id visible in Tab_widget

### DIFF
--- a/gr-qtgui/grc/qtgui_tab_widget.block.yml
+++ b/gr-qtgui/grc/qtgui_tab_widget.block.yml
@@ -1,6 +1,6 @@
 id: qtgui_tab_widget
 label: QT GUI Tab Widget
-flags: [ python ]
+flags: [show_id, python ]
 
 parameters:
 -   id: num_tabs


### PR DESCRIPTION
To make meaningfull use of the QTab_Widget it's necessary to make the id visible and changeable