### PR TITLE
msg_handler: Switch from boost::function to std::function

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -18,9 +18,9 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/sptr_magic.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/function.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <deque>
+#include <functional>
 #include <map>
 #include <string>
 
@@ -42,7 +42,7 @@ namespace gr {
 class GR_RUNTIME_API basic_block : public msg_accepter,
                                    public std::enable_shared_from_this<basic_block>
 {
-    typedef boost::function<void(pmt::pmt_t)> msg_handler_t;
+    typedef std::function<void(pmt::pmt_t)> msg_handler_t;
 
 private:
     typedef std::map<pmt::pmt_t, msg_handler_t, pmt::comparator> d_msg_handlers_t;

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -49,8 +49,7 @@ block::block(const std::string& name,
 {
     global_block_registry.register_primitive(alias(), this);
     message_port_register_in(d_system_port);
-    set_msg_handler(d_system_port,
-                    std::bind(&block::system_handler, this, std::placeholders::_1));
+    set_msg_handler(d_system_port, [this](pmt::pmt_t msg) { this->system_handler(msg); });
 }
 
 block::~block() { global_block_registry.unregister_primitive(symbol_name()); }

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -49,7 +49,8 @@ block::block(const std::string& name,
 {
     global_block_registry.register_primitive(alias(), this);
     message_port_register_in(d_system_port);
-    set_msg_handler(d_system_port, boost::bind(&block::system_handler, this, _1));
+    set_msg_handler(d_system_port,
+                    std::bind(&block::system_handler, this, std::placeholders::_1));
 }
 
 block::~block() { global_block_registry.unregister_primitive(symbol_name()); }

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -55,7 +55,7 @@ sig_source_impl<T>::sig_source_impl(double sampling_freq,
     this->set_phase(phase);
     this->message_port_register_in(pmt::mp("freq"));
     this->set_msg_handler(pmt::mp("freq"),
-                          boost::bind(&sig_source_impl<T>::set_frequency_msg, this, _1));
+                          [this](pmt::pmt_t msg) { this->set_frequency_msg(msg); });
 }
 
 template <class T>

--- a/gr-blocks/lib/copy_impl.cc
+++ b/gr-blocks/lib/copy_impl.cc
@@ -32,8 +32,7 @@ copy_impl::copy_impl(size_t itemsize)
       d_enabled(true)
 {
     message_port_register_in(pmt::mp("en"));
-    set_msg_handler(pmt::mp("en"),
-                    std::bind(&copy_impl::handle_enable, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("en"), [this](pmt::pmt_t msg) { this->handle_enable(msg); });
 }
 
 copy_impl::~copy_impl() {}

--- a/gr-blocks/lib/copy_impl.cc
+++ b/gr-blocks/lib/copy_impl.cc
@@ -32,7 +32,8 @@ copy_impl::copy_impl(size_t itemsize)
       d_enabled(true)
 {
     message_port_register_in(pmt::mp("en"));
-    set_msg_handler(pmt::mp("en"), boost::bind(&copy_impl::handle_enable, this, _1));
+    set_msg_handler(pmt::mp("en"),
+                    std::bind(&copy_impl::handle_enable, this, std::placeholders::_1));
 }
 
 copy_impl::~copy_impl() {}

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -78,14 +78,17 @@ message_debug_impl::message_debug_impl()
     : block("message_debug", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0))
 {
     message_port_register_in(pmt::mp("print"));
-    set_msg_handler(pmt::mp("print"), boost::bind(&message_debug_impl::print, this, _1));
+    set_msg_handler(pmt::mp("print"),
+                    std::bind(&message_debug_impl::print, this, std::placeholders::_1));
 
     message_port_register_in(pmt::mp("store"));
-    set_msg_handler(pmt::mp("store"), boost::bind(&message_debug_impl::store, this, _1));
+    set_msg_handler(pmt::mp("store"),
+                    std::bind(&message_debug_impl::store, this, std::placeholders::_1));
 
     message_port_register_in(pmt::mp("print_pdu"));
-    set_msg_handler(pmt::mp("print_pdu"),
-                    boost::bind(&message_debug_impl::print_pdu, this, _1));
+    set_msg_handler(
+        pmt::mp("print_pdu"),
+        std::bind(&message_debug_impl::print_pdu, this, std::placeholders::_1));
 }
 
 message_debug_impl::~message_debug_impl() {}

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -78,17 +78,14 @@ message_debug_impl::message_debug_impl()
     : block("message_debug", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0))
 {
     message_port_register_in(pmt::mp("print"));
-    set_msg_handler(pmt::mp("print"),
-                    std::bind(&message_debug_impl::print, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("print"), [this](pmt::pmt_t msg) { this->print(msg); });
 
     message_port_register_in(pmt::mp("store"));
-    set_msg_handler(pmt::mp("store"),
-                    std::bind(&message_debug_impl::store, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("store"), [this](pmt::pmt_t msg) { this->store(msg); });
 
     message_port_register_in(pmt::mp("print_pdu"));
-    set_msg_handler(
-        pmt::mp("print_pdu"),
-        std::bind(&message_debug_impl::print_pdu, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("print_pdu"),
+                    [this](pmt::pmt_t msg) { this->print_pdu(msg); });
 }
 
 message_debug_impl::~message_debug_impl() {}

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -41,8 +41,9 @@ message_strobe_impl::message_strobe_impl(pmt::pmt_t msg, long period_ms)
     message_port_register_out(d_port);
 
     message_port_register_in(pmt::mp("set_msg"));
-    set_msg_handler(pmt::mp("set_msg"),
-                    boost::bind(&message_strobe_impl::set_msg, this, _1));
+    set_msg_handler(
+        pmt::mp("set_msg"),
+        std::bind(&message_strobe_impl::set_msg, this, std::placeholders::_1));
 }
 
 message_strobe_impl::~message_strobe_impl() {}
@@ -53,7 +54,7 @@ bool message_strobe_impl::start()
     // nothing breaks on concurrent access, I'll just leave it as bool.
     d_finished = false;
     d_thread = std::shared_ptr<gr::thread::thread>(
-        new gr::thread::thread(boost::bind(&message_strobe_impl::run, this)));
+        new gr::thread::thread(std::bind(&message_strobe_impl::run, this)));
 
     return block::start();
 }

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -41,9 +41,7 @@ message_strobe_impl::message_strobe_impl(pmt::pmt_t msg, long period_ms)
     message_port_register_out(d_port);
 
     message_port_register_in(pmt::mp("set_msg"));
-    set_msg_handler(
-        pmt::mp("set_msg"),
-        std::bind(&message_strobe_impl::set_msg, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("set_msg"), [this](pmt::pmt_t msg) { this->set_msg(msg); });
 }
 
 message_strobe_impl::~message_strobe_impl() {}

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -54,9 +54,7 @@ message_strobe_random_impl::message_strobe_random_impl(
         new gr::thread::thread(std::bind(&message_strobe_random_impl::run, this)));
 
     message_port_register_in(pmt::mp("set_msg"));
-    set_msg_handler(
-        pmt::mp("set_msg"),
-        std::bind(&message_strobe_random_impl::set_msg, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("set_msg"), [this](pmt::pmt_t msg) { this->set_msg(msg); });
 }
 
 void message_strobe_random_impl::set_mean(float mean_ms)

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -51,11 +51,12 @@ message_strobe_random_impl::message_strobe_random_impl(
     // set up ports
     message_port_register_out(d_port);
     d_thread = std::shared_ptr<gr::thread::thread>(
-        new gr::thread::thread(boost::bind(&message_strobe_random_impl::run, this)));
+        new gr::thread::thread(std::bind(&message_strobe_random_impl::run, this)));
 
     message_port_register_in(pmt::mp("set_msg"));
-    set_msg_handler(pmt::mp("set_msg"),
-                    boost::bind(&message_strobe_random_impl::set_msg, this, _1));
+    set_msg_handler(
+        pmt::mp("set_msg"),
+        std::bind(&message_strobe_random_impl::set_msg, this, std::placeholders::_1));
 }
 
 void message_strobe_random_impl::set_mean(float mean_ms)

--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -223,10 +223,7 @@ multiply_matrix_impl<gr_complex>::multiply_matrix_impl(
 
     pmt::pmt_t port_name = pmt::string_to_symbol("set_A");
     message_port_register_in(port_name);
-    set_msg_handler(port_name,
-                    std::bind(&multiply_matrix_impl<gr_complex>::msg_handler_A,
-                              this,
-                              std::placeholders::_1));
+    set_msg_handler(port_name, [this](pmt::pmt_t msg) { this->msg_handler_A(msg); });
 }
 
 template <>
@@ -245,10 +242,7 @@ multiply_matrix_impl<float>::multiply_matrix_impl(
 
     pmt::pmt_t port_name = pmt::string_to_symbol("set_A");
     message_port_register_in(port_name);
-    set_msg_handler(port_name,
-                    std::bind(&multiply_matrix_impl<float>::msg_handler_A,
-                              this,
-                              std::placeholders::_1));
+    set_msg_handler(port_name, [this](pmt::pmt_t msg) { this->msg_handler_A(msg); });
 }
 
 

--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -223,9 +223,10 @@ multiply_matrix_impl<gr_complex>::multiply_matrix_impl(
 
     pmt::pmt_t port_name = pmt::string_to_symbol("set_A");
     message_port_register_in(port_name);
-    set_msg_handler(
-        port_name,
-        boost::bind(&multiply_matrix_impl<gr_complex>::msg_handler_A, this, _1));
+    set_msg_handler(port_name,
+                    std::bind(&multiply_matrix_impl<gr_complex>::msg_handler_A,
+                              this,
+                              std::placeholders::_1));
 }
 
 template <>
@@ -245,7 +246,9 @@ multiply_matrix_impl<float>::multiply_matrix_impl(
     pmt::pmt_t port_name = pmt::string_to_symbol("set_A");
     message_port_register_in(port_name);
     set_msg_handler(port_name,
-                    boost::bind(&multiply_matrix_impl<float>::msg_handler_A, this, _1));
+                    std::bind(&multiply_matrix_impl<float>::msg_handler_A,
+                              this,
+                              std::placeholders::_1));
 }
 
 

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -35,8 +35,9 @@ mute_impl<T>::mute_impl(bool mute)
       d_mute(mute)
 {
     this->message_port_register_in(pmt::intern("set_mute"));
-    this->set_msg_handler(pmt::intern("set_mute"),
-                          boost::bind(&mute_impl<T>::set_mute_pmt, this, _1));
+    this->set_msg_handler(
+        pmt::intern("set_mute"),
+        std::bind(&mute_impl<T>::set_mute_pmt, this, std::placeholders::_1));
 }
 
 template <class T>

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -35,8 +35,8 @@ mute_impl<T>::mute_impl(bool mute)
       d_mute(mute)
 {
     this->message_port_register_in(pmt::intern("set_mute"));
-    this->set_msg_handler(
-        pmt::intern("set_mute"), [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
+    this->set_msg_handler(pmt::intern("set_mute"),
+                          [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
 }
 
 template <class T>

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -36,8 +36,7 @@ mute_impl<T>::mute_impl(bool mute)
 {
     this->message_port_register_in(pmt::intern("set_mute"));
     this->set_msg_handler(
-        pmt::intern("set_mute"),
-        std::bind(&mute_impl<T>::set_mute_pmt, this, std::placeholders::_1));
+        pmt::intern("set_mute"), [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
 }
 
 template <class T>

--- a/gr-blocks/lib/nop_impl.cc
+++ b/gr-blocks/lib/nop_impl.cc
@@ -32,8 +32,9 @@ nop_impl::nop_impl(size_t sizeof_stream_item)
 {
     // Arrange to have count_received_msgs called when messages are received.
     message_port_register_in(pmt::mp("port"));
-    set_msg_handler(pmt::mp("port"),
-                    boost::bind(&nop_impl::count_received_msgs, this, _1));
+    set_msg_handler(
+        pmt::mp("port"),
+        std::bind(&nop_impl::count_received_msgs, this, std::placeholders::_1));
 }
 
 nop_impl::~nop_impl() {}

--- a/gr-blocks/lib/nop_impl.cc
+++ b/gr-blocks/lib/nop_impl.cc
@@ -32,9 +32,8 @@ nop_impl::nop_impl(size_t sizeof_stream_item)
 {
     // Arrange to have count_received_msgs called when messages are received.
     message_port_register_in(pmt::mp("port"));
-    set_msg_handler(
-        pmt::mp("port"),
-        std::bind(&nop_impl::count_received_msgs, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("port"),
+                    [this](pmt::pmt_t msg) { this->count_received_msgs(msg); });
 }
 
 nop_impl::~nop_impl() {}

--- a/gr-blocks/lib/pdu_filter_impl.cc
+++ b/gr-blocks/lib/pdu_filter_impl.cc
@@ -33,7 +33,7 @@ pdu_filter_impl::pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert)
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(),
-                    boost::bind(&pdu_filter_impl::handle_msg, this, _1));
+                    std::bind(&pdu_filter_impl::handle_msg, this, std::placeholders::_1));
 }
 
 void pdu_filter_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_filter_impl.cc
+++ b/gr-blocks/lib/pdu_filter_impl.cc
@@ -33,7 +33,7 @@ pdu_filter_impl::pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert)
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(),
-                    std::bind(&pdu_filter_impl::handle_msg, this, std::placeholders::_1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_filter_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_remove_impl.cc
+++ b/gr-blocks/lib/pdu_remove_impl.cc
@@ -31,7 +31,7 @@ pdu_remove_impl::pdu_remove_impl(pmt::pmt_t k)
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(),
-                    std::bind(&pdu_remove_impl::handle_msg, this, std::placeholders::_1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_remove_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_remove_impl.cc
+++ b/gr-blocks/lib/pdu_remove_impl.cc
@@ -31,7 +31,7 @@ pdu_remove_impl::pdu_remove_impl(pmt::pmt_t k)
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(),
-                    boost::bind(&pdu_remove_impl::handle_msg, this, _1));
+                    std::bind(&pdu_remove_impl::handle_msg, this, std::placeholders::_1));
 }
 
 void pdu_remove_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -31,8 +31,7 @@ pdu_set_impl::pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v)
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(),
-                    std::bind(&pdu_set_impl::handle_msg, this, std::placeholders::_1));
+    set_msg_handler(pdu::pdu_port_id(), [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_set_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -31,7 +31,8 @@ pdu_set_impl::pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v)
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(), boost::bind(&pdu_set_impl::handle_msg, this, _1));
+    set_msg_handler(pdu::pdu_port_id(),
+                    std::bind(&pdu_set_impl::handle_msg, this, std::placeholders::_1));
 }
 
 void pdu_set_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -31,7 +31,8 @@ pdu_set_impl::pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v)
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(), [this](pmt::pmt_t msg) { this->handle_msg(msg); });
+    set_msg_handler(pdu::pdu_port_id(),
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_set_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -38,11 +38,7 @@ random_pdu_impl::random_pdu_impl(int min_items,
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pmt::mp("generate"));
-    set_msg_handler(pmt::mp("generate"),
-                    std::bind(static_cast<void (random_pdu_impl::*)(pmt::pmt_t)>(
-                                  &random_pdu_impl::generate_pdu),
-                              this,
-                              std::placeholders::_1));
+    set_msg_handler(pmt::mp("generate"), [this](pmt::pmt_t msg) { this->generate_pdu(msg); });
     if (length_modulo < 1)
         throw std::runtime_error("length_module must be >= 1");
     if (max_items < length_modulo)

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -39,7 +39,10 @@ random_pdu_impl::random_pdu_impl(int min_items,
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pmt::mp("generate"));
     set_msg_handler(pmt::mp("generate"),
-                    boost::bind(&random_pdu_impl::generate_pdu, this, _1));
+                    std::bind(static_cast<void (random_pdu_impl::*)(pmt::pmt_t)>(
+                                  &random_pdu_impl::generate_pdu),
+                              this,
+                              std::placeholders::_1));
     if (length_modulo < 1)
         throw std::runtime_error("length_module must be >= 1");
     if (max_items < length_modulo)

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -38,7 +38,8 @@ random_pdu_impl::random_pdu_impl(int min_items,
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pmt::mp("generate"));
-    set_msg_handler(pmt::mp("generate"), [this](pmt::pmt_t msg) { this->generate_pdu(msg); });
+    set_msg_handler(pmt::mp("generate"),
+                    [this](pmt::pmt_t msg) { this->generate_pdu(msg); });
     if (length_modulo < 1)
         throw std::runtime_error("length_module must be >= 1");
     if (max_items < length_modulo)

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -32,7 +32,8 @@ repeat_impl::repeat_impl(size_t itemsize, int interp)
       d_interp(interp)
 {
     message_port_register_in(pmt::mp("interpolation"));
-    set_msg_handler(pmt::mp("interpolation"), [this](pmt::pmt_t msg) { this->msg_set_interpolation(msg); });
+    set_msg_handler(pmt::mp("interpolation"),
+                    [this](pmt::pmt_t msg) { this->msg_set_interpolation(msg); });
 }
 
 void repeat_impl::msg_set_interpolation(pmt::pmt_t msg)

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -32,8 +32,9 @@ repeat_impl::repeat_impl(size_t itemsize, int interp)
       d_interp(interp)
 {
     message_port_register_in(pmt::mp("interpolation"));
-    set_msg_handler(pmt::mp("interpolation"),
-                    boost::bind(&repeat_impl::msg_set_interpolation, this, _1));
+    set_msg_handler(
+        pmt::mp("interpolation"),
+        std::bind(&repeat_impl::msg_set_interpolation, this, std::placeholders::_1));
 }
 
 void repeat_impl::msg_set_interpolation(pmt::pmt_t msg)

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -32,9 +32,7 @@ repeat_impl::repeat_impl(size_t itemsize, int interp)
       d_interp(interp)
 {
     message_port_register_in(pmt::mp("interpolation"));
-    set_msg_handler(
-        pmt::mp("interpolation"),
-        std::bind(&repeat_impl::msg_set_interpolation, this, std::placeholders::_1));
+    set_msg_handler(pmt::mp("interpolation"), [this](pmt::pmt_t msg) { this->msg_set_interpolation(msg); });
 }
 
 void repeat_impl::msg_set_interpolation(pmt::pmt_t msg)

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -88,8 +88,9 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
 
         start_tcp_accept();
 
