### PR TITLE
gr-digital:glfsr.h: fix missing boost namespace

### DIFF
--- a/gr-digital/include/gnuradio/digital/glfsr.h
+++ b/gr-digital/include/gnuradio/digital/glfsr.h
@@ -12,7 +12,7 @@
 #define INCLUDED_DIGITAL_GLFSR_H
 
 #include <gnuradio/digital/api.h>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace gr {
 namespace digital {
@@ -27,22 +27,22 @@ namespace digital {
 class DIGITAL_API glfsr
 {
 private:
-    boost::uint32_t d_shift_register;
-    boost::uint32_t d_mask;
+    uint32_t d_shift_register;
+    uint32_t d_mask;
 
 public:
-    glfsr(boost::uint32_t mask, boost::uint32_t seed)
+    glfsr(uint32_t mask, uint32_t seed)
     {
         d_shift_register = seed;
         d_mask = mask;
     }
     ~glfsr();
 
-    static boost::uint32_t glfsr_mask(unsigned int degree);
+    static uint32_t glfsr_mask(unsigned int degree);
 
-    boost::uint8_t next_bit();
+    uint8_t next_bit();
 
-    boost::uint32_t mask() const { return d_mask; }
+    uint32_t mask() const { return d_mask; }
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr.h
+++ b/gr-digital/include/gnuradio/digital/glfsr.h
@@ -27,22 +27,22 @@ namespace digital {
 class DIGITAL_API glfsr
 {
 private:
-    uint32_t d_shift_register;
-    uint32_t d_mask;
+    boost::uint32_t d_shift_register;
+    boost::uint32_t d_mask;
 
 public:
-    glfsr(uint32_t mask, uint32_t seed)
+    glfsr(boost::uint32_t mask, boost::uint32_t seed)
     {
         d_shift_register = seed;
         d_mask = mask;
     }
     ~glfsr();
 
-    static uint32_t glfsr_mask(unsigned int degree);
+    static boost::uint32_t glfsr_mask(unsigned int degree);
 
-    uint8_t next_bit();
+    boost::uint8_t next_bit();
 
-    uint32_t mask() const { return d_mask; }
+    boost::uint32_t mask() const { return d_mask; }
 };
 
 } /* namespace digital */


### PR DESCRIPTION
gr-digital glfsr.h include boost/cstdint.hpp to have uintxx_t.
These types are in boost namespace but nor using namespace xxx, nor boost:: are used.
The result is : 
In file included from /home/buildroot/autobuild/instance-0/output-1/build/gnuradio-3.8.0.0/gr-digital/lib/glfsr.cc:23:
/home/buildroot/autobuild/instance-0/output-1/build/gnuradio-3.8.0.0/gr-digital/lib/../include/gnuradio/digital/glfsr.h:42:5: error: 'uint32_t' does not name a type; did you mean 'u_int32_t'?
     uint32_t d_shift_register;
     ^~~~~~~~
     u_int32_t

see:
- http://autobuild.buildroot.net/results/14015f499e58fee530877ac052878bbe2f799942/
- http://autobuild.buildroot.net/results/53239f98dd5e03d4dc1bb4eb91ed765f77dbf0ec/

This patch append all uintxx_t by boost::  to fix this issue