### PR TITLE
Allow grc to load flowgraphs with missing blocks

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -1,5 +1,5 @@
 """
-Copyright 2008-2015 Free Software Foundation, Inc.
+Copyright 2008-2020 Free Software Foundation, Inc.
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-2.0-or-later
@@ -77,7 +77,7 @@ class Block(Element):
 
         self.states = {'state': True, 'bus_source': False, 'bus_sink': False, 'bus_structure': None}
 
-        if 'cpp' in self.flags and not (self.is_virtual_source() or self.is_virtual_sink()):
+        if 'cpp' in self.flags and self.enabled and not (self.is_virtual_source() or self.is_virtual_sink()):
             self.orig_cpp_templates = self.cpp_templates # The original template, in case we have to edit it when transpiling to C++         
 
         self.current_bus_structure = {'source': None, 'sink': None}


### PR DESCRIPTION
Re-created previously-closed pull request after making requested edits

After a recent merge fixing some C++ code generation issues (merge request #2797), GRC now fails to load a flowgraph if it has any missing blocks.