### PR TITLE
cmake: use TIMESTAMP function to generate build_date and save to cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,12 +532,16 @@ CONFIGURE_FILE(
   ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-runtime/include/gnuradio/config.h
 )
 
-#Re-generate the constants file, now that we actually know which components will be enabled.
-configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-runtime/lib/constants.cc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-runtime/lib/constants.cc
-    ESCAPE_QUOTES
-@ONLY)
+########################################################################
+# Handle the generated constants
+########################################################################
+
+# Use TIMESTAMP to be compatible with reproducible builds
+# and put in in the cache so configure_file sees it
+string(TIMESTAMP BUILD_DATE "%a, %d %b %Y %H:%M:%S")
+set(BUILD_DATE ${BUILD_DATE} CACHE INTERNAL "Build date")
+message(STATUS "Loading build date ${BUILD_DATE} into constants...")
+message(STATUS "Loading version ${VERSION} into constants...")
 
 # Install config.h in include/gnuradio
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,7 +539,6 @@ CONFIGURE_FILE(
 # Use TIMESTAMP to be compatible with reproducible builds
 # and put in in the cache so configure_file sees it
 string(TIMESTAMP BUILD_DATE "%a, %d %b %Y %H:%M:%S")
-set(BUILD_DATE ${BUILD_DATE} CACHE INTERNAL "Build date")
 message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,7 @@ CONFIGURE_FILE(
 
 # Use TIMESTAMP to be compatible with reproducible builds
 # and put in in the cache so configure_file sees it
-string(TIMESTAMP BUILD_DATE "%a, %d %b %Y %H:%M:%S")
+string(TIMESTAMP BUILD_DATE "%a, %d %b %Y %H:%M:%S" UTC)
 message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -31,6 +31,13 @@ string(REPLACE "\\" "\\\\" prefix "${prefix}")
 string(REPLACE "\\" "\\\\" SYSCONFDIR "${SYSCONFDIR}")
 string(REPLACE "\\" "\\\\" GR_PREFSDIR "${GR_PREFSDIR}")
 
+#Generate the constants file, now that we actually know which components will be enabled.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-runtime/lib/constants.cc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-runtime/lib/constants.cc
+  ESCAPE_QUOTES
+  @ONLY)
+
 #########################################################################
 # Include subdirs rather to populate to the sources lists.
 ########################################################################
@@ -39,12 +46,6 @@ add_subdirectory(pmt)
 ########################################################################
 # Setup library
 ########################################################################
-configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/constants.cc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/constants.cc
-    ESCAPE_QUOTES
-    @ONLY)
-
 add_library(gnuradio-runtime
   ${CMAKE_CURRENT_BINARY_DIR}/constants.cc
   basic_block.cc

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -33,8 +33,8 @@ string(REPLACE "\\" "\\\\" GR_PREFSDIR "${GR_PREFSDIR}")
 
 #Generate the constants file, now that we actually know which components will be enabled.
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-runtime/lib/constants.cc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-runtime/lib/constants.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/constants.cc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/constants.cc
   ESCAPE_QUOTES
   @ONLY)
 


### PR DESCRIPTION
Previously a a custom python command was used to generate the build date
but this can be done with native CMake functions for all supported CMake
versions.

Additionally it's compatible with reproducible builds since CMake 3.8 as
it honors SOURCE_DATE_EPOCH set in the environment varibales.