### PR TITLE
GRC: testing: can't rely on set ordering; sets are unordered

### DIFF
--- a/grc/tests/test_block_flags.py
+++ b/grc/tests/test_block_flags.py
@@ -26,4 +26,4 @@ def test_extend():
     f.set(u'b')
     assert isinstance(f, Flags)
 
-    assert str(f) == 'a, b'
+    assert f.data == {'a', 'b'}


### PR DESCRIPTION
Since sets are unordered, checking the string representation character-wise fails randomly. 

Partially addresses #2678.