### PR TITLE
grc: use correct labels in log window context menu (Backport 3.8)

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -146,11 +146,11 @@ class TextDisplay(SimpleTextDisplay):
         lock.set_active(self.scroll_lock)
         lock.connect('activate', self.scroll_back_cb, view)
 
-        save = Gtk.ImageMenuItem(label = Gtk.STOCK_SAVE)
+        save = Gtk.ImageMenuItem(label = "Save Console")
         menu.append(save)
         save.connect('activate', self.save_cb, view)
 
-        clear = Gtk.ImageMenuItem(label = Gtk.STOCK_CLEAR)
+        clear = Gtk.ImageMenuItem(label = "Clear Console")
         menu.append(clear)
         clear.connect('activate', self.clear_cb, view)
         menu.show_all()


### PR DESCRIPTION
Previously 'gtk-clear' and 'gtk-save' were shown.

Gtk.STOCK_* constants are deprecated in favor of translated strings.
But grc is English-only, so it makes sense to stick to the simple
hardcoded solution.