### PR TITLE
uhd: Change import order for sip and Qt modules

### DIFF
--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -38,11 +38,10 @@ from __future__ import print_function
 from __future__ import division
 import ctypes
 import sys
-import sip
 import threading
 import time
-from distutils.version import StrictVersion
 from PyQt5 import Qt
+import sip # Needs to be imported after PyQt5, could fail otherwise
 from gnuradio import eng_notation
 from gnuradio import eng_arg
 from gnuradio import gr

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -33,16 +33,14 @@ Signal Generator App
 ##################################################
 
 from __future__ import print_function
-import sip
 import sys
 import threading
 import time
-from distutils.version import StrictVersion
 from PyQt5 import Qt
 from PyQt5.QtCore import pyqtSlot
+import sip # Needs to be imported after PyQt5, could fail otherwise
 from gnuradio import analog
 from gnuradio import eng_notation
-from gnuradio import gr
 from gnuradio import qtgui
 from gnuradio import uhd
 from gnuradio.filter import firdes
@@ -473,4 +471,3 @@ def x11_init_threads():
 if __name__ == '__main__':
     x11_init_threads()
     main()
-


### PR DESCRIPTION
This moves the `import sip` statements in uhd_fft and uhd_siggen_gui
below the import for Qt, without which import errors can occur on
platforms such as Fedora 31.

#3420 but for maint-3.8.