### PR TITLE
zeromq: Remove manual memory management

### DIFF
--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -30,8 +30,8 @@ public:
 
 protected:
     std::string last_endpoint();
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
     size_t d_vsize;
     int d_timeout;
     bool d_pass_tags;

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -28,7 +28,9 @@ pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout, bool bind)
     : gr::block("pub_msg_sink",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(timeout)
+      d_timeout(timeout),
+      d_context(1),
+      d_socket(d_context, ZMQ_PUB)
 {
     int major, minor, patch;
     zmq::version(&major, &minor, &patch);
@@ -37,28 +39,20 @@ pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    d_context = new zmq::context_t(1);
-    d_socket = new zmq::socket_t(*d_context, ZMQ_PUB);
-
     int time = 0;
-    d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
 
     if (bind) {
-        d_socket->bind(address);
+        d_socket.bind(address);
     } else {
-        d_socket->connect(address);
+        d_socket.connect(address);
     }
 
     message_port_register_in(pmt::mp("in"));
     set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handler(msg); });
 }
 
-pub_msg_sink_impl::~pub_msg_sink_impl()
-{
-    d_socket->close();
-    delete d_socket;
-    delete d_context;
-}
+pub_msg_sink_impl::~pub_msg_sink_impl() {}
 
 void pub_msg_sink_impl::handler(pmt::pmt_t msg)
 {
@@ -69,9 +63,9 @@ void pub_msg_sink_impl::handler(pmt::pmt_t msg)
 
     memcpy(zmsg.data(), s.c_str(), s.size());
 #if USE_NEW_CPPZMQ_SEND_RECV
-    d_socket->send(zmsg, zmq::send_flags::none);
+    d_socket.send(zmsg, zmq::send_flags::none);
 #else
-    d_socket->send(zmsg);
+    d_socket.send(zmsg);
 #endif
 }
 

--- a/gr-zeromq/lib/pub_msg_sink_impl.h
+++ b/gr-zeromq/lib/pub_msg_sink_impl.h
@@ -21,8 +21,8 @@ class pub_msg_sink_impl : public pub_msg_sink
 {
 private:
     float d_timeout;
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
 
 public:
     pub_msg_sink_impl(char* address, int timeout, bool bind);
@@ -33,7 +33,7 @@ public:
     {
         char addr[256];
         size_t addr_len = sizeof(addr);
-        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len - 1);
     }
 };

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -16,6 +16,7 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/thread/thread.hpp>
 
 namespace gr {
@@ -31,6 +32,8 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
       d_timeout(timeout),
+      d_context(1),
+      d_socket(d_context, ZMQ_PULL),
       d_port(pmt::mp("out"))
 {
     int major, minor, patch;
@@ -40,32 +43,25 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
         d_timeout = timeout * 1000;
     }
 
-    d_context = new zmq::context_t(1);
-    d_socket = new zmq::socket_t(*d_context, ZMQ_PULL);
-
     int time = 0;
-    d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
 
     if (bind) {
-        d_socket->bind(address);
+        d_socket.bind(address);
     } else {
-        d_socket->connect(address);
+        d_socket.connect(address);
     }
 
     message_port_register_out(d_port);
 }
 
-pull_msg_source_impl::~pull_msg_source_impl()
-{
-    d_socket->close();
-    delete d_socket;
-    delete d_context;
-}
+pull_msg_source_impl::~pull_msg_source_impl() {}
 
 bool pull_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = new boost::thread(boost::bind(&pull_msg_source_impl::readloop, this));
+    d_thread = boost::make_unique<boost::thread>(
+        boost::bind(&pull_msg_source_impl::readloop, this));
     return true;
 }
 
