### PR TITLE
update cloned port's dtype

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -207,6 +207,7 @@ class Block(Element):
     def _rewrite_nports(self, ports):
         for port in ports:
             if hasattr(port, 'master_port'):  # Not a master port and no left-over clones
+                port.dtype = port.master_port.dtype
                 continue
             nports = port.multiplicity
             for clone in port.clones[nports-1:]:


### PR DESCRIPTION
Fix a bug that left the type of some of multi-port (the cloned ports) unchanged when incrementing or decrementing block type.