### PR TITLE
fec: make SciPy an optional dependency

### DIFF
--- a/gr-fec/python/fec/polar/channel_construction.py
+++ b/gr-fec/python/fec/polar/channel_construction.py
@@ -29,8 +29,13 @@ from __future__ import absolute_import
 from .channel_construction_bec import calculate_bec_channel_capacities
 from .channel_construction_bec import design_snr_to_bec_eta
 from .channel_construction_bec import bhattacharyya_bounds
-from .channel_construction_awgn import tal_vardy_tpm_algorithm
 from .helper_functions import *
+try:
+    from .channel_construction_awgn import tal_vardy_tpm_algorithm
+except ImportError:
+    print("SciPy missing. Overwrite Tal-Vardy algorithm with BEC approximation")
+    def tal_vardy_tpm_algorithm(block_size, design_snr, mu):
+        return bhattacharyya_bounds(design_snr, block_size)
 
 
 Z_PARAM_FIRST_HEADER_LINE = "Bhattacharyya parameters (Z-parameters) for a polar code"


### PR DESCRIPTION
This is a backport of https://github.com/gnuradio/gnuradio/pull/1639 that was made to fix https://github.com/gnuradio/gnuradio/issues/1545 which specifically caught my attention as it was still open and I just tried it on maint-3.8.