### PR TITLE
grc: Fix eng_float default on argparse template

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -303,7 +303,7 @@ def argument_parser():
 
         default = param.templates.render('make')
         if type_ == 'eng_float':
-            default = '"' + eng_notation.num_to_str(float(default)) + '"'
+            default = "eng_notation.num_to_str(float(" + default + "))"
         # FIXME:
         if type_ == 'string':
             type_ = 'str'

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -271,13 +271,6 @@ gr.io_signaturev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}])\
 ##  For top block code, generate a main routine.
 ##  Instantiate the top block and run as gui or cli.
 ########################################################
-<%def name="make_default(type_, param)">
-    % if type_ == 'eng_float':
-eng_notation.num_to_str(float(${param.templates.render('make')}))
-    % else:
-${param.templates.render('make')}
-    % endif
-</%def>\
 % if not generate_options.startswith('hb'):
 <% params_eq_list = list() %>
 % if parameters:


### PR DESCRIPTION
The `import` of `eng_notation` was removed from `flow_graph.py.mako` in 678a7c2ad, and so float parameter blocks were leading to flowgraph compilation error.

Since `eng_notation` is still ultimately imported in the generated python script, we can put the call to `num_to_str` in the generated script, instead of calling it during script generation.

The second commit of this PR simply removes a definition that seems to be unused and which also contains a call to `eng_notation.num_to_str`.