### PR TITLE
runtime: fix latency issue caused by setting block alias on message blocks

### DIFF
--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -188,7 +188,7 @@ void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
     msg_queue_ready[which_port]->notify_one();
 
     // wake up thread if BLKD_IN or BLKD_OUT
-    global_block_registry.notify_blk(alias());
+    global_block_registry.notify_blk(d_symbol_name);
 }
 
 pmt::pmt_t basic_block::delete_head_nowait(pmt::pmt_t which_port)

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -47,7 +47,7 @@ block::block(const std::string& name,
       d_pmt_done(pmt::intern("done")),
       d_system_port(pmt::intern("system"))
 {
-    global_block_registry.register_primitive(alias(), this);
+    global_block_registry.register_primitive(d_symbol_name, this);
     message_port_register_in(d_system_port);
     set_msg_handler(d_system_port, [this](pmt::pmt_t msg) { this->system_handler(msg); });
 }
@@ -598,7 +598,7 @@ void block::system_handler(pmt::pmt_t msg)
     pmt::pmt_t op = pmt::car(msg);
     if (pmt::eqv(op, d_pmt_done)) {
         d_finished = pmt::to_long(pmt::cdr(msg));
-        global_block_registry.notify_blk(alias());
+        global_block_registry.notify_blk(d_symbol_name);
     } else {
         std::cout << "WARNING: bad message op on system port!\n";
         pmt::print(msg);

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -120,10 +120,14 @@ void block_registry::notify_blk(std::string blk)
     gr::thread::scoped_lock guard(d_mutex);
 
     if (primitive_map.find(blk) == primitive_map.end()) {
-        return;
+        throw std::runtime_error("block notify failed: block not found!");
     }
-    if (primitive_map[blk]->detail().get())
+    if (primitive_map[blk]->detail().get()) {
         primitive_map[blk]->detail()->d_tpb.notify_msg();
+    } else {
+        // not having block detail is not necessarily a problem; this will happen when
+        // publishing a message to a block that exists but has not yet been started
+    }
 }
 
 } /* namespace gr */


### PR DESCRIPTION
This addresses #3521 by ~~creating a new class object that contains an identifier that does not fail block lookup when messages are published to a block.~~ conducting early notification of message blocks by their `symbol_name` instead of their `alias`.

~~This is a crutch though,  a more desirable solution would be to unify the various ways blocks are addressed, mapped, and/or registered with runtime fixtures.~~

