### PR TITLE
modtool: leave out bindings for python only modules

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/__init__.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/__init__.py
@@ -14,11 +14,10 @@ import os
 
 # import pybind11 generated symbols into the howto namespace
 try:
+    # this might fail if the module is python-only
     from .howto_python import *
 except ImportError:
-    dirname, filename = os.path.split(os.path.abspath(__file__))
-    __path__.append(os.path.join(dirname, "bindings"))
-    from .howto_python import *
+    pass
 
 # import any pure python here
 #

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/CMakeLists.txt
@@ -5,6 +5,17 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+########################################################################
+# Check if there is C++ code at all
+########################################################################
+if(NOT howto_sources)
+    MESSAGE(STATUS "No C++ sources... skipping python bindings")
+    return()
+endif(NOT howto_sources)
+
+########################################################################
+# Check for pygccxml
+########################################################################
 GR_PYTHON_CHECK_MODULE_RAW(
     "pygccxml"
     "import pygccxml"


### PR DESCRIPTION
Python-only modules were not skipping out on the binding compilation causing build errors.  This copies the breakout code previously from the swig directory

Fixes #3782
