### PR TITLE
cmake: Remove find package for pythonlibs in gr-qtgui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,6 @@ include(GrBoost)
 # Enable python component
 ########################################################################
 include(GrPython)
-find_package(PythonLibs ${GR_PYTHON_MIN_VERSION})
 GR_PYTHON_CHECK_MODULE("six - python 2 and 3 compatibility library" six "True" SIX_FOUND)
 find_package(SWIG)
 

--- a/gr-qtgui/CMakeLists.txt
+++ b/gr-qtgui/CMakeLists.txt
@@ -22,8 +22,6 @@
 ########################################################################
 include(GrBoost)
 
-find_package(PythonLibs 2)
-
 include(GrPython)
 
 # Note: gr-qtgui requires Qt5.


### PR DESCRIPTION
There was an unneeded find_package(PythonLibs 2) in the gr-qtgui
CMakeLists.txt that was occasionally causing issues building the
demo when python3 was targeted.  We should just be using the
GrPython module anyway that was already included.

Signed-off-by: Brennan Ashton <bashton@brennanashton.com>