### PR TITLE
filter: Fix firdes RRC filter gain for alpha == 1 (backport for maint-3.7)

### DIFF
--- a/gr-filter/lib/firdes.cc
+++ b/gr-filter/lib/firdes.cc
@@ -582,6 +582,7 @@ vector<float> firdes::root_raised_cosine(
         } else {
             if (alpha == 1) {
                 taps[i] = -1;
+                scale += taps[i];
                 continue;
             }
             x3 = (1 - alpha) * x1;

--- a/gr-filter/python/filter/qa_firdes.py
+++ b/gr-filter/python/filter/qa_firdes.py
@@ -174,6 +174,13 @@ class test_firdes(gr_unittest.TestCase):
         new_taps = filter.firdes.root_raised_cosine(1, 4, 1, 0.35, 11)
         self.assertFloatTuplesAlmostEqual(known_taps, new_taps, 5)
 
+    def test_root_raised_cosine_gain(self):
+        """Confirm DC gain is as expected"""
+        taps = filter.firdes.root_raised_cosine(1, 4, 1, 0.35, 11)
+        self.assertAlmostEqual(sum(taps), 1.0)
+        taps = filter.firdes.root_raised_cosine(1, 4, 1, 1.0, 11)
+        self.assertAlmostEqual(sum(taps), 1.0)
+
     def test_gaussian(self):
         known_taps = (0.0003600157215259969, 0.0031858310103416443,
                       0.0182281993329525, 0.06743486225605011,


### PR DESCRIPTION
* Fix gain of firdes.root_raised_cosine() when alpha is set to 1.0. Was
  2x the expected gain for alpha==1.0 previously.
* Adds corresponding unit test.