### PR TITLE
cherry-pick corr_est_cc and constellation onto main-3.7

### DIFF
--- a/gr-digital/examples/packet/example_corr_est.grc
+++ b/gr-digital/examples/packet/example_corr_est.grc
@@ -1152,6 +1152,10 @@
       <key>threshold</key>
       <value>0.999</value>
     </param>
+    <param>
+      <key>threshold_method</key>
+      <value>digital.THRESHOLD_ABSOLUTE</value>
+    </param>
   </block>
   <block>
     <key>fir_filter_xxx</key>

--- a/gr-digital/examples/packet/example_corr_est_and_clock_sync.grc
+++ b/gr-digital/examples/packet/example_corr_est_and_clock_sync.grc
@@ -1210,6 +1210,10 @@ Found empirically.</value>
       <key>threshold</key>
       <value>0.999</value>
     </param>
+    <param>
+      <key>threshold_method</key>
+      <value>digital.THRESHOLD_ABSOLUTE</value>
+    </param>
   </block>
   <block>
     <key>digital_pfb_clock_sync_xxx</key>

--- a/gr-digital/examples/packet/example_corr_est_and_phase_sync.grc
+++ b/gr-digital/examples/packet/example_corr_est_and_phase_sync.grc
@@ -1210,6 +1210,10 @@ Found empirically.</value>
       <key>threshold</key>
       <value>0.999</value>
     </param>
+    <param>
+      <key>threshold_method</key>
+      <value>digital.THRESHOLD_ABSOLUTE</value>
+    </param>
   </block>
   <block>
     <key>digital_costas_loop_cc</key>

--- a/gr-digital/examples/packet/packet_rx.grc
+++ b/gr-digital/examples/packet/packet_rx.grc
@@ -627,6 +627,10 @@ FEC is Repetition (x3)</value>
       <key>threshold</key>
       <value>0.999</value>
     </param>
+    <param>
+      <key>threshold_method</key>
+      <value>digital.THRESHOLD_ABSOLUTE</value>
+    </param>
   </block>
   <block>
     <key>digital_costas_loop_cc</key>

--- a/gr-digital/grc/digital_corr_est_cc.xml
+++ b/gr-digital/grc/digital_corr_est_cc.xml
@@ -32,6 +32,20 @@
     <type>float</type>
   </param>
 
+  <param>
+    <name>Threshold Method</name>
+    <key>threshold_method</key>
+    <type>enum</type>
+    <option>
+      <name>Absolute</name>
+      <key>digital.corr_est_cc.THRESHOLD_ABSOLUTE</key>
+    </option>
+    <option>
+      <name>Dynamic</name>
+      <key>digital.corr_est_cc.THRESHOLD_DYNAMIC</key>
+    </option>
+  </param>
+
   <sink>
     <name>in</name>
     <type>complex</type>

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -65,7 +65,8 @@ public:
     constellation(std::vector<gr_complex> constell,
                   std::vector<int> pre_diff_code,
                   unsigned int rotational_symmetry,
-                  unsigned int dimensionality);
+                  unsigned int dimensionality,
+                  bool normalize_points = true);
     constellation();
     virtual ~constellation();
 
@@ -246,12 +247,14 @@ public:
      *                      coding) (order of list matches constell)
      * \param rotational_symmetry Number of rotations around unit circle that have the
      * same representation. \param dimensionality Number of dimensions to the
-     * constellation.
+     * constellation. \param normalize_points Normalize constellation points to
+     * mean(abs(points))=1 (default is true)
      */
     static sptr make(std::vector<gr_complex> constell,
                      std::vector<int> pre_diff_code,
                      unsigned int rotational_symmetry,
-                     unsigned int dimensionality);
+                     unsigned int dimensionality,
+                     bool normalize_points = true);
 
     unsigned int decision_maker(const gr_complex* sample);
     // void calc_metric(gr_complex *sample, float *metric, trellis_metric_type_t type);
@@ -262,7 +265,8 @@ protected:
     constellation_calcdist(std::vector<gr_complex> constell,
                            std::vector<int> pre_diff_code,
                            unsigned int rotational_symmetry,
-                           unsigned int dimensionality);
+                           unsigned int dimensionality,
+                           bool nomalize_points = true);
 };
 
 

--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -87,22 +87,30 @@ class DIGITAL_API corr_est_cc : virtual public sync_block
 public:
     typedef boost::shared_ptr<corr_est_cc> sptr;
 
