### PR TITLE
qtgui: Replace "is not" with "!=" to get rid of warning

### DIFF
--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -38,7 +38,7 @@ class Range(object):
     def find_precision(self):
         # Get the decimal part of the step
         temp = str(float(self.step) - int(self.step))[2:]
-        precision = len(temp) if temp is not '0' else 0
+        precision = len(temp) if temp != '0' else 0
         precision = min(precision, 13)
 
         if precision == 0 and self.max < 100:


### PR DESCRIPTION
The warning shows up in Python 3.8:

```python
/usr/local/lib/python3.8/site-packages/gnuradio/qtgui/range.py:41: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  precision = len(temp) if temp is not '0' else 
```