### PR TITLE
gr-uhd: fix Python apps

### DIFF
--- a/gr-analog/python/analog/fm_demod.py
+++ b/gr-analog/python/analog/fm_demod.py
@@ -110,5 +110,4 @@ class demod_200kf3e_cf(fm_demod_cf):
         fm_demod_cf.__init__(self, channel_rate, audio_decim,
                              75000,  # Deviation
                              15000,  # Audio passband
-                             16000,  # Audio stopband
-                             20.0)   # Audio gain
+                             16000)  # Audio stopband

--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 # Copyright 2015-2016,2018 Free Software Foundation, Inc.
 #
@@ -34,6 +34,8 @@ UHD FFT: Simple Spectrum Analyzer for UHD.
 # Note this is a heavily modified version of a
 # the uhd_fft.grc example.
 
+from __future__ import print_function
+from __future__ import division
 import ctypes
 import sys
 import sip
@@ -244,9 +246,9 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self.qtgui_time_sink_x_0.disable_legend()
         for i in range(2*len(self.channels)):
             if(i % 2 == 0):
-                self.qtgui_time_sink_x_0.set_line_label(i, "Re{{Channel {0}}}".format(i/2))
+                self.qtgui_time_sink_x_0.set_line_label(i, "Re{{Channel {0}}}".format(i//2))
             else:
-                self.qtgui_time_sink_x_0.set_line_label(i, "Im{{Channel {0}}}".format(i/2))
+                self.qtgui_time_sink_x_0.set_line_label(i, "Im{{Channel {0}}}".format(i//2))
             self.qtgui_time_sink_x_0.set_line_width(i, widths[i])
             self.qtgui_time_sink_x_0.set_line_color(i, colors[i])
             self.qtgui_time_sink_x_0.set_line_style(i, styles[i])
@@ -510,4 +512,3 @@ if __name__ == '__main__':
         except:
             print("Warning: failed to XInitThreads()")
     main()
-

--- a/gr-uhd/apps/uhd_rx_cfile
+++ b/gr-uhd/apps/uhd_rx_cfile
@@ -26,6 +26,7 @@ outputs single precision complex float values or complex short values
 (interleaved 16 bit signed short integers).
 """
 
+from __future__ import print_function
 import sys
 import os
 import pmt
@@ -179,13 +180,13 @@ class rx_cfile_block(gr.top_block):
                     rx_serial = info["rx_serial"]
                 rx_antenna = info["rx_antenna"]
                 rx_subdev_spec = info["rx_subdev_spec"]
-                print "[UHD_RX] Motherboard: %s (%s)" % (mboard_id, mboard_serial)
+                print("[UHD_RX] Motherboard: %s (%s)" % (mboard_id, mboard_serial))
                 if "B200" in mboard_id or "B210" in mboard_id or "E310" in mboard_id:
-                    print "[UHD_RX] Daughterboard: %s (%s, %s)" % (mboard_id, rx_antenna, rx_subdev_spec)
+                    print("[UHD_RX] Daughterboard: %s (%s, %s)" % (mboard_id, rx_antenna, rx_subdev_spec))
                 else:
-                    print "[UHD_RX] Daughterboard: %s (%s, %s, %s)" % (rx_id, rx_serial, rx_antenna, rx_subdev_spec)
+                    print("[UHD_RX] Daughterboard: %s (%s, %s, %s)" % (rx_id, rx_serial, rx_antenna, rx_subdev_spec))
             except KeyError:
-                print "[UHD_RX] Args: ", options.args
+                print("[UHD_RX] Args: ", options.args)
             print("[UHD_RX] Receiving on {} channels.".format(len(self.channels)))
             print("[UHD_RX] Rx gain:               {gain}".format(gain=gain))
             print("[UHD_RX] Rx frequency:          {freq}".format(freq=freq))

--- a/gr-uhd/apps/uhd_rx_nogui
+++ b/gr-uhd/apps/uhd_rx_nogui
@@ -61,6 +61,7 @@ blocks.
 """
 
 from __future__ import print_function
+from __future__ import division
 import sys
 from argparse import ArgumentParser
 from gnuradio import gr, gru, uhd, audio
@@ -146,8 +147,8 @@ class app_top_block(gr.top_block):
         dev.tune(options.frequency)
 
         if_rate = dev.rate()
-        channel_decim = int(if_rate // channel_rate)
-        audio_decim = int(channel_rate // audio_rate)
+        channel_decim = if_rate // channel_rate
+        audio_decim = channel_rate // audio_rate
 
         chan_taps = filter.optfir.low_pass(1.0,          # Filter gain
                                            if_rate,      # Sample rate
@@ -188,8 +189,8 @@ class app_top_block(gr.top_block):
 
         if options.output_rate != audio_rate:
             out_lcm = gru.lcm(audio_rate, options.output_rate)
-            out_interp = int(out_lcm // audio_rate)
-            out_decim = int(out_lcm // options.output_rate)
+            out_interp = out_lcm // audio_rate
+            out_decim = out_lcm // options.output_rate
             rsamp = filter.rational_resampler_fff(out_interp, out_decim)
             self.connect(tail, rsamp)
             tail = rsamp

--- a/gr-uhd/apps/uhd_rx_nogui
+++ b/gr-uhd/apps/uhd_rx_nogui
@@ -32,7 +32,7 @@ RFSQL - RF squelch zeroing output when input power below threshold
 AGC   - Automatic gain control leveling signal at [-1.0, +1.0]
 DEMOD - Demodulation block appropriate to selected signal type.
         This converts the complex baseband to real audio frequencies,
-	and applies an appropriate low pass decimating filter.
+        and applies an appropriate low pass decimating filter.
 CTCSS - Optional tone squelch zeroing output when tone is not present.
 RSAMP - Resampler block to convert audio sample rate to user specified
         sound card output rate.
@@ -40,8 +40,8 @@ AUDIO - Audio sink for playing final output to speakers.
 
 The following are required command line parameters:
 
--f FREQ		USRP receive frequency
--m MOD		Modulation type, select from AM, FM, or WFM
+-f FREQ         USRP receive frequency
+-m MOD          Modulation type, select from AM, FM, or WFM
 
 The following are optional command line parameters:
 
@@ -51,8 +51,8 @@ The following are optional command line parameters:
 -g GAIN         Daughterboard gain setting. Defaults to mid-range.
 -o RATE         Sound card output rate. Defaults to 32000. Useful if
                 your sound card only accepts particular sample rates.
--r RFSQL	RF squelch in db. Defaults to -50.0.
--p FREQ		CTCSS frequency.  Opens squelch when tone is present.
+-r RFSQL        RF squelch in db. Defaults to -50.0.
+-p FREQ         CTCSS frequency.  Opens squelch when tone is present.
 
 Once the program is running, ctrl-break (Ctrl-C) stops operation.
 
@@ -72,10 +72,10 @@ from gnuradio.eng_option import eng_option
 
 # (device_rate, channel_rate, audio_rate, channel_pass, channel_stop, demod)
 DEMOD_PARAMS = {
-		'AM'  : (256e3,  16e3, 16e3,  5000,   8000, analog.demod_10k0a3e_cf),
-		'FM'  : (256e3,  32e3,  8e3,  8000,   9000, analog.demod_20k0f3e_cf),
-		'WFM' : (320e3, 320e3, 32e3, 80000, 115000, analog.demod_200kf3e_cf)
-	       }
+                'AM'  : (256e3,  16e3, 16e3,  5000,   8000, analog.demod_10k0a3e_cf),
+                'FM'  : (256e3,  32e3,  8e3,  8000,   9000, analog.demod_20k0f3e_cf),
+                'WFM' : (320e3, 320e3, 32e3, 80000, 115000, analog.demod_200kf3e_cf)
+               }
 
 class uhd_src(gr.hier_block2):
     """
@@ -140,8 +140,8 @@ class app_top_block(gr.top_block):
         dev = uhd_src(options.args,             # UHD device address
                       options.spec,             # device subdev spec
                       options.antenna,          # device antenna
-                      dev_rate,         	# device sample rate
-                      options.gain, 	    	# Receiver gain
+                      dev_rate,                 # device sample rate
+                      options.gain,             # Receiver gain
                       options.calibration)      # Frequency offset
         dev.tune(options.frequency)
 
@@ -150,27 +150,27 @@ class app_top_block(gr.top_block):
         audio_decim = int(channel_rate // audio_rate)
 
         chan_taps = filter.optfir.low_pass(1.0,          # Filter gain
-                                           if_rate, 	 # Sample rate
+                                           if_rate,      # Sample rate
                                            channel_pass, # One sided modulation bandwidth
                                            channel_stop, # One sided channel bandwidth
-                                           0.1, 	 # Passband ripple
-                                           60) 	         # Stopband attenuation
+                                           0.1,          # Passband ripple
+                                           60)           # Stopband attenuation
 
         chan = filter.freq_xlating_fir_filter_ccf(
             channel_decim, # Decimation rate
             chan_taps,     # Filter taps
-            0.0, 	   # Offset frequency
+            0.0,           # Offset frequency
             if_rate)       # Sample rate
 
         rfsql = analog.pwr_squelch_cc(
             options.rf_squelch,    # Power threshold
             125.0/channel_rate,    # Time constant
             int(channel_rate/20),  # 50ms rise/fall
-            False)		   # Zero, not gate output
+            False)                 # Zero, not gate output
 
         agc = analog.agc_cc(1.0/channel_rate,  # Time constant
-                            1.0,     	       # Reference power
-                            1.0)	       # Gain
+                            1.0,               # Reference power
+                            1.0)               # Gain
 
         demod = demod(channel_rate, audio_decim)
 


### PR DESCRIPTION
I noticed a few bugs in gr-uhd's Python apps:

1. uhd_rx_cfile doesn't work at all in Python 3 because it uses the old `print` syntax in some places.
1. uhd_fft's "Scope" tab displays the channel names as `Re{Channel 0}` and `Im{Channel 0.5}` in Python 3 because of the change to the `/` operator.
1. Massive clipping occurs in uhd_rx_nogui's WFM receiver because it requests an audio gain of 20 (instead of the default of 1).

I've fixed these problems, and also cleaned up the whitespace in uhd_rx_nogui, which previously used a mixture of tabs and spaces.