### PR TITLE
modtool: Replaced str.format() by Python f'strings in all codes

### DIFF
--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -115,7 +115,7 @@ def get_copyrightholder(self):
         with SequenceCompleter(copyright_candidates):
             self.info['copyrightholder'] = cli_input("Please specify the copyright holder: ")
             if not self.info['copyrightholder'] or self.info['copyrightholder'].isspace():
-                self.info['copyrightholder'] = f"gr-{self.info["modname"]} author"
+                self.info['copyrightholder'] = f'gr-{self.info["modname"]} author'
     elif self.info['is_component']:
         click.secho("For GNU Radio components the FSF is added as copyright holder",
                     fg='cyan')

--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -115,8 +115,7 @@ def get_copyrightholder(self):
         with SequenceCompleter(copyright_candidates):
             self.info['copyrightholder'] = cli_input("Please specify the copyright holder: ")
             if not self.info['copyrightholder'] or self.info['copyrightholder'].isspace():
-                inf_=self.info['modname']
-                self.info['copyrightholder'] = f"gr-{inf_} author"
+                self.info['copyrightholder'] = f"gr-{self.info["modname"]} author"
     elif self.info['is_component']:
         click.secho("For GNU Radio components the FSF is added as copyright holder",
                     fg='cyan')

--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -25,7 +25,7 @@ from .base import common_params, block_name, run, cli_input, ModToolException
 
 @click.command('add')
 @click.option('-t', '--block-type', type=click.Choice(ModToolAdd.block_types),
-              help="One of {}.".format(', '.join(ModToolAdd.block_types)))
+              help=f"One of {', '.join(ModToolAdd.block_types)}.")
 @click.option('--license-file',
               help="File containing the license header for every source code file.")
 @click.option('--copyright',
@@ -49,7 +49,8 @@ def cli(**kwargs):
     click.secho("GNU Radio module name identified: " + self.info['modname'], fg='green')
     get_blocktype(self)
     get_lang(self)
-    click.secho("Language: {}".format({'cpp': 'C++', 'python': 'Python'}[self.info['lang']]), fg='green')
+    info_lang = {'cpp': 'C++', 'python': 'Python'}[self.info['lang']]
+    click.secho(f"Language: {info_lang}", fg='green')
     if ((self.skip_subdirs['lib'] and self.info['lang'] == 'cpp')
             or (self.skip_subdirs['python'] and self.info['lang'] == 'python')):
         raise ModToolException('Missing or skipping relevant subdir.')
@@ -114,7 +115,8 @@ def get_copyrightholder(self):
         with SequenceCompleter(copyright_candidates):
             self.info['copyrightholder'] = cli_input("Please specify the copyright holder: ")
             if not self.info['copyrightholder'] or self.info['copyrightholder'].isspace():
-                self.info['copyrightholder'] = "gr-{} author".format(self.info['modname'])
+                inf_=self.info['modname']
+                self.info['copyrightholder'] = f"gr-{inf_} author"
     elif self.info['is_component']:
         click.secho("For GNU Radio components the FSF is added as copyright holder",
                     fg='cyan')

--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -31,7 +31,8 @@ class ModToolException(ClickException):
     """ Exception class for enhanced CLI interface """
     def show(self, file = None):
         """ displays the colored message """
-        click.secho('ModToolException: {}'.format(self.format_message()), fg='red')
+        mesg_=self.format_message()
+        click.secho(f'ModToolException: {mesg_}', fg='red')
 
 
 class CommandCLI(click.Group):

--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -31,8 +31,7 @@ class ModToolException(ClickException):
     """ Exception class for enhanced CLI interface """
     def show(self, file = None):
         """ displays the colored message """
-        mesg_=self.format_message()
-        click.secho(f'ModToolException: {mesg_}', fg='red')
+        click.secho(f'ModToolException: {self.format_message()}', fg='red')
 
 
 class CommandCLI(click.Group):

--- a/gr-utils/modtool/cli/newmod.py
+++ b/gr-utils/modtool/cli/newmod.py
@@ -36,8 +36,7 @@ def cli(**kwargs):
     kwargs['cli'] = True
     self = ModToolNewModule(**kwargs)
     get_modname(self)
-    info_=self.info['modname']
-    self.dir = os.path.join(self.dir, f'gr-{info_}')
+    self.dir = os.path.join(self.dir, f'gr-{self.info["modname"]}')
     try:
         os.stat(self.dir)
     except OSError:

--- a/gr-utils/modtool/cli/newmod.py
+++ b/gr-utils/modtool/cli/newmod.py
@@ -36,7 +36,8 @@ def cli(**kwargs):
     kwargs['cli'] = True
     self = ModToolNewModule(**kwargs)
     get_modname(self)
-    self.dir = os.path.join(self.dir, 'gr-{}'.format(self.info['modname']))
+    info_=self.info['modname']
+    self.dir = os.path.join(self.dir, f'gr-{info_}')
     try:
         os.stat(self.dir)
     except OSError:

--- a/gr-utils/modtool/core/add.py
+++ b/gr-utils/modtool/core/add.py
@@ -232,7 +232,7 @@ class ModToolAdd(ModTool):
         if self._get_mainswigfile() is None:
             logger.warning('Warning: No main swig file found.')
             return
-        logger.info(f"Editing {self._file["swig"]}...")
+        logger.info(f'Editing {self._file["swig"]}...')
         mod_block_sep = '/'
         if self.info['version'] == '36':
             mod_block_sep = '_'
@@ -266,7 +266,7 @@ class ModToolAdd(ModTool):
         self.scm.mark_files_updated((os.path.join(self.info['pydir'], fname_py_qa),))
         if self.skip_cmakefiles or CMakeFileEditor(self._file['cmpython']).check_for_glob('qa_*.py'):
             return
-        logger.info(f"Editing {self.info["pydir"]}/CMakeLists.txt...")
+        logger.info(f'Editing {self.info["pydir"]}/CMakeLists.txt...')
         with open(self._file['cmpython'], 'a') as f:
             f.write(
                 'GR_ADD_TEST(qa_%s ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/%s)\n' % \

--- a/gr-utils/modtool/core/add.py
+++ b/gr-utils/modtool/core/add.py
@@ -143,17 +143,17 @@ class ModToolAdd(ModTool):
 
     def _run_cc_qa(self):
         " Add C++ QA files for 3.7 API if intructed from _run_lib"
-        blockname_=self.info['blockname']
+        blockname_ = self.info['blockname']
         fname_qa_h  = f'qa_{blockname_}.h'
         fname_qa_cc = f'qa_{blockname_}.cc'
         self._write_tpl('qa_cpp', 'lib', fname_qa_cc)
         self._write_tpl('qa_h',   'lib', fname_qa_h)
-        modname_= self.info['modname']
+        modname_ = self.info['modname']
         if self.skip_cmakefiles:
             return
         try:
             append_re_line_sequence(self._file['cmlib'],
-                                  fr'list\(APPEND test_{modname_}_sources.*\n',
+                                    fr'list\(APPEND test_{modname_}_sources.*\n',
                                     f'qa_{blockname_}.cc')
             append_re_line_sequence(self._file['qalib'],
                                     '#include.*\n',
@@ -168,16 +168,16 @@ class ModToolAdd(ModTool):
 
     def _run_cc_qa_boostutf(self):
         " Add C++ QA files for 3.8 API if intructed from _run_lib"
-        blockk_=self.info['blockname']
-        fname_qa_cc = f'qa_{blockk_}.cc'
+        blockname_ = self.info['blockname']
+        fname_qa_cc = f'qa_{blockname_}.cc'
         self._write_tpl('qa_cpp_boostutf', 'lib', fname_qa_cc)
-        modd_=self.info['modname']
+        modname_ = self.info['modname']
         if self.skip_cmakefiles:
             return
         try:
             append_re_line_sequence(self._file['cmlib'],
-                                   fr'list\(APPEND test_{modd_}_sources.*\n',
-                                    f'qa_{blockk_}.cc')
+                                   fr'list\(APPEND test_{modname_}_sources.*\n',
+                                    f'qa_{blockname_}.cc')
             self.scm.mark_files_updated((self._file['cmlib'],))
         except IOError:
             logger.warning("Can't add C++ QA files.")
@@ -232,8 +232,7 @@ class ModToolAdd(ModTool):
         if self._get_mainswigfile() is None:
             logger.warning('Warning: No main swig file found.')
             return
-        swig_info=self._file['swig']
-        logger.info(f"Editing {swig_info}...")
+        logger.info(f"Editing {self._file["swig"]}...")
         mod_block_sep = '/'
         if self.info['version'] == '36':
             mod_block_sep = '_'
@@ -241,8 +240,9 @@ class ModToolAdd(ModTool):
         with open(self._file['swig'], 'a') as f:
             f.write(swig_block_magic_str)
         is_component = {True: 'gnuradio/' + self.info['modname'], False: self.info['modname']}[self.info['is_component']]
-        blockn=self.info['blockname']
-        include_str = f'#include "{is_component}{mod_block_sep}{blockn}.h"'
+        blockname_ = self.info['blockname']
+        include_str = f'#include "{is_component}{mod_block_sep}{blockname_}.h"'
+
         with open(self._file['swig'], 'r') as f:
             oldfile = f.read()
         if re.search('#include', oldfile):
@@ -266,8 +266,7 @@ class ModToolAdd(ModTool):
         self.scm.mark_files_updated((os.path.join(self.info['pydir'], fname_py_qa),))
         if self.skip_cmakefiles or CMakeFileEditor(self._file['cmpython']).check_for_glob('qa_*.py'):
             return
-        pydir_=self.info['pydir']
-        logger.info(f"Editing {pydir_}/CMakeLists.txt...")
+        logger.info(f"Editing {self.info["pydir"]}/CMakeLists.txt...")
         with open(self._file['cmpython'], 'a') as f:
             f.write(
                 'GR_ADD_TEST(qa_%s ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/%s)\n' % \
@@ -282,7 +281,7 @@ class ModToolAdd(ModTool):
         - include in __init__.py
         """
         fname_py = self.info['blockname'] + '.py'
-        blockname_=self.info['blockname']
+        blockname_ = self.info['blockname']
         self._write_tpl('block_python', self.info['pydir'], fname_py)
         append_re_line_sequence(self._file['pyinit'],
                                 '(^from.*import.*\n|# import any pure.*\n)',

--- a/gr-utils/modtool/core/base.py
+++ b/gr-utils/modtool/core/base.py
@@ -129,8 +129,7 @@ class ModTool(object):
         self.info['pydir'] = 'python'
         if os.path.isdir(os.path.join('python', self.info['modname'])):
             self.info['pydir'] = os.path.join('python', self.info['modname'])
-        modn_=self.info['modname']
-        self._file['qalib']    = os.path.join('lib',    f'qa_{modn_}.cc')
+        self._file['qalib']    = os.path.join('lib',    f'qa_{self.info["modname"]}.cc')
         self._file['pyinit']   = os.path.join(self.info['pydir'], '__init__.py')
         self._file['cmlib']    = os.path.join('lib',    'CMakeLists.txt')
         self._file['cmgrc']    = os.path.join('grc',    'CMakeLists.txt')

--- a/gr-utils/modtool/core/base.py
+++ b/gr-utils/modtool/core/base.py
@@ -129,7 +129,8 @@ class ModTool(object):
         self.info['pydir'] = 'python'
         if os.path.isdir(os.path.join('python', self.info['modname'])):
             self.info['pydir'] = os.path.join('python', self.info['modname'])
-        self._file['qalib']    = os.path.join('lib',    'qa_{}.cc'.format(self.info['modname']))
+        modn_=self.info['modname']
+        self._file['qalib']    = os.path.join('lib',    f'qa_{modn_}.cc')
         self._file['pyinit']   = os.path.join(self.info['pydir'], '__init__.py')
         self._file['cmlib']    = os.path.join('lib',    'CMakeLists.txt')
         self._file['cmgrc']    = os.path.join('grc',    'CMakeLists.txt')
@@ -165,7 +166,7 @@ class ModTool(object):
             files = os.listdir(directory)
             os.chdir(directory)
         except OSError:
-            logger.error("Can't read or chdir to directory {}.".format(directory))
+            logger.error(f"Can't read or chdir to directory {directory}.")
             return False
         self.info['is_component'] = False
         for f in files:

--- a/gr-utils/modtool/core/disable.py
+++ b/gr-utils/modtool/core/disable.py
@@ -70,8 +70,7 @@ class ModToolDisable(ModTool):
                 ed.write()
                 self.scm.mark_file_updated(self._file['qalib'])
             elif self.info['version'] == '38':
-                blockname_=self._info['blockname']
-                fname_qa_cc = f'qa_{blockname_}.cc'
+                fname_qa_cc = f'qa_{self._info["blockname"]}.cc'
                 cmake.comment_out_lines(fname_qa_cc)
             elif self.info['version'] == '36':
                 cmake.comment_out_lines('add_executable.*'+fname)
@@ -84,8 +83,7 @@ class ModToolDisable(ModTool):
             as well as the block magic """
             with open(self._file['swig']) as f:
                 swigfile = f.read()
-            modn_=self.info['modname']
-            (swigfile, nsubs) = re.subn(f'(.include\s+"({modn_}/)?{fname}")',
+            (swigfile, nsubs) = re.subn(f'(.include\s+"({self.info["modname"]}/)?{fname}")',
                                         r'//\1', swigfile)
             if nsubs > 0:
                 logger.info(f"Changing {self._file['swig']}...")
@@ -122,12 +120,11 @@ class ModToolDisable(ModTool):
         else:
             from ..cli import cli_input
         # List of special rules: 0: subdir, 1: filename re match, 2: callback
-        modname_=self.info['modname']
         special_treatments = (
                 ('python', r'qa.+py$', _handle_py_qa),
                 ('python', r'^(?!qa).+py$', _handle_py_mod),
                 ('lib', r'qa.+\.cc$', _handle_cc_qa),
-                (f'include/{modname_}', r'.+\.h$', _handle_h_swig),
+                (f'include/{self.info["modname"]}', r'.+\.h$', _handle_h_swig),
                 ('include', r'.+\.h$', _handle_h_swig),
                 ('swig', r'.+\.i$', _handle_i_swig)
         )
@@ -135,7 +132,7 @@ class ModToolDisable(ModTool):
             if self.skip_subdirs[subdir]:
                 continue
             if self.info['version'] in ('37', '38') and subdir == 'include':
-                subdir = f'include/{modname_}'
+                subdir = f'include/{self.info["modname"]}'
             try:
                 cmake = CMakeFileEditor(os.path.join(subdir, 'CMakeLists.txt'))
             except IOError:

--- a/gr-utils/modtool/core/info.py
+++ b/gr-utils/modtool/core/info.py
@@ -105,8 +105,8 @@ class ModToolInfo(ModTool):
         try:
             cmakecache_fid = open(os.path.join(mod_info['build_dir'], 'CMakeCache.txt'))
             for line in cmakecache_fid:
-                if line.find('GNURADIO_RUNTIME_INCLUDE_DIRS:{}'.format(path_or_internal)) != -1:
-                    inc_dirs += line.replace('GNURADIO_RUNTIME_INCLUDE_DIRS:{}='.format(path_or_internal), '').strip().split(';')
+                if line.find(f'GNURADIO_RUNTIME_INCLUDE_DIRS:{path_or_internal}') != -1:
+                    inc_dirs += line.replace(f'GNURADIO_RUNTIME_INCLUDE_DIRS:{path_or_internal}=', '').strip().split(';')
         except IOError:
             pass
         if not inc_dirs and self._suggested_dirs is not None:
@@ -122,11 +122,12 @@ class ModToolInfo(ModTool):
                        'incdirs': 'Include directories'}
         for key in list(mod_info.keys()):
             if key == 'version':
-                print("        API version: {}".format({
+                version = {
                         '36': 'pre-3.7',
                         '37': 'post-3.7',
                         '38': 'post-3.8',
                         'autofoo': 'Autotools (pre-3.5)'
-                        }[mod_info['version']]))
+                        }[mod_info['version']]
+                print(f"        API version: {version}")
             else:
                 print('%19s: %s' % (index_names[key], mod_info[key]))

--- a/gr-utils/modtool/core/makeyaml.py
+++ b/gr-utils/modtool/core/makeyaml.py
@@ -107,8 +107,7 @@ class ModToolMakeYAML(ModTool):
         """ Take the return values from the parser and call the YAML
         generator. Also, check the makefile if the .yml file is in there.
         If necessary, add. """
-        modname_=self.info['modname']
-        fname_yml = f'{modname_}_{blockname}.block.yml'
+        fname_yml = f'{self.info["modname"]}_{blockname}.block.yml'
         path_to_yml = os.path.join('grc', fname_yml)
         # Some adaptions for the GRC
         for inout in ('in', 'out'):
@@ -203,15 +202,14 @@ def yaml_generator(self, **kwargs):
     label = header.split('_')
     del label[-1]
     yml_file = os.path.join('.', block+'_'+header+'.block.yml')
-    stri_=block.capitalize()
     _header = (('id', f'{block}_{ header}'),
                ('label', ' '.join(label).upper()),
-               ('category', f'[{stri_}]'),
+               ('category', f'[{block.capitalize()}]'),
                ('flags', '[python, cpp]')
                )
     params_list = [
         '${'+s['name']+'}' for s in self.parsed_data['properties'] if self.parsed_data['properties']]
-    str_= ', '.join(params_list)
+    str_ = ', '.join(params_list)
     _templates = [('imports', f'from gnuradio import {block}'),
                   ('make', f'{block}.{ header}({str_})')
                   ]
@@ -223,7 +221,7 @@ def yaml_generator(self, **kwargs):
             for args in param['arguments_type']:
                 arguments.append(args['name'])
             arg_list = ['${'+s+'}' for s in arguments if arguments]
-            arg_=', '.join(arg_list)
+            arg_ = ', '.join(arg_list)
             list_callbacks.append(
                 param['name']+f'({arg_})')
         callback_key = ('callbacks')
@@ -311,9 +309,8 @@ def yaml_generator(self, **kwargs):
     if output_signature:
         data['outputs'] = output_signature
      
-    file_=self.filename
-    param_=', '.join(params_list)
-    _cpp_templates = [('includes', '#include <gnuradio/{block}/{file_}>'),
+    param_ = ', '.join(params_list)
+    _cpp_templates = [('includes', '#include <gnuradio/{block}/{self.filename}>'),
                       ('declarations', '{block}::{ header}::sptr ${{id}}'),
                       ('make', 'this->${{id}} = {block}::{ header}::make({param_})')
                       ]
@@ -325,9 +322,9 @@ def yaml_generator(self, **kwargs):
             for args in param['arguments_type']:
                 arguments.append(args['name'])
             arg_list = ['${'+s+'}' for s in arguments if arguments]
-            arg_l=', '.join(arg_list)
+            arg_ = ', '.join(arg_list)
             list_callbacks.append(
-                param['name']+f'({arg_l})')
+                param['name']+f'({arg_})')
         callback_key = ('callbacks')
         callbacks = (callback_key, tuple(list_callbacks))
         _cpp_templates.append(callbacks)

--- a/gr-utils/modtool/core/newmod.py
+++ b/gr-utils/modtool/core/newmod.py
@@ -34,7 +34,8 @@ class ModToolNewModule(ModTool):
         self.directory = self.dir
 
     def assign(self):
-        self.dir = os.path.join(self.directory, 'gr-{}'.format(self.info['modname']))
+        modname_=self.info['modname']
+        self.dir = os.path.join(self.directory, f'gr-{modname_}')
         if self.srcdir is None:
             self.srcdir = os.path.join(gr.prefix(),'share','gnuradio','modtool','templates','gr-newmod')
 
@@ -64,12 +65,12 @@ class ModToolNewModule(ModTool):
             self.assign()
             self.validate()
         self._setup_scm(mode='new')
-        logger.info("Creating out-of-tree module in {}...".format(self.dir))
+        logger.info(f"Creating out-of-tree module in {self.dir}...")
         try:
             shutil.copytree(self.srcdir, self.dir)
             os.chdir(self.dir)
         except OSError:
-            raise ModToolException('Could not create directory {}.'.format(self.dir))
+            raise ModToolException(f'Could not create directory {self.dir}.')
         for root, dirs, files in os.walk('.'):
             for filename in files:
                 f = os.path.join(root, filename)

--- a/gr-utils/modtool/core/newmod.py
+++ b/gr-utils/modtool/core/newmod.py
@@ -34,8 +34,7 @@ class ModToolNewModule(ModTool):
         self.directory = self.dir
 
     def assign(self):
-        modname_=self.info['modname']
-        self.dir = os.path.join(self.directory, f'gr-{modname_}')
+        self.dir = os.path.join(self.directory, f'gr-{self.info["modname"]}')
         if self.srcdir is None:
             self.srcdir = os.path.join(gr.prefix(),'share','gnuradio','modtool','templates','gr-newmod')
 

--- a/gr-utils/modtool/core/rename.py
+++ b/gr-utils/modtool/core/rename.py
@@ -61,7 +61,7 @@ class ModToolRename(ModTool):
         module = self.info['modname']
         oldname = self.info['oldname']
         newname = self.info['newname']
-        logger.info("In module '{}' rename block '{}' to '{}'".format(module, oldname, newname))
+        logger.info(f"In module '{module}' rename block '{oldname}' to '{newname}'")
         self._run_swig_rename(self._file['swig'], oldname, newname)
         self._run_grc_rename(self.info['modname'], oldname, newname)
         self._run_python_qa(self.info['modname'], oldname, newname)
@@ -74,11 +74,11 @@ class ModToolRename(ModTool):
         """ Rename SWIG includes and block_magic """
         nsubs = self._run_file_replace(swigfilename, old, new)
         if nsubs < 1:
-            logger.info("Couldn't find '{}' in file '{}'.".format(old, swigfilename))
+            logger.info(f"Couldn't find '{old}' in file '{swigfilename}'.")
         if nsubs == 2:
             logger.info("Changing 'noblock' type file")
         if nsubs > 3:
-            logger.warning("Hm, changed more then expected while editing {}.".format(swigfilename))
+            logger.warning(f"Hm, changed more then expected while editing {swigfilename}.")
         return False
 
     def _run_lib(self, module, old, new):
@@ -147,7 +147,7 @@ class ModToolRename(ModTool):
         filename = path + 'CMakeLists.txt'
         nsubs = self._run_file_replace(filename, first, second)
         if nsubs < 1:
-            logger.info("'{}' wasn't in '{}'.".format(first, filename))
+            logger.info(f"'{first}' wasn't in '{filename}'.")
 
     def _run_file_rename(self, path, old, new):
         files = os.listdir(path)
@@ -156,14 +156,14 @@ class ModToolRename(ModTool):
                 nl = file.replace(old, new)
                 src = path + file
                 dst = path + nl
-                logger.info("Renaming file '{}' to '{}'.".format(src, dst))
+                logger.info(f"Renaming file '{src}' to '{dst}'.")
                 os.rename(src, dst)
 
     def _run_file_replace(self, filename, old, new):
         if not os.path.isfile(filename):
             return False
         else:
-            logger.info("In '{}' renaming occurrences of '{}' to '{}'".format(filename, old, new))
+            logger.info(f"In '{filename}' renaming occurrences of '{old}' to '{new}'")
 
         with open(filename) as f:
             cfile = f.read()

--- a/gr-utils/modtool/core/rm.py
+++ b/gr-utils/modtool/core/rm.py
@@ -49,7 +49,7 @@ class ModToolRemove(ModTool):
         def _remove_cc_test_case(filename=None, ed=None):
             """ Special function that removes the occurrences of a qa*.cc file
             from the CMakeLists.txt. """
-            modname_=self.info['modname']
+            modname_ = self.info['modname']
             if filename[:2] != 'qa':
                 return
             if self.info['version'] == '37':

--- a/gr-utils/modtool/core/rm.py
+++ b/gr-utils/modtool/core/rm.py
@@ -49,29 +49,29 @@ class ModToolRemove(ModTool):
         def _remove_cc_test_case(filename=None, ed=None):
             """ Special function that removes the occurrences of a qa*.cc file
             from the CMakeLists.txt. """
+            modname_=self.info['modname']
             if filename[:2] != 'qa':
                 return
             if self.info['version'] == '37':
                 (base, ext) = os.path.splitext(filename)
                 if ext == '.h':
                     remove_pattern_from_file(self._file['qalib'],
-                                             r'^#include "{}"\s*$'.format(filename))
+                                             fr'^#include "{filename}"\s*$')
                     remove_pattern_from_file(self._file['qalib'],
-                                             r'^\s*s->addTest\(gr::{}::{}::suite\(\)\);\s*$'.format(
-                                                    self.info['modname'], base)
+                                             fr'^\s*s->addTest\(gr::{modname_}::{base}::suite\(\)\);\s*$'
                                             )
                     self.scm.mark_file_updated(self._file['qalib'])
                 elif ext == '.cc':
                     ed.remove_value('list',
                                     r'\$\{CMAKE_CURRENT_SOURCE_DIR\}/%s' % filename,
-                                    to_ignore_start='APPEND test_{}_sources'.format(self.info['modname']))
+                                    to_ignore_start=f'APPEND test_{modname_}_sources')
                     self.scm.mark_file_updated(ed.filename)
             elif self.info['version'] == '38':
                 (base, ext) = os.path.splitext(filename)
                 if ext == '.cc':
                     ed.remove_value(
                         'list', filename,
-                        to_ignore_start='APPEND test_{}_sources'.format(self.info['modname']))
+                        to_ignore_start=f'APPEND test_{modname_}_sources' )
                     self.scm.mark_file_updated(ed.filename)
             else:
                 filebase = os.path.splitext(filename)[0]
