### PR TITLE
Chooser default value change in example flowgraphs

### DIFF
--- a/gr-blocks/examples/matrix_multiplexer.grc
+++ b/gr-blocks/examples/matrix_multiplexer.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: Martin Braun
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -25,6 +26,9 @@ options:
     title: Matrix Multiply/Multiplex Demo
     window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 12.0]
     rotation: 0
     state: enabled
@@ -43,6 +47,7 @@ blocks:
     label4: ''
     labels: '[]'
     num_opts: '3'
+    option0: ((1, 0), (0, 1))
     option1: ((0, 1), (1, 0))
     option2: ((.5, .5), (.5, .5))
     option3: '3'
@@ -53,7 +58,10 @@ blocks:
     value: ((1, 0), (0, 1))
     widget: combo_box
   states:
-    coordinate: [296, 12.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [294, 13]
     rotation: 0
     state: enabled
 - name: samp_rate
@@ -62,6 +70,9 @@ blocks:
     comment: ''
     value: '32000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 12.0]
     rotation: 0
     state: enabled
@@ -76,10 +87,14 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: samp_rate
     type: float
     waveform: analog.GR_COS_WAVE
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 180.0]
     rotation: 0
     state: enabled
@@ -94,7 +109,10 @@ blocks:
     msg: pmt.to_pmt(new_A)
     period: '1000'
   states:
-    coordinate: [224, 404.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [224, 404]
     rotation: 0
     state: enabled
 - name: blocks_multiply_matrix_xx_0
@@ -109,6 +127,9 @@ blocks:
     tag_propagation_policy: gr.TPP_ALL_TO_ALL
     type: float
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 216.0]
     rotation: 0
     state: enabled
@@ -117,7 +138,7 @@ blocks:
   parameters:
     affinity: ''
     alias: ''
-    bus_conns: '[[0,],]'
+    bus_structure_source: '[[0,],]'
     comment: ''
     maxoutbuf: '0'
     minoutbuf: '0'
@@ -125,6 +146,9 @@ blocks:
     type: float
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [88, 328.0]
     rotation: 0
     state: enabled
@@ -141,6 +165,9 @@ blocks:
     type: float
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [224, 316.0]
     rotation: 0
     state: enabled
@@ -161,16 +188,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"cyan"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'
@@ -235,6 +262,9 @@ blocks:
     ymin: '-1'
     yunit: '""'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [728, 204.0]
     rotation: 0
     state: enabled
@@ -255,16 +285,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"cyan"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'
@@ -329,6 +359,9 @@ blocks:
     ymin: '-1'
     yunit: '""'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [728, 300.0]
     rotation: 0
     state: enabled

--- a/gr-digital/examples/demod/constellation_soft_decoder.grc
+++ b/gr-digital/examples/demod/constellation_soft_decoder.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: Tom Rondeau
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -25,6 +26,9 @@ options:
     title: Soft Decoder Example
     window_size: 2000, 2000
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 12.0]
     rotation: 0
     state: enabled
@@ -36,6 +40,9 @@ blocks:
     comment: ''
     value: '4'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [173, 11]
     rotation: 0
     state: enabled
@@ -51,6 +58,9 @@ blocks:
     sym_map: digital.psk_4()[1]
     type: calcdist
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [208, 540.0]
     rotation: 0
     state: enabled
@@ -66,6 +76,9 @@ blocks:
     sym_map: digital.psk_2()[1]
     type: calcdist
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 540.0]
     rotation: 0
     state: disabled
@@ -81,6 +94,9 @@ blocks:
     sym_map: digital.psk_2()[1]
     type: calcdist
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1040, 540.0]
     rotation: 0
     state: disabled
@@ -96,6 +112,9 @@ blocks:
     sym_map: digital.psk_4()[1]
     type: calcdist
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: disabled
@@ -111,6 +130,9 @@ blocks:
     sym_map: digital.qam_16()[1]
     type: calcdist
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [688, 540.0]
     rotation: 0
     state: disabled
@@ -126,6 +148,9 @@ blocks:
     sym_map: digital.qam_16()[1]
     type: calcdist
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [32, 540.0]
     rotation: 0
     state: disabled
