### PR TITLE
modtool: Backport PR #2723 to maint-3.8

### DIFF
--- a/gr-utils/python/modtool/core/add.py
+++ b/gr-utils/python/modtool/core/add.py
@@ -163,8 +163,8 @@ class ModToolAdd(ModTool):
             return
         try:
             append_re_line_sequence(self._file['cmlib'],
-                                    '\$\{CMAKE_CURRENT_SOURCE_DIR\}/qa_%s.cc.*\n' % self.info['modname'],
-                                    '    ${CMAKE_CURRENT_SOURCE_DIR}/qa_%s.cc' % self.info['blockname'])
+                                    'list\(APPEND test_{}_sources.*\n'.format(self.info['modname']),
+                                    'qa_{}.cc'.format(self.info['blockname']))
             append_re_line_sequence(self._file['qalib'],
                                     '#include.*\n',
                                     '#include "{}"'.format(fname_qa_h))

--- a/gr-utils/python/modtool/core/add.py
+++ b/gr-utils/python/modtool/core/add.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2014,2017,2018 Free Software Foundation, Inc.
+# Copyright 2013-2014,2017-2019 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -177,6 +177,20 @@ class ModToolAdd(ModTool):
         except IOError:
             logger.warning("Can't add C++ QA files.")
 
+    def _run_cc_qa_boostutf(self):
+        " Add C++ QA files for 3.8 API if intructed from _run_lib"
+        fname_qa_cc = 'qa_{}.cc'.format(self.info['blockname'])
+        self._write_tpl('qa_cpp_boostutf', 'lib', fname_qa_cc)
+        if self.skip_cmakefiles:
+            return
+        try:
+            append_re_line_sequence(self._file['cmlib'],
+                                    'list\(APPEND test_{}_sources.*\n'.format(self.info['modname']),
+                                    'qa_{}.cc'.format(self.info['blockname']))
+            self.scm.mark_files_updated((self._file['cmlib'],))
+        except IOError:
+            logger.warning("Can't add C++ QA files.")
+
     def _run_lib(self):
         """ Do everything that needs doing in the subdir 'lib' and 'include'.
         - add .cc and .h files
@@ -201,7 +215,9 @@ class ModToolAdd(ModTool):
             self._write_tpl('block_h36',   self.info['includedir'], fname_h)
             self._write_tpl('block_cpp36', 'lib',                    fname_cc)
         if self.add_cc_qa:
-            if self.info['version'] in ('37', '38') :
+            if self.info['version'] == '38':
+                self._run_cc_qa_boostutf()
+            elif self.info['version'] == '37':
                 self._run_cc_qa()
             elif self.info['version'] == '36':
                 logger.warning("Warning: C++ QA files not supported for 3.6-style OOTs.")

--- a/gr-utils/python/modtool/core/disable.py
+++ b/gr-utils/python/modtool/core/disable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013, 2018 Free Software Foundation, Inc.
+# Copyright 2013, 2018, 2019 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -82,7 +82,7 @@ class ModToolDisable(ModTool):
                 ed.write()
                 self.scm.mark_file_updated(self._file['qalib'])
             elif self.info['version'] == '38':
-                fname_qa_cc = 'qa_{}.cc'.format(self._info['blockname'])
+                fname_qa_cc = 'qa_{}.cc'.format(self.info['blockname'])
                 cmake.comment_out_lines(fname_qa_cc)
             elif self.info['version'] == '36':
                 cmake.comment_out_lines('add_executable.*'+fname)

--- a/gr-utils/python/modtool/core/rm.py
+++ b/gr-utils/python/modtool/core/rm.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013, 2018 Free Software Foundation, Inc.
+# Copyright 2013, 2018, 2019 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -78,12 +78,12 @@ class ModToolRemove(ModTool):
                                     r'\$\{CMAKE_CURRENT_SOURCE_DIR\}/%s' % filename,
                                     to_ignore_start='APPEND test_{}_sources'.format(self.info['modname']))
                     self.scm.mark_file_updated(ed.filename)
-            elif self._info['version'] == '38':
+            elif self.info['version'] == '38':
                 (base, ext) = os.path.splitext(filename)
                 if ext == '.cc':
                     ed.remove_value(
                         'list', filename,
-                        to_ignore_start='APPEND test_%s_sources' % self._info['modname'])
+                        to_ignore_start='APPEND test_{}_sources'.format(self.info['modname']))
                     self.scm.mark_file_updated(ed.filename)
             else:
                 filebase = os.path.splitext(filename)[0]


### PR DESCRIPTION
Backport merge request #2723

Fixes issue mentioned on mailing list as well 
https://www.mail-archive.com/discuss-gnuradio@gnu.org/msg70053.html
where we see:
```
Can't add C++ QA files.
```
when adding a new block with cpp unit test.

The third commit in the original pull request for master was already on maint-3.8.