@@ -112,8 +112,8 @@ class ModToolRemove(ModTool):
             py_files_deleted = self._run_subdir('python', ('*.py',), ('GR_PYTHON_INSTALL',),
                                                 cmakeedit_func=_remove_py_test_case)
             for f in py_files_deleted:
-                remove_pattern_from_file(self._file['pyinit'], r'.*import\s+{}.*'.format(f[:-3]))
-                remove_pattern_from_file(self._file['pyinit'], r'.*from\s+{}\s+import.*\n'.format(f[:-3]))
+                remove_pattern_from_file(self._file['pyinit'], fr'.*import\s+{f[:-3]}.*')
+                remove_pattern_from_file(self._file['pyinit'], fr'.*from\s+{f[:-3]}\s+import.*\n')
         if not self.skip_subdirs['grc']:
             self._run_subdir('grc', ('*.yml',), ('install',))
 
@@ -130,9 +130,9 @@ class ModToolRemove(ModTool):
         # 1. Create a filtered list
         files = []
         for g in globs:
-            files = files + sorted(glob.glob("{}/{}".format(path, g)))
+            files = files + sorted(glob.glob(f"{path}/{g}"))
         files_filt = []
-        logger.info("Searching for matching files in {}/:".format(path))
+        logger.info("Searching for matching files in {path}/:")
         for f in files:
             if re.search(self.info['pattern'], os.path.basename(f)) is not None:
                 files_filt.append(f)
