### PR TITLE
blocks: fix tag propagation in the selector block

### DIFF
--- a/gr-blocks/lib/selector_impl.h
+++ b/gr-blocks/lib/selector_impl.h
@@ -22,6 +22,7 @@ class selector_impl : public selector
 private:
     const size_t d_itemsize;
     bool d_enabled;
+    std::vector<uint64_t> d_dropped_samples;
     unsigned int d_input_index, d_output_index;
     unsigned int d_num_inputs, d_num_outputs; // keep track of the topology
 


### PR DESCRIPTION
previously tags were propagated automatically which after dropping data on an output caused stale tags to be propagated with data; dropped data is now tracked for each output and tag offsets are updated accordingly.

Fixes #3569