### PR TITLE
runtime: fixup attributes for Clang, GNUC, and MSC

### DIFF
--- a/gnuradio-runtime/include/gnuradio/attributes.h
+++ b/gnuradio-runtime/include/gnuradio/attributes.h
@@ -25,7 +25,17 @@
 ////////////////////////////////////////////////////////////////////////
 // Cross-platform attribute macros
 ////////////////////////////////////////////////////////////////////////
-#if defined __GNUC__
+#if defined(__clang__) && (!defined(_MSC_VER))
+// AppleClang also defines __GNUC__, so do this check first.  These
+// will probably be the same as for __GNUC__, but let's keep them
+// separate just to be safe.
+#define __GR_ATTR_ALIGNED(x) __attribute__((aligned(x)))
+#define __GR_ATTR_UNUSED __attribute__((unused))
+#define __GR_ATTR_INLINE __attribute__((always_inline))
+#define __GR_ATTR_DEPRECATED __attribute__((deprecated))
+#define __GR_ATTR_EXPORT __attribute__((visibility("default")))
+#define __GR_ATTR_IMPORT __attribute__((visibility("default")))
+#elif defined __GNUC__
 #define __GR_ATTR_ALIGNED(x) __attribute__((aligned(x)))
 #define __GR_ATTR_UNUSED __attribute__((unused))
 #define __GR_ATTR_INLINE __attribute__((always_inline))
@@ -37,13 +47,6 @@
 #define __GR_ATTR_EXPORT
 #define __GR_ATTR_IMPORT
 #endif
-#elif defined __clang__
-#define __GR_ATTR_ALIGNED(x) __attribute__((aligned(x)))
-#define __GR_ATTR_UNUSED __attribute__((unused))
-#define __GR_ATTR_INLINE __attribute__((always_inline))
-#define __GR_ATTR_DEPRECATED __attribute__((deprecated))
-#define __GR_ATTR_EXPORT __attribute__((visibility("default")))
-#define __GR_ATTR_IMPORT __attribute__((visibility("default")))
 #elif _MSC_VER
 #define __GR_ATTR_ALIGNED(x) __declspec(align(x))
 #define __GR_ATTR_UNUSED


### PR DESCRIPTION
Relatively simple change, which should help MSC builds when using Clang.

1) put clang before GNUC, to keep their settings separate, because some clang defines GNUC.

2) change from clang to "clang but not MSC", because MSC attributes are covered in a later clause.

Related to: https://github.com/gnuradio/volk/commit/7abdaa5da2ab236ed8acfe361d04021050146778#commitcomment-36709586 and https://github.com/gnuradio/volk/pull/325