@@ -142,6 +167,7 @@ blocks:
     label4: ''
     labels: '[]'
     num_opts: '3'
+    option0: '29'
     option1: '58'
     option2: '116'
     option3: '3'
@@ -152,6 +178,9 @@ blocks:
     value: '29'
     widget: combo_box
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1464, 260.0]
     rotation: 0
     state: enabled
@@ -161,6 +190,9 @@ blocks:
     comment: ''
     value: '32'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [840, 268.0]
     rotation: 0
     state: enabled
@@ -179,6 +211,9 @@ blocks:
     value: '0.0001'
     widget: slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [32, 348.0]
     rotation: 0
     state: enabled
@@ -188,6 +223,9 @@ blocks:
     comment: ''
     value: firdes.root_raised_cosine(nfilts, nfilts, 1.0/float(sps), 0.35, 11*sps*nfilts)
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 268.0]
     rotation: 0
     state: enabled
@@ -197,6 +235,9 @@ blocks:
     comment: ''
     value: '100000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [312, 11]
     rotation: 0
     state: enabled
@@ -206,6 +247,9 @@ blocks:
     comment: ''
     value: '4'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [239, 11]
     rotation: 0
     state: enabled
@@ -223,6 +267,9 @@ blocks:
     repeat: 'True'
     type: byte
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [80, 244.0]
     rotation: 180
     state: enabled
@@ -237,6 +284,9 @@ blocks:
     scale: '1'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1272, 180.0]
     rotation: 0
     state: enabled
@@ -251,6 +301,9 @@ blocks:
     scale: '1'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1272, 124.0]
     rotation: 0
     state: enabled
@@ -265,6 +318,9 @@ blocks:
     scale: '1'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1280, 340.0]
     rotation: 0
     state: enabled
@@ -281,6 +337,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [784, 340.0]
     rotation: 0
     state: enabled
@@ -297,6 +356,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [80, 172.0]
     rotation: 0
     state: enabled
@@ -310,6 +372,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1136, 180.0]
     rotation: 0
     state: enabled
@@ -323,6 +388,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [312, 340.0]
     rotation: 0
     state: enabled
@@ -341,6 +409,9 @@ blocks:
     seed: '0'
     taps: '1.0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -353,6 +424,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1144, 128.0]
     rotation: 0
     state: enabled
@@ -366,6 +440,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1120, 284.0]
     rotation: 0
     state: enabled
@@ -384,6 +461,9 @@ blocks:
     samples_per_symbol: sps
     verbose: 'False'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [256, 148.0]
     rotation: 0
     state: enabled
@@ -397,6 +477,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [928, 124.0]
     rotation: 0
     state: enabled
@@ -410,6 +493,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1136, 236.0]
     rotation: 180
     state: enabled
@@ -430,6 +516,9 @@ blocks:
     taps: rrc_taps
     type: ccf
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [672, 124.0]
     rotation: 0
     state: enabled
@@ -440,6 +529,9 @@ blocks:
     comment: ''
     imports: import cmath
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [488, 11]
     rotation: 0
     state: enabled
@@ -450,6 +542,9 @@ blocks:
     comment: ''
     imports: import math
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [400, 11]
     rotation: 0
     state: enabled
@@ -460,6 +555,9 @@ blocks:
     comment: ''
     note: auto-build LUT
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [32, 492.0]
     rotation: 0
     state: enabled
@@ -470,6 +568,9 @@ blocks:
     comment: ''
     note: Python-generated LUT
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [688, 492.0]
     rotation: 0
     state: enabled
@@ -559,6 +660,9 @@ blocks:
     ymax: '2'
     ymin: '-2'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [928, 52.0]
     rotation: 0
     state: enabled
@@ -579,16 +683,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"cyan"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'
@@ -653,6 +757,9 @@ blocks:
     ymin: '-1'
     yunit: '""'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1464, 128.0]
     rotation: 0
     state: enabled

