### PR TITLE
qtgui: Replace firdes::window with fft::window

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/form_menus.h
+++ b/gr-qtgui/include/gnuradio/qtgui/form_menus.h
@@ -864,32 +864,32 @@ public:
             throw std::runtime_error("FFTWindowMenu::getAction: which out of range.");
     }
 
-    QAction* getActionFromWindow(gr::filter::firdes::win_type type)
+    QAction* getActionFromWindow(gr::fft::window::win_type type)
     {
         int which = 0;
         switch (static_cast<int>(type)) {
-        case ((gr::filter::firdes::WIN_NONE)):
+        case ((gr::fft::window::WIN_NONE)):
             which = 0;
             break;
-        case ((gr::filter::firdes::WIN_HAMMING)):
+        case ((gr::fft::window::WIN_HAMMING)):
             which = 1;
             break;
-        case ((gr::filter::firdes::WIN_HANN)):
+        case ((gr::fft::window::WIN_HANN)):
             which = 2;
             break;
-        case ((gr::filter::firdes::WIN_BLACKMAN)):
+        case ((gr::fft::window::WIN_BLACKMAN)):
             which = 3;
             break;
-        case ((gr::filter::firdes::WIN_BLACKMAN_hARRIS)):
+        case ((gr::fft::window::WIN_BLACKMAN_hARRIS)):
             which = 4;
             break;
-        case ((gr::filter::firdes::WIN_RECTANGULAR)):
+        case ((gr::fft::window::WIN_RECTANGULAR)):
             which = 5;
             break;
-        case ((gr::filter::firdes::WIN_KAISER)):
+        case ((gr::fft::window::WIN_KAISER)):
             which = 6;
             break;
-        case ((gr::filter::firdes::WIN_FLATTOP)):
+        case ((gr::fft::window::WIN_FLATTOP)):
             which = 7;
             break;
         }
@@ -897,20 +897,17 @@ public:
     }
 
 signals:
-    void whichTrigger(const gr::filter::firdes::win_type type);
+    void whichTrigger(const gr::fft::window::win_type type);
 
 public slots:
-    void getNone() { emit whichTrigger(gr::filter::firdes::WIN_NONE); }
-    void getHamming() { emit whichTrigger(gr::filter::firdes::WIN_HAMMING); }
-    void getHann() { emit whichTrigger(gr::filter::firdes::WIN_HANN); }
-    void getBlackman() { emit whichTrigger(gr::filter::firdes::WIN_BLACKMAN); }
-    void getBlackmanharris()
-    {
-        emit whichTrigger(gr::filter::firdes::WIN_BLACKMAN_hARRIS);
-    }
-    void getRectangular() { emit whichTrigger(gr::filter::firdes::WIN_RECTANGULAR); }
-    void getKaiser() { emit whichTrigger(gr::filter::firdes::WIN_KAISER); }
-    void getFlattop() { emit whichTrigger(gr::filter::firdes::WIN_FLATTOP); }
+    void getNone() { emit whichTrigger(gr::fft::window::WIN_NONE); }
+    void getHamming() { emit whichTrigger(gr::fft::window::WIN_HAMMING); }
+    void getHann() { emit whichTrigger(gr::fft::window::WIN_HANN); }
+    void getBlackman() { emit whichTrigger(gr::fft::window::WIN_BLACKMAN); }
+    void getBlackmanharris() { emit whichTrigger(gr::fft::window::WIN_BLACKMAN_hARRIS); }
+    void getRectangular() { emit whichTrigger(gr::fft::window::WIN_RECTANGULAR); }
+    void getKaiser() { emit whichTrigger(gr::fft::window::WIN_KAISER); }
+    void getFlattop() { emit whichTrigger(gr::fft::window::WIN_FLATTOP); }
 
 private:
     QList<QAction*> d_act;

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -15,7 +15,7 @@
 #include <Python.h>
 #endif
 
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/qtgui/api.h>
 #include <gnuradio/qtgui/trigger_mode.h>
 #include <gnuradio/sync_block.h>
