### PR TITLE
GPIO handler (via stream tags/messages), works with timed commands

### DIFF
--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -99,11 +99,13 @@ Command name | Value Type   | Description
 `time`       | timestamp    | Sets a command time. See usrp_block::set_command_time(). A value of PMT_NIL will clear the command time.
 `mboard`     | int          | Specify mboard index, where applicable.
 `antenna`    | string       | See usrp_block::set_antenna(). Defaults to all channels.
+`gpio`       | gpio         | PMT dictionary including bank, attr, value, mask for GPIO. See notes.
 
 Special types:
 
 - tune_request: Like a uhd::tune_request_t, but always uses POLICY_AUTO. This is a pair, composed of (target_frequency, lo_offset)
 - timestamp: A pair composed of (long full_secs, double frac_secs). Similar to uhd::time_spec_t
+- gpio: This is a PMT dictionary with four key/value pairs: bank (string), attr (string), value (double) and mask (double). The `gpio` command calls `set_gpio_attr` with the elements from the dictionary as arguments. Can optionally contain `mboard` to specify the mainboard. Defaults to `0` (first mboard).
 
 \b Note: Not all commands are affected by `time`. See the UHD manual for details on timed commands.
 

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -49,6 +49,7 @@ GR_UHD_API const pmt::pmt_t cmd_mboard_key();
 GR_UHD_API const pmt::pmt_t cmd_antenna_key();
 GR_UHD_API const pmt::pmt_t cmd_direction_key();
 GR_UHD_API const pmt::pmt_t cmd_tag_key();
+GR_UHD_API const pmt::pmt_t cmd_gpio_key();
 
 GR_UHD_API const pmt::pmt_t ant_direction_rx();
 GR_UHD_API const pmt::pmt_t ant_direction_tx();

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -744,31 +744,35 @@ void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t& ant,
 }
 
 void usrp_block_impl::_cmd_handler_gpio(const pmt::pmt_t& gpio_attr,
-                                      int chan,
-                                      const pmt::pmt_t& msg)
+                                        int chan,
+                                        const pmt::pmt_t& msg)
 {
     size_t mboard = pmt::to_long(pmt::dict_ref(
         msg,
         cmd_mboard_key(),
-        //pmt::from_long(::uhd::usrp::multi_usrp::ALL_MBOARDS) // Default to all mboards
+        // pmt::from_long(::uhd::usrp::multi_usrp::ALL_MBOARDS) // Default to all mboards
         pmt::from_long(0) // default to first mboard
         ));
 
     if (!pmt::is_dict(gpio_attr)) {
         GR_LOG_ERROR(d_logger,
-                     boost::format("gpio_attr in  message is neither dict nor pair: %s") % gpio_attr);
+                     boost::format("gpio_attr in  message is neither dict nor pair: %s") %
+                         gpio_attr);
         return;
     }
-    if (!pmt::dict_has_key(gpio_attr, pmt::mp("bank"))
-         || !pmt::dict_has_key(gpio_attr, pmt::mp("attr"))
-         || !pmt::dict_has_key(gpio_attr, pmt::mp("value"))
-         || !pmt::dict_has_key(gpio_attr, pmt::mp("mask"))) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("gpio_attr message must include bank, attr, value and mask"));
+    if (!pmt::dict_has_key(gpio_attr, pmt::mp("bank")) ||
+        !pmt::dict_has_key(gpio_attr, pmt::mp("attr")) ||
+        !pmt::dict_has_key(gpio_attr, pmt::mp("value")) ||
+        !pmt::dict_has_key(gpio_attr, pmt::mp("mask"))) {
+        GR_LOG_ERROR(
+            d_logger,
+            boost::format("gpio_attr message must include bank, attr, value and mask"));
         return;
     }
