### PR TITLE
grc: embedded python parameter values disappear

### DIFF
--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -149,10 +149,10 @@ class EPyBlock(Block):
     def _update_params(self, params_in_src):
         param_factory = self.parent_platform.make_param
         params = {}
-        for param in list(self.params):
-            if hasattr(param, '__epy_param__'):
-                params[param.key] = param
-                del self.params[param.key]
+        for key, value in self.params.copy().items():
+            if hasattr(value, '__epy_param__'):
+                params[key] = value
+                del self.params[key]
 
         for id_, value in params_in_src:
             try:


### PR DESCRIPTION
grc: embedded python parameter values disappear
fixes #2765