### PR TITLE
runtime: Make random seed default to current time, as documented

### DIFF
--- a/gnuradio-runtime/include/gnuradio/random.h
+++ b/gnuradio-runtime/include/gnuradio/random.h
@@ -42,8 +42,7 @@ public:
 
     /*!
      * \brief Change the seed for the initialized number generator. seed = 0 initializes
-     * the random number generator with the system time. Note that a fast initialization
-     * of various instances can result in the same seed.
+     * the random number generator with the system time.
      */
     void reseed(unsigned int seed);
 

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -54,7 +54,7 @@ void random::reseed(unsigned int seed)
 {
     d_seed = seed;
     if (d_seed == 0) {
-        d_rng.seed();
+        d_rng.seed(time(nullptr));
     } else {
         d_rng.seed(d_seed);
     }

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -30,6 +30,7 @@
 #include <gnuradio/math.h>
 #include <gnuradio/random.h>
 
+#include <chrono>
 #include <cmath>
 
 namespace gr {
@@ -54,7 +55,9 @@ void random::reseed(unsigned int seed)
 {
     d_seed = seed;
     if (d_seed == 0) {
-        d_rng.seed(time(nullptr));
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+        d_rng.seed(ns);
     } else {
         d_rng.seed(d_seed);
     }

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -59,7 +59,8 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(T))),
       d_type(type),
-      d_ampl(ampl)
+      d_ampl(ampl),
+      d_rng(seed)
 {
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, (uint64_t)seed);
@@ -76,7 +77,8 @@ fastnoise_source_impl<gr_complex>::fastnoise_source_impl(noise_type_t type,
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(gr_complex))),
       d_type(type),
-      d_ampl(ampl / sqrtf(2.0f))
+      d_ampl(ampl / sqrtf(2.0f)),
+      d_rng(seed)
 {
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, (uint64_t)seed);


### PR DESCRIPTION
This is what gnuradio currently documents seeding will do, but it's
not what C++ defaults to.

See C++11 26.5.3.2, paragraph 3. Default for mersenne twister is
constexpr 5489.

Or easier, the bottom of
https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine