### PR TITLE
replace stderr logging by calls to GR's logging facilties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 
 ## [3.9.0.0] - Unreleased
 
+### Changed
+
+#### Project Scope
+
+- Logging: removed all `std::cerr` and `fprintf(stderr,…)` by GNU Radio logging
+- Logging: Changed logging format for many multiline error logs
+
 ## [3.8.0.0] - 2019-08-09
 
 Witness me!

--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -13,6 +13,7 @@
 #endif
 
 #include <gnuradio/constants.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/sys_paths.h>
 #include <boost/format.hpp>
@@ -44,8 +45,9 @@ int main(int argc, char** argv)
         po::store(po::parse_command_line(argc, argv, desc), vm);
         po::notify(vm);
     } catch (po::error& error) {
-        std::cerr << "Error: " << error.what() << std::endl << std::endl;
-        std::cerr << desc << std::endl;
+        gr::logger_ptr logger, debug_logger;
+        gr::configure_default_loggers(logger, debug_logger, "gnuradio-config-info.cc");
+        GR_LOG_ERROR(logger, boost::format("ERROR %s %s") % error.what() % desc);
         return 1;
     }
 

--- a/gnuradio-runtime/include/gnuradio/block_detail.h
+++ b/gnuradio-runtime/include/gnuradio/block_detail.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/high_res_timer.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <gnuradio/tpb_detail.h>
@@ -231,6 +232,10 @@ public:
     int d_produce_or;
 
     int consumed() const;
+
+    // necessary because stupidly block_executor.cc's "propagate_tags" is a function, not
+    // any class member
+    gr::logger_ptr d_logger, d_debug_logger;
 
     // ----------------------------------------------------------------------------
 

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -12,9 +12,11 @@
 #define INCLUDED_GR_RUNTIME_BUFFER_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <gnuradio/thread/thread.h>
+#include <boost/weak_ptr.hpp>
 #include <map>
 #include <memory>
 
@@ -44,6 +46,9 @@ GR_RUNTIME_API buffer_sptr make_buffer(int nitems,
 class GR_RUNTIME_API buffer
 {
 public:
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
     virtual ~buffer();
 
     /*!

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -13,6 +13,7 @@
 
 #include "thrift/ControlPort.h"
 #include "thrift/gnuradio_types.h"
+#include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
 #include <boost/format.hpp>
@@ -29,6 +30,9 @@
 class rpcserver_thrift : public virtual rpcserver_base, public GNURadio::ControlPortIf
 {
 public:
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
     rpcserver_thrift();
     virtual ~rpcserver_thrift();
 
@@ -100,9 +104,11 @@ private:
         if (cur_priv <= _handlerCallback.priv) {
             _handlerCallback.callback->post(port, msg);
         } else {
-            std::cerr << "Message " << _handlerCallback.description
-                      << " requires PRIVLVL <= " << _handlerCallback.priv
-                      << " to set, currently at: " << cur_priv << std::endl;
+            std::ostringstream msg;
+            msg << _handlerCallback.description
+                << " requires PRIVLVL <= " << _handlerCallback.priv
+                << " to set, currently at: " << cur_priv;
+            GR_LOG_ERROR(logger, msg.str());
         }
     }
 
@@ -123,9 +129,11 @@ private:
                     (*iter->second.callback)
                         .post(pmt::PMT_NIL, rpcpmtconverter::To_PMT::instance(p.second));
                 } else {
-                    std::cerr << "Key " << p.first
-                              << " requires PRIVLVL <= " << iter->second.priv
-                              << " to set, currently at: " << cur_priv << std::endl;
+                    std::ostringstream msg;
+                    msg << "Key " << p.first
+                        << " requires PRIVLVL <= " << iter->second.priv
+                        << " to set, currently at: " << cur_priv;
+                    GR_LOG_ERROR(logger, msg.str());
                 }
             } else {
                 throw apache::thrift::TApplicationException(__FILE__ " " S__LINE__);
@@ -153,14 +161,16 @@ private:
                     outknobs[p] =
                         rpcpmtconverter::from_pmt((*iter->second.callback).retrieve());
                 } else {
-                    std::cerr << "Key " << iter->first
-                              << " requires PRIVLVL: <= " << iter->second.priv
-                              << " to get, currently at: " << cur_priv << std::endl;
+                    std::ostringstream msg;
+                    msg << "Key " << iter->first
+                        << " requires PRIVLVL: <= " << iter->second.priv
+                        << " to get, currently at: " << cur_priv;
+                    GR_LOG_ERROR(logger, msg.str());
                 }
             } else {
-                std::stringstream ss;
-                ss << "Ctrlport Key called with unregistered key (" << p << ")\n";
-                std::cerr << ss.str();
+                std::ostringstream smsgs;
+                msg << "Ctrlport Key called with unregistered key (" << p << ")\n";
+                GR_LOG_ERROR(logger, ss.str());
                 throw apache::thrift::TApplicationException(__FILE__ " " S__LINE__);
             }
         }
@@ -184,8 +194,10 @@ private:
                 outknobs[p.first] =
                     rpcpmtconverter::from_pmt(p.second.callback->retrieve());
             } else {
-                std::cerr << "Key " << p.first << " requires PRIVLVL <= " << p.second.priv
-                          << " to get, currently at: " << cur_priv << std::endl;
+                std::ostringstream msg;
+                msg << "Key " << p.first << " requires PRIVLVL: <= " << p.second.priv
+                    << " to get, currently at: " << cur_priv;
+                GR_LOG_ERROR(logger, msg.str());
             }
         }
 
@@ -216,8 +228,10 @@ private:
                 prop.display = static_cast<uint32_t>(p.second.display);
                 outknobs[p.first] = prop;
             } else {
-                std::cerr << "Key " << p.first << " requires PRIVLVL <= " << p.second.priv
-                          << " to get, currently at: " << cur_priv << std::endl;
+                std::ostringstream msg;
+                msg << "Key " << p.first << " requires PRIVLVL: <= " << p.second.priv
+                    << " to get, currently at: " << cur_priv;
+                GR_LOG_ERROR(logger, msg.str());
             }
         }
 
@@ -250,9 +264,11 @@ private:
                     prop.display = static_cast<uint32_t>(iter->second.display);
                     outknobs[p] = prop;
                 } else {
-                    std::cerr << "Key " << iter->first
-                              << " requires PRIVLVL: <= " << iter->second.priv
-                              << " to get, currently at: " << cur_priv << std::endl;
+                    std::ostringstream msg;
+                    msg << "Key " << iter->first
+                        << " requires PRIVLVL: <= " << iter->second.priv
+                        << " to get, currently at: " << cur_priv;
+                    GR_LOG_ERROR(logger, msg.str());
                 }
             } else {
                 throw apache::thrift::TApplicationException(__FILE__ " " S__LINE__);

--- a/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
@@ -12,6 +12,7 @@
 #define INCLUDED_THREAD_BODY_WRAPPER_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/thread/thread.h>
 #include <exception>
 #include <iostream>
@@ -28,6 +29,8 @@ private:
     F d_f;
     std::string d_name;
     bool d_catch_exceptions;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
 public:
     explicit thread_body_wrapper(F f,
@@ -35,6 +38,7 @@ public:
                                  bool catch_exceptions = true)
         : d_f(f), d_name(name), d_catch_exceptions(catch_exceptions)
     {
+        gr::configure_default_loggers(d_logger, d_debug_logger, "thread_body_wrapper");
     }
 
     void operator()()
@@ -46,10 +50,13 @@ public:
                 d_f();
             } catch (boost::thread_interrupted const&) {
             } catch (std::exception const& e) {
-                std::cerr << "thread[" << d_name << "]: " << e.what() << std::endl;
+                std::ostringstream msg;
+                msg << "ERROR thread[" << d_name << "]: " << e.what();
+                GR_LOG_ERROR(d_logger, msg.str());
             } catch (...) {
-                std::cerr << "thread[" << d_name << "]: "
-                          << "caught unrecognized exception\n";
+                std::ostringstream msg;
+                msg << "ERROR thread[" << d_name << "]: caught unrecognized exception";
+                GR_LOG_ERROR(d_logger, msg.str());
             }
 
         } else {

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -14,6 +14,7 @@
 
 #include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
+#include <gnuradio/logger.h>
 #include <iostream>
 
 namespace gr {
@@ -50,6 +51,7 @@ block_detail::block_detail(unsigned int ninputs, unsigned int noutputs)
 {
     s_ncurrently_allocated++;
     d_pc_start_time = gr::high_res_timer_now();
+    gr::configure_default_loggers(d_logger, d_debug_logger, "block_detail");
 }
 
 block_detail::~block_detail()
@@ -220,7 +222,7 @@ void block_detail::set_processor_affinity(const std::vector<int>& mask)
         try {
             gr::thread::thread_bind_to_processor(thread, mask);
         } catch (std::runtime_error& e) {
-            std::cerr << "set_processor_affinity: invalid mask." << std::endl;
+            GR_LOG_ERROR(d_logger, "set_processor_affinity: invalid mask.");
         }
     }
 }

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/block.h>
 #include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <assert.h>
 #include <block_executor.h>
@@ -41,8 +42,6 @@ namespace gr {
         ;      \
     } while (0)
 #endif
-
-static int which_scheduler = 0;
 
 inline static unsigned int round_up(unsigned int n, unsigned int multiple)
 {
@@ -201,9 +200,10 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
                 }
             }
         } else {
-            std::cerr << "Error: block_executor: propagation_policy 'ONE-TO-ONE' "
-                         "requires ninputs == noutputs"
-                      << std::endl;
+            std::ostringstream msg;
+            msg << "block_executor: propagation_policy 'ONE-TO-ONE'";
+            msg << " requires ninputs == noutputs";
+            GR_LOG_ERROR(d->d_logger, msg.str());
             return false;
         }
         break;
@@ -216,12 +216,7 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
 block_executor::block_executor(block_sptr block, int max_noutput_items)
     : d_block(block), d_max_noutput_items(max_noutput_items)
 {
-    if (ENABLE_LOGGING) {
-        std::string name = str(boost::format("sst-%03d.log") % which_scheduler++);
-        d_log = boost::make_unique<std::ofstream>(name.c_str());
-        std::unitbuf(*d_log); // make it unbuffered...
-        *d_log << "block_executor: " << d_block << std::endl;
-    }
+    gr::configure_default_loggers(d_logger, d_debug_logger, "block_executor");
 
 #ifdef GR_PERFORMANCE_COUNTERS
     prefs* prefs = prefs::singleton();
@@ -247,7 +242,7 @@ block_executor::state block_executor::run_one_iteration()
     block* m = d_block.get();
     block_detail* d = m->detail().get();
 
-    LOG(*d_log << std::endl << m);
+    LOG(std::ostringstream msg; msg << m; GR_LOG_INFO(d_debug_logger, msg.str()););
 
     max_noutput_items = round_down(d_max_noutput_items, m->output_multiple());
 
@@ -268,12 +263,13 @@ block_executor::state block_executor::run_one_iteration()
         noutput_items =
             min_available_space(d, m->output_multiple(), m->min_noutput_items());
         noutput_items = std::min(noutput_items, max_noutput_items);
-        LOG(*d_log << " source\n  noutput_items = " << noutput_items << std::endl);
+        LOG(std::ostringstream msg; msg << "source:  noutput_items = " << noutput_items;
+            GR_LOG_INFO(d_debug_logger, msg.str()););
         if (noutput_items == -1) // we're done
             goto were_done;
 
         if (noutput_items == 0) { // we're output blocked
-            LOG(*d_log << "  BLKD_OUT\n");
+            LOG(GR_LOG_INFO(d_debug_logger, "BLKD_OUT"););
             return BLKD_OUT;
         }
 
@@ -287,7 +283,7 @@ block_executor::state block_executor::run_one_iteration()
         d_input_done.resize(d->ninputs());
         d_output_items.resize(0);
         d_start_nitems_read.resize(d->ninputs());
-        LOG(*d_log << " sink\n");
+        LOG(GR_LOG_INFO(d_debug_logger, "sink"););
 
         max_items_avail = 0;
         for (int i = 0; i < d->ninputs(); i++) {
@@ -301,10 +297,12 @@ block_executor::state block_executor::run_one_iteration()
                 d_input_done[i] = in_buf->done();
             }
 
-            LOG(*d_log << "  d_ninput_items[" << i << "] = " << d_ninput_items[i]
-                       << std::endl);
-            LOG(*d_log << "  d_input_done[" << i << "] = " << d_input_done[i]
-                       << std::endl);
+            LOG(std::ostringstream msg;
+                msg << "d_ninput_items[" << i << "] = " << d_ninput_items[i];
+                GR_LOG_INFO(d_debug_logger, msg.str()););
+            LOG(std::ostringstream msg;
+                msg << "d_input_done[" << i << "] = " << d_input_done[i];
+                GR_LOG_INFO(d_debug_logger, msg.str()););
 
             if (d_ninput_items[i] < m->output_multiple() && d_input_done[i])
                 goto were_done;
@@ -316,11 +314,13 @@ block_executor::state block_executor::run_one_iteration()
         noutput_items = (int)(max_items_avail * m->relative_rate());
         noutput_items = round_down(noutput_items, m->output_multiple());
         noutput_items = std::min(noutput_items, max_noutput_items);
-        LOG(*d_log << "  max_items_avail = " << max_items_avail << std::endl);
-        LOG(*d_log << "  noutput_items = " << noutput_items << std::endl);
+        LOG(std::ostringstream msg; msg << "max_items_avail = " << max_items_avail;
+            GR_LOG_INFO(d_debug_logger, msg.str()););
+        LOG(std::ostringstream msg; msg << "noutput_items = " << noutput_items;
+            GR_LOG_INFO(d_debug_logger, msg.str()););
 
         if (noutput_items == 0) { // we're blocked on input
-            LOG(*d_log << "  BLKD_IN\n");
+            LOG(GR_LOG_INFO(d_debug_logger, "BLKD_IN"););
             return BLKD_IN;
         }
 
@@ -354,16 +354,18 @@ block_executor::state block_executor::run_one_iteration()
         noutput_items =
             min_available_space(d, m->output_multiple(), m->min_noutput_items());
         if (ENABLE_LOGGING) {
-            *d_log << " regular ";
-            *d_log << m->relative_rate_i() << ":" << m->relative_rate_d() << std::endl;
-            *d_log << "  max_items_avail = " << max_items_avail << std::endl;
-            *d_log << "  noutput_items = " << noutput_items << std::endl;
+            std::ostringstream msg;
+            msg << "regular ";
+            msg << m->relative_rate_i() << ":" << m->relative_rate_d();
+            msg << "  max_items_avail = " << max_items_avail;
+            msg << "  noutput_items = " << noutput_items;
+            GR_LOG_INFO(d_debug_logger, msg.str());
         }
         if (noutput_items == -1) // we're done
             goto were_done;
 
         if (noutput_items == 0) { // we're output blocked
-            LOG(*d_log << "  BLKD_OUT\n");
+            LOG(GR_LOG_INFO(d_debug_logger, "BLKD_OUT"););
             return BLKD_OUT;
         }
 
@@ -428,12 +430,13 @@ block_executor::state block_executor::run_one_iteration()
                 break;
 
             if (d_ninput_items_required[i] < 0) {
-                std::cerr << "\nsched: <block " << m->name() << " (" << m->unique_id()
-                          << ")>"
-                          << " thinks its ninput_items required is "
-                          << d_ninput_items_required[i] << " and cannot be negative.\n"
-                          << "Some parameterization is wrong. "
-                          << "Too large a decimation value?\n\n";
+                std::ostringstream msg;
+                msg << "sched: <block " << m->name() << " (" << m->unique_id() << ")>"
+                    << " thinks its ninput_items required is "
+                    << d_ninput_items_required[i] << " and cannot be negative."
+                    << "Some parameterization is wrong. "
+                    << "Too large a decimation value?";
+                GR_LOG_ERROR(d_logger, msg.str());
                 goto were_done;
             }
         }
@@ -447,7 +450,7 @@ block_executor::state block_executor::run_one_iteration()
             }
 
             // We're blocked on input
-            LOG(*d_log << "  BLKD_IN\n");
+            LOG(GR_LOG_INFO(d_debug_logger, "BLKD_IN"););
             if (d_input_done[i]) // If the upstream block is done, we're done
                 goto were_done;
 
@@ -455,14 +458,15 @@ block_executor::state block_executor::run_one_iteration()
             buffer_reader_sptr in_buf = d->input(i);
             if (d_ninput_items_required[i] > in_buf->max_possible_items_available()) {
                 // Nope, never going to happen...
-                std::cerr
-                    << "\nsched: <block " << m->name() << " (" << m->unique_id() << ")>"
-                    << " is requesting more input data\n"
-                    << "  than we can provide.\n"
-                    << "  ninput_items_required = " << d_ninput_items_required[i] << "\n"
+                std::ostringstream msg;
+                msg << "sched: <block " << m->name() << " (" << m->unique_id() << ")>"
+                    << " is requesting more input data"
+                    << "  than we can provide."
+                    << "  ninput_items_required = " << d_ninput_items_required[i]
                     << "  max_possible_items_available = "
-                    << in_buf->max_possible_items_available() << "\n"
-                    << "  If this is a filter, consider reducing the number of taps.\n";
+                    << in_buf->max_possible_items_available()
+                    << "  If this is a filter, consider reducing the number of taps.";
+                GR_LOG_ERROR(d_logger, msg.str());
                 goto were_done;
             }
 
@@ -504,8 +508,9 @@ block_executor::state block_executor::run_one_iteration()
             d->stop_perf_counters(noutput_items, n);
 #endif /* GR_PERFORMANCE_COUNTERS */
 
-        LOG(*d_log << "  general_work: noutput_items = " << noutput_items
-                   << " result = " << n << std::endl);
+        LOG(std::ostringstream msg;
+            msg << "general_work: noutput_items = " << noutput_items << " result = " << n;
+            GR_LOG_INFO(d_debug_logger, msg.str()););
 
         // Adjust number of unaligned items left to process
         if (m->is_unaligned()) {
@@ -564,7 +569,7 @@ block_executor::state block_executor::run_one_iteration()
     assert(0);
 
 were_done:
-    LOG(*d_log << "  were_done\n");
+    LOG(GR_LOG_INFO(d_debug_logger, "we're done"););
     d->set_done(true);
     return DONE;
 }

--- a/gnuradio-runtime/lib/block_executor.h
+++ b/gnuradio-runtime/lib/block_executor.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_RUNTIME_BLOCK_EXECUTOR_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <fstream>
@@ -27,7 +28,8 @@ class GR_RUNTIME_API block_executor
 {
 protected:
     block_sptr d_block; // The block we're trying to run
-    std::unique_ptr<std::ofstream> d_log;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
     // These are allocated here so we don't have to on each iteration
 

--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -9,6 +9,7 @@
 
 #include "thrift/gnuradio_types.h"
 #include <gnuradio/gr_complex.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <boost/assign/ptr_map_inserter.hpp>
 #include <iostream>
@@ -109,8 +110,12 @@ GNURadio::Knob rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
         result.value.__set_a_c32vector(z);
         return result;
     } else {
-        std::cerr << "Error: Don't know how to handle Knob Type (from): " << knob
-                  << std::endl;
+        // FIXME: Don't get loggers every time we need to log something.
+        gr::logger_ptr logger, debug_logger;
+        gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
+        std::ostringstream msg;
+        msg << "ERROR Don't know how to handle Knob Type (from): " << knob;
+        GR_LOG_ERROR(logger, msg.str());
         assert(0);
     }
     return GNURadio::Knob();
@@ -250,7 +255,12 @@ rpcpmtconverter::to_pmt_reg<TO_PMT_F>::to_pmt_reg(To_PMT& instance,
 
 pmt::pmt_t rpcpmtconverter::to_pmt_f::operator()(const GNURadio::Knob& knob)
 {
-    std::cerr << "Error: Don't know how to handle Knob Type: " << knob.type << std::endl;
+    // FIXME: Don't get loggers every time we need to log something.
+    gr::logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
+    std::ostringstream msg;
+    msg << "ERROR Don't know how to handle Knob Type (from): " << knob.type;
+    GR_LOG_ERROR(debug_logger, msg.str());
     assert(0);
     return pmt::pmt_t();
 }

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
@@ -25,12 +25,13 @@ using namespace rpcpmtconverter;
 
 rpcserver_thrift::rpcserver_thrift()
 {
-    // std::cerr << "rpcserver_thrift::ctor" << std::endl;
+    gr::configure_default_loggers(logger, debug_logger, "rpcserver_thrift");
+    // std::cerr << "rpcserver_thrift::ctor" ;
 }
 
 rpcserver_thrift::~rpcserver_thrift()
 {
-    // std::cerr << "rpcserver_thrift::dtor" << std::endl;
+    // std::cerr << "rpcserver_thrift::dtor" ;
 }
 
 void rpcserver_thrift::registerConfigureCallback(const std::string& id,
@@ -43,13 +44,15 @@ void rpcserver_thrift::registerConfigureCallback(const std::string& id,
             std::stringstream s;
             s << "rpcserver_thrift:: rpcserver_thrift ERROR registering set, already "
                  "registered: "
-              << id << std::endl;
+              << id;
             throw std::runtime_error(s.str().c_str());
         }
     }
 
     if (DEBUG) {
-        std::cerr << "rpcserver_thrift registering set: " << id << std::endl;
+        std::ostringstream msg;
+        msg << "registering set: " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
     }
     d_setcallbackmap.insert(ConfigureCallbackMap_t::value_type(id, callback));
 }
@@ -62,12 +65,15 @@ void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
         std::stringstream s;
         s << "rpcserver_thrift:: rpcserver_thrift ERROR unregistering set, not "
              "registered: "
-          << id << std::endl;
+          << id;
         throw std::runtime_error(s.str().c_str());
     }
 
-    if (DEBUG)
-        std::cerr << "rpcserver_thrift unregistering set: " << id << std::endl;
+    if (DEBUG) {
+        std::ostringstream msg;
+        msg << "unregistering set: " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
+    }
 
     d_setcallbackmap.erase(iter);
 }
