### PR TITLE
Add support for 16 bit polynomials to gr-fec cc_encoder 

### DIFF
--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -133,13 +133,14 @@ int cc_encoder_impl::parity(int x)
     return parityb(x);
 }
 
-int cc_encoder_impl::parityb(unsigned char x) { return Partab[x]; }
+int cc_encoder_impl::parityb(unsigned int x) { return Partab[x]; }
 
 void cc_encoder_impl::partab_init(void)
 {
     int i, cnt, ti;
 
     /* Initialize parity lookup table */
+    printf("256\n");
     for (i = 0; i < 256; i++) {
         cnt = 0;
         ti = i;
@@ -157,7 +158,7 @@ void cc_encoder_impl::generic_work(void* in_buffer, void* out_buffer)
     const unsigned char* in = (const unsigned char*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;
 
-    unsigned char my_state = d_start_state;
+    unsigned int my_state = d_start_state;
 
     if (d_mode == CC_TAILBITING) {
         for (unsigned int i = 0; i < d_k - 1; ++i) {

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -133,14 +133,13 @@ int cc_encoder_impl::parity(int x)
     return parityb(x);
 }
 
-int cc_encoder_impl::parityb(unsigned int x) { return Partab[x]; }
+int cc_encoder_impl::parityb(unsigned char x) { return Partab[x]; }
 
 void cc_encoder_impl::partab_init(void)
 {
     int i, cnt, ti;
 
     /* Initialize parity lookup table */
-    printf("256\n");
     for (i = 0; i < 256; i++) {
         cnt = 0;
         ti = i;


### PR DESCRIPTION
simple change allowing cc_encoder to work with 16 bit long polynomials (right now it is limited to 8 bit due to a byte being used as shift register of the input bits)