### PR TITLE
grc: loosen the validation of block in function probe

### DIFF
--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -5,7 +5,7 @@ flags: [ show_id, python ]
 parameters:
 -   id: block_id
     label: Block ID
-    dtype: id
+    dtype: name
     default: my_block_0
 -   id: function_name
     label: Function Name

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -70,10 +70,12 @@ def validate_block_id(param):
 
 @validates('name')
 def validate_name(param):
-    # Name of a function that will be generated literally not as a string
+    # Name of a function or other block that will be generated literally not as a string
     value = param.value
+
+    # Allow blank to pass validation
     # Can python use this as a variable?
-    if not re.match(r'^[a-z|A-Z]\w*$', value):
+    if not re.match(r'^([a-z|A-Z]\w*)?$', value):
         raise ValidateError('ID "{}" must begin with a letter and may contain letters, numbers, '
                             'and underscores.'.format(value))
     return value


### PR DESCRIPTION
The block_id parameter for the block being probed was being validated as
a block_id.  But there is a use case where this can be blank to call a
function on the flowgraph object itself.

Changed the block_id dtype to "name" just like function_name.  Could
have just changed it to raw and done no validation, but that doesn't get
displayed very nicely in the grc block

Fixes #2966