### PR TITLE
#3302 make middle mouse close flowgraphs

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -265,7 +265,7 @@ FLOW_GRAPH_CLOSE_MIDDLE_MOUSE = actions.register("app.flowgraph.close_middle_mou
     label='_Close using Middle Mouse Button',
     tooltip='Close the current flow graph using Middle Mouse',
     icon_name='window-close-middle-mouse',
-    keypresses=["Pointer_Button3"],
+    keypresses=["Pointer_Right"],
 )
 APPLICATION_INITIALIZE = actions.register("app.initialize")
 APPLICATION_QUIT = actions.register("app.quit",

--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -261,6 +261,12 @@ FLOW_GRAPH_CLOSE = actions.register("app.flowgraph.close",
     icon_name='window-close',
     keypresses=["<Ctrl>w"],
 )
+FLOW_GRAPH_CLOSE_MIDDLE_MOUSE = actions.register("app.flowgraph.close_middle_mouse",
+    label='_Close using Middle Mouse Button',
+    tooltip='Close the current flow graph using Middle Mouse',
+    icon_name='window-close-middle-mouse',
+    keypresses=["Pointer_Button3"],
+)
 APPLICATION_INITIALIZE = actions.register("app.initialize")
 APPLICATION_QUIT = actions.register("app.quit",
     label='_Quit',

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -621,6 +621,8 @@ class Application(Gtk.Application):
                 self.platform.config.default_qss_theme = file_paths[0]
         elif action == Actions.FLOW_GRAPH_CLOSE:
             main.close_page()
+        elif action == Actions.FLOW_GRAPH_CLOSE_MIDDLE_MOUSE:
+            main.close_page()
         elif action == Actions.FLOW_GRAPH_OPEN_RECENT:
             file_path = str(args[0])[1:-1]
             main.new_page(file_path, show=True)

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -176,8 +176,8 @@ class Page(Gtk.HBox):
             markup: the new markup text
         """
         self.label.set_markup(markup)
-        # print(self.label.get_label())
-        # self.label_button.set_markup(markup)
+        self.label_ = self.label_button.get_child()
+        self.label_.set_markup(markup)
 
     def set_tooltip(self, text):
         """

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -96,8 +96,11 @@ class Page(Gtk.HBox):
         flow_graph.import_data(initial_state)
         self.state_cache = StateCache(initial_state)
 
-        # tab box to hold label and close button
+        # tab box to hold label button and close button
         self.label = Gtk.Label()
+        label_button = Gtk.Button.new_with_label("untitled")
+        label_button.connect("clicked", self.close_flowgraph_using_middle_mouse)
+
         image = Gtk.Image.new_from_icon_name('window-close', Gtk.IconSize.MENU)
         image_box = Gtk.HBox(homogeneous=False, spacing=0)
         image_box.pack_start(image, True, False, 0)
@@ -107,7 +110,7 @@ class Page(Gtk.HBox):
         button.add(image_box)
 
         tab = self.tab = Gtk.HBox(homogeneous=False, spacing=0)
-        tab.pack_start(self.label, False, False, 0)
+        tab.pack_start(label_button, False, False, 0)
         tab.pack_start(button, False, False, 0)
         tab.show_all()
 
@@ -152,6 +155,17 @@ class Page(Gtk.HBox):
         """
         self.main_window.page_to_be_closed = self
         Actions.FLOW_GRAPH_CLOSE()
+
+    def close_flowgraph_using_middle_mouse(self,button):
+        """
+        The label_button was clicked
+        Make the current flowgraph selected and close it
+
+        Args:
+            the: button
+        """
+        self.main_window.page_to_be_closed = self
+        Actions.FLOW_GRAPH_CLOSE_MIDDLE_MOUSE()
 
     def set_markup(self, markup):
         """

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -98,8 +98,9 @@ class Page(Gtk.HBox):
 
         # tab box to hold label button and close button
         self.label = Gtk.Label()
-        label_button = Gtk.Button.new_with_label("untitled")
-        label_button.connect("clicked", self.close_flowgraph_using_middle_mouse)
+        self.label_button = Gtk.Button.new_with_label("untitled")
+        self.label_button.set_relief(Gtk.ReliefStyle.NONE)
+        self.label_button.connect("clicked", self.close_flowgraph_using_middle_mouse)
 
         image = Gtk.Image.new_from_icon_name('window-close', Gtk.IconSize.MENU)
         image_box = Gtk.HBox(homogeneous=False, spacing=0)
@@ -110,7 +111,7 @@ class Page(Gtk.HBox):
         button.add(image_box)
 
         tab = self.tab = Gtk.HBox(homogeneous=False, spacing=0)
-        tab.pack_start(label_button, False, False, 0)
+        tab.pack_start(self.label_button, False, False, 0)
         tab.pack_start(button, False, False, 0)
         tab.show_all()
 
@@ -175,6 +176,8 @@ class Page(Gtk.HBox):
             markup: the new markup text
         """
         self.label.set_markup(markup)
+        # print(self.label.get_label())
+        # self.label_button.set_markup(markup)
 
     def set_tooltip(self, text):
         """


### PR DESCRIPTION
References #3302 
I have added the changes, the only issue is right now the graph closes just on left clicking the label_button. I could not figure out the keypress for middle mouse. I used [https://gitlab.gnome.org/GNOME/gtk/-/blob/3.24.14/gdk/keyname-table.h](url) as reference, any help would be really appreciated. Thanks for the advice @dkozel  i have tested the change.