### PR TITLE
grc: Enable strict_undefined to ease Mako template debugging (maint-3.8)

### DIFF
--- a/grc/core/blocks/_templates.py
+++ b/grc/core/blocks/_templates.py
@@ -47,7 +47,7 @@ class MakoTemplates(dict):
     def compile(cls, text):
         text = str(text)
         try:
-            template = Template(text)
+            template = Template(text, strict_undefined=True)
         except SyntaxException as error:
             raise TemplateError(text, *error.args)
 


### PR DESCRIPTION
Backport of https://github.com/gnuradio/gnuradio/pull/3394