### PR TITLE
grc: workaround to allow epy blocks/modules to load

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -77,8 +77,11 @@ class Block(Element):
 
         self.states = {'state': True, 'bus_source': False, 'bus_sink': False, 'bus_structure': None}
 
-        if 'cpp' in self.flags and self.enabled and not (self.is_virtual_source() or self.is_virtual_sink()):
-            self.orig_cpp_templates = self.cpp_templates # The original template, in case we have to edit it when transpiling to C++         
+        if Flags.HAS_CPP in self.flags and self.enabled and not (self.is_virtual_source() or self.is_virtual_sink()):
+            # This is a workaround to allow embedded python blocks/modules to load as there is 
+            # currently 'cpp' in the flags by default caused by the other built-in blocks
+            if hasattr(self,'cpp_templates'):
+                self.orig_cpp_templates = self.cpp_templates # The original template, in case we have to edit it when transpiling to C++         
 
         self.current_bus_structure = {'source': None, 'sink': None}
 


### PR DESCRIPTION
The underlying issue is that the built in blocks all end up getting the
'cpp' flag, which is not valid for the embedded python blocks

To fix this some work needs to be done in the "Flags" class, as all the
flags added to classes that get accumulated in the build_ins list get
added to all the classes

See register_build_in decorator

Fixes #3260 for now, though a more thorough solution is needed going forward