### PR TITLE
qtgui: remove qt warnings

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
@@ -36,7 +36,7 @@ class QwtColorMap;
 class PlotTimeRaster : public QwtPlotRasterItem
 {
 public:
-    explicit PlotTimeRaster(const QString& title = QString::null);
+    explicit PlotTimeRaster(const QString& title = QString());
     virtual ~PlotTimeRaster();
 
     const TimeRasterData* data() const;

--- a/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
@@ -36,7 +36,7 @@ class QwtColorMap;
 class PlotWaterfall : public QwtPlotRasterItem
 {
 public:
-    explicit PlotWaterfall(WaterfallData* data, const QString& title = QString::null);
+    explicit PlotWaterfall(WaterfallData* data, const QString& title = QString());
     virtual ~PlotWaterfall();
 
     const WaterfallData* data() const;

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -71,7 +71,12 @@ DisplayPlot::DisplayPlot(int nplots, QWidget* parent)
 
     const QFontMetrics fm(axisWidget(QwtPlot::yLeft)->font());
     QwtScaleDraw* sd = axisScaleDraw(QwtPlot::yLeft);
-    sd->setMinimumExtent(fm.width("100.00"));
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    int min_ext = fm.horizontalAdvance("100.00");
+#else
+    int min_ext = fm.width("100.00");
+#endif
+    sd->setMinimumExtent(min_ext);
 
     QwtLegend* legendDisplay = new QwtLegend(this);
 

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -46,7 +46,7 @@ public:
     virtual QwtText label(double value) const
     {
         double secs = double(value * getSecondsPerLine());
-        return QwtText(QString("").sprintf("%.2f", secs));
+        return QwtText(QString::number(secs, 'f', 2));
     }
 
     virtual void initiateUpdate()
@@ -71,7 +71,7 @@ public:
     {
         if (d_rows > 0)
             value = d_rows - value;
-        return QwtText(QString("").sprintf("%.0f", value));
+        return QwtText(QString::number(value, 'f', 0));
     }
 
     virtual void initiateUpdate()

--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -46,7 +46,7 @@ public:
     virtual QwtText label(double value) const
     {
         double secs = double(value * getSecondsPerLine());
-        return QwtText(QString("").sprintf("%.2e", secs));
+        return QwtText(QString::number(secs, 'e', 2));
     }
 
     virtual void initiateUpdate()

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -302,7 +302,7 @@ void DisplayForm::setAxisLabels(bool en)
 
 void DisplayForm::saveFigure()
 {
-    QPixmap qpix = QPixmap::grabWidget(this);
+    QPixmap qpix = this->grab();
 
     QString types = QString(tr("JPEG file (*.jpg);;Portable Network Graphics file "
                                "(*.png);;Bitmap file (*.bmp);;TIFF file (*.tiff)"));

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -88,7 +88,11 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
             d_key->setEnabled(false);
 
             QFontMetrics fm = d_key->fontMetrics();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+            int width = 15 + fm.horizontalAdvance(key_text);
+#else
             int width = 15 + fm.width(key_text);
+#endif
 
             d_key->setFixedWidth(width);
 

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -190,7 +190,7 @@ void NumberDisplayForm::setStop()
 
 void NumberDisplayForm::saveFigure()
 {
-    QPixmap qpix = QPixmap::grabWidget(this);
+    QPixmap qpix = this->grab();
 
     QString types = QString(tr("JPEG file (*.jpg);;Portable Network Graphics file "
                                "(*.png);;Bitmap file (*.bmp);;TIFF file (*.tiff)"));


### PR DESCRIPTION
Related bug: #3349.

This replaces obsolete API calls (most of the newer alternatives are present on Qt 5.0).