@@ -141,12 +141,12 @@ class ModToolRemove(ModTool):
             return []
         # 2. Delete files, Makefile entries and other occurrences
         files_deleted = []
-        ed = CMakeFileEditor('{}/CMakeLists.txt'.format(path))
+        ed = CMakeFileEditor(f'{path}/CMakeLists.txt')
         yes = self.info['yes']
         for f in files_filt:
             b = os.path.basename(f)
             if not yes and self.cli:
-                ans = cli_input("Really delete {}? [Y/n/a/q]: ".format(f)).lower().strip()
+                ans = cli_input(f"Really delete {f}? [Y/n/a/q]: ").lower().strip()
                 if ans == 'a':
                     yes = True
                 if ans == 'q':
@@ -154,14 +154,14 @@ class ModToolRemove(ModTool):
                 if ans == 'n':
                     continue
             files_deleted.append(b)
-            logger.info("Deleting {}.".format(f))
+            logger.info(f"Deleting {f}.")
             self.scm.remove_file(f)
             os.unlink(f)
-            logger.info("Deleting occurrences of {} from {}/CMakeLists.txt...".format(b, path))
+            logger.info(f"Deleting occurrences of {b} from {path}/CMakeLists.txt...")
             for var in makefile_vars:
                 ed.remove_value(var, b)
             if cmakeedit_func is not None:
                 cmakeedit_func(b, ed)
         ed.write()
