### PR TITLE
grc: remove deprecated encoding argument from json.loads

### DIFF
--- a/grc/core/utils/extract_docs.py
+++ b/grc/core/utils/extract_docs.py
@@ -198,7 +198,7 @@ class SubprocessLoader(object):
         """ Receive response from worker's stdout """
         for line in iter(self._worker.stdout.readline, ''):
             try:
-                key, cmd, args = json.loads(line.decode('utf-8'), encoding='utf-8')
+                key, cmd, args = json.loads(line.decode('utf-8'))
                 if key != self.AUTH_CODE:
                     raise ValueError('Got wrong auth code')
                 return cmd, args
@@ -268,7 +268,7 @@ def worker_main():
     # flush out to signal the main process we are ready for new commands
     sys.stdout.flush()
     for line in iter(sys.stdin.readline, ''):
-        code, cmd, args = json.loads(line, encoding='utf-8')
+        code, cmd, args = json.loads(line)
         try:
             if cmd == 'query':
                 key, imports, make = args


### PR DESCRIPTION
The _encoding_ argument in _json.loads_ is ignored and deprecated since Python 3.1 and will be removed in Python 3.9 [[ref.](https://docs.python.org/3/library/json.html#json.loads)]. Hence, GRC built from master is throwing a lot of warnings currently about that when using Python 3.8.

https://github.com/gnuradio/gnuradio/blob/0bb482acbecb722f227e257606589b0395a32706/grc/core/utils/extract_docs.py#L201

https://github.com/gnuradio/gnuradio/blob/c750d104d938cc6f3c09417022f132676f6646e4/grc/core/utils/extract_docs.py#L271