### PR TITLE
grc: remove dead code

### DIFF
--- a/grc/core/generator/Generator.py
+++ b/grc/core/generator/Generator.py
@@ -7,18 +7,10 @@
 
 from __future__ import absolute_import
 
-import os
-
-from mako.template import Template
-
 from .hier_block import HierBlockGenerator, QtHierBlockGenerator
 from .top_block import TopBlockGenerator
 from .cpp_top_block import CppTopBlockGenerator
 from .cpp_hier_block import CppHierBlockGenerator
-
-DATA_DIR = os.path.dirname(__file__)
-FLOW_GRAPH_TEMPLATE = os.path.join(DATA_DIR, 'flow_graph.py.mako')
-flow_graph_template = Template(filename=FLOW_GRAPH_TEMPLATE)
 
 
 class Generator(object):


### PR DESCRIPTION
`Generator.py` compiles `flow_graph.py.mako` but then never uses it.

It looks like this happened in 7f7fa2f91467fdb2b11312be8562e7b51fdeb199 when some of the code from `Generator.py` was split into `top_block.py`, which now handles compilation of `flow_graph.py.mako`.

Since `flow_graph_template` is never used, it should be safe to remove this code. I didn't encounter any problems in GRC after making this change.