### PR TITLE
gr-blocks: Add Phase Shift Block with Msg Capabilities

### DIFF
--- a/gr-blocks/grc/blocks.tree.yml
+++ b/gr-blocks/grc/blocks.tree.yml
@@ -104,6 +104,7 @@
   - blocks_copy
   - blocks_selector
   - blocks_nop
+  - blocks_phase_shift
   - xmlrpc_server
   - xmlrpc_client
 - Modulators:

--- a/gr-blocks/grc/blocks_phase_shift.block.yml
+++ b/gr-blocks/grc/blocks_phase_shift.block.yml
@@ -1,0 +1,40 @@
+id: blocks_phase_shift
+label: Phase Shift
+
+parameters:
+-   id: shift
+    label: Phase Shift
+    dtype: float
+    default: '0.0'
+-   id: is_radians
+    label: Units
+    dtype: enum
+    options: ['True', 'False']
+    option_labels: ['Radians', 'Degrees']
+
+inputs:
+-   domain: stream
+    dtype: complex
+-   domain: message
+    id: shift
+    optional: true
+
+outputs:
+-   domain: stream
+    dtype: complex
+
+templates:
+    imports: from gnuradio import blocks
+    make: blocks.phase_shift(${shift}, ${is_radians})
+    callbacks:
+    - set_shift(${shift})
+
+documentation: "This block will phase shift the input signal by the specified phase\
+    \ by multiplying the input times a shift value: \n\
+    \ gr_complex(cos(d_shift_in_radians),sin(d_shift_in_radians))\n\n\
+    \ Notes:\n\
+    \ If degrees are provided, the block automatically handles the conversion.\n\
+    \ This block functions like a multiply const, but with the const limited to \
+    \ abs() == 1 to provide a constant phase shift." 
+
+file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -39,6 +39,7 @@ install(FILES
     pack_k_bits.h
     packed_to_unpacked.h
     peak_detector.h
+    phase_shift.h
     probe_signal.h
     probe_signal_v.h
     rotator.h

--- a/gr-blocks/include/gnuradio/blocks/phase_shift.h
+++ b/gr-blocks/include/gnuradio/blocks/phase_shift.h
@@ -1,0 +1,46 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_PHASESHIFT_H
+#define INCLUDED_PHASESHIFT_H
+
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+namespace blocks {
+
+/*!
+ * \brief This block will shift the incoming signal by the specified amount.
+ * Shift can be specified in either radians or degress which is configurable
+ * in the constructor.
+ *
+ * This block functions like a multiply const, but with the const limited to
+ * abs() == 1 to provide a constant phase shift.
+ * \ingroup misc_blk
+ *
+ */
+class BLOCKS_API phase_shift : virtual public gr::sync_block
+{
+public:
+    typedef boost::shared_ptr<phase_shift> sptr;
+
+    /*!
+     * \brief Create an instance of phase_shift
+     */
+    static sptr make(float shift, bool is_radians);
+    virtual float get_shift() const = 0;
+    virtual void set_shift(float new_value) = 0;
+};
+
+} // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_PHASESHIFT_H */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(gnuradio-blocks
     not_blk_impl.cc
     packed_to_unpacked_impl.cc
     peak_detector_impl.cc
+    phase_shift_impl.cc
     probe_signal_impl.cc
     probe_signal_v_impl.cc
     sample_and_hold_impl.cc

--- a/gr-blocks/lib/phase_shift_impl.cc
+++ b/gr-blocks/lib/phase_shift_impl.cc
@@ -1,0 +1,97 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "phase_shift_impl.h"
+#include <gnuradio/io_signature.h>
+
+#include <gnuradio/math.h>
+#include <volk/volk.h>
+
+namespace gr {
+namespace blocks {
+
+phase_shift::sptr phase_shift::make(float shift, bool is_radians)
+{
+    return gnuradio::get_initial_sptr(new phase_shift_impl(shift, is_radians));
+}
+
+/*
+ * The private constructor
+ */
+phase_shift_impl::phase_shift_impl(float shift, bool is_radians)
+    : gr::sync_block("phase_shift",
+                     gr::io_signature::make(1, 1, sizeof(gr_complex)),
+                     gr::io_signature::make(1, 1, sizeof(gr_complex))),
+      d_is_radians(is_radians)
+{
+    set_shift(shift);
+
+    message_port_register_in(pmt::mp("shift"));
+    set_msg_handler(pmt::mp("shift"),
+                    [this](pmt::pmt_t msg) { this->handle_msg_in(msg); });
+}
+
+/*
+ * Our virtual destructor.
+ */
+phase_shift_impl::~phase_shift_impl() {}
+
+void phase_shift_impl::handle_msg_in(pmt::pmt_t msg)
+{
+    if (pmt::is_number(msg)) {
+        set_shift(pmt::to_float(msg));
+    } else {
+        if (pmt::is_pair(msg)) {
+            pmt::pmt_t data = pmt::cdr(msg);
+            if (pmt::is_number(data)) {
+                set_shift(pmt::to_float(data));
+            } else
+                GR_LOG_WARN(
+                    d_logger,
+                    "Phase message must be a number or a number pair.  Ignoring value.");
+        }
+    }
+}
+
+void phase_shift_impl::set_shift(float new_value)
+{
+    gr::thread::scoped_lock guard(d_setlock);
+    if (d_is_radians)
+        d_shift = new_value;
+    else
+        d_shift = new_value * GR_M_PI / 180.0; // convert to radians
+
+    d_shift_cc = gr_complex(cos(d_shift), sin(d_shift));
+}
+
+int phase_shift_impl::work(int noutput_items,
+                           gr_vector_const_void_star& input_items,
+                           gr_vector_void_star& output_items)
+{
+    const gr_complex* in = (const gr_complex*)input_items[0];
+    gr_complex* out = (gr_complex*)output_items[0];
+
+    gr::thread::scoped_lock guard(d_setlock);
+
+    if (d_shift != 0.0f) {
+        volk_32fc_s32fc_multiply_32fc(out, in, d_shift_cc, noutput_items);
+    } else {
+        memcpy(out, in, sizeof(gr_complex) * noutput_items);
+    }
+
+    return noutput_items;
+}
+
+} /* namespace blocks */
+} /* namespace gr */

--- a/gr-blocks/lib/phase_shift_impl.h
+++ b/gr-blocks/lib/phase_shift_impl.h
@@ -1,0 +1,43 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_PHASE_SHIFT_IMPL_H
+#define INCLUDED_PHASE_SHIFT_IMPL_H
+
+#include <gnuradio/blocks/phase_shift.h>
+
+namespace gr {
+namespace blocks {
+
+class phase_shift_impl : public phase_shift
+{
+private:
+    bool d_is_radians;
+    float d_shift;
+    gr_complex d_shift_cc;
+
+public:
+    phase_shift_impl(float shift, bool is_radians);
+    ~phase_shift_impl();
+
+    virtual float get_shift() const { return d_shift; }
+    virtual void set_shift(float new_value);
+
+    void handle_msg_in(pmt::pmt_t msg);
+
+    int work(int noutput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items);
+};
+
+} // namespace blocks
+} // namespace gr
+
+#endif /* INCLUDED_PHASE_SHIFT_IMPL_H */

--- a/gr-blocks/swig/blocks_swig10.i
+++ b/gr-blocks/swig/blocks_swig10.i
@@ -24,6 +24,7 @@
 #include "gnuradio/blocks/patterned_interleaver.h"
 #include "gnuradio/blocks/pack_k_bits_bb.h"
 #include "gnuradio/blocks/packed_to_unpacked.h"
+#include "gnuradio/blocks/phase_shift.h"
 %}
 
 %include "gnuradio/blocks/min_blk.h"
