### PR TITLE
grc: add python snippets to GRC

### DIFF
--- a/grc/blocks/grc.tree.yml
+++ b/grc/blocks/grc.tree.yml
@@ -10,6 +10,7 @@
   - bus_structure_source
   - epy_block
   - epy_module
+  - snippets_config
   - note
   - import
 - Variables:

--- a/grc/blocks/snippets_config.block.yml
+++ b/grc/blocks/snippets_config.block.yml
@@ -1,0 +1,57 @@
+id: snippets_config
+label: Python Snippets
+flags: [ python ]
+
+parameters:
+-   id: snippet_editor
+    label: Editor
+    dtype: enum
+    options: ['Dialog','External']
+    hide: 'part'
+-   id: snippet_top
+    label: Top
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_imports
+    label: Imports
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_variables
+    label: Variables
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_blocks
+    label: Blocks
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_connections
+    label: Connections
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_callbacks
+    label: Callbacks
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_main_beginning
+    label: Main (Beginning)
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+-   id: snippet_main_end
+    label: Main (End)
+    dtype: ${'_multiline_python_external' if snippet_editor == 'External' else '_multiline'}
+    hide: 'part'
+
+templates:
+    var_make: ${code}
+
+documentation: |-
+    Insert snippets of Python code directly into the flowgraph at the end of the specified section 
+
+    Indents will be handled upon insertion into the python flowgraph
+
+    Examples:
+    print("This is my flowgraph")
+
+    Will place the print statement in the generated .py file
+
+file_format: 1

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -92,6 +92,16 @@ class FlowGraph(Element):
         parameters = [b for b in self.iter_enabled_blocks() if b.key == 'parameter']
         return parameters
 
+    def get_snippets_config(self):
+        """
+        Get a set of all code snippets (Python) in this flow graph namespace.
+
+        Returns:
+            a list of code snippets
+        """
+        # Should only be one snippets config block
+        return [b for b in self.iter_enabled_blocks() if b.key == 'snippets_config']
+
     def get_monitors(self):
         """
         Get a list of all ControlPort monitors

--- a/grc/core/base.py
+++ b/grc/core/base.py
@@ -150,6 +150,7 @@ class Element(object):
     is_param = False
     is_variable = False
     is_import = False
+    is_snippets_config = False
 
     def get_raw(self, name):
         descriptor = getattr(self.__class__, name, None)

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -303,6 +303,10 @@ class Block(Element):
     def is_import(self):
         return self.key == 'import'
 
+    @lazy_property
+    def is_snippets_config(self):
+        return self.key == 'snippets_config'
+
     @property
     def comment(self):
         return self.params['comment'].value

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -30,6 +30,16 @@ python_version = version_info.major
 # GNU Radio version: ${version}
 ##################################################
 
+% if snippets:
+% for snip in snippets:
+% if snip["section"] == 'top':
+% for line in snip["lines"]:
+${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
+
 % if generate_options == 'qt_gui':
 from distutils.version import StrictVersion
 
@@ -51,6 +61,17 @@ if __name__ == '__main__':
 ##${imp.replace("  # grc-generated hier_block", "")}
 ${imp}
 % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'imports':
+% for line in snip["lines"]:
+${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
+
 ########################################################
 ##Create Class
 ##  Write the class declaration for a top or hier block.
@@ -180,6 +201,16 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
 % for var in variables:
         ${indent(var.templates.render('var_make'))}
 % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'variables':
+% for line in snip["lines"]:
+        ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
         % if blocks:
 
         ${'##################################################'}
@@ -203,6 +234,16 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
 ##         (self.${blk.name}).set_max_output_buffer(${blk.params['maxoutbuf'].get_evaluated()})
 ##         % endif
         % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'blocks':
+% for line in snip["lines"]:
+        ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
 
 ##########################################################
 ## Create a layout entry if not manually done for BokehGUI
@@ -228,6 +269,17 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
         ${ connection.rstrip() }
         % endfor
         % endif
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'connections':
+% for line in snip["lines"]:
+        ${indent(line)}
+% endfor
+% endif
+% endfor
+
+% endif
 ########################################################
 ## QT sink close method reimplementation
 ########################################################
@@ -275,6 +327,17 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
         % endfor
         % endif
     % endfor
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'callbacks':
+% for line in snip["lines"]:
+    ${indent(line)}
+% endfor
+% endif
+% endfor
+
+% endif
 ########################################################
 ##Create Main
 ##  For top block code, generate a main routine.
@@ -328,6 +391,16 @@ def argument_parser():
 
 
 def main(top_block_cls=${class_name}, options=None):
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'main' and snip["position"] == 'beginning':
+% for line in snip["lines"]:
+    ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
     % if parameters:
     if options is None:
         options = argument_parser().parse_args()
@@ -446,6 +519,16 @@ def main(top_block_cls=${class_name}, options=None):
     % endif
     % endfor
     % endif
+% if snippets:
+
+% for snip in snippets:
+% if snip["section"] == 'main' and snip["position"] == 'end':
+% for line in snip["lines"]:
+    ${indent(line)}
+% endfor
+% endif
+% endfor
+% endif
 
 
 if __name__ == '__main__':

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -101,6 +101,7 @@ class TopBlockGenerator(object):
         variables = fg.get_variables()
         parameters = fg.get_parameters()
         monitors = fg.get_monitors()
+        snippets = self._snippets()
 
         for block in fg.iter_enabled_blocks():
             key = block.key
@@ -115,6 +116,7 @@ class TopBlockGenerator(object):
         self.namespace = {
             'flow_graph': fg,
             'variables': variables,
+            'snippets': snippets,
             'parameters': parameters,
             'monitors': monitors,
             'generate_options': self._generate_options,
@@ -174,6 +176,33 @@ class TopBlockGenerator(object):
 
         return output
 
+    def _snippets(self):
+        fg = self._flow_graph
+        output = []
+        # Snippets from All Snippets Block
+        snippets = fg.get_snippets_config()
+        for snip in snippets:
+
+            d ={'section': 'top', 'lines': snip.params['snippet_top'].value.splitlines()}
+            output.append(d)
+            d ={'section': 'imports', 'lines': snip.params['snippet_imports'].value.splitlines()}
+            output.append(d)
+            d ={'section': 'variables', 'lines': snip.params['snippet_variables'].value.splitlines()}
+            output.append(d)
+            d ={'section': 'blocks', 'lines': snip.params['snippet_blocks'].value.splitlines()}
+            output.append(d)
+            d ={'section': 'connections', 'lines': snip.params['snippet_connections'].value.splitlines()}
+            output.append(d)      
+            d ={'section': 'callbacks', 'lines': snip.params['snippet_callbacks'].value.splitlines()}
+            output.append(d)
+            d ={'section': 'main', 'position': 'beginning', 'lines': snip.params['snippet_main_beginning'].value.splitlines()}
+            output.append(d)
+            d ={'section': 'main', 'position': 'end', 'lines': snip.params['snippet_main_end'].value.splitlines()}
+            output.append(d)  
+
+
+        return output
+
     def _blocks(self):
         fg = self._flow_graph
         parameters = fg.get_parameters()
@@ -190,7 +219,7 @@ class TopBlockGenerator(object):
 
         blocks = [
             b for b in fg.blocks
-            if b.enabled and not (b.get_bypassed() or b.is_import or b in parameters or b.key == 'options')
+            if b.enabled and not (b.get_bypassed() or b.is_import or b.is_snippets_config or b in parameters or b.key == 'options')
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -251,9 +251,19 @@ class Param(Element):
                 value = [value]
             return value
         #########################
+        # Multiline String Types
+        #########################
+        elif dtype in ('_multiline', '_multiline_python_external'):
+            # Since multiline parameters are used for code, don't evaluate
+            self._stringify_flag = True
+            value = str(expr)
+            if dtype == '_multiline_python_external':
+                ast.parse(value)  # Raises SyntaxError
+            return value
+        #########################
         # String Types
         #########################
-        elif dtype in ('string', 'file_open', 'file_save', '_multiline', '_multiline_python_external'):
+        elif dtype in ('string', 'file_open', 'file_save'):
             # Do not check if file/directory exists, that is a runtime issue
             try:
                 value = self.parent_flowgraph.evaluate(expr)
@@ -262,8 +272,6 @@ class Param(Element):
             except Exception:
                 self._stringify_flag = True
                 value = str(expr)
-            if dtype == '_multiline_python_external':
-                ast.parse(value)  # Raises SyntaxError
             return value
         #########################
         # GUI Position/Hint

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -162,6 +162,12 @@ class FlowGraph(CoreFlowgraph, Drawable):
             key: the block key
             coor: an optional coordinate or None for random
         """
