### PR TITLE
fix(filter_design): Use public fft interface of numpy

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -25,17 +25,7 @@ try:
 except ImportError:
     raise SystemExit('Please install NumPy to run this script (https://www.np.org/)')
 
-try:
-    from numpy.fft import fftpack as fft_detail
-except ImportError:
-
-    print('Could not import fftpack, trying pocketfft')
-    # Numpy changed fft implementation in version 1.17
-    # from fftpack to pocketfft
-    try:
-        from numpy.fft import pocketfft as fft_detail
-    except ImportError:
-        raise SystemExit('Could not import fft implementation of numpy')
+import numpy.fft as fft_detail
     
 try:
     from scipy import poly1d, signal


### PR DESCRIPTION
At least on my machine numpy changed from `pocketfft` to `_pocketfft`. The public interface works just as well though.