### PR TITLE
grc: prevent search keystrokes from modifying flowgraph

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -756,7 +756,6 @@ class Application(Gtk.Application):
             main.update_pages()
 
         elif action == Actions.FIND_BLOCKS:
-            flow_graph.unselect()
             main.update_panel_visibility(main.BLOCKS, True)
             main.btwin.search_entry.show()
             main.btwin.search_entry.grab_focus()

--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -87,9 +87,9 @@ class DrawingArea(Gtk.DrawingArea):
 
         self.connect('leave-notify-event', _handle_notify_event, False)
         self.connect('enter-notify-event', _handle_notify_event, True)
-        # todo: fix
-#        self.set_flags(Gtk.CAN_FOCUS)  # self.set_can_focus(True)
-#        self.connect('focus-out-event', self._handle_focus_lost_event)
+
+        self.set_can_focus(True)
+        self.connect('focus-out-event', self._handle_focus_lost_event)
 
 
     ##########################################################################
@@ -119,11 +119,7 @@ class DrawingArea(Gtk.DrawingArea):
         """
         Forward button click information to the flow graph.
         """
-        # The following line causes the canvas to reset position to 0,0
-        #  when changing focus from the console or block search back to 
-        #  the canvas
-        #  Removing this line leaves the canvas alone when focus changes
-        # self.grab_focus()
+        self.grab_focus()
 
         self.ctrl_mask = event.get_state() & Gdk.ModifierType.CONTROL_MASK
         self.mod1_mask = event.get_state() & Gdk.ModifierType.MOD1_MASK
@@ -224,7 +220,7 @@ class DrawingArea(Gtk.DrawingArea):
 
     def _handle_focus_lost_event(self, widget, event):
         # don't clear selection while context menu is active
-        if not self._flow_graph.context_menu.get_take_focus():
+        if not self._flow_graph.get_context_menu()._menu.get_visible():
             self._flow_graph.unselect()
-            self._flow_graph.update_selected()
-            self._flow_graph.queue_draw()
+            self._flow_graph.update_selected_elements()
+            self.queue_draw()

--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -222,5 +222,6 @@ class DrawingArea(Gtk.DrawingArea):
         # don't clear selection while context menu is active
         if not self._flow_graph.get_context_menu()._menu.get_visible():
             self._flow_graph.unselect()
-            self._flow_graph.update_selected_elements()
+            self._flow_graph.update_selected()
             self.queue_draw()
+            Actions.ELEMENT_SELECT()

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -126,12 +126,15 @@ class Page(Gtk.HBox):
         self.drawing_area = DrawingArea(flow_graph)
         flow_graph.drawing_area = self.drawing_area
 
+        self.viewport = Gtk.Viewport()
+        self.viewport.add(self.drawing_area)
+
         self.scrolled_window = Gtk.ScrolledWindow()
         self.scrolled_window.set_size_request(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT)
         self.scrolled_window.set_policy(Gtk.PolicyType.ALWAYS, Gtk.PolicyType.ALWAYS)
         self.scrolled_window.connect('key-press-event', self._handle_scroll_window_key_press)
 
-        self.scrolled_window.add(self.drawing_area)
+        self.scrolled_window.add(self.viewport)
         self.pack_start(self.scrolled_window, True, True, 0)
         self.show_all()
 


### PR DESCRIPTION
This backports #3710 to GNU Radio 3.8. I've tested and this works as in 3.9.