@@ -34,6 +35,7 @@
 %include "gnuradio/blocks/patterned_interleaver.h"
 %include "gnuradio/blocks/pack_k_bits_bb.h"
 %include "gnuradio/blocks/packed_to_unpacked.h"
+%include "gnuradio/blocks/phase_shift.h"
 
 GR_SWIG_BLOCK_MAGIC2_TMPL(blocks, min_ff, min_blk<float>);
 GR_SWIG_BLOCK_MAGIC2_TMPL(blocks, min_ii, min_blk<std::int32_t>);
@@ -54,3 +56,4 @@ GR_SWIG_BLOCK_MAGIC2(blocks, pack_k_bits_bb);
 GR_SWIG_BLOCK_MAGIC2_TMPL(blocks, packed_to_unpacked_bb, packed_to_unpacked<std::uint8_t>);
 GR_SWIG_BLOCK_MAGIC2_TMPL(blocks, packed_to_unpacked_ss, packed_to_unpacked<std::int16_t>);
 GR_SWIG_BLOCK_MAGIC2_TMPL(blocks, packed_to_unpacked_ii, packed_to_unpacked<std::int32_t>);
+GR_SWIG_BLOCK_MAGIC2(blocks, phase_shift);


### PR DESCRIPTION
This new block provides a native ability to phase shift signals
based on radians for solutions such as DoA and array-based projects.
The block supports both variable and message based updates such that
other blocks can provide the appropriate calculations for shifting
and only send message-based updates when necessary.