### PR TITLE
Fix cmake ctrlport basic block rpcregisterhelpers

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -38,9 +38,7 @@
 #include <map>
 #include <string>
 
-#ifdef GR_CTRLPORT
 #include <gnuradio/rpcregisterhelpers.h>
-#endif
 
 namespace gr {
 

--- a/gnuradio-runtime/include/gnuradio/block_registry.h
+++ b/gnuradio-runtime/include/gnuradio/block_registry.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/basic_block.h>
+#include <gnuradio/thread/thread.h>
 #include <map>
 
 namespace gr {


### PR DESCRIPTION
Replacement of https://github.com/gnuradio/gnuradio/pull/2787 to fix building issue, by not moving the header include & also adding a header include. This PR should be replicated for master.