### PR TITLE
gr-newmod: Update MANIFEST with `gr_supported_version`

### DIFF
--- a/gr-utils/python/modtool/templates/gr-newmod/MANIFEST.md
+++ b/gr-utils/python/modtool/templates/gr-newmod/MANIFEST.md
@@ -7,6 +7,7 @@ author:
 copyright_owner:
   - Copyright Owner 1
 license:
+gr_supported_version: # Put a comma separated list of supported GR versions here
 #repo: # Put the URL of the repository here, or leave blank for default
 #website: <module_website> # If you have a separate project website, put it here
 #icon: <icon_url> # Put a URL to a square image here that will be used as an icon on CGRAN


### PR DESCRIPTION
Backport of #3189 

Cgran was extended to display supported GNU Radio versions of OOTs. To
leverage this feature, a `gr_supported_version` key needs to be provided
by the OOT's MANIFEST. This commit extends gr-newmod's MAIFEST by this
key.