### PR TITLE
Deboostify random

### DIFF
--- a/gnuradio-runtime/include/gnuradio/random.h
+++ b/gnuradio-runtime/include/gnuradio/random.h
@@ -27,8 +27,8 @@
 #include <gnuradio/gr_complex.h>
 
 #include <stdlib.h>
-#include <boost/random.hpp>
 #include <ctime>
+#include <random>
 
 namespace gr {
 
@@ -43,12 +43,10 @@ protected:
     bool d_gauss_stored;
     float d_gauss_value;
 
-    boost::mt19937* d_rng; // mersenne twister as random number generator
-    boost::uniform_real<float>*
+    std::mt19937 d_rng; // mersenne twister as random number generator
+    std::uniform_real_distribution<float>
         d_uniform; // choose uniform distribution, default is [0,1)
-    boost::uniform_int<>* d_integer_dis;
-    boost::variate_generator<boost::mt19937&, boost::uniform_real<float>>* d_generator;
-    boost::variate_generator<boost::mt19937&, boost::uniform_int<>>* d_integer_generator;
+    std::uniform_int_distribution<> d_integer_dis;
 
 public:
     random(unsigned int seed = 0, int min_integer = 0, int max_integer = 2);

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -47,28 +47,16 @@
 namespace gr {
 
 random::random(unsigned int seed, int min_integer, int max_integer)
+    : d_rng(), d_integer_dis(0, 1)
 {
     d_gauss_stored = false; // set gasdev (gauss distributed numbers) on calculation state
 
     // Setup random number generators
-    d_rng = new boost::mt19937;                     // random numbers are generated here.
-    d_uniform = new boost::uniform_real<float>;     // map random number to distribution
-    d_integer_dis = new boost::uniform_int<>(0, 1); // another "mapper"
-    d_generator = NULL; // MUST be reinstantiated on every call to reseed.
-    d_integer_generator =
-        NULL; // MUST be reinstantiated on everytime d_rng or d_integer_dis is changed.
     reseed(seed); // set seed for random number generator
     set_integer_limits(min_integer, max_integer);
 }
 
-random::~random()
-{
-    delete d_rng;
-    delete d_uniform;
-    delete d_integer_dis;
-    delete d_generator;
-    delete d_integer_generator;
-}
+random::~random() {}
 
 /*
  * Seed is initialized with time if the given seed is 0. Otherwise the seed is taken
@@ -78,43 +66,29 @@ void random::reseed(unsigned int seed)
 {
     d_seed = seed;
     if (d_seed == 0) {
-        d_rng->seed();
+        d_rng.seed();
     } else {
-        d_rng->seed(d_seed);
+        d_rng.seed(d_seed);
     }
-    // reinstantiate generators. Otherwise reseed doesn't take effect.
-    delete d_generator;
-    d_generator =
-        new boost::variate_generator<boost::mt19937&, boost::uniform_real<float>>(
-            *d_rng, *d_uniform); // create number generator in [0,1) from boost.random
-    delete d_integer_generator;
-    d_integer_generator =
-        new boost::variate_generator<boost::mt19937&, boost::uniform_int<>>(
-            *d_rng, *d_integer_dis);
 }
 
 void random::set_integer_limits(const int minimum, const int maximum)
 {
     // boost expects integer limits defined as [minimum, maximum] which is unintuitive.
     // use the expected half open interval behavior! [minimum, maximum)!
-    delete d_integer_generator;
-    delete d_integer_dis;
-    d_integer_dis = new boost::uniform_int<>(minimum, maximum - 1);
-    d_integer_generator =
-        new boost::variate_generator<boost::mt19937&, boost::uniform_int<>>(
-            *d_rng, *d_integer_dis);
+    d_integer_dis = std::uniform_int_distribution<>(minimum, maximum - 1);
 }
 
 /*!
  * Uniform random integers in the range set by 'set_integer_limits' [min, max).
  */
-int random::ran_int() { return (*d_integer_generator)(); }
+int random::ran_int() { return d_integer_dis(d_rng); }
 
 /*
  * Returns uniformly distributed numbers in [0,1) taken from boost.random using a Mersenne
  * twister
  */
-float random::ran1() { return (*d_generator)(); }
+float random::ran1() { return d_uniform(d_rng); }
 
 /*
  * Returns a normally distributed deviate with zero mean and variance 1.

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -26,14 +26,6 @@
 
 #include "message_strobe_random_impl.h"
 #include <gnuradio/io_signature.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <cstdio>
-#include <iostream>
-#include <stdexcept>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -24,11 +24,8 @@
 #define INCLUDED_GR_MESSAGE_STROBE_RANDOM_IMPL_H
 
 #include <gnuradio/blocks/message_strobe_random.h>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/poisson_distribution.hpp>
-#include <boost/random/uniform_real.hpp>
-#include <boost/random/variate_generator.hpp>
+
+#include <random>
 
 namespace gr {
 namespace blocks {
@@ -36,28 +33,20 @@ namespace blocks {
 class BLOCKS_API message_strobe_random_impl : public message_strobe_random
 {
 private:
-    boost::shared_ptr<gr::thread::thread> d_thread;
-    bool d_finished;
+    std::mt19937 d_rng;
     float d_mean_ms;
     float d_std_ms;
     message_strobe_random_distribution_t d_dist;
+    std::poisson_distribution<> pd;      //(d_mean_ms);
+    std::normal_distribution<> nd;       //(d_mean_ms, d_std_ms);
+    std::uniform_real_distribution<> ud; //(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms);
+    boost::shared_ptr<gr::thread::thread> d_thread;
+    bool d_finished;
     pmt::pmt_t d_msg;
-    void run();
-    long next_delay();
-
-    boost::mt19937 d_rng;
-    boost::shared_ptr<
-        boost::variate_generator<boost::mt19937, boost::poisson_distribution<>>>
-        d_variate_poisson;
-    boost::shared_ptr<
-        boost::variate_generator<boost::mt19937, boost::normal_distribution<>>>
-        d_variate_normal;
-    boost::shared_ptr<boost::variate_generator<boost::mt19937, boost::uniform_real<>>>
-        d_variate_uniform;
-
     const pmt::pmt_t d_port;
 
-    void update_dist();
+    void run();
+    long next_delay();
 
 public:
     message_strobe_random_impl(pmt::pmt_t msg,
@@ -68,17 +57,9 @@ public:
 
     void set_msg(pmt::pmt_t msg) { d_msg = msg; }
     pmt::pmt_t msg() const { return d_msg; }
-    void set_mean(float mean_ms)
-    {
-        d_mean_ms = mean_ms;
-        update_dist();
-    }
-    float mean() const { return d_mean_ms; }
-    void set_std(float std_ms)
-    {
-        d_std_ms = std_ms;
-        update_dist();
-    }
+    void set_mean(float mean_ms);
+    float mean() const;
+    void set_std(float std_ms);
     float std() const { return d_std_ms; }
     void set_dist(message_strobe_random_distribution_t dist) { d_dist = dist; }
     message_strobe_random_distribution_t dist() const { return d_dist; }

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -45,8 +45,6 @@ random_pdu_impl::random_pdu_impl(int min_items,
     : block("random_pdu", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
       d_urange(min_items, max_items),
       d_brange(0, 255),
-      d_rvar(d_rng, d_urange),
-      d_bvar(d_rng, d_brange),
       d_mask(byte_mask),
       d_length_modulo(length_modulo)
 {
@@ -69,13 +67,13 @@ bool random_pdu_impl::start()
 void random_pdu_impl::output_random()
 {
     // pick a random vector length
-    int len = d_rvar();
+    int len = d_urange(d_rng);
     len = std::max(d_length_modulo, len - len % d_length_modulo);
 
     // fill it with random bytes
     std::vector<unsigned char> vec(len);
     for (int i = 0; i < len; i++)
-        vec[i] = ((unsigned char)d_bvar()) & d_mask;
+        vec[i] = ((unsigned char)d_brange(d_rng)) & d_mask;
 
     // send the vector
     pmt::pmt_t vecpmt(pmt::make_blob(&vec[0], len));

--- a/gr-blocks/lib/random_pdu_impl.h
+++ b/gr-blocks/lib/random_pdu_impl.h
@@ -25,7 +25,8 @@
 
 #include <gnuradio/blocks/random_pdu.h>
 #include <boost/generator_iterator.hpp>
-#include <boost/random.hpp>
+
+#include <random>
 
 namespace gr {
 namespace blocks {
@@ -33,11 +34,9 @@ namespace blocks {
 class random_pdu_impl : public random_pdu
 {
 private:
-    boost::mt19937 d_rng;
-    boost::uniform_int<> d_urange;
-    boost::uniform_int<> d_brange;
-    boost::variate_generator<boost::mt19937, boost::uniform_int<>> d_rvar; // pdu length
-    boost::variate_generator<boost::mt19937, boost::uniform_int<>> d_bvar; // pdu contents
+    std::mt19937 d_rng;
+    std::uniform_int_distribution<> d_urange;
+    std::uniform_int_distribution<> d_brange;
     unsigned char d_mask;
     int d_length_modulo;
 

--- a/gr-channels/grc/channels_fading_model.block.yml
+++ b/gr-channels/grc/channels_fading_model.block.yml
@@ -48,10 +48,10 @@ documentation: |-
        A. Alimohammad S.F. Fard B.F. Cockburn C. Schlegel
        26th November 2008
 
-        int d_N=8;          // number of sinusoids
+        unsigned int d_N=8;          // number of sinusoids
         float d_fDTs=0.01   // normalized maximum doppler frequency (f_doppler / f_samprate)
         float d_K=4;        // Rician factor (ratio of the specular power to the scattered power)
         bool d_LOS=true;    // LOS path exists? chooses Rician (LOS) vs Rayleigh (NLOS) model.
-        int seed=0;         // noise seed
+        uint32_t seed=0;         // noise seed
 
 file_format: 1

--- a/gr-channels/grc/channels_selective_fading_model.block.yml
+++ b/gr-channels/grc/channels_selective_fading_model.block.yml
@@ -56,12 +56,12 @@ templates:
     - set_K(${K})
 
 documentation: |-
-    int d_N=8;          // number of sinusoids used to simulate gain on each ray
+    unsigned int d_N=8;          // number of sinusoids used to simulate gain on each ray
         float d_fDTs=0.01   // normalized maximum doppler frequency (f_doppler / f_samprate)
         float d_K=4;        // Rician factor (ratio of the specular power to the scattered power)
         bool d_LOS=true;    // LOS path exists? chooses Rician (LOS) vs Rayleigh (NLOS) model.
-        int seed=0;         // noise seed
-        int ntaps;          // Number of FIR taps to use in selective fading model
+        uint32_t seed=0;         // noise seed
+        unsigned int ntaps;          // Number of FIR taps to use in selective fading model
 
           These two vectors comprise the Power Delay Profile of the signal
         float_vector delays   // Time delay in the fir filter (in samples) for each arriving WSSUS Ray

--- a/gr-channels/grc/channels_selective_fading_model2.block.yml
+++ b/gr-channels/grc/channels_selective_fading_model2.block.yml
@@ -67,12 +67,12 @@ templates:
     - set_K(${K})
 
 documentation: |-
-    int d_N=8;          // number of sinusoids used to simulate gain on each ray
+    unsigned int d_N=8;          // number of sinusoids used to simulate gain on each ray
         float d_fDTs=0.01   // normalized maximum doppler frequency (f_doppler / f_samprate)
         float d_K=4;        // Rician factor (ratio of the specular power to the scattered power)
         bool d_LOS=true;    // LOS path exists? chooses Rician (LOS) vs Rayleigh (NLOS) model.
-        int seed=0;         // noise seed
-        int ntaps;          // Number of FIR taps to use in selective fading model
+        uint32_t seed=0;         // noise seed
+        unsigned int ntaps;          // Number of FIR taps to use in selective fading model
 
           These two vectors comprise the Power Delay Profile of the signal
         float_vector delays   // Time delay in the fir filter (in samples) for each arriving WSSUS Ray

--- a/gr-channels/include/gnuradio/channels/fading_model.h
+++ b/gr-channels/include/gnuradio/channels/fading_model.h
@@ -48,13 +48,17 @@ public:
     /*! \brief Build the channel simulator.
      *
      * \param N    the number of sinusoids to use in simulating the channel; 8 is a good
-     * value \param fDTs normalized maximum Doppler frequency, fD * Ts \param LOS  include
-     * Line-of-Site path? selects between Rayleigh (NLOS) and Rician (LOS) models \param K
-     * Rician factor (ratio of the specular power to the scattered power) \param seed a
-     * random number to seed the noise generators
+     *             value
+     * \param fDTs normalized maximum Doppler frequency, fD * Ts
+     * \param LOS  include Line-of-Site path? selects between Rayleigh (NLOS) and Rician
+     * (LOS) models \param K    Rician factor (ratio of the specular power to the
+     * scattered power) \param seed a random number to seed the noise generators
      */
-    static sptr
-    make(unsigned int N, float fDTs = 0.01, bool LOS = true, float K = 4, int seed = 0);
+    static sptr make(unsigned int N,
+                     float fDTs = 0.01f,
+                     bool LOS = true,
+                     float K = 4,
+                     uint32_t seed = 0);
 
     virtual float fDTs() = 0;
     virtual float K() = 0;

--- a/gr-channels/include/gnuradio/channels/selective_fading_model2.h
+++ b/gr-channels/include/gnuradio/channels/selective_fading_model2.h
@@ -66,12 +66,12 @@ public:
                      float fDTs,
                      bool LOS,
                      float K,
-                     int seed,
+                     uint32_t seed,
                      std::vector<float> delays,
-                     std::vector<float> delay_std,
-                     std::vector<float> delay_maxdev,
+                     std::vector<float> delays_std,
+                     std::vector<float> delays_maxdev,
                      std::vector<float> mags,
-                     int ntaps);
+                     unsigned int ntaps);
 
     virtual float fDTs() = 0;
     virtual float K() = 0;

