### PR TITLE
CMake/SWIG: Remove SWIG flag superfluous since 3.0.12, suppress warning

### DIFF
--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -107,7 +107,11 @@ macro(GR_SWIG_MAKE name)
     list(INSERT GR_SWIG_INCLUDE_DIRS 0 "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
     #setup the swig flags with flags and include directories
-    set(CMAKE_SWIG_FLAGS -fvirtual -modern -keyword -w511 -w314 -relativeimport -py3 -module ${name} ${GR_SWIG_FLAGS})
+    set(modern_keyword "-modern")
+    if("${SWIG_VERSION}" VERSION_GREATER "3.0.12")
+      set(modern_keyword "")
+    endif()
+    set(CMAKE_SWIG_FLAGS -fvirtual ${modern_keyword} -keyword -w511 -w314 -relativeimport -py3 -module ${name} ${GR_SWIG_FLAGS})
 
     #set the C++ property on the swig .i file so it builds
     set_source_files_properties(${ifiles} PROPERTIES CPLUSPLUS ON)


### PR DESCRIPTION
SWIG complains about "Deprecated command line option: -modern. This
option is now always on.".

As traditional with SWIG, policy changes don't appear in any
documentation; with a bit of git blaming, I found the change to have
been introduced after SWIG 3.0.12.