### PR TITLE
gr-digital: Fix typo in block tree for 'Correlate Access Code - Tag'

### DIFF
--- a/gr-digital/grc/digital.tree.yml
+++ b/gr-digital/grc/digital.tree.yml
@@ -24,7 +24,7 @@
   - variable_constellation_rect
   - variable_modulate_vector
 - Packet Operators:
-  - digital_correlate_access_code_tag_bb
+  - digital_correlate_access_code_tag_xx
   - digital_correlate_access_code_xx_ts
   - digital_crc32_bb
   - digital_crc32_async_bb


### PR DESCRIPTION
Previously the block wasn't part of any category and thus it was
only possible to find it by searching for it using some
filter string, not by clicking trough the categories.

All credits for finding and describing this bug to Johannes Wegener
aka @hpfmn.