### PR TITLE
Normalize the constellation points so that the mean square magnitude is 1 (instead of the non-squared magnitude).

### DIFF
--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -29,6 +29,13 @@ parameters:
     dtype: int
     default: '1'
     hide: ${ ( 'none' if str(type) == "calcdist" else 'all') }
+-   id: normalization
+    label: Normalization Type
+    dtype: int
+    default: digital.constellation.AMPLITUDE_NORMALIZATION
+    options: [digital.constellation.NO_NORMALIZATION, digital.constellation.POWER_NORMALIZATION, digital.constellation.AMPLITUDE_NORMALIZATION]
+    option_labels: [None, Power, Amplitude]
+    hide: ${ ( 'none' if str(type) == "calcdist" else 'all') }
 -   id: precision
     label: Soft Decisions Precision
     dtype: int
@@ -39,7 +46,7 @@ parameters:
     dtype: raw
     default: None
     hide: ${ ('part' if str(soft_dec_lut) == 'None' else 'none') }
-value: ${ digital.constellation_calcdist(const_points, sym_map, rot_sym, dims) if (str(type) == "calcdist") else getattr(digital,'constellation_'+str(type))()  }
+value: ${ digital.constellation_calcdist(const_points, sym_map, rot_sym, dims, normalization) if (str(type) == "calcdist") else getattr(digital,'constellation_'+str(type))()  }
 
 
 templates:

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -49,11 +49,17 @@ typedef std::shared_ptr<constellation> constellation_sptr;
 class DIGITAL_API constellation : public std::enable_shared_from_this<constellation>
 {
 public:
+    enum normalization_t {
+        NO_NORMALIZATION,
+        POWER_NORMALIZATION,
+        AMPLITUDE_NORMALIZATION,
+    };
+
     constellation(std::vector<gr_complex> constell,
                   std::vector<int> pre_diff_code,
                   unsigned int rotational_symmetry,
                   unsigned int dimensionality,
-                  bool normalize_points = true);
+                  normalization_t normalization = AMPLITUDE_NORMALIZATION);
     constellation();
     virtual ~constellation();
 
@@ -233,15 +239,17 @@ public:
      * \param pre_diff_code List of alphabet symbols (before applying any differential
      *                      coding) (order of list matches constell)
      * \param rotational_symmetry Number of rotations around unit circle that have the
-     * same representation. \param dimensionality Number of dimensions to the
-     * constellation. \param normalize_points Normalize constellation points to
-     * mean(abs(points))=1 (default is true)
+     * same representation.
+     * \param dimensionality Number of dimensions to the constellation.
+     * \param normalization Use AMPLITUDE_NORMALIZATION to normalize points to
+     * mean(abs(points))=1 (default), POWER_NORMALIZATION to normalize points
+     * to mean(abs(points)^2)=1 or NO_NORMALIZATION to keep the original amplitude.
      */
     static sptr make(std::vector<gr_complex> constell,
                      std::vector<int> pre_diff_code,
                      unsigned int rotational_symmetry,
                      unsigned int dimensionality,
-                     bool normalize_points = true);
+                     normalization_t normalization = AMPLITUDE_NORMALIZATION);
 
     unsigned int decision_maker(const gr_complex* sample) override;
     // void calc_metric(gr_complex *sample, float *metric, trellis_metric_type_t type);
@@ -253,7 +261,7 @@ protected:
                            std::vector<int> pre_diff_code,
                            unsigned int rotational_symmetry,
                            unsigned int dimensionality,
-                           bool nomalize_points = true);
+                           normalization_t normalization = AMPLITUDE_NORMALIZATION);
 };
 
 
@@ -286,7 +294,8 @@ public:
                          std::vector<int> pre_diff_code,
                          unsigned int rotational_symmetry,
                          unsigned int dimensionality,
-                         unsigned int n_sectors);
+                         unsigned int n_sectors,
+                         normalization_t normalization = AMPLITUDE_NORMALIZATION);
 
     ~constellation_sector() override;
 
@@ -339,13 +348,15 @@ public:
      * \param width_imag_sectors width of each imag sector to calculate decision
      * boundaries.
      */
-    static constellation_rect::sptr make(std::vector<gr_complex> constell,
-                                         std::vector<int> pre_diff_code,
-                                         unsigned int rotational_symmetry,
-                                         unsigned int real_sectors,
-                                         unsigned int imag_sectors,
-                                         float width_real_sectors,
-                                         float width_imag_sectors);
+    static constellation_rect::sptr
+    make(std::vector<gr_complex> constell,
+         std::vector<int> pre_diff_code,
+         unsigned int rotational_symmetry,
+         unsigned int real_sectors,
+         unsigned int imag_sectors,
+         float width_real_sectors,
+         float width_imag_sectors,
+         normalization_t normalization = AMPLITUDE_NORMALIZATION);
     ~constellation_rect() override;
 
 protected:
@@ -355,7 +366,8 @@ protected:
                        unsigned int real_sectors,
                        unsigned int imag_sectors,
                        float width_real_sectors,
-                       float width_imag_sectors);
+                       float width_imag_sectors,
+                       normalization_t normalization = AMPLITUDE_NORMALIZATION);
 
     unsigned int get_sector(const gr_complex* sample) override;
     gr_complex calc_sector_center(unsigned int sector);

--- a/gr-digital/python/digital/bindings/constellation_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constellation.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(5f7cb544c3d7104e228f713f28b385ee)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7830b0b770b8e3ae0fa213f34ead29b7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,17 +43,23 @@ void bind_constellation(py::module& m)
     using constellation_8psk_natural = ::gr::digital::constellation_8psk_natural;
     using constellation_16qam = ::gr::digital::constellation_16qam;
 
+    py::class_<constellation, std::shared_ptr<constellation>> constellation_class(
+        m, "constellation", D(constellation));
 
-    py::class_<constellation, std::shared_ptr<constellation>>(
-        m, "constellation", D(constellation))
+    py::enum_<constellation::normalization_t>(constellation_class, "normalization")
+        .value("NO_NORMALIZATION", constellation::NO_NORMALIZATION)
+        .value("POWER_NORMALIZATION", constellation::POWER_NORMALIZATION)
+        .value("AMPLITUDE_NORMALIZATION", constellation::AMPLITUDE_NORMALIZATION)
+        .export_values();
 
+    constellation_class
         // .def(py::init<std::vector<std::complex<float>,
         // std::allocator<std::complex<float> > >,std::vector<int, std::allocator<int>
         // >,unsigned int,unsigned int,bool>(),           py::arg("constell"),
         //    py::arg("pre_diff_code"),
         //    py::arg("rotational_symmetry"),
         //    py::arg("dimensionality"),
-        //    py::arg("normalize_points") = true,
+        //    py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
         //    D(constellation,constellation,0)
         // )
         // .def(py::init<>(),D(constellation,constellation,1))
@@ -212,7 +218,7 @@ void bind_constellation(py::module& m)
              py::arg("pre_diff_code"),
              py::arg("rotational_symmetry"),
              py::arg("dimensionality"),
-             py::arg("normalize_points") = true,
+             py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
              D(constellation_calcdist, make))
 
 
@@ -264,6 +270,7 @@ void bind_constellation(py::module& m)
              py::arg("imag_sectors"),
              py::arg("width_real_sectors"),
              py::arg("width_imag_sectors"),
+             py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
              D(constellation_rect, make))
 
 


### PR DESCRIPTION
This allows to easily create signals with normalized power and makes it consistent with the 16-QAM constellation (which is also normalized for mean square magnitude = 1).