### PR TITLE
Fix for #2926: Additive scrambler reset by count

### DIFF
--- a/gr-digital/lib/additive_scrambler_bb_impl.cc
+++ b/gr-digital/lib/additive_scrambler_bb_impl.cc
@@ -109,35 +109,19 @@ int additive_scrambler_bb_impl::work(int noutput_items,
     unsigned char* out = (unsigned char*)output_items[0];
     int reset_index = _get_next_reset_index(noutput_items);
 
-    if (d_count >= 0) {
-        for (int i = 0; i < noutput_items; i++) {
-            unsigned char scramble_byte = 0x00;
-            for (int k = 0; k < d_bits_per_byte; k++) {
-                scramble_byte ^= (d_lfsr.next_bit() << k);
-            }
-            out[i] = in[i] ^ scramble_byte;
-            d_bytes++;
-            if (i == reset_index) {
-                d_lfsr.reset();
-                d_bytes = 0;
-                reset_index = _get_next_reset_index(noutput_items, reset_index);
-            }
+    for (int i = 0; i < noutput_items; i++) {
+        // Reset should occur at/before the item associated with the tag.
+        if (i == reset_index) {
+            d_lfsr.reset();
+            d_bytes = 0;
+            reset_index = _get_next_reset_index(noutput_items, reset_index);
         }
-    } else {
-        for (int i = 0; i < noutput_items; i++) {
-            // Reset should occur at/before the item associated with the tag.
-            if (i == reset_index) {
-                d_lfsr.reset();
-                d_bytes = 0;
-                reset_index = _get_next_reset_index(noutput_items, reset_index);
-            }
-            unsigned char scramble_byte = 0x00;
-            for (int k = 0; k < d_bits_per_byte; k++) {
-                scramble_byte ^= (d_lfsr.next_bit() << k);
-            }
-            out[i] = in[i] ^ scramble_byte;
-            d_bytes++;
+        unsigned char scramble_byte = 0x00;
+        for (int k = 0; k < d_bits_per_byte; k++) {
+            scramble_byte ^= (d_lfsr.next_bit() << k);
         }
+        out[i] = in[i] ^ scramble_byte;
+        d_bytes++;
     }
 
     return noutput_items;

--- a/gr-digital/python/digital/qa_scrambler.py
+++ b/gr-digital/python/digital/qa_scrambler.py
@@ -64,28 +64,24 @@ class test_scrambler(gr_unittest.TestCase):
         self.assertEqual(src_data, dst.data())
 
     def test_additive_scrambler_reset(self):
-        src_data = (1,)*1000
+        src_data = (1,)*200
         src = blocks.vector_source_b(src_data, False)
-        scrambler = digital.additive_scrambler_bb(0x8a, 0x7f, 7, 100)
-        descrambler = digital.additive_scrambler_bb(0x8a, 0x7f, 7, 100)
+        scrambler = digital.additive_scrambler_bb(0x8a, 0x7f, 7, 50)
         dst = blocks.vector_sink_b()
-        self.tb.connect(src, scrambler, descrambler, dst)
+        self.tb.connect(src, scrambler, dst)
         self.tb.run()
-        self.assertEqual(src_data, dst.data())
+        output = dst.data()
+        self.assertEqual(output[:50] * 4, output)
 
     def test_additive_scrambler_reset_3bpb(self):
-        src_data = (5,)*2000
+        src_data = (5,)*200
         src = blocks.vector_source_b(src_data, False)
-        scrambler = digital.additive_scrambler_bb(0x8a, 0x7f, 7, 100, 3)
-        descrambler = digital.additive_scrambler_bb(0x8a, 0x7f, 7, 100, 3)
+        scrambler = digital.additive_scrambler_bb(0x8a, 0x7f, 7, 50, 3)
         dst = blocks.vector_sink_b()
-        dst2 = blocks.vector_sink_b()
-        self.tb.connect(src, scrambler, descrambler, dst)
-        self.tb.connect(scrambler, dst2)
+        self.tb.connect(src, scrambler, dst)
         self.tb.run()
-        if not (src_data == dst.data()):
-            self.fail('Not equal.')
-        self.assertEqual(src_data, src_data)
+        output = dst.data()
+        self.assertEqual(output[:50] * 4, output)
 
     def test_additive_scrambler_tags(self):
         src_data = (1,)*1000


### PR DESCRIPTION
See commit messages. Consider to ignore whitespace changes (``git diff -w``) when viewing the diff.