### PR TITLE
uhd: Control of frequency and gain in both directions at the same moment

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -144,7 +144,8 @@ public:
      * \param gain the gain in dB
      * \param chan the channel index 0 to N-1
      */
-    virtual void set_gain(double gain, size_t chan = 0) = 0;
+    virtual void
+    set_gain(double gain, size_t chan = 0, pmt::pmt_t direction = pmt::PMT_NIL) = 0;
 
     /*!
      * Set the named gain on the dboard.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -650,8 +650,8 @@ void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t& lo_offset,
     pmt::pmt_t direction =
         pmt::dict_ref(msg,
                       cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
+                      pmt::PMT_NIL // Anything except "TX" or "RX" will default to the
+                                   // messaged block direction
         );
 
     if (pmt::dict_has_key(msg, cmd_freq_key())) {

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -115,8 +115,10 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
       _nchan(stream_args.channels.size()),
       _stream_now(_nchan == 1 and ts_tag_name.empty()),
       _start_time_set(false),
-      _curr_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
-      _chans_to_tune(stream_args.channels.size())
+      _curr_tx_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
+      _curr_rx_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
+      _tx_chans_to_tune(stream_args.channels.size()),
+      _rx_chans_to_tune(stream_args.channels.size())
 {
     _dev = ::uhd::usrp::multi_usrp::make(device_addr);
 
@@ -262,11 +264,22 @@ bool usrp_block_impl::_check_mboard_sensors_locked()
     return clocks_locked;
 }
 
-void usrp_block_impl::_set_center_freq_from_internals_allchans(pmt::pmt_t direction)
+void usrp_block_impl::_set_center_freq_from_internals_allchans()
 {
-    while (_chans_to_tune.any()) {
+    unsigned int chan;
+    while (_rx_chans_to_tune.any()) {
         // This resets() bits, so this loop should not run indefinitely
-        _set_center_freq_from_internals(_chans_to_tune.find_first(), direction);
+        chan = _rx_chans_to_tune.find_first();
+        _set_center_freq_from_internals(chan, ant_direction_rx());
+        _rx_chans_to_tune.reset(chan);
+    }
+
+    while (_tx_chans_to_tune.any()) {
+        // This resets() bits, so this loop should not run indefinitely
+        chan = _tx_chans_to_tune.find_first();
+        _set_center_freq_from_internals(_tx_chans_to_tune.find_first(),
+                                        ant_direction_tx());
+        _tx_chans_to_tune.reset(chan);
     }
 }
 
@@ -552,16 +565,8 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
         }
     }
 
-    /// 4) See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
-
-    /// 5) Check if we need to re-tune
-    _set_center_freq_from_internals_allchans(direction);
+    /// 4) Check if we need to re-tune
+    _set_center_freq_from_internals_allchans();
 }
 
 
@@ -581,22 +586,35 @@ void usrp_block_impl::register_msg_cmd_handler(const pmt::pmt_t& cmd,
     _msg_cmd_handlers[cmd] = handler;
 }
 
-void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req, int chan)
+void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req,
+                                            int chan,
+                                            pmt::pmt_t direction)
 {
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
-            _update_curr_tune_req(tune_req, int(i));
+            _update_curr_tune_req(tune_req, int(i), direction);
         }
         return;
     }
 
-    if (tune_req.target_freq != _curr_tune_req[chan].target_freq ||
-        tune_req.rf_freq_policy != _curr_tune_req[chan].rf_freq_policy ||
-        tune_req.rf_freq != _curr_tune_req[chan].rf_freq ||
-        tune_req.dsp_freq != _curr_tune_req[chan].dsp_freq ||
-        tune_req.dsp_freq_policy != _curr_tune_req[chan].dsp_freq_policy) {
-        _curr_tune_req[chan] = tune_req;
-        _chans_to_tune.set(chan);
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        if (tune_req.target_freq != _curr_rx_tune_req[chan].target_freq ||
+            tune_req.rf_freq_policy != _curr_rx_tune_req[chan].rf_freq_policy ||
+            tune_req.rf_freq != _curr_rx_tune_req[chan].rf_freq ||
+            tune_req.dsp_freq != _curr_rx_tune_req[chan].dsp_freq ||
+            tune_req.dsp_freq_policy != _curr_rx_tune_req[chan].dsp_freq_policy) {
+            _curr_rx_tune_req[chan] = tune_req;
+            _rx_chans_to_tune.set(chan);
+        }
+    } else {
+        if (tune_req.target_freq != _curr_tx_tune_req[chan].target_freq ||
+            tune_req.rf_freq_policy != _curr_tx_tune_req[chan].rf_freq_policy ||
+            tune_req.rf_freq != _curr_tx_tune_req[chan].rf_freq ||
+            tune_req.dsp_freq != _curr_tx_tune_req[chan].dsp_freq ||
+            tune_req.dsp_freq_policy != _curr_tx_tune_req[chan].dsp_freq_policy) {
+            _curr_tx_tune_req[chan] = tune_req;
+            _tx_chans_to_tune.set(chan);
+        }
     }
 }
 
@@ -605,48 +623,78 @@ void usrp_block_impl::_cmd_handler_freq(const pmt::pmt_t& freq_,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     double freq = pmt::to_double(freq_);
-    ::uhd::tune_request_t new_tune_reqest(freq);
+    ::uhd::tune_request_t new_tune_request(freq);
     if (pmt::dict_has_key(msg, cmd_lo_offset_key())) {
         double lo_offset =
             pmt::to_double(pmt::dict_ref(msg, cmd_lo_offset_key(), pmt::PMT_NIL));
-        new_tune_reqest = ::uhd::tune_request_t(freq, lo_offset);
+        new_tune_request = ::uhd::tune_request_t(freq, lo_offset);
     }
 
-    _update_curr_tune_req(new_tune_reqest, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t& lo_offset,
                                             int chan,
                                             const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     if (pmt::dict_has_key(msg, cmd_freq_key())) {
         // Then it's already taken care of
         return;
     }
 
     double lo_offs = pmt::to_double(lo_offset);
-    ::uhd::tune_request_t new_tune_request = _curr_tune_req[chan];
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        new_tune_request = _curr_rx_tune_req[chan];
+    } else {
+        new_tune_request = _curr_tx_tune_req[chan];
+    }
+
     new_tune_request.rf_freq = new_tune_request.target_freq + lo_offs;
     new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_AUTO;
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t& gain_,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     double gain = pmt::to_double(gain_);
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
-            set_gain(gain, i);
+            set_gain(gain, i, direction);
         }
         return;
     }
 
-    set_gain(gain, chan);
+    set_gain(gain, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t& ant,
@@ -674,10 +722,18 @@ void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     double freq = pmt::to_double(pmt::car(tune));
     double lo_offset = pmt::to_double(pmt::cdr(tune));
-    ::uhd::tune_request_t new_tune_reqest(freq, lo_offset);
-    _update_curr_tune_req(new_tune_reqest, chan);
+    ::uhd::tune_request_t new_tune_request(freq, lo_offset);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_bw(const pmt::pmt_t& bw,
@@ -699,6 +755,14 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
                                           int chan,
                                           const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
             _cmd_handler_lofreq(lofreq, int(i), msg);
@@ -706,7 +770,13 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
         return;
     }
 
-    ::uhd::tune_request_t new_tune_request = _curr_tune_req[chan];
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        new_tune_request = _curr_rx_tune_req[chan];
+    } else {
+        new_tune_request = _curr_tx_tune_req[chan];
+    }
+
     new_tune_request.rf_freq = pmt::to_double(lofreq);
     if (pmt::dict_has_key(msg, cmd_dsp_freq_key())) {
         new_tune_request.dsp_freq =
@@ -715,13 +785,21 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
     new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
                                            int chan,
                                            const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     if (pmt::dict_has_key(msg, cmd_lo_freq_key())) {
         // Then it's already dealt with
         return;
@@ -734,10 +812,16 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
         return;
     }
 
-    ::uhd::tune_request_t new_tune_request = _curr_tune_req[chan];
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        new_tune_request = _curr_rx_tune_req[chan];
+    } else {
+        new_tune_request = _curr_tx_tune_req[chan];
+    }
+
     new_tune_request.dsp_freq = pmt::to_double(dspfreq);
     new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -133,7 +133,9 @@ protected:
     void _update_stream_args(const ::uhd::stream_args_t& stream_args_);
 
     // should be const, doesn't work though 'cause missing operator=() for tune_request_t
-    void _update_curr_tune_req(::uhd::tune_request_t& tune_req, int chan);
+    void _update_curr_tune_req(::uhd::tune_request_t& tune_req,
+                               int chan,
+                               pmt::pmt_t direction = pmt::PMT_NIL);
 
     /*! \brief Wait until a timeout or a sensor returns 'locked'.
      *
@@ -196,7 +198,7 @@ protected:
     _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction) = 0;
 
     //! Calls _set_center_freq_from_internals() on all channels
-    void _set_center_freq_from_internals_allchans(pmt::pmt_t direction);
+    void _set_center_freq_from_internals_allchans();
 
     /**********************************************************************
      * Members
@@ -215,8 +217,10 @@ protected:
     std::vector<pmt::pmt_t> _pending_cmds;
     //! Shadows the last value we told the USRP to tune to for every channel
     // (this is not necessarily the true value the USRP is currently tuned to!).
-    std::vector<::uhd::tune_request_t> _curr_tune_req;
-    boost::dynamic_bitset<> _chans_to_tune;
+    std::vector<::uhd::tune_request_t> _curr_tx_tune_req;
+    std::vector<::uhd::tune_request_t> _curr_rx_tune_req;
+    boost::dynamic_bitset<> _tx_chans_to_tune;
+    boost::dynamic_bitset<> _rx_chans_to_tune;
 
     //! Stores the individual command handlers
     ::uhd::dict<pmt::pmt_t, cmd_handler_t> _msg_cmd_handlers;

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -84,7 +84,7 @@ double usrp_sink_impl::get_samp_rate(void)
 ::uhd::tune_result_t
 usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size_t chan)
 {
-    _curr_tune_req[chan] = tune_request;
+    _curr_tx_tune_req[chan] = tune_request;
     chan = _stream_args.channels[chan];
     return _dev->set_tx_freq(tune_request, chan);
 }
@@ -92,12 +92,13 @@ usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size_t
 ::uhd::tune_result_t usrp_sink_impl::_set_center_freq_from_internals(size_t chan,
                                                                      pmt::pmt_t direction)
 {
-    _chans_to_tune.reset(chan);
     if (pmt::eqv(direction, ant_direction_rx())) {
         // TODO: what happens if the RX device is not instantiated? Catch error?
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _rx_chans_to_tune.reset(chan);
+        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _tx_chans_to_tune.reset(chan);
+        return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     }
 }
 
@@ -113,10 +114,14 @@ double usrp_sink_impl::get_center_freq(size_t chan)
     return _dev->get_tx_freq_range(chan);
 }
 
-void usrp_sink_impl::set_gain(double gain, size_t chan)
+void usrp_sink_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
 {
     chan = _stream_args.channels[chan];
-    return _dev->set_tx_gain(gain, chan);
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        return _dev->set_rx_gain(gain, chan);
+    } else {
+        return _dev->set_tx_gain(gain, chan);
+    }
 }
 
 void usrp_sink_impl::set_gain(double gain, const std::string& name, size_t chan)

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -83,7 +83,7 @@ public:
     void set_samp_rate(double rate);
     ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan);
-    void set_gain(double gain, size_t chan);
+    void set_gain(double gain, size_t chan, pmt::pmt_t direction);
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
     void set_antenna(const std::string& ant, size_t chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -98,12 +98,13 @@ usrp_source_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size
 ::uhd::tune_result_t
 usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
 {
-    _chans_to_tune.reset(chan);
     if (pmt::eqv(direction, ant_direction_tx())) {
         // TODO: what happens if the TX device is not instantiated? Catch error?
-        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _tx_chans_to_tune.reset(chan);
+        return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _rx_chans_to_tune.reset(chan);
+        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
     }
 }
 
@@ -119,10 +120,14 @@ double usrp_source_impl::get_center_freq(size_t chan)
     return _dev->get_rx_freq_range(chan);
 }
 
-void usrp_source_impl::set_gain(double gain, size_t chan)
+void usrp_source_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
 {
     chan = _stream_args.channels[chan];
-    return _dev->set_rx_gain(gain, chan);
+    if (pmt::eqv(direction, ant_direction_tx())) {
+        return _dev->set_tx_gain(gain, chan);
+    } else {
+        return _dev->set_rx_gain(gain, chan);
+    }
 }
 
 void usrp_source_impl::set_gain(double gain, const std::string& name, size_t chan)

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -68,7 +68,7 @@ public:
     void set_samp_rate(double rate);
     ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan);
-    void set_gain(double gain, size_t chan);
+    void set_gain(double gain, size_t chan = 0, pmt::pmt_t direction = pmt::PMT_NIL);
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_rx_agc(const bool enable, size_t chan);
     void set_normalized_gain(double gain, size_t chan);


### PR DESCRIPTION
This is a new revision of https://github.com/gnuradio/gnuradio/pull/3151.

After talking with Piotr, while he would like to see this patch integrated, he does not have the resources right now.

This commit fixes some issue with the original pull request.

From the original pull request:

It implements ability to control frequency and gain in **both** directions (Tx and Rx) with use of a single UHD source or sink - in the same moment. It is possible to do that in separate moments with current UHD blocks but this way it is not possible to change both Rx and Tx settings for the same burst. This pull request improves this situation.

This is next incarnation of recently closed pull request #2426.
Look at my (a bit long) explanation in the last comment there in case of doubt that such functionality have any practical application.