### PR TITLE
digital/correlate_access_code: Prevent false triggers

### DIFF
--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -90,6 +90,7 @@ unsigned long long correlate_access_code_bb_ts_impl::access_code() const
 inline void correlate_access_code_bb_ts_impl::enter_search()
 {
     d_state = STATE_SYNC_SEARCH;
+    d_data_reg_bits = 0;
 }
 
 inline void correlate_access_code_bb_ts_impl::enter_have_sync()
@@ -137,8 +138,12 @@ int correlate_access_code_bb_ts_impl::general_work(int noutput_items,
             while (count < noutput_items) {
                 // shift in new data
                 d_data_reg = (d_data_reg << 1) | ((in[count++]) & 0x1);
-
-                // compute hamming distance between desired access code and current data
+                if (d_data_reg_bits + 1 < d_len) {
+                    d_data_reg_bits++;
+                    continue;
+                }
+                // compute hamming distance between desired access code and current
+                // data
                 uint64_t wrong_bits = 0;
                 uint64_t nwrong = d_threshold + 1;
 

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.h
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.h
@@ -26,6 +26,7 @@ private:
     unsigned long long d_access_code; // access code to locate start of packet
                                       //   access code is left justified in the word
     unsigned long long d_data_reg;    // used to look for access_code
+    unsigned int d_data_reg_bits = 0; // used to makes sure we've seen the whole code
     unsigned long long d_mask;        // masks access_code bits (top N bits are set where
                                       //   N is the number of bits in the access code)
     unsigned int d_threshold;         // how many bits may be wrong in sync vector

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -90,6 +90,7 @@ unsigned long long correlate_access_code_ff_ts_impl::access_code() const
 inline void correlate_access_code_ff_ts_impl::enter_search()
 {
     d_state = STATE_SYNC_SEARCH;
+    d_data_reg_bits = 0;
 }
 
 inline void correlate_access_code_ff_ts_impl::enter_have_sync()
@@ -138,8 +139,12 @@ int correlate_access_code_ff_ts_impl::general_work(int noutput_items,
                 // shift in new data
                 d_data_reg =
                     (d_data_reg << 1) | (gr::branchless_binary_slicer(in[count++]) & 0x1);
-
-                // compute hamming distance between desired access code and current data
+                if (d_data_reg_bits + 1 < d_len) {
+                    d_data_reg_bits++;
+                    continue;
+                }
+                // compute hamming distance between desired access code and current
+                // data
                 uint64_t wrong_bits = 0;
                 uint64_t nwrong = d_threshold + 1;
 

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.h
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.h
@@ -26,6 +26,7 @@ private:
     unsigned long long d_access_code; // access code to locate start of packet
                                       //   access code is left justified in the word
     unsigned long long d_data_reg;    // used to look for access_code
+    unsigned int d_data_reg_bits = 0; // used to makes sure we've seen the whole code
     unsigned long long d_mask;        // masks access_code bits (top N bits are set where
                                       //   N is the number of bits in the access code)
     unsigned int d_threshold;         // how many bits may be wrong in sync vector

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -94,8 +94,12 @@ int correlate_access_code_tag_bb_impl::work(int noutput_items,
         uint64_t wrong_bits = 0;
         uint64_t nwrong = d_threshold + 1;
 
-        wrong_bits = (d_data_reg ^ d_access_code) & d_mask;
-        volk_64u_popcnt(&nwrong, wrong_bits);
+        if (d_data_reg_bits < d_len) {
+            d_data_reg_bits++;
+        } else {
+            wrong_bits = (d_data_reg ^ d_access_code) & d_mask;
+            volk_64u_popcnt(&nwrong, wrong_bits);
+        }
 
         // shift in new data
         d_data_reg = (d_data_reg << 1) | (in[i] & 0x1);

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.h
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.h
@@ -22,6 +22,7 @@ private:
     unsigned long long d_access_code; // access code to locate start of packet
                                       //   access code is left justified in the word
     unsigned long long d_data_reg;    // used to look for access_code
+    unsigned int d_data_reg_bits = 0; // used to makes sure we've seen the whole code
     unsigned long long d_mask;        // masks access_code bits (top N bits are set where
                                       //   N is the number of bits in the access code)
     unsigned int d_threshold;         // how many bits may be wrong in sync vector

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -95,8 +95,12 @@ int correlate_access_code_tag_ff_impl::work(int noutput_items,
         uint64_t wrong_bits = 0;
         uint64_t nwrong = d_threshold + 1;
 
-        wrong_bits = (d_data_reg ^ d_access_code) & d_mask;
-        volk_64u_popcnt(&nwrong, wrong_bits);
+        if (d_data_reg_bits < d_len) {
+            d_data_reg_bits++;
+        } else {
+            wrong_bits = (d_data_reg ^ d_access_code) & d_mask;
+            volk_64u_popcnt(&nwrong, wrong_bits);
+        }
 
         // shift in new data
         d_data_reg = (d_data_reg << 1) | (gr::branchless_binary_slicer(in[i]) & 0x1);

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.h
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.h
@@ -22,6 +22,7 @@ private:
     unsigned long long d_access_code; // access code to locate start of packet
                                       //   access code is left justified in the word
     unsigned long long d_data_reg;    // used to look for access_code
+    unsigned int d_data_reg_bits = 0; // used to makes sure we've seen the whole code
     unsigned long long d_mask;        // masks access_code bits (top N bits are set where
                                       //   N is the number of bits in the access code)
     unsigned int d_threshold;         // how many bits may be wrong in sync vector

--- a/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
+++ b/gr-digital/python/digital/qa_correlate_access_code_XX_ts.py
@@ -53,6 +53,45 @@ class test_correlate_access_code_XX_ts(gr_unittest.TestCase):
         self.assertEqual(pmt.to_long(result_tags[0].value), len(payload)*8)
         self.assertEqual(result_data, expected)
 
+    def test_bb_prefix(self):
+        payload = "test packet"     # payload length is 11 bytes
+        header = "\x00\xd0\x00\xd0" # header contains packet length, twice (bit-swapped)
+        packet = header + payload
+        pad = (0,) * 64
+        src_data = (0, 1, 1, 1, 0, 0, 0, 1, 1) + tuple(string_to_1_0_list(packet)) + pad
+        expected = list(map(int, src_data[9+32:-len(pad)]))
+        src = blocks.vector_source_b(src_data)
+        op = digital.correlate_access_code_bb_ts("0011", 0, "sync")
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.data()
+        result_tags = dst.tags()
+        self.assertEqual(len(result_data), len(payload)*8)
+        self.assertEqual(result_tags[0].offset, 0)
+        self.assertEqual(pmt.to_long(result_tags[0].value), len(payload)*8)
+        self.assertEqual(result_data, expected)
+
+    def test_bb_immediate(self):
+        """Test that packets at start of stream match"""
+        payload = "test packet"     # payload length is 11 bytes
+        header = "\x00\xd0\x00\xd0" # header contains packet length, twice (bit-swapped)
+        packet = header + payload
+        pad = (0,) * 64
+        src_data = (0, 0, 1, 1) + tuple(string_to_1_0_list(packet)) + pad
+        expected = list(map(int, src_data[4+32:-len(pad)]))
+        src = blocks.vector_source_b(src_data)
+        op = digital.correlate_access_code_bb_ts("0011", 0, "sync")
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.data()
+        result_tags = dst.tags()
+        #self.assertEqual(len(result_data), len(packet)*8)
+        self.assertEqual(result_tags[0].offset, 0)
+        #self.assertEqual(pmt.to_long(result_tags[0].value), len(payload)*8)
+        self.assertEqual(result_data, expected)
+
     def test_002(self):
         payload = "test packet"     # payload length is 11 bytes
         header = "\x00\xd0\x00\xd0" # header contains packet length, twice (bit-swapped)
@@ -73,7 +112,47 @@ class test_correlate_access_code_XX_ts(gr_unittest.TestCase):
         self.assertEqual(pmt.to_long(result_tags[0].value), len(payload)*8)
         self.assertFloatTuplesAlmostEqual(result_data, expected, 5)
 
+    def test_ff_prefix(self):
+        payload = "test packet"     # payload length is 11 bytes
+        header = "\x00\xd0\x00\xd0" # header contains packet length, twice (bit-swapped)
+        packet = header + payload
+        pad = (0,) * 64
+        src_data = (0, 1, 1, 1, 1, 0, 0, 1, 1) + tuple(string_to_1_0_list(packet)) + pad
+        src_floats = tuple(2*b-1 for b in src_data) # convert to binary antipodal symbols (-1,1)
+        expected = src_floats[9+32:-len(pad)]
+        src = blocks.vector_source_f(src_floats)
+        op = digital.correlate_access_code_ff_ts("0011", 0, "sync")
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.data()
+        result_tags = dst.tags()
+        self.assertEqual(len(result_data), len(payload)*8)
+        self.assertEqual(result_tags[0].offset, 0)
+        self.assertEqual(pmt.to_long(result_tags[0].value), len(payload)*8)
+        self.assertFloatTuplesAlmostEqual(result_data, expected, 5)
+
+    def test_ff_immediate(self):
+        """Test that packets at start of stream match"""
+        payload = "test packet"     # payload length is 11 bytes
+        header = "\x00\xd0\x00\xd0" # header contains packet length, twice (bit-swapped)
+        packet = header + payload
+        pad = (0,) * 64
+        src_data = (0, 0, 1, 1) + tuple(string_to_1_0_list(packet)) + pad
+        src_floats = tuple(2*b-1 for b in src_data) # convert to binary antipodal symbols (-1,1)
+        expected = src_floats[4+32:-len(pad)]
+        src = blocks.vector_source_f(src_floats)
+        op = digital.correlate_access_code_ff_ts("0011", 0, "sync")
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.data()
+        result_tags = dst.tags()
+        self.assertEqual(len(result_data), len(payload)*8)
+        self.assertEqual(result_tags[0].offset, 0)
+        self.assertEqual(pmt.to_long(result_tags[0].value), len(payload)*8)
+        self.assertFloatTuplesAlmostEqual(result_data, expected, 5)
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_correlate_access_code_XX_ts, "test_correlate_access_code_XX_ts.xml")
-

--- a/gr-digital/python/digital/qa_correlate_access_code_tag.py
+++ b/gr-digital/python/digital/qa_correlate_access_code_tag.py
@@ -34,7 +34,7 @@ class test_correlate_access_code(gr_unittest.TestCase):
     def tearDown(self):
         self.tb = None
 
-    def test_001(self):
+    def test_bb(self):
         pad = (0,) * 64
         src_data = (1, 0, 1, 1, 1, 1, 0, 1, 1) + pad + (0,) * 7
         src = blocks.vector_source_b(src_data)
@@ -46,6 +46,31 @@ class test_correlate_access_code(gr_unittest.TestCase):
         self.assertEqual(len(result_data), 2)
         self.assertEqual(result_data[0].offset, 4)
         self.assertEqual(result_data[1].offset, 9)
+
+    def test_bb_skip_prefix(self):
+        pad = (0,) * 64
+        src_data = (0, 1, 1, 1, 1, 0, 0, 1, 1) + pad + (0,) * 7
+        src = blocks.vector_source_b(src_data)
+        op = digital.correlate_access_code_tag_bb("0011", 0, "sync")
+        dst = blocks.tag_debug(gr.sizeof_char, "sync")
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.current_tags()
+        self.assertEqual(len(result_data), 1)
+        self.assertEqual(result_data[0].offset, 9)
+
+    def test_bb_immediate(self):
+        """Test that packets at start of stream match"""
+        pad = (0,) * 64
+        src_data = (0, 0, 1, 1) + pad + (0,) * 7
+        src = blocks.vector_source_b(src_data)
+        op = digital.correlate_access_code_tag_bb("0011", 0, "sync")
+        dst = blocks.tag_debug(gr.sizeof_char, "sync")
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.current_tags()
+        self.assertEqual(len(result_data), 1)
+        self.assertEqual(result_data[0].offset, 4)
 
     def test_002(self):
         code = tuple(string_to_1_0_list(default_access_code))
@@ -63,7 +88,7 @@ class test_correlate_access_code(gr_unittest.TestCase):
         self.assertEqual(len(result_data), 1)
         self.assertEqual(result_data[0].offset, len(code))
 
-    def test_003(self):
+    def test_ff(self):
         pad = (0,) * 64
         src_bits = (1, 0, 1, 1, 1, 1, 0, 1, 1) + pad + (0,) * 7
         src_data = [2.0*x - 1.0 for x in src_bits]
@@ -76,6 +101,33 @@ class test_correlate_access_code(gr_unittest.TestCase):
         self.assertEqual(len(result_data), 2)
         self.assertEqual(result_data[0].offset, 4)
         self.assertEqual(result_data[1].offset, 9)
+
+    def test_ff_skip_prefix(self):
+        pad = (0,) * 64
+        src_bits = (0, 1, 1, 1, 1, 0, 0, 1, 1) + pad + (0,) * 7
+        src_data = [2.0*x - 1.0 for x in src_bits]
+        src = blocks.vector_source_f(src_data)
+        op = digital.correlate_access_code_tag_ff("0011", 0, "sync")
+        dst = blocks.tag_debug(gr.sizeof_float, "sync")
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.current_tags()
+        self.assertEqual(len(result_data), 1)
+        self.assertEqual(result_data[0].offset, 9)
+
+    def test_ff_immediate(self):
+        """Test that packets at start of stream match"""
+        pad = (0,) * 64
+        src_bits = (0, 0, 1, 1) + pad + (0,) * 7
+        src_data = [2.0*x - 1.0 for x in src_bits]
+        src = blocks.vector_source_f(src_data)
+        op = digital.correlate_access_code_tag_ff("0011", 0, "sync")
+        dst = blocks.tag_debug(gr.sizeof_float, "sync")
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+        result_data = dst.current_tags()
+        self.assertEqual(len(result_data), 1)
+        self.assertEqual(result_data[0].offset, 4)
 
     def test_004(self):
         code = tuple(string_to_1_0_list(default_access_code))
@@ -96,4 +148,3 @@ class test_correlate_access_code(gr_unittest.TestCase):
 
 if __name__ == '__main__':
     gr_unittest.run(test_correlate_access_code, "test_correlate_access_code_tag.xml")
-


### PR DESCRIPTION
Leftover data from last time CAC triggered, or just leading zeroes
being ignored.

This commit prevents these by assuring that we've processed at least
as many bits as the code is, before allowing a trigger.


This PR is an alternative to https://github.com/gnuradio/gnuradio/pull/3682