### PR TITLE
filter: grc: variable_band_pass_filter_taps: fix complex taps option

### DIFF
--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -36,7 +36,8 @@ parameters:
     label: Beta
     dtype: float
     default: '6.76'
-value: ${ firdes.band_pass(gain, samp_rate, low_cutoff_freq, high_cutoff_freq, width,win, beta) }
+value: ${ getattr(firdes, str(type))(gain, samp_rate, low_cutoff_freq, high_cutoff_freq,
+    width, win, beta) }
 
 templates:
     imports: from gnuradio.filter import firdes


### PR DESCRIPTION
In the case of complex taps, firdes.complex_band_pass should be used instead of firdes.band_pass.