### PR TITLE
Move locks from boost to C++11

### DIFF
--- a/README.hacking
+++ b/README.hacking
@@ -41,6 +41,21 @@ Boost 1.35 and later is fairly common in modern distributions.
 If it isn't available for your system, please refer to
 README.building-boost for instructions
 
+As features from Boost are incorporated into standard C++ GNU Radio
+will reduce dependence on Boost.
+
+Status:
+  * program_options — Will remain
+  * shared_ptr      — PR in flight
+  * shared_mutex    — C++17
+  * filesystem      — C++17
+  * thread          — Unknown
+  * date_time       — Unknown
+  * regex           — Unknown
+  * system          — Unknown
+  * chrono          — Unknown
+  * atomic          — Unknown
+
 * C++ and Python
 
 GNU Radio is a hybrid system.  Some parts of the system are built in C++ and

--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -29,13 +29,14 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/sptr_magic.h>
 #include <gnuradio/thread/thread.h>
+#include <condition_variable>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/foreach.hpp>
 #include <boost/function.hpp>
-#include <boost/thread/condition_variable.hpp>
 #include <deque>
 #include <iostream>
 #include <map>
+#include <mutex>
 #include <string>
 
 #include <gnuradio/rpcregisterhelpers.h>
@@ -66,10 +67,10 @@ private:
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator> msg_queue_map_t;
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator>::iterator
         msg_queue_map_itr;
-    std::map<pmt::pmt_t, boost::shared_ptr<boost::condition_variable>, pmt::comparator>
+    std::map<pmt::pmt_t, boost::shared_ptr<std::condition_variable>, pmt::comparator>
         msg_queue_ready;
 
-    gr::thread::mutex mutex; //< protects all vars
+    std::mutex mutex; //< protects all vars
 
 protected:
     friend class flowgraph;

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -927,9 +927,9 @@ protected:
     /*! Used by block's setters and work functions to make
      * setting/resetting of parameters thread-safe.
      *
-     * Used by calling gr::thread::scoped_lock l(d_setlock);
+     * Used by calling gr::thread::lock_guard l(d_setlock);
      */
-    gr::thread::mutex d_setlock;
+    std::mutex d_setlock;
 
     /*! Used by blocks to access the logger system.
      */

--- a/gnuradio-runtime/include/gnuradio/block_registry.h
+++ b/gnuradio-runtime/include/gnuradio/block_registry.h
@@ -61,7 +61,7 @@ private:
     blockmap_t d_map;
     pmt::pmt_t d_ref_map;
     std::map<std::string, block*> primitive_map;
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -97,7 +97,7 @@ public:
     size_t nreaders() const { return d_readers.size(); }
     buffer_reader* reader(size_t index) { return d_readers[index]; }
 
-    gr::thread::mutex* mutex() { return &d_mutex; }
+    std::mutex* mutex() { return &d_mutex; }
 
     uint64_t nitems_written() { return d_abs_write_offset; }
 
@@ -176,7 +176,7 @@ private:
     // The mutex protects d_write_index, d_abs_write_offset, d_done, d_item_tags
     // and the d_read_index's and d_abs_read_offset's in the buffer readers.
     //
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
     unsigned int d_write_index;  // in items [0,d_bufsize)
     uint64_t d_abs_write_offset; // num items written since the start
     bool d_done;
@@ -302,7 +302,7 @@ public:
     void set_done(bool done) { d_buffer->set_done(done); }
     bool done() const { return d_buffer->done(); }
 
-    gr::thread::mutex* mutex() { return d_buffer->mutex(); }
+    std::mutex* mutex() { return d_buffer->mutex(); }
 
     uint64_t nitems_read() { return d_abs_read_offset; }
 

