### PR TITLE
blocks: transcendental: Default to complex_float in GRC bindings

### DIFF
--- a/gr-blocks/grc/blocks_transcendental.block.yml
+++ b/gr-blocks/grc/blocks_transcendental.block.yml
@@ -6,7 +6,7 @@ parameters:
 -   id: type
     label: Type
     dtype: enum
-    options: [complex_double, float]
+    options: [complex_float, float]
     option_labels: [Complex, Float]
     option_attributes:
         type: [complex, float]


### PR DESCRIPTION
The default is complex_double, or float. The former is rarely used in
GNU Radio, hence, it is not a good default.