### PR TITLE
GRC: Fix color for input boxes in parameter widget for dark themes (Backport 3.8)

### DIFF
--- a/grc/gui/Constants.py
+++ b/grc/gui/Constants.py
@@ -106,6 +106,17 @@ and kindly ask to update their GRC Block Descriptions or Block Tree to include a
 # DPI_SCALING = _SCREEN_RESOLUTION / 96.0 if _SCREEN_RESOLUTION > 0 else 1.0
 DPI_SCALING = 1.0  # todo: figure out the GTK3 way (maybe cairo does this for us
 
+# Gtk-themes classified as dark
+GTK_DARK_THEMES = [
+    'Adwaita-dark',
+    'HighContrastInverse',
+]
+
+GTK_SETTINGS_INI_PATH = '~/.config/gtk-3.0/settings.ini'
+
+GTK_INI_PREFER_DARK_KEY = 'gtk-application-prefer-dark-theme'
+GTK_INI_THEME_NAME_KEY = 'gtk-theme-name'
+
 
 def update_font_size(font_size):
     global PORT_SEPARATION, BLOCK_FONT, PORT_FONT, PARAM_FONT, FONT_SIZE

--- a/grc/gui/canvas/colors.py
+++ b/grc/gui/canvas/colors.py
@@ -75,4 +75,44 @@ PORT_TYPE_TO_COLOR.update((key, get_color(color)) for key, (_, color) in Constan
 #################################################################################
 # param box colors
 #################################################################################
+DARK_THEME_STYLES = b"""
+                         #dtype_complex         { background-color: #3399FF; }
+                         #dtype_real            { background-color: #FF8C69; }
+                         #dtype_float           { background-color: #FF8C69; }
+                         #dtype_int             { background-color: #00FF99; }
+
+                         #dtype_complex_vector  { background-color: #3399AA; }
+                         #dtype_real_vector     { background-color: #CC8C69; }
+                         #dtype_float_vector    { background-color: #CC8C69; }
+                         #dtype_int_vector      { background-color: #00CC99; }
+
+                         #dtype_bool            { background-color: #00FF99; }
+                         #dtype_hex             { background-color: #00FF99; }
+                         #dtype_string          { background-color: #CC66CC; }
+                         #dtype_id              { background-color: #DDDDDD; }
+                         #dtype_stream_id       { background-color: #DDDDDD; }
+                         #dtype_raw             { background-color: #23272A; }
+
+                         #enum_custom           { background-color: #EEEEEE; }
+                     """
+LIGHT_THEME_STYLES = b"""
+                        #dtype_complex         { background-color: #3399FF; }
+                        #dtype_real            { background-color: #FF8C69; }
+                        #dtype_float           { background-color: #FF8C69; }
+                        #dtype_int             { background-color: #00FF99; }
+
+                        #dtype_complex_vector  { background-color: #3399AA; }
+                        #dtype_real_vector     { background-color: #CC8C69; }
+                        #dtype_float_vector    { background-color: #CC8C69; }
+                        #dtype_int_vector      { background-color: #00CC99; }
+
+                        #dtype_bool            { background-color: #00FF99; }
+                        #dtype_hex             { background-color: #00FF99; }
+                        #dtype_string          { background-color: #CC66CC; }
+                        #dtype_id              { background-color: #DDDDDD; }
+                        #dtype_stream_id       { background-color: #DDDDDD; }
+                        #dtype_raw             { background-color: #FFFFFF; }
+
+                        #enum_custom           { background-color: #EEEEEE; }
+                    """
 


### PR DESCRIPTION
Cherry pick of #3017 back to maint-3.8

Authored-By: Arpit Gupta <guptarpit1997@gmail.com> Martin Braun <martin@gnuradio.org>