### PR TITLE
Save the new duplicate page to the cache

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -693,6 +693,7 @@ class Application(Gtk.Application):
             # Import the old data and mark the current as not saved
             new_flow_graph.import_data(previous.export_data())
             flow_graph_update(new_flow_graph)
+            page.state_cache.save_new_state(new_flow_graph.export_data())
             page.saved = False
         elif action == Actions.FLOW_GRAPH_SCREEN_CAPTURE:
             file_path, background_transparent = FileDialogs.SaveScreenShot(main, page.file_path).run()


### PR DESCRIPTION
If you close a dialog without make a change, it restores the flow graph from the cache, but a new page has no cache so the flow graph disappears.

Here is where it loads from the cache:
https://github.com/gnuradio/gnuradio/blob/55c55fe3e17d556484ed9139e8e941a0da00f9c4/grc/gui/Application.py#L559

This fix saves the new page to the cache so it can be loaded from the cache in the future.
fixes #2762