### PR TITLE
grc: Enable strict_undefined to ease Mako template debugging

### DIFF
--- a/grc/core/blocks/_templates.py
+++ b/grc/core/blocks/_templates.py
@@ -36,7 +36,7 @@ class MakoTemplates(dict):
     def compile(cls, text):
         text = str(text)
         try:
-            template = Template(text)
+            template = Template(text, strict_undefined=True)
         except SyntaxException as error:
             raise TemplateError(text, *error.args)
 


### PR DESCRIPTION
When generating a flowgraph, you will get the following error if there is a typo (usually a misspelled parameter) in the block's template:
`Generate Error: (NameError('Undefined'), 'fft.ctrlport_probe_psd(${nam}, ${desc}, ${len})')`
This isn't very helpful, at least not for blocks with large multi-line templates. 

With this fix, Mako will specify the name of the undefined variable:
`Generate Error: (NameError("'nam' is not defined"), 'fft.ctrlport_probe_psd(${nam}, ${desc}, ${len})')`

https://docs.makotemplates.org/en/latest/runtime.html#context-variables

Should this be backported to maint-3.8?