### PR TITLE
file_sink: Flush file on stop()

### DIFF
--- a/gr-blocks/lib/file_sink_impl.cc
+++ b/gr-blocks/lib/file_sink_impl.cc
@@ -67,5 +67,12 @@ int file_sink_impl::work(int noutput_items,
     return nwritten;
 }
 
+bool file_sink_impl::stop()
+{
+    do_update();
+    fflush(d_fp);
+    return true;
+}
+
 } /* namespace blocks */
 } /* namespace gr */

--- a/gr-blocks/lib/file_sink_impl.h
+++ b/gr-blocks/lib/file_sink_impl.h
@@ -28,6 +28,8 @@ public:
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items);
+
+    bool stop() override;
 };
 
 } /* namespace blocks */


### PR DESCRIPTION
Make sure that data passed to the file sink is written to the disk when
the flowgraph is stopped. Before this change this only happened
implicitly due to a fclose() in the base class destructor. This in turn
means that data was written delayed after stopping the flowgraph [1].

This fixes #2590.

[1] https://github.com/gnuradio/gnuradio/issues/2590