### PR TITLE
examples: fixup cmake files to include all examples

### DIFF
--- a/gr-blocks/examples/CMakeLists.txt
+++ b/gr-blocks/examples/CMakeLists.txt
@@ -21,8 +21,9 @@ install(
   FILES
   matrix_multiplexer.grc
   peak_detector2.grc
-  vector_source_with_tags.grc
+  selector.grc
   test_stream_mux_tags.grc
+  vector_source_with_tags.grc
   DESTINATION ${GR_PKG_DATA_DIR}/examples/blocks
 )
 

--- a/gr-blocks/examples/ctrlport/CMakeLists.txt
+++ b/gr-blocks/examples/ctrlport/CMakeLists.txt
@@ -31,5 +31,6 @@ install(
 GR_PYTHON_INSTALL(PROGRAMS
   simple_copy_controller.py
   usrp_source_controller.py
+  usrp_sink_controller.py
   DESTINATION ${GR_PKG_DATA_DIR}/examples/ctrlport
 )

--- a/gr-blocks/examples/msg_passing/CMakeLists.txt
+++ b/gr-blocks/examples/msg_passing/CMakeLists.txt
@@ -22,5 +22,7 @@ include(GrPython)
 install(
   FILES
   strobe.grc
+  hier/test_msg_hier.grc
+  hier/test_msg_hier_topblock.grc
   DESTINATION ${GR_PKG_DATA_DIR}/examples/msg_passing
 )

--- a/gr-blocks/examples/tags/CMakeLists.txt
+++ b/gr-blocks/examples/tags/CMakeLists.txt
@@ -19,6 +19,13 @@
 
 include(GrPython)
 
+install(
+    FILES
+    tagged_file_sink.grc
+    test_tag_prop.grc
+    DESTINATION ${GR_PKG_DATA_DIR}/examples/tags
+)
+
 GR_PYTHON_INSTALL(PROGRAMS
   test_file_tags.py
   DESTINATION ${GR_PKG_DATA_DIR}/examples/tags

--- a/gr-channels/examples/CMakeLists.txt
+++ b/gr-channels/examples/CMakeLists.txt
@@ -22,11 +22,11 @@ include(GrPython)
 install(
   FILES
   channel_tone_response.grc
-  demo_quantization.grc
-  demo_two_tone.grc
-  demo_spec_an.grc
   demo_gmsk.grc
-  demo_qam.grc
   demo_ofdm.grc
+  demo_qam.grc
+  demo_quantization.grc
+  demo_spec_an.grc
+  demo_two_tone.grc
   DESTINATION ${GR_PKG_CHANNELS_EXAMPLES_DIR}
 )

--- a/gr-digital/examples/CMakeLists.txt
+++ b/gr-digital/examples/CMakeLists.txt
@@ -21,11 +21,12 @@ include(GrPython)
 
 # Base stuff
 GR_PYTHON_INSTALL(PROGRAMS
+    berawgn.py
     example_costas.py
     example_fll.py
     example_timing.py
-    run_length.py
     gen_whitener.py
+    run_length.py
     snr_estimators.py
     DESTINATION ${GR_PKG_DIGITAL_EXAMPLES_DIR}
 )
@@ -38,10 +39,10 @@ install(
 
 # Narrowband
 GR_PYTHON_INSTALL(PROGRAMS
-    narrowband/uhd_interface.py
+    narrowband/benchmark_add_channel.py
     narrowband/digital_bert_rx.py
     narrowband/digital_bert_tx.py
-    narrowband/benchmark_add_channel.py
+    narrowband/uhd_interface.py
     DESTINATION ${GR_PKG_DIGITAL_EXAMPLES_DIR}/narrowband
 )
 
@@ -56,9 +57,12 @@ GR_PYTHON_INSTALL(PROGRAMS
 
 install(
     FILES
-    ofdm/tx_ofdm.grc
-    ofdm/rx_ofdm.grc
+    ofdm/ofdm_sync.m
+    ofdm/ofdm_sync_pn.m
+    ofdm/plot_ofdm.m
     ofdm/ofdm_loopback.grc
+    ofdm/rx_ofdm.grc
+    ofdm/tx_ofdm.grc
     DESTINATION ${GR_PKG_DIGITAL_EXAMPLES_DIR}/ofdm
 )
 
@@ -81,9 +85,9 @@ install(
 install(
     FILES
     packet/burst_tagger.grc
+    packet/example_corr_est.grc
     packet/example_corr_est_and_clock_sync.grc
     packet/example_corr_est_and_phase_sync.grc
-    packet/example_corr_est.grc
     packet/formatter_crc.grc
     packet/formatter_ofdm.grc
     packet/packet_loopback_hier.grc
@@ -97,8 +101,8 @@ install(
     packet/tx_stage3.grc
     packet/tx_stage4.grc
     packet/tx_stage5.grc
-    packet/tx_stage6a.grc
     packet/tx_stage6.grc
+    packet/tx_stage6a.grc
     packet/uhd_packet_rx.grc
     packet/uhd_packet_rx_tun.grc
     packet/uhd_packet_tx.grc

--- a/gr-dtv/examples/CMakeLists.txt
+++ b/gr-dtv/examples/CMakeLists.txt
@@ -27,12 +27,8 @@ GR_PYTHON_INSTALL(
 
 install(
     FILES
-    README.atsc
-    README.dvbs
-    README.dvbs2
-    README.dvbt
-    README.dvbt2
-    README.catv
+    catv_tx_256qam.grc
+    catv_tx_64qam.grc
     dvbs2_tx.grc
     dvbs_tx.grc
     dvbt_rx_8k.grc
@@ -40,6 +36,22 @@ install(
     dvbt_tx_8k.grc
     file_atsc_rx.grc
     file_atsc_tx.grc
+    germany-g10.grc
+    germany-g1.grc
+    germany-g2.grc
+    germany-g3.grc
+    germany-g4.grc
+    germany-g5.grc
+    germany-g6.grc
+    germany-g7.grc
+    germany-g8.grc
+    germany-g9.grc
+    README.atsc
+    README.catv
+    README.dvbs
+    README.dvbs2
+    README.dvbt
+    README.dvbt2
     uhd_atsc_capture.grc
     uhd_atsc_tx.grc
     uhd_rx_atsc.grc
@@ -63,16 +75,5 @@ install(
     vv034-dtg016.grc
     vv035-dtg052.grc
     vv036-dtg091.grc
-    germany-g1.grc
-    germany-g2.grc
-    germany-g3.grc
-    germany-g4.grc
-    germany-g5.grc
-    germany-g6.grc
-    germany-g7.grc
-    germany-g8.grc
-    germany-g9.grc
-    germany-g10.grc
-    catv_tx_64qam.grc
     DESTINATION ${GR_PKG_DTV_EXAMPLES_DIR}
 )

--- a/gr-fec/examples/CMakeLists.txt
+++ b/gr-fec/examples/CMakeLists.txt
@@ -21,21 +21,27 @@ include(GrPython)
 
 install(
     FILES
-    ber_test.grc
     ber_curve_gen.grc
     ber_curve_gen_ldpc.grc
-    fecapi_decoders.grc
-    fecapi_encoders.grc
+    ber_test.grc
     fecapi_async_decoders.grc
     fecapi_async_encoders.grc
-    fecapi_async_to_stream.grc
+    fecapi_async_ldpc_decoders.grc
+    fecapi_async_ldpc_encoders.grc
     fecapi_async_packed_decoders.grc
-    fecapi_tagged_decoders.grc
-    fecapi_tagged_encoders.grc
+    fecapi_async_to_stream.grc
     fecapi_cc_decoders.grc
+    fecapi_decoders.grc
+    fecapi_encoders.grc
+    fecapi_ldpc_decoders.grc
+    fecapi_ldpc_encoders.grc
     fecapi_polar_async_packed_decoders.grc
     fecapi_polar_decoders.grc
     fecapi_polar_encoders.grc
+    fecapi_tagged_decoders.grc
+    fecapi_tagged_encoders.grc
+    fecapi_tagged_ldpc_decoders.grc
+    fecapi_tagged_ldpc_encoders.grc
     polar_ber_curve_gen.grc
     polar_code_example.grc
     tpc_ber_curve_gen.grc

--- a/gr-filter/examples/CMakeLists.txt
+++ b/gr-filter/examples/CMakeLists.txt
@@ -28,15 +28,15 @@ GR_PYTHON_INSTALL(PROGRAMS
     fft_filter_ccc.py
     fir_filter_ccc.py
     fir_filter_fff.py
+    gr_filtdes_api.py
+    gr_filtdes_callback.py
+    gr_filtdes_live_upd.py
+    gr_filtdes_restrict.py
     interpolate.py
     reconstruction.py
     resampler.py
     synth_filter.py
     synth_to_chan.py
-    gr_filtdes_api.py
-    gr_filtdes_callback.py
-    gr_filtdes_restrict.py
-    gr_filtdes_live_upd.py
     DESTINATION ${GR_PKG_FILTER_EXAMPLES_DIR}
 )
 

--- a/gr-qtgui/examples/CMakeLists.txt
+++ b/gr-qtgui/examples/CMakeLists.txt
@@ -37,9 +37,10 @@ GR_PYTHON_INSTALL(PROGRAMS
 
 install(
     FILES
+    qtgui_message_inputs.grc
+    qtgui_multi_input.grc
     qtgui_tags_viewing.grc
     qtgui_vector_sink_example.grc
-    qtgui_message_inputs.grc
     test_qtgui_msg.grc
     DESTINATION ${GR_PKG_QTGUI_EXAMPLES_DIR}
 )

--- a/gr-trellis/examples/grc/CMakeLists.txt
+++ b/gr-trellis/examples/grc/CMakeLists.txt
@@ -51,12 +51,12 @@ configure_file(
 
 install(
     FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/tcm.grc
-    ${CMAKE_CURRENT_BINARY_DIR}/viterbi_equalization.grc
-    ${CMAKE_CURRENT_BINARY_DIR}/turbo_equalization.grc
-    ${CMAKE_CURRENT_BINARY_DIR}/sccc.grc
-    ${CMAKE_CURRENT_BINARY_DIR}/pccc.grc
     ${CMAKE_CURRENT_BINARY_DIR}/interference_cancellation.grc
+    ${CMAKE_CURRENT_BINARY_DIR}/pccc.grc
+    ${CMAKE_CURRENT_BINARY_DIR}/sccc.grc
+    ${CMAKE_CURRENT_BINARY_DIR}/tcm.grc
+    ${CMAKE_CURRENT_BINARY_DIR}/turbo_equalization.grc
+    ${CMAKE_CURRENT_BINARY_DIR}/viterbi_equalization.grc
     readme.txt
     DESTINATION ${GR_PKG_TRELLIS_EXAMPLES_DIR}
 )

--- a/gr-uhd/examples/grc/CMakeLists.txt
+++ b/gr-uhd/examples/grc/CMakeLists.txt
@@ -21,6 +21,9 @@ install(
     FILES
     uhd_const_wave.grc
     uhd_fft.grc
+    uhd_msg_tune.grc
+    uhd_normalized_gain.grc
+    uhd_siggen_gui.grc
     uhd_two_tone_loopback.grc
     uhd_wbfm_receive.grc
     DESTINATION ${GR_PKG_UHD_EXAMPLES_DIR}

--- a/gr-vocoder/examples/CMakeLists.txt
+++ b/gr-vocoder/examples/CMakeLists.txt
@@ -51,4 +51,9 @@ if(LIBGSM_FOUND)
     gsm_audio_loopback.py
     DESTINATION ${GR_PKG_VOCODER_EXAMPLES_DIR}
     )
+  install(
+    FILES
+    loopback-gsmfr.grc
+    DESTINATION ${GR_PKG_VOCODER_EXAMPLES_DIR}
+    )
 endif(LIBGSM_FOUND)


### PR DESCRIPTION
- Adds a few missing examples to cmake to be installed
- Reorders install lists to be mostly alphabetical for easier auditing 