### PR TITLE
modtool: fix non-empty argument list on cli

### DIFF
--- a/gr-utils/python/modtool/cli/add.py
+++ b/gr-utils/python/modtool/cli/add.py
@@ -124,10 +124,17 @@ def get_copyrightholder(self):
         click.secho("For GNU Radio components the FSF is added as copyright holder",
                     fg='cyan')
 
+
 def get_arglist(self):
     """ Get the argument list of the block to be added """
-    if self.info['arglist'] is not None:
-        self.info['arglist'] = click.prompt(click.style('Enter valid argument list, including default arguments: \n', fg='cyan'), prompt_suffix='')
+    if self.info['arglist'] in [None,'']: 
+        self.info['arglist'] = click.prompt(click.style(
+            'Enter valid argument list, including default arguments: \n',
+            fg='cyan'),
+                                            prompt_suffix='',
+                                            default='',
+                                            show_default=False)
+
 
 def get_py_qa(self):
     """ Get a boolean value for addition of py_qa """


### PR DESCRIPTION
When the --argument list was used on gr_modtool cli, the logic for
determining whether it was there or not was off as the empty list was
returned as an empty string

includes unmerged #2826

Fixes #2836