### PR TITLE
doc: use MathJax for HTML documentation

### DIFF
--- a/cmake/Modules/FindMathJax2.cmake
+++ b/cmake/Modules/FindMathJax2.cmake
@@ -1,0 +1,60 @@
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#####
+#
+# Find MathJax package (version 2).
+#
+# A hint can be provided by defining MATHJAX2_ROOT
+# (will succeed if ${MATHJAX2_ROOT}/MathJax.js is found).
+#
+# Alternatively, a path can be provided in MATHJAX2_USE_ROOT
+# so that ${MATHJAX2_USE_ROOT}/MathJax.js is used without
+# checking its existence.
+# This path could be a URL, an absolute local path or
+# a path relative to the generated HTML folder.
+#
+# Note that version 2 and 3 are incompatible
+# and doxygen requires version 2.
+# See: https://github.com/doxygen/doxygen/issues/7346
+#
+# Defined variables:
+#  - MATHJAX2_FOUND     - True if MathJax found
+#  - MATHJAX2_JS_PATH   - Path to MathJax.js file
+#  - MATHJAX2_PATH      - Path to the MathJax root directory
+#
+#####
+
+
+# TODO: in cmake 3.10+ use include_guard()
+if(__INCLUDED_MATHJAX2)
+  return()
+endif()
+set(__INCLUDED_MATHJAX2 TRUE)
+
+
+if(DEFINED MATHJAX2_USE_ROOT)
+  set(MATHJAX2_FOUND   TRUE)
+  set(MATHJAX2_PATH    "${MATHJAX2_USE_ROOT}/")
+  set(MATHJAX2_JS_PATH "${MATHJAX2_USE_ROOT}/MathJax.js")
+else()
+  find_file(MATHJAX2_JS_PATH
+      NAMES
+        MathJax.js
+      PATHS
+        "${MATHJAX2_ROOT}"
+        /usr/share/mathjax2/
+        /usr/share/javascript/mathjax/
+        /usr/local/share/javascript/mathjax/
+  )
+
+  get_filename_component(MATHJAX2_PATH ${MATHJAX2_JS_PATH} DIRECTORY)
+
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(MathJax2 DEFAULT_MSG MATHJAX2_JS_PATH)
+endif()
+
+mark_as_advanced(MATHJAX2_JS_PATH)
+

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -9,12 +9,14 @@
 # Setup dependencies
 ########################################################################
 find_package(Doxygen)
+find_package(MathJax2)
 
 ########################################################################
 # Register component
 ########################################################################
 include(GrComponent)
-GR_REGISTER_COMPONENT("doxygen" ENABLE_DOXYGEN DOXYGEN_FOUND)
+GR_REGISTER_COMPONENT("doxygen" ENABLE_DOXYGEN
+  DOXYGEN_FOUND)
 
 ########################################################################
 # Begin conditional configuration

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -18,6 +18,13 @@ set(enable_html_docs YES)
 set(enable_latex_docs NO)
 set(enable_xml_docs YES)
 
+if(MATHJAX2_FOUND)
+  set(enable_mathjax YES)
+else()
+  message(WARNING "MathJax 2 not found, HTML equations might not be properly rendered.")
+  set(enable_mathjax NO)
+endif()
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
     ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -232,13 +232,6 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding
-# "class=itcl::class" will allow you to use the command class in the
-# itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C
 # sources only. Doxygen will then generate output that is more tailored for C.
 # For instance, some of the names that are used will be different. The list
@@ -1309,14 +1302,14 @@ FORMULA_TRANSPARENT    = YES
 # output. When enabled you may also need to install MathJax separately and
 # configure the path to it using the MATHJAX_RELPATH option.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = @enable_mathjax@
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. Supported types are HTML-CSS, NativeMML (i.e. MathML) and
 # SVG. The default value is HTML-CSS, which is slower, but has the best
 # compatibility.
 
-MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_FORMAT         = SVG
 
 # When MathJax is enabled you need to specify the location relative to the
 # HTML output directory using the MATHJAX_RELPATH option. The destination
@@ -1328,12 +1321,12 @@ MATHJAX_FORMAT         = HTML-CSS
 # However, it is strongly recommended to install a local
 # copy of MathJax from http://www.mathjax.org before deployment.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = @MATHJAX2_PATH@
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or MathJax extension
 # names that should be enabled during MathJax rendering.
 
-MATHJAX_EXTENSIONS     =
+MATHJAX_EXTENSIONS     = TeX/AMSmath TeX/AMSsymbols
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript
 # pieces of code that will be used on startup of the MathJax code.
