### PR TITLE
pybind: fix enums previously mapped as int

### DIFF
--- a/gr-analog/grc/analog_fastnoise_source_x.block.yml
+++ b/gr-analog/grc/analog_fastnoise_source_x.block.yml
@@ -12,7 +12,7 @@ parameters:
     hide: part
 -   id: noise_type
     label: Noise Type
-    dtype: int
+    dtype: raw
     default: analog.GR_GAUSSIAN
     options: [analog.GR_UNIFORM, analog.GR_GAUSSIAN, analog.GR_LAPLACIAN, analog.GR_IMPULSE]
     option_labels: [Uniform, Gaussian, Laplacian, Impulse]

--- a/gr-analog/grc/analog_noise_source_x.block.yml
+++ b/gr-analog/grc/analog_noise_source_x.block.yml
@@ -12,7 +12,7 @@ parameters:
     hide: part
 -   id: noise_type
     label: Noise Type
-    dtype: int
+    dtype: raw
     default: analog.GR_GAUSSIAN
     options: [analog.GR_UNIFORM, analog.GR_GAUSSIAN, analog.GR_LAPLACIAN, analog.GR_IMPULSE]
     option_labels: [Uniform, Gaussian, Laplacian, Impulse]

--- a/gr-analog/grc/analog_sig_source_x.block.yml
+++ b/gr-analog/grc/analog_sig_source_x.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: samp_rate
 -   id: waveform
     label: Waveform
-    dtype: enum
+    dtype: raw
     default: analog.GR_COS_WAVE
     options: [analog.GR_CONST_WAVE, analog.GR_SIN_WAVE, analog.GR_COS_WAVE, analog.GR_SQR_WAVE,
         analog.GR_TRI_WAVE, analog.GR_SAW_WAVE]

--- a/gr-blocks/grc/blocks_ctrlport_probe2_c.block.yml
+++ b/gr-blocks/grc/blocks_ctrlport_probe2_c.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '1024'
 -   id: disp_mask
     label: Display Mask
-    dtype: int
+    dtype: raw
     default: gr.DISPTIME
     options: [gr.DISPXY | gr.DISPOPTSCATTER, gr.DISPTIME, gr.DISPPSD, gr.DISPSPEC,
         gr.DISPRAST]

--- a/gr-blocks/grc/blocks_ctrlport_probe2_x.block.yml
+++ b/gr-blocks/grc/blocks_ctrlport_probe2_x.block.yml
@@ -24,7 +24,7 @@ parameters:
     default: '1024'
 -   id: disp_mask
     label: Display Mask
-    dtype: int
+    dtype: raw
     default: gr.DISPTIME
     options: [gr.DISPXY | gr.DISPOPTSCATTER, gr.DISPTIME, gr.DISPPSD, gr.DISPSPEC,
         gr.DISPRAST]

--- a/gr-blocks/grc/blocks_packed_to_unpacked_xx.block.yml
+++ b/gr-blocks/grc/blocks_packed_to_unpacked_xx.block.yml
@@ -16,7 +16,7 @@ parameters:
     default: '2'
 -   id: endianness
     label: Endianness
-    dtype: int
+    dtype: raw
     options: [gr.GR_MSB_FIRST, gr.GR_LSB_FIRST]
     option_labels: [MSB, LSB]
 -   id: num_ports

--- a/gr-blocks/grc/blocks_unpacked_to_packed_xx.block.yml
+++ b/gr-blocks/grc/blocks_unpacked_to_packed_xx.block.yml
@@ -16,7 +16,7 @@ parameters:
     default: '2'
 -   id: endianness
     label: Endianness
-    dtype: int
+    dtype: raw
     options: [gr.GR_MSB_FIRST, gr.GR_LSB_FIRST]
     option_labels: [MSB, LSB]
 -   id: num_ports

--- a/gr-digital/grc/digital_meas_evm_cc.block.yml
+++ b/gr-digital/grc/digital_meas_evm_cc.block.yml
@@ -14,7 +14,7 @@ parameters:
 - id: meas_type
   label: EVM Meas Type
   dtype: enum
-  options: [digital.evm_measurement_t_EVM_PERCENT, digital.evm_measurement_t_EVM_DB]
+  options: [digital.evm_measurement_t.EVM_PERCENT, digital.evm_measurement_t.EVM_DB]
   option_labels: [Percent, Power-Ratio (dB)]
   hide: part
 

--- a/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
+++ b/gr-fec/grc/variable_ccsds_encoder_def_list.block.yml
@@ -28,7 +28,7 @@ parameters:
     default: '0'
 -   id: mode
     label: Streaming Behavior
-    dtype: int
+    dtype: raw
     options: ['fec.CC_STREAMING', 'fec.CC_TERMINATED', 'fec.CC_TAILBITING', 'fec.CC_TRUNCATED']
     option_labels: [Streaming, Terminated, Tailbiting, Truncated]
 value: ${ fec.ccsds_encoder_make(framebits, state_start, mode) }

