### PR TITLE
digital: add constellation_encoder block

### DIFF
--- a/gr-digital/examples/demod/constellation_encode_decode.grc
+++ b/gr-digital/examples/demod/constellation_encode_decode.grc
@@ -1,0 +1,420 @@
+options:
+  parameters:
+    author: Josh Morman
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: constellation_encode_decode
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Constellation Encoder and Decoder
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: constel
+  id: variable_constellation
+  parameters:
+    comment: ''
+    const_points: '[1,-1]'
+    dims: '1'
+    precision: '8'
+    rot_sym: '2'
+    soft_dec_lut: None
+    sym_map: '[0,1]'
+    type: bpsk
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [569, 21]
+    rotation: 0
+    state: enabled
+- name: data
+  id: variable
+  parameters:
+    comment: ''
+    value: '[random.randrange(mod_order) for i in range(data_size)]'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [175, 161]
+    rotation: 0
+    state: enabled
+- name: data_size
+  id: variable
+  parameters:
+    comment: ''
+    value: '1000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [353, 158]
+    rotation: 0
+    state: enabled
+- name: mod_order
+  id: variable
+  parameters:
+    comment: ''
+    value: len(constel.points())
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [570, 84]
+    rotation: 0
+    state: enabled
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [212, 23]
+    rotation: 0
+    state: enabled
+- name: blocks_char_to_float_0
+  id: blocks_char_to_float
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    scale: '1'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [889, 385]
+    rotation: 0
+    state: true
+- name: blocks_char_to_float_0_0
+  id: blocks_char_to_float
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    scale: '1'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [890, 440]
+    rotation: 0
+    state: true
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: byte
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [217, 295]
+    rotation: 0
+    state: enabled
+- name: blocks_vector_source_x_0_0
+  id: blocks_vector_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    repeat: 'True'
+    tags: '[]'
+    type: byte
+    vector: data
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [47, 280]
+    rotation: 0
+    state: enabled
+- name: digital_constellation_decoder_cb_0
+  id: digital_constellation_decoder_cb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    constellation: constel
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [643, 297]
+    rotation: 0
+    state: true
+- name: digital_constellation_encoder_bc_0
+  id: digital_constellation_encoder_bc
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    constellation: constel
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [402, 297]
+    rotation: 0
+    state: true
+- name: import_0_0
+  id: import
+  parameters:
+    alias: ''
+    comment: ''
+    imports: import random
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [437, 23]
+    rotation: 0
+    state: enabled
+- name: qtgui_const_sink_x_0
+  id: qtgui_const_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'False'
+    axislabels: 'True'
+    color1: '"blue"'
+    color10: '"red"'
+    color2: '"red"'
+    color3: '"red"'
+    color4: '"red"'
+    color5: '"red"'
+    color6: '"red"'
+    color7: '"red"'
+    color8: '"red"'
+    color9: '"red"'
+    comment: ''
+    grid: 'False'
+    gui_hint: ''
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    marker1: '0'
+    marker10: '0'
+    marker2: '0'
+    marker3: '0'
+    marker4: '0'
+    marker5: '0'
+    marker6: '0'
+    marker7: '0'
+    marker8: '0'
+    marker9: '0'
+    name: '""'
+    nconnections: '1'
+    size: '1024'
+    style1: '0'
+    style10: '0'
+    style2: '0'
+    style3: '0'
+    style4: '0'
+    style5: '0'
+    style6: '0'
+    style7: '0'
+    style8: '0'
+    style9: '0'
+    tr_chan: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_slope: qtgui.TRIG_SLOPE_POS
+    tr_tag: '""'
+    type: complex
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    xmax: '2'
+    xmin: '-2'
+    ymax: '2'
+    ymin: '-2'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [644, 216]
+    rotation: 0
+    state: true
+- name: qtgui_time_sink_x_0
+  id: qtgui_time_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'True'
+    axislabels: 'True'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
+    comment: ''
+    ctrlpanel: 'False'
+    entags: 'True'
+    grid: 'False'
+    gui_hint: ''
+    label1: Signal 1
+    label10: Signal 10
+    label2: Signal 2
+    label3: Signal 3
+    label4: Signal 4
+    label5: Signal 5
+    label6: Signal 6
+    label7: Signal 7
+    label8: Signal 8
+    label9: Signal 9
+    legend: 'True'
+    marker1: '-1'
+    marker10: '-1'
+    marker2: '-1'
+    marker3: '-1'
+    marker4: '-1'
+    marker5: '-1'
+    marker6: '-1'
+    marker7: '-1'
+    marker8: '-1'
+    marker9: '-1'
+    name: '""'
+    nconnections: '2'
+    size: '1024'
+    srate: '1'
+    stemplot: 'False'
+    style1: '1'
+    style10: '1'
+    style2: '1'
+    style3: '1'
+    style4: '1'
+    style5: '1'
+    style6: '1'
+    style7: '1'
+    style8: '1'
+    style9: '1'
+    tr_chan: '0'
+    tr_delay: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_slope: qtgui.TRIG_SLOPE_POS
+    tr_tag: '""'
+    type: float
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    ylabel: Amplitude
+    ymax: '1'
+    ymin: '-1'
+    yunit: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1082, 394]
+    rotation: 0
+    state: true
+
+connections:
+- [blocks_char_to_float_0, '0', qtgui_time_sink_x_0, '0']
+- [blocks_char_to_float_0_0, '0', qtgui_time_sink_x_0, '1']
+- [blocks_throttle_0, '0', blocks_char_to_float_0, '0']
+- [blocks_throttle_0, '0', digital_constellation_encoder_bc_0, '0']
+- [blocks_vector_source_x_0_0, '0', blocks_throttle_0, '0']
+- [digital_constellation_decoder_cb_0, '0', blocks_char_to_float_0_0, '0']
+- [digital_constellation_encoder_bc_0, '0', digital_constellation_decoder_cb_0, '0']
+- [digital_constellation_encoder_bc_0, '0', qtgui_const_sink_x_0, '0']
+
+metadata:
+  file_format: 1

