### PR TITLE
3.8: Use lambdas instead of boost::bind

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -61,9 +61,8 @@ block::block(const std::string& name,
 {
     global_block_registry.register_primitive(alias(), this);
     message_port_register_in(d_system_port);
-    set_msg_handler(d_system_port, boost::bind(&block::system_handler, this, _1));
-
     configure_default_loggers(d_logger, d_debug_logger, symbol_name());
+    set_msg_handler(d_system_port, [this](pmt::pmt_t msg) { this->system_handler(msg); });
 }
 
 block::~block() { global_block_registry.unregister_primitive(symbol_name()); }

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -70,7 +70,7 @@ sig_source_impl<T>::sig_source_impl(double sampling_freq,
                           [this](pmt::pmt_t msg) { this->set_cmd_msg(msg); });
     this->message_port_register_in(pmt::mp("freq"));
     this->set_msg_handler(pmt::mp("freq"),
-                          [this](pmt::pmt_t msg) { this->set_frequency_msg(msg); });
+                          [this](pmt::pmt_t msg) { this->set_freq_msg(msg); });
 }
 
 template <class T>

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -70,7 +70,7 @@ sig_source_impl<T>::sig_source_impl(double sampling_freq,
                           [this](pmt::pmt_t msg) { this->set_cmd_msg(msg); });
     this->message_port_register_in(pmt::mp("freq"));
     this->set_msg_handler(pmt::mp("freq"),
-                          [this](pmt::pmt_t msg) { this->set_freq_msg(msg); });
+                          [this](pmt::pmt_t msg) { this->set_frequency_msg(msg); });
 }
 
 template <class T>

--- a/gr-blocks/lib/copy_impl.cc
+++ b/gr-blocks/lib/copy_impl.cc
@@ -44,7 +44,7 @@ copy_impl::copy_impl(size_t itemsize)
       d_enabled(true)
 {
     message_port_register_in(pmt::mp("en"));
-    set_msg_handler(pmt::mp("en"), boost::bind(&copy_impl::handle_enable, this, _1));
+    set_msg_handler(pmt::mp("en"), [this](pmt::pmt_t msg) { this->handle_enable(msg); });
 }
 
 copy_impl::~copy_impl() {}

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -90,14 +90,14 @@ message_debug_impl::message_debug_impl()
     : block("message_debug", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0))
 {
     message_port_register_in(pmt::mp("print"));
-    set_msg_handler(pmt::mp("print"), boost::bind(&message_debug_impl::print, this, _1));
+    set_msg_handler(pmt::mp("print"), [this](pmt::pmt_t msg) { this->print(msg); });
 
     message_port_register_in(pmt::mp("store"));
-    set_msg_handler(pmt::mp("store"), boost::bind(&message_debug_impl::store, this, _1));
+    set_msg_handler(pmt::mp("store"), [this](pmt::pmt_t msg) { this->store(msg); });
 
     message_port_register_in(pmt::mp("print_pdu"));
     set_msg_handler(pmt::mp("print_pdu"),
-                    boost::bind(&message_debug_impl::print_pdu, this, _1));
+                    [this](pmt::pmt_t msg) { this->print_pdu(msg); });
 }
 
 message_debug_impl::~message_debug_impl() {}

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -53,8 +53,7 @@ message_strobe_impl::message_strobe_impl(pmt::pmt_t msg, long period_ms)
     message_port_register_out(d_port);
 
     message_port_register_in(pmt::mp("set_msg"));
-    set_msg_handler(pmt::mp("set_msg"),
-                    boost::bind(&message_strobe_impl::set_msg, this, _1));
+    set_msg_handler(pmt::mp("set_msg"), [this](pmt::pmt_t msg) { this->set_msg(msg); });
 }
 
 message_strobe_impl::~message_strobe_impl() {}

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -74,8 +74,7 @@ message_strobe_random_impl::message_strobe_random_impl(
         new gr::thread::thread(boost::bind(&message_strobe_random_impl::run, this)));
 
     message_port_register_in(pmt::mp("set_msg"));
-    set_msg_handler(pmt::mp("set_msg"),
-                    boost::bind(&message_strobe_random_impl::set_msg, this, _1));
+    set_msg_handler(pmt::mp("set_msg"), [this](pmt::pmt_t msg) { this->set_msg(msg); });
 }
 
 long message_strobe_random_impl::next_delay()

