### PR TITLE
fec: Remove manual memory management

### DIFF
--- a/gr-fec/include/gnuradio/fec/cc_common.h
+++ b/gr-fec/include/gnuradio/fec/cc_common.h
@@ -11,6 +11,8 @@
 #ifndef INCLUDED_FEC_CC_COMMON_H
 #define INCLUDED_FEC_CC_COMMON_H
 
+#include <volk/volk_alloc.hh>
+
 typedef enum _cc_mode_t {
     CC_STREAMING = 0,
     CC_TERMINATED,
@@ -31,10 +33,10 @@ typedef union {
 } metric_t;
 
 struct v {
-    unsigned char* metrics;
+    volk::vector<unsigned char> metrics;
     metric_t old_metrics, new_metrics, metrics1,
         metrics2; /* Pointers to path metrics, swapped on every bit */
-    unsigned char* decisions;
+    volk::vector<unsigned char> decisions;
 };
 
 #endif /*INCLUDED_FEC_CC_COMMON_H*/

--- a/gr-fec/include/gnuradio/fec/polar_decoder_sc.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_sc.h
@@ -59,8 +59,8 @@ private:
                      std::vector<int> frozen_bit_positions,
                      std::vector<uint8_t> frozen_bit_values);
 
-    float* d_llr_vec;
-    unsigned char* d_u_hat_vec;
+    volk::vector<float> d_llr_vec;
+    volk::vector<unsigned char> d_u_hat_vec;
 
     unsigned char retrieve_bit_from_llr(float llr, const int pos);
     void sc_decode(float* llrs, unsigned char* u);

--- a/gr-fec/include/gnuradio/fec/polar_decoder_sc_systematic.h
+++ b/gr-fec/include/gnuradio/fec/polar_decoder_sc_systematic.h
@@ -57,9 +57,9 @@ private:
     polar_decoder_sc_systematic(int block_size,
                                 int num_info_bits,
                                 std::vector<int> frozen_bit_positions);
-    float* d_llr_vec;
-    unsigned char* d_u_hat_vec;
-    unsigned char* d_frame_vec;
+    volk::vector<float> d_llr_vec;
+    volk::vector<unsigned char> d_u_hat_vec;
+    volk::vector<unsigned char> d_frame_vec;
     unsigned char retrieve_bit_from_llr(float llr, const int pos);
     void sc_decode(float* llrs, unsigned char* u);
     void extract_info_bits_reversed(unsigned char* outbuf, const unsigned char* inbuf);

--- a/gr-fec/include/gnuradio/fec/polar_encoder.h
+++ b/gr-fec/include/gnuradio/fec/polar_encoder.h
@@ -74,12 +74,13 @@ private:
                   bool is_packed);
     bool d_is_packed;
 
-    // c'tor method for packed algorithm setup.
-    void setup_frozen_bit_inserter();
+    // Helper function to allow `d_frozen_bit_prototype` to be const.
+    volk::vector<unsigned char> make_prototype() const;
 
     // methods insert input bits and frozen bits into packed array for encoding
-    unsigned char* d_frozen_bit_prototype; // packed frozen bits are written onto it and
-                                           // later copies are used.
+    const volk::vector<unsigned char>
+        d_frozen_bit_prototype; // packed frozen bits are written onto it and
+                                // later copies are used.
     void insert_packed_frozen_bits_and_reverse(unsigned char* target,
                                                const unsigned char* input) const;
     void insert_unpacked_bit_into_packed_array_at_position(unsigned char* target,

--- a/gr-fec/include/gnuradio/fec/polar_encoder_systematic.h
+++ b/gr-fec/include/gnuradio/fec/polar_encoder_systematic.h
@@ -70,7 +70,7 @@ private:
 
     void bit_reverse_and_reset_frozen_bits(unsigned char* outbuf,
                                            const unsigned char* inbuf);
-    unsigned char* d_volk_syst_intermediate;
+    volk::vector<unsigned char> d_volk_syst_intermediate;
 };
 
 } // namespace code

--- a/gr-fec/lib/cc_decoder_impl.h
+++ b/gr-fec/lib/cc_decoder_impl.h
@@ -43,7 +43,7 @@ private:
                           unsigned int tailsize);
     int find_endstate();
 
-    unsigned char* Branchtab;
+    volk::vector<unsigned char> d_branchtab;
     unsigned char Partab[256];
 
 
@@ -84,6 +84,10 @@ public:
                     cc_mode_t mode = CC_STREAMING,
                     bool padded = false);
     ~cc_decoder_impl();
