### PR TITLE
zeromq: Add bind argument for message based zeromq blocks. This is ne…

### DIFF
--- a/gr-zeromq/grc/zeromq_pub_msg_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_msg_sink.block.yml
@@ -10,6 +10,12 @@ parameters:
     label: Timeout (msec)
     dtype: float
     default: '100'
+-   id: bind
+    category: Advanced
+    label: Bind
+    dtype: bool
+    default: 'True'
+    hide: part
 
 inputs:
 -   domain: message
@@ -18,6 +24,6 @@ inputs:
 
 templates:
     imports: from gnuradio import zeromq
-    make: zeromq.pub_msg_sink(${address}, ${timeout})
+    make: zeromq.pub_msg_sink(${address}, ${timeout}, ${bind})
     
 file_format: 1

--- a/gr-zeromq/grc/zeromq_pull_msg_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_msg_source.block.yml
@@ -10,6 +10,12 @@ parameters:
     label: Timeout (msec)
     dtype: float
     default: '100'
+-   id: bind
+    category: Advanced
+    label: Bind
+    dtype: bool
+    default: 'False'
+    hide: part
 
 outputs:
 -   domain: message
@@ -18,6 +24,6 @@ outputs:
 
 templates:
     imports: from gnuradio import zeromq
-    make: zeromq.pull_msg_source(${address}, ${timeout})
+    make: zeromq.pull_msg_source(${address}, ${timeout}, ${bind})
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_push_msg_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_push_msg_sink.block.yml
@@ -10,6 +10,12 @@ parameters:
     label: Timeout (msec)
     dtype: float
     default: '100'
+-   id: bind
+    category: Advanced
+    label: Bind
+    dtype: bool
+    default: 'True'
+    hide: part
 
 inputs:
 -   domain: message
@@ -18,6 +24,6 @@ inputs:
 
 templates:
     imports: from gnuradio import zeromq
-    make: zeromq.push_msg_sink(${address}, ${timeout})
+    make: zeromq.push_msg_sink(${address}, ${timeout}, ${bind})
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_rep_msg_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_rep_msg_sink.block.yml
@@ -10,6 +10,12 @@ parameters:
     label: Timeout (msec)
     dtype: float
     default: '100'
+-   id: bind
+    category: Advanced
+    label: Bind
+    dtype: bool
+    default: 'True'
+    hide: part
 
 inputs:
 -   domain: message
@@ -18,6 +24,6 @@ inputs:
 
 templates:
     imports: from gnuradio import zeromq
-    make: zeromq.rep_msg_sink(${address}, ${timeout})
+    make: zeromq.rep_msg_sink(${address}, ${timeout}, ${bind})
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_req_msg_source.block.yml
+++ b/gr-zeromq/grc/zeromq_req_msg_source.block.yml
@@ -10,6 +10,12 @@ parameters:
     label: Timeout (msec)
     dtype: float
     default: '100'
+-   id: bind
+    category: Advanced
+    label: Bind
+    dtype: bool
+    default: 'False'
+    hide: part
 
 outputs:
 -   domain: message
@@ -18,6 +24,6 @@ outputs:
 
 templates:
     imports: from gnuradio import zeromq
-    make: zeromq.req_msg_source(${address}, ${timeout})
+    make: zeromq.req_msg_source(${address}, ${timeout}, ${bind})
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_sub_msg_source.block.yml
+++ b/gr-zeromq/grc/zeromq_sub_msg_source.block.yml
@@ -10,6 +10,12 @@ parameters:
     label: Timeout (msec)
     dtype: float
     default: '100'
+-   id: bind
+    category: Advanced
+    label: Bind
+    dtype: bool
+    default: 'False'
+    hide: part
 
 outputs:
 -   domain: message
@@ -18,6 +24,6 @@ outputs:
 
 templates:
     imports: from gnuradio import zeromq
-    make: zeromq.sub_msg_source(${address}, ${timeout})
+    make: zeromq.sub_msg_source(${address}, ${timeout}, ${bind})
 
 file_format: 1

--- a/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_msg_sink.h
@@ -50,8 +50,11 @@ public:
      *
      * \param address  ZMQ socket address specifier
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
+     * \param bind     If true this block will bind to the address, otherwise it will
+     * connect; the default is to bind
+     *
      */
