### PR TITLE
digital: pfb clock sync: Remove deprecated set_taps() API call

### DIFF
--- a/gr-digital/include/gnuradio/digital/pfb_clock_sync_ccf.h
+++ b/gr-digital/include/gnuradio/digital/pfb_clock_sync_ccf.h
@@ -193,18 +193,6 @@ public:
     virtual void update_taps(const std::vector<float>& taps) = 0;
 
     /*!
-     * Used to set the taps of the filters in the filterbank and
-     * differential filterbank.
-     *
-     * WARNING: this should not be used externally and will be moved
-     * to a private function in the next API.
-     */
-    virtual void
-    set_taps(const std::vector<float>& taps,
-             std::vector<std::vector<float>>& ourtaps,
-             std::vector<std::unique_ptr<gr::filter::kernel::fir_filter_ccf>>& ourfilter) = 0;
-
-    /*!
      * Returns all of the taps of the matched filter
      */
     virtual std::vector<std::vector<float>> taps() const = 0;

--- a/gr-digital/include/gnuradio/digital/pfb_clock_sync_fff.h
+++ b/gr-digital/include/gnuradio/digital/pfb_clock_sync_fff.h
@@ -192,18 +192,6 @@ public:
     virtual void update_taps(const std::vector<float>& taps) = 0;
 
     /*!
-     * Used to set the taps of the filters in the filterbank and
-     * differential filterbank.
-     *
-     * WARNING: this should not be used externally and will be moved
-     * to a private function in the next API.
-     */
-    virtual void
-    set_taps(const std::vector<float>& taps,
-             std::vector<std::vector<float>>& ourtaps,
-             std::vector<gr::filter::kernel::fir_filter_fff*>& ourfilter) = 0;
-
-    /*!
      * Returns all of the taps of the matched filter
      */
     virtual std::vector<std::vector<float>> taps() const = 0;

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.h
@@ -63,6 +63,10 @@ private:
     void create_diff_taps(const std::vector<float>& newtaps,
                           std::vector<float>& difftaps);
 
+    void set_taps(const std::vector<float>& taps,
+                  std::vector<std::vector<float>>& ourtaps,
+                  std::vector<std::unique_ptr<kernel::fir_filter_ccf>>& ourfilter);
+
 public:
     pfb_clock_sync_ccf_impl(double sps,
                             float loop_bw,
@@ -79,10 +83,6 @@ public:
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
 
     void update_taps(const std::vector<float>& taps);
-
-    void set_taps(const std::vector<float>& taps,
-                  std::vector<std::vector<float>>& ourtaps,
-                  std::vector<std::unique_ptr<kernel::fir_filter_ccf>>& ourfilter) override;
 
     std::vector<std::vector<float>> taps() const;
     std::vector<std::vector<float>> diff_taps() const;

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.h
@@ -61,6 +61,10 @@ private:
     void create_diff_taps(const std::vector<float>& newtaps,
                           std::vector<float>& difftaps);
 
+    void set_taps(const std::vector<float>& taps,
+                  std::vector<std::vector<float>>& ourtaps,
+                  std::vector<kernel::fir_filter_fff*>& ourfilter);
+
 public:
     pfb_clock_sync_fff_impl(double sps,
                             float gain,
@@ -76,10 +80,6 @@ public:
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
 
     void update_taps(const std::vector<float>& taps);
-
-    void set_taps(const std::vector<float>& taps,
-                  std::vector<std::vector<float>>& ourtaps,
-                  std::vector<kernel::fir_filter_fff*>& ourfilter);
 
     std::vector<std::vector<float>> taps() const;
     std::vector<std::vector<float>> diff_taps() const;


### PR DESCRIPTION
This API call was deprecated a long time ago and contained a warning
that it will be removed, so we're now being true to our promise.
This also fixes a compiler error in SWIG *if* you have old headers
installed that SWIG will find (instead of the ones in the source tree).

Note: I saw this compiler bug and it drove me crazy. SWIG shouldn't be using installed headers :anger: 