### PR TITLE
Fix Log4Cpp cmake dependency

### DIFF
--- a/cmake/Modules/FindLOG4CPP.cmake
+++ b/cmake/Modules/FindLOG4CPP.cmake
@@ -48,7 +48,7 @@ else ()
 endif ()
 
 
-if (LOG4CPP_FOUND AND NOT TARGET Log4cpp::log4cpp)
+if (LOG4CPP_FOUND AND NOT TARGET Log4Cpp::log4cpp)
   add_library(Log4Cpp::log4cpp INTERFACE IMPORTED)
   set_target_properties(Log4Cpp::log4cpp PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${LOG4CPP_INCLUDE_DIRS}"


### PR DESCRIPTION
This bug breaks `gr-iio` build in Arch Linux.

This was partially fixed in 23bf13685faabe40fed4314534ae71936cdbeece.
Apparently, proper capitalization is hard :)