### PR TITLE
grc: update namespace properly for nested variables

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -226,6 +226,7 @@ class FlowGraph(Element):
                 variable_block.rewrite()
                 value = eval(variable_block.value, namespace, variable_block.namespace)
                 namespace[variable_block.name] = value
+                self.namespace.update(namespace) # rewrite on subsequent blocks depends on an updated self.namespace 
             except TypeError: #Type Errors may happen, but that desn't matter as they are displayed in the gui
                 pass
             except Exception:
@@ -381,8 +382,7 @@ class FlowGraph(Element):
 
             block.import_data(**block_data)
 
-        self.rewrite()  # TODO: Figure out why this has to be called twice to populate bus ports correctly
-        self.rewrite()  # evaluate stuff like nports before adding connections
+        self.rewrite() 
 
         # build the connections
         def verify_and_get_port(key, block, dir):


### PR DESCRIPTION
Was getting lots of evaluation error prints when using gr-digital
examples because the nested variables were not updated until rewrite()
and evaluate were called over and over

Seems to fix the issue to update the flowgraph namespace variable after
each variable block is evaluated

I believe this also removes a previous issue (#2634) where rewrite
had to be called twice when data was being imported

Here is a situation that created the ugly printout:

![image](https://user-images.githubusercontent.com/34754695/66399936-7e0eef00-e9ae-11e9-9502-e4d980058aca.png)

![image](https://user-images.githubusercontent.com/34754695/66399963-8830ed80-e9ae-11e9-95d4-a8a03a3ecf48.png)

would print out
```
[ERROR] Failed to evaluate variable block rxmod (FlowGraph.py:233)
Traceback (most recent call last):
  File "/share/gnuradio/grdev/src/gnuradio/grc/core/FlowGraph.py", line 227, in renew_namespace
    value = eval(variable_block.value, namespace, variable_block.namespace)
  File "<string>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'to_basic_block'
ERROR:grc.core.FlowGraph:Failed to evaluate variable block rxmod
Traceback (most recent call last):
  File "/share/gnuradio/grdev/src/gnuradio/grc/core/FlowGraph.py", line 227, in renew_namespace
    value = eval(variable_block.value, namespace, variable_block.namespace)
  File "<string>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'to_basic_block'
>>> Done
```

Because the variables needed for the parameter evaluation did not exist in the namespace at the time they were being evaluated.

This also created the situation that the ber_curve_gen flowgraphs would not load up properly

![image](https://user-images.githubusercontent.com/34754695/66400266-24f38b00-e9af-11e9-8a39-75235da18e65.png)

with the error:
```
[ERROR] Failed to evaluate variable block enc_ldpc (FlowGraph.py:233)
Traceback (most recent call last):
  File "/share/gnuradio/grdev/src/gnuradio/grc/core/FlowGraph.py", line 227, in renew_namespace
    value = eval(variable_block.value, namespace, variable_block.namespace)
  File "<string>", line 1, in <module>
  File "/share/gnuradio/grdev/lib/python3.6/dist-packages/gnuradio/fec/fec_swig.py", line 1317, in ldpc_encoder_make
    return _fec_swig.ldpc_encoder_make(alist_file)
RuntimeError: Bad AList file name!
```

where the workaround was to call rewrite() twice in the import data.  This is no longer necessary with the self.namespace updated in between variable block loads


Fixes #2634 
