### PR TITLE
runtime: add GR_PREFS_PATH env variable search

### DIFF
--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -102,8 +102,7 @@ void prefs::_read_files(const std::vector<std::string>& filenames)
                         section = "default";
                         key = okey;
                     }
-                    std::transform(
-                        section.begin(), section.end(), section.begin(), ::tolower);
+                    std::transform(section.begin(), section.end(), section.begin(), ::tolower);
                     std::transform(key.begin(), key.end(), key.begin(), ::tolower);
                     // value of a basic_option is always a std::vector<string>; we only
                     // allow single values, so:

--- a/gnuradio-runtime/lib/sys_paths.cc
+++ b/gnuradio-runtime/lib/sys_paths.cc
@@ -66,8 +66,19 @@ const char* appdata_path()
 
 std::string __userconf_path()
 {
-    boost::filesystem::path p(appdata_path());
-    p = p / ".gnuradio";
+    const char* path;
+
+    // First determine if there is an environment variable specifying the prefs path
+    path = getenv("GR_PREFS_PATH");
+    boost::filesystem::path p;
+    if (path) {
+        p = path;
+    }
+    else {
+        p = appdata_path();
+        p = p / ".gnuradio";
+    }
+   
     return p.string();
 }
 

--- a/gnuradio-runtime/python/gnuradio/gr/qa_prefs.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_prefs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Copyright 2019,2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# GNU Radio is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# GNU Radio is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GNU Radio; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+from __future__ import print_function
+
+
+from gnuradio import gr, gr_unittest
+
+class test_prefs (gr_unittest.TestCase):
+
+    def test_001(self):
+        p = gr.prefs()
+
+        # Read some options
+        self.assertFalse(p.has_option('doesnt', 'exist'))
+
+        # At the time these tests are run, there is not necessarily a default
+        # configuration on the build system, so not much to do with testing here
+
+if __name__ == '__main__':
+    gr_unittest.run(test_prefs)

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -30,7 +30,7 @@ from six.moves import configparser
 HEADER = """\
 # This contains only GUI settings for GRC and is not meant for users to edit.
 #
-# GRC settings not accessible through the GUI are in gnuradio.conf under
+# GRC settings not accessible through the GUI are in config.conf under
 # section [grc].
 
 """


### PR DESCRIPTION
When looking for the config file, allow the env variable
GR_PREFS_PATH to be searched so that multiple installations
of GR each with its own prefs can be used, similar to what
is currently done in GRC

There is much more work to be done in redesigning the prefs module
but just adding a env variable to point the user generated conf 
file to a different location seems like a low hanging fruit to allow better
usage with multiple installations on one machine.  This change can also
be backported to 3.8 perhaps