--- a/gr-channels/lib/fading_model_impl.cc
+++ b/gr-channels/lib/fading_model_impl.cc
@@ -28,14 +28,14 @@ namespace gr {
 namespace channels {
 
 fading_model::sptr
-fading_model::make(unsigned int N, float fDTs, bool LOS, float K, int seed)
+fading_model::make(unsigned int N, float fDTs, bool LOS, float K, uint32_t seed)
 {
     return gnuradio::get_initial_sptr(new fading_model_impl(N, fDTs, LOS, K, seed));
 }
 
 // Block constructor
 fading_model_impl::fading_model_impl(
-    unsigned int N, float fDTs, bool LOS, float K, int seed)
+    unsigned int N, float fDTs, bool LOS, float K, uint32_t seed)
     : sync_block("fading_model",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),

--- a/gr-channels/lib/fading_model_impl.h
+++ b/gr-channels/lib/fading_model_impl.h
@@ -27,10 +27,6 @@
 #include <gnuradio/channels/fading_model.h>
 #include <gnuradio/sync_block.h>
 
-//#include <iostream>
-#include <boost/format.hpp>
-#include <boost/random.hpp>
-
 #include "sincostable.h"
 #include <gnuradio/fxpt.h>
 
@@ -43,7 +39,7 @@ private:
     gr::channels::flat_fader_impl d_fader;
 
 public:
-    fading_model_impl(unsigned int N, float fDTs, bool LOS, float K, int seed);
+    fading_model_impl(unsigned int N, float fDTs, bool LOS, float K, uint32_t seed);
     ~fading_model_impl();
     void setup_rpc();
     int work(int noutput_items,

--- a/gr-channels/lib/flat_fader_impl.cc
+++ b/gr-channels/lib/flat_fader_impl.cc
@@ -26,19 +26,16 @@
 namespace gr {
 namespace channels {
 
-flat_fader_impl::flat_fader_impl(unsigned int N, float fDTs, bool LOS, float K, int seed)
-    : seed_1((int)seed),
+flat_fader_impl::flat_fader_impl(uint32_t N, float fDTs, bool LOS, float K, uint32_t seed)
+    : rng_1(seed),
       dist_1(-GR_M_PI, GR_M_PI),
-      rv_1(seed_1, dist_1), // U(-pi,pi)
-
-      seed_2((int)seed + 1),
+      rng_2(seed + 1),
       dist_2(0, 1),
-      rv_2(seed_2, dist_2), // U(0,1)
 
       d_N(N),
       d_fDTs(fDTs),
-      d_theta(rv_1()),
-      d_theta_los(rv_1()),
+      d_theta(dist_1(rng_1)),
+      d_theta_los(dist_1(rng_1)),
       d_step(powf(0.00125 * fDTs, 1.1)), // max step size approximated from Table 2
       d_m(0),
       d_K(K),
@@ -55,8 +52,8 @@ flat_fader_impl::flat_fader_impl(unsigned int N, float fDTs, bool LOS, float K, 
 {
     // generate initial phase values
     for (int i = 0; i < d_N + 1; i++) {
-        d_psi[i] = rv_1();
-        d_phi[i] = rv_1();
+        d_psi[i] = dist_1(rng_1);
+        d_phi[i] = dist_1(rng_1);
     }
 }
 
@@ -109,7 +106,7 @@ gr_complex flat_fader_impl::next_sample()
 
 void flat_fader_impl::update_theta()
 {
-    d_theta += (d_step * rv_2());
+    d_theta += (d_step * dist_2(rng_2));
     if (d_theta > GR_M_PI) {
         d_theta = GR_M_PI;
         d_step = -d_step;

--- a/gr-channels/lib/flat_fader_impl.h
+++ b/gr-channels/lib/flat_fader_impl.h
@@ -23,15 +23,12 @@
 #ifndef FLAT_FADER_IMPL_H
 #define FLAT_FADER_IMPL_H
 
-#include <gnuradio/io_signature.h>
-#include <stdint.h>
-#include <iostream>
-
-#include <boost/format.hpp>
-#include <boost/random.hpp>
-
 #include "sincostable.h"
 #include <gnuradio/fxpt.h>
+#include <gnuradio/io_signature.h>
+
+#include <stdint.h>
+#include <random>
 
 // FASTSINCOS:  0 = slow native,  1 = gr::fxpt impl,  2 = sincostable.h
 #define FASTSINCOS 2
@@ -43,14 +40,12 @@ class flat_fader_impl
 {
 private:
     // initial theta variate generator
-    boost::mt19937 seed_1;
-    boost::uniform_real<> dist_1; // U(-pi,pi)
-    boost::variate_generator<boost::mt19937&, boost::uniform_real<>> rv_1;
+    std::mt19937 rng_1;
+    std::uniform_real_distribution<double> dist_1; // U(-pi,pi)
 
     // random walk variate
-    boost::mt19937 seed_2;
-    boost::uniform_real<> dist_2; // U(0,1)
-    boost::variate_generator<boost::mt19937&, boost::uniform_real<>> rv_2;
+    std::mt19937 rng_2;
+    std::uniform_real_distribution<double> dist_2; // U(0,1)
 
 public:
     int d_N;        // number of sinusoids
@@ -74,7 +69,7 @@ public:
 
     void update_theta();
 
-    flat_fader_impl(unsigned int N, float fDTs, bool LOS, float K, int seed);
+    flat_fader_impl(uint32_t N, float fDTs, bool LOS, float K, uint32_t seed);
     gr_complex next_sample();
     void next_samples(std::vector<gr_complex>& HVec, int n_samples);
 

--- a/gr-channels/lib/selective_fading_model2_impl.cc
+++ b/gr-channels/lib/selective_fading_model2_impl.cc
@@ -27,12 +27,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 
-#include <boost/format.hpp>
-#include <boost/random.hpp>
-
-#include <iostream>
-
-
 // FASTSINCOS:  0 = slow native,  1 = gr::fxpt impl,  2 = sincostable.h
 #define FASTSINCOS 2
 
@@ -45,12 +39,12 @@ selective_fading_model2::make(unsigned int N,
                               float fDTs,
                               bool LOS,
                               float K,
-                              int seed,
+                              uint32_t seed,
                               std::vector<float> delays,
                               std::vector<float> delays_std,
                               std::vector<float> delays_maxdev,
                               std::vector<float> mags,
-                              int ntaps)
+                              unsigned int ntaps)
 {
     return gnuradio::get_initial_sptr(new selective_fading_model2_impl(
         N, fDTs, LOS, K, seed, delays, delays_std, delays_maxdev, mags, ntaps));
@@ -62,12 +56,12 @@ selective_fading_model2_impl::selective_fading_model2_impl(
     float fDTs,
     bool LOS,
     float K,
-    int seed,
+    uint32_t seed,
     std::vector<float> delays,
     std::vector<float> delays_std,
     std::vector<float> delays_maxdev,
     std::vector<float> mags,
-    int ntaps)
+    unsigned int ntaps)
     : sync_block("selective_fading_model2",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
@@ -77,9 +71,8 @@ selective_fading_model2_impl::selective_fading_model2_impl(
       d_delays_maxdev(delays_maxdev),
       d_mags(mags),
       d_sintable(1024),
-      seed_1(0),
-      dist_1(0, 1),
-      rv_1(seed_1, dist_1)
+      rng_1(0),
+      dist_1(0, 1)
 {
     if (mags.size() != delays.size())
         throw std::runtime_error("magnitude and delay vectors must be the same length!");
@@ -94,9 +87,6 @@ selective_fading_model2_impl::selective_fading_model2_impl(
     }
 
     // set up tap history
-    if (ntaps < 1) {
-        throw std::runtime_error("ntaps must be >= 1");
-    }
     set_history(ntaps);
     d_taps.resize(ntaps, gr_complex(0, 0));
 
@@ -130,7 +120,7 @@ int selective_fading_model2_impl::work(int noutput_items,
 
         // move the tap delays around (random walk + clipping)
         for (size_t j = 0; j < d_faders.size(); j++) {
-            float tmp = d_delays[j] + rv_1() * d_delays_std[j];
+            float tmp = d_delays[j] + dist_1(rng_1) * d_delays_std[j];
             d_delays[j] = std::max(std::min(tmp, d_delays_orig[j] + d_delays_maxdev[j]),
                                    d_delays_orig[j] - d_delays_maxdev[j]);
         }

--- a/gr-channels/lib/selective_fading_model2_impl.h
+++ b/gr-channels/lib/selective_fading_model2_impl.h
@@ -27,10 +27,6 @@
 #include <gnuradio/channels/selective_fading_model2.h>
 #include <gnuradio/sync_block.h>
 
-//#include <iostream>
-#include <boost/format.hpp>
-#include <boost/random.hpp>
-
 #include "sincostable.h"
 #include <gnuradio/fxpt.h>
 
@@ -48,21 +44,20 @@ private:
     std::vector<float> d_mags;
     sincostable d_sintable;
 
-    boost::mt19937 seed_1;
-    boost::normal_distribution<> dist_1; // U(-pi,pi)
-    boost::variate_generator<boost::mt19937&, boost::normal_distribution<>> rv_1;
+    std::mt19937 rng_1;
+    std::normal_distribution<> dist_1; // U(-pi,pi)
 
 public:
     selective_fading_model2_impl(unsigned int N,
                                  float fDTs,
                                  bool LOS,
                                  float K,
-                                 int seed,
+                                 uint32_t seed,
                                  std::vector<float> delays,
-                                 std::vector<float> delay_std,
-                                 std::vector<float> delay_maxdev,
+                                 std::vector<float> delays_std,
+                                 std::vector<float> delays_maxdev,
                                  std::vector<float> mags,
-                                 int ntaps);
+                                 unsigned int ntaps);
     ~selective_fading_model2_impl();
     void setup_rpc();
     int work(int noutput_items,

--- a/gr-channels/lib/selective_fading_model_impl.cc
+++ b/gr-channels/lib/selective_fading_model_impl.cc
@@ -27,12 +27,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 
-#include <boost/format.hpp>
-#include <boost/random.hpp>
-
-#include <iostream>
-
-
 // FASTSINCOS:  0 = slow native,  1 = gr::fxpt impl,  2 = sincostable.h
 #define FASTSINCOS 2
 

--- a/gr-channels/lib/selective_fading_model_impl.h
+++ b/gr-channels/lib/selective_fading_model_impl.h
@@ -27,10 +27,6 @@
 #include <gnuradio/channels/selective_fading_model.h>
 #include <gnuradio/sync_block.h>
 
-//#include <iostream>
-#include <boost/format.hpp>
-#include <boost/random.hpp>
-
 #include "sincostable.h"
 #include <gnuradio/fxpt.h>
 


### PR DESCRIPTION
C++11 offers all the random variates that we used from boost, but with a far less awkward interface.

In the course of this, a lot of unused includes were found.

Since this not only changes API in gr-channels, but might also have subtle consequences on the random sequences generated, this is **not** backportable to maint-3.8