### PR TITLE
Remove almost all manual memory management from gr-blocks

### DIFF
--- a/gr-blocks/lib/qa_rotator.cc
+++ b/gr-blocks/lib/qa_rotator.cc
@@ -59,8 +59,8 @@ BOOST_AUTO_TEST_CASE(t2)
     static const unsigned int N = 100000;
 
     gr::blocks::rotator r;
-    gr_complex* input = new gr_complex[N];
-    gr_complex* output = new gr_complex[N];
+    std::vector<gr_complex> input(N);
+    std::vector<gr_complex> output(N);
 
     double phase_incr = 2 * GR_M_PI / 1003;
     double phase = 0;
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(t2)
         input[i] = gr_complex(1.0f, 0.0f);
 
     // Rotate it
-    r.rotateN(output, input, N);
+    r.rotateN(output.data(), input.data(), N);
 
     // Compare with expected result
     for (unsigned i = 0; i < N; i++) {
@@ -86,7 +86,4 @@ BOOST_AUTO_TEST_CASE(t2)
         if (phase >= 2 * GR_M_PI)
             phase -= 2 * GR_M_PI;
     }
-
-    delete[] output;
-    delete[] input;
 }

--- a/gr-blocks/lib/udp_sink_impl.cc
+++ b/gr-blocks/lib/udp_sink_impl.cc
@@ -20,6 +20,7 @@
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
+#include <boost/make_unique.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -64,7 +65,7 @@ void udp_sink_impl::connect(const std::string& host, int port)
             host, s_port, boost::asio::ip::resolver_query_base::passive);
         d_endpoint = *resolver.resolve(query);
 
-        d_socket = new boost::asio::ip::udp::socket(d_io_service);
+        d_socket = boost::make_unique<boost::asio::ip::udp::socket>(d_io_service);
         d_socket->open(d_endpoint.protocol());
 
         boost::asio::socket_base::reuse_address roption(true);
@@ -90,7 +91,7 @@ void udp_sink_impl::disconnect()
     }
 
     d_socket->close();
-    delete d_socket;
+    d_socket.reset();
 
     d_connected = false;
 }

--- a/gr-blocks/lib/udp_sink_impl.h
+++ b/gr-blocks/lib/udp_sink_impl.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/blocks/udp_sink.h>
 #include <boost/asio.hpp>
+#include <memory>
 
 namespace gr {
 namespace blocks {
@@ -27,7 +28,7 @@ private:
     bool d_connected;          // are we connected?
     gr::thread::mutex d_mutex; // protects d_socket and d_connected
 
-    boost::asio::ip::udp::socket* d_socket; // handle to socket
+    std::unique_ptr<boost::asio::ip::udp::socket> d_socket; // handle to socket
     boost::asio::ip::udp::endpoint d_endpoint;
     boost::asio::io_service d_io_service;
 

--- a/gr-blocks/lib/udp_source_impl.cc
+++ b/gr-blocks/lib/udp_source_impl.cc
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <boost/make_unique.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -73,7 +74,7 @@ void udp_source_impl::connect(const std::string& host, int port)
             d_host, s_port, boost::asio::ip::resolver_query_base::passive);
         d_endpoint = *resolver.resolve(query);
 
-        d_socket = new boost::asio::ip::udp::socket(d_io_service);
+        d_socket = boost::make_unique<boost::asio::ip::udp::socket>(d_io_service);
         d_socket->open(d_endpoint.protocol());
 
         boost::asio::socket_base::reuse_address roption(true);
@@ -100,7 +101,7 @@ void udp_source_impl::disconnect()
     d_udp_thread.join();
 
     d_socket->close();
-    delete d_socket;
+    d_socket.reset();
 
     d_connected = false;
 }

