### PR TITLE
uhd: Fix gain type hiding, fix uhd_normalized_gain.grc

### DIFF
--- a/gr-uhd/examples/grc/uhd_normalized_gain.grc
+++ b/gr-uhd/examples/grc/uhd_normalized_gain.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: ''
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,12 +23,11 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: Example to showcase absolute vs. relative gain settings
-    window_size: 1280, 1024
   states:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 12.0]
+    coordinate: [11, 9]
     rotation: 0
     state: enabled
 
@@ -45,7 +45,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [184, 12.0]
+    coordinate: [322, 10]
     rotation: 0
     state: enabled
 - name: gain
@@ -55,7 +55,7 @@ blocks:
     gui_hint: ''
     label: Normalized Gain
     min_len: '200'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '0'
     step: '.02'
@@ -66,7 +66,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 188.0]
+    coordinate: [898, 17]
     rotation: 0
     state: enabled
 - name: samp_rate
@@ -78,7 +78,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [8, 116.0]
+    coordinate: [20, 161]
     rotation: 0
     state: enabled
 - name: variable_qtgui_label_0
@@ -94,7 +94,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [344, 12.0]
+    coordinate: [627, 14]
     rotation: 0
     state: enabled
 - name: blocks_null_sink_0
@@ -111,7 +111,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [520, 216.0]
+    coordinate: [712, 360]
     rotation: 0
     state: enabled
 - name: uhd_usrp_source_0
@@ -291,6 +291,38 @@ blocks:
     gain7: '0'
     gain8: '0'
     gain9: '0'
+    gain_type0: normalized
+    gain_type1: default
+    gain_type10: default
+    gain_type11: default
+    gain_type12: default
+    gain_type13: default
+    gain_type14: default
+    gain_type15: default
+    gain_type16: default
+    gain_type17: default
+    gain_type18: default
+    gain_type19: default
+    gain_type2: default
+    gain_type20: default
+    gain_type21: default
+    gain_type22: default
+    gain_type23: default
+    gain_type24: default
+    gain_type25: default
+    gain_type26: default
+    gain_type27: default
+    gain_type28: default
+    gain_type29: default
+    gain_type3: default
+    gain_type30: default
+    gain_type31: default
+    gain_type4: default
+    gain_type5: default
+    gain_type6: default
+    gain_type7: default
+    gain_type8: default
+    gain_type9: default
     iq_imbal_enb0: '""'
     iq_imbal_enb1: '""'
     iq_imbal_enb10: '""'
@@ -390,38 +422,6 @@ blocks:
     maxoutbuf: '0'
     minoutbuf: '0'
     nchan: '1'
-    norm_gain0: 'True'
-    norm_gain1: 'False'
-    norm_gain10: 'False'
-    norm_gain11: 'False'
-    norm_gain12: 'False'
-    norm_gain13: 'False'
-    norm_gain14: 'False'
-    norm_gain15: 'False'
-    norm_gain16: 'False'
-    norm_gain17: 'False'
-    norm_gain18: 'False'
-    norm_gain19: 'False'
-    norm_gain2: 'False'
-    norm_gain20: 'False'
-    norm_gain21: 'False'
-    norm_gain22: 'False'
-    norm_gain23: 'False'
-    norm_gain24: 'False'
-    norm_gain25: 'False'
-    norm_gain26: 'False'
-    norm_gain27: 'False'
-    norm_gain28: 'False'
-    norm_gain29: 'False'
-    norm_gain3: 'False'
-    norm_gain30: 'False'
-    norm_gain31: 'False'
-    norm_gain4: 'False'
-    norm_gain5: 'False'
-    norm_gain6: 'False'
-    norm_gain7: 'False'
-    norm_gain8: 'False'
-    norm_gain9: 'False'
     num_mboards: '1'
     otw: ''
     rx_agc0: Default
@@ -482,7 +482,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [232, 172.0]
+    coordinate: [193, 288]
     rotation: 0
     state: enabled
 

--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -470,9 +470,9 @@ PARAMS_TMPL = """
     options: [default, normalized, power]
     option_labels: [Absolute (dB), Normalized, Absolute Power (dBm)]
 % if sourk == 'source':
-    hide: ${'$'}{ 'all' if nchan <= ${n} or rx_agc${n} == 'Enabled' else ('none' if (eval('gain_type' + str(${n})) == 'default') else 'part')}
+    hide: ${'$'}{ 'all' if nchan <= ${n} or rx_agc${n} == 'Enabled' else ('part' if (eval('gain_type' + str(${n})) == 'default') else 'none')}
 % else:
-    hide: ${'$'}{ 'all' if nchan <= ${n} else ('none' if (eval('gain_type' + str(${n})) == 'default') else 'part')}
+    hide: ${'$'}{ 'all' if nchan <= ${n} else ('part' if (eval('gain_type' + str(${n})) == 'default') else 'none')}
 % endif
 -   id: ant${n}
     label: 'Ch${n}: Antenna'


### PR DESCRIPTION
Gain type hiding was inverted: It was supposed to hide gain type for
default (absolute/dB), and not hide for normalized and absoulute/dBm.
Fixed by this commit.

Also fixes an issue in uhd_normalized_gain.grc, where the gain type was
set to absolute/dB.

This was broken by one of the recent power API commits.

The example now looks like this:
![image](https://user-images.githubusercontent.com/508035/93070103-4d5e1d80-f633-11ea-86a7-e6a58172181d.png)
Note that the gain type is not hidden (it says "Normalized"). The example was tested and works.