### PR TITLE
grc: do not populate global_blocks_path

### DIFF
--- a/grc/grc.conf.in
+++ b/grc/grc.conf.in
@@ -3,7 +3,7 @@
 # ~/.gnuradio/config.conf
 
 [grc]
-global_blocks_path = @blocksdir@
+global_blocks_path = 
 local_blocks_path =
 default_flow_graph =
 xterm_executable = @GRC_XTERM_EXE@


### PR DESCRIPTION
Every time gnuradio gets recompiled (or sometimes), it repopulates the
global_blocks_path, which in multi-prefix installations will try and
load blocks from the wrong place.  Just leave it blank by default

Fixes #2763