### PR TITLE
runtime: fixup errors from clang-tidy changes

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -91,7 +91,7 @@ protected:
     bool d_rpc_set;
 
     msg_queue_map_t msg_queue;
-    std::vector<boost::any> d_rpc_vars; // container for all RPC variables
+    std::vector<rpcbasic_sptr> d_rpc_vars; // container for all RPC variables
 
     basic_block(void) {} // allows pure virtual interface sub-classes
 

--- a/gnuradio-runtime/include/gnuradio/pycallback_object.h
+++ b/gnuradio-runtime/include/gnuradio/pycallback_object.h
@@ -150,7 +150,7 @@ private:
         return (dummy);
     };
 
-    std::vector<boost::any> d_rpc_vars; // container for all RPC variables
+    std::vector<rpcbasic_sptr> d_rpc_vars; // container for all RPC variables
     std::string d_name;
     int d_id;
 };


### PR DESCRIPTION
introduced in https://github.com/gnuradio/gnuradio/commit/c6cb3bbc35153a9635d69eddab0d252f7441b854

Since `d_rpc_vars` is of type `std::vector<boost::any>` the sptr was not constructed as before.