### PR TITLE
Add extra includes to build oot modules that use extra packages like qt5

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -201,7 +201,8 @@ foreach(file ${files})
                 message(STATUS "Regenerating Bindings in-place for " ${header_filename})
 
                 file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${file}.regen_status)
-                # Automatically regenerate the bindings               
+                # Automatically regenerate the bindings
+                string(REPLACE ";" ","  extra_include_list "${extra_includes}")  # Convert ';' separated extra_includes to ',' separated list format
                 add_custom_command( 
                     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}}/${file}
                     COMMAND  "${PYTHON_EXECUTABLE}"
@@ -214,7 +215,7 @@ foreach(file ${files})
                     "--status" ${CMAKE_CURRENT_BINARY_DIR}/${file}.regen_status 
                     "--flag_automatic" ${flag_auto}
                     "--flag_pygccxml" ${flag_pygccxml}
-                    # "--include" "$<INSTALL_INTERFACE:include>"  #FIXME: Make the pygccxml generation use the source tree headers
+                    "--include" ${extra_include_list} #Some oots may require additional includes
                     COMMENT "Automatic generation of pybind11 bindings for " ${header_full_path})
                 add_custom_target(${file}_regen_bindings ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}}/${file})
                 list(APPEND regen_targets ${file}_regen_bindings)

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -322,8 +322,8 @@ class GenericHeaderParser(BlockTool):
                 include_paths=self.include_paths,
                 compiler='gcc',
                 undefine_symbols=['__PIE__'],
-                #define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC', '__PIC__'],
-                define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC'],
+                define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC', '__PIC__'], # -fPIC corresponds to __PIC__ , so it should be set
+                #define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC'],
                 cflags='-std=c++11 -fPIC')
             decls = parser.parse(
                 [self.target_file], xml_generator_config)

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
@@ -19,7 +19,7 @@ parser.add_argument(
     '--filename', help="File to be parsed")
 
 parser.add_argument(
-    '--include', help='Additional Include Dirs, separated', default=(), nargs='+')
+    '--include', type= str, help='Additional Include Dirs, separated', default=(), nargs='*') #Empty list should be allowed
 
 parser.add_argument(
     '--status', help='Location of output file for general status (used during cmake)', default=None
@@ -40,7 +40,6 @@ name = args.module
 
 namespace = ['gr', name]
 prefix_include_root = name
-
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)


### PR DESCRIPTION
Some oot modules like gr-display use additional packages like for instance qt5.  
To create the bindings it is required to know the directories of the corresponding include files.

This patch provides a parameter for these directories to be added. 