### PR TITLE
PMT: Provide inherent differentiation between PMT dictionaries and pairs

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -642,8 +642,12 @@ c64vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
  * ------------------------------------------------------------------------
  */
 
-//! Return true if \p obj is a dictionary (warning: also returns true for a pair)
+//! Return true if \p obj is a dictionary
 PMT_API bool is_dict(const pmt_t& obj);
+
+//! Return a newly allocated dict whose car is a key-value pair \p x and whose cdr is a
+//! dict \p y.
+PMT_API pmt_t dcons(const pmt_t& x, const pmt_t& y);
 
 //! Make an empty dictionary
 PMT_API pmt_t make_dict();
@@ -713,6 +717,14 @@ PMT_API std::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t
  *			  General functions
  * ------------------------------------------------------------------------
  */
+
+/*!
+ * Returns true if the object is a PDU meaning:
+ *   the object is a pair
+ *   the car is a dictionary type object (including an empty dict)
+ *   the cdr is a uniform vector of any type
+ */
+PMT_API bool is_pdu(const pmt_t& obj);
 
 //! Return true if x and y are the same object; otherwise return false.
 PMT_API bool eq(const pmt_t& x, const pmt_t& y);
@@ -801,7 +813,7 @@ PMT_API pmt_t reverse_x(pmt_t list);
 /*!
  * \brief (acons x y a) == (cons (cons x y) a)
  */
-inline static pmt_t acons(pmt_t x, pmt_t y, pmt_t a) { return cons(cons(x, y), a); }
+inline static pmt_t acons(pmt_t x, pmt_t y, pmt_t a) { return dcons(cons(x, y), a); }
 
 /*!
  * \brief locates \p nth element of \n list where the car is the 'zeroth' element.

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -128,6 +128,15 @@ public:
     void set_cdr(pmt_t cdr) { d_cdr = cdr; }
 };
 
+class pmt_dict : public pmt_pair
+{
+public:
+    pmt_dict(const pmt_t& car, const pmt_t& cdr);
+    //~pmt_dict(){};
+
+    bool is_dict() const { return true; }
+};
+
 class pmt_vector : public pmt_base
 {
     std::vector<pmt_t> d_v;

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -21,7 +21,7 @@
 
 namespace pmt {
 
-static pmt_t parse_pair(std::streambuf& sb);
+static pmt_t parse_pair(std::streambuf& sb, uint8_t type);
 
 // ----------------------------------------------------------------
 // output primitives
@@ -279,7 +279,7 @@ tail_recursion:
     }
 
     if (is_pair(obj)) {
-        ok = serialize_untagged_u8(PST_PAIR, sb);
+        ok = serialize_untagged_u8(is_dict(obj) ? PST_DICT : PST_PAIR, sb);
         ok &= serialize(car(obj), sb);
         if (!ok)
             return false;
@@ -570,7 +570,10 @@ pmt_t deserialize(std::streambuf& sb)
         return from_long(u64);
 
     case PST_PAIR:
-        return parse_pair(sb);
+        return parse_pair(sb, PST_PAIR);
+
+    case PST_DICT:
+        return parse_pair(sb, PST_DICT);
 
     case PST_DOUBLE:
         if (!deserialize_untagged_f64(&f64, sb))
@@ -694,7 +697,6 @@ pmt_t deserialize(std::streambuf& sb)
         }
     }
 
-    case PST_DICT:
     case PST_COMMENT:
         throw notimplemented("pmt::deserialize: tag value = ", from_long(tag));
 
@@ -730,9 +732,9 @@ pmt_t deserialize_str(std::string s)
  * This is a mostly non-recursive implementation that allows us to
  * deserialize very long lists w/o exhausting the evaluation stack.
  *
- * On entry we've already eaten the PST_PAIR tag.
+ * On entry we've already eaten the PST_PAIR or PST_DICT tag.
  */
