### PR TITLE
gr-dtv: atsc_equalizer_impl: bool not int

### DIFF
--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.h
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.h
@@ -56,7 +56,7 @@ private:
     unsigned short d_flags;
     short d_segno;
 
-    int d_buff_not_filled;
+    bool d_buff_not_filled;
 
 public:
     atsc_equalizer_impl();


### PR DESCRIPTION
The 'true' and 'false' values are implicitly cast to the integer type.
See atsc_equalizer_impl.cc