### PR TITLE
gr: enable truncation option with add_file_appender

### DIFF
--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -263,7 +263,10 @@ void logger_add_file_appender(logger_ptr logger,
 {
     log4cpp::PatternLayout* layout = new log4cpp::PatternLayout();
     log4cpp::Appender* app =
-        new log4cpp::FileAppender("FileAppender::" + filename, filename);
+        new log4cpp::FileAppender(
+            "FileAppender::" + filename,
+            filename,
+            append);
     layout->setConversionPattern(pattern);
     app->setLayout(layout);
     logger->setAppender(app);


### PR DESCRIPTION
gr.logger.add_file_appender offered use of the truncation flag but did not use it in the creation of log4cpp::FileAppender. Added the bool append as an argument.

closes #2989

see: http://log4cpp.sourceforge.net/api/classlog4cpp_1_1FileAppender.html

```
Script started on 2020-01-01 14:11:37-06:00 [TERM="xterm-256color" TTY="/dev/pts/0" COLUMNS="130" LINES="32"]
❯ echo "TEST\nTEST\nTEST" >> /tmp/logfile.log
❯ cat /tmp/logfile.log
TEST
TEST
TEST
❯ python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from gnuradio import gr
>>> log = gr.logger('log')
>>> log.set_level("DEBUG")
>>> log.add_file_appender('/tmp/logfile.log', True, "%r :%p: %c{1} - %m%n")
>>> log.debug('This should append')
gr::log 2020-01-01 14:12:22,986 :DEBUG: This should append
>>>
❯ cat /tmp/logfile.log
TEST
TEST
TEST
22605 :DEBUG: log - This should append
❯ echo "Now let's truncate"
Now let's truncate
❯ python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from gnuradio import gr
>>> log = gr.logger('log')
>>> log.set_level("DEBUG")
>>> log.add_file_appender('/tmp/logfile.log', False, "%r :%p: %c{1} - %m%n")
>>> log.debug('This should truncate')
gr::log 2020-01-01 14:13:09,560 :DEBUG: This should truncate
>>>
❯ cat /tmp/logfile.log
18303 :DEBUG: log - This should truncate

```