### PR TITLE
Fix bug with non seekable file source

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -265,7 +265,8 @@ int file_source_impl::work(int noutput_items,
             // EOF reached for non seekable file, return
             if (!d_seekable && feof((FILE*)d_fp))
                 return nitems_read == 0 ? WORK_DONE : nitems_read;
-            // For seekable files, the bounds of the file are known, so unexpected nitems is an error
+            // For seekable files, the bounds of the file are known, so unexpected nitems
+            // is an error
             throw std::runtime_error("fread error");
         }
 


### PR DESCRIPTION
Reaching the end of a non seekable file (such as named pipes) currently throws and exception.
This patch checks the EOF flag if the read operation doesn't return the expected number of bytes.