### PR TITLE
examples: fixup filters cmake and polyphase channelizer demo

### DIFF
--- a/gr-filter/examples/CMakeLists.txt
+++ b/gr-filter/examples/CMakeLists.txt
@@ -21,6 +21,7 @@ include(GrPython)
 
 # Base stuff
 GR_PYTHON_INSTALL(PROGRAMS
+    benchmark_filters.py
     channelize.py
     chirp_channelize.py
     decimate.py
@@ -42,6 +43,9 @@ GR_PYTHON_INSTALL(PROGRAMS
 install(
     FILES
     filter_taps.grc
+    filter_taps_loader.grc
+    filter_taps_example_complex_bandpass_taps
+    polyphase_channelizer_demo.grc
     resampler_demo.grc
     DESTINATION ${GR_PKG_FILTER_EXAMPLES_DIR}
 )

--- a/gr-filter/examples/polyphase_channelizer_demo.grc
+++ b/gr-filter/examples/polyphase_channelizer_demo.grc
@@ -24,6 +24,9 @@ options:
     title: ''
     window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [10, 10]
     rotation: 0
     state: enabled
@@ -35,9 +38,31 @@ blocks:
     comment: ''
     value: '32000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [179, 9]
     rotation: 0
     state: enabled
+- name: analog_noise_source_x_0
+  id: analog_noise_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: '.01'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    noise_type: analog.GR_GAUSSIAN
+    seed: '0'
+    type: complex
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [72, 492.0]
+    rotation: 0
+    state: true
 - name: analog_sig_source_x_0
   id: analog_sig_source_x
   parameters:
@@ -49,10 +74,14 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: samp_rate
     type: complex
     waveform: analog.GR_COS_WAVE
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [48, 108.0]
     rotation: 0
     state: enabled
@@ -67,11 +96,15 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: samp_rate
     type: complex
     waveform: analog.GR_COS_WAVE
   states:
-    coordinate: [48, 220.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [48, 236.0]
     rotation: 0
     state: enabled
 - name: analog_sig_source_x_2
@@ -85,11 +118,15 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
+    phase: '0'
     samp_rate: samp_rate
     type: complex
     waveform: analog.GR_COS_WAVE
   states:
-    coordinate: [48, 340.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [48, 364.0]
     rotation: 0
     state: enabled
 - name: blocks_add_xx_0
@@ -100,13 +137,35 @@ blocks:
     comment: ''
     maxoutbuf: '0'
     minoutbuf: '0'
-    num_inputs: '3'
+    num_inputs: '4'
     type: complex
     vlen: '1'
   states:
-    coordinate: [264, 224.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 224.0]
     rotation: 0
     state: enabled
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [248, 508.0]
+    rotation: 0
+    state: true
 - name: pfb_channelizer_hier_ccf_0
   id: pfb_channelizer_hier_ccf
   parameters:
@@ -124,7 +183,10 @@ blocks:
     taps: None
     tb: '0.2'
   states:
-    coordinate: [384, 204.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [496, 228.0]
     rotation: 0
     state: enabled
 - name: qtgui_freq_sink_x_0
@@ -162,7 +224,7 @@ blocks:
     fftsize: '1024'
     freqhalf: 'True'
     grid: 'False'
-    gui_hint: ''
+    gui_hint: 0,0,1,3
     label: Relative Gain
     label1: ''
     label10: ''
@@ -177,7 +239,7 @@ blocks:
     legend: 'True'
     maxoutbuf: '0'
     minoutbuf: '0'
-    name: ''
+    name: '"Spectrum"'
     nconnections: '1'
     showports: 'True'
     tr_chan: '0'
@@ -201,7 +263,10 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
-    coordinate: [384, 108.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [496, 120.0]
     rotation: 0
     state: enabled
 - name: qtgui_freq_sink_x_0_0
@@ -239,7 +304,7 @@ blocks:
     fftsize: '1024'
     freqhalf: 'True'
     grid: 'False'
-    gui_hint: ''
+    gui_hint: 1,2,1,1
     label: Relative Gain
     label1: ''
     label10: ''
@@ -254,7 +319,7 @@ blocks:
     legend: 'False'
     maxoutbuf: '0'
     minoutbuf: '0'
-    name: ''
+    name: '"Ch2"'
     nconnections: '1'
     showports: 'True'
     tr_chan: '0'
@@ -278,7 +343,10 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
-    coordinate: [808, 332.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [920, 384.0]
     rotation: 0
     state: enabled
 - name: qtgui_freq_sink_x_0_1
@@ -316,7 +384,7 @@ blocks:
     fftsize: '1024'
     freqhalf: 'True'
     grid: 'False'
-    gui_hint: ''
+    gui_hint: 1,1,1,1
     label: Relative Gain
     label1: ''
     label10: ''
@@ -331,7 +399,7 @@ blocks:
     legend: 'False'
     maxoutbuf: '0'
     minoutbuf: '0'
-    name: ''
+    name: '"Ch1"'
     nconnections: '1'
     showports: 'True'
     tr_chan: '0'
@@ -355,7 +423,10 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
-    coordinate: [808, 236.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [920, 280.0]
     rotation: 0
     state: enabled
 - name: qtgui_freq_sink_x_0_2
@@ -393,7 +464,7 @@ blocks:
     fftsize: '1024'
     freqhalf: 'True'
     grid: 'False'
-    gui_hint: ''
+    gui_hint: 1,0,1,1
     label: Relative Gain
     label1: ''
     label10: ''
@@ -408,7 +479,7 @@ blocks:
     legend: 'False'
     maxoutbuf: '0'
     minoutbuf: '0'
-    name: ''
+    name: '"Ch0"'
     nconnections: '1'
     showports: 'True'
     tr_chan: '0'
@@ -432,16 +503,21 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
-    coordinate: [808, 140.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [920, 176.0]
     rotation: 0
     state: enabled
 
 connections:
+- [analog_noise_source_x_0, '0', blocks_throttle_0, '0']
 - [analog_sig_source_x_0, '0', blocks_add_xx_0, '0']
 - [analog_sig_source_x_1, '0', blocks_add_xx_0, '1']
 - [analog_sig_source_x_2, '0', blocks_add_xx_0, '2']
 - [blocks_add_xx_0, '0', pfb_channelizer_hier_ccf_0, '0']
 - [blocks_add_xx_0, '0', qtgui_freq_sink_x_0, '0']
+- [blocks_throttle_0, '0', blocks_add_xx_0, '3']
 - [pfb_channelizer_hier_ccf_0, '0', qtgui_freq_sink_x_0_2, '0']
 - [pfb_channelizer_hier_ccf_0, '1', qtgui_freq_sink_x_0_1, '0']
 - [pfb_channelizer_hier_ccf_0, '2', qtgui_freq_sink_x_0_0, '0']


### PR DESCRIPTION
- Fixes up cmake for `gr-filters/examples` to install a few files that were missing

- Renames `channelizer_demo.grc` to be `polyphase_channelizer_demo.grc`

Minor tweaks to `polyphase_channelizer_demo.grc`:
- Sets QT layout for Freq sinks
- Adds `Noise Source` and `Throttle Block`
- Adds Labels to each of the Freq sinks
- Disables Autoscaling on the Ch2 Freq sink block 

![polyphase_channelizer](https://user-images.githubusercontent.com/11846824/72658655-b25c5900-3968-11ea-9b85-30af002b5759.png)

![polyphase_channelizer_running](https://user-images.githubusercontent.com/11846824/72658657-b5efe000-3968-11ea-9273-0b3ca1e905d8.png)

