### PR TITLE
VOLK: notch down the minimum required version to 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(GCC_MIN_VERSION "4.8.4")
 set(CLANG_MIN_VERSION "3.4.0")
 set(APPLECLANG_MIN_VERSION "500")
 set(MSVC_MIN_VERSION "1800")
-set(VOLK_MIN_VERSION "2.2.1")
+set(VOLK_MIN_VERSION "2.1.0")
 
 # Enable generation of compile_commands.json for code completion engines
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
This attempts to fix the CI build issue.

Getting the latest and greatest VOLK in CI is a problem separate from managing
minimum versions, I'd say, for now. However, it's of course desirable that the
BB-included versions of VOLK do reflect the latest VOLK release.