### PR TITLE
audio: VOLKize alsa_sink 

### DIFF
--- a/gr-audio/lib/alsa/alsa_sink.h
+++ b/gr-audio/lib/alsa/alsa_sink.h
@@ -63,6 +63,8 @@ class alsa_sink : public sink
     snd_pcm_uframes_t d_period_size;  // in frames
     unsigned int d_buffer_size_bytes; // sizeof of d_buffer
     char* d_buffer;
+    unsigned int d_channel_buffers_size_bytes; // size of buffer for each chan
+    volk::vector<volk::vector<char>> d_channel_buffers;
     work_t d_worker; // the work method to use
     bool d_special_case_mono_to_stereo;
 
@@ -73,6 +75,13 @@ class alsa_sink : public sink
 
     void output_error_msg(const char* msg, int err);
     void bail(const char* msg, int err);
+    void check_output_channels(unsigned int nchan);
+    template <class T>
+    void build_output_buffer(T* buf, unsigned int startperiod, unsigned int endperiod);
+    template <class T>
+    void cast_output_buffers_to_sample_t(const float** in,
+                                         unsigned int nchan,
+                                         float scale_factor);
 
 public:
     alsa_sink(int sampling_rate, const std::string device_name, bool ok_to_block);

--- a/gr-audio/lib/alsa/alsa_sink.h
+++ b/gr-audio/lib/alsa/alsa_sink.h
@@ -29,6 +29,7 @@
 
 #include <gnuradio/audio/sink.h>
 #include <alsa/asoundlib.h>
+#include <volk/volk_alloc.hh>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
Will close #3025. This is a placeholder for future commits, I wanted to get @marcusmueller 's opinion on the implementation. I've worked on the `work_s32` function so far.

Use `volk_32f_s32f_convert_32i` to speed up converting each `float` channel to `int32_t`. Use `volk::vector` to hold each `int32_t` channel buffer until output buffer is built. I'll remove those long comments after I hear back.