### PR TITLE
modtool: fix alignment of version info

### DIFF
--- a/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/python/modtool/templates/gr-newmod/CMakeLists.txt
@@ -43,8 +43,8 @@ list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 # Set the version information here
 set(VERSION_MAJOR 1)
-set(VERSION_API    0)
-set(VERSION_ABI 0)
+set(VERSION_API   0)
+set(VERSION_ABI   0)
 set(VERSION_PATCH git)
 
 cmake_policy(SET CMP0011 NEW)


### PR DESCRIPTION
https://github.com/gnuradio/gnuradio/pull/2624 accidentally left the version information misaligned in modtool. This PR fixes the spacing to line up the components again.

This fix should be applied to the master branch as well.