### PR TITLE
GRC: Revert "Added switch button for bool types" on maint-3.8

### DIFF
--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -230,23 +230,6 @@ class EnumParam(InputParam):
     def set_tooltip_text(self, text):
         self._input.set_tooltip_text(text)
 
-class BoolParam(InputParam):
-    """Provide a switch button for Bool types."""
-
-    def __init__(self, *args, **kwargs):
-        InputParam.__init__(self, *args, **kwargs)
-        self._input = Gtk.Switch()
-        self._input.connect('state-set', self._apply_change)
-        self._input.connect('state-set', self._editing_callback)
-        self.pack_start(self._input, False, False, 0)
-        value = self.param.get_value()
-        self._input.set_active(eval(value))
-
-    def get_text(self):
-        return self._input.get_active()
-
-    def set_tooltip_text(self, text):
-        self._input.set_tooltip_text(text)
 
 class EnumEntryParam(InputParam):
     """Provide an entry box and drop down menu for Raw Enum types."""

--- a/grc/gui/canvas/param.py
+++ b/grc/gui/canvas/param.py
@@ -46,9 +46,6 @@ class Param(CoreParam):
         elif dtype == 'enum':
             input_widget_cls = ParamWidgets.EnumParam
 
-        elif dtype == 'bool':
-            input_widget_cls = ParamWidgets.BoolParam
-
         elif self.options:
             input_widget_cls = ParamWidgets.EnumEntryParam
 


### PR DESCRIPTION
Cherry pick of 3411bf5 onto maint-3.8 as this causes problems on that branch also, see https://github.com/gnuradio/gnuradio/pull/2816

Related to https://github.com/gnuradio/gnuradio/issues/2683 and https://github.com/gnuradio/gnuradio/issues/3167