### PR TITLE
vocoder: cmake: Use pybind macros to manage bindings.

### DIFF
--- a/gr-vocoder/python/vocoder/bindings/CMakeLists.txt
+++ b/gr-vocoder/python/vocoder/bindings/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Python Bindings
 ########################################################################
 
-pybind11_add_module(vocoder_python
+list(APPEND vocoder_python_files
     alaw_decode_bs_python.cc
     alaw_encode_sb_python.cc
     cvsd_decode_bs_python.cc
@@ -17,8 +17,7 @@ pybind11_add_module(vocoder_python
     ulaw_encode_sb_python.cc)
 
 if(LIBCODEC2_FOUND)
-    target_compile_definitions(vocoder_python PRIVATE LIBCODEC2_FOUND)
-    target_sources(vocoder_python PRIVATE
+    list(APPEND vocoder_python_files
     codec2_python.cc
     codec2_decode_ps_python.cc
     codec2_encode_sp_python.cc
@@ -26,8 +25,7 @@ if(LIBCODEC2_FOUND)
 endif(LIBCODEC2_FOUND)
 
 if(LIBCODEC2_HAS_FREEDV_API)
-    target_compile_definitions(vocoder_python PRIVATE LIBCODEC2_HAS_FREEDV_API)
-    target_sources(vocoder_python PRIVATE
+    list(APPEND vocoder_python_files
     freedv_api_python.cc
     freedv_rx_ss_python.cc
     freedv_tx_ss_python.cc
@@ -35,48 +33,29 @@ if(LIBCODEC2_HAS_FREEDV_API)
 endif(LIBCODEC2_HAS_FREEDV_API)
 
 if(LIBGSM_FOUND)
-    target_compile_definitions(vocoder_python PRIVATE LIBGSM_FOUND)
-    target_sources(vocoder_python PRIVATE
+    list(APPEND vocoder_python_files
     gsm_fr_decode_ps_python.cc
     gsm_fr_encode_sp_python.cc
     )
 endif(LIBGSM_FOUND)
 
-target_sources(vocoder_python PRIVATE
-    python_bindings.cc)
+list(APPEND vocoder_python_files python_bindings.cc)
 
-configure_file(${CMAKE_SOURCE_DIR}/docs/doxygen/pydoc_macros.h ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+GR_PYBIND_MAKE_CHECK_HASH(vocoder
+   ../../..
+   gr::vocoder
+   "${vocoder_python_files}")
 
-if(ENABLE_DOXYGEN)
-    add_custom_command( 
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/docstring_status
-        COMMAND python3 ${CMAKE_SOURCE_DIR}/docs/doxygen/update_pydoc.py "sub"
-        "--json_path" ${CMAKE_BINARY_DIR}/docs/doxygen/gnuradio_docstrings.json
-        "--bindings_dir" ${CMAKE_CURRENT_SOURCE_DIR}/docstrings
-        "--output_dir" ${CMAKE_CURRENT_BINARY_DIR}
-        "--filter" gr::vocoder
-        COMMENT "Adding docstrings into vocoder pybind headers ..."
-        DEPENDS gnuradio_docstrings)
-    add_custom_target(vocoder_docstrings ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/docstring_status)
-else(ENABLE_DOXYGEN)
-    add_custom_command( 
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/docstring_status
-        COMMAND python3 ${CMAKE_SOURCE_DIR}/docs/doxygen/update_pydoc.py "copy"
-        "--bindings_dir" ${CMAKE_CURRENT_SOURCE_DIR}/docstrings
-        "--output_dir" ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Copying vocoder docstring templates as pybind headers ...")
-    add_custom_target(vocoder_docstrings ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/docstring_status)
-endif(ENABLE_DOXYGEN)
+if(LIBCODEC2_FOUND)
+    target_compile_definitions(vocoder_python PRIVATE LIBCODEC2_FOUND)
+endif(LIBCODEC2_FOUND)
 
-target_include_directories(vocoder_python PUBLIC
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${PYTHON_NUMPY_INCLUDE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../lib
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
-    ${PYBIND11_INCLUDE_DIR}
-)
-target_link_libraries(vocoder_python PUBLIC ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} gnuradio-runtime gnuradio-vocoder)
-target_compile_options(vocoder_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates
-add_dependencies(vocoder_python vocoder_docstrings)
+if(LIBCODEC2_HAS_FREEDV_API)
+    target_compile_definitions(vocoder_python PRIVATE LIBCODEC2_HAS_FREEDV_API)
+endif(LIBCODEC2_HAS_FREEDV_API)
+
+if(LIBGSM_FOUND)
+    target_compile_definitions(vocoder_python PRIVATE LIBGSM_FOUND)
+endif(LIBGSM_FOUND)
 
 install(TARGETS vocoder_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/vocoder COMPONENT pythonapi)


### PR DESCRIPTION
This helps prevent current and future headaches by making sure improvements to the pybind11 CMake don't also need to be added specifically for gr-vocoder.

(I noticed that a change similar to #3788 would be needed for gr-vocoder as well, but this fixes it instead by not duplicating the CMake code that needs to be fixed.)