### PR TITLE
grc: show file path as tooltip in tab label

### DIFF
--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -371,6 +371,10 @@ class MainWindow(Gtk.ApplicationWindow):
                 foreground='black' if page.saved else 'red', ro=' (ro)' if page.get_read_only() else '',
                 title=Utils.encode(file_name or NEW_FLOGRAPH_TITLE),
             ))
+            fpath = page.file_path
+            if not fpath:
+                fpath = '(unsaved)'
+            page.set_tooltip(fpath)
         # show/hide notebook tabs
         self.notebook.set_show_tabs(len(self.get_pages()) > 1)
 

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -173,6 +173,15 @@ class Page(Gtk.HBox):
         """
         self.label.set_markup(markup)
 
+    def set_tooltip(self, text):
+        """
+        Set the tooltip text in this label.
+
+        Args:
+            text: the new tooltip text
+        """
+        self.label.set_tooltip_text(text)
+
     def get_read_only(self):
         """
         Get the read-only state of the file.


### PR DESCRIPTION
This is a backport of #3303. Fixes #3294.

I have tested thus with a python2 build as well.