### PR TITLE
gnuradio-companion: add Meta modifier key for macOS

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -24,6 +24,7 @@ import logging
 
 from gi.repository import Gtk, Gdk, Gio, GLib, GObject
 
+from . import Utils
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +137,10 @@ class Action(Gio.SimpleAction):
         self.label = label
         self.tooltip = tooltip
         self.icon_name = icon_name
-        self.keypresses = keypresses
+        if keypresses:
+            self.keypresses = [kp.replace("<Ctrl>", Utils.get_modifier_key(True)) for kp in keypresses]
+        else:
+            self.keypresses = None
         self.prefix = prefix
         self.preference_name = preference_name
         self.default = default

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -298,9 +298,10 @@ def show_help(parent):
         <u>Remove connection</u>: select the connection and press delete, or 
        drag the connection.
         \n\
-        *Press CTRL+K or see menu for Keyboard - Shortcuts
+        *Press Ctrl+K or see menu for Keyboard - Shortcuts
         \
     """)
+    markup = markup.replace("Ctrl", Utils.get_modifier_key())
 
     MessageDialogWrapper(
         parent, Gtk.MessageType.INFO, Gtk.ButtonsType.CLOSE, title='Help', markup=markup
@@ -337,6 +338,7 @@ def show_keyboard_shortcuts(parent):
             selected block.
     \
     """)
+    markup = markup.replace("Ctrl", Utils.get_modifier_key())
     
     MessageDialogWrapper(
         parent, Gtk.MessageType.INFO, Gtk.ButtonsType.CLOSE, title='Keyboard - Shortcuts', markup=markup

--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 from __future__ import absolute_import
 
+from sys import platform
 import numbers
 
 from gi.repository import GLib
@@ -163,3 +164,24 @@ def scale(coor, reverse=False):
 def scale_scalar(coor, reverse=False):
     factor = Constants.DPI_SCALING if not reverse else 1 / Constants.DPI_SCALING
     return int(coor * factor)
+
+def get_modifier_key(angle_brackets=False):
+    """
+    Get the modifier key based on platform.
+
+    Args:
+        angle_brackets: if return the modifier key with <> or not
+
+    Returns:
+        return the string with the modifier key
+    """
+    if platform == "darwin":
+        if angle_brackets:
+            return "<Meta>"
+        else:
+            return "Meta"
+    else:
+        if angle_brackets:
+            return "<Ctrl>"
+        else:
+            return "Ctrl"


### PR DESCRIPTION
implements support for the Meta key on macOS.
Others platforms continue to use Ctrl.