### PR TITLE
Extending tagged_file_sink file naming options.

### DIFF
--- a/gr-blocks/grc/blocks_tagged_file_sink.block.yml
+++ b/gr-blocks/grc/blocks_tagged_file_sink.block.yml
@@ -20,6 +20,20 @@ parameters:
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }
+-   id: directory
+    label: Directory
+    dtype: directory_path
+-   id: filename_prefix
+    label: Filename prefix
+    dtype: string
+    default: ""
+    hide: ${ 'none' if legacy_filename == False else 'all' }
+-   id: legacy_filename
+    label: Legacy filename
+    dtype: bool
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['On', 'Off']
 
 inputs:
 -   domain: stream
@@ -28,14 +42,15 @@ inputs:
 
 asserts:
 - ${ vlen > 0 }
+- ${ legacy_filename == True or len(filename_prefix) > 0 }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.tagged_file_sink(${type.size}*${vlen}, ${samp_rate})
+    make: blocks.tagged_file_sink(${type.size}*${vlen}, ${samp_rate}, ${directory}, ${filename_prefix}, ${legacy_filename})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/tagged_file_sink.h>']
     declarations: 'blocks::tagged_file_sink::sptr ${id};'
-    make: 'this->${id} = blocks::tagged_file_sink::make(${type.size}*${vlen}, ${samp_rate});'
+    make: 'this->${id} = blocks::tagged_file_sink::make(${type.size}*${vlen}, ${directory}, ${samp_rate}, ${filename_prefix}, ${legacy_filename});'
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/tagged_file_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/tagged_file_sink.h
@@ -27,11 +27,16 @@ namespace blocks {
  * of the burst data to a new file. If the value of this tag is
  * True, it will open a new file and start writing all incoming
  * data to it. If the tag is False, it will close the file (if
- * already opened). The file names are based on the time when the
- * burst tag was seen. If there is an 'rx_time' tag (standard with
+ * already opened).
+ * The file names differ between legacy and non-legacy mode.
+ * In leagcy mode, names are based on the time when the burst tag
+ * was seen. If there is an 'rx_time' tag (standard with
  * UHD sources), that is used as the time. If no 'rx_time' tag is
  * found, the new time is calculated based off the sample rate of
  * the block.
+ * In non-legacy mode, filename prefix need to be defined, the rest
+ * of the file name will be created basing on current date and time
+ * with microsecond precision: prefix_%Y-%m-%d_%H_%M_%S.%f.dat
  */
 class BLOCKS_API tagged_file_sink : virtual public sync_block
 {
@@ -45,8 +50,17 @@ public:
      * \param itemsize The item size of the input data stream.
      * \param samp_rate The sample rate used to determine the time
      *                  difference between bursts
+     * \param directory Directory where file will be be saved,
+     *                  can be empty.
+     * \param legacy_filename If true, use legacy filename generator.
+     * \param filename_prefix Prefix of the saved file in non-legacy mode.
+     *                        prefix_%Y-%m-%d_%H_%M_%S.%f.dat,
      */
-    static sptr make(size_t itemsize, double samp_rate);
+    static sptr make(size_t itemsize,
+                     double samp_rate,
+                     const std::string& directory = "",
+                     const std::string& filename_prefix = "",
+                     bool legacy_filename = true);
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/tagged_file_sink_impl.h
+++ b/gr-blocks/lib/tagged_file_sink_impl.h
@@ -29,9 +29,16 @@ private:
     int d_n;
     uint64_t d_last_N;
     double d_timeval;
+    const std::string d_directory;
+    const std::string d_filename_prefix;
+    bool d_legacy_filename;
 
 public:
-    tagged_file_sink_impl(size_t itemsize, double samp_rate);
+    tagged_file_sink_impl(size_t itemsize,
+                          double samp_rate,
+                          const std::string& directory,
+                          const std::string& filename_prefix,
+                          bool legacy_filename);
     ~tagged_file_sink_impl();
 
     int work(int noutput_items,

--- a/gr-blocks/python/blocks/qa_tag_file_sink.py
+++ b/gr-blocks/python/blocks/qa_tag_file_sink.py
@@ -26,7 +26,7 @@ class test_tag_file_sink(gr_unittest.TestCase):
         src = blocks.vector_source_i(src_data)
         trg = blocks.vector_source_s(trg_data)
         op  = blocks.burst_tagger(gr.sizeof_int)
-        snk = blocks.tagged_file_sink(gr.sizeof_int, 1)
+        snk = blocks.tagged_file_sink(gr.sizeof_int, 1, "", "")
         self.tb.connect(src, (op,0))
         self.tb.connect(trg, (op,1))
         self.tb.connect(op, snk)

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -49,7 +49,7 @@ PARAM_TYPE_NAMES = {
     'complex', 'real', 'float', 'int',
     'complex_vector', 'real_vector', 'float_vector', 'int_vector',
     'hex', 'string', 'bool',
-    'file_open', 'file_save', '_multiline', '_multiline_python_external',
+    'file_open', 'file_save', 'directory_path', '_multiline', '_multiline_python_external',
     'id', 'stream_id','name',
     'gui_hint',
     'import',

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -242,7 +242,7 @@ class Param(Element):
         #########################
         # String Types
         #########################
-        elif dtype in ('string', 'file_open', 'file_save', '_multiline', '_multiline_python_external'):
+        elif dtype in ('string', 'file_open', 'file_save', 'directory_path', '_multiline', '_multiline_python_external'):
             # Do not check if file/directory exists, that is a runtime issue
             try:
                 # Do not evaluate multiline strings (code snippets or comments)
@@ -293,7 +293,7 @@ class Param(Element):
         self._init = True
         value = self.get_value()
         # String types
-        if self.dtype in ('string', 'file_open', 'file_save', '_multiline', '_multiline_python_external'):
+        if self.dtype in ('string', 'file_open', 'file_save', 'directory_path', '_multiline', '_multiline_python_external'):
             if not self._init:
                 self.evaluate()
             return repr(value) if self._stringify_flag else value

--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -283,7 +283,7 @@ class EnumEntryParam(InputParam):
 
 
 class FileParam(EntryParam):
-    """Provide an entry box for filename and a button to browse for a file."""
+    """Provide an entry box for filename/directory and a button to browse for a file."""
 
     def __init__(self, *args, **kwargs):
         EntryParam.__init__(self, *args, **kwargs)
@@ -293,7 +293,7 @@ class FileParam(EntryParam):
 
     def _handle_clicked(self, widget=None):
         """
-        If the button was clicked, open a file dialog in open/save format.
+        If the button was clicked, open a file/directory dialog in open/save format.
         Replace the text in the entry with the new filename from the file dialog.
         """
         # get the paths
@@ -323,6 +323,12 @@ class FileParam(EntryParam):
             file_dialog.add_buttons( 'gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-save', Gtk.ResponseType.OK )
             file_dialog.set_do_overwrite_confirmation(True)
             file_dialog.set_current_name(basename)  # show the current filename
+        elif self.param.dtype == 'directory_path':
+            file_dialog = Gtk.FileChooserDialog(
+                title = 'Choose Directory...',action = Gtk.FileChooserAction.SELECT_FOLDER,
+                transient_for=self._transient_for,
+            )
+            file_dialog.add_buttons( 'gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-open' , Gtk.ResponseType.OK )
         else:
             raise ValueError("Can't open file chooser dialog for type " + repr(self.param.dtype))
         file_dialog.set_current_folder(dirname)  # current directory

--- a/grc/gui/canvas/param.py
+++ b/grc/gui/canvas/param.py
@@ -29,7 +29,7 @@ class Param(CoreParam):
             gtk input class
         """
         dtype = self.dtype
-        if dtype in ('file_open', 'file_save'):
+        if dtype in ('file_open', 'file_save', 'directory_path'):
             input_widget_cls = ParamWidgets.FileParam
 
         elif dtype == 'enum':
@@ -131,7 +131,7 @@ class Param(CoreParam):
             else:
                 # Small vectors use eval
                 dt_str = ', '.join(map(Utils.num_to_str, e))
-        elif t in ('file_open', 'file_save'):
+        elif t in ('file_open', 'file_save', 'directory_path'):
             dt_str = self.get_value()
             truncate = -1
         else:


### PR DESCRIPTION
- Introducing target directory configurable option.
- Introducing two naming styles: legacy and non legacy.

Legacy:
 - Works as before.

Non legacy:
 - Introduces configurable filename prefix.
 - Naming convention has chaned to:
  ` <prefix>_%Y-%m-%d_%H_%M_%S.%f.dat`

Signed-off-by: Igor Podoski <igor.podoski@gmail.com>