--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -235,9 +235,7 @@ multiply_matrix_impl<gr_complex>::multiply_matrix_impl(
 
     pmt::pmt_t port_name = pmt::string_to_symbol("set_A");
     message_port_register_in(port_name);
-    set_msg_handler(
-        port_name,
-        boost::bind(&multiply_matrix_impl<gr_complex>::msg_handler_A, this, _1));
+    set_msg_handler(port_name, [this](pmt::pmt_t msg) { this->msg_handler_A(msg); });
 }
 
 template <>
@@ -256,8 +254,7 @@ multiply_matrix_impl<float>::multiply_matrix_impl(
 
     pmt::pmt_t port_name = pmt::string_to_symbol("set_A");
     message_port_register_in(port_name);
-    set_msg_handler(port_name,
-                    boost::bind(&multiply_matrix_impl<float>::msg_handler_A, this, _1));
+    set_msg_handler(port_name, [this](pmt::pmt_t msg) { this->msg_handler_A(msg); });
 }
 
 

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -47,8 +47,8 @@ mute_impl<T>::mute_impl(bool mute)
       d_mute(mute)
 {
     this->message_port_register_in(pmt::intern("set_mute"));
-    this->set_msg_handler(
-        pmt::intern("set_mute"), [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
+    this->set_msg_handler(pmt::intern("set_mute"),
+                          [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
 }
 
 template <class T>

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -47,8 +47,8 @@ mute_impl<T>::mute_impl(bool mute)
       d_mute(mute)
 {
     this->message_port_register_in(pmt::intern("set_mute"));
-    this->set_msg_handler(pmt::intern("set_mute"),
-                          boost::bind(&mute_impl<T>::set_mute_pmt, this, _1));
+    this->set_msg_handler(
+        pmt::intern("set_mute"), [this](pmt::pmt_t msg) { this->set_mute_pmt(msg); });
 }
 
 template <class T>

--- a/gr-blocks/lib/nop_impl.cc
+++ b/gr-blocks/lib/nop_impl.cc
@@ -26,7 +26,6 @@
 
 #include "nop_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/bind.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/nop_impl.cc
+++ b/gr-blocks/lib/nop_impl.cc
@@ -45,7 +45,7 @@ nop_impl::nop_impl(size_t sizeof_stream_item)
     // Arrange to have count_received_msgs called when messages are received.
     message_port_register_in(pmt::mp("port"));
     set_msg_handler(pmt::mp("port"),
-                    boost::bind(&nop_impl::count_received_msgs, this, _1));
+                    [this](pmt::pmt_t msg) { this->count_received_msgs(msg); });
 }
 
 nop_impl::~nop_impl() {}

--- a/gr-blocks/lib/pdu_filter_impl.cc
+++ b/gr-blocks/lib/pdu_filter_impl.cc
@@ -45,7 +45,7 @@ pdu_filter_impl::pdu_filter_impl(pmt::pmt_t k, pmt::pmt_t v, bool invert)
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(),
-                    boost::bind(&pdu_filter_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_filter_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_remove_impl.cc
+++ b/gr-blocks/lib/pdu_remove_impl.cc
@@ -43,7 +43,7 @@ pdu_remove_impl::pdu_remove_impl(pmt::pmt_t k)
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
     set_msg_handler(pdu::pdu_port_id(),
-                    boost::bind(&pdu_remove_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_remove_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -43,7 +43,7 @@ pdu_set_impl::pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v)
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(), boost::bind(&pdu_set_impl::handle_msg, this, _1));
+    set_msg_handler(pdu::pdu_port_id(), [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_set_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/pdu_set_impl.cc
+++ b/gr-blocks/lib/pdu_set_impl.cc
@@ -43,7 +43,8 @@ pdu_set_impl::pdu_set_impl(pmt::pmt_t k, pmt::pmt_t v)
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(), [this](pmt::pmt_t msg) { this->handle_msg(msg); });
+    set_msg_handler(pdu::pdu_port_id(),
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 void pdu_set_impl::handle_msg(pmt::pmt_t pdu)

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -52,7 +52,8 @@ random_pdu_impl::random_pdu_impl(int min_items,
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pmt::mp("generate"));
-    set_msg_handler(pmt::mp("generate"), [this](pmt::pmt_t msg) { this->generate_pdu(msg); });
+    set_msg_handler(pmt::mp("generate"),
+                    [this](pmt::pmt_t msg) { this->generate_pdu(msg); });
     if (length_modulo < 1)
         throw std::runtime_error("length_module must be >= 1");
     if (max_items < length_modulo)

--- a/gr-blocks/lib/random_pdu_impl.cc
+++ b/gr-blocks/lib/random_pdu_impl.cc
@@ -52,8 +52,7 @@ random_pdu_impl::random_pdu_impl(int min_items,
 {
     message_port_register_out(pdu::pdu_port_id());
     message_port_register_in(pmt::mp("generate"));
-    set_msg_handler(pmt::mp("generate"),
-                    boost::bind(&random_pdu_impl::generate_pdu, this, _1));
+    set_msg_handler(pmt::mp("generate"), [this](pmt::pmt_t msg) { this->generate_pdu(msg); });
     if (length_modulo < 1)
         throw std::runtime_error("length_module must be >= 1");
     if (max_items < length_modulo)

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -44,7 +44,8 @@ repeat_impl::repeat_impl(size_t itemsize, int interp)
       d_interp(interp)
 {
     message_port_register_in(pmt::mp("interpolation"));
-    set_msg_handler(pmt::mp("interpolation"), [this](pmt::pmt_t msg) { this->msg_set_interpolation(msg); });
+    set_msg_handler(pmt::mp("interpolation"),
+                    [this](pmt::pmt_t msg) { this->msg_set_interpolation(msg); });
 }
 
 void repeat_impl::msg_set_interpolation(pmt::pmt_t msg)

--- a/gr-blocks/lib/repeat_impl.cc
+++ b/gr-blocks/lib/repeat_impl.cc
@@ -44,8 +44,7 @@ repeat_impl::repeat_impl(size_t itemsize, int interp)
       d_interp(interp)
 {
     message_port_register_in(pmt::mp("interpolation"));
-    set_msg_handler(pmt::mp("interpolation"),
-                    boost::bind(&repeat_impl::msg_set_interpolation, this, _1));
+    set_msg_handler(pmt::mp("interpolation"), [this](pmt::pmt_t msg) { this->msg_set_interpolation(msg); });
 }
 
 void repeat_impl::msg_set_interpolation(pmt::pmt_t msg)

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -101,7 +101,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
         start_tcp_accept();
 
         set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::tcp_server_send, this, _1));
+                        [this](pmt::pmt_t msg) { this->tcp_server_send(msg); });
     } else if (type == "TCP_CLIENT") {
         boost::system::error_code error = boost::asio::error::host_not_found;
         d_tcp_socket.reset(new boost::asio::ip::tcp::socket(d_io_service));
@@ -111,7 +111,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
         d_tcp_socket->set_option(boost::asio::ip::tcp::no_delay(d_tcp_no_delay));
 
         set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::tcp_client_send, this, _1));
+                        [this](pmt::pmt_t msg) { this->tcp_client_send(msg); });
 
         d_tcp_socket->async_read_some(
             boost::asio::buffer(d_rxbuf),
@@ -131,7 +131,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::bytes_transferred));
 
         set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::udp_send, this, _1));
