### PR TITLE
grc: prevent search keystrokes from modifying flowgraph 

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -749,7 +749,6 @@ class Application(Gtk.Application):
             main.update_pages()
 
         elif action == Actions.FIND_BLOCKS:
-            flow_graph.unselect()
             main.update_panel_visibility(main.BLOCKS, True)
             main.btwin.search_entry.show()
             main.btwin.search_entry.grab_focus()

--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -75,9 +75,9 @@ class DrawingArea(Gtk.DrawingArea):
 
         self.connect('leave-notify-event', _handle_notify_event, False)
         self.connect('enter-notify-event', _handle_notify_event, True)
-        # todo: fix
-#        self.set_flags(Gtk.CAN_FOCUS)  # self.set_can_focus(True)
-#        self.connect('focus-out-event', self._handle_focus_lost_event)
+
+        self.set_can_focus(True)
+        self.connect('focus-out-event', self._handle_focus_lost_event)
 
 
     ##########################################################################
@@ -107,11 +107,7 @@ class DrawingArea(Gtk.DrawingArea):
         """
         Forward button click information to the flow graph.
         """
-        # The following line causes the canvas to reset position to 0,0
-        #  when changing focus from the console or block search back to 
-        #  the canvas
-        #  Removing this line leaves the canvas alone when focus changes
-        # self.grab_focus()
+        self.grab_focus()
 
         self.ctrl_mask = event.get_state() & Gdk.ModifierType.CONTROL_MASK
         self.mod1_mask = event.get_state() & Gdk.ModifierType.MOD1_MASK
@@ -212,7 +208,7 @@ class DrawingArea(Gtk.DrawingArea):
 
     def _handle_focus_lost_event(self, widget, event):
         # don't clear selection while context menu is active
-        if not self._flow_graph.context_menu.get_take_focus():
+        if not self._flow_graph.get_context_menu()._menu.get_visible():
             self._flow_graph.unselect()
-            self._flow_graph.update_selected()
-            self._flow_graph.queue_draw()
+            self._flow_graph.update_selected_elements()
+            self.queue_draw()

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -114,12 +114,15 @@ class Page(Gtk.HBox):
         self.drawing_area = DrawingArea(flow_graph)
         flow_graph.drawing_area = self.drawing_area
 
+        self.viewport = Gtk.Viewport()
+        self.viewport.add(self.drawing_area)
+
         self.scrolled_window = Gtk.ScrolledWindow()
         self.scrolled_window.set_size_request(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT)
         self.scrolled_window.set_policy(Gtk.PolicyType.ALWAYS, Gtk.PolicyType.ALWAYS)
         self.scrolled_window.connect('key-press-event', self._handle_scroll_window_key_press)
 
-        self.scrolled_window.add(self.drawing_area)
+        self.scrolled_window.add(self.viewport)
         self.pack_start(self.scrolled_window, True, True, 0)
         self.show_all()
 


### PR DESCRIPTION
Fixes #2610.
Fixes #3507.

A confluence of bugs introduced while updating GRC to Python 3 results in keystrokes being sent to the drawing area while typing in the block search box.

First, the drawing area needs to be placed in a Viewport before being added into a ScrolledWindow. Fixing this allows the drawing area to grab focus as intended when it is clicked.

Second, the drawing area needs to unselect all blocks when it loses focus so that the relevant keystroke actions can be disabled. This functionality was commented out during the transition to Python 3, and I've restored it here.

The partial workaround implemented in #2574 is no longer needed, so I removed it.