### PR TITLE
grc: add python snippets to GRC

### DIFF
--- a/grc/blocks/grc.tree.yml
+++ b/grc/blocks/grc.tree.yml
@@ -12,6 +12,7 @@
   - epy_module
   - note
   - import
+  - snippet 
 - Variables:
   - variable
   - variable_struct

--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -123,6 +123,53 @@ parameters:
     default: '.:'
     hide: part
 
+-   id: snippet_editor
+    label: Editor
+    dtype: enum
+    category: Code Snippets
+    options: ['Dialog','External']
+    hide: ${'part' if output_language == 'python' else 'all'}
+
+-   id: snippet_top
+    label: Top
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_imports
+    label: Imports
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_variables
+    label: Variables
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_blocks
+    label: Blocks
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_connections
+    label: Connections
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_callbacks
+    label: Callbacks
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_main_beginning
+    label: Main (Beginning)
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
+-   id: snippet_main_end
+    label: Main (End)
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    category: Code Snippets
+    hide: ${'part' if output_language == 'python' else 'all'}
 asserts:
 - ${ not window_size or len(window_size) == 2 }
 - ${ not window_size or 300 <= window_size[0] <= 4096 }
@@ -175,4 +222,5 @@ documentation: |-
 
     The Max Number of Output is the maximum number of output items allowed for any block in the flowgraph; to disable this set the max_nouts equal to 0.Use this to adjust the maximum latency a flowgraph can exhibit.
 
+    The Code Snippets tap allows small sections of code to be inserted into the generated python flowgraph at the end of the specified section.  Note, this is an advanced feature and can lead to invalid generated flowgraphs.  Indents will be handled upon insertion into the python flowgraph.
 file_format: 1

--- a/grc/blocks/snippet.block.yml
+++ b/grc/blocks/snippet.block.yml
@@ -1,0 +1,37 @@
+id: snippet
+label: Python Snippet
+flags: [ python ]
+
+parameters:
+-   id: section
+    label: Section of Flowgraph
+    dtype: string
+    options: ['top', 'imports', 'variables', 'blocks','connections','callbacks','main' ]
+    option_labels: ['Top', 'Imports', 'Variables', 'Blocks','Connections','Callbacks','Main']
+-   id: position
+    label: Position in Section
+    dtype: string
+    options: ['beginning','end']
+    option_labels: ['Beginning','End']
+    hide: ${ ('part' if (
+            (section == "main") )
+        else 'all')
+        }
+-   id: code
+    label: Code Snippet
+    dtype: _multiline
+
+templates:
+    var_make: ${code}
+
+documentation: |-
+    Insert a snippet of Python code directly into the flowgraph at the end of the specified section 
+
+    Indents will be handled upon insertion into the python flowgraph
+
+    Examples:
+    print("This is my flowgraph")
+
+    Will place the print statement in the generated .py file
+
+file_format: 1

--- a/grc/blocks/snippet.block.yml
+++ b/grc/blocks/snippet.block.yml
@@ -1,6 +1,6 @@
 id: snippet
 label: Python Snippet
-flags: [ python ]
+flags: [ python, show_id ]
 
 parameters:
 -   id: section
@@ -17,9 +17,17 @@ parameters:
             (section == "main") )
         else 'all')
         }
+-   id: snippet_editor
+    label: Editor
+    dtype: enum
+    options: ['Dialog','External']
+    hide: part
 -   id: code
     label: Code Snippet
-    dtype: _multiline
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    default: |-
+        # Insert Python Code here
+        # Will be inserted at the end of the specified section in the generated flowgraph
 
 templates:
     var_make: ${code}

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -92,6 +92,15 @@ class FlowGraph(Element):
         parameters = [b for b in self.iter_enabled_blocks() if b.key == 'parameter']
         return parameters
 
