### PR TITLE
Switch from boost pointers to std C++11 pointers

### DIFF
--- a/README.hacking
+++ b/README.hacking
@@ -105,14 +105,14 @@ Each significant class shall be contained in its own file.
 
 * Storage management
 
-Strongly consider using the boost smart pointer templates, scoped_ptr
-and shared_ptr.  scoped_ptr should be used for locals that contain
+Strongly consider using the std smart pointer templates, unique_ptr
+and shared_ptr.  unique_ptr should be used for locals that contain
 pointers to objects that we need to delete when we exit the current
 scope.  shared_ptr implements transparent reference counting and is a
 major win.  You never have to worry about calling delete.  The right
 thing happens.
 
-See http://www.boost.org/libs/smart_ptr/smart_ptr.htm
+See https://en.cppreference.com/book/intro/smart_pointers
 
 
 * Unit tests

--- a/docs/doxygen/other/shared_ptr_docstub.h
+++ b/docs/doxygen/other/shared_ptr_docstub.h
@@ -1,4 +1,4 @@
-namespace boost {
+namespace std {
 /*!
  * \brief shared_ptr documentation stub
  *
@@ -20,4 +20,4 @@ public:
 }; // shared_ptr
 
 
-} // namespace boost
+} // namespace std

--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -54,7 +54,7 @@ namespace gr {
  * processing functions.
  */
 class GR_RUNTIME_API basic_block : public msg_accepter,
-                                   public boost::enable_shared_from_this<basic_block>
+                                   public std::enable_shared_from_this<basic_block>
 {
     typedef boost::function<void(pmt::pmt_t)> msg_handler_t;
 
@@ -66,7 +66,7 @@ private:
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator> msg_queue_map_t;
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator>::iterator
         msg_queue_map_itr;
-    std::map<pmt::pmt_t, boost::shared_ptr<boost::condition_variable>, pmt::comparator>
+    std::map<pmt::pmt_t, std::shared_ptr<boost::condition_variable>, pmt::comparator>
         msg_queue_ready;
 
     gr::thread::mutex mutex; //< protects all vars

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -967,7 +967,7 @@ typedef std::vector<block_sptr>::iterator block_viter_t;
 
 inline block_sptr cast_to_block_sptr(basic_block_sptr p)
 {
-    return boost::dynamic_pointer_cast<block, basic_block>(p);
+    return std::dynamic_pointer_cast<block, basic_block>(p);
 }
 
 GR_RUNTIME_API std::ostream& operator<<(std::ostream& os, const block* m);

--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -98,7 +98,7 @@ class GR_RUNTIME_API block_gateway : virtual public gr::block
 {
 public:
     // gr::block_gateway::sptr
-    typedef boost::shared_ptr<block_gateway> sptr;
+    typedef std::shared_ptr<block_gateway> sptr;
 
     /*!
      * Make a new gateway block.

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -170,7 +170,7 @@ private:
     gr::vmcircbuf* d_vmcircbuf;
     size_t d_sizeof_item; // in bytes
     std::vector<buffer_reader*> d_readers;
-    boost::weak_ptr<block> d_link; // block that writes to this buffer
+    std::weak_ptr<block> d_link; // block that writes to this buffer
 
     //
     // The mutex protects d_write_index, d_abs_write_offset, d_done, d_item_tags
@@ -347,7 +347,7 @@ private:
     buffer_sptr d_buffer;
     unsigned int d_read_index;     // in items [0,d->buffer.d_bufsize)
     uint64_t d_abs_read_offset;    // num items seen since the start
-    boost::weak_ptr<block> d_link; // block that reads via this buffer reader
+    std::weak_ptr<block> d_link; // block that reads via this buffer reader
     unsigned d_attr_delay;         // sample delay attribute for tag propagation
 
     //! constructor is private.  Use gr::buffer::add_reader to create instances

--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -331,7 +331,7 @@ GR_RUNTIME_API std::string dot_graph(hier_block2_sptr hierblock2);
 
 inline hier_block2_sptr cast_to_hier_block2_sptr(basic_block_sptr block)
 {
-    return boost::dynamic_pointer_cast<hier_block2, basic_block>(block);
+    return std::dynamic_pointer_cast<hier_block2, basic_block>(block);
 }
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/io_signature.h
+++ b/gnuradio-runtime/include/gnuradio/io_signature.h
@@ -43,7 +43,7 @@ class GR_RUNTIME_API io_signature
                  const std::vector<int>& sizeof_stream_items);
 
 public:
-    typedef boost::shared_ptr<io_signature> sptr;
+    typedef std::shared_ptr<io_signature> sptr;
 
     static const int IO_INFINITE = -1;
 

--- a/gnuradio-runtime/include/gnuradio/message.h
+++ b/gnuradio-runtime/include/gnuradio/message.h
@@ -39,7 +39,7 @@ namespace gr {
 class GR_RUNTIME_API message
 {
 public:
-    typedef boost::shared_ptr<message> sptr;
+    typedef std::shared_ptr<message> sptr;
 
 private:
     sptr d_next;   // link field for msg queue

--- a/gnuradio-runtime/include/gnuradio/messages/msg_accepter.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_accepter.h
@@ -24,7 +24,7 @@
 
 #include <gnuradio/api.h>
 #include <pmt/pmt.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace messages {
@@ -48,7 +48,7 @@ public:
     virtual void post(pmt::pmt_t which_port, pmt::pmt_t msg) = 0;
 };
 
-typedef boost::shared_ptr<msg_accepter> msg_accepter_sptr;
+typedef std::shared_ptr<msg_accepter> msg_accepter_sptr;
 
 } /* namespace messages */
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/messages/msg_producer.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_producer.h
@@ -24,7 +24,7 @@
 
 #include <gnuradio/api.h>
 #include <pmt/pmt.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace messages {
@@ -44,7 +44,7 @@ public:
     virtual pmt::pmt_t retrieve() = 0;
 };
 
-typedef boost::shared_ptr<msg_producer> msg_producer_sptr;
+typedef std::shared_ptr<msg_producer> msg_producer_sptr;
 
 } /* namespace messages */
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/messages/msg_queue.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_queue.h
@@ -32,7 +32,7 @@ namespace gr {
 namespace messages {
 
 class msg_queue;
-typedef boost::shared_ptr<msg_queue> msg_queue_sptr;
+typedef std::shared_ptr<msg_queue> msg_queue_sptr;
 
 msg_queue_sptr make_msg_queue(unsigned int limit = 0);
 

--- a/gnuradio-runtime/include/gnuradio/msg_handler.h
+++ b/gnuradio-runtime/include/gnuradio/msg_handler.h
@@ -29,7 +29,7 @@
 namespace gr {
 
 class msg_handler;
-typedef boost::shared_ptr<msg_handler> msg_handler_sptr;
+typedef std::shared_ptr<msg_handler> msg_handler_sptr;
 
 /*!
  * \brief abstract class of message handlers

--- a/gnuradio-runtime/include/gnuradio/msg_queue.h
+++ b/gnuradio-runtime/include/gnuradio/msg_queue.h
@@ -44,7 +44,7 @@ class GR_RUNTIME_API msg_queue : public msg_handler
     unsigned int d_limit; // max # of messages in queue.  0 -> unbounded
 
 public:
-    typedef boost::shared_ptr<msg_queue> sptr;
+    typedef std::shared_ptr<msg_queue> sptr;
 
     static sptr make(unsigned int limit = 0);
 

--- a/gnuradio-runtime/include/gnuradio/rpcmanager_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpcmanager_base.h
@@ -23,7 +23,7 @@
 #ifndef RPCMANAGER_BASE_H
 #define RPCMANAGER_BASE_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class rpcserver_booter_base;
 // class rpcserver_booter_aggregator;
@@ -31,7 +31,7 @@ class rpcserver_booter_base;
 class rpcmanager_base
 {
 public:
-    typedef boost::shared_ptr<rpcserver_booter_base> rpcserver_booter_base_sptr;
+    typedef std::shared_ptr<rpcserver_booter_base> rpcserver_booter_base_sptr;
 
     rpcmanager_base() { ; }
     ~rpcmanager_base() { ; }

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -33,7 +33,7 @@
 
 // Fixes circular dependency issue before including block_registry.h
 class rpcbasic_base;
-typedef boost::shared_ptr<rpcbasic_base> rpcbasic_sptr;
+typedef std::shared_ptr<rpcbasic_base> rpcbasic_sptr;
 
 #include <gnuradio/block_registry.h>
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_base.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_base.h
@@ -45,7 +45,7 @@ public:
 
     virtual void setCurPrivLevel(const priv_lvl_t priv) { cur_priv = priv; }
 
-    typedef boost::shared_ptr<rpcserver_base> rpcserver_base_sptr;
+    typedef std::shared_ptr<rpcserver_base> rpcserver_base_sptr;
 
 protected:
     priv_lvl_t cur_priv;

--- a/gnuradio-runtime/include/gnuradio/rpcserver_booter_aggregator.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_booter_aggregator.h
@@ -26,7 +26,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/rpcserver_aggregator.h>
 #include <gnuradio/rpcserver_booter_base.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 class rpcserver_server;
@@ -49,7 +49,7 @@ protected:
 
 private:
     std::string d_type;
-    boost::shared_ptr<rpcserver_aggregator> server;
+    std::shared_ptr<rpcserver_aggregator> server;
 };
 
 #endif /* RPCSERVER_BOOTER_AGGREGATOR */

--- a/gnuradio-runtime/include/gnuradio/runtime_types.h
+++ b/gnuradio-runtime/include/gnuradio/runtime_types.h
@@ -41,15 +41,15 @@ class flat_flowgraph;
 class flowgraph;
 class top_block;
 
-typedef boost::shared_ptr<basic_block> basic_block_sptr;
-typedef boost::shared_ptr<block> block_sptr;
-typedef boost::shared_ptr<block_detail> block_detail_sptr;
-typedef boost::shared_ptr<buffer> buffer_sptr;
-typedef boost::shared_ptr<buffer_reader> buffer_reader_sptr;
-typedef boost::shared_ptr<hier_block2> hier_block2_sptr;
-typedef boost::shared_ptr<flat_flowgraph> flat_flowgraph_sptr;
-typedef boost::shared_ptr<flowgraph> flowgraph_sptr;
-typedef boost::shared_ptr<top_block> top_block_sptr;
+typedef std::shared_ptr<basic_block> basic_block_sptr;
+typedef std::shared_ptr<block> block_sptr;
+typedef std::shared_ptr<block_detail> block_detail_sptr;
+typedef std::shared_ptr<buffer> buffer_sptr;
+typedef std::shared_ptr<buffer_reader> buffer_reader_sptr;
+typedef std::shared_ptr<hier_block2> hier_block2_sptr;
+typedef std::shared_ptr<flat_flowgraph> flat_flowgraph_sptr;
+typedef std::shared_ptr<flowgraph> flowgraph_sptr;
+typedef std::shared_ptr<top_block> top_block_sptr;
 
 } /* namespace gr */
 

--- a/gnuradio-runtime/include/gnuradio/sptr_magic.h
+++ b/gnuradio-runtime/include/gnuradio/sptr_magic.h
@@ -23,7 +23,7 @@
 #define INCLUDED_GR_RUNTIME_SPTR_MAGIC_H
 
 #include <gnuradio/api.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 class basic_block;
@@ -36,7 +36,7 @@ namespace detail {
 class GR_RUNTIME_API sptr_magic
 {
 public:
-    static boost::shared_ptr<gr::basic_block> fetch_initial_sptr(gr::basic_block* p);
+    static std::shared_ptr<gr::basic_block> fetch_initial_sptr(gr::basic_block* p);
     static void create_and_stash_initial_sptr(gr::hier_block2* p);
     static void cancel_initial_sptr(gr::hier_block2* p);
 };
@@ -44,12 +44,12 @@ public:
 
 /*
  * \brief New!  Improved!  Standard method to get/create the
- * boost::shared_ptr for a block.
+ * std::shared_ptr for a block.
  */
 template <class T>
-boost::shared_ptr<T> get_initial_sptr(T* p)
+std::shared_ptr<T> get_initial_sptr(T* p)
 {
-    return boost::dynamic_pointer_cast<T, gr::basic_block>(
+    return std::dynamic_pointer_cast<T, gr::basic_block>(
         detail::sptr_magic::fetch_initial_sptr(p));
 }
 } // namespace gnuradio

--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -23,7 +23,7 @@
 #define INCLUDED_THREAD_H
 
 #include <gnuradio/api.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/thread/barrier.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>
@@ -49,7 +49,7 @@ typedef boost::mutex mutex;
 typedef boost::unique_lock<boost::mutex> scoped_lock;
 typedef boost::condition_variable condition_variable;
 typedef boost::barrier barrier;
-typedef boost::shared_ptr<barrier> barrier_sptr;
+typedef std::shared_ptr<barrier> barrier_sptr;
 
 /*! \brief a system-dependent typedef for the underlying thread type.
  */

--- a/gnuradio-runtime/include/gnuradio/thrift_application_base.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_application_base.h
@@ -63,7 +63,7 @@ public:
     // Stores the generated endpoint string after the Thrift runtime has initialized.
     std::string d_endpointStr;
     // Thread to execute the Thrift runtime's blocking serve() function.
-    boost::shared_ptr<gr::thread::thread> d_start_thrift_thread;
+    std::shared_ptr<gr::thread::thread> d_start_thrift_thread;
 };
 
 /*!

--- a/gnuradio-runtime/include/gnuradio/thrift_server_template.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_server_template.h
@@ -50,11 +50,11 @@ protected:
     friend class thrift_application_base<TserverBase, TImplClass>;
 
 private:
-    boost::shared_ptr<TserverClass> d_handler;
-    boost::shared_ptr<thrift::TProcessor> d_processor;
-    boost::shared_ptr<thrift::transport::TServerTransport> d_serverTransport;
-    boost::shared_ptr<thrift::transport::TTransportFactory> d_transportFactory;
-    boost::shared_ptr<thrift::protocol::TProtocolFactory> d_protocolFactory;
+    std::shared_ptr<TserverClass> d_handler;
+    std::shared_ptr<thrift::TProcessor> d_processor;
+    std::shared_ptr<thrift::transport::TServerTransport> d_serverTransport;
+    std::shared_ptr<thrift::transport::TTransportFactory> d_transportFactory;
+    std::shared_ptr<thrift::protocol::TProtocolFactory> d_protocolFactory;
     /**
      * Custom TransportFactory that allows you to override the default Thrift buffer size
      * of 512 bytes.
@@ -71,10 +71,10 @@ private:
 
         virtual ~TBufferedTransportFactory() {}
 
-        virtual boost::shared_ptr<thrift::transport::TTransport>
-        getTransport(boost::shared_ptr<thrift::transport::TTransport> trans)
+        virtual std::shared_ptr<thrift::transport::TTransport>
+        getTransport(std::shared_ptr<thrift::transport::TTransport> trans)
         {
-            return boost::shared_ptr<thrift::transport::TTransport>(
+            return std::shared_ptr<thrift::transport::TTransport>(
                 new thrift::transport::TBufferedTransport(trans, bufferSize));
         }
 
@@ -133,11 +133,11 @@ thrift_server_template<TserverBase, TserverClass, TImplClass>::thrift_server_tem
                 d_processor, d_serverTransport, d_transportFactory, d_protocolFactory));
     } else {
         // std::cout << "Thrift Multi-threaded server : " << d_nthreads << std::endl;
-        boost::shared_ptr<thrift::concurrency::ThreadManager> threadManager(
+        std::shared_ptr<thrift::concurrency::ThreadManager> threadManager(
             thrift::concurrency::ThreadManager::newSimpleThreadManager(nthreads));
 
         threadManager->threadFactory(
-            boost::shared_ptr<thrift::concurrency::PlatformThreadFactory>(
+            std::shared_ptr<thrift::concurrency::PlatformThreadFactory>(
                 new thrift::concurrency::PlatformThreadFactory()));
 
         threadManager->start();

--- a/gnuradio-runtime/include/gnuradio/top_block.h
+++ b/gnuradio-runtime/include/gnuradio/top_block.h
@@ -144,7 +144,7 @@ public:
 
 inline top_block_sptr cast_to_top_block_sptr(basic_block_sptr block)
 {
-    return boost::dynamic_pointer_cast<top_block, basic_block>(block);
+    return std::dynamic_pointer_cast<top_block, basic_block>(block);
 }
 
 } // namespace gr

--- a/gnuradio-runtime/include/gnuradio/types.h
+++ b/gnuradio-runtime/include/gnuradio/types.h
@@ -25,7 +25,7 @@
 
 #include <gnuradio/api.h>
 #include <stddef.h> // size_t
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 #include <gnuradio/gr_complex.h>

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 #include <boost/any.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <complex>
 #include <iosfwd>
 #include <stdexcept>
@@ -93,7 +93,7 @@ public:
  * \brief typedef for shared pointer (transparent reference counting).
  * See http://www.boost.org/libs/smart_ptr/smart_ptr.htm
  */
-typedef boost::shared_ptr<pmt_base> pmt_t;
+typedef std::shared_ptr<pmt_base> pmt_t;
 
 class PMT_API exception : public std::logic_error
 {
@@ -715,10 +715,10 @@ PMT_API void any_set(pmt_t obj, const boost::any& any);
 PMT_API bool is_msg_accepter(const pmt_t& obj);
 
 //! make a msg_accepter
-PMT_API pmt_t make_msg_accepter(boost::shared_ptr<gr::messages::msg_accepter> ma);
+PMT_API pmt_t make_msg_accepter(std::shared_ptr<gr::messages::msg_accepter> ma);
 
 //! Return underlying msg_accepter
-PMT_API boost::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t& obj);
+PMT_API std::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t& obj);
 
 /*
  * ------------------------------------------------------------------------

--- a/gnuradio-runtime/include/pmt/pmt_sugar.h
+++ b/gnuradio-runtime/include/pmt/pmt_sugar.h
@@ -65,7 +65,7 @@ static inline pmt_t mp(std::complex<float> z)
 }
 
 //! Make pmt msg_accepter
-static inline pmt_t mp(boost::shared_ptr<gr::messages::msg_accepter> ma)
+static inline pmt_t mp(std::shared_ptr<gr::messages::msg_accepter> ma)
 {
     return make_msg_accepter(ma);
 }

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -87,7 +87,7 @@ void basic_block::message_port_register_in(pmt::pmt_t port_id)
     }
     msg_queue[port_id] = msg_queue_t();
     msg_queue_ready[port_id] =
-        boost::shared_ptr<boost::condition_variable>(new boost::condition_variable());
+        std::shared_ptr<boost::condition_variable>(new boost::condition_variable());
 }
 
 pmt::pmt_t basic_block::message_ports_in()

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -59,7 +59,7 @@ static long s_buffer_reader_count = 0;
  both want pointers to each other, and unless we do something, we'll
  never delete any of them because of the circular structure.
  They'll always have a reference count of at least one.  We could
- use boost::weak_ptr's from gr::buffer to gr::buffer_reader but that
+ use std::weak_ptr's from gr::buffer to gr::buffer_reader but that
  introduces it's own problems.  (gr::buffer_reader's destructor needs
  to call gr::buffer::drop_reader, but has no easy way to get a
  shared_ptr to itself.)

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -593,7 +593,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         if (set_all_min_buff) {
             // sets the min buff for every block within hier_block2
             if (min_buff != 0) {
-                block_sptr bb = boost::dynamic_pointer_cast<block>(b);
+                block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -602,7 +602,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
-                    hier_block2_sptr hh = boost::dynamic_pointer_cast<hier_block2>(b);
+                    hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -618,7 +618,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         if (set_all_max_buff) {
             // sets the max buff for every block within hier_block2
             if (max_buff != 0) {
-                block_sptr bb = boost::dynamic_pointer_cast<block>(b);
+                block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -627,7 +627,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
-                    hier_block2_sptr hh = boost::dynamic_pointer_cast<hier_block2>(b);
+                    hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -645,7 +645,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         if (set_all_min_buff) {
             // sets the min buff for every block within hier_block2
             if (min_buff != 0) {
-                block_sptr bb = boost::dynamic_pointer_cast<block>(b);
+                block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -654,7 +654,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
-                    hier_block2_sptr hh = boost::dynamic_pointer_cast<hier_block2>(b);
+                    hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -670,7 +670,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         if (set_all_max_buff) {
             // sets the max buff for every block within hier_block2
             if (max_buff != 0) {
-                block_sptr bb = boost::dynamic_pointer_cast<block>(b);
+                block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -679,7 +679,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
-                    hier_block2_sptr hh = boost::dynamic_pointer_cast<hier_block2>(b);
+                    hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -805,7 +805,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         if (!set_all_min_buff) {
             min_buff = d_owner->min_output_buffer(i);
             if (min_buff != 0) {
-                block_sptr bb = boost::dynamic_pointer_cast<block>(blk);
+                block_sptr bb = std::dynamic_pointer_cast<block>(blk);
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
                     if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -814,7 +814,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                                   << std::endl;
                     bb->set_min_output_buffer(bb_src_port, min_buff);
                 } else {
-                    hier_block2_sptr hh = boost::dynamic_pointer_cast<hier_block2>(blk);
+                    hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
                         if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -829,7 +829,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         if (!set_all_max_buff) {
             max_buff = d_owner->max_output_buffer(i);
             if (max_buff != 0) {
-                block_sptr bb = boost::dynamic_pointer_cast<block>(blk);
+                block_sptr bb = std::dynamic_pointer_cast<block>(blk);
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
                     if (HIER_BLOCK2_DETAIL_DEBUG)
@@ -838,7 +838,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                                   << std::endl;
                     bb->set_max_output_buffer(bb_src_port, max_buff);
                 } else {
-                    hier_block2_sptr hh = boost::dynamic_pointer_cast<hier_block2>(blk);
+                    hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
                         if (HIER_BLOCK2_DETAIL_DEBUG)

--- a/gnuradio-runtime/lib/scheduler.h
+++ b/gnuradio-runtime/lib/scheduler.h
@@ -30,7 +30,7 @@
 namespace gr {
 
 class scheduler;
-typedef boost::shared_ptr<scheduler> scheduler_sptr;
+typedef std::shared_ptr<scheduler> scheduler_sptr;
 
 /*!
  * \brief Abstract scheduler that takes a flattened flow graph and

--- a/gnuradio-runtime/lib/scheduler_tpb.cc
+++ b/gnuradio-runtime/lib/scheduler_tpb.cc
@@ -76,7 +76,7 @@ scheduler_tpb::scheduler_tpb(flat_flowgraph_sptr ffg, int max_noutput_items)
     }
 
     thread::barrier_sptr start_sync =
-        boost::make_shared<thread::barrier>(blocks.size() + 1);
+        std::make_shared<thread::barrier>(blocks.size() + 1);
 
     // Fire off a thead for each block
 

--- a/gnuradio-runtime/lib/sptr_magic.cc
+++ b/gnuradio-runtime/lib/sptr_magic.cc
@@ -65,7 +65,7 @@ void detail::sptr_magic::cancel_initial_sptr(gr::hier_block2* p)
         return; /* Not in the map, nothing to do */
     gr::basic_block_sptr sptr = pos->second;
     s_map.erase(pos);
-    boost::get_deleter<disarmable_deleter, gr::basic_block>(sptr)->disarm();
+    std::get_deleter<disarmable_deleter, gr::basic_block>(sptr)->disarm();
 }
 
 gr::basic_block_sptr detail::sptr_magic::fetch_initial_sptr(gr::basic_block* p)

--- a/gnuradio-runtime/lib/test.h
+++ b/gnuradio-runtime/lib/test.h
@@ -31,7 +31,7 @@
 namespace gr {
 
 class test;
-typedef boost::shared_ptr<test> test_sptr;
+typedef std::shared_ptr<test> test_sptr;
 
 // public constructor
 GR_RUNTIME_API test_sptr make_test(const std::string& name = std::string("test"),

--- a/gnuradio-runtime/swig/basic_block.i
+++ b/gnuradio-runtime/swig/basic_block.i
@@ -21,8 +21,8 @@
  */
 
 class gr::basic_block;
-typedef boost::shared_ptr<gr::basic_block> gr::basic_block_sptr;
-%template(basic_block_sptr) boost::shared_ptr<gr::basic_block>;
+typedef std::shared_ptr<gr::basic_block> gr::basic_block_sptr;
+%template(basic_block_sptr) std::shared_ptr<gr::basic_block>;
 
 %import "pmt_swig.i"
 

--- a/gnuradio-runtime/swig/block.i
+++ b/gnuradio-runtime/swig/block.i
@@ -23,8 +23,8 @@
 %include <basic_block.i>
 
 class gr::block;
-typedef boost::shared_ptr<gr::block> gr::block_sptr;
-%template(block_sptr) boost::shared_ptr<gr::block>;
+typedef std::shared_ptr<gr::block> gr::block_sptr;
+%template(block_sptr) std::shared_ptr<gr::block>;
 
 // support vectors of these...
 namespace std {

--- a/gnuradio-runtime/swig/block_detail.i
+++ b/gnuradio-runtime/swig/block_detail.i
@@ -21,8 +21,8 @@
  */
 
 class gr::block_detail;
-typedef boost::shared_ptr<gr::block_detail> gr::block_detail_sptr;
-%template(block_detail_sptr) boost::shared_ptr<gr::block_detail>;
+typedef std::shared_ptr<gr::block_detail> gr::block_detail_sptr;
+%template(block_detail_sptr) std::shared_ptr<gr::block_detail>;
 %rename(block_detail) gr::make_block_detail;
 %ignore gr::block_detail;
 

--- a/gnuradio-runtime/swig/block_gateway.i
+++ b/gnuradio-runtime/swig/block_gateway.i
@@ -41,7 +41,7 @@
 ////////////////////////////////////////////////////////////////////////
 %include <gnuradio/block_gateway.h>
 
-%template(block_gateway_sptr) boost::shared_ptr<gr::block_gateway>;
+%template(block_gateway_sptr) std::shared_ptr<gr::block_gateway>;
 %pythoncode %{
 block_gateway_sptr.__repr__ = lambda self: "<block_gateway>"
 block_gateway = block_gateway.make;

--- a/gnuradio-runtime/swig/buffer.i
+++ b/gnuradio-runtime/swig/buffer.i
@@ -21,8 +21,8 @@
  */
 
 class gr::buffer;
-typedef boost::shared_ptr<gr::buffer> gr::buffer_sptr;
-%template(buffer_sptr) boost::shared_ptr<gr::buffer>;
+typedef std::shared_ptr<gr::buffer> gr::buffer_sptr;
+%template(buffer_sptr) std::shared_ptr<gr::buffer>;
 %rename(buffer) gr::make_buffer;
 %ignore gr::buffer;
 
@@ -30,8 +30,8 @@ gr::buffer_sptr
 gr::make_buffer (int nitems, size_t sizeof_item, gr::block_sptr link);
 
 class gr::buffer_reader;
-typedef boost::shared_ptr<gr::buffer_reader> gr::buffer_reader_sptr;
-%template(buffer_reader_sptr) boost::shared_ptr<gr::buffer_reader>;
+typedef std::shared_ptr<gr::buffer_reader> gr::buffer_reader_sptr;
+%template(buffer_reader_sptr) std::shared_ptr<gr::buffer_reader>;
 %ignore gr::buffer_reader;
 
 %rename(buffer_add_reader) gr::buffer_add_reader;

--- a/gnuradio-runtime/swig/gr_shared_ptr.i
+++ b/gnuradio-runtime/swig/gr_shared_ptr.i
@@ -7,12 +7,12 @@
 //
 
 //
-// This is highly hacked up version of boost::shared_ptr
+// This is highly hacked up version of std::shared_ptr
 // We just need enough to get SWIG to "do the right thing" and
 // generate "Smart Pointer" code.
 //
 
-namespace boost {
+namespace std {
 
 template<class T> class shared_ptr
 {

--- a/gnuradio-runtime/swig/gr_swig_block_magic.i
+++ b/gnuradio-runtime/swig/gr_swig_block_magic.i
@@ -26,8 +26,8 @@ _GR_SWIG_BLOCK_MAGIC_HELPER(PKG, BASE_NAME, PKG ## _ ## BASE_NAME)
 
 %define _GR_SWIG_BLOCK_MAGIC_HELPER_COMMON(PKG, BASE_NAME, FULL_NAME)
 class FULL_NAME;
-typedef boost::shared_ptr<FULL_NAME> FULL_NAME ## _sptr;
-%template(FULL_NAME ## _sptr) boost::shared_ptr<FULL_NAME>;
+typedef std::shared_ptr<FULL_NAME> FULL_NAME ## _sptr;
+%template(FULL_NAME ## _sptr) std::shared_ptr<FULL_NAME>;
 %rename(BASE_NAME) PKG ## _make_ ## BASE_NAME;
 %ignore FULL_NAME;
 %enddef
@@ -42,7 +42,7 @@ FULL_NAME ## _sptr.__repr__ = lambda self: "<gr_block %s (%d)>" % (self.name(), 
 #endif
 
 %define GR_SWIG_BLOCK_MAGIC2(PKG, BASE_NAME)
-%template(BASE_NAME ## _sptr) boost::shared_ptr<gr:: ## PKG ## :: ## BASE_NAME>;
+%template(BASE_NAME ## _sptr) std::shared_ptr<gr:: ## PKG ## :: ## BASE_NAME>;
 %pythoncode %{
 BASE_NAME ## _sptr.__repr__ = lambda self: "<gr_block %s (%d)>" % (self.name(), self.unique_id())
 BASE_NAME = BASE_NAME.make;
@@ -51,7 +51,7 @@ BASE_NAME = BASE_NAME.make;
 
 %define GR_SWIG_BLOCK_MAGIC2_TMPL(PKG, BASE_NAME, TARGET_NAME...)
 %template(BASE_NAME) gr:: ## PKG ## :: ## TARGET_NAME;
-%template(BASE_NAME ## _sptr) boost::shared_ptr<gr:: ## PKG ## :: ## TARGET_NAME ## >;
+%template(BASE_NAME ## _sptr) std::shared_ptr<gr:: ## PKG ## :: ## TARGET_NAME ## >;
 %pythoncode %{
 BASE_NAME ## _sptr.__repr__ = lambda self: "<gr_block %s (%d)>" % (self.name(), self.unique_id())
 BASE_NAME = BASE_NAME.make
@@ -60,7 +60,7 @@ BASE_NAME = BASE_NAME.make
 
 
 %define GR_SWIG_BLOCK_MAGIC_FACTORY(PKG, BASE_NAME, FACTORY)
-%template(FACTORY ## _sptr) boost::shared_ptr<gr:: ## PKG ## :: ## BASE_NAME>;
+%template(FACTORY ## _sptr) std::shared_ptr<gr:: ## PKG ## :: ## BASE_NAME>;
 %pythoncode %{
 FACTORY ## _sptr.__repr__ = lambda self: "<gr_block %s (%d)>" % (self.name(), self.unique_id())
 FACTORY = BASE_NAME ## _make_ ## FACTORY;

--- a/gnuradio-runtime/swig/gr_types.i
+++ b/gnuradio-runtime/swig/gr_types.i
@@ -26,7 +26,7 @@
 %include "stdint.i"
 
 %{
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/any.hpp>
 #include <complex>
 #include <string>

--- a/gnuradio-runtime/swig/hier_block2.i
+++ b/gnuradio-runtime/swig/hier_block2.i
@@ -23,8 +23,8 @@
 %include <basic_block.i>
 
 class gr::hier_block2;
-typedef boost::shared_ptr<gr::hier_block2> gr::hier_block2_sptr;
-%template(hier_block2_sptr) boost::shared_ptr<gr::hier_block2>;
+typedef std::shared_ptr<gr::hier_block2> gr::hier_block2_sptr;
+%template(hier_block2_sptr) std::shared_ptr<gr::hier_block2>;
 
 namespace gr {
   // Hack to have a Python shim implementation of gr.hier_block2

--- a/gnuradio-runtime/swig/io_signature.i
+++ b/gnuradio-runtime/swig/io_signature.i
@@ -28,7 +28,7 @@ namespace gr {
                  const std::vector<int> &sizeof_stream_items);
 
   public:
-    typedef boost::shared_ptr<io_signature> sptr;
+    typedef std::shared_ptr<io_signature> sptr;
 
     // Avoids a swig warning, otherwise we could just
     // #include <gnuradio/io_signature.h> instead of redoing this
@@ -59,7 +59,7 @@ namespace gr {
 } /* namespace gr */
 
 
-%template(io_signature_sptr) boost::shared_ptr<gr::io_signature>;
+%template(io_signature_sptr) std::shared_ptr<gr::io_signature>;
 %pythoncode %{
 io_signature_sptr.__repr__ = lambda self: "<io_signature: %d, %d>" % (self.min_streams(), self.max_streams())
 io_signaturev = io_signature.makev;

--- a/gnuradio-runtime/swig/message.i
+++ b/gnuradio-runtime/swig/message.i
@@ -37,7 +37,7 @@ namespace gr {
   class message
   {
   public:
-    typedef boost::shared_ptr<message> sptr;
+    typedef std::shared_ptr<message> sptr;
 
   private:
     message(long type, double arg1, double arg2, size_t length);
@@ -71,7 +71,7 @@ namespace gr {
 
 
 
-%template(message_sptr) boost::shared_ptr<gr::message>;
+%template(message_sptr) std::shared_ptr<gr::message>;
 %pythoncode %{
 message_from_string = message.make_from_string
 message = message.make

--- a/gnuradio-runtime/swig/msg_queue.i
+++ b/gnuradio-runtime/swig/msg_queue.i
@@ -27,7 +27,7 @@ namespace gr {
   class msg_queue : public gr::msg_handler
   {
   public:
-    typedef boost::shared_ptr<msg_queue> sptr;
+    typedef std::shared_ptr<msg_queue> sptr;
 
     static sptr make(unsigned int limit=0);
 
@@ -98,7 +98,7 @@ namespace gr {
 %}
 
 // smash in new python delete_head and insert_tail methods...
-%template(msg_queue_sptr) boost::shared_ptr<gr::msg_queue>;
+%template(msg_queue_sptr) std::shared_ptr<gr::msg_queue>;
 %pythoncode %{
 msg_queue_sptr.delete_head = py_msg_queue__delete_head
 msg_queue_sptr.insert_tail = py_msg_queue__insert_tail

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -30,7 +30,7 @@
 %}
 
 %{
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/any.hpp>
 #include <complex>
 #include <string>
@@ -85,11 +85,11 @@ namespace pmt {
 // Language independent exception handler
 ////////////////////////////////////////////////////////////////////////
 
-%template(swig_pmt_ptr) boost::shared_ptr<pmt::pmt_base>;
+%template(swig_pmt_ptr) std::shared_ptr<pmt::pmt_base>;
 
 namespace pmt{
   class pmt_base;
-  typedef boost::shared_ptr<pmt::pmt_base> pmt_t;
+  typedef std::shared_ptr<pmt::pmt_base> pmt_t;
 
   %pythoncode
   %{
@@ -271,8 +271,8 @@ namespace pmt{
   void any_set(pmt_t obj, const boost::any &any);
 
   bool is_msg_accepter(const pmt_t &obj);
-  pmt_t make_msg_accepter(boost::shared_ptr<gr::messages::msg_accepter> ma);
-  boost::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t &obj);
+  pmt_t make_msg_accepter(std::shared_ptr<gr::messages::msg_accepter> ma);
+  std::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t &obj);
 
   bool eq(const pmt_t& x, const pmt_t& y);
   bool eqv(const pmt_t& x, const pmt_t& y);

--- a/gnuradio-runtime/swig/top_block.i
+++ b/gnuradio-runtime/swig/top_block.i
@@ -20,7 +20,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-%template(top_block_sptr) boost::shared_ptr<gr::top_block>;
+%template(top_block_sptr) std::shared_ptr<gr::top_block>;
 
 namespace gr {
   // Hack to have a Python shim implementation of gr.top_block

--- a/gr-analog/include/gnuradio/analog/agc2_cc.h
+++ b/gr-analog/include/gnuradio/analog/agc2_cc.h
@@ -42,7 +42,7 @@ class ANALOG_API agc2_cc : virtual public sync_block
 {
 public:
     // gr::analog::agc2_cc::sptr
-    typedef boost::shared_ptr<agc2_cc> sptr;
+    typedef std::shared_ptr<agc2_cc> sptr;
 
     /*!
      * Build a complex value AGC loop block with attack and decay rates.

--- a/gr-analog/include/gnuradio/analog/agc2_ff.h
+++ b/gr-analog/include/gnuradio/analog/agc2_ff.h
@@ -42,7 +42,7 @@ class ANALOG_API agc2_ff : virtual public sync_block
 {
 public:
     // gr::analog::agc2_ff::sptr
-    typedef boost::shared_ptr<agc2_ff> sptr;
+    typedef std::shared_ptr<agc2_ff> sptr;
 
     /*!
      * Build a floating point AGC loop block with attack and decay rates.

--- a/gr-analog/include/gnuradio/analog/agc3_cc.h
+++ b/gr-analog/include/gnuradio/analog/agc3_cc.h
@@ -45,7 +45,7 @@ class ANALOG_API agc3_cc : virtual public sync_block
 {
 public:
     // gr::analog::agc3_cc::sptr
-    typedef boost::shared_ptr<agc3_cc> sptr;
+    typedef std::shared_ptr<agc3_cc> sptr;
 
     /*!
      * Build a complex value AGC loop block with attack and decay rates.

--- a/gr-analog/include/gnuradio/analog/agc_cc.h
+++ b/gr-analog/include/gnuradio/analog/agc_cc.h
@@ -41,7 +41,7 @@ class ANALOG_API agc_cc : virtual public sync_block
 {
 public:
     // gr::analog::agc_cc::sptr
-    typedef boost::shared_ptr<agc_cc> sptr;
+    typedef std::shared_ptr<agc_cc> sptr;
 
     /*!
      * Build a complex value AGC loop block.

--- a/gr-analog/include/gnuradio/analog/agc_ff.h
+++ b/gr-analog/include/gnuradio/analog/agc_ff.h
@@ -41,7 +41,7 @@ class ANALOG_API agc_ff : virtual public sync_block
 {
 public:
     // gr::analog::agc_ff::sptr
-    typedef boost::shared_ptr<agc_ff> sptr;
+    typedef std::shared_ptr<agc_ff> sptr;
 
     /*!
      * Build a floating point AGC loop block.

--- a/gr-analog/include/gnuradio/analog/cpfsk_bc.h
+++ b/gr-analog/include/gnuradio/analog/cpfsk_bc.h
@@ -37,7 +37,7 @@ class ANALOG_API cpfsk_bc : virtual public sync_interpolator
 {
 public:
     // gr::analog::cpfsk_bc::sptr
-    typedef boost::shared_ptr<cpfsk_bc> sptr;
+    typedef std::shared_ptr<cpfsk_bc> sptr;
 
     /*!
      * \brief Make a CPFSK block.

--- a/gr-analog/include/gnuradio/analog/ctcss_squelch_ff.h
+++ b/gr-analog/include/gnuradio/analog/ctcss_squelch_ff.h
@@ -42,7 +42,7 @@ protected:
 
 public:
     // gr::analog::ctcss_squelch_ff::sptr
-    typedef boost::shared_ptr<ctcss_squelch_ff> sptr;
+    typedef std::shared_ptr<ctcss_squelch_ff> sptr;
 
     /*!
      * \brief Make CTCSS tone squelch block.

--- a/gr-analog/include/gnuradio/analog/dpll_bb.h
+++ b/gr-analog/include/gnuradio/analog/dpll_bb.h
@@ -41,7 +41,7 @@ class ANALOG_API dpll_bb : virtual public sync_block
 {
 public:
     // gr::analog::dpll_bb::sptr
-    typedef boost::shared_ptr<dpll_bb> sptr;
+    typedef std::shared_ptr<dpll_bb> sptr;
 
     static sptr make(float period, float gain);
 

--- a/gr-analog/include/gnuradio/analog/fastnoise_source.h
+++ b/gr-analog/include/gnuradio/analog/fastnoise_source.h
@@ -46,7 +46,7 @@ class ANALOG_API fastnoise_source : virtual public sync_block
 {
 public:
     // gr::analog::fastnoise_source::sptr
-    typedef boost::shared_ptr<fastnoise_source<T>> sptr;
+    typedef std::shared_ptr<fastnoise_source<T>> sptr;
 
     /*! \brief Make a fast noise source
      * \param type the random distribution to use (see

--- a/gr-analog/include/gnuradio/analog/feedforward_agc_cc.h
+++ b/gr-analog/include/gnuradio/analog/feedforward_agc_cc.h
@@ -38,7 +38,7 @@ class ANALOG_API feedforward_agc_cc : virtual public sync_block
 {
 public:
     // gr::analog::feedforward_agc_cc::sptr
-    typedef boost::shared_ptr<feedforward_agc_cc> sptr;
+    typedef std::shared_ptr<feedforward_agc_cc> sptr;
 
     /*!
      * Build a complex valued feed-forward AGC loop block.

--- a/gr-analog/include/gnuradio/analog/fmdet_cf.h
+++ b/gr-analog/include/gnuradio/analog/fmdet_cf.h
@@ -43,7 +43,7 @@ class ANALOG_API fmdet_cf : virtual public sync_block
 {
 public:
     // gr::analog::fmdet_cf::sptr
-    typedef boost::shared_ptr<fmdet_cf> sptr;
+    typedef std::shared_ptr<fmdet_cf> sptr;
 
     /*!
      * \brief Make FM detector block.

--- a/gr-analog/include/gnuradio/analog/frequency_modulator_fc.h
+++ b/gr-analog/include/gnuradio/analog/frequency_modulator_fc.h
@@ -63,7 +63,7 @@ class ANALOG_API frequency_modulator_fc : virtual public sync_block
 {
 public:
     // gr::analog::frequency_modulator_fc::sptr
-    typedef boost::shared_ptr<frequency_modulator_fc> sptr;
+    typedef std::shared_ptr<frequency_modulator_fc> sptr;
 
     /*!
      * Build a frequency modulator block.

--- a/gr-analog/include/gnuradio/analog/noise_source.h
+++ b/gr-analog/include/gnuradio/analog/noise_source.h
@@ -44,7 +44,7 @@ class ANALOG_API noise_source : virtual public sync_block
 {
 public:
     // gr::analog::noise_source::sptr
-    typedef boost::shared_ptr<noise_source<T>> sptr;
+    typedef std::shared_ptr<noise_source<T>> sptr;
 
     /*! Build a noise source
      * \param type the random distribution to use (see

--- a/gr-analog/include/gnuradio/analog/phase_modulator_fc.h
+++ b/gr-analog/include/gnuradio/analog/phase_modulator_fc.h
@@ -43,7 +43,7 @@ class ANALOG_API phase_modulator_fc : virtual public sync_block
 {
 public:
     // gr::analog::phase_modulator_fc::sptr
-    typedef boost::shared_ptr<phase_modulator_fc> sptr;
+    typedef std::shared_ptr<phase_modulator_fc> sptr;
 
     /* \brief Make a phase modulator block.
      *

--- a/gr-analog/include/gnuradio/analog/pll_carriertracking_cc.h
+++ b/gr-analog/include/gnuradio/analog/pll_carriertracking_cc.h
@@ -52,7 +52,7 @@ class ANALOG_API pll_carriertracking_cc : virtual public sync_block,
 {
 public:
     // gr::analog::pll_carriertracking_cc::sptr
-    typedef boost::shared_ptr<pll_carriertracking_cc> sptr;
+    typedef std::shared_ptr<pll_carriertracking_cc> sptr;
 
     /* \brief Make a carrier tracking PLL block.
      *

--- a/gr-analog/include/gnuradio/analog/pll_freqdet_cf.h
+++ b/gr-analog/include/gnuradio/analog/pll_freqdet_cf.h
@@ -51,7 +51,7 @@ class ANALOG_API pll_freqdet_cf : virtual public sync_block,
 {
 public:
     // gr::analog::pll_freqdet_cf::sptr
-    typedef boost::shared_ptr<pll_freqdet_cf> sptr;
+    typedef std::shared_ptr<pll_freqdet_cf> sptr;
 
     /* \brief Make PLL block that outputs the tracked signal's frequency.
      *

--- a/gr-analog/include/gnuradio/analog/pll_refout_cc.h
+++ b/gr-analog/include/gnuradio/analog/pll_refout_cc.h
@@ -52,7 +52,7 @@ class ANALOG_API pll_refout_cc : virtual public sync_block,
 {
 public:
     // gr::analog::pll_refout_cc::sptr
-    typedef boost::shared_ptr<pll_refout_cc> sptr;
+    typedef std::shared_ptr<pll_refout_cc> sptr;
 
     /* \brief Make PLL block that outputs the tracked carrier signal.
      *

--- a/gr-analog/include/gnuradio/analog/probe_avg_mag_sqrd_c.h
+++ b/gr-analog/include/gnuradio/analog/probe_avg_mag_sqrd_c.h
@@ -44,7 +44,7 @@ class ANALOG_API probe_avg_mag_sqrd_c : virtual public sync_block
 {
 public:
     // gr::analog::probe_avg_mag_sqrd_c::sptr
-    typedef boost::shared_ptr<probe_avg_mag_sqrd_c> sptr;
+    typedef std::shared_ptr<probe_avg_mag_sqrd_c> sptr;
 
     /*!
      * \brief Make a complex sink that computes avg magnitude squared.

--- a/gr-analog/include/gnuradio/analog/probe_avg_mag_sqrd_cf.h
+++ b/gr-analog/include/gnuradio/analog/probe_avg_mag_sqrd_cf.h
@@ -46,7 +46,7 @@ class ANALOG_API probe_avg_mag_sqrd_cf : virtual public sync_block
 {
 public:
     // gr::analog::probe_avg_mag_sqrd_cf::sptr
-    typedef boost::shared_ptr<probe_avg_mag_sqrd_cf> sptr;
+    typedef std::shared_ptr<probe_avg_mag_sqrd_cf> sptr;
 
     /*!
      * \brief Make a block that computes avg magnitude squared.

--- a/gr-analog/include/gnuradio/analog/probe_avg_mag_sqrd_f.h
+++ b/gr-analog/include/gnuradio/analog/probe_avg_mag_sqrd_f.h
@@ -45,7 +45,7 @@ class ANALOG_API probe_avg_mag_sqrd_f : virtual public sync_block
 {
 public:
     // gr::analog::probe_avg_mag_sqrd_f::sptr
-    typedef boost::shared_ptr<probe_avg_mag_sqrd_f> sptr;
+    typedef std::shared_ptr<probe_avg_mag_sqrd_f> sptr;
 
     /*!
      * \brief Make a float sink that computes avg magnitude squared.

--- a/gr-analog/include/gnuradio/analog/pwr_squelch_cc.h
+++ b/gr-analog/include/gnuradio/analog/pwr_squelch_cc.h
@@ -42,7 +42,7 @@ protected:
 
 public:
     // gr::analog::pwr_squelch_cc::sptr
-    typedef boost::shared_ptr<pwr_squelch_cc> sptr;
+    typedef std::shared_ptr<pwr_squelch_cc> sptr;
 
     /*!
      * \brief Make power-based squelch block.

--- a/gr-analog/include/gnuradio/analog/pwr_squelch_ff.h
+++ b/gr-analog/include/gnuradio/analog/pwr_squelch_ff.h
@@ -42,7 +42,7 @@ protected:
 
 public:
     // gr::analog::pwr_squelch_ff::sptr
-    typedef boost::shared_ptr<pwr_squelch_ff> sptr;
+    typedef std::shared_ptr<pwr_squelch_ff> sptr;
 
     /*!
      * \brief Make power-based squelch block.

--- a/gr-analog/include/gnuradio/analog/quadrature_demod_cf.h
+++ b/gr-analog/include/gnuradio/analog/quadrature_demod_cf.h
@@ -73,7 +73,7 @@ class ANALOG_API quadrature_demod_cf : virtual public sync_block
 {
 public:
     // gr::analog::quadrature_demod_cf::sptr
-    typedef boost::shared_ptr<quadrature_demod_cf> sptr;
+    typedef std::shared_ptr<quadrature_demod_cf> sptr;
 
     /* \brief Make a quadrature demodulator block.
      *

--- a/gr-analog/include/gnuradio/analog/rail_ff.h
+++ b/gr-analog/include/gnuradio/analog/rail_ff.h
@@ -37,7 +37,7 @@ class ANALOG_API rail_ff : virtual public sync_block
 {
 public:
     // gr::analog::rail_ff::sptr
-    typedef boost::shared_ptr<rail_ff> sptr;
+    typedef std::shared_ptr<rail_ff> sptr;
 
     /*!
      * Build a rail block.

--- a/gr-analog/include/gnuradio/analog/random_uniform_source.h
+++ b/gr-analog/include/gnuradio/analog/random_uniform_source.h
@@ -39,7 +39,7 @@ class ANALOG_API random_uniform_source : virtual public sync_block
 {
 public:
     // gr::analog::random_uniform_source::sptr
-    typedef boost::shared_ptr<random_uniform_source<T>> sptr;
+    typedef std::shared_ptr<random_uniform_source<T>> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of analog::random_uniform_source_X.

--- a/gr-analog/include/gnuradio/analog/sig_source.h
+++ b/gr-analog/include/gnuradio/analog/sig_source.h
@@ -40,7 +40,7 @@ class ANALOG_API sig_source : virtual public sync_block
 {
 public:
     // gr::analog::sig_source::sptr
-    typedef boost::shared_ptr<sig_source<T>> sptr;
+    typedef std::shared_ptr<sig_source<T>> sptr;
 
     /*!
      * Build a signal source block.

--- a/gr-analog/include/gnuradio/analog/simple_squelch_cc.h
+++ b/gr-analog/include/gnuradio/analog/simple_squelch_cc.h
@@ -37,7 +37,7 @@ class ANALOG_API simple_squelch_cc : virtual public sync_block
 {
 public:
     // gr::analog::simple_squelch_cc::sptr
-    typedef boost::shared_ptr<simple_squelch_cc> sptr;
+    typedef std::shared_ptr<simple_squelch_cc> sptr;
 
     /*!
      * \brief Make a simple squelch block.

--- a/gr-audio/include/gnuradio/audio/sink.h
+++ b/gr-audio/include/gnuradio/audio/sink.h
@@ -36,7 +36,7 @@ namespace audio {
 class GR_AUDIO_API sink : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<sink> sptr;
+    typedef std::shared_ptr<sink> sptr;
 
     /*!
      * Creates a sink from an audio device at a specified

--- a/gr-audio/include/gnuradio/audio/source.h
+++ b/gr-audio/include/gnuradio/audio/source.h
@@ -36,7 +36,7 @@ namespace audio {
 class GR_AUDIO_API source : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<source> sptr;
+    typedef std::shared_ptr<source> sptr;
 
     /*!
      * Creates a source from an audio device at a specified

--- a/gr-audio/lib/alsa/alsa_source.h
+++ b/gr-audio/lib/alsa/alsa_source.h
@@ -36,7 +36,7 @@ namespace gr {
 namespace audio {
 
 class alsa_source;
-typedef boost::shared_ptr<alsa_source> alsa_source_sptr;
+typedef std::shared_ptr<alsa_source> alsa_source_sptr;
 
 /*!
  * \brief audio source using ALSA

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -243,8 +243,8 @@ bool portaudio_sink::check_topology(int ninputs, int noutputs)
     if (Pa_IsStreamActive(d_stream)) {
         Pa_CloseStream(d_stream);
         d_stream = 0;
-        d_reader.reset(); // boost::shared_ptr for d_reader = 0
-        d_writer.reset(); // boost::shared_ptr for d_write = 0
+        d_reader.reset(); // std::shared_ptr for d_reader = 0
+        d_writer.reset(); // std::shared_ptr for d_write = 0
     }
 
     d_output_parameters.channelCount = ninputs; // # of channels we're really using

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -239,8 +239,8 @@ bool portaudio_source::check_topology(int ninputs, int noutputs)
     if (Pa_IsStreamActive(d_stream)) {
         Pa_CloseStream(d_stream);
         d_stream = 0;
-        d_reader.reset(); // boost::shared_ptr for d_reader = 0
-        d_writer.reset(); // boost::shared_ptr for d_write = 0
+        d_reader.reset(); // std::shared_ptr for d_reader = 0
+        d_writer.reset(); // std::shared_ptr for d_write = 0
     }
 
     d_input_parameters.channelCount = noutputs; // # of channels we're really using

--- a/gr-blocks/include/gnuradio/blocks/abs_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/abs_blk.h
@@ -44,7 +44,7 @@ class BLOCKS_API abs_blk : virtual public sync_block
 
 public:
     // gr::blocks::abs_blk::sptr
-    typedef boost::shared_ptr<abs_blk<T>> sptr;
+    typedef std::shared_ptr<abs_blk<T>> sptr;
 
     /*!
      * \brief Create an instance of abs_blk

--- a/gr-blocks/include/gnuradio/blocks/add_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/add_blk.h
@@ -48,7 +48,7 @@ class BLOCKS_API add_blk : virtual public sync_block
 {
 public:
     // gr::blocks::add_blk::sptr
-    typedef boost::shared_ptr<add_blk<T>> sptr;
+    typedef std::shared_ptr<add_blk<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/add_const_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_bb.h
@@ -37,7 +37,7 @@ class BLOCKS_API add_const_bb : virtual public sync_block
 {
 public:
     // gr::blocks::add_const_bb::sptr
-    typedef boost::shared_ptr<add_const_bb> sptr;
+    typedef std::shared_ptr<add_const_bb> sptr;
 
     /*!
      * \brief Create an instance of add_const_bb

--- a/gr-blocks/include/gnuradio/blocks/add_const_cc.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_cc.h
@@ -37,7 +37,7 @@ class BLOCKS_API add_const_cc : virtual public sync_block
 {
 public:
     // gr::blocks::add_const_cc::sptr
-    typedef boost::shared_ptr<add_const_cc> sptr;
+    typedef std::shared_ptr<add_const_cc> sptr;
 
     /*!
      * \brief Create an instance of add_const_cc

--- a/gr-blocks/include/gnuradio/blocks/add_const_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_ff.h
@@ -37,7 +37,7 @@ class BLOCKS_API add_const_ff : virtual public sync_block
 {
 public:
     // gr::blocks::add_const_ff::sptr
-    typedef boost::shared_ptr<add_const_ff> sptr;
+    typedef std::shared_ptr<add_const_ff> sptr;
 
     /*!
      * \brief Create an instance of add_const_ff

--- a/gr-blocks/include/gnuradio/blocks/add_const_ii.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_ii.h
@@ -37,7 +37,7 @@ class BLOCKS_API add_const_ii : virtual public sync_block
 {
 public:
     // gr::blocks::add_const_ii::sptr
-    typedef boost::shared_ptr<add_const_ii> sptr;
+    typedef std::shared_ptr<add_const_ii> sptr;
 
     /*!
      * \brief Create an instance of add_const_ii

--- a/gr-blocks/include/gnuradio/blocks/add_const_ss.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_ss.h
@@ -37,7 +37,7 @@ class BLOCKS_API add_const_ss : virtual public sync_block
 {
 public:
     // gr::blocks::add_const_ss::sptr
-    typedef boost::shared_ptr<add_const_ss> sptr;
+    typedef std::shared_ptr<add_const_ss> sptr;
 
     /*!
      * \brief Create an instance of add_const_ss

--- a/gr-blocks/include/gnuradio/blocks/add_const_v.h
+++ b/gr-blocks/include/gnuradio/blocks/add_const_v.h
@@ -39,7 +39,7 @@ class BLOCKS_API add_const_v : virtual public sync_block
 {
 
 public:
-    typedef boost::shared_ptr<add_const_v<T>> sptr;
+    typedef std::shared_ptr<add_const_v<T>> sptr;
 
     /*!
      * \brief Create an instance of add_const_v

--- a/gr-blocks/include/gnuradio/blocks/and_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/and_blk.h
@@ -43,7 +43,7 @@ class BLOCKS_API and_blk : virtual public sync_block
 {
 public:
     // gr::blocks::and_blk::sptr
-    typedef boost::shared_ptr<and_blk<T>> sptr;
+    typedef std::shared_ptr<and_blk<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/and_const.h
+++ b/gr-blocks/include/gnuradio/blocks/and_const.h
@@ -44,7 +44,7 @@ class BLOCKS_API and_const : virtual public sync_block
 
 public:
     // gr::blocks::and_const::sptr
-    typedef boost::shared_ptr<and_const<T>> sptr;
+    typedef std::shared_ptr<and_const<T>> sptr;
 
     /*!
      * \brief Create an instance of and_const

--- a/gr-blocks/include/gnuradio/blocks/annotator_1to1.h
+++ b/gr-blocks/include/gnuradio/blocks/annotator_1to1.h
@@ -50,7 +50,7 @@ class BLOCKS_API annotator_1to1 : virtual public sync_block
 {
 public:
     // gr::blocks::annotator_1to1::sptr
-    typedef boost::shared_ptr<annotator_1to1> sptr;
+    typedef std::shared_ptr<annotator_1to1> sptr;
 
     static sptr make(int when, size_t sizeof_stream_item);
 

--- a/gr-blocks/include/gnuradio/blocks/annotator_alltoall.h
+++ b/gr-blocks/include/gnuradio/blocks/annotator_alltoall.h
@@ -50,7 +50,7 @@ class BLOCKS_API annotator_alltoall : virtual public sync_block
 {
 public:
     // gr::blocks::annotator_alltoall::sptr
-    typedef boost::shared_ptr<annotator_alltoall> sptr;
+    typedef std::shared_ptr<annotator_alltoall> sptr;
 
     static sptr make(int when, size_t sizeof_stream_item);
 

--- a/gr-blocks/include/gnuradio/blocks/annotator_raw.h
+++ b/gr-blocks/include/gnuradio/blocks/annotator_raw.h
@@ -45,7 +45,7 @@ class BLOCKS_API annotator_raw : virtual public sync_block
 {
 public:
     // gr::blocks::annotator_raw::sptr
-    typedef boost::shared_ptr<annotator_raw> sptr;
+    typedef std::shared_ptr<annotator_raw> sptr;
 
     static sptr make(size_t sizeof_stream_item);
 

--- a/gr-blocks/include/gnuradio/blocks/argmax.h
+++ b/gr-blocks/include/gnuradio/blocks/argmax.h
@@ -51,7 +51,7 @@ template <class T>
 class BLOCKS_API argmax : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<argmax<T>> sptr;
+    typedef std::shared_ptr<argmax<T>> sptr;
 
     static sptr make(size_t vlen);
 };

--- a/gr-blocks/include/gnuradio/blocks/bin_statistics_f.h
+++ b/gr-blocks/include/gnuradio/blocks/bin_statistics_f.h
@@ -50,7 +50,7 @@ protected:
 
 public:
     // gr::blocks::bin_statistics_f::sptr
-    typedef boost::shared_ptr<bin_statistics_f> sptr;
+    typedef std::shared_ptr<bin_statistics_f> sptr;
 
     /*!
      * Build a bin statistics block. See qa_bin_statistics.py and

--- a/gr-blocks/include/gnuradio/blocks/burst_tagger.h
+++ b/gr-blocks/include/gnuradio/blocks/burst_tagger.h
@@ -48,7 +48,7 @@ class BLOCKS_API burst_tagger : virtual public sync_block
 {
 public:
     // gr::blocks::burst_tagger::sptr
-    typedef boost::shared_ptr<burst_tagger> sptr;
+    typedef std::shared_ptr<burst_tagger> sptr;
 
     /*!
      * Build a burst tagger gnuradio/blocks.

--- a/gr-blocks/include/gnuradio/blocks/char_to_float.h
+++ b/gr-blocks/include/gnuradio/blocks/char_to_float.h
@@ -43,7 +43,7 @@ class BLOCKS_API char_to_float : virtual public sync_block
 {
 public:
     // gr::blocks::char_to_float_ff::sptr
-    typedef boost::shared_ptr<char_to_float> sptr;
+    typedef std::shared_ptr<char_to_float> sptr;
 
     /*!
      * Build a chars to float stream converter block.

--- a/gr-blocks/include/gnuradio/blocks/char_to_short.h
+++ b/gr-blocks/include/gnuradio/blocks/char_to_short.h
@@ -43,7 +43,7 @@ class BLOCKS_API char_to_short : virtual public sync_block
 {
 public:
     // gr::blocks::char_to_short_ff::sptr
-    typedef boost::shared_ptr<char_to_short> sptr;
+    typedef std::shared_ptr<char_to_short> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/check_lfsr_32k_s.h
+++ b/gr-blocks/include/gnuradio/blocks/check_lfsr_32k_s.h
@@ -42,7 +42,7 @@ class BLOCKS_API check_lfsr_32k_s : virtual public sync_block
 {
 public:
     // gr::blocks::check_lfsr_32k_s::sptr
-    typedef boost::shared_ptr<check_lfsr_32k_s> sptr;
+    typedef std::shared_ptr<check_lfsr_32k_s> sptr;
 
     static sptr make();
 

--- a/gr-blocks/include/gnuradio/blocks/complex_to_arg.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_arg.h
@@ -37,7 +37,7 @@ class BLOCKS_API complex_to_arg : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_arg_ff::sptr
-    typedef boost::shared_ptr<complex_to_arg> sptr;
+    typedef std::shared_ptr<complex_to_arg> sptr;
 
     /*!
      * Build a complex to arg block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_float.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_float.h
@@ -43,7 +43,7 @@ class BLOCKS_API complex_to_float : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_float_ff::sptr
-    typedef boost::shared_ptr<complex_to_float> sptr;
+    typedef std::shared_ptr<complex_to_float> sptr;
 
     /*!
      * Build a complex to float block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_imag.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_imag.h
@@ -37,7 +37,7 @@ class BLOCKS_API complex_to_imag : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_imag_ff::sptr
-    typedef boost::shared_ptr<complex_to_imag> sptr;
+    typedef std::shared_ptr<complex_to_imag> sptr;
 
     /*!
      * Build a complex to imaginary part block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_interleaved_char.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_interleaved_char.h
@@ -46,7 +46,7 @@ class BLOCKS_API complex_to_interleaved_char : virtual public sync_interpolator
 {
 public:
     // gr::blocks::complex_to_interleaved_char::sptr
-    typedef boost::shared_ptr<complex_to_interleaved_char> sptr;
+    typedef std::shared_ptr<complex_to_interleaved_char> sptr;
 
     /*!
      * Build a complex to interleaved chars block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_interleaved_short.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_interleaved_short.h
@@ -46,7 +46,7 @@ class BLOCKS_API complex_to_interleaved_short : virtual public sync_interpolator
 {
 public:
     // gr::blocks::complex_to_interleaved_short::sptr
-    typedef boost::shared_ptr<complex_to_interleaved_short> sptr;
+    typedef std::shared_ptr<complex_to_interleaved_short> sptr;
 
     /*!
      * Build a complex to interleaved shorts block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_mag.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_mag.h
@@ -50,7 +50,7 @@ class BLOCKS_API complex_to_mag : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_mag_ff::sptr
-    typedef boost::shared_ptr<complex_to_mag> sptr;
+    typedef std::shared_ptr<complex_to_mag> sptr;
 
     /*!
      * Build a complex to magnitude block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_mag_squared.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_mag_squared.h
@@ -50,7 +50,7 @@ class BLOCKS_API complex_to_mag_squared : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_mag_squared_ff::sptr
-    typedef boost::shared_ptr<complex_to_mag_squared> sptr;
+    typedef std::shared_ptr<complex_to_mag_squared> sptr;
 
     /*!
      * Build a complex to magnitude squared block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_magphase.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_magphase.h
@@ -41,7 +41,7 @@ class BLOCKS_API complex_to_magphase : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_magphase_ff::sptr
-    typedef boost::shared_ptr<complex_to_magphase> sptr;
+    typedef std::shared_ptr<complex_to_magphase> sptr;
 
     /*!
      * Build a complex to magnitude and phase block.

--- a/gr-blocks/include/gnuradio/blocks/complex_to_real.h
+++ b/gr-blocks/include/gnuradio/blocks/complex_to_real.h
@@ -37,7 +37,7 @@ class BLOCKS_API complex_to_real : virtual public sync_block
 {
 public:
     // gr::blocks::complex_to_real_ff::sptr
-    typedef boost::shared_ptr<complex_to_real> sptr;
+    typedef std::shared_ptr<complex_to_real> sptr;
 
     /*!
      * Build a complex to real part block.

--- a/gr-blocks/include/gnuradio/blocks/conjugate_cc.h
+++ b/gr-blocks/include/gnuradio/blocks/conjugate_cc.h
@@ -37,7 +37,7 @@ class BLOCKS_API conjugate_cc : virtual public sync_block
 {
 public:
     // gr::blocks::conjugate_cc_ff::sptr
-    typedef boost::shared_ptr<conjugate_cc> sptr;
+    typedef std::shared_ptr<conjugate_cc> sptr;
 
     static sptr make();
 };

--- a/gr-blocks/include/gnuradio/blocks/copy.h
+++ b/gr-blocks/include/gnuradio/blocks/copy.h
@@ -47,7 +47,7 @@ class BLOCKS_API copy : virtual public block
 {
 public:
     // gr::blocks::copy::sptr
-    typedef boost::shared_ptr<copy> sptr;
+    typedef std::shared_ptr<copy> sptr;
 
     static sptr make(size_t itemsize);
 

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_b.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_b.h
@@ -44,7 +44,7 @@ class BLOCKS_API ctrlport_probe2_b : virtual public sync_block
 {
 public:
     // gr::blocks::ctrlport_probe2_b::sptr
-    typedef boost::shared_ptr<ctrlport_probe2_b> sptr;
+    typedef std::shared_ptr<ctrlport_probe2_b> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_c.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_c.h
@@ -44,7 +44,7 @@ class BLOCKS_API ctrlport_probe2_c : virtual public sync_block
 {
 public:
     // gr::blocks::ctrlport_probe2_c::sptr
-    typedef boost::shared_ptr<ctrlport_probe2_c> sptr;
+    typedef std::shared_ptr<ctrlport_probe2_c> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_f.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_f.h
@@ -44,7 +44,7 @@ class BLOCKS_API ctrlport_probe2_f : virtual public sync_block
 {
 public:
     // gr::blocks::ctrlport_probe2_f::sptr
-    typedef boost::shared_ptr<ctrlport_probe2_f> sptr;
+    typedef std::shared_ptr<ctrlport_probe2_f> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_i.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_i.h
@@ -44,7 +44,7 @@ class BLOCKS_API ctrlport_probe2_i : virtual public sync_block
 {
 public:
     // gr::blocks::ctrlport_probe2_i::sptr
-    typedef boost::shared_ptr<ctrlport_probe2_i> sptr;
+    typedef std::shared_ptr<ctrlport_probe2_i> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_s.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe2_s.h
@@ -44,7 +44,7 @@ class BLOCKS_API ctrlport_probe2_s : virtual public sync_block
 {
 public:
     // gr::blocks::ctrlport_probe2_s::sptr
-    typedef boost::shared_ptr<ctrlport_probe2_s> sptr;
+    typedef std::shared_ptr<ctrlport_probe2_s> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe_c.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe_c.h
@@ -46,7 +46,7 @@ class BLOCKS_API ctrlport_probe_c : virtual public sync_block
 {
 public:
     // gr::blocks::ctrlport_probe_c::sptr
-    typedef boost::shared_ptr<ctrlport_probe_c> sptr;
+    typedef std::shared_ptr<ctrlport_probe_c> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-blocks/include/gnuradio/blocks/deinterleave.h
+++ b/gr-blocks/include/gnuradio/blocks/deinterleave.h
@@ -60,7 +60,7 @@ class BLOCKS_API deinterleave : virtual public block
 {
 public:
     // gr::blocks::deinterleave::sptr
-    typedef boost::shared_ptr<deinterleave> sptr;
+    typedef std::shared_ptr<deinterleave> sptr;
 
     /*!
      * Make a deinterleave block.

--- a/gr-blocks/include/gnuradio/blocks/delay.h
+++ b/gr-blocks/include/gnuradio/blocks/delay.h
@@ -45,7 +45,7 @@ class BLOCKS_API delay : virtual public block
 {
 public:
     // gr::blocks::delay::sptr
-    typedef boost::shared_ptr<delay> sptr;
+    typedef std::shared_ptr<delay> sptr;
 
     /*!
      * \brief Make a delay block.

--- a/gr-blocks/include/gnuradio/blocks/divide.h
+++ b/gr-blocks/include/gnuradio/blocks/divide.h
@@ -43,7 +43,7 @@ class BLOCKS_API divide : virtual public sync_block
 {
 public:
     // gr::blocks::divide::sptr
-    typedef boost::shared_ptr<divide<T>> sptr;
+    typedef std::shared_ptr<divide<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/endian_swap.h
+++ b/gr-blocks/include/gnuradio/blocks/endian_swap.h
@@ -37,7 +37,7 @@ class BLOCKS_API endian_swap : virtual public sync_block
 {
 public:
     // gr::blocks::endian_swap::sptr
-    typedef boost::shared_ptr<endian_swap> sptr;
+    typedef std::shared_ptr<endian_swap> sptr;
 
     /*!
      * Make an endian swap block.

--- a/gr-blocks/include/gnuradio/blocks/exponentiate_const_cci.h
+++ b/gr-blocks/include/gnuradio/blocks/exponentiate_const_cci.h
@@ -46,7 +46,7 @@ namespace blocks {
 class BLOCKS_API exponentiate_const_cci : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<exponentiate_const_cci> sptr;
+    typedef std::shared_ptr<exponentiate_const_cci> sptr;
 
     /*
      * \param exponent Exponent the input stream is raised to, which must be an integer.

--- a/gr-blocks/include/gnuradio/blocks/file_descriptor_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/file_descriptor_sink.h
@@ -37,7 +37,7 @@ class BLOCKS_API file_descriptor_sink : virtual public sync_block
 {
 public:
     // gr::blocks::file_descriptor_sink::sptr
-    typedef boost::shared_ptr<file_descriptor_sink> sptr;
+    typedef std::shared_ptr<file_descriptor_sink> sptr;
 
     /*!
      * Build a file descriptor sink block. The provided file descriptor will

--- a/gr-blocks/include/gnuradio/blocks/file_descriptor_source.h
+++ b/gr-blocks/include/gnuradio/blocks/file_descriptor_source.h
@@ -43,7 +43,7 @@ protected:
 
 public:
     // gr::blocks::file_descriptor_source::sptr
-    typedef boost::shared_ptr<file_descriptor_source> sptr;
+    typedef std::shared_ptr<file_descriptor_source> sptr;
 
     /*!
      * Build a file descriptor source block. The provided file descriptor will

--- a/gr-blocks/include/gnuradio/blocks/file_meta_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/file_meta_sink.h
@@ -71,7 +71,7 @@ class BLOCKS_API file_meta_sink : virtual public sync_block
 {
 public:
     // gr::blocks::file_meta_sink::sptr
-    typedef boost::shared_ptr<file_meta_sink> sptr;
+    typedef std::shared_ptr<file_meta_sink> sptr;
 
     /*!
      * \brief Create a meta-data file sink.

--- a/gr-blocks/include/gnuradio/blocks/file_meta_source.h
+++ b/gr-blocks/include/gnuradio/blocks/file_meta_source.h
@@ -52,7 +52,7 @@ class BLOCKS_API file_meta_source : virtual public sync_block
 {
 public:
     // gr::blocks::file_meta_source::sptr
-    typedef boost::shared_ptr<file_meta_source> sptr;
+    typedef std::shared_ptr<file_meta_source> sptr;
 
     /*!
      * \brief Create a meta-data file source.

--- a/gr-blocks/include/gnuradio/blocks/file_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink.h
@@ -38,7 +38,7 @@ class BLOCKS_API file_sink : virtual public sync_block, virtual public file_sink
 {
 public:
     // gr::blocks::file_sink::sptr
-    typedef boost::shared_ptr<file_sink> sptr;
+    typedef std::shared_ptr<file_sink> sptr;
 
     /*!
      * \brief Make a file sink.

--- a/gr-blocks/include/gnuradio/blocks/file_source.h
+++ b/gr-blocks/include/gnuradio/blocks/file_source.h
@@ -37,7 +37,7 @@ class BLOCKS_API file_source : virtual public sync_block
 {
 public:
     // gr::blocks::file_source::sptr
-    typedef boost::shared_ptr<file_source> sptr;
+    typedef std::shared_ptr<file_source> sptr;
 
     /*!
      * \brief Create a file source.

--- a/gr-blocks/include/gnuradio/blocks/float_to_char.h
+++ b/gr-blocks/include/gnuradio/blocks/float_to_char.h
@@ -37,7 +37,7 @@ class BLOCKS_API float_to_char : virtual public sync_block
 {
 public:
     // gr::blocks::float_to_char_ff::sptr
-    typedef boost::shared_ptr<float_to_char> sptr;
+    typedef std::shared_ptr<float_to_char> sptr;
 
     /*!
      * Build a float to char block.

--- a/gr-blocks/include/gnuradio/blocks/float_to_complex.h
+++ b/gr-blocks/include/gnuradio/blocks/float_to_complex.h
@@ -37,7 +37,7 @@ class BLOCKS_API float_to_complex : virtual public sync_block
 {
 public:
     // gr::blocks::float_to_complex_ff::sptr
-    typedef boost::shared_ptr<float_to_complex> sptr;
+    typedef std::shared_ptr<float_to_complex> sptr;
 
     /*!
      * Build a float to complex block.

--- a/gr-blocks/include/gnuradio/blocks/float_to_int.h
+++ b/gr-blocks/include/gnuradio/blocks/float_to_int.h
@@ -37,7 +37,7 @@ class BLOCKS_API float_to_int : virtual public sync_block
 {
 public:
     // gr::blocks::float_to_int_ff::sptr
-    typedef boost::shared_ptr<float_to_int> sptr;
+    typedef std::shared_ptr<float_to_int> sptr;
 
     /*!
      * Build a float to int block.

--- a/gr-blocks/include/gnuradio/blocks/float_to_short.h
+++ b/gr-blocks/include/gnuradio/blocks/float_to_short.h
@@ -37,7 +37,7 @@ class BLOCKS_API float_to_short : virtual public sync_block
 {
 public:
     // gr::blocks::float_to_short_ff::sptr
-    typedef boost::shared_ptr<float_to_short> sptr;
+    typedef std::shared_ptr<float_to_short> sptr;
 
     /*!
      * Build a float to short block.

--- a/gr-blocks/include/gnuradio/blocks/float_to_uchar.h
+++ b/gr-blocks/include/gnuradio/blocks/float_to_uchar.h
@@ -37,7 +37,7 @@ class BLOCKS_API float_to_uchar : virtual public sync_block
 {
 public:
     // gr::blocks::float_to_uchar_ff::sptr
-    typedef boost::shared_ptr<float_to_uchar> sptr;
+    typedef std::shared_ptr<float_to_uchar> sptr;
 
     /*!
      * Build a float to uchar block.

--- a/gr-blocks/include/gnuradio/blocks/head.h
+++ b/gr-blocks/include/gnuradio/blocks/head.h
@@ -41,7 +41,7 @@ class BLOCKS_API head : virtual public sync_block
 {
 public:
     // gr::blocks::head::sptr
-    typedef boost::shared_ptr<head> sptr;
+    typedef std::shared_ptr<head> sptr;
 
     static sptr make(size_t sizeof_stream_item, uint64_t nitems);
 

--- a/gr-blocks/include/gnuradio/blocks/int_to_float.h
+++ b/gr-blocks/include/gnuradio/blocks/int_to_float.h
@@ -37,7 +37,7 @@ class BLOCKS_API int_to_float : virtual public sync_block
 {
 public:
     // gr::blocks::int_to_float_ff::sptr
-    typedef boost::shared_ptr<int_to_float> sptr;
+    typedef std::shared_ptr<int_to_float> sptr;
 
     /*!
      * Build an int to float block.

--- a/gr-blocks/include/gnuradio/blocks/integrate.h
+++ b/gr-blocks/include/gnuradio/blocks/integrate.h
@@ -40,7 +40,7 @@ class BLOCKS_API integrate : virtual public sync_decimator
 {
 public:
     // gr::blocks::integrate::sptr
-    typedef boost::shared_ptr<integrate<T>> sptr;
+    typedef std::shared_ptr<integrate<T>> sptr;
 
     static sptr make(int decim, unsigned int vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/interleave.h
+++ b/gr-blocks/include/gnuradio/blocks/interleave.h
@@ -61,7 +61,7 @@ class BLOCKS_API interleave : virtual public block
 {
 public:
     // gr::blocks::interleave::sptr
-    typedef boost::shared_ptr<interleave> sptr;
+    typedef std::shared_ptr<interleave> sptr;
 
     /*!
      * Make a stream interleave block.

--- a/gr-blocks/include/gnuradio/blocks/interleaved_char_to_complex.h
+++ b/gr-blocks/include/gnuradio/blocks/interleaved_char_to_complex.h
@@ -37,7 +37,7 @@ class BLOCKS_API interleaved_char_to_complex : virtual public sync_decimator
 {
 public:
     // gr::blocks::interleaved_char_to_complex::sptr
-    typedef boost::shared_ptr<interleaved_char_to_complex> sptr;
+    typedef std::shared_ptr<interleaved_char_to_complex> sptr;
 
     /*!
      * Build an interleaved char to complex block.

--- a/gr-blocks/include/gnuradio/blocks/interleaved_short_to_complex.h
+++ b/gr-blocks/include/gnuradio/blocks/interleaved_short_to_complex.h
@@ -37,7 +37,7 @@ class BLOCKS_API interleaved_short_to_complex : virtual public sync_decimator
 {
 public:
     // gr::blocks::interleaved_short_to_complex::sptr
-    typedef boost::shared_ptr<interleaved_short_to_complex> sptr;
+    typedef std::shared_ptr<interleaved_short_to_complex> sptr;
 
     /*!
      * Build an interleaved short to complex block.

--- a/gr-blocks/include/gnuradio/blocks/keep_m_in_n.h
+++ b/gr-blocks/include/gnuradio/blocks/keep_m_in_n.h
@@ -37,7 +37,7 @@ class BLOCKS_API keep_m_in_n : virtual public block
 {
 public:
     // gr::blocks::keep_m_in_n::sptr
-    typedef boost::shared_ptr<keep_m_in_n> sptr;
+    typedef std::shared_ptr<keep_m_in_n> sptr;
 
     /*!
      * Make a keep m in n block.

--- a/gr-blocks/include/gnuradio/blocks/keep_one_in_n.h
+++ b/gr-blocks/include/gnuradio/blocks/keep_one_in_n.h
@@ -37,7 +37,7 @@ class BLOCKS_API keep_one_in_n : virtual public block
 {
 public:
     // gr::blocks::keep_one_in_n::sptr
-    typedef boost::shared_ptr<keep_one_in_n> sptr;
+    typedef std::shared_ptr<keep_one_in_n> sptr;
 
     /*!
      * Make a keep one in n block.

--- a/gr-blocks/include/gnuradio/blocks/lfsr_32k_source_s.h
+++ b/gr-blocks/include/gnuradio/blocks/lfsr_32k_source_s.h
@@ -42,7 +42,7 @@ class BLOCKS_API lfsr_32k_source_s : virtual public sync_block
 {
 public:
     // gr::blocks::lfsr_32k_source_s::sptr
-    typedef boost::shared_ptr<lfsr_32k_source_s> sptr;
+    typedef std::shared_ptr<lfsr_32k_source_s> sptr;
 
     /*!
      * \brief Make a LFSR 32k source block.

--- a/gr-blocks/include/gnuradio/blocks/magphase_to_complex.h
+++ b/gr-blocks/include/gnuradio/blocks/magphase_to_complex.h
@@ -37,7 +37,7 @@ class BLOCKS_API magphase_to_complex : virtual public sync_block
 {
 public:
     // gr::blocks::magphase_to_complex_ff::sptr
-    typedef boost::shared_ptr<magphase_to_complex> sptr;
+    typedef std::shared_ptr<magphase_to_complex> sptr;
 
     /*!
      * Build a mag and phase to complex block.

--- a/gr-blocks/include/gnuradio/blocks/max_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/max_blk.h
@@ -51,7 +51,7 @@ class BLOCKS_API max_blk : virtual public sync_block
 {
 public:
     // gr::blocks::max_blk::sptr
-    typedef boost::shared_ptr<max_blk<T>> sptr;
+    typedef std::shared_ptr<max_blk<T>> sptr;
 
     static sptr make(size_t vlen, size_t vlen_out = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/message_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/message_debug.h
@@ -52,7 +52,7 @@ class BLOCKS_API message_debug : virtual public block
 {
 public:
     // gr::blocks::message_debug::sptr
-    typedef boost::shared_ptr<message_debug> sptr;
+    typedef std::shared_ptr<message_debug> sptr;
 
     /*!
      * \brief Build the message debug block. It takes no parameters

--- a/gr-blocks/include/gnuradio/blocks/message_strobe.h
+++ b/gr-blocks/include/gnuradio/blocks/message_strobe.h
@@ -41,7 +41,7 @@ class BLOCKS_API message_strobe : virtual public block
 {
 public:
     // gr::blocks::message_strobe::sptr
-    typedef boost::shared_ptr<message_strobe> sptr;
+    typedef std::shared_ptr<message_strobe> sptr;
 
     /*!
      * Make a message stobe block to send message \p msg every \p

--- a/gr-blocks/include/gnuradio/blocks/message_strobe_random.h
+++ b/gr-blocks/include/gnuradio/blocks/message_strobe_random.h
@@ -53,7 +53,7 @@ class BLOCKS_API message_strobe_random : virtual public block
 {
 public:
     // gr::blocks::message_strobe_random::sptr
-    typedef boost::shared_ptr<message_strobe_random> sptr;
+    typedef std::shared_ptr<message_strobe_random> sptr;
 
     /*!
      * Make a message stobe block to sends message \p msg at random

--- a/gr-blocks/include/gnuradio/blocks/min_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/min_blk.h
@@ -50,7 +50,7 @@ template <class T>
 class BLOCKS_API min_blk : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<min_blk<T>> sptr;
+    typedef std::shared_ptr<min_blk<T>> sptr;
 
     static sptr make(size_t vlen, size_t vlen_out = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/moving_average.h
+++ b/gr-blocks/include/gnuradio/blocks/moving_average.h
@@ -40,7 +40,7 @@ class BLOCKS_API moving_average : virtual public sync_block
 {
 public:
     // gr::blocks::moving_average::sptr
-    typedef boost::shared_ptr<moving_average<T>> sptr;
+    typedef std::shared_ptr<moving_average<T>> sptr;
 
     /*!
      * Create a moving average block.

--- a/gr-blocks/include/gnuradio/blocks/multiply.h
+++ b/gr-blocks/include/gnuradio/blocks/multiply.h
@@ -43,7 +43,7 @@ class BLOCKS_API multiply : virtual public sync_block
 {
 public:
     // gr::blocks::multiply::sptr
-    typedef boost::shared_ptr<multiply<T>> sptr;
+    typedef std::shared_ptr<multiply<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/multiply_by_tag_value_cc.h
+++ b/gr-blocks/include/gnuradio/blocks/multiply_by_tag_value_cc.h
@@ -45,7 +45,7 @@ class BLOCKS_API multiply_by_tag_value_cc : virtual public sync_block
 {
 public:
     // gr::blocks::multiply_by_tag_value_cc::sptr
-    typedef boost::shared_ptr<multiply_by_tag_value_cc> sptr;
+    typedef std::shared_ptr<multiply_by_tag_value_cc> sptr;
 
     /*!
      * \brief Create an instance of multiply_by_tag_value_cc

--- a/gr-blocks/include/gnuradio/blocks/multiply_conjugate_cc.h
+++ b/gr-blocks/include/gnuradio/blocks/multiply_conjugate_cc.h
@@ -37,7 +37,7 @@ class BLOCKS_API multiply_conjugate_cc : virtual public sync_block
 {
 public:
     // gr::blocks::multiply_conjugate_cc::sptr
-    typedef boost::shared_ptr<multiply_conjugate_cc> sptr;
+    typedef std::shared_ptr<multiply_conjugate_cc> sptr;
 
     /*!
      * \brief Multiplies a streams by the conjugate of a second stream

--- a/gr-blocks/include/gnuradio/blocks/multiply_const.h
+++ b/gr-blocks/include/gnuradio/blocks/multiply_const.h
@@ -41,7 +41,7 @@ class BLOCKS_API multiply_const : virtual public sync_block
 
 public:
     // gr::blocks::multiply_const::sptr
-    typedef boost::shared_ptr<multiply_const<T>> sptr;
+    typedef std::shared_ptr<multiply_const<T>> sptr;
 
     /*!
      * \brief Create an instance of multiply_const

--- a/gr-blocks/include/gnuradio/blocks/multiply_const_v.h
+++ b/gr-blocks/include/gnuradio/blocks/multiply_const_v.h
@@ -40,7 +40,7 @@ class BLOCKS_API multiply_const_v : virtual public sync_block
 
 public:
     // gr::blocks::multiply_const_v::sptr
-    typedef boost::shared_ptr<multiply_const_v<T>> sptr;
+    typedef std::shared_ptr<multiply_const_v<T>> sptr;
 
     /*!
      * \brief Create an instance of multiply_const_v

--- a/gr-blocks/include/gnuradio/blocks/multiply_matrix.h
+++ b/gr-blocks/include/gnuradio/blocks/multiply_matrix.h
@@ -70,7 +70,7 @@ template <class T>
 class BLOCKS_API multiply_matrix : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<multiply_matrix<T>> sptr;
+    typedef std::shared_ptr<multiply_matrix<T>> sptr;
 
     /*!
      * \param A The matrix

--- a/gr-blocks/include/gnuradio/blocks/mute.h
+++ b/gr-blocks/include/gnuradio/blocks/mute.h
@@ -39,7 +39,7 @@ template <class T>
 class BLOCKS_API mute_blk : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<mute_blk<T>> sptr;
+    typedef std::shared_ptr<mute_blk<T>> sptr;
 
     static sptr make(bool mute = false);
 

--- a/gr-blocks/include/gnuradio/blocks/nlog10_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/nlog10_ff.h
@@ -37,7 +37,7 @@ class BLOCKS_API nlog10_ff : virtual public sync_block
 {
 public:
     // gr::blocks::nlog10_ff::sptr
-    typedef boost::shared_ptr<nlog10_ff> sptr;
+    typedef std::shared_ptr<nlog10_ff> sptr;
 
     /*!
      * \brief Make an instance of an nlog10_ff block.

--- a/gr-blocks/include/gnuradio/blocks/nop.h
+++ b/gr-blocks/include/gnuradio/blocks/nop.h
@@ -38,7 +38,7 @@ class BLOCKS_API nop : virtual public block
 {
 public:
     // gr::blocks::nop::sptr
-    typedef boost::shared_ptr<nop> sptr;
+    typedef std::shared_ptr<nop> sptr;
 
     /*!
      * Build a nop block.

--- a/gr-blocks/include/gnuradio/blocks/not_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/not_blk.h
@@ -41,7 +41,7 @@ template <class T>
 class BLOCKS_API not_blk : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<not_blk<T>> sptr;
+    typedef std::shared_ptr<not_blk<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/null_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/null_sink.h
@@ -39,7 +39,7 @@ class BLOCKS_API null_sink : virtual public sync_block
 {
 public:
     // gr::blocks::null_sink::sptr
-    typedef boost::shared_ptr<null_sink> sptr;
+    typedef std::shared_ptr<null_sink> sptr;
 
     /*!
      * Build a null sink block.

--- a/gr-blocks/include/gnuradio/blocks/null_source.h
+++ b/gr-blocks/include/gnuradio/blocks/null_source.h
@@ -37,7 +37,7 @@ class BLOCKS_API null_source : virtual public sync_block
 {
 public:
     // gr::blocks::null_source::sptr
-    typedef boost::shared_ptr<null_source> sptr;
+    typedef std::shared_ptr<null_source> sptr;
 
     /*!
      * Build a null source block.

--- a/gr-blocks/include/gnuradio/blocks/or_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/or_blk.h
@@ -40,7 +40,7 @@ class BLOCKS_API or_blk : virtual public sync_block
 {
 public:
     // gr::blocks::or_blk::sptr
-    typedef boost::shared_ptr<or_blk<T>> sptr;
+    typedef std::shared_ptr<or_blk<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/pack_k_bits_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/pack_k_bits_bb.h
@@ -47,7 +47,7 @@ class BLOCKS_API pack_k_bits_bb : virtual public sync_decimator
 {
 public:
     // gr::blocks::pack_k_bits_bb::sptr
-    typedef boost::shared_ptr<pack_k_bits_bb> sptr;
+    typedef std::shared_ptr<pack_k_bits_bb> sptr;
 
     /*!
      * \brief Make a pack_k_bits block.

--- a/gr-blocks/include/gnuradio/blocks/packed_to_unpacked.h
+++ b/gr-blocks/include/gnuradio/blocks/packed_to_unpacked.h
@@ -63,7 +63,7 @@ class BLOCKS_API packed_to_unpacked : virtual public block
 {
 public:
     // gr::blocks::packed_to_unpacked::sptr
-    typedef boost::shared_ptr<packed_to_unpacked<T>> sptr;
+    typedef std::shared_ptr<packed_to_unpacked<T>> sptr;
 
     static sptr make(unsigned int bits_per_chunk, endianness_t endianness);
 };

--- a/gr-blocks/include/gnuradio/blocks/patterned_interleaver.h
+++ b/gr-blocks/include/gnuradio/blocks/patterned_interleaver.h
@@ -36,7 +36,7 @@ namespace blocks {
 class BLOCKS_API patterned_interleaver : virtual public block
 {
 public:
-    typedef boost::shared_ptr<patterned_interleaver> sptr;
+    typedef std::shared_ptr<patterned_interleaver> sptr;
 
     /*!
      * Make a patterned interleaver block.

--- a/gr-blocks/include/gnuradio/blocks/pdu_filter.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_filter.h
@@ -38,7 +38,7 @@ class BLOCKS_API pdu_filter : virtual public block
 {
 public:
     // gr::blocks::pdu_filter::sptr
-    typedef boost::shared_ptr<pdu_filter> sptr;
+    typedef std::shared_ptr<pdu_filter> sptr;
 
     /*!
      * \brief Construct a PDU filter

--- a/gr-blocks/include/gnuradio/blocks/pdu_remove.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_remove.h
@@ -38,7 +38,7 @@ class BLOCKS_API pdu_remove : virtual public block
 {
 public:
     // gr::blocks::pdu_remove::sptr
-    typedef boost::shared_ptr<pdu_remove> sptr;
+    typedef std::shared_ptr<pdu_remove> sptr;
 
     /*!
      * \brief Construct a PDU meta remove block

--- a/gr-blocks/include/gnuradio/blocks/pdu_set.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_set.h
@@ -38,7 +38,7 @@ class BLOCKS_API pdu_set : virtual public block
 {
 public:
     // gr::blocks::pdu_set::sptr
-    typedef boost::shared_ptr<pdu_set> sptr;
+    typedef std::shared_ptr<pdu_set> sptr;
 
     /*!
      * \brief Construct a PDU meta set block

--- a/gr-blocks/include/gnuradio/blocks/pdu_to_tagged_stream.h
+++ b/gr-blocks/include/gnuradio/blocks/pdu_to_tagged_stream.h
@@ -38,7 +38,7 @@ class BLOCKS_API pdu_to_tagged_stream : virtual public tagged_stream_block
 {
 public:
     // gr::blocks::pdu_to_tagged_stream::sptr
-    typedef boost::shared_ptr<pdu_to_tagged_stream> sptr;
+    typedef std::shared_ptr<pdu_to_tagged_stream> sptr;
 
     /*!
      * \brief Construct a pdu_to_tagged_stream block

--- a/gr-blocks/include/gnuradio/blocks/peak_detector.h
+++ b/gr-blocks/include/gnuradio/blocks/peak_detector.h
@@ -42,7 +42,7 @@ template <class T>
 class BLOCKS_API peak_detector : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<peak_detector<T>> sptr;
+    typedef std::shared_ptr<peak_detector<T>> sptr;
 
     /*!
      * Make a peak detector block.

--- a/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
+++ b/gr-blocks/include/gnuradio/blocks/peak_detector2_fb.h
@@ -42,7 +42,7 @@ class BLOCKS_API peak_detector2_fb : virtual public sync_block
 {
 public:
     // gr::blocks::peak_detector2_fb::sptr
-    typedef boost::shared_ptr<peak_detector2_fb> sptr;
+    typedef std::shared_ptr<peak_detector2_fb> sptr;
 
     /*!
      * Build a peak detector block with float in, byte out.

--- a/gr-blocks/include/gnuradio/blocks/plateau_detector_fb.h
+++ b/gr-blocks/include/gnuradio/blocks/plateau_detector_fb.h
@@ -54,7 +54,7 @@ namespace blocks {
 class BLOCKS_API plateau_detector_fb : virtual public block
 {
 public:
-    typedef boost::shared_ptr<plateau_detector_fb> sptr;
+    typedef std::shared_ptr<plateau_detector_fb> sptr;
 
     /*!
      * \param max_len Maximum length of the plateau

--- a/gr-blocks/include/gnuradio/blocks/probe_rate.h
+++ b/gr-blocks/include/gnuradio/blocks/probe_rate.h
@@ -37,7 +37,7 @@ class BLOCKS_API probe_rate : virtual public sync_block
 {
 public:
     // gr::blocks::probe_rate::sptr
-    typedef boost::shared_ptr<probe_rate> sptr;
+    typedef std::shared_ptr<probe_rate> sptr;
 
     /*!
      * \brief Make a throughput measurement block

--- a/gr-blocks/include/gnuradio/blocks/probe_signal.h
+++ b/gr-blocks/include/gnuradio/blocks/probe_signal.h
@@ -40,7 +40,7 @@ class BLOCKS_API probe_signal : virtual public sync_block
 {
 public:
     // gr::blocks::probe_signal::sptr
-    typedef boost::shared_ptr<probe_signal<T>> sptr;
+    typedef std::shared_ptr<probe_signal<T>> sptr;
 
     static sptr make();
 

--- a/gr-blocks/include/gnuradio/blocks/probe_signal_v.h
+++ b/gr-blocks/include/gnuradio/blocks/probe_signal_v.h
@@ -40,7 +40,7 @@ template <class T>
 class BLOCKS_API probe_signal_v : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<probe_signal_v<T>> sptr;
+    typedef std::shared_ptr<probe_signal_v<T>> sptr;
 
     static sptr make(size_t size);
 

--- a/gr-blocks/include/gnuradio/blocks/random_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/random_pdu.h
@@ -38,7 +38,7 @@ class BLOCKS_API random_pdu : virtual public block
 {
 public:
     // gr::blocks::random_pdu::sptr
-    typedef boost::shared_ptr<random_pdu> sptr;
+    typedef std::shared_ptr<random_pdu> sptr;
 
     /*!
      * \brief Construct a random PDU generator

--- a/gr-blocks/include/gnuradio/blocks/regenerate_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/regenerate_bb.h
@@ -45,7 +45,7 @@ class BLOCKS_API regenerate_bb : virtual public sync_block
 {
 public:
     // gr::blocks::regenerate_bb::sptr
-    typedef boost::shared_ptr<regenerate_bb> sptr;
+    typedef std::shared_ptr<regenerate_bb> sptr;
 
     /*!
      * \brief Make a regenerate block

--- a/gr-blocks/include/gnuradio/blocks/repack_bits_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/repack_bits_bb.h
@@ -68,7 +68,7 @@ namespace blocks {
 class BLOCKS_API repack_bits_bb : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<repack_bits_bb> sptr;
+    typedef std::shared_ptr<repack_bits_bb> sptr;
 
     /*!
      * \param k Number of relevant bits on the input stream

--- a/gr-blocks/include/gnuradio/blocks/repeat.h
+++ b/gr-blocks/include/gnuradio/blocks/repeat.h
@@ -42,7 +42,7 @@ class BLOCKS_API repeat : virtual public sync_interpolator
 {
 public:
     // gr::blocks::repeat::sptr
-    typedef boost::shared_ptr<repeat> sptr;
+    typedef std::shared_ptr<repeat> sptr;
 
     /*!
      * Make a repeat block.

--- a/gr-blocks/include/gnuradio/blocks/rms_cf.h
+++ b/gr-blocks/include/gnuradio/blocks/rms_cf.h
@@ -37,7 +37,7 @@ class BLOCKS_API rms_cf : virtual public sync_block
 {
 public:
     // gr::blocks::rms_cf::sptr
-    typedef boost::shared_ptr<rms_cf> sptr;
+    typedef std::shared_ptr<rms_cf> sptr;
 
     /*!
      * \brief Make an RMS calc. block.

--- a/gr-blocks/include/gnuradio/blocks/rms_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/rms_ff.h
@@ -37,7 +37,7 @@ class BLOCKS_API rms_ff : virtual public sync_block
 {
 public:
     // gr::blocks::rms_ff::sptr
-    typedef boost::shared_ptr<rms_ff> sptr;
+    typedef std::shared_ptr<rms_ff> sptr;
 
     /*!
      * \brief Make an RMS calc. block.

--- a/gr-blocks/include/gnuradio/blocks/rotator_cc.h
+++ b/gr-blocks/include/gnuradio/blocks/rotator_cc.h
@@ -37,7 +37,7 @@ class BLOCKS_API rotator_cc : virtual public sync_block
 {
 public:
     // gr::blocks::rotator_cc::sptr
-    typedef boost::shared_ptr<rotator_cc> sptr;
+    typedef std::shared_ptr<rotator_cc> sptr;
 
     /*!
      * \brief Make an complex rotator block

--- a/gr-blocks/include/gnuradio/blocks/sample_and_hold.h
+++ b/gr-blocks/include/gnuradio/blocks/sample_and_hold.h
@@ -44,7 +44,7 @@ class BLOCKS_API sample_and_hold : virtual public sync_block
 {
 public:
     // gr::blocks::sample_and_hold::sptr
-    typedef boost::shared_ptr<sample_and_hold<T>> sptr;
+    typedef std::shared_ptr<sample_and_hold<T>> sptr;
 
     static sptr make();
 };

--- a/gr-blocks/include/gnuradio/blocks/selector.h
+++ b/gr-blocks/include/gnuradio/blocks/selector.h
@@ -42,7 +42,7 @@ namespace blocks {
 class BLOCKS_API selector : virtual public block
 {
 public:
-    typedef boost::shared_ptr<selector> sptr;
+    typedef std::shared_ptr<selector> sptr;
 
     static sptr
     make(size_t itemsize, unsigned int input_index, unsigned int output_index);

--- a/gr-blocks/include/gnuradio/blocks/short_to_char.h
+++ b/gr-blocks/include/gnuradio/blocks/short_to_char.h
@@ -47,7 +47,7 @@ class BLOCKS_API short_to_char : virtual public sync_block
 {
 public:
     // gr::blocks::short_to_char_ff::sptr
-    typedef boost::shared_ptr<short_to_char> sptr;
+    typedef std::shared_ptr<short_to_char> sptr;
 
     /*!
      * Build a short to char block.

--- a/gr-blocks/include/gnuradio/blocks/short_to_float.h
+++ b/gr-blocks/include/gnuradio/blocks/short_to_float.h
@@ -37,7 +37,7 @@ class BLOCKS_API short_to_float : virtual public sync_block
 {
 public:
     // gr::blocks::short_to_float_ff::sptr
-    typedef boost::shared_ptr<short_to_float> sptr;
+    typedef std::shared_ptr<short_to_float> sptr;
 
     /*!
      * Build a short to float block.

--- a/gr-blocks/include/gnuradio/blocks/skiphead.h
+++ b/gr-blocks/include/gnuradio/blocks/skiphead.h
@@ -42,7 +42,7 @@ class BLOCKS_API skiphead : virtual public block
 {
 public:
     // gr::blocks::skiphead::sptr
-    typedef boost::shared_ptr<skiphead> sptr;
+    typedef std::shared_ptr<skiphead> sptr;
 
     static sptr make(size_t itemsize, uint64_t nitems_to_skip);
 };

--- a/gr-blocks/include/gnuradio/blocks/socket_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/socket_pdu.h
@@ -37,7 +37,7 @@ class BLOCKS_API socket_pdu : virtual public block
 {
 public:
     // gr::blocks::socket_pdu::sptr
-    typedef boost::shared_ptr<socket_pdu> sptr;
+    typedef std::shared_ptr<socket_pdu> sptr;
 
     /*!
      * \brief Construct a SOCKET PDU interface

--- a/gr-blocks/include/gnuradio/blocks/stream_mux.h
+++ b/gr-blocks/include/gnuradio/blocks/stream_mux.h
@@ -46,7 +46,7 @@ class BLOCKS_API stream_mux : virtual public block
 {
 public:
     // gr::blocks::stream_mux::sptr
-    typedef boost::shared_ptr<stream_mux> sptr;
+    typedef std::shared_ptr<stream_mux> sptr;
 
     /*!
      * \brief Creates a stream muxing block to multiplex many streams into

--- a/gr-blocks/include/gnuradio/blocks/stream_to_streams.h
+++ b/gr-blocks/include/gnuradio/blocks/stream_to_streams.h
@@ -41,7 +41,7 @@ class BLOCKS_API stream_to_streams : virtual public sync_decimator
 {
 public:
     // gr::blocks::stream_to_streams::sptr
-    typedef boost::shared_ptr<stream_to_streams> sptr;
+    typedef std::shared_ptr<stream_to_streams> sptr;
 
     /*!
      * Make a stream-to-streams block.

--- a/gr-blocks/include/gnuradio/blocks/stream_to_tagged_stream.h
+++ b/gr-blocks/include/gnuradio/blocks/stream_to_tagged_stream.h
@@ -45,7 +45,7 @@ namespace blocks {
 class BLOCKS_API stream_to_tagged_stream : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<stream_to_tagged_stream> sptr;
+    typedef std::shared_ptr<stream_to_tagged_stream> sptr;
 
     /*!
      * \param itemsize Item size

--- a/gr-blocks/include/gnuradio/blocks/stream_to_vector.h
+++ b/gr-blocks/include/gnuradio/blocks/stream_to_vector.h
@@ -37,7 +37,7 @@ class BLOCKS_API stream_to_vector : virtual public sync_decimator
 {
 public:
     // gr::blocks::stream_to_vector::sptr
-    typedef boost::shared_ptr<stream_to_vector> sptr;
+    typedef std::shared_ptr<stream_to_vector> sptr;
 
     /*!
      * Make a stream-to-vector block.

--- a/gr-blocks/include/gnuradio/blocks/streams_to_stream.h
+++ b/gr-blocks/include/gnuradio/blocks/streams_to_stream.h
@@ -41,7 +41,7 @@ class BLOCKS_API streams_to_stream : virtual public sync_interpolator
 {
 public:
     // gr::blocks::streams_to_stream::sptr
-    typedef boost::shared_ptr<streams_to_stream> sptr;
+    typedef std::shared_ptr<streams_to_stream> sptr;
 
     /*!
      * Make a streams-to-stream block.

--- a/gr-blocks/include/gnuradio/blocks/streams_to_vector.h
+++ b/gr-blocks/include/gnuradio/blocks/streams_to_vector.h
@@ -37,7 +37,7 @@ class BLOCKS_API streams_to_vector : virtual public sync_block
 {
 public:
     // gr::blocks::streams_to_vector::sptr
-    typedef boost::shared_ptr<streams_to_vector> sptr;
+    typedef std::shared_ptr<streams_to_vector> sptr;
 
     /*!
      * Make a stream-to-vector block.

--- a/gr-blocks/include/gnuradio/blocks/stretch_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/stretch_ff.h
@@ -39,7 +39,7 @@ class BLOCKS_API stretch_ff : virtual public sync_block
 {
 public:
     // gr::blocks::stretch_ff::sptr
-    typedef boost::shared_ptr<stretch_ff> sptr;
+    typedef std::shared_ptr<stretch_ff> sptr;
 
     /*!
      * \brief Make a stretch block.

--- a/gr-blocks/include/gnuradio/blocks/sub.h
+++ b/gr-blocks/include/gnuradio/blocks/sub.h
@@ -43,7 +43,7 @@ class BLOCKS_API sub : virtual public sync_block
 {
 public:
     // gr::blocks::sub::sptr
-    typedef boost::shared_ptr<sub<T>> sptr;
+    typedef std::shared_ptr<sub<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/include/gnuradio/blocks/tag_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/tag_debug.h
@@ -59,7 +59,7 @@ class BLOCKS_API tag_debug : virtual public sync_block
 {
 public:
     // gr::blocks::tag_debug::sptr
-    typedef boost::shared_ptr<tag_debug> sptr;
+    typedef std::shared_ptr<tag_debug> sptr;
 
     /*!
      * Build a tag debug block

--- a/gr-blocks/include/gnuradio/blocks/tag_gate.h
+++ b/gr-blocks/include/gnuradio/blocks/tag_gate.h
@@ -38,7 +38,7 @@ namespace blocks {
 class BLOCKS_API tag_gate : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<tag_gate> sptr;
+    typedef std::shared_ptr<tag_gate> sptr;
 
     virtual void set_propagation(bool propagate_tags) = 0;
 

--- a/gr-blocks/include/gnuradio/blocks/tag_share.h
+++ b/gr-blocks/include/gnuradio/blocks/tag_share.h
@@ -47,7 +47,7 @@ namespace blocks {
 class BLOCKS_API tag_share : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<tag_share> sptr;
+    typedef std::shared_ptr<tag_share> sptr;
 
     /*!
      * \param sizeof_io_item The size of the Input 0/Output 0 stream type. Input 0

--- a/gr-blocks/include/gnuradio/blocks/tagged_file_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/tagged_file_sink.h
@@ -49,7 +49,7 @@ class BLOCKS_API tagged_file_sink : virtual public sync_block
 {
 public:
     // gr::blocks::tagged_file_sink::sptr
-    typedef boost::shared_ptr<tagged_file_sink> sptr;
+    typedef std::shared_ptr<tagged_file_sink> sptr;
 
     /*!
      * \brief Build a tagged_file_sink block.

--- a/gr-blocks/include/gnuradio/blocks/tagged_stream_align.h
+++ b/gr-blocks/include/gnuradio/blocks/tagged_stream_align.h
@@ -38,7 +38,7 @@ namespace blocks {
 class BLOCKS_API tagged_stream_align : virtual public block
 {
 public:
-    typedef boost::shared_ptr<tagged_stream_align> sptr;
+    typedef std::shared_ptr<tagged_stream_align> sptr;
 
     /*!
      * Make a tagged stream align

--- a/gr-blocks/include/gnuradio/blocks/tagged_stream_multiply_length.h
+++ b/gr-blocks/include/gnuradio/blocks/tagged_stream_multiply_length.h
@@ -40,7 +40,7 @@ namespace blocks {
 class BLOCKS_API tagged_stream_multiply_length : virtual public block
 {
 public:
-    typedef boost::shared_ptr<tagged_stream_multiply_length> sptr;
+    typedef std::shared_ptr<tagged_stream_multiply_length> sptr;
     virtual void set_scalar(double scalar) = 0;
 
     /*!

--- a/gr-blocks/include/gnuradio/blocks/tagged_stream_mux.h
+++ b/gr-blocks/include/gnuradio/blocks/tagged_stream_mux.h
@@ -50,7 +50,7 @@ namespace blocks {
 class BLOCKS_API tagged_stream_mux : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<tagged_stream_mux> sptr;
+    typedef std::shared_ptr<tagged_stream_mux> sptr;
 
     /*!
      * Make a tagged stream mux block.

--- a/gr-blocks/include/gnuradio/blocks/tagged_stream_to_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/tagged_stream_to_pdu.h
@@ -43,7 +43,7 @@ class BLOCKS_API tagged_stream_to_pdu : virtual public tagged_stream_block
 {
 public:
     // gr::blocks::tagged_stream_to_pdu::sptr
-    typedef boost::shared_ptr<tagged_stream_to_pdu> sptr;
+    typedef std::shared_ptr<tagged_stream_to_pdu> sptr;
 
     /*!
      * \brief Construct a tagged_stream_to_pdu block

--- a/gr-blocks/include/gnuradio/blocks/tags_strobe.h
+++ b/gr-blocks/include/gnuradio/blocks/tags_strobe.h
@@ -45,7 +45,7 @@ class BLOCKS_API tags_strobe : virtual public sync_block
 {
 public:
     // gr::blocks::tags_strobe::sptr
-    typedef boost::shared_ptr<tags_strobe> sptr;
+    typedef std::shared_ptr<tags_strobe> sptr;
 
     /*!
      * Make a tags stobe block to send tags with value \p value

--- a/gr-blocks/include/gnuradio/blocks/tcp_server_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/tcp_server_sink.h
@@ -42,7 +42,7 @@ class BLOCKS_API tcp_server_sink : virtual public gr::sync_block
 {
 public:
     // gr::blocks::tcp_server_sink::sptr
-    typedef boost::shared_ptr<tcp_server_sink> sptr;
+    typedef std::shared_ptr<tcp_server_sink> sptr;
 
     /*!
      * \brief TCP Server Sink Constructor

--- a/gr-blocks/include/gnuradio/blocks/test_tag_variable_rate_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/test_tag_variable_rate_ff.h
@@ -59,7 +59,7 @@ class BLOCKS_API test_tag_variable_rate_ff : virtual public block
 {
 public:
     // gr::blocks::test_tag_variable_rate_ff::sptr
-    typedef boost::shared_ptr<test_tag_variable_rate_ff> sptr;
+    typedef std::shared_ptr<test_tag_variable_rate_ff> sptr;
 
     /*!
      * Build a test_tag_variable_rate_ff block.

--- a/gr-blocks/include/gnuradio/blocks/threshold_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/threshold_ff.h
@@ -42,7 +42,7 @@ class BLOCKS_API threshold_ff : virtual public sync_block
 {
 public:
     // gr::blocks::threshold_ff::sptr
-    typedef boost::shared_ptr<threshold_ff> sptr;
+    typedef std::shared_ptr<threshold_ff> sptr;
 
     /* \brief Create a threadshold block.
      * \param lo Threshold input signal needs to drop below to

--- a/gr-blocks/include/gnuradio/blocks/throttle.h
+++ b/gr-blocks/include/gnuradio/blocks/throttle.h
@@ -46,7 +46,7 @@ namespace blocks {
 class BLOCKS_API throttle : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<throttle> sptr;
+    typedef std::shared_ptr<throttle> sptr;
 
     static sptr make(size_t itemsize, double samples_per_sec, bool ignore_tags = true);
 

--- a/gr-blocks/include/gnuradio/blocks/transcendental.h
+++ b/gr-blocks/include/gnuradio/blocks/transcendental.h
@@ -46,7 +46,7 @@ class BLOCKS_API transcendental : virtual public sync_block
 {
 public:
     // gr::blocks::transcendental::sptr
-    typedef boost::shared_ptr<transcendental> sptr;
+    typedef std::shared_ptr<transcendental> sptr;
 
     static sptr make(const std::string& name, const std::string& type = "float");
 };

--- a/gr-blocks/include/gnuradio/blocks/tsb_vector_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/tsb_vector_sink.h
@@ -42,7 +42,7 @@ template <class T>
 class BLOCKS_API tsb_vector_sink : virtual public gr::tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<tsb_vector_sink<T>> sptr;
+    typedef std::shared_ptr<tsb_vector_sink<T>> sptr;
 
     virtual void reset() = 0;
     virtual std::vector<std::vector<T>> data() const = 0;

--- a/gr-blocks/include/gnuradio/blocks/tuntap_pdu.h
+++ b/gr-blocks/include/gnuradio/blocks/tuntap_pdu.h
@@ -37,7 +37,7 @@ class BLOCKS_API tuntap_pdu : virtual public block
 {
 public:
     // gr::blocks::tuntap_pdu::sptr
-    typedef boost::shared_ptr<tuntap_pdu> sptr;
+    typedef std::shared_ptr<tuntap_pdu> sptr;
 
     /*!
      * \brief Construct a TUNTAP PDU interface

--- a/gr-blocks/include/gnuradio/blocks/uchar_to_float.h
+++ b/gr-blocks/include/gnuradio/blocks/uchar_to_float.h
@@ -37,7 +37,7 @@ class BLOCKS_API uchar_to_float : virtual public sync_block
 {
 public:
     // gr::blocks::uchar_to_float_ff::sptr
-    typedef boost::shared_ptr<uchar_to_float> sptr;
+    typedef std::shared_ptr<uchar_to_float> sptr;
 
     /*!
      * Build a uchar to float block.

--- a/gr-blocks/include/gnuradio/blocks/udp_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/udp_sink.h
@@ -37,7 +37,7 @@ class BLOCKS_API udp_sink : virtual public sync_block
 {
 public:
     // gr::blocks::udp_sink::sptr
-    typedef boost::shared_ptr<udp_sink> sptr;
+    typedef std::shared_ptr<udp_sink> sptr;
 
     /*!
      * \brief UDP Sink Constructor

--- a/gr-blocks/include/gnuradio/blocks/udp_source.h
+++ b/gr-blocks/include/gnuradio/blocks/udp_source.h
@@ -37,7 +37,7 @@ class BLOCKS_API udp_source : virtual public sync_block
 {
 public:
     // gr::blocks::udp_source::sptr
-    typedef boost::shared_ptr<udp_source> sptr;
+    typedef std::shared_ptr<udp_source> sptr;
 
     /*!
      * \brief UDP Source Constructor

--- a/gr-blocks/include/gnuradio/blocks/unpack_k_bits_bb.h
+++ b/gr-blocks/include/gnuradio/blocks/unpack_k_bits_bb.h
@@ -45,7 +45,7 @@ class BLOCKS_API unpack_k_bits_bb : virtual public sync_interpolator
 {
 public:
     // gr::blocks::unpack_k_bits_bb::sptr
-    typedef boost::shared_ptr<unpack_k_bits_bb> sptr;
+    typedef std::shared_ptr<unpack_k_bits_bb> sptr;
 
     /*!
      * \brief Make an unpack_k_bits block.

--- a/gr-blocks/include/gnuradio/blocks/unpacked_to_packed.h
+++ b/gr-blocks/include/gnuradio/blocks/unpacked_to_packed.h
@@ -62,7 +62,7 @@ class BLOCKS_API unpacked_to_packed : virtual public block
 {
 public:
     // gr::blocks::unpacked_to_packed::sptr
-    typedef boost::shared_ptr<unpacked_to_packed<T>> sptr;
+    typedef std::shared_ptr<unpacked_to_packed<T>> sptr;
 
     static sptr make(unsigned int bits_per_chunk, endianness_t endianness);
 };

--- a/gr-blocks/include/gnuradio/blocks/vco_c.h
+++ b/gr-blocks/include/gnuradio/blocks/vco_c.h
@@ -41,7 +41,7 @@ class BLOCKS_API vco_c : virtual public sync_block
 {
 public:
     // gr::blocks::vco_c::sptr
-    typedef boost::shared_ptr<vco_c> sptr;
+    typedef std::shared_ptr<vco_c> sptr;
 
     /*!
      * \brief VCO - Voltage controlled oscillator

--- a/gr-blocks/include/gnuradio/blocks/vco_f.h
+++ b/gr-blocks/include/gnuradio/blocks/vco_f.h
@@ -41,7 +41,7 @@ class BLOCKS_API vco_f : virtual public sync_block
 {
 public:
     // gr::blocks::vco_f::sptr
-    typedef boost::shared_ptr<vco_f> sptr;
+    typedef std::shared_ptr<vco_f> sptr;
 
     /*!
      * \brief VCO - Voltage controlled oscillator

--- a/gr-blocks/include/gnuradio/blocks/vector_insert.h
+++ b/gr-blocks/include/gnuradio/blocks/vector_insert.h
@@ -40,7 +40,7 @@ class BLOCKS_API vector_insert : virtual public block
 {
 public:
     // gr::blocks::vector_insert::sptr
-    typedef boost::shared_ptr<vector_insert<T>> sptr;
+    typedef std::shared_ptr<vector_insert<T>> sptr;
 
     /*!
      * Make vector insert block.

--- a/gr-blocks/include/gnuradio/blocks/vector_map.h
+++ b/gr-blocks/include/gnuradio/blocks/vector_map.h
@@ -49,7 +49,7 @@ class BLOCKS_API vector_map : virtual public sync_block
 {
 public:
     // gr::blocks::vector_map::sptr
-    typedef boost::shared_ptr<vector_map> sptr;
+    typedef std::shared_ptr<vector_map> sptr;
 
     /*!
      * Build a vector map block.

--- a/gr-blocks/include/gnuradio/blocks/vector_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/vector_sink.h
@@ -40,7 +40,7 @@ class BLOCKS_API vector_sink : virtual public sync_block
 {
 public:
     // gr::blocks::vector_sink::sptr
-    typedef boost::shared_ptr<vector_sink<T>> sptr;
+    typedef std::shared_ptr<vector_sink<T>> sptr;
 
     /*!
      * \brief Make a new instance of the vector source, and return a shared pointer to it.

--- a/gr-blocks/include/gnuradio/blocks/vector_source.h
+++ b/gr-blocks/include/gnuradio/blocks/vector_source.h
@@ -68,7 +68,7 @@ class BLOCKS_API vector_source : virtual public sync_block
 {
 public:
     // gr::blocks::vector_source::sptr
-    typedef boost::shared_ptr<vector_source<T>> sptr;
+    typedef std::shared_ptr<vector_source<T>> sptr;
 
     static sptr make(const std::vector<T>& data,
                      bool repeat = false,

--- a/gr-blocks/include/gnuradio/blocks/vector_to_stream.h
+++ b/gr-blocks/include/gnuradio/blocks/vector_to_stream.h
@@ -37,7 +37,7 @@ class BLOCKS_API vector_to_stream : virtual public sync_interpolator
 {
 public:
     // gr::blocks::vector_to_stream::sptr
-    typedef boost::shared_ptr<vector_to_stream> sptr;
+    typedef std::shared_ptr<vector_to_stream> sptr;
 
     /*!
      * Make vector-to-stream block

--- a/gr-blocks/include/gnuradio/blocks/vector_to_streams.h
+++ b/gr-blocks/include/gnuradio/blocks/vector_to_streams.h
@@ -37,7 +37,7 @@ class BLOCKS_API vector_to_streams : virtual public sync_block
 {
 public:
     // gr::blocks::vector_to_streams::sptr
-    typedef boost::shared_ptr<vector_to_streams> sptr;
+    typedef std::shared_ptr<vector_to_streams> sptr;
 
     /*!
      * Make vector-to-streams block

--- a/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
@@ -41,7 +41,7 @@ class BLOCKS_API wavfile_sink : virtual public sync_block
 {
 public:
     // gr::blocks::wavfile_sink::sptr
-    typedef boost::shared_ptr<wavfile_sink> sptr;
+    typedef std::shared_ptr<wavfile_sink> sptr;
 
     /*
      * \param filename The .wav file to be opened

--- a/gr-blocks/include/gnuradio/blocks/wavfile_source.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_source.h
@@ -41,7 +41,7 @@ class BLOCKS_API wavfile_source : virtual public sync_block
 {
 public:
     // gr::blocks::wavfile_source::sptr
-    typedef boost::shared_ptr<wavfile_source> sptr;
+    typedef std::shared_ptr<wavfile_source> sptr;
 
     static sptr make(const char* filename, bool repeat = false);
 

--- a/gr-blocks/include/gnuradio/blocks/xor_blk.h
+++ b/gr-blocks/include/gnuradio/blocks/xor_blk.h
@@ -42,7 +42,7 @@ class BLOCKS_API xor_blk : virtual public sync_block
 {
 public:
     // gr::blocks::xor::sptr
-    typedef boost::shared_ptr<xor_blk<T>> sptr;
+    typedef std::shared_ptr<xor_blk<T>> sptr;
 
     static sptr make(size_t vlen = 1);
 };

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -64,7 +64,7 @@ bool message_strobe_impl::start()
     // NOTE: d_finished should be something explicitly thread safe. But since
     // nothing breaks on concurrent access, I'll just leave it as bool.
     d_finished = false;
-    d_thread = boost::shared_ptr<gr::thread::thread>(
+    d_thread = std::shared_ptr<gr::thread::thread>(
         new gr::thread::thread(boost::bind(&message_strobe_impl::run, this)));
 
     return block::start();

--- a/gr-blocks/lib/message_strobe_impl.h
+++ b/gr-blocks/lib/message_strobe_impl.h
@@ -31,7 +31,7 @@ namespace blocks {
 class BLOCKS_API message_strobe_impl : public message_strobe
 {
 private:
-    boost::shared_ptr<gr::thread::thread> d_thread;
+    std::shared_ptr<gr::thread::thread> d_thread;
     bool d_finished;
     long d_period_ms;
     pmt::pmt_t d_msg;

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -62,7 +62,7 @@ message_strobe_random_impl::message_strobe_random_impl(
 {
     // set up ports
     message_port_register_out(d_port);
-    d_thread = boost::shared_ptr<gr::thread::thread>(
+    d_thread = std::shared_ptr<gr::thread::thread>(
         new gr::thread::thread(boost::bind(&message_strobe_random_impl::run, this)));
 
     message_port_register_in(pmt::mp("set_msg"));
@@ -102,7 +102,6 @@ long message_strobe_random_impl::next_delay()
             "message_strobe_random_impl::d_distribution is very unhappy with you");
     }
 }
-
 
 message_strobe_random_impl::~message_strobe_random_impl()
 {

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -40,7 +40,7 @@ private:
     std::poisson_distribution<> pd;      //(d_mean_ms);
     std::normal_distribution<> nd;       //(d_mean_ms, d_std_ms);
     std::uniform_real_distribution<> ud; //(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms);
-    boost::shared_ptr<gr::thread::thread> d_thread;
+    std::shared_ptr<gr::thread::thread> d_thread;
     bool d_finished;
     pmt::pmt_t d_msg;
     const pmt::pmt_t d_port;

--- a/gr-blocks/lib/qa_gr_flowgraph.cc
+++ b/gr-blocks/lib/qa_gr_flowgraph.cc
@@ -35,7 +35,7 @@ namespace blocks {
 class null_qa_source : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<null_qa_source> sptr;
+    typedef std::shared_ptr<null_qa_source> sptr;
     static sptr make(size_t sizeof_stream_item);
 };
 class null_source_qa_impl : public null_qa_source
@@ -68,7 +68,7 @@ null_qa_source::sptr null_qa_source::make(size_t sizeof_stream_item)
 class null_qa_sink : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<null_qa_sink> sptr;
+    typedef std::shared_ptr<null_qa_sink> sptr;
     static sptr make(size_t sizeof_stream_item);
 };
 class null_sink_qa_impl : public null_qa_sink

--- a/gr-blocks/lib/qa_gr_hier_block2_derived.cc
+++ b/gr-blocks/lib/qa_gr_hier_block2_derived.cc
@@ -35,7 +35,7 @@
 // Declare a test C++ hierarchical block
 
 class gr_derived_block;
-typedef boost::shared_ptr<gr_derived_block> gr_derived_block_sptr;
+typedef std::shared_ptr<gr_derived_block> gr_derived_block_sptr;
 gr_derived_block_sptr gr_make_derived_block();
 
 class gr_derived_block : public gr::hier_block2

--- a/gr-blocks/lib/socket_pdu_impl.h
+++ b/gr-blocks/lib/socket_pdu_impl.h
@@ -46,20 +46,20 @@ private:
     bool d_tcp_no_delay;
 
     // TCP server specific
-    boost::shared_ptr<boost::asio::ip::tcp::acceptor> d_acceptor_tcp;
+    std::shared_ptr<boost::asio::ip::tcp::acceptor> d_acceptor_tcp;
     void start_tcp_accept();
     void tcp_server_send(pmt::pmt_t msg);
     void handle_tcp_accept(tcp_connection::sptr new_connection,
                            const boost::system::error_code& error);
 
     // TCP client specific
-    boost::shared_ptr<boost::asio::ip::tcp::socket> d_tcp_socket;
+    std::shared_ptr<boost::asio::ip::tcp::socket> d_tcp_socket;
     void tcp_client_send(pmt::pmt_t msg);
 
     // UDP specific
     boost::asio::ip::udp::endpoint d_udp_endpoint;
     boost::asio::ip::udp::endpoint d_udp_endpoint_other;
-    boost::shared_ptr<boost::asio::ip::udp::socket> d_udp_socket;
+    std::shared_ptr<boost::asio::ip::udp::socket> d_udp_socket;
     void handle_udp_read(const boost::system::error_code& error,
                          size_t bytes_transferred);
     void udp_send(pmt::pmt_t msg);

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -57,7 +57,7 @@ void tcp_connection::send(pmt::pmt_t vector)
     size_t len = pmt::blob_length(vector);
 
     // Asio async_write() requires the buffer to remain valid until the handler is called.
-    boost::shared_ptr<char[]> txbuf(new char[len]);
+    std::shared_ptr<char[]> txbuf(new char[len]);
 
     size_t temp = 0;
     memcpy(txbuf.get(), pmt::uniform_vector_elements(vector, temp), len);

--- a/gr-blocks/lib/tcp_connection.h
+++ b/gr-blocks/lib/tcp_connection.h
@@ -26,7 +26,7 @@
 #include <pmt/pmt.h>
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 
@@ -47,7 +47,7 @@ private:
                    bool no_delay = false);
 
 public:
-    typedef boost::shared_ptr<tcp_connection> sptr;
+    typedef std::shared_ptr<tcp_connection> sptr;
 
     static sptr
     make(boost::asio::io_service& io_service, int MTU = 10000, bool no_delay = false);
@@ -57,7 +57,7 @@ public:
     void start(gr::basic_block* block);
     void send(pmt::pmt_t vector);
     void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-    void handle_write(boost::shared_ptr<char[]> txbuf,
+    void handle_write(std::shared_ptr<char[]> txbuf,
                       const boost::system::error_code& error,
                       size_t bytes_transferred)
     {

--- a/gr-blocks/lib/tcp_server_sink_impl.h
+++ b/gr-blocks/lib/tcp_server_sink_impl.h
@@ -43,7 +43,7 @@ private:
     std::set<boost::asio::ip::tcp::socket*> d_sockets;
     boost::asio::ip::tcp::acceptor d_acceptor;
 
-    boost::shared_ptr<uint8_t[]> d_buf;
+    std::shared_ptr<uint8_t[]> d_buf;
     enum {
         BUF_SIZE = 256 * 1024,
     };

--- a/gr-channels/include/gnuradio/channels/cfo_model.h
+++ b/gr-channels/include/gnuradio/channels/cfo_model.h
@@ -45,7 +45,7 @@ class CHANNELS_API cfo_model : virtual public sync_block
 {
 public:
     // gr::channels::cfo_model::sptr
-    typedef boost::shared_ptr<cfo_model> sptr;
+    typedef std::shared_ptr<cfo_model> sptr;
 
     /*! \brief Build the carrier frequency offset model
      *

--- a/gr-channels/include/gnuradio/channels/channel_model.h
+++ b/gr-channels/include/gnuradio/channels/channel_model.h
@@ -56,7 +56,7 @@ class CHANNELS_API channel_model : virtual public hier_block2
 {
 public:
     // gr::channels::channel_model::sptr
-    typedef boost::shared_ptr<channel_model> sptr;
+    typedef std::shared_ptr<channel_model> sptr;
 
     /*! \brief Build the channel simulator.
      *

--- a/gr-channels/include/gnuradio/channels/channel_model2.h
+++ b/gr-channels/include/gnuradio/channels/channel_model2.h
@@ -72,7 +72,7 @@ class CHANNELS_API channel_model2 : virtual public hier_block2
 {
 public:
     // gr::channels::channel_model2::sptr
-    typedef boost::shared_ptr<channel_model2> sptr;
+    typedef std::shared_ptr<channel_model2> sptr;
 
     /*! \brief Build the channel simulator.
      *

--- a/gr-channels/include/gnuradio/channels/dynamic_channel_model.h
+++ b/gr-channels/include/gnuradio/channels/dynamic_channel_model.h
@@ -49,7 +49,7 @@ class CHANNELS_API dynamic_channel_model : virtual public hier_block2
 {
 public:
     // gr::channels::dynamic_channel_model::sptr
-    typedef boost::shared_ptr<dynamic_channel_model> sptr;
+    typedef std::shared_ptr<dynamic_channel_model> sptr;
 
     /*! \brief Build the dynamic channel simulator.
      *

--- a/gr-channels/include/gnuradio/channels/fading_model.h
+++ b/gr-channels/include/gnuradio/channels/fading_model.h
@@ -43,7 +43,7 @@ class CHANNELS_API fading_model : virtual public sync_block
 {
 public:
     // gr::channels::channel_model::sptr
-    typedef boost::shared_ptr<fading_model> sptr;
+    typedef std::shared_ptr<fading_model> sptr;
 
     /*! \brief Build the channel simulator.
      *

--- a/gr-channels/include/gnuradio/channels/selective_fading_model.h
+++ b/gr-channels/include/gnuradio/channels/selective_fading_model.h
@@ -46,7 +46,7 @@ class CHANNELS_API selective_fading_model : virtual public sync_block
 {
 public:
     // gr::channels::channel_model::sptr
-    typedef boost::shared_ptr<selective_fading_model> sptr;
+    typedef std::shared_ptr<selective_fading_model> sptr;
 
     /*! \brief Build the channel simulator.
      *

--- a/gr-channels/include/gnuradio/channels/selective_fading_model2.h
+++ b/gr-channels/include/gnuradio/channels/selective_fading_model2.h
@@ -46,7 +46,7 @@ class CHANNELS_API selective_fading_model2 : virtual public sync_block
 {
 public:
     // gr::channels::channel_model2::sptr
-    typedef boost::shared_ptr<selective_fading_model2> sptr;
+    typedef std::shared_ptr<selective_fading_model2> sptr;
 
     /*! \brief Build the channel simulator.
      *

--- a/gr-channels/include/gnuradio/channels/sro_model.h
+++ b/gr-channels/include/gnuradio/channels/sro_model.h
@@ -43,7 +43,7 @@ class CHANNELS_API sro_model : virtual public block
 {
 public:
     // gr::channels::sro_model::sptr
-    typedef boost::shared_ptr<sro_model> sptr;
+    typedef std::shared_ptr<sro_model> sptr;
 
     /*! \brief Build the sample rate offset model
      *

--- a/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
@@ -54,7 +54,7 @@ class DIGITAL_API additive_scrambler_bb : virtual public sync_block
 {
 public:
     // gr::digital::additive_scrambler_bb::sptr
-    typedef boost::shared_ptr<additive_scrambler_bb> sptr;
+    typedef std::shared_ptr<additive_scrambler_bb> sptr;
 
     /*!
      * \brief Create additive scrambler.

--- a/gr-digital/include/gnuradio/digital/binary_slicer_fb.h
+++ b/gr-digital/include/gnuradio/digital/binary_slicer_fb.h
@@ -41,7 +41,7 @@ class DIGITAL_API binary_slicer_fb : virtual public sync_block
 {
 public:
     // gr::digital::binary_slicer_fb::sptr
-    typedef boost::shared_ptr<binary_slicer_fb> sptr;
+    typedef std::shared_ptr<binary_slicer_fb> sptr;
 
     /*!
      * \brief Make binary symbol slicer block.

--- a/gr-digital/include/gnuradio/digital/burst_shaper.h
+++ b/gr-digital/include/gnuradio/digital/burst_shaper.h
@@ -64,7 +64,7 @@ template <class T>
 class DIGITAL_API burst_shaper : virtual public block
 {
 public:
-    typedef boost::shared_ptr<burst_shaper<T>> sptr;
+    typedef std::shared_ptr<burst_shaper<T>> sptr;
 
     /*!
      * Make a burst shaper block.

--- a/gr-digital/include/gnuradio/digital/chunks_to_symbols.h
+++ b/gr-digital/include/gnuradio/digital/chunks_to_symbols.h
@@ -55,7 +55,7 @@ template <class IN_T, class OUT_T>
 class DIGITAL_API chunks_to_symbols : virtual public sync_interpolator
 {
 public:
-    typedef boost::shared_ptr<chunks_to_symbols<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<chunks_to_symbols<IN_T, OUT_T>> sptr;
 
     /*!
      * Make a chunks-to-symbols block.

--- a/gr-digital/include/gnuradio/digital/clock_recovery_mm_cc.h
+++ b/gr-digital/include/gnuradio/digital/clock_recovery_mm_cc.h
@@ -72,7 +72,7 @@ class DIGITAL_API clock_recovery_mm_cc : virtual public block
 {
 public:
     // gr::digital::clock_recovery_mm_cc::sptr
-    typedef boost::shared_ptr<clock_recovery_mm_cc> sptr;
+    typedef std::shared_ptr<clock_recovery_mm_cc> sptr;
 
     /*!
      * Make a M&M clock recovery block.

--- a/gr-digital/include/gnuradio/digital/clock_recovery_mm_ff.h
+++ b/gr-digital/include/gnuradio/digital/clock_recovery_mm_ff.h
@@ -69,7 +69,7 @@ class DIGITAL_API clock_recovery_mm_ff : virtual public block
 {
 public:
     // gr::digital::clock_recovery_mm_ff::sptr
-    typedef boost::shared_ptr<clock_recovery_mm_ff> sptr;
+    typedef std::shared_ptr<clock_recovery_mm_ff> sptr;
 
     /*!
      * Make a M&M clock recovery block.

--- a/gr-digital/include/gnuradio/digital/cma_equalizer_cc.h
+++ b/gr-digital/include/gnuradio/digital/cma_equalizer_cc.h
@@ -49,7 +49,7 @@ protected:
 
 public:
     // gr::digital::cma_equalizer_cc::sptr
-    typedef boost::shared_ptr<cma_equalizer_cc> sptr;
+    typedef std::shared_ptr<cma_equalizer_cc> sptr;
 
     /*!
      * Make a CMA Equalizer block

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -41,7 +41,7 @@ namespace digital {
 /************************************************************/
 
 class constellation;
-typedef boost::shared_ptr<constellation> constellation_sptr;
+typedef std::shared_ptr<constellation> constellation_sptr;
 
 /*!
  * \brief An abstracted constellation object
@@ -59,7 +59,7 @@ typedef boost::shared_ptr<constellation> constellation_sptr;
  * from this class and overloaded to perform optimized slicing and
  * constellation mappings.
  */
-class DIGITAL_API constellation : public boost::enable_shared_from_this<constellation>
+class DIGITAL_API constellation : public std::enable_shared_from_this<constellation>
 {
 public:
     constellation(std::vector<gr_complex> constell,
@@ -236,7 +236,7 @@ protected:
 class DIGITAL_API constellation_calcdist : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_calcdist> sptr;
+    typedef std::shared_ptr<constellation_calcdist> sptr;
 
     /*!
      * Make a general constellation object that calculates the Euclidean distance for hard
@@ -337,7 +337,7 @@ private:
 class DIGITAL_API constellation_rect : public constellation_sector
 {
 public:
-    typedef boost::shared_ptr<constellation_rect> sptr;
+    typedef std::shared_ptr<constellation_rect> sptr;
 
     /*!
      * Make a rectangular constellation object.
@@ -406,7 +406,7 @@ private:
 class DIGITAL_API constellation_expl_rect : public constellation_rect
 {
 public:
-    typedef boost::shared_ptr<constellation_expl_rect> sptr;
+    typedef std::shared_ptr<constellation_expl_rect> sptr;
 
     static sptr make(std::vector<gr_complex> constellation,
                      std::vector<int> pre_diff_code,
@@ -456,7 +456,7 @@ private:
 class DIGITAL_API constellation_psk : public constellation_sector
 {
 public:
-    typedef boost::shared_ptr<constellation_psk> sptr;
+    typedef std::shared_ptr<constellation_psk> sptr;
 
     // public constructor
     static sptr make(std::vector<gr_complex> constell,
@@ -495,7 +495,7 @@ protected:
 class DIGITAL_API constellation_bpsk : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_bpsk> sptr;
+    typedef std::shared_ptr<constellation_bpsk> sptr;
 
     // public constructor
     static sptr make();
@@ -531,7 +531,7 @@ protected:
 class DIGITAL_API constellation_qpsk : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_qpsk> sptr;
+    typedef std::shared_ptr<constellation_qpsk> sptr;
 
     // public constructor
     static sptr make();
@@ -566,7 +566,7 @@ protected:
 class DIGITAL_API constellation_dqpsk : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_dqpsk> sptr;
+    typedef std::shared_ptr<constellation_dqpsk> sptr;
 
     // public constructor
     static sptr make();
@@ -603,7 +603,7 @@ protected:
 class DIGITAL_API constellation_8psk : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_8psk> sptr;
+    typedef std::shared_ptr<constellation_8psk> sptr;
 
     // public constructor
     static sptr make();
@@ -639,7 +639,7 @@ protected:
 class DIGITAL_API constellation_8psk_natural : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_8psk_natural> sptr;
+    typedef std::shared_ptr<constellation_8psk_natural> sptr;
 
     // public constructor
     static sptr make();
@@ -677,7 +677,7 @@ protected:
 class DIGITAL_API constellation_16qam : public constellation
 {
 public:
-    typedef boost::shared_ptr<constellation_16qam> sptr;
+    typedef std::shared_ptr<constellation_16qam> sptr;
 
     // public constructor
     static sptr make();

--- a/gr-digital/include/gnuradio/digital/constellation_decoder_cb.h
+++ b/gr-digital/include/gnuradio/digital/constellation_decoder_cb.h
@@ -43,7 +43,7 @@ class DIGITAL_API constellation_decoder_cb : virtual public block
 {
 public:
     // gr::digital::constellation_decoder_cb::sptr
-    typedef boost::shared_ptr<constellation_decoder_cb> sptr;
+    typedef std::shared_ptr<constellation_decoder_cb> sptr;
 
     /*!
      * \brief Make constellation decoder block.

--- a/gr-digital/include/gnuradio/digital/constellation_receiver_cb.h
+++ b/gr-digital/include/gnuradio/digital/constellation_receiver_cb.h
@@ -60,7 +60,7 @@ class DIGITAL_API constellation_receiver_cb : virtual public block,
 {
 public:
     // gr::digital::constellation_receiver_cb::sptr
-    typedef boost::shared_ptr<constellation_receiver_cb> sptr;
+    typedef std::shared_ptr<constellation_receiver_cb> sptr;
 
     /*!
      * \brief Constructs a constellation receiver that (phase/fine

--- a/gr-digital/include/gnuradio/digital/constellation_soft_decoder_cf.h
+++ b/gr-digital/include/gnuradio/digital/constellation_soft_decoder_cf.h
@@ -43,7 +43,7 @@ class DIGITAL_API constellation_soft_decoder_cf : virtual public sync_interpolat
 {
 public:
     // gr::digital::constellation_soft_decoder_cf::sptr
-    typedef boost::shared_ptr<constellation_soft_decoder_cf> sptr;
+    typedef std::shared_ptr<constellation_soft_decoder_cf> sptr;
 
     /*!
      * \brief Make constellation decoder block.

--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -90,7 +90,7 @@ typedef enum {
 class DIGITAL_API corr_est_cc : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<corr_est_cc> sptr;
+    typedef std::shared_ptr<corr_est_cc> sptr;
 
     /*!
      * Make a block that correlates against the \p symbols vector

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_bb.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_bb.h
@@ -49,7 +49,7 @@ class DIGITAL_API correlate_access_code_bb : virtual public sync_block
 {
 public:
     // gr::digital::correlate_access_code_bb::sptr
-    typedef boost::shared_ptr<correlate_access_code_bb> sptr;
+    typedef std::shared_ptr<correlate_access_code_bb> sptr;
 
     /*!
      * Make a correlate_access_code block.

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_bb_ts.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_bb_ts.h
@@ -53,7 +53,7 @@ class DIGITAL_API correlate_access_code_bb_ts : virtual public block
 {
 public:
     // gr::digital::correlate_access_code_bb_ts::sptr
-    typedef boost::shared_ptr<correlate_access_code_bb_ts> sptr;
+    typedef std::shared_ptr<correlate_access_code_bb_ts> sptr;
 
     /*!
      * \param access_code is represented with 1 byte per bit,

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_ff_ts.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_ff_ts.h
@@ -53,7 +53,7 @@ class DIGITAL_API correlate_access_code_ff_ts : virtual public block
 {
 public:
     // gr::digital::correlate_access_code_ff_ts::sptr
-    typedef boost::shared_ptr<correlate_access_code_ff_ts> sptr;
+    typedef std::shared_ptr<correlate_access_code_ff_ts> sptr;
 
     /*!
      * \param access_code is represented with 1 byte per bit,

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_tag_bb.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_tag_bb.h
@@ -46,7 +46,7 @@ class DIGITAL_API correlate_access_code_tag_bb : virtual public sync_block
 {
 public:
     // gr::digital::correlate_access_code_tag_bb::sptr
-    typedef boost::shared_ptr<correlate_access_code_tag_bb> sptr;
+    typedef std::shared_ptr<correlate_access_code_tag_bb> sptr;
 
     /*!
      * \param access_code is represented with 1 byte per bit,

--- a/gr-digital/include/gnuradio/digital/correlate_access_code_tag_ff.h
+++ b/gr-digital/include/gnuradio/digital/correlate_access_code_tag_ff.h
@@ -47,7 +47,7 @@ class DIGITAL_API correlate_access_code_tag_ff : virtual public sync_block
 {
 public:
     // gr::digital::correlate_access_code_tag_ff::sptr
-    typedef boost::shared_ptr<correlate_access_code_tag_ff> sptr;
+    typedef std::shared_ptr<correlate_access_code_tag_ff> sptr;
 
     /*!
      * \param access_code is represented with 1 byte per bit,

--- a/gr-digital/include/gnuradio/digital/costas_loop_cc.h
+++ b/gr-digital/include/gnuradio/digital/costas_loop_cc.h
@@ -67,7 +67,7 @@ class DIGITAL_API costas_loop_cc : virtual public sync_block,
 {
 public:
     // gr::digital::costas_loop_cc::sptr
-    typedef boost::shared_ptr<costas_loop_cc> sptr;
+    typedef std::shared_ptr<costas_loop_cc> sptr;
 
     /*!
      * Make a Costas loop carrier recovery block.

--- a/gr-digital/include/gnuradio/digital/cpmmod_bc.h
+++ b/gr-digital/include/gnuradio/digital/cpmmod_bc.h
@@ -50,7 +50,7 @@ class DIGITAL_API cpmmod_bc : virtual public hier_block2
 {
 public:
     // gr::digital::cpmmod_bc::sptr
-    typedef boost::shared_ptr<cpmmod_bc> sptr;
+    typedef std::shared_ptr<cpmmod_bc> sptr;
 
     /*!
      * Make CPM modulator block.

--- a/gr-digital/include/gnuradio/digital/crc32_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_async_bb.h
@@ -56,7 +56,7 @@ namespace digital {
 class DIGITAL_API crc32_async_bb : virtual public block
 {
 public:
-    typedef boost::shared_ptr<crc32_async_bb> sptr;
+    typedef std::shared_ptr<crc32_async_bb> sptr;
 
     /*!
      * \param check Set to true if you want to check CRC, false to create CRC.

--- a/gr-digital/include/gnuradio/digital/crc32_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_bb.h
@@ -45,7 +45,7 @@ namespace digital {
 class DIGITAL_API crc32_bb : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<crc32_bb> sptr;
+    typedef std::shared_ptr<crc32_bb> sptr;
 
     /*!
      * \param check Set to true if you want to check CRC, false to create CRC.

--- a/gr-digital/include/gnuradio/digital/descrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/descrambler_bb.h
@@ -42,7 +42,7 @@ class DIGITAL_API descrambler_bb : virtual public sync_block
 {
 public:
     // gr::digital::descrambler_bb::sptr
-    typedef boost::shared_ptr<descrambler_bb> sptr;
+    typedef std::shared_ptr<descrambler_bb> sptr;
 
     /*!
      * \brief Make a descrambler block.

--- a/gr-digital/include/gnuradio/digital/diff_decoder_bb.h
+++ b/gr-digital/include/gnuradio/digital/diff_decoder_bb.h
@@ -41,7 +41,7 @@ class DIGITAL_API diff_decoder_bb : virtual public sync_block
 {
 public:
     // gr::digital::diff_decoder_bb::sptr
-    typedef boost::shared_ptr<diff_decoder_bb> sptr;
+    typedef std::shared_ptr<diff_decoder_bb> sptr;
 
     /*!
      * Make a differential decoder block.

--- a/gr-digital/include/gnuradio/digital/diff_encoder_bb.h
+++ b/gr-digital/include/gnuradio/digital/diff_encoder_bb.h
@@ -41,7 +41,7 @@ class DIGITAL_API diff_encoder_bb : virtual public sync_block
 {
 public:
     // gr::digital::diff_encoder_bb::sptr
-    typedef boost::shared_ptr<diff_encoder_bb> sptr;
+    typedef std::shared_ptr<diff_encoder_bb> sptr;
 
     /*!
      * Make a differential encoder block.

--- a/gr-digital/include/gnuradio/digital/diff_phasor_cc.h
+++ b/gr-digital/include/gnuradio/digital/diff_phasor_cc.h
@@ -43,7 +43,7 @@ class DIGITAL_API diff_phasor_cc : virtual public sync_block
 {
 public:
     // gr::digital::diff_phasor_cc::sptr
-    typedef boost::shared_ptr<diff_phasor_cc> sptr;
+    typedef std::shared_ptr<diff_phasor_cc> sptr;
 
     /*!
      * Make a differential phasor decoding block.

--- a/gr-digital/include/gnuradio/digital/fll_band_edge_cc.h
+++ b/gr-digital/include/gnuradio/digital/fll_band_edge_cc.h
@@ -85,7 +85,7 @@ class DIGITAL_API fll_band_edge_cc : virtual public sync_block,
 {
 public:
     // gr::digital::fll_band_edge_cc::sptr
-    typedef boost::shared_ptr<fll_band_edge_cc> sptr;
+    typedef std::shared_ptr<fll_band_edge_cc> sptr;
 
     /*!
      * Make an FLL block.

--- a/gr-digital/include/gnuradio/digital/framer_sink_1.h
+++ b/gr-digital/include/gnuradio/digital/framer_sink_1.h
@@ -52,7 +52,7 @@ class DIGITAL_API framer_sink_1 : virtual public sync_block
 {
 public:
     // gr::digital::framer_sink_1::sptr
-    typedef boost::shared_ptr<framer_sink_1> sptr;
+    typedef std::shared_ptr<framer_sink_1> sptr;
 
     /*!
      * Make a framer_sink_1 block.

--- a/gr-digital/include/gnuradio/digital/glfsr_source_b.h
+++ b/gr-digital/include/gnuradio/digital/glfsr_source_b.h
@@ -37,7 +37,7 @@ class DIGITAL_API glfsr_source_b : virtual public sync_block
 {
 public:
     // gr::digital::glfsr_source_b::sptr
-    typedef boost::shared_ptr<glfsr_source_b> sptr;
+    typedef std::shared_ptr<glfsr_source_b> sptr;
 
     /*!
      * Make a Galois LFSR pseudo-random source block.

--- a/gr-digital/include/gnuradio/digital/glfsr_source_f.h
+++ b/gr-digital/include/gnuradio/digital/glfsr_source_f.h
@@ -37,7 +37,7 @@ class DIGITAL_API glfsr_source_f : virtual public sync_block
 {
 public:
     // gr::digital::glfsr_source_f::sptr
-    typedef boost::shared_ptr<glfsr_source_f> sptr;
+    typedef std::shared_ptr<glfsr_source_f> sptr;
 
     /*!
      * Make a Galois LFSR pseudo-random source block.

--- a/gr-digital/include/gnuradio/digital/hdlc_deframer_bp.h
+++ b/gr-digital/include/gnuradio/digital/hdlc_deframer_bp.h
@@ -39,7 +39,7 @@ namespace digital {
 class DIGITAL_API hdlc_deframer_bp : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<hdlc_deframer_bp> sptr;
+    typedef std::shared_ptr<hdlc_deframer_bp> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of digital::hdlc_deframer.

--- a/gr-digital/include/gnuradio/digital/hdlc_framer_pb.h
+++ b/gr-digital/include/gnuradio/digital/hdlc_framer_pb.h
@@ -48,7 +48,7 @@ namespace digital {
 class DIGITAL_API hdlc_framer_pb : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<hdlc_framer_pb> sptr;
+    typedef std::shared_ptr<hdlc_framer_pb> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of digital::hdlc_framer.

--- a/gr-digital/include/gnuradio/digital/header_format_base.h
+++ b/gr-digital/include/gnuradio/digital/header_format_base.h
@@ -121,10 +121,10 @@ namespace digital {
  * \sa header_format_counter
  */
 class DIGITAL_API header_format_base
-    : public boost::enable_shared_from_this<gr::digital::header_format_base>
+    : public std::enable_shared_from_this<gr::digital::header_format_base>
 {
 public:
-    typedef boost::shared_ptr<header_format_base> sptr;
+    typedef std::shared_ptr<header_format_base> sptr;
 
     header_format_base();
     virtual ~header_format_base();

--- a/gr-digital/include/gnuradio/digital/header_payload_demux.h
+++ b/gr-digital/include/gnuradio/digital/header_payload_demux.h
@@ -162,7 +162,7 @@ namespace digital {
 class DIGITAL_API header_payload_demux : virtual public block
 {
 public:
-    typedef boost::shared_ptr<header_payload_demux> sptr;
+    typedef std::shared_ptr<header_payload_demux> sptr;
 
     /*!
      * \param header_len Number of symbols per header

--- a/gr-digital/include/gnuradio/digital/kurtotic_equalizer_cc.h
+++ b/gr-digital/include/gnuradio/digital/kurtotic_equalizer_cc.h
@@ -48,7 +48,7 @@ protected:
 
 public:
     // gr::digital::kurtotic_equalizer_cc::sptr
-    typedef boost::shared_ptr<kurtotic_equalizer_cc> sptr;
+    typedef std::shared_ptr<kurtotic_equalizer_cc> sptr;
 
     static sptr make(int num_taps, float mu);
 

--- a/gr-digital/include/gnuradio/digital/lms_dd_equalizer_cc.h
+++ b/gr-digital/include/gnuradio/digital/lms_dd_equalizer_cc.h
@@ -72,7 +72,7 @@ protected:
 
 public:
     // gr::digital::lms_dd_equalizer_cc::sptr
-    typedef boost::shared_ptr<lms_dd_equalizer_cc> sptr;
+    typedef std::shared_ptr<lms_dd_equalizer_cc> sptr;
 
     /*!
      * Make an LMS decision-directed equalizer

--- a/gr-digital/include/gnuradio/digital/map_bb.h
+++ b/gr-digital/include/gnuradio/digital/map_bb.h
@@ -44,7 +44,7 @@ class DIGITAL_API map_bb : virtual public sync_block
 {
 public:
     // gr::digital::map_bb::sptr
-    typedef boost::shared_ptr<map_bb> sptr;
+    typedef std::shared_ptr<map_bb> sptr;
 
     /*!
      * Make a map block.

--- a/gr-digital/include/gnuradio/digital/mpsk_snr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/mpsk_snr_est_cc.h
@@ -53,7 +53,7 @@ class DIGITAL_API mpsk_snr_est_cc : virtual public sync_block
 {
 public:
     // gr::digital::mpsk_snr_est_cc::sptr
-    typedef boost::shared_ptr<mpsk_snr_est_cc> sptr;
+    typedef std::shared_ptr<mpsk_snr_est_cc> sptr;
 
     /*! Factory function returning shared pointer of this class
      *

--- a/gr-digital/include/gnuradio/digital/msk_timing_recovery_cc.h
+++ b/gr-digital/include/gnuradio/digital/msk_timing_recovery_cc.h
@@ -46,7 +46,7 @@ namespace digital {
 class DIGITAL_API msk_timing_recovery_cc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<msk_timing_recovery_cc> sptr;
+    typedef std::shared_ptr<msk_timing_recovery_cc> sptr;
 
     /*!
      * \brief Make an MSK timing recovery block.

--- a/gr-digital/include/gnuradio/digital/ofdm_carrier_allocator_cvc.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_carrier_allocator_cvc.h
@@ -71,7 +71,7 @@ namespace digital {
 class DIGITAL_API ofdm_carrier_allocator_cvc : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<ofdm_carrier_allocator_cvc> sptr;
+    typedef std::shared_ptr<ofdm_carrier_allocator_cvc> sptr;
 
     virtual std::string len_tag_key() = 0;
     virtual const int fft_len() = 0;

--- a/gr-digital/include/gnuradio/digital/ofdm_chanest_vcvc.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_chanest_vcvc.h
@@ -57,7 +57,7 @@ namespace digital {
 class DIGITAL_API ofdm_chanest_vcvc : virtual public block
 {
 public:
-    typedef boost::shared_ptr<ofdm_chanest_vcvc> sptr;
+    typedef std::shared_ptr<ofdm_chanest_vcvc> sptr;
 
     /*!
      * \param sync_symbol1 First synchronisation symbol in the frequency domain. Its

--- a/gr-digital/include/gnuradio/digital/ofdm_cyclic_prefixer.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_cyclic_prefixer.h
@@ -49,7 +49,7 @@ namespace digital {
 class DIGITAL_API ofdm_cyclic_prefixer : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<ofdm_cyclic_prefixer> sptr;
+    typedef std::shared_ptr<ofdm_cyclic_prefixer> sptr;
 
     /*!
      * \param input_size FFT length (i.e. length of the OFDM symbols)

--- a/gr-digital/include/gnuradio/digital/ofdm_equalizer_base.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_equalizer_base.h
@@ -36,13 +36,13 @@ namespace digital {
  * \ingroup equalizers_blk
  */
 class DIGITAL_API ofdm_equalizer_base
-    : public boost::enable_shared_from_this<ofdm_equalizer_base>
+    : public std::enable_shared_from_this<ofdm_equalizer_base>
 {
 protected:
     int d_fft_len;
 
 public:
-    typedef boost::shared_ptr<ofdm_equalizer_base> sptr;
+    typedef std::shared_ptr<ofdm_equalizer_base> sptr;
 
     ofdm_equalizer_base(int fft_len);
     virtual ~ofdm_equalizer_base();
@@ -88,7 +88,7 @@ protected:
     std::vector<gr_complex> d_channel_state;
 
 public:
-    typedef boost::shared_ptr<ofdm_equalizer_1d_pilots> sptr;
+    typedef std::shared_ptr<ofdm_equalizer_1d_pilots> sptr;
 
     ofdm_equalizer_1d_pilots(int fft_len,
                              const std::vector<std::vector<int>>& occupied_carriers,

--- a/gr-digital/include/gnuradio/digital/ofdm_equalizer_simpledfe.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_equalizer_simpledfe.h
@@ -64,7 +64,7 @@ namespace digital {
 class DIGITAL_API ofdm_equalizer_simpledfe : public ofdm_equalizer_1d_pilots
 {
 public:
-    typedef boost::shared_ptr<ofdm_equalizer_simpledfe> sptr;
+    typedef std::shared_ptr<ofdm_equalizer_simpledfe> sptr;
 
     ofdm_equalizer_simpledfe(int fft_len,
                              const gr::digital::constellation_sptr& constellation,

--- a/gr-digital/include/gnuradio/digital/ofdm_equalizer_static.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_equalizer_static.h
@@ -46,7 +46,7 @@ namespace digital {
 class DIGITAL_API ofdm_equalizer_static : public ofdm_equalizer_1d_pilots
 {
 public:
-    typedef boost::shared_ptr<ofdm_equalizer_static> sptr;
+    typedef std::shared_ptr<ofdm_equalizer_static> sptr;
 
     ofdm_equalizer_static(int fft_len,
                           const std::vector<std::vector<int>>& occupied_carriers =

--- a/gr-digital/include/gnuradio/digital/ofdm_frame_equalizer_vcvc.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_frame_equalizer_vcvc.h
@@ -53,7 +53,7 @@ namespace digital {
 class DIGITAL_API ofdm_frame_equalizer_vcvc : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<ofdm_frame_equalizer_vcvc> sptr;
+    typedef std::shared_ptr<ofdm_frame_equalizer_vcvc> sptr;
 
     /*!
      * \param equalizer The equalizer object that will do the actual work

--- a/gr-digital/include/gnuradio/digital/ofdm_serializer_vcc.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_serializer_vcc.h
@@ -55,7 +55,7 @@ namespace digital {
 class DIGITAL_API ofdm_serializer_vcc : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<ofdm_serializer_vcc> sptr;
+    typedef std::shared_ptr<ofdm_serializer_vcc> sptr;
 
     /*!
      * \param fft_len FFT length

--- a/gr-digital/include/gnuradio/digital/ofdm_sync_sc_cfb.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_sync_sc_cfb.h
@@ -64,7 +64,7 @@ namespace digital {
 class DIGITAL_API ofdm_sync_sc_cfb : virtual public hier_block2
 {
 public:
-    typedef boost::shared_ptr<ofdm_sync_sc_cfb> sptr;
+    typedef std::shared_ptr<ofdm_sync_sc_cfb> sptr;
 
     /*! \param fft_len FFT length
      *  \param cp_len Length of the guard interval (cyclic prefix) in samples

--- a/gr-digital/include/gnuradio/digital/packet_header_default.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_default.h
@@ -47,10 +47,10 @@ namespace digital {
  * this class to create packet headers from data streams.
  */
 class DIGITAL_API packet_header_default
-    : public boost::enable_shared_from_this<gr::digital::packet_header_default>
+    : public std::enable_shared_from_this<gr::digital::packet_header_default>
 {
 public:
-    typedef boost::shared_ptr<packet_header_default> sptr;
+    typedef std::shared_ptr<packet_header_default> sptr;
 
     packet_header_default(long header_len,
                           const std::string& len_tag_key = "packet_len",

--- a/gr-digital/include/gnuradio/digital/packet_header_ofdm.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_ofdm.h
@@ -36,7 +36,7 @@ namespace digital {
 class DIGITAL_API packet_header_ofdm : public packet_header_default
 {
 public:
-    typedef boost::shared_ptr<packet_header_ofdm> sptr;
+    typedef std::shared_ptr<packet_header_ofdm> sptr;
 
     packet_header_ofdm(const std::vector<std::vector<int>>& occupied_carriers,
                        int n_syms,

--- a/gr-digital/include/gnuradio/digital/packet_headergenerator_bb.h
+++ b/gr-digital/include/gnuradio/digital/packet_headergenerator_bb.h
@@ -44,7 +44,7 @@ namespace digital {
 class DIGITAL_API packet_headergenerator_bb : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<packet_headergenerator_bb> sptr;
+    typedef std::shared_ptr<packet_headergenerator_bb> sptr;
 
     /* \param header_formatter A header formatter object.
      * \param len_tag_key Length tag key. Note that for header generation,

--- a/gr-digital/include/gnuradio/digital/packet_headerparser_b.h
+++ b/gr-digital/include/gnuradio/digital/packet_headerparser_b.h
@@ -49,7 +49,7 @@ namespace digital {
 class DIGITAL_API packet_headerparser_b : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<packet_headerparser_b> sptr;
+    typedef std::shared_ptr<packet_headerparser_b> sptr;
 
     /*!
      * \param header_formatter Header object. This should be the same as used for

--- a/gr-digital/include/gnuradio/digital/packet_sink.h
+++ b/gr-digital/include/gnuradio/digital/packet_sink.h
@@ -57,7 +57,7 @@ class DIGITAL_API packet_sink : virtual public sync_block
 {
 public:
     // gr::digital::packet_sink::sptr
-    typedef boost::shared_ptr<packet_sink> sptr;
+    typedef std::shared_ptr<packet_sink> sptr;
 
     /*!
      * Make a packet_sink block.

--- a/gr-digital/include/gnuradio/digital/pfb_clock_sync_ccf.h
+++ b/gr-digital/include/gnuradio/digital/pfb_clock_sync_ccf.h
@@ -157,7 +157,7 @@ class DIGITAL_API pfb_clock_sync_ccf : virtual public block
 {
 public:
     // gr::digital::pfb_clock_sync_ccf::sptr
-    typedef boost::shared_ptr<pfb_clock_sync_ccf> sptr;
+    typedef std::shared_ptr<pfb_clock_sync_ccf> sptr;
 
     /*!
      * Build the polyphase filterbank timing synchronizer.

--- a/gr-digital/include/gnuradio/digital/pfb_clock_sync_fff.h
+++ b/gr-digital/include/gnuradio/digital/pfb_clock_sync_fff.h
@@ -156,7 +156,7 @@ class DIGITAL_API pfb_clock_sync_fff : virtual public block
 {
 public:
     // gr::digital::pfb_clock_sync_fff::sptr
-    typedef boost::shared_ptr<pfb_clock_sync_fff> sptr;
+    typedef std::shared_ptr<pfb_clock_sync_fff> sptr;
 
     /*!
      * Build the polyphase filterbank timing synchronizer.

--- a/gr-digital/include/gnuradio/digital/pn_correlator_cc.h
+++ b/gr-digital/include/gnuradio/digital/pn_correlator_cc.h
@@ -42,7 +42,7 @@ class DIGITAL_API pn_correlator_cc : virtual public sync_decimator
 {
 public:
     // gr::digital::pn_correlator_cc::sptr
-    typedef boost::shared_ptr<pn_correlator_cc> sptr;
+    typedef std::shared_ptr<pn_correlator_cc> sptr;
 
     /*!
      * \brief Make PN code sequential search correlator block.

--- a/gr-digital/include/gnuradio/digital/probe_density_b.h
+++ b/gr-digital/include/gnuradio/digital/probe_density_b.h
@@ -41,7 +41,7 @@ class DIGITAL_API probe_density_b : virtual public sync_block
 {
 public:
     // gr::digital::probe_density_b::sptr
-    typedef boost::shared_ptr<probe_density_b> sptr;
+    typedef std::shared_ptr<probe_density_b> sptr;
 
     /*!
      * Make a density probe block.

--- a/gr-digital/include/gnuradio/digital/probe_mpsk_snr_est_c.h
+++ b/gr-digital/include/gnuradio/digital/probe_mpsk_snr_est_c.h
@@ -60,7 +60,7 @@ class DIGITAL_API probe_mpsk_snr_est_c : virtual public sync_block
 {
 public:
     // gr::digital::probe_mpsk_snr_est_c::sptr
-    typedef boost::shared_ptr<probe_mpsk_snr_est_c> sptr;
+    typedef std::shared_ptr<probe_mpsk_snr_est_c> sptr;
 
     /*! Make an MPSK SNR probe.
      *

--- a/gr-digital/include/gnuradio/digital/protocol_formatter_async.h
+++ b/gr-digital/include/gnuradio/digital/protocol_formatter_async.h
@@ -71,7 +71,7 @@ namespace digital {
 class DIGITAL_API protocol_formatter_async : virtual public block
 {
 public:
-    typedef boost::shared_ptr<protocol_formatter_async> sptr;
+    typedef std::shared_ptr<protocol_formatter_async> sptr;
 
     /*!
      * Make a packet header block using a given \p format.

--- a/gr-digital/include/gnuradio/digital/protocol_formatter_bb.h
+++ b/gr-digital/include/gnuradio/digital/protocol_formatter_bb.h
@@ -59,7 +59,7 @@ namespace digital {
 class DIGITAL_API protocol_formatter_bb : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<protocol_formatter_bb> sptr;
+    typedef std::shared_ptr<protocol_formatter_bb> sptr;
 
     /*!
      * Make a packet header block using a given \p format.

--- a/gr-digital/include/gnuradio/digital/protocol_parser_b.h
+++ b/gr-digital/include/gnuradio/digital/protocol_parser_b.h
@@ -63,7 +63,7 @@ namespace digital {
 class DIGITAL_API protocol_parser_b : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<protocol_parser_b> sptr;
+    typedef std::shared_ptr<protocol_parser_b> sptr;
 
     /*!
      * Make a packet header block using a given \p format.

--- a/gr-digital/include/gnuradio/digital/scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/scrambler_bb.h
@@ -42,7 +42,7 @@ class DIGITAL_API scrambler_bb : virtual public sync_block
 {
 public:
     // gr::digital::scrambler_bb::sptr
-    typedef boost::shared_ptr<scrambler_bb> sptr;
+    typedef std::shared_ptr<scrambler_bb> sptr;
 
     /*!
      * Make a scramber block.

--- a/gr-digital/include/gnuradio/digital/simple_correlator.h
+++ b/gr-digital/include/gnuradio/digital/simple_correlator.h
@@ -38,7 +38,7 @@ class DIGITAL_API simple_correlator : virtual public block
 {
 public:
     // gr::digital::simple_correlator::sptr
-    typedef boost::shared_ptr<simple_correlator> sptr;
+    typedef std::shared_ptr<simple_correlator> sptr;
 
     static sptr make(int payload_bytesize);
 };

--- a/gr-digital/include/gnuradio/digital/simple_framer.h
+++ b/gr-digital/include/gnuradio/digital/simple_framer.h
@@ -43,7 +43,7 @@ class DIGITAL_API simple_framer : virtual public block
 {
 public:
     // gr::digital::simple_framer::sptr
-    typedef boost::shared_ptr<simple_framer> sptr;
+    typedef std::shared_ptr<simple_framer> sptr;
 
     /*!
      * Make a simple_framer block.

--- a/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
@@ -56,7 +56,7 @@ class DIGITAL_API symbol_sync_cc : virtual public block
 {
 public:
     // gr::digital::symbol_sync_cc::sptr
-    typedef boost::shared_ptr<symbol_sync_cc> sptr;
+    typedef std::shared_ptr<symbol_sync_cc> sptr;
 
     /*!
      * Make a Symbol Synchronizer block.

--- a/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
@@ -56,7 +56,7 @@ class DIGITAL_API symbol_sync_ff : virtual public block
 {
 public:
     // gr::digital::symbol_sync_ff::sptr
-    typedef boost::shared_ptr<symbol_sync_ff> sptr;
+    typedef std::shared_ptr<symbol_sync_ff> sptr;
 
     /*!
      * Make a Symbol Synchronizer block.

--- a/gr-digital/swig/constellation.i
+++ b/gr-digital/swig/constellation.i
@@ -20,63 +20,63 @@
  * Boston, MA 02110-1301, USA.
  */
 
-%template(constellation_sptr) boost::shared_ptr<gr::digital::constellation>;
+%template(constellation_sptr) std::shared_ptr<gr::digital::constellation>;
 
-%template(constellation_calcdist_sptr) boost::shared_ptr<gr::digital::constellation_calcdist>;
+%template(constellation_calcdist_sptr) std::shared_ptr<gr::digital::constellation_calcdist>;
 %pythoncode %{
 constellation_calcdist_sptr.__repr__ = lambda self: "<constellation calcdist (m=%d)>" % (len(self.points()))
 constellation_calcdist = constellation_calcdist.make;
 %}
 
-%template(constellation_rect_sptr) boost::shared_ptr<gr::digital::constellation_rect>;
+%template(constellation_rect_sptr) std::shared_ptr<gr::digital::constellation_rect>;
 %pythoncode %{
 constellation_rect_sptr.__repr__ = lambda self: "<constellation rect (m=%d)>" % (len(self.points()))
 constellation_rect = constellation_rect.make;
 %}
 
-%template(constellation_expl_rect_sptr) boost::shared_ptr<gr::digital::constellation_expl_rect>;
+%template(constellation_expl_rect_sptr) std::shared_ptr<gr::digital::constellation_expl_rect>;
 %pythoncode %{
 constellation_expl_rect_sptr.__repr__ = lambda self: "<constellation expl rect (m=%d)>" % (len(self.points()))
 constellation_expl_rect = constellation_expl_rect.make;
 %}
 
-%template(constellation_psk_sptr) boost::shared_ptr<gr::digital::constellation_psk>;
+%template(constellation_psk_sptr) std::shared_ptr<gr::digital::constellation_psk>;
 %pythoncode %{
 constellation_psk_sptr.__repr__ = lambda self: "<constellation PSK (m=%d)>" % (len(self.points()))
 constellation_psk = constellation_psk.make;
 %}
 
-%template(constellation_bpsk_sptr) boost::shared_ptr<gr::digital::constellation_bpsk>;
+%template(constellation_bpsk_sptr) std::shared_ptr<gr::digital::constellation_bpsk>;
 %pythoncode %{
 constellation_bpsk_sptr.__repr__ = lambda self: "<constellation BPSK>"
 constellation_bpsk = constellation_bpsk.make;
 %}
 
-%template(constellation_qpsk_sptr) boost::shared_ptr<gr::digital::constellation_qpsk>;
+%template(constellation_qpsk_sptr) std::shared_ptr<gr::digital::constellation_qpsk>;
 %pythoncode %{
 constellation_qpsk_sptr.__repr__ = lambda self: "<constellation QPSK>"
 constellation_qpsk = constellation_qpsk.make;
 %}
 
-%template(constellation_dqpsk_sptr) boost::shared_ptr<gr::digital::constellation_dqpsk>;
+%template(constellation_dqpsk_sptr) std::shared_ptr<gr::digital::constellation_dqpsk>;
 %pythoncode %{
 constellation_dqpsk_sptr.__repr__ = lambda self: "<constellation DQPSK>"
 constellation_dqpsk = constellation_dqpsk.make;
 %}
 
-%template(constellation_8psk_sptr) boost::shared_ptr<gr::digital::constellation_8psk>;
+%template(constellation_8psk_sptr) std::shared_ptr<gr::digital::constellation_8psk>;
 %pythoncode %{
 constellation_8psk_sptr.__repr__ = lambda self: "<constellation 8PSK>"
 constellation_8psk = constellation_8psk.make;
 %}
 
-%template(constellation_8psk_natural_sptr) boost::shared_ptr<gr::digital::constellation_8psk_natural>;
+%template(constellation_8psk_natural_sptr) std::shared_ptr<gr::digital::constellation_8psk_natural>;
 %pythoncode %{
 constellation_8psk_natural_sptr.__repr__ = lambda self: "<constellation 8PSK_natural>"
 constellation_8psk_natural = constellation_8psk_natural.make;
 %}
 
-%template(constellation_16qam_sptr) boost::shared_ptr<gr::digital::constellation_16qam>;
+%template(constellation_16qam_sptr) std::shared_ptr<gr::digital::constellation_16qam>;
 %pythoncode %{
 constellation_16qam_sptr.__repr__ = lambda self: "<constellation 16qam>"
 constellation_16qam = constellation_16qam.make;

--- a/gr-digital/swig/ofdm_equalizer.i
+++ b/gr-digital/swig/ofdm_equalizer.i
@@ -19,13 +19,13 @@
  * Boston, MA 02110-1301, USA.
  */
 
-%template(ofdm_equalizer_base_sptr) boost::shared_ptr<gr::digital::ofdm_equalizer_base>;
-%template(ofdm_equalizer_1d_pilots_sptr) boost::shared_ptr<gr::digital::ofdm_equalizer_1d_pilots>;
+%template(ofdm_equalizer_base_sptr) std::shared_ptr<gr::digital::ofdm_equalizer_base>;
+%template(ofdm_equalizer_1d_pilots_sptr) std::shared_ptr<gr::digital::ofdm_equalizer_1d_pilots>;
 %pythoncode %{
 ofdm_equalizer_1d_pilots_sptr.__repr__ = lambda self: "<OFDM equalizer 1D base class>"
 %}
 
-%template(ofdm_equalizer_simpledfe_sptr) boost::shared_ptr<gr::digital::ofdm_equalizer_simpledfe>;
+%template(ofdm_equalizer_simpledfe_sptr) std::shared_ptr<gr::digital::ofdm_equalizer_simpledfe>;
 %pythoncode %{
 ofdm_equalizer_simpledfe_sptr.__repr__ = lambda self: "<OFDM equalizer simpledfe>"
 ofdm_equalizer_simpledfe = ofdm_equalizer_simpledfe.make;
@@ -33,7 +33,7 @@ ofdm_equalizer_simpledfe = ofdm_equalizer_simpledfe.make;
 //%rename(ofdm_equalizer_simpledfe) make_ofdm_equalizer_simpledfe;
 //%ignore ofdm_equalizer_simpledfe;
 
-%template(ofdm_equalizer_static_sptr) boost::shared_ptr<gr::digital::ofdm_equalizer_static>;
+%template(ofdm_equalizer_static_sptr) std::shared_ptr<gr::digital::ofdm_equalizer_static>;
 %pythoncode %{
 ofdm_equalizer_static_sptr.__repr__ = lambda self: "<OFDM equalizer static>"
 ofdm_equalizer_static = ofdm_equalizer_static.make;

--- a/gr-digital/swig/packet_header.i
+++ b/gr-digital/swig/packet_header.i
@@ -20,40 +20,40 @@
  * Boston, MA 02110-1301, USA.
  */
 
-%template(packet_header_default_sptr) boost::shared_ptr<gr::digital::packet_header_default>;
+%template(packet_header_default_sptr) std::shared_ptr<gr::digital::packet_header_default>;
 %pythoncode %{
 packet_header_default_sptr.__repr__ = lambda self: "<packet_header_default>"
 packet_header_default = packet_header_default .make;
 %}
 
-%template(packet_header_ofdm_sptr) boost::shared_ptr<gr::digital::packet_header_ofdm>;
+%template(packet_header_ofdm_sptr) std::shared_ptr<gr::digital::packet_header_ofdm>;
 %pythoncode %{
 packet_header_ofdm_sptr.__repr__ = lambda self: "<packet_header_ofdm>"
 packet_header_ofdm = packet_header_ofdm .make;
 %}
 
-%template(header_format_base_sptr) boost::shared_ptr<gr::digital::header_format_base>;
+%template(header_format_base_sptr) std::shared_ptr<gr::digital::header_format_base>;
 
-%template(header_format_default_sptr) boost::shared_ptr<gr::digital::header_format_default>;
+%template(header_format_default_sptr) std::shared_ptr<gr::digital::header_format_default>;
 %pythoncode %{
 header_format_default_sptr.__repr__ = lambda self: "<header_format_default>"
 header_format_default = header_format_default .make;
 %}
 
 
-%template(header_format_counter_sptr) boost::shared_ptr<gr::digital::header_format_counter>;
+%template(header_format_counter_sptr) std::shared_ptr<gr::digital::header_format_counter>;
 %pythoncode %{
 header_format_counter_sptr.__repr__ = lambda self: "<header_format_counter>"
 header_format_counter = header_format_counter .make;
 %}
 
-%template(header_format_crc_sptr) boost::shared_ptr<gr::digital::header_format_crc>;
+%template(header_format_crc_sptr) std::shared_ptr<gr::digital::header_format_crc>;
 %pythoncode %{
 header_format_crc_sptr.__repr__ = lambda self: "<header_format_crc>"
 header_format_crc = header_format_crc .make;
 %}
 
-%template(header_format_ofdm_sptr) boost::shared_ptr<gr::digital::header_format_ofdm>;
+%template(header_format_ofdm_sptr) std::shared_ptr<gr::digital::header_format_ofdm>;
 %pythoncode %{
 header_format_ofdm_sptr.__repr__ = lambda self: "<header_format_ofdm>"
 header_format_ofdm = header_format_ofdm .make;

--- a/gr-dtv/include/gnuradio/dtv/atsc_deinterleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_deinterleaver.h
@@ -39,7 +39,7 @@ class DTV_API atsc_deinterleaver : virtual public gr::sync_block
 {
 public:
     // gr::dtv::atsc_deinterleaver::sptr
-    typedef boost::shared_ptr<atsc_deinterleaver> sptr;
+    typedef std::shared_ptr<atsc_deinterleaver> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_deinterleaver.

--- a/gr-dtv/include/gnuradio/dtv/atsc_depad.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_depad.h
@@ -39,7 +39,7 @@ class DTV_API atsc_depad : virtual public gr::sync_interpolator
 {
 public:
     // gr::dtv::atsc_depad::sptr
-    typedef boost::shared_ptr<atsc_depad> sptr;
+    typedef std::shared_ptr<atsc_depad> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_depad.

--- a/gr-dtv/include/gnuradio/dtv/atsc_derandomizer.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_derandomizer.h
@@ -39,7 +39,7 @@ class DTV_API atsc_derandomizer : virtual public gr::sync_block
 {
 public:
     // gr::dtv::atsc_derandomizer::sptr
-    typedef boost::shared_ptr<atsc_derandomizer> sptr;
+    typedef std::shared_ptr<atsc_derandomizer> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_derandomizer.

--- a/gr-dtv/include/gnuradio/dtv/atsc_equalizer.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_equalizer.h
@@ -38,7 +38,7 @@ class DTV_API atsc_equalizer : virtual public gr::block
 {
 public:
     // gr::dtv::atsc_equalizer::sptr
-    typedef boost::shared_ptr<atsc_equalizer> sptr;
+    typedef std::shared_ptr<atsc_equalizer> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_equalizer.

--- a/gr-dtv/include/gnuradio/dtv/atsc_field_sync_mux.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_field_sync_mux.h
@@ -35,7 +35,7 @@ namespace dtv {
 class DTV_API atsc_field_sync_mux : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<atsc_field_sync_mux> sptr;
+    typedef std::shared_ptr<atsc_field_sync_mux> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of dtv::atsc_field_sync_mux.

--- a/gr-dtv/include/gnuradio/dtv/atsc_fpll.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_fpll.h
@@ -53,7 +53,7 @@ class DTV_API atsc_fpll : virtual public gr::sync_block
 {
 public:
     // gr::dtv::atsc_fpll::sptr
-    typedef boost::shared_ptr<atsc_fpll> sptr;
+    typedef std::shared_ptr<atsc_fpll> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_fpll.

--- a/gr-dtv/include/gnuradio/dtv/atsc_fs_checker.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_fs_checker.h
@@ -38,7 +38,7 @@ class DTV_API atsc_fs_checker : virtual public gr::block
 {
 public:
     // gr::dtv::atsc_fs_checker::sptr
-    typedef boost::shared_ptr<atsc_fs_checker> sptr;
+    typedef std::shared_ptr<atsc_fs_checker> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_fs_checker.

--- a/gr-dtv/include/gnuradio/dtv/atsc_interleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_interleaver.h
@@ -35,7 +35,7 @@ namespace dtv {
 class DTV_API atsc_interleaver : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<atsc_interleaver> sptr;
+    typedef std::shared_ptr<atsc_interleaver> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of dtv::atsc_interleaver.

--- a/gr-dtv/include/gnuradio/dtv/atsc_pad.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_pad.h
@@ -35,7 +35,7 @@ namespace dtv {
 class DTV_API atsc_pad : virtual public gr::sync_decimator
 {
 public:
-    typedef boost::shared_ptr<atsc_pad> sptr;
+    typedef std::shared_ptr<atsc_pad> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of dtv::atsc_pad.

--- a/gr-dtv/include/gnuradio/dtv/atsc_randomizer.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_randomizer.h
@@ -36,7 +36,7 @@ namespace dtv {
 class DTV_API atsc_randomizer : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<atsc_randomizer> sptr;
+    typedef std::shared_ptr<atsc_randomizer> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of dtv::atsc_randomizer.

--- a/gr-dtv/include/gnuradio/dtv/atsc_rs_decoder.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_rs_decoder.h
@@ -38,7 +38,7 @@ class DTV_API atsc_rs_decoder : virtual public gr::sync_block
 {
 public:
     // gr::dtv::atsc_rs_decoder::sptr
-    typedef boost::shared_ptr<atsc_rs_decoder> sptr;
+    typedef std::shared_ptr<atsc_rs_decoder> sptr;
 
     /*!
      * Returns the number of errors corrected by the decoder.

--- a/gr-dtv/include/gnuradio/dtv/atsc_rs_encoder.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_rs_encoder.h
@@ -36,7 +36,7 @@ namespace dtv {
 class DTV_API atsc_rs_encoder : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<atsc_rs_encoder> sptr;
+    typedef std::shared_ptr<atsc_rs_encoder> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of dtv::atsc_rs_encoder.

--- a/gr-dtv/include/gnuradio/dtv/atsc_sync.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_sync.h
@@ -38,7 +38,7 @@ class DTV_API atsc_sync : virtual public gr::block
 {
 public:
     // gr::dtv::atsc_sync::sptr
-    typedef boost::shared_ptr<atsc_sync> sptr;
+    typedef std::shared_ptr<atsc_sync> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_sync.

--- a/gr-dtv/include/gnuradio/dtv/atsc_trellis_encoder.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_trellis_encoder.h
@@ -35,7 +35,7 @@ namespace dtv {
 class DTV_API atsc_trellis_encoder : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<atsc_trellis_encoder> sptr;
+    typedef std::shared_ptr<atsc_trellis_encoder> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of dtv::atsc_trellis_encoder.

--- a/gr-dtv/include/gnuradio/dtv/atsc_viterbi_decoder.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_viterbi_decoder.h
@@ -38,7 +38,7 @@ class DTV_API atsc_viterbi_decoder : virtual public gr::sync_block
 {
 public:
     // gr::dtv::atsc_viterbi_decoder::sptr
-    typedef boost::shared_ptr<atsc_viterbi_decoder> sptr;
+    typedef std::shared_ptr<atsc_viterbi_decoder> sptr;
 
     /*!
      * \brief Make a new instance of gr::dtv::atsc_viterbi_decoder.

--- a/gr-dtv/include/gnuradio/dtv/catv_frame_sync_enc_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/catv_frame_sync_enc_bb.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API catv_frame_sync_enc_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<catv_frame_sync_enc_bb> sptr;
+    typedef std::shared_ptr<catv_frame_sync_enc_bb> sptr;
 
     /*!
      * \brief Create an ITU-T J.83B Frame Sync Encoder.

--- a/gr-dtv/include/gnuradio/dtv/catv_randomizer_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/catv_randomizer_bb.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API catv_randomizer_bb : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<catv_randomizer_bb> sptr;
+    typedef std::shared_ptr<catv_randomizer_bb> sptr;
 
     /*!
      * \brief Create an ITU-T J.83B randomizer.

--- a/gr-dtv/include/gnuradio/dtv/catv_reed_solomon_enc_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/catv_reed_solomon_enc_bb.h
@@ -37,7 +37,7 @@ namespace dtv {
 class DTV_API catv_reed_solomon_enc_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<catv_reed_solomon_enc_bb> sptr;
+    typedef std::shared_ptr<catv_reed_solomon_enc_bb> sptr;
 
     /*!
      * \brief Create an ITU-T J.83B Reed Solomon encoder.

--- a/gr-dtv/include/gnuradio/dtv/catv_transport_framing_enc_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/catv_transport_framing_enc_bb.h
@@ -37,7 +37,7 @@ namespace dtv {
 class DTV_API catv_transport_framing_enc_bb : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<catv_transport_framing_enc_bb> sptr;
+    typedef std::shared_ptr<catv_transport_framing_enc_bb> sptr;
 
     /*!
      * \brief Create an ITU-T J.83B Transport Framing Encoder.

--- a/gr-dtv/include/gnuradio/dtv/catv_trellis_enc_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/catv_trellis_enc_bb.h
@@ -40,7 +40,7 @@ namespace dtv {
 class DTV_API catv_trellis_enc_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<catv_trellis_enc_bb> sptr;
+    typedef std::shared_ptr<catv_trellis_enc_bb> sptr;
 
     /*!
      * \brief Create an ITU-T J.83B Trellis Encoder.

--- a/gr-dtv/include/gnuradio/dtv/dvb_bbheader_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/dvb_bbheader_bb.h
@@ -43,7 +43,7 @@ namespace dtv {
 class DTV_API dvb_bbheader_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvb_bbheader_bb> sptr;
+    typedef std::shared_ptr<dvb_bbheader_bb> sptr;
 
     /*!
      * \brief Create a baseband header formatter.

--- a/gr-dtv/include/gnuradio/dtv/dvb_bbscrambler_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/dvb_bbscrambler_bb.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvb_bbscrambler_bb : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<dvb_bbscrambler_bb> sptr;
+    typedef std::shared_ptr<dvb_bbscrambler_bb> sptr;
 
     /*!
      * \brief Create a baseband frame scrambler.

--- a/gr-dtv/include/gnuradio/dtv/dvb_bch_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/dvb_bch_bb.h
@@ -40,7 +40,7 @@ namespace dtv {
 class DTV_API dvb_bch_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvb_bch_bb> sptr;
+    typedef std::shared_ptr<dvb_bch_bb> sptr;
 
     /*!
      * \brief Create a baseband frame BCH encoder.

--- a/gr-dtv/include/gnuradio/dtv/dvb_ldpc_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/dvb_ldpc_bb.h
@@ -38,7 +38,7 @@ namespace dtv {
 class DTV_API dvb_ldpc_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvb_ldpc_bb> sptr;
+    typedef std::shared_ptr<dvb_ldpc_bb> sptr;
 
     /*!
      * \brief Create a baseband frame LDPC encoder.

--- a/gr-dtv/include/gnuradio/dtv/dvbs2_interleaver_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbs2_interleaver_bb.h
@@ -38,7 +38,7 @@ namespace dtv {
 class DTV_API dvbs2_interleaver_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbs2_interleaver_bb> sptr;
+    typedef std::shared_ptr<dvbs2_interleaver_bb> sptr;
 
     /*!
      * \brief Create a DVB-S2 bit interleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbs2_modulator_bc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbs2_modulator_bc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbs2_modulator_bc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbs2_modulator_bc> sptr;
+    typedef std::shared_ptr<dvbs2_modulator_bc> sptr;
 
     /*!
      * \brief Create a DVB-S2 constellation modulator.

--- a/gr-dtv/include/gnuradio/dtv/dvbs2_physical_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbs2_physical_cc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbs2_physical_cc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbs2_physical_cc> sptr;
+    typedef std::shared_ptr<dvbs2_physical_cc> sptr;
 
     /*!
      * \brief Create a DVB-S2 physical layer framer.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_cellinterleaver_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_cellinterleaver_cc.h
@@ -38,7 +38,7 @@ namespace dtv {
 class DTV_API dvbt2_cellinterleaver_cc : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_cellinterleaver_cc> sptr;
+    typedef std::shared_ptr<dvbt2_cellinterleaver_cc> sptr;
 
     /*!
      * \brief Create a DVB-T2 cell and time interleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_framemapper_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_framemapper_cc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt2_framemapper_cc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_framemapper_cc> sptr;
+    typedef std::shared_ptr<dvbt2_framemapper_cc> sptr;
 
     /*!
      * \brief Create a DVB-T2 frame mapper.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_freqinterleaver_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_freqinterleaver_cc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt2_freqinterleaver_cc : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_freqinterleaver_cc> sptr;
+    typedef std::shared_ptr<dvbt2_freqinterleaver_cc> sptr;
 
     /*!
      * \brief Create a DVB-T2 frequency interleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_interleaver_bb.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_interleaver_bb.h
@@ -38,7 +38,7 @@ namespace dtv {
 class DTV_API dvbt2_interleaver_bb : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_interleaver_bb> sptr;
+    typedef std::shared_ptr<dvbt2_interleaver_bb> sptr;
 
     /*!
      * \brief Create a DVB-T2 bit interleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_miso_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_miso_cc.h
@@ -40,7 +40,7 @@ namespace dtv {
 class DTV_API dvbt2_miso_cc : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_miso_cc> sptr;
+    typedef std::shared_ptr<dvbt2_miso_cc> sptr;
 
     /*!
      * \brief Create a MISO processor.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_modulator_bc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_modulator_bc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt2_modulator_bc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_modulator_bc> sptr;
+    typedef std::shared_ptr<dvbt2_modulator_bc> sptr;
 
     /*!
      * \brief Create a DVB-T2 constellation modulator.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_p1insertion_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_p1insertion_cc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt2_p1insertion_cc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_p1insertion_cc> sptr;
+    typedef std::shared_ptr<dvbt2_p1insertion_cc> sptr;
 
     /*!
      * \brief Create a P1 symbol inserter.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_paprtr_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_paprtr_cc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt2_paprtr_cc : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_paprtr_cc> sptr;
+    typedef std::shared_ptr<dvbt2_paprtr_cc> sptr;
 
     /*!
      * \brief Create a PAPR reducer.

--- a/gr-dtv/include/gnuradio/dtv/dvbt2_pilotgenerator_cc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt2_pilotgenerator_cc.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt2_pilotgenerator_cc : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbt2_pilotgenerator_cc> sptr;
+    typedef std::shared_ptr<dvbt2_pilotgenerator_cc> sptr;
 
     /*!
      * \brief Create a DVB-T2 pilot generator.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_bit_inner_deinterleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_bit_inner_deinterleaver.h
@@ -47,7 +47,7 @@ namespace dtv {
 class DTV_API dvbt_bit_inner_deinterleaver : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_bit_inner_deinterleaver> sptr;
+    typedef std::shared_ptr<dvbt_bit_inner_deinterleaver> sptr;
 
     /*!
      * \brief Create a Bit Inner deinterleaver

--- a/gr-dtv/include/gnuradio/dtv/dvbt_bit_inner_interleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_bit_inner_interleaver.h
@@ -47,7 +47,7 @@ namespace dtv {
 class DTV_API dvbt_bit_inner_interleaver : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_bit_inner_interleaver> sptr;
+    typedef std::shared_ptr<dvbt_bit_inner_interleaver> sptr;
 
     /*!
      * \brief Create a Bit Inner interleaver

--- a/gr-dtv/include/gnuradio/dtv/dvbt_convolutional_deinterleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_convolutional_deinterleaver.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt_convolutional_deinterleaver : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_convolutional_deinterleaver> sptr;
+    typedef std::shared_ptr<dvbt_convolutional_deinterleaver> sptr;
 
     /*!
      * \brief Create a DVB-T convolutional deinterleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_convolutional_interleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_convolutional_interleaver.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt_convolutional_interleaver : virtual public sync_interpolator
 {
 public:
-    typedef boost::shared_ptr<dvbt_convolutional_interleaver> sptr;
+    typedef std::shared_ptr<dvbt_convolutional_interleaver> sptr;
 
     /*!
      * \brief Create a DVB-T convolutional interleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_demap.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_demap.h
@@ -44,7 +44,7 @@ namespace dtv {
 class DTV_API dvbt_demap : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_demap> sptr;
+    typedef std::shared_ptr<dvbt_demap> sptr;
 
     /*!
      * \brief Create a DVB-T demapper.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_demod_reference_signals.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_demod_reference_signals.h
@@ -42,7 +42,7 @@ namespace dtv {
 class DTV_API dvbt_demod_reference_signals : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_demod_reference_signals> sptr;
+    typedef std::shared_ptr<dvbt_demod_reference_signals> sptr;
 
     /*!
      * \brief Create Reference signals demodulator.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_energy_descramble.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_energy_descramble.h
@@ -41,7 +41,7 @@ namespace dtv {
 class DTV_API dvbt_energy_descramble : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_energy_descramble> sptr;
+    typedef std::shared_ptr<dvbt_energy_descramble> sptr;
 
     /*!
      * \brief Create DVB-T Energy descramble.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_energy_dispersal.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_energy_dispersal.h
@@ -41,7 +41,7 @@ namespace dtv {
 class DTV_API dvbt_energy_dispersal : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dvbt_energy_dispersal> sptr;
+    typedef std::shared_ptr<dvbt_energy_dispersal> sptr;
 
     /*!
      * \brief Create DVB-T energy dispersal.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_inner_coder.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_inner_coder.h
@@ -48,7 +48,7 @@ namespace dtv {
 class DTV_API dvbt_inner_coder : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_inner_coder> sptr;
+    typedef std::shared_ptr<dvbt_inner_coder> sptr;
 
     /*!
      * \brief Create an Inner coder with Puncturing.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_map.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_map.h
@@ -44,7 +44,7 @@ namespace dtv {
 class DTV_API dvbt_map : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_map> sptr;
+    typedef std::shared_ptr<dvbt_map> sptr;
 
     /*!
      * \brief Create a DVB-T mapper.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_ofdm_sym_acquisition.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_ofdm_sym_acquisition.h
@@ -39,7 +39,7 @@ namespace dtv {
 class DTV_API dvbt_ofdm_sym_acquisition : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_ofdm_sym_acquisition> sptr;
+    typedef std::shared_ptr<dvbt_ofdm_sym_acquisition> sptr;
 
     /*!
      * \brief Create OFDM symbol acquisition.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_reed_solomon_dec.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_reed_solomon_dec.h
@@ -37,7 +37,7 @@ namespace dtv {
 class DTV_API dvbt_reed_solomon_dec : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_reed_solomon_dec> sptr;
+    typedef std::shared_ptr<dvbt_reed_solomon_dec> sptr;
 
     /*!
      * \brief Create a Reed Solomon decoder.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_reed_solomon_enc.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_reed_solomon_enc.h
@@ -37,7 +37,7 @@ namespace dtv {
 class DTV_API dvbt_reed_solomon_enc : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_reed_solomon_enc> sptr;
+    typedef std::shared_ptr<dvbt_reed_solomon_enc> sptr;
 
     /*!
      * \brief Create a Reed Solomon encoder.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_reference_signals.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_reference_signals.h
@@ -42,7 +42,7 @@ namespace dtv {
 class DTV_API dvbt_reference_signals : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_reference_signals> sptr;
+    typedef std::shared_ptr<dvbt_reference_signals> sptr;
 
     /*!
      * \brief Create Reference signals generator.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_symbol_inner_interleaver.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_symbol_inner_interleaver.h
@@ -47,7 +47,7 @@ namespace dtv {
 class DTV_API dvbt_symbol_inner_interleaver : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_symbol_inner_interleaver> sptr;
+    typedef std::shared_ptr<dvbt_symbol_inner_interleaver> sptr;
 
     /*!
      * \brief Create a Symbol interleaver.

--- a/gr-dtv/include/gnuradio/dtv/dvbt_viterbi_decoder.h
+++ b/gr-dtv/include/gnuradio/dtv/dvbt_viterbi_decoder.h
@@ -48,7 +48,7 @@ namespace dtv {
 class DTV_API dvbt_viterbi_decoder : virtual public block
 {
 public:
-    typedef boost::shared_ptr<dvbt_viterbi_decoder> sptr;
+    typedef std::shared_ptr<dvbt_viterbi_decoder> sptr;
 
     /*!
      * \brief Create a DVB-T Viterbi decoder.

--- a/gr-fec/include/gnuradio/fec/async_decoder.h
+++ b/gr-fec/include/gnuradio/fec/async_decoder.h
@@ -26,7 +26,7 @@
 #include <gnuradio/block.h>
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_decoder.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -79,7 +79,7 @@ namespace fec {
 class FEC_API async_decoder : virtual public block
 {
 public:
-    typedef boost::shared_ptr<async_decoder> sptr;
+    typedef std::shared_ptr<async_decoder> sptr;
 
     /*!
      * Build the PDU-based FEC decoder block from an FECAPI decoder object.

--- a/gr-fec/include/gnuradio/fec/async_encoder.h
+++ b/gr-fec/include/gnuradio/fec/async_encoder.h
@@ -26,7 +26,7 @@
 #include <gnuradio/block.h>
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_encoder.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -73,7 +73,7 @@ namespace fec {
 class FEC_API async_encoder : virtual public block
 {
 public:
-    typedef boost::shared_ptr<async_encoder> sptr;
+    typedef std::shared_ptr<async_encoder> sptr;
 
     /*!
      * Build the PDU-based FEC encoder block from an FECAPI encoder object.

--- a/gr-fec/include/gnuradio/fec/ber_bf.h
+++ b/gr-fec/include/gnuradio/fec/ber_bf.h
@@ -64,7 +64,7 @@ class FEC_API ber_bf : virtual public block
 {
 public:
     // gr::fec::ber_bf::sptr
-    typedef boost::shared_ptr<ber_bf> sptr;
+    typedef std::shared_ptr<ber_bf> sptr;
 
     /*!
      * Get total number of errors counter value.

--- a/gr-fec/include/gnuradio/fec/conv_bit_corr_bb.h
+++ b/gr-fec/include/gnuradio/fec/conv_bit_corr_bb.h
@@ -42,7 +42,7 @@ class FEC_API conv_bit_corr_bb : virtual public block
 {
 public:
     // gr::fec::conv_bit_corr_bb::sptr
-    typedef boost::shared_ptr<conv_bit_corr_bb> sptr;
+    typedef std::shared_ptr<conv_bit_corr_bb> sptr;
 
     static sptr make(std::vector<unsigned long long> correlator,
                      int corr_sym,

--- a/gr-fec/include/gnuradio/fec/decode_ccsds_27_fb.h
+++ b/gr-fec/include/gnuradio/fec/decode_ccsds_27_fb.h
@@ -53,7 +53,7 @@ class FEC_API decode_ccsds_27_fb : virtual public sync_decimator
 {
 public:
     // gr::fec::decode_ccsds_27_fb::sptr
-    typedef boost::shared_ptr<decode_ccsds_27_fb> sptr;
+    typedef std::shared_ptr<decode_ccsds_27_fb> sptr;
 
     static sptr make();
 };

--- a/gr-fec/include/gnuradio/fec/decoder.h
+++ b/gr-fec/include/gnuradio/fec/decoder.h
@@ -28,7 +28,7 @@
 #include <gnuradio/fec/generic_decoder.h>
 #include <boost/format.hpp>
 #include <boost/shared_array.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -66,7 +66,7 @@ namespace fec {
 class FEC_API decoder : virtual public block
 {
 public:
-    typedef boost::shared_ptr<decoder> sptr;
+    typedef std::shared_ptr<decoder> sptr;
     typedef boost::shared_array<unsigned char> buf_sptr;
 
     /*!

--- a/gr-fec/include/gnuradio/fec/depuncture_bb.h
+++ b/gr-fec/include/gnuradio/fec/depuncture_bb.h
@@ -91,7 +91,7 @@ class FEC_API depuncture_bb : virtual public block
 {
 public:
     // gr::fec::depuncture_bb::sptr
-    typedef boost::shared_ptr<depuncture_bb> sptr;
+    typedef std::shared_ptr<depuncture_bb> sptr;
 
     /*!
      * \brief Constructs a depuncture block.

--- a/gr-fec/include/gnuradio/fec/encode_ccsds_27_bb.h
+++ b/gr-fec/include/gnuradio/fec/encode_ccsds_27_bb.h
@@ -50,7 +50,7 @@ class FEC_API encode_ccsds_27_bb : virtual public sync_interpolator
 {
 public:
     // gr::fec::encode_ccsds_27_bb::sptr
-    typedef boost::shared_ptr<encode_ccsds_27_bb> sptr;
+    typedef std::shared_ptr<encode_ccsds_27_bb> sptr;
 
     static sptr make();
 };

--- a/gr-fec/include/gnuradio/fec/encoder.h
+++ b/gr-fec/include/gnuradio/fec/encoder.h
@@ -26,7 +26,7 @@
 #include <gnuradio/block.h>
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_encoder.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -47,7 +47,7 @@ namespace fec {
 class FEC_API encoder : virtual public block
 {
 public:
-    typedef boost::shared_ptr<encoder> sptr;
+    typedef std::shared_ptr<encoder> sptr;
 
     /*!
      * Build the FEC encoder block from an FECAPI encoder object.

--- a/gr-fec/include/gnuradio/fec/fec_mtrx.h
+++ b/gr-fec/include/gnuradio/fec/fec_mtrx.h
@@ -22,7 +22,7 @@
 #define INCLUDED_fec_mtrx_H
 
 #include <gnuradio/fec/api.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <cstdlib>
 
 namespace gr {
@@ -45,10 +45,10 @@ typedef struct {
 
 FEC_API void matrix_free(matrix* x);
 
-typedef boost::shared_ptr<matrix> matrix_sptr;
+typedef std::shared_ptr<matrix> matrix_sptr;
 
 class fec_mtrx;
-typedef boost::shared_ptr<fec_mtrx> fec_mtrx_sptr;
+typedef std::shared_ptr<fec_mtrx> fec_mtrx_sptr;
 
 /*!
  * \brief Read in an alist file and produce the matrix object.

--- a/gr-fec/include/gnuradio/fec/generic_decoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_decoder.h
@@ -26,7 +26,7 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/logger.h>
 #include <boost/format.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -72,7 +72,7 @@ public:
     std::string alias() { return (boost::format("%s%d") % d_name % unique_id()).str(); }
 
 public:
-    typedef boost::shared_ptr<generic_decoder> sptr;
+    typedef std::shared_ptr<generic_decoder> sptr;
 
     generic_decoder(void){};
     generic_decoder(std::string name);

--- a/gr-fec/include/gnuradio/fec/generic_encoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_encoder.h
@@ -26,7 +26,7 @@
 #include <gnuradio/block.h>
 #include <gnuradio/fec/api.h>
 #include <gnuradio/logger.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -46,7 +46,7 @@ public:
     std::string alias() { return (boost::format("%s%d") % d_name % unique_id()).str(); }
 
 public:
-    typedef boost::shared_ptr<generic_encoder> sptr;
+    typedef std::shared_ptr<generic_encoder> sptr;
 
     /*!
      * Returns the rate of the code. For every 1 input bit, there

--- a/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
@@ -24,7 +24,7 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/fec_mtrx.h>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -52,10 +52,10 @@ namespace code {
  * ldpc_bit_flip_decoder classes.
  */
 class FEC_API ldpc_G_matrix : virtual public fec_mtrx,
-                              public boost::enable_shared_from_this<ldpc_G_matrix>
+                              public std::enable_shared_from_this<ldpc_G_matrix>
 {
 public:
-    typedef boost::shared_ptr<ldpc_G_matrix> sptr;
+    typedef std::shared_ptr<ldpc_G_matrix> sptr;
 
     /*!
      * \brief Constructor given alist file

--- a/gr-fec/include/gnuradio/fec/ldpc_H_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_H_matrix.h
@@ -24,7 +24,7 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/fec_mtrx.h>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -47,10 +47,10 @@ namespace code {
  * /lib/python2.7/dist-packages/gnuradio/fec/LDPC/Generate_LDPC_matrix.py.
  */
 class FEC_API ldpc_H_matrix : virtual public fec_mtrx,
-                              public boost::enable_shared_from_this<ldpc_H_matrix>
+                              public std::enable_shared_from_this<ldpc_H_matrix>
 {
 public:
-    typedef boost::shared_ptr<ldpc_H_matrix> sptr;
+    typedef std::shared_ptr<ldpc_H_matrix> sptr;
 
     /*!
      * \brief Constructor given alist file and gap

--- a/gr-fec/include/gnuradio/fec/puncture_bb.h
+++ b/gr-fec/include/gnuradio/fec/puncture_bb.h
@@ -90,7 +90,7 @@ class FEC_API puncture_bb : virtual public block
 {
 public:
     // gr::fec::puncture_bb::sptr
-    typedef boost::shared_ptr<puncture_bb> sptr;
+    typedef std::shared_ptr<puncture_bb> sptr;
 
     /*!
      * \brief Constructs a puncture block for unpacked bits.

--- a/gr-fec/include/gnuradio/fec/puncture_ff.h
+++ b/gr-fec/include/gnuradio/fec/puncture_ff.h
@@ -89,7 +89,7 @@ class FEC_API puncture_ff : virtual public block
 {
 public:
     // gr::fec::puncture_ff::sptr
-    typedef boost::shared_ptr<puncture_ff> sptr;
+    typedef std::shared_ptr<puncture_ff> sptr;
 
     /*!
      * \brief Constructs a puncture block for floats.

--- a/gr-fec/include/gnuradio/fec/tagged_decoder.h
+++ b/gr-fec/include/gnuradio/fec/tagged_decoder.h
@@ -27,7 +27,7 @@
 #include <gnuradio/fec/generic_decoder.h>
 #include <gnuradio/tagged_stream_block.h>
 #include <boost/shared_array.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -65,7 +65,7 @@ namespace fec {
 class FEC_API tagged_decoder : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<tagged_decoder> sptr;
+    typedef std::shared_ptr<tagged_decoder> sptr;
     typedef boost::shared_array<unsigned char> buf_sptr;
 
     /*!

--- a/gr-fec/include/gnuradio/fec/tagged_encoder.h
+++ b/gr-fec/include/gnuradio/fec/tagged_encoder.h
@@ -26,7 +26,7 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_encoder.h>
 #include <gnuradio/tagged_stream_block.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace gr {
 namespace fec {
@@ -47,7 +47,7 @@ namespace fec {
 class FEC_API tagged_encoder : virtual public tagged_stream_block
 {
 public:
-    typedef boost::shared_ptr<tagged_encoder> sptr;
+    typedef std::shared_ptr<tagged_encoder> sptr;
 
     /*!
      * Build the FEC encoder block from an FECAPI encoder object.

--- a/gr-fec/lib/fec_mtrx_impl.cc
+++ b/gr-fec/lib/fec_mtrx_impl.cc
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+#include <algorithm>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/swig/fec_swig.i
+++ b/gr-fec/swig/fec_swig.i
@@ -30,10 +30,10 @@
 %include "gnuradio/fec/cc_common.h"
 
 %nodefaultctor gr::fec::generic_encoder;
-%template(generic_encoder_sptr) boost::shared_ptr<gr::fec::generic_encoder>;
+%template(generic_encoder_sptr) std::shared_ptr<gr::fec::generic_encoder>;
 
 %nodefaultctor gr::fec::generic_decoder;
-%template(generic_decoder_sptr) boost::shared_ptr<gr::fec::generic_decoder>;
+%template(generic_decoder_sptr) std::shared_ptr<gr::fec::generic_decoder>;
 
 %{
 #include "gnuradio/fec/generic_decoder.h"

--- a/gr-fec/swig/ldpc.i
+++ b/gr-fec/swig/ldpc.i
@@ -20,15 +20,15 @@
  * Boston, MA 02110-1301, USA.
  */
 
-%template(matrix_sptr) boost::shared_ptr<gr::fec::code::matrix>;
-%template(fec_mtrx_sptr) boost::shared_ptr<gr::fec::code::fec_mtrx>;
+%template(matrix_sptr) std::shared_ptr<gr::fec::code::matrix>;
+%template(fec_mtrx_sptr) std::shared_ptr<gr::fec::code::fec_mtrx>;
 
-%template(ldpc_H_matrix_sptr) boost::shared_ptr<gr::fec::code::ldpc_H_matrix>;
+%template(ldpc_H_matrix_sptr) std::shared_ptr<gr::fec::code::ldpc_H_matrix>;
 %pythoncode %{
   ldpc_H_matrix = ldpc_H_matrix.make;
 %}
 
-%template(ldpc_G_matrix_sptr) boost::shared_ptr<gr::fec::code::ldpc_G_matrix>;
+%template(ldpc_G_matrix_sptr) std::shared_ptr<gr::fec::code::ldpc_G_matrix>;
 %pythoncode %{
   ldpc_G_matrix = ldpc_G_matrix.make;
 %}

--- a/gr-fft/include/gnuradio/fft/ctrlport_probe_psd.h
+++ b/gr-fft/include/gnuradio/fft/ctrlport_probe_psd.h
@@ -43,7 +43,7 @@ namespace fft {
 class FFT_API ctrlport_probe_psd : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<ctrlport_probe_psd> sptr;
+    typedef std::shared_ptr<ctrlport_probe_psd> sptr;
 
     /*!
      * \brief Make a ControlPort probe block.

--- a/gr-fft/include/gnuradio/fft/fft_vcc.h
+++ b/gr-fft/include/gnuradio/fft/fft_vcc.h
@@ -60,7 +60,7 @@ class FFT_API fft_vcc : virtual public sync_block
 {
 public:
     // gr::fft::fft_vcc::sptr
-    typedef boost::shared_ptr<fft_vcc> sptr;
+    typedef std::shared_ptr<fft_vcc> sptr;
     /*! \brief
      * \param[in] fft_size N.
      * \param[in] forward True performs FFT, False performs IFFT.

--- a/gr-fft/include/gnuradio/fft/fft_vfc.h
+++ b/gr-fft/include/gnuradio/fft/fft_vfc.h
@@ -60,7 +60,7 @@ class FFT_API fft_vfc : virtual public sync_block
 {
 public:
     // gr::fft::fft_vfc::sptr
-    typedef boost::shared_ptr<fft_vfc> sptr;
+    typedef std::shared_ptr<fft_vfc> sptr;
 
     /*! \brief
      * \param[in] fft_size N.

--- a/gr-fft/include/gnuradio/fft/goertzel_fc.h
+++ b/gr-fft/include/gnuradio/fft/goertzel_fc.h
@@ -37,7 +37,7 @@ class FFT_API goertzel_fc : virtual public sync_decimator
 {
 public:
     // gr::fft::goertzel_fc::sptr
-    typedef boost::shared_ptr<goertzel_fc> sptr;
+    typedef std::shared_ptr<goertzel_fc> sptr;
 
     static sptr make(int rate, int len, float freq);
 

--- a/gr-filter/include/gnuradio/filter/dc_blocker_cc.h
+++ b/gr-filter/include/gnuradio/filter/dc_blocker_cc.h
@@ -58,7 +58,7 @@ class FILTER_API dc_blocker_cc : virtual public sync_block
 {
 public:
     // gr::filter::dc_blocker_cc::sptr
-    typedef boost::shared_ptr<dc_blocker_cc> sptr;
+    typedef std::shared_ptr<dc_blocker_cc> sptr;
 
     /*!
      * Make a DC blocker block.

--- a/gr-filter/include/gnuradio/filter/dc_blocker_ff.h
+++ b/gr-filter/include/gnuradio/filter/dc_blocker_ff.h
@@ -61,7 +61,7 @@ class FILTER_API dc_blocker_ff : virtual public sync_block
 {
 public:
     // gr::filter::dc_blocker_ff::sptr
-    typedef boost::shared_ptr<dc_blocker_ff> sptr;
+    typedef std::shared_ptr<dc_blocker_ff> sptr;
 
     /*!
      * Make a DC blocker block.

--- a/gr-filter/include/gnuradio/filter/fft_filter_ccc.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter_ccc.h
@@ -56,7 +56,7 @@ class FILTER_API fft_filter_ccc : virtual public sync_decimator
 {
 public:
     // gr::filter::fft_filter_ccc::sptr
-    typedef boost::shared_ptr<fft_filter_ccc> sptr;
+    typedef std::shared_ptr<fft_filter_ccc> sptr;
 
     /*!
      * Build an FFT filter blocks.

--- a/gr-filter/include/gnuradio/filter/fft_filter_ccf.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter_ccf.h
@@ -56,7 +56,7 @@ class FILTER_API fft_filter_ccf : virtual public sync_decimator
 {
 public:
     // gr::filter::fft_filter_ccf::sptr
-    typedef boost::shared_ptr<fft_filter_ccf> sptr;
+    typedef std::shared_ptr<fft_filter_ccf> sptr;
 
     /*!
      * Build an FFT filter blocks.

--- a/gr-filter/include/gnuradio/filter/fft_filter_fff.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter_fff.h
@@ -56,7 +56,7 @@ class FILTER_API fft_filter_fff : virtual public sync_decimator
 {
 public:
     // gr::filter::fft_filter_fff::sptr
-    typedef boost::shared_ptr<fft_filter_fff> sptr;
+    typedef std::shared_ptr<fft_filter_fff> sptr;
 
     /*!
      * Build an FFT filter block.

--- a/gr-filter/include/gnuradio/filter/filter_delay_fc.h
+++ b/gr-filter/include/gnuradio/filter/filter_delay_fc.h
@@ -53,7 +53,7 @@ class FILTER_API filter_delay_fc : virtual public sync_block
 {
 public:
     // gr::filter::filter_delay_fc::sptr
-    typedef boost::shared_ptr<filter_delay_fc> sptr;
+    typedef std::shared_ptr<filter_delay_fc> sptr;
 
     /*!
      * Build a filter with delay block.

--- a/gr-filter/include/gnuradio/filter/filterbank_vcvcf.h
+++ b/gr-filter/include/gnuradio/filter/filterbank_vcvcf.h
@@ -43,7 +43,7 @@ namespace filter {
 class FILTER_API filterbank_vcvcf : virtual public block
 {
 public:
-    typedef boost::shared_ptr<filterbank_vcvcf> sptr;
+    typedef std::shared_ptr<filterbank_vcvcf> sptr;
 
     /*!
      * Build the filterbank.

--- a/gr-filter/include/gnuradio/filter/fir_filter_blk.h
+++ b/gr-filter/include/gnuradio/filter/fir_filter_blk.h
@@ -58,7 +58,7 @@ template <class IN_T, class OUT_T, class TAP_T>
 class FILTER_API fir_filter_blk : virtual public sync_decimator
 {
 public:
-    typedef boost::shared_ptr<fir_filter_blk<IN_T, OUT_T, TAP_T>> sptr;
+    typedef std::shared_ptr<fir_filter_blk<IN_T, OUT_T, TAP_T>> sptr;
 
     /*!
      * \brief FIR filter with IN_T input, OUT_T output, and TAP_T taps

--- a/gr-filter/include/gnuradio/filter/freq_xlating_fir_filter.h
+++ b/gr-filter/include/gnuradio/filter/freq_xlating_fir_filter.h
@@ -58,7 +58,7 @@ template <class IN_T, class OUT_T, class TAP_T>
 class FILTER_API freq_xlating_fir_filter : virtual public sync_decimator
 {
 public:
-    typedef boost::shared_ptr<freq_xlating_fir_filter<IN_T, OUT_T, TAP_T>> sptr;
+    typedef std::shared_ptr<freq_xlating_fir_filter<IN_T, OUT_T, TAP_T>> sptr;
 
     /*!
      * \brief FIR filter with IN_T input, OUT_T output, and

--- a/gr-filter/include/gnuradio/filter/hilbert_fc.h
+++ b/gr-filter/include/gnuradio/filter/hilbert_fc.h
@@ -44,7 +44,7 @@ class FILTER_API hilbert_fc : virtual public sync_block
 {
 public:
     // gr::filter::hilbert_fc::sptr
-    typedef boost::shared_ptr<hilbert_fc> sptr;
+    typedef std::shared_ptr<hilbert_fc> sptr;
 
     /*!
      * Build a Hilbert transformer filter block.

--- a/gr-filter/include/gnuradio/filter/iir_filter_ccc.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter_ccc.h
@@ -69,7 +69,7 @@ class FILTER_API iir_filter_ccc : virtual public sync_block
 {
 public:
     // gr::filter::iir_filter_ccc::sptr
-    typedef boost::shared_ptr<iir_filter_ccc> sptr;
+    typedef std::shared_ptr<iir_filter_ccc> sptr;
 
     static sptr make(const std::vector<gr_complex>& fftaps,
                      const std::vector<gr_complex>& fbtaps,

--- a/gr-filter/include/gnuradio/filter/iir_filter_ccd.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter_ccd.h
@@ -69,7 +69,7 @@ class FILTER_API iir_filter_ccd : virtual public sync_block
 {
 public:
     // gr::filter::iir_filter_ccd::sptr
-    typedef boost::shared_ptr<iir_filter_ccd> sptr;
+    typedef std::shared_ptr<iir_filter_ccd> sptr;
 
     static sptr make(const std::vector<double>& fftaps,
                      const std::vector<double>& fbtaps,

--- a/gr-filter/include/gnuradio/filter/iir_filter_ccf.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter_ccf.h
@@ -69,7 +69,7 @@ class FILTER_API iir_filter_ccf : virtual public sync_block
 {
 public:
     // gr::filter::iir_filter_ccf::sptr
-    typedef boost::shared_ptr<iir_filter_ccf> sptr;
+    typedef std::shared_ptr<iir_filter_ccf> sptr;
 
     static sptr make(const std::vector<float>& fftaps,
                      const std::vector<float>& fbtaps,

--- a/gr-filter/include/gnuradio/filter/iir_filter_ccz.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter_ccz.h
@@ -69,7 +69,7 @@ class FILTER_API iir_filter_ccz : virtual public sync_block
 {
 public:
     // gr::filter::iir_filter_ccz::sptr
-    typedef boost::shared_ptr<iir_filter_ccz> sptr;
+    typedef std::shared_ptr<iir_filter_ccz> sptr;
 
     static sptr make(const std::vector<gr_complexd>& fftaps,
                      const std::vector<gr_complexd>& fbtaps,

--- a/gr-filter/include/gnuradio/filter/iir_filter_ffd.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter_ffd.h
@@ -67,7 +67,7 @@ class FILTER_API iir_filter_ffd : virtual public sync_block
 {
 public:
     // gr::filter::iir_filter_ffd::sptr
-    typedef boost::shared_ptr<iir_filter_ffd> sptr;
+    typedef std::shared_ptr<iir_filter_ffd> sptr;
 
     static sptr make(const std::vector<double>& fftaps,
                      const std::vector<double>& fbtaps,

--- a/gr-filter/include/gnuradio/filter/interp_fir_filter.h
+++ b/gr-filter/include/gnuradio/filter/interp_fir_filter.h
@@ -60,7 +60,7 @@ class FILTER_API interp_fir_filter : virtual public sync_interpolator
 {
 public:
     // gr::filter::interp_fir_filter::sptr
-    typedef boost::shared_ptr<interp_fir_filter> sptr;
+    typedef std::shared_ptr<interp_fir_filter> sptr;
 
     /*!
      * \brief Interpolating FIR filter with IN_T input, OUT_T output, and TAP_T taps

--- a/gr-filter/include/gnuradio/filter/mmse_interpolator_cc.h
+++ b/gr-filter/include/gnuradio/filter/mmse_interpolator_cc.h
@@ -37,7 +37,7 @@ class FILTER_API mmse_interpolator_cc : virtual public block
 {
 public:
     // gr::filter::mmse_interpolator_cc::sptr
-    typedef boost::shared_ptr<mmse_interpolator_cc> sptr;
+    typedef std::shared_ptr<mmse_interpolator_cc> sptr;
 
     /*!
      * \brief Build the interpolating MMSE filter (complex input, complex output)

--- a/gr-filter/include/gnuradio/filter/mmse_interpolator_ff.h
+++ b/gr-filter/include/gnuradio/filter/mmse_interpolator_ff.h
@@ -37,7 +37,7 @@ class FILTER_API mmse_interpolator_ff : virtual public block
 {
 public:
     // gr::filter::mmse_interpolator_ff::sptr
-    typedef boost::shared_ptr<mmse_interpolator_ff> sptr;
+    typedef std::shared_ptr<mmse_interpolator_ff> sptr;
 
     /*!
      * \brief Build the interpolating MMSE filter (float input, float output)

--- a/gr-filter/include/gnuradio/filter/mmse_resampler_cc.h
+++ b/gr-filter/include/gnuradio/filter/mmse_resampler_cc.h
@@ -42,7 +42,7 @@ class FILTER_API mmse_resampler_cc : virtual public block
 {
 public:
     // gr::filter::mmse_resampler_cc::sptr
-    typedef boost::shared_ptr<mmse_resampler_cc> sptr;
+    typedef std::shared_ptr<mmse_resampler_cc> sptr;
 
     /*!
      * \brief Build the resampling MMSE filter (complex input, complex output)

--- a/gr-filter/include/gnuradio/filter/mmse_resampler_ff.h
+++ b/gr-filter/include/gnuradio/filter/mmse_resampler_ff.h
@@ -43,7 +43,7 @@ class FILTER_API mmse_resampler_ff : virtual public block
 {
 public:
     // gr::filter::mmse_resampler_ff::sptr
-    typedef boost::shared_ptr<mmse_resampler_ff> sptr;
+    typedef std::shared_ptr<mmse_resampler_ff> sptr;
 
     /*!
      * \brief Build the resampling MMSE filter (float input, float output)

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler_ccc.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler_ccc.h
@@ -47,7 +47,7 @@ class FILTER_API pfb_arb_resampler_ccc : virtual public block
 {
 public:
     // gr::filter::pfb_arb_resampler_ccc::sptr
-    typedef boost::shared_ptr<pfb_arb_resampler_ccc> sptr;
+    typedef std::shared_ptr<pfb_arb_resampler_ccc> sptr;
 
     /*!
      * Build the polyphase filterbank arbitrary resampler.

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler_ccf.h
@@ -47,7 +47,7 @@ class FILTER_API pfb_arb_resampler_ccf : virtual public block
 {
 public:
     // gr::filter::pfb_arb_resampler_ccf::sptr
-    typedef boost::shared_ptr<pfb_arb_resampler_ccf> sptr;
+    typedef std::shared_ptr<pfb_arb_resampler_ccf> sptr;
 
     /*!
      * Build the polyphase filterbank arbitrary resampler.

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler_fff.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler_fff.h
@@ -96,7 +96,7 @@ class FILTER_API pfb_arb_resampler_fff : virtual public block
 {
 public:
     // gr::filter::pfb_arb_resampler_fff::sptr
-    typedef boost::shared_ptr<pfb_arb_resampler_fff> sptr;
+    typedef std::shared_ptr<pfb_arb_resampler_fff> sptr;
 
     /*!
      * Build the polyphase filterbank arbitrary resampler.

--- a/gr-filter/include/gnuradio/filter/pfb_channelizer_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_channelizer_ccf.h
@@ -113,7 +113,7 @@ class FILTER_API pfb_channelizer_ccf : virtual public block
 {
 public:
     // gr::filter::pfb_channelizer_ccf::sptr
-    typedef boost::shared_ptr<pfb_channelizer_ccf> sptr;
+    typedef std::shared_ptr<pfb_channelizer_ccf> sptr;
 
     /*!
      * Build the polyphase filterbank decimator.

--- a/gr-filter/include/gnuradio/filter/pfb_decimator_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_decimator_ccf.h
@@ -92,7 +92,7 @@ class FILTER_API pfb_decimator_ccf : virtual public sync_block
 {
 public:
     // gr::filter::pfb_decimator_ccf::sptr
-    typedef boost::shared_ptr<pfb_decimator_ccf> sptr;
+    typedef std::shared_ptr<pfb_decimator_ccf> sptr;
 
     /*!
      * Build the polyphase filterbank decimator.

--- a/gr-filter/include/gnuradio/filter/pfb_interpolator_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_interpolator_ccf.h
@@ -80,7 +80,7 @@ class FILTER_API pfb_interpolator_ccf : virtual public sync_interpolator
 {
 public:
     // gr::filter::pfb_interpolator_ccf::sptr
-    typedef boost::shared_ptr<pfb_interpolator_ccf> sptr;
+    typedef std::shared_ptr<pfb_interpolator_ccf> sptr;
 
     /*!
      * Build the polyphase filterbank interpolator.

--- a/gr-filter/include/gnuradio/filter/pfb_synthesizer_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_synthesizer_ccf.h
@@ -90,7 +90,7 @@ class FILTER_API pfb_synthesizer_ccf : virtual public sync_interpolator
 {
 public:
     // gr::filter::pfb_synthesizer_ccf::sptr
-    typedef boost::shared_ptr<pfb_synthesizer_ccf> sptr;
+    typedef std::shared_ptr<pfb_synthesizer_ccf> sptr;
 
     /*!
      * Build the polyphase synthesis filterbank.

--- a/gr-filter/include/gnuradio/filter/rational_resampler_base.h
+++ b/gr-filter/include/gnuradio/filter/rational_resampler_base.h
@@ -70,7 +70,7 @@ template <class IN_T, class OUT_T, class TAP_T>
 class FILTER_API rational_resampler_base : virtual public block
 {
 public:
-    typedef boost::shared_ptr<rational_resampler_base<IN_T, OUT_T, TAP_T>> sptr;
+    typedef std::shared_ptr<rational_resampler_base<IN_T, OUT_T, TAP_T>> sptr;
 
     /*!
      * Make a rational resampling FIR filter.

--- a/gr-filter/include/gnuradio/filter/single_pole_iir_filter_cc.h
+++ b/gr-filter/include/gnuradio/filter/single_pole_iir_filter_cc.h
@@ -66,7 +66,7 @@ class FILTER_API single_pole_iir_filter_cc : virtual public sync_block
 {
 public:
     // gr::filter::single_pole_iir_filter_cc::sptr
-    typedef boost::shared_ptr<single_pole_iir_filter_cc> sptr;
+    typedef std::shared_ptr<single_pole_iir_filter_cc> sptr;
 
     static sptr make(double alpha, unsigned int vlen = 1);
 

--- a/gr-filter/include/gnuradio/filter/single_pole_iir_filter_ff.h
+++ b/gr-filter/include/gnuradio/filter/single_pole_iir_filter_ff.h
@@ -66,7 +66,7 @@ class FILTER_API single_pole_iir_filter_ff : virtual public sync_block
 {
 public:
     // gr::filter::single_pole_iir_filter_ff::sptr
-    typedef boost::shared_ptr<single_pole_iir_filter_ff> sptr;
+    typedef std::shared_ptr<single_pole_iir_filter_ff> sptr;
 
     static sptr make(double alpha, unsigned int vlen = 1);
 

--- a/gr-qtgui/include/gnuradio/qtgui/ber_sink_b.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ber_sink_b.h
@@ -39,7 +39,7 @@ class QTGUI_API ber_sink_b : virtual public block
 {
 public:
     // gr::fec::ber_sink_b::sptr
-    typedef boost::shared_ptr<ber_sink_b> sptr;
+    typedef std::shared_ptr<ber_sink_b> sptr;
 
     static sptr make(std::vector<float> esnos,
                      int curves = 1,

--- a/gr-qtgui/include/gnuradio/qtgui/const_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/const_sink_c.h
@@ -60,7 +60,7 @@ class QTGUI_API const_sink_c : virtual public sync_block
 {
 public:
     // gr::qtgui::const_sink_c::sptr
-    typedef boost::shared_ptr<const_sink_c> sptr;
+    typedef std::shared_ptr<const_sink_c> sptr;
 
     /*!
      * \brief Build a constellation plot sink.

--- a/gr-qtgui/include/gnuradio/qtgui/edit_box_msg.h
+++ b/gr-qtgui/include/gnuradio/qtgui/edit_box_msg.h
@@ -108,7 +108,7 @@ class QTGUI_API edit_box_msg : virtual public block
 {
 public:
     // gr::qtgui::edit_box_msg::sptr
-    typedef boost::shared_ptr<edit_box_msg> sptr;
+    typedef std::shared_ptr<edit_box_msg> sptr;
 
     /*!
      * \brief Constructs the Edit box block.

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -87,7 +87,7 @@ class QTGUI_API freq_sink_c : virtual public sync_block
 {
 public:
     // gr::qtgui::freq_sink_c::sptr
-    typedef boost::shared_ptr<freq_sink_c> sptr;
+    typedef std::shared_ptr<freq_sink_c> sptr;
 
     /*!
      * \brief Build a complex PSD sink.

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -87,7 +87,7 @@ class QTGUI_API freq_sink_f : virtual public sync_block
 {
 public:
     // gr::qtgui::freq_sink_f::sptr
-    typedef boost::shared_ptr<freq_sink_f> sptr;
+    typedef std::shared_ptr<freq_sink_f> sptr;
 
     /*!
      * \brief Build a floating point PSD sink.

--- a/gr-qtgui/include/gnuradio/qtgui/histogram_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/histogram_sink_f.h
@@ -76,7 +76,7 @@ class QTGUI_API histogram_sink_f : virtual public sync_block
 {
 public:
     // gr::qtgui::histogram_sink_f::sptr
-    typedef boost::shared_ptr<histogram_sink_f> sptr;
+    typedef std::shared_ptr<histogram_sink_f> sptr;
 
     /*!
      * \brief Build floating point histogram sink

--- a/gr-qtgui/include/gnuradio/qtgui/number_sink.h
+++ b/gr-qtgui/include/gnuradio/qtgui/number_sink.h
@@ -66,7 +66,7 @@ class QTGUI_API number_sink : virtual public sync_block
 {
 public:
     // gr::qtgui::number_sink::sptr
-    typedef boost::shared_ptr<number_sink> sptr;
+    typedef std::shared_ptr<number_sink> sptr;
 
     /*!
      * \brief Build a number sink

--- a/gr-qtgui/include/gnuradio/qtgui/sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/sink_c.h
@@ -71,7 +71,7 @@ class QTGUI_API sink_c : virtual public block
 {
 public:
     // gr::qtgui::sink_c::sptr
-    typedef boost::shared_ptr<sink_c> sptr;
+    typedef std::shared_ptr<sink_c> sptr;
 
     /*!
      * \brief Build a complex qtgui sink.

--- a/gr-qtgui/include/gnuradio/qtgui/sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/sink_f.h
@@ -71,7 +71,7 @@ class QTGUI_API sink_f : virtual public block
 {
 public:
     // gr::qtgui::sink_f::sptr
-    typedef boost::shared_ptr<sink_f> sptr;
+    typedef std::shared_ptr<sink_f> sptr;
 
     /*!
      * \brief Build a floating point qtgui sink.

--- a/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_b.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_b.h
@@ -64,7 +64,7 @@ class QTGUI_API time_raster_sink_b : virtual public sync_block
 {
 public:
     // gr::qtgui::time_raster_sink_b::sptr
-    typedef boost::shared_ptr<time_raster_sink_b> sptr;
+    typedef std::shared_ptr<time_raster_sink_b> sptr;
 
     /*!
      * \brief Build a bit time raster sink.

--- a/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_f.h
@@ -60,7 +60,7 @@ class QTGUI_API time_raster_sink_f : virtual public sync_block
 {
 public:
     // gr::qtgui::time_raster_sink_f::sptr
-    typedef boost::shared_ptr<time_raster_sink_f> sptr;
+    typedef std::shared_ptr<time_raster_sink_f> sptr;
 
     /*!
      * \brief Build a floating point time raster sink.

--- a/gr-qtgui/include/gnuradio/qtgui/time_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_sink_c.h
@@ -63,7 +63,7 @@ class QTGUI_API time_sink_c : virtual public sync_block
 {
 public:
     // gr::qtgui::time_sink_c::sptr
-    typedef boost::shared_ptr<time_sink_c> sptr;
+    typedef std::shared_ptr<time_sink_c> sptr;
 
     /*!
      * \brief Build complex time sink

--- a/gr-qtgui/include/gnuradio/qtgui/time_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_sink_f.h
@@ -61,7 +61,7 @@ class QTGUI_API time_sink_f : virtual public sync_block
 {
 public:
     // gr::qtgui::time_sink_f::sptr
-    typedef boost::shared_ptr<time_sink_f> sptr;
+    typedef std::shared_ptr<time_sink_f> sptr;
 
     /*!
      * \brief Build floating point time sink

--- a/gr-qtgui/include/gnuradio/qtgui/vector_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/vector_sink_f.h
@@ -54,7 +54,7 @@ class QTGUI_API vector_sink_f : virtual public sync_block
 {
 public:
     // gr::qtgui::vector_sink_f::sptr
-    typedef boost::shared_ptr<vector_sink_f> sptr;
+    typedef std::shared_ptr<vector_sink_f> sptr;
 
     /*!
      * \brief Build a vector plotting sink.

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
@@ -92,7 +92,7 @@ class QTGUI_API waterfall_sink_c : virtual public sync_block
 {
 public:
     // gr::qtgui::waterfall_sink_c::sptr
-    typedef boost::shared_ptr<waterfall_sink_c> sptr;
+    typedef std::shared_ptr<waterfall_sink_c> sptr;
 
     /*!
      * \brief Build a complex waterfall sink.

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
@@ -93,7 +93,7 @@ class QTGUI_API waterfall_sink_f : virtual public sync_block
 {
 public:
     // gr::qtgui::waterfall_sink_f::sptr
-    typedef boost::shared_ptr<waterfall_sink_f> sptr;
+    typedef std::shared_ptr<waterfall_sink_f> sptr;
 
     /*!
      * \brief Build a floating point waterfall sink.

--- a/gr-trellis/include/gnuradio/trellis/constellation_metrics_cf.h
+++ b/gr-trellis/include/gnuradio/trellis/constellation_metrics_cf.h
@@ -39,7 +39,7 @@ class TRELLIS_API constellation_metrics_cf : virtual public block
 {
 public:
     // gr::trellis::constellation_metrics_cf::sptr
-    typedef boost::shared_ptr<constellation_metrics_cf> sptr;
+    typedef std::shared_ptr<constellation_metrics_cf> sptr;
 
     static sptr make(digital::constellation_sptr constellation,
                      digital::trellis_metric_type_t TYPE);

--- a/gr-trellis/include/gnuradio/trellis/encoder.h
+++ b/gr-trellis/include/gnuradio/trellis/encoder.h
@@ -39,7 +39,7 @@ template <class IN_T, class OUT_T>
 class TRELLIS_API encoder : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<encoder<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<encoder<IN_T, OUT_T>> sptr;
 
     static sptr make(const fsm& FSM, int ST);
 

--- a/gr-trellis/include/gnuradio/trellis/metrics.h
+++ b/gr-trellis/include/gnuradio/trellis/metrics.h
@@ -41,7 +41,7 @@ class TRELLIS_API metrics : virtual public block
 {
 public:
     // gr::trellis::metrics::sptr
-    typedef boost::shared_ptr<metrics<T>> sptr;
+    typedef std::shared_ptr<metrics<T>> sptr;
 
     static sptr
     make(int O, int D, const std::vector<T>& TABLE, digital::trellis_metric_type_t TYPE);

--- a/gr-trellis/include/gnuradio/trellis/pccc_decoder_blk.h
+++ b/gr-trellis/include/gnuradio/trellis/pccc_decoder_blk.h
@@ -43,7 +43,7 @@ class TRELLIS_API pccc_decoder_blk : virtual public block
 {
 public:
     // gr::trellis::pccc_decoder_blk::sptr
-    typedef boost::shared_ptr<pccc_decoder_blk<T>> sptr;
+    typedef std::shared_ptr<pccc_decoder_blk<T>> sptr;
 
     static sptr make(const fsm& FSM1,
                      int ST10,

--- a/gr-trellis/include/gnuradio/trellis/pccc_decoder_combined_blk.h
+++ b/gr-trellis/include/gnuradio/trellis/pccc_decoder_combined_blk.h
@@ -42,7 +42,7 @@ template <class IN_T, class OUT_T>
 class TRELLIS_API pccc_decoder_combined_blk : virtual public block
 {
 public:
-    typedef boost::shared_ptr<pccc_decoder_combined_blk<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<pccc_decoder_combined_blk<IN_T, OUT_T>> sptr;
 
     static sptr make(const fsm& FSMo,
                      int STo0,

--- a/gr-trellis/include/gnuradio/trellis/pccc_encoder.h
+++ b/gr-trellis/include/gnuradio/trellis/pccc_encoder.h
@@ -41,7 +41,7 @@ template <class IN_T, class OUT_T>
 class TRELLIS_API pccc_encoder : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<pccc_encoder<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<pccc_encoder<IN_T, OUT_T>> sptr;
 
     static sptr make(const fsm& FSM1,
                      int ST1,

--- a/gr-trellis/include/gnuradio/trellis/permutation.h
+++ b/gr-trellis/include/gnuradio/trellis/permutation.h
@@ -38,7 +38,7 @@ class TRELLIS_API permutation : virtual public sync_block
 {
 public:
     // gr::trellis::permutation::sptr
-    typedef boost::shared_ptr<permutation> sptr;
+    typedef std::shared_ptr<permutation> sptr;
 
     static sptr
     make(int K, const std::vector<int>& TABLE, int SYMS_PER_BLOCK, size_t NBYTES);

--- a/gr-trellis/include/gnuradio/trellis/sccc_decoder_blk.h
+++ b/gr-trellis/include/gnuradio/trellis/sccc_decoder_blk.h
@@ -43,7 +43,7 @@ class TRELLIS_API sccc_decoder_blk : virtual public block
 {
 public:
     // gr::trellis::sccc_decoder_blk::sptr
-    typedef boost::shared_ptr<sccc_decoder_blk<T>> sptr;
+    typedef std::shared_ptr<sccc_decoder_blk<T>> sptr;
 
     static sptr make(const fsm& FSMo,
                      int STo0,

--- a/gr-trellis/include/gnuradio/trellis/sccc_decoder_combined_blk.h
+++ b/gr-trellis/include/gnuradio/trellis/sccc_decoder_combined_blk.h
@@ -42,7 +42,7 @@ template <class IN_T, class OUT_T>
 class TRELLIS_API sccc_decoder_combined_blk : virtual public block
 {
 public:
-    typedef boost::shared_ptr<sccc_decoder_combined_blk<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<sccc_decoder_combined_blk<IN_T, OUT_T>> sptr;
 
     static sptr make(const fsm& FSMo,
                      int STo0,

--- a/gr-trellis/include/gnuradio/trellis/sccc_encoder.h
+++ b/gr-trellis/include/gnuradio/trellis/sccc_encoder.h
@@ -40,7 +40,7 @@ template <class IN_T, class OUT_T>
 class TRELLIS_API sccc_encoder : virtual public sync_block
 {
 public:
-    typedef boost::shared_ptr<sccc_encoder<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<sccc_encoder<IN_T, OUT_T>> sptr;
 
     static sptr make(const fsm& FSMo,
                      int STo,

--- a/gr-trellis/include/gnuradio/trellis/siso_combined_f.h
+++ b/gr-trellis/include/gnuradio/trellis/siso_combined_f.h
@@ -40,7 +40,7 @@ class TRELLIS_API siso_combined_f : virtual public block
 {
 public:
     // gr::trellis::siso_combined_f::sptr
-    typedef boost::shared_ptr<siso_combined_f> sptr;
+    typedef std::shared_ptr<siso_combined_f> sptr;
 
     static sptr make(const fsm& FSM,
                      int K,

--- a/gr-trellis/include/gnuradio/trellis/siso_f.h
+++ b/gr-trellis/include/gnuradio/trellis/siso_f.h
@@ -39,7 +39,7 @@ class TRELLIS_API siso_f : virtual public block
 {
 public:
     // gr::trellis::siso_f::sptr
-    typedef boost::shared_ptr<siso_f> sptr;
+    typedef std::shared_ptr<siso_f> sptr;
 
     static sptr make(const fsm& FSM,
                      int K,

--- a/gr-trellis/include/gnuradio/trellis/viterbi.h
+++ b/gr-trellis/include/gnuradio/trellis/viterbi.h
@@ -41,7 +41,7 @@ class TRELLIS_API viterbi : virtual public block
 {
 public:
     // gr::trellis::viterbi::sptr
-    typedef boost::shared_ptr<viterbi<T>> sptr;
+    typedef std::shared_ptr<viterbi<T>> sptr;
 
     static sptr make(const fsm& FSM, int K, int S0, int SK);
 

--- a/gr-trellis/include/gnuradio/trellis/viterbi_combined.h
+++ b/gr-trellis/include/gnuradio/trellis/viterbi_combined.h
@@ -40,7 +40,7 @@ template <class IN_T, class OUT_T>
 class TRELLIS_API viterbi_combined : virtual public block
 {
 public:
-    typedef boost::shared_ptr<viterbi_combined<IN_T, OUT_T>> sptr;
+    typedef std::shared_ptr<viterbi_combined<IN_T, OUT_T>> sptr;
 
     static sptr make(const fsm& FSM,
                      int K,

--- a/gr-uhd/examples/c++/tags_demo.cc
+++ b/gr-uhd/examples/c++/tags_demo.cc
@@ -98,7 +98,7 @@ int UHD_SAFE_MAIN(int argc, char* argv[])
     usrp_source->set_samp_rate(samp_rate);
     usrp_source->set_center_freq(center_freq);
 
-    boost::shared_ptr<tag_sink_demo> tag_sink = boost::make_shared<tag_sink_demo>();
+    std::shared_ptr<tag_sink_demo> tag_sink = std::make_shared<tag_sink_demo>();
 
     //------------------------------------------------------------------
     //-- connect the usrp source test blocks
@@ -115,7 +115,7 @@ int UHD_SAFE_MAIN(int argc, char* argv[])
     const uhd::time_spec_t time_now = usrp_sink->get_time_now();
     const double actual_samp_rate = usrp_sink->get_samp_rate();
 
-    boost::shared_ptr<tag_source_demo> tag_source = boost::make_shared<tag_source_demo>(
+    std::shared_ptr<tag_source_demo> tag_source = std::make_shared<tag_source_demo>(
         time_now.get_full_secs() + 1,
         time_now.get_frac_secs(), // time now + 1 second
         actual_samp_rate,

--- a/gr-uhd/include/gnuradio/uhd/amsg_source.h
+++ b/gr-uhd/include/gnuradio/uhd/amsg_source.h
@@ -36,7 +36,7 @@ class GR_UHD_API amsg_source
 {
 public:
     // gr::uhd::amsg_source::sptr
-    typedef boost::shared_ptr<amsg_source> sptr;
+    typedef std::shared_ptr<amsg_source> sptr;
 
     /*!
      * \brief Destructor

--- a/gr-uhd/include/gnuradio/uhd/usrp_sink.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_sink.h
@@ -99,7 +99,7 @@ class GR_UHD_API usrp_sink : virtual public usrp_block
 {
 public:
     // gr::uhd::usrp_sink::sptr
-    typedef boost::shared_ptr<usrp_sink> sptr;
+    typedef std::shared_ptr<usrp_sink> sptr;
 
     /*!
      * \param device_addr the address to identify the hardware

--- a/gr-uhd/include/gnuradio/uhd/usrp_source.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_source.h
@@ -58,7 +58,7 @@ class GR_UHD_API usrp_source : virtual public usrp_block
 {
 public:
     // gr::uhd::usrp_source::sptr
-    typedef boost::shared_ptr<usrp_source> sptr;
+    typedef std::shared_ptr<usrp_source> sptr;
 
     /*!
      * \param device_addr the address to identify the hardware

--- a/gr-uhd/swig/uhd_swig.i
+++ b/gr-uhd/swig/uhd_swig.i
@@ -124,7 +124,7 @@
 %include <uhd/types/serial.hpp>
 %include <uhd/usrp/dboard_iface.hpp>
 
-%template(dboard_iface_sptr) boost::shared_ptr<uhd::usrp::dboard_iface>;
+%template(dboard_iface_sptr) std::shared_ptr<uhd::usrp::dboard_iface>;
 
 ////////////////////////////////////////////////////////////////////////
 // block magic

--- a/gr-utils/python/modtool/templates/templates.py
+++ b/gr-utils/python/modtool/templates/templates.py
@@ -313,7 +313,7 @@ namespace gr {
     class ${modname.upper()}_API ${blockname} : virtual public gr::${grblocktype}
     {
      public:
-      typedef boost::shared_ptr<${blockname}> sptr;
+      typedef std::shared_ptr<${blockname}> sptr;
 
       /*!
        * \brief Return a shared_ptr to a new instance of ${modname}::${blockname}.
@@ -750,7 +750,7 @@ class ${modname.upper()}_API ${blockname}
 
 class ${modname}_${blockname};
 
-typedef boost::shared_ptr<${modname}_${blockname}> ${modname}_${blockname}_sptr;
+typedef std::shared_ptr<${modname}_${blockname}> ${modname}_${blockname}_sptr;
 
 ${modname.upper()}_API ${modname}_${blockname}_sptr ${modname}_make_${blockname} (${arglist});
 

--- a/gr-video-sdl/include/gnuradio/video_sdl/sink_s.h
+++ b/gr-video-sdl/include/gnuradio/video_sdl/sink_s.h
@@ -42,7 +42,7 @@ class VIDEO_SDL_API sink_s : virtual public sync_block
 {
 public:
     // gr::video_sdl::sink_s::sptr
-    typedef boost::shared_ptr<sink_s> sptr;
+    typedef std::shared_ptr<sink_s> sptr;
 
     static sptr make(double framerate,
                      int width,

--- a/gr-video-sdl/include/gnuradio/video_sdl/sink_uc.h
+++ b/gr-video-sdl/include/gnuradio/video_sdl/sink_uc.h
@@ -42,7 +42,7 @@ class VIDEO_SDL_API sink_uc : virtual public sync_block
 {
 public:
     // gr::video_sdl::sink_uc::sptr
-    typedef boost::shared_ptr<sink_uc> sptr;
+    typedef std::shared_ptr<sink_uc> sptr;
 
     static sptr make(double framerate,
                      int width,

--- a/gr-vocoder/include/gnuradio/vocoder/alaw_decode_bs.h
+++ b/gr-vocoder/include/gnuradio/vocoder/alaw_decode_bs.h
@@ -37,7 +37,7 @@ class VOCODER_API alaw_decode_bs : virtual public sync_block
 {
 public:
     // gr::vocoder::alaw_decode_bs::sptr
-    typedef boost::shared_ptr<alaw_decode_bs> sptr;
+    typedef std::shared_ptr<alaw_decode_bs> sptr;
 
     /*!
      * \brief Make alaw decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/alaw_encode_sb.h
+++ b/gr-vocoder/include/gnuradio/vocoder/alaw_encode_sb.h
@@ -37,7 +37,7 @@ class VOCODER_API alaw_encode_sb : virtual public sync_block
 {
 public:
     // gr::vocoder::alaw_encode_sb::sptr
-    typedef boost::shared_ptr<alaw_encode_sb> sptr;
+    typedef std::shared_ptr<alaw_encode_sb> sptr;
 
     /*!
      * \brief Make alaw encoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/codec2_decode_ps.h
+++ b/gr-vocoder/include/gnuradio/vocoder/codec2_decode_ps.h
@@ -44,7 +44,7 @@ class VOCODER_API codec2_decode_ps : virtual public sync_interpolator
 {
 public:
     // gr::vocoder::codec2_decode_ps::sptr
-    typedef boost::shared_ptr<codec2_decode_ps> sptr;
+    typedef std::shared_ptr<codec2_decode_ps> sptr;
 
     /*!
      * \brief Make Codec2 decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/codec2_encode_sp.h
+++ b/gr-vocoder/include/gnuradio/vocoder/codec2_encode_sp.h
@@ -45,7 +45,7 @@ class VOCODER_API codec2_encode_sp : virtual public sync_decimator
 {
 public:
     // gr::vocoder::codec2_encode_sp::sptr
-    typedef boost::shared_ptr<codec2_encode_sp> sptr;
+    typedef std::shared_ptr<codec2_encode_sp> sptr;
 
     /*!
      * \brief Make Codec2 encoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/cvsd_decode_bs.h
+++ b/gr-vocoder/include/gnuradio/vocoder/cvsd_decode_bs.h
@@ -91,7 +91,7 @@ class VOCODER_API cvsd_decode_bs : virtual public sync_interpolator
 {
 public:
     // gr::vocoder::cvsd_decode_bs::sptr
-    typedef boost::shared_ptr<cvsd_decode_bs> sptr;
+    typedef std::shared_ptr<cvsd_decode_bs> sptr;
 
     /*!
      * \brief Constructor parameters to initialize the CVSD decoder.

--- a/gr-vocoder/include/gnuradio/vocoder/cvsd_encode_sb.h
+++ b/gr-vocoder/include/gnuradio/vocoder/cvsd_encode_sb.h
@@ -88,7 +88,7 @@ class VOCODER_API cvsd_encode_sb : virtual public sync_decimator
 {
 public:
     // gr::vocoder::cvsd_encode_sb::sptr
-    typedef boost::shared_ptr<cvsd_encode_sb> sptr;
+    typedef std::shared_ptr<cvsd_encode_sb> sptr;
 
     /*!
      * \brief Constructor parameters to initialize the CVSD encoder.

--- a/gr-vocoder/include/gnuradio/vocoder/freedv_rx_ss.h
+++ b/gr-vocoder/include/gnuradio/vocoder/freedv_rx_ss.h
@@ -43,7 +43,7 @@ namespace vocoder {
 class VOCODER_API freedv_rx_ss : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<freedv_rx_ss> sptr;
+    typedef std::shared_ptr<freedv_rx_ss> sptr;
 
     /*!
      * \brief Make FreeDV modem demodulator block.

--- a/gr-vocoder/include/gnuradio/vocoder/freedv_tx_ss.h
+++ b/gr-vocoder/include/gnuradio/vocoder/freedv_tx_ss.h
@@ -42,7 +42,7 @@ namespace vocoder {
 class VOCODER_API freedv_tx_ss : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<freedv_tx_ss> sptr;
+    typedef std::shared_ptr<freedv_tx_ss> sptr;
 
     /*!
      * \brief Make FreeDV Modem modulator block.

--- a/gr-vocoder/include/gnuradio/vocoder/g721_decode_bs.h
+++ b/gr-vocoder/include/gnuradio/vocoder/g721_decode_bs.h
@@ -37,7 +37,7 @@ class VOCODER_API g721_decode_bs : virtual public sync_block
 {
 public:
     // gr::vocoder::g721_decode_bs::sptr
-    typedef boost::shared_ptr<g721_decode_bs> sptr;
+    typedef std::shared_ptr<g721_decode_bs> sptr;
 
     /*!
      * \brief Make G721 decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/g721_encode_sb.h
+++ b/gr-vocoder/include/gnuradio/vocoder/g721_encode_sb.h
@@ -37,7 +37,7 @@ class VOCODER_API g721_encode_sb : virtual public sync_block
 {
 public:
     // gr::vocoder::g721_encode_sb::sptr
-    typedef boost::shared_ptr<g721_encode_sb> sptr;
+    typedef std::shared_ptr<g721_encode_sb> sptr;
 
     /*!
      * \brief Make G721 encoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/g723_24_decode_bs.h
+++ b/gr-vocoder/include/gnuradio/vocoder/g723_24_decode_bs.h
@@ -37,7 +37,7 @@ class VOCODER_API g723_24_decode_bs : virtual public sync_block
 {
 public:
     // gr::vocoder::g723_24_decode_bs::sptr
-    typedef boost::shared_ptr<g723_24_decode_bs> sptr;
+    typedef std::shared_ptr<g723_24_decode_bs> sptr;
 
     /*!
      * \brief Make G722_24 decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/g723_24_encode_sb.h
+++ b/gr-vocoder/include/gnuradio/vocoder/g723_24_encode_sb.h
@@ -37,7 +37,7 @@ class VOCODER_API g723_24_encode_sb : virtual public sync_block
 {
 public:
     // gr::vocoder::g723_24_encode_sb::sptr
-    typedef boost::shared_ptr<g723_24_encode_sb> sptr;
+    typedef std::shared_ptr<g723_24_encode_sb> sptr;
 
     /*!
      * \brief Make G722_24 encoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/g723_40_decode_bs.h
+++ b/gr-vocoder/include/gnuradio/vocoder/g723_40_decode_bs.h
@@ -37,7 +37,7 @@ class VOCODER_API g723_40_decode_bs : virtual public sync_block
 {
 public:
     // gr::vocoder::g723_40_decode_bs::sptr
-    typedef boost::shared_ptr<g723_40_decode_bs> sptr;
+    typedef std::shared_ptr<g723_40_decode_bs> sptr;
 
     /*!
      * \brief Make G722_40 decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/g723_40_encode_sb.h
+++ b/gr-vocoder/include/gnuradio/vocoder/g723_40_encode_sb.h
@@ -37,7 +37,7 @@ class VOCODER_API g723_40_encode_sb : virtual public sync_block
 {
 public:
     // gr::vocoder::g723_40_encode_sb::sptr
-    typedef boost::shared_ptr<g723_40_encode_sb> sptr;
+    typedef std::shared_ptr<g723_40_encode_sb> sptr;
 
     /*!
      * \brief Make G722_40 encoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/gsm_fr_decode_ps.h
+++ b/gr-vocoder/include/gnuradio/vocoder/gsm_fr_decode_ps.h
@@ -40,7 +40,7 @@ class VOCODER_API gsm_fr_decode_ps : virtual public sync_interpolator
 {
 public:
     // gr::vocoder::gsm_fr_decode_ps::sptr
-    typedef boost::shared_ptr<gsm_fr_decode_ps> sptr;
+    typedef std::shared_ptr<gsm_fr_decode_ps> sptr;
 
     /*!
      * \brief Make GSM decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/gsm_fr_encode_sp.h
+++ b/gr-vocoder/include/gnuradio/vocoder/gsm_fr_encode_sp.h
@@ -40,7 +40,7 @@ class VOCODER_API gsm_fr_encode_sp : virtual public sync_decimator
 {
 public:
     // gr::vocoder::gsm_fr_encode_sp::sptr
-    typedef boost::shared_ptr<gsm_fr_encode_sp> sptr;
+    typedef std::shared_ptr<gsm_fr_encode_sp> sptr;
 
     /*!
      * \brief Make GSM encoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/ulaw_decode_bs.h
+++ b/gr-vocoder/include/gnuradio/vocoder/ulaw_decode_bs.h
@@ -37,7 +37,7 @@ class VOCODER_API ulaw_decode_bs : virtual public sync_block
 {
 public:
     // gr::vocoder::ulaw_decode_bs::sptr
-    typedef boost::shared_ptr<ulaw_decode_bs> sptr;
+    typedef std::shared_ptr<ulaw_decode_bs> sptr;
 
     /*!
      * \brief Make ulaw decoder block.

--- a/gr-vocoder/include/gnuradio/vocoder/ulaw_encode_sb.h
+++ b/gr-vocoder/include/gnuradio/vocoder/ulaw_encode_sb.h
@@ -37,7 +37,7 @@ class VOCODER_API ulaw_encode_sb : virtual public sync_block
 {
 public:
     // gr::vocoder::ulaw_encode_sb::sptr
-    typedef boost::shared_ptr<ulaw_encode_sb> sptr;
+    typedef std::shared_ptr<ulaw_encode_sb> sptr;
 
     /*!
      * \brief Make ulaw encoder block.

--- a/gr-wavelet/include/gnuradio/wavelet/squash_ff.h
+++ b/gr-wavelet/include/gnuradio/wavelet/squash_ff.h
@@ -38,7 +38,7 @@ class WAVELET_API squash_ff : virtual public sync_block
 {
 public:
     // gr::wavelet::squash_ff::sptr
-    typedef boost::shared_ptr<squash_ff> sptr;
+    typedef std::shared_ptr<squash_ff> sptr;
 
     /*!
      * \param igrid

--- a/gr-wavelet/include/gnuradio/wavelet/wavelet_ff.h
+++ b/gr-wavelet/include/gnuradio/wavelet/wavelet_ff.h
@@ -37,7 +37,7 @@ class WAVELET_API wavelet_ff : virtual public sync_block
 {
 public:
     // gr::wavelet::wavelet_ff:sptr
-    typedef boost::shared_ptr<wavelet_ff> sptr;
+    typedef std::shared_ptr<wavelet_ff> sptr;
 
     /*!
      * \param size

--- a/gr-wavelet/include/gnuradio/wavelet/wvps_ff.h
+++ b/gr-wavelet/include/gnuradio/wavelet/wvps_ff.h
@@ -39,7 +39,7 @@ class WAVELET_API wvps_ff : virtual public sync_block
 {
 public:
     // gr::wavelet::wvps_ff::sptr
-    typedef boost::shared_ptr<wvps_ff> sptr;
+    typedef std::shared_ptr<wvps_ff> sptr;
 
     /*!
       \param ilen

--- a/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
@@ -43,7 +43,7 @@ namespace zeromq {
 class ZEROMQ_API pub_msg_sink : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<pub_msg_sink> sptr;
+    typedef std::shared_ptr<pub_msg_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of zeromq::pub_msg_sink.

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -43,7 +43,7 @@ namespace zeromq {
 class ZEROMQ_API pub_sink : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<pub_sink> sptr;
+    typedef std::shared_ptr<pub_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of zeromq::pub_sink.

--- a/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
@@ -40,7 +40,7 @@ namespace zeromq {
 class ZEROMQ_API pull_msg_source : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<pull_msg_source> sptr;
+    typedef std::shared_ptr<pull_msg_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of gr::zeromq::pull_msg_source.

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -40,7 +40,7 @@ namespace zeromq {
 class ZEROMQ_API pull_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<pull_source> sptr;
+    typedef std::shared_ptr<pull_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of gr::zeromq::pull_source.

--- a/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
@@ -42,7 +42,7 @@ namespace zeromq {
 class ZEROMQ_API push_msg_sink : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<push_msg_sink> sptr;
+    typedef std::shared_ptr<push_msg_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of gr::zeromq::push_msg_sink

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -44,7 +44,7 @@ namespace zeromq {
 class ZEROMQ_API push_sink : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<push_sink> sptr;
+    typedef std::shared_ptr<push_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of gr::zeromq::push_sink

--- a/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
@@ -42,7 +42,7 @@ namespace zeromq {
 class ZEROMQ_API rep_msg_sink : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<rep_msg_sink> sptr;
+    typedef std::shared_ptr<rep_msg_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of zeromq::rep_msg_sink.

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -42,7 +42,7 @@ namespace zeromq {
 class ZEROMQ_API rep_sink : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<rep_sink> sptr;
+    typedef std::shared_ptr<rep_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of zeromq::rep_sink.

--- a/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
@@ -40,7 +40,7 @@ namespace zeromq {
 class ZEROMQ_API req_msg_source : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<req_msg_source> sptr;
+    typedef std::shared_ptr<req_msg_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of zeromq::req_msg_source.

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -40,7 +40,7 @@ namespace zeromq {
 class ZEROMQ_API req_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<req_source> sptr;
+    typedef std::shared_ptr<req_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of zeromq::req_source.

--- a/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
@@ -40,7 +40,7 @@ namespace zeromq {
 class ZEROMQ_API sub_msg_source : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<sub_msg_source> sptr;
+    typedef std::shared_ptr<sub_msg_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of gr::zeromq::sub_msg_source.

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -40,7 +40,7 @@ namespace zeromq {
 class ZEROMQ_API sub_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<sub_source> sptr;
+    typedef std::shared_ptr<sub_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of gr::zeromq::sub_source.


### PR DESCRIPTION
Most of this code is automated code changes:

```
SUB="s/dummy/dummy/"
for i in shared_ptr make_shared dynamic_pointer_cast weak_ptr enable_shared_from_this get_deleter; do
    SUB="$SUB;s/boost::$i/std::$i/g"
done
SUB="$SUB;s^#include <boost/shared_ptr.hpp>^#include <memory>^g"
SUB="$SUB;s^namespace boost^namespace std^g"

find . \( -name "*.cc" -o -name "*.h" -o -name "*.i" -o -name "*.cxx" -o -name "*.py" \) -print0 | xargs -0 sed -i "$SUB"
```

Only one manual change. In `./gr-fec/lib/fec_mtrx_impl.cc`, add
`#include <algorithm>`.