--- a/gr-digital/grc/digital.tree.yml
+++ b/gr-digital/grc/digital.tree.yml
@@ -55,6 +55,7 @@
   - digital_binary_slicer_fb
   - digital_chunks_to_symbols_xx
   - digital_constellation_decoder_cb
+  - digital_constellation_encoder_bc
   - digital_constellation_receiver_cb
   - digital_constellation_soft_decoder_cf
   - digital_diff_decoder_bb

--- a/gr-digital/grc/digital_constellation_encoder_bc.block.yml
+++ b/gr-digital/grc/digital_constellation_encoder_bc.block.yml
@@ -1,0 +1,28 @@
+id: digital_constellation_encoder_bc
+label: Constellation Encoder
+flags: [ python, cpp ]
+
+parameters:
+-   id: constellation
+    label: Constellation Object
+    dtype: raw
+
+outputs:
+-   domain: stream
+    dtype: complex
+
+inputs:
+-   domain: stream
+    dtype: byte
+
+templates:
+    imports: from gnuradio import digital
+    make: digital.constellation_encoder_bc(${constellation})
+
+cpp_templates:
+    includes: ['#include <gnuradio/digital/constellation_encoder_bc.h>']
+    declarations: 'digital::constellation_encoder_bc::sptr ${id};'
+    make: 'this->${id} = digital::constellation_encoder_bc::make(${constellation});'
+    link: ['gnuradio-digital']
+
+file_format: 1

