### PR TITLE
cmake: add boost unit_test_framework required only when ENABLE_TESTING=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,6 @@ project(gnuradio CXX C)
 enable_testing()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-OPTION(ENABLE_TESTING "Enable testing support" ON)
-
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
@@ -47,6 +45,9 @@ endif(NOT CMAKE_BUILD_TYPE)
 GR_CHECK_BUILD_TYPE(${CMAKE_BUILD_TYPE})
 SET(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 message(STATUS "Build type set to ${CMAKE_BUILD_TYPE}.")
+
+include(GrComponent)
+GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING)
 
 # Set the version information here
 SET(VERSION_MAJOR 3)
@@ -376,10 +377,6 @@ GR_REGISTER_COMPONENT("python-support" ENABLE_PYTHON
     SWIG_FOUND
     SWIG_VERSION_CHECK
     SIX_FOUND
-)
-
-GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING
-    Boost_FOUND
 )
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Coverage")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ project(gnuradio CXX C)
 enable_testing()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+OPTION(ENABLE_TESTING "Enable testing support" ON)
+
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 

--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -34,7 +34,9 @@ set(BOOST_REQUIRED_COMPONENTS
     thread
 )
 
-set(ENABLE_TESTING @ENABLE_TESTING@ CACHE BOOL "Enable testing support")
+if (NOT ENABLE_TESTING)
+  set(ENABLE_TESTING @ENABLE_TESTING@ CACHE BOOL "Enable testing support")
+endif()
 
 if(ENABLE_TESTING)
   list(APPEND BOOST_REQUIRED_COMPONENTS unit_test_framework)

--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -24,15 +24,23 @@ list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
 
 find_dependency(LOG4CPP)
 find_dependency(MPLIB)
-find_dependency(Boost "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@.@Boost_SUBMINOR_VERSION@" COMPONENTS
+
+set(BOOST_REQUIRED_COMPONENTS
     date_time
     program_options
     filesystem
     system
     regex
     thread
-    unit_test_framework
-    )
+)
+
+set(ENABLE_TESTING @ENABLE_TESTING@ CACHE BOOL "Enable testing support")
+
+if(ENABLE_TESTING)
+  list(APPEND BOOST_REQUIRED_COMPONENTS unit_test_framework)
+endif(ENABLE_TESTING)
+
+find_dependency(Boost "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@.@Boost_SUBMINOR_VERSION@" COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
 find_dependency(Volk)
 set(ENABLE_PYTHON @ENABLE_PYTHON@ CACHE BOOL "Enable Python & SWIG")
 if(${ENABLE_PYTHON})

--- a/cmake/Modules/GrBoost.cmake
+++ b/cmake/Modules/GrBoost.cmake
@@ -33,8 +33,11 @@ set(BOOST_REQUIRED_COMPONENTS
     system
     regex
     thread
-    unit_test_framework
 )
+
+if(ENABLE_TESTING)
+    list(APPEND BOOST_REQUIRED_COMPONENTS unit_test_framework)
+endif(ENABLE_TESTING)
 
 if(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
     list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix


### PR DESCRIPTION
Functions provided by boost unit_test_framework are only used when ENABLE_TESTING is set. Otherwise this library is not used.
This patch add unit_test_framework only if it's mandatory, and adds an option set ton ON by default to avoid wrong detection.