### PR TITLE
grc: save epy blocks/modules to hier_block_dir

### DIFF
--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from . import Block, register_build_in
 from ._templates import MakoTemplates
+from ._flags import Flags
 
 from .. import utils
 from ..base import Element
@@ -218,15 +219,14 @@ class EPyModule(Block):
         to set parameters of other blocks in your flowgraph.
     """)}
 
-    epy_flags = Block.flags
-    epy_flags.set(epy_flags.SHOW_ID)
+    flags = Flags(Flags.SHOW_ID)
 
     parameters_data = build_params(
         params_raw=[
             dict(label='Code', id='source_code', dtype='_multiline_python_external',
                  default='# this module will be imported in the into your flowgraph',
                  hide='part')
-        ], have_inputs=False, have_outputs=False, flags=epy_flags, block_id=key
+        ], have_inputs=False, have_outputs=False, flags=flags, block_id=key
     )
 
     templates = MakoTemplates(

--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -85,6 +85,7 @@ class EPyBlock(Block):
         super(EPyBlock, self).__init__(flow_graph, **kwargs)
         self.states['_io_cache'] = ''
 
+        self.module_name = self.name
         self._epy_source_hash = -1
         self._epy_reload_error = None
 
@@ -120,7 +121,9 @@ class EPyBlock(Block):
         self.label = blk_io.name or blk_io.cls
         self.documentation = {'': blk_io.doc}
 
-        self.templates['imports'] = 'import ' + self.name
+        self.module_name = "{}_{}".format(self.parent_flowgraph.get_option("id"), self.name)
+        self.templates['imports'] = 'import {} as {}  # embedded python block'.format(
+            self.module_name, self.name)
         self.templates['make'] = '{mod}.{cls}({args})'.format(
             mod=self.name,
             cls=blk_io.cls,
@@ -229,6 +232,12 @@ class EPyModule(Block):
         ], have_inputs=False, have_outputs=False, flags=flags, block_id=key
     )
 
-    templates = MakoTemplates(
-        imports='import ${ id }  # embedded python module',
-    )
+    def __init__(self, flow_graph, **kwargs):
+        super(EPyModule, self).__init__(flow_graph, **kwargs)
+        self.module_name = self.name
+
+    def rewrite(self):
+        super(EPyModule, self).rewrite()
+        self.module_name = "{}_{}".format(self.parent_flowgraph.get_option("id"), self.name)
+        self.templates['imports'] = 'import {} as {}  # embedded python module'.format(
+            self.module_name, self.name)

--- a/grc/core/generator/hier_block.py
+++ b/grc/core/generator/hier_block.py
@@ -12,24 +12,21 @@ from ..io import yaml
 class HierBlockGenerator(TopBlockGenerator):
     """Extends the top block generator to also generate a block YML file"""
 
-    def __init__(self, flow_graph, file_path):
+    def __init__(self, flow_graph, _):
         """
         Initialize the hier block generator object.
 
         Args:
             flow_graph: the flow graph object
-            file_path: where to write the py file (the yml goes into HIER_BLOCK_LIB_DIR)
         """
-        TopBlockGenerator.__init__(self, flow_graph, file_path)
         platform = flow_graph.parent
+        output_dir = platform.config.hier_block_lib_dir
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
 
-        hier_block_lib_dir = platform.config.hier_block_lib_dir
-        if not os.path.exists(hier_block_lib_dir):
-            os.mkdir(hier_block_lib_dir)
-
+        TopBlockGenerator.__init__(self, flow_graph, output_dir)
         self._mode = Constants.HIER_BLOCK_FILE_MODE
-        self.file_path = os.path.join(hier_block_lib_dir, self._flow_graph.get_option('id') + '.py')
-        self.file_path_yml = self.file_path + '.block.yml'
+        self.file_path_yml = self.file_path[:-3] + '.block.yml'
 
     def write(self):
         """generate output and write it to files"""

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -110,7 +110,7 @@ class TopBlockGenerator(object):
             else:
                 continue
 
-            file_path = os.path.join(self.output_dir, block.name + ".py")
+            file_path = os.path.join(self.output_dir, block.module_name + ".py")
             output.append((file_path, src))
 
         self.namespace = {


### PR DESCRIPTION
fixes issues mentioned in #3618

* embedded modules are placed next to hier_block
* remove ".py" from block wrapper filename
* prefix generated modules with flowgraph id (to avoid clashes)