### PR TITLE
Replace rand() by gr::random() (maint-3.7 branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Older Logs can be found in `docs/RELEASE-NOTES-*`.
 
+## UNRELESEASED
+
+### Changed
+#### Project Scope
+- COMPATIBILITY WARNING: Replaced non-threadsafe (s)rand with our own xoroshiro-based PRNG 
+
+#### gr-digital
+- COMPATIBILITY: Change of random OFDM pilots
+
+#### gr-trellis
+- COMPATIBILITY: random interleaver: PRNG change -> different interleaver
+
+### Added
+#### gnuradio-runtime
+- XOROSHIRO128+-based PRNG
+
 ## [3.7.13.5] - 2019-04-20
 
 ### Fixed

--- a/gr-digital/lib/ofdm_mapper_bcv_impl.cc
+++ b/gr-digital/lib/ofdm_mapper_bcv_impl.cc
@@ -60,7 +60,8 @@ ofdm_mapper_bcv_impl::ofdm_mapper_bcv_impl(const std::vector<gr_complex>& conste
       d_bit_offset(0),
       d_pending_flag(0),
       d_resid(0),
-      d_nresid(0)
+      d_nresid(0),
+      d_rnd_sym(gr::random(1765399812, 0, constellation.size()))
 {
     GR_LOG_WARN(d_logger, "The gr::digital::ofdm_mapper_bcv block has been deprecated.");
 
@@ -137,7 +138,7 @@ ofdm_mapper_bcv_impl::ofdm_mapper_bcv_impl(const std::vector<gr_complex>& conste
 
 ofdm_mapper_bcv_impl::~ofdm_mapper_bcv_impl() {}
 
-int ofdm_mapper_bcv_impl::randsym() { return (rand() % d_constellation.size()); }
+int ofdm_mapper_bcv_impl::randsym() { return (d_rnd_sym.ran_int()); }
 
 int ofdm_mapper_bcv_impl::work(int noutput_items,
                                gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/ofdm_mapper_bcv_impl.h
+++ b/gr-digital/lib/ofdm_mapper_bcv_impl.h
@@ -25,6 +25,7 @@
 
 #include <gnuradio/digital/ofdm_mapper_bcv.h>
 #include <gnuradio/message.h>
+#include <gnuradio/random.h>
 #include <vector>
 
 namespace gr {
@@ -33,6 +34,8 @@ namespace digital {
 class ofdm_mapper_bcv_impl : public ofdm_mapper_bcv
 {
 private:
+    /* NOTE: d_rand_sym.set_integer_limits(0, new_const.size()) must be called
+     *        * if set_constellation() is ever added */
     std::vector<gr_complex> d_constellation;
     msg_queue::sptr d_msgq;
     message::sptr d_msg;
@@ -52,6 +55,7 @@ private:
 
     std::vector<int> d_subcarrier_map;
 
+    gr::random d_rnd_sym;
     int randsym();
 
 public:

--- a/gr-digital/lib/qa_header_format.cc
+++ b/gr-digital/lib/qa_header_format.cc
@@ -36,20 +36,38 @@
 #include <gnuradio/blocks/unpack_k_bits.h>
 #include <gnuradio/digital/header_format_counter.h>
 #include <gnuradio/digital/header_format_default.h>
+#include <gnuradio/xoroshiro128p.h>
+
+static void
+xoroshiro_fill_buffer(uint8_t* buffer, unsigned int length, uint64_t seed = 42)
+{
+    uint64_t rng_state[2];
+    xoroshiro128p_seed(rng_state, seed);
+    uint64_t* data_ptr = reinterpret_cast<uint64_t*>(buffer);
+    for (unsigned int i = 0; i < length / 8; ++i) {
+        *data_ptr = xoroshiro128p_next(rng_state);
+        data_ptr++;
+    }
+    if (length % 8) {
+        uint64_t tmp = xoroshiro128p_next(rng_state);
+        uint8_t* tmpptr = reinterpret_cast<uint8_t*>(&tmp);
+        for (unsigned int counter = length - length % 8; counter < length; ++counter) {
+            buffer[counter] = *tmpptr;
+            ++tmpptr;
+        }
+    }
+}
 
 void qa_header_format::test_default_format()
 {
-    static const int N = 4800;
+    static const int N = 4800; /* multiple of 8 for easy random generation */
     int upper8 = (N >> 8) & 0xFF;
     int lower8 = N & 0xFF;
 
     std::string ac = "1010101010101010"; // 0xAAAA
     unsigned char* data =
         (unsigned char*)volk_malloc(N * sizeof(unsigned char), volk_get_alignment());
-    srand(time(NULL));
-    for (unsigned int i = 0; i < N; i++) {
-        data[i] = rand() % 256;
-    }
+    xoroshiro_fill_buffer(data, N);
 
     gr::digital::header_format_default::sptr hdr_format;
     hdr_format = gr::digital::header_format_default::make(ac, 0);
@@ -93,12 +111,7 @@ void qa_header_format::test_default_parse()
     unsigned char* bits =
         (unsigned char*)volk_malloc(nbits * sizeof(unsigned char), volk_get_alignment());
 
-    srand(time(NULL));
-
-    // Fill bytes with random values
-    for (unsigned int i = 0; i < nbytes; i++) {
-        bytes[i] = rand() % 256;
-    }
+    xoroshiro_fill_buffer(bytes, nbytes);
 
     int index = 0;
     bytes[index + 0] = 0xAA;
@@ -143,10 +156,7 @@ void qa_header_format::test_counter_format()
     std::string ac = "1010101010101010"; // 0xAAAA
     unsigned char* data =
         (unsigned char*)volk_malloc(N * sizeof(unsigned char), volk_get_alignment());
-    srand(time(NULL));
-    for (unsigned int i = 0; i < N; i++) {
-        data[i] = rand() % 256;
-    }
+    xoroshiro_fill_buffer(data, N);
 
     uint16_t expected_bps = 2;
     gr::digital::header_format_counter::sptr hdr_format;
@@ -208,12 +218,7 @@ void qa_header_format::test_counter_parse()
     unsigned char* bits =
         (unsigned char*)volk_malloc(nbits * sizeof(unsigned char), volk_get_alignment());
 
-    srand(time(NULL));
-
-    // Fill bytes with random values
-    for (unsigned int i = 0; i < nbytes; i++) {
-        bytes[i] = rand() % 256;
-    }
+    xoroshiro_fill_buffer(bytes, nbytes);
 
     int index = 0;
     bytes[index + 0] = 0xAA;

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -20,14 +20,20 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include <gnuradio/random.h>
 #include <gnuradio/trellis/interleaver.h>
 #include <gnuradio/trellis/quicksort_index.h>
 #include <cmath>
+#if __cplusplus >= 201103L
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <stdexcept>
+// #include <stdexcept>
 #include <string>
 
 namespace gr {
@@ -109,12 +115,14 @@ interleaver::interleaver(int K, int seed)
     d_INTER.resize(d_K);
     d_DEINTER.resize(d_K);
 
+    gr::random rnd_int(seed, 0, INT_MAX);
+
     if (seed >= 0)
         srand((unsigned int)seed);
     std::vector<int> tmp(d_K);
     for (int i = 0; i < d_K; i++) {
         d_INTER[i] = i;
-        tmp[i] = rand();
+        tmp[i] = rnd_int.ran_int();
     }
     quicksort_index<int>(tmp, d_INTER, 0, d_K - 1);
 


### PR DESCRIPTION
Continuation of https://github.com/gnuradio/gnuradio/pull/2594/commits.

To quote @rear1019:

This is the last pull request to fix issue #1841. Changes in gr-digital and gr-trellis can be considered as API changes: User-visible behavior is modified. However, no code modifications in GNU Radio or OOT modules are required (as far as I can tell).
