### PR TITLE
Always include gnuradio/rpcregisterhelpers.h in basic_block.h

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -26,6 +26,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/msg_accepter.h>
+#include <gnuradio/rpcregisterhelpers.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/sptr_magic.h>
 #include <gnuradio/thread/thread.h>
@@ -38,9 +39,6 @@
 #include <map>
 #include <string>
 
-#ifdef GR_CTRLPORT
-#include <gnuradio/rpcregisterhelpers.h>
-#endif
 
 namespace gr {
 


### PR DESCRIPTION
If `GR_CTRLPORT` is not defined, then rpcbasic_sptr is not defined in basic_block.h, which breaks compilation of external applications including basic_block.h but not having `GR_CTRLPORT` defined.

This PR removes the `#ifdef GR_CTRLPORT` from around `#include <gnuradio/rpcregisterhelpers.h>`.

See #2785 