@@ -80,7 +76,7 @@ void pull_msg_source_impl::readloop()
 {
     while (!d_finished) {
 
-        zmq::pollitem_t items[] = { { static_cast<void*>(*d_socket), 0, ZMQ_POLLIN, 0 } };
+        zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
         zmq::poll(&items[0], 1, d_timeout);
 
         //  If we got a reply, process
@@ -89,9 +85,9 @@ void pull_msg_source_impl::readloop()
             // Receive data
             zmq::message_t msg;
 #if USE_NEW_CPPZMQ_SEND_RECV
-            d_socket->recv(msg);
+            d_socket.recv(msg);
 #else
-            d_socket->recv(&msg);
+            d_socket.recv(&msg);
 #endif
 
             std::string buf(static_cast<char*>(msg.data()), msg.size());

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -21,9 +21,9 @@ class pull_msg_source_impl : public pull_msg_source
 {
 private:
     int d_timeout; // microseconds, -1 is blocking
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
-    boost::thread* d_thread;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
+    std::unique_ptr<boost::thread> d_thread;
     const pmt::pmt_t d_port;
 
     void readloop();
@@ -41,7 +41,7 @@ public:
     {
         char addr[256];
         size_t addr_len = sizeof(addr);
-        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len - 1);
     }
 };

--- a/gr-zeromq/lib/push_msg_sink_impl.h
+++ b/gr-zeromq/lib/push_msg_sink_impl.h
@@ -21,8 +21,8 @@ class push_msg_sink_impl : public push_msg_sink
 {
 private:
     float d_timeout;
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
 
 public:
     push_msg_sink_impl(char* address, int timeout, bool bind);
@@ -33,7 +33,7 @@ public:
     {
         char addr[256];
         size_t addr_len = sizeof(addr);
-        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len - 1);
     }
 };

