### PR TITLE
pmt: Fix RuntimeError in pmt_to_python

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -89,7 +89,7 @@ public:
     exception(const std::string& msg, pmt_t obj);
 };
 
-class PMT_API wrong_type : public exception
+class PMT_API wrong_type : public std::invalid_argument
 {
 public:
     wrong_type(const std::string& msg, pmt_t obj);

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -37,7 +37,7 @@ exception::exception(const std::string& msg, pmt_t obj)
 }
 
 wrong_type::wrong_type(const std::string& msg, pmt_t obj)
-    : exception(msg + ": wrong_type ", obj)
+    : invalid_argument(msg + ": wrong_type " + write_string(obj))
 {
 }
 

--- a/gnuradio-runtime/swig/gr_extras.i
+++ b/gnuradio-runtime/swig/gr_extras.i
@@ -19,6 +19,9 @@
     try {
         $action
     }
+    catch(std::invalid_argument &e) {
+        SWIG_exception(SWIG_TypeError, e.what());
+    }
     catch(std::exception &e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
     }

--- a/gr-blocks/python/blocks/qa_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_hier_block2.py
@@ -74,7 +74,7 @@ class test_hier_block2(gr_unittest.TestCase):
         nop1 = blocks.nop(gr.sizeof_int)
         nop2 = blocks.nop(gr.sizeof_int)
         hblock.connect(nop1, hblock)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.connect(nop2, hblock))
 
     def test_006_connect_invalid_src_port_neg(self):
@@ -82,7 +82,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int),
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.connect((hblock, -1), nop1))
 
     def test_005_connect_invalid_src_port_exceeds(self):
@@ -90,7 +90,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int),
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.connect((hblock, 1), nop1))
 
     def test_007_connect_invalid_dst_port_neg(self):
@@ -99,7 +99,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
         nop2 = blocks.nop(gr.sizeof_int)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.connect(nop1, (nop2, -1)))
 
     def test_008_connect_invalid_dst_port_exceeds(self):
@@ -108,7 +108,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.null_sink(gr.sizeof_int)
         nop2 = blocks.null_sink(gr.sizeof_int)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.connect(nop1, (nop2, 1)))
 
     def test_009_check_topology(self):
@@ -144,7 +144,7 @@ class test_hier_block2(gr_unittest.TestCase):
         nop1 = blocks.nop(gr.sizeof_int)
         nop2 = blocks.nop(gr.sizeof_int)
         hblock.connect(hblock, nop1)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.disconnect(hblock, nop2))
 
     def test_014_disconnect_input_neg(self):
@@ -153,7 +153,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
         hblock.connect(hblock, nop1)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.disconnect((hblock, -1), nop1))
 
     def test_015_disconnect_input_exceeds(self):
@@ -162,7 +162,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
         hblock.connect(hblock, nop1)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.disconnect((hblock, 1), nop1))
 
     def test_016_disconnect_output(self):
@@ -180,7 +180,7 @@ class test_hier_block2(gr_unittest.TestCase):
         nop1 = blocks.nop(gr.sizeof_int)
         nop2 = blocks.nop(gr.sizeof_int)
         hblock.connect(nop1, hblock)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.disconnect(nop2, hblock))
 
     def test_018_disconnect_output_neg(self):
@@ -189,7 +189,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
         hblock.connect(hblock, nop1)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.disconnect(nop1, (hblock, -1)))
 
     def test_019_disconnect_output_exceeds(self):
@@ -198,7 +198,7 @@ class test_hier_block2(gr_unittest.TestCase):
                                 gr.io_signature(1,1,gr.sizeof_int))
         nop1 = blocks.nop(gr.sizeof_int)
         hblock.connect(nop1, hblock)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
             lambda: hblock.disconnect(nop1, (hblock, 1)))
 
     def test_020_run(self):
@@ -222,7 +222,7 @@ class test_hier_block2(gr_unittest.TestCase):
         blk = gr.hier_block2("block",
                              gr.io_signature(1, 1, 1),
                              gr.io_signature(1, 1, 1))
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
                           lambda: hblock.connect(blk))
 
     def test_023_connect_single_twice(self):
@@ -231,7 +231,7 @@ class test_hier_block2(gr_unittest.TestCase):
                              gr.io_signature(0, 0, 0),
                              gr.io_signature(0, 0, 0))
         hblock.connect(blk)
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
                           lambda: hblock.connect(blk))
 
     def test_024_disconnect_single(self):
