### PR TITLE
dtv: enhance ATSC RX example

### DIFF
--- a/gr-dtv/examples/CMakeLists.txt
+++ b/gr-dtv/examples/CMakeLists.txt
@@ -42,7 +42,7 @@ install(
     README.dvbt2
     uhd_atsc_capture.grc
     uhd_atsc_tx.grc
-    uhd_rx_atsc.grc
+    uhd_atsc_rx.grc
     vv001-cr35.grc
     vv003-cr23.grc
     vv004-8kfft.grc

--- a/gr-dtv/examples/uhd_atsc_rx.grc
+++ b/gr-dtv/examples/uhd_atsc_rx.grc
@@ -11,7 +11,7 @@ options:
     gen_linking: dynamic
     generate_options: qt_gui
     hier_block_src_path: '.:'
-    id: uhd_rx_atsc
+    id: uhd_atsc_rx
     max_nouts: '0'
     output_language: python
     placement: (0,0)
@@ -48,36 +48,74 @@ blocks:
   id: variable_qtgui_entry
   parameters:
     comment: Digital Ch 28 - 557 MHz
-    gui_hint: 0,0,1,2
+    gui_hint: 0,0,1,1
     label: Center Frequency
     type: real
-    value: 557e6
+    value: (channel*1e6)+3e6
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [792, 4.0]
+    coordinate: [792, 12.0]
     rotation: 0
     state: enabled
+- name: channel
+  id: variable_qtgui_chooser
+  parameters:
+    comment: ''
+    gui_hint: 0,2,1,1
+    label: Channel
+    label0: ''
+    label1: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    labels: '[''2'', ''3'', ''4'', ''5'', ''6'', ''7'', ''8'', ''9'', ''10'', ''11'',
+      ''12'', ''13'', ''14'', ''15'', ''16'', ''17'', ''18'', ''19'', ''20'', ''21'',
+      ''22'', ''23'', ''24'', ''25'', ''26'', ''27'', ''28'', ''29'', ''30'', ''31'',
+      ''32'', ''33'', ''34'', ''35'', ''36'', ''CATV 57'', ''CATV 58'', ''CATV 59'',
+      ''CATV 60'', ''CATV 61'', ''CATV 143'', ''CATV 144'', ''CATV 145'']'
+    num_opts: '0'
+    option0: '0'
+    option1: '1'
+    option2: '2'
+    option3: '3'
+    option4: '4'
+    options: '[54, 60, 66, 76, 82, 174, 180, 186, 192, 198, 204, 210, 470, 476, 482,
+      488, 494, 500, 506, 512, 518, 524, 530, 536, 542, 548, 554, 560, 566, 572, 578,
+      584, 590, 596, 602, 420, 426, 432, 438, 444, 906, 912, 918]
+
+      '
+    orient: Qt.QVBoxLayout
+    type: int
+    value: '554'
+    widget: combo_box
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [936, 12.0]
+    rotation: 0
+    state: true
 - name: gain
   id: variable_qtgui_range
   parameters:
     comment: ''
-    gui_hint: 1,0,1,2
+    gui_hint: 0,1,1,1
     label: Gain
     min_len: '200'
     orient: Qt.Horizontal
     rangeType: float
     start: '0'
-    step: '2'
-    stop: '60'
-    value: '46'
+    step: '.01'
+    stop: '1'
+    value: '.5'
     widget: counter_slider
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [656, 4.0]
+    coordinate: [656, 12.0]
     rotation: 0
     state: enabled
 - name: oversampled_rate
@@ -133,7 +171,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1032, 244.0]
+    coordinate: [968, 292.0]
     rotation: 0
     state: enabled
 - name: blocks_file_sink_0
@@ -151,7 +189,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [832, 668.0]
+    coordinate: [872, 556.0]
     rotation: 0
     state: enabled
 - name: dc_blocker_xx_0