-        set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::tcp_server_send, this, _1));
+        set_msg_handler(
+            pdu::pdu_port_id(),
+            std::bind(&socket_pdu_impl::tcp_server_send, this, std::placeholders::_1));
     } else if (type == "TCP_CLIENT") {
         boost::system::error_code error = boost::asio::error::host_not_found;
         d_tcp_socket.reset(new boost::asio::ip::tcp::socket(d_io_service));
@@ -98,8 +99,9 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
             throw boost::system::system_error(error);
         d_tcp_socket->set_option(boost::asio::ip::tcp::no_delay(d_tcp_no_delay));
 
-        set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::tcp_client_send, this, _1));
+        set_msg_handler(
+            pdu::pdu_port_id(),
+            std::bind(&socket_pdu_impl::tcp_client_send, this, std::placeholders::_1));
 
         d_tcp_socket->async_read_some(
             boost::asio::buffer(d_rxbuf),
@@ -118,8 +120,9 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred));
 
-        set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::udp_send, this, _1));
+        set_msg_handler(
+            pdu::pdu_port_id(),
+            std::bind(&socket_pdu_impl::udp_send, this, std::placeholders::_1));
     } else if (type == "UDP_CLIENT") {
         d_udp_socket.reset(
             new boost::asio::ip::udp::socket(d_io_service, d_udp_endpoint));
@@ -131,8 +134,9 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred));
 