--- a/gr-zeromq/lib/push_sink_impl.cc
+++ b/gr-zeromq/lib/push_sink_impl.cc
@@ -41,7 +41,7 @@ int push_sink_impl::work(int noutput_items,
                          gr_vector_void_star& output_items)
 {
     // Poll with a timeout (FIXME: scheduler can't wait for us)
-    zmq::pollitem_t itemsout[] = { { static_cast<void*>(*d_socket), 0, ZMQ_POLLOUT, 0 } };
+    zmq::pollitem_t itemsout[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLOUT, 0 } };
     zmq::poll(&itemsout[0], 1, d_timeout);
 
     // If we can send something, do it

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -15,6 +15,7 @@
 #include "rep_msg_sink_impl.h"
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
+#include <boost/make_unique.hpp>
 
 namespace gr {
 namespace zeromq {
@@ -29,6 +30,8 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
       d_timeout(timeout),
+      d_context(1),
+      d_socket(d_context, ZMQ_REP),
       d_port(pmt::mp("in"))
 {
     int major, minor, patch;
@@ -38,32 +41,25 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    d_context = new zmq::context_t(1);
-    d_socket = new zmq::socket_t(*d_context, ZMQ_REP);
-
     int time = 0;
-    d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
 
     if (bind) {
-        d_socket->bind(address);
+        d_socket.bind(address);
     } else {
-        d_socket->connect(address);
+        d_socket.connect(address);
     }
 
     message_port_register_in(d_port);
 }
 
-rep_msg_sink_impl::~rep_msg_sink_impl()
-{
-    d_socket->close();
-    delete d_socket;
-    delete d_context;
-}
+rep_msg_sink_impl::~rep_msg_sink_impl() {}
 
 bool rep_msg_sink_impl::start()
 {
     d_finished = false;
-    d_thread = new boost::thread(boost::bind(&rep_msg_sink_impl::readloop, this));
+    d_thread = boost::make_unique<boost::thread>(
+        boost::bind(&rep_msg_sink_impl::readloop, this));
     return true;
 }
 
@@ -83,7 +79,7 @@ void rep_msg_sink_impl::readloop()
 
             // wait for query...
             zmq::pollitem_t items[] = {
-                { static_cast<void*>(*d_socket), 0, ZMQ_POLLIN, 0 }
+                { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 }
             };
             zmq::poll(&items[0], 1, d_timeout);
 
@@ -93,9 +89,9 @@ void rep_msg_sink_impl::readloop()
                 // receive data request
                 zmq::message_t request;
 #if USE_NEW_CPPZMQ_SEND_RECV
-                d_socket->recv(request);
+                d_socket.recv(request);
 #else
-                d_socket->recv(&request);
+                d_socket.recv(&request);
 #endif
 
                 int req_output_items = *(static_cast<int*>(request.data()));
@@ -111,9 +107,9 @@ void rep_msg_sink_impl::readloop()
                 zmq::message_t zmsg(s.size());
                 memcpy(zmsg.data(), s.c_str(), s.size());
 #if USE_NEW_CPPZMQ_SEND_RECV
-                d_socket->send(zmsg, zmq::send_flags::none);
+                d_socket.send(zmsg, zmq::send_flags::none);
 #else
-                d_socket->send(zmsg);
+                d_socket.send(zmsg);
 #endif
             } // if req
         }     // while !empty

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -21,9 +21,9 @@ class rep_msg_sink_impl : public rep_msg_sink
 {
 private:
     int d_timeout;
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
-    boost::thread* d_thread;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
+    std::unique_ptr<boost::thread> d_thread;
     bool d_finished;
 
     const pmt::pmt_t d_port;
@@ -41,7 +41,7 @@ public:
     {
         char addr[256];
         size_t addr_len = sizeof(addr);
-        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len - 1);
     }
 };

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -49,7 +49,7 @@ int rep_sink_impl::work(int noutput_items,
         /* Wait for a small time (FIXME: scheduler can't wait for us) */
         /* We only wait if its the first iteration, for the others we'll
          * let the scheduler retry */
-        zmq::pollitem_t items[] = { { static_cast<void*>(*d_socket), 0, ZMQ_POLLIN, 0 } };
+        zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
         zmq::poll(&items[0], 1, first ? d_timeout : 0);
 
         /* If we don't have anything, we're done */
@@ -59,9 +59,9 @@ int rep_sink_impl::work(int noutput_items,
         /* Get and parse the request */
         zmq::message_t request;
 #if USE_NEW_CPPZMQ_SEND_RECV
-        d_socket->recv(request);
+        d_socket.recv(request);
 #else
-        d_socket->recv(&request);
+        d_socket.recv(&request);
 #endif
 
         int nitems_send = noutput_items - done;

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -16,6 +16,7 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/thread/thread.hpp>
 
 namespace gr {
@@ -31,6 +32,8 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
       d_timeout(timeout),
+      d_context(1),
+      d_socket(d_context, ZMQ_REQ),
       d_port(pmt::mp("out"))
 {
     int major, minor, patch;
@@ -40,32 +43,25 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    d_context = new zmq::context_t(1);
-    d_socket = new zmq::socket_t(*d_context, ZMQ_REQ);
-
     int time = 0;
-    d_socket->setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
 
     if (bind) {
-        d_socket->bind(address);
+        d_socket.bind(address);
     } else {
-        d_socket->connect(address);
+        d_socket.connect(address);
     }
 
     message_port_register_out(d_port);
 }
 
-req_msg_source_impl::~req_msg_source_impl()
-{
-    d_socket->close();
-    delete d_socket;
-    delete d_context;
-}
+req_msg_source_impl::~req_msg_source_impl() {}
 
 bool req_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = new boost::thread(boost::bind(&req_msg_source_impl::readloop, this));
+    d_thread = boost::make_unique<boost::thread>(
+        boost::bind(&req_msg_source_impl::readloop, this));
     return true;
 }
 
@@ -82,7 +78,7 @@ void req_msg_source_impl::readloop()
         // std::cout << "readloop\n";
 
         zmq::pollitem_t itemsout[] = {
-            { static_cast<void*>(*d_socket), 0, ZMQ_POLLOUT, 0 }
+            { static_cast<void*>(d_socket), 0, ZMQ_POLLOUT, 0 }
         };
         zmq::poll(&itemsout[0], 1, d_timeout);
 
@@ -93,13 +89,13 @@ void req_msg_source_impl::readloop()
             zmq::message_t request(sizeof(int));
             memcpy((void*)request.data(), &nmsg, sizeof(int));
 #if USE_NEW_CPPZMQ_SEND_RECV
-            d_socket->send(request, zmq::send_flags::none);
+            d_socket.send(request, zmq::send_flags::none);
 #else
-            d_socket->send(request);
+            d_socket.send(request);
 #endif
         }
 
-        zmq::pollitem_t items[] = { { static_cast<void*>(*d_socket), 0, ZMQ_POLLIN, 0 } };
+        zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
         zmq::poll(&items[0], 1, d_timeout);
 
         //  If we got a reply, process
@@ -107,9 +103,9 @@ void req_msg_source_impl::readloop()
             // Receive data
             zmq::message_t msg;
 #if USE_NEW_CPPZMQ_SEND_RECV
-            d_socket->recv(msg);
+            d_socket.recv(msg);
 #else
-            d_socket->recv(&msg);
+            d_socket.recv(&msg);
 #endif
 
             std::string buf(static_cast<char*>(msg.data()), msg.size());

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -21,9 +21,9 @@ class req_msg_source_impl : public req_msg_source
 {
 private:
     int d_timeout;
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
-    boost::thread* d_thread;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
+    std::unique_ptr<boost::thread> d_thread;
     const pmt::pmt_t d_port;
 
     void readloop();
@@ -41,7 +41,7 @@ public:
     {
         char addr[256];
         size_t addr_len = sizeof(addr);
-        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len - 1);
     }
 };

