### PR TITLE
blocks: selector: update to only forecast active input

### DIFF
--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -126,8 +126,9 @@ void selector_impl::forecast(int noutput_items, gr_vector_int& ninput_items_requ
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {
-        ninput_items_required[i] = noutput_items;
+        ninput_items_required[i] = 0;
     }
+    ninput_items_required[d_input_index] = noutput_items;
 }
 
 bool selector_impl::check_topology(int ninputs, int noutputs)


### PR DESCRIPTION
Fixes #3762 

The selector block was forecasting that input samples were needed on all inputs rather than the active input, which caused the scheduler to stop calling the work() function when samples weren't being presented to the inactive input