### PR TITLE
Updated OFDM tx_ofdm.grc example for more occupied carrier flexibility

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -37,9 +37,14 @@ set(PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE} CACHE FILEPATH "python interpreter")
 set(QA_PYTHON_EXECUTABLE ${QA_PYTHON_EXECUTABLE} CACHE FILEPATH "python interpreter for QA tests")
 
 add_library(Python::Python INTERFACE IMPORTED)
+if(APPLE)
+    set_target_properties(Python::Python PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "-undefined dynamic_lookup"
+      )
 # Need to handle special cases where both debug and release
 # libraries are available (in form of debug;A;optimized;B) in PYTHON_LIBRARIES
-if(PYTHON_LIBRARY_DEBUG AND PYTHON_LIBRARY_RELEASE)
+elseif(PYTHON_LIBRARY_DEBUG AND PYTHON_LIBRARY_RELEASE)
     set_target_properties(Python::Python PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
       INTERFACE_LINK_LIBRARIES "$<$<NOT:$<CONFIG:Debug>>:${PYTHON_LIBRARY_RELEASE}>;$<$<CONFIG:Debug>:${PYTHON_LIBRARY_DEBUG}>"

--- a/gr-digital/examples/ofdm/tx_ofdm.grc
+++ b/gr-digital/examples/ofdm/tx_ofdm.grc
@@ -23,7 +23,6 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: OFDM Tx
-    window_size: 1280, 1024
   states:
     bus_sink: false
     bus_source: false
@@ -42,19 +41,21 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [208, 12.0]
+    coordinate: [282, 16]
     rotation: 0
     state: enabled
-- name: hdr_format
+- name: header_formatter
   id: variable
   parameters:
     comment: ''
-    value: digital.header_format_ofdm(occupied_carriers, 1, length_tag_key,)
+    value: digital.packet_header_ofdm(occupied_carriers, n_syms=1, len_tag_key=length_tag_key,
+      frame_len_tag_key=length_tag_key, bits_per_header_sym=header_mod.bits_per_symbol(),
+      bits_per_payload_sym=payload_mod.bits_per_symbol(), scramble_header=False)
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [912, 68.0]
+    coordinate: [989, 74]
     rotation: 0
     state: enabled
 - name: header_mod
@@ -66,7 +67,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [592, 12.0]
+    coordinate: [666, 16]
     rotation: 0
     state: enabled
 - name: length_tag_key
@@ -78,7 +79,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [368, 12.0]
+    coordinate: [442, 16]
     rotation: 0
     state: enabled
 - name: occupied_carriers
@@ -91,7 +92,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [512, 68.0]
+    coordinate: [584, 73]
     rotation: 0
     state: enabled
 - name: packet_len
@@ -103,7 +104,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [496, 12.0]
+    coordinate: [570, 16]
     rotation: 0
     state: enabled
 - name: payload_mod
@@ -115,7 +116,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [752, 12.0]
+    coordinate: [826, 16]
     rotation: 0
     state: enabled
 - name: pilot_carriers
@@ -127,7 +128,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [672, 68.0]
+    coordinate: [746, 72]
     rotation: 0
     state: enabled
 - name: pilot_symbols
@@ -139,7 +140,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [800, 68.0]
+    coordinate: [874, 72]
     rotation: 0
     state: enabled
 - name: rolloff
@@ -151,7 +152,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [912, 12.0]
+    coordinate: [986, 16]
     rotation: 0
     state: enabled
 - name: samp_rate
@@ -163,7 +164,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [272, 12.0]
+    coordinate: [346, 16]
     rotation: 0
     state: enabled
 - name: sync_word1
@@ -180,7 +181,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [208, 68.0]
+    coordinate: [282, 72]
     rotation: 0
     state: enabled
 - name: sync_word2
@@ -194,7 +195,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [336, 68.0]
+    coordinate: [410, 72]
     rotation: 0
     state: enabled
 - name: analog_random_source_x_0
@@ -214,7 +215,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [16, 164.0]
+    coordinate: [90, 168]
     rotation: 0
     state: enabled
 - name: blocks_multiply_const_vxx_0
@@ -232,7 +233,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [200, 692.0]
+    coordinate: [274, 696]
     rotation: 0
     state: enabled
 - name: blocks_repack_bits_bb_0
@@ -252,27 +253,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [640, 244.0]
-    rotation: 0
-    state: enabled
-- name: blocks_repack_bits_bb_0_0
-  id: blocks_repack_bits_bb
-  parameters:
-    affinity: ''
-    alias: ''
-    align_output: 'False'
-    comment: ''
-    endianness: gr.GR_LSB_FIRST
-    k: '8'
-    l: '1'
-    len_tag_key: length_tag_key
-    maxoutbuf: '0'
-    minoutbuf: '0'
-  states:
-    bus_sink: false
-    bus_source: false
-    bus_structure: null
-    coordinate: [880, 180.0]
+    coordinate: [714, 248]
     rotation: 0
     state: enabled
 - name: blocks_stream_to_tagged_stream_0
@@ -291,7 +272,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [176, 180.0]
+    coordinate: [250, 184]
     rotation: 0
     state: enabled
 - name: blocks_tag_debug_0
@@ -310,7 +291,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [712, 828.0]
+    coordinate: [786, 832]
     rotation: 0
     state: enabled
 - name: blocks_tag_gate_0
@@ -329,7 +310,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [360, 684.0]
+    coordinate: [434, 688]
     rotation: 0
     state: enabled
 - name: blocks_tagged_stream_mux_0
@@ -349,7 +330,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [512, 360.0]
+    coordinate: [586, 364]
     rotation: 0
     state: enabled
 - name: blocks_throttle_0
@@ -368,7 +349,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [552, 692.0]
+    coordinate: [626, 696]
     rotation: 0
     state: enabled
 - name: channels_channel_model_0
@@ -389,7 +370,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [200, 812.0]
+    coordinate: [274, 816]
     rotation: 0
     state: enabled
 - name: digital_chunks_to_symbols_xx_0
@@ -409,7 +390,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [216, 320.0]
+    coordinate: [290, 324]
     rotation: 0
     state: enabled
 - name: digital_chunks_to_symbols_xx_0_0
@@ -429,7 +410,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [216, 392.0]
+    coordinate: [290, 396]
     rotation: 0
     state: enabled
 - name: digital_crc32_bb_0
@@ -447,7 +428,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [384, 172.0]
+    coordinate: [458, 176]
     rotation: 0
     state: enabled
 - name: digital_ofdm_carrier_allocator_cvc_0
@@ -469,7 +450,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [200, 476.0]
+    coordinate: [274, 480]
     rotation: 0
     state: enabled
 - name: digital_ofdm_cyclic_prefixer_0
@@ -478,7 +459,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    cp_len: fft_len/4
+    cp_len: fft_len//4
     input_size: fft_len
     maxoutbuf: '0'
     minoutbuf: '0'
@@ -488,7 +469,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [624, 508.0]
+    coordinate: [698, 512]
     rotation: 0
     state: enabled
 - name: digital_ofdm_rx_0
@@ -515,16 +496,16 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [440, 764.0]
+    coordinate: [514, 768]
     rotation: 0
     state: enabled
-- name: digital_protocol_formatter_bb_0
-  id: digital_protocol_formatter_bb
+- name: digital_packet_headergenerator_bb_0
+  id: digital_packet_headergenerator_bb
   parameters:
     affinity: ''
     alias: ''
     comment: ''
-    format: hdr_format
+    header_formatter: header_formatter.base()
     len_tag_key: length_tag_key
     maxoutbuf: '0'
     minoutbuf: '0'
@@ -532,7 +513,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [640, 180.0]
+    coordinate: [781, 169]
     rotation: 0
     state: enabled
 - name: fft_vxx_0
@@ -553,7 +534,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [416, 492.0]
+    coordinate: [490, 496]
     rotation: 0
     state: enabled
 - name: header_bits
@@ -566,7 +547,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [1088, 188.0]
+    coordinate: [1162, 192]
     rotation: 0
     state: enabled
 - name: qtgui_freq_sink_x_0
@@ -646,7 +627,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [960, 756.0]
+    coordinate: [1034, 760]
     rotation: 0
     state: enabled
 - name: qtgui_time_sink_x_0
@@ -743,7 +724,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [960, 668.0]
+    coordinate: [1034, 672]
     rotation: 0
     state: enabled
 - name: virtual_sink_0
@@ -756,7 +737,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [856, 524]
+    coordinate: [930, 528]
     rotation: 0
     state: enabled
 - name: virtual_sink_0_0
@@ -769,7 +750,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [832, 252.0]
+    coordinate: [906, 256]
     rotation: 0
     state: enabled
 - name: virtual_sink_0_0_0
@@ -782,7 +763,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [744, 372.0]
+    coordinate: [818, 376]
     rotation: 0
     state: enabled
 - name: virtual_sink_1
@@ -795,7 +776,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [960, 620.0]
+    coordinate: [1034, 624]
     rotation: 0
     state: enabled
 - name: virtual_source_0
@@ -808,7 +789,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 316.0]
+    coordinate: [82, 320]
     rotation: 0
     state: enabled
 - name: virtual_source_0_0
