### PR TITLE
grc: add python snippets to GRC

### DIFF
--- a/gr-blocks/examples/CMakeLists.txt
+++ b/gr-blocks/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ install(
   FILES
   matrix_multiplexer.grc
   peak_detector2.grc
+  py_snippets_demo.grc
   selector.grc
   test_stream_mux_tags.grc
   vector_source_with_tags.grc

--- a/gr-blocks/examples/py_snippets_demo.grc
+++ b/gr-blocks/examples/py_snippets_demo.grc
@@ -1,0 +1,290 @@
+options:
+  parameters:
+    author: Josh Morman
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: Copyright 2020
+    description: Show simple examples of Python Snippets inserted into flowgraph
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: snippets_demo
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Python Snippets Example Flowgraph
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: foo_mod
+  id: epy_module
+  parameters:
+    alias: ''
+    comment: ''
+    source_code: "# this module will be imported in the into your flowgraph\n\ndef\
+      \ add(a,b):\n    return a+b\n"
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [850, 264]
+    rotation: 0
+    state: true
+- name: head_block
+  id: blocks_head
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_items: '12'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [937, 351]
+    rotation: 0
+    state: true
+- name: s0
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After start - 500 priority''
+
+      print(s)'
+    comment: ''
+    priority: '500'
+    section: main_after_start
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [263, 115]
+    rotation: 0
+    state: true
+- name: s1
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After start - 200 priority''
+
+      print(s)'
+    comment: ''
+    priority: '200'
+    section: main_after_start
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [264, 208]
+    rotation: 0
+    state: true
+- name: s2
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After start - negative priority''
+
+      print(s)'
+    comment: ''
+    priority: '-400'
+    section: main_after_start
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [267, 298]
+    rotation: 0
+    state: true
+- name: s3
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After start - 0 priority''
+
+      print(s)'
+    comment: ''
+    priority: '0'
+    section: main_after_start
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [270, 371]
+    rotation: 0
+    state: true
+- name: s4
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After Init - 100 priority''
+
+      print(s)'
+    comment: ''
+    priority: '100'
+    section: main_after_init
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [549, 88]
+    rotation: 0
+    state: true
+- name: s5
+  id: snippet
+  parameters:
+    alias: ''
+    code: 'x = 4
+
+      y = foo_mod.add(x,x)
+
+      print(y)
+
+      s = ''After init - 200 priority''
+
+      print(s)'
+    comment: "This snippet shows how to call a \nmethod from an embedded python \n\
+      module"
+    priority: '200'
+    section: main_after_init
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [550, 209]
+    rotation: 0
+    state: true
+- name: s6
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After Stop - 500 priority''
+
+      print(s)'
+    comment: ''
+    priority: '500'
+    section: main_after_stop
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [865, 52]
+    rotation: 0
+    state: true
+- name: s7
+  id: snippet
+  parameters:
+    alias: ''
+    code: 's = ''After Stop - 200 priority''
+
+      print(s)
+
+      print(self.vsink.data())'
+    comment: 'This snippet shows an example of calling
+
+      a method on another block from within the
+
+      flowgraph - (use at your own risk)'
+    priority: '200'
+    section: main_after_stop
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1120, 55]
+    rotation: 0
+    state: true
+- name: throttle_block
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [752, 384]
+    rotation: 0
+    state: enabled
+- name: vsink
+  id: blocks_vector_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    reserve_items: '1024'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1118, 337]
+    rotation: 0
+    state: true
+- name: vsrc
+  id: blocks_vector_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    repeat: 'True'
+    tags: '[]'
+    type: float
+    vector: list(range(10))
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [531, 390]
+    rotation: 0
+    state: true
+
+connections:
+- [head_block, '0', vsink, '0']
+- [throttle_block, '0', head_block, '0']
+- [vsrc, '0', throttle_block, '0']
+
+metadata:
+  file_format: 1

--- a/grc/blocks/grc.tree.yml
+++ b/grc/blocks/grc.tree.yml
@@ -13,6 +13,7 @@
   - epy_module
   - note
   - import
+  - snippet 
 - Variables:
   - variable
   - variable_struct

--- a/grc/blocks/snippet.block.yml
+++ b/grc/blocks/snippet.block.yml
@@ -1,0 +1,45 @@
+id: snippet
+label: Python Snippet
+flags: [ python ]
+
+parameters:
+-   id: section
+    label: Section of Flowgraph
+    dtype: string
+    options: ['main_after_init', 'main_after_start', 'main_after_stop' ]
+    option_labels: ['Main - After Init', 'Main - After Start', 'Main - After Stop']
+-   id: priority
+    label: Priority
+    dtype: int
+    hide: ${'part' if priority <= 0 else 'none'}
+-   id: code
+    label: Code Snippet
+    dtype: _multiline
+
+templates:
+    var_make: ${code}
+
+documentation: |-
+    CAUTION: This is an ADVANCED feature and can lead to unintended consequences in the rendering of a flowgraph.  Use at your own risk.
+
+    Insert a snippet of Python code directly into the flowgraph at the end of the specified section. \
+    For each snippet a function is generated with the block name of the snippet (use GRC Show Block IDs option to modify).  These functions are\
+    then grouped into their respective sections in the rendered flowgraph.
+
+    The purpose of the python snippets is to be able to exercise features from within GRC that are not entirely supported by the block callbacks, \ 
+    methods and mechanisms to generate the code.  One example of this would be calling UHD timed commands before starting the flowgraph
+
+    Indents will be handled upon insertion into the python flowgraph
+
+    Example 1:
+    epy_mod_0.some_function(self.some_block.some_property)
+
+    Will place the function call in the generated .py file using the name of the appropriate embedded python block in the proper scope
+    The scope is relative to the blocks in the flowgraph, e.g. to reference a block, it should be identified as self.block
+
+    Example 2:
+    print('The flowgraph has been stopped')
+
+    With section selected as 'Main - After Stop', will place the print statement after the flowgraph has been stopped.
+
+file_format: 1

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -81,6 +81,47 @@ class FlowGraph(Element):
         parameters = [b for b in self.iter_enabled_blocks() if b.key == 'parameter']
         return parameters
 
