### PR TITLE
gr-dtv: Decrease send_frame_size in all examples with a UHD sink block.

### DIFF
--- a/gr-dtv/examples/catv_tx_256qam.grc
+++ b/gr-dtv/examples/catv_tx_256qam.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 12]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: '6'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 220.0]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: '128'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 268.0]
     rotation: 0
     state: enabled
@@ -53,6 +62,9 @@ blocks:
     comment: ''
     value: '4'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 316.0]
     rotation: 0
     state: enabled
@@ -62,6 +74,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 124.0]
     rotation: 0
     state: enabled
@@ -71,6 +86,9 @@ blocks:
     comment: ''
     value: '100'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 172.0]
     rotation: 0
     state: enabled
@@ -80,6 +98,9 @@ blocks:
     comment: ''
     value: 5360537 * 2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -90,7 +111,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -98,6 +119,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 20.0]
     rotation: 0
     state: enabled
@@ -108,7 +132,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -116,6 +140,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [296, 20.0]
     rotation: 0
     state: enabled
@@ -126,7 +153,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -134,6 +161,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [408, 20.0]
     rotation: 0
     state: enabled
@@ -153,6 +183,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 124.0]
     rotation: 0
     state: enabled
@@ -169,6 +202,9 @@ blocks:
     num_ports: '1'
     type: byte
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [648, 148.0]
     rotation: 0
     state: enabled
@@ -184,6 +220,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1136, 160.0]
     rotation: 0
     state: enabled
@@ -198,6 +237,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 300.0]
     rotation: 0
     state: enabled
@@ -211,6 +253,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [424, 308.0]
     rotation: 0
     state: enabled
@@ -223,6 +268,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [880, 160]
     rotation: 0
     state: enabled
@@ -235,6 +283,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [376, 160]
     rotation: 0
     state: enabled
@@ -248,6 +299,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 436.0]
     rotation: 0
     state: enabled
@@ -266,6 +320,9 @@ blocks:
     rate2: C1_5_MEDIUM
     rate3: C1_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [392, 428.0]
     rotation: 0
     state: enabled
@@ -281,6 +338,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 292.0]
     rotation: 0
     state: enabled
@@ -298,6 +358,9 @@ blocks:
     taps: firdes.root_raised_cosine(0.06, samp_rate, samp_rate/2, 0.12, rrc_taps)
     type: ccf
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 420.0]
     rotation: 0
     state: enabled
@@ -375,6 +438,9 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 284.0]
     rotation: 0
     state: enabled
@@ -489,7 +555,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -648,54 +714,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 380.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: rsenc-convint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 204.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: frame-trellis
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 364.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: rsenc-convint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 244.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: frame-trellis
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 388.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/catv_tx_64qam.grc
+++ b/gr-dtv/examples/catv_tx_64qam.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 12]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: '6'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 220.0]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: '128'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 268.0]
     rotation: 0
     state: enabled
@@ -53,6 +62,9 @@ blocks:
     comment: ''
     value: '4'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 316.0]
     rotation: 0
     state: enabled
@@ -62,6 +74,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 124.0]
     rotation: 0
     state: enabled
@@ -71,6 +86,9 @@ blocks:
     comment: ''
     value: '100'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 172.0]
     rotation: 0
     state: enabled
@@ -80,6 +98,9 @@ blocks:
     comment: ''
     value: 5056941 * 2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -90,7 +111,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -98,6 +119,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 20.0]
     rotation: 0
     state: enabled
@@ -108,7 +132,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -116,6 +140,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [296, 20.0]
     rotation: 0
     state: enabled
@@ -126,7 +153,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -134,6 +161,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [408, 20.0]
     rotation: 0
     state: enabled
@@ -153,6 +183,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 124.0]
     rotation: 0
     state: enabled
@@ -169,6 +202,9 @@ blocks:
     num_ports: '1'
     type: byte
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [648, 148.0]
     rotation: 0
     state: enabled
@@ -184,6 +220,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1136, 160.0]
     rotation: 0
     state: enabled
@@ -198,6 +237,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 300.0]
     rotation: 0
     state: enabled
@@ -211,6 +253,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [424, 308.0]
     rotation: 0
     state: enabled
