### PR TITLE
gr-fft: added tukey and gaussian windows

### DIFF
--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -211,9 +211,20 @@ public:
     static std::vector<float> nuttal_cfd(int ntaps);
 
     /*!
-     * \brief Build a flat top window.
+     * \brief Build a flat top window per the SRS specification
      *
-     * See: http://en.wikipedia.org/wiki/Window_function#Flat_top_window
+     * See:
+     * <pre>
+     *     Stanford Research Systems, "Model SR785 Dynamic Signal
+     *     Analyzer: Operating Manual and Programming Reference,"
+     *     2017, pp 2-13
+     * </pre>
+     *
+     * Note: there are many flat top windows, and this implementation is different from
+     * SciPY and Matlab which use the coefficients from D’Antona et al. "Digital Signal
+     * Processing for Measurement Systems" with the following cosine coefficients: <pre>
+     *     [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
+     * </pre>
      *
      * \param ntaps Number of coefficients in the window.
      */

--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -288,6 +288,16 @@ public:
     static std::vector<float> riemann(int ntaps);
 
     /*!
+     * \brief Build a Tukey window.
+     *
+     * \param ntaps Number of coefficients in the window.
+     * \param alpha Shaping parameter for the Tukey window, an
+     *        alpha of zero is equivalent to a rectangular
+     *        window, an alpha of 1 is equivalent to Hann.
+     */
+    static std::vector<float> tukey(int ntaps, float alpha);
+
+    /*!
      * \brief Build a window using gr::fft::win_type to index the
      * type of window desired.
      *

--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -300,6 +300,10 @@ public:
 
     /*!
      * \brief Build a Tukey window.
+     * <pre>
+     * Bloomfield, P. Fourier Analysis of Time Series: An Introduction. New York:
+     * Wiley-Interscience, 2000, pp 69 (eqn 6.9)
+     * </pre>
      *
      * \param ntaps Number of coefficients in the window.
      * \param alpha Shaping parameter for the Tukey window, an
@@ -307,6 +311,17 @@ public:
      *        window, an alpha of 1 is equivalent to Hann.
      */
     static std::vector<float> tukey(int ntaps, float alpha);
+
+    /*!
+     * \brief Build a Gaussian window using the equation
+     * <pre>
+     * exp(-(1/2) * (n/sigma)^2)
+     * </pre>
+     *
+     * \param ntaps Number of coefficients in the window.
+     * \param sigma Standard deviation of gaussian distribution.
+     */
+    static std::vector<float> gaussian(int ntaps, float sigma);
 
     /*!
      * \brief Build a window using gr::fft::win_type to index the

--- a/gr-fft/lib/window.cc
+++ b/gr-fft/lib/window.cc
@@ -339,6 +339,22 @@ std::vector<float> window::tukey(int ntaps, float a)
     return taps;
 }
 
+std::vector<float> window::gaussian(int ntaps, float sigma)
+{
+    if (sigma <= 0)
+        throw std::out_of_range("window::gaussian: sigma must be > 0");
+
+    float a = 2 * sigma * sigma;
+    double m1 = midm1(ntaps);
+    std::vector<float> taps(ntaps);
+    for (int i = 0; i < midn(ntaps); i++) {
+        float N = (i - m1);
+        taps[i] = exp(-(N * N / a));
+        taps[ntaps - 1 - i] = taps[i];
+    }
+    return taps;
+}
+
 std::vector<float> window::build(win_type type, int ntaps, double beta)
 {
     switch (type) {

--- a/gr-fft/lib/window.cc
+++ b/gr-fft/lib/window.cc
@@ -316,6 +316,29 @@ std::vector<float> window::riemann(int ntaps)
     return taps;
 }
 
+std::vector<float> window::tukey(int ntaps, float a)
+{
+    if ((a < 0) || (a > 1))
+        throw std::out_of_range("window::tukey: alpha must be between 0 and 1");
+
+    float N = static_cast<float>(ntaps - 1);
+
+    float aN = a * N;
+    float p1 = aN / 2.0;
+    float mid = midn(ntaps);
+    std::vector<float> taps(ntaps);
+    for (int i = 0; i < mid; i++) {
+        if (abs(i) < p1) {
+            taps[i] = 0.5 * (1.0 - cos((2 * GR_M_PI * i) / (aN)));
+            taps[ntaps - 1 - i] = taps[i];
+        } else {
+            taps[i] = 1.0;
+            taps[ntaps - i - 1] = 1.0;
+        }
+    }
+    return taps;
+}
+
 std::vector<float> window::build(win_type type, int ntaps, double beta)
 {
     switch (type) {


### PR DESCRIPTION
Adds Tukey window generation.

Sanity check:
```
>>> from gnuradio import fft
>>> from matplotlib import pyplot as plt
>>> plt.plot(fft.window.hann(17), '-o');
[<matplotlib.lines.Line2D object at 0x7f0a64b49748>]
>>> plt.plot(fft.window.tukey(33, .5), '-o'); plt.show()
[<matplotlib.lines.Line2D object at 0x7f0a64b49828>]
>>> plt.show()
```
![image](https://user-images.githubusercontent.com/7121282/80244299-ec9f5b80-8625-11ea-991a-fa043e77b52d.png)