-        self.scm.mark_files_updated(('{}/CMakeLists.txt'.format(path)))
+        self.scm.mark_files_updated((f'{path}/CMakeLists.txt'))
         return files_deleted

--- a/gr-utils/modtool/core/update.py
+++ b/gr-utils/modtool/core/update.py
@@ -73,11 +73,11 @@ class ModToolUpdate(ModTool):
         else:
             blocks = [self.info['blockname']]
         for blockname in blocks:
-            xml_file = "{}_{}.xml".format(module_name, blockname)
-            yml_file = "{}_{}.block.yml".format(module_name, blockname)
+            xml_file = f"{module_name}_{blockname}.xml"
+            yml_file = f"{module_name}_{blockname}.block.yml"
             if not conv.load_block_xml(path+xml_file, self.info["include_blacklisted"]):
                 continue
-            logger.info("Converted {} to {}".format(xml_file, yml_file))
+            logger.info(f"Converted {xml_file} to {yml_file}")
             os.remove(path+xml_file)
             nsubs = self._run_cmakelists(xml_file, yml_file)
             if nsubs > 1:

--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -23,13 +23,13 @@ Copyright %d {copyrightholder}.
 SPDX-License-Identifier: GPL-3.0-or-later
 ''' % datetime.now().year
 
-Templates['grlicense'] = '''
-Copyright {0} Free Software Foundation, Inc.
+Templates['grlicense'] = f'''
+Copyright {datetime.now().year} Free Software Foundation, Inc.
 
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-3.0-or-later
-'''.format(datetime.now().year)
+'''
 
 # Header file of a sync/decimator/interpolator block
 Templates['block_impl_h'] = '''/* -*- c++ -*- */

