### PR TITLE
gr-uhd: Added message handler for (fully) manual tuning

### DIFF
--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -104,8 +104,29 @@ Command name | Value Type     | Description
 Special types:
 
 - tune_request: Like a uhd::tune_request_t, but always uses POLICY_AUTO. This is a pair, composed of (target_frequency, lo_offset)
-- tune_request_t: Exact copy of uhd::tune_request_t, implemented as pmt::dict. It copies the fields dsp_freq, dsp_freq_policy, rf_freq, rf_freq_policy, target_freq, args to an actual tune_request_t object. Hence it supports fully customized tunings with all policies and integer-N tuning. The policies are strings A, N, M for automatic, none and manual tuning.
+- tune_request_t: Exact copt of uhd::tune_request_t, allowing full control. See details below
+Hence it supports fully customized tunings with all policies and integer-N tuning. The policies are strings A, N, M for automatic, none and manual tuning.
 - timestamp: A pair composed of (long full_secs, double frac_secs). Similar to uhd::time_spec_t
+
+Further notes on command `mtune`:
+
+The object is of type pmt::dict and has the same fields as uhd::tune_request_t:
+- `dsp_freq`: the dsp frequency as pmt double type.
+- `dsp_freq_policy`: policy for DSP tuning. Should be a string "A" (automatic), "M" (manual) or "N" (none). If not set, defaults to "A".
+- `rf_freq`: the rf frequency as pmt double type.
+- `rf_freq_policy`: policy for RF tuning. Should be a string "A" (automatic), "M" (manual) or "N" (none). If not set, defaults to "A".
+- `target_freq`: target frequency (for automatic runing) as pmt double type
+- `args`: string containing additional arguments, for example for integer N tuning.
+
+Example:
+
+\code
+tune_rx = pmt.make_dict()
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('rf_freq'), pmt.to_pmt(rf_freq))
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('rf_freq_policy'), pmt.to_pmt('M'))
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('dsp_freq_policy'), pmt.to_pmt('N'))
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('args'), pmt.to_pmt('mode_n=integer,int_n_step=1000e3'))
+\endcode
 
 \b Note: Not all commands are affected by `time`. See the UHD manual for details on timed commands.
 

--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -84,25 +84,27 @@ set.
 
 The following command keys are understood by both UHD Source and Sink:
 