+    enum tm_type {
+        THRESHOLD_DYNAMIC,
+        THRESHOLD_ABSOLUTE,
+    };
+
     /*!
      * Make a block that correlates against the \p symbols vector
      * and outputs a phase and symbol timing estimate.
      *
-     * \param symbols    Set of symbols to correlate against (e.g., a
-     *                   sync word).
-     * \param sps        Samples per symbol
-     * \param mark_delay tag marking delay in samples after the
-     *                   corr_start tag
-     * \param threshold  Threshold of correlator, relative to a 100%
-     *                   correlation (1.0). Default is 0.9.
+     * \param symbols           Set of symbols to correlate against (e.g., a
+     *                          sync word).
+     * \param sps               Samples per symbol
+     * \param mark_delay        tag marking delay in samples after the
+     *                          corr_start tag
+     * \param threshold         Threshold of correlator, relative to a 100%
+     *                          correlation (1.0). Default is 0.9.
+     * \param threshold_method  Method for computing threshold.
+     *
      */
     static sptr make(const std::vector<gr_complex>& symbols,
                      float sps,
                      unsigned int mark_delay,
-                     float threshold = 0.9);
+                     float threshold = 0.9,
+                     tm_type threshold_method = THRESHOLD_ABSOLUTE);
 
     virtual std::vector<gr_complex> symbols() const = 0;
     virtual void set_symbols(const std::vector<gr_complex>& symbols) = 0;

