### PR TITLE
grc: fix dark theme detection

### DIFF
--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -35,7 +35,7 @@ def have_dark_theme():
         """
         Check if a theme is dark based on its name.
         """
-        return theme_name in Constants.GTK_DARK_THEMES or "dark" in theme_name.lower()
+        return theme_name and (theme_name in Constants.GTK_DARK_THEMES or "dark" in theme_name.lower())
     # GoGoGo
     config = configparser.ConfigParser()
     config.read(os.path.expanduser(Constants.GTK_SETTINGS_INI_PATH))


### PR DESCRIPTION
...for systems with no theme set.

This is a backport of bfe366bf35 to maint-3.8

Fixes #3723