### PR TITLE
grc: always perform version check in flow_graph.py.mako

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -1,9 +1,9 @@
-% if not generate_options.startswith('hb'):
 <%
 from sys import version_info
 from gnuradio import eng_notation
 python_version = version_info.major
 %>\
+% if not generate_options.startswith('hb'):
 % if python_version == 2:
 #!/usr/bin/env python2
 % elif python_version == 3:


### PR DESCRIPTION
Just moved the if for hier block down so the python_version is always populated since it is used for both hier and non-hier blocks

Fixes #3527 