### PR TITLE
ctrlport: fix examples

### DIFF
--- a/gr-blocks/examples/ctrlport/simple_copy_controller.py
+++ b/gr-blocks/examples/ctrlport/simple_copy_controller.py
@@ -13,8 +13,7 @@ if(len(args) < 4):
 hostname = args[1]
 portnum = int(args[2])
 msg = args[3].lower()
-argv = [None, hostname, portnum]
-radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+radiosys = GNURadioControlPortClient(host=hostname, port=portnum, rpcmethod='thrift')
 radio = radiosys.client
 
 if(msg == 'true'):

--- a/gr-blocks/examples/ctrlport/usrp_sink_controller.py
+++ b/gr-blocks/examples/ctrlport/usrp_sink_controller.py
@@ -30,8 +30,7 @@ elif(cmd == "antenna"):
 else:
     val = pmt.from_double(float(val))
 
-argv = [None, args.host, args.port]
-radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+radiosys = GNURadioControlPortClient(host=args.host, port=args.port, rpcmethod='thrift')
 radio = radiosys.client
 
 radio.postMessage(args.alias, port, pmt.cons(pmt.intern(cmd), val))

--- a/gr-blocks/examples/ctrlport/usrp_source_controller.py
+++ b/gr-blocks/examples/ctrlport/usrp_source_controller.py
@@ -30,8 +30,7 @@ if(cmd == "antenna"):
 else:
     val = pmt.from_double(float(val))
 
-argv = [None, args.host, args.port]
-radiosys = GNURadioControlPortClient(argv=argv, rpcmethod='thrift')
+radiosys = GNURadioControlPortClient(host=args.host, port=args.port, rpcmethod='thrift')
 radio = radiosys.client
 
 radio.postMessage(args.alias, port, pmt.cons(pmt.intern(cmd), val))


### PR DESCRIPTION
`GNURadioControlPortClient` changed its constructor interface in cb044a4c4b2c6657876f996617a24a44d1ac3b5d.

This updates the examples accordingly. I could not test the USRP examples as I don't have the hardware.