### PR TITLE
grc 3.8: new bokehgui event loop

### DIFF
--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -139,12 +139,6 @@ templates:
         % if generate_options == 'qt_gui':
         from PyQt5 import Qt
         % endif
-        % if generate_options == 'bokeh_gui':
-        import time
-        import functools
-        from bokeh.client import push_session
-        from bokeh.plotting import curdoc
-        % endif
         % if not generate_options.startswith('hb'):
         from argparse import ArgumentParser
         from gnuradio.eng_arg import eng_float, intx

--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -70,6 +70,11 @@ parameters:
     dtype: int_vector
     default: (0,0)
     hide: ${ ('part' if generate_options == 'bokeh_gui' else 'all') }
+-   id: window_size
+    label: Window size
+    dtype: int_vector
+    default: (1000,1000)
+    hide: ${ ('part' if generate_options == 'bokeh_gui' else 'all') }
 -   id: sizing_mode
     label: Sizing Mode
     dtype: enum

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -397,7 +397,7 @@ def main(top_block_cls=${class_name}, options=None):
     try:
         tb.start()
         ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}
-        bokehgui.utils.run_server(tb)
+        bokehgui.utils.run_server(tb, sizing_mode = "${flow_graph.get_option('sizing_mode')}",  widget_placement =  ${flow_graph.get_option('placement')}, window_size =  ${flow_graph.get_option('window_size')})
     finally:
         print("Exiting the simulation. Stopping Bokeh Server")
         tb.stop()

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -103,7 +103,7 @@ class ${class_name}(gr.top_block, Qt.QWidget):
 % elif generate_options == 'bokeh_gui':
 
 class ${class_name}(gr.top_block):
-    def __init__(self):
+    def __init__(${param_str}):
         gr.top_block.__init__(self, "${title}")
         self.plot_lst = []
         self.widget_lst = []
@@ -392,7 +392,7 @@ def main(top_block_cls=${class_name}, options=None):
     qapp.exec_()
     % elif generate_options == 'bokeh_gui':
     # Create Top Block instance
-    tb = top_block_cls()
+    tb = top_block_cls(${ ', '.join(params_eq_list) })
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
     try:
         tb.start()

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -391,18 +391,12 @@ def main(top_block_cls=${class_name}, options=None):
     % endfor
     qapp.exec_()
     % elif generate_options == 'bokeh_gui':
-    def killProc(signum, frame, tb):
-        tb.stop()
-        tb.wait()
-        ${'snippets_main_after_stop(tb)' if snippets['main_after_stop'] else ''}
-    time.sleep(1)
-        # Create Top Block instance
+    # Create Top Block instance
     tb = top_block_cls()
     ${'snippets_main_after_init(tb)' if snippets['main_after_init'] else ''}
     try:
         tb.start()
         ${'snippets_main_after_start(tb)' if snippets['main_after_start'] else ''}
-        signal.signal(signal.SIGTERM, functools.partial(killProc, tb=tb))
         bokehgui.utils.run_server(tb)
     finally:
         print("Exiting the simulation. Stopping Bokeh Server")


### PR DESCRIPTION
gr-bokehgui previously used a deprecated way to do its event loop and it was removed in bokeh 2.0, so we have changed it to be more inline with best practices, and this impacts the gnuradio interface.

I took the opportunity to move as much as possible of the code inside of gr-bokehgui itself to reduce the need for subsequent PRs (but no promises).
In the process, I added a new option to set the display size of the bokeh interface in the browser and to properly support parameters (so it supersedes [this previous PR](https://github.com/gnuradio/gnuradio/pull/3300)). Tell me if you prefer me to split this into several PRs.

To try this, use the [3.8-bokeh-2](https://github.com/gnuradio/gr-bokehgui/tree/3.8-bokeh-2)  branch. I'm waiting for this PR before merging to bokehgui's maint-3.8.

All these changes should be able to be picked for master without issue, but I haven't ported gr-bokehgui to pybind11 yet so I have no way of testing.