### PR TITLE
runtime: fix python math script generating wrong sine table

### DIFF
--- a/gnuradio-runtime/lib/math/gen_sine_table.py
+++ b/gnuradio-runtime/lib/math/gen_sine_table.py
@@ -20,7 +20,6 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from __future__ import division
 from __future__ import unicode_literals
 import math
 import sys
@@ -41,7 +40,7 @@ def gen_approx_table (f, nentries, min_x, max_x):
         a = (i * incx) + min_x
         b = ((i + 1) * incx) + min_x
         m = (f(b)-f(a)) / (b-a)
-        c = (3*a+b)*(f(a)-f(b))/(4*(b-a)) + (f((a+b)/2) + f(a))//2
+        c = (3.0*a+b)*(f(a)-f(b))/(4.0*(b-a)) + (f((a+b)/2.0) + f(a))/2.0
         abs_error = c+m*a-f(a)
         r.append ((m, c, abs_error))
     return r
@@ -71,7 +70,7 @@ def gen_sine_table ():
     # sys.stdout.write ('static const double sine_table[%d][2] = {\n'% (nentries,))
 
     for e in t:
-        sys.stdout.write ('  { %22.15e, %22.15e },\n' % (2 * e[0], e[1]))
+        sys.stdout.write ('  { %22.15e, %22.15e },\n' % (2.0 * e[0], e[1]))
 
     # sys.stdout.write ('};\n')
 


### PR DESCRIPTION
Fixes commit 48d535e9d9d95524b2c8ed35b44c7eda541aea68