### PR TITLE
modtool: ensure add_py_qa and add_cc_qa are booleans

### DIFF
--- a/gr-utils/python/modtool/cli/add.py
+++ b/gr-utils/python/modtool/cli/add.py
@@ -138,13 +138,17 @@ def get_arglist(self):
 
 def get_py_qa(self):
     """ Get a boolean value for addition of py_qa """
-    if not (self.info['blocktype'] in ('noblock') or self.skip_subdirs['python']):
-        if self.add_py_qa is None:
+    if self.add_py_qa is None:
+        if not (self.info['blocktype'] in ('noblock') or self.skip_subdirs['python']):
             self.add_py_qa = ask_yes_no(click.style('Add Python QA code?', fg='cyan'), True)
+        else:
+            self.add_py_qa = False
 
 def get_cpp_qa(self):
     """ Get a boolean value for addition of cpp_qa """
-    if self.info['lang'] == 'cpp':
-        if self.add_cc_qa is None:
+    if self.add_cc_qa is None:
+        if self.info['lang'] == 'cpp':
             self.add_cc_qa = ask_yes_no(click.style('Add C++ QA code?', fg='cyan'),
                                         not self.add_py_qa)
+        else:
+            self.add_cc_qa = False


### PR DESCRIPTION
When I attempt to create a Python block with `gr_modtool` in GNU Radio 3.8, I get the following error:
```
$ gr_modtool add
GNU Radio module name identified: foo
('sink', 'source', 'sync', 'decimator', 'interpolator', 'general', 'tagged_stream', 'hier', 'noblock')
Enter block type: sink
Language (python/cpp): python
Language: Python
Enter name of block/code (without module name prefix): bar
Block/code identifier: bar
Please specify the copyright holder: Clayton Smith
Enter valid argument list, including default arguments: 

Add Python QA code? [Y/n] 
Traceback (most recent call last):
  File "/home/argilo/prefix_next/bin/gr_modtool", line 30, in <module>
    cli()
  File "/home/argilo/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/argilo/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/argilo/.local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/argilo/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/argilo/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/argilo/prefix_next/lib/python3/dist-packages/gnuradio/modtool/cli/base.py", line 153, in wrapper
    return func(*args, **kwargs)
  File "/home/argilo/prefix_next/lib/python3/dist-packages/gnuradio/modtool/cli/add.py", line 81, in cli
    run(self)
  File "/home/argilo/prefix_next/lib/python3/dist-packages/gnuradio/modtool/cli/base.py", line 172, in run
    module.run()
  File "/home/argilo/prefix_next/lib/python3/dist-packages/gnuradio/modtool/core/add.py", line 134, in run
    self.validate()
  File "/home/argilo/prefix_next/lib/python3/dist-packages/gnuradio/modtool/core/add.py", line 79, in validate
    raise ModToolException('Expected a boolean value for add_cpp_qa.')
gnuradio.modtool.core.base.ModToolException: Expected a boolean value for add_cpp_qa.
```
This code requires `add_py_qa` and `add_cc_qa` to be booleans:

https://github.com/gnuradio/gnuradio/blob/089843b12593ae5567540117dd039edb0dfd7f86/gr-utils/python/modtool/core/add.py#L76-L79

They start out as `None` if the corresponding command line options are not given:

https://github.com/gnuradio/gnuradio/blob/089843b12593ae5567540117dd039edb0dfd7f86/gr-utils/python/modtool/cli/add.py#L46-L49

Then these functions are called, which ask the user for their choice, if necessary:

https://github.com/gnuradio/gnuradio/blob/089843b12593ae5567540117dd039edb0dfd7f86/gr-utils/python/modtool/cli/add.py#L139-L150

But in cases where the command line options are not specified and the user is not asked for their input (for example, because they're creating a Python module, which doesn't need C++ QA) the value will be left as `None`, causing the validation to fail.

To fix the problem, I've modified `get_py_qa` and `get_cpp_qa` so that they always replace `None` with either `True` or `False`.