### PR TITLE
Use `dist-packages` on Linux only

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -112,7 +112,10 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
 import os
 import sys
 if os.name == 'posix':
-    print(os.path.join('lib', 'python' + sys.version[:3], 'dist-packages'))
+    if sys.platform == 'linux':
+        print(os.path.join('lib', 'python' + sys.version[:3], 'dist-packages'))
+    else:
+        print(os.path.join('lib', 'python' + sys.version[:3], 'site-packages'))
 if os.name == 'nt':
     print(os.path.join('Lib', 'site-packages'))
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
`dist-packages` directory is a Debian/Ubuntu/... specific path
On other posix systems the default `site-packages` dir should be used.

https://stackoverflow.com/questions/42339034/python-module-in-dist-packages-vs-site-packages

Ex. on macOS, there is no "dist-packages" directory, whatever the installed packages

    $ ls /usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-* |wc  -l
         208
    $ ls /usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/dist-* | wc -l
       No such file or directory
       0

Moreover, even GR hesitates about the installation path:

    $ ls /usr/local/opt/gnuradio/lib/python3.7/dist-packages/
    gnuradio pmt
    $ ls /usr/local/opt/gnuradio/lib/python3.7/site-packages/
    volk_modtool

This ends up with confusion, multiple `PYTHONPATH` to make GR/GRC run, etc.

I'm not sure this PR is the proper way to fix this issue, but `dist-packages` does not seem to be a valid path except for Debian-style installations.
