### PR TITLE
edit_msg_box not useable without setting an unneeded key.

### DIFF
--- a/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
+++ b/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
@@ -39,7 +39,7 @@ parameters:
     hide: part
 
 asserts:
-- ${(is_pair and is_static and len(key) > 0) or not (is_pair and is_static)}
+- ${(len(key) > 0) or not ((is_pair == 'True') and (is_static == 'True'))}
 
 inputs:
 -   domain: message


### PR DESCRIPTION
Although is_pair ( or is_static) is set to false the assertion always  fails if no key is set.