### PR TITLE
blocks: fix typo, artifact of log2_l_type renaming

### DIFF
--- a/gr-blocks/lib/packed_to_unpacked_impl.cc
+++ b/gr-blocks/lib/packed_to_unpacked_impl.cc
@@ -139,7 +139,7 @@ int packed_to_unpacked_impl<T>::general_work(int noutput_items,
 
         // printf("almost got to end\n");
         assert(ninput_items[m] >=
-               (int)((d_index + (this->d_bits_per_type - 1)) >> this->d_log2_l_type));
+               (int)((d_index + (this->d_bits_per_type - 1)) >> this->log2_l_type()));
     }
 
     d_index = index_tmp;


### PR DESCRIPTION
This fixes a typo in the assert of packed_to_unpacked that was leftover an a naming conversion from d_log2 to log2.

This prevents the ubuntu packages from building - not sure why it passes CI