### PR TITLE
fft: window: Allow normalizing windows

### DIFF
--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -332,7 +332,7 @@ public:
      * \param ntaps Number of coefficients in the window.
      * \param beta Used only for building Kaiser windows.
      */
-    static std::vector<float> build(win_type type, int ntaps, double beta);
+    static std::vector<float> build(win_type type, int ntaps, double beta = 6.76);
 };
 
 } /* namespace fft */

--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -331,8 +331,10 @@ public:
      * \param type a gr::fft::win_type index for the type of window.
      * \param ntaps Number of coefficients in the window.
      * \param beta Used only for building Kaiser windows.
+     * \param normalize If true, return a window with unit power
      */
-    static std::vector<float> build(win_type type, int ntaps, double beta = 6.76);
+    static std::vector<float>
+    build(win_type type, int ntaps, double beta = 6.76, const bool normalize = false);
 };
 
 } /* namespace fft */

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(window.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(b55c3b96105267729782fc5262efa28a)                     */
+/* BINDTOOL_HEADER_FILE(window.h)                                                  */
+/* BINDTOOL_HEADER_FILE_HASH(22de6d8875628eec777952b4902a09e9)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -176,6 +176,7 @@ void bind_window(py::module& m)
                     py::arg("type"),
                     py::arg("ntaps"),
                     py::arg("beta") = 6.76,
+                    py::arg("normalize") = false,
                     D(window, build))
 
         ;

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -175,7 +175,7 @@ void bind_window(py::module& m)
                     &window::build,
                     py::arg("type"),
                     py::arg("ntaps"),
-                    py::arg("beta"),
+                    py::arg("beta") = 6.76,
                     D(window, build))
 
         ;

--- a/gr-fft/python/fft/qa_window.py
+++ b/gr-fft/python/fft/qa_window.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+#
+# Copyright 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+"""
+Unit tests for fft.window
+"""
+
+import numpy
+from gnuradio import gr_unittest
+from gnuradio import fft
+
+class test_window(gr_unittest.TestCase):
+    """
+    Unit tests for fft.window
+    """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_normwin(self):
+        """
+        Verify window normalization
+        """
+        win = fft.window.build(fft.win_type.WIN_BLACKMAN_hARRIS, 21, normalize=True)
+        power = numpy.sum([x*x for x in win])/len(win)
+        self.assertAlmostEqual(power, 1.0)
+
+if __name__ == '__main__':
+    gr_unittest.run(test_window)


### PR DESCRIPTION
```
commit f960615febe49a5cc68d3359c090a8c8b0068de1 (HEAD -> norm-win, mb/norm-win)
Author: Martin Braun <martin.braun@ettus.com>
Date:   Thu Aug 13 17:06:36 2020 +0200

    fft: window: Allow normalizing windows
    
    In some applications, it is useful to generate windows that have unit
    power. The boxcar window (rectangle) is always of unit power, but the
    other windows are not, leading to apple-to-oranges comparisons, e.g.,
    when switching between window types in a live spectrum estimation
    application.

commit 56d4ad1d69eafe299880b4aad407f5717c5933d1
Author: Martin Braun <martin.braun@ettus.com>
Date:   Thu Aug 13 15:08:08 2020 +0200

    fft: window: Provide default value for beta param on window::build
    
    The API call fft::window::build() takes a third parameter, beta, that
    only applies for the Kaiser window. For other windows, it is necessary
    to provide a dummy value to call this function.
    
    The declared-deprecated version firdes::window() on the other hand does
    not require specifying beta when not needed. Instead, we provide
    a default value of 6.76 which will still generate a valid (and generally
    useful) Kaiser window, but means we don't have to specify beta for other
    windows.
```