### PR TITLE
runtime: move loggers from gr::block to gr::basic_block

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/io_signature.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/msg_accepter.h>
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/sptr_magic.h>
@@ -20,7 +21,6 @@
 #include <boost/function.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <deque>
-#include <iostream>
 #include <map>
 #include <string>
 
@@ -73,6 +73,11 @@ protected:
     std::string d_symbol_alias;
     vcolor d_color;
     bool d_rpc_set;
+
+    /*! Used by blocks to access the logger system.
+     */
+    gr::logger_ptr d_logger;       //! Default logger
+    gr::logger_ptr d_debug_logger; //! Verbose logger
 
     msg_queue_map_t msg_queue;
     std::vector<rpcbasic_sptr> d_rpc_vars; // container for all RPC variables

--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -919,11 +919,6 @@ protected:
      */
     gr::thread::mutex d_setlock;
 
-    /*! Used by blocks to access the logger system.
-     */
-    gr::logger_ptr d_logger;
-    gr::logger_ptr d_debug_logger;
-
     // These are really only for internal use, but leaving them public avoids
     // having to work up an ever-varying list of friend GR_RUNTIME_APIs
 

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -39,6 +39,7 @@ basic_block::basic_block(const std::string& name,
       d_rpc_set(false),
       d_message_subscribers(pmt::make_dict())
 {
+    configure_default_loggers(d_logger, d_debug_logger, d_symbol_name);
     s_ncurrently_allocated++;
 }
 
@@ -177,7 +178,9 @@ void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
 
     if ((msg_queue.find(which_port) == msg_queue.end()) ||
         (msg_queue_ready.find(which_port) == msg_queue_ready.end())) {
-        std::cout << "target port = " << pmt::symbol_to_string(which_port) << std::endl;
+        GR_LOG_ERROR(d_logger,
+                     std::string("attempted insertion on invalid queue ") +
+                         pmt::symbol_to_string(which_port));
         throw std::runtime_error("attempted to insert_tail on invalid queue!");
     }
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -50,8 +50,6 @@ block::block(const std::string& name,
     global_block_registry.register_primitive(alias(), this);
     message_port_register_in(d_system_port);
     set_msg_handler(d_system_port, boost::bind(&block::system_handler, this, _1));
-
-    configure_default_loggers(d_logger, d_debug_logger, symbol_name());
 }
 
 block::~block() { global_block_registry.unregister_primitive(symbol_name()); }


### PR DESCRIPTION
No reason to assume only `general_work`-containing blocks would want to
log.

This enables us especially to log in `basic_block` itself.

This will lead to a lot more restructuring – there's a lot block-owned loggers that shouldn't exist. Partly my fault.