### PR TITLE
fft: window: Add WIN_NONE

### DIFF
--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -23,6 +23,7 @@ class FFT_API window
 {
 public:
     enum win_type {
+        WIN_NONE = -1,       //!< don't use a window
         WIN_HAMMING = 0,     //!< Hamming window; max attenuation 53 dB
         WIN_HANN = 1,        //!< Hann window; max attenuation 44 dB
         WIN_BLACKMAN = 2,    //!< Blackman window; max attenuation 74 dB

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(window.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a2896456164142169fe7717e5f6570fc)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b55c3b96105267729782fc5262efa28a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
fft::window is slated to replace firdes::window, we add the missing
WIN_NONE for consistency between the two.