### PR TITLE
blocks: Remove manual memory management

### DIFF
--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -51,8 +51,7 @@ bool message_strobe_impl::start()
     // NOTE: d_finished should be something explicitly thread safe. But since
     // nothing breaks on concurrent access, I'll just leave it as bool.
     d_finished = false;
-    d_thread = std::shared_ptr<gr::thread::thread>(
-        new gr::thread::thread(std::bind(&message_strobe_impl::run, this)));
+    d_thread = gr::thread::thread(std::bind(&message_strobe_impl::run, this));
 
     return block::start();
 }
@@ -61,8 +60,8 @@ bool message_strobe_impl::stop()
 {
     // Shut down the thread
     d_finished = true;
-    d_thread->interrupt();
-    d_thread->join();
+    d_thread.interrupt();
+    d_thread.join();
 
     return block::stop();
 }

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -48,8 +48,6 @@ message_strobe_impl::~message_strobe_impl() {}
 
 bool message_strobe_impl::start()
 {
-    // NOTE: d_finished should be something explicitly thread safe. But since
-    // nothing breaks on concurrent access, I'll just leave it as bool.
     d_finished = false;
     d_thread = gr::thread::thread(std::bind(&message_strobe_impl::run, this));
 

--- a/gr-blocks/lib/message_strobe_impl.h
+++ b/gr-blocks/lib/message_strobe_impl.h
@@ -19,7 +19,7 @@ namespace blocks {
 class BLOCKS_API message_strobe_impl : public message_strobe
 {
 private:
-    std::shared_ptr<gr::thread::thread> d_thread;
+    gr::thread::thread d_thread;
     bool d_finished;
     long d_period_ms;
     pmt::pmt_t d_msg;

--- a/gr-blocks/lib/message_strobe_impl.h
+++ b/gr-blocks/lib/message_strobe_impl.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_MESSAGE_STROBE_IMPL_H
 
 #include <gnuradio/blocks/message_strobe.h>
+#include <atomic>
 
 namespace gr {
 namespace blocks {
@@ -20,7 +21,7 @@ class BLOCKS_API message_strobe_impl : public message_strobe
 {
 private:
     gr::thread::thread d_thread;
-    bool d_finished;
+    std::atomic<bool> d_finished;
     long d_period_ms;
     pmt::pmt_t d_msg;
     const pmt::pmt_t d_port;

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -50,8 +50,7 @@ message_strobe_random_impl::message_strobe_random_impl(
 {
     // set up ports
     message_port_register_out(d_port);
-    d_thread = std::shared_ptr<gr::thread::thread>(
-        new gr::thread::thread(std::bind(&message_strobe_random_impl::run, this)));
+    d_thread = gr::thread::thread(std::bind(&message_strobe_random_impl::run, this));
 
     message_port_register_in(pmt::mp("set_msg"));
     set_msg_handler(pmt::mp("set_msg"), [this](pmt::pmt_t msg) { this->set_msg(msg); });
@@ -94,8 +93,8 @@ long message_strobe_random_impl::next_delay()
 message_strobe_random_impl::~message_strobe_random_impl()
 {
     d_finished = true;
-    d_thread->interrupt();
-    d_thread->join();
+    d_thread.interrupt();
+    d_thread.join();
 }
 
 void message_strobe_random_impl::run()

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/blocks/message_strobe_random.h>
 
+#include <atomic>
 #include <random>
 
 namespace gr {
@@ -29,7 +30,7 @@ private:
     std::normal_distribution<> nd;       //(d_mean_ms, d_std_ms);
     std::uniform_real_distribution<> ud; //(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms);
     gr::thread::thread d_thread;
-    bool d_finished;
+    std::atomic<bool> d_finished;
     pmt::pmt_t d_msg;
     const pmt::pmt_t d_port;
 

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -28,7 +28,7 @@ private:
     std::poisson_distribution<> pd;      //(d_mean_ms);
     std::normal_distribution<> nd;       //(d_mean_ms, d_std_ms);
     std::uniform_real_distribution<> ud; //(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms);
-    std::shared_ptr<gr::thread::thread> d_thread;
+    gr::thread::thread d_thread;
     bool d_finished;
     pmt::pmt_t d_msg;
     const pmt::pmt_t d_port;

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -82,8 +82,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
     }
 
     if (type == "TCP_SERVER") {
-        d_acceptor_tcp.reset(
-            new boost::asio::ip::tcp::acceptor(d_io_service, d_tcp_endpoint));
+        d_acceptor_tcp = std::make_shared<boost::asio::ip::tcp::acceptor>(d_io_service,
+                                                                          d_tcp_endpoint);
         d_acceptor_tcp->set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
 
         start_tcp_accept();
@@ -92,7 +92,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         [this](pmt::pmt_t msg) { this->tcp_server_send(msg); });
     } else if (type == "TCP_CLIENT") {
         boost::system::error_code error = boost::asio::error::host_not_found;
-        d_tcp_socket.reset(new boost::asio::ip::tcp::socket(d_io_service));
+        d_tcp_socket = std::make_shared<boost::asio::ip::tcp::socket>(d_io_service);
         d_tcp_socket->connect(d_tcp_endpoint, error);
         if (error)
             throw boost::system::system_error(error);
@@ -108,8 +108,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred));
     } else if (type == "UDP_SERVER") {
-        d_udp_socket.reset(
-            new boost::asio::ip::udp::socket(d_io_service, d_udp_endpoint));
+        d_udp_socket =
+            std::make_shared<boost::asio::ip::udp::socket>(d_io_service, d_udp_endpoint);
         d_udp_socket->async_receive_from(
             boost::asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
@@ -121,8 +121,8 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
         set_msg_handler(pdu::pdu_port_id(),
                         [this](pmt::pmt_t msg) { this->udp_send(msg); });
     } else if (type == "UDP_CLIENT") {
-        d_udp_socket.reset(
-            new boost::asio::ip::udp::socket(d_io_service, d_udp_endpoint));
+        d_udp_socket =
+            std::make_shared<boost::asio::ip::udp::socket>(d_io_service, d_udp_endpoint);
         d_udp_socket->async_receive_from(
             boost::asio::buffer(d_rxbuf),
             d_udp_endpoint_other,

--- a/gr-blocks/lib/tcp_connection.cc
+++ b/gr-blocks/lib/tcp_connection.cc
@@ -29,9 +29,8 @@ tcp_connection::sptr tcp_connection::make(boost::asio::io_service& io_service,
 tcp_connection::tcp_connection(boost::asio::io_service& io_service,
                                int MTU /*= 10000*/,
                                bool no_delay /*=false*/)
-    : d_socket(io_service), d_block(NULL), d_no_delay(no_delay)
+    : d_socket(io_service), d_buf(MTU), d_block(NULL), d_no_delay(no_delay)
 {
-    d_buf.resize(MTU);
     try {
         d_socket.set_option(boost::asio::ip::tcp::no_delay(no_delay));
     } catch (...) {

--- a/gr-blocks/lib/tcp_connection.h
+++ b/gr-blocks/lib/tcp_connection.h
@@ -34,6 +34,8 @@ private:
                    int MTU = 10000,
                    bool no_delay = false);
 
+    void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
+
 public:
     typedef std::shared_ptr<tcp_connection> sptr;
 
@@ -44,12 +46,6 @@ public:
 
     void start(gr::basic_block* block);
     void send(pmt::pmt_t vector);
-    void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-    void handle_write(std::shared_ptr<char[]> txbuf,
-                      const boost::system::error_code& error,
-                      size_t bytes_transferred)
-    {
-    }
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/tcp_server_sink_impl.h
+++ b/gr-blocks/lib/tcp_server_sink_impl.h
@@ -28,13 +28,13 @@ private:
     gr::thread::thread d_io_serv_thread;
     boost::asio::ip::tcp::endpoint d_endpoint;
     std::unique_ptr<boost::asio::ip::tcp::socket> d_socket;
-    std::set<boost::asio::ip::tcp::socket*> d_sockets;
+    std::set<std::unique_ptr<boost::asio::ip::tcp::socket>> d_sockets;
     boost::asio::ip::tcp::acceptor d_acceptor;
 
-    std::shared_ptr<uint8_t[]> d_buf;
     enum {
         BUF_SIZE = 256 * 1024,
     };
+    std::array<uint8_t, BUF_SIZE> d_buf;
 
     int d_writing;
     boost::condition_variable d_writing_cond;
@@ -43,7 +43,7 @@ private:
     void do_accept(const boost::system::error_code& error);
     void do_write(const boost::system::error_code& error,
                   std::size_t len,
-                  std::set<boost::asio::ip::tcp::socket*>::iterator);
+                  std::set<std::unique_ptr<boost::asio::ip::tcp::socket>>::iterator);
 
 public:
     tcp_server_sink_impl(size_t itemsize,


### PR DESCRIPTION
Remove manual memory management in gr-blocks.

Now there's only one `new`, and there's no good way to work around it. But on the other hand it's fine. It's readable still.