+        # Snippets should be singleton
+        # TODO: Add singleton pattern into .yml?
+        if key == 'snippets_config':
+            if key in (blk.key for blk in self.blocks):
+                return None
+
         id = self._get_unique_id(key)
         scroll_pane = self.drawing_area.get_parent().get_parent()
         # calculate the position coordinate
@@ -280,6 +286,11 @@ class FlowGraph(CoreFlowgraph, Drawable):
             block_key = block_n.get('id')
             if block_key == 'options':
                 continue
+            
+            # Don't paste in another snippets block
+            if block_key == 'snippets_config':
+                if block_key in (blk.key for blk in self.blocks):
+                    continue
 
             block_name = block_n.get('name')
             # Verify whether a block with this name exists before adding it


### PR DESCRIPTION
This feature adds the ability to insert arbitrary code into the python
flowgraph.  It gives a little more low-level flexibility for quickly
modifying flowgraphs and adding custom bits of code rather than having
to go and edit the generated py file

One example is synchronizing multiple USRP objects - sometimes you want
different sync than what is offered in the multi-usrp object, so you can
put a bit of code in the snippet block to do the custom synchronization

Singleton block to contain all the snippets (moved out of the options block so that the snippets can be copy and pasted).

Split _multiline and _multiline_external dtypes from string in the
processing as code block and snippet are getting evaluated multiple
times.  If the code contains sleep or print, this wreaks havoc.

![image](https://user-images.githubusercontent.com/34754695/65551519-270a1400-def0-11e9-9762-2c3da83c09e6.png)

![image](https://user-images.githubusercontent.com/34754695/65551441-fa55fc80-deef-11e9-88a9-76ec6d0c4f5a.png)

![image](https://user-images.githubusercontent.com/34754695/65551486-1194ea00-def0-11e9-92ca-3a6f3db08dea.png)

![image](https://user-images.githubusercontent.com/34754695/65551501-1b1e5200-def0-11e9-8e67-a2e58cacddce.png)