--- a/gnuradio-runtime/include/gnuradio/messages/msg_queue.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_queue.h
@@ -42,9 +42,9 @@ msg_queue_sptr make_msg_queue(unsigned int limit = 0);
 class GR_RUNTIME_API msg_queue
 {
 private:
-    gr::thread::mutex d_mutex;
-    gr::thread::condition_variable d_not_empty;
-    gr::thread::condition_variable d_not_full;
+    std::mutex d_mutex;
+    std::condition_variable d_not_empty;
+    std::condition_variable d_not_full;
     unsigned int d_limit; // max # of messages in queue.  0 -> unbounded
 
     std::deque<pmt::pmt_t> d_msgs;

--- a/gnuradio-runtime/include/gnuradio/msg_queue.h
+++ b/gnuradio-runtime/include/gnuradio/msg_queue.h
@@ -35,9 +35,9 @@ namespace gr {
  */
 class GR_RUNTIME_API msg_queue : public msg_handler
 {
-    gr::thread::mutex d_mutex;
-    gr::thread::condition_variable d_not_empty;
-    gr::thread::condition_variable d_not_full;
+    std::mutex d_mutex;
+    std::condition_variable d_not_empty;
+    std::condition_variable d_not_full;
     message::sptr d_head;
     message::sptr d_tail;
     unsigned int d_count; // # of messages in queue.

--- a/gnuradio-runtime/include/gnuradio/prefs.h
+++ b/gnuradio-runtime/include/gnuradio/prefs.h
@@ -163,7 +163,7 @@ protected:
     virtual char* option_to_env(std::string section, std::string option);
 
 private:
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
     config_map_t d_config_map;
 };
 

--- a/gnuradio-runtime/include/gnuradio/rpcbufferedget.h
+++ b/gnuradio-runtime/include/gnuradio/rpcbufferedget.h
@@ -23,8 +23,8 @@
 #ifndef RPCBUFFEREDGET_H
 #define RPCBUFFEREDGET_H
 
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/mutex.hpp>
+#include <condition_variable>
+#include <mutex>
 
 template <typename TdataType>
 class rpcbufferedget
@@ -46,7 +46,7 @@ public:
         if (!d_data_needed)
             return;
         {
-            boost::mutex::scoped_lock lock(d_buffer_lock);
+            gr::thread::lock_guard lock(d_buffer_lock);
             d_buffer = data;
             d_data_needed = false;
         }
@@ -55,7 +55,7 @@ public:
 
     TdataType get()
     {
-        boost::mutex::scoped_lock lock(d_buffer_lock);
+        gr::thread::unique_lock lock(d_buffer_lock);
         d_data_needed = true;
         d_data_ready.wait(lock);
         return d_buffer;
@@ -63,8 +63,8 @@ public:
 
 private:
     bool d_data_needed;
-    boost::condition_variable d_data_ready;
-    boost::mutex d_buffer_lock;
+    std::condition_variable d_data_ready;
+    std::mutex d_buffer_lock;
     TdataType d_buffer;
 };
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -28,9 +28,9 @@
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
 #include <boost/format.hpp>
-#include <boost/thread/mutex.hpp>
 #include <iostream>
 #include <map>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -90,7 +90,7 @@ public:
     virtual void shutdown();
 
 private:
-    boost::mutex d_callback_map_lock;
+    std::mutex d_callback_map_lock;
 
     typedef std::map<std::string, configureCallback_t> ConfigureCallbackMap_t;
     ConfigureCallbackMap_t d_setcallbackmap;

--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -23,12 +23,11 @@
 #define INCLUDED_THREAD_H
 
 #include <gnuradio/api.h>
+#include <condition_variable>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/barrier.hpp>
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
+#include <mutex>
 #include <vector>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
@@ -45,9 +44,9 @@ namespace gr {
 namespace thread {
 
 typedef boost::thread thread;
-typedef boost::mutex mutex;
-typedef boost::unique_lock<boost::mutex> scoped_lock;
-typedef boost::condition_variable condition_variable;
+typedef std::unique_lock<std::mutex> unique_lock;
+typedef std::lock_guard<std::mutex> lock_guard;
+typedef std::lock_guard<std::recursive_mutex> recursive_lock_guard;
 typedef boost::barrier barrier;
 typedef boost::shared_ptr<barrier> barrier_sptr;
 

--- a/gnuradio-runtime/include/gnuradio/thrift_application_base.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_application_base.h
@@ -185,7 +185,7 @@ private:
     static boost::scoped_ptr<thrift_application_base_impl> p_impl;
 
     // Mutex to protect the endpoint string.
-    gr::thread::mutex d_lock;
+    std::mutex d_lock;
 
     // Will be set to true by a the application_started() function,
     // specialized for a particular booter implementation, once the
@@ -247,7 +247,7 @@ template <typename TserverBase, typename TserverClass>
 void thrift_application_base<TserverBase, TserverClass>::set_endpoint(
     const std::string& endpoint)
 {
-    gr::thread::scoped_lock guard(d_lock);
+    gr::thread::lock_guard guard(d_lock);
     p_impl->d_endpointStr = endpoint;
 }
 

--- a/gnuradio-runtime/include/gnuradio/tpb_detail.h
+++ b/gnuradio-runtime/include/gnuradio/tpb_detail.h
@@ -35,11 +35,11 @@ class block_detail;
  * \brief used by thread-per-block scheduler
  */
 struct GR_RUNTIME_API tpb_detail {
-    gr::thread::mutex mutex; //< protects all vars
+    std::mutex mutex; //< protects all vars
     bool input_changed;
-    gr::thread::condition_variable input_cond;
+    std::condition_variable input_cond;
     bool output_changed;
-    gr::thread::condition_variable output_cond;
+    std::condition_variable output_cond;
 
 public:
     tpb_detail() : input_changed(false), output_changed(false) {}
@@ -58,7 +58,7 @@ public:
     //! Called by pmt msg posters
     void notify_msg()
     {
-        gr::thread::scoped_lock guard(mutex);
+        gr::thread::lock_guard guard(mutex);
         input_changed = true;
         input_cond.notify_one();
         output_changed = true;
@@ -68,7 +68,7 @@ public:
     //! Called by us
     void clear_changed()
     {
-        gr::thread::scoped_lock guard(mutex);
+        gr::thread::lock_guard guard(mutex);
         input_changed = false;
         output_changed = false;
     }
@@ -77,7 +77,7 @@ private:
     //! Used by notify_downstream
     void set_input_changed()
     {
-        gr::thread::scoped_lock guard(mutex);
+        gr::thread::lock_guard guard(mutex);
         input_changed = true;
         input_cond.notify_one();
     }
@@ -85,7 +85,7 @@ private:
     //! Used by notify_upstream
     void set_output_changed()
     {
-        gr::thread::scoped_lock guard(mutex);
+        gr::thread::lock_guard guard(mutex);
         output_changed = true;
         output_cond.notify_one();
     }

--- a/gnuradio-runtime/include/pmt/pmt_pool.h
+++ b/gnuradio-runtime/include/pmt/pmt_pool.h
@@ -21,9 +21,12 @@
 #ifndef INCLUDED_PMT_POOL_H
 #define INCLUDED_PMT_POOL_H
 
+#include <gnuradio/thread/thread.h>
+#include <condition_variable>
 #include <pmt/api.h>
 #include <boost/thread.hpp>
 #include <cstddef>
+#include <mutex>
 #include <vector>
 
 namespace pmt {
@@ -41,9 +44,8 @@ class PMT_API pmt_pool
         struct item* d_next;
     };
 
-    typedef boost::unique_lock<boost::mutex> scoped_lock;
-    mutable boost::mutex d_mutex;
-    boost::condition_variable d_cond;
+    mutable std::mutex d_mutex;
+    std::condition_variable d_cond;
 
     size_t d_itemsize;
     size_t d_alignment;

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -87,7 +87,7 @@ void basic_block::message_port_register_in(pmt::pmt_t port_id)
     }
     msg_queue[port_id] = msg_queue_t();
     msg_queue_ready[port_id] =
-        boost::shared_ptr<boost::condition_variable>(new boost::condition_variable());
+        boost::shared_ptr<std::condition_variable>(new std::condition_variable());
 }
 
 pmt::pmt_t basic_block::message_ports_in()
@@ -185,7 +185,7 @@ void basic_block::_post(pmt::pmt_t which_port, pmt::pmt_t msg)
 
 void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
 {
-    gr::thread::scoped_lock guard(mutex);
+    gr::thread::lock_guard guard(mutex);
 
     if ((msg_queue.find(which_port) == msg_queue.end()) ||
         (msg_queue_ready.find(which_port) == msg_queue_ready.end())) {
@@ -202,7 +202,7 @@ void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
 
 pmt::pmt_t basic_block::delete_head_nowait(pmt::pmt_t which_port)
 {
-    gr::thread::scoped_lock guard(mutex);
+    gr::thread::lock_guard guard(mutex);
 
     if (empty_p(which_port)) {
         return pmt::pmt_t();

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -285,7 +285,7 @@ void block_detail::stop_perf_counters(int noutput_items, int nproduced)
         d_pc_start_time = (float)gr::high_res_timer_now();
         for (size_t i = 0; i < d_input.size(); i++) {
             buffer_reader_sptr in_buf = d_input[i];
-            gr::thread::scoped_lock guard(*in_buf->mutex());
+            gr::thread::lock_guard guard(*in_buf->mutex());
             float pfull = static_cast<float>(in_buf->items_available()) /
                           static_cast<float>(in_buf->max_possible_items_available());
             d_ins_input_buffers_full[i] = pfull;
@@ -294,7 +294,7 @@ void block_detail::stop_perf_counters(int noutput_items, int nproduced)
         }
         for (size_t i = 0; i < d_output.size(); i++) {
             buffer_sptr out_buf = d_output[i];
-            gr::thread::scoped_lock guard(*out_buf->mutex());
+            gr::thread::lock_guard guard(*out_buf->mutex());
             float pfull = 1.0f - static_cast<float>(out_buf->space_available()) /
                                      static_cast<float>(out_buf->bufsize());
             d_ins_output_buffers_full[i] = pfull;
@@ -325,7 +325,7 @@ void block_detail::stop_perf_counters(int noutput_items, int nproduced)
 
         for (size_t i = 0; i < d_input.size(); i++) {
             buffer_reader_sptr in_buf = d_input[i];
-            gr::thread::scoped_lock guard(*in_buf->mutex());
+            gr::thread::lock_guard guard(*in_buf->mutex());
             float pfull = static_cast<float>(in_buf->items_available()) /
                           static_cast<float>(in_buf->max_possible_items_available());
 
@@ -337,7 +337,7 @@ void block_detail::stop_perf_counters(int noutput_items, int nproduced)
 
         for (size_t i = 0; i < d_output.size(); i++) {
             buffer_sptr out_buf = d_output[i];
-            gr::thread::scoped_lock guard(*out_buf->mutex());
+            gr::thread::lock_guard guard(*out_buf->mutex());
             float pfull = 1.0f - static_cast<float>(out_buf->space_available()) /
                                      static_cast<float>(out_buf->bufsize());
 

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -78,7 +78,7 @@ min_available_space(block_detail* d, int output_multiple, int min_noutput_items)
         min_noutput_items = 1;
     for (int i = 0; i < d->noutputs(); i++) {
         buffer_sptr out_buf = d->output(i);
-        gr::thread::scoped_lock guard(*out_buf->mutex());
+        gr::thread::lock_guard guard(*out_buf->mutex());
         int avail_n = round_down(out_buf->space_available(), output_multiple);
         int best_n = round_down(out_buf->bufsize() / 2, output_multiple);
         if (best_n < min_noutput_items)
@@ -310,7 +310,7 @@ block_executor::state block_executor::run_one_iteration()
                  * Acquire the mutex and grab local copies of items_available and done.
                  */
                 buffer_reader_sptr in_buf = d->input(i);
-                gr::thread::scoped_lock guard(*in_buf->mutex());
+                gr::thread::lock_guard guard(*in_buf->mutex());
                 d_ninput_items[i] = in_buf->items_available();
                 d_input_done[i] = in_buf->done();
             }
@@ -357,7 +357,7 @@ block_executor::state block_executor::run_one_iteration()
                  * Acquire the mutex and grab local copies of items_available and done.
                  */
                 buffer_reader_sptr in_buf = d->input(i);
-                gr::thread::scoped_lock guard(*in_buf->mutex());
+                gr::thread::lock_guard guard(*in_buf->mutex());
                 d_ninput_items[i] = in_buf->items_available();
                 d_input_done[i] = in_buf->done();
             }

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -35,7 +35,7 @@ block_registry::block_registry() { d_ref_map = pmt::make_dict(); }
 
 long block_registry::block_register(basic_block* block)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (d_map.find(block->name()) == d_map.end()) {
         d_map[block->name()] = blocksubmap_t();
@@ -54,7 +54,7 @@ long block_registry::block_register(basic_block* block)
 
 void block_registry::block_unregister(basic_block* block)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_map[block->name()].erase(d_map[block->name()].find(block->symbolic_id()));
     d_ref_map = pmt::dict_delete(d_ref_map, pmt::intern(block->symbol_name()));
@@ -74,7 +74,7 @@ std::string block_registry::register_symbolic_name(basic_block* block)
 
 void block_registry::register_symbolic_name(basic_block* block, std::string name)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (pmt::dict_has_key(d_ref_map, pmt::intern(name))) {
         throw std::runtime_error("symbol already exists, can not re-use!");
@@ -84,7 +84,7 @@ void block_registry::register_symbolic_name(basic_block* block, std::string name
 
 void block_registry::update_symbolic_name(basic_block* block, std::string name)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (pmt::dict_has_key(d_ref_map, pmt::intern(name))) {
         throw std::runtime_error("symbol already exists, can not re-use!");
@@ -103,7 +103,7 @@ void block_registry::update_symbolic_name(basic_block* block, std::string name)
 
 basic_block_sptr block_registry::block_lookup(pmt::pmt_t symbol)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     pmt::pmt_t ref = pmt::dict_ref(d_ref_map, symbol, pmt::PMT_NIL);
     if (pmt::eq(ref, pmt::PMT_NIL)) {
@@ -115,21 +115,21 @@ basic_block_sptr block_registry::block_lookup(pmt::pmt_t symbol)
 
 void block_registry::register_primitive(std::string blk, block* ref)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     primitive_map[blk] = ref;
 }
 
 void block_registry::unregister_primitive(std::string blk)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     primitive_map.erase(primitive_map.find(blk));
 }
 
 void block_registry::notify_blk(std::string blk)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (primitive_map.find(blk) == primitive_map.end()) {
         return;

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -192,14 +192,14 @@ void* buffer::write_pointer() { return &d_base[d_write_index * d_sizeof_item]; }
 
 void buffer::update_write_pointer(int nitems)
 {
-    gr::thread::scoped_lock guard(*mutex());
+    gr::thread::lock_guard guard(*mutex());
     d_write_index = index_add(d_write_index, nitems);
     d_abs_write_offset += nitems;
 }
 
 void buffer::set_done(bool done)
 {
-    gr::thread::scoped_lock guard(*mutex());
+    gr::thread::lock_guard guard(*mutex());
     d_done = done;
 }
 
@@ -230,13 +230,13 @@ void buffer::drop_reader(buffer_reader* reader)
 
 void buffer::add_item_tag(const tag_t& tag)
 {
-    gr::thread::scoped_lock guard(*mutex());
+    gr::thread::lock_guard guard(*mutex());
     d_item_tags.insert(std::pair<uint64_t, tag_t>(tag.offset, tag));
 }
 
 void buffer::remove_item_tag(const tag_t& tag, long id)
 {
-    gr::thread::scoped_lock guard(*mutex());
+    gr::thread::lock_guard guard(*mutex());
     for (std::multimap<uint64_t, tag_t>::iterator it =
              d_item_tags.lower_bound(tag.offset);
          it != d_item_tags.upper_bound(tag.offset);
@@ -256,7 +256,7 @@ void buffer::prune_tags(uint64_t max_time)
 
        If this function is used elsewhere, remember to lock the
        buffer's mutex al la the scoped_lock:
-           gr::thread::scoped_lock guard(*mutex());
+           gr::thread::lock_guard guard(*mutex());
      */
 
     /*
@@ -328,7 +328,7 @@ const void* buffer_reader::read_pointer()
 
 void buffer_reader::update_read_pointer(int nitems)
 {
-    gr::thread::scoped_lock guard(*mutex());
+    gr::thread::lock_guard guard(*mutex());
     d_read_index = d_buffer->index_add(d_read_index, nitems);
     d_abs_read_offset += nitems;
 }
@@ -338,7 +338,7 @@ void buffer_reader::get_tags_in_range(std::vector<tag_t>& v,
                                       uint64_t abs_end,
                                       long id)
 {
-    gr::thread::scoped_lock guard(*mutex());
+    gr::thread::lock_guard guard(*mutex());
 
     v.clear();
     std::multimap<uint64_t, tag_t>::iterator itr =

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
@@ -48,7 +48,7 @@ rpcserver_thrift::~rpcserver_thrift()
 void rpcserver_thrift::registerConfigureCallback(const std::string& id,
                                                  const configureCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     {
         ConfigureCallbackMap_t::const_iterator iter(d_setcallbackmap.find(id));
         if (iter != d_setcallbackmap.end()) {
@@ -68,7 +68,7 @@ void rpcserver_thrift::registerConfigureCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     ConfigureCallbackMap_t::iterator iter(d_setcallbackmap.find(id));
     if (iter == d_setcallbackmap.end()) {
         std::stringstream s;
@@ -87,7 +87,7 @@ void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
 void rpcserver_thrift::registerQueryCallback(const std::string& id,
                                              const queryCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     {
         QueryCallbackMap_t::const_iterator iter(d_getcallbackmap.find(id));
         if (iter != d_getcallbackmap.end()) {
@@ -107,7 +107,7 @@ void rpcserver_thrift::registerQueryCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     QueryCallbackMap_t::iterator iter(d_getcallbackmap.find(id));
     if (iter == d_getcallbackmap.end()) {
         std::stringstream s;
@@ -127,7 +127,7 @@ void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
 void rpcserver_thrift::registerHandlerCallback(const std::string& id,
                                                const handlerCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     {
         HandlerCallbackMap_t::const_iterator iter(d_handlercallbackmap.find(id));
         if (iter != d_handlercallbackmap.end()) {
@@ -147,7 +147,7 @@ void rpcserver_thrift::registerHandlerCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     HandlerCallbackMap_t::iterator iter(d_handlercallbackmap.find(id));
     if (iter == d_handlercallbackmap.end()) {
         std::stringstream s;
@@ -167,7 +167,7 @@ void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
 
 void rpcserver_thrift::setKnobs(const GNURadio::KnobMap& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     std::for_each(knobs.begin(),
                   knobs.end(),
                   set_f<GNURadio::KnobMap::value_type, ConfigureCallbackMap_t>(
@@ -177,7 +177,7 @@ void rpcserver_thrift::setKnobs(const GNURadio::KnobMap& knobs)
 void rpcserver_thrift::getKnobs(GNURadio::KnobMap& _return,
                                 const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     if (knobs.size() == 0) {
         std::for_each(d_getcallbackmap.begin(),
                       d_getcallbackmap.end(),
@@ -195,7 +195,7 @@ void rpcserver_thrift::getKnobs(GNURadio::KnobMap& _return,
 void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
                              const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     if (knobs.size() == 0) {
         std::for_each(d_getcallbackmap.begin(),
                       d_getcallbackmap.end(),
@@ -221,7 +221,7 @@ void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
 void rpcserver_thrift::properties(GNURadio::KnobPropMap& _return,
                                   const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
     if (knobs.size() == 0) {
         std::for_each(
             d_getcallbackmap.begin(),
@@ -250,7 +250,7 @@ void rpcserver_thrift::postMessage(const std::string& alias,
     // just need to get the PMT itself out of this to pass to the set_h
     // function for handling the message post.
 
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    gr::thread::lock_guard lock(d_callback_map_lock);
 
     pmt::pmt_t alias_pmt = pmt::deserialize_str(alias);
     pmt::pmt_t port_pmt = pmt::deserialize_str(port);

--- a/gnuradio-runtime/lib/messages/msg_queue.cc
+++ b/gnuradio-runtime/lib/messages/msg_queue.cc
@@ -41,7 +41,7 @@ msg_queue::~msg_queue() { flush(); }
 
 void msg_queue::insert_tail(pmt::pmt_t msg)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::unique_lock guard(d_mutex);
 
     while (full_p())
         d_not_full.wait(guard);
@@ -52,7 +52,7 @@ void msg_queue::insert_tail(pmt::pmt_t msg)
 
 pmt::pmt_t msg_queue::delete_head()
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::unique_lock guard(d_mutex);
 
     while (empty_p())
         d_not_empty.wait(guard);
@@ -68,7 +68,7 @@ pmt::pmt_t msg_queue::delete_head()
 
 pmt::pmt_t msg_queue::delete_head_nowait()
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (empty_p())
         return pmt::pmt_t();

--- a/gnuradio-runtime/lib/msg_queue.cc
+++ b/gnuradio-runtime/lib/msg_queue.cc
@@ -49,7 +49,7 @@ void msg_queue::insert_tail(message::sptr msg)
     if (msg->d_next)
         throw std::invalid_argument("gr::msg_queue::insert_tail: msg already in queue");
 
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::unique_lock guard(d_mutex);
 
     while (full_p())
         d_not_full.wait(guard);
@@ -70,7 +70,7 @@ void msg_queue::insert_tail(message::sptr msg)
 
 message::sptr msg_queue::delete_head()
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::unique_lock guard(d_mutex);
     message::sptr m;
 
     while ((m = d_head) == 0)
@@ -91,7 +91,7 @@ message::sptr msg_queue::delete_head()
 
 message::sptr msg_queue::delete_head_nowait()
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     message::sptr m;
 
     if ((m = d_head) == 0) {

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -26,10 +26,12 @@
 
 #include "pmt_int.h"
 #include <gnuradio/messages/msg_accepter.h>
+#include <gnuradio/thread/thread.h>
 #include <pmt/pmt.h>
 #include <pmt/pmt_pool.h>
 #include <stdio.h>
 #include <string.h>
+#include <mutex>
 #include <vector>
 
 namespace pmt {
@@ -189,8 +191,8 @@ pmt_t string_to_symbol(const std::string& name)
     }
 
     // Lock the table on insert for thread safety:
-    static boost::mutex thread_safety;
-    boost::mutex::scoped_lock lock(thread_safety);
+    static std::mutex thread_safety;
+    gr::thread::lock_guard lock(thread_safety);
     // Re-do the search in case another thread inserted this symbol into the table
     // before we got the lock
     for (pmt_t sym = (*get_symbol_hash_table())[hash]; sym; sym = _symbol(sym)->next()) {

--- a/gnuradio-runtime/lib/pmt/pmt_pool.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_pool.cc
@@ -56,7 +56,7 @@ pmt_pool::~pmt_pool()
 
 void* pmt_pool::malloc()
 {
-    scoped_lock guard(d_mutex);
+    gr::thread::unique_lock guard(d_mutex);
     item* p;
 
     if (d_max_items != 0) {
@@ -100,7 +100,7 @@ void pmt_pool::free(void* foo)
     if (!foo)
         return;
 
-    scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     item* p = (item*)foo;
     p->d_next = d_freelist;

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -90,7 +90,7 @@ top_block_impl::~top_block_impl()
 
 void top_block_impl::start(int max_noutput_items)
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::unique_lock l(d_mutex);
 
     d_max_noutput_items = max_noutput_items;
 
@@ -121,7 +121,7 @@ void top_block_impl::start(int max_noutput_items)
 
 void top_block_impl::stop()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
 
     if (d_scheduler)
         d_scheduler->stop();
@@ -134,7 +134,7 @@ void top_block_impl::wait()
     do {
         wait_for_jobs();
         {
-            gr::thread::scoped_lock lock(d_mutex);
+            gr::thread::unique_lock lock(d_mutex);
             if (!d_lock_count) {
                 if (d_retry_wait) {
                     d_retry_wait = false;
@@ -158,7 +158,7 @@ void top_block_impl::wait_for_jobs()
 // thread or deadlock will occur when reconfiguration happens
 void top_block_impl::lock()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     if (d_scheduler)
         d_scheduler->stop();
     d_lock_count++;
@@ -166,7 +166,7 @@ void top_block_impl::lock()
 
 void top_block_impl::unlock()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
 
     if (d_lock_count <= 0) {
         d_lock_count = 0; // fix it, then complain

--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -79,11 +79,11 @@ protected:
     flat_flowgraph_sptr d_ffg;
     scheduler_sptr d_scheduler;
 
-    gr::thread::mutex d_mutex; // protects d_state and d_lock_count
+    std::mutex d_mutex; // protects d_state and d_lock_count
     tb_state d_state;
     int d_lock_count;
     bool d_retry_wait;
-    boost::condition_variable d_lock_cond;
+    std::condition_variable d_lock_cond;
     int d_max_noutput_items;
 
 private:

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -153,18 +153,16 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
 
         case block_executor::BLKD_IN: // Wait for input.
         {
-            gr::thread::scoped_lock guard(d->d_tpb.mutex);
+            gr::thread::unique_lock guard(d->d_tpb.mutex);
 
             if (!d->d_tpb.input_changed) {
-                boost::system_time const timeout =
-                    boost::get_system_time() + boost::posix_time::milliseconds(250);
-                d->d_tpb.input_cond.timed_wait(guard, timeout);
+                d->d_tpb.input_cond.wait_for(guard, std::chrono::milliseconds(250));
             }
         } break;
 
         case block_executor::BLKD_OUT: // Wait for output buffer space.
         {
-            gr::thread::scoped_lock guard(d->d_tpb.mutex);
+            gr::thread::unique_lock guard(d->d_tpb.mutex);
             while (!d->d_tpb.output_changed) {
                 d->d_tpb.output_cond.wait(guard);
             }

--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -40,7 +40,7 @@
 #include "vmcircbuf_mmap_tmpfile.h"
 #include "vmcircbuf_sysv_shm.h"
 
-gr::thread::mutex s_vm_mutex;
+std::mutex s_vm_mutex;
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/vmcircbuf.h
+++ b/gnuradio-runtime/lib/vmcircbuf.h
@@ -27,7 +27,7 @@
 #include <gnuradio/thread/thread.h>
 #include <vector>
 
-extern gr::thread::mutex s_vm_mutex;
+extern std::mutex s_vm_mutex;
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
@@ -67,7 +67,7 @@ vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(int size) : gr::vmcircb
     fprintf(stderr, "%s: createfilemapping is not available\n", __FUNCTION__);
     throw std::runtime_error("gr::vmcircbuf_createfilemapping");
 #else
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     static int s_seg_counter = 0;
 
@@ -158,7 +158,7 @@ vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(int size) : gr::vmcircb
 vmcircbuf_createfilemapping::~vmcircbuf_createfilemapping()
 {
 #ifdef HAVE_CREATEFILEMAPPING
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     if (UnmapViewOfFile(d_first_copy) == 0) {
         werror("gr::vmcircbuf_createfilemapping: UnmapViewOfFile(d_first_copy)",

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
@@ -49,7 +49,7 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
     fprintf(stderr, "gr::vmcircbuf_mmap_shm_open: mmap or shm_open is not available\n");
     throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
 #else
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     static int s_seg_counter = 0;
 
@@ -165,7 +165,7 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
 vmcircbuf_mmap_shm_open::~vmcircbuf_mmap_shm_open()
 {
 #if defined(HAVE_MMAP)
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     if (munmap(d_base, 2 * d_size) == -1) {
         perror("gr::vmcircbuf_mmap_shm_open: munmap (2)");

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.cc
@@ -51,7 +51,7 @@ vmcircbuf_mmap_tmpfile::vmcircbuf_mmap_tmpfile(int size) : gr::vmcircbuf(size)
     fprintf(stderr, "gr::vmcircbuf_mmap_tmpfile: mmap or mkstemp is not available\n");
     throw std::runtime_error("gr::vmcircbuf_mmap_tmpfile");
 #else
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     if (size <= 0 || (size % gr::pagesize()) != 0) {
         fprintf(stderr, "gr::vmcircbuf_mmap_tmpfile: invalid size = %d\n", size);
@@ -160,7 +160,7 @@ vmcircbuf_mmap_tmpfile::vmcircbuf_mmap_tmpfile(int size) : gr::vmcircbuf(size)
 vmcircbuf_mmap_tmpfile::~vmcircbuf_mmap_tmpfile()
 {
 #if defined(HAVE_MMAP)
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     if (munmap(d_base, 2 * d_size) == -1) {
         perror("gr::vmcircbuf_mmap_tmpfile: munmap(2)");

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -65,7 +65,7 @@ static void ensure_dir_path()
 
 int vmcircbuf_prefs::get(const char* key, char* value, int value_size)
 {
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     FILE* fp = fopen(pathname(key).c_str(), "r");
     if (fp == 0) {
@@ -88,7 +88,7 @@ int vmcircbuf_prefs::get(const char* key, char* value, int value_size)
 
 void vmcircbuf_prefs::set(const char* key, const char* value)
 {
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     ensure_dir_path();
 

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
@@ -51,7 +51,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
     throw std::runtime_error("gr::vmcircbuf_sysv_shm");
 #else
 
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     int pagesize = gr::pagesize();
 
@@ -165,7 +165,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
 vmcircbuf_sysv_shm::~vmcircbuf_sysv_shm()
 {
 #if defined(HAVE_SYS_SHM_H)
-    gr::thread::scoped_lock guard(s_vm_mutex);
+    gr::thread::lock_guard guard(s_vm_mutex);
 
     if (shmdt(d_base - gr::pagesize()) == -1 || shmdt(d_base) == -1 ||
         shmdt(d_base + d_size) == -1 || shmdt(d_base + 2 * d_size) == -1) {

--- a/gr-analog/lib/ctcss_squelch_ff_impl.cc
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.cc
@@ -143,13 +143,13 @@ void ctcss_squelch_ff_impl::update_state(const float& in)
 
 void ctcss_squelch_ff_impl::set_level(float level)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_level = level;
 }
 
 void ctcss_squelch_ff_impl::set_frequency(float frequency)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_freq = frequency;
     update_fft_params();
 }

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -103,7 +103,7 @@ fastnoise_source_impl<T>::~fastnoise_source_impl()
 template <class T>
 void fastnoise_source_impl<T>::set_type(noise_type_t type)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_type = type;
     generate();
 }
@@ -111,7 +111,7 @@ void fastnoise_source_impl<T>::set_type(noise_type_t type)
 template <class T>
 void fastnoise_source_impl<T>::set_amplitude(float ampl)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_ampl = ampl;
     generate();
 }
@@ -119,7 +119,7 @@ void fastnoise_source_impl<T>::set_amplitude(float ampl)
 template <>
 void fastnoise_source_impl<gr_complex>::set_amplitude(float ampl)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_ampl = ampl / sqrtf(2.0f);
     generate();
 }
@@ -160,7 +160,7 @@ int fastnoise_source_impl<T>::work(int noutput_items,
                                    gr_vector_const_void_star& input_items,
                                    gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
 
     T* out = (T*)output_items[0];
 

--- a/gr-analog/lib/noise_source_impl.cc
+++ b/gr-analog/lib/noise_source_impl.cc
@@ -70,21 +70,21 @@ noise_source_impl<T>::~noise_source_impl<T>()
 template <class T>
 void noise_source_impl<T>::set_type(noise_type_t type)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_type = type;
 }
 
 template <class T>
 void noise_source_impl<T>::set_amplitude(float ampl)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_ampl = ampl;
 }
 
 template <>
 void noise_source_impl<gr_complex>::set_amplitude(float ampl)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_ampl = ampl / sqrtf(2.0f);
 }
 
@@ -94,7 +94,7 @@ int noise_source_impl<T>::work(int noutput_items,
                                gr_vector_const_void_star& input_items,
                                gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
 
     T* out = (T*)output_items[0];
 
@@ -134,7 +134,7 @@ int noise_source_impl<gr_complex>::work(int noutput_items,
                                         gr_vector_const_void_star& input_items,
                                         gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
 
     gr_complex* out = (gr_complex*)output_items[0];
 

--- a/gr-analog/lib/pwr_squelch_cc_impl.cc
+++ b/gr-analog/lib/pwr_squelch_cc_impl.cc
@@ -69,13 +69,13 @@ void pwr_squelch_cc_impl::update_state(const gr_complex& in)
 
 void pwr_squelch_cc_impl::set_threshold(double db)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_threshold = std::pow(10.0, db / 10);
 }
 
 void pwr_squelch_cc_impl::set_alpha(double alpha)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_iir.set_taps(alpha);
 }
 

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -111,7 +111,7 @@ int sig_source_impl<T>::work(int noutput_items,
 {
     T* optr = (T*)output_items[0];
     T t;
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
 
     switch (d_waveform) {
     case GR_CONST_WAVE:
@@ -187,7 +187,7 @@ int sig_source_impl<gr_complex>::work(int noutput_items,
 {
     gr_complex* optr = (gr_complex*)output_items[0];
     gr_complex t;
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
 
     switch (d_waveform) {
     case GR_CONST_WAVE:
@@ -315,7 +315,7 @@ void sig_source_impl<T>::set_offset(T offset)
 template <class T>
 void sig_source_impl<T>::set_phase(float phase)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_nco.set_phase(phase);
 }
 

--- a/gr-analog/lib/squelch_base_cc_impl.cc
+++ b/gr-analog/lib/squelch_base_cc_impl.cc
@@ -52,7 +52,7 @@ int squelch_base_cc_impl::ramp() const { return d_ramp; }
 
 void squelch_base_cc_impl::set_ramp(int ramp)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_ramp = ramp;
 }
 
@@ -60,7 +60,7 @@ bool squelch_base_cc_impl::gate() const { return d_gate; }
 
 void squelch_base_cc_impl::set_gate(bool gate)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_gate = gate;
 }
 
@@ -79,7 +79,7 @@ int squelch_base_cc_impl::general_work(int noutput_items,
 
     int j = 0;
 
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
 
     for (int i = 0; i < noutput_items; i++) {
         update_state(in[i]);

--- a/gr-audio/lib/osx/osx_sink.cc
+++ b/gr-audio/lib/osx/osx_sink.cc
@@ -694,7 +694,7 @@ int osx_sink::work(int noutput_items,
 {
 #if _OSX_AU_DEBUG_RENDER_
     {
-        gr::thread::scoped_lock l(d_internal);
+        gr::thread::lock_guard l(d_internal);
         std::cerr << ((void*)(pthread_self())) << " : audio_osx_sink::work: "
                   << "Starting: #OI = " << noutput_items
                   << ", reset = " << (d_do_reset ? "true" : "false") << std::endl;
@@ -726,7 +726,7 @@ int osx_sink::work(int noutput_items,
 
 #if _OSX_AU_DEBUG_RENDER_
             {
-                gr::thread::scoped_lock l(d_internal);
+                gr::thread::lock_guard l(d_internal);
                 std::cerr << ((void*)(pthread_self())) << " : audio_osx_sink::work: "
                           << "doing reset." << std::endl;
             }
@@ -743,7 +743,7 @@ int osx_sink::work(int noutput_items,
 
             teardown();
 
-            gr::thread::scoped_lock l(d_internal);
+            gr::thread::lock_guard l(d_internal);
 
             setup();
             start();
@@ -756,7 +756,7 @@ int osx_sink::work(int noutput_items,
         }
     }
 
-    gr::thread::scoped_lock l(d_internal);
+    gr::thread::lock_guard l(d_internal);
 
     // take the input data, copy it, and push it to the bottom of
     // the queue.  mono input is pushed onto queue[0]; stereo input
@@ -882,7 +882,7 @@ OSStatus osx_sink::au_output_callback(void* in_ref_con,
     osx_sink* This = reinterpret_cast<osx_sink*>(in_ref_con);
     OSStatus err = noErr;
 
-    gr::thread::scoped_lock l(This->d_internal);
+    gr::thread::lock_guard l(This->d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
     std::cerr << ((void*)(pthread_self())) << " : audio_osx_sink::au_output_callback: "

--- a/gr-audio/lib/osx/osx_sink.h
+++ b/gr-audio/lib/osx/osx_sink.h
@@ -47,8 +47,8 @@ protected:
     UInt32 d_queue_sample_count, d_buffer_size_samples;
     bool d_ok_to_block, d_do_reset, d_hardware_changed;
     bool d_using_default_device, d_waiting_for_data;
-    gr::thread::mutex d_internal;
-    gr::thread::condition_variable d_cond_data;
+    std::mutex d_internal;
+    std::condition_variable d_cond_data;
     std::vector<circular_buffer<float>*> d_buffers;
     std::string d_desired_name, d_selected_name;
 

--- a/gr-audio/lib/osx/osx_source.cc
+++ b/gr-audio/lib/osx/osx_source.cc
@@ -1025,7 +1025,7 @@ int osx_source::work(int noutput_items,
 
             teardown();
 
-            gr::thread::scoped_lock l(d_internal);
+            gr::thread::lock_guard l(d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
             std::cerr << "audio_osx_source::work: mutex locked." << std::endl;
@@ -1041,7 +1041,7 @@ int osx_source::work(int noutput_items,
         }
     }
 
-    gr::thread::scoped_lock l(d_internal);
+    gr::thread::lock_guard l(d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
     std::cerr << "audio_osx_source::work: mutex locked." << std::endl;
@@ -1201,7 +1201,7 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
 #endif
 
     osx_source* This = reinterpret_cast<osx_source*>(in_ref_con);
-    gr::thread::scoped_lock l(This->d_internal);
+    gr::thread::lock_guard l(This->d_internal);
     gr::logger_ptr d_logger = This->d_logger;
 
 #if _OSX_AU_DEBUG_RENDER_

--- a/gr-audio/lib/osx/osx_source.h
+++ b/gr-audio/lib/osx/osx_source.h
@@ -54,8 +54,8 @@ private:
     bool d_ok_to_block, d_pass_through;
     bool d_waiting_for_data, d_do_reset, d_hardware_changed;
     bool d_using_default_device;
-    gr::thread::mutex d_internal;
-    gr::thread::condition_variable d_cond_data;
+    std::mutex d_internal;
+    std::condition_variable d_cond_data;
     std::vector<circular_buffer<float>*> d_buffers;
     std::string d_desired_name, d_selected_name;
 

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -102,7 +102,7 @@ int portaudio_sink_callback(const void* inputBuffer,
 
     if (nreqd_samples <= navail_samples) { // We've got enough data...
         {
-            gr::thread::scoped_lock guard(self->d_ringbuffer_mutex);
+            gr::thread::lock_guard guard(self->d_ringbuffer_mutex);
 
             memcpy(outputBuffer,
                    self->d_reader->read_pointer(),
@@ -322,7 +322,7 @@ int portaudio_sink::work(int noutput_items,
         if (nframes == 0) {                                // no room...
             if (d_ok_to_block) {
                 {
-                    gr::thread::scoped_lock guard(d_ringbuffer_mutex);
+                    gr::thread::unique_lock guard(d_ringbuffer_mutex);
                     while (!d_ringbuffer_ready)
                         d_ringbuffer_cond.wait(guard);
                 }
@@ -339,7 +339,7 @@ int portaudio_sink::work(int noutput_items,
 
         // We can write the smaller of the request and the room we've got
         {
-            gr::thread::scoped_lock guard(d_ringbuffer_mutex);
+            gr::thread::lock_guard guard(d_ringbuffer_mutex);
 
             int nf = std::min(noutput_items - k, nframes);
             float* p = (float*)d_writer->write_pointer();

--- a/gr-audio/lib/portaudio/portaudio_sink.h
+++ b/gr-audio/lib/portaudio/portaudio_sink.h
@@ -58,8 +58,8 @@ class portaudio_sink : public sink
     gr::buffer_sptr d_writer; // buffer used between work and callback
     gr::buffer_reader_sptr d_reader;
 
-    gr::thread::mutex d_ringbuffer_mutex;
-    gr::thread::condition_variable d_ringbuffer_cond;
+    std::mutex d_ringbuffer_mutex;
+    std::condition_variable d_ringbuffer_cond;
     bool d_ringbuffer_ready;
 
     // random stats

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -106,7 +106,7 @@ int portaudio_source_callback(const void* inputBuffer,
 
         // copy from input buffer to ringbuffer
         {
-            gr::thread::scoped_lock guard(self->d_ringbuffer_mutex);
+            gr::thread::lock_guard l(self->d_ringbuffer_mutex);
 
             memcpy(self->d_writer->write_pointer(),
                    inputBuffer,
@@ -315,7 +315,7 @@ int portaudio_source::work(int noutput_items,
                 return k;
 
             if (d_ok_to_block) {
-                gr::thread::scoped_lock guard(d_ringbuffer_mutex);
+                gr::thread::unique_lock guard(d_ringbuffer_mutex);
                 while (d_ringbuffer_ready == false)
                     d_ringbuffer_cond.wait(guard); // block here, then try again
                 continue;
@@ -334,7 +334,7 @@ int portaudio_source::work(int noutput_items,
 
             // Fill with some frames of zeros
             {
-                gr::thread::scoped_lock guard(d_ringbuffer_mutex);
+                gr::thread::lock_guard guard(d_ringbuffer_mutex);
 
                 int nf = std::min(noutput_items - k, (int)d_portaudio_buffer_size_frames);
                 for (int i = 0; i < nf; i++) {
@@ -351,7 +351,7 @@ int portaudio_source::work(int noutput_items,
 
         // We can read the smaller of the request and what's in the buffer.
         {
-            gr::thread::scoped_lock guard(d_ringbuffer_mutex);
+            gr::thread::lock_guard guard(d_ringbuffer_mutex);
 
             int nf = std::min(noutput_items - k, nframes);
 

--- a/gr-audio/lib/portaudio/portaudio_source.h
+++ b/gr-audio/lib/portaudio/portaudio_source.h
@@ -27,6 +27,8 @@
 #include <gnuradio/buffer.h>
 #include <gnuradio/thread/thread.h>
 #include <portaudio.h>
+#include <mutex>
+#include <condition_variable>
 #include <stdexcept>
 #include <string>
 
@@ -58,8 +60,8 @@ class portaudio_source : public source
     gr::buffer_sptr d_writer; // buffer used between work and callback
     gr::buffer_reader_sptr d_reader;
 
-    gr::thread::mutex d_ringbuffer_mutex;
-    gr::thread::condition_variable d_ringbuffer_cond;
+    std::mutex d_ringbuffer_mutex;
+    std::condition_variable d_ringbuffer_cond;
     bool d_ringbuffer_ready;
 
     // random stats

--- a/gr-blocks/include/gnuradio/blocks/file_sink_base.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink_base.h
@@ -24,8 +24,8 @@
 #define INCLUDED_GR_FILE_SINK_BASE_H
 
 #include <gnuradio/blocks/api.h>
-#include <boost/thread.hpp>
 #include <cstdio>
+#include <mutex>
 
 namespace gr {
 namespace blocks {
@@ -40,7 +40,7 @@ protected:
     FILE* d_new_fp; // new FILE pointer
     bool d_updated; // is there a new FILE pointer?
     bool d_is_binary;
-    boost::mutex d_mutex;
+    std::mutex d_mutex;
     bool d_unbuffered;
     bool d_append;
 

--- a/gr-blocks/lib/annotator_raw_impl.cc
+++ b/gr-blocks/lib/annotator_raw_impl.cc
@@ -55,7 +55,7 @@ annotator_raw_impl::~annotator_raw_impl() {}
 
 void annotator_raw_impl::add_tag(uint64_t offset, pmt_t key, pmt_t val)
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
 
     tag_t tag;
     tag.srcid = pmt::intern(name());
@@ -78,7 +78,7 @@ int annotator_raw_impl::work(int noutput_items,
                              gr_vector_const_void_star& input_items,
                              gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
 
     const char* in = (const char*)input_items[0];
     char* out = (char*)output_items[0];

--- a/gr-blocks/lib/annotator_raw_impl.h
+++ b/gr-blocks/lib/annotator_raw_impl.h
@@ -34,7 +34,7 @@ class annotator_raw_impl : public annotator_raw
 private:
     size_t d_itemsize;
     std::vector<tag_t> d_queued_tags;
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
 
 public:
     annotator_raw_impl(size_t sizeof_stream_item);

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.cc
@@ -69,7 +69,7 @@ std::vector<signed char> ctrlport_probe2_b_impl::get() { return buffered_get.get
 
 void ctrlport_probe2_b_impl::set_length(int len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     if (len > 8191) {
         GR_LOG_WARN(d_logger,
@@ -92,7 +92,7 @@ int ctrlport_probe2_b_impl::work(int noutput_items,
 {
     const char* in = (const char*)input_items[0];
 
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     // copy samples to get buffer if we need samples
     if (d_index < d_len) {

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.cc
@@ -69,7 +69,7 @@ std::vector<gr_complex> ctrlport_probe2_c_impl::get() { return buffered_get.get(
 
 void ctrlport_probe2_c_impl::set_length(int len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     if (len > 8191) {
         GR_LOG_WARN(d_logger,
@@ -92,7 +92,7 @@ int ctrlport_probe2_c_impl::work(int noutput_items,
 {
     const gr_complex* in = (const gr_complex*)input_items[0];
 
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     // copy samples to get buffer if we need samples
     if (d_index < d_len) {

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.cc
@@ -69,7 +69,7 @@ std::vector<float> ctrlport_probe2_f_impl::get() { return buffered_get.get(); }
 
 void ctrlport_probe2_f_impl::set_length(int len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     if (len > 8191) {
         GR_LOG_WARN(d_logger,
@@ -92,7 +92,7 @@ int ctrlport_probe2_f_impl::work(int noutput_items,
 {
     const float* in = (const float*)input_items[0];
 
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     // copy samples to get buffer if we need samples
     if (d_index < d_len) {

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.cc
@@ -68,7 +68,7 @@ std::vector<int> ctrlport_probe2_i_impl::get() { return buffered_get.get(); }
 
 void ctrlport_probe2_i_impl::set_length(int len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     if (len > 8191) {
         GR_LOG_WARN(d_logger,
@@ -91,7 +91,7 @@ int ctrlport_probe2_i_impl::work(int noutput_items,
 {
     const int* in = (const int*)input_items[0];
 
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     // copy samples to get buffer if we need samples
     if (d_index < d_len) {

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.cc
@@ -69,7 +69,7 @@ std::vector<short> ctrlport_probe2_s_impl::get() { return buffered_get.get(); }
 
 void ctrlport_probe2_s_impl::set_length(int len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     if (len > 8191) {
         GR_LOG_WARN(d_logger,
@@ -92,7 +92,7 @@ int ctrlport_probe2_s_impl::work(int noutput_items,
 {
     const short* in = (const short*)input_items[0];
 
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     // copy samples to get buffer if we need samples
     if (d_index < d_len) {

--- a/gr-blocks/lib/delay_impl.cc
+++ b/gr-blocks/lib/delay_impl.cc
@@ -65,7 +65,7 @@ void delay_impl::set_dly(int d)
     // protects from quickly-repeated calls to this function that
     // would end with d_delta=0.
     if (d != dly()) {
-        gr::thread::scoped_lock l(d_mutex_delay);
+        gr::thread::lock_guard l(d_mutex_delay);
         int old = dly();
         set_history(d + 1);
         declare_sample_delay(history() - 1);
@@ -78,7 +78,7 @@ int delay_impl::general_work(int noutput_items,
                              gr_vector_const_void_star& input_items,
                              gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(d_mutex_delay);
+    gr::thread::lock_guard l(d_mutex_delay);
     assert(input_items.size() == output_items.size());
 
     const char* iptr;

--- a/gr-blocks/lib/delay_impl.h
+++ b/gr-blocks/lib/delay_impl.h
@@ -36,7 +36,7 @@ private:
 
     size_t d_itemsize;
     int d_delta;
-    gr::thread::mutex d_mutex_delay;
+    std::mutex d_mutex_delay;
 
 public:
     delay_impl(size_t itemsize, int delay);

--- a/gr-blocks/lib/exponentiate_const_cci_impl.cc
+++ b/gr-blocks/lib/exponentiate_const_cci_impl.cc
@@ -62,7 +62,7 @@ bool exponentiate_const_cci_impl::check_topology(int ninputs, int noutputs)
 
 void exponentiate_const_cci_impl::set_exponent(int exponent)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_exponent = exponent;
 }
 
@@ -70,7 +70,7 @@ int exponentiate_const_cci_impl::work(int noutput_items,
                                       gr_vector_const_void_star& input_items,
                                       gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
 
     for (unsigned int i = 0; i < input_items.size(); i++) {
         const gr_complex* in = (const gr_complex*)input_items[i];

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -159,7 +159,7 @@ bool file_meta_sink_impl::open(const std::string& filename)
 
 bool file_meta_sink_impl::_open(FILE** fp, const char* filename)
 {
-    gr::thread::scoped_lock guard(d_setlock); // hold mutex for duration of this function
+    gr::thread::lock_guard guard(d_setlock); // hold mutex for duration of this function
 
     bool ret = true;
     int fd;
@@ -188,7 +188,7 @@ bool file_meta_sink_impl::_open(FILE** fp, const char* filename)
 
 void file_meta_sink_impl::close()
 {
-    gr::thread::scoped_lock guard(d_setlock); // hold mutex for duration of this function
+    gr::thread::lock_guard guard(d_setlock); // hold mutex for duration of this function
     update_last_header();
 
     if (d_state == STATE_DETACHED) {
@@ -220,7 +220,7 @@ void file_meta_sink_impl::close()
 void file_meta_sink_impl::do_update()
 {
     if (d_updated) {
-        gr::thread::scoped_lock guard(d_setlock); // hold mutex for duration of this block
+        gr::thread::lock_guard guard(d_setlock); // hold mutex for duration of this block
         if (d_state == STATE_DETACHED) {
             if (d_hdr_fp)
                 fclose(d_hdr_fp);

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -269,7 +269,7 @@ bool file_meta_source_impl::open(const std::string& filename,
 
 bool file_meta_source_impl::_open(FILE** fp, const char* filename)
 {
-    gr::thread::scoped_lock guard(d_setlock); // hold mutex for duration of this function
+    gr::thread::lock_guard guard(d_setlock); // hold mutex for duration of this function
 
     bool ret = true;
     int fd;
@@ -296,7 +296,7 @@ bool file_meta_source_impl::_open(FILE** fp, const char* filename)
 
 void file_meta_source_impl::close()
 {
-    gr::thread::scoped_lock guard(d_setlock); // hold mutex for duration of this function
+    gr::thread::lock_guard guard(d_setlock); // hold mutex for duration of this function
     if (d_state == STATE_DETACHED) {
         if (d_new_hdr_fp) {
             fclose(d_new_hdr_fp);
@@ -326,7 +326,7 @@ void file_meta_source_impl::close()
 void file_meta_source_impl::do_update()
 {
     if (d_updated) {
-        gr::thread::scoped_lock guard(d_setlock); // hold mutex for duration of this block
+        gr::thread::lock_guard guard(d_setlock); // hold mutex for duration of this block
         if (d_state == STATE_DETACHED) {
             if (d_hdr_fp)
                 fclose(d_hdr_fp);
@@ -383,7 +383,7 @@ int file_meta_source_impl::work(int noutput_items,
         d_tags.pop_back();
     }
 
-    gr::thread::scoped_lock lock(d_setlock); // hold for the rest of this function
+    gr::thread::lock_guard lock(d_setlock); // hold for the rest of this function
     while (size) {
         i = fread(out, d_itemsize, size, d_fp);
 

--- a/gr-blocks/lib/file_sink_base.cc
+++ b/gr-blocks/lib/file_sink_base.cc
@@ -71,7 +71,7 @@ file_sink_base::~file_sink_base()
 
 bool file_sink_base::open(const char* filename)
 {
-    gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this function
+    gr::thread::lock_guard guard(d_mutex); // hold mutex for duration of this function
 
     // we use the open system call to get access to the O_LARGEFILE flag.
     int fd;
@@ -101,7 +101,7 @@ bool file_sink_base::open(const char* filename)
 
 void file_sink_base::close()
 {
-    gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this function
+    gr::thread::lock_guard guard(d_mutex); // hold mutex for duration of this function
 
     if (d_new_fp) {
         fclose(d_new_fp);
@@ -113,7 +113,7 @@ void file_sink_base::close()
 void file_sink_base::do_update()
 {
     if (d_updated) {
-        gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this block
+        gr::thread::lock_guard guard(d_mutex); // hold mutex for duration of this block
         if (d_fp)
             fclose(d_fp);
         d_fp = d_new_fp; // install new file pointer

--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -134,7 +134,7 @@ void file_source_impl::open(const char* filename,
                             uint64_t length_items)
 {
     // obtain exclusive access for duration of this function
-    gr::thread::scoped_lock lock(fp_mutex);
+    gr::thread::lock_guard lock(fp_mutex);
 
     if (d_new_fp) {
         fclose(d_new_fp);
@@ -211,7 +211,7 @@ void file_source_impl::open(const char* filename,
 void file_source_impl::close()
 {
     // obtain exclusive access for duration of this function
-    gr::thread::scoped_lock lock(fp_mutex);
+    gr::thread::lock_guard lock(fp_mutex);
 
     if (d_new_fp != NULL) {
         fclose(d_new_fp);
@@ -223,7 +223,7 @@ void file_source_impl::close()
 void file_source_impl::do_update()
 {
     if (d_updated) {
-        gr::thread::scoped_lock lock(fp_mutex); // hold while in scope
+        gr::thread::lock_guard lock(fp_mutex); // hold while in scope
 
         if (d_fp)
             fclose(d_fp);
@@ -248,7 +248,7 @@ int file_source_impl::work(int noutput_items,
     if (d_fp == NULL)
         throw std::runtime_error("work with file not open");
 
-    gr::thread::scoped_lock lock(fp_mutex); // hold for the rest of this function
+    gr::thread::lock_guard lock(fp_mutex); // hold for the rest of this function
 
     // No items remaining - all done
     if (d_items_remaining == 0)

--- a/gr-blocks/lib/file_source_impl.h
+++ b/gr-blocks/lib/file_source_impl.h
@@ -24,7 +24,7 @@
 #define INCLUDED_BLOCKS_FILE_SOURCE_IMPL_H
 
 #include <gnuradio/blocks/file_source.h>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 namespace gr {
 namespace blocks {
@@ -45,7 +45,7 @@ private:
     long d_repeat_cnt;
     pmt::pmt_t d_add_begin_tag;
 
-    boost::mutex fp_mutex;
+    std::mutex fp_mutex;
     pmt::pmt_t _id;
 
     void do_update();

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -46,7 +46,7 @@ void message_debug_impl::print(pmt::pmt_t msg)
 
 void message_debug_impl::store(pmt::pmt_t msg)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_messages.push_back(msg);
 }
 
@@ -77,7 +77,7 @@ int message_debug_impl::num_messages() { return (int)d_messages.size(); }
 
 pmt::pmt_t message_debug_impl::get_message(int i)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if ((size_t)i >= d_messages.size()) {
         throw std::runtime_error("message_debug: index for message out of bounds.");

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -71,7 +71,7 @@ private:
      */
     void store(pmt::pmt_t msg);
 
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
     std::vector<pmt::pmt_t> d_messages;
 
 public:

--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -57,14 +57,14 @@ peak_detector2_fb_impl::~peak_detector2_fb_impl() {}
 
 void peak_detector2_fb_impl::set_threshold_factor_rise(float thr)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     d_threshold_factor_rise = thr;
     invalidate();
 }
 
 void peak_detector2_fb_impl::set_look_ahead(int look)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     d_look_ahead = look;
     invalidate();
 }
@@ -90,7 +90,7 @@ int peak_detector2_fb_impl::work(int noutput_items,
 
     memset(optr, 0, noutput_items * sizeof(char));
 
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     // have not crossed threshold yet
     if (d_found == false) {

--- a/gr-blocks/lib/plateau_detector_fb_impl.cc
+++ b/gr-blocks/lib/plateau_detector_fb_impl.cc
@@ -57,7 +57,7 @@ int plateau_detector_fb_impl::general_work(int noutput_items,
                                            gr_vector_void_star& output_items)
 {
     // thread-safe protection from ::set_threshold
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
 
     const float* in = (const float*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
@@ -88,7 +88,7 @@ int plateau_detector_fb_impl::general_work(int noutput_items,
 void plateau_detector_fb_impl::set_threshold(float threshold)
 {
     // thread-safe protection from ::set_threshold
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_threshold = threshold;
 }
 

--- a/gr-blocks/lib/repack_bits_bb_impl.cc
+++ b/gr-blocks/lib/repack_bits_bb_impl.cc
@@ -66,7 +66,7 @@ repack_bits_bb_impl::repack_bits_bb_impl(int k,
 
 void repack_bits_bb_impl::set_k_and_l(int k, int l)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_k = k;
     d_l = l;
     set_relative_rate((uint64_t)d_k, (uint64_t)d_l);
@@ -90,7 +90,7 @@ int repack_bits_bb_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
     int bytes_to_write = noutput_items;

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -62,7 +62,7 @@ selector_impl::~selector_impl() {}
 
 void selector_impl::set_input_index(unsigned int input_index)
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
     if (input_index < d_num_inputs)
         d_input_index = input_index;
     else
@@ -71,7 +71,7 @@ void selector_impl::set_input_index(unsigned int input_index)
 
 void selector_impl::set_output_index(unsigned int output_index)
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
     if (output_index < d_num_outputs)
         d_output_index = output_index;
     else
@@ -82,7 +82,7 @@ void selector_impl::handle_enable(pmt::pmt_t msg)
 {
     if (pmt::is_bool(msg)) {
         bool en = pmt::to_bool(msg);
-        gr::thread::scoped_lock l(d_mutex);
+        gr::thread::lock_guard l(d_mutex);
         d_enabled = en;
     } else {
         GR_LOG_WARN(d_logger,
@@ -119,7 +119,7 @@ int selector_impl::general_work(int noutput_items,
     const uint8_t** in = (const uint8_t**)&input_items[0];
     uint8_t** out = (uint8_t**)&output_items[0];
 
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
     if (d_enabled) {
         std::copy(in[d_input_index],
                   in[d_input_index] + noutput_items * d_itemsize,

--- a/gr-blocks/lib/selector_impl.h
+++ b/gr-blocks/lib/selector_impl.h
@@ -37,7 +37,7 @@ private:
     unsigned int d_input_index, d_output_index;
     unsigned int d_num_inputs, d_num_outputs; // keep track of the topology
 
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
 
 
 public:
@@ -50,7 +50,7 @@ public:
     void handle_enable(pmt::pmt_t msg);
     void set_enabled(bool enable)
     {
-        gr::thread::scoped_lock l(d_mutex);
+        gr::thread::lock_guard l(d_mutex);
         d_enabled = enable;
     }
     bool enabled() const { return d_enabled; }

--- a/gr-blocks/lib/stream_to_tagged_stream_impl.cc
+++ b/gr-blocks/lib/stream_to_tagged_stream_impl.cc
@@ -60,19 +60,19 @@ stream_to_tagged_stream_impl::~stream_to_tagged_stream_impl() {}
 
 void stream_to_tagged_stream_impl::set_packet_len(unsigned packet_len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_packet_len = packet_len;
 }
 void stream_to_tagged_stream_impl::set_packet_len_pmt(unsigned packet_len)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_packet_len_pmt = pmt::from_long(packet_len);
 }
 int stream_to_tagged_stream_impl::work(int noutput_items,
                                        gr_vector_const_void_star& input_items,
                                        gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
     // Copy data

--- a/gr-blocks/lib/tag_debug_impl.cc
+++ b/gr-blocks/lib/tag_debug_impl.cc
@@ -56,7 +56,7 @@ tag_debug_impl::~tag_debug_impl() {}
 
 std::vector<tag_t> tag_debug_impl::current_tags()
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
     return d_tags;
 }
 
@@ -83,7 +83,7 @@ int tag_debug_impl::work(int noutput_items,
                          gr_vector_const_void_star& input_items,
                          gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(d_mutex);
+    gr::thread::lock_guard l(d_mutex);
     bool toprint = false;
 
     std::stringstream sout;

--- a/gr-blocks/lib/tag_debug_impl.h
+++ b/gr-blocks/lib/tag_debug_impl.h
@@ -37,7 +37,7 @@ private:
     std::vector<tag_t> d_tags;
     bool d_display;
     pmt::pmt_t d_filter;
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
 
 public:
     tag_debug_impl(size_t sizeof_stream_item,

--- a/gr-blocks/lib/tcp_server_sink_impl.h
+++ b/gr-blocks/lib/tcp_server_sink_impl.h
@@ -49,8 +49,8 @@ private:
     };
 
     int d_writing;
-    boost::condition_variable d_writing_cond;
-    boost::mutex d_writing_mut;
+    std::condition_variable d_writing_cond;
+    std::mutex d_writing_mut;
 
     void do_accept(const boost::system::error_code& error);
     void do_write(const boost::system::error_code& error,

--- a/gr-blocks/lib/udp_sink_impl.cc
+++ b/gr-blocks/lib/udp_sink_impl.cc
@@ -91,7 +91,7 @@ void udp_sink_impl::disconnect()
     if (!d_connected)
         return;
 
-    gr::thread::scoped_lock guard(d_mutex); // protect d_socket from work()
+    gr::thread::lock_guard guard(d_mutex); // protect d_socket from work()
 
     // Send a few zero-length packets to signal receiver we are done
     boost::array<char, 0> send_buf;
@@ -115,7 +115,7 @@ int udp_sink_impl::work(int noutput_items,
     ssize_t r = 0, bytes_sent = 0, bytes_to_send = 0;
     ssize_t total_size = noutput_items * d_itemsize;
 
-    gr::thread::scoped_lock guard(d_mutex); // protect d_socket
+    gr::thread::lock_guard guard(d_mutex); // protect d_socket
 
     while (bytes_sent < total_size) {
         bytes_to_send = std::min((ssize_t)d_payload_size, (total_size - bytes_sent));

--- a/gr-blocks/lib/udp_sink_impl.h
+++ b/gr-blocks/lib/udp_sink_impl.h
@@ -37,7 +37,7 @@ private:
     int d_payload_size;        // maximum transmission unit (packet length)
     bool d_eof;                // send zero-length packet on disconnect
     bool d_connected;          // are we connected?
-    gr::thread::mutex d_mutex; // protects d_socket and d_connected
+    std::mutex d_mutex; // protects d_socket and d_connected
 
     boost::asio::ip::udp::socket* d_socket; // handle to socket
     boost::asio::ip::udp::endpoint d_endpoint;

--- a/gr-blocks/lib/udp_source_impl.h
+++ b/gr-blocks/lib/udp_source_impl.h
@@ -54,8 +54,8 @@ private:
     boost::asio::ip::udp::endpoint d_endpoint_rcvd;
     boost::asio::io_service d_io_service;
 
-    gr::thread::condition_variable d_cond_wait;
-    gr::thread::mutex d_udp_mutex;
+    std::condition_variable d_cond_wait;
+    std::mutex d_udp_mutex;
     gr::thread::thread d_udp_thread;
 
     void start_receive();

--- a/gr-blocks/lib/vector_map_impl.cc
+++ b/gr-blocks/lib/vector_map_impl.cc
@@ -99,7 +99,7 @@ void vector_map_impl::set_mapping(std::vector<std::vector<std::vector<size_t>>> 
             }
         }
     }
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_mapping = mapping;
 }
 

--- a/gr-blocks/lib/vector_map_impl.h
+++ b/gr-blocks/lib/vector_map_impl.h
@@ -35,7 +35,7 @@ private:
     size_t d_item_size;
     std::vector<size_t> d_in_vlens;
     std::vector<std::vector<std::vector<size_t>>> d_mapping;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     vector_map_impl(size_t item_size,

--- a/gr-blocks/lib/vector_sink_impl.cc
+++ b/gr-blocks/lib/vector_sink_impl.cc
@@ -48,7 +48,7 @@ vector_sink_impl<T>::vector_sink_impl(unsigned int vlen, const int reserve_items
                  io_signature::make(0, 0, 0)),
       d_vlen(vlen)
 {
-    gr::thread::scoped_lock guard(d_data_mutex);
+    gr::thread::lock_guard guard(d_data_mutex);
     d_data.reserve(d_vlen * reserve_items);
 }
 
@@ -60,14 +60,14 @@ vector_sink_impl<T>::~vector_sink_impl()
 template <class T>
 std::vector<T> vector_sink_impl<T>::data() const
 {
-    gr::thread::scoped_lock guard(d_data_mutex);
+    gr::thread::lock_guard guard(d_data_mutex);
     return d_data;
 }
 
 template <class T>
 std::vector<tag_t> vector_sink_impl<T>::tags() const
 {
-    gr::thread::scoped_lock guard(d_data_mutex);
+    gr::thread::lock_guard guard(d_data_mutex);
     return d_tags;
 }
 
@@ -75,7 +75,7 @@ std::vector<tag_t> vector_sink_impl<T>::tags() const
 template <class T>
 void vector_sink_impl<T>::reset()
 {
-    gr::thread::scoped_lock guard(d_data_mutex);
+    gr::thread::lock_guard guard(d_data_mutex);
     d_tags.clear();
     d_data.clear();
 }
@@ -89,7 +89,7 @@ int vector_sink_impl<T>::work(int noutput_items,
 
     // can't touch this (as long as work() is working, the accessors shall not
     // read the data
-    gr::thread::scoped_lock guard(d_data_mutex);
+    gr::thread::lock_guard guard(d_data_mutex);
     for (unsigned int i = 0; i < noutput_items * d_vlen; i++)
         d_data.push_back(iptr[i]);
     std::vector<tag_t> tags;

--- a/gr-blocks/lib/vector_sink_impl.h
+++ b/gr-blocks/lib/vector_sink_impl.h
@@ -36,7 +36,7 @@ class vector_sink_impl : public vector_sink<T>
 private:
     std::vector<T> d_data;
     std::vector<tag_t> d_tags;
-    mutable gr::thread::mutex d_data_mutex; // protects internal data access.
+    mutable std::mutex d_data_mutex; // protects internal data access.
     unsigned int d_vlen;
 
 public:

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -102,7 +102,7 @@ wavfile_sink_impl::wavfile_sink_impl(const char* filename,
 
 bool wavfile_sink_impl::open(const char* filename)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     // we use the open system call to get access to the O_LARGEFILE flag.
     int fd;
@@ -135,7 +135,7 @@ bool wavfile_sink_impl::open(const char* filename)
 
 void wavfile_sink_impl::close()
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (!d_fp)
         return;
@@ -178,7 +178,7 @@ int wavfile_sink_impl::work(int noutput_items,
 
     int nwritten;
 
-    gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this block
+    gr::thread::lock_guard guard(d_mutex); // hold mutex for duration of this block
     do_update();                            // update: d_fp is reqd
     if (!d_fp)                              // drop output on the floor
         return noutput_items;
@@ -222,7 +222,7 @@ short int wavfile_sink_impl::convert_to_short(float sample)
 
 void wavfile_sink_impl::set_bits_per_sample(int bits_per_sample)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     if (bits_per_sample == 8 || bits_per_sample == 16) {
         d_bytes_per_sample_new = bits_per_sample / 8;
     }
@@ -230,7 +230,7 @@ void wavfile_sink_impl::set_bits_per_sample(int bits_per_sample)
 
 void wavfile_sink_impl::set_sample_rate(unsigned int sample_rate)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_sample_rate = sample_rate;
 }
 

--- a/gr-blocks/lib/wavfile_sink_impl.h
+++ b/gr-blocks/lib/wavfile_sink_impl.h
@@ -44,7 +44,7 @@ private:
     FILE* d_fp;
     FILE* d_new_fp;
     bool d_updated;
-    boost::mutex d_mutex;
+    std::mutex d_mutex;
 
     /*!
      * \brief Convert a sample value within [-1;+1] to a corresponding

--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -93,7 +93,7 @@ template <class IN_T, class OUT_T>
 void chunks_to_symbols_impl<IN_T, OUT_T>::set_symbol_table(
     const std::vector<OUT_T>& symbol_table)
 {
-    gr::thread::scoped_lock lock(this->d_setlock);
+    gr::thread::lock_guard lock(this->d_setlock);
     d_symbol_table = symbol_table;
 }
 
@@ -102,7 +102,7 @@ int chunks_to_symbols_impl<IN_T, OUT_T>::work(int noutput_items,
                                               gr_vector_const_void_star& input_items,
                                               gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock lock(this->d_setlock);
+    gr::thread::lock_guard lock(this->d_setlock);
     assert(noutput_items % d_D == 0);
     assert(input_items.size() == output_items.size());
     int nstreams = input_items.size();

--- a/gr-digital/lib/corr_est_cc_impl.cc
+++ b/gr-digital/lib/corr_est_cc_impl.cc
@@ -123,7 +123,7 @@ std::vector<gr_complex> corr_est_cc_impl::symbols() const { return d_symbols; }
 
 void corr_est_cc_impl::set_symbols(const std::vector<gr_complex>& symbols)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     d_symbols = symbols;
 
@@ -172,7 +172,7 @@ void corr_est_cc_impl::_set_mark_delay(unsigned int mark_delay)
 
 void corr_est_cc_impl::set_mark_delay(unsigned int mark_delay)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _set_mark_delay(mark_delay);
 }
 
@@ -202,7 +202,7 @@ void corr_est_cc_impl::_set_threshold(float threshold)
 
 void corr_est_cc_impl::set_threshold(float threshold)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _set_threshold(threshold);
 }
 
@@ -210,7 +210,7 @@ int corr_est_cc_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     const gr_complex* in = (gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -68,7 +68,7 @@ correlate_access_code_tag_bb_impl::~correlate_access_code_tag_bb_impl() {}
 
 bool correlate_access_code_tag_bb_impl::set_access_code(const std::string& access_code)
 {
-    gr::thread::scoped_lock l(d_mutex_access_code);
+    gr::thread::lock_guard l(d_mutex_access_code);
 
     d_len = access_code.length(); // # of bytes in string
     if (d_len > 64)
@@ -92,7 +92,7 @@ int correlate_access_code_tag_bb_impl::work(int noutput_items,
                                             gr_vector_const_void_star& input_items,
                                             gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(d_mutex_access_code);
+    gr::thread::lock_guard l(d_mutex_access_code);
 
     const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.h
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.h
@@ -41,7 +41,7 @@ private:
 
     pmt::pmt_t d_key, d_me; // d_key is the tag name, d_me is the block name + unique ID
 
-    gr::thread::mutex d_mutex_access_code;
+    std::mutex d_mutex_access_code;
 
 public:
     correlate_access_code_tag_bb_impl(const std::string& access_code,

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -69,7 +69,7 @@ correlate_access_code_tag_ff_impl::~correlate_access_code_tag_ff_impl() {}
 
 bool correlate_access_code_tag_ff_impl::set_access_code(const std::string& access_code)
 {
-    gr::thread::scoped_lock l(d_mutex_access_code);
+    gr::thread::lock_guard l(d_mutex_access_code);
 
     d_len = access_code.length(); // # of bytes in string
     if (d_len > 64)
@@ -93,7 +93,7 @@ int correlate_access_code_tag_ff_impl::work(int noutput_items,
                                             gr_vector_const_void_star& input_items,
                                             gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(d_mutex_access_code);
+    gr::thread::lock_guard l(d_mutex_access_code);
 
     const float* in = (const float*)input_items[0];
     float* out = (float*)output_items[0];

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.h
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.h
@@ -41,7 +41,7 @@ private:
 
     pmt::pmt_t d_key, d_me; // d_key is the tag name, d_me is the block name + unique ID
 
-    gr::thread::mutex d_mutex_access_code;
+    std::mutex d_mutex_access_code;
 
 public:
     correlate_access_code_tag_ff_impl(const std::string& access_code,

--- a/gr-digital/lib/map_bb_impl.cc
+++ b/gr-digital/lib/map_bb_impl.cc
@@ -47,7 +47,7 @@ map_bb_impl::~map_bb_impl() {}
 
 void map_bb_impl::set_map(const std::vector<int>& map)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     for (int i = 0; i < 0x100; i++)
         d_map[i] = i;
@@ -69,7 +69,7 @@ int map_bb_impl::work(int noutput_items,
                       gr_vector_const_void_star& input_items,
                       gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];

--- a/gr-digital/lib/map_bb_impl.h
+++ b/gr-digital/lib/map_bb_impl.h
@@ -33,7 +33,7 @@ class map_bb_impl : public map_bb
 {
 private:
     unsigned char d_map[0x100];
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
 
 public:
     map_bb_impl(const std::vector<int>& map);

--- a/gr-digital/lib/packet_headergenerator_bb_impl.cc
+++ b/gr-digital/lib/packet_headergenerator_bb_impl.cc
@@ -67,7 +67,7 @@ packet_headergenerator_bb_impl::packet_headergenerator_bb_impl(
 void packet_headergenerator_bb_impl::set_header_formatter(
     packet_header_default::sptr header_formatter)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_formatter = header_formatter;
 }
 packet_headergenerator_bb_impl::~packet_headergenerator_bb_impl() {}
@@ -77,7 +77,7 @@ int packet_headergenerator_bb_impl::work(int noutput_items,
                                          gr_vector_const_void_star& input_items,
                                          gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     unsigned char* out = (unsigned char*)output_items[0];
 
     std::vector<tag_t> tags;

--- a/gr-digital/lib/protocol_formatter_bb_impl.cc
+++ b/gr-digital/lib/protocol_formatter_bb_impl.cc
@@ -59,7 +59,7 @@ protocol_formatter_bb_impl::~protocol_formatter_bb_impl() {}
 
 void protocol_formatter_bb_impl::set_header_format(header_format_base::sptr& format)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_format = format;
 }
 
@@ -68,7 +68,7 @@ int protocol_formatter_bb_impl::work(int noutput_items,
                                      gr_vector_const_void_star& input_items,
                                      gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     unsigned char* out = (unsigned char*)output_items[0];
     const unsigned char* in = (const unsigned char*)input_items[0];
 

--- a/gr-fft/include/gnuradio/fft/fft.h
+++ b/gr-fft/include/gnuradio/fft/fft.h
@@ -29,7 +29,7 @@
 
 #include <gnuradio/fft/api.h>
 #include <gnuradio/gr_complex.h>
-#include <boost/thread.hpp>
+#include <mutex>
 
 namespace gr {
 namespace fft {
@@ -58,11 +58,10 @@ FFT_API void free(void* b);
 class FFT_API planner
 {
 public:
-    typedef boost::mutex::scoped_lock scoped_lock;
     /*!
      * Return reference to planner mutex
      */
-    static boost::mutex& mutex();
+    static std::mutex& mutex();
 };
 
 /*!

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -62,8 +62,8 @@ void ctrlport_probe_psd_impl::forecast(int noutput_items,
 }
 
 //    boost::shared_mutex mutex_buffer;
-//    mutable boost::mutex mutex_notify;
-//    boost::condition_variable condition_buffer_ready;
+//    mutable std::mutex mutex_notify;
+//    std::condition_variable condition_buffer_ready;
 std::vector<gr_complex> ctrlport_probe_psd_impl::get()
 {
     mutex_buffer.lock();
@@ -71,7 +71,7 @@ std::vector<gr_complex> ctrlport_probe_psd_impl::get()
     mutex_buffer.unlock();
 
     // wait for condition
-    boost::mutex::scoped_lock lock(mutex_notify);
+    gr::thread::unique_lock lock(mutex_notify);
     condition_buffer_ready.wait(lock);
 
     mutex_buffer.lock();

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -61,9 +61,6 @@ void ctrlport_probe_psd_impl::forecast(int noutput_items,
         ninput_items_required[i] = d_len;
 }
 
-//    boost::shared_mutex mutex_buffer;
-//    mutable std::mutex mutex_notify;
-//    std::condition_variable condition_buffer_ready;
 std::vector<gr_complex> ctrlport_probe_psd_impl::get()
 {
     mutex_buffer.lock();

--- a/gr-fft/lib/ctrlport_probe_psd_impl.h
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.h
@@ -38,8 +38,8 @@ private:
     std::string d_desc;
     size_t d_len;
     boost::shared_mutex mutex_buffer;
-    mutable boost::mutex mutex_notify;
-    boost::condition_variable condition_buffer_ready;
+    mutable std::mutex mutex_notify;
+    std::condition_variable condition_buffer_ready;
 
     std::vector<gr_complex> d_buffer;
     gr::fft::fft_complex d_fft;

--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -27,6 +27,7 @@
 #include <gnuradio/filter/api.h>
 #include <gnuradio/gr_complex.h>
 #include <volk/volk_alloc.hh>
+#include <memory>
 #include <vector>
 
 namespace gr {

--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -50,7 +50,7 @@ filterbank_vcvcf_impl::~filterbank_vcvcf_impl() {}
 
 void filterbank_vcvcf_impl::set_taps(const std::vector<std::vector<float>>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     filterbank::set_taps(taps);
     set_history(d_ntaps + 1);
     d_updated = true;
@@ -68,7 +68,7 @@ int filterbank_vcvcf_impl::general_work(int noutput_items,
                                         gr_vector_const_void_star& input_items,
                                         gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     gr_complex* in = (gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];

--- a/gr-filter/lib/filterbank_vcvcf_impl.h
+++ b/gr-filter/lib/filterbank_vcvcf_impl.h
@@ -35,7 +35,7 @@ class FILTER_API filterbank_vcvcf_impl : public filterbank_vcvcf, kernel::filter
 {
 private:
     bool d_updated;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     filterbank_vcvcf_impl(const std::vector<std::vector<float>>& taps);

--- a/gr-filter/lib/fir_filter.cc
+++ b/gr-filter/lib/fir_filter.cc
@@ -23,6 +23,7 @@
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/filter/fir_filter.h>
 #include <volk/volk.h>
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 

--- a/gr-filter/lib/fir_filter_blk_impl.cc
+++ b/gr-filter/lib/fir_filter_blk_impl.cc
@@ -65,7 +65,7 @@ fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::~fir_filter_blk_impl()
 template <class IN_T, class OUT_T, class TAP_T>
 void fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::set_taps(const std::vector<TAP_T>& taps)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
     d_fir->set_taps(taps);
     d_updated = true;
 }
@@ -81,7 +81,7 @@ int fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::work(int noutput_items,
                                                   gr_vector_const_void_star& input_items,
                                                   gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock l(this->d_setlock);
+    gr::thread::lock_guard l(this->d_setlock);
 
     const IN_T* in = (const IN_T*)input_items[0];
     OUT_T* out = (OUT_T*)output_items[0];

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
@@ -69,7 +69,7 @@ void pfb_arb_resampler_ccc_impl::forecast(int noutput_items,
 
 void pfb_arb_resampler_ccc_impl::set_taps(const std::vector<gr_complex>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_resamp->set_taps(taps);
     set_history(d_resamp->taps_per_filter());
@@ -85,7 +85,7 @@ void pfb_arb_resampler_ccc_impl::print_taps() { d_resamp->print_taps(); }
 
 void pfb_arb_resampler_ccc_impl::set_rate(float rate)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_resamp->set_rate(rate);
     set_relative_rate(rate);
@@ -93,7 +93,7 @@ void pfb_arb_resampler_ccc_impl::set_rate(float rate)
 
 void pfb_arb_resampler_ccc_impl::set_phase(float ph)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_resamp->set_phase(ph);
 }
 
@@ -131,7 +131,7 @@ int pfb_arb_resampler_ccc_impl::general_work(int noutput_items,
                                              gr_vector_const_void_star& input_items,
                                              gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     gr_complex* in = (gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
@@ -36,7 +36,7 @@ class FILTER_API pfb_arb_resampler_ccc_impl : public pfb_arb_resampler_ccc
 private:
     kernel::pfb_arb_resampler_ccc* d_resamp;
     bool d_updated;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     pfb_arb_resampler_ccc_impl(float rate,

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
@@ -71,7 +71,7 @@ void pfb_arb_resampler_ccf_impl::forecast(int noutput_items,
 
 void pfb_arb_resampler_ccf_impl::set_taps(const std::vector<float>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_resamp->set_taps(taps);
     set_history(d_resamp->taps_per_filter());
@@ -87,7 +87,7 @@ void pfb_arb_resampler_ccf_impl::print_taps() { d_resamp->print_taps(); }
 
 void pfb_arb_resampler_ccf_impl::set_rate(float rate)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_resamp->set_rate(rate);
     set_relative_rate(rate);
@@ -95,7 +95,7 @@ void pfb_arb_resampler_ccf_impl::set_rate(float rate)
 
 void pfb_arb_resampler_ccf_impl::set_phase(float ph)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_resamp->set_phase(ph);
 }
 
@@ -133,7 +133,7 @@ int pfb_arb_resampler_ccf_impl::general_work(int noutput_items,
                                              gr_vector_const_void_star& input_items,
                                              gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     gr_complex* in = (gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
@@ -36,7 +36,7 @@ class FILTER_API pfb_arb_resampler_ccf_impl : public pfb_arb_resampler_ccf
 private:
     kernel::pfb_arb_resampler_ccf* d_resamp;
     bool d_updated;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     pfb_arb_resampler_ccf_impl(float rate,

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
@@ -71,7 +71,7 @@ void pfb_arb_resampler_fff_impl::forecast(int noutput_items,
 
 void pfb_arb_resampler_fff_impl::set_taps(const std::vector<float>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_resamp->set_taps(taps);
     set_history(d_resamp->taps_per_filter());
@@ -87,7 +87,7 @@ void pfb_arb_resampler_fff_impl::print_taps() { d_resamp->print_taps(); }
 
 void pfb_arb_resampler_fff_impl::set_rate(float rate)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     d_resamp->set_rate(rate);
     set_relative_rate(rate);
@@ -95,7 +95,7 @@ void pfb_arb_resampler_fff_impl::set_rate(float rate)
 
 void pfb_arb_resampler_fff_impl::set_phase(float ph)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_resamp->set_phase(ph);
 }
 
@@ -133,7 +133,7 @@ int pfb_arb_resampler_fff_impl::general_work(int noutput_items,
                                              gr_vector_const_void_star& input_items,
                                              gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     float* in = (float*)input_items[0];
     float* out = (float*)output_items[0];

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.h
@@ -36,7 +36,7 @@ class FILTER_API pfb_arb_resampler_fff_impl : public pfb_arb_resampler_fff
 private:
     kernel::pfb_arb_resampler_fff* d_resamp;
     bool d_updated;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     pfb_arb_resampler_fff_impl(float rate,

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.cc
@@ -107,7 +107,7 @@ pfb_channelizer_ccf_impl::~pfb_channelizer_ccf_impl() { delete[] d_idxlut; }
 
 void pfb_channelizer_ccf_impl::set_taps(const std::vector<float>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     polyphase_filterbank::set_taps(taps);
     set_history(d_taps_per_filter + 1);
@@ -123,7 +123,7 @@ std::vector<std::vector<float>> pfb_channelizer_ccf_impl::taps() const
 
 void pfb_channelizer_ccf_impl::set_channel_map(const std::vector<int>& map)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (!map.empty()) {
         unsigned int max = (unsigned int)*std::max_element(map.begin(), map.end());
@@ -142,7 +142,7 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
                                            gr_vector_const_void_star& input_items,
                                            gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     gr_complex* in = (gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.h
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.h
@@ -42,7 +42,7 @@ private:
     int d_rate_ratio;
     int d_output_multiple;
     std::vector<int> d_channel_map;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     pfb_channelizer_ccf_impl(unsigned int nfilts,

--- a/gr-filter/lib/pfb_decimator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.cc
@@ -98,7 +98,7 @@ pfb_decimator_ccf_impl::~pfb_decimator_ccf_impl() { delete[] d_rotator; }
 
 void pfb_decimator_ccf_impl::set_taps(const std::vector<float>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     polyphase_filterbank::set_taps(taps);
     set_history(d_taps_per_filter);
@@ -114,7 +114,7 @@ std::vector<std::vector<float>> pfb_decimator_ccf_impl::taps() const
 
 void pfb_decimator_ccf_impl::set_channel(const unsigned int chan)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
     d_chan = chan;
 }
 
@@ -122,7 +122,7 @@ int pfb_decimator_ccf_impl::work(int noutput_items,
                                  gr_vector_const_void_star& input_items,
                                  gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (d_updated) {
         d_updated = false;

--- a/gr-filter/lib/pfb_decimator_ccf_impl.h
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.h
@@ -42,7 +42,7 @@ private:
     bool d_use_fft_filters;
     gr_complex* d_rotator;
     gr_complex* d_tmp;         // used for fft filters
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
     inline int work_fir_exp(int noutput_items,
                             gr_vector_const_void_star& input_items,

--- a/gr-filter/lib/pfb_interpolator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_interpolator_ccf_impl.cc
@@ -54,7 +54,7 @@ pfb_interpolator_ccf_impl::~pfb_interpolator_ccf_impl() {}
 
 void pfb_interpolator_ccf_impl::set_taps(const std::vector<float>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     polyphase_filterbank::set_taps(taps);
     set_history(d_taps_per_filter);

--- a/gr-filter/lib/pfb_interpolator_ccf_impl.h
+++ b/gr-filter/lib/pfb_interpolator_ccf_impl.h
@@ -39,7 +39,7 @@ class FILTER_API pfb_interpolator_ccf_impl : public pfb_interpolator_ccf,
 private:
     bool d_updated;
     unsigned int d_rate;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
 public:
     pfb_interpolator_ccf_impl(unsigned int interp, const std::vector<float>& taps);

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -88,7 +88,7 @@ pfb_synthesizer_ccf_impl::~pfb_synthesizer_ccf_impl()
 
 void pfb_synthesizer_ccf_impl::set_taps(const std::vector<float>& taps)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     // The different modes, 1x or 2x the sampling rate, have
     // different filtering partitions.
@@ -212,7 +212,7 @@ std::vector<std::vector<float>> pfb_synthesizer_ccf_impl::taps() const { return 
 
 void pfb_synthesizer_ccf_impl::set_channel_map(const std::vector<int>& map)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     if (!map.empty()) {
         int max = *std::max_element(map.begin(), map.end());
@@ -234,7 +234,7 @@ int pfb_synthesizer_ccf_impl::work(int noutput_items,
                                    gr_vector_const_void_star& input_items,
                                    gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_mutex);
+    gr::thread::lock_guard guard(d_mutex);
 
     gr_complex* in = (gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.h
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.h
@@ -48,7 +48,7 @@ private:
     int d_state;
     std::vector<int> d_channel_map;
     unsigned int d_twox;
-    gr::thread::mutex d_mutex; // mutex to protect set/work access
+    std::mutex d_mutex; // mutex to protect set/work access
 
     /*!
      * \brief Tap setting algorithm for critically sampled channels

--- a/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
+++ b/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
@@ -116,7 +116,7 @@ public:
 
 protected:
 private:
-    gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
     int64_t _dataPoints;
     std::string _title;
     double _centerFrequency;

--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -165,7 +165,7 @@ void SpectrumGUIClass::setDisplayTitle(const std::string newString)
 
 bool SpectrumGUIClass::getWindowOpenFlag()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     bool returnFlag = false;
     returnFlag = _windowOpennedFlag;
     return returnFlag;
@@ -174,7 +174,7 @@ bool SpectrumGUIClass::getWindowOpenFlag()
 
 void SpectrumGUIClass::setWindowOpenFlag(const bool newFlag)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _windowOpennedFlag = newFlag;
 }
 
@@ -182,7 +182,7 @@ void SpectrumGUIClass::setFrequencyRange(const double centerFreq,
                                          const double startFreq,
                                          const double stopFreq)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _centerFrequency = centerFreq;
     _startFrequency = startFreq;
     _stopFrequency = stopFreq;
@@ -194,7 +194,7 @@ void SpectrumGUIClass::setFrequencyRange(const double centerFreq,
 
 double SpectrumGUIClass::getStartFrequency()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     double returnValue = 0.0;
     returnValue = _startFrequency;
     return returnValue;
@@ -202,7 +202,7 @@ double SpectrumGUIClass::getStartFrequency()
 
 double SpectrumGUIClass::getStopFrequency()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     double returnValue = 0.0;
     returnValue = _stopFrequency;
     return returnValue;
@@ -210,7 +210,7 @@ double SpectrumGUIClass::getStopFrequency()
 
 double SpectrumGUIClass::getCenterFrequency()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     double returnValue = 0.0;
     returnValue = _centerFrequency;
     return returnValue;
@@ -227,7 +227,7 @@ void SpectrumGUIClass::updateWindow(const bool updateDisplayFlag,
                                     const gr::high_res_timer_type timestamp,
                                     const bool lastOfMultipleFFTUpdateFlag)
 {
-    // gr::thread::scoped_lock lock(d_mutex);
+    // gr::thread::lock_guard lock(d_mutex);
     int64_t bufferSize = inputBufferSize;
     bool repeatDataFlag = false;
     if (bufferSize > _dataPoints) {
@@ -306,7 +306,7 @@ void SpectrumGUIClass::updateWindow(const bool updateDisplayFlag,
 
 float SpectrumGUIClass::getPowerValue()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     float returnValue = 0;
     returnValue = _powerValue;
     return returnValue;
@@ -314,13 +314,13 @@ float SpectrumGUIClass::getPowerValue()
 
 void SpectrumGUIClass::setPowerValue(const float value)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _powerValue = value;
 }
 
 int SpectrumGUIClass::getWindowType()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     int returnValue = 0;
     returnValue = _windowType;
     return returnValue;
@@ -328,7 +328,7 @@ int SpectrumGUIClass::getWindowType()
 
 void SpectrumGUIClass::setWindowType(const int newType)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _windowType = newType;
 }
 
@@ -341,7 +341,7 @@ int SpectrumGUIClass::getFFTSize()
 
 int SpectrumGUIClass::getFFTSizeIndex()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     int fftsize = getFFTSize();
     int rv = 0;
     switch (fftsize) {
@@ -372,13 +372,13 @@ int SpectrumGUIClass::getFFTSizeIndex()
 
 void SpectrumGUIClass::setFFTSize(const int newSize)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _fftSize = newSize;
 }
 
 gr::high_res_timer_type SpectrumGUIClass::getLastGUIUpdateTime()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     gr::high_res_timer_type returnValue;
     returnValue = _lastGUIUpdateTime;
     return returnValue;
@@ -386,13 +386,13 @@ gr::high_res_timer_type SpectrumGUIClass::getLastGUIUpdateTime()
 
 void SpectrumGUIClass::setLastGUIUpdateTime(const gr::high_res_timer_type newTime)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _lastGUIUpdateTime = newTime;
 }
 
 unsigned int SpectrumGUIClass::getPendingGUIUpdateEvents()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     unsigned int returnValue = 0;
     returnValue = _pendingGUIUpdateEventsCount;
     return returnValue;
@@ -400,13 +400,13 @@ unsigned int SpectrumGUIClass::getPendingGUIUpdateEvents()
 
 void SpectrumGUIClass::incrementPendingGUIUpdateEvents()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _pendingGUIUpdateEventsCount++;
 }
 
 void SpectrumGUIClass::decrementPendingGUIUpdateEvents()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     if (_pendingGUIUpdateEventsCount > 0) {
         _pendingGUIUpdateEventsCount--;
     }
@@ -414,20 +414,20 @@ void SpectrumGUIClass::decrementPendingGUIUpdateEvents()
 
 void SpectrumGUIClass::resetPendingGUIUpdateEvents()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _pendingGUIUpdateEventsCount = 0;
 }
 
 
 QWidget* SpectrumGUIClass::qwidget()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     return (QWidget*)_spectrumDisplayForm;
 }
 
 void SpectrumGUIClass::setTimeDomainAxis(double min, double max)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _spectrumDisplayForm->setTimeDomainAxis(min, max);
 }
 
@@ -436,45 +436,45 @@ void SpectrumGUIClass::setConstellationAxis(double xmin,
                                             double ymin,
                                             double ymax)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _spectrumDisplayForm->setConstellationAxis(xmin, xmax, ymin, ymax);
 }
 
 void SpectrumGUIClass::setConstellationPenSize(int size)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _spectrumDisplayForm->setConstellationPenSize(size);
 }
 
 
 void SpectrumGUIClass::setFrequencyAxis(double min, double max)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _spectrumDisplayForm->setFrequencyAxis(min, max);
 }
 
 void SpectrumGUIClass::setUpdateTime(double t)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _updateTime = t;
     _spectrumDisplayForm->setUpdateTime(_updateTime);
 }
 
 void SpectrumGUIClass::enableRFFreq(bool en)
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     _spectrumDisplayForm->toggleRFFrequencies(en);
 }
 
 bool SpectrumGUIClass::checkClicked()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     return _spectrumDisplayForm->checkClicked();
 }
 
 float SpectrumGUIClass::getClickedFreq()
 {
-    gr::thread::scoped_lock lock(d_mutex);
+    gr::thread::lock_guard lock(d_mutex);
     return _spectrumDisplayForm->getClickedFreq();
 }
 

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -220,7 +220,7 @@ void const_sink_c_impl::set_trigger_mode(trigger_mode mode,
                                          int channel,
                                          const std::string& tag_key)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     d_trigger_mode = mode;
     d_trigger_slope = slope;
@@ -278,7 +278,7 @@ double const_sink_c_impl::line_alpha(unsigned int which)
 
 void const_sink_c_impl::set_nsamps(const int newsize)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     if (newsize != d_size) {
         // Set new size and reset buffer index
@@ -320,7 +320,7 @@ void const_sink_c_impl::disable_legend() { d_main_gui->disableLegend(); }
 
 void const_sink_c_impl::reset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _reset();
 }
 

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -292,7 +292,7 @@ void freq_sink_c_impl::set_trigger_mode(trigger_mode mode,
                                         int channel,
                                         const std::string& tag_key)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     d_trigger_mode = mode;
     d_trigger_level = level;
@@ -369,7 +369,7 @@ void freq_sink_c_impl::disable_legend() { d_main_gui->disableLegend(); }
 
 void freq_sink_c_impl::reset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _reset();
 }
 
@@ -404,7 +404,7 @@ void freq_sink_c_impl::fft(float* data_out, const gr_complex* data_in, int size)
 
 bool freq_sink_c_impl::windowreset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     filter::firdes::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
@@ -426,7 +426,7 @@ void freq_sink_c_impl::buildwindow()
 
 bool freq_sink_c_impl::fftresize()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     int newfftsize = d_main_gui->getFFTSize();
     d_fftavg = d_main_gui->getFFTAverage();
@@ -576,7 +576,7 @@ int freq_sink_c_impl::work(int noutput_items,
     check_clicked();
     _gui_update_trigger();
 
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     for (d_index = 0; d_index < noutput_items; d_index += d_fftsize) {
 
         if ((gr::high_res_timer_now() - d_last_time) > d_update_time) {

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -294,7 +294,7 @@ void freq_sink_f_impl::set_trigger_mode(trigger_mode mode,
                                         int channel,
                                         const std::string& tag_key)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     d_trigger_mode = mode;
     d_trigger_level = level;
@@ -371,7 +371,7 @@ void freq_sink_f_impl::disable_legend() { d_main_gui->disableLegend(); }
 
 void freq_sink_f_impl::reset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _reset();
 }
 
@@ -407,7 +407,7 @@ void freq_sink_f_impl::fft(float* data_out, const float* data_in, int size)
 
 bool freq_sink_f_impl::windowreset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     filter::firdes::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
@@ -429,7 +429,7 @@ void freq_sink_f_impl::buildwindow()
 
 bool freq_sink_f_impl::fftresize()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     int newfftsize = d_main_gui->getFFTSize();
     d_fftavg = d_main_gui->getFFTAverage();
@@ -579,7 +579,7 @@ int freq_sink_f_impl::work(int noutput_items,
     check_clicked();
     _gui_update_trigger();
 
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     for (d_index = 0; d_index < noutput_items; d_index += d_fftsize) {
 
         if ((gr::high_res_timer_now() - d_last_time) > d_update_time) {

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -252,7 +252,7 @@ double histogram_sink_f_impl::line_alpha(unsigned int which)
 
 void histogram_sink_f_impl::set_nsamps(const int newsize)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     if (newsize != d_size) {
         // Resize residbuf and replace data
@@ -275,7 +275,7 @@ void histogram_sink_f_impl::set_nsamps(const int newsize)
 
 void histogram_sink_f_impl::set_bins(const int bins)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     d_bins = bins;
     d_main_gui->setNumBins(d_bins);
 }

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -246,7 +246,7 @@ void number_sink_impl::enable_autoscale(bool en) { d_main_gui->autoScale(en); }
 
 void number_sink_impl::reset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _reset();
 }
 
@@ -297,7 +297,7 @@ int number_sink_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     _gui_update_trigger();
 

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -233,7 +233,7 @@ void time_raster_sink_b_impl::set_num_rows(double rows) { d_main_gui->setNumRows
 void time_raster_sink_b_impl::set_num_cols(double cols)
 {
     if (d_cols != cols) {
-        gr::thread::scoped_lock lock(d_setlock);
+        gr::thread::lock_guard lock(d_setlock);
 
         d_qApplication->postEvent(d_main_gui, new TimeRasterSetSize(d_rows, cols));
 

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -228,7 +228,7 @@ void time_raster_sink_f_impl::set_samp_rate(const double samp_rate)
 
 void time_raster_sink_f_impl::set_num_rows(double rows)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     d_rows = rows;
     d_main_gui->setNumRows(rows);
 }
@@ -236,7 +236,7 @@ void time_raster_sink_f_impl::set_num_rows(double rows)
 void time_raster_sink_f_impl::set_num_cols(double cols)
 {
     if (d_cols != cols) {
-        gr::thread::scoped_lock lock(d_setlock);
+        gr::thread::lock_guard lock(d_setlock);
 
         d_qApplication->postEvent(d_main_gui, new TimeRasterSetSize(d_rows, cols));
 

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -235,7 +235,7 @@ void time_sink_c_impl::set_trigger_mode(trigger_mode mode,
                                         int channel,
                                         const std::string& tag_key)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     d_trigger_mode = mode;
     d_trigger_slope = slope;
@@ -305,7 +305,7 @@ double time_sink_c_impl::line_alpha(unsigned int which)
 void time_sink_c_impl::set_nsamps(const int newsize)
 {
     if (newsize != d_size) {
-        gr::thread::scoped_lock lock(d_setlock);
+        gr::thread::lock_guard lock(d_setlock);
 
         // Set new size and reset buffer index
         // (throws away any currently held data, but who cares?)
@@ -345,7 +345,7 @@ void time_sink_c_impl::set_nsamps(const int newsize)
 
 void time_sink_c_impl::set_samp_rate(const double samp_rate)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     d_samp_rate = samp_rate;
     d_main_gui->setSampleRate(d_samp_rate);
 }
@@ -390,7 +390,7 @@ void time_sink_c_impl::disable_legend() { d_main_gui->disableLegend(); }
 
 void time_sink_c_impl::reset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _reset();
 }
 
@@ -564,7 +564,7 @@ int time_sink_c_impl::work(int noutput_items,
     _npoints_resize();
     _gui_update_trigger();
 
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     int nfill = d_end - d_index;                 // how much room left in buffers
     int nitems = std::min(noutput_items, nfill); // num items we can put in buffers

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -230,7 +230,7 @@ void time_sink_f_impl::set_trigger_mode(trigger_mode mode,
                                         int channel,
                                         const std::string& tag_key)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     d_trigger_mode = mode;
     d_trigger_slope = slope;
@@ -300,7 +300,7 @@ double time_sink_f_impl::line_alpha(unsigned int which)
 void time_sink_f_impl::set_nsamps(const int newsize)
 {
     if (newsize != d_size) {
-        gr::thread::scoped_lock lock(d_setlock);
+        gr::thread::lock_guard lock(d_setlock);
 
         // Set new size and reset buffer index
         // (throws away any currently held data, but who cares?)
@@ -338,7 +338,7 @@ void time_sink_f_impl::set_nsamps(const int newsize)
 
 void time_sink_f_impl::set_samp_rate(const double samp_rate)
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     d_samp_rate = samp_rate;
     d_main_gui->setSampleRate(d_samp_rate);
 }
@@ -383,7 +383,7 @@ void time_sink_f_impl::disable_legend() { d_main_gui->disableLegend(); }
 
 void time_sink_f_impl::reset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
     _reset();
 }
 
@@ -551,7 +551,7 @@ int time_sink_f_impl::work(int noutput_items,
     _npoints_resize();
     _gui_update_trigger();
 
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     int nfill = d_end - d_index;                 // how much room left in buffers
     int nitems = std::min(noutput_items, nfill); // num items we can put in buffers

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -335,7 +335,7 @@ void waterfall_sink_c_impl::fft(float* data_out, const gr_complex* data_in, int 
 
 void waterfall_sink_c_impl::windowreset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     filter::firdes::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
@@ -355,7 +355,7 @@ void waterfall_sink_c_impl::buildwindow()
 
 void waterfall_sink_c_impl::fftresize()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     int newfftsize = d_main_gui->getFFTSize();
     d_fftavg = d_main_gui->getFFTAverage();

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -341,7 +341,7 @@ void waterfall_sink_f_impl::fft(float* data_out, const float* data_in, int size)
 
 void waterfall_sink_f_impl::windowreset()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     filter::firdes::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
@@ -361,7 +361,7 @@ void waterfall_sink_f_impl::buildwindow()
 
 void waterfall_sink_f_impl::fftresize()
 {
-    gr::thread::scoped_lock lock(d_setlock);
+    gr::thread::lock_guard lock(d_setlock);
 
     int newfftsize = d_main_gui->getFFTSize();
     d_fftavg = d_main_gui->getFFTAverage();

--- a/gr-trellis/lib/encoder_impl.cc
+++ b/gr-trellis/lib/encoder_impl.cc
@@ -59,21 +59,21 @@ encoder_impl<IN_T, OUT_T>::encoder_impl(const fsm& FSM, int ST, int K, bool B)
 template <class IN_T, class OUT_T>
 void encoder_impl<IN_T, OUT_T>::set_FSM(const fsm& FSM)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_FSM = FSM;
 }
 
 template <class IN_T, class OUT_T>
 void encoder_impl<IN_T, OUT_T>::set_ST(int ST)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_ST = ST;
 }
 
 template <class IN_T, class OUT_T>
 void encoder_impl<IN_T, OUT_T>::set_K(int K)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_K = K;
 }
 
@@ -87,7 +87,7 @@ int encoder_impl<IN_T, OUT_T>::work(int noutput_items,
                                     gr_vector_const_void_star& input_items,
                                     gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     int ST_tmp = 0;
 
     if (d_B) { // blockwise operation

--- a/gr-trellis/lib/metrics_impl.cc
+++ b/gr-trellis/lib/metrics_impl.cc
@@ -63,7 +63,7 @@ metrics_impl<T>::metrics_impl(int O,
 template <class T>
 void metrics_impl<T>::set_O(int O)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_O = O;
     this->set_relative_rate((uint64_t)d_O, (uint64_t)d_D);
     this->set_output_multiple((int)d_O);
@@ -72,7 +72,7 @@ void metrics_impl<T>::set_O(int O)
 template <class T>
 void metrics_impl<T>::set_D(int D)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_D = D;
     this->set_relative_rate((uint64_t)d_O, (uint64_t)d_D);
 }
@@ -80,14 +80,14 @@ void metrics_impl<T>::set_D(int D)
 template <class T>
 void metrics_impl<T>::set_TYPE(digital::trellis_metric_type_t type)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_TYPE = type;
 }
 
 template <class T>
 void metrics_impl<T>::set_TABLE(const std::vector<T>& table)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_TABLE = table;
 }
 
@@ -112,7 +112,7 @@ int metrics_impl<T>::general_work(int noutput_items,
                                   gr_vector_const_void_star& input_items,
                                   gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     int nstreams = input_items.size();
 
     for (int m = 0; m < nstreams; m++) {

--- a/gr-trellis/lib/pccc_decoder_combined_blk_impl.cc
+++ b/gr-trellis/lib/pccc_decoder_combined_blk_impl.cc
@@ -113,7 +113,7 @@ pccc_decoder_combined_blk_impl<IN_T, OUT_T>::~pccc_decoder_combined_blk_impl()
 template <class IN_T, class OUT_T>
 void pccc_decoder_combined_blk_impl<IN_T, OUT_T>::set_scaling(float scaling)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_scaling = scaling;
 }
 
@@ -134,7 +134,7 @@ int pccc_decoder_combined_blk_impl<IN_T, OUT_T>::general_work(
     gr_vector_const_void_star& input_items,
     gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     int nblocks = noutput_items / d_blocklength;
 
     float (*p2min)(float, float) = NULL;

--- a/gr-trellis/lib/permutation_impl.cc
+++ b/gr-trellis/lib/permutation_impl.cc
@@ -59,20 +59,20 @@ permutation_impl::permutation_impl(int K,
 
 void permutation_impl::set_K(int K)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_K = K;
     set_output_multiple(d_K * d_SYMS_PER_BLOCK);
 }
 
 void permutation_impl::set_TABLE(const std::vector<int>& table)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_TABLE = table;
 }
 
 void permutation_impl::set_SYMS_PER_BLOCK(int spb)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_SYMS_PER_BLOCK = spb;
     set_output_multiple(d_K * d_SYMS_PER_BLOCK);
 }
@@ -83,7 +83,7 @@ int permutation_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     int nstreams = input_items.size();
 
     for (int m = 0; m < nstreams; m++) {

--- a/gr-trellis/lib/sccc_decoder_combined_blk_impl.cc
+++ b/gr-trellis/lib/sccc_decoder_combined_blk_impl.cc
@@ -112,7 +112,7 @@ sccc_decoder_combined_blk_impl<IN_T, OUT_T>::~sccc_decoder_combined_blk_impl()
 template <class IN_T, class OUT_T>
 void sccc_decoder_combined_blk_impl<IN_T, OUT_T>::set_scaling(float scaling)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_scaling = scaling;
 }
 
@@ -133,7 +133,7 @@ int sccc_decoder_combined_blk_impl<IN_T, OUT_T>::general_work(
     gr_vector_const_void_star& input_items,
     gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     int nblocks = noutput_items / d_blocklength;
     float (*p2min)(float, float) = NULL;
 

--- a/gr-trellis/lib/siso_combined_f_impl.cc
+++ b/gr-trellis/lib/siso_combined_f_impl.cc
@@ -106,66 +106,66 @@ siso_combined_f_impl::siso_combined_f_impl(const fsm& FSM,
 
 void siso_combined_f_impl::set_FSM(const fsm& FSM)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_FSM = FSM;
     recalculate();
 }
 
 void siso_combined_f_impl::set_K(int K)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_K = K;
     recalculate();
 }
 
 void siso_combined_f_impl::set_POSTI(bool POSTI)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_POSTI = POSTI;
     recalculate();
 }
 
 void siso_combined_f_impl::set_POSTO(bool POSTO)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_POSTO = POSTO;
     recalculate();
 }
 
 void siso_combined_f_impl::set_D(int D)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_D = D;
     recalculate();
 }
 
 void siso_combined_f_impl::set_S0(int S0)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_S0 = S0;
 }
 
 void siso_combined_f_impl::set_SK(int SK)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_SK = SK;
 }
 
 void siso_combined_f_impl::set_SISO_TYPE(trellis::siso_type_t type)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_SISO_TYPE = type;
 }
 
 void siso_combined_f_impl::set_TABLE(const std::vector<float>& table)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_TABLE = table;
 }
 
 void siso_combined_f_impl::set_TYPE(digital::trellis_metric_type_t type)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_TYPE = type;
 }
 
@@ -202,7 +202,7 @@ int siso_combined_f_impl::general_work(int noutput_items,
                                        gr_vector_const_void_star& input_items,
                                        gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     int nstreams = output_items.size();
     // printf("general_work:Streams:  %d\n",nstreams);
 

--- a/gr-trellis/lib/siso_f_impl.cc
+++ b/gr-trellis/lib/siso_f_impl.cc
@@ -87,47 +87,47 @@ siso_f_impl::siso_f_impl(
 
 void siso_f_impl::set_FSM(const fsm& FSM)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_FSM = FSM;
     recalculate();
 }
 
 void siso_f_impl::set_K(int K)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_K = K;
     recalculate();
 }
 
 void siso_f_impl::set_POSTI(bool POSTI)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_POSTI = POSTI;
     recalculate();
 }
 
 void siso_f_impl::set_POSTO(bool POSTO)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_POSTO = POSTO;
     recalculate();
 }
 
 void siso_f_impl::set_S0(int S0)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_S0 = S0;
 }
 
 void siso_f_impl::set_SK(int SK)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_SK = SK;
 }
 
 void siso_f_impl::set_SISO_TYPE(trellis::siso_type_t type)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     d_SISO_TYPE = type;
 }
 
@@ -162,7 +162,7 @@ int siso_f_impl::general_work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
+    gr::thread::lock_guard guard(d_setlock);
     int nstreams = output_items.size();
     // printf("general_work:Streams:  %d\n",nstreams);
     int multiple;

--- a/gr-trellis/lib/viterbi_combined_impl.cc
+++ b/gr-trellis/lib/viterbi_combined_impl.cc
@@ -73,7 +73,7 @@ viterbi_combined_impl<IN_T, OUT_T>::viterbi_combined_impl(
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_K(int K)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_K = K;
     this->set_output_multiple(d_K);
 }
@@ -81,7 +81,7 @@ void viterbi_combined_impl<IN_T, OUT_T>::set_K(int K)
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_D(int D)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_D = D;
     this->set_relative_rate(1, (uint64_t)d_D);
 }
@@ -89,35 +89,35 @@ void viterbi_combined_impl<IN_T, OUT_T>::set_D(int D)
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_FSM(const fsm& FSM)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_FSM = FSM;
 }
 
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_S0(int S0)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_S0 = S0;
 }
 
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_SK(int SK)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_SK = SK;
 }
 
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_TYPE(digital::trellis_metric_type_t type)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_TYPE = type;
 }
 
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::set_TABLE(const std::vector<IN_T>& table)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_TABLE = table;
 }
 
@@ -144,7 +144,7 @@ int viterbi_combined_impl<IN_T, OUT_T>::general_work(
     gr_vector_const_void_star& input_items,
     gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     int nstreams = input_items.size();
     int nblocks = noutput_items / d_K;
 

--- a/gr-trellis/lib/viterbi_impl.cc
+++ b/gr-trellis/lib/viterbi_impl.cc
@@ -56,7 +56,7 @@ viterbi_impl<T>::viterbi_impl(const fsm& FSM, int K, int S0, int SK)
 template <class T>
 void viterbi_impl<T>::set_FSM(const fsm& FSM)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_FSM = FSM;
     this->set_relative_rate(1, (uint64_t)d_FSM.O());
 }
@@ -64,7 +64,7 @@ void viterbi_impl<T>::set_FSM(const fsm& FSM)
 template <class T>
 void viterbi_impl<T>::set_K(int K)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_K = K;
     this->set_output_multiple(d_K);
 }
@@ -72,14 +72,14 @@ void viterbi_impl<T>::set_K(int K)
 template <class T>
 void viterbi_impl<T>::set_S0(int S0)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_S0 = S0;
 }
 
 template <class T>
 void viterbi_impl<T>::set_SK(int SK)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     d_SK = SK;
 }
 
@@ -104,7 +104,7 @@ int viterbi_impl<T>::general_work(int noutput_items,
                                   gr_vector_const_void_star& input_items,
                                   gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(this->d_setlock);
+    gr::thread::lock_guard guard(this->d_setlock);
     int nstreams = input_items.size();
     int nblocks = noutput_items / d_K;
 

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -22,9 +22,9 @@
 
 #include "gr_uhd_common.h"
 #include "usrp_source_impl.h"
+#include <gnuradio/thread/thread.h>
 #include <boost/format.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/thread/thread.hpp>
 #include <iostream>
 #include <stdexcept>
 
@@ -432,7 +432,7 @@ void usrp_source_impl::set_recv_timeout(const double timeout, const bool one_pac
 
 bool usrp_source_impl::start(void)
 {
-    boost::recursive_mutex::scoped_lock lock(d_mutex);
+    gr::thread::recursive_lock_guard lock(d_mutex);
     if (not _rx_stream) {
         _rx_stream = _dev->get_rx_stream(_stream_args);
         _samps_per_packet = _rx_stream->get_max_num_samps();
@@ -478,7 +478,7 @@ void usrp_source_impl::flush(void)
 
 bool usrp_source_impl::stop(void)
 {
-    boost::recursive_mutex::scoped_lock lock(d_mutex);
+    gr::thread::recursive_lock_guard lock(d_mutex);
     this->issue_stream_cmd(::uhd::stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS);
     this->flush();
 
@@ -538,7 +538,7 @@ int usrp_source_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)
 {
-    boost::recursive_mutex::scoped_lock lock(d_mutex);
+    gr::thread::recursive_lock_guard lock(d_mutex);
     boost::this_thread::disable_interruption disable_interrupt;
     // In order to allow for low-latency:
     // We receive all available packets without timeout.

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -23,7 +23,7 @@
 #include "usrp_block_impl.h"
 #include <gnuradio/uhd/usrp_source.h>
 #include <uhd/convert.hpp>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 static const pmt::pmt_t TIME_KEY = pmt::string_to_symbol("rx_time");
 static const pmt::pmt_t RATE_KEY = pmt::string_to_symbol("rx_rate");
@@ -137,7 +137,7 @@ private:
     // tag shadows
     double _samp_rate;
 
-    boost::recursive_mutex d_mutex;
+    std::recursive_mutex d_mutex;
 };
 
 } /* namespace uhd */

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -144,14 +144,14 @@ void datatx(void* callback_state, unsigned char* packet, size_t* size) { return;
 
 void freedv_rx_ss_impl::set_squelch_thresh(float squelch_thresh)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_squelch_thresh = squelch_thresh;
     freedv_set_snr_squelch_thresh(d_freedv, d_squelch_thresh);
 }
 
 void freedv_rx_ss_impl::set_squelch_en(bool squelch_enabled)
 {
-    gr::thread::scoped_lock l(d_setlock);
+    gr::thread::lock_guard l(d_setlock);
     d_squelch_en = squelch_enabled;
     if (squelch_enabled)
         freedv_set_squelch_en(d_freedv, 1);


### PR DESCRIPTION
This one includes a bit more manual fixups, to clarify which type of lock is actually being used.

* `lock_guard`: Simple RAII lock
* `scoped_lock`: RAII lock that can lock multiple locks (C++17, and not needed in codebase)
* `unique_lock`: RAII lock, plus ability to unlock. Needed for `condition_variable`.

I kept the `gr::thread::` typedefs, since at least with C++11 it's a bit verbose to type without the template type inference that's newer than C++11.

This PR has only been minimally tested.

Note that this also fixes a bug, where a lock is not actually acquired: https://github.com/gnuradio/gnuradio/blob/master/gr-audio/lib/portaudio/portaudio_source.cc#L109
