### PR TITLE
fft: add shim implementation for python fft library

### DIFF
--- a/gr-fft/python/fft/__init__.py
+++ b/gr-fft/python/fft/__init__.py
@@ -22,3 +22,22 @@ except ImportError:
     dirname, filename = os.path.split(os.path.abspath(__file__))
     __path__.append(os.path.join(dirname, "..", "..", "swig"))
     from .fft_swig import *
+
+# Shim the appropriate python fft library here
+fft_detail = None
+try:
+    from numpy.fft import fftpack as fft_detail
+except ImportError:
+    # Numpy changed fft implementation in version 1.17
+    # from fftpack to pocketfft
+    try:
+        from numpy.fft import pocketfft as fft_detail
+    except ImportError:
+        try:
+            from numpy.fft import fft as fft_detail
+        except ImportError:
+            try:
+                from scipy import fft as fft_detail
+            except ImportError:
+                raise ImportError("Unable to load FFT library from NumPy or SciPy")
+        

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -19,24 +19,13 @@ import warnings
 from optparse import OptionParser
 
 from gnuradio import filter
+from gnuradio.fft import fft_detail
 
 try:
     import numpy as np
 except ImportError:
     raise SystemExit('Please install NumPy to run this script (https://www.np.org/)')
 
-try:
-    from numpy.fft import fftpack as fft_detail
-except ImportError:
-
-    print('Could not import fftpack, trying pocketfft')
-    # Numpy changed fft implementation in version 1.17
-    # from fftpack to pocketfft
-    try:
-        from numpy.fft import pocketfft as fft_detail
-    except ImportError:
-        raise SystemExit('Could not import fft implementation of numpy')
-    
 try:
     from scipy import poly1d, signal
 except ImportError:
@@ -51,7 +40,6 @@ try:
     import pyqtgraph as pg
 except ImportError:
     raise SystemExit('Please install pyqtgraph to run this script (http://www.pyqtgraph.org)')
-
 
 try:
     from gnuradio.filter.pyqt_filter_stacked import Ui_MainWindow

--- a/gr-utils/python/utils/plot_fft_base.py
+++ b/gr-utils/python/utils/plot_fft_base.py
@@ -12,8 +12,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-import numpy
-from numpy.fft import fftpack
+from gnuradio.fft import fft_detail
 
 try:
     from pylab import Button, connect, draw, figure, figtext, get_current_fig_manager, show, rcParams, ceil
@@ -88,7 +87,7 @@ class plot_fft_base(object):
 
     def dofft(self, iq):
         N = len(iq)
-        iq_fft = numpy.fft.fftshift(fftpack.fft(iq))       # fft and shift axis
+        iq_fft = numpy.fft.fftshift(fft_detail.fft(iq))       # fft and shift axis
         iq_fft = 20*numpy.log10(abs((iq_fft+1e-15) / N)) # convert to decibels, adjust power
         # adding 1e-15 (-300 dB) to protect against value errors if an item in iq_fft is 0
         return iq_fft


### PR DESCRIPTION
Wrap the underlying available fft library inside of gnuradio.fft so that
the search is not done in multiple places.  The search here will fail
raise an ImportError on import of gnuradio.fft if no appropriate
underlying implementation is found

Fixes #3235 