+                        [this](pmt::pmt_t msg) { this->udp_send(msg); });
     } else if (type == "UDP_CLIENT") {
         d_udp_socket.reset(
             new boost::asio::ip::udp::socket(d_io_service, d_udp_endpoint));
@@ -144,7 +144,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         boost::asio::placeholders::bytes_transferred));
 
         set_msg_handler(pdu::pdu_port_id(),
-                        boost::bind(&socket_pdu_impl::udp_send, this, _1));
+                        [this](pmt::pmt_t msg) { this->udp_send(msg); });
     } else
         throw std::runtime_error("gr::blocks:socket_pdu: unknown socket type");
 

--- a/gr-blocks/lib/tagged_stream_multiply_length_impl.cc
+++ b/gr-blocks/lib/tagged_stream_multiply_length_impl.cc
@@ -49,9 +49,8 @@ tagged_stream_multiply_length_impl::tagged_stream_multiply_length_impl(
     set_tag_propagation_policy(TPP_DONT);
     set_relative_rate(1, 1);
     message_port_register_in(pmt::intern("set_scalar"));
-    set_msg_handler(
-        pmt::intern("set_scalar"),
-        boost::bind(&tagged_stream_multiply_length_impl::set_scalar_pmt, this, _1));
+    set_msg_handler(pmt::intern("set_scalar"),
+                    [this](pmt::pmt_t msg) { this->set_scalar_pmt(msg); });
 }
 
 tagged_stream_multiply_length_impl::~tagged_stream_multiply_length_impl() {}

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -96,7 +96,7 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
 
     // set up input message port
     message_port_register_in(pdu::pdu_port_id());
