### PR TITLE
filter: fix FFT frequency range calculation

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -980,9 +980,8 @@ class gr_plot_filter(QtGui.QMainWindow):
 #            self.update_group_curves()
 
     def get_fft(self, fs, taps, Npts):
-        Ts = 1.0 / fs
         fftpts = fft_detail.fft(taps, Npts)
-        self.freq = np.arange(0, fs, 1.0 / (Npts*Ts))
+        self.freq = np.linspace(start=0, stop=fs, num=Npts, endpoint=False)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             self.fftdB = 20.0*np.log10(abs(fftpts))


### PR DESCRIPTION
When using certain sample rate values (e.g. 320001), the Filter Design 
Tool fails with "ValueError: operands could not be broadcast together 
with shapes (9999,) (10000,)". This occurs because the self.freq array 
in the get_fft function has one too many values. The self.freq array is 
generated using numpy.arange. Its documentation warns: "When using a 
non-integer step, such as 0.1, the results will often not be consistent. 
It is better to use numpy.linspace for these cases."

As recommended, I've switched this code to use numpy.linspace, which is 
guaranteed to produce the correct number of values.