### PR TITLE
uhd: Properly ignore len_tag_name in USRP source (3.8)

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -150,9 +150,11 @@ templates:
                 channels=list(range(0,${'$'}{nchan})),
                 ${'%'} endif
             ),
+            % if sourk == 'sink':
             ${'%'} if len_tag_name:
             ${'$'}{len_tag_name},
             ${'%'} endif
+            % endif
         )
         % for m in range(max_mboards):
         ${'%'} if context.get('num_mboards')() > ${m}:


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/3437.
I'll make a PR for master too if this one gets approved.