-    set_msg_handler(pdu::pdu_port_id(), boost::bind(&tuntap_pdu_impl::send, this, _1));
+    set_msg_handler(pdu::pdu_port_id(), [this](pmt::pmt_t msg) { this->send(msg); });
 }
 
 int tuntap_pdu_impl::tun_alloc(char* dev, int flags)

--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -51,10 +51,8 @@ chunks_to_symbols_impl<IN_T, OUT_T>::chunks_to_symbols_impl(
       d_symbol_table(symbol_table)
 {
     this->message_port_register_in(pmt::mp("set_symbol_table"));
-    this->set_msg_handler(
-        pmt::mp("set_symbol_table"),
-        boost::bind(
-            &chunks_to_symbols_impl<IN_T, OUT_T>::handle_set_symbol_table, this, _1));
+    this->set_msg_handler(pmt::mp("set_symbol_table"),
+                          [this](pmt::pmt_t msg) { this->handle_set_symbol_table(msg); });
 }
 
 template <class IN_T, class OUT_T>

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -61,14 +61,12 @@ constellation_receiver_cb_impl::constellation_receiver_cb_impl(
             "This receiver only works with constellations of dimension 1.");
 
     message_port_register_in(pmt::mp("set_constellation"));
-    set_msg_handler(
-        pmt::mp("set_constellation"),
-        boost::bind(&constellation_receiver_cb_impl::handle_set_constellation, this, _1));
+    set_msg_handler(pmt::mp("set_constellation"),
+                    [this](pmt::pmt_t msg) { this->handle_set_constellation(msg); });
 
     message_port_register_in(pmt::mp("rotate_phase"));
-    set_msg_handler(
-        pmt::mp("rotate_phase"),
-        boost::bind(&constellation_receiver_cb_impl::handle_rotate_phase, this, _1));
+    set_msg_handler(pmt::mp("rotate_phase"),
+                    [this](pmt::pmt_t msg) { this->handle_rotate_phase(msg); });
 }
 
 constellation_receiver_cb_impl::~constellation_receiver_cb_impl() {}

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -82,7 +82,7 @@ costas_loop_cc_impl::costas_loop_cc_impl(float loop_bw, int order, bool use_snr)
 
     message_port_register_in(pmt::mp("noise"));
     set_msg_handler(pmt::mp("noise"),
-                    boost::bind(&costas_loop_cc_impl::handle_set_noise, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_set_noise(msg); });
 }
 
 costas_loop_cc_impl::~costas_loop_cc_impl() {}

--- a/gr-digital/lib/crc32_async_bb_impl.cc
+++ b/gr-digital/lib/crc32_async_bb_impl.cc
@@ -48,9 +48,9 @@ crc32_async_bb_impl::crc32_async_bb_impl(bool check)
     message_port_register_out(d_out_port);
 
     if (check)
-        set_msg_handler(d_in_port, boost::bind(&crc32_async_bb_impl::check, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->check(msg); });
     else
-        set_msg_handler(d_in_port, boost::bind(&crc32_async_bb_impl::calc, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->calc(msg); });
 }
 
 crc32_async_bb_impl::~crc32_async_bb_impl() {}

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -150,9 +150,8 @@ header_payload_demux_impl::header_payload_demux_impl(
     }
     set_tag_propagation_policy(TPP_DONT);
     message_port_register_in(msg_port_id());
