### PR TITLE
Revert Python 3 fstring usage

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -151,7 +151,8 @@ class Block(Element):
             # this is ok behavior, unfortunately we could be hiding other import bugs
             pass
         except Exception:
-            self.add_error_message(f'Failed to evaluate import expression {imports!r}')
+            log.exception('Failed to evaluate import expression "{0}"'.format(expr), exc_info=True)
+            pass
 
     def update_bus_logic(self):
         ###############################


### PR DESCRIPTION
maint-3.8 must support Python 2 and 3.
1591d414c842d561dd209cb4d615219749bfc203 introduced an fstring while addressing other issues.