### PR TITLE
uhd: Change Unknown PPS behavior

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -300,7 +300,7 @@ cpp_templates:
       ${'%'} endif
       this->${'$'}{id}->set_samp_rate(${'$'}{samp_rate});
       ${'%'} if sync == 'sync':
-      this->${'$'}{id}->set_time_unknown_pps(::uhd::time_spec_t());
+      this->${'$'}{id}->set_time_unknown_pps(::uhd::time_spec_t(time(NULL)));
       ${'%'} elif sync == 'pc_clock':
       this->${'$'}{id}->set_time_now(::uhd::time_spec_t(time(NULL)), ::uhd::usrp::multi_usrp::ALL_MBOARDS);
       ${'%'} else:

--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -169,7 +169,7 @@ templates:
         self.${'$'}{id}.set_samp_rate(${'$'}{samp_rate})
 
         ${'%'} if sync == 'sync':
-        self.${'$'}{id}.set_time_unknown_pps(uhd.time_spec(0))
+        self.${'$'}{id}.set_time_unknown_pps(uhd.time_spec(time.time()))
         ${'%'} elif sync == 'pc_clock':
         self.${'$'}{id}.set_time_now(uhd.time_spec(time.time()), uhd.ALL_MBOARDS)
         ${'%'} else:


### PR DESCRIPTION
Instead of setting USRP time to 0 with `time_unknown_pps`, set it to current
time. This does not help with fine sync but it helps to stay in the same
ball park with all clocks.
One might accidently send timed commands with PC clock time. A USRP
would try to wait 50 years at this point to actually execute that
command or to send that burst if the time given in case of "Unknown
PPS" is 0. This may cause issues during shutdown because it may force a user
to send a kill signal to the flowgraph. In turn that may require a USRP
reboot.