--- a/gr-blocks/lib/udp_source_impl.cc
+++ b/gr-blocks/lib/udp_source_impl.cc
@@ -43,12 +43,10 @@ udp_source_impl::udp_source_impl(
       d_eof(eof),
       d_connected(false),
       d_residual(0),
-      d_sent(0)
+      d_sent(0),
+      d_rxbuf(4 * payload_size),
+      d_residbuf(BUF_SIZE_PAYLOADS * payload_size)
 {
-    // Give us some more room to play.
-    d_rxbuf = new char[4 * d_payload_size];
-    d_residbuf = new char[BUF_SIZE_PAYLOADS * d_payload_size];
-
     connect(host, port);
 }
 
@@ -56,9 +54,6 @@ udp_source_impl::~udp_source_impl()
 {
     if (d_connected)
         disconnect();
-
-    delete[] d_rxbuf;
-    delete[] d_residbuf;
 }
 
 void udp_source_impl::connect(const std::string& host, int port)
@@ -120,7 +115,7 @@ int udp_source_impl::get_port(void)
 void udp_source_impl::start_receive()
 {
     d_socket->async_receive_from(
-        boost::asio::buffer((void*)d_rxbuf, d_payload_size),
+        boost::asio::buffer((void*)d_rxbuf.data(), d_payload_size),
         d_endpoint_rcvd,
         boost::bind(&udp_source_impl::handle_read,
                     this,
@@ -150,7 +145,9 @@ void udp_source_impl::handle_read(const boost::system::error_code& error,
                 } else {
                     // otherwise, copy received data into local buffer for
                     // copying later.
-                    memcpy(d_residbuf + d_residual, d_rxbuf, bytes_transferred);
+                    memcpy(d_residbuf.data() + d_residual,
+                           d_rxbuf.data(),
+                           bytes_transferred);
                     d_residual += bytes_transferred;
                 }
             }
@@ -185,7 +182,7 @@ int udp_source_impl::work(int noutput_items,
     int bytes_to_send = std::min<int>(d_itemsize * noutput_items, bytes_left_in_buffer);
 
     // Copy the received data in the residual buffer to the output stream
-    memcpy(out, d_residbuf + d_sent, bytes_to_send);
+    memcpy(out, d_residbuf.data() + d_sent, bytes_to_send);
     int nitems = bytes_to_send / d_itemsize;
 
     // Keep track of where we are if we don't have enough output

--- a/gr-blocks/lib/udp_source_impl.h
+++ b/gr-blocks/lib/udp_source_impl.h
@@ -23,11 +23,11 @@ class udp_source_impl : public udp_source
 {
 private:
     const size_t d_itemsize;
-    int d_payload_size; // maximum transmission unit (packet length)
-    const bool d_eof;   // look for an EOF signal
-    bool d_connected;   // are we connected?
-    char* d_rxbuf;      // get UDP buffer items
-    char* d_residbuf;   // hold buffer between calls
+    int d_payload_size;           // maximum transmission unit (packet length)
+    const bool d_eof;             // look for an EOF signal
+    bool d_connected;             // are we connected?
+    std::vector<char> d_rxbuf;    // get UDP buffer items
+    std::vector<char> d_residbuf; // hold buffer between calls
     ssize_t d_residual; // hold information about number of bytes stored in residbuf
     ssize_t d_sent;     // track how much of d_residbuf we've outputted
 

--- a/gr-blocks/lib/udp_source_impl.h
+++ b/gr-blocks/lib/udp_source_impl.h
@@ -15,6 +15,7 @@
 #include <gnuradio/thread/thread.h>
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
+#include <memory>
 
 namespace gr {
 namespace blocks {
@@ -37,7 +38,7 @@ private:
     std::string d_host;
     unsigned short d_port;
 
-    boost::asio::ip::udp::socket* d_socket;
+    std::unique_ptr<boost::asio::ip::udp::socket> d_socket;
     boost::asio::ip::udp::endpoint d_endpoint;
     boost::asio::ip::udp::endpoint d_endpoint_rcvd;
     boost::asio::io_service d_io_service;


### PR DESCRIPTION
The remaining one is `tcp_server_sink`, which is a bit trickier, so leaving it for a future PR.