### PR TITLE
gr-filter: Add ichar and ishort decimator

### DIFF
--- a/gr-filter/examples/test_ichar_decim.grc
+++ b/gr-filter/examples/test_ichar_decim.grc
@@ -1,0 +1,299 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: test_ichar_decim
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: IChar Decimator
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: decim
+  id: variable
+  parameters:
+    comment: ''
+    value: '5'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [381, 20]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '500000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 12]
+    rotation: 0
+    state: enabled
+- name: analog_sig_source_x_0
+  id: analog_sig_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: '127'
+    comment: ''
+    freq: '1000'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: '0'
+    phase: '0'
+    samp_rate: samp_rate
+    type: complex
+    waveform: analog.GR_COS_WAVE
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [41, 238]
+    rotation: 0
+    state: true
+- name: blocks_complex_to_interleaved_char_0
+  id: blocks_complex_to_interleaved_char
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    scale_factor: '1.0'
+    vector_output: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [488, 336]
+    rotation: 0
+    state: true
+- name: blocks_complex_to_interleaved_char_0_0
+  id: blocks_complex_to_interleaved_char
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    scale_factor: '1.0'
+    vector_output: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [714, 221]
+    rotation: 0
+    state: true
+- name: blocks_interleaved_char_to_complex_0
+  id: blocks_interleaved_char_to_complex
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    scale_factor: '1.0'
+    vector_input: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [934, 339]
+    rotation: 0
+    state: true
+- name: blocks_interleaved_char_to_complex_0_0
+  id: blocks_interleaved_char_to_complex
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    scale_factor: '1.0'
+    vector_input: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [935, 219]
+    rotation: 0
+    state: true
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [274, 278]
+    rotation: 0
+    state: true
+- name: ival_decimator_0
+  id: ival_decimator
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    datatype: byte
+    decimation: decim
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [683, 346]
+    rotation: 0
+    state: true
+- name: qtgui_freq_sink_x_0
+  id: qtgui_freq_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'False'
+    average: '1.0'
+    axislabels: 'True'
+    bw: samp_rate/decim
+    color1: '"blue"'
+    color10: '"dark blue"'
+    color2: '"red"'
+    color3: '"green"'
+    color4: '"black"'
+    color5: '"cyan"'
+    color6: '"magenta"'
+    color7: '"yellow"'
+    color8: '"dark red"'
+    color9: '"dark green"'
+    comment: ''
+    ctrlpanel: 'False'
+    fc: '0'
+    fftsize: '1024'
+    freqhalf: 'True'
+    grid: 'False'
+    gui_hint: ''
+    label: Relative Gain
+    label1: Resampler
+    label10: ''''''
+    label2: ichar decim
+    label3: ''''''
+    label4: ''''''
+    label5: ''''''
+    label6: ''''''
+    label7: ''''''
+    label8: ''''''
+    label9: ''''''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '2'
+    showports: 'False'
+    tr_chan: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_tag: '""'
+    type: complex
+    units: dB
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    wintype: firdes.WIN_BLACKMAN_hARRIS
+    ymax: '20'
+    ymin: '-120'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1178, 244]
+    rotation: 0
+    state: true
+- name: rational_resampler_xxx_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: decim
+    fbw: '0'
+    interp: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [482, 195]
+    rotation: 0
+    state: true
+
+connections:
+- [analog_sig_source_x_0, '0', blocks_throttle_0, '0']
+- [blocks_complex_to_interleaved_char_0, '0', ival_decimator_0, '0']
+- [blocks_complex_to_interleaved_char_0_0, '0', blocks_interleaved_char_to_complex_0_0,
+  '0']
+- [blocks_interleaved_char_to_complex_0, '0', qtgui_freq_sink_x_0, '1']
+- [blocks_interleaved_char_to_complex_0_0, '0', qtgui_freq_sink_x_0, '0']
+- [blocks_throttle_0, '0', blocks_complex_to_interleaved_char_0, '0']
+- [blocks_throttle_0, '0', rational_resampler_xxx_0, '0']
+- [ival_decimator_0, '0', blocks_interleaved_char_to_complex_0, '0']
+- [rational_resampler_xxx_0, '0', blocks_complex_to_interleaved_char_0_0, '0']
+
+metadata:
+  file_format: 1

--- a/gr-filter/grc/CMakeLists.txt
+++ b/gr-filter/grc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2012 Free Software Foundation, Inc.
+# Copyright 2012,2020 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -14,6 +14,7 @@ install(FILES
     filter_fir_filter_xxx.block.yml
     filter_filter_delay_fc.block.yml
     filter_filterbank_vcvcf.block.yml
