### PR TITLE
volk: Replace star imports with explicit imports

### DIFF
--- a/gnuradio-runtime/examples/volk_benchmark/volk_math.py
+++ b/gnuradio-runtime/examples/volk_benchmark/volk_math.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 from gnuradio import gr
 from gnuradio import blocks
 import argparse
-from volk_test_funcs import *
+from volk_test_funcs import (create_connection, new_table, replace_results,
+                             helper, timeit, format_results)
 
 try:
     from gnuradio import blocks

--- a/gnuradio-runtime/examples/volk_benchmark/volk_plot.py
+++ b/gnuradio-runtime/examples/volk_benchmark/volk_plot.py
@@ -4,7 +4,8 @@ from __future__ import division
 from __future__ import unicode_literals
 import sys, math
 import argparse
-from volk_test_funcs import *
+from volk_test_funcs import (create_connection, list_tables, get_results,
+                             helper, timeit, format_results)
 
 try:
     import matplotlib

--- a/gnuradio-runtime/examples/volk_benchmark/volk_types.py
+++ b/gnuradio-runtime/examples/volk_benchmark/volk_types.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 from gnuradio import gr
 from gnuradio import blocks
 import argparse
-from volk_test_funcs import *
+from volk_test_funcs import (create_connection, new_table, replace_results,
+                             helper, timeit, format_results)
 
 ######################################################################
 


### PR DESCRIPTION
I tested this as much as I know how, but I'm not that familiar with gnuradio so I can't cover all the cases. Unit tests seem to be unaffected for me, but let me know if I'm missing any additional testing I can make.

Part of #1466