### PR TITLE
Backport to 3.8 (Jan 6 2019)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -170,62 +170,62 @@ typedef log4cpp::Category* logger_ptr;
 #define GR_DEBUG(name, msg)                                         \
     {                                                               \
         gr::logger_ptr logger = gr::logger_get_logger(name);        \
-        *logger << log4cpp::Priority::DEBUG << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::DEBUG << (msg) << log4cpp::eol; \
     }
 
 #define GR_INFO(name, msg)                                         \
     {                                                              \
         gr::logger_ptr logger = gr::logger_get_logger(name);       \
-        *logger << log4cpp::Priority::INFO << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::INFO << (msg) << log4cpp::eol; \
     }
 
 #define GR_NOTICE(name, msg)                                 \
     {                                                        \
         gr::logger_ptr logger = gr::logger_get_logger(name); \
-        *logger << log4cpp::Priority::NOTICE << msg;         \
+        *logger << log4cpp::Priority::NOTICE << (msg);         \
     }
 
 #define GR_WARN(name, msg)                                         \
     {                                                              \
         gr::logger_ptr logger = gr::logger_get_logger(name);       \
-        *logger << log4cpp::Priority::WARN << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::WARN << (msg) << log4cpp::eol; \
     }
 
 #define GR_ERROR(name, msg)                                         \
     {                                                               \
         gr::logger_ptr logger = gr::logger_get_logger(name);        \
-        *logger << log4cpp::Priority::ERROR << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
     }
 
 #define GR_CRIT(name, msg)                                         \
     {                                                              \
         gr::logger_ptr logger = gr::logger_get_logger(name);       \
-        *logger << log4cpp::Priority::CRIT << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::CRIT << (msg) << log4cpp::eol; \
     }
 
 #define GR_ALERT(name, msg)                                         \
     {                                                               \
         gr::logger_ptr logger = gr::logger_get_logger(name);        \
-        *logger << log4cpp::Priority::ALERT << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::ALERT << (msg) << log4cpp::eol; \
     }
 
 #define GR_FATAL(name, msg)                                         \
     {                                                               \
         gr::logger_ptr logger = gr::logger_get_logger(name);        \
-        *logger << log4cpp::Priority::FATAL << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::FATAL << (msg) << log4cpp::eol; \
     }
 
 #define GR_EMERG(name, msg)                                         \
     {                                                               \
         gr::logger_ptr logger = gr::logger_get_logger(name);        \
-        *logger << log4cpp::Priority::EMERG << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
     }
 
 #define GR_ERRORIF(name, cond, msg)                                     \
     {                                                                   \
         if ((cond)) {                                                   \
             gr::logger_ptr logger = gr::logger_get_logger(name);        \
-            *logger << log4cpp::Priority::ERROR << msg << log4cpp::eol; \
+            *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
         }                                                               \
     }
 
@@ -233,7 +233,7 @@ typedef log4cpp::Category* logger_ptr;
     {                                                                   \
         if (!(cond)) {                                                  \
             gr::logger_ptr logger = gr::logger_get_logger(name);        \
-            *logger << log4cpp::Priority::EMERG << msg << log4cpp::eol; \
+            *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
         }                                                               \
         assert(0);                                                      \
     }
@@ -241,60 +241,60 @@ typedef log4cpp::Category* logger_ptr;
 /* LoggerPtr Referenced Macros */
 #define GR_LOG_DEBUG(logger, msg)                                   \
     {                                                               \
-        *logger << log4cpp::Priority::DEBUG << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::DEBUG << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_INFO(logger, msg)                                   \
     {                                                              \
-        *logger << log4cpp::Priority::INFO << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::INFO << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_NOTICE(logger, msg)                                   \
     {                                                                \
-        *logger << log4cpp::Priority::NOTICE << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::NOTICE << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_WARN(logger, msg)                                   \
     {                                                              \
-        *logger << log4cpp::Priority::WARN << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::WARN << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_ERROR(logger, msg)                                   \
     {                                                               \
-        *logger << log4cpp::Priority::ERROR << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_CRIT(logger, msg)                                   \
     {                                                              \
-        *logger << log4cpp::Priority::CRIT << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::CRIT << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_ALERT(logger, msg)                                   \
     {                                                               \
-        *logger << log4cpp::Priority::ALERT << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::ALERT << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_FATAL(logger, msg)                                   \
     {                                                               \
-        *logger << log4cpp::Priority::FATAL << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::FATAL << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_EMERG(logger, msg)                                   \
     {                                                               \
-        *logger << log4cpp::Priority::EMERG << msg << log4cpp::eol; \
+        *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
     }
 
 #define GR_LOG_ERRORIF(logger, cond, msg)                               \
     {                                                                   \
         if ((cond)) {                                                   \
-            *logger << log4cpp::Priority::ERROR << msg << log4cpp::eol; \
+            *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
         }                                                               \
     }
 
 #define GR_LOG_ASSERT(logger, cond, msg)                                \
     {                                                                   \
         if (!(cond)) {                                                  \
-            *logger << log4cpp::Priority::EMERG << msg << log4cpp::eol; \
+            *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
             assert(0);                                                  \
         }                                                               \
     }


### PR DESCRIPTION
logging: (msg) to avoid logged statement taken apart by operator prec…edence

Oldie but a goldie:
Macro containing

     logger << "something " << msg << "\n";

will happily break code in hard-to-understand ways, since `<<` has
higher precedence than binary, comparison and logical operators.