### PR TITLE
cmake: Make numpy a first-class dependency for Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(GR_SWIG_MIN_VERSION "3.0.8")
 set(GR_CMAKE_MIN_VERSION "3.5.1")
 set(GR_MAKO_MIN_VERSION "0.4.2")
 set(GR_PYTHON_MIN_VERSION "3.6.5")
+set(GR_NUMPY_MIN_VERSION "1.13.0")
 set(GCC_MIN_VERSION "4.8.4")
 set(CLANG_MIN_VERSION "3.4.0")
 set(APPLECLANG_MIN_VERSION "500")
@@ -330,6 +331,11 @@ include(GrBoost)
 ########################################################################
 include(GrPython)
 GR_PYTHON_CHECK_MODULE("six - python 2 and 3 compatibility library" six "True" SIX_FOUND)
+GR_PYTHON_CHECK_MODULE(
+    "numpy"
+    numpy
+    "LooseVersion(numpy.__version__) >= LooseVersion('${GR_NUMPY_MIN_VERSION}')"
+    NUMPY_FOUND)
 find_package(SWIG)
 
 if(SWIG_FOUND)
@@ -346,6 +352,7 @@ GR_REGISTER_COMPONENT("python-support" ENABLE_PYTHON
     SWIG_FOUND
     SWIG_VERSION_CHECK
     SIX_FOUND
+    NUMPY_FOUND
 )
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Coverage")

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -78,6 +78,7 @@ macro(GR_PYTHON_CHECK_MODULE desc mod cmd have)
     GR_PYTHON_CHECK_MODULE_RAW(
         "${desc}" "
 #########################################
+from distutils.version import LooseVersion
 try:
     import ${mod}
     assert ${cmd}


### PR DESCRIPTION
Yeah, I hate dependencies. But let's not kid ourselves, numpy was always a dependency of GNU Radio. Might as well treat it as such. Should then obviate #3280.