### PR TITLE
blocks: Fix XMLRPC Client block templates

### DIFF
--- a/gr-blocks/grc/xmlrpc_client.block.yml
+++ b/gr-blocks/grc/xmlrpc_client.block.yml
@@ -5,7 +5,7 @@ flags: [ python ]
 parameters:
 -   id: addr
     label: Address
-    dtype: string
+    dtype: raw
     default: localhost
 -   id: port
     label: Port
@@ -13,15 +13,15 @@ parameters:
     default: '8080'
 -   id: callback
     label: Callback
-    dtype: string
+    dtype: raw
     default: set_
 -   id: variable
     label: Variable
     dtype: raw
 
 templates:
-    imports: import xmlrpclib
-    make: xmlrpclib.Server('http://${addr}:${port}')
+    imports: from xmlrpc.client import ServerProxy
+    make: ServerProxy('http://${addr}:${port}')
     callbacks:
     - ${callback}(${variable})
 


### PR DESCRIPTION
The XMLRPC Client block is currently broken because it tries to import 
the Python 2 XMLRPC module, and because the "addr" and "callback" 
parameters are inserted as quoted strings. To fix these problems, I've 
switched to the Python 3 version of the XMLRPC module, and changed the 
data types of the problematic parameters to "raw".

I tested this with the following flowgraphs:

Server:

![Screenshot from 2020-06-07 21-53-46](https://user-images.githubusercontent.com/583749/83986062-7b7fe300-a909-11ea-8262-bb7a09545e9e.png)

Client:

![Screenshot from 2020-06-07 21-53-56](https://user-images.githubusercontent.com/583749/83986065-7fac0080-a909-11ea-815e-bc14ee5a6150.png)

I'll open a separate pull request to fix this in GNU Radio 3.8, which needs to support both Python 2 and Python 3.