--- a/gr-utils/modtool/tools/cmakefile_editor.py
+++ b/gr-utils/modtool/tools/cmakefile_editor.py
@@ -29,7 +29,7 @@ class CMakeFileEditor(object):
 
     def append_value(self, entry, value, to_ignore_start='', to_ignore_end=''):
         """ Add a value to an entry. """
-        regexp = re.compile(r'({}\({}[^()]*?)\s*?(\s?{})\)'.format(entry, to_ignore_start, to_ignore_end),
+        regexp = re.compile(fr'({entry}\({to_ignore_start}[^()]*?)\s*?(\s?{to_ignore_end})\)',
                             re.MULTILINE)
         substi = r'\1' + self.separator + value + r'\2)'
         (self.cfile, nsubs) = regexp.subn(substi, self.cfile, count=1)
@@ -74,7 +74,7 @@ class CMakeFileEditor(object):
 
     def delete_entry(self, entry, value_pattern=''):
         """Remove an entry from the current buffer."""
-        regexp = r'{}\s*\([^()]*{}[^()]*\)[^\n]*\n'.format(entry, value_pattern)
+        regexp = fr'{entry}\s*\([^()]*{value_pattern}[^()]*\)[^\n]*\n'
         regexp = re.compile(regexp, re.MULTILINE)
         (self.cfile, nsubs) = re.subn(regexp, '', self.cfile, count=1)
         return nsubs
@@ -124,9 +124,9 @@ class CMakeFileEditor(object):
             comment_out_re = r'\n' + self.indent + comment_out_re
         (self.cfile, nsubs) = re.subn(r'(\b'+fname+r'\b)\s*', comment_out_re, self.cfile)
         if nsubs == 0:
-            logger.warning("Warning: A replacement failed when commenting out {}. Check the CMakeFile.txt manually.".format(fname))
+            logger.warning(f"Warning: A replacement failed when commenting out {fname}. Check the CMakeFile.txt manually.")
         elif nsubs > 1:
-            logger.warning("Warning: Replaced {} {} times (instead of once). Check the CMakeFile.txt manually.".format(fname, nsubs))
+            logger.warning(f"Warning: Replaced {fname} {nsubs} times (instead of once). Check the CMakeFile.txt manually.")
 
     def comment_out_lines(self, pattern, comment_str='#'):
         """ Comments out all lines that match with pattern """
@@ -136,5 +136,6 @@ class CMakeFileEditor(object):
 
     def check_for_glob(self, globstr):
         """ Returns true if a glob as in globstr is found in the cmake file """
-        glob_re = r'GLOB\s[a-z_]+\s"{}"'.format(globstr.replace('*', r'\*'))
+        str_=globstr.replace('*', r'\*')
+        glob_re = fr'GLOB\s[a-z_]+\s"{str_}"'
         return re.search(glob_re, self.cfile, flags=re.MULTILINE|re.IGNORECASE) is not None

--- a/gr-utils/modtool/tools/cmakefile_editor.py
+++ b/gr-utils/modtool/tools/cmakefile_editor.py
@@ -136,6 +136,6 @@ class CMakeFileEditor(object):
 
     def check_for_glob(self, globstr):
         """ Returns true if a glob as in globstr is found in the cmake file """
-        str_=globstr.replace('*', r'\*')
+        str_ = globstr.replace('*', r'\*')
         glob_re = fr'GLOB\s[a-z_]+\s"{str_}"'
         return re.search(glob_re, self.cfile, flags=re.MULTILINE|re.IGNORECASE) is not None

--- a/gr-utils/modtool/tools/grc_yaml_generator.py
+++ b/gr-utils/modtool/tools/grc_yaml_generator.py
@@ -45,7 +45,7 @@ class GRCYAMLGenerator(object):
         """docstring for __init__"""
         params_list = ['${'+s['key']+'}' for s in params if s['in_constructor']]
         # Can't make a dict 'cause order matters
-        str_=', '.join(params_list)
+        str_ = ', '.join(params_list)
         self._header = (('id', f'{modname}_{blockname}'),
                         ('label', blockname.replace('_', ' ')),
                         (f'category', '[{modname.capitalize()}]')

--- a/gr-utils/modtool/tools/grc_yaml_generator.py
+++ b/gr-utils/modtool/tools/grc_yaml_generator.py
@@ -45,12 +45,13 @@ class GRCYAMLGenerator(object):
         """docstring for __init__"""
         params_list = ['${'+s['key']+'}' for s in params if s['in_constructor']]
         # Can't make a dict 'cause order matters
-        self._header = (('id', '{}_{}'.format(modname, blockname)),
+        str_=', '.join(params_list)
+        self._header = (('id', f'{modname}_{blockname}'),
                         ('label', blockname.replace('_', ' ')),
-                        ('category', '[{}]'.format(modname.capitalize()))
+                        (f'category', '[{modname.capitalize()}]')
                        )
-        self._templates = (('imports', 'import {}'.format(modname)),
-                           ('make', '{}.{}({})'.format(modname, blockname, ', '.join(params_list)))
+        self._templates = (('imports', f'import {modname}'),
+                           ('make', f'{modname}.{blockname}({str_})')
                           )
         self.params = params
         self.iosig = iosig


### PR DESCRIPTION
Use of **Python f'strings** or "Literal String Interpolation" makes code clearer and much more readable.
They are also faster than str.format() and %-formatting due to run time evaluation.
For more details check this: https://hackernoon.com/a-closer-look-at-how-python-f-strings-work-f197736b3bdb

Replaced all **str.format()** by **Python f'strings** except a few due to formatting of variable which falls into exception category for Python f'strings as they can format only **string literal**.
Check this:https://stackoverflow.com/questions/54351740/how-can-i-use-f-string-with-a-variable-not-with-a-string-literal

 Also I have tested the modtool using testsuite and it passes the tests.

Screenshot:
![Screenshot from 2020-03-14 17-26-46](https://user-images.githubusercontent.com/43706342/76681689-a2d15780-661b-11ea-9dd7-c15990b1f52f.png)
