### PR TITLE
FECAPI Fix heap corruption bug in async_decoder

### DIFF
--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -116,7 +116,7 @@ void async_decoder_impl::decode_unpacked(pmt::pmt_t msg)
     size_t nbits_in = pmt::length(bits);
     size_t nbits_out = 0;
     size_t nblocks = 1;
-    bool variable_frame_size = d_decoder->set_frame_size(nbits_in * d_decoder->rate());
+    bool variable_frame_size = d_decoder->set_frame_size(nbits_in * d_decoder->rate() - diff);
 
     // Check here if the frame size is larger than what we've
     // allocated for in the constructor.


### PR DESCRIPTION
When using async_decoder with a CC decoder with k = 7 and no input byte packing, the frame size of the underlying FEC decoder is set incorrectly to a too large value. This causes out of bounds accesses which corrupt the heap.

The context of this bug is as follows. When using the FECAPI Async Decoder with a CC Decoder to perform Viterbi decoding of frames with r=1/2, k=7 terminated CC, no input byte padding and unpacked output, for some frame sizes the heap is quickly corrupted by the decoder, causing a segmentation fault. The flowgraph [here](https://gist.github.com/daniestevez/98d397a3076decd8243677f31ae014c1) reproduces this bug. It will segfault under maint-3.8 (and most likely GNU Radio 3.7 and `master`), and doesn't segfault with this patch applied.

This is a longstanding issue. I first encountered it in [March 2018](https://lists.gnu.org/archive/html/discuss-gnuradio/2018-03/msg00218.html), but only now I set down to study and track the problem.

Below, I included a more detailed explanation of the arithmetic leading to this problem.

Assume an (uncoded) frame size of `B` bits, terminated CC with `r = 1/2`, `k = 7`. The coded
frame is `2*B + 12` bits long. We don't use input padding.

We enter [`async_decoder_impl::decode_unpacked()`](https://github.com/gnuradio/gnuradio/blob/f3dcc45afea4fafa84b0c0e861031105a67bbaf2/gr-fec/lib/async_decoder_impl.cc#L104). We have
```
d_decoder->rate() = 1.0/d_rate = 0.5
d_decoder->get_input_size() = d_rate * (d_frame_size + d_k - 1) + d_padding
d_decoder->get_output_size() = d_frame_size
```
Therefore
```
diff = d_decoder->rate() * d_decoder->get_input_size() - d_decoder->get_output_size()
     = d_k - 1 + d_padding
```
Note `d_padding = 0`, so
```
diff = 6
```

Now we call [`cc_decoder_impl::set_frame_size()`](https://github.com/gnuradio/gnuradio/blob/f3dcc45afea4fafa84b0c0e861031105a67bbaf2/gr-fec/lib/cc_decoder_impl.cc#L393) by doing
```
d_decoder->set_frame_size(nbits_in * d_decoder->rate())
```
We have `nbits_in = 2*B + 12`, so the argument in this call is `B + 6`. Since `d_padding = 0`, this
call just sets
```
d_veclen = d_frame_size + d_k - 1 = B + 12
```
and returns `true`.

Back in `async_decoder_impl::decode_unpacked()`, we set
```
nbits_out = nbits_in * d_decoder->rate() - diff = B + 6 - diff = B
```
This is correct. The output should be `B` bits. Note that `outvect` is allocated a
size of `nbits_out = B` `uint8_t`'s for unpacked bit output.

However now we call
```
d_decoder->generic_work((void*)d_tmp_u8, (void*)u8out)
```
This will call
```
update_viterbi_blk(d_managed_in, d_veclen)
```
with `d_veclen = B + 12` as it was set before.

This parameter enters as the `nbits` parameter in the call to `d_kernel()` as
```
d_kernel(d_vp->new_metrics.t,
             d_vp->old_metrics.t,
             syms,
             d,
             nbits - (d_k - 1),
             d_k - 1,
             Branchtab);
```
So the 5th parameter of `d_kernel()` is
```
n_bits - (d_k - 1) = B + 6
```
Now, `d_kernel()` is `volk_8u_x4_conv_k7_r2_8u()`. If we look at the implementation
[`volk_8u_x4_conv_k7_r2_8u_generic()`](https://github.com/gnuradio/volk/blob/99037d9641e125dbb77c22cb4cb7608be4b8f262/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h#L615), the 5th parameter is `framebits`. There we
also have
```
nbits = framebits + excess = nbits - (d_k - 1) + d_k - 1 = nbits = B + 12.
```
The `BFLY()` loop now loops as
```
for (s=0;s<nbits;s++)
```
As we can see in the implementation of [`BFLY()`](https://github.com/gnuradio/volk/blob/master/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h#L89), each call to `BFLY()` looks at
```
syms[s*RATE+j] for j = 0,..., RATE-1.
```
Therefore, for `r = 1/2`, each call to `BFLY()` looks at 2 input symbols and this
call ends up consuming `2*nbits = 2*B + 24` input symbols. This is not correct, as there
are only `2*B + 12` symbols.

Of course this out of bound access in the input is not correct but it doesn't justify the heap corruption per se. I haven't delved any further, but I guess that since the Viterbi decoder processes `2*B+24` input symbols, it also too many output symbols, causing an out of bounds access in `outvec`.

The problem can be traced back: `d_veclen` should be `B + 6` instead of `B + 12`, so the call to
`
d_decoder->set_frame_size()
`
should be made with `B` instead of `B + 6`. This is accomplished by calling
```
d_decoder->set_frame_size(nbits_in * d_decoder->rate() - diff)
```
instead of
```
d_decoder->set_frame_size(nbits_in * d_decoder->rate())
```

**Note:** I haven't considered the effects of this patch for other FEC decoders. In particular, the calculation of `diff` is [already marked](https://github.com/gnuradio/gnuradio/blob/f3dcc45afea4fafa84b0c0e861031105a67bbaf2/gr-fec/lib/async_decoder_impl.cc#L110) as potentially problematic.
