### PR TITLE
qtgui: Add set_fft_window_normalized() API call to freq_sink

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -26,8 +26,8 @@ parameters:
 -   id: freqhalf
     label: Spectrum Width
     dtype: enum
-    default: 'True'
-    options: ['True', 'False']
+    default: True
+    options: [True, False]
     option_labels: [Full, Half]
     hide: ${ ('part' if type == "float" or type == "msg_float" else 'all') }
 -   id: wintype
@@ -39,6 +39,13 @@ parameters:
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     hide: part
+-   id: norm_window
+    label: Normalize Window Power
+    dtype: enum
+    default: 'False'
+    options: ['True', 'False']
+    option_labels: [Yes, No]
+    hide: ${ ('none' if norm_window == 'True' else 'part') }
 -   id: fc
     label: Center Frequency (Hz)
     dtype: real
@@ -416,6 +423,7 @@ templates:
         self.${id}.set_fft_average(${average})
         self.${id}.enable_axis_labels(${axislabels})
         self.${id}.enable_control_panel(${ctrlpanel})
+        self.${id}.set_fft_window_normalized(${norm_window})
 
         % if legend == "False":
         self.${id}.disable_legend()

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -116,6 +116,8 @@ public:
     virtual float fft_average() const = 0;
     virtual void set_fft_window(const gr::filter::firdes::win_type win) = 0;
     virtual gr::filter::firdes::win_type fft_window() = 0;
+    //! If true, normalize window to unit power
+    virtual void set_fft_window_normalized(const bool enable) = 0;
 
     virtual void set_frequency_range(const double centerfreq, const double bandwidth) = 0;
     virtual void set_y_axis(double min, double max) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -116,6 +116,8 @@ public:
     virtual float fft_average() const = 0;
     virtual void set_fft_window(const gr::filter::firdes::win_type win) = 0;
     virtual gr::filter::firdes::win_type fft_window() = 0;
+    //! If true, normalize window to unit power
+    virtual void set_fft_window_normalized(const bool enable) = 0;
 
     virtual void set_frequency_range(const double centerfreq, const double bandwidth) = 0;
     virtual void set_y_axis(double min, double max) = 0;

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -32,6 +32,7 @@ private:
     float d_fftavg;
     filter::firdes::win_type d_wintype;
     std::vector<float> d_window;
+    bool d_window_normalize = false;
     double d_center_freq;
     double d_bandwidth;
     const std::string d_name;
@@ -114,6 +115,7 @@ public:
     float fft_average() const;
     void set_fft_window(const filter::firdes::win_type win);
     filter::firdes::win_type fft_window();
+    void set_fft_window_normalized(const bool enable);
 
     void set_frequency_range(const double centerfreq, const double bandwidth);
     void set_y_axis(double min, double max);

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -20,6 +20,9 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/numeric.hpp>
+
 #include <string.h>
 
 namespace gr {
@@ -207,6 +210,12 @@ void freq_sink_f_impl::set_fft_window(const filter::firdes::win_type win)
 }
 
 filter::firdes::win_type freq_sink_f_impl::fft_window() { return d_wintype; }
+
+void freq_sink_f_impl::set_fft_window_normalized(const bool enable)
+{
+    d_window_normalize = enable;
+    buildwindow();
+}
 
 void freq_sink_f_impl::set_frequency_range(const double centerfreq,
                                            const double bandwidth)
@@ -413,6 +422,19 @@ void freq_sink_f_impl::buildwindow()
     if (d_wintype != filter::firdes::WIN_NONE) {
         d_window = filter::firdes::window(d_wintype, d_fftsize, 6.76);
     }
+
+    if (!d_window_normalize) {
+        return;
+    }
+    // Calculate power of the window as 1/N * sum of squares
+    const float power =
+        boost::accumulate(
+            d_window | boost::adaptors::transformed([](const float x) { return x * x; }),
+            0.0) /
+        d_window.size();
+    const double norm_factor = std::sqrt(power);
+    // Now normalize such that the power of d_window is 1
+    std::for_each(d_window.begin(), d_window.end(), [&](float& x) { x /= norm_factor; });
 }
 
 bool freq_sink_f_impl::fftresize()

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -32,6 +32,7 @@ private:
     float d_fftavg;
     filter::firdes::win_type d_wintype;
     std::vector<float> d_window;
+    bool d_window_normalize = false;
     double d_center_freq;
     double d_bandwidth;
     const std::string d_name;
@@ -114,6 +115,7 @@ public:
     float fft_average() const;
     void set_fft_window(const filter::firdes::win_type win);
     filter::firdes::win_type fft_window();
+    void set_fft_window_normalized(const bool enable);
 
     void set_frequency_range(const double centerfreq, const double bandwidth);
     void set_y_axis(double min, double max);


### PR DESCRIPTION
This adds an API call set_fft_window_normalized() to the QT GUI
frequency sink. It will modify the window to have normalized power,
regardless of the window shape. This will allow changing window types
without signal peaks varying in amplitude due to window power
differences. Note that this does not affect scalloping loss, or
processing loss from the window. In other words, this normalizes the
energy content to remain constant during window, the amplitude of a peak
can still vary when switching windows.