### PR TITLE
Fix parameter hiding on symbol sync block YAML

### DIFF
--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -61,8 +61,8 @@ parameters:
     option_labels: ['MMSE, 8 tap FIR', 'Polyphase Filterbank, MMSE', 'Polyphase Filterbank,
             MF']
     option_attributes:
-        hide_nfilters: [all, '', '']
-        hide_pfb_mf_taps: [all, all, '']
+        hide_nfilters: [all, none, none]
+        hide_pfb_mf_taps: [all, all, none]
 -   id: nfilters
     label: Filterbank Arms
     dtype: int


### PR DESCRIPTION
Fix the options that are used in order to hide the "Filterbank Arms" and "PFB MF
Taps" parameters of the symbol sync block (digital_symbol_sync_xx), depending on
the chosen interpolating resampler.

Before this, if *Interpolating Resampler* type was set for instance to *Polyphase Filterbank, MF* on the Symbol Sync block, that is, parameter `resamp_type` set to `digital.IR_PFB_MF`, gnuradio companion would display:

![symbol_sync_xx_err](https://user-images.githubusercontent.com/5166844/71528275-dd014780-28bd-11ea-827d-30d3b084edf2.png)

I saw that the original line came from auto-generated YAML on baf7eaf8f29d5a490f2580917362cf5b3db47281, so I assumed it was a mistake. 