### PR TITLE
Update qtgui_chooser.block.yml

### DIFF
--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -126,11 +126,7 @@ templates:
         % if int(num_opts):
         self._${id}_labels = (\
         % for lbl in all_labels:
-        % if lbl:
         ${lbl}, \
-        % else:
-        self._${id}_options[${i}], \
-        % endif
         % endfor
         )
         % elif labels:


### PR DESCRIPTION
Trying to build a chooser block fails with Generate Error: (NameError("'i' is not defined")
154b2b7 commit is missing from maint-3.8. #3437 