--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -82,15 +82,14 @@ namespace digital {
  * _on_Signal_Processing_, Volume 47, No. 9, September 1999
  *
  */
-class DIGITAL_API corr_est_cc : virtual public sync_block
-{
-public:
-    typedef boost::shared_ptr<corr_est_cc> sptr;
+typedef enum {
+    THRESHOLD_DYNAMIC,
+    THRESHOLD_ABSOLUTE,
+} tm_type;
 
-    enum tm_type {
-        THRESHOLD_DYNAMIC,
-        THRESHOLD_ABSOLUTE,
-    };
+class DIGITAL_API corr_est_cc : virtual public sync_block {
+    public:
+    typedef boost::shared_ptr<corr_est_cc> sptr;
 
     /*!
      * Make a block that correlates against the \p symbols vector

--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -44,7 +44,8 @@ namespace digital {
 constellation::constellation(std::vector<gr_complex> constell,
                              std::vector<int> pre_diff_code,
                              unsigned int rotational_symmetry,
-                             unsigned int dimensionality)
+                             unsigned int dimensionality,
+                             bool normalize_points)
     : d_constellation(constell),
       d_pre_diff_code(pre_diff_code),
       d_rotational_symmetry(rotational_symmetry),
@@ -56,16 +57,18 @@ constellation::constellation(std::vector<gr_complex> constell,
       d_lut_precision(0),
       d_lut_scale(0)
 {
-    // Scale constellation points so that average magnitude is 1.
-    float summed_mag = 0;
     unsigned int constsize = d_constellation.size();
-    for (unsigned int i = 0; i < constsize; i++) {
-        gr_complex c = d_constellation[i];
-        summed_mag += sqrt(c.real() * c.real() + c.imag() * c.imag());
-    }
-    d_scalefactor = constsize / summed_mag;
-    for (unsigned int i = 0; i < constsize; i++) {
-        d_constellation[i] = d_constellation[i] * d_scalefactor;
+    if (normalize_points) {
+        // Scale constellation points so that average magnitude is 1.
+        float summed_mag = 0;
+        for (unsigned int i = 0; i < constsize; i++) {
+            gr_complex c = d_constellation[i];
+            summed_mag += sqrt(c.real() * c.real() + c.imag() * c.imag());
+        }
+        d_scalefactor = constsize / summed_mag;
+        for (unsigned int i = 0; i < constsize; i++) {
+            d_constellation[i] = d_constellation[i] * d_scalefactor;
+        }
     }
     if (pre_diff_code.size() == 0)
         d_apply_pre_diff_code = false;
@@ -378,17 +381,20 @@ constellation_calcdist::sptr
 constellation_calcdist::make(std::vector<gr_complex> constell,
                              std::vector<int> pre_diff_code,
                              unsigned int rotational_symmetry,
-                             unsigned int dimensionality)
+                             unsigned int dimensionality,
+                             bool normalize_points)
 {
     return constellation_calcdist::sptr(new constellation_calcdist(
-        constell, pre_diff_code, rotational_symmetry, dimensionality));
+        constell, pre_diff_code, rotational_symmetry, dimensionality, normalize_points));
 }
 
 constellation_calcdist::constellation_calcdist(std::vector<gr_complex> constell,
                                                std::vector<int> pre_diff_code,
                                                unsigned int rotational_symmetry,
-                                               unsigned int dimensionality)
-    : constellation(constell, pre_diff_code, rotational_symmetry, dimensionality)
+                                               unsigned int dimensionality,
+                                               bool normalize_points)
+    : constellation(
+          constell, pre_diff_code, rotational_symmetry, dimensionality, normalize_points)
 {
 }
 

--- a/gr-digital/lib/corr_est_cc_impl.cc
+++ b/gr-digital/lib/corr_est_cc_impl.cc
@@ -39,22 +39,25 @@ namespace digital {
 corr_est_cc::sptr corr_est_cc::make(const std::vector<gr_complex>& symbols,
                                     float sps,
                                     unsigned int mark_delay,
-                                    float threshold)
+                                    float threshold,
+                                    tm_type threshold_method)
 {
     return gnuradio::get_initial_sptr(
-        new corr_est_cc_impl(symbols, sps, mark_delay, threshold));
+        new corr_est_cc_impl(symbols, sps, mark_delay, threshold, threshold_method));
 }
 
 corr_est_cc_impl::corr_est_cc_impl(const std::vector<gr_complex>& symbols,
                                    float sps,
                                    unsigned int mark_delay,
-                                   float threshold)
+                                   float threshold,
+                                   tm_type threshold_method)
     : sync_block("corr_est_cc",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 2, sizeof(gr_complex))),
       d_src_id(pmt::intern(alias()))
 {
     d_sps = sps;
+    d_threshold_method = threshold_method;
 
     // In order to easily support the optional second output,
     // don't deal with an unbounded max number of output items.
@@ -178,7 +181,23 @@ float corr_est_cc_impl::threshold() const { return d_thresh; }
 void corr_est_cc_impl::_set_threshold(float threshold)
 {
     d_stashed_threshold = threshold;
-    d_pfa = -logf(1.0f - threshold);
+
+    // TODO: Right now two methods are computed this should be conditional
+    switch (d_threshold_method) {
+    case THRESHOLD_DYNAMIC:
+        d_pfa = -logf(1.0f - threshold);
+        break;
+    case THRESHOLD_ABSOLUTE:
+    default:
+        // Compute a correlation threshold.
+        // Compute the value of the discrete autocorrelation of the matched
+        // filter with offset 0 (aka the autocorrelation peak).
+        float corr = 0;
+        for (size_t i = 0; i < d_symbols.size(); i++)
+            corr += abs(d_symbols[i] * conj(d_symbols[i]));
+        d_thresh = threshold * corr * corr;
+        break;
+    }
 }
 
 void corr_est_cc_impl::set_threshold(float threshold)
@@ -212,21 +231,34 @@ int corr_est_cc_impl::work(int noutput_items,
     volk_32fc_magnitude_squared_32f(&d_corr_mag[0], corr, noutput_items);
 
     float detection = 0;
-    for (int i = 0; i < noutput_items; i++) {
-        detection += d_corr_mag[i];
+    if (d_threshold_method == THRESHOLD_DYNAMIC) {
+        for (int i = 0; i < noutput_items; i++) {
+            detection += d_corr_mag[i];
+        }
+        detection /= static_cast<float>(noutput_items);
+        detection *= d_pfa;
     }
-    detection /= static_cast<float>(noutput_items);
-    detection *= d_pfa;
 
     int isps = (int)(d_sps + 0.5f);
     int i = 0;
     while (i < noutput_items) {
-        // Look for the correlator output to cross the threshold.
-        // Sum power over two consecutive symbols in case we're offset
-        // in time. If off by 1/2 a symbol, the peak of any one point
-        // is much lower.
-        float corr_mag = d_corr_mag[i] + d_corr_mag[i + 1];
-        if (corr_mag <= 4 * detection) {
+        float corr_mag;
+        switch (d_threshold_method) {
+        case THRESHOLD_DYNAMIC:
+            // Look for the correlator output to cross the threshold.
+            // Sum power over two consecutive symbols in case we're offset
+            // in time. If off by 1/2 a symbol, the peak of any one point
+            // is much lower.
+            corr_mag = (d_corr_mag[i] + d_corr_mag[i + 1]) * 0.5f;
+            d_thresh = 2 * detection;
+            break;
+        case THRESHOLD_ABSOLUTE:
+        default:
+            corr_mag = d_corr_mag[i];
+            break;
+        }
+
+        if (corr_mag <= d_thresh) {
             i++;
             continue;
         }

--- a/gr-digital/lib/corr_est_cc_impl.h
+++ b/gr-digital/lib/corr_est_cc_impl.h
@@ -47,6 +47,8 @@ private:
     float d_scale;
     float d_pfa; // probability of false alarm
 
+    tm_type d_threshold_method;
+
     void _set_mark_delay(unsigned int mark_delay);
     void _set_threshold(float threshold);
 
@@ -54,7 +56,8 @@ public:
     corr_est_cc_impl(const std::vector<gr_complex>& symbols,
                      float sps,
                      unsigned int mark_delay,
-                     float threshold = 0.9);
+                     float threshold = 0.9,
+                     tm_type threshold_method = THRESHOLD_ABSOLUTE);
     ~corr_est_cc_impl();
 
     std::vector<gr_complex> symbols() const;


### PR DESCRIPTION
Do I understand correctly that 3.7.x tags are made from the main-3.7 branch?

If yes, can the two commits be added to the maint-3.7 branch? They are quite old and I need them in 3.7x.

Thanks