### PR TITLE
gr-blocks: Add Msg Port to Delay Block

### DIFF
--- a/gr-blocks/grc/blocks_delay.block.yml
+++ b/gr-blocks/grc/blocks_delay.block.yml
@@ -31,6 +31,9 @@ inputs:
     dtype: ${ type }
     vlen: ${ vlen }
     multiplicity: ${ num_ports }
+-   domain: message
+    id: dly
+    optional: true
 
 outputs:
 -   domain: stream

--- a/gr-blocks/lib/delay_impl.h
+++ b/gr-blocks/lib/delay_impl.h
@@ -24,7 +24,7 @@ private:
 
     size_t d_itemsize;
     int d_delta;
-    gr::thread::mutex d_mutex_delay;
+    void handle_msg(pmt::pmt_t msg);
 
 public:
     delay_impl(size_t itemsize, int delay);


### PR DESCRIPTION
These updates add the ability to set the block delay value with
an asynchronous message.  In this manner, blocks doing calculations
such as those for DoA or antenna arrays can provide delay updates
only when needed.