### PR TITLE
grc: fix importing configparser in variable config block

### DIFF
--- a/grc/blocks/variable_config.block.yml
+++ b/grc/blocks/variable_config.block.yml
@@ -34,8 +34,12 @@ parameters:
 value: ${ value }
 
 templates:
-    imports: import ConfigParser
-    var_make: 'self._${id}_config = ConfigParser.ConfigParser()
+    imports: |-
+        try:
+            import configparser
+        except ImportError:
+            import ConfigParser as configparser
+    var_make: 'self._${id}_config = configparser.ConfigParser()
 
         self._${id}_config.read(${config_file})
 
@@ -46,7 +50,7 @@ templates:
         self.${id} = ${id}'
     callbacks:
     - self.set_${id}(${value})
-    - "self._${id}_config = ConfigParser.ConfigParser()\nself._${id}_config.read(${config_file})\n\
+    - "self._${id}_config = configparser.ConfigParser()\nself._${id}_config.read(${config_file})\n\
         if not self._${id}_config.has_section(${section}):\n\tself._${id}_config.add_section(${section})\n\
         self._${id}_config.set(${section}, ${option}, str(${writeback}))\nself._${id}_config.write(open(${config_file},\
         \ 'w'))"


### PR DESCRIPTION
Partially fixes #2782.

This backports #2867 to GNU Radio 3.8 so that the Variable Config block works in both Python 2 and Python 3.