### PR TITLE
qtgui_chooser.block.yml fails to build

### DIFF
--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -126,11 +126,7 @@ templates:
         % if int(num_opts):
         self._${id}_labels = (\
         % for lbl in all_labels:
-        % if lbl:
         ${lbl}, \
-        % else:
-        self._${id}_options[${i}], \
-        % endif
         % endfor
         )
         % elif labels:


### PR DESCRIPTION
After updating to latest git version of gnuradio and  Ubuntu 20.04
trying to build a chooser block fails with Generate Error: (NameError("'i' is not defined")

This is correct
https://github.com/gnuradio/gnuradio/blob/aa8f15d6408b0a2b70b6a012c53b8cf0bd955b9c/gr-qtgui/grc/qtgui_chooser.block.yml#L132

i is not defined at this point. No idea why it worked before.

Creating the labels list the same way as the options list fixes this issue