### PR TITLE
modtool: allow empty arg list in interactive mode

### DIFF
--- a/gr-utils/python/modtool/cli/add.py
+++ b/gr-utils/python/modtool/cli/add.py
@@ -124,10 +124,17 @@ def get_copyrightholder(self):
         click.secho("For GNU Radio components the FSF is added as copyright holder",
                     fg='cyan')
 
+
 def get_arglist(self):
     """ Get the argument list of the block to be added """
     if self.info['arglist'] is not None:
-        self.info['arglist'] = click.prompt(click.style('Enter valid argument list, including default arguments: \n', fg='cyan'), prompt_suffix='')
+        self.info['arglist'] = click.prompt(click.style(
+            'Enter valid argument list, including default arguments: \n',
+            fg='cyan'),
+                                            prompt_suffix='',
+                                            default='',
+                                            show_default=False)
+
 
 def get_py_qa(self):
     """ Get a boolean value for addition of py_qa """


### PR DESCRIPTION
maint-3.8 will be dealt with separately: #2827 