+    def get_snippets(self):
+        """
+        Get a set of all code snippets (Python) in this flow graph namespace.
+
+        Returns:
+            a list of code snippets
+        """
+        return [b for b in self.iter_enabled_blocks() if b.key == 'snippet']
+
+    def get_snippets_dict(self, section=None):
+        """
+        Get a dictionary of code snippet information for a particular section.
+
+        Args:
+            section: string specifier of section of snippets to return, section=None returns all
+
+        Returns:
+            a list of code snippets dicts
+        """
+        snippets = self.get_snippets()
+        if not snippets:
+            return []
+
+        output = []
+        for snip in snippets:
+            d ={}
+            sect = snip.params['section'].value
+            d['section'] = sect
+            d['priority'] = snip.params['priority'].value
+            d['lines'] = snip.params['code'].value.splitlines()
+            d['def'] = 'def snipfcn_{}(self):'.format(snip.name)
+            d['call'] = 'snipfcn_{}(tb)'.format(snip.name)
+            if not section or sect == section:
+                output.append(d)
+
+        # Sort by descending priority 
+        if section:
+            output = sorted(output, key=lambda x: x['priority'], reverse=True)
+
+        return output
+
     def get_monitors(self):
         """
         Get a list of all ControlPort monitors

--- a/grc/core/base.py
+++ b/grc/core/base.py
@@ -139,6 +139,7 @@ class Element(object):
     is_param = False
     is_variable = False
     is_import = False
+    is_snippet = False
 
     def get_raw(self, name):
         descriptor = getattr(self.__class__, name, None)

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -293,6 +293,10 @@ class Block(Element):
     def is_import(self):
         return self.key == 'import'
 
+    @lazy_property
+    def is_snippet(self):
+        return self.key == 'snippet'
+
     @property
     def comment(self):
         return self.params['comment'].value

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -191,7 +191,7 @@ class TopBlockGenerator(object):
 
         blocks = [
             b for b in fg.blocks
-            if b.enabled and not (b.get_bypassed() or b.is_import or b in parameters or b.key == 'options')
+            if b.enabled and not (b.get_bypassed() or b.is_import or b.is_snippet or b in parameters or b.key == 'options')
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -245,9 +245,13 @@ class Param(Element):
         elif dtype in ('string', 'file_open', 'file_save', '_multiline', '_multiline_python_external'):
             # Do not check if file/directory exists, that is a runtime issue
             try:
-                value = self.parent_flowgraph.evaluate(expr)
-                if not isinstance(value, str):
-                    raise Exception()
+                # Do not evaluate multiline strings (code snippets or comments)
+                if dtype not in ['_multiline','_multiline_python_external']:
+                    value = self.parent_flowgraph.evaluate(expr)
+                    if not isinstance(value, str):
+                        raise Exception()
+                else:
+                    value = str(expr)
             except Exception:
                 self._stringify_flag = True
                 value = str(expr)


### PR DESCRIPTION
This feature adds the ability to insert arbitrary code into the python
flowgraph.  It gives a little more low-level flexibility for quickly
modifying flowgraphs and adding custom bits of code rather than having
to go and edit the generated py file

One example is synchronizing multiple USRP objects - sometimes you want
different sync than what is offered in the multi-usrp object, so you can
put a bit of code in the snippet block to do the custom synchronization

-----------------------------------
This supercedes #2779 and #2814 - hopefully the issues identified on those PRs have been sufficiently resolved, as the details of last iteration were worked out with @dkozel and @marcusmueller at the ESA hackfest.

- Went back to a single snippet block.  This way they can be easily arranged and copied/pasted
- Priority was added to the block so multiple snippets added to the same section can be sorted by priority
- Reduce the possible placements in the rendered flowgraph to inside the main function (can add more later if requested)
- Cleaned up the rendered flowgraph to put the snippet code within their own functions


![image](https://user-images.githubusercontent.com/34754695/73793328-73bb0100-47a6-11ea-8b50-bbe4f0c1a76f.png)

![image](https://user-images.githubusercontent.com/34754695/73793354-7fa6c300-47a6-11ea-96bc-6c082c6f191f.png)




