### PR TITLE
gr-uhd: Add set_start_time for grc in 3.7

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -43,6 +43,9 @@ MAIN_TMPL = """\
 		\#end if
 	),$lentag_arg
 )
+\#if \$start_time() >= 0
+self.\$(id).set_start_time(uhd.time_spec(\$start_time))
+\#end if
 \#if \$clock_rate()
 self.\$(id).set_clock_rate(\$clock_rate, uhd.ALL_MBOARDS)
 \#end if
@@ -236,6 +239,17 @@ set_lo_export_enabled(\$lo_export$(n), uhd.ALL_LOS, $n)
 		<option>
 			<name>don't sync</name>
 			<key></key>
+		</option>
+	</param>
+	<param>
+		<name>Start Time (seconds)</name>
+		<key>start_time</key>
+		<value>-1</value>
+		<type>real</type>
+		<hide>\#if \$start_time() >= 0 then 'none' else 'part'#</hide>
+		<option>
+			<name>Default</name>
+			<key>-1</key>
 		</option>
 	</param>
 	<param>


### PR DESCRIPTION
Currently, `set_start_time` cannot be set in GRC.
When this is needed, the python file has to be changed manually which is overwritten when saving the next time.

This patch adds set_start_time to USRP Source/Sink.
It only shows up when it is set. Normally, it is set to `Default` which results in identical behavior than now. It can be set to an arbitrary float value indicating a time to start in seconds.