@@ -223,6 +268,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [880, 160]
     rotation: 0
     state: enabled
@@ -235,6 +283,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [376, 160]
     rotation: 0
     state: enabled
@@ -248,6 +299,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 436.0]
     rotation: 0
     state: enabled
@@ -266,6 +320,9 @@ blocks:
     rate2: C1_5_MEDIUM
     rate3: C1_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [392, 428.0]
     rotation: 0
     state: enabled
@@ -281,6 +338,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 292.0]
     rotation: 0
     state: enabled
@@ -298,6 +358,9 @@ blocks:
     taps: firdes.root_raised_cosine(0.14, samp_rate, samp_rate/2, 0.18, rrc_taps)
     type: ccf
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 420.0]
     rotation: 0
     state: enabled
@@ -375,6 +438,9 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 284.0]
     rotation: 0
     state: enabled
@@ -489,7 +555,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -648,54 +714,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 380.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: frame-trellis
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 364.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: rsenc-convint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 204.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: frame-trellis
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 388.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: rsenc-convint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [144, 244.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/dvbs2_tx.grc
+++ b/gr-dtv/examples/dvbs2_tx.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 1280e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 172.0]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: '0.2'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 220.0]
     rotation: 0
     state: enabled
@@ -53,6 +62,9 @@ blocks:
     comment: ''
     value: symbol_rate * 2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 75]
     rotation: 0
     state: enabled
@@ -62,6 +74,9 @@ blocks:
     comment: ''
     value: '5000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 124.0]
     rotation: 0
     state: enabled
@@ -71,6 +86,9 @@ blocks:
     comment: ''
     value: '100'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 268.0]
     rotation: 0
     state: enabled
@@ -81,7 +99,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -89,6 +107,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [240, 468.0]
     rotation: 0
     state: enabled
@@ -99,7 +120,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -107,6 +128,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 468.0]
     rotation: 0
     state: enabled
@@ -117,7 +141,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -125,6 +149,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 468.0]
     rotation: 0
     state: enabled
@@ -140,6 +167,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [776, 420.0]
     rotation: 0
     state: disabled
@@ -159,6 +189,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12.0]
     rotation: 0
     state: enabled
@@ -184,6 +217,9 @@ blocks:
     standard: STANDARD_DVBS2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [424, 20.0]
     rotation: 0
     state: enabled
@@ -204,6 +240,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBS2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [640, 28.0]
     rotation: 0
     state: enabled
@@ -224,6 +263,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBS2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 28.0]
     rotation: 0
     state: enabled
@@ -245,6 +287,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBS2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1088, 20.0]
     rotation: 0
     state: enabled
@@ -262,6 +307,9 @@ blocks:
     rate2: C1_5_MEDIUM
     rate3: C1_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 188.0]
     rotation: 0
     state: enabled
@@ -280,6 +328,9 @@ blocks:
     rate2: C1_5_MEDIUM
     rate3: C1_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [456, 180.0]
     rotation: 0
     state: enabled
@@ -299,6 +350,9 @@ blocks:
     rate2: C1_5_MEDIUM
     rate3: C1_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 332.0]
     rotation: 0
     state: enabled
@@ -316,6 +370,9 @@ blocks:
     taps: firdes.root_raised_cosine(0.9, samp_rate, samp_rate/2, rolloff, taps)
     type: ccc
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [456, 348.0]
     rotation: 0
     state: enabled
@@ -393,6 +450,9 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1056, 204.0]
     rotation: 0
     state: enabled
@@ -508,7 +568,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=256,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=256,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -667,54 +727,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1056, 308.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-int
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1088, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: mod-phy
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [704, 204.0]
     rotation: 0
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-int
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 140.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: mod-phy
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 284.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/dvbs_tx.grc
+++ b/gr-dtv/examples/dvbs_tx.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 12]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 1280e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 172.0]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: '100'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 220.0]
     rotation: 0
     state: enabled
@@ -53,6 +62,9 @@ blocks:
     comment: ''
     value: symbol_rate * 2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -62,6 +74,9 @@ blocks:
     comment: ''
     value: '8000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 124.0]
     rotation: 0
     state: enabled
@@ -72,7 +87,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -80,6 +95,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [240, 468.0]
     rotation: 0
     state: enabled
