### PR TITLE
blocks: move rotator workaround up into rotateN

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/rotator.h
+++ b/gr-blocks/include/gnuradio/blocks/rotator.h
@@ -60,7 +60,13 @@ public:
 
     void rotateN(gr_complex* out, const gr_complex* in, int n)
     {
+#ifdef APPLY_BROKEN_ROTATOR_WORKAROUND
+        for (int i = 0; i < n; i++) {
+            out[i] = rotate(in[i]);
+        }
+#else
         volk_32fc_s32fc_x2_rotator_32fc(out, in, d_phase_incr, &d_phase, n);
+#endif
     }
 };
 

--- a/gr-blocks/lib/rotator_cc_impl.cc
+++ b/gr-blocks/lib/rotator_cc_impl.cc
@@ -59,12 +59,7 @@ int rotator_cc_impl::work(int noutput_items,
     const gr_complex* in = (const gr_complex*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
 
-#ifdef APPLY_BROKEN_ROTATOR_WORKAROUND
-    for (int i = 0; i < noutput_items; i++)
-        out[i] = d_r.rotate(in[i]);
-#else
     d_r.rotateN(out, in, noutput_items);
-#endif
 
     return noutput_items;
 }


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/3308.
Related pull requests: https://github.com/gnuradio/gnuradio/pull/3062 https://github.com/gnuradio/gnuradio/pull/3205

Since `rotateN` is part of the GNU Radio API, it should get the workaround for VOLK 2.0.0's rotator bug.
