### PR TITLE
gr-blocks: only apply rotator workaround to VOLK 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,12 @@ if(NOT Volk_FOUND)
 
     SET(VOLK_INSTALL_LIBRARY_DIR ${CMAKE_INSTALL_PREFIX}/lib)
     SET(VOLK_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/volk/.lastrelease)
+        file(READ ${CMAKE_CURRENT_SOURCE_DIR}/volk/.lastrelease Volk_VERSION OFFSET 1)
+    else()
+        set(Volk_VERSION "2.0.0")
+    endif()
 else()
     message(STATUS "  An external VOLK has been found and will be used for build.")
     SET(ENABLE_VOLK TRUE)
@@ -445,6 +451,11 @@ else()
 endif(NOT Volk_FOUND)
 
 message(STATUS "  Override with -DENABLE_INTERNAL_VOLK=ON/OFF")
+
+if (Volk_VERSION VERSION_EQUAL "2.0.0")
+  message("  Version 2.0.0 of VOLK was detected. Applying workaround for broken rotator kernel.")
+  add_definitions(-DAPPLY_BROKEN_ROTATOR_WORKAROUND)
+endif()
 
 # Handle logging
 find_package(LOG4CPP REQUIRED)

--- a/gr-blocks/lib/rotator_cc_impl.cc
+++ b/gr-blocks/lib/rotator_cc_impl.cc
@@ -59,7 +59,7 @@ int rotator_cc_impl::work(int noutput_items,
     const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
-#if 1
+#ifdef APPLY_BROKEN_ROTATOR_WORKAROUND
     for (int i = 0; i < noutput_items; i++)
         out[i] = d_r.rotate(in[i]);
 #else


### PR DESCRIPTION
In https://github.com/gnuradio/gnuradio/pull/3062, VOLK was disabled in the rotator block to work around a bug in VOLK 2.0.0. The workaround is unconditionally applied, so the block's performance suffers even when VOLK 2.1.0 or later is used. (Debian, for one, has already moved to 2.1.0.) To solve this, I've implemented @michaelld's [suggestion](https://github.com/gnuradio/gnuradio/pull/3062#pullrequestreview-341541758) to detect the VOLK version and only apply the workaround for VOLK 2.0.0.

If an external VOLK is used, then `find_package(Volk)` will set `Volk_VERSION`. If an internal VOLK is used, then the version number is extracted from `.lastrelease`, if present. This file was added in VOLK 2.1.0. If `.lastrelease` is missing, then the VOLK version is assumed to be 2.0.0. If the resulting `Volk_VERSION` is 2.0.0, then `APPLY_BROKEN_ROTATOR_WORKAROUND` is defined, causing the workaround to be applied.