@@ -114,8 +114,8 @@ public:
     virtual int fft_size() const = 0;
     virtual void set_fft_average(const float fftavg) = 0;
     virtual float fft_average() const = 0;
-    virtual void set_fft_window(const gr::filter::firdes::win_type win) = 0;
-    virtual gr::filter::firdes::win_type fft_window() = 0;
+    virtual void set_fft_window(const gr::fft::window::win_type win) = 0;
+    virtual gr::fft::window::win_type fft_window() = 0;
 
     virtual void set_frequency_range(const double centerfreq, const double bandwidth) = 0;
     virtual void set_y_axis(double min, double max) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -15,7 +15,7 @@
 #include <Python.h>
 #endif
 
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/qtgui/api.h>
 #include <gnuradio/qtgui/trigger_mode.h>
 #include <gnuradio/sync_block.h>
@@ -114,8 +114,8 @@ public:
     virtual int fft_size() const = 0;
     virtual void set_fft_average(const float fftavg) = 0;
     virtual float fft_average() const = 0;
-    virtual void set_fft_window(const gr::filter::firdes::win_type win) = 0;
-    virtual gr::filter::firdes::win_type fft_window() = 0;
+    virtual void set_fft_window(const gr::fft::window::win_type win) = 0;
+    virtual gr::fft::window::win_type fft_window() = 0;
 
     virtual void set_frequency_range(const double centerfreq, const double bandwidth) = 0;
     virtual void set_y_axis(double min, double max) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -11,7 +11,7 @@
 #ifndef FREQ_DISPLAY_FORM_H
 #define FREQ_DISPLAY_FORM_H
 
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/qtgui/FrequencyDisplayPlot.h>
 #include <gnuradio/qtgui/spectrumUpdateEvents.h>
 #include <QtGui/QtGui>
@@ -37,7 +37,7 @@ public:
 
     int getFFTSize() const;
     float getFFTAverage() const;
-    gr::filter::firdes::win_type getFFTWindowType() const;
+    gr::fft::window::win_type getFFTWindowType() const;
 
     // Trigger methods
     gr::qtgui::trigger_mode getTriggerMode() const;
@@ -58,7 +58,7 @@ public slots:
     void setSampleRate(const QString& samprate);
     void setFFTSize(const int);
     void setFFTAverage(const float);
-    void setFFTWindowType(const gr::filter::firdes::win_type);
+    void setFFTWindowType(const gr::fft::window::win_type);
 
     void setFrequencyRange(const double centerfreq, const double bandwidth);
     void setYaxis(double min, double max);
@@ -98,7 +98,7 @@ public slots:
 
 signals:
     void signalFFTSize(int size);
-    void signalFFTWindow(gr::filter::firdes::win_type win);
+    void signalFFTWindow(gr::fft::window::win_type win);
     void signalClearMaxData();
     void signalClearMinData();
     void signalSetMaxFFTVisible(bool en);
@@ -119,7 +119,7 @@ private:
     double d_samp_rate, d_center_freq;
     int d_fftsize;
     float d_fftavg;
-    gr::filter::firdes::win_type d_fftwintype;
+    gr::fft::window::win_type d_fftwintype;
     double d_units;
 
     bool d_clicked;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
@@ -15,7 +15,7 @@
 #include <Python.h>
 #endif
 
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/qtgui/api.h>
 #include <gnuradio/sync_block.h>
 #include <qapplication.h>
@@ -122,8 +122,8 @@ public:
     virtual void set_time_per_fft(const double t) = 0;
     virtual void set_fft_average(const float fftavg) = 0;
     virtual float fft_average() const = 0;
-    virtual void set_fft_window(const gr::filter::firdes::win_type win) = 0;
-    virtual gr::filter::firdes::win_type fft_window() = 0;
+    virtual void set_fft_window(const gr::fft::window::win_type win) = 0;
+    virtual gr::fft::window::win_type fft_window() = 0;
 
     virtual void set_frequency_range(const double centerfreq, const double bandwidth) = 0;
     virtual void set_intensity_range(const double min, const double max) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
