### PR TITLE
channels: Remove manual memory management

### DIFF
--- a/gr-channels/lib/selective_fading_model2_impl.h
+++ b/gr-channels/lib/selective_fading_model2_impl.h
@@ -24,7 +24,7 @@ namespace channels {
 class CHANNELS_API selective_fading_model2_impl : public selective_fading_model2
 {
 private:
-    std::vector<gr::channels::flat_fader_impl*> d_faders;
+    std::vector<gr::channels::flat_fader_impl> d_faders;
     std::vector<float> d_delays;
     std::vector<float> d_delays_orig;
     std::vector<float> d_delays_std;
@@ -47,35 +47,40 @@ public:
                                  std::vector<float> mags,
                                  unsigned int ntaps);
     ~selective_fading_model2_impl();
+
+    // Disallow copy. This is a heavy object.
+    selective_fading_model2_impl(const selective_fading_model2_impl&) = delete;
+    selective_fading_model2_impl& operator=(const selective_fading_model2_impl&) = delete;
+
     void setup_rpc();
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items);
     std::vector<gr_complex> d_taps;
 
-    virtual float fDTs() { return d_faders[0]->d_fDTs; }
-    virtual float K() { return d_faders[0]->d_K; }
-    virtual float step() { return d_faders[0]->d_step; }
+    virtual float fDTs() { return d_faders[0].d_fDTs; }
+    virtual float K() { return d_faders[0].d_K; }
+    virtual float step() { return d_faders[0].d_step; }
 
     virtual void set_fDTs(float fDTs)
     {
-        for (const auto& fader : d_faders) {
-            fader->d_fDTs = fDTs;
-            fader->d_step = powf(0.00125 * fDTs, 1.1);
+        for (auto& fader : d_faders) {
+            fader.d_fDTs = fDTs;
+            fader.d_step = powf(0.00125 * fDTs, 1.1);
         }
     }
     virtual void set_K(float K)
     {
-        for (const auto& fader : d_faders) {
-            fader->d_K = K;
-            fader->scale_los = sqrtf(fader->d_K) / sqrtf(fader->d_K + 1);
-            fader->scale_nlos = (1 / sqrtf(fader->d_K + 1));
+        for (auto& fader : d_faders) {
+            fader.d_K = K;
+            fader.scale_los = sqrtf(fader.d_K) / sqrtf(fader.d_K + 1);
+            fader.scale_nlos = (1 / sqrtf(fader.d_K + 1));
         }
     }
     virtual void set_step(float step)
     {
-        for (const auto& fader : d_faders) {
-            fader->d_step = step;
+        for (auto& fader : d_faders) {
+            fader.d_step = step;
         }
     }
 };

--- a/gr-channels/lib/selective_fading_model_impl.cc
+++ b/gr-channels/lib/selective_fading_model_impl.cc
@@ -54,9 +54,9 @@ selective_fading_model_impl::selective_fading_model_impl(unsigned int N,
     if (mags.size() != delays.size())
         throw std::runtime_error("magnitude and delay vectors must be the same length!");
 
+    d_faders.reserve(mags.size());
     for (size_t i = 0; i < mags.size(); i++) {
-        d_faders.push_back(
-            new gr::channels::flat_fader_impl(N, fDTs, (i == 0) && (LOS), K, seed + i));
+        d_faders.emplace_back(N, fDTs, (i == 0) && (LOS), K, seed + i);
     }
 
     // set up tap history
@@ -67,12 +67,7 @@ selective_fading_model_impl::selective_fading_model_impl(unsigned int N,
     d_taps.resize(ntaps, gr_complex(0, 0));
 }
 
-selective_fading_model_impl::~selective_fading_model_impl()
-{
-    for (size_t i = 0; i < d_faders.size(); i++) {
-        delete d_faders[i];
-    }
-}
+selective_fading_model_impl::~selective_fading_model_impl() {}
 
 int selective_fading_model_impl::work(int noutput_items,
                                       gr_vector_const_void_star& input_items,
@@ -82,10 +77,9 @@ int selective_fading_model_impl::work(int noutput_items,
     gr_complex* out = (gr_complex*)output_items[0];
 
     // pregenerate fading components
-    std::vector<std::vector<gr_complex>> fading_taps;
+    std::vector<std::vector<gr_complex>> fading_taps(d_faders.size());
     for (size_t j = 0; j < d_faders.size(); j++) {
-        fading_taps.push_back(std::vector<gr_complex>());
-        d_faders[j]->next_samples(fading_taps[j], noutput_items);
+        d_faders[j].next_samples(fading_taps[j], noutput_items);
     }
 
     // loop over each output sample
@@ -99,7 +93,7 @@ int selective_fading_model_impl::work(int noutput_items,
         // add each flat fading component to the taps
         for (size_t j = 0; j < d_faders.size(); j++) {
             gr_complex ff_H(fading_taps[j][i]);
-            // gr_complex ff_H(d_faders[j]->next_sample());
+            // gr_complex ff_H(d_faders[j].next_sample());
             for (size_t k = 0; k < d_taps.size(); k++) {
                 float dist = k - d_delays[j];
                 float interpmag = d_sintable.sinc(GR_M_PI * dist);

--- a/gr-channels/lib/selective_fading_model_impl.h
+++ b/gr-channels/lib/selective_fading_model_impl.h
@@ -24,7 +24,7 @@ namespace channels {
 class CHANNELS_API selective_fading_model_impl : public selective_fading_model
 {
 private:
-    std::vector<gr::channels::flat_fader_impl*> d_faders;
+    std::vector<gr::channels::flat_fader_impl> d_faders;
     std::vector<float> d_delays;
     std::vector<float> d_mags;
     sincostable d_sintable;
@@ -39,35 +39,40 @@ public:
                                 std::vector<float> mags,
                                 int ntaps);
     ~selective_fading_model_impl();
+
+    // Disallow copy. This is a heavy object.
+    selective_fading_model_impl(const selective_fading_model_impl&) = delete;
+    selective_fading_model_impl& operator=(const selective_fading_model_impl&) = delete;
+
     void setup_rpc();
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items);
     std::vector<gr_complex> d_taps;
 
-    virtual float fDTs() { return d_faders[0]->d_fDTs; }
-    virtual float K() { return d_faders[0]->d_K; }
-    virtual float step() { return d_faders[0]->d_step; }
+    virtual float fDTs() { return d_faders[0].d_fDTs; }
+    virtual float K() { return d_faders[0].d_K; }
+    virtual float step() { return d_faders[0].d_step; }
 
     virtual void set_fDTs(float fDTs)
     {
-        for (const auto& fader : d_faders) {
-            fader->d_fDTs = fDTs;
-            fader->d_step = powf(0.00125 * fDTs, 1.1);
+        for (auto& fader : d_faders) {
+            fader.d_fDTs = fDTs;
+            fader.d_step = powf(0.00125 * fDTs, 1.1);
         }
     }
     virtual void set_K(float K)
     {
-        for (const auto& fader : d_faders) {
-            fader->d_K = K;
-            fader->scale_los = sqrtf(fader->d_K) / sqrtf(fader->d_K + 1);
-            fader->scale_nlos = (1 / sqrtf(fader->d_K + 1));
+        for (auto& fader : d_faders) {
+            fader.d_K = K;
+            fader.scale_los = sqrtf(fader.d_K) / sqrtf(fader.d_K + 1);
+            fader.scale_nlos = (1 / sqrtf(fader.d_K + 1));
         }
     }
     virtual void set_step(float step)
     {
-        for (const auto& fader : d_faders) {
-            fader->d_step = step;
+        for (auto& fader : d_faders) {
+            fader.d_step = step;
         }
     }
 };

--- a/gr-channels/lib/sro_model_impl.cc
+++ b/gr-channels/lib/sro_model_impl.cc
@@ -41,7 +41,6 @@ sro_model_impl::sro_model_impl(double sample_rate_hz,
       d_samp_rate(sample_rate_hz),
       d_max_dev_hz(max_dev_hz),
       d_std_dev_hz(std_dev_hz),
-      d_interp(new gr::filter::mmse_fir_interpolator_cc()),
       d_noise(gr::analog::fastnoise_source_f::make(
           analog::GR_GAUSSIAN, std_dev_hz, noise_seed)),
       d_noise_seed(noise_seed)
@@ -50,15 +49,14 @@ sro_model_impl::sro_model_impl(double sample_rate_hz,
     set_relative_rate(1, 1);
 }
 
-sro_model_impl::~sro_model_impl() { delete d_interp; }
+sro_model_impl::~sro_model_impl() {}
 
 void sro_model_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
-        ninput_items_required[i] =
-            (int)ceil((noutput_items * (d_mu_inc + d_max_dev_hz / d_samp_rate)) +
-                      d_interp->ntaps());
+        ninput_items_required[i] = (int)ceil(
+            (noutput_items * (d_mu_inc + d_max_dev_hz / d_samp_rate)) + d_interp.ntaps());
     }
 }
 
@@ -81,7 +79,7 @@ int sro_model_impl::general_work(int noutput_items,
         d_sro = std::max(d_sro, -d_max_dev_hz);
         d_mu_inc = 1.0 + d_sro / d_samp_rate;
 
-        out[oo++] = d_interp->interpolate(&in[ii], d_mu);
+        out[oo++] = d_interp.interpolate(&in[ii], d_mu);
 
         double s = d_mu + d_mu_inc;
         double f = floor(s);

--- a/gr-channels/lib/sro_model_impl.h
+++ b/gr-channels/lib/sro_model_impl.h
@@ -28,7 +28,7 @@ private:
     float d_samp_rate;
     float d_max_dev_hz;
     float d_std_dev_hz;
-    gr::filter::mmse_fir_interpolator_cc* d_interp;
+    const gr::filter::mmse_fir_interpolator_cc d_interp;
     gr::analog::fastnoise_source_f::sptr d_noise;
     double d_noise_seed;
 


### PR DESCRIPTION
There are some `new` statements left, but they are immediately casted to shared pointers (`rpcbasic_sptr`), so should not be a problem. And a `make_shared` solution is a separate decision, and is probably best done with some `sed` magic refactoring instead.