-        set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::udp_send, this, _1));
+        set_msg_handler(
+            pdu::pdu_port_id(),
+            std::bind(&socket_pdu_impl::udp_send, this, std::placeholders::_1));
     } else
         throw std::runtime_error("gr::blocks:socket_pdu: unknown socket type");
 

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -88,9 +88,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
 
         start_tcp_accept();
 
-        set_msg_handler(
-            pdu::pdu_port_id(),
-            std::bind(&socket_pdu_impl::tcp_server_send, this, std::placeholders::_1));
+        set_msg_handler(pdu::pdu_port_id(),
+                        [this](pmt::pmt_t msg) { this->tcp_server_send(msg); });
     } else if (type == "TCP_CLIENT") {
         boost::system::error_code error = boost::asio::error::host_not_found;
         d_tcp_socket.reset(new boost::asio::ip::tcp::socket(d_io_service));
@@ -99,9 +98,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
             throw boost::system::system_error(error);
         d_tcp_socket->set_option(boost::asio::ip::tcp::no_delay(d_tcp_no_delay));
 
-        set_msg_handler(
-            pdu::pdu_port_id(),
-            std::bind(&socket_pdu_impl::tcp_client_send, this, std::placeholders::_1));
+        set_msg_handler(pdu::pdu_port_id(),
+                        [this](pmt::pmt_t msg) { this->tcp_client_send(msg); });
 
         d_tcp_socket->async_read_some(
             boost::asio::buffer(d_rxbuf),
@@ -120,9 +118,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred));
 
