### PR TITLE
cmake: add boost 1.71 as acceptable version

### DIFF
--- a/cmake/Modules/GrBoost.cmake
+++ b/cmake/Modules/GrBoost.cmake
@@ -69,18 +69,20 @@ if(MSVC)
     endif(BOOST_ALL_DYN_LINK)
 endif(MSVC)
 
-find_package(Boost ${GR_BOOST_MIN_VERSION} COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
-
 # This does not allow us to disable specific versions. It is used
 # internally by cmake to know the formation newer versions. As newer
 # Boost version beyond what is shown here are produced, we must extend
 # this list. To disable Boost versions, see below.
+
 set(Boost_ADDITIONAL_VERSIONS
     "1.53" "1.54.0" "1.54"
     "1.55.0" "1.55" "1.56.0" "1.56" "1.57.0" "1.57" "1.58.0" "1.58" "1.59.0" "1.59"
     "1.60.0" "1.60" "1.61.0" "1.61" "1.62.0" "1.62" "1.63.0" "1.63" "1.64.0" "1.64"
     "1.65.0" "1.65" "1.66.0" "1.66" "1.67.0" "1.67" "1.68.0" "1.68" "1.69.0" "1.69"
+    "1.71.0" "1.71"
 )
+
+find_package(Boost ${GR_BOOST_MIN_VERSION} COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 
 # Boost 1.52 disabled, see https://svn.boost.org/trac/boost/ticket/7669
 # Similar problems with Boost 1.46 and 1.47.


### PR DESCRIPTION
Tested Boost 1.71 against the master branch.  All tests pass.

Also, Boost_ADDITIONAL_VERSIONS is an input to FindBoost, so should come before calling it.