-pmt_t parse_pair(std::streambuf& sb)
+pmt_t parse_pair(std::streambuf& sb, uint8_t type)
 {
     uint8_t tag;
     pmt_t val, expr, lastnptr, nptr;
@@ -744,7 +746,11 @@ pmt_t parse_pair(std::streambuf& sb)
     while (1) {
         expr = deserialize(sb); // read the car
 
-        nptr = cons(expr, PMT_NIL); // build new cell
+        if (type == PST_DICT)
+            nptr = dcons(expr, PMT_NIL); // build new cell
+        else
+            nptr = cons(expr, PMT_NIL); // build new cell
+
         if (is_null(lastnptr))
             val = nptr;
         else

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -383,7 +383,27 @@ BOOST_AUTO_TEST_CASE(test_dict)
     // std::cout << "pmt::dict_keys:   " << pmt::dict_keys(dict) << std::endl;
     // std::cout << "pmt::dict_values: " << pmt::dict_values(dict) << std::endl;
     BOOST_CHECK(pmt::equal(keys, pmt::dict_keys(dict)));
-    BOOST_CHECK(pmt::equal(vals, pmt::dict_values(dict)));
+
+    dict = pmt::dict_delete(dict, k1);
+    BOOST_CHECK(pmt::eqv(pmt::dict_ref(dict, k0, not_found), v0));
+    BOOST_CHECK(pmt::is_dict(dict));
+    dict = pmt::dict_add(dict, k3, v3);
+    dict = pmt::reverse(dict);
+    BOOST_CHECK(pmt::eqv(pmt::dict_ref(dict, k0, not_found), v0));
+    BOOST_CHECK(pmt::is_dict(dict));
+}
+
+BOOST_AUTO_TEST_CASE(test_pdu)
+{
+    pmt::pmt_t dict = pmt::dict_add(pmt::make_dict(), pmt::mp("k0"), pmt::mp("v0"));
+    pmt::pmt_t vec = pmt::make_u8vector(1, 0);
+    BOOST_CHECK(!pmt::is_pdu(pmt::PMT_T));
+    BOOST_CHECK(!pmt::is_pdu(vec));
+    BOOST_CHECK(!pmt::is_pdu(dict));
+    BOOST_CHECK(!pmt::is_pdu(pmt::cons(dict, pmt::PMT_NIL)));
+    BOOST_CHECK(!pmt::is_pdu(pmt::cons(pmt::PMT_F, vec)));
+    BOOST_CHECK(pmt::is_pdu(pmt::cons(pmt::make_dict(), vec)));
+    BOOST_CHECK(pmt::is_pdu(pmt::cons(dict, vec)));
 }
 
 BOOST_AUTO_TEST_CASE(test_io)

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -163,6 +163,7 @@ class test_pmt(unittest.TestCase):
         d = pmt.dict_add(d, min_key, _min)
         s = pmt.serialize_str(d)
         deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.is_dict(deser))
         self.assertTrue(pmt.equal(d, deser))
         p_dict = pmt.to_python(deser)
         self.assertEqual(self.MAXINT32, p_dict["MAX"])

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -238,6 +238,7 @@ namespace pmt{
 
   bool is_dict(const pmt_t &obj);
   pmt_t make_dict();
+  pmt_t dcons(const pmt_t& x, const pmt_t& y);
   pmt_t dict_add(const pmt_t &dict, const pmt_t &key, const pmt_t &value);
   pmt_t dict_delete(const pmt_t &dict, const pmt_t &key);
   bool  dict_has_key(const pmt_t &dict, const pmt_t &key);
@@ -256,6 +257,7 @@ namespace pmt{
   pmt_t make_msg_accepter(std::shared_ptr<gr::messages::msg_accepter> ma);
   std::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t &obj);
 
+  bool is_pdu(const pmt_t& obj);
   bool eq(const pmt_t& x, const pmt_t& y);
   bool eqv(const pmt_t& x, const pmt_t& y);
   bool equal(const pmt_t& x, const pmt_t& y);


### PR DESCRIPTION
This modification attempts to resolve the persistent [bug identified by @mbr0wn back in 2016](https://github.com/gnuradio/gnuradio/issues/965) in which PMT objects have no built in tests between dicts and pairs which can be frustrating and causes clumbsy workarounds when working with PMT data structures such as PDUs. This fix is not necessarily ideal, but is relatively low risk and should retain all existing functionality and be API compatible.

This adds a new class `pmt_dict` that is essentially identical to `pmt_pair`, however the built in base class `is_dict()` returns true. The public `is_dict()` function has been updated to call the underlying objects `is_dict()` function instead of checking if it is a pair. Thus, dicts are still a special case of pair and tests accordingly, but all pairs are not dicts.

Previously `acons()` would create a new `pmt_pair` of the provided key and value, and then return a new `pmt_pair` of the K-V PMT pair and the provided existing PMT dict. Now it returns a new `pmt_dict` object of the KV pair and the existing dictonary. Thus, objects returned from `acons()` will be `pmt_dict` and not `pmt_pair` objects.

The car and cdr data elements borrowed from the `pmt_pair` class have not been changed for `pmt_dict` to preserve the PMT API, however it may be a good idea to have a subsequent modification that makes these less similar to pairs. Because these inherent pair constructs still exist and the `pmt_dict` can be upcast to the `pmt_pair` the majority of existing alist functionality remains intact for both pairs and dicts.

This could be extended by adding another class `pmt_pdu` which will be similar and allow for more consistent handling of PDU type objects which consist of a dictionary (now easily verifiable!) and either a PMT_NIL or uniform vector object, however a more comprehensive solution would probably be to create an intermediate class derived from `pmt_base` which pair-type objects like `pmt_pair`, `pmt_dict`, and `pmt_pdu` could themselves be derived from.

Specific changes to testing include:
- non-dictionary pairs (and by extension PDUs) return `false` for `is_dict()`
- `dict_keys()` and `dict_values()` will throw `wrong_type` exceptions on all PDUs (previously PDUs that had dictionaries other than PMT_NIL would return a result)
- `dict_items()` will throw `wrong_type` exceptions on all PDUs (previously PDUs with NULL vectors would pass).

There are still a couple things that should probably throw `wrong_type` exceptions, but this is more complicated as far as i can tell:
- `dict_delete()` and `dict_update()` both return values when provided a PDU which has a dictionary that is not NULL, and have a PMT_NIL for the uniform vector (cdr) component... its debatable if this is actually even a PDU since it is not a `(dict . uniform_vector)` pair...
- various other  cases which have to do with the use of PMT_NIL for an empty dictionary not being of special type `pdu_dict`

All these changes i would consider to be fixes for unintended behavior.