### PR TITLE
grc: Add dir_select parameter type

### DIFF
--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -49,7 +49,7 @@ PARAM_TYPE_NAMES = {
     'complex', 'real', 'float', 'int',
     'complex_vector', 'real_vector', 'float_vector', 'int_vector',
     'hex', 'string', 'bool',
-    'file_open', 'file_save', '_multiline', '_multiline_python_external',
+    'file_open', 'file_save', 'dir_select', '_multiline', '_multiline_python_external',
     'id', 'stream_id','name',
     'gui_hint',
     'import',

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -242,7 +242,7 @@ class Param(Element):
         #########################
         # String Types
         #########################
-        elif dtype in ('string', 'file_open', 'file_save', '_multiline', '_multiline_python_external'):
+        elif dtype in ('string', 'file_open', 'file_save', 'dir_select', '_multiline', '_multiline_python_external'):
             # Do not check if file/directory exists, that is a runtime issue
             try:
                 # Do not evaluate multiline strings (code snippets or comments)
@@ -293,7 +293,7 @@ class Param(Element):
         self._init = True
         value = self.get_value()
         # String types
-        if self.dtype in ('string', 'file_open', 'file_save', '_multiline', '_multiline_python_external'):
+        if self.dtype in ('string', 'file_open', 'file_save', 'dir_select', '_multiline', '_multiline_python_external'):
             if not self._init:
                 self.evaluate()
             return repr(value) if self._stringify_flag else value

--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -334,3 +334,41 @@ class FileParam(EntryParam):
             self._editing_callback()
             self._apply_change()
         file_dialog.destroy()  # destroy the dialog
+
+class DirectoryParam(FileParam):
+    """Provide an entry box for a directory and a button to browse for it."""
+
+    def _handle_clicked(self, widget=None):
+        """
+        Open the directory selector, when the button is clicked.
+        On success, update the entry.
+        """
+        dirname = self.param.get_evaluated() if self.param.is_valid() else ''
+        
+        if not os.path.isdir(dirname): # Check if directory exists, if not fall back to workdir
+            dirname = os.getcwd()
+
+        if self.param.dtype == "dir_select": # Setup directory selection dialog, and fail for unexpected dtype
+            dir_dialog = Gtk.FileChooserDialog(
+                title = 'Select a Directory...', action = Gtk.FileChooserAction.SELECT_FOLDER,
+                transient_for = self._transient_for
+            )
+        else:
+            raise ValueError("Can't open directory chooser dialog for type " + repr(self.param.dtype))
+
+        # Set dialog properties
+        dir_dialog.add_buttons( 'gtk-cancel', Gtk.ResponseType.CANCEL, 'gtk-open', Gtk.ResponseType.OK )
+        dir_dialog.set_current_folder(dirname)
+        dir_dialog.set_local_only(True)
+        dir_dialog.set_select_multiple(False)
+        
+        # Show dialog and update paramter on success
+        if Gtk.ResponseType.OK == dir_dialog.run():
+            path = dir_dialog.get_filename()
+            self._input.set_text(path)
+            self._editing_callback()
+            self._apply_change()
+
+        # Cleanup dialog
+        dir_dialog.destroy()
+

--- a/grc/gui/canvas/param.py
+++ b/grc/gui/canvas/param.py
@@ -32,6 +32,9 @@ class Param(CoreParam):
         if dtype in ('file_open', 'file_save'):
             input_widget_cls = ParamWidgets.FileParam
 
+        elif dtype == 'dir_select':
+            input_widget_cls = ParamWidgets.DirectoryParam
+
         elif dtype == 'enum':
             input_widget_cls = ParamWidgets.EnumParam
 


### PR DESCRIPTION
This commit adds a new parameter type to GNURadio Companion that allows
you to select directories using a gui. This functionality is
very similar to that of the previously available "file_open" and
"file_save" parameter types, and mainly differs by calling GTKs file
chooser with FileChooserAction.SELECT_FOLDER.

Example:
![image](https://user-images.githubusercontent.com/11067063/87877250-84220980-c9dd-11ea-92fa-0205f1bda796.png)