-    set_msg_handler(
-        msg_port_id(),
-        boost::bind(&header_payload_demux_impl::parse_header_data_msg, this, _1));
+    set_msg_handler(msg_port_id(),
+                    [this](pmt::pmt_t msg) { this->parse_header_data_msg(msg); });
     for (size_t i = 0; i < special_tags.size(); i++) {
         d_special_tags.push_back(pmt::string_to_symbol(special_tags[i]));
         d_special_tags_last_value.push_back(pmt::PMT_NIL);

--- a/gr-digital/lib/protocol_formatter_async_impl.cc
+++ b/gr-digital/lib/protocol_formatter_async_impl.cc
@@ -54,8 +54,7 @@ protocol_formatter_async_impl::protocol_formatter_async_impl(
     message_port_register_out(d_hdr_port);
     message_port_register_out(d_pld_port);
 
-    set_msg_handler(d_in_port,
-                    boost::bind(&protocol_formatter_async_impl::append, this, _1));
+    set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->append(msg); });
 }
 
 protocol_formatter_async_impl::~protocol_formatter_async_impl() {}

--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -64,11 +64,10 @@ async_decoder_impl::async_decoder_impl(generic_decoder::sptr my_decoder,
 
     if (d_packed) {
         d_pack = new blocks::kernel::pack_k_bits(8);
-        set_msg_handler(d_in_port,
-                        boost::bind(&async_decoder_impl::decode_packed, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->decode_packed(msg); });
     } else {
         set_msg_handler(d_in_port,
-                        boost::bind(&async_decoder_impl::decode_unpacked, this, _1));
+                        [this](pmt::pmt_t msg) { this->decode_unpacked(msg); });
     }
 
     // The maximum frame size is set by the initial frame size of the decoder.

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -63,8 +63,7 @@ async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
     message_port_register_out(d_out_port);
 
     if (d_packed) {
-        set_msg_handler(d_in_port,
-                        boost::bind(&async_encoder_impl::encode_packed, this, _1));
+        set_msg_handler(d_in_port, [this](pmt::pmt_t msg) { this->encode_packed(msg); });
 
         d_unpack = new blocks::kernel::unpack_k_bits(8);
 
@@ -74,7 +73,7 @@ async_encoder_impl::async_encoder_impl(generic_encoder::sptr my_encoder,
 
     } else {
         set_msg_handler(d_in_port,
-                        boost::bind(&async_encoder_impl::encode_unpacked, this, _1));
+                        [this](pmt::pmt_t msg) { this->encode_unpacked(msg); });
     }
 
     if (d_packed || (strncmp(d_encoder->get_input_conversion(), "pack", 4) == 0)) {

--- a/gr-fec/lib/depuncture_bb_impl.cc
+++ b/gr-fec/lib/depuncture_bb_impl.cc
@@ -74,7 +74,7 @@ depuncture_bb_impl::depuncture_bb_impl(int puncsize, int puncpat, int delay, cha
     set_fixed_rate(true);
     set_relative_rate((uint64_t)d_puncsize, (uint64_t)(d_puncsize - d_puncholes));
     set_output_multiple(d_puncsize);
-    // set_msg_handler(boost::bind(&depuncture_bb_impl::catch_msg, this, _1));
+    // set_msg_handler(<portname>, [this](pmt::pmt_t msg) { this->catch_msg(msg); });
 }
 
 depuncture_bb_impl::~depuncture_bb_impl() {}

--- a/gr-fec/lib/puncture_bb_impl.cc
+++ b/gr-fec/lib/puncture_bb_impl.cc
@@ -72,7 +72,7 @@ puncture_bb_impl::puncture_bb_impl(int puncsize, int puncpat, int delay)
     set_fixed_rate(true);
     set_relative_rate((uint64_t)(d_puncsize - d_puncholes), (uint64_t)d_puncsize);
     set_output_multiple(d_puncsize - d_puncholes);
-    // set_msg_handler(boost::bind(&puncture_bb_impl::catch_msg, this, _1));
+    // set_msg_handler(<portname>, [this](pmt::pmt_t msg) { this->catch_msg(msg); });
 }
 
 puncture_bb_impl::~puncture_bb_impl() {}

--- a/gr-fec/lib/puncture_ff_impl.cc
+++ b/gr-fec/lib/puncture_ff_impl.cc
@@ -72,7 +72,7 @@ puncture_ff_impl::puncture_ff_impl(int puncsize, int puncpat, int delay)
     set_fixed_rate(true);
     set_relative_rate((uint64_t)(d_puncsize - d_puncholes), (uint64_t)d_puncsize);
     set_output_multiple(d_puncsize - d_puncholes);
