### PR TITLE
Make Id visible in Tab_widget

### DIFF
--- a/gr-qtgui/grc/qtgui_tab_widget.block.yml
+++ b/gr-qtgui/grc/qtgui_tab_widget.block.yml
@@ -1,6 +1,6 @@
 id: qtgui_tab_widget
 label: QT GUI Tab Widget
-flags: [ python ]
+flags: [show_id, python ]
 
 parameters:
 -   id: num_tabs


### PR DESCRIPTION
It's a reminder , to fix this issue in maint-3.8, too