### PR TITLE
gr-fec: fix compiler warning

### DIFF
--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -168,7 +168,7 @@ void cc_encoder_impl::generic_work(void* in_buffer, void* out_buffer)
     const unsigned char* in = (const unsigned char*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;
 
-    unsigned my_state = d_start_state;
+    unsigned int my_state = d_start_state;
 
     if (d_mode == CC_TAILBITING) {
         for (unsigned int i = 0; i < d_k - 1; ++i) {

--- a/gr-fec/lib/cc_encoder_impl.h
+++ b/gr-fec/lib/cc_encoder_impl.h
@@ -34,7 +34,7 @@ private:
     unsigned int d_rate;
     unsigned int d_k;
     std::vector<int> d_polys;
-    int d_start_state;
+    unsigned int d_start_state;
     cc_mode_t d_mode;
     int d_padding;
     int d_output_size;


### PR DESCRIPTION
The change to cc_encoder_impl.h fixes the following warning:
```
/home/argilo/prefix_39/src/gnuradio/gr-fec/lib/cc_encoder_impl.cc: In constructor ‘gr::fec::code::cc_encoder_impl::cc_encoder_impl(int, int, int, std::vector<int>, int, cc_mode_t, bool)’:
/home/argilo/prefix_39/src/gnuradio/gr-fec/lib/cc_encoder_impl.cc:71:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (d_start_state >= (1u << (d_k - 1))) {
         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```
I also explicitly wrote out `unsigned int` in cc_encoder_impl.cc for clarity.