### PR TITLE
grc: ensure that strings are valid utf8 when evaluating parameters

### DIFF
--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -183,6 +183,9 @@ class VariableEditor(Gtk.VBox):
                     # Evaluate the params
                     for key in block.params :
                         evaluated = str(block.params[key].evaluate())
+                        # ensure that evaluated is a UTF-8 string
+                        # PMTs can produce non-UTF-8 strings
+                        evaluated = evaluated.encode('utf-8', 'backslashreplace').decode('utf-8')
                         self.set_tooltip_text(evaluated)
 
                     # Evaluate the block value

--- a/grc/gui/canvas/param.py
+++ b/grc/gui/canvas/param.py
@@ -73,6 +73,9 @@ class Param(CoreParam):
             if hasattr(value,"__len__"):
                 tooltip_lines.append('Length: {}'.format(len(value)))
             value = str(value)
+            # ensure that value is a UTF-8 string
+            # PMTs can produce non-UTF-8 strings
+            value = value.encode('utf-8', 'backslashreplace').decode('utf-8')
             if len(value) > 100:
                 value = '{}...{}'.format(value[:50], value[-50:])
             tooltip_lines.append('Value: ' + value)
@@ -139,6 +142,9 @@ class Param(CoreParam):
         else:
             # Other types
             dt_str = str(e)
+            # ensure that value is a UTF-8 string
+            # PMTs can produce non-UTF-8 strings
+            dt_str = dt_str.encode('utf-8', 'backslashreplace').decode('utf-8')
 
         # Done
         return _truncate(dt_str, truncate)


### PR DESCRIPTION
Some objects, notably PMTs can produce non-UTF-8 strings when their `__str__()` method is called. For instance
```
>>> str(pmt.init_u8vector(1, [203]))
'#[\udccb]'
```

These kinds of strings eventually give a `UnicodeEncodeError`, for instance when calling `print()` or displaying them with GTK. Python3 strings are supposed to be valid UTF-8.

When these objects are used inside block parameters in GRC, it will produce several tracebacks and hang up. This commit fixes the problem by sanitizing the strings to convert them to valid UTF-8. The sanitization uses the `'backslashreplace' `error response from Python.

Issue #3398 is caused by this problem.

---

I also may add that issue #3398 is important rather than a curiosity. It is common to define test packet as u8vector PMTs (in a message strobe, for instance). If these packets contain non-ASCII characters, then GRC will hang.

As a final remark, the underlying problem is that the `__str()__` method of a PMT can return a string which is not valid UTF-8. This is quite dangerous in Python 3. It might be good to take a look at this underlying problem.