### PR TITLE
zmq: Handle the PMT exceptions

### DIFF
--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -91,8 +91,12 @@ void pull_msg_source_impl::readloop()
 
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
-            pmt::pmt_t m = pmt::deserialize(sb);
-            message_port_pub(d_port, m);
+            try {
+                pmt::pmt_t m = pmt::deserialize(sb);
+                message_port_pub(d_port, m);
+            } catch (pmt::exception& e) {
+                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+            }
 
         } else {
             boost::this_thread::sleep(boost::posix_time::microseconds(100));

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -109,8 +109,12 @@ void req_msg_source_impl::readloop()
 
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
-            pmt::pmt_t m = pmt::deserialize(sb);
-            message_port_pub(d_port, m);
+            try {
+                pmt::pmt_t m = pmt::deserialize(sb);
+                message_port_pub(d_port, m);
+            } catch (pmt::exception& e) {
+                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+            }
 
         } else {
             boost::this_thread::sleep(boost::posix_time::microseconds(100));

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -89,9 +89,12 @@ void sub_msg_source_impl::readloop()
 #endif
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
-            pmt::pmt_t m = pmt::deserialize(sb);
-
-            message_port_pub(d_port, m);
+            try {
+                pmt::pmt_t m = pmt::deserialize(sb);
+                message_port_pub(d_port, m);
+            } catch (pmt::exception& e) {
+                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+            }
         } else {
             boost::this_thread::sleep(boost::posix_time::microseconds(100));
         }

--- a/gr-zeromq/python/zeromq/qa_zeromq_pull_msg_source.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pull_msg_source.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+"""Unit tests for ZMQ PULL Message Source block"""
+
+import time
+import zmq
+
+from gnuradio import gr, gr_unittest, blocks, zeromq
+import pmt
+
+class qa_zeromq_pull_msg_source(gr_unittest.TestCase):
+    """Unit tests for ZMQ PULL Message Source block"""
+
+    def setUp(self):
+        addr = 'tcp://127.0.0.1'
+        self.context = zmq.Context()
+        self.zmq_sock = self.context.socket(zmq.PUSH)
+        port = self.zmq_sock.bind_to_random_port(addr)
+
+        self.zeromq_pull_msg_source = zeromq.pull_msg_source(('%s:%s' % (addr, port)), 100)
+        self.message_debug = blocks.message_debug()
+        self.tb = gr.top_block()
+        self.tb.msg_connect((self.zeromq_pull_msg_source, 'out'), (self.message_debug, 'store'))
+
+        self.tb.start()
+        time.sleep(0.1)
+
+    def tearDown(self):
+        self.tb.stop()
+        self.tb.wait()
+        self.zeromq_pull_msg_source = None
+        self.message_debug = None
+        self.tb = None
+        self.zmq_sock.close()
+        self.context.term()
+
+    def test_valid_pmt(self):
+        """Test receiving of valid PMT messages"""
+        msg = pmt.to_pmt('test_valid_pmt')
+        self.zmq_sock.send(pmt.serialize_str(msg))
+
+        time.sleep(0.1)
+        self.assertEqual(1, self.message_debug.num_messages())
+        self.assertTrue(pmt.equal(msg, self.message_debug.get_message(0)))
+
+    def test_invalid_pmt(self):
+        """Test receiving of invalid PMT messages"""
+        self.zmq_sock.send_string('test_invalid_pmt')
+
+        time.sleep(0.1)
+        self.assertEqual(0, self.message_debug.num_messages())
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_zeromq_pull_msg_source)