+
+    // Disable copy because of the raw pointers.
+    cc_decoder_impl(const cc_decoder_impl&) = delete;
+    cc_decoder_impl& operator=(const cc_decoder_impl&) = delete;
 
     void generic_work(void* inbuffer, void* outbuffer);
     bool set_frame_size(unsigned int frame_size);

--- a/gr-fec/lib/polar_decoder_sc.cc
+++ b/gr-fec/lib/polar_decoder_sc.cc
@@ -37,30 +37,22 @@ polar_decoder_sc::polar_decoder_sc(int block_size,
                                    std::vector<int> frozen_bit_positions,
                                    std::vector<uint8_t> frozen_bit_values)
     : polar_decoder_common(
-          block_size, num_info_bits, frozen_bit_positions, frozen_bit_values)
+          block_size, num_info_bits, frozen_bit_positions, frozen_bit_values),
+      d_llr_vec(block_size * (block_power() + 1)),
+      d_u_hat_vec(block_size * (block_power() + 1))
 {
-    d_llr_vec = (float*)volk_malloc(sizeof(float) * block_size * (block_power() + 1),
-                                    volk_get_alignment());
-    memset(d_llr_vec, 0, sizeof(float) * block_size * (block_power() + 1));
-    d_u_hat_vec = (unsigned char*)volk_malloc(block_size * (block_power() + 1),
-                                              volk_get_alignment());
-    memset(d_u_hat_vec, 0, sizeof(unsigned char) * block_size * (block_power() + 1));
 }
 
-polar_decoder_sc::~polar_decoder_sc()
-{
-    volk_free(d_llr_vec);
-    volk_free(d_u_hat_vec);
-}
+polar_decoder_sc::~polar_decoder_sc() {}
 
 void polar_decoder_sc::generic_work(void* in_buffer, void* out_buffer)
 {
     const float* in = (const float*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;
 
-    initialize_decoder(d_u_hat_vec, d_llr_vec, in);
-    sc_decode(d_llr_vec, d_u_hat_vec);
-    extract_info_bits(out, d_u_hat_vec);
+    initialize_decoder(d_u_hat_vec.data(), d_llr_vec.data(), in);
+    sc_decode(d_llr_vec.data(), d_u_hat_vec.data());
+    extract_info_bits(out, d_u_hat_vec.data());
 }
 
 void polar_decoder_sc::sc_decode(float* llrs, unsigned char* u)

--- a/gr-fec/lib/polar_decoder_sc_systematic.cc
+++ b/gr-fec/lib/polar_decoder_sc_systematic.cc
@@ -30,34 +30,24 @@ generic_decoder::sptr polar_decoder_sc_systematic::make(
 polar_decoder_sc_systematic::polar_decoder_sc_systematic(
     int block_size, int num_info_bits, std::vector<int> frozen_bit_positions)
     : polar_decoder_common(
-          block_size, num_info_bits, frozen_bit_positions, std::vector<uint8_t>())
+          block_size, num_info_bits, frozen_bit_positions, std::vector<uint8_t>()),
+      d_llr_vec(block_size * (block_power() + 1)),
+      d_u_hat_vec(block_size * (block_power() + 1)),
+      d_frame_vec(block_size)
 {
-    d_llr_vec = (float*)volk_malloc(sizeof(float) * block_size * (block_power() + 1),
-                                    volk_get_alignment());
-    memset(d_llr_vec, 0, sizeof(float) * block_size * (block_power() + 1));
-    d_u_hat_vec = (unsigned char*)volk_malloc(block_size * (block_power() + 1),
-                                              volk_get_alignment());
-    memset(d_u_hat_vec, 0, sizeof(unsigned char) * block_size * (block_power() + 1));
-    d_frame_vec = (unsigned char*)volk_malloc(block_size, volk_get_alignment());
-    memset(d_frame_vec, 0, sizeof(unsigned char) * block_size);
 }
 
-polar_decoder_sc_systematic::~polar_decoder_sc_systematic()
-{
-    volk_free(d_llr_vec);
-    volk_free(d_u_hat_vec);
-    volk_free(d_frame_vec);
-}
+polar_decoder_sc_systematic::~polar_decoder_sc_systematic() {}
 
 void polar_decoder_sc_systematic::generic_work(void* in_buffer, void* out_buffer)
 {
     const float* in = (const float*)in_buffer;
     unsigned char* out = (unsigned char*)out_buffer;
 
-    initialize_decoder(d_u_hat_vec, d_llr_vec, in);
-    sc_decode(d_llr_vec, d_u_hat_vec);
-    volk_encode_block(d_frame_vec, d_u_hat_vec);
-    extract_info_bits_reversed(out, d_frame_vec);
+    initialize_decoder(d_u_hat_vec.data(), d_llr_vec.data(), in);
+    sc_decode(d_llr_vec.data(), d_u_hat_vec.data());
+    volk_encode_block(d_frame_vec.data(), d_u_hat_vec.data());
+    extract_info_bits_reversed(out, d_frame_vec.data());
 }
 
 void polar_decoder_sc_systematic::sc_decode(float* llrs, unsigned char* u)

--- a/gr-fec/lib/polar_encoder_systematic.cc
+++ b/gr-fec/lib/polar_encoder_systematic.cc
@@ -31,16 +31,12 @@ polar_encoder_systematic::polar_encoder_systematic(int block_size,
                                                    int num_info_bits,
                                                    std::vector<int> frozen_bit_positions)
     : polar_common(
-          block_size, num_info_bits, frozen_bit_positions, std::vector<uint8_t>())
+          block_size, num_info_bits, frozen_bit_positions, std::vector<uint8_t>()),
+      d_volk_syst_intermediate(block_size)
 {
-    d_volk_syst_intermediate = (unsigned char*)volk_malloc(
-        sizeof(unsigned char) * block_size, volk_get_alignment());
 }
 
