### PR TITLE
gr-blocks: Fix wavfile sink and source block performance issues.

### DIFF
--- a/gr-blocks/lib/wavfile_sink_impl.h
+++ b/gr-blocks/lib/wavfile_sink_impl.h
@@ -29,11 +29,15 @@ private:
     float d_min_sample_val;
     float d_normalize_shift;
     float d_normalize_fac;
+    std::vector<float> d_buffer;
 
     SNDFILE* d_fp;
     SNDFILE* d_new_fp;
     bool d_updated;
     boost::mutex d_mutex;
+
+    static constexpr int s_items_size = 8192;
+    static constexpr int s_max_channels = 24;
 
     /*!
      * \brief If any file changes have occurred, update now. This is called

--- a/gr-blocks/lib/wavfile_source_impl.h
+++ b/gr-blocks/lib/wavfile_source_impl.h
@@ -26,6 +26,10 @@ private:
 
     wav_header_info d_h;
     long long d_sample_idx;
+    std::vector<float> d_buffer;
+
+    static constexpr int s_items_size = 1024;
+    static constexpr int s_max_channels = 24;
 
 public:
     wavfile_source_impl(const char* filename, bool repeat);


### PR DESCRIPTION
Calling libsndfile sf_read/write_float() for every sample created
too much overhead. sf_read/write_float() now called every 1024 samples.