--- a/gr-zeromq/python/zeromq/qa_zeromq_req_msg_source.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_req_msg_source.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+"""Unit tests for ZMQ REQ Message Source block"""
+
+import sys
+import time
+import zmq
+
+from gnuradio import gr, gr_unittest, blocks, zeromq
+import pmt
+
+class qa_zeromq_req_msg_source(gr_unittest.TestCase):
+    """Unit tests for ZMQ REQ Message Source block"""
+
+    def setUp(self):
+        addr = 'tcp://127.0.0.1'
+        self.context = zmq.Context()
+        self.zmq_sock = self.context.socket(zmq.REP)
+        port = self.zmq_sock.bind_to_random_port(addr)
+
+        self.zeromq_req_msg_source = zeromq.req_msg_source(('%s:%s' % (addr, port)), 100)
+        self.message_debug = blocks.message_debug()
+        self.tb = gr.top_block()
+        self.tb.msg_connect((self.zeromq_req_msg_source, 'out'), (self.message_debug, 'store'))
+
+        self.tb.start()
+
+    def tearDown(self):
+        self.tb.stop()
+        self.tb.wait()
+        self.zeromq_req_msg_source = None
+        self.message_debug = None
+        self.tb = None
+        self.zmq_sock.close()
+        self.context.term()
+
+    def recv_request(self):
+        """Receive the request output items message"""
+        req = self.zmq_sock.recv()
+        req_output_items = int.from_bytes(req, sys.byteorder)
+        self.assertEqual(1, req_output_items)
+
+    def send_messages(self, msgs):
+        """Send multiple messages"""
+        for msg in msgs:
+            self.recv_request()
+            self.zmq_sock.send(pmt.serialize_str(msg))
+
+    def test_valid_pmt(self):
+        """Test receiving of valid PMT messages"""
+        msg = pmt.to_pmt('test_valid_pmt')
+        self.send_messages([msg])
+
+        time.sleep(0.1)
+        self.assertEqual(1, self.message_debug.num_messages())
+        self.assertTrue(pmt.equal(msg, self.message_debug.get_message(0)))
+
+    def test_multiple_messages(self):
+        """Test receiving of multiple PMT messages"""
+        msgs = [pmt.to_pmt('test_valid_pmt msg0'),
+                pmt.to_pmt('test_valid_pmt msg1'),
+                pmt.to_pmt('test_valid_pmt msg2')]
+        self.send_messages(msgs)
+
+        time.sleep(0.1)
+        self.assertEqual(len(msgs), self.message_debug.num_messages())
+        for index, msg in enumerate(msgs):
+            self.assertTrue(pmt.equal(msg, self.message_debug.get_message(index)))
+
+    def test_invalid_pmt(self):
+        """Test receiving of invalid PMT messages"""
+        self.recv_request()
+
+        #Do not use pmt.serialize_str here as we don't want a valid PMT message
+        self.zmq_sock.send_string('test_invalid_pmt')
+
+        time.sleep(0.1)
+        self.assertEqual(0, self.message_debug.num_messages())
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_zeromq_req_msg_source)

--- a/gr-zeromq/python/zeromq/qa_zeromq_sub_msg_source.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_sub_msg_source.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+"""Unit tests for ZMQ SUB Message Source block"""
+
+import time
+import zmq
+
+from gnuradio import gr, gr_unittest, blocks, zeromq
+import pmt
+
+class qa_zeromq_sub_msg_source(gr_unittest.TestCase):
+    """Unit tests for ZMQ SUB Message Source block"""
+
+    def setUp(self):
+        addr = 'tcp://127.0.0.1'
+        self.context = zmq.Context()
+        self.zmq_sock = self.context.socket(zmq.PUB)
+        port = self.zmq_sock.bind_to_random_port(addr)
+
+        self.zeromq_sub_msg_source = zeromq.sub_msg_source(('%s:%s' % (addr, port)), 100)
+        self.message_debug = blocks.message_debug()
+        self.tb = gr.top_block()
+        self.tb.msg_connect((self.zeromq_sub_msg_source, 'out'), (self.message_debug, 'store'))
+
+        self.tb.start()
+        time.sleep(0.1)
+
+    def tearDown(self):
+        self.tb.stop()
+        self.tb.wait()
+        self.zeromq_sub_msg_source = None
+        self.message_debug = None
+        self.tb = None
+        self.zmq_sock.close()
+        self.context.term()
+
+    def test_valid_pmt(self):
+        """Test receiving of valid PMT messages"""
+        msg = pmt.to_pmt('test_valid_pmt')
+        self.zmq_sock.send(pmt.serialize_str(msg))
+
+        time.sleep(0.1)
+        self.assertEqual(1, self.message_debug.num_messages())
+        self.assertTrue(pmt.equal(msg, self.message_debug.get_message(0)))
+
+    def test_invalid_pmt(self):
+        """Test receiving of invalid PMT messages"""
+        self.zmq_sock.send_string('test_invalid_pmt')
+
+        time.sleep(0.1)
+        self.assertEqual(0, self.message_debug.num_messages())
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_zeromq_sub_msg_source)


### PR DESCRIPTION
Handle the PMT exceptions when deserializing the received ZMQ messages,
log an error message and continue the execution.

Previously the unhandled exceptions were aborting the process: #3217

terminate called after throwing an instance of 'pmt::exception'
  what():  pmt::deserialize: malformed input stream, tag value = : 50
Aborted (core dumped)