-polar_encoder_systematic::~polar_encoder_systematic()
-{
-    volk_free(d_volk_syst_intermediate);
-}
+polar_encoder_systematic::~polar_encoder_systematic() {}
 
 void polar_encoder_systematic::generic_work(void* in_buffer, void* out_buffer)
 {
@@ -48,8 +44,8 @@ void polar_encoder_systematic::generic_work(void* in_buffer, void* out_buffer)
     unsigned char* out = (unsigned char*)out_buffer;
 
     volk_encode(out, in);
-    bit_reverse_and_reset_frozen_bits(d_volk_syst_intermediate, out);
-    volk_encode_block(out, d_volk_syst_intermediate);
+    bit_reverse_and_reset_frozen_bits(d_volk_syst_intermediate.data(), out);
+    volk_encode_block(out, d_volk_syst_intermediate.data());
 }
 
 void polar_encoder_systematic::bit_reverse_and_reset_frozen_bits(

--- a/gr-fec/lib/scl_list.h
+++ b/gr-fec/lib/scl_list.h
@@ -20,6 +20,9 @@ namespace polar {
 
 struct path {
     path();
+    // Disable copy because of raw pointers.
+    path(const path&) = delete;
+    path& operator=(const path&) = delete;
     ~path();
     float path_metric;
     bool owns_vectors;
@@ -56,6 +59,11 @@ public:
     scl_list(const unsigned int list_size,
              const unsigned int block_size,
              const unsigned int block_power);
+
+    // Disable copy because of raw pointers.
+    scl_list(const scl_list&) = delete;
+    scl_list& operator=(const scl_list&) = delete;
+
     virtual ~scl_list();
     const unsigned int size() const { return d_list_size; };
     const unsigned int active_size() const { return d_active_path_counter; };

--- a/gr-fec/python/fec/bindings/polar_decoder_sc_python.cc
+++ b/gr-fec/python/fec/bindings/polar_decoder_sc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polar_decoder_sc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4f87bd7af297a4f14cb8cc3e99af54df)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e88266330956e15ca422091c6a3c2474)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_decoder_sc_systematic_python.cc
+++ b/gr-fec/python/fec/bindings/polar_decoder_sc_systematic_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polar_decoder_sc_systematic.h) */
-/* BINDTOOL_HEADER_FILE_HASH(309212b7e2e5619a81028e00aec2914b)                     */
+/* BINDTOOL_HEADER_FILE_HASH(6c8471f4ff472e9759f2d45d5a357780)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_encoder_python.cc
+++ b/gr-fec/python/fec/bindings/polar_encoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polar_encoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(58ba51702adfdf1118d059d3f9880beb)                     */
+/* BINDTOOL_HEADER_FILE_HASH(edc7bd542cbccfc54f3a5195196f1298)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/polar_encoder_systematic_python.cc
+++ b/gr-fec/python/fec/bindings/polar_encoder_systematic_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polar_encoder_systematic.h) */
-/* BINDTOOL_HEADER_FILE_HASH(3030c93396c633b5f7fdba0b4d888e9e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7c456083d56b811565b459f2865eae7e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
This removes almost all manual memory management in gr-fec/.
`scl_list` is a bit of magic, so requires more thinking.