@@ -15,7 +15,7 @@
 #include <Python.h>
 #endif
 
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/qtgui/api.h>
 #include <gnuradio/sync_block.h>
 #include <qapplication.h>
@@ -123,8 +123,8 @@ public:
     virtual void set_time_per_fft(const double t) = 0;
     virtual void set_fft_average(const float fftavg) = 0;
     virtual float fft_average() const = 0;
-    virtual void set_fft_window(const gr::filter::firdes::win_type win) = 0;
-    virtual gr::filter::firdes::win_type fft_window() = 0;
+    virtual void set_fft_window(const gr::fft::window::win_type win) = 0;
+    virtual gr::fft::window::win_type fft_window() = 0;
 
     virtual void set_frequency_range(const double centerfreq, const double bandwidth) = 0;
     virtual void set_intensity_range(const double min, const double max) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
@@ -36,7 +36,7 @@ public:
     int getFFTSize() const;
     double getTimePerFFT();
     float getFFTAverage() const;
-    gr::filter::firdes::win_type getFFTWindowType() const;
+    gr::fft::window::win_type getFFTWindowType() const;
 
     int getColorMap(unsigned int which);
     int getAlpha(unsigned int which);
@@ -57,7 +57,7 @@ public slots:
     void setSampleRate(const QString& samprate);
     void setFFTSize(const int);
     void setFFTAverage(const float);
-    void setFFTWindowType(const gr::filter::firdes::win_type);
+    void setFFTWindowType(const gr::fft::window::win_type);
 
     void setFrequencyRange(const double centerfreq, const double bandwidth);
 
@@ -88,7 +88,7 @@ private:
     int d_fftsize;
     double d_time_per_fft;
     float d_fftavg;
