### PR TITLE
gr-qtgui: use boost placeholders explicitly in eye sink

### DIFF
--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -24,6 +24,9 @@
 #include <string.h>
 #include <algorithm>
 
+#include <boost/bind/placeholders.hpp>
+using namespace boost::placeholders;
+
 namespace gr {
 namespace qtgui {
 

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -24,6 +24,9 @@
 
 #include <string.h>
 
+#include <boost/bind/placeholders.hpp>
+using namespace boost::placeholders;
+
 namespace gr {
 namespace qtgui {
 


### PR DESCRIPTION
I'm building master in my Gentoo system. I've found that if [Boost placeholders](https://www.boost.org/doc/libs/1_69_0/libs/hof/doc/html/include/boost/hof/placeholders.html) are used, I need to `#include <boost/bind/placeholders.hpp>` and use the placeholders from namespace `boost::placeholders`. Otherwise this won't build.

I'm using Boost 1.73 and gcc 10.1.0.

It think this is the correct way to fix this problem, but as I'm not C++-savvy, please correct me if I'm wrong.