### PR TITLE
Filter: Improve Performance in xlating FIR Filter

### DIFF
--- a/gr-filter/lib/freq_xlating_fir_filter_impl.h
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.h
@@ -42,6 +42,7 @@ protected:
     double d_center_freq;
     double d_sampling_freq;
     bool d_updated;
+    const int d_decim;
 
     virtual void build_composite_fir();
 


### PR DESCRIPTION
Re-ordered work call to let rotate take advantage of volk.  Rather than rotating individually with each for, the rotate happens after with a rotateN to use the volk version for the data.  Removed decimation() function stack push/pop with each loop iteration.