### PR TITLE
Update log4cpp cmake module to search in lib64 directories.

### DIFF
--- a/cmake/Modules/FindLOG4CPP.cmake
+++ b/cmake/Modules/FindLOG4CPP.cmake
@@ -20,7 +20,7 @@ find_path(LOG4CPP_INCLUDE_DIR log4cpp/Category.hh
 set(LOG4CPP_NAMES log4cpp)
 find_library(LOG4CPP_LIBRARY
   NAMES ${LOG4CPP_NAMES}
-  PATHS /usr/lib /usr/local/lib /opt/local/lib
+  PATHS /usr/lib /usr/local/lib /opt/local/lib /usr/lib64 /usr/local/lib64
 )
 
 


### PR DESCRIPTION
Signed-off-by: Philip Balister <philip@balister.org>