@@ -169,7 +207,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [832, 260.0]
+    coordinate: [808, 308.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_deinterleaver_0
@@ -184,7 +222,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [120, 608.0]
+    coordinate: [144, 576.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_depad_0
@@ -199,7 +237,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [752, 608.0]
+    coordinate: [736, 576.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_derandomizer_0
@@ -214,7 +252,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [568, 608.0]
+    coordinate: [560, 576.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_equalizer_0
@@ -229,7 +267,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [664, 504.0]
+    coordinate: [640, 472.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_fpll_0
@@ -245,7 +283,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [608, 268.0]
+    coordinate: [608, 316.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_fs_checker_0
@@ -260,7 +298,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [440, 504.0]
+    coordinate: [424, 472.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_rs_decoder_0
@@ -275,7 +313,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [320, 608.0]
+    coordinate: [320, 576.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_sync_0
@@ -291,7 +329,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [200, 500.0]
+    coordinate: [224, 468.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_viterbi_decoder_0
@@ -306,7 +344,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [816, 504.0]
+    coordinate: [800, 472.0]
     rotation: 0
     state: enabled
 - name: filter_fft_rrc_filter_0
@@ -322,7 +360,7 @@ blocks:
     gain: '1'
     maxoutbuf: '0'
     minoutbuf: '0'
-    ntaps: int((2*8 + 1)*sps)
+    ntaps: '50'
     nthreads: '1'
     samp_rate: sample_rate
     sym_rate: atsc_sym_rate/2.0
@@ -331,7 +369,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [272, 228.0]
+    coordinate: [296, 220.0]
     rotation: 0
     state: true
 - name: note_0
@@ -346,7 +384,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [856, 380.0]
+    coordinate: [912, 188.0]
     rotation: 0
     state: true
 - name: note_1
@@ -368,7 +406,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1024, 516.0]
+    coordinate: [1048, 436.0]
     rotation: 0
     state: true
 - name: u
@@ -651,7 +689,7 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     nchan: '1'
-    norm_gain0: 'False'
+    norm_gain0: 'True'
     norm_gain1: 'False'
     norm_gain10: 'False'
     norm_gain11: 'False'
@@ -781,11 +819,11 @@ blocks:
     fftsize: '2048'
     freqhalf: 'True'
     grid: 'True'
-    gui_hint: 3,0,1,4
+    gui_hint: 1,0,1,3
     label: Relative Gain
     label1: RX Signal
     label10: ''
-    label2: ''
+    label2: Filtered
     label3: ''
     label4: ''
     label5: ''
@@ -797,7 +835,7 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     name: '"RX Spectrum"'
-    nconnections: '1'
+    nconnections: '2'
     showports: 'True'
     tr_chan: '0'
     tr_level: '0.0'
@@ -817,13 +855,13 @@ blocks:
     width8: '1'
     width9: '1'
     wintype: firdes.WIN_BLACKMAN_hARRIS
-    ymax: '-20'
-    ymin: '-100'
+    ymax: '0'
+    ymin: '-140'
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [304, 112.0]
+    coordinate: [600, 176.0]
     rotation: 0
     state: enabled
 
@@ -840,6 +878,7 @@ connections:
 - [dtv_atsc_sync_0, '0', dtv_atsc_fs_checker_0, '0']
 - [dtv_atsc_viterbi_decoder_0, '0', dtv_atsc_deinterleaver_0, '0']
 - [filter_fft_rrc_filter_0, '0', dtv_atsc_fpll_0, '0']
+- [filter_fft_rrc_filter_0, '0', usrp_freq_sink, '1']
 - [u, '0', filter_fft_rrc_filter_0, '0']
 - [u, '0', usrp_freq_sink, '0']
 


### PR DESCRIPTION
- Renamed `uhd_rx_atsc.grc` to `uhd_atsc_rx.grc`
- Add QT GUI Chooser populated with NA ATSC channels 2-36, plus CATV 58 (429 MHz)
	- The Frequency values are the lower edge (center_freq-3e6)
	- 3e6 is added to the `channel` value within `center_freq`
	- Leaves `center_freq` as a Entry widget in case someone wants to hard set a freq
- Switch `gain` to use Normalized values in UHD Source
- Switch QT GUI Frequency sink to have 2 inputs => RX Spectrum and post RRC Filter
- Update FFT RRC Filter to use 50 taps instead of 18
	- See @drmpeg's post here: https://github.com/gnuradio/gnuradio/pull/3154#issuecomment-582143764
	- I've observed improved performance with 50 taps too
- Updated the QT grid layout for the widgets

![atsc_fixup](https://user-images.githubusercontent.com/11846824/74121012-89e80900-4b7a-11ea-9d48-4ad0057416b0.png)
