### PR TITLE
filter: Remove manual memory management

### DIFF
--- a/gr-filter/include/gnuradio/filter/filterbank.h
+++ b/gr-filter/include/gnuradio/filter/filterbank.h
@@ -41,10 +41,10 @@ namespace kernel {
 class FILTER_API filterbank
 {
 protected:
+    std::vector<std::vector<float>> d_taps;
     unsigned int d_nfilts;
     unsigned int d_ntaps;
-    std::vector<kernel::fir_filter_ccf*> d_fir_filters;
-    std::vector<std::vector<float>> d_taps;
+    std::vector<kernel::fir_filter_ccf> d_fir_filters;
     std::vector<bool> d_active;
     unsigned int d_taps_per_filter;
 

--- a/gr-filter/include/gnuradio/filter/fir_filter.h
+++ b/gr-filter/include/gnuradio/filter/fir_filter.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/filter/api.h>
 #include <gnuradio/gr_complex.h>
+#include <volk/volk_alloc.hh>
 #include <cstdint>
 #include <vector>
 
@@ -27,12 +28,21 @@ public:
     fir_filter(int decimation, const std::vector<TAP_T>& taps);
     ~fir_filter();
 
+    // Disallow copy.
+    //
+    // This prevents accidentally doing needless copies, not just of fir_filter,
+    // but every block that contains one.
+    fir_filter(const fir_filter&) = delete;
+    fir_filter(fir_filter&&) = default;
+    fir_filter& operator=(const fir_filter&) = delete;
+    fir_filter& operator=(fir_filter&&) = default;
+
     void set_taps(const std::vector<TAP_T>& taps);
     void update_tap(TAP_T t, unsigned int index);
     std::vector<TAP_T> taps() const;
     unsigned int ntaps() const;
 
-    OUT_T filter(const IN_T input[]);
+    OUT_T filter(const IN_T input[]) const;
     void filterN(OUT_T output[], const IN_T input[], unsigned long n);
     void filterNdec(OUT_T output[],
                     const IN_T input[],
@@ -42,8 +52,8 @@ public:
 protected:
     std::vector<TAP_T> d_taps;
     unsigned int d_ntaps;
-    TAP_T** d_aligned_taps;
-    OUT_T* d_output;
+    std::vector<volk::vector<TAP_T>> d_aligned_taps;
+    volk::vector<OUT_T> d_output;
     int d_align;
     int d_naligned;
 };

--- a/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_cc.h
+++ b/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_cc.h
@@ -58,7 +58,7 @@ public:
     gr_complex interpolate(const gr_complex input[], float mu) const;
 
 protected:
-    std::vector<kernel::fir_filter_ccf*> filters;
+    const std::vector<kernel::fir_filter_ccf> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_ff.h
+++ b/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_ff.h
@@ -56,7 +56,7 @@ public:
     float interpolate(const float input[], float mu) const;
 
 protected:
-    std::vector<kernel::fir_filter_fff*> filters;
+    const std::vector<kernel::fir_filter_fff> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_cc.h
+++ b/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_cc.h
@@ -59,7 +59,7 @@ public:
     gr_complex differentiate(const gr_complex input[], float mu) const;
 
 protected:
-    std::vector<kernel::fir_filter_ccf*> filters;
+    const std::vector<kernel::fir_filter_ccf> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_ff.h
+++ b/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_ff.h
@@ -58,7 +58,7 @@ public:
     float differentiate(const float input[], float mu) const;
 
 protected:
-    std::vector<kernel::fir_filter_fff*> filters;
+    const std::vector<kernel::fir_filter_fff> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
@@ -82,8 +82,8 @@ namespace kernel {
 class FILTER_API pfb_arb_resampler_ccf
 {
 private:
-    std::vector<fir_filter_ccf*> d_filters;
-    std::vector<fir_filter_ccf*> d_diff_filters;
+    std::vector<fir_filter_ccf> d_filters;
+    std::vector<fir_filter_ccf> d_diff_filters;
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_dtaps;
     unsigned int d_int_rate;        // the number of filters (interpolation rate)
@@ -115,7 +115,7 @@ private:
      */
     void create_taps(const std::vector<float>& newtaps,
                      std::vector<std::vector<float>>& ourtaps,
-                     std::vector<kernel::fir_filter_ccf*>& ourfilter);
+                     std::vector<kernel::fir_filter_ccf>& ourfilter);
 
 public:
     /*!
@@ -210,8 +210,8 @@ public:
 class FILTER_API pfb_arb_resampler_ccc
 {
 private:
-    std::vector<fir_filter_ccc*> d_filters;
-    std::vector<fir_filter_ccc*> d_diff_filters;
+    std::vector<fir_filter_ccc> d_filters;
+    std::vector<fir_filter_ccc> d_diff_filters;
     std::vector<std::vector<gr_complex>> d_taps;
     std::vector<std::vector<gr_complex>> d_dtaps;
     unsigned int d_int_rate;        // the number of filters (interpolation rate)
@@ -243,7 +243,7 @@ private:
      */
     void create_taps(const std::vector<gr_complex>& newtaps,
                      std::vector<std::vector<gr_complex>>& ourtaps,
-                     std::vector<kernel::fir_filter_ccc*>& ourfilter);
+                     std::vector<kernel::fir_filter_ccc>& ourfilter);
 
 public:
     /*!
@@ -399,8 +399,8 @@ public:
 class FILTER_API pfb_arb_resampler_fff
 {
 private:
-    std::vector<fir_filter_fff*> d_filters;
-    std::vector<fir_filter_fff*> d_diff_filters;
+    std::vector<fir_filter_fff> d_filters;
+    std::vector<fir_filter_fff> d_diff_filters;
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_dtaps;
     unsigned int d_int_rate;        // the number of filters (interpolation rate)
@@ -432,7 +432,7 @@ private:
      */
     void create_taps(const std::vector<float>& newtaps,
                      std::vector<std::vector<float>>& ourtaps,
-                     std::vector<kernel::fir_filter_fff*>& ourfilter);
+                     std::vector<kernel::fir_filter_fff>& ourfilter);
 
 public:
     /*!

--- a/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
+++ b/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
@@ -90,11 +90,11 @@ class FILTER_API polyphase_filterbank
 {
 protected:
     unsigned int d_nfilts;
-    std::vector<kernel::fir_filter_ccf*> d_fir_filters;
-    std::vector<kernel::fft_filter_ccf*> d_fft_filters;
+    std::vector<kernel::fir_filter_ccf> d_fir_filters;
+    std::vector<kernel::fft_filter_ccf> d_fft_filters;
     std::vector<std::vector<float>> d_taps;
     unsigned int d_taps_per_filter;
-    fft::fft_complex* d_fft;
+    fft::fft_complex d_fft;
 
 public:
     /*!

--- a/gr-filter/lib/dc_blocker_cc_impl.cc
+++ b/gr-filter/lib/dc_blocker_cc_impl.cc
@@ -14,15 +14,19 @@
 
 #include "dc_blocker_cc_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/make_unique.hpp>
 #include <cstdio>
 
 namespace gr {
 namespace filter {
 
 moving_averager_c::moving_averager_c(int D)
-    : d_length(D), d_out(0), d_out_d1(0), d_out_d2(0)
+    : d_length(D),
+      d_out(0),
+      d_out_d1(0),
+      d_out_d2(0),
+      d_delay_line(d_length - 1, gr_complex(0, 0))
 {
-    d_delay_line = std::deque<gr_complex>(d_length - 1, gr_complex(0, 0));
 }
 
 moving_averager_c::~moving_averager_c() {}
@@ -52,34 +56,18 @@ dc_blocker_cc_impl::dc_blocker_cc_impl(int D, bool long_form)
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
       d_length(D),
-      d_long_form(long_form)
+      d_long_form(long_form),
+      d_ma_0(D),
+      d_ma_1(D)
 {
     if (d_long_form) {
-        d_ma_0 = new moving_averager_c(D);
-        d_ma_1 = new moving_averager_c(D);
-        d_ma_2 = new moving_averager_c(D);
-        d_ma_3 = new moving_averager_c(D);
+        d_ma_2 = boost::make_unique<moving_averager_c>(D);
+        d_ma_3 = boost::make_unique<moving_averager_c>(D);
         d_delay_line = std::deque<gr_complex>(d_length - 1, gr_complex(0, 0));
-    } else {
-        d_ma_0 = new moving_averager_c(D);
-        d_ma_1 = new moving_averager_c(D);
-        d_ma_2 = NULL;
-        d_ma_3 = NULL;
     }
 }
 
-dc_blocker_cc_impl::~dc_blocker_cc_impl()
-{
-    if (d_long_form) {
-        delete d_ma_0;
-        delete d_ma_1;
-        delete d_ma_2;
-        delete d_ma_3;
-    } else {
-        delete d_ma_0;
-        delete d_ma_1;
-    }
-}
+dc_blocker_cc_impl::~dc_blocker_cc_impl() {}
 
 int dc_blocker_cc_impl::group_delay()
 {
@@ -99,12 +87,12 @@ int dc_blocker_cc_impl::work(int noutput_items,
     if (d_long_form) {
         gr_complex y1, y2, y3, y4, d;
         for (int i = 0; i < noutput_items; i++) {
-            y1 = d_ma_0->filter(in[i]);
-            y2 = d_ma_1->filter(y1);
+            y1 = d_ma_0.filter(in[i]);
+            y2 = d_ma_1.filter(y1);
             y3 = d_ma_2->filter(y2);
             y4 = d_ma_3->filter(y3);
 
-            d_delay_line.push_back(d_ma_0->delayed_sig());
+            d_delay_line.push_back(d_ma_0.delayed_sig());
             d = d_delay_line[0];
             d_delay_line.pop_front();
 
@@ -113,9 +101,9 @@ int dc_blocker_cc_impl::work(int noutput_items,
     } else {
         gr_complex y1, y2;
         for (int i = 0; i < noutput_items; i++) {
-            y1 = d_ma_0->filter(in[i]);
-            y2 = d_ma_1->filter(y1);
-            out[i] = d_ma_0->delayed_sig() - y2;
+            y1 = d_ma_0.filter(in[i]);
+            y2 = d_ma_1.filter(y1);
+            out[i] = d_ma_0.delayed_sig() - y2;
         }
     }
 

--- a/gr-filter/lib/dc_blocker_cc_impl.h
+++ b/gr-filter/lib/dc_blocker_cc_impl.h
@@ -28,7 +28,7 @@ public:
     gr_complex delayed_sig() { return d_out; }
 
 private:
-    int d_length;
+    const int d_length;
     gr_complex d_out, d_out_d1, d_out_d2;
     std::deque<gr_complex> d_delay_line;
 };
@@ -38,10 +38,10 @@ class FILTER_API dc_blocker_cc_impl : public dc_blocker_cc
 private:
     int d_length;
     bool d_long_form;
-    moving_averager_c* d_ma_0;
-    moving_averager_c* d_ma_1;
-    moving_averager_c* d_ma_2;
-    moving_averager_c* d_ma_3;
+    moving_averager_c d_ma_0;
+    moving_averager_c d_ma_1;
+    std::unique_ptr<moving_averager_c> d_ma_2;
+    std::unique_ptr<moving_averager_c> d_ma_3;
     std::deque<gr_complex> d_delay_line;
 
 public:

--- a/gr-filter/lib/dc_blocker_ff_impl.cc
+++ b/gr-filter/lib/dc_blocker_ff_impl.cc
@@ -14,15 +14,15 @@
 
 #include "dc_blocker_ff_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/make_unique.hpp>
 #include <cstdio>
 
 namespace gr {
 namespace filter {
 
 moving_averager_f::moving_averager_f(int D)
-    : d_length(D), d_out(0), d_out_d1(0), d_out_d2(0)
+    : d_length(D), d_out(0), d_out_d1(0), d_out_d2(0), d_delay_line(d_length - 1, 0)
 {
-    d_delay_line = std::deque<float>(d_length - 1, 0);
 }
 
 moving_averager_f::~moving_averager_f() {}
@@ -51,34 +51,18 @@ dc_blocker_ff_impl::dc_blocker_ff_impl(int D, bool long_form)
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(float))),
       d_length(D),
-      d_long_form(long_form)
+      d_long_form(long_form),
+      d_ma_0(D),
+      d_ma_1(D)
 {
     if (d_long_form) {
-        d_ma_0 = new moving_averager_f(D);
-        d_ma_1 = new moving_averager_f(D);
-        d_ma_2 = new moving_averager_f(D);
-        d_ma_3 = new moving_averager_f(D);
+        d_ma_2 = boost::make_unique<moving_averager_f>(D);
+        d_ma_3 = boost::make_unique<moving_averager_f>(D);
         d_delay_line = std::deque<float>(d_length - 1, 0);
-    } else {
-        d_ma_0 = new moving_averager_f(D);
-        d_ma_1 = new moving_averager_f(D);
-        d_ma_2 = NULL;
-        d_ma_3 = NULL;
     }
 }
 
-dc_blocker_ff_impl::~dc_blocker_ff_impl()
-{
-    if (d_long_form) {
-        delete d_ma_0;
-        delete d_ma_1;
-        delete d_ma_2;
-        delete d_ma_3;
-    } else {
-        delete d_ma_0;
-        delete d_ma_1;
-    }
-}
+dc_blocker_ff_impl::~dc_blocker_ff_impl() {}
 
 int dc_blocker_ff_impl::group_delay()
 {
@@ -98,12 +82,12 @@ int dc_blocker_ff_impl::work(int noutput_items,
     if (d_long_form) {
         float y1, y2, y3, y4, d;
         for (int i = 0; i < noutput_items; i++) {
-            y1 = d_ma_0->filter(in[i]);
-            y2 = d_ma_1->filter(y1);
+            y1 = d_ma_0.filter(in[i]);
+            y2 = d_ma_1.filter(y1);
             y3 = d_ma_2->filter(y2);
             y4 = d_ma_3->filter(y3);
 
-            d_delay_line.push_back(d_ma_0->delayed_sig());
+            d_delay_line.push_back(d_ma_0.delayed_sig());
             d = d_delay_line[0];
             d_delay_line.pop_front();
 
@@ -112,9 +96,9 @@ int dc_blocker_ff_impl::work(int noutput_items,
     } else {
         float y1, y2;
         for (int i = 0; i < noutput_items; i++) {
-            y1 = d_ma_0->filter(in[i]);
-            y2 = d_ma_1->filter(y1);
-            out[i] = d_ma_0->delayed_sig() - y2;
+            y1 = d_ma_0.filter(in[i]);
+            y2 = d_ma_1.filter(y1);
+            out[i] = d_ma_0.delayed_sig() - y2;
         }
     }
 

--- a/gr-filter/lib/dc_blocker_ff_impl.h
+++ b/gr-filter/lib/dc_blocker_ff_impl.h
@@ -38,10 +38,10 @@ class FILTER_API dc_blocker_ff_impl : public dc_blocker_ff
 private:
     int d_length;
     bool d_long_form;
-    moving_averager_f* d_ma_0;
-    moving_averager_f* d_ma_1;
-    moving_averager_f* d_ma_2;
-    moving_averager_f* d_ma_3;
+    moving_averager_f d_ma_0;
+    moving_averager_f d_ma_1;
+    std::unique_ptr<moving_averager_f> d_ma_2;
+    std::unique_ptr<moving_averager_f> d_ma_3;
     std::deque<float> d_delay_line;
 
 public:

--- a/gr-filter/lib/filter_delay_fc_impl.h
+++ b/gr-filter/lib/filter_delay_fc_impl.h
@@ -21,9 +21,9 @@ namespace filter {
 class FILTER_API filter_delay_fc_impl : public filter_delay_fc
 {
 private:
-    unsigned int d_delay;
-    kernel::fir_filter_fff* d_fir;
     std::vector<float> d_taps;
+    kernel::fir_filter_fff d_fir;
+    unsigned int d_delay;
     bool d_update;
 
 public:

--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -66,9 +66,7 @@ int filterbank_vcvcf_impl::general_work(int noutput_items,
         return 0; // history requirements may have changed.
     }
 
-    gr_complex* working;
-
-    working = new gr_complex[noutput_items + d_ntaps];
+    std::vector<gr_complex> working(noutput_items + d_ntaps);
 
     for (unsigned int i = 0; i < d_nfilts; i++) {
         // Only call the filter method on active filters.
@@ -79,7 +77,7 @@ int filterbank_vcvcf_impl::general_work(int noutput_items,
             }
             for (unsigned int j = 0; j < (unsigned int)(noutput_items); j++) {
                 unsigned int p = i + j * d_nfilts;
-                out[p] = d_fir_filters[i]->filter(working + j);
+                out[p] = d_fir_filters[i].filter(&working[j]);
             }
         } else {
             // Otherwise just output 0s.
@@ -90,7 +88,6 @@ int filterbank_vcvcf_impl::general_work(int noutput_items,
         }
     }
 
-    delete[] working;
     consume_each(noutput_items);
     return noutput_items;
 }

--- a/gr-filter/lib/fir_filter_blk_impl.cc
+++ b/gr-filter/lib/fir_filter_blk_impl.cc
@@ -34,11 +34,11 @@ fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::fir_filter_blk_impl(
     : sync_decimator("fir_filter_blk<IN_T,OUT_T,TAP_T>",
                      io_signature::make(1, 1, sizeof(IN_T)),
                      io_signature::make(1, 1, sizeof(OUT_T)),
-                     decimation)
+                     decimation),
+      d_fir(decimation, taps),
+      d_updated(false)
 {
-    d_fir = new kernel::fir_filter<IN_T, OUT_T, TAP_T>(decimation, taps);
-    d_updated = false;
-    this->set_history(d_fir->ntaps());
+    this->set_history(d_fir.ntaps());
 
     const int alignment_multiple = volk_get_alignment() / sizeof(float);
     this->set_alignment(std::max(1, alignment_multiple));
@@ -47,21 +47,20 @@ fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::fir_filter_blk_impl(
 template <class IN_T, class OUT_T, class TAP_T>
 fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::~fir_filter_blk_impl()
 {
-    delete d_fir;
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
 void fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::set_taps(const std::vector<TAP_T>& taps)
 {
     gr::thread::scoped_lock l(this->d_setlock);
-    d_fir->set_taps(taps);
+    d_fir.set_taps(taps);
     d_updated = true;
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
 std::vector<TAP_T> fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::taps() const
 {
-    return d_fir->taps();
+    return d_fir.taps();
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
@@ -75,15 +74,15 @@ int fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::work(int noutput_items,
     OUT_T* out = (OUT_T*)output_items[0];
 
     if (d_updated) {
-        this->set_history(d_fir->ntaps());
+        this->set_history(d_fir.ntaps());
         d_updated = false;
         return 0; // history requirements may have changed.
     }
 
     if (this->decimation() == 1) {
-        d_fir->filterN(out, in, noutput_items);
+        d_fir.filterN(out, in, noutput_items);
     } else {
-        d_fir->filterNdec(out, in, noutput_items, this->decimation());
+        d_fir.filterNdec(out, in, noutput_items, this->decimation());
     }
 
     return noutput_items;

--- a/gr-filter/lib/fir_filter_blk_impl.h
+++ b/gr-filter/lib/fir_filter_blk_impl.h
@@ -21,7 +21,7 @@ template <class IN_T, class OUT_T, class TAP_T>
 class FILTER_API fir_filter_blk_impl : public fir_filter_blk<IN_T, OUT_T, TAP_T>
 {
 private:
-    kernel::fir_filter<IN_T, OUT_T, TAP_T>* d_fir;
+    kernel::fir_filter<IN_T, OUT_T, TAP_T> d_fir;
     bool d_updated;
 
 public:

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.cc
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.cc
@@ -43,15 +43,12 @@ freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::freq_xlating_fir_filter_impl(
                      io_signature::make(1, 1, sizeof(OUT_T)),
                      decimation),
       d_proto_taps(taps),
+      d_composite_fir(decimation, {}),
       d_center_freq(center_freq),
       d_sampling_freq(sampling_freq),
       d_updated(false),
       d_decim(decimation)
 {
-    std::vector<gr_complex> dummy_taps;
-    d_composite_fir =
-        new kernel::fir_filter<IN_T, OUT_T, gr_complex>(decimation, dummy_taps);
-
     this->set_history(this->d_proto_taps.size());
     this->build_composite_fir();
 
@@ -63,7 +60,6 @@ freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::freq_xlating_fir_filter_impl(
 template <class IN_T, class OUT_T, class TAP_T>
 freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::~freq_xlating_fir_filter_impl()
 {
-    delete d_composite_fir;
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
@@ -84,7 +80,7 @@ void freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::build_composite_fir()
         ctaps[i] = d_proto_taps[i] * exp(gr_complex(0, i * fwT0));
     }
 
-    d_composite_fir->set_taps(ctaps);
+    d_composite_fir.set_taps(ctaps);
     d_r.set_phase_incr(exp(gr_complex(0, -fwT0 * this->decimation())));
 }
 
@@ -160,7 +156,7 @@ int freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::work(
 
     unsigned j = 0;
     for (int i = 0; i < noutput_items; i++) {
-        out[i] = d_composite_fir->filter(&in[j]);
+        out[i] = d_composite_fir.filter(&in[j]);
         j += d_decim;
     }
 

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.h
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.h
@@ -25,7 +25,7 @@ class FILTER_API freq_xlating_fir_filter_impl
 {
 protected:
     std::vector<TAP_T> d_proto_taps;
-    kernel::fir_filter<IN_T, OUT_T, gr_complex>* d_composite_fir;
+    kernel::fir_filter<IN_T, OUT_T, gr_complex> d_composite_fir;
     blocks::rotator d_r;
     double d_center_freq;
     double d_sampling_freq;

--- a/gr-filter/lib/hilbert_fc_impl.cc
+++ b/gr-filter/lib/hilbert_fc_impl.cc
@@ -29,16 +29,16 @@ hilbert_fc_impl::hilbert_fc_impl(unsigned int ntaps, firdes::win_type window, do
     : sync_block("hilbert_fc",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      d_ntaps(ntaps | 0x1) // ensure ntaps is odd
+      d_ntaps(ntaps | 0x1), // ensure ntaps is odd
+      d_hilb(1, firdes::hilbert(d_ntaps, window, beta))
 {
-    d_hilb = new kernel::fir_filter_fff(1, firdes::hilbert(d_ntaps, window, beta));
     set_history(d_ntaps);
 
     const int alignment_multiple = volk_get_alignment() / sizeof(float);
     set_alignment(std::max(1, alignment_multiple));
 }
 
-hilbert_fc_impl::~hilbert_fc_impl() { delete d_hilb; }
+hilbert_fc_impl::~hilbert_fc_impl() {}
 
 int hilbert_fc_impl::work(int noutput_items,
                           gr_vector_const_void_star& input_items,
@@ -48,7 +48,7 @@ int hilbert_fc_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     for (int i = 0; i < noutput_items; i++) {
-        out[i] = gr_complex(in[i + d_ntaps / 2], d_hilb->filter(&in[i]));
+        out[i] = gr_complex(in[i + d_ntaps / 2], d_hilb.filter(&in[i]));
     }
 
     return noutput_items;

--- a/gr-filter/lib/hilbert_fc_impl.h
+++ b/gr-filter/lib/hilbert_fc_impl.h
@@ -22,7 +22,7 @@ class FILTER_API hilbert_fc_impl : public hilbert_fc
 {
 private:
     unsigned int d_ntaps;
-    kernel::fir_filter_fff* d_hilb;
+    kernel::fir_filter_fff d_hilb;
 
 public:
     hilbert_fc_impl(unsigned int ntaps,

--- a/gr-filter/lib/iir_filter_ccc_impl.cc
+++ b/gr-filter/lib/iir_filter_ccc_impl.cc
@@ -32,13 +32,12 @@ iir_filter_ccc_impl::iir_filter_ccc_impl(const std::vector<gr_complex>& fftaps,
     : sync_block("iir_filter_ccc",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      d_updated(false)
+      d_updated(false),
+      d_iir(fftaps, fbtaps, oldstyle)
 {
-    d_iir = new kernel::iir_filter<gr_complex, gr_complex, gr_complex, gr_complex>(
-        fftaps, fbtaps, oldstyle);
 }
 
-iir_filter_ccc_impl::~iir_filter_ccc_impl() { delete d_iir; }
+iir_filter_ccc_impl::~iir_filter_ccc_impl() {}
 
 void iir_filter_ccc_impl::set_taps(const std::vector<gr_complex>& fftaps,
                                    const std::vector<gr_complex>& fbtaps)
@@ -56,11 +55,11 @@ int iir_filter_ccc_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
-        d_iir->set_taps(d_new_fftaps, d_new_fbtaps);
+        d_iir.set_taps(d_new_fftaps, d_new_fbtaps);
         d_updated = false;
     }
 
-    d_iir->filter_n(out, in, noutput_items);
+    d_iir.filter_n(out, in, noutput_items);
     return noutput_items;
 };
 

--- a/gr-filter/lib/iir_filter_ccc_impl.h
+++ b/gr-filter/lib/iir_filter_ccc_impl.h
@@ -21,7 +21,7 @@ class FILTER_API iir_filter_ccc_impl : public iir_filter_ccc
 {
 private:
     bool d_updated;
-    kernel::iir_filter<gr_complex, gr_complex, gr_complex, gr_complex>* d_iir;
+    kernel::iir_filter<gr_complex, gr_complex, gr_complex, gr_complex> d_iir;
     std::vector<gr_complex> d_new_fftaps;
     std::vector<gr_complex> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ccd_impl.cc
+++ b/gr-filter/lib/iir_filter_ccd_impl.cc
@@ -32,13 +32,12 @@ iir_filter_ccd_impl::iir_filter_ccd_impl(const std::vector<double>& fftaps,
     : sync_block("iir_filter_ccd",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      d_updated(false)
+      d_updated(false),
+      d_iir(fftaps, fbtaps, oldstyle)
 {
-    d_iir = new kernel::iir_filter<gr_complex, gr_complex, double, gr_complexd>(
-        fftaps, fbtaps, oldstyle);
 }
 
-iir_filter_ccd_impl::~iir_filter_ccd_impl() { delete d_iir; }
+iir_filter_ccd_impl::~iir_filter_ccd_impl() {}
 
 void iir_filter_ccd_impl::set_taps(const std::vector<double>& fftaps,
                                    const std::vector<double>& fbtaps)
@@ -56,11 +55,11 @@ int iir_filter_ccd_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
-        d_iir->set_taps(d_new_fftaps, d_new_fbtaps);
+        d_iir.set_taps(d_new_fftaps, d_new_fbtaps);
         d_updated = false;
     }
 
-    d_iir->filter_n(out, in, noutput_items);
+    d_iir.filter_n(out, in, noutput_items);
     return noutput_items;
 };
 

--- a/gr-filter/lib/iir_filter_ccd_impl.h
+++ b/gr-filter/lib/iir_filter_ccd_impl.h
@@ -21,7 +21,7 @@ class FILTER_API iir_filter_ccd_impl : public iir_filter_ccd
 {
 private:
     bool d_updated;
-    kernel::iir_filter<gr_complex, gr_complex, double, gr_complexd>* d_iir;
+    kernel::iir_filter<gr_complex, gr_complex, double, gr_complexd> d_iir;
     std::vector<double> d_new_fftaps;
     std::vector<double> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ccf_impl.cc
+++ b/gr-filter/lib/iir_filter_ccf_impl.cc
@@ -32,13 +32,12 @@ iir_filter_ccf_impl::iir_filter_ccf_impl(const std::vector<float>& fftaps,
     : sync_block("iir_filter_ccf",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      d_updated(false)
+      d_updated(false),
+      d_iir(fftaps, fbtaps, oldstyle)
 {
-    d_iir = new kernel::iir_filter<gr_complex, gr_complex, float, gr_complex>(
-        fftaps, fbtaps, oldstyle);
 }
 
-iir_filter_ccf_impl::~iir_filter_ccf_impl() { delete d_iir; }
+iir_filter_ccf_impl::~iir_filter_ccf_impl() {}
 
 void iir_filter_ccf_impl::set_taps(const std::vector<float>& fftaps,
                                    const std::vector<float>& fbtaps)
@@ -56,11 +55,11 @@ int iir_filter_ccf_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
-        d_iir->set_taps(d_new_fftaps, d_new_fbtaps);
+        d_iir.set_taps(d_new_fftaps, d_new_fbtaps);
         d_updated = false;
     }
 
-    d_iir->filter_n(out, in, noutput_items);
+    d_iir.filter_n(out, in, noutput_items);
     return noutput_items;
 };
 

--- a/gr-filter/lib/iir_filter_ccf_impl.h
+++ b/gr-filter/lib/iir_filter_ccf_impl.h
@@ -21,7 +21,7 @@ class FILTER_API iir_filter_ccf_impl : public iir_filter_ccf
 {
 private:
     bool d_updated;
-    kernel::iir_filter<gr_complex, gr_complex, float, gr_complex>* d_iir;
+    kernel::iir_filter<gr_complex, gr_complex, float, gr_complex> d_iir;
     std::vector<float> d_new_fftaps;
     std::vector<float> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ccz_impl.cc
+++ b/gr-filter/lib/iir_filter_ccz_impl.cc
@@ -32,13 +32,12 @@ iir_filter_ccz_impl::iir_filter_ccz_impl(const std::vector<gr_complexd>& fftaps,
     : sync_block("iir_filter_ccz",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      d_updated(false)
+      d_updated(false),
+      d_iir(fftaps, fbtaps, oldstyle)
 {
-    d_iir = new kernel::iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd>(
-        fftaps, fbtaps, oldstyle);
 }
 
-iir_filter_ccz_impl::~iir_filter_ccz_impl() { delete d_iir; }
+iir_filter_ccz_impl::~iir_filter_ccz_impl() {}
 
 void iir_filter_ccz_impl::set_taps(const std::vector<gr_complexd>& fftaps,
                                    const std::vector<gr_complexd>& fbtaps)
@@ -56,11 +55,11 @@ int iir_filter_ccz_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     if (d_updated) {
-        d_iir->set_taps(d_new_fftaps, d_new_fbtaps);
+        d_iir.set_taps(d_new_fftaps, d_new_fbtaps);
         d_updated = false;
     }
 
-    d_iir->filter_n(out, in, noutput_items);
+    d_iir.filter_n(out, in, noutput_items);
     return noutput_items;
 };
 

--- a/gr-filter/lib/iir_filter_ccz_impl.h
+++ b/gr-filter/lib/iir_filter_ccz_impl.h
@@ -21,7 +21,7 @@ class FILTER_API iir_filter_ccz_impl : public iir_filter_ccz
 {
 private:
     bool d_updated;
-    kernel::iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd>* d_iir;
+    kernel::iir_filter<gr_complex, gr_complex, gr_complexd, gr_complexd> d_iir;
     std::vector<gr_complexd> d_new_fftaps;
     std::vector<gr_complexd> d_new_fbtaps;
 

--- a/gr-filter/lib/iir_filter_ffd_impl.cc
+++ b/gr-filter/lib/iir_filter_ffd_impl.cc
@@ -32,13 +32,12 @@ iir_filter_ffd_impl::iir_filter_ffd_impl(const std::vector<double>& fftaps,
     : sync_block("iir_filter_ffd",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(float))),
-      d_updated(false)
+      d_updated(false),
+      d_iir(fftaps, fbtaps, oldstyle)
 {
-    d_iir =
-        new kernel::iir_filter<float, float, double, double>(fftaps, fbtaps, oldstyle);
 }
 
-iir_filter_ffd_impl::~iir_filter_ffd_impl() { delete d_iir; }
+iir_filter_ffd_impl::~iir_filter_ffd_impl() {}
 
 void iir_filter_ffd_impl::set_taps(const std::vector<double>& fftaps,
                                    const std::vector<double>& fbtaps)
@@ -56,11 +55,11 @@ int iir_filter_ffd_impl::work(int noutput_items,
     float* out = (float*)output_items[0];
 
     if (d_updated) {
-        d_iir->set_taps(d_new_fftaps, d_new_fbtaps);
+        d_iir.set_taps(d_new_fftaps, d_new_fbtaps);
         d_updated = false;
     }
 
-    d_iir->filter_n(out, in, noutput_items);
+    d_iir.filter_n(out, in, noutput_items);
     return noutput_items;
 }
 

--- a/gr-filter/lib/iir_filter_ffd_impl.h
+++ b/gr-filter/lib/iir_filter_ffd_impl.h
@@ -21,7 +21,7 @@ class FILTER_API iir_filter_ffd_impl : public iir_filter_ffd
 {
 private:
     bool d_updated;
-    kernel::iir_filter<float, float, double, double>* d_iir;
+    kernel::iir_filter<float, float, double, double> d_iir;
     std::vector<double> d_new_fftaps;
     std::vector<double> d_new_fbtaps;
 

--- a/gr-filter/lib/interp_fir_filter_impl.cc
+++ b/gr-filter/lib/interp_fir_filter_impl.cc
@@ -36,8 +36,7 @@ interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::interp_fir_filter_impl(
                         io_signature::make(1, 1, sizeof(IN_T)),
                         io_signature::make(1, 1, sizeof(OUT_T)),
                         interpolation),
-      d_updated(false),
-      d_firs(interpolation)
+      d_updated(false)
 {
     if (interpolation == 0) {
         throw std::out_of_range("interp_fir_filter_impl: interpolation must be > 0");
@@ -49,8 +48,9 @@ interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::interp_fir_filter_impl(
 
     std::vector<TAP_T> dummy_taps;
 
+    d_firs.reserve(interpolation);
     for (unsigned i = 0; i < interpolation; i++) {
-        d_firs[i] = new kernel::fir_filter<IN_T, OUT_T, TAP_T>(1, dummy_taps);
+        d_firs.emplace_back(1, dummy_taps);
     }
 
     set_taps(taps);
@@ -60,9 +60,6 @@ interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::interp_fir_filter_impl(
 template <class IN_T, class OUT_T, class TAP_T>
 interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::~interp_fir_filter_impl()
 {
-    for (unsigned i = 0; i < this->interpolation(); i++) {
-        delete d_firs[i];
-    }
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
@@ -104,7 +101,7 @@ void interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::install_taps(
     }
 
     for (unsigned n = 0; n < nfilters; n++) {
-        d_firs[n]->set_taps(xtaps[n]);
+        d_firs[n].set_taps(xtaps[n]);
     }
 
     this->set_history(nt);
@@ -136,7 +133,7 @@ int interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::work(
 
     for (int i = 0; i < ni; i++) {
         for (int nf = 0; nf < nfilters; nf++) {
-            out[nf] = d_firs[nf]->filter(&in[i]);
+            out[nf] = d_firs[nf].filter(&in[i]);
         }
         out += nfilters;
     }

--- a/gr-filter/lib/interp_fir_filter_impl.h
+++ b/gr-filter/lib/interp_fir_filter_impl.h
@@ -24,7 +24,7 @@ class FILTER_API interp_fir_filter_impl : public interp_fir_filter<IN_T, OUT_T, 
 {
 private:
     bool d_updated;
-    std::vector<kernel::fir_filter<IN_T, OUT_T, TAP_T>*> d_firs;
+    std::vector<kernel::fir_filter<IN_T, OUT_T, TAP_T>> d_firs;
     std::vector<TAP_T> d_new_taps;
 
     void install_taps(const std::vector<TAP_T>& taps);

--- a/gr-filter/lib/mmse_fir_interpolator_cc.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_cc.cc
@@ -19,21 +19,22 @@
 namespace gr {
 namespace filter {
 
-mmse_fir_interpolator_cc::mmse_fir_interpolator_cc()
+namespace {
+std::vector<kernel::fir_filter_ccf> build_filters()
 {
-    filters.resize(NSTEPS + 1);
-
+    std::vector<kernel::fir_filter_ccf> filters;
+    filters.reserve(NSTEPS + 1);
     for (int i = 0; i < NSTEPS + 1; i++) {
         std::vector<float> t(&taps[i][0], &taps[i][NTAPS]);
-        filters[i] = new kernel::fir_filter_ccf(1, t);
+        filters.emplace_back(1, t);
     }
+    return filters;
 }
+} // namespace
 
-mmse_fir_interpolator_cc::~mmse_fir_interpolator_cc()
-{
-    for (int i = 0; i < NSTEPS + 1; i++)
-        delete filters[i];
-}
+mmse_fir_interpolator_cc::mmse_fir_interpolator_cc() : filters(build_filters()) {}
+
+mmse_fir_interpolator_cc::~mmse_fir_interpolator_cc() {}
 
 unsigned mmse_fir_interpolator_cc::ntaps() const { return NTAPS; }
 
@@ -47,7 +48,7 @@ gr_complex mmse_fir_interpolator_cc::interpolate(const gr_complex input[], float
         throw std::runtime_error("mmse_fir_interpolator_cc: imu out of bounds.");
     }
 
-    gr_complex r = filters[imu]->filter(input);
+    gr_complex r = filters[imu].filter(input);
     return r;
 }
 

--- a/gr-filter/lib/mmse_fir_interpolator_ff.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_ff.cc
@@ -19,21 +19,22 @@
 namespace gr {
 namespace filter {
 
-mmse_fir_interpolator_ff::mmse_fir_interpolator_ff()
+namespace {
+std::vector<kernel::fir_filter_fff> build_filters()
 {
-    filters.resize(NSTEPS + 1);
-
+    std::vector<kernel::fir_filter_fff> filters;
+    filters.reserve(NSTEPS + 1);
     for (int i = 0; i < NSTEPS + 1; i++) {
         std::vector<float> t(&taps[i][0], &taps[i][NTAPS]);
-        filters[i] = new kernel::fir_filter_fff(1, t);
+        filters.emplace_back(1, t);
     }
+    return filters;
 }
+} // namespace
 
-mmse_fir_interpolator_ff::~mmse_fir_interpolator_ff()
-{
-    for (int i = 0; i < NSTEPS + 1; i++)
-        delete filters[i];
-}
+mmse_fir_interpolator_ff::mmse_fir_interpolator_ff() : filters(build_filters()) {}
+
+mmse_fir_interpolator_ff::~mmse_fir_interpolator_ff() {}
 
 unsigned mmse_fir_interpolator_ff::ntaps() const { return NTAPS; }
 
@@ -47,7 +48,7 @@ float mmse_fir_interpolator_ff::interpolate(const float input[], float mu) const
         throw std::runtime_error("mmse_fir_interpolator_ff: imu out of bounds.");
     }
 
-    float r = filters[imu]->filter(input);
+    float r = filters[imu].filter(input);
     return r;
 }
 

--- a/gr-filter/lib/mmse_interp_differentiator_cc.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_cc.cc
@@ -19,21 +19,25 @@
 namespace gr {
 namespace filter {
 
-mmse_interp_differentiator_cc::mmse_interp_differentiator_cc()
+namespace {
+std::vector<kernel::fir_filter_ccf> build_filters()
 {
-    filters.resize(DNSTEPS + 1);
-
+    std::vector<kernel::fir_filter_ccf> filters;
+    filters.reserve(DNSTEPS + 1);
     for (int i = 0; i < DNSTEPS + 1; i++) {
         std::vector<float> t(&Dtaps[i][0], &Dtaps[i][DNTAPS]);
-        filters[i] = new kernel::fir_filter_ccf(1, t);
+        filters.emplace_back(1, t);
     }
+    return filters;
+}
+} // namespace
+
+
+mmse_interp_differentiator_cc::mmse_interp_differentiator_cc() : filters(build_filters())
+{
 }
 
-mmse_interp_differentiator_cc::~mmse_interp_differentiator_cc()
-{
-    for (int i = 0; i < DNSTEPS + 1; i++)
-        delete filters[i];
-}
+mmse_interp_differentiator_cc::~mmse_interp_differentiator_cc() {}
 
 unsigned mmse_interp_differentiator_cc::ntaps() const { return DNTAPS; }
 
@@ -48,7 +52,7 @@ gr_complex mmse_interp_differentiator_cc::differentiate(const gr_complex input[]
         throw std::runtime_error("mmse_interp_differentiator_cc: imu out of bounds.");
     }
 
-    gr_complex r = filters[imu]->filter(input);
+    gr_complex r = filters[imu].filter(input);
     return r;
 }
 

--- a/gr-filter/lib/mmse_interp_differentiator_ff.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_ff.cc
@@ -19,21 +19,24 @@
 namespace gr {
 namespace filter {
 
-mmse_interp_differentiator_ff::mmse_interp_differentiator_ff()
+namespace {
+std::vector<kernel::fir_filter_fff> build_filters()
 {
-    filters.resize(DNSTEPS + 1);
-
+    std::vector<kernel::fir_filter_fff> filters;
+    filters.reserve(DNSTEPS + 1);
     for (int i = 0; i < DNSTEPS + 1; i++) {
         std::vector<float> t(&Dtaps[i][0], &Dtaps[i][DNTAPS]);
-        filters[i] = new kernel::fir_filter_fff(1, t);
+        filters.emplace_back(1, t);
     }
+    return filters;
+}
+} // namespace
+
+mmse_interp_differentiator_ff::mmse_interp_differentiator_ff() : filters(build_filters())
+{
 }
 
-mmse_interp_differentiator_ff::~mmse_interp_differentiator_ff()
-{
-    for (int i = 0; i < DNSTEPS + 1; i++)
-        delete filters[i];
-}
+mmse_interp_differentiator_ff::~mmse_interp_differentiator_ff() {}
 
 unsigned mmse_interp_differentiator_ff::ntaps() const { return DNTAPS; }
 
@@ -47,7 +50,7 @@ float mmse_interp_differentiator_ff::differentiate(const float input[], float mu
         throw std::runtime_error("mmse_interp_differentiator_ff: imu out of bounds.");
     }
 
-    float r = filters[imu]->filter(input);
+    float r = filters[imu].filter(input);
     return r;
 }
 

--- a/gr-filter/lib/mmse_interpolator_cc_impl.cc
+++ b/gr-filter/lib/mmse_interpolator_cc_impl.cc
@@ -32,8 +32,7 @@ mmse_interpolator_cc_impl::mmse_interpolator_cc_impl(float phase_shift,
             io_signature::make(1, 1, sizeof(gr_complex)),
             io_signature::make(1, 1, sizeof(gr_complex))),
       d_mu(phase_shift),
-      d_mu_inc(interp_ratio),
-      d_interp(new mmse_fir_interpolator_cc())
+      d_mu_inc(interp_ratio)
 {
     GR_LOG_WARN(d_logger,
                 "mmse_interpolator is deprecated. Please use mmse_resampler instead.");
@@ -46,7 +45,7 @@ mmse_interpolator_cc_impl::mmse_interpolator_cc_impl(float phase_shift,
     set_inverse_relative_rate(d_mu_inc);
 }
 
-mmse_interpolator_cc_impl::~mmse_interpolator_cc_impl() { delete d_interp; }
+mmse_interpolator_cc_impl::~mmse_interpolator_cc_impl() {}
 
 void mmse_interpolator_cc_impl::forecast(int noutput_items,
                                          gr_vector_int& ninput_items_required)
@@ -54,7 +53,7 @@ void mmse_interpolator_cc_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_mu_inc) + d_interp->ntaps());
+            (int)ceil((noutput_items * d_mu_inc) + d_interp.ntaps());
     }
 }
 
@@ -70,7 +69,7 @@ int mmse_interpolator_cc_impl::general_work(int noutput_items,
     int oo = 0; // output index
 
     while (oo < noutput_items) {
-        out[oo++] = d_interp->interpolate(&in[ii], static_cast<float>(d_mu));
+        out[oo++] = d_interp.interpolate(&in[ii], static_cast<float>(d_mu));
 
         double s = d_mu + d_mu_inc;
         double f = floor(s);

--- a/gr-filter/lib/mmse_interpolator_cc_impl.h
+++ b/gr-filter/lib/mmse_interpolator_cc_impl.h
@@ -22,7 +22,7 @@ class FILTER_API mmse_interpolator_cc_impl : public mmse_interpolator_cc
 private:
     double d_mu;
     double d_mu_inc;
-    mmse_fir_interpolator_cc* d_interp;
+    mmse_fir_interpolator_cc d_interp;
 
 public:
     mmse_interpolator_cc_impl(float phase_shift, float interp_ratio);

--- a/gr-filter/lib/mmse_interpolator_ff_impl.cc
+++ b/gr-filter/lib/mmse_interpolator_ff_impl.cc
@@ -32,8 +32,7 @@ mmse_interpolator_ff_impl::mmse_interpolator_ff_impl(float phase_shift,
             io_signature::make(1, 1, sizeof(float)),
             io_signature::make(1, 1, sizeof(float))),
       d_mu(phase_shift),
-      d_mu_inc(interp_ratio),
-      d_interp(new mmse_fir_interpolator_ff())
+      d_mu_inc(interp_ratio)
 {
     GR_LOG_WARN(d_logger,
                 "mmse_interpolator is deprecated. Please use mmse_resampler instead.");
@@ -46,7 +45,7 @@ mmse_interpolator_ff_impl::mmse_interpolator_ff_impl(float phase_shift,
     set_inverse_relative_rate(d_mu_inc);
 }
 
-mmse_interpolator_ff_impl::~mmse_interpolator_ff_impl() { delete d_interp; }
+mmse_interpolator_ff_impl::~mmse_interpolator_ff_impl() {}
 
 void mmse_interpolator_ff_impl::forecast(int noutput_items,
                                          gr_vector_int& ninput_items_required)
@@ -54,7 +53,7 @@ void mmse_interpolator_ff_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_mu_inc) + d_interp->ntaps());
+            (int)ceil((noutput_items * d_mu_inc) + d_interp.ntaps());
     }
 }
 
@@ -70,7 +69,7 @@ int mmse_interpolator_ff_impl::general_work(int noutput_items,
     int oo = 0; // output index
 
     while (oo < noutput_items) {
-        out[oo++] = d_interp->interpolate(&in[ii], static_cast<float>(d_mu));
+        out[oo++] = d_interp.interpolate(&in[ii], static_cast<float>(d_mu));
 
         double s = d_mu + d_mu_inc;
         double f = floor(s);

--- a/gr-filter/lib/mmse_interpolator_ff_impl.h
+++ b/gr-filter/lib/mmse_interpolator_ff_impl.h
@@ -22,7 +22,7 @@ class FILTER_API mmse_interpolator_ff_impl : public mmse_interpolator_ff
 private:
     double d_mu;
     double d_mu_inc;
-    mmse_fir_interpolator_ff* d_interp;
+    mmse_fir_interpolator_ff d_interp;
 
 public:
     mmse_interpolator_ff_impl(float phase_shift, float interp_ratio);

--- a/gr-filter/lib/mmse_resampler_cc_impl.cc
+++ b/gr-filter/lib/mmse_resampler_cc_impl.cc
@@ -30,8 +30,7 @@ mmse_resampler_cc_impl::mmse_resampler_cc_impl(float phase_shift, float resamp_r
             io_signature::make2(1, 2, sizeof(gr_complex), sizeof(float)),
             io_signature::make(1, 1, sizeof(gr_complex))),
       d_mu(phase_shift),
-      d_mu_inc(resamp_ratio),
-      d_resamp(new mmse_fir_interpolator_cc())
+      d_mu_inc(resamp_ratio)
 {
     if (resamp_ratio <= 0)
         throw std::out_of_range("resampling ratio must be > 0");
@@ -44,7 +43,7 @@ mmse_resampler_cc_impl::mmse_resampler_cc_impl(float phase_shift, float resamp_r
                     [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
-mmse_resampler_cc_impl::~mmse_resampler_cc_impl() { delete d_resamp; }
+mmse_resampler_cc_impl::~mmse_resampler_cc_impl() {}
 
 void mmse_resampler_cc_impl::handle_msg(pmt::pmt_t msg)
 {
@@ -67,7 +66,7 @@ void mmse_resampler_cc_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_mu_inc) + d_resamp->ntaps());
+            (int)ceil((noutput_items * d_mu_inc) + d_resamp.ntaps());
     }
 }
 
@@ -84,7 +83,7 @@ int mmse_resampler_cc_impl::general_work(int noutput_items,
 
     if (ninput_items.size() == 1) {
         while (oo < noutput_items) {
-            out[oo++] = d_resamp->interpolate(&in[ii], static_cast<float>(d_mu));
+            out[oo++] = d_resamp.interpolate(&in[ii], static_cast<float>(d_mu));
 
             double s = d_mu + d_mu_inc;
             double f = floor(s);
@@ -100,7 +99,7 @@ int mmse_resampler_cc_impl::general_work(int noutput_items,
     else {
         const float* rr = (const float*)input_items[1];
         while (oo < noutput_items) {
-            out[oo++] = d_resamp->interpolate(&in[ii], static_cast<float>(d_mu));
+            out[oo++] = d_resamp.interpolate(&in[ii], static_cast<float>(d_mu));
             d_mu_inc = static_cast<double>(rr[ii]);
 
             double s = d_mu + d_mu_inc;

--- a/gr-filter/lib/mmse_resampler_cc_impl.h
+++ b/gr-filter/lib/mmse_resampler_cc_impl.h
@@ -22,7 +22,7 @@ class FILTER_API mmse_resampler_cc_impl : public mmse_resampler_cc
 private:
     double d_mu;
     double d_mu_inc;
-    mmse_fir_interpolator_cc* d_resamp;
+    const mmse_fir_interpolator_cc d_resamp;
 
 public:
     mmse_resampler_cc_impl(float phase_shift, float resamp_ratio);

--- a/gr-filter/lib/mmse_resampler_ff_impl.cc
+++ b/gr-filter/lib/mmse_resampler_ff_impl.cc
@@ -30,8 +30,7 @@ mmse_resampler_ff_impl::mmse_resampler_ff_impl(float phase_shift, float resamp_r
             io_signature::make(1, 2, sizeof(float)),
             io_signature::make(1, 1, sizeof(float))),
       d_mu(phase_shift),
-      d_mu_inc(resamp_ratio),
-      d_resamp(new mmse_fir_interpolator_ff())
+      d_mu_inc(resamp_ratio)
 {
     if (resamp_ratio <= 0)
         throw std::out_of_range("resampling ratio must be > 0");
@@ -45,7 +44,7 @@ mmse_resampler_ff_impl::mmse_resampler_ff_impl(float phase_shift, float resamp_r
                     [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
-mmse_resampler_ff_impl::~mmse_resampler_ff_impl() { delete d_resamp; }
+mmse_resampler_ff_impl::~mmse_resampler_ff_impl() {}
 
 void mmse_resampler_ff_impl::handle_msg(pmt::pmt_t msg)
 {
@@ -68,7 +67,7 @@ void mmse_resampler_ff_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_mu_inc) + d_resamp->ntaps());
+            (int)ceil((noutput_items * d_mu_inc) + d_resamp.ntaps());
     }
 }
 
@@ -85,7 +84,7 @@ int mmse_resampler_ff_impl::general_work(int noutput_items,
 
     if (ninput_items.size() == 1) {
         while (oo < noutput_items) {
-            out[oo++] = d_resamp->interpolate(&in[ii], static_cast<float>(d_mu));
+            out[oo++] = d_resamp.interpolate(&in[ii], static_cast<float>(d_mu));
 
             double s = d_mu + d_mu_inc;
             double f = floor(s);
@@ -99,7 +98,7 @@ int mmse_resampler_ff_impl::general_work(int noutput_items,
     } else {
         const float* rr = (const float*)input_items[1];
         while (oo < noutput_items) {
-            out[oo++] = d_resamp->interpolate(&in[ii], static_cast<float>(d_mu));
+            out[oo++] = d_resamp.interpolate(&in[ii], static_cast<float>(d_mu));
             d_mu_inc = static_cast<double>(rr[ii]);
 
             double s = d_mu + d_mu_inc;

--- a/gr-filter/lib/mmse_resampler_ff_impl.h
+++ b/gr-filter/lib/mmse_resampler_ff_impl.h
@@ -22,7 +22,7 @@ class FILTER_API mmse_resampler_ff_impl : public mmse_resampler_ff
 private:
     double d_mu;
     double d_mu_inc;
-    mmse_fir_interpolator_ff* d_resamp;
+    const mmse_fir_interpolator_ff d_resamp;
 
 public:
     mmse_resampler_ff_impl(float phase_shift, float resamp_ratio);

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
@@ -31,16 +31,16 @@ pfb_arb_resampler_ccc_impl::pfb_arb_resampler_ccc_impl(
     float rate, const std::vector<gr_complex>& taps, unsigned int filter_size)
     : block("pfb_arb_resampler_ccc",
             io_signature::make(1, 1, sizeof(gr_complex)),
-            io_signature::make(1, 1, sizeof(gr_complex)))
+            io_signature::make(1, 1, sizeof(gr_complex))),
+      d_resamp(rate, taps, filter_size)
 {
     d_updated = false;
 
-    d_resamp = new kernel::pfb_arb_resampler_ccc(rate, taps, filter_size);
-    set_history(d_resamp->taps_per_filter());
+    set_history(d_resamp.taps_per_filter());
     set_relative_rate(rate);
 }
 
-pfb_arb_resampler_ccc_impl::~pfb_arb_resampler_ccc_impl() { delete d_resamp; }
+pfb_arb_resampler_ccc_impl::~pfb_arb_resampler_ccc_impl() {}
 
 void pfb_arb_resampler_ccc_impl::forecast(int noutput_items,
                                           gr_vector_int& ninput_items_required)
@@ -59,59 +59,59 @@ void pfb_arb_resampler_ccc_impl::set_taps(const std::vector<gr_complex>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    d_resamp->set_taps(taps);
-    set_history(d_resamp->taps_per_filter());
+    d_resamp.set_taps(taps);
+    set_history(d_resamp.taps_per_filter());
     d_updated = true;
 }
 
 std::vector<std::vector<gr_complex>> pfb_arb_resampler_ccc_impl::taps() const
 {
-    return d_resamp->taps();
+    return d_resamp.taps();
 }
 
-void pfb_arb_resampler_ccc_impl::print_taps() { d_resamp->print_taps(); }
+void pfb_arb_resampler_ccc_impl::print_taps() { d_resamp.print_taps(); }
 
 void pfb_arb_resampler_ccc_impl::set_rate(float rate)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    d_resamp->set_rate(rate);
+    d_resamp.set_rate(rate);
     set_relative_rate(rate);
 }
 
 void pfb_arb_resampler_ccc_impl::set_phase(float ph)
 {
     gr::thread::scoped_lock guard(d_mutex);
-    d_resamp->set_phase(ph);
+    d_resamp.set_phase(ph);
 }
 
-float pfb_arb_resampler_ccc_impl::phase() const { return d_resamp->phase(); }
+float pfb_arb_resampler_ccc_impl::phase() const { return d_resamp.phase(); }
 
 unsigned int pfb_arb_resampler_ccc_impl::interpolation_rate() const
 {
-    return d_resamp->interpolation_rate();
+    return d_resamp.interpolation_rate();
 }
 
 unsigned int pfb_arb_resampler_ccc_impl::decimation_rate() const
 {
-    return d_resamp->decimation_rate();
+    return d_resamp.decimation_rate();
 }
 
 float pfb_arb_resampler_ccc_impl::fractional_rate() const
 {
-    return d_resamp->fractional_rate();
+    return d_resamp.fractional_rate();
 }
 
 unsigned int pfb_arb_resampler_ccc_impl::taps_per_filter() const
 {
-    return d_resamp->taps_per_filter();
+    return d_resamp.taps_per_filter();
 }
 
-int pfb_arb_resampler_ccc_impl::group_delay() const { return d_resamp->group_delay(); }
+int pfb_arb_resampler_ccc_impl::group_delay() const { return d_resamp.group_delay(); }
 
 float pfb_arb_resampler_ccc_impl::phase_offset(float freq, float fs)
 {
-    return d_resamp->phase_offset(freq, fs);
+    return d_resamp.phase_offset(freq, fs);
 }
 
 int pfb_arb_resampler_ccc_impl::general_work(int noutput_items,
@@ -131,7 +131,7 @@ int pfb_arb_resampler_ccc_impl::general_work(int noutput_items,
 
     int nitems_read;
     int nitems = floorf((float)noutput_items / relative_rate());
-    int processed = d_resamp->filter(out, in, nitems, nitems_read);
+    int processed = d_resamp.filter(out, in, nitems, nitems_read);
 
     consume_each(nitems_read);
     return processed;

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
@@ -22,7 +22,7 @@ namespace filter {
 class FILTER_API pfb_arb_resampler_ccc_impl : public pfb_arb_resampler_ccc
 {
 private:
-    kernel::pfb_arb_resampler_ccc* d_resamp;
+    kernel::pfb_arb_resampler_ccc d_resamp;
     bool d_updated;
     gr::thread::mutex d_mutex; // mutex to protect set/work access
 

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
@@ -33,16 +33,16 @@ pfb_arb_resampler_ccf_impl::pfb_arb_resampler_ccf_impl(float rate,
                                                        unsigned int filter_size)
     : block("pfb_arb_resampler_ccf",
             io_signature::make(1, 1, sizeof(gr_complex)),
-            io_signature::make(1, 1, sizeof(gr_complex)))
+            io_signature::make(1, 1, sizeof(gr_complex))),
+      d_resamp(rate, taps, filter_size)
 {
     d_updated = false;
 
-    d_resamp = new kernel::pfb_arb_resampler_ccf(rate, taps, filter_size);
-    set_history(d_resamp->taps_per_filter());
+    set_history(d_resamp.taps_per_filter());
     set_relative_rate(rate);
 }
 
-pfb_arb_resampler_ccf_impl::~pfb_arb_resampler_ccf_impl() { delete d_resamp; }
+pfb_arb_resampler_ccf_impl::~pfb_arb_resampler_ccf_impl() {}
 
 void pfb_arb_resampler_ccf_impl::forecast(int noutput_items,
                                           gr_vector_int& ninput_items_required)
@@ -61,59 +61,59 @@ void pfb_arb_resampler_ccf_impl::set_taps(const std::vector<float>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    d_resamp->set_taps(taps);
-    set_history(d_resamp->taps_per_filter());
+    d_resamp.set_taps(taps);
+    set_history(d_resamp.taps_per_filter());
     d_updated = true;
 }
 
 std::vector<std::vector<float>> pfb_arb_resampler_ccf_impl::taps() const
 {
-    return d_resamp->taps();
+    return d_resamp.taps();
 }
 
-void pfb_arb_resampler_ccf_impl::print_taps() { d_resamp->print_taps(); }
+void pfb_arb_resampler_ccf_impl::print_taps() { d_resamp.print_taps(); }
 
 void pfb_arb_resampler_ccf_impl::set_rate(float rate)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    d_resamp->set_rate(rate);
+    d_resamp.set_rate(rate);
     set_relative_rate(rate);
 }
 
 void pfb_arb_resampler_ccf_impl::set_phase(float ph)
 {
     gr::thread::scoped_lock guard(d_mutex);
-    d_resamp->set_phase(ph);
+    d_resamp.set_phase(ph);
 }
 
-float pfb_arb_resampler_ccf_impl::phase() const { return d_resamp->phase(); }
+float pfb_arb_resampler_ccf_impl::phase() const { return d_resamp.phase(); }
 
 unsigned int pfb_arb_resampler_ccf_impl::interpolation_rate() const
 {
-    return d_resamp->interpolation_rate();
+    return d_resamp.interpolation_rate();
 }
 
 unsigned int pfb_arb_resampler_ccf_impl::decimation_rate() const
 {
-    return d_resamp->decimation_rate();
+    return d_resamp.decimation_rate();
 }
 
 float pfb_arb_resampler_ccf_impl::fractional_rate() const
 {
-    return d_resamp->fractional_rate();
+    return d_resamp.fractional_rate();
 }
 
 unsigned int pfb_arb_resampler_ccf_impl::taps_per_filter() const
 {
-    return d_resamp->taps_per_filter();
+    return d_resamp.taps_per_filter();
 }
 
-int pfb_arb_resampler_ccf_impl::group_delay() const { return d_resamp->group_delay(); }
+int pfb_arb_resampler_ccf_impl::group_delay() const { return d_resamp.group_delay(); }
 
 float pfb_arb_resampler_ccf_impl::phase_offset(float freq, float fs)
 {
-    return d_resamp->phase_offset(freq, fs);
+    return d_resamp.phase_offset(freq, fs);
 }
 
 int pfb_arb_resampler_ccf_impl::general_work(int noutput_items,
@@ -133,7 +133,7 @@ int pfb_arb_resampler_ccf_impl::general_work(int noutput_items,
 
     int nitems_read;
     int nitems = floorf((float)noutput_items / relative_rate());
-    int processed = d_resamp->filter(out, in, nitems, nitems_read);
+    int processed = d_resamp.filter(out, in, nitems, nitems_read);
 
     consume_each(nitems_read);
     return processed;

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
@@ -22,7 +22,7 @@ namespace filter {
 class FILTER_API pfb_arb_resampler_ccf_impl : public pfb_arb_resampler_ccf
 {
 private:
-    kernel::pfb_arb_resampler_ccf* d_resamp;
+    kernel::pfb_arb_resampler_ccf d_resamp;
     bool d_updated;
     gr::thread::mutex d_mutex; // mutex to protect set/work access
 

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
@@ -33,16 +33,16 @@ pfb_arb_resampler_fff_impl::pfb_arb_resampler_fff_impl(float rate,
                                                        unsigned int filter_size)
     : block("pfb_arb_resampler_fff",
             io_signature::make(1, 1, sizeof(float)),
-            io_signature::make(1, 1, sizeof(float)))
+            io_signature::make(1, 1, sizeof(float))),
+      d_resamp(rate, taps, filter_size)
 {
     d_updated = false;
 
-    d_resamp = new kernel::pfb_arb_resampler_fff(rate, taps, filter_size);
-    set_history(d_resamp->taps_per_filter());
+    set_history(d_resamp.taps_per_filter());
     set_relative_rate(rate);
 }
 
-pfb_arb_resampler_fff_impl::~pfb_arb_resampler_fff_impl() { delete d_resamp; }
+pfb_arb_resampler_fff_impl::~pfb_arb_resampler_fff_impl() {}
 
 void pfb_arb_resampler_fff_impl::forecast(int noutput_items,
                                           gr_vector_int& ninput_items_required)
@@ -61,59 +61,59 @@ void pfb_arb_resampler_fff_impl::set_taps(const std::vector<float>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    d_resamp->set_taps(taps);
-    set_history(d_resamp->taps_per_filter());
+    d_resamp.set_taps(taps);
+    set_history(d_resamp.taps_per_filter());
     d_updated = true;
 }
 
 std::vector<std::vector<float>> pfb_arb_resampler_fff_impl::taps() const
 {
-    return d_resamp->taps();
+    return d_resamp.taps();
 }
 
-void pfb_arb_resampler_fff_impl::print_taps() { d_resamp->print_taps(); }
+void pfb_arb_resampler_fff_impl::print_taps() { d_resamp.print_taps(); }
 
 void pfb_arb_resampler_fff_impl::set_rate(float rate)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    d_resamp->set_rate(rate);
+    d_resamp.set_rate(rate);
     set_relative_rate(rate);
 }
 
 void pfb_arb_resampler_fff_impl::set_phase(float ph)
 {
     gr::thread::scoped_lock guard(d_mutex);
-    d_resamp->set_phase(ph);
+    d_resamp.set_phase(ph);
 }
 
-float pfb_arb_resampler_fff_impl::phase() const { return d_resamp->phase(); }
+float pfb_arb_resampler_fff_impl::phase() const { return d_resamp.phase(); }
 
 unsigned int pfb_arb_resampler_fff_impl::interpolation_rate() const
 {
-    return d_resamp->interpolation_rate();
+    return d_resamp.interpolation_rate();
 }
 
 unsigned int pfb_arb_resampler_fff_impl::decimation_rate() const
 {
-    return d_resamp->decimation_rate();
+    return d_resamp.decimation_rate();
 }
 
 float pfb_arb_resampler_fff_impl::fractional_rate() const
 {
-    return d_resamp->fractional_rate();
+    return d_resamp.fractional_rate();
 }
 
 unsigned int pfb_arb_resampler_fff_impl::taps_per_filter() const
 {
-    return d_resamp->taps_per_filter();
+    return d_resamp.taps_per_filter();
 }
 
-int pfb_arb_resampler_fff_impl::group_delay() const { return d_resamp->group_delay(); }
+int pfb_arb_resampler_fff_impl::group_delay() const { return d_resamp.group_delay(); }
 
 float pfb_arb_resampler_fff_impl::phase_offset(float freq, float fs)
 {
-    return d_resamp->phase_offset(freq, fs);
+    return d_resamp.phase_offset(freq, fs);
 }
 
 int pfb_arb_resampler_fff_impl::general_work(int noutput_items,
@@ -133,7 +133,7 @@ int pfb_arb_resampler_fff_impl::general_work(int noutput_items,
 
     int nitems_read;
     int nitems = floorf((float)noutput_items / relative_rate());
-    int processed = d_resamp->filter(out, in, nitems, nitems_read);
+    int processed = d_resamp.filter(out, in, nitems, nitems_read);
 
     consume_each(nitems_read);
     return processed;

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.h
@@ -22,7 +22,7 @@ namespace filter {
 class FILTER_API pfb_arb_resampler_fff_impl : public pfb_arb_resampler_fff
 {
 private:
-    kernel::pfb_arb_resampler_fff* d_resamp;
+    kernel::pfb_arb_resampler_fff d_resamp;
     bool d_updated;
     gr::thread::mutex d_mutex; // mutex to protect set/work access
 

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.cc
@@ -71,7 +71,7 @@ pfb_channelizer_ccf_impl::pfb_channelizer_ccf_impl(unsigned int nfilts,
     // with the first and put it into the fft object properly for
     // the same effect.
     d_rate_ratio = (int)rintf(d_nfilts / d_oversample_rate);
-    d_idxlut = new int[d_nfilts];
+    d_idxlut.resize(d_nfilts);
     for (unsigned int i = 0; i < d_nfilts; i++) {
         d_idxlut[i] = d_nfilts - ((i + d_rate_ratio) % d_nfilts) - 1;
     }
@@ -91,7 +91,7 @@ pfb_channelizer_ccf_impl::pfb_channelizer_ccf_impl(unsigned int nfilts,
     set_tag_propagation_policy(TPP_ONE_TO_ONE);
 }
 
-pfb_channelizer_ccf_impl::~pfb_channelizer_ccf_impl() { delete[] d_idxlut; }
+pfb_channelizer_ccf_impl::~pfb_channelizer_ccf_impl() {}
 
 void pfb_channelizer_ccf_impl::set_taps(const std::vector<float>& taps)
 {
@@ -162,7 +162,7 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
         last = i;
         while (i >= 0) {
             in = (gr_complex*)input_items[j];
-            d_fft->get_inbuf()[d_idxlut[j]] = d_fir_filters[i]->filter(&in[n]);
+            d_fft.get_inbuf()[d_idxlut[j]] = d_fir_filters[i].filter(&in[n]);
             j++;
             i--;
         }
@@ -170,7 +170,7 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
         i = d_nfilts - 1;
         while (i > last) {
             in = (gr_complex*)input_items[j];
-            d_fft->get_inbuf()[d_idxlut[j]] = d_fir_filters[i]->filter(&in[n - 1]);
+            d_fft.get_inbuf()[d_idxlut[j]] = d_fir_filters[i].filter(&in[n - 1]);
             j++;
             i--;
         }
@@ -178,12 +178,12 @@ int pfb_channelizer_ccf_impl::general_work(int noutput_items,
         n += (i + d_rate_ratio) >= (int)d_nfilts;
 
         // despin through FFT
-        d_fft->execute();
+        d_fft.execute();
 
         // Send to output channels
         for (unsigned int nn = 0; nn < noutputs; nn++) {
             out = (gr_complex*)output_items[nn];
-            out[oo] = d_fft->get_outbuf()[d_channel_map[nn]];
+            out[oo] = d_fft.get_outbuf()[d_channel_map[nn]];
         }
         oo++;
     }

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.h
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.h
@@ -26,7 +26,7 @@ class FILTER_API pfb_channelizer_ccf_impl : public pfb_channelizer_ccf,
 private:
     bool d_updated;
     float d_oversample_rate;
-    int* d_idxlut;
+    std::vector<int> d_idxlut;
     int d_rate_ratio;
     int d_output_multiple;
     std::vector<int> d_channel_map;

--- a/gr-filter/lib/pfb_decimator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.cc
@@ -46,7 +46,7 @@ pfb_decimator_ccf_impl::pfb_decimator_ccf_impl(unsigned int decim,
       d_use_fft_filters(use_fft_filters)
 {
     d_rate = decim;
-    d_rotator = new gr_complex[d_rate];
+    d_rotator.resize(d_rate);
     for (unsigned int i = 0; i < d_rate; i++) {
         d_rotator[i] = gr_expj(i * d_chan * 2 * GR_M_PI / d_rate);
     }
@@ -55,8 +55,7 @@ pfb_decimator_ccf_impl::pfb_decimator_ccf_impl(unsigned int decim,
 
     if (d_use_fft_filters) {
         set_history(1);
-        set_output_multiple(d_fft_filters[0]->filtersize() - d_fft_filters[0]->ntaps() +
-                            1);
+        set_output_multiple(d_fft_filters[0].filtersize() - d_fft_filters[0].ntaps() + 1);
     } else {
         set_history(d_taps_per_filter);
     }
@@ -82,7 +81,7 @@ bool pfb_decimator_ccf_impl::stop()
     return block::stop();
 }
 
-pfb_decimator_ccf_impl::~pfb_decimator_ccf_impl() { delete[] d_rotator; }
+pfb_decimator_ccf_impl::~pfb_decimator_ccf_impl() {}
 
 void pfb_decimator_ccf_impl::set_taps(const std::vector<float>& taps)
 {
@@ -146,7 +145,7 @@ int pfb_decimator_ccf_impl::work_fir_exp(int noutput_items,
         for (int j = d_rate - 1; j >= 0; j--) {
             // Take items from M-1 to 0; filter and rotate
             in = (gr_complex*)input_items[d_rate - 1 - j];
-            out[i] += d_fir_filters[j]->filter(&in[i]) * d_rotator[j];
+            out[i] += d_fir_filters[j].filter(&in[i]) * d_rotator[j];
         }
     }
 
@@ -167,14 +166,14 @@ int pfb_decimator_ccf_impl::work_fir_fft(int noutput_items,
         for (unsigned int j = 0; j < d_rate; j++) {
             // Take in the items from the first input stream to d_rate
             in = (gr_complex*)input_items[d_rate - 1 - j];
-            d_fft->get_inbuf()[j] = d_fir_filters[j]->filter(&in[i]);
+            d_fft.get_inbuf()[j] = d_fir_filters[j].filter(&in[i]);
         }
 
         // Perform the FFT to do the complex multiply despinning for all channels
-        d_fft->execute();
+        d_fft.execute();
 
         // Select only the desired channel out
-        out[i] = d_fft->get_outbuf()[d_chan];
+        out[i] = d_fft.get_outbuf()[d_chan];
     }
 
     return noutput_items;
@@ -194,7 +193,7 @@ int pfb_decimator_ccf_impl::work_fft_exp(int noutput_items,
     // setup and operation.
     for (unsigned int j = 0; j < d_rate; j++) {
         in = (gr_complex*)input_items[d_rate - j - 1];
-        d_fft_filters[j]->filter(noutput_items, in, &(d_tmp[j * noutput_items]));
+        d_fft_filters[j].filter(noutput_items, in, &(d_tmp[j * noutput_items]));
     }
 
     // Rotate and add filter outputs (k=channel number; M=number of
@@ -221,21 +220,21 @@ int pfb_decimator_ccf_impl::work_fft_fft(int noutput_items,
 
     for (unsigned int j = 0; j < d_rate; j++) {
         in = (gr_complex*)input_items[d_rate - j - 1];
-        d_fft_filters[j]->filter(noutput_items, in, &d_tmp[j * noutput_items]);
+        d_fft_filters[j].filter(noutput_items, in, &d_tmp[j * noutput_items]);
     }
 
     // Performs the rotate and add operations by implementing it as
     // an FFT.
     for (i = 0; i < noutput_items; i++) {
         for (unsigned int j = 0; j < d_rate; j++) {
-            d_fft->get_inbuf()[j] = d_tmp[j * noutput_items + i];
+            d_fft.get_inbuf()[j] = d_tmp[j * noutput_items + i];
         }
 
         // Perform the FFT to do the complex multiply despinning for all channels
-        d_fft->execute();
+        d_fft.execute();
 
         // Select only the desired channel out
-        out[i] = d_fft->get_outbuf()[d_chan];
+        out[i] = d_fft.get_outbuf()[d_chan];
     }
 
     return noutput_items;

--- a/gr-filter/lib/pfb_decimator_ccf_impl.h
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.h
@@ -28,7 +28,7 @@ private:
     unsigned int d_chan;
     bool d_use_fft_rotator;
     bool d_use_fft_filters;
-    gr_complex* d_rotator;
+    std::vector<gr_complex> d_rotator;
     gr_complex* d_tmp;         // used for fft filters
     gr::thread::mutex d_mutex; // mutex to protect set/work access
 
@@ -53,6 +53,10 @@ public:
                            bool use_fft_filters = true);
 
     ~pfb_decimator_ccf_impl();
+
+    // No copy because d_tmp.
+    pfb_decimator_ccf_impl(const pfb_decimator_ccf_impl&) = delete;
+    pfb_decimator_ccf_impl& operator=(const pfb_decimator_ccf_impl&) = delete;
 
     void set_taps(const std::vector<float>& taps);
     void print_taps();

--- a/gr-filter/lib/pfb_interpolator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_interpolator_ccf_impl.cc
@@ -72,7 +72,7 @@ int pfb_interpolator_ccf_impl::work(int noutput_items,
 
     while (i < noutput_items) {
         for (unsigned int j = 0; j < d_rate; j++) {
-            out[i] = d_fir_filters[j]->filter(&in[count]);
+            out[i] = d_fir_filters[j].filter(&in[count]);
             i++;
         }
         count++;

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.h
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.h
@@ -30,12 +30,12 @@ private:
     bool d_updated;
     unsigned int d_numchans;
     unsigned int d_taps_per_filter;
-    fft::fft_complex* d_fft;
-    std::vector<kernel::fir_filter_with_buffer_ccf*> d_filters;
+    std::vector<kernel::fir_filter_with_buffer_ccf> d_filters;
     std::vector<std::vector<float>> d_taps;
     int d_state;
     std::vector<int> d_channel_map;
     unsigned int d_twox;
+    fft::fft_complex d_fft;
     gr::thread::mutex d_mutex; // mutex to protect set/work access
 
     /*!

--- a/gr-filter/lib/qa_fir_filter_with_buffer.cc
+++ b/gr-filter/lib/qa_fir_filter_with_buffer.cc
@@ -110,12 +110,11 @@ void test_decimate(unsigned int decimate)
 
             // build filter
             vector<tap_type> f1_taps(&taps[0], &taps[n]);
-            kernel::fir_filter_with_buffer_fff* f1 =
-                new kernel::fir_filter_with_buffer_fff(f1_taps);
+            kernel::fir_filter_with_buffer_fff f1(f1_taps);
 
             // zero the output, then do the filtering
             memset(actual_output, 0, OUTPUT_LEN * sizeof(o_type));
-            f1->filterNdec(actual_output, input, ol / decimate, decimate);
+            f1.filterNdec(actual_output, input, ol / decimate, decimate);
 
             // check results
             //
@@ -128,7 +127,6 @@ void test_decimate(unsigned int decimate)
                 BOOST_CHECK(std::abs(expected_output[o] - actual_output[o]) <=
                             sqrt((float)n) * 0.25 * MAX_DATA * MAX_DATA * ERR_DELTA);
             }
-            delete f1;
         }
     }
     volk_free(input);
@@ -213,12 +211,11 @@ void test_decimate(unsigned int decimate)
 
             // build filter
             vector<tap_type> f1_taps(&taps[0], &taps[n]);
-            kernel::fir_filter_with_buffer_ccc* f1 =
-                new kernel::fir_filter_with_buffer_ccc(f1_taps);
+            kernel::fir_filter_with_buffer_ccc f1(f1_taps);
 
             // zero the output, then do the filtering
             std::fill_n(actual_output, OUTPUT_LEN, 0);
-            f1->filterNdec(actual_output, input, ol / decimate, decimate);
+            f1.filterNdec(actual_output, input, ol / decimate, decimate);
 
             // check results
             //
@@ -231,7 +228,6 @@ void test_decimate(unsigned int decimate)
                 BOOST_CHECK(std::abs(expected_output[o] - actual_output[o]) <=
                             sqrt((float)n) * 0.25 * MAX_DATA * MAX_DATA * ERR_DELTA);
             }
-            delete f1;
         }
     }
     volk_free(input);
@@ -314,12 +310,11 @@ void test_decimate(unsigned int decimate)
 
             // build filter
             vector<tap_type> f1_taps(&taps[0], &taps[n]);
-            kernel::fir_filter_with_buffer_ccf* f1 =
-                new kernel::fir_filter_with_buffer_ccf(f1_taps);
+            kernel::fir_filter_with_buffer_ccf f1(f1_taps);
 
             // zero the output, then do the filtering
             std::fill_n(actual_output, OUTPUT_LEN, 0);
-            f1->filterNdec(actual_output, input, ol / decimate, decimate);
+            f1.filterNdec(actual_output, input, ol / decimate, decimate);
 
             // check results
             //
@@ -332,7 +327,6 @@ void test_decimate(unsigned int decimate)
                 BOOST_CHECK(std::abs(expected_output[o] - actual_output[o]) <=
                             sqrt((float)n) * 0.25 * MAX_DATA * MAX_DATA * ERR_DELTA);
             }
-            delete f1;
         }
     }
     volk_free(input);

--- a/gr-filter/lib/rational_resampler_base_impl.h
+++ b/gr-filter/lib/rational_resampler_base_impl.h
@@ -23,11 +23,10 @@ class FILTER_API rational_resampler_base_impl
 {
 private:
     unsigned d_history;
-    unsigned d_interpolation;
     unsigned d_decimation;
     unsigned d_ctr;
     std::vector<TAP_T> d_new_taps;
-    std::vector<kernel::fir_filter<IN_T, OUT_T, TAP_T>*> d_firs;
+    std::vector<kernel::fir_filter<IN_T, OUT_T, TAP_T>> d_firs;
     bool d_updated;
 
     void install_taps(const std::vector<TAP_T>& taps);
@@ -42,7 +41,7 @@ public:
     unsigned history() const { return d_history; }
     void set_history(unsigned history) { d_history = history; }
 
-    unsigned interpolation() const { return d_interpolation; }
+    unsigned interpolation() const { return d_firs.size(); }
     unsigned decimation() const { return d_decimation; }
 
     void set_taps(const std::vector<TAP_T>& taps);

--- a/gr-filter/python/filter/bindings/filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(db1e15f3685e422f95ab563c96e5d0fb)                     */
+/* BINDTOOL_HEADER_FILE_HASH(be850101db6157f52549d1616dc228a0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -41,9 +41,6 @@ void bind_filterbank(py::module& m)
                  std::allocator<std::vector<float, std::allocator<float>>>> const&>(),
              py::arg("taps"),
              D(kernel, filterbank, filterbank, 0))
-        .def(py::init<gr::filter::kernel::filterbank const&>(),
-             py::arg("arg0"),
-             D(kernel, filterbank, filterbank, 1))
 
         .def("set_taps",
              &filterbank::set_taps,

--- a/gr-filter/python/filter/bindings/fir_filter_python.cc
+++ b/gr-filter/python/filter/bindings/fir_filter_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fir_filter.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a65b2f7ecd60af3279d22a7a14b04222)                     */
+/* BINDTOOL_HEADER_FILE_HASH(48049333c1cea0b522a397159553f186)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/mmse_fir_interpolator_cc_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_fir_interpolator_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_fir_interpolator_cc.h) */
-/* BINDTOOL_HEADER_FILE_HASH(57116daf3cd447341f637b476450f903)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c618917f7ba9048d2b73da399ca5cf60)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -37,9 +37,6 @@ void bind_mmse_fir_interpolator_cc(py::module& m)
         m, "mmse_fir_interpolator_cc", D(mmse_fir_interpolator_cc))
 
         .def(py::init<>(), D(mmse_fir_interpolator_cc, mmse_fir_interpolator_cc, 0))
-        .def(py::init<gr::filter::mmse_fir_interpolator_cc const&>(),
-             py::arg("arg0"),
-             D(mmse_fir_interpolator_cc, mmse_fir_interpolator_cc, 1))
 
 
         .def(

--- a/gr-filter/python/filter/bindings/mmse_fir_interpolator_ff_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_fir_interpolator_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_fir_interpolator_ff.h) */
-/* BINDTOOL_HEADER_FILE_HASH(cdefd265e0c9caa146dd3a52f3338dc2)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a5230c4b6ad2c4241956c24184a499c5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -37,9 +37,6 @@ void bind_mmse_fir_interpolator_ff(py::module& m)
         m, "mmse_fir_interpolator_ff", D(mmse_fir_interpolator_ff))
 
         .def(py::init<>(), D(mmse_fir_interpolator_ff, mmse_fir_interpolator_ff, 0))
-        .def(py::init<gr::filter::mmse_fir_interpolator_ff const&>(),
-             py::arg("arg0"),
-             D(mmse_fir_interpolator_ff, mmse_fir_interpolator_ff, 1))
 
 
         .def(

--- a/gr-filter/python/filter/bindings/mmse_interp_differentiator_cc_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_interp_differentiator_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_interp_differentiator_cc.h) */
-/* BINDTOOL_HEADER_FILE_HASH(6a36328c76e867c856906630b5b92ffa)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7aceb77ae6aefbaff71960b27310ffe1)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -39,9 +39,6 @@ void bind_mmse_interp_differentiator_cc(py::module& m)
 
         .def(py::init<>(),
              D(mmse_interp_differentiator_cc, mmse_interp_differentiator_cc, 0))
-        .def(py::init<gr::filter::mmse_interp_differentiator_cc const&>(),
-             py::arg("arg0"),
-             D(mmse_interp_differentiator_cc, mmse_interp_differentiator_cc, 1))
 
 
         .def("ntaps",

--- a/gr-filter/python/filter/bindings/mmse_interp_differentiator_ff_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_interp_differentiator_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_interp_differentiator_ff.h) */
-/* BINDTOOL_HEADER_FILE_HASH(e977b0951d9e294d926e0bed6ff513c6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8f07bad55ded4360fdf5b74807e0635b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -39,9 +39,6 @@ void bind_mmse_interp_differentiator_ff(py::module& m)
 
         .def(py::init<>(),
              D(mmse_interp_differentiator_ff, mmse_interp_differentiator_ff, 0))
-        .def(py::init<gr::filter::mmse_interp_differentiator_ff const&>(),
-             py::arg("arg0"),
-             D(mmse_interp_differentiator_ff, mmse_interp_differentiator_ff, 1))
 
 
         .def("ntaps",

--- a/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_arb_resampler.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3ed59ae8b40af2ab691ebbf0000db786)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7cc3fce37ee5e8d755875d6741d1bac5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -48,9 +48,6 @@ void bind_pfb_arb_resampler(py::module& m)
              py::arg("taps"),
              py::arg("filter_size"),
              D(kernel, pfb_arb_resampler_ccf, pfb_arb_resampler_ccf, 0))
-        .def(py::init<gr::filter::kernel::pfb_arb_resampler_ccf const&>(),
-             py::arg("arg0"),
-             D(kernel, pfb_arb_resampler_ccf, pfb_arb_resampler_ccf, 1))
 
 
         .def("set_taps",
@@ -138,9 +135,6 @@ void bind_pfb_arb_resampler(py::module& m)
              py::arg("taps"),
              py::arg("filter_size"),
              D(kernel, pfb_arb_resampler_ccc, pfb_arb_resampler_ccc, 0))
-        .def(py::init<gr::filter::kernel::pfb_arb_resampler_ccc const&>(),
-             py::arg("arg0"),
-             D(kernel, pfb_arb_resampler_ccc, pfb_arb_resampler_ccc, 1))
 
 
         .def("set_taps",
@@ -227,9 +221,6 @@ void bind_pfb_arb_resampler(py::module& m)
              py::arg("taps"),
              py::arg("filter_size"),
              D(kernel, pfb_arb_resampler_fff, pfb_arb_resampler_fff, 0))
-        .def(py::init<gr::filter::kernel::pfb_arb_resampler_fff const&>(),
-             py::arg("arg0"),
-             D(kernel, pfb_arb_resampler_fff, pfb_arb_resampler_fff, 1))
 
 
         .def("set_taps",

--- a/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polyphase_filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1b2cf402bd792e0f7b6c6ee043486754)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8651c06a82eb420afdb769759d3fa4bd)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -46,9 +46,6 @@ void bind_polyphase_filterbank(py::module& m)
              py::arg("taps"),
              py::arg("fft_forward") = false,
              D(kernel, polyphase_filterbank, polyphase_filterbank, 0))
-        .def(py::init<gr::filter::kernel::polyphase_filterbank const&>(),
-             py::arg("arg0"),
-             D(kernel, polyphase_filterbank, polyphase_filterbank, 1))
 
 
         .def("set_taps",


### PR DESCRIPTION
Mostly manual work, followed by updating checksums.

Note that there were (and still remain) a lot of default copy
constructors and copy assignment operators in the codebase that are
not safe. And they're even exported to Python (some removed in this
commit).

While it's perfectly possible to allow safe copies once raw pointers
are removed, it seems like a performance trap waiting to happen. Hence
I removed the fir_filter copy cons/assignment.

Short script I used to update the header file hashes for pybind11:

```
a=polyphase_filterbank
S=$(md5sum $(find -name "${a}.h") | awk '{print $1}')
sed -i -r "s/(BINDTOOL_HEADER_FILE_HASH)[(].*[)]/\1($S)/" $(find -name "${a}_python.cc")
```