### PR TITLE
gr-blocks: use monotonic clock for throttle

### DIFF
--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -76,6 +76,12 @@ int throttle_impl::work(int noutput_items,
         }
     }
 
+    // copy all samples output[i] <= input[i]
+    const char* in = (const char*)input_items[0];
+    char* out = (char*)output_items[0];
+    std::memcpy(out, in, noutput_items * d_itemsize);
+    d_total_samples += noutput_items;
+
     auto now = std::chrono::steady_clock::now();
     auto expected_time = d_start + d_sample_period * d_total_samples;
 
@@ -90,11 +96,6 @@ int throttle_impl::work(int noutput_items,
         std::this_thread::sleep_until(expected_time);
     }
 
-    // copy all samples output[i] <= input[i]
-    const char* in = (const char*)input_items[0];
-    char* out = (char*)output_items[0];
-    std::memcpy(out, in, noutput_items * d_itemsize);
-    d_total_samples += noutput_items;
     return noutput_items;
 }
 

--- a/gr-blocks/lib/throttle_impl.h
+++ b/gr-blocks/lib/throttle_impl.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_THROTTLE_IMPL_H
 
 #include <gnuradio/blocks/throttle.h>
+#include <chrono>
 
 namespace gr {
 namespace blocks {
@@ -19,10 +20,11 @@ namespace blocks {
 class throttle_impl : public throttle
 {
 private:
-    boost::system_time d_start;
+    std::chrono::time_point<std::chrono::steady_clock> d_start;
     size_t d_itemsize;
     uint64_t d_total_samples;
-    double d_samps_per_tick, d_samps_per_us;
+    double d_sample_rate;
+    std::chrono::duration<double> d_sample_period;
     bool d_ignore_tags;
 
 public:

--- a/gr-blocks/python/blocks/qa_throttle.py
+++ b/gr-blocks/python/blocks/qa_throttle.py
@@ -9,7 +9,10 @@
 #
 
 
+import time
+import pmt
 from gnuradio import gr, gr_unittest, blocks
+
 
 class test_throttle(gr_unittest.TestCase):
 
@@ -19,9 +22,47 @@ class test_throttle(gr_unittest.TestCase):
     def tearDown(self):
         self.tb = None
 
-    def test_01(self):
-        # Test that we can make the block
-        op = blocks.throttle(gr.sizeof_gr_complex, 1)
+    def test_throttling(self):
+        src_data = (1, 2, 3)
+        src = blocks.vector_source_c(src_data)
+        thr = blocks.throttle(gr.sizeof_gr_complex, 10)
+        dst = blocks.vector_sink_c()
+        self.tb.connect(src, thr, dst)
+
+        start_time = time.perf_counter()
+        self.tb.run()
+        end_time = time.perf_counter()
+
+        total_time = end_time - start_time
+        self.assertGreater(total_time, 0.3)
+        self.assertLess(total_time, 0.4)
+
+        dst_data = dst.data()
+        self.assertEqual(src_data, dst_data)
+
+    def test_rx_rate_tag(self):
+        src_data = (1, 2, 3, 4, 5, 6)
+        tag = gr.tag_t()
+        tag.key = pmt.string_to_symbol("rx_rate")
+        tag.value = pmt.to_pmt(20)
+        tag.offset = 0
+
+        src = blocks.vector_source_c(src_data, tags=(tag,))
+        thr = blocks.throttle(gr.sizeof_gr_complex, 10, ignore_tags=False)
+        dst = blocks.vector_sink_c()
+        self.tb.connect(src, thr, dst)
+
+        start_time = time.perf_counter()
+        self.tb.run()
+        end_time = time.perf_counter()
+
+        total_time = end_time - start_time
+        self.assertGreater(total_time, 0.3)
+        self.assertLess(total_time, 0.4)
+
+        dst_data = dst.data()
+        self.assertEqual(src_data, dst_data)
+
 
 if __name__ == '__main__':
-    gr_unittest.run(test_throttle, "test_throttle.xml")
+    gr_unittest.run(test_throttle)


### PR DESCRIPTION
To ensure that the Throttle block operates normally even if the system clock changes, I've switched it to use `std::chrono::steady_clock`, which is a monotonic clock.

Prior to this change, setting the system clock back would stop the throttle, and setting it ahead would allow a large burst of samples to pass through the throttle.

This change also rids the Throttle block of Boost.