### PR TITLE
pmt: conditionalize testing of long > 2³² on sizeof(long)

### DIFF
--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -18,6 +18,10 @@ class test_pmt(unittest.TestCase):
     MAXINT32 = (2**31)-1
     MININT32 = (-MAXINT32)-1
 
+    def setUp(self):
+        from ctypes import sizeof, c_long
+        self.sizeof_long = sizeof(c_long)
+
     def test01(self):
         a = pmt.intern("a")
         b = pmt.from_double(123765)
@@ -112,6 +116,8 @@ class test_pmt(unittest.TestCase):
         self.assertEqual(const,pmt.to_long(deser))
 
     def test15(self):
+        if(self.sizeof_long <= 4):
+            return
         const = self.MAXINT32 + 1
         x_pmt = pmt.from_long(const)
         s = pmt.serialize_str(x_pmt)
@@ -137,6 +143,8 @@ class test_pmt(unittest.TestCase):
         self.assertEqual(const, x_long)
 
     def test18(self):
+        if(self.sizeof_long <= 4):
+            return
         const = self.MININT32 - 1
         x_pmt = pmt.from_long(const)
         s = pmt.serialize_str(x_pmt)


### PR DESCRIPTION
fixes #3326

After reports of @drmpeg that qa_pmt assumes sizeof(long)>4, I circumvented the test that do.

However, this is a fundamental architectural flaw: On @drmpegs 32-bit ARM, a long is 4 Bytes.
On my machine, it's 8.

This yields different deserializability of serialized PMTs.

PMT is supposed to be a portable serialization format.

It's not.

I'd try to change PMT, but it's too busy eating crayons.