@@ -90,7 +108,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -98,6 +116,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 468.0]
     rotation: 0
     state: enabled
@@ -108,7 +129,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -116,6 +137,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 468.0]
     rotation: 0
     state: enabled
@@ -131,6 +155,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [808, 436.0]
     rotation: 0
     state: disabled
@@ -150,6 +177,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12.0]
     rotation: 0
     state: enabled
@@ -165,6 +195,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 224.0]
     rotation: 0
     state: enabled
@@ -183,6 +216,9 @@ blocks:
     rate2: C1_5_MEDIUM
     rate3: C1_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 356.0]
     rotation: 0
     state: enabled
@@ -198,6 +234,9 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1032, 60.0]
     rotation: 0
     state: enabled
@@ -211,6 +250,9 @@ blocks:
     minoutbuf: '0'
     nsize: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [456, 44.0]
     rotation: 0
     state: enabled
@@ -228,6 +270,9 @@ blocks:
     ninput: '1'
     noutput: '1512'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 188.0]
     rotation: 0
     state: enabled
@@ -248,6 +293,9 @@ blocks:
     s: '51'
     t: '8'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [728, 20.0]
     rotation: 0
     state: enabled
@@ -265,6 +313,9 @@ blocks:
     taps: firdes.root_raised_cosine(1.0, samp_rate, samp_rate/2, 0.35, rrc_taps)
     type: ccc
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 364.0]
     rotation: 0
     state: enabled
@@ -342,6 +393,9 @@ blocks:
     ymax: '10'
     ymin: '-140'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1040, 220.0]
     rotation: 0
     state: enabled
@@ -456,7 +510,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=256,master_clock_rate=" + str(samp_rate*2)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=256,master_clock_rate=" + str(samp_rate*2)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -615,54 +669,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1040, 324.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: inner-mod
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [728, 220.0]
     rotation: 0
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: int-inner
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1088, 140.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: inner-mod
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 308.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: int-inner
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [184, 140.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/dvbt_tx_2k.grc
+++ b/gr-dtv/examples/dvbt_tx_2k.grc
@@ -63,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -84,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -105,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -426,7 +426,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'

--- a/gr-dtv/examples/dvbt_tx_8k.grc
+++ b/gr-dtv/examples/dvbt_tx_8k.grc
@@ -63,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -84,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -105,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -426,7 +426,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'

--- a/gr-dtv/examples/germany-g1.grc
+++ b/gr-dtv/examples/germany-g1.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C1_2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g10.grc
+++ b/gr-dtv/examples/germany-g10.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C1_2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g2.grc
+++ b/gr-dtv/examples/germany-g2.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g3.grc
+++ b/gr-dtv/examples/germany-g3.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g4.grc
+++ b/gr-dtv/examples/germany-g4.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g5.grc
+++ b/gr-dtv/examples/germany-g5.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g6.grc
+++ b/gr-dtv/examples/germany-g6.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g7.grc
+++ b/gr-dtv/examples/germany-g7.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g8.grc
+++ b/gr-dtv/examples/germany-g8.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/germany-g9.grc
+++ b/gr-dtv/examples/germany-g9.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C1_2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/uhd_atsc_tx.grc
+++ b/gr-dtv/examples/uhd_atsc_tx.grc
@@ -75,7 +75,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '1'
@@ -96,7 +96,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -117,7 +117,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -556,7 +556,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(symbol_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(symbol_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'

--- a/gr-dtv/examples/vv001-cr35.grc
+++ b/gr-dtv/examples/vv001-cr35.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 76.0]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv003-cr23.grc
+++ b/gr-dtv/examples/vv003-cr23.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv004-8kfft.grc
+++ b/gr-dtv/examples/vv004-8kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '1'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv005-8kfft.grc
+++ b/gr-dtv/examples/vv005-8kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv007-16kfft.grc
+++ b/gr-dtv/examples/vv007-16kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv008-16kfft.grc
+++ b/gr-dtv/examples/vv008-16kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C4_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv009-4kfft.grc
+++ b/gr-dtv/examples/vv009-4kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C2_3
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv010-2kfft.grc
+++ b/gr-dtv/examples/vv010-2kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv011-1kfft.grc
+++ b/gr-dtv/examples/vv011-1kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [872, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [872, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1040, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C1_2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv012-64qam45.grc
+++ b/gr-dtv/examples/vv012-64qam45.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C4_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '2.57'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv013-64qam56.grc
+++ b/gr-dtv/examples/vv013-64qam56.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C5_6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '3.0'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv014-64qam34.grc
+++ b/gr-dtv/examples/vv014-64qam34.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '2.83'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv015-8kfft.grc
+++ b/gr-dtv/examples/vv015-8kfft.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv016-256qam34.grc
+++ b/gr-dtv/examples/vv016-256qam34.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv017-paprtr.grc
+++ b/gr-dtv/examples/vv017-paprtr.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '1'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C4_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '3.05'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv018-miso.grc
+++ b/gr-dtv/examples/vv018-miso.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0) * 8 / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 75]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 60.0]
     rotation: 0
     state: enabled
@@ -77,6 +89,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 364]
     rotation: 0
     state: disabled
