### PR TITLE
blocks: support saving of all tags on tag debug

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/tag_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/tag_debug.h
@@ -77,6 +77,12 @@ public:
     virtual void set_display(bool d) = 0;
 
     /*!
+     * \brief Set whether to store all tags ever received (s=True) or solely the
+     * tags from the last work (s=False).
+     */
+    virtual void set_save_all(bool s) = 0;
+
+    /*!
      * \brief Set a new key to filter with.
      */
     virtual void set_key_filter(const std::string& key_filter) = 0;

--- a/gr-blocks/lib/tag_debug_impl.h
+++ b/gr-blocks/lib/tag_debug_impl.h
@@ -22,8 +22,10 @@ class tag_debug_impl : public tag_debug
 {
 private:
     const std::string d_name;
-    std::vector<tag_t> d_tags;
+    std::vector<tag_t> d_work_tags; /** tags from last work */
+    std::vector<tag_t> d_tags;      /** optionally holds all tags ever received */
     bool d_display;
+    bool d_save_all;
     pmt::pmt_t d_filter;
     gr::thread::mutex d_mutex;
 
@@ -39,6 +41,8 @@ public:
     int num_tags();
 
     void set_display(bool d);
+
+    void set_save_all(bool s);
 
     void set_key_filter(const std::string& key_filter);
     std::string key_filter() const;


### PR DESCRIPTION
For testing, it is often useful to check all tags ever received, rather than
solely the tags from the last call to the Tag Debug's work function. This patch
adds this option and a public method for activating it.

This is more appropriate for controlled test environments, where the vector of
tags is known not to grown indefinitely. Hence, the option is not exposed as a
block parameter.