### PR TITLE
blocktool: Monkeypatch time module for pygccxml to work under Python>=3.8

### DIFF
--- a/gr-utils/blocktool/core/parseheader.py
+++ b/gr-utils/blocktool/core/parseheader.py
@@ -18,6 +18,12 @@ import codecs
 import logging
 
 PYGCCXML_AVAILABLE = False
+# ugly hack to make pygccxml work with Python >= 3.8
+import time
+try:
+    time.clock
+except:
+    time.clock = time.perf_counter
 try:
     from pygccxml import parser, declarations, utils
     PYGCCXML_AVAILABLE = True

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -24,6 +24,13 @@ from ..core import Constants
 
 LOGGER = logging.getLogger(__name__)
 PYGCCXML_AVAILABLE = False
+# ugly hack to make pygccxml work with Python >= 3.8
+import time
+try:
+    time.clock
+except:
+    time.clock = time.perf_counter
+
 try:
     from pygccxml import parser, declarations, utils
     PYGCCXML_AVAILABLE = True

--- a/gr-utils/blocktool/tests/test_blocktool.py
+++ b/gr-utils/blocktool/tests/test_blocktool.py
@@ -15,6 +15,14 @@ from __future__ import unicode_literals
 import os
 import unittest
 import warnings
+
+# ugly hack to make pygccxml work with Python >= 3.8
+import time
+try:
+    time.clock
+except:
+    time.clock = time.perf_counter
+
 try:
     import pygccxml
     SKIP_BLOCK_TEST = False


### PR DESCRIPTION
pygccxml tries to import time.clock, which was deprecated since Py3.3,
and removed in Py3.8

Thus, for these platforms:

    time.clock = time.perf_counter