### PR TITLE
replace boost endian check with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,12 @@ include(CMakeOverloads)
 ########################################################################
 include(GrMiscUtils) #compiler flag check
 
+include(TestBigEndian)
+TEST_BIG_ENDIAN(GR_IS_BIG_ENDIAN)
+if(GR_IS_BIG_ENDIAN)
+    add_definitions(-DGR_IS_BIG_ENDIAN)
+endif(GR_IS_BIG_ENDIAN)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(NOT WIN32)

--- a/gr-audio/lib/osx/osx_common.h
+++ b/gr-audio/lib/osx/osx_common.h
@@ -48,8 +48,7 @@ namespace osx {
         GR_LOG_WARN(d_logger, boost::format("  %s:%d") % __FILE__ % __LINE__);        \
     }
 
-#include <boost/detail/endian.hpp> //BOOST_BIG_ENDIAN
-#ifdef BOOST_BIG_ENDIAN
+#ifdef GR_IS_BIG_ENDIAN
 #define GR_PCM_ENDIANNESS kLinearPCMFormatFlagIsBigEndian
 #else
 #define GR_PCM_ENDIANNESS 0

--- a/gr-blocks/lib/wavfile.cc
+++ b/gr-blocks/lib/wavfile.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/blocks/wavfile.h>
 #include <stdint.h>
-#include <boost/detail/endian.hpp> //BOOST_BIG_ENDIAN
 #include <cstring>
 
 namespace gr {
@@ -23,7 +22,7 @@ namespace blocks {
 
 // Basically, this is the opposite of htonx() and ntohx()
 // Define host to/from worknet (little endian) short and long
-#ifdef BOOST_BIG_ENDIAN
+#ifdef GR_IS_BIG_ENDIAN
 
 static inline uint16_t __gri_wav_bs16(uint16_t x) { return (x >> 8) | (x << 8); }
 
@@ -45,7 +44,7 @@ static inline uint32_t __gri_wav_bs32(uint32_t x)
 #define htows(x) uint16_t(x)
 #define wtohs(x) uint16_t(x)
 
-#endif // BOOST_BIG_ENDIAN
+#endif // GR_IS_BIG_ENDIAN
 
 // WAV files are always little-endian, so we need some byte switching macros
 static inline uint32_t host_to_wav(uint32_t x) { return htowl(x); }


### PR DESCRIPTION
This uses cmake's TEST_BIG_ENDIAN instead of Boost.

Note that current use of `boost/detail/endian.hpp` is deprecated:
```The use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Please include <boost/predef/other/endian.h> and use BOOST_ENDIAN_*_BYTE instead```

Also, I am not sure if GNU Radio works on any of the remaining big-endian platforms.