--- a/gr-digital/examples/demod/symbol_sync_test_complex.grc
+++ b/gr-digital/examples/demod/symbol_sync_test_complex.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: Andy Walls
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -57,6 +58,7 @@ blocks:
     label4: Packets
     labels: '[]'
     num_opts: '5'
+    option0: (0,0,0,0,1)
     option1: (0,1,0,0,0)
     option2: (0,0,1,0,0)
     option3: (0,0,0,1,0)
@@ -613,16 +615,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"magenta"'
-    color3: '"red"'
-    color4: '"green"'
-    color5: '"black"'
-    color6: '"yellow"'
-    color7: '"black"'
-    color8: '"black"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'
@@ -710,16 +712,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"dark green"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'

--- a/gr-digital/examples/demod/symbol_sync_test_float.grc
+++ b/gr-digital/examples/demod/symbol_sync_test_float.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: Andy Walls
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -57,6 +58,7 @@ blocks:
     label4: Packets
     labels: '[]'
     num_opts: '5'
+    option0: (0,0,0,0,1)
     option1: (0,1,0,0,0)
     option2: (0,0,1,0,0)
     option3: (0,0,0,1,0)
@@ -547,16 +549,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"cyan"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'
@@ -644,16 +646,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'False'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"dark green"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'False'
     entags: 'True'

--- a/gr-dtv/examples/uhd_rx_atsc.grc
+++ b/gr-dtv/examples/uhd_rx_atsc.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -24,6 +25,9 @@ options:
     title: Receive ATSC from UHD
     window_size: 4000, 4000
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [10, 10]
     rotation: 0
     state: enabled
@@ -42,6 +46,7 @@ blocks:
     label4: ''
     labels: '[]'
     num_opts: '2'
+    option0: TX/RX
     option1: RX2
     option2: '2'
     option3: '3'
@@ -52,6 +57,9 @@ blocks:
     value: TX/RX
     widget: radio_buttons
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 20.0]
     rotation: 0
     state: enabled
@@ -61,6 +69,9 @@ blocks:
     comment: ''
     value: 4.5e6/286*684
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [96, 108.0]
     rotation: 0
     state: enabled
@@ -73,6 +84,9 @@ blocks:
     type: real
     value: 605e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [520, 20.0]
     rotation: 0
     state: enabled
@@ -91,6 +105,9 @@ blocks:
     value: '18'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [664, 20.0]
     rotation: 0
     state: enabled
@@ -100,6 +117,9 @@ blocks:
     comment: ''
     value: atsc_sym_rate*sps
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [216, 108.0]
     rotation: 0
     state: enabled
@@ -112,6 +132,9 @@ blocks:
     type: real
     value: 6.25e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [520, 92.0]
     rotation: 0
     state: enabled
@@ -121,6 +144,9 @@ blocks:
     comment: ''
     value: '1.1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [16, 108.0]
     rotation: 0
     state: enabled
@@ -138,6 +164,9 @@ blocks:
     reference: '4.0'
     type: float
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1144, 204.0]
     rotation: 0
     state: enabled
@@ -153,6 +182,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1120, 476.0]
     rotation: 0
     state: enabled
@@ -168,6 +200,9 @@ blocks:
     minoutbuf: '0'
     type: ff
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [912, 220.0]
     rotation: 0
     state: enabled
@@ -199,6 +234,9 @@ blocks:
     label9: Tab 9
     num_tabs: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [192, 28.0]
     rotation: 0
     state: enabled
@@ -211,6 +249,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [136, 496.0]
     rotation: 0
     state: enabled
@@ -223,6 +264,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [928, 496.0]
     rotation: 0
     state: enabled
@@ -235,6 +279,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 496.0]
     rotation: 0
     state: enabled
@@ -247,6 +294,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [848, 360.0]
     rotation: 0
     state: enabled
@@ -259,6 +309,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [568, 360.0]
     rotation: 0
     state: enabled
@@ -271,6 +324,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [376, 496.0]
     rotation: 0
     state: enabled
@@ -284,6 +340,9 @@ blocks:
     minoutbuf: '0'
     rate: oversampled_rate
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 356.0]
     rotation: 0
     state: enabled
@@ -296,6 +355,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 360.0]
     rotation: 0
     state: enabled