-    gr::filter::firdes::win_type d_fftwintype;
+    gr::fft::window::win_type d_fftwintype;
     double d_units;
 
     bool d_clicked;

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -51,7 +51,7 @@ freq_sink_c_impl::freq_sink_c_impl(int fftsize,
       d_fftsize(fftsize),
       d_fft_shift(fftsize),
       d_fftavg(1.0),
-      d_wintype((filter::firdes::win_type)(wintype)),
+      d_wintype((fft::window::win_type)(wintype)),
       d_center_freq(fc),
       d_bandwidth(bw),
       d_name(name),
@@ -201,12 +201,12 @@ void freq_sink_c_impl::set_fft_average(const float fftavg)
 
 float freq_sink_c_impl::fft_average() const { return d_fftavg; }
 
-void freq_sink_c_impl::set_fft_window(const filter::firdes::win_type win)
+void freq_sink_c_impl::set_fft_window(const fft::window::win_type win)
 {
     d_main_gui->setFFTWindowType(win);
 }
 
-filter::firdes::win_type freq_sink_c_impl::fft_window() { return d_wintype; }
+fft::window::win_type freq_sink_c_impl::fft_window() { return d_wintype; }
 
 void freq_sink_c_impl::set_frequency_range(const double centerfreq,
                                            const double bandwidth)
@@ -394,7 +394,7 @@ bool freq_sink_c_impl::windowreset()
 {
     gr::thread::scoped_lock lock(d_setlock);
 
-    filter::firdes::win_type newwintype;
+    fft::window::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
     if (d_wintype != newwintype) {
         d_wintype = newwintype;
@@ -407,8 +407,8 @@ bool freq_sink_c_impl::windowreset()
 void freq_sink_c_impl::buildwindow()
 {
     d_window.clear();
-    if (d_wintype != filter::firdes::WIN_NONE) {
-        d_window = filter::firdes::window(d_wintype, d_fftsize, 6.76);
+    if (d_wintype != fft::window::WIN_NONE) {
+        d_window = fft::window::build(d_wintype, d_fftsize);
     }
 }
 

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -15,7 +15,7 @@
 
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/fft/fft_shift.h>
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/freqdisplayform.h>
 
@@ -30,7 +30,7 @@ private:
     int d_fftsize;
     fft::fft_shift<float> d_fft_shift;
     float d_fftavg;
-    filter::firdes::win_type d_wintype;
+    fft::window::win_type d_wintype;
     std::vector<float> d_window;
     double d_center_freq;
     double d_bandwidth;
@@ -112,8 +112,8 @@ public:
     int fft_size() const;
     void set_fft_average(const float fftavg);
     float fft_average() const;
-    void set_fft_window(const filter::firdes::win_type win);
-    filter::firdes::win_type fft_window();
+    void set_fft_window(const fft::window::win_type win);
+    fft::window::win_type fft_window();
 
     void set_frequency_range(const double centerfreq, const double bandwidth);
     void set_y_axis(double min, double max);

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -51,7 +51,7 @@ freq_sink_f_impl::freq_sink_f_impl(int fftsize,
       d_fftsize(fftsize),
       d_fft_shift(fftsize),
       d_fftavg(1.0),
-      d_wintype((filter::firdes::win_type)(wintype)),
+      d_wintype((fft::window::win_type)(wintype)),
       d_center_freq(fc),
       d_bandwidth(bw),
       d_name(name),
@@ -201,12 +201,12 @@ void freq_sink_f_impl::set_fft_average(const float fftavg)
 
 float freq_sink_f_impl::fft_average() const { return d_fftavg; }
 
-void freq_sink_f_impl::set_fft_window(const filter::firdes::win_type win)
+void freq_sink_f_impl::set_fft_window(const fft::window::win_type win)
 {
     d_main_gui->setFFTWindowType(win);
 }
 
-filter::firdes::win_type freq_sink_f_impl::fft_window() { return d_wintype; }
+fft::window::win_type freq_sink_f_impl::fft_window() { return d_wintype; }
 
 void freq_sink_f_impl::set_frequency_range(const double centerfreq,
                                            const double bandwidth)
@@ -397,7 +397,7 @@ bool freq_sink_f_impl::windowreset()
 {
     gr::thread::scoped_lock lock(d_setlock);
 
-    filter::firdes::win_type newwintype;
+    fft::window::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
     if (d_wintype != newwintype) {
         d_wintype = newwintype;
@@ -410,8 +410,8 @@ bool freq_sink_f_impl::windowreset()
 void freq_sink_f_impl::buildwindow()
 {
     d_window.clear();
-    if (d_wintype != filter::firdes::WIN_NONE) {
-        d_window = filter::firdes::window(d_wintype, d_fftsize, 6.76);
+    if (d_wintype != fft::window::WIN_NONE) {
+        d_window = fft::window::build(d_wintype, d_fftsize);
     }
 }
 

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -15,7 +15,7 @@
 
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/fft/fft_shift.h>
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/freqdisplayform.h>
 
@@ -30,7 +30,7 @@ private:
     int d_fftsize;
     fft::fft_shift<float> d_fft_shift;
     float d_fftavg;
-    filter::firdes::win_type d_wintype;
+    fft::window::win_type d_wintype;
     std::vector<float> d_window;
     double d_center_freq;
     double d_bandwidth;
@@ -112,8 +112,8 @@ public:
     int fft_size() const;
     void set_fft_average(const float fftavg);
     float fft_average() const;
-    void set_fft_window(const filter::firdes::win_type win);
-    filter::firdes::win_type fft_window();
+    void set_fft_window(const fft::window::win_type win);
+    fft::window::win_type fft_window();
 
     void set_frequency_range(const double centerfreq, const double bandwidth);
     void set_y_axis(double min, double max);

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -53,9 +53,9 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
     connect(
         d_avgmenu, SIGNAL(whichTrigger(float)), this, SLOT(setFFTAverage(const float)));
     connect(d_winmenu,
-            SIGNAL(whichTrigger(gr::filter::firdes::win_type)),
+            SIGNAL(whichTrigger(gr::fft::window::win_type)),
             this,
-            SLOT(setFFTWindowType(const gr::filter::firdes::win_type)));
+            SLOT(setFFTWindowType(const gr::fft::window::win_type)));
 
     PopupMenu* maxymenu = new PopupMenu("Y Max", this);
     d_menu->addAction(maxymenu);
@@ -178,14 +178,14 @@ void FreqDisplayForm::setupControlPanel()
     connect(
         d_sizemenu, SIGNAL(whichTrigger(int)), d_controlpanel, SLOT(toggleFFTSize(int)));
     connect(d_winmenu,
-            SIGNAL(whichTrigger(gr::filter::firdes::win_type)),
+            SIGNAL(whichTrigger(gr::fft::window::win_type)),
             d_controlpanel,
-            SLOT(toggleFFTWindow(gr::filter::firdes::win_type)));
+            SLOT(toggleFFTWindow(gr::fft::window::win_type)));
     connect(this, SIGNAL(signalFFTSize(int)), d_controlpanel, SLOT(toggleFFTSize(int)));
     connect(this,
-            SIGNAL(signalFFTWindow(gr::filter::firdes::win_type)),
+            SIGNAL(signalFFTWindow(gr::fft::window::win_type)),
             d_controlpanel,
-            SLOT(toggleFFTWindow(gr::filter::firdes::win_type)));
+            SLOT(toggleFFTWindow(gr::fft::window::win_type)));
     connect(d_maxhold_act,
             SIGNAL(triggered(bool)),
             d_controlpanel,
@@ -260,7 +260,7 @@ int FreqDisplayForm::getFFTSize() const { return d_fftsize; }
 
 float FreqDisplayForm::getFFTAverage() const { return d_fftavg; }
 
-gr::filter::firdes::win_type FreqDisplayForm::getFFTWindowType() const
+gr::fft::window::win_type FreqDisplayForm::getFFTWindowType() const
 {
     return d_fftwintype;
 }
@@ -287,7 +287,7 @@ void FreqDisplayForm::setFFTAverage(const float newavg)
     // emit signalFFTAverage(newavg);
 }
 
-void FreqDisplayForm::setFFTWindowType(const gr::filter::firdes::win_type newwin)
+void FreqDisplayForm::setFFTWindowType(const gr::fft::window::win_type newwin)
 {
     d_fftwintype = newwin;
     d_winmenu->getActionFromWindow(newwin)->setChecked(true);
@@ -548,21 +548,21 @@ void FreqDisplayForm::notifyFFTSize(const QString& s) { setFFTSize(s.toInt()); }
 void FreqDisplayForm::notifyFFTWindow(const QString& s)
 {
     if (s == "None") {
-        d_fftwintype = gr::filter::firdes::WIN_NONE;
+        d_fftwintype = gr::fft::window::WIN_NONE;
     } else if (s == "Hamming") {
-        d_fftwintype = gr::filter::firdes::WIN_HAMMING;
+        d_fftwintype = gr::fft::window::WIN_HAMMING;
     } else if (s == "Hann") {
-        d_fftwintype = gr::filter::firdes::WIN_HANN;
+        d_fftwintype = gr::fft::window::WIN_HANN;
     } else if (s == "Blackman") {
-        d_fftwintype = gr::filter::firdes::WIN_BLACKMAN;
+        d_fftwintype = gr::fft::window::WIN_BLACKMAN;
     } else if (s == "Blackman-harris") {
-        d_fftwintype = gr::filter::firdes::WIN_BLACKMAN_hARRIS;
+        d_fftwintype = gr::fft::window::WIN_BLACKMAN_hARRIS;
     } else if (s == "Rectangular") {
-        d_fftwintype = gr::filter::firdes::WIN_RECTANGULAR;
+        d_fftwintype = gr::fft::window::WIN_RECTANGULAR;
     } else if (s == "Kaiser") {
-        d_fftwintype = gr::filter::firdes::WIN_KAISER;
+        d_fftwintype = gr::fft::window::WIN_KAISER;
     } else if (s == "Flat-top") {
-        d_fftwintype = gr::filter::firdes::WIN_FLATTOP;
+        d_fftwintype = gr::fft::window::WIN_FLATTOP;
     }
 
     d_winmenu->getActionFromWindow(d_fftwintype)->setChecked(true);

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -52,7 +52,7 @@ waterfall_sink_c_impl::waterfall_sink_c_impl(int fftsize,
       d_fftsize(fftsize),
       d_fft_shift(fftsize),
       d_fftavg(1.0),
-      d_wintype((filter::firdes::win_type)(wintype)),
+      d_wintype((fft::window::win_type)(wintype)),
       d_center_freq(fc),
       d_bandwidth(bw),
       d_name(name),
@@ -206,12 +206,12 @@ void waterfall_sink_c_impl::set_fft_average(const float fftavg)
 
 float waterfall_sink_c_impl::fft_average() const { return d_fftavg; }
 
-void waterfall_sink_c_impl::set_fft_window(const filter::firdes::win_type win)
+void waterfall_sink_c_impl::set_fft_window(const fft::window::win_type win)
 {
     d_main_gui->setFFTWindowType(win);
 }
 
-filter::firdes::win_type waterfall_sink_c_impl::fft_window() { return d_wintype; }
+fft::window::win_type waterfall_sink_c_impl::fft_window() { return d_wintype; }
 
 void waterfall_sink_c_impl::set_frequency_range(const double centerfreq,
                                                 const double bandwidth)
@@ -322,7 +322,7 @@ void waterfall_sink_c_impl::windowreset()
 {
     gr::thread::scoped_lock lock(d_setlock);
 
-    filter::firdes::win_type newwintype;
+    fft::window::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
     if (d_wintype != newwintype) {
         d_wintype = newwintype;
@@ -333,8 +333,8 @@ void waterfall_sink_c_impl::windowreset()
 void waterfall_sink_c_impl::buildwindow()
 {
     d_window.clear();
-    if (d_wintype != filter::firdes::WIN_NONE) {
-        d_window = filter::firdes::window(d_wintype, d_fftsize, 6.76);
+    if (d_wintype != fft::window::WIN_NONE) {
+        d_window = fft::window::build(d_wintype, d_fftsize);
     }
 }
 

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -15,7 +15,7 @@
 
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/fft/fft_shift.h>
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/waterfalldisplayform.h>
 
@@ -32,7 +32,7 @@ private:
     int d_fftsize;
     fft::fft_shift<float> d_fft_shift;
     float d_fftavg;
-    filter::firdes::win_type d_wintype;
+    fft::window::win_type d_wintype;
     std::vector<float> d_window;
     double d_center_freq;
     double d_bandwidth;
@@ -104,8 +104,8 @@ public:
     int fft_size() const;
     void set_fft_average(const float fftavg);
     float fft_average() const;
-    void set_fft_window(const gr::filter::firdes::win_type win);
-    gr::filter::firdes::win_type fft_window();
+    void set_fft_window(const gr::fft::window::win_type win);
+    gr::fft::window::win_type fft_window();
 
     void set_frequency_range(const double centerfreq, const double bandwidth);
     void set_intensity_range(const double min, const double max);

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -50,7 +50,7 @@ waterfall_sink_f_impl::waterfall_sink_f_impl(int fftsize,
       d_fftsize(fftsize),
       d_fft_shift(fftsize),
       d_fftavg(1.0),
-      d_wintype((filter::firdes::win_type)(wintype)),
+      d_wintype((fft::window::win_type)(wintype)),
       d_center_freq(fc),
       d_bandwidth(bw),
       d_name(name),
@@ -204,12 +204,12 @@ void waterfall_sink_f_impl::set_fft_average(const float fftavg)
 
 float waterfall_sink_f_impl::fft_average() const { return d_fftavg; }
 
-void waterfall_sink_f_impl::set_fft_window(const filter::firdes::win_type win)
+void waterfall_sink_f_impl::set_fft_window(const fft::window::win_type win)
 {
     d_main_gui->setFFTWindowType(win);
 }
 
-filter::firdes::win_type waterfall_sink_f_impl::fft_window() { return d_wintype; }
+fft::window::win_type waterfall_sink_f_impl::fft_window() { return d_wintype; }
 
 void waterfall_sink_f_impl::set_frequency_range(const double centerfreq,
                                                 const double bandwidth)
@@ -328,7 +328,7 @@ void waterfall_sink_f_impl::windowreset()
 {
     gr::thread::scoped_lock lock(d_setlock);
 
-    filter::firdes::win_type newwintype;
+    fft::window::win_type newwintype;
     newwintype = d_main_gui->getFFTWindowType();
     if (d_wintype != newwintype) {
         d_wintype = newwintype;
@@ -339,8 +339,8 @@ void waterfall_sink_f_impl::windowreset()
 void waterfall_sink_f_impl::buildwindow()
 {
     d_window.clear();
-    if (d_wintype != filter::firdes::WIN_NONE) {
-        d_window = filter::firdes::window(d_wintype, d_fftsize, 6.76);
+    if (d_wintype != fft::window::WIN_NONE) {
+        d_window = fft::window::build(d_wintype, d_fftsize);
     }
 }
 

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -15,7 +15,7 @@
 
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/fft/fft_shift.h>
-#include <gnuradio/filter/firdes.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/waterfalldisplayform.h>
 
@@ -32,7 +32,7 @@ private:
     int d_fftsize;
     fft::fft_shift<float> d_fft_shift;
     float d_fftavg;
-    filter::firdes::win_type d_wintype;
+    fft::window::win_type d_wintype;
     std::vector<float> d_window;
     double d_center_freq;
     double d_bandwidth;
@@ -104,8 +104,8 @@ public:
     int fft_size() const;
     void set_fft_average(const float fftavg);
     float fft_average() const;
-    void set_fft_window(const gr::filter::firdes::win_type win);
-    gr::filter::firdes::win_type fft_window();
+    void set_fft_window(const gr::fft::window::win_type win);
+    gr::fft::window::win_type fft_window();
 
     void set_frequency_range(const double centerfreq, const double bandwidth);
     void set_intensity_range(const double min, const double max);

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -84,9 +84,9 @@ WaterfallDisplayForm::WaterfallDisplayForm(int nplots, QWidget* parent)
     connect(
         d_avgmenu, SIGNAL(whichTrigger(float)), this, SLOT(setFFTAverage(const float)));
     connect(d_winmenu,
-            SIGNAL(whichTrigger(gr::filter::firdes::win_type)),
+            SIGNAL(whichTrigger(gr::fft::window::win_type)),
             this,
-            SLOT(setFFTWindowType(const gr::filter::firdes::win_type)));
+            SLOT(setFFTWindowType(const gr::fft::window::win_type)));
 
     PopupMenu* maxintmenu = new PopupMenu("Int. Max", this);
     d_menu->addAction(maxintmenu);
@@ -155,7 +155,7 @@ int WaterfallDisplayForm::getFFTSize() const { return d_fftsize; }
 
 float WaterfallDisplayForm::getFFTAverage() const { return d_fftavg; }
 
-gr::filter::firdes::win_type WaterfallDisplayForm::getFFTWindowType() const
+gr::fft::window::win_type WaterfallDisplayForm::getFFTWindowType() const
 {
     return d_fftwintype;
 }
@@ -199,7 +199,7 @@ void WaterfallDisplayForm::setFFTAverage(const float newavg)
     getPlot()->replot();
 }
 
-void WaterfallDisplayForm::setFFTWindowType(const gr::filter::firdes::win_type newwin)
+void WaterfallDisplayForm::setFFTWindowType(const gr::fft::window::win_type newwin)
 {
     d_fftwintype = newwin;
     d_winmenu->getActionFromWindow(newwin)->setChecked(true);


### PR DESCRIPTION
The former has been declared deprecated, hence the shift.