### PR TITLE
Fix to d_data_reg in 'correlate access code tag stream' for bb and ff

### DIFF
--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -90,6 +90,8 @@ unsigned long long correlate_access_code_bb_ts_impl::access_code() const
 inline void correlate_access_code_bb_ts_impl::enter_search()
 {
     d_state = STATE_SYNC_SEARCH;
+    d_data_reg = 0;                 // K. McQuiggin - zero between access code searches to eliminate false detects due to poorly-chosen
+                                    // access codes.  2020.07.25
 }
 
 inline void correlate_access_code_bb_ts_impl::enter_have_sync()

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -90,8 +90,9 @@ unsigned long long correlate_access_code_bb_ts_impl::access_code() const
 inline void correlate_access_code_bb_ts_impl::enter_search()
 {
     d_state = STATE_SYNC_SEARCH;
-    d_data_reg = 0;                 // K. McQuiggin - zero between access code searches to eliminate false detects due to poorly-chosen
-                                    // access codes.  2020.07.25
+    d_data_reg = 0; // K. McQuiggin - zero between access code searches to eliminate false
+                    // detects due to poorly-chosen access codes.  2020.07.25
+
 }
 
 inline void correlate_access_code_bb_ts_impl::enter_have_sync()

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -92,7 +92,6 @@ inline void correlate_access_code_bb_ts_impl::enter_search()
     d_state = STATE_SYNC_SEARCH;
     d_data_reg = 0; // K. McQuiggin - zero between access code searches to eliminate false
                     // detects due to poorly-chosen access codes.  2020.07.25
-
 }
 
 inline void correlate_access_code_bb_ts_impl::enter_have_sync()

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -90,8 +90,8 @@ unsigned long long correlate_access_code_ff_ts_impl::access_code() const
 inline void correlate_access_code_ff_ts_impl::enter_search()
 {
     d_state = STATE_SYNC_SEARCH;
-    d_data_reg = 0;                 // K. McQuiggin 2020.07.25 - zero this variable between searches to preclude false detections due to 
-                                    // poorly-chosen access codes
+    d_data_reg = 0; // K. McQuiggin - zero between access code searches to eliminate false
+                    // detects due to poorly-chosen access codes.  2020.07.25
 }
 
 inline void correlate_access_code_ff_ts_impl::enter_have_sync()

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -90,6 +90,8 @@ unsigned long long correlate_access_code_ff_ts_impl::access_code() const
 inline void correlate_access_code_ff_ts_impl::enter_search()
 {
     d_state = STATE_SYNC_SEARCH;
+    d_data_reg = 0;                 // K. McQuiggin 2020.07.25 - zero this variable between searches to preclude false detections due to 
+                                    // poorly-chosen access codes
 }
 
 inline void correlate_access_code_ff_ts_impl::enter_have_sync()


### PR DESCRIPTION
Currently the variable d_data_reg is used to compare a received bit stream with a known access code.  This variable is not re-initialized between received packets. 

When the state machine finishes a packet and enters the 'enter_search' state, a poorly-chosen cyclical access code (simplest example: '11111111') will cause false detection of a new, correct access code before the requisite number of valid bits have been read.  

In my example of '11111111' (8 bits), after a valid packet when the state machine starts a new search, the first 1 of the next packet will cause a false detection of a new packet As only one bit will have been read rather than the requisite 8 bits.  

It is better to re-initialize d_data_reg when starting a new search in order to prevent this false detection.