### PR TITLE
GRC: default to showing of block comments

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -432,7 +432,8 @@ TOGGLE_AUTO_HIDE_PORT_LABELS = actions.register("win.auto_hide_port_labels",
 TOGGLE_SHOW_BLOCK_COMMENTS = actions.register("win.show_block_comments",
     label='Show Block Comments',
     tooltip="Show comment beneath each block",
-    preference_name='show_block_comments'
+    preference_name='show_block_comments',
+    default=True
 )
 TOGGLE_SHOW_CODE_PREVIEW_TAB = actions.register("win.toggle_code_preview",
     label='Generated Code Preview',


### PR DESCRIPTION
This is a reduced backport of #3431 to 3.8.
It only touches the "show block comments" setting to default to True