### PR TITLE
grc: validate gui hints

### DIFF
--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -115,3 +115,10 @@ def validate_vector(param):
     if not all(isinstance(item, valid_types) for item in param.get_evaluated()):
         raise ValidateError('Expression {!r} is invalid for type {!r}.'.format(
             param.get_evaluated(), param.dtype))
+
+@validates('gui_hint')
+def validate_gui_hint(param):
+    try:
+        param.parse_gui_hint(param.value)
+    except Exception as e:
+        raise ValidateError(str(e))


### PR DESCRIPTION
committing the fix suggested by @haakov 
Make gui_hint collisions show up as validation errors

As shown in #2287, when there are gui hint collisions, there are a flurry of error messages, whereas with this fix, the collisions are flagged in grc:

![image](https://user-images.githubusercontent.com/34754695/66324434-6a528280-e8f3-11e9-9663-978296db099a.png)

![image](https://user-images.githubusercontent.com/34754695/66324445-71799080-e8f3-11e9-99ba-bfbb62a5ad09.png)






Fixes #2287