### PR TITLE
grc: add hotkeys to clear/save console, and to toggle autoscroll

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -480,7 +480,8 @@ TOGGLE_BLOCKS_WINDOW = actions.register("win.toggle_blocks_window",
 TOGGLE_SCROLL_LOCK = actions.register("win.console.scroll_lock",
     label='Console Scroll _Lock',
     tooltip='Toggle scroll lock for the console window',
-    preference_name='scroll_lock'
+    preference_name='scroll_lock',
+    keypresses=["Scroll_Lock"],
 )
 ABOUT_WINDOW_DISPLAY = actions.register("app.about",
     label='_About',
@@ -555,11 +556,13 @@ CLEAR_CONSOLE = actions.register("win.console.clear",
     label='_Clear Console',
     tooltip='Clear Console',
     icon_name='edit-clear',
+    keypresses=["<Ctrl>l"],
 )
 SAVE_CONSOLE = actions.register("win.console.save",
     label='_Save Console',
     tooltip='Save Console',
     icon_name='edit-save',
+    keypresses=["<Ctrl><Shift>p"],
 )
 OPEN_HIER = actions.register("win.open_hier",
     label='Open H_ier',

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -300,24 +300,26 @@ def show_keyboard_shortcuts(parent):
     markup = textwrap.dedent("""\
     <b>Keyboard Shortcuts</b>
     \n\
-    <u>Ctrl+N</u>: Create a new flowgraph. 
+    <u>Ctrl+N</u>: Create a new flowgraph.
     <u>Ctrl+O</u>: Open an existing flowgraph.
-    <u>Ctrl+S</u>: Save the current flowgraph or save as for new. 
+    <u>Ctrl+S</u>: Save the current flowgraph or save as for new.
     <u>Ctrl+W</u>: Close the current flowgraph.
-    <u>Ctrl+Z</u>: Undo a change to the flowgraph.         
+    <u>Ctrl+Z</u>: Undo a change to the flowgraph.
     <u>Ctrl+Y</u>: Redo a change to the flowgraph.
     <u>Ctrl+A</u>: Selects all blocks and connections.
     <u>Ctrl+P</u>: Screen Capture of the Flowgraph.
-    <u>Ctrl+E</u>: Show variable editor. 
-    <u>Ctrl+F</u>: Search for a block by name.       
-    <u>Ctrl+Q</u>: Quit. 
-    <u>F1</u>    : Help menu.            
-    <u>F5</u>    : Generate the Flowgraph. 
-    <u>F6</u>    : Execute the Flowgraph.     
+    <u>Ctrl+Shift+P</u>: Save the console output to file.
+    <u>Ctrl+L</u>: Clear the console.
+    <u>Ctrl+E</u>: Show variable editor.
+    <u>Ctrl+F</u>: Search for a block by name.
+    <u>Ctrl+Q</u>: Quit.
+    <u>F1</u>    : Help menu.
+    <u>F5</u>    : Generate the Flowgraph.
+    <u>F6</u>    : Execute the Flowgraph.
     <u>F7</u>    : Kill the Flowgraph.
     <u>Ctrl+Shift+S</u>: Save as the current flowgraph.
-    <u>Ctrl+Shift+D</u>: Create a duplicate of current flow graph.   
-    
+    <u>Ctrl+Shift+D</u>: Create a duplicate of current flow graph.
+
     <u>Ctrl+X/C/V</u>: Edit-cut/copy/paste.
     <u>Ctrl+D/B/R</u>: Toggle visibility of disabled blocks or
             connections/block tree widget/console.


### PR DESCRIPTION
Adds the following GRC hotkeys:
<ctrl><shift>C = clear console
<ctrl><shift>P = save the console to file
<ctrl><shift>L = toggle console scroll lock

Debatable if these are the best bindings, but specifically clearing the console is very helpful to have a hotkey for. Copying console to clipboard would be awesome too but that was not immediately apparent and I do not know much about how to implement that....