### PR TITLE
Remove hardcoded GR_PYTHON_DIR

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -35,7 +35,6 @@ find_dependency(Volk)
 set(ENABLE_PYTHON @ENABLE_PYTHON@ CACHE BOOL "Enable Python & pybind11 Bindings")
 if(${ENABLE_PYTHON})
   set(PYTHON_EXECUTABLE @PYTHON_EXECUTABLE@)
-  set(GR_PYTHON_DIR @GR_PYTHON_DIR@)
   include(GrPython)
 endif()
 


### PR DESCRIPTION
GrPython.cmake now sets the default correctly thanks to #2939

Closes #3729