### PR TITLE
fix(filter_design): Change numpy.fft.fftpack to numpy.fft and increase dependency on Numpy instead of Scipy

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -1009,10 +1009,10 @@ class gr_plot_filter(QtGui.QMainWindow):
 
         # Set Data.
         if(type(self.taps[0]) == scipy.complex128):
-            self.rcurve.setData(scipy.arange(ntaps), self.taps.real)
-            self.icurve.setData(scipy.arange(ntaps), self.taps.imag)
+            self.rcurve.setData(np.arange(ntaps), self.taps.real)
+            self.icurve.setData(np.arange(ntaps), self.taps.imag)
         else:
-            self.rcurve.setData(scipy.arange(ntaps), self.taps)
+            self.rcurve.setData(np.arange(ntaps), self.taps)
             self.icurve.setData([],[]);
 
         if self.mttaps:
@@ -1028,11 +1028,11 @@ class gr_plot_filter(QtGui.QMainWindow):
                                                 np.dstack((np.zeros(self.taps.imag.shape[0], dtype=int),
                                                             self.taps.imag)).flatten())
 
-                self.mtimecurve_i.setData(scipy.arange(ntaps), self.taps.imag)
+                self.mtimecurve_i.setData(np.arange(ntaps), self.taps.imag)
 
             else:
-                self.mtimecurve.setData(scipy.arange(ntaps), self.taps)
-                self.mtimecurve_stems.setData(np.repeat(scipy.arange(ntaps), 2),
+                self.mtimecurve.setData(np.arange(ntaps), self.taps)
+                self.mtimecurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                                 np.dstack((np.zeros(self.taps.shape[0], dtype=int),
                                                         self.taps)).flatten())
 
@@ -1077,13 +1077,13 @@ class gr_plot_filter(QtGui.QMainWindow):
                                               np.dstack((np.zeros(stepres.imag.shape[0], dtype=int),
                                                          stepres.imag)).flatten())
 
-            self.steprescurve_i.setData(scipy.arange(ntaps), stepres.imag)
+            self.steprescurve_i.setData(np.arange(ntaps), stepres.imag)
         else:
-            self.steprescurve_stems.setData(np.repeat(scipy.arange(ntaps), 2),
+            self.steprescurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                             np.dstack((np.zeros(stepres.shape[0], dtype=int),
                                                        stepres)).flatten())
 
-            self.steprescurve.setData(scipy.arange(ntaps), stepres)
+            self.steprescurve.setData(np.arange(ntaps), stepres)
             self.steprescurve_i_stems.setData([],[])
             self.steprescurve_i.setData([],[])
 
@@ -1100,13 +1100,13 @@ class gr_plot_filter(QtGui.QMainWindow):
                                                 np.dstack((np.zeros(stepres.imag.shape[0], dtype=int),
                                                             stepres.imag)).flatten())
 
-                self.mtimecurve_i.setData(scipy.arange(ntaps), stepres.imag)
+                self.mtimecurve_i.setData(np.arange(ntaps), stepres.imag)
             else:
-                self.mtimecurve_stems.setData(np.repeat(scipy.arange(ntaps), 2),
+                self.mtimecurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                                 np.dstack((np.zeros(stepres.shape[0], dtype=int),
                                                         stepres)).flatten())
 
-                self.mtimecurve.setData(scipy.arange(ntaps), stepres)
+                self.mtimecurve.setData(np.arange(ntaps), stepres)
                 self.mtimecurve_i_stems.setData([],[])
                 self.mtimecurve_i.setData([],[])
 
@@ -1146,9 +1146,9 @@ class gr_plot_filter(QtGui.QMainWindow):
                                              np.dstack((np.zeros(impres.imag.shape[0], dtype=int),
                                                         impres.imag)).flatten())
 
-            self.imprescurve_i.setData(scipy.arange(ntaps), impres.imag)
+            self.imprescurve_i.setData(np.arange(ntaps), impres.imag)
         else:
-            self.imprescurve_stems.setData(np.repeat(scipy.arange(ntaps), 2),
+            self.imprescurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                            np.dstack((np.zeros(impres.shape[0], dtype=int),
                                                       impres)).flatten())
 
@@ -1165,13 +1165,13 @@ class gr_plot_filter(QtGui.QMainWindow):
                                                 np.dstack((np.zeros(impres.imag.shape[0], dtype=int),
                                                             impres.imag)).flatten())
 