@@ -247,7 +247,7 @@ class test_hier_block2(gr_unittest.TestCase):
         blk = gr.hier_block2("block",
                              gr.io_signature(0, 0, 0),
                              gr.io_signature(0, 0, 0))
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
                           lambda: hblock.disconnect(blk))
 
     def test_026_run_single(self):

--- a/gr-blocks/python/blocks/qa_vector_sink_source.py
+++ b/gr-blocks/python/blocks/qa_vector_sink_source.py
@@ -65,7 +65,7 @@ class test_vector_sink_source(gr_unittest.TestCase):
         # vector has sufficient size
         src_data = [float(x) for x in range(16)]
         expected_result = tuple(src_data)
-        self.assertRaises(RuntimeError, lambda : blocks.vector_source_f(src_data, False, 3))
+        self.assertRaises(TypeError, lambda : blocks.vector_source_f(src_data, False, 3))
 
     def test_004(self):
         # Test sending and receiving tagged streams

--- a/gr-digital/python/digital/qa_ofdm_carrier_allocator_cvc.py
+++ b/gr-digital/python/digital/qa_ofdm_carrier_allocator_cvc.py
@@ -198,12 +198,12 @@ class qa_digital_carrier_allocator_cvc (gr_unittest.TestCase):
 
     def test_004_t (self):
         """
-        Provoking RuntimeError exceptions providing wrong user input (earlier invisible SIGFPE).
+        Provoking TypeError exceptions providing wrong user input (earlier invisible SIGFPE).
         """
         fft_len = 6
 
         # Occupied carriers
-        with self.assertRaises(RuntimeError) as oc:
+        with self.assertRaises(TypeError) as oc:
           alloc = digital.ofdm_carrier_allocator_cvc(fft_len,
                         (),
                         ((),),
@@ -212,7 +212,7 @@ class qa_digital_carrier_allocator_cvc (gr_unittest.TestCase):
                         self.tsb_key)
 
         # Pilot carriers
-        with self.assertRaises(RuntimeError) as pc:
+        with self.assertRaises(TypeError) as pc:
           alloc = digital.ofdm_carrier_allocator_cvc(fft_len,
                         ((),),
                         (),
@@ -221,7 +221,7 @@ class qa_digital_carrier_allocator_cvc (gr_unittest.TestCase):
                         self.tsb_key)
 
         # Pilot carrier symbols
-        with self.assertRaises(RuntimeError) as ps:
+        with self.assertRaises(TypeError) as ps:
           alloc = digital.ofdm_carrier_allocator_cvc(fft_len,
                         ((),),
                         ((),),

--- a/gr-digital/python/digital/qa_ofdm_serializer_vcc.py
+++ b/gr-digital/python/digital/qa_ofdm_serializer_vcc.py
@@ -195,7 +195,7 @@ class qa_ofdm_serializer_vcc (gr_unittest.TestCase):
         """ Make sure it fails if it should """
         fft_len = 16
         occupied_carriers = ((1, 3, 4, 11, 12, 112),) # Something invalid
-        self.assertRaises(RuntimeError, digital.ofdm_serializer_vcc, fft_len, occupied_carriers, self.tsb_key)
+        self.assertRaises(TypeError, digital.ofdm_serializer_vcc, fft_len, occupied_carriers, self.tsb_key)
 
 
 if __name__ == '__main__':

--- a/gr-filter/python/filter/qa_pfb_channelizer.py
+++ b/gr-filter/python/filter/qa_pfb_channelizer.py
@@ -61,7 +61,7 @@ class test_pfb_channelizer(gr_unittest.TestCase):
 
     def test_0003(self):
         """Test roundig error handling for oversample rate, (bad)."""
-        self.assertRaises(RuntimeError,
+        self.assertRaises(TypeError,
                           filter.pfb.channelizer_ccf,
                           36, taps=self.taps, oversample_rate=10.1334)
 


### PR DESCRIPTION
Python3 now has a RuntimeError that's thrown during the pmt to_python function.
Instead of throwing this error, SWIG has been updated to throw a TypeError.
This allows us to keep the same behavior whereby we iterate over PMT types until the proper conversion is found

Resolves #2961