### PR TITLE
fft: Add message to static_assert

### DIFF
--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -161,7 +161,8 @@ fft_complex::fft_complex(int fft_size, bool forward, int nthreads)
     // Hold global mutex during plan construction and destruction.
     planner::scoped_lock lock(planner::mutex());
 
-    static_assert(sizeof(fftwf_complex) == sizeof(gr_complex));
+    static_assert(sizeof(fftwf_complex) == sizeof(gr_complex),
+                  "The size of fftwf_complex is not equal to gr_complex");
 
     if (fft_size <= 0) {
         throw std::out_of_range("fft_impl_fftw: invalid fft_size");
@@ -218,7 +219,8 @@ fft_real_fwd::fft_real_fwd(int fft_size, int nthreads)
     // Hold global mutex during plan construction and destruction.
     planner::scoped_lock lock(planner::mutex());
 
-    static_assert(sizeof(fftwf_complex) == sizeof(gr_complex));
+    static_assert(sizeof(fftwf_complex) == sizeof(gr_complex),
+                  "The size of fftwf_complex is not equal to gr_complex");
 
     if (fft_size <= 0) {
         throw std::out_of_range("gr::fft: invalid fft_size");
@@ -275,7 +277,8 @@ fft_real_rev::fft_real_rev(int fft_size, int nthreads)
     // Hold global mutex during plan construction and destruction.
     planner::scoped_lock lock(planner::mutex());
 
-    static_assert(sizeof(fftwf_complex) == sizeof(gr_complex));
+    static_assert(sizeof(fftwf_complex) == sizeof(gr_complex),
+                  "The size of fftwf_complex is not equal to gr_complex");
 
     if (fft_size <= 0) {
         throw std::out_of_range("gr::fft::fft_real_rev: invalid fft_size");


### PR DESCRIPTION
In c++11 the static_assert takes two parameters while in c++17 a version
with only one parameter was added

https://en.cppreference.com/w/cpp/language/static_assert

Compilation on CentOS 7 with gcc 4.8.5 [fails with](https://ci.gnuradio.org/buildbot/#/builders/59/builds/439/steps/7/logs/stdio)

gr-fft/lib/fft.cc:164:62: error: expected ',' before ')' token
     static_assert(sizeof(fftwf_complex) == sizeof(gr_complex));