### PR TITLE
Blocks: Changed decimation() and interpolation() methods to inline

### DIFF
--- a/gnuradio-runtime/include/gnuradio/sync_decimator.h
+++ b/gnuradio-runtime/include/gnuradio/sync_decimator.h
@@ -47,7 +47,7 @@ protected:
                    unsigned decimation);
 
 public:
-    unsigned decimation() const { return d_decimation; }
+    inline unsigned decimation() const { return d_decimation; }
     void set_decimation(unsigned decimation)
     {
         d_decimation = decimation;

--- a/gnuradio-runtime/include/gnuradio/sync_interpolator.h
+++ b/gnuradio-runtime/include/gnuradio/sync_interpolator.h
@@ -47,7 +47,7 @@ protected:
                       unsigned interpolation);
 
 public:
-    unsigned interpolation() const { return d_interpolation; }
+    inline unsigned interpolation() const { return d_interpolation; }
     void set_interpolation(unsigned interpolation)
     {
         d_interpolation = interpolation;


### PR DESCRIPTION
Some blocks use the function call to decimation() or interpolation() in a for loop resulting in stack push/pops to get the static result every iteration.  Moving to inline should eliminate the jump and improve performance when used in loops.