### PR TITLE
PROPOSAL: grc: Make it possible to copy error message to buffer

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -10,7 +10,7 @@ import sys
 import textwrap
 from distutils.spawn import find_executable
 
-from gi.repository import Gtk, GLib
+from gi.repository import Gtk, GLib, Gdk
 
 from . import Utils, Actions, Constants
 from ..core import Messages
@@ -204,6 +204,7 @@ class ErrorsDialog(Gtk.Dialog):
             modal=True,
             destroy_with_parent=True,
         )
+        self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         self.add_buttons(Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT)
         self.set_size_request(750, Constants.MIN_DIALOG_HEIGHT)
         self.set_border_width(10)
@@ -212,6 +213,7 @@ class ErrorsDialog(Gtk.Dialog):
         self.update(flowgraph)
 
         self.treeview = Gtk.TreeView(model=self.store)
+        self.treeview.connect("button_press_event", self.mouse_click)
         for i, column_title in enumerate(["Block", "Aspect", "Message"]):
             renderer = Gtk.CellRendererText()
             column = Gtk.TreeViewColumn(column_title, renderer, text=i)
@@ -248,6 +250,20 @@ class ErrorsDialog(Gtk.Dialog):
         response = self.run()
         self.hide()
         return response
+
+    def mouse_click(self, _, event):
+        """ Handle mouse click, so user can copy the error message """
+        if event.button == 3:
+            path_info = self.treeview.get_path_at_pos(event.x, event.y)
+            if path_info is not None:
+                path, col, _, _ = path_info
+                self.treeview.grab_focus()
+                self.treeview.set_cursor(path, col, 0)
+
+            selection = self.treeview.get_selection()
+            (model, iterator) = selection.get_selected()
+            self.clipboard.set_text(model[iterator][2], -1)
+            print(model[iterator][2])
 
 
 def show_about(parent, config):


### PR DESCRIPTION
Hey folks.

So, I have this proposal: error messages displayed in the `Errors and Warnings` dialog are quite long sometimes. As I user I would like to be able to copy it to buffer, so I can web search it or post somewhere, e.g. forum, GitHub issue, IRC, etc.

I have made a quick proof of concept where the error message is copied to the buffer on right mouse click. The UI mechanism can be reworked, e.g. we can have a menu with the 'Copy' item showing up or whatever.

Please let me know what you think of this idea. Thank you.