-        set_msg_handler(
-            pdu::pdu_port_id(),
-            std::bind(&socket_pdu_impl::udp_send, this, std::placeholders::_1));
+        set_msg_handler(pdu::pdu_port_id(),
+                        [this](pmt::pmt_t msg) { this->udp_send(msg); });
     } else if (type == "UDP_CLIENT") {
         d_udp_socket.reset(
             new boost::asio::ip::udp::socket(d_io_service, d_udp_endpoint));
@@ -134,9 +131,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred));
 
-        set_msg_handler(
-            pdu::pdu_port_id(),
-            std::bind(&socket_pdu_impl::udp_send, this, std::placeholders::_1));
+        set_msg_handler(pdu::pdu_port_id(),
+                        [this](pmt::pmt_t msg) { this->udp_send(msg); });
     } else
         throw std::runtime_error("gr::blocks:socket_pdu: unknown socket type");
 

--- a/gr-blocks/lib/stream_pdu_base.cc
+++ b/gr-blocks/lib/stream_pdu_base.cc
@@ -44,7 +44,7 @@ void stream_pdu_base::start_rxthread(basic_block* blk, pmt::pmt_t port)
 {
     d_blk = blk;
     d_port = port;
-    d_thread = gr::thread::thread(boost::bind(&stream_pdu_base::run, this));
+    d_thread = gr::thread::thread(std::bind(&stream_pdu_base::run, this));
     d_started = true;
 }
 

