### PR TITLE
filter: Fix firdes RRC filter gain for alpha == 1

### DIFF
--- a/gr-filter/lib/firdes.cc
+++ b/gr-filter/lib/firdes.cc
@@ -571,6 +571,7 @@ vector<float> firdes::root_raised_cosine(
         } else {
             if (alpha == 1) {
                 taps[i] = -1;
+                scale += taps[i];
                 continue;
             }
             x3 = (1 - alpha) * x1;

--- a/gr-filter/python/filter/qa_firdes.py
+++ b/gr-filter/python/filter/qa_firdes.py
@@ -163,6 +163,13 @@ class test_firdes(gr_unittest.TestCase):
         new_taps = filter.firdes.root_raised_cosine(1, 4, 1, 0.35, 11)
         self.assertFloatTuplesAlmostEqual(known_taps, new_taps, 5)
 
+    def test_root_raised_cosine_gain(self):
+        """Confirm DC gain is as expected"""
+        taps = filter.firdes.root_raised_cosine(1, 4, 1, 0.35, 11)
+        self.assertAlmostEqual(sum(taps), 1.0)
+        taps = filter.firdes.root_raised_cosine(1, 4, 1, 1.0, 11)
+        self.assertAlmostEqual(sum(taps), 1.0)
+
     def test_gaussian(self):
         known_taps = (0.0003600157215259969, 0.0031858310103416443,
                       0.0182281993329525, 0.06743486225605011,


### PR DESCRIPTION
`firdes.root_raised_cosine()` does not normalize the coefficients correctly when `alpha == 1` due to a bug in special-case handling for that specific value of `alpha`. Fixed in this PR along with new unit test.

To reproduce (annotated):
```
In [1]: from gnuradio.filter import firdes

# setting alpha to 0.99 (any value less than 1.0 should give similar results)
In [2]: h = firdes.root_raised_cosine(1, 4, 1, 0.99, 128)                                                                           

# as expected, the sum of all coefficients is roughly 1.0
In [3]: np.sum(h)                                                                                                                   
Out[3]: 1.0000000041691237

# setting alpha to 1.0
In [4]: h = firdes.root_raised_cosine(1, 4, 1, 1.0, 128)                                                                            

# uhhhh...that's not right
In [5]: np.sum(h)                                                                           
Out[5]: 2.0001506736152805
```