--- a/gr-zeromq/lib/req_source_impl.cc
+++ b/gr-zeromq/lib/req_source_impl.cc
@@ -66,9 +66,9 @@ int req_source_impl::work(int noutput_items,
                 zmq::message_t request(sizeof(uint32_t));
                 memcpy((void*)request.data(), &req_len, sizeof(uint32_t));
 #if USE_NEW_CPPZMQ_SEND_RECV
-                d_socket->send(request, zmq::send_flags::none);
+                d_socket.send(request, zmq::send_flags::none);
 #else
-                d_socket->send(request);
+                d_socket.send(request);
 #endif
 
                 d_req_pending = true;

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -16,6 +16,7 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/make_unique.hpp>
 #include <boost/thread/thread.hpp>
 
 namespace gr {
@@ -31,6 +32,8 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
       d_timeout(timeout),
+      d_context(1),
+      d_socket(d_context, ZMQ_SUB),
       d_port(pmt::mp("out"))
 {
     int major, minor, patch;
@@ -40,31 +43,24 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    d_context = new zmq::context_t(1);
-    d_socket = new zmq::socket_t(*d_context, ZMQ_SUB);
-
-    d_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
+    d_socket.setsockopt(ZMQ_SUBSCRIBE, "", 0);
 
     if (bind) {
-        d_socket->bind(address);
+        d_socket.bind(address);
     } else {
-        d_socket->connect(address);
+        d_socket.connect(address);
     }
 
     message_port_register_out(d_port);
 }
 
-sub_msg_source_impl::~sub_msg_source_impl()
-{
-    d_socket->close();
-    delete d_socket;
-    delete d_context;
-}
+sub_msg_source_impl::~sub_msg_source_impl() {}
 
 bool sub_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = new boost::thread(boost::bind(&sub_msg_source_impl::readloop, this));
+    d_thread = boost::make_unique<boost::thread>(
+        boost::bind(&sub_msg_source_impl::readloop, this));
     return true;
 }
 
@@ -79,7 +75,7 @@ void sub_msg_source_impl::readloop()
 {
     while (!d_finished) {
 
-        zmq::pollitem_t items[] = { { static_cast<void*>(*d_socket), 0, ZMQ_POLLIN, 0 } };
+        zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
         zmq::poll(&items[0], 1, d_timeout);
 
         //  If we got a reply, process
@@ -88,9 +84,9 @@ void sub_msg_source_impl::readloop()
             // Receive data
             zmq::message_t msg;
 #if USE_NEW_CPPZMQ_SEND_RECV
-            d_socket->recv(msg);
+            d_socket.recv(msg);
 #else
-            d_socket->recv(&msg);
+            d_socket.recv(&msg);
 #endif
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -21,9 +21,9 @@ class sub_msg_source_impl : public sub_msg_source
 {
 private:
     int d_timeout; // microseconds, -1 is blocking
-    zmq::context_t* d_context;
-    zmq::socket_t* d_socket;
-    boost::thread* d_thread;
+    zmq::context_t d_context;
+    zmq::socket_t d_socket;
+    std::unique_ptr<boost::thread> d_thread;
     const pmt::pmt_t d_port;
 
     void readloop();
@@ -41,7 +41,7 @@ public:
     {
         char addr[256];
         size_t addr_len = sizeof(addr);
-        d_socket->getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
+        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
         return std::string(addr, addr_len - 1);
     }
 };

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -44,7 +44,7 @@ sub_source_impl::sub_source_impl(size_t itemsize,
       base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm, key)
 {
     /* Subscribe */
-    d_socket->setsockopt(ZMQ_SUBSCRIBE, key.c_str(), key.size());
+    d_socket.setsockopt(ZMQ_SUBSCRIBE, key.c_str(), key.size());
 }
 
 int sub_source_impl::work(int noutput_items,


### PR DESCRIPTION
I believe this fixes a memory leak, as the thread objects were never deleted.