-    // set_msg_handler(boost::bind(&puncture_ff_impl::catch_msg, this, _1));
+    // set_msg_handler(<portname>, [this](pmt::pmt_t msg) { this->catch_msg(msg); });
 }
 
 puncture_ff_impl::~puncture_ff_impl() {}

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.cc
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.cc
@@ -67,12 +67,8 @@ freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::freq_xlating_fir_filter_impl(
     this->build_composite_fir();
 
     this->message_port_register_in(pmt::mp("freq"));
-    this->set_msg_handler(
-        pmt::mp("freq"),
-        boost::bind(
-            &freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::handle_set_center_freq,
-            this,
-            _1));
+    this->set_msg_handler(pmt::mp("freq"),
+                          [this](pmt::pmt_t msg) { this->handle_set_center_freq(msg); });
 }
 
 template <class IN_T, class OUT_T, class TAP_T>

--- a/gr-filter/lib/mmse_resampler_cc_impl.cc
+++ b/gr-filter/lib/mmse_resampler_cc_impl.cc
@@ -53,7 +53,7 @@ mmse_resampler_cc_impl::mmse_resampler_cc_impl(float phase_shift, float resamp_r
     set_inverse_relative_rate(d_mu_inc);
     message_port_register_in(pmt::intern("msg_in"));
     set_msg_handler(pmt::intern("msg_in"),
-                    boost::bind(&mmse_resampler_cc_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 mmse_resampler_cc_impl::~mmse_resampler_cc_impl() { delete d_resamp; }

--- a/gr-filter/lib/mmse_resampler_ff_impl.cc
+++ b/gr-filter/lib/mmse_resampler_ff_impl.cc
@@ -54,7 +54,7 @@ mmse_resampler_ff_impl::mmse_resampler_ff_impl(float phase_shift, float resamp_r
 
     message_port_register_in(pmt::intern("msg_in"));
     set_msg_handler(pmt::intern("msg_in"),
-                    boost::bind(&mmse_resampler_ff_impl::handle_msg, this, _1));
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
 mmse_resampler_ff_impl::~mmse_resampler_ff_impl() { delete d_resamp; }

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -69,8 +69,7 @@ const_sink_c_impl::const_sink_c_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&const_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     for (int i = 0; i < d_nconnections; i++) {
         d_residbufs_real.push_back(

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -158,7 +158,7 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
     message_port_register_out(d_port);
     message_port_register_in(pmt::mp("val"));
 
-    set_msg_handler(pmt::mp("val"), boost::bind(&edit_box_msg_impl::set_value, this, _1));
+    set_msg_handler(pmt::mp("val"), [this](pmt::pmt_t msg) { this->set_value(msg); });
 }
 
 edit_box_msg_impl::~edit_box_msg_impl()

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -82,17 +82,17 @@ freq_sink_c_impl::freq_sink_c_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw, boost::bind(&freq_sink_c_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&freq_sink_c_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&freq_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -82,17 +82,17 @@ freq_sink_f_impl::freq_sink_f_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw, boost::bind(&freq_sink_f_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&freq_sink_f_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&freq_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -81,8 +81,7 @@ histogram_sink_f_impl::histogram_sink_f_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&histogram_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     // +1 for the PDU buffer
     for (int i = 0; i < d_nconnections + 1; i++) {

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -96,7 +96,7 @@ sink_c_impl::sink_c_impl(int fftsize,
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&sink_c_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -95,7 +95,7 @@ sink_f_impl::sink_f_impl(int fftsize,
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port, boost::bind(&sink_f_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     d_main_gui = NULL;
 

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -83,8 +83,7 @@ time_raster_sink_b_impl::time_raster_sink_b_impl(double samp_rate,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&time_raster_sink_b_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_scale = 1.0f;
 

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -83,8 +83,7 @@ time_raster_sink_f_impl::time_raster_sink_f_impl(double samp_rate,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&time_raster_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     d_icols = static_cast<int>(ceil(d_cols));
     d_tmpflt = (float*)volk_malloc(d_icols * sizeof(float), volk_get_alignment());

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -80,7 +80,7 @@ time_sink_c_impl::time_sink_c_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&time_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     // +2 for the PDU message buffers
     for (unsigned int n = 0; n < d_nconnections + 2; n++) {

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -80,7 +80,7 @@ time_sink_f_impl::time_sink_f_impl(int size,
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&time_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
     // +1 for the PDU buffer
     for (unsigned int n = 0; n < d_nconnections + 1; n++) {

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -117,20 +117,17 @@ waterfall_sink_c_impl::waterfall_sink_c_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw,
-                    boost::bind(&waterfall_sink_c_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port,
-                    boost::bind(&waterfall_sink_c_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&waterfall_sink_c_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 }
 
 waterfall_sink_c_impl::~waterfall_sink_c_impl()

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -115,20 +115,17 @@ waterfall_sink_f_impl::waterfall_sink_f_impl(int fftsize,
 
     // setup bw input port
     message_port_register_in(d_port_bw);
-    set_msg_handler(d_port_bw,
-                    boost::bind(&waterfall_sink_f_impl::handle_set_bw, this, _1));
+    set_msg_handler(d_port_bw, [this](pmt::pmt_t msg) { this->handle_set_bw(msg); });
 
     // setup output message port to post frequency when display is
     // double-clicked
     message_port_register_out(d_port);
     message_port_register_in(d_port);
-    set_msg_handler(d_port,
-                    boost::bind(&waterfall_sink_f_impl::handle_set_freq, this, _1));
+    set_msg_handler(d_port, [this](pmt::pmt_t msg) { this->handle_set_freq(msg); });
 
     // setup PDU handling input port
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"),
-                    boost::bind(&waterfall_sink_f_impl::handle_pdus, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 }
 
 waterfall_sink_f_impl::~waterfall_sink_f_impl()

--- a/gr-uhd/lib/amsg_source_impl.cc
+++ b/gr-uhd/lib/amsg_source_impl.cc
@@ -43,7 +43,7 @@ amsg_source_impl::amsg_source_impl(const ::uhd::device_addr_t& device_addr,
     : _msgq(msgq), _running(true)
 {
     _dev = ::uhd::usrp::multi_usrp::make(device_addr);
-    _amsg_thread = gr::thread::thread([this]() {this->recv_loop();});
+    _amsg_thread = gr::thread::thread([this]() { this->recv_loop(); });
 }
 
 amsg_source_impl::~amsg_source_impl()

--- a/gr-uhd/lib/amsg_source_impl.cc
+++ b/gr-uhd/lib/amsg_source_impl.cc
@@ -22,7 +22,6 @@
 
 #include "amsg_source_impl.h"
 #include "gr_uhd_common.h"
-#include <boost/bind.hpp>
 
 namespace gr {
 namespace uhd {
@@ -44,7 +43,7 @@ amsg_source_impl::amsg_source_impl(const ::uhd::device_addr_t& device_addr,
     : _msgq(msgq), _running(true)
 {
     _dev = ::uhd::usrp::multi_usrp::make(device_addr);
-    _amsg_thread = gr::thread::thread(boost::bind(&amsg_source_impl::recv_loop, this));
+    _amsg_thread = gr::thread::thread([this]() {this->recv_loop();});
 }
 
 amsg_source_impl::~amsg_source_impl()

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -21,7 +21,7 @@
  */
 
 #include "usrp_block_impl.h"
-#include <boost/make_shared.hpp>
+#include <functional>
 
 using namespace gr::uhd;
 
@@ -139,10 +139,11 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     set_msg_handler(pmt::mp("command"),
                     [this](pmt::pmt_t msg) { this->msg_handler_command(msg); });
 
-// cuz we lazy:
+    // because we're highly efficient and adverse to work
+    namespace ph = std::placeholders;
 #define REGISTER_CMD_HANDLER(key, _handler) \
     register_msg_cmd_handler(key,           \
-                             boost::bind(&usrp_block_impl::_handler, this, _1, _2, _3))
+                             std::bind(&usrp_block_impl::_handler, this, ph::_1, ph::_2, ph::_3))
     // Register default command handlers:
     REGISTER_CMD_HANDLER(cmd_freq_key(), _cmd_handler_freq);
     REGISTER_CMD_HANDLER(cmd_gain_key(), _cmd_handler_gain);
@@ -153,6 +154,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     REGISTER_CMD_HANDLER(cmd_rate_key(), _cmd_handler_rate);
     REGISTER_CMD_HANDLER(cmd_bandwidth_key(), _cmd_handler_bw);
     REGISTER_CMD_HANDLER(cmd_antenna_key(), _cmd_handler_antenna);
+#undef REGISTER_CMD_HANDLER
 }
 
 usrp_block_impl::~usrp_block_impl()

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -142,8 +142,8 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     // because we're highly efficient and adverse to work
     namespace ph = std::placeholders;
 #define REGISTER_CMD_HANDLER(key, _handler) \
-    register_msg_cmd_handler(key,           \
-                             std::bind(&usrp_block_impl::_handler, this, ph::_1, ph::_2, ph::_3))
+    register_msg_cmd_handler(               \
+        key, std::bind(&usrp_block_impl::_handler, this, ph::_1, ph::_2, ph::_3))
     // Register default command handlers:
     REGISTER_CMD_HANDLER(cmd_freq_key(), _cmd_handler_freq);
     REGISTER_CMD_HANDLER(cmd_gain_key(), _cmd_handler_gain);

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -137,7 +137,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     // Set up message ports:
     message_port_register_in(pmt::mp("command"));
     set_msg_handler(pmt::mp("command"),
-                    boost::bind(&usrp_block_impl::msg_handler_command, this, _1));
+                    [this](pmt::pmt_t msg) { this->msg_handler_command(msg); });
 
 // cuz we lazy:
 #define REGISTER_CMD_HANDLER(key, _handler) \

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -26,7 +26,6 @@
 #include <gnuradio/uhd/usrp_block.h>
 #include <pmt/pmt.h>
 #include <uhd/usrp/multi_usrp.hpp>
-#include <boost/bind.hpp>
 #include <boost/dynamic_bitset.hpp>
 
 

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -58,7 +58,7 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
     _samp_rate = this->get_samp_rate();
     _samps_per_packet = 1;
     register_msg_cmd_handler(cmd_tag_key(),
-                             [this](pmt::pmt_t msg) { this->_cmd_handler_tag(msg); });
+                             [this](const pmt::pmt_t& val, int chan, const pmt::pmt_t& msg) { this->_cmd_handler_tag(val); });
 }
 
 usrp_source_impl::~usrp_source_impl() {}

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -57,8 +57,10 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
 
     _samp_rate = this->get_samp_rate();
     _samps_per_packet = 1;
-    register_msg_cmd_handler(cmd_tag_key(),
-                             [this](const pmt::pmt_t& val, int chan, const pmt::pmt_t& msg) { this->_cmd_handler_tag(val); });
+    register_msg_cmd_handler(
+        cmd_tag_key(), [this](const pmt::pmt_t& val, int chan, const pmt::pmt_t& msg) {
+            this->_cmd_handler_tag(val);
+        });
 }
 
 usrp_source_impl::~usrp_source_impl() {}

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -57,8 +57,8 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
 
     _samp_rate = this->get_samp_rate();
     _samps_per_packet = 1;
-    register_msg_cmd_handler(cmd_tag_key(),[this](pmt::pmt_t msg) {
-        this->_cmd_handler_tag(msg);};
+    register_msg_cmd_handler(cmd_tag_key(),
+                             [this](pmt::pmt_t msg) { this->_cmd_handler_tag(msg); });
 }
 
 usrp_source_impl::~usrp_source_impl() {}

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -57,8 +57,8 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
 
     _samp_rate = this->get_samp_rate();
     _samps_per_packet = 1;
-    register_msg_cmd_handler(cmd_tag_key(),
-                             boost::bind(&usrp_source_impl::_cmd_handler_tag, this, _1));
+    register_msg_cmd_handler(cmd_tag_key(),[this](pmt::pmt_t msg) {
+        this->_cmd_handler_tag(msg);};
 }
 
 usrp_source_impl::~usrp_source_impl() {}

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -62,7 +62,7 @@ pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout, bool bind)
     }
 
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&pub_msg_sink_impl::handler, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handler(msg); });
 }
 
 pub_msg_sink_impl::~pub_msg_sink_impl()

--- a/gr-zeromq/lib/push_msg_sink_impl.cc
+++ b/gr-zeromq/lib/push_msg_sink_impl.cc
@@ -62,7 +62,7 @@ push_msg_sink_impl::push_msg_sink_impl(char* address, int timeout, bool bind)
     }
 
     message_port_register_in(pmt::mp("in"));
-    set_msg_handler(pmt::mp("in"), boost::bind(&push_msg_sink_impl::handler, this, _1));
+    set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handler(msg); });
 }
 
 push_msg_sink_impl::~push_msg_sink_impl()


### PR DESCRIPTION
This is mostly a backport of master functionality.

Fixes #3720

Discussion there.