### PR TITLE
Block gateway add alias affinity

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -116,6 +116,18 @@ public:
 
     void block__set_history(unsigned history) { return gr::block::set_history(history); }
 
+    void block__set_block_alias(std::string alias)
+    {
+        return gr::block::set_block_alias(alias);
+    }
+
+    std::string block__alias(void) const { return gr::block::alias(); }
+
+    void block__set_processor_affinity(std::vector<int> mask)
+    {
+        return gr::block::set_processor_affinity(mask);
+    }
+
     void block__set_fixed_rate(bool fixed_rate)
     {
         return gr::block::set_fixed_rate(fixed_rate);


### PR DESCRIPTION
Both `set_block_alias()` and `set_processor_affinity()` exist as GUI settable fields for all blocks, but for python blocks these are not exposed causing runtime exceptions if used the way GRC does (can only be used via `blockname.to_basic_block().set_block_alias()`). This PR adds both to block_gateway objects, and allows python blocks to use `self.alias()` to return their alias.