### PR TITLE
runtime: Remove most manual memory management

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -148,14 +148,14 @@ private:
                                                                int delay);
 
 protected:
-    char* d_base;           // base address of buffer
+    char* d_base;           // base address of buffer inside d_vmcircbuf.
     unsigned int d_bufsize; // in items
 
     // Keep track of maximum sample delay of any reader; Only prune tags past this.
     unsigned d_max_reader_delay;
 
 private:
-    gr::vmcircbuf* d_vmcircbuf;
+    std::unique_ptr<gr::vmcircbuf> d_vmcircbuf;
     size_t d_sizeof_item; // in bytes
     std::vector<buffer_reader*> d_readers;
     std::weak_ptr<block> d_link; // block that writes to this buffer

--- a/gnuradio-runtime/include/gnuradio/hier_block2.h
+++ b/gnuradio-runtime/include/gnuradio/hier_block2.h
@@ -40,13 +40,16 @@ private:
                      gr::io_signature::sptr output_signature);
 
     /*!
-     * \brief Private implementation details of gr::hier_block2
+     * \brief Private implementation details of gr::hier_block2.
+     *
+     * This is a pointer in order to not break ABI when implementation object
+     * changes.
      */
-    hier_block2_detail* d_detail;
+    std::unique_ptr<hier_block2_detail> d_detail;
 
 
 protected:
-    hier_block2(void) {} // allows pure virtual interface sub-classes
+    hier_block2(); // allows pure virtual interface sub-classes
     hier_block2(const std::string& name,
                 gr::io_signature::sptr input_signature,
                 gr::io_signature::sptr output_signature);