+    def get_snippets(self):
+        """
+        Get a set of all code snippets (Python) in this flow graph namespace.
+
+        Returns:
+            a list of code snippets
+        """
+        return [b for b in self.iter_enabled_blocks() if b.key == 'snippet']
+
     def get_monitors(self):
         """
         Get a list of all ControlPort monitors

--- a/grc/core/base.py
+++ b/grc/core/base.py
@@ -150,6 +150,7 @@ class Element(object):
     is_param = False
     is_variable = False
     is_import = False
+    is_snippet = False
 
     def get_raw(self, name):
         descriptor = getattr(self.__class__, name, None)

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -303,6 +303,10 @@ class Block(Element):
     def is_import(self):
         return self.key == 'import'
 
+    @lazy_property
+    def is_snippet(self):
+        return self.key == 'snippet'
+
     @property
     def comment(self):
         return self.params['comment'].value

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -30,6 +30,16 @@ python_version = version_info.major
 # GNU Radio version: ${version}
 ##################################################
 
+% if snippets:
+% for snip in snippets:
+% if snip["section"] == 'top':
+% for line in snip["lines"]:
+${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
+
 % if generate_options == 'qt_gui':
 from distutils.version import StrictVersion
 
@@ -51,6 +61,17 @@ if __name__ == '__main__':
 ##${imp.replace("  # grc-generated hier_block", "")}
 ${imp}
 % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'imports':
+% for line in snip["lines"]:
+${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
+
 ########################################################
 ##Create Class
 ##  Write the class declaration for a top or hier block.
@@ -180,6 +201,16 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
 % for var in variables:
         ${indent(var.templates.render('var_make'))}
 % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'variables':
+% for line in snip["lines"]:
+        ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
         % if blocks:
 
         ${'##################################################'}
@@ -203,6 +234,16 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
 ##         (self.${blk.name}).set_max_output_buffer(${blk.params['maxoutbuf'].get_evaluated()})
 ##         % endif
         % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'blocks':
+% for line in snip["lines"]:
+        ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
 
 ##########################################################
 ## Create a layout entry if not manually done for BokehGUI
@@ -228,6 +269,17 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
         ${ connection.rstrip() }
         % endfor
         % endif
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'connections':
+% for line in snip["lines"]:
+        ${indent(line)}
+% endfor
+% endif
+% endfor
+
+% endif
 ########################################################
 ## QT sink close method reimplementation
 ########################################################
@@ -275,6 +327,17 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
         % endfor
         % endif
     % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'callbacks':
+% for line in snip["lines"]:
+    ${indent(line)}
+% endfor
+% endif
+% endfor
+
+% endif
 ########################################################
 ##Create Main
 ##  For top block code, generate a main routine.
@@ -328,6 +391,16 @@ def argument_parser():
 
 
 def main(top_block_cls=${class_name}, options=None):
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'main' and snip["position"] == 'beginning':
+% for line in snip["lines"]:
+    ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
     % if parameters:
     if options is None:
         options = argument_parser().parse_args()
@@ -446,6 +519,16 @@ def main(top_block_cls=${class_name}, options=None):
     % endif
     % endfor
     % endif
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'main' and snip["position"] == 'end':
+% for line in snip["lines"]:
+    ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
 
 
 if __name__ == '__main__':

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -176,18 +176,51 @@ class TopBlockGenerator(object):
 
         return output
 
+    # def _snippets(self):
+    #     fg = self._flow_graph
+    #     snippets = fg.get_snippets()
+    #     if not snippets:
+    #         return None
+
+    #     output = []
+    #     for snip in snippets:
+    #         d ={}
+    #         d['section'] = snip.params['section'].value
+    #         d['position'] = snip.params['position'].value
+
+    #         d['lines'] = snip.params['code'].value.splitlines()
+    #         output.append(d)
+
+        return output
+
     def _snippets(self):
         fg = self._flow_graph
-        snippets = fg.get_snippets()
-        if not snippets:
-            return None
 
+        # Snippets from the Options Block
         output = []
+        d ={'section': 'top', 'lines': fg.get_option('snippet_top').splitlines()}
+        output.append(d)
+        d ={'section': 'imports', 'lines': fg.get_option('snippet_imports').splitlines()}
+        output.append(d)
+        d ={'section': 'variables', 'lines': fg.get_option('snippet_variables').splitlines()}
+        output.append(d)
+        d ={'section': 'blocks', 'lines': fg.get_option('snippet_blocks').splitlines()}
+        output.append(d)
+        d ={'section': 'connections', 'lines': fg.get_option('snippet_connections').splitlines()}
+        output.append(d)      
+        d ={'section': 'callbacks', 'lines': fg.get_option('snippet_callbacks').splitlines()}
+        output.append(d)
+        d ={'section': 'main', 'position': 'beginning', 'lines': fg.get_option('snippet_main_beginning').splitlines()}
+        output.append(d)
+        d ={'section': 'main', 'position': 'end', 'lines': fg.get_option('snippet_main_end').splitlines()}
+        output.append(d)  
+
+        # Snippets from Individual Snippet Blocks
+        snippets = fg.get_snippets()
         for snip in snippets:
             d ={}
             d['section'] = snip.params['section'].value
             d['position'] = snip.params['position'].value
-
             d['lines'] = snip.params['code'].value.splitlines()
             output.append(d)
 

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -101,6 +101,7 @@ class TopBlockGenerator(object):
         variables = fg.get_variables()
         parameters = fg.get_parameters()
         monitors = fg.get_monitors()
+        snippets = self._snippets()
 
         for block in fg.iter_enabled_blocks():
             key = block.key
@@ -115,6 +116,7 @@ class TopBlockGenerator(object):
         self.namespace = {
             'flow_graph': fg,
             'variables': variables,
+            'snippets': snippets,
             'parameters': parameters,
             'monitors': monitors,
             'generate_options': self._generate_options,
@@ -174,6 +176,23 @@ class TopBlockGenerator(object):
 
         return output
 
+    def _snippets(self):
+        fg = self._flow_graph
+        snippets = fg.get_snippets()
+        if not snippets:
+            return None
+
+        output = []
+        for snip in snippets:
+            d ={}
+            d['section'] = snip.params['section'].value
+            d['position'] = snip.params['position'].value
+
+            d['lines'] = snip.params['code'].value.splitlines()
+            output.append(d)
+
+        return output
+
     def _blocks(self):
         fg = self._flow_graph
         parameters = fg.get_parameters()
@@ -190,7 +209,7 @@ class TopBlockGenerator(object):
 
         blocks = [
             b for b in fg.blocks
-            if b.enabled and not (b.get_bypassed() or b.is_import or b in parameters or b.key == 'options')
+            if b.enabled and not (b.get_bypassed() or b.is_import or b.is_snippet or b in parameters or b.key == 'options')
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)


### PR DESCRIPTION
-- Looking for feedback on this 

This feature adds the ability to insert arbitrary code into the python
flowgraph.  It gives a little more low-level flexibility for quickly
modifying flowgraphs and adding custom bits of code rather than having
to go and edit the generated py file

Here is a contrived example that just queries the ref_locked sensor:
![image](https://user-images.githubusercontent.com/34754695/64034505-ce2ba380-cb1c-11e9-919f-2eaf09a354b5.png)
![image](https://user-images.githubusercontent.com/34754695/64034537-de438300-cb1c-11e9-846a-a3d104ca4d52.png)

This would then generate the .py output with the code inserted after the specified section:
![image](https://user-images.githubusercontent.com/34754695/64034611-00d59c00-cb1d-11e9-84d1-a84df480aeb2.png)

