### PR TITLE
controlport: include <algorithm> when using std::for_each()

### DIFF
--- a/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
+++ b/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
@@ -10,6 +10,7 @@
 
 #include <gnuradio/rpcserver_aggregator.h>
 #include <gnuradio/rpcserver_booter_base.h>
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
I'm building master in my Gentoo system and I need to `#include <algorithm>` whenever `std::for_each()` is used, since otherwise it won't build. I believe that this is the correct way to fix this problem, but since I'm not so savvy about C++, please correct me if I'm not right.