### PR TITLE
blocks: Fix XMLRPC Client and Server block templates

### DIFF
--- a/gr-blocks/grc/xmlrpc_client.block.yml
+++ b/gr-blocks/grc/xmlrpc_client.block.yml
@@ -5,7 +5,7 @@ flags: [ python ]
 parameters:
 -   id: addr
     label: Address
-    dtype: string
+    dtype: raw
     default: localhost
 -   id: port
     label: Port
@@ -13,15 +13,19 @@ parameters:
     default: '8080'
 -   id: callback
     label: Callback
-    dtype: string
+    dtype: raw
     default: set_
 -   id: variable
     label: Variable
     dtype: raw
 
 templates:
-    imports: import xmlrpclib
-    make: xmlrpclib.Server('http://${addr}:${port}')
+    imports: |-
+        try:
+            from xmlrpc.client import ServerProxy
+        except ImportError:
+            from xmlrpclib import ServerProxy
+    make: ServerProxy('http://${addr}:${port}')
     callbacks:
     - ${callback}(${variable})
 

--- a/gr-blocks/grc/xmlrpc_server.block.yml
+++ b/gr-blocks/grc/xmlrpc_server.block.yml
@@ -14,10 +14,13 @@ parameters:
 
 templates:
     imports: |-
-        import SimpleXMLRPCServer
+        try:
+            from xmlrpc.server import SimpleXMLRPCServer
+        except ImportError:
+            from SimpleXMLRPCServer import SimpleXMLRPCServer
         import threading
     make: |-
-        SimpleXMLRPCServer.SimpleXMLRPCServer((${addr}, ${port}), allow_none=True)
+        SimpleXMLRPCServer((${addr}, ${port}), allow_none=True)
         self.${id}.register_instance(self)
         self.${id}_thread = threading.Thread(target=self.${id}.serve_forever)
         self.${id}_thread.daemon = True


### PR DESCRIPTION
The XMLRPC Client block is currently broken because it tries to import 
the Python 2 XMLRPC module, and because the "addr" and "callback" 
parameters are inserted as quoted strings. To fix these problems, I've 
switched to the Python 3 version of the XMLRPC module with a fallback to 
the Python 2 version, and changed the data types of the problematic 
parameters to "raw".

The XMLRPC Server block is currently broken because it tries to import 
the Python 2 XMLRPC module. To fix this problem, I've switched to the 
Python 3 version of the XMLRPC module with a fallback to the Python 2 
version.

I tested this with the following flowgraphs:

Server:

![Screenshot from 2020-06-07 21-53-46](https://user-images.githubusercontent.com/583749/83986062-7b7fe300-a909-11ea-8262-bb7a09545e9e.png)

Client:

![Screenshot from 2020-06-07 21-53-56](https://user-images.githubusercontent.com/583749/83986065-7fac0080-a909-11ea-815e-bc14ee5a6150.png)