--- a/gr-blocks/lib/tagged_stream_multiply_length_impl.cc
+++ b/gr-blocks/lib/tagged_stream_multiply_length_impl.cc
@@ -37,9 +37,10 @@ tagged_stream_multiply_length_impl::tagged_stream_multiply_length_impl(
     set_tag_propagation_policy(TPP_DONT);
     set_relative_rate(1, 1);
     message_port_register_in(pmt::intern("set_scalar"));
-    set_msg_handler(
-        pmt::intern("set_scalar"),
-        boost::bind(&tagged_stream_multiply_length_impl::set_scalar_pmt, this, _1));
+    set_msg_handler(pmt::intern("set_scalar"),
+                    std::bind(&tagged_stream_multiply_length_impl::set_scalar_pmt,
+                              this,
+                              std::placeholders::_1));
 }
 
 tagged_stream_multiply_length_impl::~tagged_stream_multiply_length_impl() {}

--- a/gr-blocks/lib/tagged_stream_multiply_length_impl.cc
+++ b/gr-blocks/lib/tagged_stream_multiply_length_impl.cc
@@ -38,9 +38,7 @@ tagged_stream_multiply_length_impl::tagged_stream_multiply_length_impl(
     set_relative_rate(1, 1);
     message_port_register_in(pmt::intern("set_scalar"));
     set_msg_handler(pmt::intern("set_scalar"),
-                    std::bind(&tagged_stream_multiply_length_impl::set_scalar_pmt,
-                              this,
-                              std::placeholders::_1));
+                    [this](pmt::pmt_t msg) { this->set_scalar_pmt(msg); });
 }
 
 tagged_stream_multiply_length_impl::~tagged_stream_multiply_length_impl() {}

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -86,8 +86,7 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
 
     // set up input message port
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(),
-                    std::bind(&tuntap_pdu_impl::send, this, std::placeholders::_1));
+    set_msg_handler(pdu::pdu_port_id(), [this](pmt::pmt_t msg) { this->send(msg); });
 }
 
 int tuntap_pdu_impl::tun_alloc(char* dev, int flags)

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -86,7 +86,8 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
 
     // set up input message port
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(), boost::bind(&tuntap_pdu_impl::send, this, _1));
+    set_msg_handler(pdu::pdu_port_id(),
+                    std::bind(&tuntap_pdu_impl::send, this, std::placeholders::_1));
 }
 
 int tuntap_pdu_impl::tun_alloc(char* dev, int flags)