+    filter_ival_decimator.block.yml
     filter_mmse_interpolator_xx.block.yml
     filter_mmse_resampler_xx.block.yml
     filter_freq_xlating_fft_filter_ccc.block.yml

--- a/gr-filter/grc/filter.tree.yml
+++ b/gr-filter/grc/filter.tree.yml
@@ -26,6 +26,7 @@
   - pfb_arb_resampler_xxx
   - rational_resampler_xxx
   - rational_resampler_base_xxx
+  - ival_decimator
 - Channelizers:
   - freq_xlating_fft_filter_ccc
   - freq_xlating_fir_filter_xxx

--- a/gr-filter/grc/filter_ival_decimator.block.yml
+++ b/gr-filter/grc/filter_ival_decimator.block.yml
@@ -1,0 +1,34 @@
+id: ival_decimator
+label: Interleaved Stream Decimator
+
+parameters:
+-   id: datatype
+    label: Input Type
+    dtype: enum
+    options: [byte, short]
+    option_attributes:
+        datasize: [gr.sizeof_char, gr.sizeof_short]
+    hide: part
+-   id: decimation
+    label: Decimation
+    dtype: int
+    default: '1'
+
+inputs:
+-   domain: stream
+    dtype: ${ type }
+
+outputs:
+-   domain: stream
+    dtype: ${ type }
+    
+templates:
+    imports: from gnuradio import filter
+    make: filter.ival_decimator(${decimation}, ${datatype.datasize})
+
+documentation: |-
+    This block will directly decimate an incoming stream made up of the specified complex samples.  
+    One example would be if you have a source streaming 8-bit complex at high speeds and you want to 
+    decimate directly from a high-speed source, or before writing to a file or network sink.
+    
+file_format: 1

--- a/gr-filter/include/gnuradio/filter/CMakeLists.txt
+++ b/gr-filter/include/gnuradio/filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2012,2014,2017 Free Software Foundation, Inc.
+# Copyright (C) 2012,2014,2017,2020 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -15,6 +15,7 @@ install(FILES
     fir_filter_blk.h
     fir_filter_with_buffer.h
     fft_filter.h
+    ival_decimator.h
     iir_filter.h
     interpolator_taps.h
     interp_fir_filter.h

--- a/gr-filter/include/gnuradio/filter/ival_decimator.h
+++ b/gr-filter/include/gnuradio/filter/ival_decimator.h
@@ -1,0 +1,40 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_IVAL_DECIMATOR_H
+#define INCLUDED_IVAL_DECIMATOR_H
+
+#include <gnuradio/filter/api.h>
+#include <gnuradio/sync_decimator.h>
+
+namespace gr {
+namespace filter {
+
+/*!
+ * \brief Filter-Delay Combination Block.
+ * \ingroup resamplers_blk
+ *
+ * \details
+ * This block provides interleaved char and short decimation without
+ * first having to convert to a type supported by a resampler.
+ *
+ */
+class FILTER_API ival_decimator : virtual public gr::sync_decimator
+{
+public:
+    typedef boost::shared_ptr<ival_decimator> sptr;
+
+    static sptr make(int decimation, int data_size);
+};
+
+} // namespace filter
+} // namespace gr
+
+#endif /* INCLUDED_IVAL_DECIMATOR_H */

--- a/gr-filter/lib/CMakeLists.txt
+++ b/gr-filter/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2014,2017-2019 Free Software Foundation, Inc.
+# Copyright (C) 2012-2014,2017-2019,2020 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -15,6 +15,7 @@ add_library(gnuradio-filter
   fft_filter.cc
   firdes.cc
   freq_xlating_fir_filter_impl.cc
+  ival_decimator_impl.cc
   iir_filter.cc
   interp_fir_filter_impl.cc
   mmse_fir_interpolator_cc.cc