@@ -92,6 +107,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 556]
     rotation: 0
     state: disabled
@@ -111,6 +129,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 108.0]
     rotation: 180
     state: enabled
@@ -126,6 +147,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 508]
     rotation: 0
     state: enabled
@@ -141,6 +165,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444]
     rotation: 0
     state: enabled
@@ -157,6 +184,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [48, 524.0]
     rotation: 0
     state: enabled
@@ -173,6 +203,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [48, 444.0]
     rotation: 0
     state: enabled
@@ -198,6 +231,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 4.0]
     rotation: 0
     state: enabled
@@ -218,6 +254,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [656, 20.0]
     rotation: 0
     state: enabled
@@ -238,6 +277,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [888, 20.0]
     rotation: 0
     state: enabled
@@ -259,6 +301,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1120, 20.0]
     rotation: 0
     state: enabled
@@ -275,6 +320,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 100.0]
     rotation: 180
     state: enabled
@@ -310,6 +358,9 @@ blocks:
     tiblocks: '1'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [48, 156.0]
     rotation: 0
     state: enabled
@@ -332,6 +383,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 212.0]
     rotation: 0
     state: enabled
@@ -347,6 +401,9 @@ blocks:
     minoutbuf: '0'
     rate: C5_6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1120, 108.0]
     rotation: 180
     state: enabled
@@ -367,6 +424,9 @@ blocks:
     pilotpattern: PILOT_PP2
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [696, 220.0]
     rotation: 0
     state: enabled
@@ -382,6 +442,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [840, 108.0]
     rotation: 180
     state: enabled
@@ -404,6 +467,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [312, 500.0]
     rotation: 0
     state: enabled
@@ -426,6 +492,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [312, 364.0]
     rotation: 0
     state: enabled
@@ -451,6 +520,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 380.0]
     rotation: 0
     state: enabled
@@ -476,6 +548,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 188.0]
     rotation: 0
     state: enabled
@@ -590,7 +665,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*2)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*2)'
     dev_args: '""'
     gain0: tx_gain
     gain1: tx_gain
@@ -749,6 +824,9 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [816, 412.0]
     rotation: 0
     state: enabled

--- a/gr-dtv/examples/vv019-norot.grc
+++ b/gr-dtv/examples/vv019-norot.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1064, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_OFF
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv034-dtg016.grc
+++ b/gr-dtv/examples/vv034-dtg016.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [504, 332.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [272, 332.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [384, 332.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [344, 476.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1120, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '0'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '0'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C4_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [576, 444.0]
     rotation: 0
     state: enabled
@@ -399,6 +459,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -513,7 +576,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -672,54 +735,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv035-dtg052.grc
+++ b/gr-dtv/examples/vv035-dtg052.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 8) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_4
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '2.9'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true

--- a/gr-dtv/examples/vv036-dtg091.grc
+++ b/gr-dtv/examples/vv036-dtg091.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,8 +23,10 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: ''
-    window_size: 1280, 1024
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 11]
     rotation: 0
     state: enabled
@@ -35,6 +38,9 @@ blocks:
     comment: ''
     value: 429e6
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [176, 12]
     rotation: 0
     state: enabled
@@ -44,6 +50,9 @@ blocks:
     comment: ''
     value: (8000000.0 * 7) / 7
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 76]
     rotation: 0
     state: enabled
@@ -54,7 +63,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '0.5'
@@ -62,6 +71,9 @@ blocks:
     value: '50'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 132.0]
     rotation: 0
     state: enabled
