### PR TITLE
cmake: fix toplevel cmake for CONTRIBUTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,7 +452,7 @@ find_package(LOG4CPP REQUIRED)
 # Distribute the README file
 ########################################################################
 install(
-    FILES README.md README.hacking CHANGELOG.md
+    FILES README.md CONTRIBUTING.md CHANGELOG.md
     DESTINATION ${GR_PKG_DOC_DIR}
 )
 


### PR DESCRIPTION
Fixes:

```
Install the project...
-- Install configuration: "Release"
-- Installing: /home/user/sdr/installs/v3.15.0.0_filter_examples/share/doc/gnuradio-3.9.0.0-git/README.md
CMake Error at cmake_install.cmake:41 (file):
  file INSTALL cannot find
  "/home/user/sdr/installs/v3.15.0.0_filter_examples/src/gnuradio/README.hacking":
  No such file or directory.


Makefile:128: recipe for target 'install' failed
make: *** [install] Error 1

```

From: https://github.com/gnuradio/gnuradio/commit/14779d119ae0abc06814724d513de78a0b5b5f87