### PR TITLE
uhd: remove import from uhd

### DIFF
--- a/gr-uhd/python/uhd/__init__.py
+++ b/gr-uhd/python/uhd/__init__.py
@@ -13,8 +13,6 @@ Used to send and receive data between the Ettus Research, LLC product
 line.
 '''
 
-import uhd  # TODO: verify uhd python is installed as a dependency for gr-uhd with python
-
 ########################################################################
 # Prepare uhd swig module to make it more pythonic
 ########################################################################


### PR DESCRIPTION
There is no need to have the dependence on uhd python bindings as the
types that are used in gr-uhd are wrapped separately

This especially causes issues when using the PPA packages, since uhd doesn't by default package their python bindings, so this unnecessary line will cause an exception