### PR TITLE
digital: add filter response truncation to generic mod

### DIFF
--- a/gr-digital/grc/digital_constellation_modulator.block.yml
+++ b/gr-digital/grc/digital_constellation_modulator.block.yml
@@ -34,7 +34,13 @@ parameters:
     options: ['True', 'False']
     option_labels: ['On', 'Off']
     hide: ${ ('part' if str(log) == 'False' else 'none') }
-
+-   id: truncate
+    label: Truncate Filter Transient
+    dtype: bool
+    default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: ${ ('part' if str(truncate) == 'False' else 'none') }
 inputs:
 -   domain: stream
     dtype: byte
@@ -53,6 +59,7 @@ templates:
             pre_diff_code=True,
             excess_bw=${excess_bw},
             verbose=${verbose},
-            log=${log})
+            log=${log},
+            truncate=${truncate})
 
 file_format: 1

--- a/gr-digital/python/digital/generic_mod_demod.py
+++ b/gr-digital/python/digital/generic_mod_demod.py
@@ -41,6 +41,7 @@ _def_samples_per_symbol = 2
 _def_excess_bw = 0.35
 _def_verbose = False
 _def_log = False
+_def_truncate = False
 
 # Frequency correction
 _def_freq_bw = 2*math.pi/100.0
@@ -93,6 +94,7 @@ class generic_mod(gr.hier_block2):
         excess_bw: Root-raised cosine filter excess bandwidth (float)
         verbose: Print information about modulator? (boolean)
         log: Log modulation data to files? (boolean)
+        truncate: Truncate the modulated output to account for the RRC filter response (boolean)
     """
 
     def __init__(self, constellation,
@@ -101,7 +103,8 @@ class generic_mod(gr.hier_block2):
                  pre_diff_code=True,
                  excess_bw=_def_excess_bw,
                  verbose=_def_verbose,
-                 log=_def_log):
+                 log=_def_log,
+                 truncate=_def_truncate):
 
         gr.hier_block2.__init__(self, "generic_mod",
                                 gr.io_signature(1, 1, gr.sizeof_char),       # Input signature
@@ -133,7 +136,8 @@ class generic_mod(gr.hier_block2):
 
         # pulse shaping filter
         nfilts = 32
-        ntaps = nfilts * 11 * int(self._samples_per_symbol)    # make nfilts filters of ntaps each
+        ntaps_per_filt = 11
+        ntaps = nfilts * ntaps_per_filt * int(self._samples_per_symbol)    # make nfilts filters of ntaps each
         self.rrc_taps = filter.firdes.root_raised_cosine(
             nfilts,          # gain
             nfilts,          # sampling rate based on 32 filters in resampler
@@ -143,13 +147,23 @@ class generic_mod(gr.hier_block2):
         self.rrc_filter = filter.pfb_arb_resampler_ccf(self._samples_per_symbol,
                                                        self.rrc_taps)
 
+        # Remove the filter transient at the beginning of the transmission
+        if truncate:
+            fsps = float(self._samples_per_symbol)
+            len_filt_delay = (ntaps_per_filt*fsps*fsps-fsps)/2.0 # Length of delay through rrc filter
+            self.skiphead = blocks.skiphead(gr.sizeof_gr_complex*1, len_filt_delay)
+
         # Connect
         self._blocks = [self, self.bytes2chunks]
         if self.pre_diff_code:
             self._blocks.append(self.symbol_mapper)
         if differential:
             self._blocks.append(self.diffenc)
-        self._blocks += [self.chunks2symbols, self.rrc_filter, self]
+        self._blocks += [self.chunks2symbols, self.rrc_filter]
+        
+        if truncate:
+            self._blocks.append(self.skiphead)
+        self._blocks.append(self)
         self.connect(*self._blocks)
 
         if verbose:

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -322,7 +322,7 @@ def show_types(parent):
 def show_missing_xterm(parent, xterm):
     markup = textwrap.dedent("""\
         The xterm executable {0!r} is missing.
-        You can change this setting in your gnurado.conf, in section [grc], 'xterm_executable'.
+        You can change this setting in your gnuradio.conf, in section [grc], 'xterm_executable'.
         \n\
         (This message is shown only once)\
     """).format(xterm)


### PR DESCRIPTION
The generic mod implementation is a convenience hier block to modulate
bits to symbols and apply an RRC filter.  One downside is the output is
delayed by the length of the RRC filter (which is specified inside the
block).  This adds an option to truncate the output according to the
length of the filter response such that the start of output is aligned to the first symbol.

For instance, with the following flowgraph:

![image](https://user-images.githubusercontent.com/34754695/70159421-def13580-1686-11ea-9bf3-770e199fdd44.png)

the output bursts are not aligned:

![image](https://user-images.githubusercontent.com/34754695/70159406-d7319100-1686-11ea-897b-f706e39b253b.png)

But when the truncation flag is set, the pulses are now aligned because the filter response was sent through a skip head:

![image](https://user-images.githubusercontent.com/34754695/70159338-bd904980-1686-11ea-8966-b0c316fdbf80.png)

And we get aligned bursts of 00001111 as we would expect
![image](https://user-images.githubusercontent.com/34754695/70159541-1364f180-1687-11ea-9305-90523708887b.png)

Fixes #2920