@@ -821,7 +802,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 388.0]
+    coordinate: [82, 392]
     rotation: 0
     state: enabled
 - name: virtual_source_0_0_0
@@ -834,7 +815,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 524.0]
+    coordinate: [82, 528]
     rotation: 0
     state: enabled
 - name: virtual_source_0_0_0_0
@@ -847,7 +828,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 692.0]
+    coordinate: [82, 696]
     rotation: 0
     state: enabled
 - name: virtual_source_1
@@ -860,7 +841,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 844.0]
+    coordinate: [82, 848]
     rotation: 0
     state: enabled
 
@@ -868,7 +849,6 @@ connections:
 - [analog_random_source_x_0, '0', blocks_stream_to_tagged_stream_0, '0']
 - [blocks_multiply_const_vxx_0, '0', blocks_tag_gate_0, '0']
 - [blocks_repack_bits_bb_0, '0', virtual_sink_0_0, '0']
-- [blocks_repack_bits_bb_0_0, '0', header_bits, '0']
 - [blocks_stream_to_tagged_stream_0, '0', digital_crc32_bb_0, '0']
 - [blocks_tag_gate_0, '0', blocks_throttle_0, '0']
 - [blocks_tagged_stream_mux_0, '0', virtual_sink_0_0_0, '0']
