### PR TITLE
qa: Run qtgui tests with xvfb-run when needed

### DIFF
--- a/gr-qtgui/python/qtgui/CMakeLists.txt
+++ b/gr-qtgui/python/qtgui/CMakeLists.txt
@@ -48,10 +48,17 @@ if(ENABLE_TESTING)
     ${CMAKE_BINARY_DIR}/gr-qtgui/swig
     )
 
+  if(LINUX AND NOT DEFINED ENV{DISPLAY})
+    find_program(XVFB_EXECUTABLE xvfb-run)
+    if(XVFB_EXECUTABLE)
+      set(QA_DISPLAY_SERVER "${XVFB_EXECUTABLE}")
+    endif()
+  endif()
+
   include(GrTest)
   file(GLOB py_qa_test_files "qa_*.py")
   foreach(py_qa_test_file ${py_qa_test_files})
     get_filename_component(py_qa_test_name ${py_qa_test_file} NAME_WE)
-    GR_ADD_TEST(${py_qa_test_name} ${QA_PYTHON_EXECUTABLE} -B ${py_qa_test_file})
+    GR_ADD_TEST(${py_qa_test_name} ${QA_DISPLAY_SERVER} ${QA_PYTHON_EXECUTABLE} -B ${py_qa_test_file})
   endforeach(py_qa_test_file)
 endif(ENABLE_TESTING)


### PR DESCRIPTION
If running on Linux, the `DISPLAY` environment variable is not set and xvfb-run is present then run the Qt tests with xvfb-run. This would allows running the Qt test in the gnuradio's CI.