### PR TITLE
grc: Add Options block to (Core) Misc category

### DIFF
--- a/grc/blocks/grc.tree.yml
+++ b/grc/blocks/grc.tree.yml
@@ -1,5 +1,6 @@
 '[Core]':
 - Misc:
+  - options
   - pad_source
   - pad_sink
   - virtual_source


### PR DESCRIPTION
I noticed that GRC was outputting the following error upon opening the Options block's properties dialog:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/gnuradio/grc/gui/PropsDialog.py", line 210, in update_gui
    self._update_docs_page()
  File "/usr/local/lib/python3.8/dist-packages/gnuradio/grc/gui/PropsDialog.py", line 220, in _update_docs_page
    if self._block.category[0] == "Core":
IndexError: list index out of range
```
This happens because the Options block's category is just an empty list. 

A side effect of this PR is that the Options block now shows up in the right-hand block list. However, when trying to add another Options block to the flowgraph, the original block is just moved. In other words, no duplicate is created.

Investigate: 
- Should we refuse to load blocks that don't have a category?
- Should the dummy block be added to this category as well?