### PR TITLE
Release 3.8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning](http://semver.org/spec/v2.0.0.html), starting with version 3.7.12.0.
 
 Older Logs can be found in `docs/RELEASE-NOTES-*`.
 
-## [3.8.1.0-rc1] - 2020-02-16
+## [3.8.1.0] - 2020-04-08
 
 ### Changed
 
@@ -17,15 +17,26 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
   - Throw exceptions by value, catch by reference
   - `emplace_back` where applicable
   - `empty()` instead of `vector::size() == 0`
+- Use CMake to check for endianness instead of `BOOST_BIG_ENDIAN`
+
+#### gr-fec
+
+- Scipy becomes optional dependency (for polar channel code construction)
+
+#### gr_modtool
+
+- use Boost.UTF instead of cppunit
 
 ### Fixed
 
-#### Project scope
+#### Project Scope
 
 - FindQwt paths
 - floatAlmostEqual unittest assert function wrongly passing on sequence types
 - Only require boost unittest when testing is enabled
 - FindLOG4CPP typo
+- numpy.fft(pack) imports
+- several scipy imports that can be done with numpy alone
 
 #### gnuradio-runtime
 
@@ -35,14 +46,7 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 - Sine table generation python was wrong
 - `get_tags_in_range` for delay < (end-start)
 - premature tag pruning
-
-#### gr_modtool
-
-- wrong use of `input` -> `raw_input`
-- allow empty argument list
-- testing
-- check for and deny TSB under Python
-- QA addition bugs 
+- release flattened flowgraph after stopping; fixes restartability/shutdown issues
 
 #### gr-analog
 
@@ -53,9 +57,9 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 
 - portaudio source: lock acquisition
 
-#### gr-blocks 
+#### gr-blocks
 
-- broken `rotator` workaround
+- rotator VOLK workaround
 
 #### gr-digital
 
@@ -81,6 +85,15 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 - fixed examples under Py3
 - multichannel objects not populating channels
 
+#### gr_modtool
+
+- wrong use of `input` -> `raw_input`
+- allow empty argument list
+- testing
+- check for and deny TSB under Python
+- QA addition bugs
+- correct path for C++ QA tests
+
 #### GRC
 
 - several issues with YAML files
@@ -88,6 +101,10 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 - comments now included in block bounds calculation
 - Wiki documentation link removed from OOT blocks' docs tab
 - Dragging connections to auto-hide ports works now
+- generated and re-generated several example flowgraphs
+- `bokeh_layout` module name
+- Revert toggle buttons to text entry for bool block props, allowing GRC
+  variables to be used
 
 ### Added
 
@@ -100,6 +117,7 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 #### gnuradio-runtime
 
 - dot graphs now contain message edges
+- Python wrapping for blocks' `set_affinity` and `{g,s}et_alias`
 
 #### gr-uhd
 
@@ -109,6 +127,10 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 
 - block affinity, buffer sizes available as advanced options for blocks
 - testing
+- Python snippets (please snippet responsibly!)
+- `show_id` flag added to embedded python blocks, Probes
+- global option to toggle showing of IDs
+- Help "Keyboard Shortcut" entry
 
 ## [3.8.0.0] - 2019-08-09
 


### PR DESCRIPTION
Contributors
------------

-  Alba Mendez me@alba.sh
-  alekhgupta1441 alekhgupta1441@gmail.com
-  Anders Kalør anders@kaloer.com
-  Artem Pisarenko artem.k.pisarenko@gmail.com
-  Bastian Bloessl mail@bastibl.net
-  Brennan Ashton bashton@brennanashton.com
-  Chris christopher.donohue@gmail.com
-  Clayton Smith argilo@gmail.com
-  CMorin barthy42@laposte.net
-  Daniel Estévez daniel@destevez.net
-  Davide Gerhard rainbow@irh.it
-  Derek Kozel derek.kozel@gmail.com
-  duggabe
-  Glenn Richardson glenn.richardson@live.com
-  Grant Cox grant.cox@deepspaceamps.com
-  Gwenhael Goavec-Merou gwenhael.goavec-merou@trabucayre.com
-  Håkon Vågsether haakonsv@gmail.com
-  Igor Freire igor.auad@gmail.com
-  Jacob Gilbert mrjacobagilbert@gmail.com
-  Jan Kraemer kraemer.jn@gmail.com
-  japm48
-  Johannes Demel ufcsy@student.kit.edu
-  Josh Morman jmorman@perspectalabs.com
-  karel
-  luz.paz
-  Marc L marcll@vt.edu
-  Marcus Müller mmueller@gnuradio.org
-  Martin Braun martin.braun@ettus.com
-  Michael Dickens michael.dickens@ettus.com
-  Michael Roe mroe@cornstalk.org.uk
-  Nathan West nwest@deepsig.io
-  Nick Østergaard oe.nick@gmail.com
-  Nicolas Cuervo cuervonicolas@gmail.com
-  Notou barthy42@laposte.net
-  Philip Balister philip@balister.org
-  rear1019 rear1019@posteo.de
-  RedStone002
-  Ron Economos w6rz@comcast.net
-  Ryan Schutt
-  Ryan Volz rvolz@mit.edu
-  Sebastian Koslowski sebastian.koslowski@gmail.com
-  Sebastian Müller gsenpo@gmail.com
-  Sylvain Munaut tnt@246tNt.com
-  Terry May terrydmay@gmail.com
-  Thomas Habets thomas@habets.se
-  Vasil Velichkov vvvelichkov@gmail.com
-  Volker Schroer
-  wcampbell wcampbell1995@gmail.com
-  William Barnhart williambbarnhart@gmail.com

[3.8.1.0] - 2020-04-08
----------------------

Changed
~~~~~~~

Project Scope
^^^^^^^^^^^^^

-  clang-tidy improvements

   -  Throw exceptions by value, catch by reference
   -  ``emplace_back`` where applicable
   -  ``empty()`` instead of ``vector::size() == 0``

-  Use CMake to check for endianness instead of ``BOOST_BIG_ENDIAN``

gr-fec
^^^^^^

-  Scipy becomes optional dependency (for polar channel code
   construction)

gr_modtool
^^^^^^^^^^

-  use Boost.UTF instead of cppunit

Fixed
~~~~~

Project Scope
^^^^^^^^^^^^^

-  FindQwt paths
-  floatAlmostEqual unittest assert function wrongly passing on sequence
   types
-  Only require boost unittest when testing is enabled
-  FindLOG4CPP typo
-  numpy.fft(pack) imports
-  several scipy imports that can be done with numpy alone

gnuradio-runtime
^^^^^^^^^^^^^^^^

-  block gateway shadowed system port
-  Flaky message passing unit test contained timeout (not the test's
   job)
-  ctrlport/\ ``rpcaggregator`` & Co: removed storage of references to
   scope-lifetime objects
-  Sine table generation python was wrong
-  ``get_tags_in_range`` for delay < (end-start)
-  premature tag pruning
-  release flattened flowgraph after stopping; fixes
   restartability/shutdown issues

gr-analog
^^^^^^^^^

-  clipping in FM receiver: remove superfluous gain
-  C++ generation for multiple blocks

gr-audio
^^^^^^^^

-  portaudio source: lock acquisition

gr-blocks
^^^^^^^^^

-  rotator VOLK workaround

gr-digital
^^^^^^^^^^

-  ``map_bb`` buffer overflow
-  ``map_bb`` thread safety
-  ``additive_scrambler``\ count based reset

gr-fec
^^^^^^

-  heap corruption in ``async_decoder``
-  ``cc_encoder`` was broken for constraint lengths > 8

gr-fft
^^^^^^

-  restore Boost 1.53 compat

gr-qtgui
^^^^^^^^

-  no longer requiring unnecessary key in ``edit_box_msg``

gr-uhd
^^^^^^

-  fixed examples under Py3
-  multichannel objects not populating channels

gr_modtool
^^^^^^^^^^

-  wrong use of ``input`` -> ``raw_input``
-  allow empty argument list
-  testing
-  check for and deny TSB under Python
-  QA addition bugs
-  correct path for C++ QA tests

GRC
^^^

-  several issues with YAML files
-  nested objects now properly populate namespaces
-  comments now included in block bounds calculation
-  Wiki documentation link removed from OOT blocks' docs tab
-  Dragging connections to auto-hide ports works now
-  generated and re-generated several example flowgraphs
-  ``bokeh_layout`` module name
-  Revert toggle buttons to text entry for bool block props, allowing
   GRC variables to be used

Added
~~~~~

Project Scope
^^^^^^^^^^^^^

-  Codec2 development branch / future compat
-  Boost 1.71 compat
-  CI now checks for formatting

gnuradio-runtime
^^^^^^^^^^^^^^^^

-  dot graphs now contain message edges
-  Python wrapping for blocks' ``set_affinity`` and ``{g,s}et_alias``

gr-uhd
^^^^^^

-  UHD Filter API

GRC
^^^

-  block affinity, buffer sizes available as advanced options for blocks
-  testing
-  Python snippets (please snippet responsibly!)
-  ``show_id`` flag added to embedded python blocks, Probes
-  global option to toggle showing of IDs
-  Help "Keyboard Shortcut" entry