### PR TITLE
grc: Fix crash when using function probe with BokehGUI

### DIFF
--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -31,12 +31,22 @@ templates:
         import time
         import threading
     var_make: self.${id} = ${id} = ${value}
-    make: "\ndef _${id}_probe():\n    while True:\n        <% obj = 'self' + ('.'\
-        \ + block_id if block_id else '') %>\n        val = ${obj}.${function_name}(${function_args})\n\
-        \        try:\n            self.set_${id}(val)\n        except AttributeError:\n\
-        \            pass\n        time.sleep(1.0 / (${poll_rate}))\n_${id}_thread\
-        \ = threading.Thread(target=_${id}_probe)\n_${id}_thread.daemon = True\n_${id}_thread.start()\n\
-        \    "
+    make: |+
+        def _${id}_probe():
+          while True:
+            <% obj = 'self' + ('.' + block_id if block_id else '') %>
+            val = ${obj}.${function_name}(${function_args})
+            try:
+              try:
+                self.doc.add_next_tick_callback(functools.partial(self.set_${id},val))
+              except AttributeError:
+                self.set_${id}(val)
+            except AttributeError:
+              pass
+            time.sleep(1.0 / (${poll_rate}))
+        _${id}_thread = threading.Thread(target=_${id}_probe)
+        _${id}_thread.daemon = True
+        _${id}_thread.start()
     callbacks:
     - self.set_${id}(${value})
 


### PR DESCRIPTION
The function probe block creates a new worker thread to do it's thing, this means that the callback to update the value of the block is executed in that separate thread.
The bokeh framework doesn't allow that, so using a probe block value in a BokehGUI block causes a crash.
This PR solves it by giving the callback function to the bokeh framework so it can execute it in its own thread.
I did not know how to check whether QT or bokeh is active from the yaml file, so I made a nested try.

This can be backported to maint-3.8.