### PR TITLE
cppgen: Update to modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ install(
   DESTINATION ${CMAKE_MODULES_DIR}/gnuradio
 )
 
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/grc/grc.conf "enabled_components = ${_gr_enabled_components}")
 
 ########################################################################
 # Print summary

--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -25,6 +25,7 @@ class Config(object):
         self._gr_prefs = prefs if prefs else DummyPrefs()
         self.version = version
         self.version_parts = version_parts or version[1:].split('-', 1)[0].split('.')[:3]
+        self.enabled_components = self._gr_prefs.get_string('grc', 'enabled_components', '')
         if name:
             self.name = name
 

--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -8,32 +8,33 @@
 % if flow_graph.get_option('description'):
 # Description: ${flow_graph.get_option('description')}
 % endif
-# GNU Radio version: ${version}
+# GNU Radio version: ${config.version}
 #####################
 
 <%
 class_name = flow_graph.get_option('id')
+version_list = config.version.split(".")
+short_version = '.'.join(version_list[0:2])
 %>\
 
 cmake_minimum_required(VERSION 3.8)
 set(CMAKE_CXX_STANDARD 11)
 
-% if generate_options == 'qt_gui':
-find_package(Qt5Widgets REQUIRED)
-% endif
+project(${class_name})
 
-include_directories(
-    ${'$'}{GNURADIO_ALL_INCLUDE_DIRS}
-    ${'$'}{Boost_INCLUDE_DIRS}
-    % if generate_options == 'qt_gui':
-    ${'$'}{Qt5Widgets_INCLUDE_DIRS}
+
+find_package(Gnuradio "${short_version}" COMPONENTS
+    % for component in config.enabled_components.split(";"):
+    % if component.startswith("gr-"):
+    % if not component in ['gr-utils', 'gr-ctrlport']:
+    ${component.replace("gr-", "")}
     % endif
-    $ENV{HOME}/.grc_gnuradio
+    % endif
+    % endfor
 )
 
 % if generate_options == 'qt_gui':
-add_definitions(${'$'}{Qt5Widgets_DEFINITIONS})
-set(CMAKE_CXX_FLAGS "${'$'}{CMAKE_CXX_FLAGS} -fPIC")
+find_package(Qt5Widgets REQUIRED)
 set(CMAKE_AUTOMOC TRUE)
 % endif
 
@@ -49,21 +50,14 @@ set(CMAKE_EXE_LINKER_FLAGS " -static")
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 % endif
 
-set(GR_LIBRARIES
-    boost_system
-    % if parameters:
-    boost_program_options
-    % endif
-    gnuradio-blocks
-    gnuradio-runtime
-    gnuradio-pmt
-    log4cpp
+add_executable(${class_name} ${class_name}.cpp)
+target_link_libraries(${class_name}
+    gnuradio::gnuradio-blocks
     % for link in links:
     % if link:
-    ${link}
+    ${link.replace("gnuradio-", "gnuradio::gnuradio-")}
     % endif
     % endfor
+
 )
 
-add_executable(${class_name} ${class_name}.cpp)
-target_link_libraries(${class_name} ${'$'}{GR_LIBRARIES})

--- a/grc/core/generator/cpp_templates/flow_graph.cpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.cpp.mako
@@ -9,7 +9,7 @@ Author: ${flow_graph.get_option('author')}
 % if flow_graph.get_option('description'):
 Description: ${flow_graph.get_option('description')}
 % endif
-GNU Radio version: ${version}
+GNU Radio version: ${config.version}
 ********************/
 
 #include "${flow_graph.get_option('id')}.hpp"

--- a/grc/core/generator/cpp_templates/flow_graph.hpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.hpp.mako
@@ -12,7 +12,7 @@ Author: ${flow_graph.get_option('author')}
 % if flow_graph.get_option('description'):
 Description: ${flow_graph.get_option('description')}
 % endif
-GNU Radio version: ${version}
+GNU Radio version: ${config.version}
 ********************/
 
 /********************

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -72,7 +72,7 @@ class CppTopBlockGenerator(TopBlockGenerator):
             'parameters': parameters,
             'monitors': monitors,
             'generate_options': self._generate_options,
-            'version': platform.config.version
+            'config': platform.config
         }
 
         if not os.path.exists(self.file_path):


### PR DESCRIPTION
I'd appreciate some testing and feedback on this.

A few comments:

- I was originally planning on using the `link` field in the blocks' `cpp_templates` to figure out what components to include in the `find_package` call, but this isn't as straightforward as one might think, since some of the components depend on others and `find_package` doesn't follow these dependencies. This could work, but one would need to hard code the dependencies somewhere. In this PR, the find_package call enables **all available components** instead (all components that GR has been built with).
- I put the file/append call in the top-level `CMakeLists.txt` because `grc/CMakeLists.txt` doesn't know what components are enabled. This seems a little untidy, so I wouldn't mind any comments on other ways to let GRC know what components are enabled.
- grc.conf ends up looking something like this: 
```
# This file contains system wide configuration data for GNU Radio.
# You may override any setting on a per-user basis by editing
# ~/.gnuradio/config.conf

[grc]
global_blocks_path = /usr/local/share/gnuradio/grc/blocks
local_blocks_path =
default_flow_graph =
xterm_executable = /usr/bin/xterm
canvas_font_size = 8
canvas_default_size = 1280, 1024
enabled_components = testing-support;python-support;post-install;gnuradio-runtime;gr-ctrlport;gnuradio-companion;gr-blocks;gr-fec;gr-fft;gr-filter;gr-analog;gr-digital;gr-dtv;gr-audio;* alsa;* oss;* jack;* portaudio;gr-channels;gr-qtgui;gr-trellis;gr-utils;gr_modtool;gr_blocktool;gr-vocoder;* codec2;* freedv;* gsm
```