### PR TITLE
gr-audio/portaudio_source: Fix lock acquisition

### DIFF
--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -106,7 +106,7 @@ int portaudio_source_callback(const void* inputBuffer,
 
         // copy from input buffer to ringbuffer
         {
-            gr::thread::scoped_lock(d_ringbuffer_mutex);
+            gr::thread::scoped_lock guard(self->d_ringbuffer_mutex);
 
             memcpy(self->d_writer->write_pointer(),
                    inputBuffer,


### PR DESCRIPTION
This is also part of https://github.com/gnuradio/gnuradio/pull/2976, but maybe cleaner to merge this PR on its own, as it's easier to review.