### PR TITLE
grc: fix broken flow_graph template

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -1,6 +1,5 @@
 % if not generate_options.startswith('hb'):
 <%
-from __future__ import print_function
 from sys import version_info
 from gnuradio import eng_notation
 python_version = version_info.major

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -30,6 +30,9 @@ python_version = version_info.major
 # GNU Radio version: ${version}
 ##################################################
 
+% if python_version == 2:
+from __future__ import print_function
+% endif
 % if generate_options == 'qt_gui':
 from distutils.version import StrictVersion
 


### PR DESCRIPTION
Fixes #3506.
Fixes #3141.

The change in #3442 put the `from __future__ import print_function` into a Mako Python block instead of the generated flowgraph. This broke GRC, at least on Python 3.

To fix this I reverted #3442 and moved `from __future__ import print_function` to the correct place. I also put it in a Mako `% if` block so it's only generated in Python 2.