### PR TITLE
gr-analog: fix default gain in quadrature demod

### DIFF
--- a/gr-analog/grc/analog_quadrature_demod_cf.block.yml
+++ b/gr-analog/grc/analog_quadrature_demod_cf.block.yml
@@ -6,7 +6,7 @@ parameters:
 -   id: gain
     label: Gain
     dtype: real
-    default: samp_rate/(2*math.pi*fsk_deviation_hz/8.0)
+    default: samp_rate/(2*math.pi*fsk_deviation_hz)
 
 inputs:
 -   domain: stream


### PR DESCRIPTION
A default gain value of `samp_rate/(2*math.pi*fsk_deviation_hz/8.0)` was added to the Quadrature Demod block in f06367bcf0c2b414295e8ef46c4b8dda1bbe559e. The division by 8.0 causes the output value to vary between -8 and +8, which is inconvenient because the convention in GNU Radio is to work with signal that vary between -1 and +1. Therefore, I propose to remove it.