### PR TITLE
gr-blocks: Add Msg to Var and Var to Msg Conversion Blocks

### DIFF
--- a/gr-blocks/examples/CMakeLists.txt
+++ b/gr-blocks/examples/CMakeLists.txt
@@ -13,6 +13,8 @@ install(
   selector.grc
   test_stream_mux_tags.grc
   vector_source_with_tags.grc
+  msg_to_var.grc
+  var_to_msg.grc
   DESTINATION ${GR_PKG_DATA_DIR}/examples/blocks
 )
 

--- a/gr-blocks/examples/msg_to_var.grc
+++ b/gr-blocks/examples/msg_to_var.grc
@@ -1,0 +1,160 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: test_msg_to_var
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Test Msg to Var Conversion
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: test
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: 0,1,1,1
+    label: Msg Output
+    type: int
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [707, 43]
+    rotation: 0
+    state: true
+- name: blocks_msgpair_to_var_0
+  id: blocks_msgpair_to_var
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    target: test
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [548, 122]
+    rotation: 0
+    state: true
+- name: blocks_null_sink_0
+  id: blocks_null_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_sink: '[[0,],]'
+    comment: ''
+    num_inputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [661, 220]
+    rotation: 0
+    state: true
+- name: blocks_null_source_0
+  id: blocks_null_source
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_source: '[[0,],]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_outputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [305, 213]
+    rotation: 0
+    state: true
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [458, 211]
+    rotation: 0
+    state: true
+- name: qtgui_edit_box_msg_0
+  id: qtgui_edit_box_msg
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    gui_hint: 0,0,1,1
+    is_pair: 'True'
+    is_static: 'True'
+    key: testval
+    label: Test Int
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: int
+    value: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 13]
+    rotation: 0
+    state: true
+
+connections:
+- [blocks_null_source_0, '0', blocks_throttle_0, '0']
+- [blocks_throttle_0, '0', blocks_null_sink_0, '0']
+- [qtgui_edit_box_msg_0, msg, blocks_msgpair_to_var_0, inpair]
+
+metadata:
+  file_format: 1

--- a/gr-blocks/examples/var_to_msg.grc
+++ b/gr-blocks/examples/var_to_msg.grc
@@ -1,0 +1,154 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: var_to_msg
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Test Var To Msg
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: test
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: 0,1,1,1
+    label: Test Variable
+    type: int
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [295, 19]
+    rotation: 0
+    state: true
+- name: blocks_message_debug_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [804, 82]
+    rotation: 0
+    state: true
+- name: blocks_null_sink_0
+  id: blocks_null_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_sink: '[[0,],]'
+    comment: ''
+    num_inputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [575, 224]
+    rotation: 0
+    state: true
+- name: blocks_null_source_0
+  id: blocks_null_source
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_source: '[[0,],]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_outputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [219, 217]
+    rotation: 0
+    state: true
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [372, 215]
+    rotation: 0
+    state: true
+- name: blocks_var_to_msg_0
+  id: blocks_var_to_msg
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    msgname: test
+    target: test
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [468, 64]
+    rotation: 0
+    state: true
+
+connections:
+- [blocks_null_source_0, '0', blocks_throttle_0, '0']
+- [blocks_throttle_0, '0', blocks_null_sink_0, '0']
+- [blocks_var_to_msg_0, msgout, blocks_message_debug_0, print]
+
+metadata:
+  file_format: 1

--- a/gr-blocks/grc/blocks.tree.yml
+++ b/gr-blocks/grc/blocks.tree.yml
@@ -85,6 +85,9 @@
   - blocks_tagged_stream_multiply_length
   - blocks_tagged_stream_to_pdu
   - blocks_random_pdu
+  - blocks_var_to_msg
+  - blocks_msgpair_to_var
+  - blocks_msg_meta_to_pair
 - Misc:
   - blocks_throttle
   - blocks_vector_source_x

