### PR TITLE
modtool: CMake template should allow building OOT modules without python if desired

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -152,8 +152,14 @@ add_subdirectory(include/howto)
 add_subdirectory(lib)
 add_subdirectory(apps)
 add_subdirectory(docs)
-add_subdirectory(python)
-add_subdirectory(grc)
+# NOTE: manually update below to use GRC to generate C++ flowgraphs w/o python
+if(ENABLE_PYTHON)
+  message(STATUS "PYTHON and GRC components are enabled")
+  add_subdirectory(python)
+  add_subdirectory(grc)
+else(ENABLE_PYTHON)
+  message(STATUS "PYTHON and GRC components are disabled")
+endif(ENABLE_PYTHON)
 
 ########################################################################
 # Install cmake search helper for this library


### PR DESCRIPTION
The gr_modtool utility should respect the `-DENABLE_PYTHON=OFF` setting to allow modules to be built without python support. This also does not install any GRC files even though it is possible to use GRC to generate flowgraphs without runtime python; however, this disabling python _and_ using GRC for C++ generation is a very advanced feature so the included note should be sufficient to inform anyone using in this way.

It should be possible to automatically install blocks that have `cpp_template`s defined at some point in the future should that become a necessary feature; for now even C++ only OOT's is a fairly niche need.