### PR TITLE
cmake: Use standard way of getting python prefix

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -109,12 +109,8 @@ endmacro(GR_PYTHON_CHECK_MODULE)
 ########################################################################
 if(NOT DEFINED GR_PYTHON_DIR)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
-import os
-import sys
-if os.name == 'posix':
-    print(os.path.join('lib', 'python' + sys.version[:3], 'dist-packages'))
-if os.name == 'nt':
-    print(os.path.join('Lib', 'site-packages'))
+from distutils import sysconfig
+print(sysconfig.get_python_lib(plat_specific=True, prefix=''))
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 endif()


### PR DESCRIPTION
Fixes #2006

This is exactly the same logic as is used in volk. Also the same logic
used for the GR_PYTHON_RELATIVE just below ... so if it works for those
on all OSes/config, no reasons it won't work here.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>