--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -55,10 +55,8 @@ chunks_to_symbols_impl<IN_T, OUT_T>::chunks_to_symbols_impl(
       d_symbol_table(symbol_table)
 {
     this->message_port_register_in(pmt::mp("set_symbol_table"));
-    this->set_msg_handler(
-        pmt::mp("set_symbol_table"),
-        boost::bind(
-            &chunks_to_symbols_impl<IN_T, OUT_T>::handle_set_symbol_table, this, _1));
+    this->set_msg_handler(pmt::mp("set_symbol_table"),
+                          [this](pmt::pmt_t msg) { this->handle_set_symbol_table(msg); });
 }
 
 template <class IN_T, class OUT_T>

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -49,14 +49,12 @@ constellation_receiver_cb_impl::constellation_receiver_cb_impl(
             "This receiver only works with constellations of dimension 1.");
 
     message_port_register_in(pmt::mp("set_constellation"));
-    set_msg_handler(
-        pmt::mp("set_constellation"),
-        boost::bind(&constellation_receiver_cb_impl::handle_set_constellation, this, _1));
+    set_msg_handler(pmt::mp("set_constellation"),
+                    [this](pmt::pmt_t msg) { this->handle_set_constellation(msg); });
 
     message_port_register_in(pmt::mp("rotate_phase"));
-    set_msg_handler(
-        pmt::mp("rotate_phase"),
-        boost::bind(&constellation_receiver_cb_impl::handle_rotate_phase, this, _1));
+    set_msg_handler(pmt::mp("rotate_phase"),
+                    [this](pmt::pmt_t msg) { this->handle_rotate_phase(msg); });
 }
 
 constellation_receiver_cb_impl::~constellation_receiver_cb_impl() {}

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -42,7 +42,7 @@ costas_loop_cc_impl::costas_loop_cc_impl(float loop_bw, unsigned int order, bool
 {
     message_port_register_in(pmt::mp("noise"));
     set_msg_handler(pmt::mp("noise"),
-                    boost::bind(&costas_loop_cc_impl::handle_set_noise, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_set_noise(msg); });
 }
 
 costas_loop_cc_impl::~costas_loop_cc_impl() {}

--- a/gr-digital/lib/crc32_async_bb_impl.cc
+++ b/gr-digital/lib/crc32_async_bb_impl.cc
@@ -36,9 +36,9 @@ crc32_async_bb_impl::crc32_async_bb_impl(bool check)
     message_port_register_out(d_out_port);
 
     if (check)
-        set_msg_handler(d_in_port, boost::bind(&crc32_async_bb_impl::check, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->check(msg); });
     else
-        set_msg_handler(d_in_port, boost::bind(&crc32_async_bb_impl::calc, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->calc(msg); });
 }
 
 crc32_async_bb_impl::~crc32_async_bb_impl() {}

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -138,9 +138,8 @@ header_payload_demux_impl::header_payload_demux_impl(
     }
     set_tag_propagation_policy(TPP_DONT);
     message_port_register_in(msg_port_id());
-    set_msg_handler(
-        msg_port_id(),
-        boost::bind(&header_payload_demux_impl::parse_header_data_msg, this, _1));
+    set_msg_handler(msg_port_id(),
+                    [this](pmt::pmt_t msg) { this->parse_header_data_msg(msg); });
     for (size_t i = 0; i < special_tags.size(); i++) {
         d_special_tags.push_back(pmt::string_to_symbol(special_tags[i]));
         d_special_tags_last_value.push_back(pmt::PMT_NIL);

--- a/gr-digital/lib/protocol_formatter_async_impl.cc
+++ b/gr-digital/lib/protocol_formatter_async_impl.cc
@@ -42,8 +42,7 @@ protocol_formatter_async_impl::protocol_formatter_async_impl(
     message_port_register_out(d_hdr_port);
     message_port_register_out(d_pld_port);
 
-    set_msg_handler(d_in_port,
-                    boost::bind(&protocol_formatter_async_impl::append, this, _1));
+    set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->append(msg); });
 }
 
 protocol_formatter_async_impl::~protocol_formatter_async_impl() {}

