### PR TITLE
digital: Remove manual memory management

### DIFF
--- a/gr-digital/include/gnuradio/digital/header_buffer.h
+++ b/gr-digital/include/gnuradio/digital/header_buffer.h
@@ -71,8 +71,7 @@ namespace digital {
  * As simple example of using this class in transmit mode:
  *
  * \verbatim
- uint8_t* buffer = (uint8_t*)volk_malloc(header_nbytes(),
-                                         volk_get_alignment());
+ volk::vector<uint8_t> buffer(header_nbytes());
 
  header_buffer hdr(buffer);
  hdr.add_field64(sync_word, sync_word_len);
@@ -81,8 +80,6 @@ namespace digital {
  hdr.add_field8(header_options);
 
  // Do something with the header
-
- volk_free(buffer);
  \endverbatim
  *
  * In this example, the header contains four fields:

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -43,7 +43,6 @@ clock_recovery_mm_cc_impl::clock_recovery_mm_cc_impl(
       d_omega_relative_limit(omega_relative_limit),
       d_gain_mu(gain_mu),
       d_last_sample(0),
-      d_interp(new filter::mmse_fir_interpolator_cc()),
       d_verbose(prefs::singleton()->get_bool("clock_recovery_mm_cc", "verbose", false)),
       d_p_2T(0),
       d_p_1T(0),
@@ -63,7 +62,7 @@ clock_recovery_mm_cc_impl::clock_recovery_mm_cc_impl(
     enable_update_rate(true); // fixes tag propagation through variable rate block
 }
 
-clock_recovery_mm_cc_impl::~clock_recovery_mm_cc_impl() { delete d_interp; }
+clock_recovery_mm_cc_impl::~clock_recovery_mm_cc_impl() {}
 
 void clock_recovery_mm_cc_impl::forecast(int noutput_items,
                                          gr_vector_int& ninput_items_required)
@@ -71,7 +70,7 @@ void clock_recovery_mm_cc_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_omega) + d_interp->ntaps()) + FUDGE;
+            (int)ceil((noutput_items * d_omega) + d_interp.ntaps()) + FUDGE;
 }
 
 void clock_recovery_mm_cc_impl::set_omega(float omega)
