### PR TITLE
grc: prevent search keystrokes from modifying flowgraph, take two

### DIFF
--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -210,5 +210,6 @@ class DrawingArea(Gtk.DrawingArea):
         # don't clear selection while context menu is active
         if not self._flow_graph.get_context_menu()._menu.get_visible():
             self._flow_graph.unselect()
-            self._flow_graph.update_selected_elements()
+            self._flow_graph.update_selected()
             self.queue_draw()
+            Actions.ELEMENT_SELECT()


### PR DESCRIPTION
This pull request resolves the residual issue I noted in https://github.com/gnuradio/gnuradio/pull/3710#issuecomment-676538092.

After blocks are unselected, it's necessary to trigger an `Action` so that keystroke action handlers will be updated in `Application._handle_action`. In my previous pull request, I achieved this by replacing a `FlowGraph.update_selected()` call with a `FlowGraph.update_selected_elements()` call, since the latter happens to trigger an `Action`. However, this does not occur in all cases, because `FlowGraph.update_selected_elements()` can return early.

To fix the issue, I've reverted that change and changed the `DrawingArea`'s `focus-out-event` handler to explicitly trigger `Actions.ELEMENT_SELECT()`.

After this change, blocks appear to be unselect in all cases when accessing the block search box.