@@ -879,11 +859,11 @@ connections:
 - [digital_chunks_to_symbols_xx_0, '0', blocks_tagged_stream_mux_0, '0']
 - [digital_chunks_to_symbols_xx_0_0, '0', blocks_tagged_stream_mux_0, '1']
 - [digital_crc32_bb_0, '0', blocks_repack_bits_bb_0, '0']
-- [digital_crc32_bb_0, '0', digital_protocol_formatter_bb_0, '0']
+- [digital_crc32_bb_0, '0', digital_packet_headergenerator_bb_0, '0']
 - [digital_ofdm_carrier_allocator_cvc_0, '0', fft_vxx_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', virtual_sink_0, '0']
 - [digital_ofdm_rx_0, '0', blocks_tag_debug_0, '0']
-- [digital_protocol_formatter_bb_0, '0', blocks_repack_bits_bb_0_0, '0']
+- [digital_packet_headergenerator_bb_0, '0', header_bits, '0']
 - [fft_vxx_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', digital_chunks_to_symbols_xx_0, '0']
 - [virtual_source_0_0, '0', digital_chunks_to_symbols_xx_0_0, '0']


### PR DESCRIPTION
The OFDM tx_ofdm.grc example appears to only work when the occupied carriers are in multiple of 8 however the OFDM Loopback example and the Receiver example work with greater occupied carrier flexibility. 

I examined the ofdm_txrx.py file an noted that it did not utilize the Protocol Formatter Block but instead utilized the Packet Header Generator block (ofdm_txrx.py also did not include the Repack Bits block on the header chain). After modifying tx_ofdm.grc to utilize the Packet Header Generator I was able to change the occupied_carrier variable to (list(range(-24, -21)) + list(range(-20, -7)) + list(range(-6, 0)) + list(range(1, 7)) + list(range(8, 21)) + list(range(22, 25)),) and still properly decode values after the receiver with a QT GUI Time Sink which did not work with the Protocol Formatter Block.