### PR TITLE
gr-utils: '#'replaced by '%' for commenting in codes.

### DIFF
--- a/gr-utils/octave/cic_comp_taps.m
+++ b/gr-utils/octave/cic_comp_taps.m
@@ -1,17 +1,17 @@
-#
-# Copyright 2008 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2008 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
-# See Altera Application Note AN455
-#
-# R  = decimation factor, 8-256
-# Fc = passband (one-sided) cutoff frequency
-# L  = number of taps
+% See Altera Application Note AN455
+%
+% R  = decimation factor, 8-256
+% Fc = passband (one-sided) cutoff frequency
+% L  = number of taps
 
 function taps = cic_comp_taps(R, Fc, L)
     M = 1;                                   %% Differential delay

--- a/gr-utils/octave/plot_cic_decimator_response.m
+++ b/gr-utils/octave/plot_cic_decimator_response.m
@@ -1,32 +1,32 @@
-#
-# Copyright 2004 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2004 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function plot_cic_decimator_response (R, N, M)
-  ## R = decimation rate
-  ## N = number of stages (4)
-  ## M = 1
+  %% R = decimation rate
+  %% N = number of stages (4)
+  %% M = 1
   gain = (R*M)^N
   npoints = 1024;
   w = 0:1/npoints:1-1/npoints;
   w = w * 1 * pi;
-  ## w = w * R;
+  %% w = w * R;
   length(w);
   num = sin (w*R*M/2);
   length (num);
-  ## H = sin (w*R*M/2) ./ sin (w/2)
+  %% H = sin (w*R*M/2) ./ sin (w/2)
   denom = sin(w/2);
   length (denom);
   H = (num ./ denom) .^ N;
   H(1) = gain;
   H = H ./ gain;
   plot (R*w/(2*pi), 10 * log10 (H));
-  ## plot (R*w/(2*pi), H);
+  %% plot (R*w/(2*pi), H);
 endfunction
 
 

--- a/gr-utils/octave/plot_freq_response.m
+++ b/gr-utils/octave/plot_freq_response.m
@@ -1,18 +1,18 @@
-#
-# Copyright 2001 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2001 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function plot_freq_response (b,...)
   if (nargin == 1)
-    ## Response of an FIR filter
+    %% Response of an FIR filter
     a = 1;
   elseif (nargin == 2)
-    ## response of an IIR filter
+    %% response of an IIR filter
     a = va_arg ();
   endif
 

--- a/gr-utils/octave/plot_freq_response_db.m
+++ b/gr-utils/octave/plot_freq_response_db.m
@@ -1,18 +1,18 @@
-#
-# Copyright 2001 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2001 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function plot_freq_response_db (b,...)
   if (nargin == 1)
-    ## Response of an FIR filter
+    %% Response of an FIR filter
     a = 1;
   elseif (nargin == 2)
-    ## response of an IIR filter
+    %% response of an IIR filter
     a = va_arg ();
   endif
 
@@ -22,6 +22,6 @@ function plot_freq_response_db (b,...)
   xlabel ('Normalized Frequency (Fs == 1)');
   ylabel ('Magnitude Squared (dB)');
   abs = abs(H);
-# plot (w/(2*pi), 20 * log10 (abs/max(abs)));
+% plot (w/(2*pi), 20 * log10 (abs/max(abs)));
   plot (w/(2*pi), 20 * log10 (abs));
 endfunction

--- a/gr-utils/octave/plot_freq_response_phase.m
+++ b/gr-utils/octave/plot_freq_response_phase.m
@@ -1,18 +1,18 @@
-#
-# Copyright 2001 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2001 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function plot_freq_response_db (b,...)
   if (nargin == 1)
-    ## Response of an FIR filter
+    %% Response of an FIR filter
     a = 1;
   elseif (nargin == 2)
-    ## response of an IIR filter
+    %% response of an IIR filter
     a = va_arg ();
   endif
 

--- a/gr-utils/octave/single_pole_iir.m
+++ b/gr-utils/octave/single_pole_iir.m
@@ -1,11 +1,11 @@
-#
-# Copyright 2002 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2002 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function [b, a] = single_pole_iir (alpha)
   b = [alpha];

--- a/gr-utils/octave/write_float_binary.m
+++ b/gr-utils/octave/write_float_binary.m
@@ -1,18 +1,18 @@
-#
-# Copyright 2001 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2001 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function v = write_float_binary (data, filename)
 
-  ## usage: write_float_binary (data, filename)
-  ##
-  ##  open filename and write data to it as 32 bit floats
-  ##
+  %% usage: write_float_binary (data, filename)
+  %%
+  %%  open filename and write data to it as 32 bit floats
+  %%
 
   if ((m = nargchk (2,2,nargin)))
     usage (m);

--- a/gr-utils/octave/write_short_binary.m
+++ b/gr-utils/octave/write_short_binary.m
@@ -1,18 +1,18 @@
-#
-# Copyright 2001 Free Software Foundation, Inc.
-#
-# This file is part of GNU Radio
-#
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-#
+%
+% Copyright 2001 Free Software Foundation, Inc.
+%
+% This file is part of GNU Radio
+%
+% SPDX-License-Identifier: GPL-3.0-or-later
+%
+%
 
 function v = write_short_binary (data, filename)
 
-  ## usage: write_short_binary (data, filename)
-  ##
-  ##  open filename and write data to it as 16 bit shorts
-  ##
+  %% usage: write_short_binary (data, filename)
+  %%
+  %%  open filename and write data to it as 16 bit shorts
+  %%
 
   if ((m = nargchk (2,2,nargin)))
     usage (m);


### PR DESCRIPTION
Fixes #3195 
In gr-utils/octave, replaced every '#' by '%' in matlab as Octave supports either of them for commenting while Matlab supports only '%'.This expands usability of code.