### PR TITLE
fec: make gsl optional for python bindings

### DIFF
--- a/gr-fec/python/fec/bindings/CMakeLists.txt
+++ b/gr-fec/python/fec/bindings/CMakeLists.txt
@@ -22,19 +22,13 @@ list(APPEND fec_python_files
     dummy_decoder_python.cc
     dummy_encoder_python.cc
     encode_ccsds_27_bb_python.cc
-    encoder_python.cc
-    fec_mtrx_python.cc
+    encoder_python.cc    
     generic_decoder_python.cc
     generic_encoder_python.cc
     #gf2mat_python.cc
     #gf2vec_python.cc
-    ldpc_G_matrix_python.cc
-    ldpc_H_matrix_python.cc
-    ldpc_bit_flip_decoder_python.cc
     ldpc_decoder_python.cc
     ldpc_encoder_python.cc
-    ldpc_gen_mtrx_encoder_python.cc
-    ldpc_par_mtrx_encoder_python.cc
     #maxstar_python.cc
     polar_common_python.cc
     polar_decoder_common_python.cc
@@ -54,13 +48,27 @@ list(APPEND fec_python_files
     tpc_decoder_python.cc
     tpc_encoder_python.cc
     # #viterbi_python.cc
+    )
+
+if(GSL_FOUND)
+    list(APPEND fec_python_files
+        fec_mtrx_python.cc
+        ldpc_G_matrix_python.cc
+        ldpc_H_matrix_python.cc
+        ldpc_bit_flip_decoder_python.cc
+        ldpc_gen_mtrx_encoder_python.cc
+        ldpc_par_mtrx_encoder_python.cc)
+endif(GSL_FOUND)
+
+
+list(APPEND fec_python_files
     python_bindings.cc)
 
 GR_PYBIND_MAKE_CHECK_HASH(fec 
    ../../.. 
    gr::fec
-   "${fec_python_files}")
+   "${fec_python_files}") 
 
-target_link_libraries(fec_python PUBLIC gnuradio-runtime gnuradio-blocks gsl::gsl)
+target_link_libraries(fec_python PUBLIC gnuradio-runtime gnuradio-blocks)
 
 install(TARGETS fec_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/fec COMPONENT pythonapi)


### PR DESCRIPTION
Only adds in sources that require gsl and links gsl if gsl is found in gr-fec

Fixes #3587 