### PR TITLE
cmake: Make cmake_c*_standard unconditionally set to 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,28 +132,10 @@ ENDIF()
 # set after CppUnit check below). Use the variable CMAKE_CXX_STANDARD
 # since it will actually be used for this purposes starting in CMake 3.1.
 
-SET(CMAKE_C_EXTENSIONS OFF)
-SET(CMAKE_CXX_EXTENSIONS OFF)
-
-IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    SET(CMAKE_CXX_STANDARD 11)
-ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    SET(CMAKE_CXX_STANDARD 11)
-ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    SET(CMAKE_CXX_STANDARD 11)
-ELSE()
-    message(WARNING "C++ standard could not be set because compiler is not GNU, Clang or MSVC.")
-ENDIF()
-
-IF(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    SET(CMAKE_C_STANDARD 11)
-ELSEIF(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    SET(CMAKE_C_STANDARD 11)
-ELSEIF(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-    SET(CMAKE_C_STANDARD 11)
-ELSE()
-    message(WARNING "C standard could not be set because compiler is not GNU, Clang or MSVC.")
-ENDIF()
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
 
 ########################################################################
 # Environment setup


### PR DESCRIPTION
The previous CMake would only set the C/C++ standard to 11 for gcc,
clang, and MSVC. This has two issues:
1) It prevents non-common compilers to properly function. We might hit
   the else() clause for a compiler, which then goes to C++98, which
   then doesn't work.
2) The compiler check is not necessary for setting the C/C++ standard
   and originates from an era where we had to set different compiler
   flags per compiler. Now, we're trying to beat CMake at its own game
   by assuming that it can't handle CMAKE_CXX_STANDARD properly.

This removes the compiler type check, and fully gives control to CMake
to set the C/C++ standard.