### PR TITLE
blocks: default value for file_meta_sink in yml (backport 3.8)

### DIFF
--- a/gr-blocks/grc/blocks_file_meta_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_meta_sink.block.yml
@@ -37,7 +37,7 @@ parameters:
 -   id: extra_dict
     label: Extra Dict.
     dtype: raw
-    default: '""'
+    default: pmt.make_dict()
 -   id: detached
     label: Detached
     dtype: bool


### PR DESCRIPTION
File meta sink has invalid default value of "" when it expects an empty dict PMT

Just changed the yml to give it the same value that is in the example files for this block

backport of #3475 