### PR TITLE
grc: disable save prompt on new blank pages

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -132,7 +132,6 @@ class Application(Gtk.Application):
                     main.new_page(file_path, show=file_path_to_show == file_path)
             if not main.current_page:
                 main.new_page()  # ensure that at least a blank page exists
-                main.current_page.saved = False
 
             main.btwin.search_entry.hide()
 
@@ -594,7 +593,6 @@ class Application(Gtk.Application):
         ##################################################
         elif action == Actions.FLOW_GRAPH_NEW:
             main.new_page()
-            main.current_page.saved = False
             args = (GLib.Variant('s', 'qt_gui'),)
             flow_graph = main.current_page.flow_graph
             flow_graph.options_block.params['generate_options'].set_value(str(args[0])[1:-1])

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -332,7 +332,6 @@ class MainWindow(Gtk.ApplicationWindow):
         self.notebook.remove_page(self.notebook.page_num(self.page_to_be_closed))
         if ensure and self.notebook.get_n_pages() == 0:
             self.new_page() #no pages, make a new one
-            self.current_page.saved = False
         self.page_to_be_closed = None #set the page to be closed back to None
         return True
 


### PR DESCRIPTION
This is just a simple UX papercut fix: avoid showing the "unsaved changes" dialog when a new flowgraph is created and then closed without changes; in particular, I find it a bit irritating that it appears when I open and close grc without doing anything at all.

Hopefully, this change doesn't break any other behaviour.