-Command name | Value Type   | Description
--------------|--------------|-------------------------------------------------------------
-`chan`       | int          | Specifies a channel. If this is not given, either all channels are chosen, or channel 0, depending on the action. A value of -1 forces 'all channels', where possible.
-`gain`       | double       | Sets the Tx or Rx gain (in dB). Defaults to all channels.
-`freq`       | double       | Sets the Tx or Rx frequency. Defaults to all channels. If specified without `lo_offset`, it will set the LO offset to zero.
-`lo_offset`  | double       | Sets an LO offset. Defaults to all channels. Note this does not affect the effective center frequency.
-`tune`       | tune_request | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.
-`lo_freq`    | double       | For fully manual tuning: Set the LO frequency (RF frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
-`dsp_freq`   | double       | For fully manual tuning: Set the DSP frequency (CORDIC frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
-`direction`  | string       | Used for timed transceiver tuning to ensure tuning order is maintained. Values other than 'TX' or 'RX' will be ignored.
-`rate`       | double       | See usrp_block::set_samp_rate(). *Always* affects all channels.
-`bandwidth`  | double       | See usrp_block::set_bandwidth(). Defaults to all channels.
-`time`       | timestamp    | Sets a command time. See usrp_block::set_command_time(). A value of PMT_NIL will clear the command time.
-`mboard`     | int          | Specify mboard index, where applicable.
-`antenna`    | string       | See usrp_block::set_antenna(). Defaults to all channels.
+Command name | Value Type     | Description
+-------------|----------------|-------------------------------------------------------------
+`chan`       | int            | Specifies a channel. If this is not given, either all channels are chosen, or channel 0, depending on the action. A value of -1 forces 'all channels', where possible.
+`gain`       | double         | Sets the Tx or Rx gain (in dB). Defaults to all channels.
+`freq`       | double         | Sets the Tx or Rx frequency. Defaults to all channels. If specified without `lo_offset`, it will set the LO offset to zero.
+`lo_offset`  | double         | Sets an LO offset. Defaults to all channels. Note this does not affect the effective center frequency.
+`tune`       | tune_request   | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.
+`mtune`      | tune_request_t | Like tune, but supports a full manual tune request as uhd::tune_request_t. Defaults to all channels.
+`lo_freq`    | double         | For fully manual tuning: Set the LO frequency (RF frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
+`dsp_freq`   | double         | For fully manual tuning: Set the DSP frequency (CORDIC frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
+`direction`  | string         | Used for timed transceiver tuning to ensure tuning order is maintained. Values other than 'TX' or 'RX' will be ignored.
+`rate`       | double         | See usrp_block::set_samp_rate(). *Always* affects all channels.
+`bandwidth`  | double         | See usrp_block::set_bandwidth(). Defaults to all channels.
+`time`       | timestamp      | Sets a command time. See usrp_block::set_command_time(). A value of PMT_NIL will clear the command time.
+`mboard`     | int            | Specify mboard index, where applicable.
+`antenna`    | string         | See usrp_block::set_antenna(). Defaults to all channels.
 
 Special types:
 
 - tune_request: Like a uhd::tune_request_t, but always uses POLICY_AUTO. This is a pair, composed of (target_frequency, lo_offset)
+- tune_request_t: Exact copy of uhd::tune_request_t, implemented as pmt::dict. It copies the fields dsp_freq, dsp_freq_policy, rf_freq, rf_freq_policy, target_freq, args to an actual tune_request_t object. Hence it supports fully customized tunings with all policies and integer-N tuning. The policies are strings A, N, M for automatic, none and manual tuning.
 - timestamp: A pair composed of (long full_secs, double frac_secs). Similar to uhd::time_spec_t
 
 \b Note: Not all commands are affected by `time`. See the UHD manual for details on timed commands.

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -23,6 +23,7 @@ GR_UHD_API const pmt::pmt_t cmd_gain_key();
 GR_UHD_API const pmt::pmt_t cmd_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_offset_key();
 GR_UHD_API const pmt::pmt_t cmd_tune_key();
+GR_UHD_API const pmt::pmt_t cmd_mtune_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_dsp_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_rate_key();

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -686,44 +686,48 @@ void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,
     _update_curr_tune_req(new_tune_reqest, chan);
 }
 
-void usrp_block_impl::_cmd_handler_mtune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg)
+void usrp_block_impl::_cmd_handler_mtune(const pmt::pmt_t& tune,
+                                         int chan,
+                                         const pmt::pmt_t& msg)
 {
     ::uhd::tune_request_t new_tune_request;
     if (pmt::dict_has_key(tune, pmt::mp("dsp_freq"))) {
-        new_tune_request.dsp_freq = pmt::to_double(pmt::dict_ref(tune, pmt::mp("dsp_freq"), 0));
+        new_tune_request.dsp_freq =
+            pmt::to_double(pmt::dict_ref(tune, pmt::mp("dsp_freq"), 0));
     }
     if (pmt::dict_has_key(tune, pmt::mp("rf_freq"))) {
-        new_tune_request.rf_freq = pmt::to_double(pmt::dict_ref(tune, pmt::mp("rf_freq"), 0));
+        new_tune_request.rf_freq =
+            pmt::to_double(pmt::dict_ref(tune, pmt::mp("rf_freq"), 0));
     }
     if (pmt::dict_has_key(tune, pmt::mp("target_freq"))) {
-        new_tune_request.dsp_freq = pmt::to_double(pmt::dict_ref(tune, pmt::mp("target_freq"), 0));
+        new_tune_request.dsp_freq =
+            pmt::to_double(pmt::dict_ref(tune, pmt::mp("target_freq"), 0));
     }
     if (pmt::dict_has_key(tune, pmt::mp("dsp_freq_policy"))) {
-        std::string policy = pmt::symbol_to_string(pmt::dict_ref(tune, pmt::mp("dsp_freq_policy"), pmt::mp("A")));
-        if(policy == "M") {
+        std::string policy = pmt::symbol_to_string(
+            pmt::dict_ref(tune, pmt::mp("dsp_freq_policy"), pmt::mp("A")));
+        if (policy == "M") {
             new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
-        }
-        else if(policy == "A") {
+        } else if (policy == "A") {
             new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_AUTO;
-        }
-        else {
+        } else {
             new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_NONE;
         }
     }
     if (pmt::dict_has_key(tune, pmt::mp("rf_freq_policy"))) {
-        std::string policy = pmt::symbol_to_string(pmt::dict_ref(tune, pmt::mp("rf_freq_policy"), pmt::mp("A")));
-        if(policy == "M") {
+        std::string policy = pmt::symbol_to_string(
+            pmt::dict_ref(tune, pmt::mp("rf_freq_policy"), pmt::mp("A")));
+        if (policy == "M") {
             new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
-        }
-        else if(policy == "A") {
+        } else if (policy == "A") {
             new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_AUTO;
-        }
-        else {
+        } else {
             new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_NONE;
         }
     }
     if (pmt::dict_has_key(tune, pmt::mp("args"))) {
-        new_tune_request.args = ::uhd::device_addr_t(pmt::symbol_to_string(pmt::dict_ref(tune, pmt::mp("args"), pmt::mp(""))));
+        new_tune_request.args = ::uhd::device_addr_t(
+            pmt::symbol_to_string(pmt::dict_ref(tune, pmt::mp("args"), pmt::mp(""))));
     }
 
     _update_curr_tune_req(new_tune_request, chan);

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -121,6 +121,7 @@ protected:
     void _cmd_handler_antenna(const pmt::pmt_t& ant, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_rate(const pmt::pmt_t& rate, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_tune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_mtune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_bw(const pmt::pmt_t& bw, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_lofreq(const pmt::pmt_t& lofreq, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_dspfreq(const pmt::pmt_t& dspfreq, int chan, const pmt::pmt_t& msg);


### PR DESCRIPTION
The current message handler of USRP Source/Sink is very sparse. The message handler for "tune" lacks the ability of the original uhd::tune_request_t class. It also sets the policy to "AUTO".
Of particular importance is the "args" part which encodes options for integer-N tuning. Current implementation does not allow for integer-N tuning.

While I would love to fix the "tune" command, it would break current code that relies on "tune" being a pair of dsp_freq and rf_freq.
Hence I added the command "mtune" (="manual tune").
It implements all fields of uhd::tune_request_t completely as a dict (args, dsp_freq, dsp_freq_policy, rf_freq, rf_freq_policy, target_freq).

It would be great if this could be back-integrated into 2.7 as well.