### PR TITLE
Exception Handling QA: increase wait time to ensure error could've occured

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
@@ -74,7 +74,7 @@ class test_uncaught_exception(gr_unittest.TestCase):
         p = Process(target=process_func, args=(False,))
         p.daemon = True
         p.start()
-        p.join(0.5)
+        p.join(2.5)
         exit_code = p.exitcode
         self.assertIsNotNone(
             exit_code, "exception did not cause flowgraph exit")
@@ -85,7 +85,7 @@ class test_uncaught_exception(gr_unittest.TestCase):
         p = Process(target=process_func, args=(True,))
         p.daemon = True
         p.start()
-        p.join(0.5)
+        p.join(2.5)
         exit_code = p.exitcode
         self.assertIsNone(
             exit_code, "exception caused flowgraph exit")


### PR DESCRIPTION
Prior to this, the unit test was flaky, especially when running the test
suite concurrently, as test setup could take more than 0.5 s.