@@ -72,7 +84,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '-35'
     step: '1'
@@ -80,6 +92,9 @@ blocks:
     value: '-8'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 132.0]
     rotation: 0
     state: enabled
@@ -90,7 +105,7 @@ blocks:
     gui_hint: ''
     label: ''
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: int
     start: '0'
     step: '1'
@@ -98,6 +113,9 @@ blocks:
     value: '10'
     widget: counter_slider
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [472, 132.0]
     rotation: 0
     state: enabled
@@ -113,6 +131,9 @@ blocks:
     unbuffered: 'False'
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 420.0]
     rotation: 0
     state: disabled
@@ -132,6 +153,9 @@ blocks:
     type: byte
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [120, 75]
     rotation: 0
     state: enabled
@@ -147,6 +171,9 @@ blocks:
     type: complex
     vlen: '1'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [864, 540.0]
     rotation: 0
     state: enabled
@@ -163,6 +190,9 @@ blocks:
     rolloff: '0'
     tagname: ''
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [480, 332.0]
     rotation: 0
     state: enabled
@@ -188,6 +218,9 @@ blocks:
     standard: STANDARD_DVBT2
     tsrate: '4000000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [360, 20.0]
     rotation: 0
     state: enabled
@@ -208,6 +241,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [680, 36.0]
     rotation: 0
     state: enabled
@@ -228,6 +264,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [896, 36.0]
     rotation: 0
     state: enabled
@@ -249,6 +288,9 @@ blocks:
     rate5: C1_4
     standard: STANDARD_DVBT2
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1112, 36.0]
     rotation: 0
     state: enabled
@@ -265,6 +307,9 @@ blocks:
     minoutbuf: '0'
     tiblocks: '3'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [528, 228.0]
     rotation: 0
     state: enabled
@@ -300,6 +345,9 @@ blocks:
     tiblocks: '3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [768, 132.0]
     rotation: 0
     state: enabled
@@ -322,6 +370,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1072, 196.0]
     rotation: 0
     state: enabled
@@ -337,6 +388,9 @@ blocks:
     minoutbuf: '0'
     rate: C3_5
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 236.0]
     rotation: 0
     state: enabled
@@ -352,6 +406,9 @@ blocks:
     minoutbuf: '0'
     rotation: ROTATION_ON
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [288, 236.0]
     rotation: 0
     state: enabled
@@ -374,6 +431,9 @@ blocks:
     vclip: '3.3'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [592, 444.0]
     rotation: 0
     state: enabled
@@ -396,6 +456,9 @@ blocks:
     vclip: '3.0'
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [320, 428]
     rotation: 0
     state: enabled
@@ -421,6 +484,9 @@ blocks:
     preamble2: PREAMBLE_T2_SISO
     version: VERSION_111
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 428]
     rotation: 0
     state: enabled
@@ -535,7 +601,7 @@ blocks:
     clock_source6: ''
     clock_source7: ''
     comment: ''
-    dev_addr: '"send_frame_size=65536,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
+    dev_addr: '"send_frame_size=8192,num_send_frames=128,master_clock_rate=" + str(samp_rate*4)'
     dev_args: '""'
     gain0: tx_gain
     gain1: '0'
@@ -694,54 +760,61 @@ blocks:
     time_source7: ''
     type: fc32
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1080, 420.0]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1128, 116.0]
     rotation: 180
     state: true
 - name: virtual_sink_1
   id: virtual_sink
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [1104, 356.0]
     rotation: 180
     state: true
 - name: virtual_source_0
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: ldpc-bitint
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 188.0]
     rotation: 180
     state: true
 - name: virtual_source_1
   id: virtual_source
   parameters:
-    affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
     stream_id: freqint-pilotgen
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [56, 380.0]
     rotation: 180
     state: true


### PR DESCRIPTION
UHD no longer supports large send_frame_size values after v3.13.0.3-rc1.
Large values will cause "Got a ctrl packet with unknown SID" errors.