### PR TITLE
gr-blocks: SimpleXMLRPCServer was moved in Python3

### DIFF
--- a/gr-blocks/grc/xmlrpc_server.block.yml
+++ b/gr-blocks/grc/xmlrpc_server.block.yml
@@ -14,10 +14,10 @@ parameters:
 
 templates:
     imports: |-
-        import SimpleXMLRPCServer
+        from xmlrpc.server import SimpleXMLRPCServer
         import threading
     make: |-
-        SimpleXMLRPCServer.SimpleXMLRPCServer((${addr}, ${port}), allow_none=True)
+        SimpleXMLRPCServer((${addr}, ${port}), allow_none=True)
         self.${id}.register_instance(self)
         self.${id}_thread = threading.Thread(target=self.${id}.serve_forever)
         self.${id}_thread.daemon = True


### PR DESCRIPTION
The **XML RPC Server** block will not work in a python3-based GNU Radio installation, because of this:

> **Note** The SimpleXMLRPCServer module has been merged into xmlrpc.server in Python 3.
> (Source: https://docs.python.org/2/library/simplexmlrpcserver.html)

This PR fixes the issue and works correctly in Python 3.

NB: This should probably also make its way into maint-3.8, but I'm new to the party... please let me know if I should resubmit in a different way to achieve this.