### PR TITLE
qa: Fix the stop condition in qa_header_payload_demux

### DIFF
--- a/gr-digital/python/digital/qa_header_payload_demux.py
+++ b/gr-digital/python/digital/qa_header_payload_demux.py
@@ -103,8 +103,8 @@ class qa_header_payload_demux (gr_unittest.TestCase):
         """Execute self.tb"""
         stop_time = time.time() + timeout
         self.tb.start()
-        while len(payload_sink.data()) < payload_len and \
-                len(header_sink.data()) < header_len and \
+        while (len(payload_sink.data()) < payload_len or \
+                len(header_sink.data()) < header_len) and \
                 time.time() < stop_time:
             time.sleep(.2)
         self.tb.stop()


### PR DESCRIPTION
Tests nees to run until both payload_sink and header_sink recive the
specified amount of data or the time limit is reached and should not
stop when only one of the sinks has received enough data.

This should fix the sporadic tests failures.
Fixes #2215