### PR TITLE
gr-uhd: Fix assumption that pmt pair passes is_dict

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -487,22 +487,19 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     }
     // End of legacy backward compat code.
 
+    // Apparently, pmt::is_dict does not return true for pairs anymore. Yeah!
+    if (pmt::is_pair(msg)) {
+        GR_LOG_DEBUG(d_logger,
+                     boost::format("Command message is pair, converting to dict: %s") %
+                         msg);
+        msg = pmt::dict_add(pmt::make_dict(), pmt::car(msg), pmt::cdr(msg));
+    }
+
     // Turn pair into dict
     if (!pmt::is_dict(msg)) {
         GR_LOG_ERROR(d_logger,
                      boost::format("Command message is neither dict nor pair: %s") % msg);
         return;
-    }
-
-    // OK, here comes the horrible part. Pairs pass is_dict(), but they're not dicts. Such
-    // dicks.
-    try {
-        // This will fail if msg is a pair:
-        pmt::pmt_t keys = pmt::dict_keys(msg);
-    } catch (const pmt::wrong_type& e) {
-        // So we fix it:
-        GR_LOG_DEBUG(d_debug_logger, boost::format("Converting pair to dict: %s") % msg);
-        msg = pmt::dict_add(pmt::make_dict(), pmt::car(msg), pmt::cdr(msg));
     }
 
     /*** Start the actual message processing *************************/

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -487,15 +487,18 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     }
     // End of legacy backward compat code.
 
-    // Apparently, pmt::is_dict does not return true for pairs anymore. Yeah!
-    if (pmt::is_pair(msg)) {
-        GR_LOG_DEBUG(d_logger,
-                     boost::format("Command message is pair, converting to dict: %s") %
-                         msg);
+    // pmt_dict is a subclass of pmt_pair. Make sure we use pmt_pair!
+    // Old behavior was that these checks were interchangably. Be aware of this change!
+    if (!(pmt::is_dict(msg)) && pmt::is_pair(msg)) {
+        GR_LOG_DEBUG(
+            d_logger,
+            boost::format(
+                "Command message is pair, converting to dict: '%s': car(%s), cdr(%s)") %
+                msg % pmt::car(msg) % pmt::cdr(msg));
         msg = pmt::dict_add(pmt::make_dict(), pmt::car(msg), pmt::cdr(msg));
     }
 
-    // Turn pair into dict
+    // Make sure, we use dicts!
     if (!pmt::is_dict(msg)) {
         GR_LOG_ERROR(d_logger,
                      boost::format("Command message is neither dict nor pair: %s") % msg);


### PR DESCRIPTION
Previously, `pmt::is_dict` would return `true` for pairs and vice versa.
This assumption was built into gr-uhd command handling. With this
commit, a new check `if(pmt::is_pair(...))` is introduced to convert
pairs to dicts for further processing.

This behavior is [documented here](https://www.gnuradio.org/doc/doxygen/namespacepmt.html#a2b5a9b0e21ac7a90078ce5033182104e) but apparently, it does not hold anymore.

The new behavior looks like this:
```cpp
pmt::is_pair(pmt::make_dict()); //return false.
pmt::is_dict(pmt::cons(pmt::intern("key), pmt::intern("val))); //return false.
```
When did that change?