### PR TITLE
utils: Make modtool generate C++ style compliant code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,12 @@ install(
     DESTINATION ${GR_PKG_DOC_DIR}
 )
 
+install(
+    FILES .clang-format
+    RENAME clang-format.conf
+    DESTINATION ${GR_PKG_DATA_DIR}
+)
+
 ########################################################################
 # The following dependency libraries are needed by all gr modules:
 ########################################################################

--- a/gr-utils/modtool/core/add.py
+++ b/gr-utils/modtool/core/add.py
@@ -15,12 +15,27 @@ from __future__ import unicode_literals
 import os
 import re
 import logging
+import subprocess
 
+from gnuradio import gr
 from ..tools import render_template, append_re_line_sequence, CMakeFileEditor
 from ..templates import Templates
 from .base import ModTool, ModToolException
 
 logger = logging.getLogger(__name__)
+
+
+def clang_format(s):
+    try:
+      p = subprocess.Popen(["clang-format"], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+      out, err = p.communicate(s.encode('utf-8'))
+      if p.returncode != 0:
+        print("Failed to run clang-format: %s", err)
+        return s
+      return out.decode('utf-8')
+    except (RuntimeError, FileNotFoundError) as e:
+      print("Failed to run clang-format: %s", e)
+      return s
 
 
 class ModToolAdd(ModTool):
@@ -111,8 +126,11 @@ class ModToolAdd(ModTool):
         """ Shorthand for writing a substituted template to a file"""
         path_to_file = os.path.join(path, fname)
         logger.info(f"Adding file '{path_to_file}'...")
+        formatter = lambda x: x
+        if fname.endswith('.cc') or fname.endswith('.h'):
+          formatter = clang_format
         with open(path_to_file, 'w') as f:
-            f.write(render_template(tpl, **self.info))
+            f.write(formatter(render_template(tpl, **self.info)))
         self.scm.add_files((path_to_file,))
 
     def run(self):

--- a/gr-utils/modtool/core/newmod.py
+++ b/gr-utils/modtool/core/newmod.py
@@ -67,6 +67,10 @@ class ModToolNewModule(ModTool):
         logger.info(f"Creating out-of-tree module in {self.dir}...")
         try:
             shutil.copytree(self.srcdir, self.dir)
+            try:
+              shutil.copy(os.path.join(gr.prefix(), 'share', 'gnuradio', 'clang-format.conf'), os.path.join(self.dir))
+            except FileNotFoundError as e:
+              logger.info(f'Failed to copy .clang-format: {e}')
             os.chdir(self.dir)
         except OSError:
             raise ModToolException(f'Could not create directory {self.dir}.')

--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -119,23 +119,23 @@ ${blockname}::make(${strip_default_values(arglist)})
 
 <%
     if blocktype == 'decimator':
-        decimation = ', <+decimation+>'
+        decimation = ', REPLACE_ME_decimation'
     elif blocktype == 'interpolator':
-        decimation = ', <+interpolation+>'
+        decimation = ', REPLACE_ME_interpolation'
     elif blocktype == 'tagged_stream':
-        decimation = ', <+len_tag_key+>'
+        decimation = ', REPLACE_ME_len_tag_key'
     else:
         decimation = ''
     endif
     if blocktype == 'source':
         inputsig = '0, 0, 0'
     else:
-        inputsig = '<+MIN_IN+>, <+MAX_IN+>, sizeof(<+ITYPE+>)'
+        inputsig = 'REPLACE_ME_MIN_IN, REPLACE_ME_MAX_IN, sizeof(REPLACE_ME_ITYPE)'
     endif
     if blocktype == 'sink':
         outputsig = '0, 0, 0'
     else:
-        outputsig = '<+MIN_OUT+>, <+MAX_OUT+>, sizeof(<+OTYPE+>)'
+        outputsig = 'REPLACE_ME_MIN_OUT, REPLACE_ME_MAX_OUT, sizeof(REPLACE_ME_OTYPE)'
     endif
 %>
 /*
@@ -164,7 +164,7 @@ ${blockname}_impl::~${blockname}_impl() {}
   % if blocktype == 'general':
 void ${blockname}_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
 {
-    /* <+forecast+> e.g. ninput_items_required[0] = noutput_items */
+    /* REPLACE_ME_forecast e.g. ninput_items_required[0] = noutput_items */
 }
 
 int ${blockname}_impl::general_work (int noutput_items,
@@ -172,10 +172,10 @@ int ${blockname}_impl::general_work (int noutput_items,
                    gr_vector_const_void_star& input_items,
                    gr_vector_void_star& output_items)
 {
-    auto in = static_cast<const +ITYPE+*>(input_items[0]);
-    auto out = static_cast<+OTYPE+*>(output_items[0]);
+    auto in = static_cast<const REPLACE_ME_ITYPE*>(input_items[0]);
+    auto out = static_cast<REPLACE_ME_OTYPE*>(output_items[0]);
 
-    // Do <+signal processing+>
+    // Do REPLACE_ME_signal processing
     // Tell runtime system how many input items we consumed on
     // each input stream.
     consume_each(noutput_items);
@@ -187,7 +187,7 @@ int ${blockname}_impl::general_work (int noutput_items,
 int
 ${blockname}_impl::calculate_output_stream_length(const gr_vector_int& ninput_items)
 {
-    int noutput_items = /* <+set this+> */;
+    int noutput_items = REPLACE_ME; /* set this */;
     return noutput_items ;
 }
 
@@ -197,10 +197,10 @@ ${blockname}_impl::work (int noutput_items,
                    gr_vector_const_void_star& input_items,
                    gr_vector_void_star& output_items)
 {
-    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    auto in = static_cast<const REPLACE_ME_ITYPE*>(input_items[0]);
+    auto out = static_cast<REPLACE_ME_OTYPE*>(output_items[0]);
 
-    // Do <+signal processing+>
+    // Do signal processing
 
     // Tell runtime system how many output items we produced.
     return noutput_items;
@@ -213,13 +213,13 @@ ${blockname}_impl::work(int noutput_items,
     gr_vector_void_star& output_items)
 {
     % if blocktype != 'source':
-    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+    auto in = static_cast<const REPLACE_ME_ITYPE*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    auto out = static_cast<REPLACE_ME_OTYPE*>(output_items[0]);
     % endif
 
-    // Do <+signal processing+>
+    // Do signal processing
 
     // Tell runtime system how many output items we produced.
     return noutput_items;
@@ -247,7 +247,7 @@ namespace ${modname} {
 
 % if blocktype == 'noblock':
 /*!
- * \brief <+description+>
+ * \brief REPLACE_ME_description
  *
  */
 class ${modname.upper()}_API ${blockname}
@@ -259,7 +259,7 @@ private:
 };
 % else:
 /*!
- * \brief <+description of block+>
+ * \brief REPLACE_ME_description of block
  * \ingroup ${modname}
  *
  */
@@ -310,29 +310,29 @@ import numpy\
     if blocktype == 'source':
         inputsig = 'None'
     else:
-        inputsig = '[<+numpy.float32+>, ]'
+        inputsig = '[REPLACE_ME_numpy.float32, ]'
     if blocktype == 'sink':
         outputsig = 'None'
     else:
-        outputsig = '[<+numpy.float32+>, ]'
+        outputsig = '[REPLACE_ME_numpy.float32, ]'
 %>
 % else:
 <%
     if blocktype == 'source':
         inputsig = '0, 0, 0'
     else:
-        inputsig = '<+MIN_IN+>, <+MAX_IN+>, gr.sizeof_<+ITYPE+>'
+        inputsig = 'REPLACE_ME_MIN_IN, REPLACE_ME_MAX_IN, gr.sizeof_REPLACE_ME_ITYPE'
     if blocktype == 'sink':
         outputsig = '0, 0, 0'
     else:
-        outputsig = '<+MIN_OUT+>, <+MAX_OUT+>, gr.sizeof_<+OTYPE+>'
+        outputsig = 'REPLACE_ME_MIN_OUT, REPLACE_ME_MAX_OUT, gr.sizeof_REPLACE_ME_OTYPE'
 %>
 % endif
 <%
     if blocktype == 'interpolator':
-        deciminterp = ', <+interpolation+>'
+        deciminterp = ', REPLACE_ME_interpolation'
     elif blocktype == 'decimator':
-        deciminterp = ', <+decimation+>'
+        deciminterp = ', REPLACE_ME_decimation'
     else:
         deciminterp = ''
     if arglist == '':
@@ -382,7 +382,7 @@ class ${blockname}(${parenttype}):
 % if blocktype != 'sink':
         out = output_items[0]
 % endif
-        # <+signal processing here+>
+        # REPLACE_ME_signal processing here
 % if blocktype in ('sync', 'decimator', 'interpolator'):
         out[:] = in0
         return len(output_items[0])
@@ -591,9 +591,9 @@ ${modname}_make_${blockname} (${strip_default_values(arglist)})
 
 <%
     if blocktype == 'interpolator':
-        deciminterp = ', <+interpolation+>'
+        deciminterp = ', REPLACE_ME_interpolation'
     elif blocktype == 'decimator':
-        deciminterp = ', <+decimation+>'
+        deciminterp = ', REPLACE_ME_decimation'
     else:
         deciminterp = ''
     if arglist == '':
@@ -603,12 +603,12 @@ ${modname}_make_${blockname} (${strip_default_values(arglist)})
     if blocktype == 'source':
         inputsig = '0, 0, 0'
     else:
-        inputsig = '<+MIN_IN+>, <+MAX_IN+>, sizeof(<+ITYPE+>)'
+        inputsig = 'REPLACE_ME_MIN_IN, REPLACE_ME_MAX_IN, sizeof(REPLACE_ME_ITYPE)'
     endif
     if blocktype == 'sink':
         outputsig = '0, 0, 0'
     else:
-        outputsig = '<+MIN_OUT+>, <+MAX_OUT+>, sizeof(<+OTYPE+>)'
+        outputsig = 'REPLACE_ME_MIN_OUT, REPLACE_ME_MAX_OUT, sizeof(REPLACE_ME_OTYPE)'
     endif
 %>
 
@@ -622,10 +622,10 @@ ${modname}_${blockname}::${modname}_${blockname} (${strip_default_values(arglist
 {
 % if blocktype == 'hier'
     connect(self(), 0, d_firstblock, 0);
-    // <+connect other blocks+>
+    // REPLACE_ME_connect other blocks
     connect(d_lastblock, 0, self(), 0);
 % else:
-    // Put in <+constructor stuff+> here
+    // Put in REPLACE_ME_constructor stuff here
 % endif
 }
 
@@ -635,7 +635,7 @@ ${modname}_${blockname}::${modname}_${blockname} (${strip_default_values(arglist
  */
 ${modname}_${blockname}::~${modname}_${blockname}()
 {
-  // Put in <+destructor stuff+> here
+  // Put in REPLACE_ME_destructor stuff here
 }
 % endif
 
@@ -644,7 +644,7 @@ ${modname}_${blockname}::~${modname}_${blockname}()
 void
 ${modname}_${blockname}::forecast(int noutput_items, gr_vector_int& ninput_items_required)
 {
-    /* <+forecast+> e.g. ninput_items_required[0] = noutput_items */
+    /* REPLACE_ME_forecast e.g. ninput_items_required[0] = noutput_items */
 }
 
 int
@@ -653,10 +653,10 @@ ${modname}_${blockname}::general_work (int noutput_items,
            gr_vector_const_void_star& input_items,
            gr_vector_void_star& output_items)
 {
-    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    const REPLACE_ME_ITYPE *in = (const REPLACE_ME_ITYPE *) input_items[0];
+    REPLACE_ME_OTYPE *out = (REPLACE_ME_OTYPE *) output_items[0];
 
-    // Do <+signal processing+>
+    // Do REPLACE_ME_signal processing
     // Tell runtime system how many input items we consumed on
     // each input stream.
     consume_each (noutput_items);
@@ -671,10 +671,10 @@ ${modname}_${blockname}::work(int noutput_items,
       gr_vector_const_void_star& input_items,
       gr_vector_void_star& output_items)
 {
-    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    const REPLACE_ME_ITYPE *in = (const REPLACE_ME_ITYPE *) input_items[0];
+    REPLACE_ME_OTYPE *out = (REPLACE_ME_OTYPE *) output_items[0];
 
-    // Do <+signal processing+>
+    // Do REPLACE_ME_signal processing
 
     // Tell runtime system how many output items we produced.
     return noutput_items;
@@ -708,7 +708,7 @@ typedef std::shared_ptr<${modname}_${blockname}> ${modname}_${blockname}_sptr;
 ${modname.upper()}_API ${modname}_${blockname}_sptr ${modname}_make_${blockname} (${arglist});
 
 /*!
- * \brief <+description+>
+ * \brief REPLACE_ME_description
  * \ingroup ${modname}
  *
  */

--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -40,53 +40,48 @@ ${str_to_fancyc_comment(license)}
 #include <${include_dir_prefix}/${blockname}.h>
 
 namespace gr {
-  namespace ${modname} {
+namespace ${modname} {
 
-    class ${blockname}_impl : public ${blockname}
-    {
-     private:
-      // Nothing to declare in this block.
+class ${blockname}_impl : public ${blockname}
+{
+private:
+    // Nothing to declare in this block.
 
 % if blocktype == 'tagged_stream':
-     protected:
-      int calculate_output_stream_length(const gr_vector_int &ninput_items);
+protected:
+    int calculate_output_stream_length(const gr_vector_int& ninput_items);
 
 % endif
-     public:
-      ${blockname}_impl(${strip_default_values(arglist)});
-      ~${blockname}_impl();
+public:
+    ${blockname}_impl(${strip_default_values(arglist)});
+    ~${blockname}_impl();
 
-      // Where all the action really happens
+    // Where all the action really happens
 % if blocktype == 'general':
-      void forecast (int noutput_items, gr_vector_int &ninput_items_required);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
 
-      int general_work(int noutput_items,
-           gr_vector_int &ninput_items,
-           gr_vector_const_void_star &input_items,
-           gr_vector_void_star &output_items);
+    int general_work(int noutput_items,
+                     gr_vector_int& ninput_items,
+                     gr_vector_const_void_star& input_items,
+                     gr_vector_void_star& output_items);
 
 % elif blocktype == 'tagged_stream':
-      int work(
-              int noutput_items,
-              gr_vector_int &ninput_items,
-              gr_vector_const_void_star &input_items,
-              gr_vector_void_star &output_items
-      );
+    int work(int noutput_items,
+             gr_vector_int& ninput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items);
 % elif blocktype == 'hier':
 % else:
-      int work(
-              int noutput_items,
-              gr_vector_const_void_star &input_items,
-              gr_vector_void_star &output_items
-      );
+    int work(int noutput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items);
 % endif
-    };
+};
 
-  } // namespace ${modname}
+} // namespace ${modname}
 } // namespace gr
 
 #endif /* INCLUDED_${modname.upper()}_${blockname.upper()}_IMPL_H */
-
 '''
 
 # C++ file of a GR block
@@ -96,31 +91,31 @@ ${str_to_fancyc_comment(license)}
 #include "config.h"
 #endif
 
-#include <gnuradio/io_signature.h>
 % if blocktype == 'noblock':
 #include <${include_dir_prefix}/${blockname}.h>
 % else:
 #include "${blockname}_impl.h"
 % endif
+#include <gnuradio/io_signature.h>
 
 namespace gr {
-  namespace ${modname} {
+namespace ${modname} {
 
 % if blocktype == 'noblock':
-    ${blockname}::${blockname}(${strip_default_values(arglist)})
-    {
-    }
+${blockname}::${blockname}(${strip_default_values(arglist)})
+{
+}
 
-    ${blockname}::~${blockname}()
-    {
-    }
+${blockname}::~${blockname}()
+{
+}
 % else:
-    ${blockname}::sptr
-    ${blockname}::make(${strip_default_values(arglist)})
-    {
-      return gnuradio::get_initial_sptr
-        (new ${blockname}_impl(${strip_arg_types(arglist)}));
-    }
+${blockname}::sptr
+${blockname}::make(${strip_default_values(arglist)})
+{
+    return gnuradio::get_initial_sptr(
+        new ${blockname}_impl(${strip_arg_types(arglist)}));
+}
 
 <%
     if blocktype == 'decimator':
@@ -143,101 +138,97 @@ namespace gr {
         outputsig = '<+MIN_OUT+>, <+MAX_OUT+>, sizeof(<+OTYPE+>)'
     endif
 %>
-    /*
-     * The private constructor
-     */
-    ${blockname}_impl::${blockname}_impl(${strip_default_values(arglist)})
-      : gr::${grblocktype}("${blockname}",
-              gr::io_signature::make(${inputsig}),
-              gr::io_signature::make(${outputsig})${decimation})
+/*
+ * The private constructor
+ */
+${blockname}_impl::${blockname}_impl(${strip_default_values(arglist)})
+    : gr::${grblocktype}("${blockname}",
+                gr::io_signature::make(${inputsig}),
+                gr::io_signature::make(${outputsig})${decimation})
   % if blocktype == 'hier':
-    {
-      connect(self(), 0, d_firstblock, 0);
-      // connect other blocks
-      connect(d_lastblock, 0, self(), 0);
-    }
+{
+    connect(self(), 0, d_firstblock, 0);
+    // connect other blocks
+    connect(d_lastblock, 0, self(), 0);
+}
   % else:
-    {}
+{
+}
   % endif
 
-    /*
-     * Our virtual destructor.
-     */
-    ${blockname}_impl::~${blockname}_impl()
-    {
-    }
+/*
+ * Our virtual destructor.
+ */
+${blockname}_impl::~${blockname}_impl() {}
 
   % if blocktype == 'general':
-    void
-    ${blockname}_impl::forecast (int noutput_items, gr_vector_int &ninput_items_required)
-    {
-      /* <+forecast+> e.g. ninput_items_required[0] = noutput_items */
-    }
+void ${blockname}_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+{
+    /* <+forecast+> e.g. ninput_items_required[0] = noutput_items */
+}
 
-    int
-    ${blockname}_impl::general_work (int noutput_items,
-                       gr_vector_int &ninput_items,
-                       gr_vector_const_void_star &input_items,
-                       gr_vector_void_star &output_items)
-    {
-      const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-      <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+int ${blockname}_impl::general_work (int noutput_items,
+                   gr_vector_int& ninput_items,
+                   gr_vector_const_void_star& input_items,
+                   gr_vector_void_star& output_items)
+{
+    auto in = static_cast<const +ITYPE+*>(input_items[0]);
+    auto out = static_cast<+OTYPE+*>(output_items[0]);
 
-      // Do <+signal processing+>
-      // Tell runtime system how many input items we consumed on
-      // each input stream.
-      consume_each (noutput_items);
+    // Do <+signal processing+>
+    // Tell runtime system how many input items we consumed on
+    // each input stream.
+    consume_each(noutput_items);
 
-      // Tell runtime system how many output items we produced.
-      return noutput_items;
-    }
+    // Tell runtime system how many output items we produced.
+    return noutput_items;
+}
   % elif blocktype == 'tagged_stream':
-    int
-    ${blockname}_impl::calculate_output_stream_length(const gr_vector_int &ninput_items)
-    {
-      int noutput_items = /* <+set this+> */;
-      return noutput_items ;
-    }
+int
+${blockname}_impl::calculate_output_stream_length(const gr_vector_int& ninput_items)
+{
+    int noutput_items = /* <+set this+> */;
+    return noutput_items ;
+}
 
-    int
-    ${blockname}_impl::work (int noutput_items,
-                       gr_vector_int &ninput_items,
-                       gr_vector_const_void_star &input_items,
-                       gr_vector_void_star &output_items)
-    {
-      const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-      <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+int
+${blockname}_impl::work (int noutput_items,
+                   gr_vector_int& ninput_items,
+                   gr_vector_const_void_star& input_items,
+                   gr_vector_void_star& output_items)
+{
+    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
 
-      // Do <+signal processing+>
+    // Do <+signal processing+>
 
-      // Tell runtime system how many output items we produced.
-      return noutput_items;
-    }
+    // Tell runtime system how many output items we produced.
+    return noutput_items;
+}
   % elif blocktype == 'hier':
   % else:
-    int
-    ${blockname}_impl::work(int noutput_items,
-        gr_vector_const_void_star &input_items,
-        gr_vector_void_star &output_items)
-    {
+int
+${blockname}_impl::work(int noutput_items,
+    gr_vector_const_void_star& input_items,
+    gr_vector_void_star& output_items)
+{
     % if blocktype != 'source':
-      const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
     % endif
     % if blocktype != 'sink':
-      <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
     % endif
 
-      // Do <+signal processing+>
+    // Do <+signal processing+>
 
-      // Tell runtime system how many output items we produced.
-      return noutput_items;
-    }
+    // Tell runtime system how many output items we produced.
+    return noutput_items;
+}
   % endif
 % endif
 
-  } /* namespace ${modname} */
+} /* namespace ${modname} */
 } /* namespace gr */
-
 '''
 
 # Block definition header file (for include/)
@@ -246,50 +237,50 @@ ${str_to_fancyc_comment(license)}
 #ifndef INCLUDED_${modname.upper()}_${blockname.upper()}_H
 #define INCLUDED_${modname.upper()}_${blockname.upper()}_H
 
-#include <${include_dir_prefix}/api.h>
 % if blocktype != 'noblock':
 #include <gnuradio/${grblocktype}.h>
 % endif
+#include <${include_dir_prefix}/api.h>
 
 namespace gr {
-  namespace ${modname} {
+namespace ${modname} {
 
 % if blocktype == 'noblock':
-    /*!
-     * \brief <+description+>
-     *
-     */
-    class ${modname.upper()}_API ${blockname}
-    {
-    public:
-      ${blockname}(${arglist});
-      ~${blockname}();
-    private:
-    };
+/*!
+ * \brief <+description+>
+ *
+ */
+class ${modname.upper()}_API ${blockname}
+{
+public:
+  ${blockname}(${arglist});
+  ~${blockname}();
+private:
+};
 % else:
-    /*!
-     * \brief <+description of block+>
-     * \ingroup ${modname}
-     *
-     */
-    class ${modname.upper()}_API ${blockname} : virtual public gr::${grblocktype}
-    {
-     public:
-      typedef std::shared_ptr<${blockname}> sptr;
+/*!
+ * \brief <+description of block+>
+ * \ingroup ${modname}
+ *
+ */
+class ${modname.upper()}_API ${blockname} : virtual public gr::${grblocktype}
+{
+public:
+    typedef std::shared_ptr<${blockname}> sptr;
 
-      /*!
-       * \brief Return a shared_ptr to a new instance of ${modname}::${blockname}.
-       *
-       * To avoid accidental use of raw pointers, ${modname}::${blockname}'s
-       * constructor is in a private implementation
-       * class. ${modname}::${blockname}::make is the public interface for
-       * creating new instances.
-       */
-      static sptr make(${arglist});
-    };
+    /*!
+     * \brief Return a shared_ptr to a new instance of ${modname}::${blockname}.
+     *
+     * To avoid accidental use of raw pointers, ${modname}::${blockname}'s
+     * constructor is in a private implementation
+     * class. ${modname}::${blockname}::make is the public interface for
+     * creating new instances.
+     */
+    static sptr make(${arglist});
+};
 % endif
 
-  } // namespace ${modname}
+} // namespace ${modname}
 } // namespace gr
 
 #endif /* INCLUDED_${modname.upper()}_${blockname.upper()}_H */
@@ -416,14 +407,14 @@ ${str_to_fancyc_comment(license)}
 #include <boost/test/unit_test.hpp>
 
 namespace gr {
-  namespace ${modname} {
+namespace ${modname} {
 
-    BOOST_AUTO_TEST_CASE(test_${blockname}_t1)
-    {
-      // Put test here
-    }
+BOOST_AUTO_TEST_CASE(test_${blockname}_t1)
+{
+    // Put test here
+}
 
-  } /* namespace ${modname} */
+} /* namespace ${modname} */
 } /* namespace gr */
 '''
 
@@ -436,15 +427,15 @@ ${str_to_fancyc_comment(license)}
 #include <${include_dir_prefix}/${blockname}.h>
 
 namespace gr {
-  namespace ${modname} {
+namespace ${modname} {
 
-    void
-    qa_${blockname}::t1()
-    {
-      // Put test here
-    }
+void
+qa_${blockname}::t1()
+{
+    // Put test here
+}
 
-  } /* namespace ${modname} */
+} /* namespace ${modname} */
 } /* namespace gr */
 
 '''
@@ -459,20 +450,20 @@ ${str_to_fancyc_comment(license)}
 #include <cppunit/TestCase.h>
 
 namespace gr {
-  namespace ${modname} {
+namespace ${modname} {
 
-    class qa_${blockname} : public CppUnit::TestCase
-    {
-    public:
-      CPPUNIT_TEST_SUITE(qa_${blockname});
-      CPPUNIT_TEST(t1);
-      CPPUNIT_TEST_SUITE_END();
+class qa_${blockname} : public CppUnit::TestCase
+{
+public:
+    CPPUNIT_TEST_SUITE(qa_${blockname});
+    CPPUNIT_TEST(t1);
+    CPPUNIT_TEST_SUITE_END();
 
-    private:
-      void t1();
-    };
+private:
+    void t1();
+};
 
-  } /* namespace ${modname} */
+} /* namespace ${modname} */
 } /* namespace gr */
 
 #endif /* _QA_${blockname.upper()}_H_ */
@@ -595,7 +586,7 @@ ${modname}_${blockname}::~${modname}_${blockname}()
 ${modname}_${blockname}_sptr
 ${modname}_make_${blockname} (${strip_default_values(arglist)})
 {
-  return gnuradio::get_initial_sptr (new ${modname}_${blockname}(${strip_arg_types(arglist)}));
+    return gnuradio::get_initial_sptr (new ${modname}_${blockname}(${strip_arg_types(arglist)}));
 }
 
 <%
@@ -625,16 +616,16 @@ ${modname}_make_${blockname} (${strip_default_values(arglist)})
  * The private constructor
  */
 ${modname}_${blockname}::${modname}_${blockname} (${strip_default_values(arglist)})
-  : gr_${grblocktype} ("${blockname}",
-       gr_make_io_signature(${inputsig}),
-       gr_make_io_signature(${outputsig})${deciminterp})
+    : gr_${grblocktype} ("${blockname}",
+         gr_make_io_signature(${inputsig}),
+         gr_make_io_signature(${outputsig})${deciminterp})
 {
 % if blocktype == 'hier'
-  connect(self(), 0, d_firstblock, 0);
-  // <+connect other blocks+>
-  connect(d_lastblock, 0, self(), 0);
+    connect(self(), 0, d_firstblock, 0);
+    // <+connect other blocks+>
+    connect(d_lastblock, 0, self(), 0);
 % else:
-  // Put in <+constructor stuff+> here
+    // Put in <+constructor stuff+> here
 % endif
 }
 
@@ -651,42 +642,42 @@ ${modname}_${blockname}::~${modname}_${blockname}()
 
 % if blocktype == 'general'
 void
-${modname}_${blockname}::forecast (int noutput_items, gr_vector_int &ninput_items_required)
+${modname}_${blockname}::forecast(int noutput_items, gr_vector_int& ninput_items_required)
 {
-  /* <+forecast+> e.g. ninput_items_required[0] = noutput_items */
+    /* <+forecast+> e.g. ninput_items_required[0] = noutput_items */
 }
 
 int
 ${modname}_${blockname}::general_work (int noutput_items,
-           gr_vector_int &ninput_items,
-           gr_vector_const_void_star &input_items,
-           gr_vector_void_star &output_items)
+           gr_vector_int& ninput_items,
+           gr_vector_const_void_star& input_items,
+           gr_vector_void_star& output_items)
 {
-  const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-  <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
 
-  // Do <+signal processing+>
-  // Tell runtime system how many input items we consumed on
-  // each input stream.
-  consume_each (noutput_items);
+    // Do <+signal processing+>
+    // Tell runtime system how many input items we consumed on
+    // each input stream.
+    consume_each (noutput_items);
 
-  // Tell runtime system how many output items we produced.
-  return noutput_items;
+    // Tell runtime system how many output items we produced.
+    return noutput_items;
 }
 % elif blocktype == 'hier' or $blocktype == 'noblock':
 % else:
 int
 ${modname}_${blockname}::work(int noutput_items,
-      gr_vector_const_void_star &input_items,
-      gr_vector_void_star &output_items)
+      gr_vector_const_void_star& input_items,
+      gr_vector_void_star& output_items)
 {
-  const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
-  <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
+    const <+ITYPE+> *in = (const <+ITYPE+> *) input_items[0];
+    <+OTYPE+> *out = (<+OTYPE+> *) output_items[0];
 
-  // Do <+signal processing+>
+    // Do <+signal processing+>
 
-  // Tell runtime system how many output items we produced.
-  return noutput_items;
+    // Tell runtime system how many output items we produced.
+    return noutput_items;
 }
 % endif
 
@@ -702,9 +693,9 @@ ${str_to_fancyc_comment(license)}
 % if blocktype == 'noblock':
 class ${modname.upper()}_API ${blockname}
 {
-  ${blockname}(${arglist});
-  ~${blockname}();
- private:
+    ${blockname}(${arglist});
+    ~${blockname}();
+private:
 };
 
 % else:
@@ -723,28 +714,28 @@ ${modname.upper()}_API ${modname}_${blockname}_sptr ${modname}_make_${blockname}
  */
 class ${modname.upper()}_API ${modname}_${blockname} : public gr_${grblocktype}
 {
- private:
-  friend ${modname.upper()}_API ${modname}_${blockname}_sptr ${modname}_make_${blockname} (${strip_default_values(arglist)});
+private:
+    friend ${modname.upper()}_API ${modname}_${blockname}_sptr ${modname}_make_${blockname} (${strip_default_values(arglist)});
 
-  ${modname}_${blockname}(${strip_default_values(arglist)});
+    ${modname}_${blockname}(${strip_default_values(arglist)});
 
- public:
-  ~${modname}_${blockname}();
+public:
+    ~${modname}_${blockname}();
 
   % if blocktype == 'general':
-  void forecast (int noutput_items, gr_vector_int &ninput_items_required);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
 
-  // Where all the action really happens
-  int general_work (int noutput_items,
-      gr_vector_int &ninput_items,
-      gr_vector_const_void_star &input_items,
-      gr_vector_void_star &output_items);
+    // Where all the action really happens
+    int general_work (int noutput_items,
+                      gr_vector_int& ninput_items,
+                      gr_vector_const_void_star& input_items,
+                      gr_vector_void_star& output_items);
   % elif blocktype == 'hier':
   % else:
-  // Where all the action really happens
-  int work (int noutput_items,
-      gr_vector_const_void_star &input_items,
-      gr_vector_void_star &output_items);
+    // Where all the action really happens
+    int work (int noutput_items,
+              gr_vector_const_void_star& input_items,
+              gr_vector_void_star& output_items);
   % endif
 };
 % endif


### PR DESCRIPTION
This doesn't entirely make it perfect, since some formatting depends
on the length of the name of the block, and the length of its
parameters.

In the general case it can't be made perfect without reimplementing
`clang-format`, but even then the generated code is not actually valid
C++ (the size of the data is not defined at `gr_modtool add` time, so
uncompilable placeholders are put in place).

So this may be as close as we'll get generating the code.