### PR TITLE
Display import errors in gr_modtool

### DIFF
--- a/gr-utils/python/modtool/cli/base.py
+++ b/gr-utils/python/modtool/cli/base.py
@@ -63,6 +63,7 @@ class CommandCLI(click.Group):
         try:
             mod = import_module('gnuradio.modtool.cli.' + cmd_name)
         except ImportError:
+            logging.error(ImportError)
             return self.commands.get(cmd_name)
         return mod.cli
 


### PR DESCRIPTION
gr_modtool catches and discards import errors. This change displays import errors to the user.
fixes #2801 