### PR TITLE
blocks: prevent losing rx_time precision in gr_read_file_metadata

### DIFF
--- a/gr-blocks/python/blocks/parse_file_metadata.py
+++ b/gr-blocks/python/blocks/parse_file_metadata.py
@@ -10,6 +10,7 @@
 
 
 import sys
+import decimal
 from gnuradio import gr, blocks
 import pmt
 
@@ -75,12 +76,20 @@ def parse_header(p, VERBOSE=False):
         r = pmt.dict_ref(p, pmt.string_to_symbol("rx_time"), dump)
         secs = pmt.tuple_ref(r, 0)
         fracs = pmt.tuple_ref(r, 1)
-        secs = float(pmt.to_uint64(secs))
+        secs = pmt.to_uint64(secs)
         fracs = pmt.to_double(fracs)
-        t = secs + fracs
+        t = float(secs) + fracs
+        info["rx_time_secs"] = secs
+        info["rx_time_fracs"] = fracs
         info["rx_time"] = t
         if(VERBOSE):
-            print("Seconds: {0:.6f}".format(t))
+                # We need are going to print with ~1e-16 resolution,
+                # which is the precision we can expect in secs.
+                # The default value of precision for decimal
+                # is 28. The value of secs is not expected to be larger
+                # than 1e12, so this precision is enough.
+                s = decimal.Decimal(secs) + decimal.Decimal(fracs)
+                print("Seconds: {0:.16f}".format(s))
     else:
         sys.stderr.write("Could not find key 'time': invalid or corrupt data file.\n")
         sys.exit(1)


### PR DESCRIPTION
The utility gr_read_file_metadata uses parse_file_metadata.parse_header()
from gr-blocks to parse and print headers in a metadata file. Currently,
the rx_time field is printed with us precision. However, the rx_time is
stored as the integer seconds of the UNIX timestamp in an uint64_t plus
a double storing the fraction of a second, so the rx_time has more
precision.

A precision on the order of 1ns is necessary for many ranging applications,
since 1us is approximately 300m of range.

This modifies parse_file_metadata.parse_header() to print the full
fractional part as stored in the double. Aditionally, it adds
"rx_time_secs" and "rx_time_fracs" fields to the dict() return value of
parse_header(), in case they are ever needed. The "rx_time" field in this
dict() is a double, and as such it is unable to store a UNIX timestamp with
1ns precision.

**Note:** This is just a proposal of how to improve the current behaviour. Others might have better suggestions. In my particular use case I just need `gr_read_file_metadata` to print the full precision of `rx_time` as stored in the headers, since the output of `gr_read_file_metadata` is then parsed by another tool.