--- a/gr-blocks/grc/blocks_meta_to_pair.block.yml
+++ b/gr-blocks/grc/blocks_meta_to_pair.block.yml
@@ -1,0 +1,29 @@
+id: blocks_msg_meta_to_pair
+label: Message Meta Value to Pair
+
+parameters:
+-   id: keyin
+    label: Incoming Meta Name
+    dtype: string
+    default: key in
+-   id: keyout
+    label: Outgoing Pair Name
+    dtype: string
+    default: key out
+
+inputs:
+-   domain: message
+    id: inmeta
+
+outputs:
+-   domain: message
+    id: outpair
+
+templates:
+    imports: from gnuradio import blocks
+    make: blocks.meta_to_pair(${keyin},${keyout})
+
+documentation: |-
+    This block converts a metadata dictionary item to a pmt pair that is compatible with other blocks expecting a pair in.  You can specify which item in the incoming metadata to output as a pair and what the pair name is.
+
+file_format: 1

--- a/gr-blocks/grc/blocks_msg_pair_to_var.block.yml
+++ b/gr-blocks/grc/blocks_msg_pair_to_var.block.yml
@@ -1,0 +1,21 @@
+id: blocks_msgpair_to_var
+label: Message Pair to Var
+
+parameters:
+-   id: target
+    label: Variable
+    dtype: string
+    default: 'freq'
+
+inputs:
+-   domain: message
+    id: inpair
+
+templates:
+    imports: from gnuradio import blocks
+    make: blocks.msg_pair_to_var(${ 'self.set_' + context.get('target')() })
+  
+documentation: |-
+    This block will take an input message pair and allow you to set a gnuradio variable.
+
+file_format: 1

--- a/gr-blocks/grc/blocks_var_to_msg.block.yml
+++ b/gr-blocks/grc/blocks_var_to_msg.block.yml
@@ -1,0 +1,26 @@
+id: blocks_var_to_msg
+label: Variable to Message
+
+parameters:
+-   id: target
+    label: Variable
+    default: freq
+-   id: msgname
+    label: Message Variable Name
+    dtype: string
+    default: 'freq'
+
+outputs:
+-   domain: message
+    id: msgout
+
+templates:
+    imports: from gnuradio import blocks
+    make: blocks.var_to_msg_pair(${msgname})
+    callbacks:
+    - variable_changed(${target})
+  
+documentation: |-
+    This block will monitor a variable, and when it changes, generate a message.
+
+file_format: 1

--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -13,6 +13,9 @@ GR_PYTHON_INSTALL(
     __init__.py
     parse_file_metadata.py
     stream_to_vector_decimator.py
+    msg_pair_to_var.py
+    msg_meta_to_pair.py
+    var_to_msg.py
     DESTINATION ${GR_PYTHON_DIR}/gnuradio/blocks
 )
 

--- a/gr-blocks/python/blocks/__init__.py
+++ b/gr-blocks/python/blocks/__init__.py
@@ -24,6 +24,9 @@ except ImportError:
     from .blocks_swig import *
 
 from .stream_to_vector_decimator import *
+from .msg_meta_to_pair import meta_to_pair
+from .msg_pair_to_var import msg_pair_to_var
+from .var_to_msg import var_to_msg_pair
 
 #alias old add_vXX and multiply_vXX
 add_vcc = add_cc

