### PR TITLE
gr-uhd: multichannel uhd object not populating channels

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -144,10 +144,10 @@ templates:
                 ${'%'} if stream_args:
                 args=${'$'}{stream_args},
                 ${'%'} endif
-                ${'%'} if stream_chans:
+                ${'%'} if eval(stream_chans):
                 channels=${'$'}{stream_chans},
                 ${'%'} else:
-                channels=range(${'$'}{nchan}),
+                channels=list(range(0,${'$'}{nchan})),
                 ${'%'} endif
             ),
             ${'%'} if len_tag_name:


### PR DESCRIPTION
Due to the way the template interprets the stream_chans value as string,
it always returns True and the '[]' from stream chans was used as the
channels parameter.

With this change, channels in the case where stream chans is empty,
chans populates as before, which is range(num_chans)

Fixes #2789
Fixes #2612 