### PR TITLE
grc: report flowgraph loading errors nicely in grcc

### DIFF
--- a/grc/core/Messages.py
+++ b/grc/core/Messages.py
@@ -143,3 +143,17 @@ def send_fail_save_preferences(prefs_file_path):
 
 def send_warning(warning):
     send('>>> Warning: %s\n' % warning)
+
+
+def send_flowgraph_error_report(flowgraph):
+    """ verbose error report for flowgraphs """
+    error_list = flowgraph.get_error_messages()
+    if not error_list:
+        return
+
+    send('*' * 50 + '\n')
+    summary_msg = '{} errors from flowgraph:\n'.format(len(error_list))
+    send(summary_msg)
+    for err in error_list:
+        send(err)
+    send('\n' + '*' * 50 + '\n')

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -110,6 +110,7 @@ class Platform(Element):
                 raise Exception('Not a hier block')
         except Exception as e:
             Messages.send('>>> Load Error: {}: {}\n'.format(file_path, str(e)))
+            self._flowgraph_error_report(flow_graph)
             return None, None
         finally:
             self._auto_hier_block_generate_chain.discard(file_path)
@@ -391,6 +392,19 @@ class Platform(Element):
         output_language_default = param.get('default')
         return [(value, name, value == output_language_default)
                 for value, name in zip(param['options'], param['option_labels'])]
+
+    def _flowgraph_error_report(self, flowgraph):
+        """ verbose error report upon loading exception """
+        error_list = flowgraph.get_error_messages()
+        if not error_list:
+            return
+
+        Messages.send('*' * 50 + '\n')
+        summary_msg = '{} errors from flowgraph:\n'.format(len(error_list))
+        Messages.send(summary_msg)
+        for err in error_list:
+            Messages.send(err)
+        Messages.send('\n' + '*' * 50 + '\n')
 
     ##############################################
     # Factories

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -110,7 +110,7 @@ class Platform(Element):
                 raise Exception('Not a hier block')
         except Exception as e:
             Messages.send('>>> Load Error: {}: {}\n'.format(file_path, str(e)))
-            self._flowgraph_error_report(flow_graph)
+            Messages.send_flowgraph_error_report(flow_graph)
             return None, None
         finally:
             self._auto_hier_block_generate_chain.discard(file_path)
@@ -392,19 +392,6 @@ class Platform(Element):
         output_language_default = param.get('default')
         return [(value, name, value == output_language_default)
                 for value, name in zip(param['options'], param['option_labels'])]
-
-    def _flowgraph_error_report(self, flowgraph):
-        """ verbose error report upon loading exception """
-        error_list = flowgraph.get_error_messages()
-        if not error_list:
-            return
-
-        Messages.send('*' * 50 + '\n')
-        summary_msg = '{} errors from flowgraph:\n'.format(len(error_list))
-        Messages.send(summary_msg)
-        for err in error_list:
-            Messages.send(err)
-        Messages.send('\n' + '*' * 50 + '\n')
 
     ##############################################
     # Factories


### PR DESCRIPTION
closes #2900 

As mentioned in the issue, use `flowgraph.get_error_messages()` to print a nice error summary when loading a flowgraph in `grcc` raises an exception. I wanted to add the functionality of the `_flowgraph_error_report` function to the `Element` class for child classes to use, but the Messages module is not imported in `Element`.

**Normal output:**
```
$ python3 ~/gnuradio/grc/scripts/grcc -o /tmp/grtest ~/gr-tutorial/examples/tutorial2/grc_files/tutorial_two_2.grc
Running from source tree
<<< Welcome to GNU Radio Companion Compiler 3.9.0.0-git >>>

Block paths:
	/usr/local/share/gnuradio/grc/blocks

>>> Loading: /home/kvothe/gr-tutorial/examples/tutorial2/grc_files/tutorial_two_2.grc
>>> Generating: /tmp/grtest/tutorial_two_2.py


```
**Error Output after disconnecting some blocks:**
```
$ python3 ~/gnuradio/grc/scripts/grcc -o /tmp/grtest ~/gr-tutorial/examples/tutorial2/grc_files/tutorial_two_2.grc
Running from source tree
<<< Welcome to GNU Radio Companion Compiler 3.9.0.0-git >>>

Block paths:
	/usr/local/share/gnuradio/grc/blocks

>>> Loading: /home/kvothe/gr-tutorial/examples/tutorial2/grc_files/tutorial_two_2.grc
>>> Load Error: /home/kvothe/gr-tutorial/examples/tutorial2/grc_files/tutorial_two_2.grc: Flowgraph invalid
**************************************************
3 errors from flowgraph:
Source - out(0):
	Port is not connected.Source - out(0):
	Port is not connected.Sink - in(0):
	Port is not connected.
**************************************************
Compilation error
```