--- a/gr-digital/include/gnuradio/digital/CMakeLists.txt
+++ b/gr-digital/include/gnuradio/digital/CMakeLists.txt
@@ -23,6 +23,7 @@ install(FILES
     cma_equalizer_cc.h
     constellation.h
     constellation_decoder_cb.h
+    constellation_encoder_bc.h
     constellation_receiver_cb.h
     constellation_soft_decoder_cf.h
     corr_est_cc.h

--- a/gr-digital/include/gnuradio/digital/constellation_decoder_cb.h
+++ b/gr-digital/include/gnuradio/digital/constellation_decoder_cb.h
@@ -24,7 +24,7 @@ namespace digital {
  *
  * \details
  * Decode a constellation's points from a complex space to
- * (unpacked) bits based on the map of the \p constellation
+ * index of constellation symbol based on the map of the \p constellation
  * object.
  */
 class DIGITAL_API constellation_decoder_cb : virtual public block

--- a/gr-digital/include/gnuradio/digital/constellation_encoder_bc.h
+++ b/gr-digital/include/gnuradio/digital/constellation_encoder_bc.h
@@ -23,8 +23,8 @@ namespace digital {
  * \ingroup symbol_coding_blk
  *
  * \details
- * Encode upacked bits into a constellation's complex space
- * bits based on the map of the \p constellation object.
+ * Encode index of constellation points into a constellation's complex
+ * space based on the map of the \p constellation object.
  */
 class DIGITAL_API constellation_encoder_bc : virtual public sync_interpolator
 {

--- a/gr-digital/include/gnuradio/digital/constellation_encoder_bc.h
+++ b/gr-digital/include/gnuradio/digital/constellation_encoder_bc.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2011,2012 Free Software Foundation, Inc.
+ * Copyright 2020 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -8,30 +8,29 @@
  *
  */
 
-#ifndef INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_H
-#define INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_H
+#ifndef INCLUDED_DIGITAL_CONSTELLATION_ENCODER_BC_H
+#define INCLUDED_DIGITAL_CONSTELLATION_ENCODER_BC_H
 
-#include <gnuradio/block.h>
 #include <gnuradio/digital/api.h>
 #include <gnuradio/digital/constellation.h>
+#include <gnuradio/sync_interpolator.h>
 
 namespace gr {
 namespace digital {
 
 /*!
- * \brief Constellation Decoder
+ * \brief Constellation Encoder
  * \ingroup symbol_coding_blk
  *
  * \details
- * Decode a constellation's points from a complex space to
- * (unpacked) bits based on the map of the \p constellation
- * object.
+ * Encode upacked bits into a constellation's complex space
+ * bits based on the map of the \p constellation object.
  */
-class DIGITAL_API constellation_decoder_cb : virtual public block
+class DIGITAL_API constellation_encoder_bc : virtual public sync_interpolator
 {
 public:
-    // gr::digital::constellation_decoder_cb::sptr
-    typedef std::shared_ptr<constellation_decoder_cb> sptr;
+    // gr::digital::constellation_encoder_bc::sptr
+    typedef std::shared_ptr<constellation_encoder_bc> sptr;
 
     /*!
      * \brief Make constellation decoder block.
@@ -46,4 +45,4 @@ public:
 } /* namespace digital */
 } /* namespace gr */
 
-#endif /* INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_H */
+#endif /* INCLUDED_DIGITAL_CONSTELLATION_ENCODER_BC_H */

--- a/gr-digital/lib/CMakeLists.txt
+++ b/gr-digital/lib/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(gnuradio-digital
     cma_equalizer_cc_impl.cc
     constellation.cc
     constellation_decoder_cb_impl.cc
+    constellation_encoder_bc_impl.cc
     constellation_receiver_cb_impl.cc
     constellation_soft_decoder_cf_impl.cc
     corr_est_cc_impl.cc

--- a/gr-digital/lib/constellation_encoder_bc_impl.cc
+++ b/gr-digital/lib/constellation_encoder_bc_impl.cc
@@ -1,0 +1,57 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "constellation_encoder_bc_impl.h"
+#include <gnuradio/io_signature.h>
+
+namespace gr {
+namespace digital {
+
+constellation_encoder_bc::sptr
+constellation_encoder_bc::make(constellation_sptr constellation)
+{
+    return gnuradio::get_initial_sptr(new constellation_encoder_bc_impl(constellation));
+}
+
+constellation_encoder_bc_impl::constellation_encoder_bc_impl(
+    constellation_sptr constellation)
+    : sync_interpolator("constellation_encoder_bc",
+                        io_signature::make(1, 1, sizeof(unsigned char)),
+                        io_signature::make(1, 1, sizeof(gr_complex)),
+                        constellation->dimensionality()),
+      d_constellation(constellation)
+{
+}
+
+constellation_encoder_bc_impl::~constellation_encoder_bc_impl() {}
+
+int constellation_encoder_bc_impl::work(int noutput_items,
+                                        gr_vector_const_void_star& input_items,
+                                        gr_vector_void_star& output_items)
+{
+    unsigned char const* in = (const unsigned char*)input_items[0];
+    gr_complex* out = (gr_complex*)output_items[0];
+
+    int ninput_items = noutput_items / d_constellation->dimensionality();
+
+    for (int i = 0; i < ninput_items; i++) {
+        d_constellation->map_to_points(in[i],
+                                       &out[i * d_constellation->dimensionality()]);
+    }
+
+    return noutput_items;
+}
+
+} /* namespace digital */
+} /* namespace gr */

--- a/gr-digital/lib/constellation_encoder_bc_impl.h
+++ b/gr-digital/lib/constellation_encoder_bc_impl.h
@@ -1,0 +1,36 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_IMPL_H
+#define INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_IMPL_H
+
+#include <gnuradio/digital/constellation_encoder_bc.h>
+
+namespace gr {
+namespace digital {
+
+class constellation_encoder_bc_impl : public constellation_encoder_bc
+{
+private:
+    constellation_sptr d_constellation;
+
+public:
+    constellation_encoder_bc_impl(constellation_sptr constellation);
+    ~constellation_encoder_bc_impl();
+
+    int work(int noutput_items,
+             gr_vector_const_void_star& input_items,
+             gr_vector_void_star& output_items);
+};
+
+} /* namespace digital */
+} /* namespace gr */
+
+#endif /* INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_IMPL_H */

--- a/gr-digital/python/digital/bindings/CMakeLists.txt
+++ b/gr-digital/python/digital/bindings/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND digital_python_files
     cma_equalizer_cc_python.cc
     constellation_python.cc
     constellation_decoder_cb_python.cc
+    constellation_encoder_bc_python.cc
     constellation_receiver_cb_python.cc
     constellation_soft_decoder_cf_python.cc
     corr_est_cc_python.cc

--- a/gr-digital/python/digital/bindings/constellation_encoder_bc_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_encoder_bc_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(constellation_decoder_cb.h) */
-/* BINDTOOL_HEADER_FILE_HASH(688ec1fa379a5cdd51c2b31886991b28)                     */
+/* BINDTOOL_HEADER_FILE(constellation_encoder_bc.h) */
+/* BINDTOOL_HEADER_FILE_HASH(b7a40d63f0e359222f614398dd1483a3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -23,26 +23,21 @@
 
 namespace py = pybind11;
 
-#include <gnuradio/digital/constellation_decoder_cb.h>
+#include <gnuradio/digital/constellation_encoder_bc.h>
 // pydoc.h is automatically generated in the build directory
-#include <constellation_decoder_cb_pydoc.h>
+#include <constellation_encoder_bc_pydoc.h>
 
-void bind_constellation_decoder_cb(py::module& m)
+void bind_constellation_encoder_bc(py::module& m)
 {
 
-    using constellation_decoder_cb = ::gr::digital::constellation_decoder_cb;
+    using constellation_encoder_bc = ::gr::digital::constellation_encoder_bc;
 
+    py::class_<constellation_encoder_bc,
+               gr::sync_interpolator,
+               std::shared_ptr<constellation_encoder_bc>>(
+        m, "constellation_encoder_bc", D(constellation_encoder_bc))
 
-    py::class_<constellation_decoder_cb,
-               gr::block,
-               gr::basic_block,
-               std::shared_ptr<constellation_decoder_cb>>(
-        m, "constellation_decoder_cb", D(constellation_decoder_cb))
-
-        .def(py::init(&constellation_decoder_cb::make),
+        .def(py::init(&constellation_encoder_bc::make),
              py::arg("constellation"),
-             D(constellation_decoder_cb, make))
-
-
-        ;
+             D(constellation_encoder_bc, make));
 }

--- a/gr-digital/python/digital/bindings/docstrings/constellation_encoder_bc_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/constellation_encoder_bc_pydoc_template.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+#include "pydoc_macros.h"
+#define D(...) DOC(gr, digital, __VA_ARGS__)
+/*
+  This file contains placeholders for docstrings for the Python bindings.
+  Do not edit! These were automatically extracted during the binding process
+  and will be overwritten during the build process
+ */
+
+
+static const char* __doc_gr_digital_constellation_encoder_bc = R"doc()doc";
+
+
+static const char* __doc_gr_digital_constellation_encoder_bc_constellation_encoder_bc =
+    R"doc()doc";
+
+
+static const char* __doc_gr_digital_constellation_encoder_bc_make = R"doc()doc";

--- a/gr-digital/python/digital/bindings/python_bindings.cc
+++ b/gr-digital/python/digital/bindings/python_bindings.cc
@@ -28,6 +28,7 @@ void bind_clock_recovery_mm_ff(py::module&);
 void bind_cma_equalizer_cc(py::module&);
 void bind_constellation(py::module&);
 void bind_constellation_decoder_cb(py::module&);
+void bind_constellation_encoder_bc(py::module&);
 void bind_constellation_receiver_cb(py::module&);
 void bind_constellation_soft_decoder_cf(py::module&);
 void bind_corr_est_cc(py::module&);
@@ -134,6 +135,7 @@ PYBIND11_MODULE(digital_python, m)
     bind_cma_equalizer_cc(m);
     bind_constellation(m);
     bind_constellation_decoder_cb(m);
+    bind_constellation_encoder_bc(m);
     bind_constellation_receiver_cb(m);
     bind_constellation_soft_decoder_cf(m);
     bind_corr_est_cc(m);

--- a/gr-digital/python/digital/qa_constellation_encoder_bc.py
+++ b/gr-digital/python/digital/qa_constellation_encoder_bc.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2004,2007,2010-2013,2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest, digital, blocks
+import numpy as np
+
+class test_constellation_encoder(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_constellation_encoder_bc_bpsk(self):
+        cnst = digital.constellation_bpsk()
+
+        src_data = (1,           1,           0,            0,
+                    1,           0,           1)
+        const_map = [-1.0, 1.0]
+        expected_result = [const_map[x] for x in src_data]
+
+        src = blocks.vector_source_b(src_data)
+        op = digital.constellation_encoder_bc(cnst.base())
+        dst = blocks.vector_sink_c()
+
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()               # run the graph and wait for it to finish
+
+        actual_result = dst.data()  # fetch the contents of the sink
+        # print "actual result", actual_result
+        # print "expected result", expected_result
+        self.assertFloatTuplesAlmostEqual(expected_result, actual_result)
+
+    def test_constellation_encoder_bc_qpsk(self):
+        cnst = digital.constellation_qpsk()
+        src_data = (3,           1,           0,            2,
+                    3,           2,           1)
+        expected_result = [cnst.points()[x] for x in src_data]
+        src = blocks.vector_source_b(src_data)
+        op = digital.constellation_encoder_bc(cnst.base())
+        dst = blocks.vector_sink_c()
+
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()               # run the graph and wait for it to finish
+
+        actual_result = dst.data()  # fetch the contents of the sink
+        # print "actual result", actual_result
+        # print "expected result", expected_result
+        self.assertFloatTuplesAlmostEqual(expected_result, actual_result)
+
+
+    def test_constellation_encoder_bc_qpsk_random(self):
+        cnst = digital.constellation_qpsk()
+        src_data = np.random.randint(0, 4, size=20000)
+        expected_result = [cnst.points()[x] for x in src_data]
+        src = blocks.vector_source_b(src_data)
+        op = digital.constellation_encoder_bc(cnst.base())
+        dst = blocks.vector_sink_c()
+
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()               # run the graph and wait for it to finish
+
+        actual_result = dst.data()  # fetch the contents of the sink
+        # print "actual result", actual_result
+        # print "expected result", expected_result
+        self.assertFloatTuplesAlmostEqual(expected_result, actual_result)
+
+if __name__ == '__main__':
+    gr_unittest.run(test_constellation_encoder)


### PR DESCRIPTION
Add a new block that is the reverse of constellation decoder, to allow more flexibility in making modulation flowgraphs (not requiring chunks to symbols, constellation modulator, etc.)

![image](https://user-images.githubusercontent.com/34754695/83526833-ff267380-a4b4-11ea-8ca3-72199d36e7da.png)

Fixes #1801 