### PR TITLE
gr-digital/costas_loop: use std::norm for |z|^2

### DIFF
--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -123,7 +123,7 @@ float costas_loop_cc_impl::phase_detector_2(gr_complex sample) const
 float costas_loop_cc_impl::phase_detector_snr_8(gr_complex sample) const
 {
     const float K = (sqrtf(2.0) - 1);
-    const float snr = (sample * std::conj(sample)).real() / d_noise;
+    const float snr = std::norm(sample) / d_noise;
     if (fabsf(sample.real()) >= fabsf(sample.imag())) {
         return ((blocks::tanhf_lut(snr * sample.real()) * sample.imag()) -
                 (blocks::tanhf_lut(snr * sample.imag()) * sample.real() * K));
@@ -135,14 +135,14 @@ float costas_loop_cc_impl::phase_detector_snr_8(gr_complex sample) const
 
 float costas_loop_cc_impl::phase_detector_snr_4(gr_complex sample) const
 {
-    const float snr = (sample * std::conj(sample)).real() / d_noise;
+    const float snr = std::norm(sample) / d_noise;
     return ((blocks::tanhf_lut(snr * sample.real()) * sample.imag()) -
             (blocks::tanhf_lut(snr * sample.imag()) * sample.real()));
 }
 
 float costas_loop_cc_impl::phase_detector_snr_2(gr_complex sample) const
 {
-    const float snr = (sample * std::conj(sample)).real() / d_noise;
+    const float snr = std::norm(sample) / d_noise;
     return blocks::tanhf_lut(snr * sample.real()) * sample.imag();
 }
 


### PR DESCRIPTION
Use `std::norm(z)` instead of `(z*std::conj(z)).real()`. This should be faster (except for compiler optimizations) as the imaginary part is not computed and it is also easier to read.
The only downside is that the poorly named `std::norm` can lead to confusion.

This is based on fdb80ea8d32497a358b8787f47f1c70bcf18bb21.