### PR TITLE
runtime: fix gr_unittest floatAlmostEqual

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr_unittest.py
+++ b/gnuradio-runtime/python/gnuradio/gr_unittest.py
@@ -82,10 +82,10 @@ class TestCase(unittest.TestCase):
         places.0
         """
         self.assertEqual(len(a), len(b))
-        return all((
+        return all([
             self.assertComplexAlmostEqual(x, y, places, msg)
             for (x, y) in zip(a, b)
-        ))
+        ])
 
 
     def assertComplexTuplesAlmostEqual2(self, a, b,
@@ -95,10 +95,10 @@ class TestCase(unittest.TestCase):
         Approximate equality is determined by calling assertComplexAlmostEqual().
         """
         self.assertEqual(len(a), len(b))
-        return all((
+        return all([
             self.assertComplexAlmostEqual2(x, y, abs_eps, rel_eps, msg)
             for (x, y) in zip(a, b)
-        ))
+        ])
 
 
     def assertFloatTuplesAlmostEqual(self, a, b, places=7, msg=None):
@@ -108,19 +108,19 @@ class TestCase(unittest.TestCase):
         places.
         """
         self.assertEqual(len(a), len(b))
-        return all((
+        return all([
             self.assertAlmostEqual(x, y, places, msg)
             for (x, y) in zip(a, b)
-        ))
+        ])
 
 
     def assertFloatTuplesAlmostEqual2(self, a, b,
                                       abs_eps=1e-12, rel_eps=1e-6, msg=None):
         self.assertEqual(len(a), len(b))
-        return all((
+        return all([
             self.assertComplexAlmostEqual2(x, y, abs_eps, rel_eps, msg)
             for (x, y) in zip(a, b)
-        ))
+        ])
 
 TestResult = unittest.TestResult
 TestSuite = unittest.TestSuite

--- a/gr-analog/python/analog/qa_sig_source.py
+++ b/gr-analog/python/analog/qa_sig_source.py
@@ -69,7 +69,7 @@ class test_sig_source(gr_unittest.TestCase):
         tb.run()
         dst_data = dst1.data()
         self.assertEqual(expected_result, dst_data)
-        
+
     def test_sine_f(self):
         tb = self.tb
         sqrt2 = math.sqrt(2) / 2
@@ -97,7 +97,9 @@ class test_sig_source(gr_unittest.TestCase):
         tb.connect(op, dst1)
         tb.run()
         dst_data = dst1.data()
-        self.assertFloatTuplesAlmostEqual(expected_result, dst_data)        
+        # Let the python know we are dealing with signed int behind scenes
+        dst_data_signed = [b if b < 127 else (256 - b) * -1 for b in dst_data]
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data_signed)
 
     def test_cosine_f(self):
         tb = self.tb


### PR DESCRIPTION
This is related to https://github.com/gnuradio/gnuradio/pull/2897 (just noticed that the fix might apply to master as well - I'll leave the other PR open as well. Either merging both or backporting this yields to same results)

The call inside this assert was using a generator inside the standard all(),
which was always returning False, and silently passing the test, instead of
actually asserting in fail. Changing to list comprehension for assertion raising

Fixes #2883