### PR TITLE
uhd: wrap get_usrp_info to compatible return type

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -572,6 +572,15 @@ public:
      * @return the filter object
      */
     virtual ::uhd::filter_info_base::sptr get_filter(const std::string& path) = 0;
+
+    /*!
+     * Returns identifying information about this USRP's configuration.
+     * Returns motherboard ID, name, and serial.
+     * Returns daughterboard TX ID, subdev name and spec, serial, and antenna.
+     * \param chan channel index 0 to N-1
+     * \return TX info
+     */
+    virtual ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan = 0) = 0;
 };
 
 } /* namespace uhd */

--- a/gr-uhd/include/gnuradio/uhd/usrp_sink.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_sink.h
@@ -123,15 +123,6 @@ public:
     virtual void set_start_time(const ::uhd::time_spec_t& time) = 0;
 
     /*!
-     * Returns identifying information about this USRP's configuration.
-     * Returns motherboard ID, name, and serial.
-     * Returns daughterboard TX ID, subdev name and spec, serial, and antenna.
-     * \param chan channel index 0 to N-1
-     * \return TX info
-     */
-    virtual ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan = 0) = 0;
-
-    /*!
      * Get a list of possible LO stage names
      * \param chan the channel index 0 to N-1
      * \return a vector of strings for possible LO names

--- a/gr-uhd/include/gnuradio/uhd/usrp_source.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_source.h
@@ -120,16 +120,6 @@ public:
     virtual void set_recv_timeout(const double timeout, const bool one_packet = true) = 0;
 
     /*!
-     * Returns identifying information about this USRP's configuration.
-     * Returns motherboard ID, name, and serial.
-     * Returns daughterboard RX ID, subdev name and spec, serial, and antenna.
-     * \param chan channel index 0 to N-1
-     * \return RX info
-     */
-    virtual ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan = 0) = 0;
-
-
-    /*!
      * Get a list of possible LO stage names
      * \param chan the channel index 0 to N-1
      * \return a vector of strings for possible LO names

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -741,3 +741,9 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
 
     _update_curr_tune_req(new_tune_request, chan);
 }
+
+::uhd::dict<std::string, std::string> usrp_block_impl::get_usrp_info(size_t chan)
+{
+    chan = _stream_args.channels[chan];
+    return _dev->get_usrp_rx_info(chan);
+}

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -75,6 +75,7 @@ public:
                        const boost::uint32_t mask,
                        const size_t mboard);
     void set_filter(const std::string& path, ::uhd::filter_info_base::sptr filter);
+    ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
 
     // RPC
     void setup_rpc();

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -47,12 +47,6 @@ usrp_sink_impl::~usrp_sink_impl()
     _async_event_thread.join();
 }
 
-::uhd::dict<std::string, std::string> usrp_sink_impl::get_usrp_info(size_t chan)
-{
-    chan = _stream_args.channels[chan];
-    return _dev->get_usrp_tx_info(chan);
-}
-
 void usrp_sink_impl::set_subdev_spec(const std::string& spec, size_t mboard)
 {
     return _dev->set_tx_subdev_spec(spec, mboard);

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -55,7 +55,6 @@ public:
                    const std::string& length_tag_name);
     ~usrp_sink_impl();
 
-    ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
     double get_samp_rate(void);
     ::uhd::meta_range_t get_samp_rates(void);
     double get_center_freq(size_t chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -51,12 +51,6 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
 
 usrp_source_impl::~usrp_source_impl() {}
 
-::uhd::dict<std::string, std::string> usrp_source_impl::get_usrp_info(size_t chan)
-{
-    chan = _stream_args.channels[chan];
-    return _dev->get_usrp_rx_info(chan);
-}
-
 void usrp_source_impl::set_subdev_spec(const std::string& spec, size_t mboard)
 {
     return _dev->set_rx_subdev_spec(spec, mboard);

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -39,7 +39,6 @@ public:
     ~usrp_source_impl();
 
     // Get Commands
-    ::uhd::dict<std::string, std::string> get_usrp_info(size_t chan);
     std::string get_subdev_spec(size_t mboard);
     double get_samp_rate(void);
     ::uhd::meta_range_t get_samp_rates(void);

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
@@ -186,6 +186,9 @@ static const char* __doc_gr_uhd_usrp_block_set_filter = R"doc()doc";
 static const char* __doc_gr_uhd_usrp_block_get_filter = R"doc()doc";
 
 
+static const char* __doc_gr_uhd_usrp_block_get_usrp_info = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_cmd_chan_key = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_sink_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_sink_pydoc_template.h
@@ -30,9 +30,6 @@ static const char* __doc_gr_uhd_usrp_sink_make = R"doc()doc";
 static const char* __doc_gr_uhd_usrp_sink_set_start_time = R"doc()doc";
 
 
-static const char* __doc_gr_uhd_usrp_sink_get_usrp_info = R"doc()doc";
-
-
 static const char* __doc_gr_uhd_usrp_sink_get_lo_names = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_source_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_source_pydoc_template.h
@@ -36,9 +36,6 @@ static const char* __doc_gr_uhd_usrp_source_issue_stream_cmd = R"doc()doc";
 static const char* __doc_gr_uhd_usrp_source_set_recv_timeout = R"doc()doc";
 
 
-static const char* __doc_gr_uhd_usrp_source_get_usrp_info = R"doc()doc";
-
-
 static const char* __doc_gr_uhd_usrp_source_get_lo_names = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -389,7 +389,14 @@ void bind_usrp_block(py::module& m)
              py::arg("path"),
              D(usrp_block, get_filter))
 
-        ;
+        .def(
+            "get_usrp_info",
+            [](usrp_block& self, const size_t chan = 0) {
+                return static_cast<std::map<std::string, std::string>>(
+                    self.get_usrp_info(chan));
+            },
+            py::arg("chan") = 0,
+            D(usrp_block, get_usrp_info));
 
 
     m.def("cmd_chan_key", &::gr::uhd::cmd_chan_key, D(cmd_chan_key));

--- a/gr-uhd/python/uhd/bindings/usrp_sink_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_sink_python.cc
@@ -57,12 +57,6 @@ void bind_usrp_sink(py::module& m)
              D(usrp_sink, set_start_time))
 
 
-        .def("get_usrp_info",
-             &usrp_sink::get_usrp_info,
-             py::arg("chan") = 0,
-             D(usrp_sink, get_usrp_info))
-
-
         .def("get_lo_names",
              &usrp_sink::get_lo_names,
              py::arg("chan") = 0,

--- a/gr-uhd/python/uhd/bindings/usrp_source_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_source_python.cc
@@ -70,12 +70,6 @@ void bind_usrp_source(py::module& m)
              D(usrp_source, set_recv_timeout))
 
 
-        .def("get_usrp_info",
-             &usrp_source::get_usrp_info,
-             py::arg("chan") = 0,
-             D(usrp_source, get_usrp_info))
-
-
         .def("get_lo_names",
              &usrp_source::get_lo_names,
              py::arg("chan") = 0,


### PR DESCRIPTION
Copied the wrapping mechanism into a lambda from pyuhd for these functions

Fixes #3608