### PR TITLE
grc: Deduplicate block paths

### DIFF
--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 import os
 from os.path import expanduser, normpath, expandvars, exists
+from collections import OrderedDict
 
 from . import Constants
 
@@ -43,6 +44,9 @@ class Config(object):
 
         valid_paths = [normpath(expanduser(expandvars(path)))
                        for path in collected_paths if exists(path)]
+        # Deduplicate paths to avoid warnings about finding blocks twice, but
+        # preserve order of paths
+        valid_paths = list(OrderedDict.fromkeys(valid_paths))
 
         return valid_paths
 


### PR DESCRIPTION
GRC reads paths from various sources, including the GRC_BLOCKS_PATH
environment variable. It can happen that paths appear twice in the list,
causing warnings about findings blocks twice.

This deduplicates the paths in the config object.