### PR TITLE
runtime: release the flattened flowgraph after stopping

### DIFF
--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -122,6 +122,8 @@ void top_block_impl::stop()
     if (d_scheduler)
         d_scheduler->stop();
 
+    d_ffg.reset();
+
     d_state = IDLE;
 }
 


### PR DESCRIPTION
GNU Radio uses shared pointers to keep track of blocks, so that they are automatically destroyed when they are no longer referenced. While investigating an issue in Gqrx, I noticed a bug in this system: in certain circumstances, a block that is added to a flowgraph continues to be referenced even after it is removed from the flowgraph.

This happens because `top_block_impl` keeps a flattened copy of the flowgraph:

https://github.com/gnuradio/gnuradio/blob/c3333eb0d7238c82442d1d901df03d5199557213/gnuradio-runtime/lib/top_block_impl.h#L67

The flattened copy is calculated in `top_block_impl::start` (and updated in `top_block_impl::restart` if the flowgraph is updated while it is running), but it is not discarded in `top_block_impl::stop`. As a result, `top_block_impl` keeps blocks alive even after they are removed from a flowgraph, since the flattened copy still references them and continues to do so until the next time the flowgraph is started.

This is particularly problematic for hardware blocks, since a hardware device is typically kept open until its block is destroyed. In Gqrx, it is currently impossible to reconfigure an RTL-SDR device because `top_block_impl` holds onto a reference to it indefinitely.

To solve the problem, I've changed `top_block_impl::stop` to release the reference to the flattened flowgraph, so that its blocks can be destroyed if they are no longer referenced. I've added a test which verifies that blocks are no longer referenced after they are removed from a stopped flowgraph. (Without the change to `top_block_impl.cc` this test fails.)

This change has one small side effect: `top_block_impl::edge_list`, `top_block_impl::msg_edge_list` and `top_block_impl::dump` all calculate their return values based on the cached flow graph. Currently they will continue to return information about a flow graph even after it is stopped (and if it is subsequently reconfigured, they will continue to return information about its previous state). After this change, they will only return information about a flow graph while it is running. Since the previous behaviour seems like a bug to me, it probably wouldn't be risky to backport this change to GNU Radio 3.8.