### PR TITLE
uhd: Add power reference APIs

### DIFF
--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -88,6 +88,7 @@ Command name | Value Type   | Description
 -------------|--------------|-------------------------------------------------------------
 `chan`       | int          | Specifies a channel. If this is not given, either all channels are chosen, or channel 0, depending on the action. A value of -1 forces 'all channels', where possible.
 `gain`       | double       | Sets the Tx or Rx gain (in dB). Defaults to all channels.
+`power_dbm`  | double       | Sets the Tx or Rx power reference level (in dBm). Defaults to all channels. Works for certain devices only, and only if calibration data is available.
 `freq`       | double       | Sets the Tx or Rx frequency. Defaults to all channels. If specified without `lo_offset`, it will set the LO offset to zero.
 `lo_offset`  | double       | Sets an LO offset. Defaults to all channels. Note this does not affect the effective center frequency.
 `tune`       | tune_request | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -20,6 +20,7 @@ namespace uhd {
 
 GR_UHD_API const pmt::pmt_t cmd_chan_key();
 GR_UHD_API const pmt::pmt_t cmd_gain_key();
+GR_UHD_API const pmt::pmt_t cmd_power_key();
 GR_UHD_API const pmt::pmt_t cmd_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_offset_key();
 GR_UHD_API const pmt::pmt_t cmd_tune_key();
@@ -228,6 +229,65 @@ public:
      */
     virtual ::uhd::gain_range_t get_gain_range(const std::string& name,
                                                size_t chan = 0) = 0;
+
+    /*! Query if this device is capable of absolute power levels
+     *
+     * If true, the set_power_reference() and get_power_reference() APIs can be
+     * used as well.
+     * Note that if the underlying UHD version doesn't support power APIs, a
+     * warning will be printed, and the return value is always false.
+     *
+     * \param chan the channel index 0 to N-1
+     * \returns true if there is a power reference API available for this channel
+     */
+    virtual bool has_power_reference(size_t chan = 0) = 0;
+
+    /*! Set the absolute power reference level for this channel
+     *
+     * Note that this API is available for certain devices only, and only if
+     * calibration data is available. Refer to the UHD manual for greater
+     * detail: https://files.ettus.com/manual/page_power.html
+     *
+     * In a nutshell, using the power reference will configure the device such
+     * that a full-scale signal (0 dBFS) corresponds to a signal at the
+     * antenna connector of \p power_dbm.
+     * After calling this function, the device will attempt to keep the power
+     * level constant after retuning, which means the gain level may be changed
+     * after a re-tune.
+     *
+     * The device may coerce the available power level (for example, if the
+     * requested power level is not achievable by the device). The coerced
+     * value may be read by calling get_power_reference().
+     *
+     * \param power_dbm The power reference level in dBm
+     * \param chan the channel index 0 to N-1
+     * \throws std::runtime_error if the underlying UHD version does not support
+     *         the power API.
+     */
+    virtual void set_power_reference(double power_dbm, size_t chan = 0) = 0;
+
+    /*! Return the absolute power reference level for this channel
+     *
+     * Note that this API is only available for certain devices, and assuming
+     * the existence of calibration data. Refer to the UHD manual for greater
+     * detail: https://files.ettus.com/manual/page_compat.html
+     *
+     * See also set_power_reference().
+     *
+     * \param chan the channel index 0 to N-1
+     * \throws std::runtime_error if the underlying UHD version does not support
+     *         the power API.
+     */
+    virtual double get_power_reference(size_t chan = 0) = 0;
+
+    /*! Return the available power range
+     *
+     * \param chan the channel index 0 to N-1
+     * \return the power range in dBm
+     * \throws std::runtime_error if the underlying UHD version does not support
+     *         the power API.
+     */
+    virtual ::uhd::meta_range_t get_power_range(size_t chan = 0) = 0;
 
     /*!
      * Set the antenna to use for a given channel.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -36,6 +36,11 @@ const pmt::pmt_t gr::uhd::cmd_gain_key()
     static const pmt::pmt_t val = pmt::mp("gain");
     return val;
 }
+const pmt::pmt_t gr::uhd::cmd_power_key()
+{
+    static const pmt::pmt_t val = pmt::mp("power_dbm");
+    return val;
+}
 const pmt::pmt_t gr::uhd::cmd_freq_key()
 {
     static const pmt::pmt_t val = pmt::mp("freq");
@@ -134,6 +139,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     // Register default command handlers:
     REGISTER_CMD_HANDLER(cmd_freq_key(), _cmd_handler_freq);
     REGISTER_CMD_HANDLER(cmd_gain_key(), _cmd_handler_gain);
+    REGISTER_CMD_HANDLER(cmd_power_key(), _cmd_handler_power);
     REGISTER_CMD_HANDLER(cmd_lo_offset_key(), _cmd_handler_looffset);
     REGISTER_CMD_HANDLER(cmd_tune_key(), _cmd_handler_tune);
     REGISTER_CMD_HANDLER(cmd_lo_freq_key(), _cmd_handler_lofreq);
@@ -647,6 +653,21 @@ void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t& gain_,
     }
 
     set_gain(gain, chan);
+}
+
+void usrp_block_impl::_cmd_handler_power(const pmt::pmt_t& power_dbm_,
+                                         int chan,
+                                         const pmt::pmt_t& msg)
+{
+    double power_dbm = pmt::to_double(power_dbm_);
+    if (chan == -1) {
+        for (size_t i = 0; i < _nchan; i++) {
+            set_power_reference(power_dbm, i);
+        }
+        return;
+    }
+
+    set_power_reference(power_dbm, chan);
 }
 
 void usrp_block_impl::_cmd_handler_antenna(const pmt::pmt_t& ant,

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -118,6 +118,7 @@ protected:
     void
     _cmd_handler_looffset(const pmt::pmt_t& lo_offset, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_gain(const pmt::pmt_t& gain, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_power(const pmt::pmt_t& power_dbm, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_antenna(const pmt::pmt_t& ant, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_rate(const pmt::pmt_t& rate, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_tune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -187,6 +187,66 @@ std::vector<std::string> usrp_sink_impl::get_gain_names(size_t chan)
     return _dev->get_tx_gain_range(name, chan);
 }
 
+bool usrp_sink_impl::has_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->has_tx_power_reference(dev_chan);
+#else
+    GR_LOG_WARN(d_logger,
+                "UHD version 4.0 or greater required for power reference API. ");
+    return false;
+#endif
+}
+
+void usrp_sink_impl::set_power_reference(double power_dbm, size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    _dev->set_tx_power_reference(power_dbm, dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+double usrp_sink_impl::get_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_tx_power_reference(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::meta_range_t usrp_sink_impl::get_power_range(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_tx_power_range(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void usrp_sink_impl::set_antenna(const std::string& ant, size_t chan)
 {
     chan = _stream_args.channels[chan];

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -66,6 +66,9 @@ public:
     std::vector<std::string> get_gain_names(size_t chan);
     ::uhd::gain_range_t get_gain_range(size_t chan);
     ::uhd::gain_range_t get_gain_range(const std::string& name, size_t chan);
+    bool has_power_reference(size_t chan);
+    double get_power_reference(size_t chan);
+    ::uhd::meta_range_t get_power_range(size_t chan);
     std::string get_antenna(size_t chan);
     std::vector<std::string> get_antennas(size_t chan);
     ::uhd::sensor_value_t get_sensor(const std::string& name, size_t chan);
@@ -86,6 +89,7 @@ public:
     void set_gain(double gain, size_t chan);
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
+    void set_power_reference(double power_dbm, size_t chan);
     void set_antenna(const std::string& ant, size_t chan);
     void set_bandwidth(double bandwidth, size_t chan);
     double get_bandwidth(size_t chan);

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -203,6 +203,65 @@ std::vector<std::string> usrp_source_impl::get_gain_names(size_t chan)
     return _dev->get_rx_gain_range(name, chan);
 }
 
+bool usrp_source_impl::has_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->has_rx_power_reference(dev_chan);
+#else
+    GR_LOG_WARN(d_logger, "UHD version 4.0 or greater required for power reference API.");
+    return false;
+#endif
+}
+
+void usrp_source_impl::set_power_reference(double power_dbm, size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    _dev->set_rx_power_reference(power_dbm, dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+double usrp_source_impl::get_power_reference(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_rx_power_reference(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
+::uhd::meta_range_t usrp_source_impl::get_power_range(size_t chan)
+{
+#ifdef UHD_USRP_MULTI_USRP_POWER_LEVEL
+    if (chan >= _stream_args.channels.size()) {
+        throw std::out_of_range("Invalid channel: " + std::to_string(chan));
+    }
+    const size_t dev_chan = _stream_args.channels[chan];
+    return _dev->get_rx_power_range(dev_chan);
+#else
+    GR_LOG_ERROR(d_logger,
+                 "UHD version 4.0 or greater required for power reference API.");
+    throw std::runtime_error("not implemented in this version");
+#endif
+}
+
 void usrp_source_impl::set_antenna(const std::string& ant, size_t chan)
 {
     chan = _stream_args.channels[chan];

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -51,6 +51,9 @@ public:
     std::vector<std::string> get_gain_names(size_t chan);
     ::uhd::gain_range_t get_gain_range(size_t chan);
     ::uhd::gain_range_t get_gain_range(const std::string& name, size_t chan);
+    bool has_power_reference(size_t chan);
+    double get_power_reference(size_t chan);
+    ::uhd::meta_range_t get_power_range(size_t chan);
     std::string get_antenna(size_t chan);
     std::vector<std::string> get_antennas(size_t chan);
     ::uhd::sensor_value_t get_sensor(const std::string& name, size_t chan);
@@ -72,6 +75,7 @@ public:
     void set_gain(double gain, const std::string& name, size_t chan);
     void set_rx_agc(const bool enable, size_t chan);
     void set_normalized_gain(double gain, size_t chan);
+    void set_power_reference(double power_dbm, size_t chan);
     void set_antenna(const std::string& ant, size_t chan);
     void set_bandwidth(double bandwidth, size_t chan);
     double get_bandwidth(size_t chan);

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
@@ -75,6 +75,18 @@ static const char* __doc_gr_uhd_usrp_block_get_gain_range_0 = R"doc()doc";
 static const char* __doc_gr_uhd_usrp_block_get_gain_range_1 = R"doc()doc";
 
 
+static const char* __doc_gr_uhd_usrp_block_has_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_set_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_get_power_reference = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_usrp_block_get_power_range = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_usrp_block_set_antenna = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -151,6 +151,31 @@ void bind_usrp_block(py::module& m)
              D(usrp_block, get_gain_range, 1))
 
 
+        .def("has_power_reference",
+             &usrp_block::has_power_reference,
+             py::arg("chan") = 0,
+             D(usrp_block, has_power_reference))
+
+
+        .def("set_power_reference",
+             &usrp_block::set_power_reference,
+             py::arg("power_dbm"),
+             py::arg("chan") = 0,
+             D(usrp_block, set_power_reference))
+
+
+        .def("get_power_reference",
+             &usrp_block::get_power_reference,
+             py::arg("chan") = 0,
+             D(usrp_block, get_power_reference))
+
+
+        .def("get_power_range",
+             &usrp_block::get_power_range,
+             py::arg("chan") = 0,
+             D(usrp_block, get_power_range))
+
+
         .def("set_antenna",
              &usrp_block::set_antenna,
              py::arg("ant"),


### PR DESCRIPTION
UHD 4.0 is introducing a power reference level API, which will now
become available in GNU Radio. Its availability is conditionally
compiled into GNU Radio based on whether or not the feature is available
in the UHD version GNU Radio was compiled against.

USRP source and sink blocks receive the following new APIs:
- has_power_reference()
- set_power_reference()
- get_power_reference()

The command interface now understands a new `power_dbm` dictionary key.
The GRC bindings can now switch between absolute gain, normalized gain,
and absolute power settings.