### PR TITLE
Improve complex math speed by disabling NaN/Inf checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,14 @@ message(STATUS "  Override with -DENABLE_INTERNAL_VOLK=ON/OFF")
 find_package(LOG4CPP REQUIRED)
 
 ########################################################################
+# Disable complex math NaN/INFO range checking for performance
+########################################################################
+check_cxx_compiler_flag(-fcx-limited-range HAVE_CX_LIMITED_RANGE)
+if(HAVE_CX_LIMITED_RANGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcx-limited-range")
+endif(HAVE_CX_LIMITED_RANGE)
+
+########################################################################
 # Distribute the README file
 ########################################################################
 install(


### PR DESCRIPTION
(This PR is to start the conversation on this performance enhancement)

During other testing, it was identified that basic cc*cc math was
significantly slower than doing the multiplication inline.  Research
uncovered that without the CX_LIMITED_RANGE flag set, complex math
has significant overhead in NaN and INF checking.  One researcher
quantified it as 6-times slower.  This was observed in perfromance
tuning other code as well.  I'm recommending that the
-fcx-limited-range CXX_FLAG be set to improve overall GR performance.