### PR TITLE
gr-digital/python : Updated soft_dec_lut_gen.py to avoid depreciation warnings.

### DIFF
--- a/gr-digital/python/digital/soft_dec_lut_gen.py
+++ b/gr-digital/python/digital/soft_dec_lut_gen.py
@@ -73,7 +73,7 @@ def soft_dec_table_generator(soft_dec_gen, prec, Es=1):
 
     '''
 
-    npts = 2.0**prec
+    npts = int(2.0**prec)
     maxd = Es*numpy.sqrt(2.0)/2.0
     yrng = numpy.linspace(-maxd, maxd, npts)
     xrng = numpy.linspace(-maxd, maxd, npts)
@@ -110,7 +110,7 @@ def soft_dec_table(constel, symbols, prec, npwr=1):
     re_max = max(numpy.array(constel).real)
     im_max = max(numpy.array(constel).imag)
 
-    npts = 2.0**prec
+    npts = int(2.0**prec)
     yrng = numpy.linspace(im_min, im_max, npts)
     xrng = numpy.linspace(re_min, re_max, npts)
 


### PR DESCRIPTION
Fixes: #3268 
In soft_dec_lut_gen.py, npts is a float and is used as third parameter of numpy.linspace which should be int according to [numpy's documentation](https://numpy.org/devdocs/reference/generated/numpy.linspace.html). This PR removes the warnings.