### PR TITLE
allow GRC to use module specific variables in assert statements

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -130,6 +130,19 @@ class Block(Element):
         self.active_sources = [p for p in self.sources if not p.hidden]
         self.active_sinks = [p for p in self.sinks if not p.hidden]
 
+        # namespaces may have changed, update them
+        self.block_namespace = {}
+        try:
+            exec(self.templates.render('imports'), self.block_namespace)
+        except ImportError:
+            # We do not have a good way right now to determine if an import is for a
+            # hier block, these imports will fail as they are not in the search path
+            # this is ok behavior, unfortunately we could be hiding other import bugs
+            pass
+        except Exception:
+            log.exception('Failed to evaluate import expression "{0}"'.format(expr), exc_info=True)
+            pass
+
     def update_bus_logic(self):
         ###############################
         ## Bus Logic
@@ -581,7 +594,9 @@ class Block(Element):
     ##############################################
     @property
     def namespace(self):
-        return {key: param.get_evaluated() for key, param in six.iteritems(self.params)}
+        # update block namespace
+        self.block_namespace.update({key:param.get_evaluated() for key, param in six.iteritems(self.params)})
+        return self.block_namespace
 
     @property
     def namespace_templates(self):


### PR DESCRIPTION
Currently GRC will not evaluate asserts that contain objects from imported modules, because the assert check is performed without using the parent flowgraph namespace and the objects do not exist there. This is not a significant in-tree issue, but it is an issue for several OOTs and I believe one check that was commented out [here](https://github.com/gnuradio/gnuradio/blob/master/gr-blocks/grc/blocks_multiply_matrix_xx.block.yml#L40):

![image](https://user-images.githubusercontent.com/7121282/78627287-4ba35900-784e-11ea-97dd-bbc6fb0ddb11.png)

This fix explicitly uses the parent flowgraph namespace and allows for checks using module objects.

Credit: Peter Knee