### PR TITLE
cmake: Add quotation marks around $PATH in GrTest.cmake

### DIFF
--- a/cmake/Modules/GrTest.cmake
+++ b/cmake/Modules/GrTest.cmake
@@ -77,7 +77,7 @@ function(GR_ADD_TEST test_name)
             set(LD_PATH_VAR "DYLD_LIBRARY_PATH")
         endif()
 
-        set(binpath "${bindir}:$PATH")
+        set(binpath "${bindir}:\"$PATH\"")
         list(APPEND libpath "$${LD_PATH_VAR}")
         list(APPEND pypath "$PYTHONPATH")
 


### PR DESCRIPTION
This quotes the SHELL variable in the resulting
shell scripts for execute the tests in the correct
environment and allows paths with spaces.

Thanks to Daniel Estévez for reporting this and providing the
correct fix.

Closes #3560