### PR TITLE
fft_filter: Construct std::unique_ptr directly

### DIFF
--- a/gnuradio-runtime/include/gnuradio/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/CMakeLists.txt
@@ -34,6 +34,7 @@ install(FILES
   io_signature.h
   logger.h
   math.h
+  memory.h
   message.h
   misc.h
   msg_accepter.h

--- a/gnuradio-runtime/include/gnuradio/memory.h
+++ b/gnuradio-runtime/include/gnuradio/memory.h
@@ -1,0 +1,33 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_GR_MEMORY_H
+#define INCLUDED_GR_MEMORY_H
+
+namespace gr {
+
+/*!
+ * \brief Constructs an object of type T and wraps it in a std::unique_ptr.
+ *
+ * The gr::make_unique is needed because boost::make_unique was added
+ * in boost 1.56 while the minimal boost version that gnuradio requires is 1.53.
+ *
+ * The other alternative is std::make_unique but it is a c++14 feature
+ * and once gnuradio moves to c++14 gr::make_unique can be removed.
+ */
+template <class T, class... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+} // namespace gr
+
+#endif /* INCLUDED_GR_MEMORY_H */

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2010,2012,2014 Free Software Foundation, Inc.
+ * Copyright 2010,2012,2014,2020 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -13,8 +13,8 @@
 #endif
 
 #include <gnuradio/filter/fft_filter.h>
+#include <gnuradio/memory.h>
 #include <volk/volk.h>
-#include <boost/smart_ptr/make_unique.hpp>
 #include <cstring>
 #include <iostream>
 
@@ -82,8 +82,8 @@ void fft_filter_fff::compute_sizes(int ntaps)
 
     // compute new plans
     if (d_fftsize != old_fftsize) {
-        d_fwdfft = boost::make_unique<fft::fft_real_fwd>(d_fftsize);
-        d_invfft = boost::make_unique<fft::fft_real_rev>(d_fftsize);
+        d_fwdfft = gr::make_unique<fft::fft_real_fwd>(d_fftsize);
+        d_invfft = gr::make_unique<fft::fft_real_rev>(d_fftsize);
         d_xformed_taps.resize(d_fftsize / 2 + 1);
     }
 }
@@ -210,8 +210,8 @@ void fft_filter_ccc::compute_sizes(int ntaps)
 
     // compute new plans
     if (d_fftsize != old_fftsize) {
-        d_fwdfft = boost::make_unique<fft::fft_complex>(d_fftsize, true, d_nthreads);
-        d_invfft = boost::make_unique<fft::fft_complex>(d_fftsize, false, d_nthreads);
+        d_fwdfft = gr::make_unique<fft::fft_complex>(d_fftsize, true, d_nthreads);
+        d_invfft = gr::make_unique<fft::fft_complex>(d_fftsize, false, d_nthreads);
         d_xformed_taps.resize(d_fftsize);
     }
 }
@@ -339,8 +339,8 @@ void fft_filter_ccf::compute_sizes(int ntaps)
 
     // compute new plans
     if (d_fftsize != old_fftsize) {
-        d_fwdfft = boost::make_unique<fft::fft_complex>(d_fftsize, true, d_nthreads);
-        d_invfft = boost::make_unique<fft::fft_complex>(d_fftsize, false, d_nthreads);
+        d_fwdfft = gr::make_unique<fft::fft_complex>(d_fftsize, true, d_nthreads);
+        d_invfft = gr::make_unique<fft::fft_complex>(d_fftsize, false, d_nthreads);
         d_xformed_taps.resize(d_fftsize);
     }
 }


### PR DESCRIPTION
The `boost::make_unique` was added in boost `1.56.0` while the minimal boost
version in CMakeLists.txt is set to `1.53`.

This also fixes a compile error on CentOS 7 where the boost version is
`1.53`

From https://ci.gnuradio.org/buildbot/#/builders/59/builds/469/steps/7/logs/stdio
```
/cache/workdir/Centos_7_6_0/build_Centos_7_6/src/gr-filter/lib/fft_filter.cc:17:43: fatal error: boost/smart_ptr/make_unique.hpp: No such file or directory
 #include <boost/smart_ptr/make_unique.hpp>
```