@@ -309,6 +371,9 @@ blocks:
     minoutbuf: '0'
     rate: oversampled_rate
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [616, 228.0]
     rotation: 0
     state: enabled
@@ -323,6 +388,9 @@ blocks:
     rate: sample_rate
     sps: sps
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [336, 220.0]
     rotation: 0
     state: enabled
@@ -636,6 +704,38 @@ blocks:
     norm_gain9: 'False'
     num_mboards: '1'
     otw: ''
+    rx_agc0: Default
+    rx_agc1: Default
+    rx_agc10: Default
+    rx_agc11: Default
+    rx_agc12: Default
+    rx_agc13: Default
+    rx_agc14: Default
+    rx_agc15: Default
+    rx_agc16: Default
+    rx_agc17: Default
+    rx_agc18: Default
+    rx_agc19: Default
+    rx_agc2: Default
+    rx_agc20: Default
+    rx_agc21: Default
+    rx_agc22: Default
+    rx_agc23: Default
+    rx_agc24: Default
+    rx_agc25: Default
+    rx_agc26: Default
+    rx_agc27: Default
+    rx_agc28: Default
+    rx_agc29: Default
+    rx_agc3: Default
+    rx_agc30: Default
+    rx_agc31: Default
+    rx_agc4: Default
+    rx_agc5: Default
+    rx_agc6: Default
+    rx_agc7: Default
+    rx_agc8: Default
+    rx_agc9: Default
     samp_rate: sample_rate
     sd_spec0: ''
     sd_spec1: ''
@@ -659,6 +759,9 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [40, 180.0]
     rotation: 0
     state: true
@@ -736,54 +839,61 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [40, 332.0]
     rotation: 180
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: agc-sync
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1136, 300.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: viterbi-deint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1120, 404.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: viterbi-deint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [136, 444.0]
     rotation: 180
     state: true
 - name: virtual_source_2
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: agc-sync
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 300.0]
     rotation: 180
     state: true

--- a/gr-uhd/examples/grc/uhd_fft.grc
+++ b/gr-uhd/examples/grc/uhd_fft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: Example
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -45,6 +46,7 @@ blocks:
     label4: ''
     labels: '[]'
     num_opts: '4'
+    option0: RX2
     option1: TX/RX
     option2: J1
     option3: J2
@@ -421,16 +423,16 @@ blocks:
     alpha9: '1.0'
     autoscale: 'True'
     axislabels: 'True'
-    color1: '"blue"'
-    color10: '"blue"'
-    color2: '"red"'
-    color3: '"green"'
-    color4: '"black"'
-    color5: '"cyan"'
-    color6: '"magenta"'
-    color7: '"yellow"'
-    color8: '"dark red"'
-    color9: '"dark green"'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
     comment: ''
     ctrlpanel: 'True'
     entags: 'True'

--- a/gr-uhd/examples/grc/uhd_msg_tune.grc
+++ b/gr-uhd/examples/grc/uhd_msg_tune.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -46,6 +47,7 @@ blocks:
     label4: ''
     labels: '[]'
     num_opts: '2'
+    option0: TX/RX
     option1: RX2
     option2: '2'
     option3: '3'

--- a/gr-uhd/examples/grc/uhd_siggen_gui.grc
+++ b/gr-uhd/examples/grc/uhd_siggen_gui.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: Ettus Research
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -66,6 +67,7 @@ blocks:
     label4: ''
     labels: '[]'
     num_opts: '2'
+    option0: RX2
     option1: TX/RX
     option2: J1
     option3: J2
@@ -317,6 +319,7 @@ blocks:
     label4: Sweep
     labels: '[]'
     num_opts: '5'
+    option0: '0'
     option1: '1'
     option2: '2'
     option3: '3'


### PR DESCRIPTION
After the way the default value was configured for QT GUI Chooser, this did not propagate correctly in flowgraphs that use it.  

The new "default" value was set to whatever open 0 was set to, then option 0 was set to "0"

This fixes the example flowgraphs only, not the underlying problem that made the new behavior not update automatically

Fixes #3027 