--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -52,11 +52,10 @@ async_decoder_impl::async_decoder_impl(generic_decoder::sptr my_decoder,
 
     if (d_packed) {
         d_pack = new blocks::kernel::pack_k_bits(8);
-        set_msg_handler(d_in_port,
-                        boost::bind(&async_decoder_impl::decode_packed, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->decode_packed(msg); });
     } else {
         set_msg_handler(d_in_port,
-                        boost::bind(&async_decoder_impl::decode_unpacked, this, _1));
+                        [this](pmt::pmt_t msg) { this->decode_unpacked(msg); });
     }
 
     // The maximum frame size is set by the initial frame size of the decoder.

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -51,8 +51,7 @@ async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
     message_port_register_out(d_out_port);
 
     if (d_packed) {
-        set_msg_handler(d_in_port,
-                        boost::bind(&async_encoder_impl::encode_packed, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->encode_packed(msg); });
 
         d_unpack = new blocks::kernel::unpack_k_bits(8);
 
@@ -62,7 +61,7 @@ async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
 
     } else {
         set_msg_handler(d_in_port,
-                        boost::bind(&async_encoder_impl::encode_unpacked, this, _1));
+                        [this](pmt::pmt_t msg) { this->encode_unpacked(msg); });
     }
 
     if (d_packed || (strncmp(d_encoder->get_input_conversion(), "pack", 4) == 0)) {

--- a/gr-fec/lib/depuncture_bb_impl.cc
+++ b/gr-fec/lib/depuncture_bb_impl.cc
@@ -62,7 +62,7 @@ depuncture_bb_impl::depuncture_bb_impl(int puncsize, int puncpat, int delay, uin
     set_fixed_rate(true);
     set_relative_rate((uint64_t)d_puncsize, (uint64_t)(d_puncsize - d_puncholes));
     set_output_multiple(d_puncsize);
-    // set_msg_handler(boost::bind(&depuncture_bb_impl::catch_msg, this, _1));
+    // set_msg_handler(<portname>, [this](pmt::pmt_t msg) { this->catch_msg(msg); });
 }
 
 depuncture_bb_impl::~depuncture_bb_impl() {}

--- a/gr-fec/lib/puncture_bb_impl.cc
+++ b/gr-fec/lib/puncture_bb_impl.cc
@@ -60,7 +60,7 @@ puncture_bb_impl::puncture_bb_impl(int puncsize, int puncpat, int delay)
     set_fixed_rate(true);
     set_relative_rate((uint64_t)(d_puncsize - d_puncholes), (uint64_t)d_puncsize);
     set_output_multiple(d_puncsize - d_puncholes);
-    // set_msg_handler(boost::bind(&puncture_bb_impl::catch_msg, this, _1));
+    // set_msg_handler(<portname>, [this](pmt::pmt_t msg) { this->catch_msg(msg); });
 }
 
 puncture_bb_impl::~puncture_bb_impl() {}

--- a/gr-fec/lib/puncture_ff_impl.cc
+++ b/gr-fec/lib/puncture_ff_impl.cc
@@ -60,7 +60,7 @@ puncture_ff_impl::puncture_ff_impl(int puncsize, int puncpat, int delay)
     set_fixed_rate(true);
     set_relative_rate((uint64_t)(d_puncsize - d_puncholes), (uint64_t)d_puncsize);
     set_output_multiple(d_puncsize - d_puncholes);
-    // set_msg_handler(boost::bind(&puncture_ff_impl::catch_msg, this, _1));
+    // set_msg_handler(<portname>, [this](pmt::pmt_t msg) { this->catch_msg(msg); });
 }
 
 puncture_ff_impl::~puncture_ff_impl() {}

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.cc
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.cc
@@ -56,12 +56,8 @@ freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::freq_xlating_fir_filter_impl(
     this->build_composite_fir();
 
     this->message_port_register_in(pmt::mp("freq"));
-    this->set_msg_handler(
-        pmt::mp("freq"),
-        boost::bind(
-            &freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::handle_set_center_freq,
-            this,
-            _1));
+    this->set_msg_handler(pmt::mp("freq"),
+                          [this](pmt::pmt_t msg) { this->handle_set_center_freq(msg); });
 }
 
 template <class IN_T, class OUT_T, class TAP_T>

