### PR TITLE
add optional error handler for c++ api.

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/thread/CMakeLists.txt
@@ -12,5 +12,6 @@ install(FILES
   thread.h
   thread_body_wrapper.h
   thread_group.h
+  basic_error_handler.h
   DESTINATION ${GR_INCLUDE_DIR}/gnuradio/thread
 )

--- a/gnuradio-runtime/include/gnuradio/thread/basic_error_handler.h
+++ b/gnuradio-runtime/include/gnuradio/thread/basic_error_handler.h
@@ -1,0 +1,12 @@
+#ifndef BASIC_ERROR_HANDLER_H
+#define BASIC_ERROR_HANDLER_H
+
+#include <string>
+
+class basic_error_handler
+{
+public:
+    virtual ~basic_error_handler() = default;
+    virtual void addError(const std::string& error) = 0;
+};
+#endif // BASIC_ERROR_HANDLER_H

--- a/gnuradio-runtime/include/gnuradio/top_block.h
+++ b/gnuradio-runtime/include/gnuradio/top_block.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/hier_block2.h>
+#include <gnuradio/thread/basic_error_handler.h>
 
 namespace gr {
 
@@ -130,6 +131,9 @@ public:
     top_block_sptr to_top_block(); // Needed for Python type coercion
 
     void setup_rpc();
+
+    //!  register error handler for getting exceptions in c++ api
+    void register_error_handler(std::shared_ptr<basic_error_handler> handler);
 };
 
 inline top_block_sptr cast_to_top_block_sptr(basic_block_sptr block)

--- a/gnuradio-runtime/lib/scheduler.cc
+++ b/gnuradio-runtime/lib/scheduler.cc
@@ -24,4 +24,10 @@ scheduler::scheduler(flat_flowgraph_sptr ffg,
 
 scheduler::~scheduler() {}
 
+void scheduler::register_error_handler(std::shared_ptr<basic_error_handler> handler)
+{
+    errorHandler = handler;
+}
+
+std::shared_ptr<basic_error_handler> scheduler::errorHandler;
 } /* namespace gr */

--- a/gnuradio-runtime/lib/scheduler.h
+++ b/gnuradio-runtime/lib/scheduler.h
@@ -14,6 +14,7 @@
 #include "flat_flowgraph.h"
 #include <gnuradio/api.h>
 #include <gnuradio/block.h>
+#include <gnuradio/thread/basic_error_handler.h>
 #include <boost/utility.hpp>
 
 namespace gr {
@@ -50,6 +51,14 @@ public:
      * \brief Block until the graph is done.
      */
     virtual void wait() = 0;
+
+    /*!
+     * \brief register error handler for c++ api to handle exceptions.
+     */
+    static void register_error_handler(std::shared_ptr<basic_error_handler> handler);
+
+protected:
+    static std::shared_ptr<basic_error_handler> errorHandler;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/scheduler_tpb.cc
+++ b/gnuradio-runtime/lib/scheduler_tpb.cc
@@ -72,6 +72,7 @@ scheduler_tpb::scheduler_tpb(flat_flowgraph_sptr ffg,
 
     // Fire off a thead for each block
 
+    thread::thread_body_wrapper<tpb_container>::register_error_handler(errorHandler);
     for (size_t i = 0; i < blocks.size(); i++) {
         std::stringstream name;
         name << "thread-per-block[" << i << "]: " << blocks[i];

--- a/gnuradio-runtime/lib/top_block.cc
+++ b/gnuradio-runtime/lib/top_block.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 
 namespace gr {
+
 top_block_sptr make_top_block(const std::string& name, bool catch_exceptions)
 {
     return gnuradio::get_initial_sptr(new top_block(name, catch_exceptions));
@@ -175,6 +176,12 @@ void top_block::setup_rpc()
                                                   DISPNULL)));
     rpc_set();
 #endif /* GR_CTRLPORT */
+}
+
+
+void top_block::register_error_handler(std::shared_ptr<basic_error_handler> handler)
+{
+    d_impl->register_error_handler(handler);
 }
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -223,4 +223,9 @@ int top_block_impl::max_noutput_items() { return d_max_noutput_items; }
 
 void top_block_impl::set_max_noutput_items(int nmax) { d_max_noutput_items = nmax; }
 
+void top_block_impl::register_error_handler(std::shared_ptr<basic_error_handler> handler)
+{
+    d_error_handler = handler;
+}
+
 } /* namespace gr */

--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -13,6 +13,7 @@
 
 #include "scheduler.h"
 #include <gnuradio/api.h>
+#include <gnuradio/thread/basic_error_handler.h>
 #include <gnuradio/thread/thread.h>
 
 namespace gr {
@@ -60,12 +61,16 @@ public:
     // Set the maximum number of noutput_items in the flowgraph
     void set_max_noutput_items(int nmax);
 
+
+    void register_error_handler(std::shared_ptr<basic_error_handler> handler);
+
 protected:
     enum tb_state { IDLE, RUNNING };
 
     top_block* d_owner;
     flat_flowgraph_sptr d_ffg;
     scheduler_sptr d_scheduler;
+    std::shared_ptr<basic_error_handler> d_error_handler;
 
     gr::thread::mutex d_mutex; // protects d_state and d_lock_count
     tb_state d_state;


### PR DESCRIPTION
Thread exceptions was captured in thread_body_wrapper and only used cerr to print them in console but in c++ api usage in programs like gqrx and other programs we need to get error to handle them in our program (show in gui or ... ).
So i added an optional error handler to use in c++ api if you need. and we use it in our programs.
