### PR TITLE
pmt: remove dead typo code

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -992,16 +992,6 @@ public:
     }
 };
 
-// FIXME: Remove in 3.8.
-class comperator
-{
-public:
-    bool operator()(pmt::pmt_t const& p1, pmt::pmt_t const& p2) const
-    {
-        return pmt::eqv(p1, p2) ? false : p1.get() > p2.get();
-    }
-};
-
 } /* namespace pmt */
 
 #include <pmt/pmt_sugar.h>


### PR DESCRIPTION
Class with misspelling comperator had been replaced with the proper
spelling comparator and a note to remove in 3.8.  Removing it here