### PR TITLE
qtgui: remove optional flag on stream ports

### DIFF
--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -391,7 +391,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -929,7 +929,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -368,7 +368,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if (type == 'msg_complex' or type == 'msg_float') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 -   domain: message
     id: freq
     optional: true

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -355,7 +355,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -211,7 +211,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -993,7 +993,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -252,7 +252,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -230,7 +230,7 @@ inputs:
 -   domain: stream
     dtype: ${ type.t }
     multiplicity: ${ (0 if type.startswith('msg') else nconnections) }
-    optional: true
+    optional: ${ (True if type.startswith('msg') else False) }
 -   domain: message
     id: freq
     optional: true


### PR DESCRIPTION
The qtgui blocks are all labeled as optional on their input ports, which is only appropriate for message blocks.  This PR puts a conditional flag on the optional parameter for the input ports

Fixes #3036 