### PR TITLE
gr-filter/fft_filter: Use smart instead of raw pointers

### DIFF
--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -26,6 +26,7 @@
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/filter/api.h>
 #include <gnuradio/gr_complex.h>
+#include <volk/volk_alloc.hh>
 #include <vector>
 
 namespace gr {
@@ -70,13 +71,13 @@ private:
     int d_ntaps;
     int d_nsamples;
     int d_fftsize; // fftsize = ntaps + nsamples - 1
-    int d_decimation;
-    fft::fft_real_fwd* d_fwdfft; // forward "plan"
-    fft::fft_real_rev* d_invfft; // inverse "plan"
+    const int d_decimation;
+    std::unique_ptr<fft::fft_real_fwd> d_fwdfft; // forward "plan"
+    std::unique_ptr<fft::fft_real_rev> d_invfft; // inverse "plan"
     int d_nthreads;              // number of FFTW threads to use
     std::vector<float> d_tail;   // state carried between blocks for overlap-add
     std::vector<float> d_taps;   // stores time domain taps
-    gr_complex* d_xformed_taps;  // Fourier xformed taps
+    volk::vector<gr_complex> d_xformed_taps;  // Fourier xformed taps
 
     void compute_sizes(int ntaps);
     int tailsize() const { return d_ntaps - 1; }
@@ -94,8 +95,6 @@ public:
      * \param nthreads   The number of threads for the FFT to use (int)
      */
     fft_filter_fff(int decimation, const std::vector<float>& taps, int nthreads = 1);
-
-    ~fft_filter_fff();
 
     /*!
      * \brief Set new taps for the filter.
@@ -174,13 +173,13 @@ private:
     int d_ntaps;
     int d_nsamples;
     int d_fftsize; // fftsize = ntaps + nsamples - 1
-    int d_decimation;
-    fft::fft_complex* d_fwdfft;     // forward "plan"
-    fft::fft_complex* d_invfft;     // inverse "plan"
+    const int d_decimation;
+    std::unique_ptr<fft::fft_complex> d_fwdfft;     // forward "plan"
+    std::unique_ptr<fft::fft_complex> d_invfft;     // inverse "plan"
     int d_nthreads;                 // number of FFTW threads to use
     std::vector<gr_complex> d_tail; // state carried between blocks for overlap-add
     std::vector<gr_complex> d_taps; // stores time domain taps
-    gr_complex* d_xformed_taps;     // Fourier xformed taps
+    volk::vector<gr_complex> d_xformed_taps;     // Fourier xformed taps
 
     void compute_sizes(int ntaps);
     int tailsize() const { return d_ntaps - 1; }
@@ -198,8 +197,6 @@ public:
      * \param nthreads   The number of threads for the FFT to use (int)
      */
     fft_filter_ccc(int decimation, const std::vector<gr_complex>& taps, int nthreads = 1);
-
-    ~fft_filter_ccc();
 
     /*!
      * \brief Set new taps for the filter.
@@ -278,13 +275,13 @@ private:
     int d_ntaps;
     int d_nsamples;
     int d_fftsize; // fftsize = ntaps + nsamples - 1
-    int d_decimation;
-    fft::fft_complex* d_fwdfft;     // forward "plan"
-    fft::fft_complex* d_invfft;     // inverse "plan"
+    const int d_decimation;
+    std::unique_ptr<fft::fft_complex> d_fwdfft;     // forward "plan"
+    std::unique_ptr<fft::fft_complex> d_invfft;     // inverse "plan"
     int d_nthreads;                 // number of FFTW threads to use
     std::vector<gr_complex> d_tail; // state carried between blocks for overlap-add
     std::vector<float> d_taps;      // stores time domain taps
-    gr_complex* d_xformed_taps;     // Fourier xformed taps
+    volk::vector<gr_complex> d_xformed_taps;     // Fourier xformed taps
 
     void compute_sizes(int ntaps);
     int tailsize() const { return d_ntaps - 1; }
@@ -302,8 +299,6 @@ public:
      * \param nthreads   The number of threads for the FFT to use (int)
      */
     fft_filter_ccf(int decimation, const std::vector<float>& taps, int nthreads = 1);
-
-    ~fft_filter_ccf();
 
     /*!
      * \brief Set new taps for the filter.

--- a/gr-filter/lib/fft_filter_ccc_impl.cc
+++ b/gr-filter/lib/fft_filter_ccc_impl.cc
@@ -48,18 +48,15 @@ fft_filter_ccc_impl::fft_filter_ccc_impl(int decimation,
                      io_signature::make(1, 1, sizeof(gr_complex)),
                      io_signature::make(1, 1, sizeof(gr_complex)),
                      decimation),
-      d_updated(false)
+      d_updated(false),
+      d_filter(decimation, taps, nthreads)
 {
     set_history(1);
 
-    d_filter = new kernel::fft_filter_ccc(decimation, taps, nthreads);
-
     d_new_taps = taps;
-    d_nsamples = d_filter->set_taps(taps);
+    d_nsamples = d_filter.set_taps(taps);
     set_output_multiple(d_nsamples);
 }
-
-fft_filter_ccc_impl::~fft_filter_ccc_impl() { delete d_filter; }
 
 void fft_filter_ccc_impl::set_taps(const std::vector<gr_complex>& taps)
 {
@@ -71,16 +68,12 @@ std::vector<gr_complex> fft_filter_ccc_impl::taps() const { return d_new_taps; }
 
 void fft_filter_ccc_impl::set_nthreads(int n)
 {
-    if (d_filter)
-        d_filter->set_nthreads(n);
+    d_filter.set_nthreads(n);
 }
 
 int fft_filter_ccc_impl::nthreads() const
 {
-    if (d_filter)
-        return d_filter->nthreads();
-    else
-        return 0;
+    return d_filter.nthreads();
 }
 
 int fft_filter_ccc_impl::work(int noutput_items,
@@ -91,13 +84,13 @@ int fft_filter_ccc_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
-        d_nsamples = d_filter->set_taps(d_new_taps);
+        d_nsamples = d_filter.set_taps(d_new_taps);
         d_updated = false;
         set_output_multiple(d_nsamples);
         return 0; // output multiple may have changed
     }
 
-    d_filter->filter(noutput_items, in, out);
+    d_filter.filter(noutput_items, in, out);
 
     return noutput_items;
 }

--- a/gr-filter/lib/fft_filter_ccc_impl.h
+++ b/gr-filter/lib/fft_filter_ccc_impl.h
@@ -34,15 +34,13 @@ class FILTER_API fft_filter_ccc_impl : public fft_filter_ccc
 private:
     int d_nsamples;
     bool d_updated;
-    kernel::fft_filter_ccc* d_filter;
+    kernel::fft_filter_ccc d_filter;
     std::vector<gr_complex> d_new_taps;
 
 public:
     fft_filter_ccc_impl(int decimation,
                         const std::vector<gr_complex>& taps,
                         int nthreads = 1);
-
-    ~fft_filter_ccc_impl();
 
     void set_taps(const std::vector<gr_complex>& taps);
     std::vector<gr_complex> taps() const;

--- a/gr-filter/lib/fft_filter_ccf_impl.cc
+++ b/gr-filter/lib/fft_filter_ccf_impl.cc
@@ -48,18 +48,15 @@ fft_filter_ccf_impl::fft_filter_ccf_impl(int decimation,
                      io_signature::make(1, 1, sizeof(gr_complex)),
                      io_signature::make(1, 1, sizeof(gr_complex)),
                      decimation),
-      d_updated(false)
+      d_updated(false),
+      d_filter(decimation, taps, nthreads)
 {
     set_history(1);
 
-    d_filter = new kernel::fft_filter_ccf(decimation, taps, nthreads);
-
     d_new_taps = taps;
-    d_nsamples = d_filter->set_taps(taps);
+    d_nsamples = d_filter.set_taps(taps);
     set_output_multiple(d_nsamples);
 }
-
-fft_filter_ccf_impl::~fft_filter_ccf_impl() { delete d_filter; }
 
 void fft_filter_ccf_impl::set_taps(const std::vector<float>& taps)
 {
@@ -71,16 +68,12 @@ std::vector<float> fft_filter_ccf_impl::taps() const { return d_new_taps; }
 
 void fft_filter_ccf_impl::set_nthreads(int n)
 {
-    if (d_filter)
-        d_filter->set_nthreads(n);
+    d_filter.set_nthreads(n);
 }
 
 int fft_filter_ccf_impl::nthreads() const
 {
-    if (d_filter)
-        return d_filter->nthreads();
-    else
-        return 0;
+    return d_filter.nthreads();
 }
 
 int fft_filter_ccf_impl::work(int noutput_items,
@@ -91,13 +84,13 @@ int fft_filter_ccf_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
-        d_nsamples = d_filter->set_taps(d_new_taps);
+        d_nsamples = d_filter.set_taps(d_new_taps);
         d_updated = false;
         set_output_multiple(d_nsamples);
         return 0; // output multiple may have changed
     }
 
-    d_filter->filter(noutput_items, in, out);
+    d_filter.filter(noutput_items, in, out);
 
     return noutput_items;
 }

--- a/gr-filter/lib/fft_filter_ccf_impl.h
+++ b/gr-filter/lib/fft_filter_ccf_impl.h
@@ -35,13 +35,11 @@ class FILTER_API fft_filter_ccf_impl : public fft_filter_ccf
 private:
     int d_nsamples;
     bool d_updated;
-    kernel::fft_filter_ccf* d_filter;
+    kernel::fft_filter_ccf d_filter;
     std::vector<float> d_new_taps;
 
 public:
     fft_filter_ccf_impl(int decimation, const std::vector<float>& taps, int nthreads = 1);
-
-    ~fft_filter_ccf_impl();
 
     void set_taps(const std::vector<float>& taps);
     std::vector<float> taps() const;

--- a/gr-filter/lib/fft_filter_fff_impl.cc
+++ b/gr-filter/lib/fft_filter_fff_impl.cc
@@ -49,18 +49,15 @@ fft_filter_fff_impl::fft_filter_fff_impl(int decimation,
                      io_signature::make(1, 1, sizeof(float)),
                      io_signature::make(1, 1, sizeof(float)),
                      decimation),
-      d_updated(false)
+      d_updated(false),
+      d_filter(decimation, taps, nthreads)
 {
     set_history(1);
 
-    d_filter = new kernel::fft_filter_fff(decimation, taps, nthreads);
-
     d_new_taps = taps;
-    d_nsamples = d_filter->set_taps(taps);
+    d_nsamples = d_filter.set_taps(taps);
     set_output_multiple(d_nsamples);
 }
-
-fft_filter_fff_impl::~fft_filter_fff_impl() { delete d_filter; }
 
 void fft_filter_fff_impl::set_taps(const std::vector<float>& taps)
 {
@@ -72,16 +69,12 @@ std::vector<float> fft_filter_fff_impl::taps() const { return d_new_taps; }
 
 void fft_filter_fff_impl::set_nthreads(int n)
 {
-    if (d_filter)
-        d_filter->set_nthreads(n);
+    d_filter.set_nthreads(n);
 }
 
 int fft_filter_fff_impl::nthreads() const
 {
-    if (d_filter)
-        return d_filter->nthreads();
-    else
-        return 0;
+    return d_filter.nthreads();
 }
 
 int fft_filter_fff_impl::work(int noutput_items,
@@ -92,13 +85,13 @@ int fft_filter_fff_impl::work(int noutput_items,
     float* out = (float*)output_items[0];
 
     if (d_updated) {
-        d_nsamples = d_filter->set_taps(d_new_taps);
+        d_nsamples = d_filter.set_taps(d_new_taps);
         d_updated = false;
         set_output_multiple(d_nsamples);
         return 0; // output multiple may have changed
     }
 
-    d_filter->filter(noutput_items, in, out);
+    d_filter.filter(noutput_items, in, out);
 
     return noutput_items;
 }

--- a/gr-filter/lib/fft_filter_fff_impl.h
+++ b/gr-filter/lib/fft_filter_fff_impl.h
@@ -34,13 +34,11 @@ class FILTER_API fft_filter_fff_impl : public fft_filter_fff
 private:
     int d_nsamples;
     bool d_updated;
-    kernel::fft_filter_fff* d_filter;
+    kernel::fft_filter_fff d_filter;
     std::vector<float> d_new_taps;
 
 public:
     fft_filter_fff_impl(int decimation, const std::vector<float>& taps, int nthreads = 1);
-
-    ~fft_filter_fff_impl();
 
     void set_taps(const std::vector<float>& taps);
     std::vector<float> taps() const;


### PR DESCRIPTION
This reduces amount of code, and risk of dangling pointers and memory leaks.

I thought I'd do this one to get opinions. It takes a while (especially with custom deleter), so don't expect me to do all of it at least at this point. :-)

