### PR TITLE
digital/map_bb: Add missing definition for a static class member

### DIFF
--- a/gr-digital/lib/map_bb_impl.cc
+++ b/gr-digital/lib/map_bb_impl.cc
@@ -30,6 +30,8 @@
 namespace gr {
 namespace digital {
 
+constexpr size_t map_bb_impl::s_map_size;
+
 map_bb::sptr map_bb::make(const std::vector<int>& map)
 {
     return gnuradio::get_initial_sptr(new map_bb_impl(map));


### PR DESCRIPTION
This fixes #3670 and possibly #3014.

Which C++ revision is used on master? As far as I know, this patch shouldn’t be required with C++17 (and shouldn’t hurt either).