### PR TITLE
codec2: development (master) branch support

### DIFF
--- a/gr-vocoder/include/gnuradio/vocoder/freedv_api.h
+++ b/gr-vocoder/include/gnuradio/vocoder/freedv_api.h
@@ -25,11 +25,18 @@
 
 #include <gnuradio/vocoder/api.h>
 
+// version >=0.9.1 contains fixes that doesn't require "extern C"
+// between 0.8.1 and 0.9.1 the build fail
+#include <codec2/version.h>
+#if CODEC2_VERSION_MAJOR == 0 && CODEC2_VERSION_MINOR < 9
 extern "C" {
+#endif
 #include <codec2/codec2.h>
 #include <codec2/freedv_api.h>
 #include <codec2/modem_stats.h>
+#if CODEC2_VERSION_MAJOR == 0 && CODEC2_VERSION_MINOR < 9
 }
+#endif
 
 namespace gr {
 namespace vocoder {


### PR DESCRIPTION
add support for the development branch (master) of codec2 but still
maintaining compatibility with version 0.8.1.

The unique way that I know to enable or disable `extern "C"` is to
check codec2 version but the version bump was not synchronized with
the implementation therefore you should always use the latest commit.

This fix should also be merged into `maint-3.8`.
