### PR TITLE
modtool: use prefix path for modtool instead of prefs

### DIFF
--- a/gr-utils/python/modtool/cli/newmod.py
+++ b/gr-utils/python/modtool/cli/newmod.py
@@ -21,7 +21,6 @@ from gnuradio import gr
 from ..core import ModToolNewModule
 from .base import common_params, run, cli_input, ModToolException
 
-
 @click.command('newmod', short_help=ModToolNewModule.description)
 @click.option('--srcdir',
               help="Source directory for the module template.")
@@ -45,8 +44,7 @@ def cli(**kwargs):
     else:
         raise ModToolException('The given directory exists.')
     if self.srcdir is None:
-        self.srcdir = '/usr/local/share/gnuradio/modtool/templates/gr-newmod'
-    self.srcdir = gr.prefs().get_string('modtool', 'newmod_path', self.srcdir)
+        self.srcdir = os.path.join(gr.prefix(),'share','gnuradio','modtool','templates','gr-newmod')
     if not os.path.isdir(self.srcdir):
         raise ModToolException('Could not find gr-newmod source dir.')
     run(self)

--- a/gr-utils/python/modtool/core/newmod.py
+++ b/gr-utils/python/modtool/core/newmod.py
@@ -23,7 +23,6 @@ from .base import ModTool, ModToolException
 
 logger = logging.getLogger(__name__)
 
-
 class ModToolNewModule(ModTool):
     """ Create a new out-of-tree module """
     name = 'newmod'
@@ -37,8 +36,7 @@ class ModToolNewModule(ModTool):
     def assign(self):
         self.dir = os.path.join(self.directory, 'gr-{}'.format(self.info['modname']))
         if self.srcdir is None:
-            self.srcdir = '/usr/local/share/gnuradio/modtool/templates/gr-newmod'
-        self.srcdir = gr.prefs().get_string('modtool', 'newmod_path', self.srcdir)
+            self.srcdir = os.path.join(gr.prefix(),'share','gnuradio','modtool','templates','gr-newmod')
 
     def validate(self):
         """ Validates the arguments """


### PR DESCRIPTION
Putting this up here for discussion - though I don't see the downsides to this change just yet.

When a prefix gets installed, the [modtool] section in prefs hardcodes
the path to the templates in the newly installed prefix as a global path
for all modtools.  This creates major problems when bouncing between
prefixes, especially when newmod changes between releases

Why not just use the prefix as the root of where to look for the
templates

This potentially contributed to issues such as #2812 and #2873