-    std::string bank = pmt::symbol_to_string(pmt::dict_ref(gpio_attr, pmt::mp("bank"), pmt::mp("")));
-    std::string attr = pmt::symbol_to_string(pmt::dict_ref(gpio_attr, pmt::mp("attr"), pmt::mp("")));
+    std::string bank =
+        pmt::symbol_to_string(pmt::dict_ref(gpio_attr, pmt::mp("bank"), pmt::mp("")));
+    std::string attr =
+        pmt::symbol_to_string(pmt::dict_ref(gpio_attr, pmt::mp("attr"), pmt::mp("")));
     uint32_t value = pmt::to_double(pmt::dict_ref(gpio_attr, pmt::mp("value"), 0));
     uint32_t mask = pmt::to_double(pmt::dict_ref(gpio_attr, pmt::mp("mask"), 0));
 

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -110,6 +110,12 @@ const pmt::pmt_t gr::uhd::cmd_tag_key()
     return val;
 }
 
+const pmt::pmt_t gr::uhd::cmd_gpio_key()
+{
+    static const pmt::pmt_t val = pmt::mp("gpio");
+    return val;
+}
+
 const pmt::pmt_t gr::uhd::ant_direction_rx()
 {
     static const pmt::pmt_t val = pmt::mp("RX");
@@ -159,6 +165,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     REGISTER_CMD_HANDLER(cmd_rate_key(), _cmd_handler_rate);
     REGISTER_CMD_HANDLER(cmd_bandwidth_key(), _cmd_handler_bw);
     REGISTER_CMD_HANDLER(cmd_antenna_key(), _cmd_handler_antenna);
+    REGISTER_CMD_HANDLER(cmd_gpio_key(), _cmd_handler_gpio);
 }
 
 usrp_block_impl::~usrp_block_impl()
@@ -734,6 +741,38 @@ void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t& ant,
     }
 
     set_antenna(antenna, chan);
+}
+
+void usrp_block_impl::_cmd_handler_gpio(const pmt::pmt_t& gpio_attr,
+                                      int chan,
+                                      const pmt::pmt_t& msg)
+{
+    size_t mboard = pmt::to_long(pmt::dict_ref(
+        msg,
+        cmd_mboard_key(),
+        //pmt::from_long(::uhd::usrp::multi_usrp::ALL_MBOARDS) // Default to all mboards
+        pmt::from_long(0) // default to first mboard
+        ));
+
+    if (!pmt::is_dict(gpio_attr)) {
+        GR_LOG_ERROR(d_logger,
+                     boost::format("gpio_attr in  message is neither dict nor pair: %s") % gpio_attr);
+        return;
+    }
+    if (!pmt::dict_has_key(gpio_attr, pmt::mp("bank"))
+         || !pmt::dict_has_key(gpio_attr, pmt::mp("attr"))
+         || !pmt::dict_has_key(gpio_attr, pmt::mp("value"))
+         || !pmt::dict_has_key(gpio_attr, pmt::mp("mask"))) {
+        GR_LOG_ERROR(d_logger,
+                     boost::format("gpio_attr message must include bank, attr, value and mask"));
+        return;
+    }
+    std::string bank = pmt::symbol_to_string(pmt::dict_ref(gpio_attr, pmt::mp("bank"), pmt::mp("")));
+    std::string attr = pmt::symbol_to_string(pmt::dict_ref(gpio_attr, pmt::mp("attr"), pmt::mp("")));
+    uint32_t value = pmt::to_double(pmt::dict_ref(gpio_attr, pmt::mp("value"), 0));
+    uint32_t mask = pmt::to_double(pmt::dict_ref(gpio_attr, pmt::mp("mask"), 0));
+
+    set_gpio_attr(bank, attr, value, mask, mboard);
 }
 
 void usrp_block_impl::_cmd_handler_rate(const pmt::pmt_t& rate_, int, const pmt::pmt_t&)

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -136,6 +136,7 @@ protected:
     void _cmd_handler_bw(const pmt::pmt_t& bw, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_lofreq(const pmt::pmt_t& lofreq, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_dspfreq(const pmt::pmt_t& dspfreq, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_gpio(const pmt::pmt_t& gpio_attr, int chan, const pmt::pmt_t& msg);
 
     /**********************************************************************
      * Helpers


### PR DESCRIPTION
gr-uhd does not provide any ability to manipulate GPIO (except by directly calling member functions).

This pull request fixes that and adds a message handler for gpio that can be used via strema tags or messages and works in combination with timed commands etc.

It adds a new command `gpio` having a dict as parameter. It contains the usual fields `bank`, `attr`, `value` and `mask`