--- a/gr-fec/grc/variable_polar_code_configurator.block.yml
+++ b/gr-fec/grc/variable_polar_code_configurator.block.yml
@@ -5,7 +5,7 @@ flags: [ show_id ]
 parameters:
 -   id: channel
     label: Channel
-    dtype: string
+    dtype: raw
     default: polar.CHANNEL_TYPE_BEC
     options: [polar.CHANNEL_TYPE_BEC, polar.CHANNEL_TYPE_AWGN]
     option_labels: [BEC, AWGN]

--- a/gr-filter/grc/filter_band_pass_filter.block.yml
+++ b/gr-filter/grc/filter_band_pass_filter.block.yml
@@ -50,7 +50,7 @@ parameters:
     default: '1'
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/filter_band_reject_filter.block.yml
+++ b/gr-filter/grc/filter_band_reject_filter.block.yml
@@ -42,7 +42,7 @@ parameters:
     dtype: real
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/filter_fft_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_fft_low_pass_filter.block.yml
@@ -36,7 +36,7 @@ parameters:
     dtype: real
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/filter_high_pass_filter.block.yml
+++ b/gr-filter/grc/filter_high_pass_filter.block.yml
@@ -39,7 +39,7 @@ parameters:
     dtype: real
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/filter_hilbert_fc.block.yml
+++ b/gr-filter/grc/filter_hilbert_fc.block.yml
@@ -9,7 +9,7 @@ parameters:
     default: '65'
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_BLACKMAN_hARRIS,
         firdes.WIN_RECTANGULAR, firdes.WIN_KAISER]

--- a/gr-filter/grc/filter_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_filter.block.yml
@@ -39,7 +39,7 @@ parameters:
     dtype: real
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
@@ -40,7 +40,7 @@ parameters:
     dtype: real
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -27,7 +27,7 @@ parameters:
     dtype: float
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -22,7 +22,7 @@ parameters:
     dtype: float
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -19,7 +19,7 @@ parameters:
     dtype: float
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -19,7 +19,7 @@ parameters:
     dtype: float
 -   id: win
     label: Window
-    dtype: int
+    dtype: raw
     default: firdes.WIN_HAMMING
     options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
         firdes.WIN_KAISER]

--- a/gr-vocoder/grc/vocoder_codec2_decode_ps.block.yml
+++ b/gr-vocoder/grc/vocoder_codec2_decode_ps.block.yml
@@ -4,7 +4,7 @@ label: CODEC2 Audio Decoder
 parameters:
 -   id: mode
     label: Bit rate
-    dtype: int
+    dtype: raw
     default: codec2.MODE_2400
     options: [codec2.MODE_3200, codec2.MODE_2400, codec2.MODE_1600, codec2.MODE_1400,
         codec2.MODE_1300, codec2.MODE_1200, codec2.MODE_700, codec2.MODE_700B,

--- a/gr-vocoder/grc/vocoder_codec2_encode_sp.block.yml
+++ b/gr-vocoder/grc/vocoder_codec2_encode_sp.block.yml
@@ -4,7 +4,7 @@ label: CODEC2 Audio Encoder
 parameters:
 -   id: mode
     label: Bit rate
-    dtype: int
+    dtype: raw
     default: codec2.MODE_2400
     options: [codec2.MODE_3200, codec2.MODE_2400, codec2.MODE_1600, codec2.MODE_1400,
         codec2.MODE_1300, codec2.MODE_1200, codec2.MODE_700, codec2.MODE_700B,

--- a/gr-vocoder/grc/vocoder_freedv_rx_ss.block.yml
+++ b/gr-vocoder/grc/vocoder_freedv_rx_ss.block.yml
@@ -4,7 +4,7 @@ label: FreeDV demodulator
 parameters:
 -   id: mode
     label: Operating Mode
-    dtype: int
+    dtype: raw
     default: freedv_api.MODE_1600
     options: [freedv_api.MODE_1600, freedv_api.MODE_700, freedv_api.MODE_700B, freedv_api.MODE_2400A,
         freedv_api.MODE_2400B, freedv_api.MODE_800XA, freedv_api.MODE_700C, freedv_api.MODE_700D]

--- a/gr-vocoder/grc/vocoder_freedv_tx_ss.block.yml
+++ b/gr-vocoder/grc/vocoder_freedv_tx_ss.block.yml
@@ -4,7 +4,7 @@ label: FreeDV modulator
 parameters:
 -   id: mode
     label: Operating Mode
-    dtype: int
+    dtype: raw
     default: freedv_api.MODE_1600
     options: [freedv_api.MODE_1600, freedv_api.MODE_700, freedv_api.MODE_700B, freedv_api.MODE_2400A,
         freedv_api.MODE_2400B, freedv_api.MODE_800XA, freedv_api.MODE_700C, freedv_api.MODE_700D]


### PR DESCRIPTION
With pybind11 ints are not implicitly mapped to enum, so some of the yml files that use ints to send as enum parameters no longer work.  Instead, map these to "raw"

Fixes #3454 