-    static sptr make(char* address, int timeout = 100);
+    static sptr make(char* address, int timeout = 100, bool bind = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_msg_source.h
@@ -47,9 +47,11 @@ public:
      *
      * \param address  ZMQ socket address specifier
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
+     * \param bind     If true this block will bind to the address, otherwise it will
+     * connect; the default is to connect
      *
      */
-    static sptr make(char* address, int timeout = 100);
+    static sptr make(char* address, int timeout = 100, bool bind = false);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_msg_sink.h
@@ -49,9 +49,11 @@ public:
      *
      * \param address  ZMQ socket address specifier
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
+     * \param bind     If true this block will bind to the address, otherwise it will
+     * connect; the default is to bind
      *
      */
-    static sptr make(char* address, int timeout = 100);
+    static sptr make(char* address, int timeout = 100, bool bind = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_msg_sink.h
@@ -49,9 +49,11 @@ public:
      *
      * \param address  ZMQ socket address specifier
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
+     * \param bind     If true this block will bind to the address, otherwise it will
+     * connect; the default is to bind
      *
      */
-    static sptr make(char* address, int timeout = 100);
+    static sptr make(char* address, int timeout = 100, bool bind = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_msg_source.h
@@ -47,9 +47,11 @@ public:
      *
      * \param address  ZMQ socket address specifier
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
+     * \param bind     If true this block will bind to the address, otherwise it will
+     * connect; the default is to connect
      *
      */
-    static sptr make(char* address, int timeout = 100);
+    static sptr make(char* address, int timeout = 100, bool bind = false);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_msg_source.h
@@ -47,9 +47,11 @@ public:
      *
      * \param address  ZMQ socket address specifier
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments
+     * \param bind     If true this block will bind to the address, otherwise it will
+     * connect; the default is to connect
      *
      */
-    static sptr make(char* address, int timeout = 100);
+    static sptr make(char* address, int timeout = 100, bool bind = false);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -31,12 +31,12 @@
 namespace gr {
 namespace zeromq {
 
-pub_msg_sink::sptr pub_msg_sink::make(char* address, int timeout)
+pub_msg_sink::sptr pub_msg_sink::make(char* address, int timeout, bool bind)
 {
-    return gnuradio::get_initial_sptr(new pub_msg_sink_impl(address, timeout));
+    return gnuradio::get_initial_sptr(new pub_msg_sink_impl(address, timeout, bind));
 }
 
-pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout)
+pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout, bool bind)
     : gr::block("pub_msg_sink",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
@@ -44,15 +44,22 @@ pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout)
 {
     int major, minor, patch;
     zmq::version(&major, &minor, &patch);
+
     if (major < 3) {
         d_timeout = timeout * 1000;
     }
 
     d_context = new zmq::context_t(1);
     d_socket = new zmq::socket_t(*d_context, ZMQ_PUB);
+
     int time = 0;
     d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-    d_socket->bind(address);
+
+    if (bind) {
+        d_socket->bind(address);
+    } else {
+        d_socket->connect(address);
+    }
 
     message_port_register_in(pmt::mp("in"));
     set_msg_handler(pmt::mp("in"), boost::bind(&pub_msg_sink_impl::handler, this, _1));

--- a/gr-zeromq/lib/pub_msg_sink_impl.h
+++ b/gr-zeromq/lib/pub_msg_sink_impl.h
@@ -37,7 +37,7 @@ private:
     zmq::socket_t* d_socket;
 
 public:
-    pub_msg_sink_impl(char* address, int timeout);
+    pub_msg_sink_impl(char* address, int timeout, bool bind);
     ~pub_msg_sink_impl();
 
     void handler(pmt::pmt_t msg);

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -33,12 +33,12 @@
 namespace gr {
 namespace zeromq {
 
-pull_msg_source::sptr pull_msg_source::make(char* address, int timeout)
+pull_msg_source::sptr pull_msg_source::make(char* address, int timeout, bool bind)
 {
-    return gnuradio::get_initial_sptr(new pull_msg_source_impl(address, timeout));
+    return gnuradio::get_initial_sptr(new pull_msg_source_impl(address, timeout, bind));
 }
 
-pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout)
+pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("pull_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
@@ -57,7 +57,12 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout)
 
     int time = 0;
     d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-    d_socket->connect(address);
+
+    if (bind) {
+        d_socket->bind(address);
+    } else {
+        d_socket->connect(address);
+    }
 
     message_port_register_out(d_port);
 }

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -43,7 +43,7 @@ private:
 public:
     bool d_finished;
 
-    pull_msg_source_impl(char* address, int timeout);
+    pull_msg_source_impl(char* address, int timeout, bool bind);
     ~pull_msg_source_impl();
 
     bool start();

--- a/gr-zeromq/lib/push_msg_sink_impl.cc
+++ b/gr-zeromq/lib/push_msg_sink_impl.cc
@@ -31,12 +31,12 @@
 namespace gr {
 namespace zeromq {
 
-push_msg_sink::sptr push_msg_sink::make(char* address, int timeout)
+push_msg_sink::sptr push_msg_sink::make(char* address, int timeout, bool bind)
 {
-    return gnuradio::get_initial_sptr(new push_msg_sink_impl(address, timeout));
+    return gnuradio::get_initial_sptr(new push_msg_sink_impl(address, timeout, bind));
 }
 
-push_msg_sink_impl::push_msg_sink_impl(char* address, int timeout)
+push_msg_sink_impl::push_msg_sink_impl(char* address, int timeout, bool bind)
     : gr::block("push_msg_sink",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
@@ -54,7 +54,12 @@ push_msg_sink_impl::push_msg_sink_impl(char* address, int timeout)
 
     int time = 0;
     d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-    d_socket->bind(address);
+
+    if (bind) {
+        d_socket->bind(address);
+    } else {
+        d_socket->connect(address);
+    }
 
     message_port_register_in(pmt::mp("in"));
     set_msg_handler(pmt::mp("in"), boost::bind(&push_msg_sink_impl::handler, this, _1));

--- a/gr-zeromq/lib/push_msg_sink_impl.h
+++ b/gr-zeromq/lib/push_msg_sink_impl.h
@@ -37,7 +37,7 @@ private:
     zmq::socket_t* d_socket;
 
 public:
-    push_msg_sink_impl(char* address, int timeout);
+    push_msg_sink_impl(char* address, int timeout, bool bind);
     ~push_msg_sink_impl();
 
     void handler(pmt::pmt_t msg);

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -31,12 +31,12 @@
 namespace gr {
 namespace zeromq {
 
-rep_msg_sink::sptr rep_msg_sink::make(char* address, int timeout)
+rep_msg_sink::sptr rep_msg_sink::make(char* address, int timeout, bool bind)
 {
-    return gnuradio::get_initial_sptr(new rep_msg_sink_impl(address, timeout));
+    return gnuradio::get_initial_sptr(new rep_msg_sink_impl(address, timeout, bind));
 }
 
-rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout)
+rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
     : gr::block("rep_msg_sink",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
@@ -55,7 +55,12 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout)
 
     int time = 0;
     d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-    d_socket->bind(address);
+
+    if (bind) {
+        d_socket->bind(address);
+    } else {
+        d_socket->connect(address);
+    }
 
     message_port_register_in(d_port);
 }

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -43,7 +43,7 @@ private:
     void readloop();
 
 public:
-    rep_msg_sink_impl(char* address, int timeout);
+    rep_msg_sink_impl(char* address, int timeout, bool bind);
     ~rep_msg_sink_impl();
 
     bool start();

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -33,12 +33,12 @@
 namespace gr {
 namespace zeromq {
 
-req_msg_source::sptr req_msg_source::make(char* address, int timeout)
+req_msg_source::sptr req_msg_source::make(char* address, int timeout, bool bind)
 {
-    return gnuradio::get_initial_sptr(new req_msg_source_impl(address, timeout));
+    return gnuradio::get_initial_sptr(new req_msg_source_impl(address, timeout, bind));
 }
 
-req_msg_source_impl::req_msg_source_impl(char* address, int timeout)
+req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("req_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
@@ -57,7 +57,12 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout)
 
     int time = 0;
     d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
-    d_socket->connect(address);
+
+    if (bind) {
+        d_socket->bind(address);
+    } else {
+        d_socket->connect(address);
+    }
 
     message_port_register_out(d_port);
 }

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -43,7 +43,7 @@ private:
 public:
     bool d_finished;
 
-    req_msg_source_impl(char* address, int timeout);
+    req_msg_source_impl(char* address, int timeout, bool bind);
     ~req_msg_source_impl();
 
     bool start();

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -33,12 +33,12 @@
 namespace gr {
 namespace zeromq {
 
-sub_msg_source::sptr sub_msg_source::make(char* address, int timeout)
+sub_msg_source::sptr sub_msg_source::make(char* address, int timeout, bool bind)
 {
-    return gnuradio::get_initial_sptr(new sub_msg_source_impl(address, timeout));
+    return gnuradio::get_initial_sptr(new sub_msg_source_impl(address, timeout, bind));
 }
 
-sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout)
+sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("sub_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
@@ -56,7 +56,12 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout)
     d_socket = new zmq::socket_t(*d_context, ZMQ_SUB);
 
     d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
-    d_socket->connect(address);
+
+    if (bind) {
+        d_socket->bind(address);
+    } else {
+        d_socket->connect(address);
+    }
 
     message_port_register_out(d_port);
 }

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -43,7 +43,7 @@ private:
 public:
     bool d_finished;
 
-    sub_msg_source_impl(char* address, int timeout);
+    sub_msg_source_impl(char* address, int timeout, bool bind);
     ~sub_msg_source_impl();
 
     bool start();


### PR DESCRIPTION
…eded to support N:1 patterns. To avoid confusion, since this is probably a feature only needed by those who Know What They Are Doing, the option is added to the Advanced block property tab.

backport to maint-3.8 of #3329