--- a/gr-blocks/python/blocks/msg_meta_to_pair.py
+++ b/gr-blocks/python/blocks/msg_meta_to_pair.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+from gnuradio import gr
+import pmt
+
+class meta_to_pair(gr.sync_block):
+    """
+    This block converts a metadata dictionary item to a pmt pair that is
+    compatible with other blocks expecting a pair in.  You can specify
+    which item in the incoming metadata to output as a pair and what
+    the pair name is.
+    """
+    def __init__(self, incomingKeyName, outgoingPairName):
+        gr.sync_block.__init__(self, name="meta_to_pair", in_sig=None, out_sig=None)
+
+        self.incomingKeyName = str(incomingKeyName)
+        self.outgoingPairName = str(outgoingPairName)
+
+        self.message_port_register_in(pmt.intern("inmeta"))
+        self.set_msg_handler(pmt.intern("inmeta"), self.msg_handler)
+        self.message_port_register_out(pmt.intern("outpair"))
+
+    def msg_handler(self, msg):
+        if not pmt.is_pair(msg):
+            gr.log.warn("Incoming message is not a pair.  Only pairs are supported.  "
+                        "No message generated.")
+            return
+
+        meta = pmt.to_python(pmt.car(msg))
+
+        if not type(meta) is dict:
+            gr.log.warn("Incoming message does not contain a dictionary.  "
+                        "No message generated.")
+            return
+
+        if not self.incomingKeyName in meta:
+            gr.log.warn("Incoming message dictionary does not contain key %s.  "
+                        "No message generated." % self.incomingKeyName)
+            return
+
+        incomingVal = meta[self.incomingKeyName]
+
+        new_pair = None
+
+        try:
+            new_pair = pmt.cons(pmt.intern(self.outgoingPairName), pmt.to_pmt(incomingVal))
+        except Exception as e:
+            gr.log.error("Cannot construct new message: %s" % str(e))
+            return
+
+        try:
+            self.message_port_pub(pmt.intern("outpair"), new_pair)
+        except Exception as e:
+            gr.log.error("Cannot send message: %s" % str(e))
+            gr.log.error("Incoming dictionary (%s):" % str(type(meta)))
+            gr.log.error(str(meta))
+
+    def stop(self):
+        return True

--- a/gr-blocks/python/blocks/msg_pair_to_var.py
+++ b/gr-blocks/python/blocks/msg_pair_to_var.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+from gnuradio import gr
+import pmt
+
+class msg_pair_to_var(gr.sync_block):
+    """
+    This block will take an input message pair and allow you to set a gnuradio variable.
+    """
+    def __init__(self, callback):
+        gr.sync_block.__init__(self, name="msg_pair_to_var", in_sig=None, out_sig=None)
+
+        self.callback = callback
+
+        self.message_port_register_in(pmt.intern("inpair"))
+        self.set_msg_handler(pmt.intern("inpair"), self.msg_handler)
+
+    def msg_handler(self, msg):
+        try:
+            new_val = pmt.to_python(pmt.cdr(msg))
+
+            self.callback(new_val)
+
+        except Exception as e:
+            gr.log.error("Error with message conversion: %s" % str(e))
+
+    def stop(self):
+        return True

--- a/gr-blocks/python/blocks/var_to_msg.py
+++ b/gr-blocks/python/blocks/var_to_msg.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+from gnuradio import gr
+import pmt
+
+class var_to_msg_pair(gr.sync_block):
+    """
+    This block will monitor a variable, and when it changes, generate a message.
+    """
+    def __init__(self, pairname):
+        gr.sync_block.__init__(self, name="var_to_msg_pair", in_sig=None, out_sig=None)
+
+        self.pairname = pairname
+
+        self.message_port_register_out(pmt.intern("msgout"))
+
+    def variable_changed(self, value):
+        if type(value) == float:
+            p = pmt.from_float(value)
+        elif type(value) == int:
+            p = pmt.from_long(value)
+        elif type(value) == bool:
+            p = pmt.from_bool(value)
+        else:
+            p = pmt.intern(value)
+
+        self.message_port_pub(pmt.intern("msgout"), pmt.cons(pmt.intern(self.pairname), p))
+
+    def stop(self):
+        return True


### PR DESCRIPTION
These 3 new blocks provide the missing glue to move between messages
and variables in the same flowgraph.  There are 3 variants here:
1. Monitor a variable and produce a user-specified message (pair)
when the variable changes.  Useful bridging standard GUI controls
to message-based blocks.
2. When an inbound message (pair) is received, update a specified
variable.
3. When an inbound message (dict) is received, extract a single
dictionary entry and produce a message pair (useful if you have a
multi-value dictionary but you just want to pull off a single
attribute such as frequency or gain without modifying the upstream
block. This can be paired with (2) if necessary to move from a
dictionary item to a variable.