### PR TITLE
uhd: Add PC clock resync command

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -32,6 +32,7 @@ GR_UHD_API const pmt::pmt_t cmd_mboard_key();
 GR_UHD_API const pmt::pmt_t cmd_antenna_key();
 GR_UHD_API const pmt::pmt_t cmd_direction_key();
 GR_UHD_API const pmt::pmt_t cmd_tag_key();
+GR_UHD_API const pmt::pmt_t cmd_pc_clock_resync_key();
 
 GR_UHD_API const pmt::pmt_t ant_direction_rx();
 GR_UHD_API const pmt::pmt_t ant_direction_tx();

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -96,6 +96,11 @@ const pmt::pmt_t gr::uhd::cmd_tag_key()
     static const pmt::pmt_t val = pmt::mp("tag");
     return val;
 }
+const pmt::pmt_t gr::uhd::cmd_pc_clock_resync_key()
+{
+    static const pmt::pmt_t val = pmt::mp("pc_clock_resync");
+    return val;
+}
 
 const pmt::pmt_t gr::uhd::ant_direction_rx()
 {
@@ -141,6 +146,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     REGISTER_CMD_HANDLER(cmd_rate_key(), _cmd_handler_rate);
     REGISTER_CMD_HANDLER(cmd_bandwidth_key(), _cmd_handler_bw);
     REGISTER_CMD_HANDLER(cmd_antenna_key(), _cmd_handler_antenna);
+    REGISTER_CMD_HANDLER(cmd_pc_clock_resync_key(), _cmd_handler_pc_clock_resync);
 }
 
 usrp_block_impl::~usrp_block_impl()
@@ -668,6 +674,18 @@ void usrp_block_impl::_cmd_handler_rate(const pmt::pmt_t& rate_, int, const pmt:
 {
     const double rate = pmt::to_double(rate_);
     set_samp_rate(rate);
+}
+
+void usrp_block_impl::_cmd_handler_pc_clock_resync(const pmt::pmt_t&,
+                                                   int,
+                                                   const pmt::pmt_t&)
+{
+    const uint64_t ticks =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::high_resolution_clock::now().time_since_epoch())
+            .count();
+    const ::uhd::time_spec_t& time_spec = ::uhd::time_spec_t::from_ticks(ticks, 1.0e9);
+    set_time_now(time_spec, ::uhd::usrp::multi_usrp::ALL_MBOARDS);
 }
 
 void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -124,6 +124,9 @@ protected:
     void _cmd_handler_bw(const pmt::pmt_t& bw, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_lofreq(const pmt::pmt_t& lofreq, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_dspfreq(const pmt::pmt_t& dspfreq, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_pc_clock_resync(const pmt::pmt_t& timespec,
+                                      int chan,
+                                      const pmt::pmt_t& msg);
 
     /**********************************************************************
      * Helpers


### PR DESCRIPTION
USRPs may be synchronized to a host clock. Over time USRP and host clock
deviate. This is an issue for timed commands. With this commit it is
possible to resync both devices.

The new command key is `pc_clock_resync`. The command does not expect
any argument.

It may be possible that USRP time is not strictly monotonic anymore. If
that is a requirement, other options should be explored.

e.g. connect a 'Message Strobe' block to a USRP command port and send a
message with `pmt.dict_add(pmt.make_dict(), pmt.intern('pc_clock_resync'), pmt.PMT_T)`
periodically. It is sufficient to send such a message every couple of
seconds.