### PR TITLE
clang-format: disable `SortIncludes` option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,7 +87,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
-SortIncludes:    true
+SortIncludes:    false
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true


### PR DESCRIPTION
The `SortIncludes` option in clang-format potentially breaks code.
Includes of each group (e.g. ^[a-Z]*>$) are sorted alphabetically.  This
is dangerous since the include order should be determined by
functionality, not by name.
Example of what this could break: Qt uses the keyword slots. However,
Python also uses this name for other purposes. This makes it necessary
to include Python before Qt, or else the slots statements in Python will
be treated as Qt keywords, which leads to build failure.
Solves #3120 .