### PR TITLE
uhd: Properly ignore len_tag_name in USRP source (master)

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -138,9 +138,11 @@ templates:
                 channels=list(range(0,${'$'}{nchan})),
                 ${'%'} endif
             ),
+            % if sourk == 'sink':
             ${'%'} if len_tag_name:
             ${'$'}{len_tag_name},
             ${'%'} endif
+            % endif
         )
         ${'%'} if clock_rate():
         self.${'$'}{id}.set_clock_rate(${'$'}{clock_rate}, uhd.ALL_MBOARDS)


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/3437 for master.
Fix for 3.8: https://github.com/gnuradio/gnuradio/pull/3464 (merged)