### PR TITLE
grc: use os.pathsep (Windows)

### DIFF
--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -29,8 +29,6 @@ class Config(object):
 
     @property
     def block_paths(self):
-        path_list_sep = {'/': ':', '\\': ';'}[os.path.sep]
-
         paths_sources = (
             self.hier_block_lib_dir,
             os.environ.get('GRC_BLOCKS_PATH', ''),
@@ -38,7 +36,7 @@ class Config(object):
             self._gr_prefs.get_string('grc', 'global_blocks_path', ''),
         )
 
-        collected_paths = sum((paths.split(path_list_sep)
+        collected_paths = sum((paths.split(os.pathsep)
                                for paths in paths_sources), [])
 
         valid_paths = [normpath(expanduser(expandvars(path)))


### PR DESCRIPTION
`os.path.sep` is unreliable in Windows (`\` in official python, `/` in MSYS2)

With this change, `os.pathsep` is used instead to get the path separator:
`:` (*nix) or `;` (Windows)