### PR TITLE
blocktool: minor convenience changes and resolve some parsing errors

### DIFF
--- a/gr-utils/python/blocktool/cli.py
+++ b/gr-utils/python/blocktool/cli.py
@@ -66,6 +66,8 @@ def run_blocktool(module):
               help='blocktool helper comments will be added in the header file')
 @click.option('-o', '--output', is_flag=True,
               help='If given, a file with desired output format will be generated')
+@click.option('-I', '--include_paths', default=None,
+              help='Comma separated list of include paths for header files')
 def cli(**kwargs):
     """
     Block header parsing tool.

--- a/gr-utils/python/blocktool/core/base.py
+++ b/gr-utils/python/blocktool/core/base.py
@@ -39,7 +39,7 @@ class BlockTool(ABC):
 
     def __init__(self, modname=None, filename=None, targetdir=None,
                  target_file=None, module=None, impldir=None, impl_file=None,
-                 yaml=False, json=False, **kwargs):
+                 yaml=False, json=False, include_paths=None, **kwargs):
         """ __init__ """
         pass
 

--- a/gr-utils/python/blocktool/core/parseheader.py
+++ b/gr-utils/python/blocktool/core/parseheader.py
@@ -51,11 +51,13 @@ class BlockHeaderParser(BlockTool):
     name = 'Block Parse Header'
     description = 'Create a parsed output from a block header file'
 
-    def __init__(self, file_path=None, blocktool_comments=False, **kwargs):
+    def __init__(self, file_path=None, blocktool_comments=False, include_paths=None, **kwargs):
         """ __init__ """
         BlockTool.__init__(self, **kwargs)
         self.parsed_data = {}
         self.addcomments = blocktool_comments
+        if (include_paths):
+            self.include_paths = [p.strip() for p in include_paths.split(',')]
         if not os.path.isfile(file_path):
             raise BlockToolException('file does not exist')
         file_path = os.path.abspath(file_path)
@@ -104,6 +106,7 @@ class BlockHeaderParser(BlockTool):
         xml_generator_config = parser.xml_generator_configuration_t(
             xml_generator_path=generator_path,
             xml_generator=generator_name,
+            include_paths=self.include_paths,
             compiler='gcc')
         decls = parser.parse(
             [self.target_file], xml_generator_config)

--- a/gr-utils/python/blocktool/core/parseheader.py
+++ b/gr-utils/python/blocktool/core/parseheader.py
@@ -56,6 +56,7 @@ class BlockHeaderParser(BlockTool):
         BlockTool.__init__(self, **kwargs)
         self.parsed_data = {}
         self.addcomments = blocktool_comments
+        self.include_paths = None
         if (include_paths):
             self.include_paths = [p.strip() for p in include_paths.split(',')]
         if not os.path.isfile(file_path):
@@ -107,7 +108,9 @@ class BlockHeaderParser(BlockTool):
             xml_generator_path=generator_path,
             xml_generator=generator_name,
             include_paths=self.include_paths,
-            compiler='gcc')
+            compiler='gcc',
+            define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC'],
+            cflags='-std=c++11')
         decls = parser.parse(
             [self.target_file], xml_generator_config)
         global_namespace = declarations.get_global_namespace(decls)


### PR DESCRIPTION
My setup here is Ubuntu 19.10 with gcc-9 which may come into play as to why these changes were needed

1) pygccxml was throwing "invalid constraint in asm" related to boost
to resolve this had to add the define BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC
without this you get a bunch of:
```
/usr/include/boost/atomic/detail/extra_ops_gcc_x86.hpp:56:50: error: invalid output constraint '=@ccc' in asm
            : [storage] "+m" (storage), [result] "=@ccc" (res)
                                                 ^
/usr/include/boost/atomic/detail/extra_ops_gcc_x86.hpp:80:50: error: invalid output constraint '=@ccc' in asm
            : [storage] "+m" (storage), [result] "=@ccc" (res)
```
also had to add -std=c++11, which without that you get
```
/usr/include/c++/9/bits/stl_function.h:418:6: error: use of undeclared identifier '__builtin_is_constant_evaluated'
        if (__builtin_is_constant_evaluated())
```
2) include paths were assuming /usr/include which is not always the case
- added extra cli parameters for include paths
3) made gr_blocktool a top level program that gets installed

