### PR TITLE
blocks: Add show_id flag to Probe Signal (and Vector)

### DIFF
--- a/gr-blocks/grc/blocks_probe_signal_vx.block.yml
+++ b/gr-blocks/grc/blocks_probe_signal_vx.block.yml
@@ -1,6 +1,6 @@
 id: blocks_probe_signal_vx
 label: Probe Signal Vector
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: type

--- a/gr-blocks/grc/blocks_probe_signal_x.block.yml
+++ b/gr-blocks/grc/blocks_probe_signal_x.block.yml
@@ -1,6 +1,6 @@
 id: blocks_probe_signal_x
 label: Probe Signal
-flags: [ python, cpp ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: type


### PR DESCRIPTION
Continuing the discussion from https://github.com/gnuradio/gnuradio/issues/2766, this PR makes the ID visible for the Probe Signal and Probe Signal Vector blocks, as suggested by @ThomasHabets: https://github.com/gnuradio/gnuradio/issues/2766#issuecomment-550528435