### PR TITLE
grc: Display documentation for blocks without category key

### DIFF
--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -217,7 +217,7 @@ class PropsDialog(Gtk.Dialog):
         pos = buf.get_end_iter()
 
         # Add link to wiki page for this block, at the top, as long as it's not an OOT block
-        if self._block.category[0] == "Core":
+        if self._block.category and self._block.category[0] == "Core":
             note = "Wiki Page for this Block: "
             prefix = self._config.wiki_block_docs_url_prefix
             suffix = self._block.label.replace(" ", "_")


### PR DESCRIPTION
Check that the category list is not empty before accessing its first
element. Some OOT modules does not have category key and documentation
tab is left empty because of this missing check.
```
Traceback (most recent call last):
  File "/usr/local/lib64/python3.7/site-packages/gnuradio/grc/gui/PropsDialog.py", line 210, in update_gui
    self._update_docs_page()
  File "/usr/local/lib64/python3.7/site-packages/gnuradio/grc/gui/PropsDialog.py", line 220, in _update_docs_page
    if self._block.category[0] == "Core":
IndexError: list index out of range
```