### PR TITLE
runtime: attributes: Remove check for gcc 3

### DIFF
--- a/gnuradio-runtime/include/gnuradio/attributes.h
+++ b/gnuradio-runtime/include/gnuradio/attributes.h
@@ -28,13 +28,8 @@
 #define __GR_ATTR_UNUSED __attribute__((unused))
 #define __GR_ATTR_INLINE __attribute__((always_inline))
 #define __GR_ATTR_DEPRECATED __attribute__((deprecated))
-#if __GNUC__ >= 4
 #define __GR_ATTR_EXPORT __attribute__((visibility("default")))
 #define __GR_ATTR_IMPORT __attribute__((visibility("default")))
-#else
-#define __GR_ATTR_EXPORT
-#define __GR_ATTR_IMPORT
-#endif
 #elif _MSC_VER
 #define __GR_ATTR_ALIGNED(x) __declspec(align(x))
 #define __GR_ATTR_UNUSED


### PR DESCRIPTION
gcc 4 has been a requirement for many years now, so we can remove the
check for gcc 3.