### PR TITLE
blocks: improvements to the message_debug block

### DIFF
--- a/gr-blocks/grc/blocks_message_debug.block.yml
+++ b/gr-blocks/grc/blocks_message_debug.block.yml
@@ -2,6 +2,14 @@ id: blocks_message_debug
 label: Message Debug
 flags: [ python, cpp ]
 
+parameters:
+-   id: en_uvec
+    label: PDU Vectors
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['On', 'Off']
+
 inputs:
 -   domain: message
     id: print
@@ -15,7 +23,9 @@ inputs:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.message_debug()
+    make: blocks.message_debug(${en_uvec})
+    callbacks:
+    - set_vector_print(${en_uvec})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/message_debug.h>']

--- a/gr-blocks/include/gnuradio/blocks/message_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/message_debug.h
@@ -47,7 +47,7 @@ public:
      * and has three message ports: print, store, and
      * print_pdu.
      */
-    static sptr make();
+    static sptr make(bool en_uvec = true);
 
     /*!
      * \brief Reports the number of messages received by this block.
@@ -68,6 +68,11 @@ public:
      * \return a message at index \p i as a pmt_t.
      */
     virtual pmt::pmt_t get_message(int i) = 0;
+
+    /*!
+     * \brief Enables or disables printing of PDU uniform vector data.
+     */
+    virtual void set_vector_print(bool en) = 0;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -20,16 +20,36 @@
 namespace gr {
 namespace blocks {
 
-message_debug::sptr message_debug::make()
+message_debug::sptr message_debug::make(bool en_uvec)
 {
-    return gnuradio::make_block_sptr<message_debug_impl>();
+    return gnuradio::make_block_sptr<message_debug_impl>(en_uvec);
 }
+
+message_debug_impl::message_debug_impl(bool en_uvec)
+    : block("message_debug", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
+      d_en_uvec(en_uvec)
+{
+    message_port_register_in(pmt::mp("print"));
+    set_msg_handler(pmt::mp("print"), [this](pmt::pmt_t msg) { this->print(msg); });
+
+    message_port_register_in(pmt::mp("store"));
+    set_msg_handler(pmt::mp("store"), [this](pmt::pmt_t msg) { this->store(msg); });
+
+    message_port_register_in(pmt::mp("print_pdu"));
+    set_msg_handler(pmt::mp("print_pdu"),
+                    [this](pmt::pmt_t msg) { this->print_pdu(msg); });
+}
+
+message_debug_impl::~message_debug_impl() {}
 
 void message_debug_impl::print(pmt::pmt_t msg)
 {
-    std::cout << "******* MESSAGE DEBUG PRINT ********\n";
-    pmt::print(msg);
-    std::cout << "************************************\n";
+    std::stringstream sout;
+
+    sout << "******* MESSAGE DEBUG PRINT ********" << std::endl
+         << pmt::write_string(msg) << std::endl
+         << "************************************" << std::endl;
+    std::cout << sout.str();
 }
 
 void message_debug_impl::store(pmt::pmt_t msg)
@@ -40,25 +60,44 @@ void message_debug_impl::store(pmt::pmt_t msg)
 
 void message_debug_impl::print_pdu(pmt::pmt_t pdu)
 {
-    pmt::pmt_t meta = pmt::car(pdu);
-    pmt::pmt_t vector = pmt::cdr(pdu);
-    std::cout << "* MESSAGE DEBUG PRINT PDU VERBOSE *\n";
-    pmt::print(meta);
-    size_t len = pmt::blob_length(vector);
-    std::cout << "pdu_length = " << len << std::endl;
-    std::cout << "contents = " << std::endl;
-    size_t offset(0);
-    const uint8_t* d = (const uint8_t*)pmt::uniform_vector_elements(vector, offset);
-    for (size_t i = 0; i < len; i += 16) {
-        printf("%04x: ", ((unsigned int)i));
-        for (size_t j = i; j < std::min(i + 16, len); j++) {
-            printf("%02x ", d[j]);
-        }
-
-        std::cout << std::endl;
+    if (pmt::is_null(pdu) || !pmt::is_pair(pdu)) {
+        return;
     }
 
-    std::cout << "***********************************\n";
+    std::stringstream sout;
+
+    pmt::pmt_t meta = pmt::car(pdu);
+    pmt::pmt_t vector = pmt::cdr(pdu);
+
+    sout << "***** VERBOSE PDU DEBUG PRINT ******" << std::endl
+         << pmt::write_string(meta) << std::endl;
+
+    if (pmt::is_uniform_vector(vector)) {
+        size_t len = pmt::blob_length(vector);
+        if (d_en_uvec) {
+            sout << "pdu length = " << len << " bytes" << std::endl
+                 << "pdu vector contents = " << std::endl;
+            size_t offset(0);
+            const uint8_t* d =
+                (const uint8_t*)pmt::uniform_vector_elements(vector, offset);
+            for (size_t i = 0; i < len; i += 16) {
+                sout << std::hex << std::setw(4) << std::setfill('0')
+                     << static_cast<unsigned int>(i) << ": ";
+                for (size_t j = i; j < std::min(i + 16, len); j++) {
+                    sout << std::hex << std::setw(2) << std::setfill('0')
+                         << static_cast<unsigned int>(d[j]) << " ";
+                }
+                sout << std::endl;
+            }
+        } else {
+            sout << "pdu length = " << len << " bytes (printing disabled)" << std::endl;
+        }
+    } else {
+        sout << "Message CDR is not a uniform vector..." << std::endl;
+    }
+
+    sout << "************************************" << std::endl;
+    std::cout << sout.str();
 }
 
 int message_debug_impl::num_messages() { return (int)d_messages.size(); }
@@ -73,22 +112,6 @@ pmt::pmt_t message_debug_impl::get_message(int i)
 
     return d_messages[i];
 }
-
-message_debug_impl::message_debug_impl()
-    : block("message_debug", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0))
-{
-    message_port_register_in(pmt::mp("print"));
-    set_msg_handler(pmt::mp("print"), [this](pmt::pmt_t msg) { this->print(msg); });
-
-    message_port_register_in(pmt::mp("store"));
-    set_msg_handler(pmt::mp("store"), [this](pmt::pmt_t msg) { this->store(msg); });
-
-    message_port_register_in(pmt::mp("print_pdu"));
-    set_msg_handler(pmt::mp("print_pdu"),
-                    [this](pmt::pmt_t msg) { this->print_pdu(msg); });
-}
-
-message_debug_impl::~message_debug_impl() {}
 
 } /* namespace blocks */
 } /* namespace gr */

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -22,6 +22,8 @@ namespace blocks {
 class message_debug_impl : public message_debug
 {
 private:
+    bool d_en_uvec;
+
     /*!
      * \brief Messages received in this port are printed to stdout.
      *
@@ -63,11 +65,12 @@ private:
     std::vector<pmt::pmt_t> d_messages;
 
 public:
-    message_debug_impl();
+    message_debug_impl(bool en_uvec);
     ~message_debug_impl();
 
     int num_messages();
     pmt::pmt_t get_message(int i);
+    void set_vector_print(bool en) { d_en_uvec = en; };
 };
 
 } /* namespace blocks */

--- a/gr-blocks/python/blocks/bindings/docstrings/message_debug_pydoc_template.h
+++ b/gr-blocks/python/blocks/bindings/docstrings/message_debug_pydoc_template.h
@@ -31,3 +31,6 @@ static const char* __doc_gr_blocks_message_debug_num_messages = R"doc()doc";
 
 
 static const char* __doc_gr_blocks_message_debug_get_message = R"doc()doc";
+
+
+static const char* __doc_gr_blocks_message_debug_set_vector_print = R"doc()doc";

--- a/gr-blocks/python/blocks/bindings/message_debug_python.cc
+++ b/gr-blocks/python/blocks/bindings/message_debug_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(message_debug.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d30bdecc7a85481cac1f2c6ff843509b)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5768fa881c26e7018f934e8997ac36de)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -36,7 +36,9 @@ void bind_message_debug(py::module& m)
     py::class_<message_debug, gr::block, gr::basic_block, std::shared_ptr<message_debug>>(
         m, "message_debug", D(message_debug))
 
-        .def(py::init(&message_debug::make), D(message_debug, make))
+        .def(py::init(&message_debug::make),
+             py::arg("en_uvec") = true,
+             D(message_debug, make))
 
 
         .def("num_messages", &message_debug::num_messages, D(message_debug, num_messages))
@@ -46,6 +48,12 @@ void bind_message_debug(py::module& m)
              &message_debug::get_message,
              py::arg("i"),
              D(message_debug, get_message))
+
+
+        .def("set_vector_print",
+             &message_debug::set_vector_print,
+             py::arg("en"),
+             D(message_debug, set_vector_print))
 
         ;
 }


### PR DESCRIPTION
aggregates the data to be printed into a stringstream so that it is printed at the same time reducing debug information becoming muddled between competing cout statements. this change also provides an argument to this block to disable the printing of PDU uniform vectors which are often not needed for debug purposes

I also moved the constructor and destructor to be more consistent with other blocks