@@ -91,10 +90,9 @@ int clock_recovery_mm_cc_impl::general_work(int noutput_items,
 
     bool write_foptr = output_items.size() >= 2;
 
-    int ii = 0; // input index
-    int oo = 0; // output index
-    int ni =
-        ninput_items[0] - d_interp->ntaps() - FUDGE; // don't use more input than this
+    int ii = 0;                                          // input index
+    int oo = 0;                                          // output index
+    int ni = ninput_items[0] - d_interp.ntaps() - FUDGE; // don't use more input than this
 
     assert(d_mu >= 0.0);
     assert(d_mu <= 1.0);
@@ -108,7 +106,7 @@ int clock_recovery_mm_cc_impl::general_work(int noutput_items,
         while (oo < noutput_items && ii < ni) {
             d_p_2T = d_p_1T;
             d_p_1T = d_p_0T;
-            d_p_0T = d_interp->interpolate(&in[ii], d_mu);
+            d_p_0T = d_interp.interpolate(&in[ii], d_mu);
 
             d_c_2T = d_c_1T;
             d_c_1T = d_c_0T;
@@ -142,7 +140,7 @@ int clock_recovery_mm_cc_impl::general_work(int noutput_items,
         while (oo < noutput_items && ii < ni) {
             d_p_2T = d_p_1T;
             d_p_1T = d_p_0T;
-            d_p_0T = d_interp->interpolate(&in[ii], d_mu);
+            d_p_0T = d_interp.interpolate(&in[ii], d_mu);
 
             d_c_2T = d_c_1T;
             d_c_1T = d_c_0T;

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.h
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.h
@@ -54,7 +54,7 @@ private:
     float d_gain_mu;              // gain for adjusting mu
 
     gr_complex d_last_sample;
-    filter::mmse_fir_interpolator_cc* d_interp;
+    filter::mmse_fir_interpolator_cc d_interp;
 
     bool d_verbose;
 

--- a/gr-digital/lib/clock_recovery_mm_ff_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_ff_impl.cc
@@ -36,8 +36,7 @@ clock_recovery_mm_ff_impl::clock_recovery_mm_ff_impl(
       d_gain_mu(gain_mu),
       d_gain_omega(gain_omega),
       d_omega_relative_limit(omega_relative_limit),
-      d_last_sample(0),
-      d_interp(new filter::mmse_fir_interpolator_ff())
+      d_last_sample(0)
 {
     if (omega < 1)
         throw std::out_of_range("clock rate must be > 0");
@@ -49,7 +48,7 @@ clock_recovery_mm_ff_impl::clock_recovery_mm_ff_impl(
     enable_update_rate(true); // fixes tag propagation through variable rate block
 }
 
-clock_recovery_mm_ff_impl::~clock_recovery_mm_ff_impl() { delete d_interp; }
+clock_recovery_mm_ff_impl::~clock_recovery_mm_ff_impl() {}
 
 void clock_recovery_mm_ff_impl::forecast(int noutput_items,
                                          gr_vector_int& ninput_items_required)
@@ -57,7 +56,7 @@ void clock_recovery_mm_ff_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_omega) + d_interp->ntaps());
+            (int)ceil((noutput_items * d_omega) + d_interp.ntaps());
 }
 
 void clock_recovery_mm_ff_impl::set_omega(float omega)
@@ -75,14 +74,14 @@ int clock_recovery_mm_ff_impl::general_work(int noutput_items,
     const float* in = (const float*)input_items[0];
     float* out = (float*)output_items[0];
 
-    int ii = 0;                                   // input index
-    int oo = 0;                                   // output index
-    int ni = ninput_items[0] - d_interp->ntaps(); // don't use more input than this
+    int ii = 0;                                  // input index
+    int oo = 0;                                  // output index
+    int ni = ninput_items[0] - d_interp.ntaps(); // don't use more input than this
     float mm_val;
 
     while (oo < noutput_items && ii < ni) {
         // produce output sample
-        out[oo] = d_interp->interpolate(&in[ii], d_mu);
+        out[oo] = d_interp.interpolate(&in[ii], d_mu);
         mm_val = slice(d_last_sample) * out[oo] - slice(out[oo]) * d_last_sample;
         d_last_sample = out[oo];
 

--- a/gr-digital/lib/clock_recovery_mm_ff_impl.h
+++ b/gr-digital/lib/clock_recovery_mm_ff_impl.h
@@ -54,7 +54,7 @@ private:
     float d_omega_lim;            // actual omega clipping limit
 
     float d_last_sample;
-    filter::mmse_fir_interpolator_ff* d_interp;
+    filter::mmse_fir_interpolator_ff d_interp;
 
     bool d_verbose;
 

--- a/gr-digital/lib/corr_est_cc_impl.h
+++ b/gr-digital/lib/corr_est_cc_impl.h
@@ -24,21 +24,23 @@ class corr_est_cc_impl : public corr_est_cc
 private:
     pmt::pmt_t d_src_id;
     std::vector<gr_complex> d_symbols;
-    float d_sps;
+    const float d_sps;
     unsigned int d_mark_delay, d_stashed_mark_delay;
     float d_thresh, d_stashed_threshold;
-    kernel::fft_filter_ccc* d_filter;
+    kernel::fft_filter_ccc d_filter;
 
-    gr_complex* d_corr;
-    float* d_corr_mag;
+    volk::vector<gr_complex> d_corr;
+    volk::vector<float> d_corr_mag;
 
     float d_scale;
     float d_pfa; // probability of false alarm
 
-    tm_type d_threshold_method;
+    const tm_type d_threshold_method;
 
     void _set_mark_delay(unsigned int mark_delay);
     void _set_threshold(float threshold);
+
+    static constexpr int s_nitems = 24 * 1024;
 
 public:
     corr_est_cc_impl(const std::vector<gr_complex>& symbols,

--- a/gr-digital/lib/glfsr_source_b_impl.cc
+++ b/gr-digital/lib/glfsr_source_b_impl.cc
@@ -32,6 +32,7 @@ glfsr_source_b_impl::glfsr_source_b_impl(unsigned int degree,
     : sync_block("glfsr_source_b",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(unsigned char))),
+      d_glfsr(mask ? mask : glfsr::glfsr_mask(degree), seed),
       d_repeat(repeat),
       d_index(0),
       d_length((((uint32_t)1) << degree) - 1)
@@ -39,15 +40,11 @@ glfsr_source_b_impl::glfsr_source_b_impl(unsigned int degree,
     if (degree < 1 || degree > 32)
         throw std::runtime_error(
             "glfsr_source_b_impl: degree must be between 1 and 32 inclusive");
-
-    if (mask == 0)
-        mask = glfsr::glfsr_mask(degree);
-    d_glfsr = new glfsr(mask, seed);
 }
 
-glfsr_source_b_impl::~glfsr_source_b_impl() { delete d_glfsr; }
+glfsr_source_b_impl::~glfsr_source_b_impl() {}
 
-uint32_t glfsr_source_b_impl::mask() const { return d_glfsr->mask(); }
+uint32_t glfsr_source_b_impl::mask() const { return d_glfsr.mask(); }
 
 int glfsr_source_b_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
@@ -59,7 +56,7 @@ int glfsr_source_b_impl::work(int noutput_items,
 
     int i;
     for (i = 0; i < noutput_items; i++) {
-        out[i] = d_glfsr->next_bit();
+        out[i] = d_glfsr.next_bit();
         d_index++;
         if (d_index > d_length && d_repeat == false)
             break;

--- a/gr-digital/lib/glfsr_source_b_impl.h
+++ b/gr-digital/lib/glfsr_source_b_impl.h
@@ -20,7 +20,7 @@ namespace digital {
 class glfsr_source_b_impl : public glfsr_source_b
 {
 private:
-    glfsr* d_glfsr;
+    glfsr d_glfsr;
 
     bool d_repeat;
     uint32_t d_index;

--- a/gr-digital/lib/glfsr_source_f_impl.cc
+++ b/gr-digital/lib/glfsr_source_f_impl.cc
@@ -33,6 +33,7 @@ glfsr_source_f_impl::glfsr_source_f_impl(unsigned int degree,
     : sync_block("glfsr_source_f",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(float))),
+      d_glfsr(mask ? mask : glfsr::glfsr_mask(degree), seed),
       d_repeat(repeat),
       d_index(0),
       d_length((((uint32_t)1) << degree) - 1)
@@ -40,15 +41,11 @@ glfsr_source_f_impl::glfsr_source_f_impl(unsigned int degree,
     if (degree < 1 || degree > 32)
         throw std::runtime_error(
             "glfsr_source_f_impl: degree must be between 1 and 32 inclusive");
-
-    if (mask == 0)
-        mask = glfsr::glfsr_mask(degree);
-    d_glfsr = new glfsr(mask, seed);
 }
 
-glfsr_source_f_impl::~glfsr_source_f_impl() { delete d_glfsr; }
+glfsr_source_f_impl::~glfsr_source_f_impl() {}
 
-uint32_t glfsr_source_f_impl::mask() const { return d_glfsr->mask(); }
+uint32_t glfsr_source_f_impl::mask() const { return d_glfsr.mask(); }
 
 int glfsr_source_f_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
@@ -60,7 +57,7 @@ int glfsr_source_f_impl::work(int noutput_items,
 
     int i;
     for (i = 0; i < noutput_items; i++) {
-        out[i] = (float)d_glfsr->next_bit() * 2.0 - 1.0;
+        out[i] = (float)d_glfsr.next_bit() * 2.0 - 1.0;
         d_index++;
         if (d_index > d_length && d_repeat == false)
             break;

--- a/gr-digital/lib/glfsr_source_f_impl.h
+++ b/gr-digital/lib/glfsr_source_f_impl.h
@@ -20,7 +20,7 @@ namespace digital {
 class glfsr_source_f_impl : public glfsr_source_f
 {
 private:
-    glfsr* d_glfsr;
+    glfsr d_glfsr;
 
     bool d_repeat;
     uint32_t d_index;

--- a/gr-digital/lib/header_format_counter.cc
+++ b/gr-digital/lib/header_format_counter.cc
@@ -15,7 +15,7 @@
 #include <gnuradio/digital/header_format_counter.h>
 #include <gnuradio/math.h>
 #include <string.h>
-#include <volk/volk.h>
+#include <volk/volk_alloc.hh>
 #include <iomanip>
 #include <iostream>
 
@@ -45,9 +45,10 @@ bool header_format_counter::format(int nbytes_in,
                                    pmt::pmt_t& info)
 
 {
-    uint8_t* bytes_out = (uint8_t*)volk_malloc(header_nbytes(), volk_get_alignment());
+    // Creating the output pmt copies data; free our own here when done.
+    volk::vector<uint8_t> bytes_out(header_nbytes());
 
-    header_buffer header(bytes_out);
+    header_buffer header(bytes_out.data());
     header.add_field64(d_access_code, d_access_code_len);
     header.add_field16((uint16_t)(nbytes_in));
     header.add_field16((uint16_t)(nbytes_in));
@@ -55,10 +56,7 @@ bool header_format_counter::format(int nbytes_in,
     header.add_field16((uint16_t)(d_counter));
 
     // Package output data into a PMT vector
-    output = pmt::init_u8vector(header_nbytes(), bytes_out);
-
-    // Creating the output pmt copies data; free our own here.
-    volk_free(bytes_out);
+    output = pmt::init_u8vector(header_nbytes(), bytes_out.data());
 
     d_counter++;
 

--- a/gr-digital/lib/header_format_default.cc
+++ b/gr-digital/lib/header_format_default.cc
@@ -14,7 +14,7 @@
 #include <gnuradio/digital/header_format_default.h>
 #include <gnuradio/math.h>
 #include <string.h>
-#include <volk/volk.h>
+#include <volk/volk_alloc.hh>
 #include <iostream>
 
 namespace gr {
@@ -85,18 +85,16 @@ bool header_format_default::format(int nbytes_in,
                                    pmt::pmt_t& output,
                                    pmt::pmt_t& info)
 {
-    uint8_t* bytes_out = (uint8_t*)volk_malloc(header_nbytes(), volk_get_alignment());
+    // Creating the output pmt copies data; free our own here when done.
+    volk::vector<uint8_t> bytes_out(header_nbytes());
 
-    header_buffer header(bytes_out);
+    header_buffer header(bytes_out.data());
     header.add_field64(d_access_code, d_access_code_len);
     header.add_field16((uint16_t)(nbytes_in));
     header.add_field16((uint16_t)(nbytes_in));
 
     // Package output data into a PMT vector
-    output = pmt::init_u8vector(header_nbytes(), bytes_out);
-
-    // Creating the output pmt copies data; free our own here.
-    volk_free(bytes_out);
+    output = pmt::init_u8vector(header_nbytes(), bytes_out.data());
 
     return true;
 }

--- a/gr-digital/lib/interpolating_resampler.cc
+++ b/gr-digital/lib/interpolating_resampler.cc
@@ -93,52 +93,40 @@ void interpolating_resampler::sync_reset(float phase)
 
 /*************************************************************************/
 
-interpolating_resampler_ccf* interpolating_resampler_ccf::make(
+std::unique_ptr<interpolating_resampler_ccf> interpolating_resampler_ccf::make(
     enum ir_type type, bool derivative, int nfilts, const std::vector<float>& taps)
 {
-    interpolating_resampler_ccf* ret = NULL;
     switch (type) {
     case IR_MMSE_8TAP:
-        ret = new interp_resampler_mmse_8tap_cc(derivative);
-        break;
+        return boost::make_unique<interp_resampler_mmse_8tap_cc>(derivative);
     case IR_PFB_NO_MF:
-        ret = new interp_resampler_pfb_no_mf_cc(derivative, nfilts);
-        break;
+        return boost::make_unique<interp_resampler_pfb_no_mf_cc>(derivative, nfilts);
     case IR_PFB_MF:
-        ret = new interp_resampler_pfb_mf_ccf(taps, nfilts, derivative);
-        break;
+        return boost::make_unique<interp_resampler_pfb_mf_ccf>(taps, nfilts, derivative);
     case IR_NONE:
-    default:
-        throw std::invalid_argument("interpolating_resampler_ccf: invalid "
-                                    "interpolating resampler type.");
-        break;
+        return nullptr;
     }
-    return ret;
+    throw std::invalid_argument("interpolating_resampler_ccf: invalid "
+                                "interpolating resampler type.");
 }
 
 /*************************************************************************/
 
-interpolating_resampler_fff* interpolating_resampler_fff::make(
+std::unique_ptr<interpolating_resampler_fff> interpolating_resampler_fff::make(
     enum ir_type type, bool derivative, int nfilts, const std::vector<float>& taps)
 {
-    interpolating_resampler_fff* ret = NULL;
     switch (type) {
     case IR_MMSE_8TAP:
-        ret = new interp_resampler_mmse_8tap_ff(derivative);
-        break;
+        return boost::make_unique<interp_resampler_mmse_8tap_ff>(derivative);
     case IR_PFB_NO_MF:
-        ret = new interp_resampler_pfb_no_mf_ff(derivative, nfilts);
-        break;
+        return boost::make_unique<interp_resampler_pfb_no_mf_ff>(derivative, nfilts);
     case IR_PFB_MF:
-        ret = new interp_resampler_pfb_mf_fff(taps, nfilts, derivative);
-        break;
+        return boost::make_unique<interp_resampler_pfb_mf_fff>(taps, nfilts, derivative);
     case IR_NONE:
-    default:
-        throw std::invalid_argument("interpolating_resampler_fff: invalid "
-                                    "interpolating resampler type.");
-        break;
+        return nullptr;
     }
-    return ret;
+    throw std::invalid_argument("interpolating_resampler_fff: invalid "
+                                "interpolating resampler type.");
 }
 
 /*************************************************************************/

--- a/gr-digital/lib/interpolating_resampler.h
+++ b/gr-digital/lib/interpolating_resampler.h
@@ -160,7 +160,7 @@ public:
      * \param taps   Prototype filter for the polyphase filter bank. Only
      *               needed for some types.
      */
-    static interpolating_resampler_ccf*
+    static std::unique_ptr<interpolating_resampler_ccf>
     make(enum ir_type type,
          bool derivative = false,
          int nfilts = 32,
@@ -222,7 +222,7 @@ public:
      * \param taps   Prototype filter for the polyphase filter bank. Only
      *               needed for some types.
      */
-    static interpolating_resampler_fff*
+    static std::unique_ptr<interpolating_resampler_fff>
     make(enum ir_type type,
          bool derivative = false,
          int nfilts = 32,

--- a/gr-digital/lib/interpolating_resampler.h
+++ b/gr-digital/lib/interpolating_resampler.h
@@ -17,6 +17,7 @@
 #include <gnuradio/filter/mmse_interp_differentiator_cc.h>
 #include <gnuradio/filter/mmse_interp_differentiator_ff.h>
 #include <gnuradio/gr_complex.h>
+#include <memory>
 #include <vector>
 
 namespace gr {
@@ -116,7 +117,7 @@ private:
 protected:
     interpolating_resampler(enum ir_type type, bool derivative = false);
 
-    bool d_derivative;
+    const bool d_derivative;
 
     float d_phase;
     float d_phase_wrapped;
@@ -296,8 +297,8 @@ public:
     gr_complex differentiate(const gr_complex input[], float mu) const;
 
 private:
-    filter::mmse_fir_interpolator_cc* d_interp;
-    filter::mmse_interp_differentiator_cc* d_interp_diff;
+    filter::mmse_fir_interpolator_cc d_interp;
+    std::unique_ptr<filter::mmse_interp_differentiator_cc> d_interp_diff;
 };
 
 /*!
@@ -344,8 +345,8 @@ public:
     float differentiate(const float input[], float mu) const;
 
 private:
-    filter::mmse_fir_interpolator_ff* d_interp;
-    filter::mmse_interp_differentiator_ff* d_interp_diff;
+    filter::mmse_fir_interpolator_ff d_interp;
+    std::unique_ptr<filter::mmse_interp_differentiator_ff> d_interp_diff;
 };
 
 /*************************************************************************/
@@ -399,8 +400,8 @@ public:
 
 private:
     int d_nfilters;
-    std::vector<filter::kernel::fir_filter_ccf*> d_filters;
-    std::vector<filter::kernel::fir_filter_ccf*> d_diff_filters;
+    std::vector<filter::kernel::fir_filter_ccf> d_filters;
+    std::vector<filter::kernel::fir_filter_ccf> d_diff_filters;
 };
 
 /*!
@@ -452,8 +453,8 @@ public:
 
 private:
     int d_nfilters;
-    std::vector<filter::kernel::fir_filter_fff*> d_filters;
-    std::vector<filter::kernel::fir_filter_fff*> d_diff_filters;
+    std::vector<filter::kernel::fir_filter_fff> d_filters;
+    std::vector<filter::kernel::fir_filter_fff> d_diff_filters;
 };
 
 /*************************************************************************/
@@ -510,8 +511,8 @@ public:
 private:
     int d_nfilters;
     const unsigned int d_taps_per_filter;
-    std::vector<filter::kernel::fir_filter_ccf*> d_filters;
-    std::vector<filter::kernel::fir_filter_ccf*> d_diff_filters;
+    std::vector<filter::kernel::fir_filter_ccf> d_filters;
+    std::vector<filter::kernel::fir_filter_ccf> d_diff_filters;
 
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_diff_taps;
@@ -569,8 +570,8 @@ public:
 private:
     int d_nfilters;
     const unsigned int d_taps_per_filter;
-    std::vector<filter::kernel::fir_filter_fff*> d_filters;
-    std::vector<filter::kernel::fir_filter_fff*> d_diff_filters;
+    std::vector<filter::kernel::fir_filter_fff> d_filters;
+    std::vector<filter::kernel::fir_filter_fff> d_diff_filters;
 
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_diff_taps;

--- a/gr-digital/lib/mpsk_snr_est_cc_impl.h
+++ b/gr-digital/lib/mpsk_snr_est_cc_impl.h
@@ -24,7 +24,7 @@ private:
     snr_est_type_t d_type;
     int d_nsamples, d_count;
     double d_alpha;
-    mpsk_snr_est* d_snr_est;
+    std::unique_ptr<mpsk_snr_est> d_snr_est;
 
     // d_key is the tag name, 'snr', d_me is the block name + unique ID
     pmt::pmt_t d_key, d_me;

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -38,7 +38,6 @@ msk_timing_recovery_cc_impl::msk_timing_recovery_cc_impl(float sps,
                 gr::io_signature::make3(
                     1, 3, sizeof(gr_complex), sizeof(float), sizeof(float))),
       d_limit(limit),
-      d_interp(new filter::mmse_fir_interpolator_cc()),
       d_dly_conj_1(0),
       d_dly_conj_2(0),
       d_dly_diff_1(0),
@@ -53,7 +52,7 @@ msk_timing_recovery_cc_impl::msk_timing_recovery_cc_impl(float sps,
         throw std::out_of_range("osps must be 1 or 2");
 }
 
-msk_timing_recovery_cc_impl::~msk_timing_recovery_cc_impl() { delete d_interp; }
+msk_timing_recovery_cc_impl::~msk_timing_recovery_cc_impl() {}
 
 void msk_timing_recovery_cc_impl::set_sps(float sps)
 {
@@ -85,7 +84,7 @@ void msk_timing_recovery_cc_impl::forecast(int noutput_items,
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
         ninput_items_required[i] =
-            (int)ceil((noutput_items * d_sps * 2) + 3.0 * d_sps + d_interp->ntaps());
+            (int)ceil((noutput_items * d_sps * 2) + 3.0 * d_sps + d_interp.ntaps());
     }
 }
 
@@ -159,7 +158,7 @@ int msk_timing_recovery_cc_impl::general_work(int noutput_items,
         // the actual equation for the nonlinearity is as follows:
         // e(n) = in[n]^2 * in[n-sps].conj()^2
         // we then differentiate the error by subtracting the sample delayed by d_sps/2
-        in_interp = d_interp->interpolate(&in[iidx], d_mu);
+        in_interp = d_interp.interpolate(&in[iidx], d_mu);
         sq = in_interp * in_interp;
         // conjugation is distributive.
         dly_conj = std::conj(d_dly_conj_2 * d_dly_conj_2);

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.h
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.h
@@ -25,7 +25,7 @@ private:
     float d_sps;
     float d_gain;
     float d_limit;
-    filter::mmse_fir_interpolator_cc* d_interp;
+    filter::mmse_fir_interpolator_cc d_interp;
     gr_complex d_dly_conj_1, d_dly_conj_2, d_dly_diff_1;
     float d_mu, d_omega, d_gain_omega;
     int d_div;

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -80,14 +80,14 @@ pfb_clock_sync_ccf_impl::pfb_clock_sync_ccf_impl(double sps,
     d_rate_f = d_rate - (float)d_rate_i;
     d_filtnum = (int)floor(d_k);
 
-    d_filters.resize(d_nfilters);
-    d_diff_filters.resize(d_nfilters);
+    d_filters.reserve(d_nfilters);
+    d_diff_filters.reserve(d_nfilters);
 
     // Create an FIR filter for each channel and zero out the taps
     std::vector<float> vtaps(1, 0);
     for (int i = 0; i < d_nfilters; i++) {
-        d_filters[i].reset(new kernel::fir_filter_ccf(1, vtaps));
-        d_diff_filters[i].reset(new kernel::fir_filter_ccf(1, vtaps));
+        d_filters.emplace_back(1, vtaps);
+        d_diff_filters.emplace_back(1, vtaps);
     }
 
     // Now, actually set the filters' taps
@@ -194,10 +194,9 @@ void pfb_clock_sync_ccf_impl::update_gains()
     d_beta = (4 * d_loop_bw * d_loop_bw) / denom;
 }
 
-void pfb_clock_sync_ccf_impl::set_taps(
-    const std::vector<float>& newtaps,
-    std::vector<std::vector<float>>& ourtaps,
-    std::vector<std::unique_ptr<kernel::fir_filter_ccf>>& ourfilter)
+void pfb_clock_sync_ccf_impl::set_taps(const std::vector<float>& newtaps,
+                                       std::vector<std::vector<float>>& ourtaps,
+                                       std::vector<kernel::fir_filter_ccf>& ourfilter)
 {
     int i, j;
 
@@ -224,7 +223,7 @@ void pfb_clock_sync_ccf_impl::set_taps(
         }
 
         // Build a filter for each channel and add it's taps to it
-        ourfilter[i]->set_taps(ourtaps[i]);
+        ourfilter[i].set_taps(ourtaps[i]);
     }
 
     // Set the history to ensure enough input items for each filter
@@ -390,7 +389,7 @@ int pfb_clock_sync_ccf_impl::general_work(int noutput_items,
                 count -= 1;
             }
 
-            out[i + d_out_idx] = d_filters[d_filtnum]->filter(&in[count + d_out_idx]);
+            out[i + d_out_idx] = d_filters[d_filtnum].filter(&in[count + d_out_idx]);
             d_k = d_k + d_rate_i + d_rate_f; // update phase
 
 
@@ -427,7 +426,7 @@ int pfb_clock_sync_ccf_impl::general_work(int noutput_items,
         d_out_idx = 0;
 
         // Update the phase and rate estimates for this symbol
-        gr_complex diff = d_diff_filters[d_filtnum]->filter(&in[count]);
+        gr_complex diff = d_diff_filters[d_filtnum].filter(&in[count]);
         error_r = out[i].real() * diff.real();
         error_i = out[i].imag() * diff.imag();
         d_error = (error_i + error_r) / 2.0; // average error from I&Q channel

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.h
@@ -30,8 +30,8 @@ private:
 
     const int d_nfilters;
     int d_taps_per_filter;
-    std::vector<std::unique_ptr<kernel::fir_filter_ccf>> d_filters;
-    std::vector<std::unique_ptr<kernel::fir_filter_ccf>> d_diff_filters;
+    std::vector<kernel::fir_filter_ccf> d_filters;
+    std::vector<kernel::fir_filter_ccf> d_diff_filters;
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_dtaps;
     std::vector<float> d_updated_taps;
@@ -53,7 +53,7 @@ private:
 
     void set_taps(const std::vector<float>& taps,
                   std::vector<std::vector<float>>& ourtaps,
-                  std::vector<std::unique_ptr<kernel::fir_filter_ccf>>& ourfilter);
+                  std::vector<kernel::fir_filter_ccf>& ourfilter);
 
 public:
     pfb_clock_sync_ccf_impl(double sps,

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.h
@@ -30,8 +30,8 @@ private:
 
     const int d_nfilters;
     int d_taps_per_filter;
-    std::vector<kernel::fir_filter_fff*> d_filters;
-    std::vector<kernel::fir_filter_fff*> d_diff_filters;
+    std::vector<kernel::fir_filter_fff> d_filters;
+    std::vector<kernel::fir_filter_fff> d_diff_filters;
     std::vector<std::vector<float>> d_taps;
     std::vector<std::vector<float>> d_dtaps;
     std::vector<float> d_updated_taps;
@@ -51,7 +51,7 @@ private:
 
     void set_taps(const std::vector<float>& taps,
                   std::vector<std::vector<float>>& ourtaps,
-                  std::vector<kernel::fir_filter_fff*>& ourfilter);
+                  std::vector<kernel::fir_filter_fff>& ourfilter);
 
 public:
     pfb_clock_sync_fff_impl(double sps,
@@ -75,6 +75,7 @@ public:
     std::vector<float> diff_channel_taps(int channel) const;
     std::string taps_as_string() const;
     std::string diff_taps_as_string() const;
+
 
     void set_loop_bandwidth(float bw);
     void set_damping_factor(float df);

--- a/gr-digital/lib/pn_correlator_cc_impl.h
+++ b/gr-digital/lib/pn_correlator_cc_impl.h
@@ -20,9 +20,9 @@ namespace digital {
 class pn_correlator_cc_impl : public pn_correlator_cc
 {
 private:
-    int d_len;
+    const int d_len;
     float d_pn;
-    glfsr* d_reference;
+    glfsr d_reference;
 
 public:
     pn_correlator_cc_impl(int degree, int mask = 0, int seed = 1);

--- a/gr-digital/lib/probe_mpsk_snr_est_c_impl.h
+++ b/gr-digital/lib/probe_mpsk_snr_est_c_impl.h
@@ -22,7 +22,7 @@ private:
     snr_est_type_t d_type;
     int d_nsamples, d_count;
     double d_alpha;
-    mpsk_snr_est* d_snr_est;
+    std::unique_ptr<mpsk_snr_est> d_snr_est;
 
     // Message port names
     pmt::pmt_t d_snr_port;

--- a/gr-digital/lib/protocol_formatter_async_impl.cc
+++ b/gr-digital/lib/protocol_formatter_async_impl.cc
@@ -15,7 +15,7 @@
 #include "protocol_formatter_async_impl.h"
 #include <gnuradio/io_signature.h>
 #include <stdio.h>
-#include <volk/volk.h>
+#include <volk/volk_alloc.hh>
 
 namespace gr {
 namespace digital {
@@ -58,11 +58,9 @@ void protocol_formatter_async_impl::append(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(input, pkt_len);
 
     // Pad the payload with 0's
-    uint8_t* payload =
-        (uint8_t*)volk_malloc(pkt_len * sizeof(uint8_t), volk_get_alignment());
-    memcpy(payload, bytes_in, pkt_len * sizeof(uint8_t));
-    output = pmt::init_u8vector(pkt_len, payload);
-    volk_free(payload);
+    volk::vector<uint8_t> payload(pkt_len);
+    memcpy(payload.data(), bytes_in, pkt_len * sizeof(uint8_t));
+    output = pmt::init_u8vector(pkt_len, payload.data());
 
     // Build the header from the input, metadata, and format
     d_format->format(pkt_len, bytes_in, header, meta);

--- a/gr-digital/lib/qa_header_buffer.cc
+++ b/gr-digital/lib/qa_header_buffer.cc
@@ -15,15 +15,15 @@
 #include <gnuradio/attributes.h>
 #include <gnuradio/digital/header_buffer.h>
 #include <stdio.h>
-#include <volk/volk.h>
+#include <volk/volk_alloc.hh>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE(test_add8)
 {
     size_t len = sizeof(uint8_t);
-    uint8_t* buf = (uint8_t*)volk_malloc(len, volk_get_alignment());
+    volk::vector<uint8_t> buf(len);
 
-    gr::digital::header_buffer header(buf);
+    gr::digital::header_buffer header(buf.data());
     header.add_field8(0xAF);
 
     BOOST_REQUIRE_EQUAL(len, header.length());
@@ -31,18 +31,16 @@ BOOST_AUTO_TEST_CASE(test_add8)
 
     header.clear();
     BOOST_REQUIRE_EQUAL((size_t)0, header.length());
-
-    volk_free(buf);
 }
 
 BOOST_AUTO_TEST_CASE(test_add16)
 {
     size_t len = sizeof(uint16_t);
-    uint8_t* buf = (uint8_t*)volk_malloc(len, volk_get_alignment());
+    volk::vector<uint8_t> buf(len);
 
     uint16_t data = 0xAF5C;
 
-    gr::digital::header_buffer header(buf);
+    gr::digital::header_buffer header(buf.data());
     header.add_field16(data);
 
     // Test standard add of a uint16
@@ -72,18 +70,16 @@ BOOST_AUTO_TEST_CASE(test_add16)
     BOOST_REQUIRE_EQUAL((size_t)1, header.length());
     BOOST_REQUIRE_EQUAL((uint8_t)0x5C, header.header()[0]);
     header.clear();
-
-    volk_free(buf);
 }
 
 BOOST_AUTO_TEST_CASE(test_add32)
 {
     size_t len = sizeof(uint32_t);
-    uint8_t* buf = (uint8_t*)volk_malloc(len, volk_get_alignment());
+    volk::vector<uint8_t> buf(len);
 
     uint32_t data = 0xAF5C7654;
 
-    gr::digital::header_buffer header(buf);
+    gr::digital::header_buffer header(buf.data());
     header.add_field32(data);
 
     // Test standard add of a uint32
@@ -119,18 +115,16 @@ BOOST_AUTO_TEST_CASE(test_add32)
     BOOST_REQUIRE_EQUAL((uint8_t)0x76, header.header()[1]);
     BOOST_REQUIRE_EQUAL((uint8_t)0x5C, header.header()[2]);
     header.clear();
-
-    volk_free(buf);
 }
 
 BOOST_AUTO_TEST_CASE(test_add64)
 {
     size_t len = sizeof(uint64_t);
-    uint8_t* buf = (uint8_t*)volk_malloc(len, volk_get_alignment());
+    volk::vector<uint8_t> buf(len);
 
     uint64_t data = 0xAF5C765432104567;
 
-    gr::digital::header_buffer header(buf);
+    gr::digital::header_buffer header(buf.data());
     header.add_field64(data);
 
     // Test standard add of a uint64
@@ -181,16 +175,14 @@ BOOST_AUTO_TEST_CASE(test_add64)
     BOOST_REQUIRE_EQUAL((uint8_t)0x32, header.header()[3]);
     BOOST_REQUIRE_EQUAL((uint8_t)0x54, header.header()[4]);
     header.clear();
-
-    volk_free(buf);
 }
 
 BOOST_AUTO_TEST_CASE(test_add_many)
 {
     size_t len = (32 + 64 + 8 + 16 + 32) / 8;
-    uint8_t* buf = (uint8_t*)volk_malloc(len, volk_get_alignment());
+    volk::vector<uint8_t> buf(len);
 
-    gr::digital::header_buffer header(buf);
+    gr::digital::header_buffer header(buf.data());
     header.add_field32(0x01234567);
     header.add_field64(0x89ABCDEFFEDCBA98);
     header.add_field8(0x76);

--- a/gr-digital/lib/symbol_sync_cc_impl.h
+++ b/gr-digital/lib/symbol_sync_cc_impl.h
@@ -41,27 +41,27 @@ public:
                      gr_vector_void_star& output_items);
 
     // Symbol Clock Tracking and Estimation
-    float loop_bandwidth() const { return d_clock->get_loop_bandwidth(); }
-    float damping_factor() const { return d_clock->get_damping_factor(); }
-    float ted_gain() const { return d_clock->get_ted_gain(); }
-    float alpha() const { return d_clock->get_alpha(); }
-    float beta() const { return d_clock->get_beta(); }
+    float loop_bandwidth() const { return d_clock.get_loop_bandwidth(); }
+    float damping_factor() const { return d_clock.get_damping_factor(); }
+    float ted_gain() const { return d_clock.get_ted_gain(); }
+    float alpha() const { return d_clock.get_alpha(); }
+    float beta() const { return d_clock.get_beta(); }
 
     void set_loop_bandwidth(float omega_n_norm)
     {
-        d_clock->set_loop_bandwidth(omega_n_norm);
+        d_clock.set_loop_bandwidth(omega_n_norm);
     }
-    void set_damping_factor(float zeta) { d_clock->set_damping_factor(zeta); }
-    void set_ted_gain(float ted_gain) { d_clock->set_ted_gain(ted_gain); }
-    void set_alpha(float alpha) { d_clock->set_alpha(alpha); }
-    void set_beta(float beta) { d_clock->set_beta(beta); }
+    void set_damping_factor(float zeta) { d_clock.set_damping_factor(zeta); }
+    void set_ted_gain(float ted_gain) { d_clock.set_ted_gain(ted_gain); }
+    void set_alpha(float alpha) { d_clock.set_alpha(alpha); }
+    void set_beta(float beta) { d_clock.set_beta(beta); }
 
 private:
     // Timing Error Detector
     std::unique_ptr<timing_error_detector> d_ted;
 
     // Symbol Clock Tracking and Estimation
-    std::unique_ptr<clock_tracking_loop> d_clock;
+    clock_tracking_loop d_clock;
 
     // Interpolator and Interpolator Positioning and Alignment
     std::unique_ptr<interpolating_resampler_ccf> d_interp;

--- a/gr-digital/lib/symbol_sync_ff_impl.h
+++ b/gr-digital/lib/symbol_sync_ff_impl.h
@@ -42,30 +42,30 @@ public:
                      gr_vector_void_star& output_items);
 
     // Symbol Clock Tracking and Estimation
-    float loop_bandwidth() const { return d_clock->get_loop_bandwidth(); }
-    float damping_factor() const { return d_clock->get_damping_factor(); }
-    float ted_gain() const { return d_clock->get_ted_gain(); }
-    float alpha() const { return d_clock->get_alpha(); }
-    float beta() const { return d_clock->get_beta(); }
+    float loop_bandwidth() const { return d_clock.get_loop_bandwidth(); }
+    float damping_factor() const { return d_clock.get_damping_factor(); }
+    float ted_gain() const { return d_clock.get_ted_gain(); }
+    float alpha() const { return d_clock.get_alpha(); }
+    float beta() const { return d_clock.get_beta(); }
 
     void set_loop_bandwidth(float omega_n_norm)
     {
-        d_clock->set_loop_bandwidth(omega_n_norm);
+        d_clock.set_loop_bandwidth(omega_n_norm);
     }
-    void set_damping_factor(float zeta) { d_clock->set_damping_factor(zeta); }
-    void set_ted_gain(float ted_gain) { d_clock->set_ted_gain(ted_gain); }
-    void set_alpha(float alpha) { d_clock->set_alpha(alpha); }
-    void set_beta(float beta) { d_clock->set_beta(beta); }
+    void set_damping_factor(float zeta) { d_clock.set_damping_factor(zeta); }
+    void set_ted_gain(float ted_gain) { d_clock.set_ted_gain(ted_gain); }
+    void set_alpha(float alpha) { d_clock.set_alpha(alpha); }
+    void set_beta(float beta) { d_clock.set_beta(beta); }
 
 private:
     // Timing Error Detector
-    timing_error_detector* d_ted;
+    std::unique_ptr<timing_error_detector> d_ted;
 
     // Symbol Clock Tracking and Estimation
-    clock_tracking_loop* d_clock;
+    clock_tracking_loop d_clock;
 
     // Interpolator and Interpolator Positioning and Alignment
-    interpolating_resampler_fff* d_interp;
+    std::unique_ptr<interpolating_resampler_fff> d_interp;
 
     // Block Internal Clocks
     // 4 clocks that run synchronously, aligned to the Symbol Clock:

--- a/gr-digital/lib/timing_error_detector.cc
+++ b/gr-digital/lib/timing_error_detector.cc
@@ -14,49 +14,38 @@
 
 #include "timing_error_detector.h"
 #include <gnuradio/math.h>
+#include <boost/make_unique.hpp>
 #include <stdexcept>
 
 namespace gr {
 namespace digital {
 
-timing_error_detector* timing_error_detector::make(enum ted_type type,
-                                                   constellation_sptr constellation)
+std::unique_ptr<timing_error_detector>
+timing_error_detector::make(enum ted_type type, constellation_sptr constellation)
 {
-    timing_error_detector* ret = NULL;
     switch (type) {
     case TED_NONE:
-        break;
+        return nullptr;
     case TED_MUELLER_AND_MULLER:
-        ret = new ted_mueller_and_muller(constellation);
-        break;
+        return boost::make_unique<ted_mueller_and_muller>(constellation);
     case TED_MOD_MUELLER_AND_MULLER:
-        ret = new ted_mod_mueller_and_muller(constellation);
-        break;
+        return boost::make_unique<ted_mod_mueller_and_muller>(constellation);
     case TED_ZERO_CROSSING:
-        ret = new ted_zero_crossing(constellation);
-        break;
+        return boost::make_unique<ted_zero_crossing>(constellation);
     case TED_GARDNER:
-        ret = new ted_gardner();
-        break;
+        return boost::make_unique<ted_gardner>();
     case TED_EARLY_LATE:
-        ret = new ted_early_late();
-        break;
+        return boost::make_unique<ted_early_late>();
     case TED_DANDREA_AND_MENGALI_GEN_MSK:
-        ret = new ted_generalized_msk();
-        break;
+        return boost::make_unique<ted_generalized_msk>();
     case TED_SIGNAL_TIMES_SLOPE_ML:
-        ret = new ted_signal_times_slope_ml();
-        break;
+        return boost::make_unique<ted_signal_times_slope_ml>();
     case TED_SIGNUM_TIMES_SLOPE_ML:
-        ret = new ted_signum_times_slope_ml();
-        break;
+        return boost::make_unique<ted_signum_times_slope_ml>();
     case TED_MENGALI_AND_DANDREA_GMSK:
-        ret = new ted_gaussian_msk();
-        break;
-    default:
-        break;
+        return boost::make_unique<ted_gaussian_msk>();
     }
-    return ret;
+    return nullptr;
 }
 
 timing_error_detector::timing_error_detector(enum ted_type type,

--- a/gr-digital/lib/timing_error_detector.h
+++ b/gr-digital/lib/timing_error_detector.h
@@ -50,7 +50,7 @@ public:
      *                      for decision directed timing error detector
      *                      algorithms
      */
-    static timing_error_detector*
+    static std::unique_ptr<timing_error_detector>
     make(enum ted_type type, constellation_sptr constellation = constellation_sptr());
 
     virtual ~timing_error_detector(){};

--- a/gr-digital/python/digital/bindings/header_buffer_python.cc
+++ b/gr-digital/python/digital/bindings/header_buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_buffer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(cb0f4b24d7fa8f9c23b864584c361e11)                     */
+/* BINDTOOL_HEADER_FILE_HASH(fa6a18f60473f6981e632c4cf3005793)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
There's still a bunch of `new` in the module, but looks like it's all directly-assign-to-smartptr.

This PR takes away all `volk_free` and `delete`, at least.

I'd like to get rid of that too, so that it's more obviously not leaking memory (and probably some don't need to be pointers at all), but this is enough for today.