### PR TITLE
boost: increase minimum version to 1.58 for boost/endian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ SET(VERSION_PATCH 0-git)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:
-set(GR_BOOST_MIN_VERSION "1.53")
+set(GR_BOOST_MIN_VERSION "1.58")
 set(GR_CMAKE_MIN_VERSION "3.5.1")
 set(GR_MAKO_MIN_VERSION "0.4.2")
 set(GR_PYTHON_MIN_VERSION "3.6.5")


### PR DESCRIPTION
PR #3369 incorporated boost/endian, which does not appear until Boost 1.58
Either more conditional includes need to be added or we bump up the min boost version (losing support for Centos7)