--- a/gr-filter/lib/ival_decimator_impl.cc
+++ b/gr-filter/lib/ival_decimator_impl.cc
@@ -1,0 +1,93 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ival_decimator_impl.h"
+#include <gnuradio/io_signature.h>
+
+namespace gr {
+namespace filter {
+
+
+ival_decimator::sptr ival_decimator::make(int decimation, int data_size)
+{
+    return gnuradio::get_initial_sptr(new ival_decimator_impl(decimation, data_size));
+}
+
+/*
+ * The private constructor
+ */
+ival_decimator_impl::ival_decimator_impl(int decimation, int data_size)
+    : gr::sync_decimator("ival_decimator",
+                         gr::io_signature::make(1, 1, data_size),
+                         gr::io_signature::make(1, 1, data_size),
+                         decimation),
+      d_data_size(data_size)
+{
+    if ((data_size != 1) && (data_size != 2))
+        throw std::invalid_argument("data size must be in 1 (char) or 2 (short)");
+
+    d_doubledecimation = 2 * decimation;
+
+    // Make sure we work with pairs of bytes (I and Q as byte)
+    gr::block::set_output_multiple(2);
+}
+
+/*
+ * Our virtual destructor.
+ */
+ival_decimator_impl::~ival_decimator_impl() {}
+
+int ival_decimator_impl::work(int noutput_items,
+                              gr_vector_const_void_star& input_items,
+                              gr_vector_void_star& output_items)
+{
+    long i = 0;
+    int octr = 0;
+
+    long nin = noutput_items * decimation();
+
+    switch (d_data_size) {
+    case 2: {
+        const int16_t* in = (const int16_t*)input_items[0];
+        int16_t* out = (int16_t*)output_items[0];
+
+        while (i < nin) {
+            *out++ = in[i];
+            *out++ = in[i + 1];
+
+            i += d_doubledecimation;
+            octr += 2;
+        }
+    } break;
+
+    case 1: {
+        const char* in = (const char*)input_items[0];
+        char* out = (char*)output_items[0];
+
+        while (i < nin) {
+            *out++ = in[i];
+            *out++ = in[i + 1];
+
+            i += d_doubledecimation;
+            octr += 2;
+        }
+    } break;
+    }
+
+    // Tell runtime system how many output items we produced.
+    return octr;
+}
+
+} /* namespace filter */
+} /* namespace gr */

--- a/gr-filter/lib/ival_decimator_impl.h
+++ b/gr-filter/lib/ival_decimator_impl.h
@@ -1,0 +1,38 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_IVAL_DECIMATOR_IMPL_H
+#define INCLUDED_IVAL_DECIMATOR_IMPL_H
+
+#include <gnuradio/filter/ival_decimator.h>
+
+namespace gr {
+namespace filter {
+
+class FILTER_API ival_decimator_impl : public ival_decimator
+{
+private:
+    int d_doubledecimation;
+    int d_data_size;
+
+public:
+    ival_decimator_impl(int decimation, int data_size);
+    ~ival_decimator_impl();
+
+    // Where all the action really happens
+    int work(int noutput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items);
+};
+
+} // namespace filter
+} // namespace gr
+
+#endif /* INCLUDED_IVAL_DECIMATOR_IMPL_H */

--- a/gr-filter/swig/CMakeLists.txt
+++ b/gr-filter/swig/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2012,2019 Free Software Foundation, Inc.
+# Copyright 2012,2019,2020 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #

--- a/gr-filter/swig/filter_swig.i
+++ b/gr-filter/swig/filter_swig.i
@@ -26,6 +26,7 @@
 #include "gnuradio/filter/fft_filter_ccc.h"
 #include "gnuradio/filter/fft_filter_ccf.h"
 #include "gnuradio/filter/fft_filter_fff.h"
+#include "gnuradio/filter/ival_decimator.h"
 #include "gnuradio/filter/mmse_interpolator_cc.h"
 #include "gnuradio/filter/mmse_interpolator_ff.h"
 #include "gnuradio/filter/mmse_resampler_cc.h"
@@ -54,6 +55,7 @@
 %include "gnuradio/filter/pm_remez.h"
 %include "gnuradio/filter/dc_blocker_cc.h"
 %include "gnuradio/filter/dc_blocker_ff.h"
+%include "gnuradio/filter/ival_decimator.h"
 %include "gnuradio/filter/filter_delay_fc.h"
 %include "gnuradio/filter/filterbank_vcvcf.h"
 %include "gnuradio/filter/fir_filter_blk.h"
@@ -85,6 +87,7 @@
 
 GR_SWIG_BLOCK_MAGIC2(filter, dc_blocker_cc);
 GR_SWIG_BLOCK_MAGIC2(filter, dc_blocker_ff);
+GR_SWIG_BLOCK_MAGIC2(filter, ival_decimator);
 GR_SWIG_BLOCK_MAGIC2(filter, filter_delay_fc);
 GR_SWIG_BLOCK_MAGIC2(filter, filterbank_vcvcf);
 GR_SWIG_BLOCK_MAGIC2_TMPL(filter, fir_filter_ccc, fir_filter_blk<gr_complex, gr_complex, gr_complex>);


### PR DESCRIPTION
Current resamplers do not support ichar as an input type.  However,
when processing high-speed wide bandwidth streaming ichar 
data from external sources (such as the ATA), decimation in 
native ichar would be faster than converting
to another data type then decimating.  This block provides the ability
to decimate the ichar stream directly.