@@ -82,13 +88,15 @@ void rpcserver_thrift::registerQueryCallback(const std::string& id,
             std::stringstream s;
             s << "rpcserver_thrift:: rpcserver_thrift ERROR registering get, already "
                  "registered: "
-              << id << std::endl;
+              << id;
             throw std::runtime_error(s.str().c_str());
         }
     }
 
     if (DEBUG) {
-        std::cerr << "rpcserver_thrift registering get: " << id << std::endl;
+        std::ostringstream msg;
+        msg << "registering get: " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
     }
     d_getcallbackmap.insert(QueryCallbackMap_t::value_type(id, callback));
 }
@@ -100,12 +108,14 @@ void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
     if (iter == d_getcallbackmap.end()) {
         std::stringstream s;
         s << "rpcserver_thrift:: rpcserver_thrift ERROR unregistering get,  registered: "
-          << id << std::endl;
+          << id;
         throw std::runtime_error(s.str().c_str());
     }
 
     if (DEBUG) {
-        std::cerr << "rpcserver_thrift unregistering get: " << id << std::endl;
+        std::ostringstream msg;
+        msg << "unregistering get: " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
     }
 
     d_getcallbackmap.erase(iter);
@@ -122,13 +132,15 @@ void rpcserver_thrift::registerHandlerCallback(const std::string& id,
             std::stringstream s;
             s << "rpcserver_thrift:: rpcserver_thrift ERROR registering handler, already "
                  "registered: "
-              << id << std::endl;
+              << id;
             throw std::runtime_error(s.str().c_str());
         }
     }
 
     if (DEBUG) {
-        std::cerr << "rpcserver_thrift registering handler: " << id << std::endl;
+        std::ostringstream msg;
+        msg << "registering handler: " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
     }
     d_handlercallbackmap.insert(HandlerCallbackMap_t::value_type(id, callback));
 }
@@ -141,12 +153,14 @@ void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
         std::stringstream s;
         s << "rpcserver_thrift:: rpcserver_thrift ERROR unregistering handler, "
              "registered: "
-          << id << std::endl;
+          << id;
         throw std::runtime_error(s.str().c_str());
     }
 
     if (DEBUG) {
-        std::cerr << "rpcserver_thrift unregistering handler: " << id << std::endl;
+        std::ostringstream msg;
+        msg << "unregistering handler: " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
     }
 
     d_handlercallbackmap.erase(iter);
@@ -258,6 +272,8 @@ void rpcserver_thrift::postMessage(const std::string& alias,
 void rpcserver_thrift::shutdown()
 {
     if (DEBUG) {
-        std::cerr << "Shutting down..." << std::endl;
+        std::ostringstream msg;
+        msg << "shutting down... " << id;
+        GR_LOG_INFO(d_debug_logger, msg.str());
     }
 }

--- a/gnuradio-runtime/lib/local_sighandler.cc
+++ b/gnuradio-runtime/lib/local_sighandler.cc
@@ -31,8 +31,10 @@ local_sighandler::local_sighandler(int signum, void (*new_handler)(int))
     sigemptyset(&new_action.sa_mask);
     new_action.sa_flags = 0;
 
+    gr::configure_default_loggers(d_logger, d_debug_logger, "local_sighandler");
     if (sigaction(d_signum, &new_action, &d_old_action) < 0) {
-        perror("sigaction (install new)");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("sigaction (install new): %s") % strerror(errno))
         throw std::runtime_error("sigaction");
     }
 #endif
@@ -42,7 +44,8 @@ local_sighandler::~local_sighandler() noexcept(false)
 {
 #ifdef HAVE_SIGACTION
     if (sigaction(d_signum, &d_old_action, 0) < 0) {
-        perror("sigaction (restore old)");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("sigaction (restore old): %s") % strerror(errno))
         throw std::runtime_error("sigaction");
     }
 #endif

