### PR TITLE
modtool: Run all generated C++ code through clang-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,12 @@ install(
     DESTINATION ${GR_PKG_DOC_DIR}
 )
 
+install(
+    FILES .clang-format
+    RENAME clang-format.conf
+    DESTINATION ${GR_PKG_DATA_DIR}
+)
+
 ########################################################################
 # The following dependency libraries are needed by all gr modules:
 ########################################################################

--- a/gr-utils/modtool/core/newmod.py
+++ b/gr-utils/modtool/core/newmod.py
@@ -67,6 +67,11 @@ class ModToolNewModule(ModTool):
         logger.info(f"Creating out-of-tree module in {self.dir}...")
         try:
             shutil.copytree(self.srcdir, self.dir)
+            try:
+              shutil.copyfile(os.path.join(gr.prefix(), 'share', 'gnuradio', 'clang-format.conf'),
+                              os.path.join(self.dir, '.clang-format'))
+            except FileNotFoundError as e:
+              logger.info(f'Failed to copy .clang-format: {e}')
             os.chdir(self.dir)
         except OSError:
             raise ModToolException(f'Could not create directory {self.dir}.')


### PR DESCRIPTION
Forked off of https://github.com/gnuradio/gnuradio/pull/3377 since that was left unreviewed to the point where it could not be salvaged.