### PR TITLE
GRC: "Symbol Sync" block: fix parsing erros due to wrong data type

### DIFF
--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -61,8 +61,8 @@ parameters:
     option_labels: ['MMSE, 8 tap FIR', 'Polyphase Filterbank, MMSE', 'Polyphase Filterbank,
             MF']
     option_attributes:
-        hide_nfilters: [all, '', '']
-        hide_pfb_mf_taps: [all, all, '']
+        hide_nfilters: ['all', 'none', 'none']
+        hide_pfb_mf_taps: ['all', 'all', 'none']
 -   id: nfilters
     label: Filterbank Arms
     dtype: int

--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -24,7 +24,7 @@ parameters:
             D'Andrea GMSK, 'y[n]y''[n] Maximum Likelyhood', 'sgn(y[n])y''[n] Maximum
             Likelyhood']
     option_attributes:
-        hide_constellation: [part, part, part, all, all, all, all, all, all]
+        hide_constellation: ['part', 'part', 'part', 'all', 'all', 'all', 'all', 'all', 'all']
 -   id: constellation
     label: TED Slicer Constellation
     dtype: raw


### PR DESCRIPTION
The hide_constellations attributes work when they are strings. (tested on GR 3.8.0 beta on Windows, Phyton 2.7)
#2987 