### PR TITLE
gr-blocks: work around broken rotator in VOLK 2.0.0

### DIFF
--- a/gr-blocks/lib/rotator_cc_impl.cc
+++ b/gr-blocks/lib/rotator_cc_impl.cc
@@ -59,7 +59,7 @@ int rotator_cc_impl::work(int noutput_items,
     const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
-#if 0
+#if 1
       for (int i=0; i<noutput_items; i++)
       	out[i] = d_r.rotate(in[i]);
 #else


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/2748.

Replaces https://github.com/gnuradio/gnuradio/pull/3056.

Since GNU Radio 3.8 appears to be stuck with VOLK 2.0.0's broken rotator implementation, I propose to work around the problem by not using VOLK in the rotator block. It seems to me that it's better to have a slow rotator block than one that doesn't work at all.

This workaround is not needed on the master branch, since it already uses VOLK 2.1.0, which has a functioning rotator kernel.

@mbr0wn @michaelld @devnulling 