-                self.mtimecurve_i.setData(scipy.arange(ntaps), impres.imag)
+                self.mtimecurve_i.setData(np.arange(ntaps), impres.imag)
             else:
-                self.mtimecurve_stems.setData(np.repeat(scipy.arange(ntaps), 2),
+                self.mtimecurve_stems.setData(np.repeat(np.arange(ntaps), 2),
                                             np.dstack((np.zeros(impres.shape[0], dtype=int),
                                                         impres)).flatten())
 
-                self.mtimecurve.setData(scipy.arange(ntaps), impres)
+                self.mtimecurve.setData(np.arange(ntaps), impres)
                 self.mtimecurve_i_stems.setData([],[])
                 self.mtimecurve_i.setData([],[])
 

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -38,16 +38,9 @@ except ImportError:
     raise SystemExit('Please install NumPy to run this script (https://www.np.org/)')
 
 try:
-    from numpy.fft import fftpack as fft_detail
+    import numpy.fft as fft_detail
 except ImportError:
-
-    print('Could not import fftpack, trying pocketfft')
-    # Numpy changed fft implementation in version 1.17
-    # from fftpack to pocketfft
-    try:
-        from numpy.fft import pocketfft as fft_detail
-    except ImportError:
-        raise SystemExit('Could not import fft implementation of numpy')
+    raise SystemExit('Could not import fft implementation of numpy')
     
 try:
     from scipy import poly1d, signal

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -43,7 +43,12 @@ except ImportError:
     raise SystemExit('Could not import fft implementation of numpy')
     
 try:
-    from scipy import poly1d, signal
+    from numpy import poly1d
+except ImportError:
+    raise SystemExit('Please install NumPy to run this script (https://www.np.org)')
+
+try:
+    from scipy import signal
 except ImportError:
     raise SystemExit('Please install SciPy to run this script (https://www.scipy.org)')
 

--- a/gr-filter/python/filter/gui/pyqt_filter_stacked.py
+++ b/gr-filter/python/filter/gui/pyqt_filter_stacked.py
@@ -1229,7 +1229,7 @@ class Ui_MainWindow(object):
         self.mfilterspecView.setTabText(self.mfilterspecView.indexOf(self.mpoleZero), _translate("MainWindow", "Pole-Zero Plot"))
         self.mfilterspecView.setTabText(self.mfilterspecView.indexOf(self.mfcTab), _translate("MainWindow", "Filter Coefficients"))
         self.fselectComboBox.setItemText(0, _translate("MainWindow", "FIR"))
-        self.fselectComboBox.setItemText(1, _translate("MainWindow", "IIR(scipy)"))
+        self.fselectComboBox.setItemText(1, _translate("MainWindow", "IIR"))
         self.filterTypeComboBox.setItemText(0, _translate("MainWindow", "Low Pass"))
         self.filterTypeComboBox.setItemText(1, _translate("MainWindow", "High Pass"))
         self.filterTypeComboBox.setItemText(2, _translate("MainWindow", "Band Pass"))


### PR DESCRIPTION
Sorry for making a mess with my previous pull requests. Hopefully you will find this to be much more organized. For convenience, here are my previous notes:

Referring back to #3100, it seems that the only way for the Filter Design Tool to run correctly run is to update `numpy.fft.fftpack` to `numpy.fft` and run `pip3 install git+https://github.com/pyqtgraph/pyqtgraph@develop`. It seems that only the development build of `pyqtgraph` works with the filter tool. Should the development version be added as a dependency?

I changed the label from `IIR(scipy)` to `IIR` in `pyqt_filter_stacked.py`, since scipy is being abandoned in the future. I also set up `filter_design.py` to call `poly1d` from `numpy` rather than `scipy`, since there's a consensus that GNU Radio needs to abandon its dependency on scipy. I know that `gr.fft` is going to be used in the future, but I think numpy is a fair substitute for now. 

I also found a potential bug with IIR Bessel filters. For whatever reason, band pass and notch filters are not generated correctly. This issue is consistent in #3241 after changing only `scipy.arange()` to `np.arange()`, since a notification kept appearing and keeping me from using the IIR tool due to the deprectation of `scipy.arange()`.

Also, when installing from source, `python3-scipy` and `python3-numpy` don't seem to get this working, but when I ran `pip3 install numpy scipy`, it worked fine.