### PR TITLE
Remove some star imports to replace them with explicit names

### DIFF
--- a/gr-channels/python/channels/__init__.py
+++ b/gr-channels/python/channels/__init__.py
@@ -35,12 +35,12 @@ except ImportError:
     from .channels_swig import *
 
 # Blocks for Hardware Impairments
-from .amp_bal import *
-from .conj_fs_iqcorr import *
-from .distortion_2_gen import *
-from .distortion_3_gen import *
-from .iqbal_gen import *
-from .impairments import *
-from .phase_bal import *
-from .phase_noise_gen import *
-from .quantizer import *
+from .amp_bal import amp_bal
+from .conj_fs_iqcorr import conj_fs_iqcorr
+from .distortion_2_gen import distortion_2_gen
+from .distortion_3_gen import distortion_3_gen
+from .impairments import impairments
+from .iqbal_gen import iqbal_gen
+from .phase_bal import phase_bal
+from .phase_noise_gen import phase_noise_gen
+from .quantizer import quantizer

--- a/gr-channels/python/channels/__init__.py
+++ b/gr-channels/python/channels/__init__.py
@@ -28,7 +28,7 @@ from __future__ import unicode_literals
 import os
 
 try:
-    from .channels_swig import *
+    from .channels_swig import channels_swig
 except ImportError:
     dirname, filename = os.path.split(os.path.abspath(__file__))
     __path__.append(os.path.join(dirname, "..", "..", "swig"))

--- a/gr-channels/python/channels/impairments.py
+++ b/gr-channels/python/channels/impairments.py
@@ -16,10 +16,10 @@ from gnuradio.filter import firdes
 import math
 
 #Import locally
-from .phase_noise_gen import *
-from .iqbal_gen import *
-from .distortion_2_gen import *
-from .distortion_3_gen import *
+from .phase_noise_gen import phase_noise_gen
+from .iqbal_gen import iqbal_gen
+from .distortion_2_gen import distortion_2_gen
+from .distortion_3_gen import distortion_3_gen
 
 class impairments(gr.hier_block2):
 


### PR DESCRIPTION
This removes some star imports to make the code cleaner as talked about in: [#1466](https://github.com/gnuradio/gnuradio/issues/1466)