### PR TITLE
cmake: grc: Provide ENABLE_POSTINSTALL option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,6 +479,12 @@ find_package(MPLIB)
 add_definitions(${MPLIB_DEFINITIONS})
 
 ########################################################################
+# Post-Install tasks are tasks that are usually not executed during
+# install, but for source builds, that's actually more convenient.
+########################################################################
+GR_REGISTER_COMPONENT("post-install" ENABLE_POSTINSTALL)
+
+########################################################################
 # Add subdirectories (in order of deps)
 ########################################################################
 add_subdirectory(docs)

--- a/grc/scripts/freedesktop/CMakeLists.txt
+++ b/grc/scripts/freedesktop/CMakeLists.txt
@@ -61,7 +61,9 @@ if(UNIX AND HAVE_XDG_UTILS)
         DESTINATION ${GR_PKG_LIBEXEC_DIR}
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
     )
-    install (
-        CODE "execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/${GR_PKG_LIBEXEC_DIR}/grc_setup_freedesktop install)" 
+    if(ENABLE_POSTINSTALL)
+        install (
+            CODE "execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/${GR_PKG_LIBEXEC_DIR}/grc_setup_freedesktop install)"
     )
+    endif(ENABLE_POSTINSTALL)
 endif(UNIX AND HAVE_XDG_UTILS)


### PR DESCRIPTION
This option allows disabling post-install tasks. Currently, there is one
such task: The execution of `grc_setup_freedesktop install`.

For developers building from source, this is very convenient to do
during installation. However, for package maintainers, this is not
desired and should be executed separately. Maintainers of packages can
thus provide ENABLE_POSTINSTALL=OFF to avoid permission errors.

This continues bc0592b6, which defaulted to always running the script.

See the discussion in https://github.com/gnuradio/gnuradio/pull/2580/files.