--- a/gr-filter/lib/mmse_resampler_cc_impl.cc
+++ b/gr-filter/lib/mmse_resampler_cc_impl.cc
@@ -41,7 +41,7 @@ mmse_resampler_cc_impl::mmse_resampler_cc_impl(float phase_shift, float resamp_r
     set_inverse_relative_rate(d_mu_inc);
     message_port_register_in(pmt::intern("msg_in"));
     set_msg_handler(pmt::intern("msg_in"),
-                    boost::bind(&mmse_resampler_cc_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 mmse_resampler_cc_impl::~mmse_resampler_cc_impl() { delete d_resamp; }

--- a/gr-filter/lib/mmse_resampler_ff_impl.cc
+++ b/gr-filter/lib/mmse_resampler_ff_impl.cc
@@ -42,7 +42,7 @@ mmse_resampler_ff_impl::mmse_resampler_ff_impl(float phase_shift, float resamp_r
 
     message_port_register_in(pmt::intern("msg_in"));
     set_msg_handler(pmt::intern("msg_in"),
-                    boost::bind(&mmse_resampler_ff_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 mmse_resampler_ff_impl::~mmse_resampler_ff_impl() { delete d_resamp; }

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -57,8 +57,7 @@ const_sink_c_impl::const_sink_c_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&const_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     for (int i = 0; i < d_nconnections; i++) {
         d_residbufs_real.push_back(

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -145,7 +145,7 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
     message_port_register_out(d_port);
     message_port_register_in(pmt::mp("val"));
 
-    set_msg_handler(pmt::mp("val"), boost::bind(&edit_box_msg_impl::set_value, this, _1));
+    set_msg_handler(pmt::mp("val"), [this](pmt::pmt_t msg) { this->set_value(msg); });
 }
 
 edit_box_msg_impl::~edit_box_msg_impl()

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -70,17 +70,17 @@ freq_sink_c_impl::freq_sink_c_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw, boost::bind(&freq_sink_c_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&freq_sink_c_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&freq_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -70,17 +70,17 @@ freq_sink_f_impl::freq_sink_f_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw, boost::bind(&freq_sink_f_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&freq_sink_f_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&freq_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -69,8 +69,7 @@ histogram_sink_f_impl::histogram_sink_f_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&histogram_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     // +1 for the PDU buffer
     for (int i = 0; i < d_nconnections + 1; i++) {

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -84,7 +84,7 @@ sink_c_impl::sink_c_impl(int fftsize,
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&sink_c_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -83,7 +83,7 @@ sink_f_impl::sink_f_impl(int fftsize,
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&sink_f_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -71,8 +71,7 @@ time_raster_sink_b_impl::time_raster_sink_b_impl(double samp_rate,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&time_raster_sink_b_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_scale = 1.0f;
 

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -71,8 +71,7 @@ time_raster_sink_f_impl::time_raster_sink_f_impl(double samp_rate,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&time_raster_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_icols = static_cast<int>(ceil(d_cols));
     d_tmpflt = (float*)volk_malloc(d_icols * sizeof(float), volk_get_alignment());

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -68,7 +68,7 @@ time_sink_c_impl::time_sink_c_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&time_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     // +2 for the PDU message buffers
     for (unsigned int n = 0; n < d_nconnections + 2; n++) {

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -68,7 +68,7 @@ time_sink_f_impl::time_sink_f_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&time_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     // +1 for the PDU buffer
     for (unsigned int n = 0; n < d_nconnections + 1; n++) {

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -105,20 +105,17 @@ waterfall_sink_c_impl::waterfall_sink_c_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw,
-                    boost::bind(&waterfall_sink_c_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port,
-                    boost::bind(&waterfall_sink_c_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&waterfall_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 }
 
 waterfall_sink_c_impl::~waterfall_sink_c_impl()

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -103,20 +103,17 @@ waterfall_sink_f_impl::waterfall_sink_f_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw,
-                    boost::bind(&waterfall_sink_f_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port,
-                    boost::bind(&waterfall_sink_f_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&waterfall_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 }
 
 waterfall_sink_f_impl::~waterfall_sink_f_impl()

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -125,7 +125,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     // Set up message ports:
     message_port_register_in(pmt::mp("command"));
     set_msg_handler(pmt::mp("command"),
-                    boost::bind(&usrp_block_impl::msg_handler_command, this, _1));
+                    [this](pmt::pmt_t msg) { this->msg_handler_command(msg); });
 
 // cuz we lazy:
 #define REGISTER_CMD_HANDLER(key, _handler) \

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -50,7 +50,7 @@ pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout, bool bind)
     }
 
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&pub_msg_sink_impl::handler, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handler(msg); });
 }
 
 pub_msg_sink_impl::~pub_msg_sink_impl()

--- a/gr-zeromq/lib/push_msg_sink_impl.cc
+++ b/gr-zeromq/lib/push_msg_sink_impl.cc
@@ -50,7 +50,7 @@ push_msg_sink_impl::push_msg_sink_impl(char* address, int timeout, bool bind)
     }
 
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&push_msg_sink_impl::handler, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handler(msg); });
 }
 
 push_msg_sink_impl::~push_msg_sink_impl()


### PR DESCRIPTION
This commit is a first stab at moving from `boost::function` to `std::function`.
For now, it does only update gr-blocks. Also, this requires more testing.

If others can confirm that this change works, I'll continue to update all modules.

@marcusmueller recommends to merge this into pybind to consolidate OOT API breaking changes.

This is a work in progress at the moment!