--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -37,6 +37,7 @@ typedef int mode_t;
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <iostream>
+#include <memory>
 
 namespace gr {
 
@@ -302,8 +303,8 @@ private:
     /*! \brief Period (seconds) over which watcher thread checks config file for changes
      */
     unsigned int watch_period;
-    /*! \brief Pointer to watch thread for config file changes */
-    boost::thread* watch_thread;
+    /*! \brief watch thread for config file changes */
+    std::unique_ptr<boost::thread> watch_thread;
 
     /*! \brief Watcher thread method
      * /param filename Name of configuration file

--- a/gnuradio-runtime/include/gnuradio/message.h
+++ b/gnuradio-runtime/include/gnuradio/message.h
@@ -35,17 +35,16 @@ private:
     double d_arg1; // optional arg1
     double d_arg2; // optional arg2
 
-    unsigned char* d_buf_start; // start of allocated buffer
+    std::vector<unsigned char> d_buf;
     unsigned char* d_msg_start; // where the msg starts
     unsigned char* d_msg_end;   // one beyond end of msg
-    unsigned char* d_buf_end;   // one beyond end of allocated buffer
 
     message(long type, double arg1, double arg2, size_t length);
 
     friend class msg_queue;
 
-    unsigned char* buf_data() const { return d_buf_start; }
-    size_t buf_len() const { return d_buf_end - d_buf_start; }
+    unsigned char* buf_data() { return d_buf.data(); }
+    size_t buf_len() const { return d_buf.size(); }
 
 public:
     /*!

--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -20,6 +20,7 @@
 #include <boost/function.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/utility.hpp>
+#include <memory>
 
 namespace gr {
 namespace thread {
@@ -31,14 +32,14 @@ public:
     ~thread_group();
 
     boost::thread* create_thread(const boost::function0<void>& threadfunc);
-    void add_thread(boost::thread* thrd);
+    void add_thread(std::unique_ptr<boost::thread> thrd);
     void remove_thread(boost::thread* thrd);
     void join_all();
     void interrupt_all();
     size_t size() const;
 
 private:
-    std::list<boost::thread*> m_threads;
+    std::list<std::unique_ptr<boost::thread>> m_threads;
     mutable boost::shared_mutex m_mutex;
 };
 

--- a/gnuradio-runtime/include/gnuradio/top_block.h
+++ b/gnuradio-runtime/include/gnuradio/top_block.h
@@ -31,7 +31,7 @@ private:
     friend GR_RUNTIME_API top_block_sptr make_top_block(const std::string& name,
                                                         bool catch_exceptions);
 
-    top_block_impl* d_impl;
+    std::unique_ptr<top_block_impl> d_impl;
 
 protected:
     top_block(const std::string& name, bool catch_exceptions = true);

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -20,6 +20,7 @@
 #include <block_executor.h>
 #include <stdio.h>
 #include <boost/format.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/thread.hpp>
 #include <iostream>
 #include <limits>
@@ -213,11 +214,11 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
 }
 
 block_executor::block_executor(block_sptr block, int max_noutput_items)
-    : d_block(block), d_log(0), d_max_noutput_items(max_noutput_items)
+    : d_block(block), d_max_noutput_items(max_noutput_items)
 {
     if (ENABLE_LOGGING) {
         std::string name = str(boost::format("sst-%03d.log") % which_scheduler++);
-        d_log = new std::ofstream(name.c_str());
+        d_log = boost::make_unique<std::ofstream>(name.c_str());
         std::unitbuf(*d_log); // make it unbuffered...
         *d_log << "block_executor: " << d_block << std::endl;
     }
@@ -232,9 +233,6 @@ block_executor::block_executor(block_sptr block, int max_noutput_items)
 
 block_executor::~block_executor()
 {
-    if (ENABLE_LOGGING)
-        delete d_log;
-
     d_block->stop(); // stop any drivers, etc.
 }
 

--- a/gnuradio-runtime/lib/block_executor.h
+++ b/gnuradio-runtime/lib/block_executor.h
@@ -15,6 +15,7 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <fstream>
+#include <memory>
 
 namespace gr {
 
@@ -26,7 +27,7 @@ class GR_RUNTIME_API block_executor
 {
 protected:
     block_sptr d_block; // The block we're trying to run
-    std::ofstream* d_log;
+    std::unique_ptr<std::ofstream> d_log;
 
     // These are allocated here so we don't have to on each iteration
 

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -82,7 +82,6 @@ buffer::buffer(int nitems, size_t sizeof_item, block_sptr link)
     : d_base(0),
       d_bufsize(0),
       d_max_reader_delay(0),
-      d_vmcircbuf(0),
       d_sizeof_item(sizeof_item),
       d_link(link),
       d_write_index(0),
@@ -103,7 +102,6 @@ buffer_sptr make_buffer(int nitems, size_t sizeof_item, block_sptr link)
 
 buffer::~buffer()
 {
-    delete d_vmcircbuf;
     assert(d_readers.size() == 0);
     s_buffer_count--;
 }
@@ -139,7 +137,7 @@ bool buffer::allocate_buffer(int nitems, size_t sizeof_item)
     }
 
     d_bufsize = nitems;
-    d_vmcircbuf = gr::vmcircbuf_sysconfig::make(d_bufsize * d_sizeof_item);
+    d_vmcircbuf.reset(gr::vmcircbuf_sysconfig::make(d_bufsize * d_sizeof_item));
     if (d_vmcircbuf == 0) {
         std::cerr << "gr::buffer::allocate_buffer: failed to allocate buffer of size "
                   << d_bufsize * d_sizeof_item / 1024 << " KB\n";

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/flowgraph.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
+#include <boost/make_unique.hpp>
 #include <iostream>
 
 namespace gr {
@@ -30,11 +31,13 @@ hier_block2_sptr make_hier_block2(const std::string& name,
         new hier_block2(name, input_signature, output_signature));
 }
 
+hier_block2::hier_block2() {}
+
 hier_block2::hier_block2(const std::string& name,
                          gr::io_signature::sptr input_signature,
                          gr::io_signature::sptr output_signature)
     : basic_block(name, input_signature, output_signature),
-      d_detail(new hier_block2_detail(this)),
+      d_detail(boost::make_unique<hier_block2_detail>(this)),
       hier_message_ports_in(pmt::PMT_NIL),
       hier_message_ports_out(pmt::PMT_NIL)
 {
@@ -46,7 +49,6 @@ hier_block2::~hier_block2()
 {
     disconnect_all();
     gnuradio::detail::sptr_magic::cancel_initial_sptr(this);
-    delete d_detail;
 }
 
 hier_block2::opaque_self hier_block2::self() { return shared_from_this(); }

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -20,6 +20,7 @@
 
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
+#include <boost/make_unique.hpp>
 #include <algorithm>
 #include <stdexcept>
 
@@ -87,7 +88,7 @@ void logger_config::load_config(std::string filename, unsigned int watch_period)
         instance.filename = filename;
         instance.watch_period = watch_period;
         // Stop any file watching thread
-        if (instance.watch_thread != NULL)
+        if (instance.watch_thread)
             stop_watch();
         // Load configuration
         // std::cout<<"GNURadio Loading logger
@@ -95,8 +96,8 @@ void logger_config::load_config(std::string filename, unsigned int watch_period)
         logger_configured = logger_load_config(instance.filename);
         // Start watch if required
         if (instance.watch_period > 0) {
-            instance.watch_thread =
-                new boost::thread(watch_file, instance.filename, instance.watch_period);
+            instance.watch_thread = boost::make_unique<boost::thread>(
+                watch_file, instance.filename, instance.watch_period);
         }
     }
 }
@@ -108,8 +109,7 @@ void logger_config::stop_watch()
     if (instance.watch_thread) {
         instance.watch_thread->interrupt();
         instance.watch_thread->join();
-        delete (instance.watch_thread);
-        instance.watch_thread = NULL;
+        instance.watch_thread.reset();
     }
 }
 

--- a/gnuradio-runtime/lib/math/qa_fxpt_nco.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt_nco.cc
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(t1)
 {
     gr::nco<float, float> ref_nco;
     gr::fxpt_nco new_nco;
-    gr_complex* ref_block = new gr_complex[SIN_COS_BLOCK_SIZE];
-    gr_complex* new_block = new gr_complex[SIN_COS_BLOCK_SIZE];
+    std::vector<gr_complex> ref_block(SIN_COS_BLOCK_SIZE);
+    std::vector<gr_complex> new_block(SIN_COS_BLOCK_SIZE);
     double max_error = 0;
 
     ref_nco.set_freq((float)(2 * GR_M_PI / SIN_COS_FREQ));
@@ -81,8 +81,8 @@ BOOST_AUTO_TEST_CASE(t1)
 
     BOOST_CHECK(std::abs(ref_nco.get_freq() - new_nco.get_freq()) <= SIN_COS_TOLERANCE);
 
-    ref_nco.sincos((gr_complex*)ref_block, SIN_COS_BLOCK_SIZE);
-    new_nco.sincos((gr_complex*)new_block, SIN_COS_BLOCK_SIZE);
+    ref_nco.sincos((gr_complex*)ref_block.data(), SIN_COS_BLOCK_SIZE);
+    new_nco.sincos((gr_complex*)new_block.data(), SIN_COS_BLOCK_SIZE);
 
     for (int i = 0; i < SIN_COS_BLOCK_SIZE; i++) {
         BOOST_CHECK(std::abs(ref_block[i].real() - new_block[i].real()) <=
@@ -96,6 +96,4 @@ BOOST_AUTO_TEST_CASE(t1)
     BOOST_CHECK(std::abs(ref_nco.get_phase() - new_nco.get_phase()) <= SIN_COS_TOLERANCE);
     // printf ("Fxpt  max error %.9f, max phase error %.9f\n", max_error,
     // max_phase_error);
-    delete[] ref_block;
-    delete[] new_block;
 }

--- a/gnuradio-runtime/lib/math/qa_fxpt_vco.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt_vco.cc
@@ -64,17 +64,19 @@ BOOST_AUTO_TEST_CASE(t1)
 {
     gr::vco<float, float> ref_vco;
     gr::fxpt_vco new_vco;
-    float* ref_block = new float[SIN_COS_BLOCK_SIZE];
-    float* new_block = new float[SIN_COS_BLOCK_SIZE];
-    float* input = new float[SIN_COS_BLOCK_SIZE];
+    std::vector<float> ref_block(SIN_COS_BLOCK_SIZE);
+    std::vector<float> new_block(SIN_COS_BLOCK_SIZE);
+    std::vector<float> input(SIN_COS_BLOCK_SIZE);
     double max_error = 0;
 
     for (int i = 0; i < SIN_COS_BLOCK_SIZE; i++) {
         input[i] = sin(double(i));
     }
 
-    ref_vco.cos(ref_block, input, SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
-    new_vco.cos(new_block, input, SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
+    ref_vco.cos(
+        ref_block.data(), input.data(), SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
+    new_vco.cos(
+        new_block.data(), input.data(), SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
 
     for (int i = 0; i < SIN_COS_BLOCK_SIZE; i++) {
         BOOST_CHECK(std::abs(ref_block[i] - new_block[i]) <= SIN_COS_TOLERANCE);
@@ -83,9 +85,6 @@ BOOST_AUTO_TEST_CASE(t1)
     BOOST_CHECK(std::abs(ref_vco.get_phase() - new_vco.get_phase()) <= SIN_COS_TOLERANCE);
     // printf ("Fxpt  max error %.9f, max phase error %.9f\n", max_error,
     // ref_vco.get_phase()-new_vco.get_phase());
-    delete[] ref_block;
-    delete[] new_block;
-    delete[] input;
 }
 
 
@@ -93,17 +92,19 @@ BOOST_AUTO_TEST_CASE(t2)
 {
     gr::vco<gr_complex, float> ref_vco;
     gr::fxpt_vco new_vco;
-    gr_complex* ref_block = new gr_complex[SIN_COS_BLOCK_SIZE];
-    gr_complex* new_block = new gr_complex[SIN_COS_BLOCK_SIZE];
-    float* input = new float[SIN_COS_BLOCK_SIZE];
+    std::vector<gr_complex> ref_block(SIN_COS_BLOCK_SIZE);
+    std::vector<gr_complex> new_block(SIN_COS_BLOCK_SIZE);
+    std::vector<float> input(SIN_COS_BLOCK_SIZE);
     double max_error = 0;
 
     for (int i = 0; i < SIN_COS_BLOCK_SIZE; i++) {
         input[i] = sin(double(i));
     }
 
-    ref_vco.sincos(ref_block, input, SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
-    new_vco.sincos(new_block, input, SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
+    ref_vco.sincos(
+        ref_block.data(), input.data(), SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
+    new_vco.sincos(
+        new_block.data(), input.data(), SIN_COS_BLOCK_SIZE, SIN_COS_K, SIN_COS_AMPL);
 
     for (int i = 0; i < SIN_COS_BLOCK_SIZE; i++) {
         BOOST_CHECK(std::abs(ref_block[i] - new_block[i]) <= SIN_COS_TOLERANCE);
@@ -112,7 +113,4 @@ BOOST_AUTO_TEST_CASE(t2)
     BOOST_CHECK(std::abs(ref_vco.get_phase() - new_vco.get_phase()) <= SIN_COS_TOLERANCE);
     // printf ("Fxpt  max error %.9f, max phase error %.9f\n", max_error,
     // ref_vco.get_phase()-new_vco.get_phase());
-    delete[] ref_block;
-    delete[] new_block;
-    delete[] input;
 }

--- a/gnuradio-runtime/lib/message.cc
+++ b/gnuradio-runtime/lib/message.cc
@@ -34,14 +34,13 @@ message::make_from_string(const std::string s, long type, double arg1, double ar
 }
 
 message::message(long type, double arg1, double arg2, size_t length)
-    : d_type(type), d_arg1(arg1), d_arg2(arg2)
+    : d_type(type), d_arg1(arg1), d_arg2(arg2), d_buf(length)
 {
     if (length == 0)
-        d_buf_start = d_msg_start = d_msg_end = d_buf_end = 0;
+        d_msg_start = d_msg_end = nullptr;
     else {
-        d_buf_start = new unsigned char[length];
-        d_msg_start = d_buf_start;
-        d_msg_end = d_buf_end = d_buf_start + length;
+        d_msg_start = d_buf.data();
+        d_msg_end = d_msg_start + length;
     }
     s_ncurrently_allocated++;
 }
@@ -49,8 +48,6 @@ message::message(long type, double arg1, double arg2, size_t length)
 message::~message()
 {
     assert(d_next == 0);
-    delete[] d_buf_start;
-    d_msg_start = d_msg_end = d_buf_end = 0;
     s_ncurrently_allocated--;
 }
 

--- a/gnuradio-runtime/lib/top_block.cc
+++ b/gnuradio-runtime/lib/top_block.cc
@@ -18,6 +18,7 @@
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
 #include <unistd.h>
+#include <boost/make_unique.hpp>
 #include <iostream>
 
 namespace gr {
@@ -27,17 +28,15 @@ top_block_sptr make_top_block(const std::string& name, bool catch_exceptions)
 }
 
 top_block::top_block(const std::string& name, bool catch_exceptions)
-    : hier_block2(name, io_signature::make(0, 0, 0), io_signature::make(0, 0, 0))
+    : hier_block2(name, io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
+      d_impl(boost::make_unique<top_block_impl>(this, catch_exceptions))
 {
-    d_impl = new top_block_impl(this, catch_exceptions);
 }
 
 top_block::~top_block()
 {
     stop();
     wait();
-
-    delete d_impl;
 }
 
 void top_block::start(int max_noutput_items)


### PR DESCRIPTION
The remaining ones:
* `pmt_pool.cc`, which is a memory allocator so that makes sense
* the tricky and aptly named `sptr_magic.cc`.