### PR TITLE
Raw values in Variable or Parameter blocks in grc are invisible visible

### DIFF
--- a/grc/gui/canvas/colors.py
+++ b/grc/gui/canvas/colors.py
@@ -80,7 +80,7 @@ DARK_THEME_STYLES = b"""
                          #dtype_string          { background-color: #CC66CC; }
                          #dtype_id              { background-color: #DDDDDD; }
                          #dtype_stream_id       { background-color: #DDDDDD; }
-                         #dtype_raw             { background-color: #23272A; }
+                         #dtype_raw             { background-color: #DDDDDD; }
 
                          #enum_custom           { background-color: #EEEEEE; }
                      """


### PR DESCRIPTION

![Variable](https://user-images.githubusercontent.com/3470424/81954082-b5aadd00-9608-11ea-81c2-0a018ea30fe9.png)
Using a gtk3 dark theme makes the content of raw types in grc variable or parameter blocks invisible.
Changing the background color to a light grey fixes this issue