--- a/gnuradio-runtime/lib/local_sighandler.h
+++ b/gnuradio-runtime/lib/local_sighandler.h
@@ -16,6 +16,7 @@
 #endif
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
 #include <string>
 
 namespace gr {
@@ -36,6 +37,8 @@ private:
 #endif
 
 public:
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
     local_sighandler(int signum, void (*new_handler)(int));
     ~local_sighandler() noexcept(false);
 

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -12,6 +12,9 @@
 #include "config.h"
 #endif
 
+#include <gnuradio/logger.h>
+#include <gnuradio/prefs.h>
+
 #include "pagesize.h"
 #include <stdio.h>
 #include <unistd.h>
@@ -25,6 +28,8 @@ extern "C" size_t getpagesize(void);
 int pagesize()
 {
     static int s_pagesize = -1;
+    gr::logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "pagesize");
 
     if (s_pagesize == -1) {
 #if defined(HAVE_GETPAGESIZE)
@@ -32,11 +37,11 @@ int pagesize()
 #elif defined(HAVE_SYSCONF)
         s_pagesize = sysconf(_SC_PAGESIZE);
         if (s_pagesize == -1) {
-            perror("_SC_PAGESIZE");
+            GR_LOG_ERROR(logger, boost::format("_SC_PAGESIZE: %s") strerror(errno));
             s_pagesize = 4096;
         }
 #else
-        fprintf(stderr, "gr::pagesize: no info; setting pagesize = 4096\n");
+        GR_LOG_ERROR(logger, "no info; setting pagesize = 4096");
         s_pagesize = 4096;
 #endif
     }

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -12,6 +12,8 @@
 #include <config.h>
 #endif
 
+#include <gnuradio/logger.h>
+#include <gnuradio/prefs.h>
 #include <gnuradio/realtime_impl.h>
 
 #ifdef HAVE_SCHED_H
@@ -109,8 +111,12 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
         if (result == EPERM) // N.B., return value, not errno
             return RT_NO_PRIVS;
         else {
-            fprintf(stderr,
-                    "pthread_setschedparam: failed to set real time priority: %s\n",
+            gr::logger_ptr logger, debug_logger;
+            gr::configure_default_loggers(logger, debug_logger, "realtime_impl");
+            GR_LOG_ERROR(
+                logger,
+                boost::format(
+                    "pthread_setschedparam: failed to set real time priority: %s") %
                     strerror(result));
             return RT_OTHER_ERROR;
         }
@@ -148,7 +154,11 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
         if (errno == EPERM)
             return RT_NO_PRIVS;
         else {
-            perror("sched_setscheduler: failed to set real time priority");
+            gr::logger_ptr logger, debug_logger;
+            gr::configure_default_loggers(logger, debug_logger, "realtime_impl");
+            GR_LOG_ERROR(
+                logger,
+                boost::format("sched_setscheduler: failed to set real time priority."));
             return RT_OTHER_ERROR;
         }
     }

--- a/gnuradio-runtime/lib/test.cc
+++ b/gnuradio-runtime/lib/test.cc
@@ -92,13 +92,12 @@ int test::general_work(int noutput_items,
     for (unsigned i = 0; i < ninputs; i++) {
         char* in = (char*)input_items[i];
         if (ninput_items[i] < (int)(noutput_items + history())) {
-            std::cerr << "ERROR: ninput_items[" << i << "] < noutput_items+history()"
-                      << std::endl;
-            std::cerr << "ninput_items[" << i << "] = " << ninput_items[i] << std::endl;
-            std::cerr << "noutput_items+history() = " << noutput_items + history()
-                      << std::endl;
-            std::cerr << "noutput_items = " << noutput_items << std::endl;
-            std::cerr << "history() = " << history() << std::endl;
+            std::ostringstream msg;
+            msg << "ninput_items[" << i << "] < noutput_items+history()"
+                << "ninput_items[" << i << "] = " << ninput_items[i]
+                << "noutput_items+history() = " << (noutput_items + history())
+                << "noutput_items = " << noutput_items << "history() = " << history();
+            GR_LOG_ERROR(d_logger, msg.str());
             throw std::runtime_error("test");
         } else {
             for (int j = 0; j < ninput_items[i]; j++) {

--- a/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
+++ b/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
@@ -12,6 +12,7 @@
 #include <config.h>
 #endif
 
+#include <gnuradio/logger.h>
 #include <gnuradio/thread/thread_body_wrapper.h>
 
 #ifdef HAVE_SIGNAL_H
@@ -63,8 +64,13 @@ void mask_signals()
     sigaddset(&new_set, SIGXFSZ);
 #endif
     r = pthread_sigmask(SIG_BLOCK, &new_set, 0);
-    if (r != 0)
-        perror("pthread_sigmask");
+    if (r != 0) {
+        // FIXME use predefined loggers
+        gr::logger_ptr logger, debug_logger;
+        gr::configure_default_loggers(
+            logger, debug_logger, "thread_body_wrapper::mask_signals");
+        GR_LOG_ERROR(logger, boost::format("pthread_sigmask: %s") % strerror(errno));
+    }
 }
 
 #else

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -15,6 +15,7 @@
 #include "flat_flowgraph.h"
 #include "scheduler_tpb.h"
 #include "top_block_impl.h"
+#include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
 
@@ -57,8 +58,12 @@ make_scheduler(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_except
                 }
             }
             if (factory == 0) {
-                std::cerr << "warning: Invalid GR_SCHEDULER environment variable value \""
-                          << v << "\".  Using \"" << scheduler_table[0].name << "\"\n";
+                gr::logger_ptr logger, debug_logger;
+                gr::configure_default_loggers(logger, debug_logger, "top_block_impl");
+                std::ostringstream msg;
+                msg << "Invalid GR_SCHEDULER environment variable value \"" << v
+                    << "\".  Using \"" << scheduler_table[0].name << "\"";
+                GR_LOG_WARN(logger, msg.str());
                 factory = scheduler_table[0].f;
             }
         }
@@ -74,13 +79,16 @@ top_block_impl::top_block_impl(top_block* owner, bool catch_exceptions = true)
       d_retry_wait(false),
       d_catch_exceptions(catch_exceptions)
 {
+    gr::configure_default_loggers(d_logger, d_debug_logger, "top_block_impl");
 }
 
 top_block_impl::~top_block_impl()
 {
     if (d_lock_count) {
-        std::cerr << "error: destroying locked block." << std::endl;
+        GR_LOG_ERROR(d_logger, "destroying locked block.");
     }
+    // NOTE: Investigate the sensibility of setting a raw pointer to zero at the end of
+    // destructor
     d_owner = 0;
 }
 

--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -78,6 +78,8 @@ protected:
 private:
     void restart();
     void wait_for_jobs();
+
+    gr::logger_ptr d_logger, d_debug_logger;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -51,15 +51,16 @@ vmcircbuf_factory* vmcircbuf_sysconfig::get_default_factory()
 
     std::vector<gr::vmcircbuf_factory*> all = all_factories();
 
+    logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "vmcircbuf_sysconfig");
+
     char name[1024];
     if (gr::vmcircbuf_prefs::get(FACTORY_PREF_KEY, name, sizeof(name)) >= 0) {
         for (unsigned int i = 0; i < all.size(); i++) {
             if (strncmp(name, all[i]->name(), strlen(all[i]->name())) == 0) {
                 s_default_factory = all[i];
-                if (verbose)
-                    fprintf(stderr,
-                            "gr::vmcircbuf_sysconfig: using %s\n",
-                            s_default_factory->name());
+                GR_LOG_INFO(debug_logger,
+                            boost::format("Using %s") % s_default_factory->name());
                 return s_default_factory;
             }
         }
@@ -68,8 +69,7 @@ vmcircbuf_factory* vmcircbuf_sysconfig::get_default_factory()
     // either we don't have a default, or the default named is not in our
     // list of factories.  Find the first factory that works.
 
-    if (verbose)
-        fprintf(stderr, "gr::vmcircbuf_sysconfig: finding a working factory...\n");
+    GR_LOG_INFO(debug_logger, "finding a working factory...");
 
     for (unsigned int i = 0; i < all.size(); i++) {
         if (test_factory(all[i], verbose)) {
@@ -79,7 +79,7 @@ vmcircbuf_factory* vmcircbuf_sysconfig::get_default_factory()
     }
 
     // We're screwed!
-    fprintf(stderr, "gr::vmcircbuf_sysconfig: unable to find a working factory!\n");
+    GR_LOG_ERROR(logger, "unable to find a working factory!");
     throw std::runtime_error("gr::vmcircbuf_sysconfig");
 }
 
@@ -115,36 +115,34 @@ static void init_buffer(const vmcircbuf& c, int counter, int size)
         p[i] = counter + i;
 }
 
-static bool
-check_mapping(const vmcircbuf& c, int counter, int size, const char* msg, bool verbose)
+static bool check_mapping(
+    const vmcircbuf& c, int counter, int size, const char* msg, logger_ptr debug_logger)
 {
     bool ok = true;
 
-    if (verbose)
-        fprintf(stderr, "... %s", msg);
+    GR_LOG_INFO(debug_logger, msg);
 
     unsigned int* p1 = (unsigned int*)c.pointer_to_first_copy();
     unsigned int* p2 = (unsigned int*)c.pointer_to_second_copy();
 
-    // fprintf(stderr, "p1 = %p, p2 = %p\n", p1, p2);
-
     for (unsigned int i = 0; i < size / sizeof(int); i++) {
         if (p1[i] != counter + i) {
             ok = false;
-            if (verbose)
-                fprintf(stderr, "  p1[%d] == %u, expected %u\n", i, p1[i], counter + i);
+            GR_LOG_INFO(debug_logger,
+                        boost::format("p1[%d] == %u, expected %u") % i % p1[i] %
+                            (counter + i));
             break;
         }
         if (p2[i] != counter + i) {
-            if (verbose)
-                fprintf(stderr, "  p2[%d] == %u, expected %u\n", i, p2[i], counter + i);
+            GR_LOG_ERROR(debug_logger,
+                         boost::format("p1[%d] == %u, expected %u") % i % p2[i] %
+                             (counter + i));
             ok = false;
             break;
         }
     }
-
-    if (ok && verbose) {
-        fprintf(stderr, "  OK\n");
+    if (ok) {
+        GR_LOG_INFO(debug_logger, "mapping OK");
     }
     return ok;
 }
@@ -170,17 +168,17 @@ test_a_bunch(vmcircbuf_factory* factory, int n, int size, int* start_ptr, bool v
     std::vector<std::unique_ptr<vmcircbuf>> c(n);
     int cum_size = 0;
 
+    logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "gr::test_a_bunch");
+
     for (int i = 0; i < n; i++) {
         counter[i] = *start_ptr;
         *start_ptr += size;
         if ((c[i] = std::unique_ptr<vmcircbuf>(factory->make(size))) == 0) {
-            if (verbose)
-                fprintf(
-                    stderr,
-                    "Failed to allocate gr::vmcircbuf number %d of size %d (cum = %s)\n",
-                    i + 1,
-                    size,
-                    memsize(cum_size));
+            GR_LOG_INFO(debug_logger,
+                        boost::format("Failed to allocate gr::vmcircbuf "
+                                      "number %d of size %d (cum = %s)") %
+                            (i + 1) % size % memsize(cum_size))
             return false;
         }
         init_buffer(*c[i], counter[i], size);
@@ -190,38 +188,41 @@ test_a_bunch(vmcircbuf_factory* factory, int n, int size, int* start_ptr, bool v
     for (int i = 0; i < n; i++) {
         std::string msg =
             str(boost::format("test_a_bunch_%dx%s[%d]") % n % memsize(size) % i);
-        ok &= check_mapping(*c[i], counter[i], size, msg.c_str(), verbose);
+        ok = check_mapping(*c[i], counter[i], size, msg.c_str(), debug_logger) && ok;
     }
     return ok;
 }
 
 static bool standard_tests(vmcircbuf_factory* f, int verbose)
 {
-    if (verbose >= 1)
-        fprintf(stderr, "Testing %s...\n", f->name());
+    logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "standard_tests");
+
+    GR_LOG_INFO(debug_logger, boost::format("Testing %s...") % f->name());
 
     bool v = verbose >= 2;
     int granularity = f->granularity();
     int start = 0;
     bool ok = true;
 
-    ok &= test_a_bunch(f, 1, 1 * granularity, &start, v); //   1 x   4KB =   4KB
+    ok = test_a_bunch(f, 1, 1 * granularity, &start, v) && ok; //   1 x   4KB =   4KB
 
     if (ok) {
-        ok &= test_a_bunch(f, 64, 4 * granularity, &start, v); //  64 x  16KB =   1MB
-        ok &= test_a_bunch(f, 4, 4 * (1L << 20), &start, v);   //   4 x   4MB =  16MB
-        //  ok &= test_a_bunch(f, 256, 256 * (1L << 10),  &start, v);  // 256 x 256KB =
-        //  64MB
+        ok = test_a_bunch(f, 64, 4 * granularity, &start, v) && ok; //  64 x  16KB =   1MB
+        ok = test_a_bunch(f, 4, 4 * (1L << 20), &start, v) && ok;   //   4 x   4MB =  16MB
+        //  ok = test_a_bunch(f, 256, 256 * (1L << 10),  &start, v) && ok;  // 256 x 256KB
+        //  = 64MB
     }
 
-    if (verbose >= 1)
-        fprintf(stderr, "....... %s: %s", f->name(), ok ? "OK\n" : "Doesn't work\n");
-
+    GR_LOG_INFO(debug_logger,
+                boost::format("%s: %s") % f->name() % (ok ? "OK" : "Doesn't work"))
     return ok;
 }
 
 bool vmcircbuf_sysconfig::test_factory(vmcircbuf_factory* f, int verbose)
 {
+    logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "gr::vmcircbuf_sysconfig");
     // Install local signal handlers for SIGSEGV and SIGBUS.
     // If something goes wrong, these signals may be invoked.
 
@@ -238,22 +239,15 @@ bool vmcircbuf_sysconfig::test_factory(vmcircbuf_factory* f, int verbose)
     try {
         return standard_tests(f, verbose);
     } catch (gr::signal& sig) {
-        if (verbose) {
-            fprintf(stderr, "....... %s: %s", f->name(), "Doesn't work\n");
-            fprintf(stderr,
-                    "gr::vmcircbuf_factory::test_factory (%s): caught %s\n",
-                    f->name(),
-                    sig.name().c_str());
-            return false;
-        }
+        GR_LOG_INFO(debug_logger,
+                    boost::format("vmcircbuf_factory::test_factory (%s): caught %s") %
+                        f->name() % sig.name().c_str())
+        return false;
     } catch (...) {
-        if (verbose) {
-            fprintf(stderr, "....... %s: %s", f->name(), "Doesn't work\n");
-            fprintf(stderr,
-                    "gr::vmcircbuf_factory::test_factory (%s): some kind of uncaught "
-                    "exception\n",
-                    f->name());
-        }
+        GR_LOG_WARN(debug_logger,
+                    boost::format("vmcircbuf_factory::test_factory (%s) some "
+                                  "kind of uncaught exception.") %
+                        f->name())
         return false;
     }
     return false; // never gets here.  shut compiler up.

--- a/gnuradio-runtime/lib/vmcircbuf.h
+++ b/gnuradio-runtime/lib/vmcircbuf.h
@@ -12,6 +12,8 @@
 #define GR_VMCIRCBUF_H
 
 #include <gnuradio/api.h>
+#include <gnuradio/logger.h>
+#include <gnuradio/prefs.h>
 #include <gnuradio/thread/thread.h>
 #include <vector>
 
@@ -28,9 +30,14 @@ class GR_RUNTIME_API vmcircbuf
 protected:
     int d_size;
     char* d_base;
+    logger_ptr d_logger;
+    logger_ptr d_debug_logger;
 
     // CREATORS
-    vmcircbuf(int size) : d_size(size), d_base(0){};
+    vmcircbuf(int size) : d_size(size), d_base(0)
+    {
+        gr::configure_default_loggers(d_logger, d_debug_logger, "gr::vmcircbuf");
+    };
 
 public:
     virtual ~vmcircbuf();

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
@@ -34,7 +34,9 @@ namespace gr {
 vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
 {
 #if !defined(HAVE_MMAP) || !defined(HAVE_SHM_OPEN)
-    fprintf(stderr, "gr::vmcircbuf_mmap_shm_open: mmap or shm_open is not available\n");
+    std::stringstream error_msg;
+    error_msg << "mmap or shm_open is not available";
+    GR_LOG_ERROR(d_logger, error_msg.str());
     throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
 #else
     gr::thread::scoped_lock guard(s_vm_mutex);
@@ -42,7 +44,7 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
     static int s_seg_counter = 0;
 
     if (size <= 0 || (size % gr::pagesize()) != 0) {
-        fprintf(stderr, "gr::vmcircbuf_mmap_shm_open: invalid size = %d\n", size);
+        GR_LOG_ERROR(d_logger, "invalid size =" + std::to_string(size));
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
@@ -79,9 +81,9 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
                 EEXIST) // Named segment already exists (shouldn't happen).  Try again
                 continue;
 
-            static std::string msg = str(
-                boost::format("gr::vmcircbuf_mmap_shm_open: shm_open [%s]") % seg_name);
-            perror(msg.c_str());
+            static std::string msg =
+                str(boost::format("shm_open [%s] failed") % seg_name);
+            GR_LOG_ERROR(d_logger, msg.c_str());
             throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
         }
         break;
@@ -91,7 +93,7 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
     // Now set it's length to 2x what we really want and mmap it in.
     if (ftruncate(shm_fd, (off_t)2 * size) == -1) {
         close(shm_fd); // cleanup
-        perror("gr::vmcircbuf_mmap_shm_open: ftruncate (1)");
+        GR_LOG_ERROR(d_logger, "ftruncate failed");
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
@@ -100,14 +102,14 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
 
     if (first_copy == MAP_FAILED) {
         close(shm_fd); // cleanup
-        perror("gr::vmcircbuf_mmap_shm_open: mmap (1)");
+        GR_LOG_ERROR(d_logger, "mmap (1) failed");
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
     // unmap the 2nd half
     if (munmap((char*)first_copy + size, size) == -1) {
         close(shm_fd); // cleanup
-        perror("gr::vmcircbuf_mmap_shm_open: munmap (1)");
+        GR_LOG_ERROR(d_logger, "munmap (1) failed");
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
@@ -122,7 +124,7 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
 
     if (second_copy == MAP_FAILED) {
         close(shm_fd); // cleanup
-        perror("gr::vmcircbuf_mmap_shm_open: mmap (2)");
+        GR_LOG_ERROR(d_logger, "mmap (2) failed");
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
@@ -139,7 +141,7 @@ vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
     close(shm_fd); // fd no longer needed.  The mapping is retained.
 
     if (shm_unlink(seg_name.c_str()) == -1) { // unlink the seg_name.
-        perror("gr::vmcircbuf_mmap_shm_open: shm_unlink");
+        GR_LOG_ERROR(d_logger, "shm_unlink failed");
         throw std::runtime_error("gr::vmcircbuf_mmap_shm_open");
     }
 
@@ -155,7 +157,7 @@ vmcircbuf_mmap_shm_open::~vmcircbuf_mmap_shm_open()
     gr::thread::scoped_lock guard(s_vm_mutex);
 
     if (munmap(d_base, 2 * d_size) == -1) {
-        perror("gr::vmcircbuf_mmap_shm_open: munmap (2)");
+        GR_LOG_ERROR(d_logger, "munmap (2) failed");
     }
 #endif
 }

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
@@ -35,7 +35,7 @@ namespace gr {
 vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
 {
 #if !defined(HAVE_SYS_SHM_H)
-    fprintf(stderr, "gr::vmcircbuf_sysv_shm: sysv shared memory is not available\n");
+    GR_LOG_ERROR(d_logger, "sysv shared memory is not available");
     throw std::runtime_error("gr::vmcircbuf_sysv_shm");
 #else
 
@@ -44,7 +44,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
     int pagesize = gr::pagesize();
 
     if (size <= 0 || (size % pagesize) != 0) {
-        fprintf(stderr, "gr::vmcircbuf_sysv_shm: invalid size = %d\n", size);
+        GR_LOG_ERROR(d_logger, boost::format("invalid size = %d") % size);
         throw std::runtime_error("gr::vmcircbuf_sysv_shm");
     }
 
@@ -60,19 +60,19 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
         // buffer. Ideally we'd map it no access, but I don't think that's possible with
         // SysV
         if ((shmid_guard = shmget(IPC_PRIVATE, pagesize, IPC_CREAT | 0400)) == -1) {
-            perror("gr::vmcircbuf_sysv_shm: shmget (0)");
+            GR_LOG_ERROR(d_logger, boost::format("shmget (0): %s") % strerror(errno));
             continue;
         }
 
         if ((shmid2 = shmget(IPC_PRIVATE, 2 * size + 2 * pagesize, IPC_CREAT | 0700)) ==
             -1) {
-            perror("gr::vmcircbuf_sysv_shm: shmget (1)");
+            GR_LOG_ERROR(d_logger, boost::format("shmget (1): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             continue;
         }
 
         if ((shmid1 = shmget(IPC_PRIVATE, size, IPC_CREAT | 0700)) == -1) {
-            perror("gr::vmcircbuf_sysv_shm: shmget (2)");
+            GR_LOG_ERROR(d_logger, boost::format("shmget (2): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid2, IPC_RMID, 0);
             continue;
@@ -80,7 +80,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
 
         void* first_copy = shmat(shmid2, 0, 0);
         if (first_copy == (void*)-1) {
-            perror("gr::vmcircbuf_sysv_shm: shmat (1)");
+            GR_LOG_ERROR(d_logger, boost::format("shmat (1): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid2, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
@@ -100,7 +100,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
 
         // first read-only guard page
         if (shmat(shmid_guard, first_copy, SHM_RDONLY) == (void*)-1) {
-            perror("gr::vmcircbuf_sysv_shm: shmat (2)");
+            GR_LOG_ERROR(d_logger, boost::format("shmat (2): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             continue;
@@ -108,7 +108,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
 
         // first copy
         if (shmat(shmid1, (char*)first_copy + pagesize, 0) == (void*)-1) {
-            perror("gr::vmcircbuf_sysv_shm: shmat (3)");
+            GR_LOG_ERROR(d_logger, boost::format("shmat (3): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             shmdt(first_copy);
@@ -117,7 +117,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
 
         // second copy
         if (shmat(shmid1, (char*)first_copy + pagesize + size, 0) == (void*)-1) {
-            perror("gr::vmcircbuf_sysv_shm: shmat (4)");
+            GR_LOG_ERROR(d_logger, boost::format("shmat (4): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             shmdt((char*)first_copy + pagesize);
@@ -127,7 +127,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
         // second read-only guard page
         if (shmat(shmid_guard, (char*)first_copy + pagesize + 2 * size, SHM_RDONLY) ==
             (void*)-1) {
-            perror("gr::vmcircbuf_sysv_shm: shmat (5)");
+            GR_LOG_ERROR(d_logger, boost::format("shmat (5): %s") % strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             shmdt(first_copy);
@@ -157,7 +157,7 @@ vmcircbuf_sysv_shm::~vmcircbuf_sysv_shm()
 
     if (shmdt(d_base - gr::pagesize()) == -1 || shmdt(d_base) == -1 ||
         shmdt(d_base + d_size) == -1 || shmdt(d_base + 2 * d_size) == -1) {
-        perror("gr::vmcircbuf_sysv_shm: shmdt (2)");
+        GR_LOG_ERROR(d_logger, boost::format("shmdt (2): %s") % strerror(errno));
     }
 #endif
 }

--- a/gr-analog/lib/dpll_bb_impl.cc
+++ b/gr-analog/lib/dpll_bb_impl.cc
@@ -14,7 +14,6 @@
 
 #include "dpll_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <cstdio>
 
 namespace gr {
 namespace analog {
@@ -34,13 +33,6 @@ dpll_bb_impl::dpll_bb_impl(float period, float gain)
     d_pulse_frequency = 1.0 / period;
     d_gain = gain;
     d_decision_threshold = 1.0 - 0.5 * d_pulse_frequency;
-#if 0
-      fprintf(stderr,"frequency = %f period = %f gain = %f threshold = %f\n",
-	      d_pulse_frequency,
-	      period,
-	      d_gain,
-	      d_decision_threshold);
-#endif
 }
 
 dpll_bb_impl::~dpll_bb_impl() {}

--- a/gr-audio/lib/alsa/alsa_impl.cc
+++ b/gr-audio/lib/alsa/alsa_impl.cc
@@ -9,8 +9,11 @@
  */
 
 #ifdef HAVE_CONFIG_H
+#warning "ALSA CONFIG H"
 #include "config.h"
 #endif
+
+#include <gnuradio/logger.h>
 
 #include "alsa_impl.h"
 #include <algorithm>
@@ -138,22 +141,23 @@ bool gri_alsa_pick_acceptable_format(snd_pcm_t* pcm,
                                      bool verbose)
 {
     int err;
+    gr::logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(
+        logger, debug_logger, "gri_alsa_pick_acceptable_format");
 
     // pick a format that we like...
     for (unsigned i = 0; i < nacceptable_formats; i++) {
         if (snd_pcm_hw_params_test_format(pcm, hwparams, acceptable_formats[i]) == 0) {
             err = snd_pcm_hw_params_set_format(pcm, hwparams, acceptable_formats[i]);
             if (err < 0) {
-                fprintf(stderr,
-                        "%s[%s]: failed to set format: %s\n",
-                        error_msg_tag,
-                        snd_pcm_name(pcm),
-                        snd_strerror(err));
+                GR_LOG_ERROR(logger,
+                             boost::format("%s[%s]: failed to set format: %s") %
+                                 error_msg_tag % snd_pcm_name(pcm) % snd_strerror(err));
                 return false;
             }
             if (verbose)
                 fprintf(stdout,
-                        "%s[%s]: using %s\n",
+                        "%s[%s]: using %s",
                         error_msg_tag,
                         snd_pcm_name(pcm),
                         snd_pcm_format_name(acceptable_formats[i]));
@@ -162,9 +166,8 @@ bool gri_alsa_pick_acceptable_format(snd_pcm_t* pcm,
         }
     }
 
-    fprintf(stderr,
-            "%s[%s]: failed to find acceptable format",
-            error_msg_tag,
-            snd_pcm_name(pcm));
+    GR_LOG_ERROR(logger,
+                 boost::format("%s[%s]: failed to find acceptable format") %
+                     error_msg_tag % snd_pcm_name(pcm));
     return false;
 }

--- a/gr-audio/lib/audio_registry.cc
+++ b/gr-audio/lib/audio_registry.cc
@@ -132,16 +132,20 @@ static void do_arch_warning(const std::string& arch)
 {
     if (arch == "auto")
         return; // no warning when arch not specified
-    std::cerr << "Could not find audio architecture \"" << arch << "\" in registry."
-              << std::endl;
-    std::cerr << "    Defaulting to the first available architecture..." << std::endl;
+
+    gr::logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "audio_registry");
+    std::ostringstream msg;
+    msg << "Could not find audio architecture \"" << arch << "\" in registry.";
+    msg << " Defaulting to the first available architecture.";
+    GR_LOG_ERROR(logger, msg.str());
 }
 
 source::sptr
 source::make(int sampling_rate, const std::string device_name, bool ok_to_block)
 {
     gr::logger_ptr logger, debug_logger;
-    configure_default_loggers(logger, debug_logger, "audio source");
+    configure_default_loggers(logger, debug_logger, "audio_source");
 
     if (get_source_registry().empty()) {
         throw std::runtime_error("no available audio source factories");
@@ -158,7 +162,7 @@ source::make(int sampling_rate, const std::string device_name, bool ok_to_block)
         return e.source(sampling_rate, device_name, ok_to_block);
     }
 
-    GR_LOG_INFO(logger, boost::format("Audio source arch: %1%") % (entry.arch));
+    GR_LOG_INFO(debug_logger, boost::format("Audio source arch: %1%") % (entry.arch));
     return entry.source(sampling_rate, device_name, ok_to_block);
 }
 
@@ -183,7 +187,7 @@ sink::sptr sink::make(int sampling_rate, const std::string device_name, bool ok_
     }
 
     do_arch_warning(arch);
-    GR_LOG_INFO(logger, boost::format("Audio sink arch: %1%") % (entry.arch));
+    GR_LOG_INFO(debug_logger, boost::format("Audio sink arch: %1%") % (entry.arch));
     return entry.sink(sampling_rate, device_name, ok_to_block);
 }
 

--- a/gr-audio/lib/oss/oss_sink.cc
+++ b/gr-audio/lib/oss/oss_sink.cc
@@ -52,8 +52,9 @@ oss_sink::oss_sink(int sampling_rate, const std::string device_name, bool ok_to_
       d_chunk_size(0)
 {
     if ((d_fd = open(d_device_name.c_str(), O_WRONLY)) < 0) {
-        fprintf(stderr, "audio_oss_sink: ");
-        perror(d_device_name.c_str());
+        GR_LOG_ERROR(d_logger,
+                     boost::format("opening device %s: %s") % d_device_name %
+                         strerror(errno));
         throw std::runtime_error("audio_oss_sink");
     }
 
@@ -68,31 +69,36 @@ oss_sink::oss_sink(int sampling_rate, const std::string device_name, bool ok_to_
     int format = AFMT_S16_NE;
     int orig_format = format;
     if (ioctl(d_fd, SNDCTL_DSP_SETFMT, &format) < 0) {
-        std::cerr << "audio_oss_sink: " << d_device_name << " ioctl failed\n";
-        perror(d_device_name.c_str());
+        GR_LOG_ERROR(d_logger,
+                     boost::format("%s ioctl failed: %s") % d_device_name %
+                         strerror(errno));
         throw std::runtime_error("audio_oss_sink");
     }
 
     if (format != orig_format) {
-        fprintf(stderr, "audio_oss_sink: unable to support format %d\n", orig_format);
-        fprintf(stderr, "  card requested %d instead.\n", format);
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("%s unable to support format %d. card requested %d instead.") %
+                orig_format % format);
     }
 
     // set to stereo no matter what.  Some hardware only does stereo
     int channels = 2;
     if (ioctl(d_fd, SNDCTL_DSP_CHANNELS, &channels) < 0 || channels != 2) {
-        perror("audio_oss_sink: could not set STEREO mode");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("could not set STEREO mode: %s") % strerror(errno));
         throw std::runtime_error("audio_oss_sink");
     }
 
     // set sampling freq
     int sf = sampling_rate;
     if (ioctl(d_fd, SNDCTL_DSP_SPEED, &sf) < 0) {
-        std::cerr << "audio_oss_sink: " << d_device_name << ": invalid sampling_rate "
-                  << sampling_rate << "\n";
+        GR_LOG_ERROR(d_logger,
+                     boost::format("%s: invalid sampling_rate %d") % d_device_name %
+                         sampling_rate);
         sampling_rate = 8000;
         if (ioctl(d_fd, SNDCTL_DSP_SPEED, &sf) < 0) {
-            std::cerr << "audio_oss_sink: failed to set sampling_rate to 8000\n";
+            GR_LOG_ERROR(d_logger, "failed to set sampling_rate to 8000");
             throw std::runtime_error("audio_oss_sink");
         }
     }
@@ -121,7 +127,7 @@ int oss_sink::work(int noutput_items,
             }
             f0 += d_chunk_size;
             if (write(d_fd, d_buffer, 2 * d_chunk_size * sizeof(short)) < 0)
-                perror("audio_oss_sink: write");
+                GR_LOG_ERROR(d_logger, boost::format("write %s") % strerror(errno));
         }
         break;
 
@@ -137,7 +143,7 @@ int oss_sink::work(int noutput_items,
             f0 += d_chunk_size;
             f1 += d_chunk_size;
             if (write(d_fd, d_buffer, 2 * d_chunk_size * sizeof(short)) < 0)
-                perror("audio_oss_sink: write");
+                GR_LOG_ERROR(d_logger, boost::format("write %s") % strerror(errno));
         }
         break;
     }

--- a/gr-audio/lib/oss/oss_source.cc
+++ b/gr-audio/lib/oss/oss_source.cc
@@ -52,8 +52,9 @@ oss_source::oss_source(int sampling_rate, const std::string device_name, bool ok
       d_chunk_size(0)
 {
     if ((d_fd = open(d_device_name.c_str(), O_RDONLY)) < 0) {
-        fprintf(stderr, "audio_oss_source: ");
-        perror(d_device_name.c_str());
+        GR_LOG_ERROR(d_logger,
+                     boost::format("opening device %s: %s") % d_device_name %
+                         strerror(errno));
         throw std::runtime_error("audio_oss_source");
     }
 
@@ -68,31 +69,36 @@ oss_source::oss_source(int sampling_rate, const std::string device_name, bool ok
     int format = AFMT_S16_NE;
     int orig_format = format;
     if (ioctl(d_fd, SNDCTL_DSP_SETFMT, &format) < 0) {
-        std::cerr << "audio_oss_source: " << d_device_name << " ioctl failed\n";
-        perror(d_device_name.c_str());
+        GR_LOG_ERROR(d_logger,
+                     boost::format("%s ioctl failed %s") % d_device_name %
+                         strerror(errno));
         throw std::runtime_error("audio_oss_source");
     }
 
     if (format != orig_format) {
-        fprintf(stderr, "audio_oss_source: unable to support format %d\n", orig_format);
-        fprintf(stderr, "  card requested %d instead.\n", format);
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("%s unable to support format %d. card requested %d instead.") %
+                orig_format % format);
     }
 
     // set to stereo no matter what.  Some hardware only does stereo
     int channels = 2;
     if (ioctl(d_fd, SNDCTL_DSP_CHANNELS, &channels) < 0 || channels != 2) {
-        perror("audio_oss_source: could not set STEREO mode");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("could not set STEREO mode: %s") % strerror(errno));
         throw std::runtime_error("audio_oss_source");
     }
 
     // set sampling freq
     int sf = sampling_rate;
     if (ioctl(d_fd, SNDCTL_DSP_SPEED, &sf) < 0) {
-        std::cerr << "audio_oss_source: " << d_device_name << ": invalid sampling_rate "
-                  << sampling_rate << "\n";
+        GR_LOG_ERROR(d_logger,
+                     boost::format("ERROR %s: invalid sampling_rate %d") % d_device_name %
+                         sampling_rate);
         sampling_rate = 8000;
         if (ioctl(d_fd, SNDCTL_DSP_SPEED, &sf) < 0) {
-            std::cerr << "audio_oss_source: failed to set sampling_rate to 8000\n";
+            GR_LOG_ERROR(d_logger, "failed to set sampling_rate to 8000");
             throw std::runtime_error("audio_oss_source");
         }
     }
@@ -127,12 +133,13 @@ int oss_source::work(int noutput_items,
         int result_nbytes = read(d_fd, d_buffer, nbytes);
 
         if (result_nbytes < 0) {
-            perror("audio_oss_source");
+            GR_LOG_ERROR(d_logger,
+                         boost::format("audio_oss_source: %s") % strerror(errno));
             return -1; // say we're done
         }
 
         if ((result_nbytes & (bytes_per_item - 1)) != 0) {
-            fprintf(stderr, "audio_oss_source: internal error.\n");
+            GR_LOG_ERROR(d_logger, "internal error.");
             throw std::runtime_error("internal error");
         }
 

--- a/gr-audio/lib/osx/osx_impl.cc
+++ b/gr-audio/lib/osx/osx_impl.cc
@@ -15,6 +15,7 @@
 #include "../audio_registry.h"
 
 #include <gnuradio/audio/osx_impl.h>
+#include <gnuradio/logger.h>
 
 #include <algorithm>
 #include <iostream>
@@ -151,8 +152,12 @@ void find_audio_devices(const std::string& device_name,
     if ((err = AudioObjectGetPropertyDataSize(
              kAudioObjectSystemObject, &ao_address, 0, NULL, &prop_size)) != noErr) {
 #if _OSX_AU_DEBUG_
-        std::cerr << "audio_osx::find_audio_devices: "
-                  << "Unable to retrieve number of audio objects: " << err << std::endl;
+        gr::logger_ptr logger, debug_logger;
+        gr::configure_default_loggers(
+            logger, debug_logger, "osx_impl::find_audio_devices");
+        std::ostringstream msg;
+        msg << "Unable to retrieve number of audio objects: " << err;
+        GR_LOG_ERROR(logger, msg.str());
 #endif
         return;
     }
@@ -172,8 +177,9 @@ void find_audio_devices(const std::string& device_name,
                                           &prop_size,
                                           all_dev_ids.get())) != noErr) {
 #if _OSX_AU_DEBUG_
-        std::cerr << "audio_osx::find_audio_devices: "
-                  << "Unable to retrieve audio object ids: " << err << std::endl;
+        std::ostringstream msg;
+        msg << "Unable to retrieve audio object ids: " << err;
+        GR_LOG_ERROR(logger, msg.str());
 #endif
         return;
     }
@@ -227,9 +233,9 @@ void find_audio_devices(const std::string& device_name,
         if ((err = AudioObjectGetPropertyData(
                  t_id, &ao_address, 0, NULL, &prop_size, (void*)c_name_buf)) != noErr) {
 #if _OSX_AU_DEBUG_
-            std::cerr << "audio_osx::find_audio_devices: "
-                      << "Unable to retrieve audio device name #" << (nn + 1) << ": "
-                      << err << std::endl;
+            std::ostringstream msg;
+            msg << "Unable to retrieve audio device name #" << (nn + 1) << ": " << err;
+            GR_LOG_ERROR(logger, msg.str());
 #endif
             continue;
         }

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <future>
 #include <iostream>
 #include <stdexcept>
 #ifdef _MSC_VER
@@ -58,17 +59,24 @@ void portaudio_sink::create_ringbuffer(void)
     int bufsize_samples =
         d_portaudio_buffer_size_frames * d_output_parameters.channelCount;
 
-    if (d_verbose) {
-        fprintf(stderr,
-                "ring buffer size  = %d frames\n",
-                N_BUFFERS * bufsize_samples / d_output_parameters.channelCount);
-    }
+    if (d_verbose)
+        GR_LOG_INFO(d_debug_logger,
+                    boost::format("ring buffer size  = %d frames") %
+                        (N_BUFFERS * bufsize_samples / d_output_parameters.channelCount));
 
     // FYI, the buffer indices are in units of samples.
     d_writer = gr::make_buffer(N_BUFFERS * bufsize_samples, sizeof(sample_t));
     d_reader = gr::buffer_add_reader(d_writer, 0);
 }
 
+
+void portaudio_underrun_notification(gr::logger_ptr logger)
+{
+    ssize_t r = ::write(2, "aU", 2);
+    if (r == -1) {
+        GR_LOG_ERROR(logger, "portaudio_source_callback write error to stderr.");
+    }
+}
 /*
  * This routine will be called by the PortAudio engine when audio is needed.
  * It may called at interrupt level on some machines so don't do anything
@@ -83,7 +91,7 @@ int portaudio_sink_callback(const void* inputBuffer,
                             PaStreamCallbackFlags statusFlags,
                             void* arg)
 {
-    portaudio_sink* self = (portaudio_sink*)arg;
+    auto self = reinterpret_cast<portaudio_sink*>(arg);
     int nreqd_samples = framesPerBuffer * self->d_output_parameters.channelCount;
 
     int navail_samples = self->d_reader->items_available();
@@ -106,13 +114,7 @@ int portaudio_sink_callback(const void* inputBuffer,
     }
 
     else { // underrun
-        self->d_nunderuns++;
-        ssize_t r = ::write(2, "aU", 2); // FIXME change to non-blocking call
-        if (r == -1) {
-            perror("audio_portaudio_source::portaudio_source_callback write error to "
-                   "stderr.");
-        }
-
+        std::async(&portaudio_underrun_notification, self->d_logger);
         // FIXME we should transfer what we've got and pad the rest
         memset(outputBuffer, 0, nreqd_samples * sizeof(sample_t));
 
@@ -139,12 +141,9 @@ portaudio_sink::portaudio_sink(int sampling_rate,
       d_stream(0),
       d_ringbuffer_mutex(),
       d_ringbuffer_cond(),
-      d_ringbuffer_ready(false),
-      d_nunderuns(0)
+      d_ringbuffer_ready(false)
 {
     memset(&d_output_parameters, 0, sizeof(d_output_parameters));
-    // if(LOGGING)
-    //  d_log = gri_logger::singleton();
 
     PaError err;
     int i, numDevices;
@@ -167,38 +166,34 @@ portaudio_sink::portaudio_sink(int sampling_rate,
 
     if (d_device_name.empty()) {
         // FIXME Get smarter about picking something
-        fprintf(stderr, "\nUsing Default Device\n");
+        GR_LOG_INFO(d_debug_logger, "Using Default Devicee");
         device = Pa_GetDefaultOutputDevice();
         deviceInfo = Pa_GetDeviceInfo(device);
-        fprintf(stderr,
-                "%s is the chosen device using %s as the host\n",
-                deviceInfo->name,
-                Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("%s is the chosen device using %s as the host") %
+                         deviceInfo->name % Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
     } else {
         bool found = false;
-        fprintf(stderr, "\nTest Devices\n");
+        GR_LOG_INFO(d_debug_logger, "Test Devices");
         for (i = 0; i < numDevices; i++) {
             deviceInfo = Pa_GetDeviceInfo(i);
-            fprintf(stderr, "Testing device name: %s", deviceInfo->name);
-
+            GR_LOG_INFO(d_debug_logger,
+                        boost::format("Testing device name: %s...") % deviceInfo->name);
             if (deviceInfo->maxOutputChannels <= 0) {
-                fprintf(stderr, "\n");
                 continue;
             }
 
             if (strstr(deviceInfo->name, d_device_name.c_str())) {
-                fprintf(stderr, "  Chosen!\n");
+                GR_LOG_INFO(d_debug_logger, "  Chosen!");
                 device = i;
-                fprintf(stderr,
-                        "%s using %s as the host\n",
-                        d_device_name.c_str(),
-                        Pa_GetHostApiInfo(deviceInfo->hostApi)->name),
-                    fflush(stderr);
+                GR_LOG_INFO(d_debug_logger,
+                            boost::format("%s using %s as the host") %
+                                d_device_name.c_str() %
+                                Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
                 found = true;
                 deviceInfo = Pa_GetDeviceInfo(device);
                 i = numDevices; // force loop exit
-            } else
-                fprintf(stderr, "\n"), fflush(stderr);
+            }
         }
 
         if (!found) {
@@ -240,11 +235,9 @@ bool portaudio_sink::check_topology(int ninputs, int noutputs)
 #if 1
     d_portaudio_buffer_size_frames =
         (int)(0.0213333333 * d_sampling_rate + 0.5); // Force 1024 frame buffers at 48000
-    fprintf(stderr,
-            "Latency = %8.5f, requested sampling_rate = %g\n", // Force latency
-                                                               // to 21.3333333.. ms
-            0.0213333333,
-            (double)d_sampling_rate);
+    GR_LOG_ERROR(d_logger,
+                 boost::format("Latency = %8.5f, requested sampling_rate = %g") %
+                     0.0213333333 % (double)d_sampling_rate);
 #endif
     err = Pa_OpenStream(&d_stream,
                         NULL, // No input
@@ -261,15 +254,19 @@ bool portaudio_sink::check_topology(int ninputs, int noutputs)
     }
 
 #if 0
-      const PaStreamInfo *psi = Pa_GetStreamInfo(d_stream);
+        const PaStreamInfo *psi = Pa_GetStreamInfo(d_stream);
 
-      d_portaudio_buffer_size_frames = (int)(d_output_parameters.suggestedLatency  * psi->sampleRate);
-      fprintf(stderr, "Latency = %7.4f, psi->sampleRate = %g\n",
-              d_output_parameters.suggestedLatency, psi->sampleRate);
+        d_portaudio_buffer_size_frames = (int)(d_output_parameters.suggestedLatency  * psi->sampleRate);
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("Latency = %7.4f, psi->sampleRate = %g") %
+            d_input_parameters.suggestedLatency
+            % psi->sampleRate
+        );
 #endif
-
-    fprintf(
-        stderr, "d_portaudio_buffer_size_frames = %d\n", d_portaudio_buffer_size_frames);
+    GR_LOG_ERROR(d_logger,
+                 boost::format("d_portaudio_buffer_size_frames = %d") %
+                     d_portaudio_buffer_size_frames);
 
     assert(d_portaudio_buffer_size_frames != 0);
 
@@ -350,11 +347,9 @@ int portaudio_sink::work(int noutput_items,
 
 void portaudio_sink::output_error_msg(const char* msg, int err)
 {
-    fprintf(stderr,
-            "audio_portaudio_sink[%s]: %s: %s\n",
-            d_device_name.c_str(),
-            msg,
-            Pa_GetErrorText(err));
+    GR_LOG_ERROR(d_logger,
+                 boost::format("%s: %s %s") % d_device_name.c_str() % msg %
+                     Pa_GetErrorText(err));
 }
 
 void portaudio_sink::bail(const char* msg, int err)

--- a/gr-audio/lib/portaudio/portaudio_sink.h
+++ b/gr-audio/lib/portaudio/portaudio_sink.h
@@ -12,6 +12,7 @@
 
 #include <gnuradio/audio/sink.h>
 #include <gnuradio/buffer.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/thread/thread.h>
 #include <portaudio.h>
 #include <stdexcept>
@@ -50,9 +51,6 @@ class portaudio_sink : public sink
     gr::thread::condition_variable d_ringbuffer_cond;
     bool d_ringbuffer_ready;
 
-    // random stats
-    int d_nunderuns; // count of underruns
-    // gri_logger_sptr d_log;  // handle to non-blocking logging instance
 
     void output_error_msg(const char* msg, int err);
     void bail(const char* msg, int err);

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -58,11 +58,10 @@ void portaudio_source::create_ringbuffer(void)
     int bufsize_samples =
         d_portaudio_buffer_size_frames * d_input_parameters.channelCount;
 
-    if (d_verbose) {
-        fprintf(stderr,
-                "ring buffer size  = %d frames\n",
-                N_BUFFERS * bufsize_samples / d_input_parameters.channelCount);
-    }
+    if (d_verbose)
+        GR_LOG_INFO(d_debug_logger,
+                    boost::format("ring buffer size  = %d frames") %
+                        (N_BUFFERS * bufsize_samples / d_input_parameters.channelCount));
 
     // FYI, the buffer indices are in units of samples.
     d_writer = gr::make_buffer(N_BUFFERS * bufsize_samples, sizeof(sample_t));
@@ -113,8 +112,10 @@ int portaudio_source_callback(const void* inputBuffer,
         self->d_noverruns++;
         ssize_t r = ::write(2, "aO", 2); // FIXME change to non-blocking call
         if (r == -1) {
-            perror("audio_portaudio_source::portaudio_source_callback write error to "
-                   "stderr.");
+            gr::logger_ptr logger, debug_logger;
+            gr::configure_default_loggers(
+                logger, debug_logger, "portaudio_source_callback");
+            GR_LOG_ERROR(logger, boost::format("write error: %s") % strerror(errno));
         }
 
         self->d_ringbuffer_ready = false;
@@ -143,8 +144,6 @@ portaudio_source::portaudio_source(int sampling_rate,
       d_noverruns(0)
 {
     memset(&d_input_parameters, 0, sizeof(d_input_parameters));
-    // if(LOGGING)
-    //  d_log = gri_logger::singleton();
 
     PaError err;
     int i, numDevices;
@@ -169,33 +168,30 @@ portaudio_source::portaudio_source(int sampling_rate,
         // FIXME Get smarter about picking something
         device = Pa_GetDefaultInputDevice();
         deviceInfo = Pa_GetDeviceInfo(device);
-        fprintf(stderr,
-                "%s is the chosen device using %s as the host\n",
-                deviceInfo->name,
-                Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("%s is the chosen device using %s as the host") %
+                         deviceInfo->name % Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
     } else {
         bool found = false;
-
+        GR_LOG_INFO(d_debug_logger, "Test Devices");
         for (i = 0; i < numDevices; i++) {
             deviceInfo = Pa_GetDeviceInfo(i);
-            fprintf(stderr, "Testing device name: %s", deviceInfo->name);
+            GR_LOG_INFO(d_debug_logger,
+                        boost::format("Testing device name: %s...") % deviceInfo->name);
             if (deviceInfo->maxInputChannels <= 0) {
-                fprintf(stderr, "\n");
                 continue;
             }
             if (strstr(deviceInfo->name, d_device_name.c_str())) {
-                fprintf(stderr, "  Chosen!\n");
+                GR_LOG_INFO(d_debug_logger, "  Chosen!");
                 device = i;
-                fprintf(stderr,
-                        "%s using %s as the host\n",
-                        d_device_name.c_str(),
-                        Pa_GetHostApiInfo(deviceInfo->hostApi)->name),
-                    fflush(stderr);
+                GR_LOG_INFO(d_debug_logger,
+                            boost::format("%s using %s as the host") %
+                                d_device_name.c_str() %
+                                Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
                 found = true;
                 deviceInfo = Pa_GetDeviceInfo(device);
                 i = numDevices; // force loop exit
-            } else
-                fprintf(stderr, "\n"), fflush(stderr);
+            }
         }
 
         if (!found) {
@@ -236,11 +232,9 @@ bool portaudio_source::check_topology(int ninputs, int noutputs)
 #if 1
     d_portaudio_buffer_size_frames =
         (int)(0.0213333333 * d_sampling_rate + 0.5); // Force 512 frame buffers at 48000
-    fprintf(stderr,
-            "Latency = %8.5f, requested sampling_rate = %g\n", // Force latency
-                                                               // to 21.3333333.. ms
-            0.0213333333,
-            (double)d_sampling_rate);
+    GR_LOG_ERROR(d_logger,
+                 boost::format("Latency = %8.5f, requested sampling_rate = %g") %
+                     0.0213333333 % (double)d_sampling_rate);
 #endif
     err = Pa_OpenStream(&d_stream,
                         &d_input_parameters,
@@ -257,15 +251,16 @@ bool portaudio_source::check_topology(int ninputs, int noutputs)
     }
 
 #if 0
-      const PaStreamInfo *psi = Pa_GetStreamInfo(d_stream);
+        const PaStreamInfo *psi = Pa_GetStreamInfo(d_stream);
 
-      d_portaudio_buffer_size_frames = (int)(d_input_parameters.suggestedLatency  * psi->sampleRate);
-      fprintf(stderr, "Latency = %7.4f, psi->sampleRate = %g\n",
-              d_input_parameters.suggestedLatency, psi->sampleRate);
+        d_portaudio_buffer_size_frames = (int)(d_input_parameters.suggestedLatency  * psi->sampleRate);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("Latency = %7.4f, psi->sampleRate = %g") %
+                     d_input_parameters.suggestedLatency % psi->sampleRate);
 #endif
-
-    fprintf(
-        stderr, "d_portaudio_buffer_size_frames = %d\n", d_portaudio_buffer_size_frames);
+    GR_LOG_ERROR(d_logger,
+                 boost::format("d_portaudio_buffer_size_frames = %d") %
+                     d_portaudio_buffer_size_frames);
 
     assert(d_portaudio_buffer_size_frames != 0);
 
@@ -360,11 +355,9 @@ int portaudio_source::work(int noutput_items,
 
 void portaudio_source::output_error_msg(const char* msg, int err)
 {
-    fprintf(stderr,
-            "audio_portaudio_source[%s]: %s: %s\n",
-            d_device_name.c_str(),
-            msg,
-            Pa_GetErrorText(err));
+    GR_LOG_ERROR(d_logger,
+                 boost::format("%s: %s %s") % d_device_name.c_str() % msg %
+                     Pa_GetErrorText(err));
 }
 
 void portaudio_source::bail(const char* msg, int err)

--- a/gr-audio/lib/portaudio/portaudio_source.h
+++ b/gr-audio/lib/portaudio/portaudio_source.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/audio/source.h>
 #include <gnuradio/buffer.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/thread/thread.h>
 #include <portaudio.h>
 #include <stdexcept>

--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -89,10 +89,11 @@ windows_sink::windows_sink(int sampling_freq,
 
     d_wave_write_event = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (open_waveout_device() < 0) {
-        perror("audio_windows_sink:open_waveout_device() failed\n");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("open_waveout_device() failed: %s") % strerror(errno));
         throw std::runtime_error("audio_windows_sink:open_waveout_device() failed");
-    } else if (verbose) {
-        GR_LOG_INFO(d_logger, "Opened windows waveout device");
+    } else {
+        GR_LOG_INFO(d_debug_logger, "Opened windows waveout device");
     }
     d_buffers = new LPWAVEHDR[nPeriods];
     for (int i = 0; i < nPeriods; i++) {
@@ -102,12 +103,11 @@ windows_sink::windows_sink(int sampling_freq,
         d_buffers[i]->dwBufferLength = d_buffer_size;
         d_buffers[i]->lpData = new CHAR[d_buffer_size];
     }
-    if (verbose)
-        GR_LOG_INFO(
-            d_logger,
-            boost::format(
-                "Initialized %1% %2%ms audio buffers, total memory used: %3$0.2fkB") %
-                (nPeriods) % (CHUNK_TIME * 1000) % ((d_buffer_size * nPeriods) / 1024.0));
+    GR_LOG_INFO(
+        d_debug_logger,
+        boost::format(
+            "Initialized %1% %2% ms audio buffers, total memory used: %3$0.2f kB") %
+            (nPeriods) % (CHUNK_TIME * 1000) % ((d_buffer_size * nPeriods) / 1024.0));
 }
 
 windows_sink::~windows_sink()
@@ -178,9 +178,12 @@ int windows_sink::work(int noutput_items,
                 // let's just fail and give some debugging information about the status of
                 // the buffers.
                 for (int i = 0; i < nPeriods; i++) {
-                    printf("%d: %d\n", i, d_buffers[i]->dwFlags);
+                    GR_LOG_ERROR(
+                        d_logger, "audio buffer %d: %d", i, d_buffers[i]->dwFlags);
                 }
-                perror("audio_windows_sink: no audio buffers available");
+                GR_LOG_ERROR(d_logger,
+                             boost::format("no audio buffers available: %s") %
+                                 strerror(errno));
                 return -1;
             }
         }
@@ -209,7 +212,7 @@ int windows_sink::work(int noutput_items,
             break;
         }
         if (write_waveout(chosen_header) < 0) {
-            perror("audio_windows_sink: write failed");
+            GR_LOG_ERROR(d_logger, boost::format("write failed: %s") % strerror(errno));
         }
         samples_sent += samples_tosend;
     }
@@ -253,8 +256,8 @@ UINT windows_sink::find_device(std::string szDeviceName)
             if (num < num_devices) {
                 result = num;
             } else {
-                GR_LOG_INFO(d_logger,
-                            boost::format("Warning: waveOut deviceID %d was not found, "
+                GR_LOG_WARN(d_logger,
+                            boost::format("waveOut deviceID %d was not found. "
                                           "defaulting to WAVE_MAPPER") %
                                 num);
                 result = WAVE_MAPPER;
@@ -265,27 +268,32 @@ UINT windows_sink::find_device(std::string szDeviceName)
             for (UINT i = 0; i < num_devices; i++) {
                 WAVEOUTCAPS woc;
                 if (waveOutGetDevCaps(i, &woc, sizeof(woc)) != MMSYSERR_NOERROR) {
-                    perror("Error: Could not retrieve wave out device capabilities for "
-                           "device");
+                    GR_LOG_ERROR(d_logger,
+                                 boost::format("Could not retrieve wave out device "
+                                               "capabilities for %s device") %
+                                     strerror(errno));
                     return -1;
                 }
                 if (woc.szPname == szDeviceName) {
                     result = i;
                 }
-                if (verbose)
-                    GR_LOG_INFO(d_logger,
+                if (verbose) {
+                    GR_LOG_INFO(d_debug_logger,
                                 boost::format("WaveOut Device %d: %s") % i % woc.szPname);
+                }
             }
             if (result == -1) {
-                GR_LOG_INFO(d_logger,
-                            boost::format("Warning: waveOut device '%s' was not found, "
+                GR_LOG_WARN(d_logger,
+                            boost::format("waveOut device '%s' was not found, "
                                           "defaulting to WAVE_MAPPER") %
                                 szDeviceName);
                 result = WAVE_MAPPER;
             }
         }
     } else {
-        perror("Error: No WaveOut devices present or accessible");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("No WaveOut devices present or accessible: %s") %
+                         strerror(errno));
     }
     return result;
 }
@@ -311,16 +319,19 @@ int windows_sink::open_waveout_device(void)
         // and stick with WAVE_MAPPER
         u_device_id = find_device(d_device_name);
     if (verbose)
-        GR_LOG_INFO(d_logger, boost::format("waveOut Device ID: %1%") % (u_device_id));
+        GR_LOG_INFO(d_debug_logger,
+                    boost::format("waveOut Device ID: %1%") % (u_device_id));
 
     // Check if the sampling rate/bits/channels are good to go with the device.
     MMRESULT supported = is_format_supported(&wave_format, u_device_id);
     if (supported != MMSYSERR_NOERROR) {
         char err_msg[50];
         waveOutGetErrorText(supported, err_msg, 50);
-        GR_LOG_INFO(d_logger, boost::format("format error: %s") % err_msg);
-        perror("audio_windows_sink: Requested audio format is not supported by device "
-               "driver");
+        GR_LOG_INFO(d_debug_logger, boost::format("format error: %s") % err_msg);
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("Requested audio format is not supported by device %s driver") %
+                strerror(errno));
         return -1;
     }
 
@@ -332,10 +343,11 @@ int windows_sink::open_waveout_device(void)
                          0,
                          CALLBACK_EVENT | WAVE_ALLOWSYNC);
 
-    if (result) {
-        perror("audio_windows_sink: Failed to open waveform output device.");
-        return -1;
-    }
+    if (result)
+        GR_LOG_ERROR(d_logger,
+                     boost::format("Failed to open waveform output device. %s") %
+                         strerr(errno));
+    return -1;
     return 0;
 }
 
@@ -350,30 +362,32 @@ int windows_sink::write_waveout(LPWAVEHDR lp_wave_hdr)
 
     w_result = waveOutPrepareHeader(d_h_waveout, lp_wave_hdr, sizeof(WAVEHDR));
     if (w_result != 0) {
-        perror("audio_windows_sink: Failed to waveOutPrepareHeader");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("Failed to waveOutPrepareHeader %s") % strerr(errno));
         return -1;
     }
 
     w_result = waveOutWrite(d_h_waveout, lp_wave_hdr, sizeof(WAVEHDR));
     if (w_result != 0) {
-        perror("audio_windows_sink: Failed to write block to device");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("Failed to write block to device %s") % strerr(errno));
         switch (w_result) {
         case MMSYSERR_INVALHANDLE:
-            fprintf(stderr, "Specified device handle is invalid.\n");
+            GR_LOG_ERROR(d_logger, "Specified device handle is invalid");
             break;
         case MMSYSERR_NODRIVER:
-            fprintf(stderr, " No device driver is present.\n");
+            GR_LOG_ERROR(d_logger, "No device driver is present");
             break;
         case MMSYSERR_NOMEM:
-            fprintf(stderr, " Unable to allocate or lock memory.\n");
+            GR_LOG_ERROR(d_logger, "Unable to allocate or lock memory");
             break;
         case WAVERR_UNPREPARED:
-            fprintf(stderr,
-                    " The data block pointed to by the pwh parameter hasn't been "
-                    "prepared.\n");
+            GR_LOG_ERROR(d_logger,
+                         "The data block pointed to by the pwh parameter hasn't "
+                         "been prepared.");
             break;
         default:
-            fprintf(stderr, "Unknown error %i\n", w_result);
+            GR_LOG_ERROR(d_logger, boost::format("Unknown error %i") % w_result);
         }
         waveOutUnprepareHeader(d_h_waveout, lp_wave_hdr, sizeof(WAVEHDR));
         return -1;

--- a/gr-audio/lib/windows/windows_sink.h
+++ b/gr-audio/lib/windows/windows_sink.h
@@ -18,6 +18,7 @@
 #include <windows.h>
 
 #include <gnuradio/audio/sink.h>
+#include <gnuradio/logger.h>
 #include <string>
 
 namespace gr {

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -90,10 +90,11 @@ windows_source::windows_source(int sampling_freq, const std::string device_name)
         (wave_format.wBitsPerSample / 8); // room for 16-bit audio on one channel.
 
     if (open_wavein_device() < 0) {
-        perror("audio_windows_source:open_wavein_device() failed\n");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("open_wavein_device() failed %s" % strerror(errno)));
         throw std::runtime_error("audio_windows_source:open_wavein_device() failed");
-    } else if (verbose) {
-        GR_LOG_INFO(d_logger, "Opened windows wavein device");
+    } else {
+        GR_LOG_INFO(d_debug_logger, "Opened windows wavein device");
     }
     lp_buffers = new LPWAVEHDR[nPeriods];
     for (int i = 0; i < nPeriods; i++) {
@@ -105,18 +106,21 @@ windows_source::windows_source(int sampling_freq, const std::string device_name)
         lp_buffer->lpData = new CHAR[d_buffer_size];
         MMRESULT w_result = waveInPrepareHeader(d_h_wavein, lp_buffer, sizeof(WAVEHDR));
         if (w_result != 0) {
-            perror("audio_windows_source: Failed to waveInPrepareHeader");
-            throw std::runtime_error("audio_windows_source:open_wavein_device() failed");
+            GR_LOG_ERROR(
+                d_logger,
+                boost::format("Failed to waveInPrepareHeader %s" % strerror(errno)));
+            throw std::runtime_error("open_wavein_device() failed");
         }
         waveInAddBuffer(d_h_wavein, lp_buffer, sizeof(WAVEHDR));
     }
     waveInStart(d_h_wavein);
-    if (verbose)
+    if (verbose) {
         GR_LOG_INFO(
-            d_logger,
+            d_debug_logger,
             boost::format(
-                "Initialized %1% %2%ms audio buffers, total memory used: %3$0.2fkB") %
+                "Initialized %1% %2% ms audio buffers, total memory used: %3$0.2f kiB") %
                 (nPeriods) % (CHUNK_TIME * 1000) % ((d_buffer_size * nPeriods) / 1024.0));
+    }
 }
 
 windows_source::~windows_source()
@@ -226,8 +230,8 @@ UINT windows_source::find_device(std::string szDeviceName)
             if (num < num_devices) {
                 result = num;
             } else {
-                GR_LOG_INFO(d_logger,
-                            boost::format("Warning: waveIn deviceID %d was not found, "
+                GR_LOG_WARN(d_logger,
+                            boost::format("waveIn deviceID %d was not found, "
                                           "defaulting to WAVE_MAPPER") %
                                 num);
                 result = WAVE_MAPPER;
@@ -238,19 +242,21 @@ UINT windows_source::find_device(std::string szDeviceName)
             for (UINT i = 0; i < num_devices; i++) {
                 WAVEINCAPS woc;
                 if (waveInGetDevCaps(i, &woc, sizeof(woc)) != MMSYSERR_NOERROR) {
-                    perror("Error: Could not retrieve wave out device capabilities for "
-                           "device");
+                    GR_LOG_ERROR(d_logger,
+                                 boost::format("Could not retrieve wave out device "
+                                               "capabilities for device %s" %
+                                               strerror(errno)));
                     return -1;
                 }
                 if (woc.szPname == szDeviceName) {
                     result = i;
                 }
                 if (verbose)
-                    GR_LOG_INFO(d_logger,
+                    GR_LOG_INFO(d_debug_logger,
                                 boost::format("WaveIn Device %d: %s") % i % woc.szPname);
             }
             if (result == -1) {
-                GR_LOG_INFO(d_logger,
+                GR_LOG_INFO(d_debug_logger,
                             boost::format("Warning: waveIn device '%s' was not found, "
                                           "defaulting to WAVE_MAPPER") %
                                 szDeviceName);
@@ -258,7 +264,9 @@ UINT windows_source::find_device(std::string szDeviceName)
             }
         }
     } else {
-        perror("Error: No WaveIn devices present or accessible");
+        GR_LOG_ERROR(d_logger,
+                     boost::format("No WaveIn devices present or accessible: %s" %
+                                   strerror(errno)));
     }
     return result;
 }
@@ -284,16 +292,19 @@ int windows_source::open_wavein_device(void)
         // and stick with WAVE_MAPPER
         u_device_id = find_device(d_device_name);
     if (verbose)
-        GR_LOG_INFO(d_logger, boost::format("waveIn Device ID: %1%") % (u_device_id));
+        GR_LOG_INFO(d_debug_logger,
+                    boost::format("waveIn Device ID: %1%") % (u_device_id));
 
     // Check if the sampling rate/bits/channels are good to go with the device.
     MMRESULT supported = is_format_supported(&wave_format, u_device_id);
     if (supported != MMSYSERR_NOERROR) {
         char err_msg[50];
         waveInGetErrorText(supported, err_msg, 50);
-        GR_LOG_INFO(d_logger, boost::format("format error: %s") % err_msg);
-        perror("audio_windows_source: Requested audio format is not supported by device "
-               "driver");
+        GR_LOG_INFO(d_debug_logger, boost::format("format error: %s") % err_msg);
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("Requested audio format is not supported by device driver: %s" %
+                          strerror(errno)));
         return -1;
     }
 
@@ -306,7 +317,9 @@ int windows_source::open_wavein_device(void)
                         CALLBACK_FUNCTION | WAVE_ALLOWSYNC);
 
     if (result) {
-        perror("audio_windows_source: Failed to open waveform output device.");
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("Failed to open waveform output device: %s" % strerror(errno)));
         return -1;
     }
     return 0;
@@ -318,7 +331,9 @@ static void CALLBACK read_wavein(
     // Ignore WIM_OPEN and WIM_CLOSE messages
     if (uMsg == WIM_DATA) {
         if (!dwInstance) {
-            perror("audio_windows_source: callback function missing buffer queue");
+            GR_LOG_ERROR(d_logger,
+                         boost::format("callback function missing buffer queue: %s" %
+                                       strerror(errno)));
         }
         LPWAVEHDR lp_wave_hdr = (LPWAVEHDR)dwParam1; // The new audio data
         boost::lockfree::spsc_queue<LPWAVEHDR>* q =

--- a/gr-blocks/include/gnuradio/blocks/file_sink_base.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink_base.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_FILE_SINK_BASE_H
 
 #include <gnuradio/blocks/api.h>
+#include <gnuradio/logger.h>
 #include <boost/thread.hpp>
 #include <cstdio>
 
@@ -31,6 +32,7 @@ protected:
     boost::mutex d_mutex;
     bool d_unbuffered;
     bool d_append;
+    gr::logger_ptr d_logger, d_debug_logger;
 
 protected:
     file_sink_base(const char* filename, bool is_binary, bool append);

--- a/gr-blocks/lib/file_descriptor_sink_impl.cc
+++ b/gr-blocks/lib/file_descriptor_sink_impl.cc
@@ -60,7 +60,7 @@ int file_descriptor_sink_impl::work(int noutput_items,
             if (errno == EINTR)
                 continue;
             else {
-                perror("file_descriptor_sink");
+                GR_LOG_ERROR(d_logger, strerror(errno));
                 return -1; // indicate we're done
             }
         } else {

--- a/gr-blocks/lib/file_descriptor_source_impl.cc
+++ b/gr-blocks/lib/file_descriptor_source_impl.cc
@@ -107,7 +107,9 @@ int file_descriptor_source_impl::work(int noutput_items,
             if (errno == EINTR)
                 continue;
             else {
-                perror("file_descriptor_source[read]");
+                GR_LOG_ERROR(d_logger,
+                             boost::format("file_descriptor_source[read]: %s") %
+                                 strerror(errno));
                 return -1;
             }
         } else if (r == 0) { // end of file
@@ -116,7 +118,9 @@ int file_descriptor_source_impl::work(int noutput_items,
             else {
                 flush_residue();
                 if (lseek(d_fd, 0, SEEK_SET) == -1) {
-                    perror("file_descriptor_source[lseek]");
+                    GR_LOG_ERROR(d_logger,
+                                 boost::format("file_descriptor_source[lseek]: %s") %
+                                     strerror(errno));
                     return -1;
                 }
             }

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -155,7 +155,7 @@ bool file_meta_sink_impl::_open(FILE** fp, const char* filename)
     if ((fd = ::open(filename,
                      O_WRONLY | O_CREAT | O_TRUNC | OUR_O_LARGEFILE | OUR_O_BINARY,
                      0664)) < 0) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
         return false;
     }
 
@@ -165,7 +165,7 @@ bool file_meta_sink_impl::_open(FILE** fp, const char* filename)
     }
 
     if ((*fp = fdopen(fd, "wb")) == NULL) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
     }
 

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -263,7 +263,7 @@ bool file_meta_source_impl::_open(FILE** fp, const char* filename)
     int fd;
 
     if ((fd = ::open(filename, O_RDONLY | OUR_O_LARGEFILE | OUR_O_BINARY)) < 0) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
         return false;
     }
 
@@ -273,7 +273,7 @@ bool file_meta_source_impl::_open(FILE** fp, const char* filename)
     }
 
     if ((*fp = fdopen(fd, "rb")) == NULL) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
     }
 

--- a/gr-blocks/lib/stream_pdu_base.cc
+++ b/gr-blocks/lib/stream_pdu_base.cc
@@ -23,6 +23,7 @@
 #include "stream_pdu_base.h"
 #include <gnuradio/basic_block.h>
 #include <gnuradio/blocks/pdu.h>
+#include <gnuradio/logger.h>
 #include <boost/format.hpp>
 
 static const long timeout_us = 100 * 1000; // 100ms
@@ -32,6 +33,7 @@ namespace blocks {
 
 stream_pdu_base::stream_pdu_base(int MTU) : d_fd(-1), d_started(false), d_finished(false)
 {
+    gr::configure_default_loggers(d_pdu_logger, d_pdu_debug_logger, "stream_pdu_base");
     // reserve space for rx buffer
     d_rxbuf.resize(MTU, 0);
 }
@@ -98,10 +100,9 @@ void stream_pdu_base::send(pmt::pmt_t msg)
 
     const int rv = write(d_fd, pmt::uniform_vector_elements(vector, offset), len);
     if (rv != len) {
-        std::cerr << boost::format("WARNING: stream_pdu_base::send(pdu) write failed! "
-                                   "(d_fd=%d, len=%d, rv=%d)") %
-                         d_fd % len % rv
-                  << std::endl;
+        static auto msg = boost::format(
+            "stream_pdu_base::send(pdu) write failed! (d_fd=%d, len=%d, rv=%d)");
+        GR_LOG_WARN(d_pdu_logger, msg % d_fd % len % rv);
     }
 }
 

--- a/gr-blocks/lib/stream_pdu_base.h
+++ b/gr-blocks/lib/stream_pdu_base.h
@@ -12,6 +12,7 @@
 #define INCLUDED_STREAM_PDU_BASE_H
 
 #include <gnuradio/basic_block.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/thread/thread.h>
 #include <pmt/pmt.h>
 
@@ -41,6 +42,8 @@ protected:
     bool wait_ready();
     void start_rxthread(basic_block* blk, pmt::pmt_t rxport);
     void stop_rxthread();
+
+    gr::logger_ptr d_pdu_logger, d_pdu_debug_logger;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -153,14 +153,18 @@ int tagged_file_sink_impl::work(int noutput_items,
                                      O_WRONLY | O_CREAT | O_TRUNC | OUR_O_LARGEFILE |
                                          OUR_O_BINARY,
                                      0664)) < 0) {
-                        perror(filename.str().c_str());
+                        GR_LOG_ERROR(d_logger,
+                                     boost::format("::open %s: %s") % filename.str() %
+                                         strerror(errno));
                         return -1;
                     }
 
                     // FIXME:
                     // if((d_handle = fdopen (fd, d_is_binary ? "wb" : "w")) == NULL) {
                     if ((d_handle = fdopen(fd, "wb")) == NULL) {
-                        perror(filename.str().c_str());
+                        GR_LOG_ERROR(d_logger,
+                                     boost::format("fdopen %s: %s") % filename.str() %
+                                         strerror(errno));
                         ::close(fd); // don't leak file descriptor if fdopen fails.
                     }
 
@@ -187,7 +191,9 @@ int tagged_file_sink_impl::work(int noutput_items,
                         &inbuf[d_itemsize * idx], d_itemsize, idx_stop - idx, d_handle);
                     if (count == 0) {
                         if (ferror(d_handle)) {
-                            perror("tagged_file_sink: error writing file");
+                            GR_LOG_ERROR(d_logger,
+                                         boost::format("writing file(1): %s") %
+                                             strerror(errno));
                         }
                     }
                     idx = idx_stop;
@@ -204,7 +210,9 @@ int tagged_file_sink_impl::work(int noutput_items,
                     &inbuf[d_itemsize * idx], d_itemsize, noutput_items - idx, d_handle);
                 if (count == 0) {
                     if (ferror(d_handle)) {
-                        perror("tagged_file_sink: error writing file");
+                        GR_LOG_ERROR(d_logger,
+                                     boost::format("writing file(2): %s") %
+                                         strerror(errno));
                     }
                 }
                 idx = noutput_items;

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -63,12 +63,14 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
             "gr::tuntap_pdu::make: tun_alloc failed (are you running as root?)");
 
     int err = set_mtu(dev_cstr, MTU);
-    if (err < 0)
-        std::cerr << boost::format("gr::tuntap_pdu: failed to set MTU to %d.\n"
-                                   "You should use ifconfig to set the MTU. E.g.,\n"
-                                   "  $ sudo ifconfig %s mtu %d\n") %
-                         MTU % dev % MTU
-                  << std::endl;
+    if (err < 0) {
+        std::ostringstream msg;
+        msg << boost::format("failed to set MTU to %d. You should use ifconfig to set "
+                             "the MTU. E.g., `$ sudo ifconfig %s mtu %d`") %
+                   MTU % dev % MTU;
+        GR_LOG_ERROR(d_logger, msg.str());
+    }
+
 
     std::cout << boost::format("Allocated virtual ethernet interface: %s\n"
                                "You must now use ifconfig to set its IP address. E.g.,\n"

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -97,7 +97,8 @@ bool wavfile_sink_impl::open(const char* filename)
     if ((fd = ::open(filename,
                      O_WRONLY | O_CREAT | O_TRUNC | OUR_O_LARGEFILE | OUR_O_BINARY,
                      0664)) < 0) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("::open: %s: %s") % filename % strerror(errno));
         return false;
     }
 
@@ -107,14 +108,16 @@ bool wavfile_sink_impl::open(const char* filename)
     }
 
     if ((d_new_fp = fdopen(fd, "wb")) == NULL) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("fdopen: %s: %s") % filename % strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
         return false;
     }
     d_updated = true;
 
     if (!wavheader_write(d_new_fp, d_sample_rate, d_nchans, d_bytes_per_sample_new)) {
-        fprintf(stderr, "[%s] could not write to WAV file\n", __FILE__);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("could not write to WAV file: %s") % strerror(errno))
         exit(-1);
     }
 
@@ -184,7 +187,8 @@ int wavfile_sink_impl::work(int noutput_items,
             wav_write_sample(d_fp, sample_buf_s, d_bytes_per_sample);
 
             if (feof(d_fp) || ferror(d_fp)) {
-                fprintf(stderr, "[%s] file i/o error\n", __FILE__);
+                GR_LOG_ERROR(d_logger,
+                             boost::format("file i/o error %s") % strerror(errno));
                 close();
                 exit(-1);
             }

--- a/gr-blocks/lib/wavfile_source_impl.cc
+++ b/gr-blocks/lib/wavfile_source_impl.cc
@@ -59,13 +59,15 @@ wavfile_source_impl::wavfile_source_impl(const char* filename, bool repeat)
     // we use "open" to use to the O_LARGEFILE flag
 
     int fd;
-    if ((fd = open(filename, O_RDONLY | OUR_O_LARGEFILE | OUR_O_BINARY)) < 0) {
-        perror(filename);
+    if ((fd = ::open(filename, O_RDONLY | OUR_O_LARGEFILE | OUR_O_BINARY)) < 0) {
+        GR_LOG_ERROR(d_logger,
+                     boost::format("::open: %s: %s") % filename % strerror(errno));
         throw std::runtime_error("can't open file");
     }
 
     if ((d_fp = fdopen(fd, "rb")) == NULL) {
-        perror(filename);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("fdopen: %s: %s") % filename % strerror(errno));
         throw std::runtime_error("can't open file");
     }
 
@@ -123,7 +125,8 @@ int wavfile_source_impl::work(int noutput_items,
             }
 
             if (fseek(d_fp, d_first_sample_pos, SEEK_SET) == -1) {
-                fprintf(stderr, "[%s] fseek failed\n", __FILE__);
+                GR_LOG_ERROR(d_logger,
+                             boost::format("fseek failed %s") % strerror(errno));
                 exit(-1);
             }
 
@@ -145,9 +148,9 @@ int wavfile_source_impl::work(int noutput_items,
         // trouble they won't be processed. Serves them bloody right.
         if (feof(d_fp) || ferror(d_fp)) {
             if (i == 0) {
-                fprintf(stderr,
-                        "[%s] WAV file has corrupted header or i/o error\n",
-                        __FILE__);
+                GR_LOG_ERROR(d_logger,
+                             boost::format("WAV file has corrupted header or i/o error") %
+                                 strerror(errno));
                 return -1;
             }
             return i;

--- a/gr-digital/lib/packet_sink_impl.cc
+++ b/gr-digital/lib/packet_sink_impl.cc
@@ -33,8 +33,9 @@ static const int DEFAULT_THRESHOLD = 12;
 
 inline void packet_sink_impl::enter_search()
 {
-    if (VERBOSE)
-        fprintf(stderr, "@ enter_search\n");
+    if (VERBOSE) {
+        GR_LOG_INFO(d_debug_logger, "enter_search");
+    }
 
     d_state = STATE_SYNC_SEARCH;
     d_shift_reg = 0;
@@ -42,9 +43,9 @@ inline void packet_sink_impl::enter_search()
 
 inline void packet_sink_impl::enter_have_sync()
 {
-    if (VERBOSE)
-        fprintf(stderr, "@ enter_have_sync\n");
-
+    if (VERBOSE) {
+        GR_LOG_INFO(d_debug_logger, "enter_have_sync");
+    }
     d_state = STATE_HAVE_SYNC;
     d_header = 0;
     d_headerbitlen_cnt = 0;
@@ -52,9 +53,10 @@ inline void packet_sink_impl::enter_have_sync()
 
 inline void packet_sink_impl::enter_have_header(int payload_len)
 {
-    if (VERBOSE)
-        fprintf(stderr, "@ enter_have_header (payload_len = %d)\n", payload_len);
-
+    if (VERBOSE) {
+        GR_LOG_INFO(d_debug_logger,
+                    boost::format("enter_have_header (payload_len = %d)") % payload_len);
+    }
     d_state = STATE_HAVE_HEADER;
     d_packetlen = payload_len;
     d_packetlen_cnt = 0;
@@ -97,16 +99,16 @@ int packet_sink_impl::work(int noutput_items,
     float* inbuf = (float*)input_items[0];
     int count = 0;
 
-    if (VERBOSE)
-        fprintf(stderr, ">>> Entering state machine\n"), fflush(stderr);
+    if (VERBOSE) {
+        GR_LOG_INFO(d_debug_logger, "enter state machine");
+    }
 
     while (count < noutput_items) {
         switch (d_state) {
 
         case STATE_SYNC_SEARCH: // Look for sync vector
             if (VERBOSE)
-                fprintf(stderr, "SYNC Search, noutput=%d\n", noutput_items),
-                    fflush(stderr);
+                GR_LOG_INFO(d_debug_logger, "SYNC Search, noutput=%d");
 
             while (count < noutput_items) {
                 if (slice(inbuf[count++]))
@@ -126,11 +128,9 @@ int packet_sink_impl::work(int noutput_items,
 
         case STATE_HAVE_SYNC:
             if (VERBOSE)
-                fprintf(stderr,
-                        "Header Search bitcnt=%d, header=0x%08x\n",
-                        d_headerbitlen_cnt,
-                        d_header),
-                    fflush(stderr);
+                GR_LOG_INFO(d_debug_logger,
+                            boost::format("Header Search bitcnt=%d, header=0x%08x") %
+                                d_headerbitlen_cnt % d_header);
 
             while (count < noutput_items) { // Shift bits one at a time into header
                 if (slice(inbuf[count++]))
@@ -140,7 +140,8 @@ int packet_sink_impl::work(int noutput_items,
 
                 if (++d_headerbitlen_cnt == HEADERBITLEN) {
                     if (VERBOSE)
-                        fprintf(stderr, "got header: 0x%08x\n", d_header);
+                        GR_LOG_INFO(d_debug_logger,
+                                    boost::format("got header: 0x%08x") % d_header);
 
                     // we have a full header, check to see if it has been received
                     // properly
@@ -158,8 +159,9 @@ int packet_sink_impl::work(int noutput_items,
             break;
 
         case STATE_HAVE_HEADER:
-            if (VERBOSE)
-                fprintf(stderr, "Packet Build\n"), fflush(stderr);
+            if (VERBOSE) {
+                GR_LOG_INFO(d_debug_logger, "Packet Build");
+            }
 
             while (count <
                    noutput_items) { // shift bits into bytes of packet one at a time

--- a/gr-dtv/lib/atsc/atsc_fs_checker_impl.h
+++ b/gr-dtv/lib/atsc/atsc_fs_checker_impl.h
@@ -13,6 +13,7 @@
 
 #include "atsc_syminfo_impl.h"
 #include <gnuradio/dtv/atsc_fs_checker.h>
+#include <gnuradio/logger.h>
 
 namespace gr {
 namespace dtv {
@@ -27,6 +28,8 @@ private:
     unsigned char d_bit_sr[SRSIZE];     // binary decision shift register
     int d_field_num;
     int d_segment_num;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
     static constexpr int OFFSET_511 = 4;      // offset to second PN 63 pattern
     static constexpr int LENGTH_511 = 511;    // length of PN 63 pattern

--- a/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
@@ -102,6 +102,8 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
       d_prev_mod_symbol_index(0),
       d_mod_symbol_index(0)
 {
+
+    gr::configure_default_loggers(d_logger, d_debug_logger, "dvbt_pilot_gen");
     // Determine parameters from config file
     d_Kmin = config.d_Kmin;
     d_Kmax = config.d_Kmax;
@@ -139,7 +141,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // allocate PRBS buffer
     d_wk = new (std::nothrow) char[d_Kmax - d_Kmin + 1];
     if (d_wk == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_wk." << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_wk.");
         throw std::bad_alloc();
     }
     // Generate wk sequence
@@ -148,9 +150,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // allocate buffer for scattered pilots
     d_spilot_carriers_val = new (std::nothrow) gr_complex[d_Kmax - d_Kmin + 1];
     if (d_spilot_carriers_val == NULL) {
-        std::cerr
-            << "Reference Signals, cannot allocate memory for d_spilot_carriers_val."
-            << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_spilot_carriers_val.");
         delete[] d_wk;
         throw std::bad_alloc();
     }
@@ -158,8 +158,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // allocate buffer for channel gains (for each useful carrier)
     d_channel_gain = new (std::nothrow) gr_complex[d_Kmax - d_Kmin + 1];
     if (d_channel_gain == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_channel_gain."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_channel_gain.");
         delete[] d_spilot_carriers_val;
         delete[] d_wk;
         throw std::bad_alloc();
@@ -168,8 +167,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // Allocate buffer for continual pilots phase diffs
     d_known_phase_diff = new (std::nothrow) float[d_cpilot_carriers_size - 1];
     if (d_known_phase_diff == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_known_phase_diff."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_known_phase_diff.");
         delete[] d_channel_gain;
         delete[] d_spilot_carriers_val;
         delete[] d_wk;
@@ -184,8 +182,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
 
     d_cpilot_phase_diff = new (std::nothrow) float[d_cpilot_carriers_size - 1];
     if (d_cpilot_phase_diff == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_cpilot_phase_diff."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_cpilot_phase_diff.");
         delete[] d_known_phase_diff;
         delete[] d_channel_gain;
         delete[] d_spilot_carriers_val;
@@ -196,8 +193,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // Allocate buffer for derotated input symbol
     d_derot_in = new (std::nothrow) gr_complex[d_fft_length];
     if (d_derot_in == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_derot_in."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_derot_in.");
         delete[] d_cpilot_phase_diff;
         delete[] d_known_phase_diff;
         delete[] d_channel_gain;
@@ -209,8 +205,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // allocate buffer for first tps symbol constellation
     d_tps_carriers_val = new (std::nothrow) gr_complex[d_tps_carriers_size];
     if (d_tps_carriers_val == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_tps_carriers_val."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_tps_carriers_val.");
         delete[] d_derot_in;
         delete[] d_cpilot_phase_diff;
         delete[] d_known_phase_diff;
@@ -223,8 +218,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // allocate tps data buffer
     d_tps_data = new (std::nothrow) unsigned char[d_symbols_per_frame];
     if (d_tps_data == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_tps_data."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_tps_data.");
         delete[] d_tps_carriers_val;
         delete[] d_derot_in;
         delete[] d_cpilot_phase_diff;
@@ -237,8 +231,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
 
     d_prev_tps_symbol = new (std::nothrow) gr_complex[d_tps_carriers_size];
     if (d_prev_tps_symbol == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_prev_tps_symbol."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_prev_tps_symbol.");
         delete[] d_tps_data;
         delete[] d_tps_carriers_val;
         delete[] d_derot_in;
@@ -253,8 +246,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
 
     d_tps_symbol = new (std::nothrow) gr_complex[d_tps_carriers_size];
     if (d_tps_symbol == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_tps_symbol."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_tps_symbol.");
         delete[] d_prev_tps_symbol;
         delete[] d_tps_data;
         delete[] d_tps_carriers_val;
@@ -282,8 +274,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // Allocate buffer for channel estimation carriers
     d_chanestim_carriers = new (std::nothrow) int[d_Kmax - d_Kmin + 1];
     if (d_chanestim_carriers == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_chanestim_carriers."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_chanestim_carriers.");
         delete[] d_tps_symbol;
         delete[] d_prev_tps_symbol;
         delete[] d_tps_data;
@@ -300,8 +291,7 @@ dvbt_pilot_gen::dvbt_pilot_gen(const dvbt_configure& c)
     // Allocate buffer for payload carriers
     d_payload_carriers = new (std::nothrow) int[d_Kmax - d_Kmin + 1];
     if (d_payload_carriers == NULL) {
-        std::cerr << "Reference Signals, cannot allocate memory for d_payload_carriers."
-                  << std::endl;
+        GR_LOG_ERROR(d_logger, "cannot allocate memory for d_payload_carriers.");
         delete[] d_chanestim_carriers;
         delete[] d_tps_symbol;
         delete[] d_prev_tps_symbol;

--- a/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.h
@@ -12,6 +12,7 @@
 #include "dvbt_configure.h"
 #include <gnuradio/dtv/dvbt_reference_signals.h>
 #include <gnuradio/fft/fft.h>
+#include <gnuradio/logger.h>
 #include <deque>
 #include <vector>
 
@@ -194,6 +195,8 @@ private:
     void process_payload_data(const gr_complex* in, gr_complex* out);
 
 public:
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
     dvbt_pilot_gen(const dvbt_configure& config);
     ~dvbt_pilot_gen();
 

--- a/gr-fec/lib/conv_bit_corr_bb_impl.cc
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.cc
@@ -127,7 +127,7 @@ int conv_bit_corr_bb_impl::general_work(int noutput_items,
     uint8_t* score_in = (uint8_t*)input_items[0];
 
     // counting on  1:1 forecast + history to provide enough ninput_items... may need to
-    // insert check printf("%d, %d, %d\n", ninput_items[0], noutput_items, d_counter);
+    // insert check printf("%d, %d, %d", ninput_items[0], noutput_items, d_counter);
     int correlation_cycles =
         (noutput_items / output_multiple() <= static_cast<int>(d_counter))
             ? noutput_items / output_multiple()
@@ -180,14 +180,14 @@ int conv_bit_corr_bb_impl::general_work(int noutput_items,
                     d_acquire = k;
                     d_lane = i + 1;
                     d_op = 1;
-                    // printf("winner: lane %u, punc_cycle %u, pos/neg corr %d\n", i, k,
+                    // printf("winner: lane %u, punc_cycle %u, pos/neg corr %d", i, k,
                     // d_op);
                     break;
                 } else if (d_acc[i * (d_corr_sym) + k] > (d_cut - d_thresh)) {
                     d_acquire = k;
                     d_lane = i + 1;
                     d_op = -1;
-                    // printf("winner: lane %u, punc_cycle %u, pos/neg corr %d\n", i, k,
+                    // printf("winner: lane %u, punc_cycle %u, pos/neg corr %d", i, k,
                     // d_op);
                     break;
                 }
@@ -215,7 +215,7 @@ int conv_bit_corr_bb_impl::general_work(int noutput_items,
     // states are set
 
     if (d_produce) {
-        // printf("producing\n");
+        // printf("producing");
         unsigned char* out = (unsigned char*)output_items[0];
         memcpy(out,
                &(in[d_acquire]),
@@ -243,7 +243,7 @@ float conv_bit_corr_bb_impl::data_garble_rate(int taps, float target)
     answer = 0.5 * (1 - pow(base, expo));
 
     if ((errno == EDOM) || (errno == ERANGE)) {
-        fprintf(stderr, "Out of range errors while computing garble rate.\n");
+        GR_LOG_ERROR(d_logger, "Out of range errors while computing garble rate.");
         exit(-1);
     }
     return answer;

--- a/gr-fft/include/gnuradio/fft/fft.h
+++ b/gr-fft/include/gnuradio/fft/fft.h
@@ -17,6 +17,7 @@
 
 #include <gnuradio/fft/api.h>
 #include <gnuradio/gr_complex.h>
+#include <gnuradio/logger.h>
 #include <volk/volk_alloc.hh>
 #include <boost/thread.hpp>
 
@@ -58,6 +59,8 @@ class FFT_API fft_complex
     volk::vector<gr_complex> d_inbuf;
     volk::vector<gr_complex> d_outbuf;
     void* d_plan;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
 public:
     fft_complex(int fft_size, bool forward = true, int nthreads = 1);
@@ -104,6 +107,8 @@ class FFT_API fft_real_fwd
     volk::vector<float> d_inbuf;
     volk::vector<gr_complex> d_outbuf;
     void* d_plan;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
 public:
     fft_real_fwd(int fft_size, int nthreads = 1);
@@ -150,6 +155,8 @@ class FFT_API fft_real_rev
     volk::vector<gr_complex> d_inbuf;
     volk::vector<float> d_outbuf;
     void* d_plan;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
 public:
     fft_real_rev(int fft_size, int nthreads = 1);

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -83,8 +83,9 @@ std::vector<gr_complex> ctrlport_probe_psd_impl::get()
 void ctrlport_probe_psd_impl::set_length(int len)
 {
     if (len > 8191) {
-        std::cerr << "probe_psd: length " << len << " exceeds maximum buffer size of 8191"
-                  << std::endl;
+        std::ostringstream msg;
+        msg << "length " << len << " exceeds maximum buffer size of 8191";
+        GR_LOG_ERROR(d_logger, msg.str());
         len = 8191;
     }
 

--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -14,6 +14,7 @@
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/filter/api.h>
 #include <gnuradio/gr_complex.h>
+#include <gnuradio/logger.h>
 #include <volk/volk_alloc.hh>
 #include <vector>
 
@@ -69,6 +70,8 @@ private:
 
     void compute_sizes(int ntaps);
     int tailsize() const { return d_ntaps - 1; }
+
+    gr::logger_ptr d_logger, d_debug_logger;
 
 public:
     /*!
@@ -172,6 +175,8 @@ private:
     void compute_sizes(int ntaps);
     int tailsize() const { return d_ntaps - 1; }
 
+    gr::logger_ptr d_logger, d_debug_logger;
+
 public:
     /*!
      * \brief Construct an FFT filter for complex vectors with the given taps and
@@ -273,6 +278,8 @@ private:
 
     void compute_sizes(int ntaps);
     int tailsize() const { return d_ntaps - 1; }
+
+    gr::logger_ptr d_logger, d_debug_logger;
 
 public:
     /*!

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -13,6 +13,7 @@
 #endif
 
 #include <gnuradio/filter/fft_filter.h>
+#include <gnuradio/logger.h>
 #include <volk/volk.h>
 #include <boost/smart_ptr/make_unique.hpp>
 #include <cstring>
@@ -29,6 +30,7 @@ fft_filter_fff::fft_filter_fff(int decimation,
                                int nthreads)
     : d_fftsize(-1), d_decimation(decimation), d_nthreads(nthreads)
 {
+    gr::configure_default_loggers(d_logger, d_debug_logger, "fft_filter_fff");
     set_taps(taps);
 }
 
@@ -76,8 +78,10 @@ void fft_filter_fff::compute_sizes(int ntaps)
     d_nsamples = d_fftsize - d_ntaps + 1;
 
     if (VERBOSE) {
-        std::cerr << "fft_filter_fff: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
-                  << " nsamples = " << d_nsamples << std::endl;
+        std::ostringstream msg;
+        msg << "fft_filter_fff: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
+            << " nsamples = " << d_nsamples;
+        GR_LOG_ERROR(d_logger, msg.str());
     }
 
     // compute new plans
@@ -157,6 +161,7 @@ fft_filter_ccc::fft_filter_ccc(int decimation,
                                int nthreads)
     : d_fftsize(-1), d_decimation(decimation), d_nthreads(nthreads)
 {
+    gr::configure_default_loggers(d_logger, d_debug_logger, "fft_filter_ccc");
     set_taps(taps);
 }
 
@@ -204,8 +209,11 @@ void fft_filter_ccc::compute_sizes(int ntaps)
     d_nsamples = d_fftsize - d_ntaps + 1;
 
     if (VERBOSE) {
-        std::cerr << "fft_filter_ccc: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
-                  << " nsamples = " << d_nsamples << std::endl;
+        gr::logger_ptr logger, debug_logger;
+        std::ostringstream msg;
+        msg << "fft_filter_ccc: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
+            << " nsamples = " << d_nsamples;
+        GR_LOG_ERROR(logger, msg.str());
     }
 
     // compute new plans
@@ -286,6 +294,7 @@ fft_filter_ccf::fft_filter_ccf(int decimation,
                                int nthreads)
     : d_fftsize(-1), d_decimation(decimation), d_nthreads(nthreads)
 {
+    gr::configure_default_loggers(d_logger, d_debug_logger, "fft_filter_ccf");
     set_taps(taps);
 }
 
@@ -333,8 +342,12 @@ void fft_filter_ccf::compute_sizes(int ntaps)
     d_nsamples = d_fftsize - d_ntaps + 1;
 
     if (VERBOSE) {
-        std::cerr << "fft_filter_ccf: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
-                  << " nsamples = " << d_nsamples << std::endl;
+        gr::logger_ptr logger, debug_logger;
+        gr::configure_default_loggers(logger, debug_logger, "fft_filter_ccf");
+        std::ostringstream msg;
+        msg << "fft_filter_ccf: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
+            << " nsamples = " << d_nsamples;
+        GR_LOG_ERROR(logger, msg.str());
     }
 
     // compute new plans

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -8,26 +8,26 @@
  *
  */
 
+#include <gnuradio/logger.h>
 #include <gnuradio/qtgui/timerasterdisplayform.h>
 
 #include <QColorDialog>
 #include <QMessageBox>
 
 #include <cmath>
-#include <iostream>
 
 TimeRasterDisplayForm::TimeRasterDisplayForm(
     int nplots, double samp_rate, double rows, double cols, double zmax, QWidget* parent)
     : DisplayForm(nplots, parent)
 {
 #if QWT_VERSION < 0x060000
-    std::cerr
-        << "Warning: QWT5 has been found which has serious performance issues with "
-           "raster plots."
-        << std::endl
-        << "         Consider updating to QWT version 6 to use the time raster GUIs."
-        << std::endl
-        << std::endl;
+    gr::logger_ptr logger, debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "timerasterdisplayform");
+
+    GR_LOG_WARN(
+        logger,
+        "Warning: QWT5 has been found which has serious performance issues with raster "
+        "plots. Consider updating to QWT version 6 to use the time raster GUIs.");
 #endif
 
     d_layout = new QGridLayout(this);

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -388,7 +388,7 @@ int usrp_sink_impl::work(int noutput_items,
             // There is a tag gap since no length_tag was found immediately following
             // the last sample of the previous burst. Drop samples until the next
             // length_tag is found. Notify the user of the tag gap.
-            std::cerr << "tG" << std::flush;
+            GR_LOG_ERROR(d_logger, "tG");
             // increment the timespec by the number of samples dropped
             _metadata.time_spec += ::uhd::time_spec_t(0, ninput_items, _sample_rate);
             return ninput_items;
@@ -504,7 +504,7 @@ void usrp_sink_impl::tag_work(int& ninput_items)
             // preempted. Set the items remaining counter to the new burst length. Notify
             // the user of the tag preemption.
             else if (_nitems_to_send > 0) {
-                std::cerr << "tP" << std::flush;
+                GR_LOG_ERROR(d_logger, "tP");
             }
             _nitems_to_send = pmt::to_long(value);
             _metadata.start_of_burst = true;
@@ -521,14 +521,13 @@ void usrp_sink_impl::tag_work(int& ninput_items)
          */
         else if (pmt::equal(key, FREQ_KEY) && my_tag_count == samp0_count) {
             // If it's on the first sample, immediately do the tune:
-            GR_LOG_DEBUG(d_debug_logger,
-                         boost::format("Received tx_freq on start of burst."));
+            GR_LOG_DEBUG(d_debug_logger, "Received tx_freq on start of burst.");
             pmt::pmt_t freq_cmd = pmt::make_dict();
             freq_cmd = pmt::dict_add(freq_cmd, cmd_freq_key(), value);
             msg_handler_command(freq_cmd);
         } else if (pmt::equal(key, FREQ_KEY)) {
             // If it's not on the first sample, queue this command and only tx until here:
-            GR_LOG_DEBUG(d_debug_logger, boost::format("Received tx_freq mid-burst."));
+            GR_LOG_DEBUG(d_debug_logger, "Received tx_freq mid-burst.");
             pmt::pmt_t freq_cmd = pmt::make_dict();
             freq_cmd = pmt::dict_add(freq_cmd, cmd_freq_key(), value);
             commands_in_burst.push_back(freq_cmd);

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -76,8 +76,10 @@ sink_s_impl::sink_s_impl(double framerate,
 
     atexit(SDL_Quit); // check if this is the way to do this
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        std::cerr << "video_sdl::sink_s: Couldn't initialize SDL:" << SDL_GetError()
-                  << " \n SDL_Init(SDL_INIT_VIDEO) failed\n";
+        std::ostringstream msg;
+        msg << "Couldn't initialize SDL:" << SDL_GetError()
+            << "; SDL_Init(SDL_INIT_VIDEO) failed";
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_s");
     };
 
@@ -90,8 +92,10 @@ sink_s_impl::sink_s_impl(double framerate,
             SDL_ANYFORMAT); // SDL_DOUBLEBUF |SDL_SWSURFACE| SDL_HWSURFACE||SDL_FULLSCREEN
 
     if (d_screen == NULL) {
-        std::cerr << "Unable to set SDL video mode: " << SDL_GetError()
-                  << "\n SDL_SetVideoMode() Failed \n";
+        std::ostringstream msg;
+        msg << "Unable to set SDL video mode: " << SDL_GetError()
+            << "; SDL_SetVideoMode() Failed";
+        GR_LOG_ERROR(d_logger, msg.str());
         exit(1);
     }
     if (d_image) {
@@ -101,12 +105,16 @@ sink_s_impl::sink_s_impl(double framerate,
     /* Initialize and create the YUV Overlay used for video out */
     if (!(d_image =
               SDL_CreateYUVOverlay(d_width, d_height, SDL_YV12_OVERLAY, d_screen))) {
-        std::cerr << "SDL: Couldn't create a YUV overlay: \n" << SDL_GetError() << "\n";
+        std::ostringstream msg;
+        msg << "Couldn't create a YUV overlay: " << SDL_GetError();
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_s");
     }
 
-    printf("SDL screen_mode %d bits-per-pixel\n", d_screen->format->BitsPerPixel);
-    printf("SDL overlay_mode %i \n", d_image->format);
+    GR_LOG_INFO(d_debug_logger,
+                boost::format("SDL screen_mode %d bits-per-pixel") %
+                    d_screen->format->BitsPerPixel);
+    GR_LOG_INFO(d_debug_logger, boost::format("SDL overlay_mode %i") % d_image->format);
 
     d_chunk_size = std::min(1, 16384 / width); // width*16;
     d_chunk_size = d_chunk_size * width;
@@ -121,7 +129,9 @@ sink_s_impl::sink_s_impl(double framerate,
     // clear the surface to grey
 
     if (SDL_LockYUVOverlay(d_image)) {
-        std::cerr << "SDL: Couldn't lock YUV overlay: \n" << SDL_GetError() << "\n";
+        std::ostringstream msg;
+        msg << "Couldn't lock a YUV overlay:" << SDL_GetError();
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_s");
     }
 
@@ -307,10 +317,11 @@ int sink_s_impl::work(int noutput_items,
         }
         break;
     default: // 0 or more then 3 channels
-        std::cerr << "video_sdl::sink_s: Wrong number of channels: ";
-        std::cerr
-            << "1, 2 or 3 channels are supported.\n  Requested number of channels is "
-            << input_items.size() << "\n";
+        std::ostringstream msg;
+        msg << "Wrong number of channels: 1, 2 or 3 channels are supported. Requested "
+               "number of channels is "
+            << input_items.size();
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_s");
     }
 

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -77,8 +77,10 @@ sink_uc_impl::sink_uc_impl(double framerate,
 
     atexit(SDL_Quit); // check if this is the way to do this
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        std::cerr << "video_sdl::sink_uc: Couldn't initialize SDL:" << SDL_GetError()
-                  << " \n SDL_Init(SDL_INIT_VIDEO) failed\n";
+        std::ostringstream msg;
+        msg << "Couldn't initialize SDL:" << SDL_GetError()
+            << "; SDL_Init(SDL_INIT_VIDEO) failed";
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
@@ -91,8 +93,10 @@ sink_uc_impl::sink_uc_impl(double framerate,
             SDL_ANYFORMAT); // SDL_DOUBLEBUF |SDL_SWSURFACE| SDL_HWSURFACE||SDL_FULLSCREEN
 
     if (d_screen == NULL) {
-        std::cerr << "Unable to set SDL video mode: " << SDL_GetError()
-                  << "\n SDL_SetVideoMode() Failed \n";
+        std::ostringstream msg;
+        msg << "Unable to set SDL video mode: " << SDL_GetError()
+            << "; SDL_SetVideoMode() Failed";
+        GR_LOG_ERROR(d_logger, msg.str());
         exit(1);
     }
 
@@ -103,12 +107,16 @@ sink_uc_impl::sink_uc_impl(double framerate,
     /* Initialize and create the YUV Overlay used for video out */
     if (!(d_image =
               SDL_CreateYUVOverlay(d_width, d_height, SDL_YV12_OVERLAY, d_screen))) {
-        std::cerr << "SDL: Couldn't create a YUV overlay: \n" << SDL_GetError() << "\n";
+        std::ostringstream msg;
+        msg << "SDL: Couldn't create a YUV overlay: " << SDL_GetError();
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
-    printf("SDL screen_mode %d bits-per-pixel\n", d_screen->format->BitsPerPixel);
-    printf("SDL overlay_mode %i \n", d_image->format);
+    GR_LOG_INFO(d_debug_logger,
+                boost::format("SDL screen_mode %d bits-per-pixel") %
+                    d_screen->format->BitsPerPixel);
+    GR_LOG_INFO(d_debug_logger, boost::format("SDL overlay_mode %i ") % d_image->format);
 
     d_chunk_size = std::min(1, 16384 / width); // width*16;
     d_chunk_size = d_chunk_size * width;
@@ -123,7 +131,9 @@ sink_uc_impl::sink_uc_impl(double framerate,
     // clear the surface to grey
 
     if (SDL_LockYUVOverlay(d_image)) {
-        std::cerr << "SDL: Couldn't lock YUV overlay: \n" << SDL_GetError() << "\n";
+        std::ostringstream msg;
+        msg << "SDL: Couldn't lock a YUV overlay: " << SDL_GetError();
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
@@ -303,10 +313,11 @@ int sink_uc_impl::work(int noutput_items,
         }
         break;
     default: // 0 or more then 3 channels
-        std::cerr << "video_sdl::sink_uc: Wrong number of channels: ";
-        std::cerr
-            << "1, 2 or 3 channels are supported.\n  Requested number of channels is "
-            << input_items.size() << "\n";
+        std::ostringstream msg;
+        msg << "Wrong number of channels: 1, 2 or 3 channels are supported. Requested "
+               "number of channels is "
+            << input_items.size();
+        GR_LOG_ERROR(d_logger, msg.str());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -82,11 +82,9 @@ freedv_rx_ss_impl::~freedv_rx_ss_impl()
     if (freedv_get_test_frames(d_freedv)) {
         total_bits = freedv_get_total_bits(d_freedv);
         total_bit_errors = freedv_get_total_bit_errors(d_freedv);
-        fprintf(stderr,
-                "bits: %d errors: %d BER: %3.2f\n",
-                total_bits,
-                total_bit_errors,
-                (1.0 * total_bit_errors) / total_bits);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("bits: %d errors: %d BER: %3.2f") % total_bits %
+                         total_bit_errors % ((1.0 * total_bit_errors) / total_bits));
     }
     freedv_close(d_freedv);
 }


### PR DESCRIPTION
Supersedes #3024.

This is a squashed attempt to make #3024 viable.

It incorporates gvanh's work, which sadly wasn't error-free and bisectable.

Atop of that, rework from my side, where inappropriate loggers were chosen.

*Attention:* This is not the end to logging conversion; this really focuses on stderr logging; printf debugging is still at large, but since output to stderr almost certainly is log-relevant, and I tried to keep the changeset manageable, let's do this first and overhaul the rest of logging later.