### PR TITLE
fft_shift: use unit test macros that exist in Boost 1.53

### DIFF
--- a/gr-fft/lib/qa_fft_shift.cc
+++ b/gr-fft/lib/qa_fft_shift.cc
@@ -39,12 +39,24 @@ BOOST_AUTO_TEST_CASE(t1)
     std::vector<int> y_even{ -4, -3, -2, -1, 0, 1, 2, 3 }; // expected result
 
     s.shift(x_even);
-    BOOST_TEST(x_even == y_even, boost::test_tools::per_element());
+    if (x_even.size() == y_even.size()) {
+        for (unsigned int i = 0; i < x_even.size(); i++) {
+            BOOST_CHECK(x_even[i] == y_even[i]);
+        }
+    } else {
+        BOOST_CHECK(x_even.size() == y_even.size());
+    }
 
     // two shifts should not change the result
     s.shift(x_even);
     s.shift(x_even);
-    BOOST_TEST(x_even == y_even, boost::test_tools::per_element());
+    if (x_even.size() == y_even.size()) {
+        for (unsigned int i = 0; i < x_even.size(); i++) {
+            BOOST_CHECK(x_even[i] == y_even[i]);
+        }
+    } else {
+        BOOST_CHECK(x_even.size() == y_even.size());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(t2)
@@ -55,7 +67,13 @@ BOOST_AUTO_TEST_CASE(t2)
     std::vector<int> y_odd{ -3, -2, -1, 0, 1, 2, 3 }; // expected result
 
     s.shift(x_odd);
-    BOOST_TEST(x_odd == y_odd, boost::test_tools::per_element());
+    if (x_odd.size() == y_odd.size()) {
+        for (unsigned int i = 0; i < x_odd.size(); i++) {
+            BOOST_CHECK(x_odd[i] == y_odd[i]);
+        }
+    } else {
+        BOOST_CHECK(x_odd.size() == y_odd.size());
+    }
 }
 
 } /* namespace fft */


### PR DESCRIPTION
gr-fft mixes in Boost 1.59 dependency, but we only guarantee 1.53

Addresses https://github.com/gnuradio/gnuradio/issues/2685