### PR TITLE
grc: start process on flowgraph folder

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -17,6 +17,7 @@ from distutils.spawn import find_executable
 from gi.repository import GLib
 
 from ..core import Messages
+from . import Utils
 
 
 class ExecFlowGraphThread(threading.Thread):
@@ -87,7 +88,9 @@ class ExecFlowGraphThread(threading.Thread):
 
         xterm_executable = find_executable(self.xterm_executable)
 
-        run_command_args = f'cmake .. && make && cd ../.. && {xterm_executable} -e {run_command}'
+        nproc = Utils.get_cmake_nproc()
+
+        run_command_args = f'cmake .. && cmake --build . -j{nproc} && cd ../.. && {xterm_executable} -e {run_command}'
         Messages.send_start_exec(run_command_args)
 
         return subprocess.Popen(

--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -11,6 +11,7 @@ import shlex
 import subprocess
 import threading
 import time
+from pathlib import Path
 from distutils.spawn import find_executable
 
 from gi.repository import GLib
@@ -62,8 +63,11 @@ class ExecFlowGraphThread(threading.Thread):
         # it looks really ugly and confusing in the console panel.
         Messages.send_start_exec(' '.join(run_command_args))
 
+        dirname = Path(generator.file_path).parent
+
         return subprocess.Popen(
             args=run_command_args,
+            cwd=dirname,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             shell=False, universal_newlines=True
         )
@@ -83,11 +87,11 @@ class ExecFlowGraphThread(threading.Thread):
 
         xterm_executable = find_executable(self.xterm_executable)
 
-        run_command_args = ['cmake .. &&', 'make && ', xterm_executable, '-e', run_command]
-        Messages.send_start_exec(' '.join(run_command_args))
+        run_command_args = f'cmake .. && make && cd ../.. && {xterm_executable} -e {run_command}'
+        Messages.send_start_exec(run_command_args)
 
         return subprocess.Popen(
-            args=' '.join(run_command_args),
+            args=run_command_args,
             cwd=builddir,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             shell=True, universal_newlines=True

--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -9,6 +9,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import absolute_import
 
 from sys import platform
+import os
 import numbers
 
 from gi.repository import GLib
@@ -174,3 +175,21 @@ def get_modifier_key(angle_brackets=False):
             return "<Ctrl>"
         else:
             return "Ctrl"
+
+
+_nproc = None
+def get_cmake_nproc():
+    """ Get number of cmake processes for C++ flowgraphs """
+    global _nproc # Cached result
+    if _nproc:
+        return _nproc
+    try:
+        # See https://docs.python.org/3.8/library/os.html#os.cpu_count
+        _nproc = len(os.sched_getaffinity(0))
+    except:
+        _nproc = os.cpu_count()
+    if not _nproc:
+        _nproc = 1
+
+    _nproc = max(_nproc//2 - 1, 1)
+    return _nproc


### PR DESCRIPTION
Allow the use of predictable relative paths.

This also includes changes on cmake compilation.