@@ -1909,7 +1902,7 @@ DIRECTORY_GRAPH        = NO
 # HTML_FILE_EXTENSION to xhtml in order to make the SVG files
 # visible in IE 9+ (other browsers do not have this requirement).
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.

--- a/docs/doxygen/Doxyfile.swig_doc.in
+++ b/docs/doxygen/Doxyfile.swig_doc.in
@@ -199,13 +199,6 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding
-# "class=itcl::class" will allow you to use the command class in the
-# itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C
 # sources only. Doxygen will then generate output that is more tailored for C.
 # For instance, some of the names that are used will be different. The list
@@ -1318,7 +1311,7 @@ COMPACT_LATEX          = NO
 # by the printer. Possible values are: a4, letter, legal and
 # executive. If left blank a4 will be used.
 
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = letter
 
 # The EXTRA_PACKAGES tag can be to specify one or more names of LaTeX
 # packages that should be included in the LaTeX output.

--- a/docs/doxygen/other/build_guide.dox.in
+++ b/docs/doxygen/other/build_guide.dox.in
@@ -55,6 +55,7 @@ Other compilers may work, but are not supported.
 
 \subsection dep_docs docs: Building the documentation
 \li doxygen     (>= 1.5)     http://www.stack.nl/~dimitri/doxygen/download.html
+\li MathJax     (>= 2, <3)   https://github.com/mathjax/MathJax-src
 
 \subsection dep_grc grc: The GNU Radio Companion
 \li Cheetah     (>= 2.0)     http://www.cheetahtemplate.org/

--- a/gr-utils/modtool/templates/gr-newmod/docs/doxygen/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/docs/doxygen/CMakeLists.txt
@@ -17,6 +17,7 @@ file(TO_NATIVE_PATH ${CMAKE_BINARY_DIR} abs_top_builddir)
 set(HAVE_DOT ${DOXYGEN_DOT_FOUND})
 set(enable_html_docs YES)
 set(enable_latex_docs NO)
+set(enable_mathjax NO)
 set(enable_xml_docs YES)
 
 configure_file(

--- a/gr-utils/modtool/templates/gr-newmod/docs/doxygen/Doxyfile.in
+++ b/gr-utils/modtool/templates/gr-newmod/docs/doxygen/Doxyfile.in
@@ -199,13 +199,6 @@ TAB_SIZE               = 8
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding
-# "class=itcl::class" will allow you to use the command class in the
-# itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C
 # sources only. Doxygen will then generate output that is more tailored for C.
 # For instance, some of the names that are used will be different. The list
@@ -1218,14 +1211,14 @@ FORMULA_TRANSPARENT    = YES
 # output. When enabled you may also need to install MathJax separately and
 # configure the path to it using the MATHJAX_RELPATH option.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = @enable_mathjax@
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. Supported types are HTML-CSS, NativeMML (i.e. MathML) and
 # SVG. The default value is HTML-CSS, which is slower, but has the best
 # compatibility.
 
-MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_FORMAT         = SVG
 
 # When MathJax is enabled you need to specify the location relative to the
 # HTML output directory using the MATHJAX_RELPATH option. The destination
@@ -1237,12 +1230,12 @@ MATHJAX_FORMAT         = HTML-CSS
 # However, it is strongly recommended to install a local
 # copy of MathJax from http://www.mathjax.org before deployment.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = @MATHJAX2_PATH@
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or MathJax extension
 # names that should be enabled during MathJax rendering.
 
-MATHJAX_EXTENSIONS     =
+MATHJAX_EXTENSIONS     = TeX/AMSmath TeX/AMSsymbols
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript
 # pieces of code that will be used on startup of the MathJax code.
@@ -1818,7 +1811,7 @@ DIRECTORY_GRAPH        = YES
 # HTML_FILE_EXTENSION to xhtml in order to make the SVG files
 # visible in IE 9+ (other browsers do not have this requirement).
 
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 
 # If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
 # enable generation of interactive SVG images that allow zooming and panning.


### PR DESCRIPTION
Fixes #2707.

A full LaTeX installation is no longer required for generating the HTML docs.

Apparently this was previously broken (?), e.g.: https://www.gnuradio.org/doc/doxygen/classgr_1_1fec_1_1code_1_1ldpc__gen__mtrx__encoder.html

Note that this adds a newer dependency but replaces the former hefty LaTeX dependency (which was undocumented?).
