### PR TITLE
grc: ctrl+a now selects all text if search box in focus

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -224,7 +224,10 @@ class Application(Gtk.Application):
         elif action == Actions.NOTHING_SELECT:
             flow_graph.unselect()
         elif action == Actions.SELECT_ALL:
-            flow_graph.select_all()
+            if main.btwin.search_entry.has_focus():
+                main.btwin.search_entry.select_region(0, -1)
+            else:
+                flow_graph.select_all()
         ##################################################
         # Enable/Disable
         ##################################################


### PR DESCRIPTION
ctrl+a now selects all search text if search box in focus
fixes #2552 

Previously if you have the search box in focus, ctrl+a would select everything in the flow graph. Now if you have the search box in focus, ctrl+a will select all the search text to allow for easy clearing of the text (ctrl+a,backspace) that is consistent with other applications.