### PR TITLE
lib, include: Add missing headers.

### DIFF
--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -13,6 +13,7 @@
 #endif
 
 #include <gnuradio/io_signature.h>
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-fec/include/gnuradio/fec/fec_mtrx.h
+++ b/gr-fec/include/gnuradio/fec/fec_mtrx.h
@@ -12,6 +12,7 @@
 #include <gnuradio/fec/api.h>
 #include <cstdlib>
 #include <memory>
+#include <string>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
@@ -12,6 +12,7 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/fec_mtrx.h>
 #include <memory>
+#include <string>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/include/gnuradio/fec/ldpc_H_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_H_matrix.h
@@ -12,6 +12,7 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/fec_mtrx.h>
 #include <memory>
+#include <string>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/polar_common.cc
+++ b/gr-fec/lib/polar_common.cc
@@ -19,6 +19,7 @@
 #include <gnuradio/blocks/pack_k_bits.h>
 #include <gnuradio/blocks/unpack_k_bits.h>
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <stdexcept>

--- a/gr-fec/python/fec/bindings/fec_mtrx_python.cc
+++ b/gr-fec/python/fec/bindings/fec_mtrx_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fec_mtrx.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(80c2f34bc9bdb9ac03abdf0c26b3d024)                     */
+/* BINDTOOL_HEADER_FILE_HASH(27f3285cd440f36bd0cb37fb3371c395)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/ldpc_G_matrix_python.cc
+++ b/gr-fec/python/fec/bindings/ldpc_G_matrix_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(ldpc_G_matrix.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e7cba655800bc51dc4ee066fbd16f621)                     */
+/* BINDTOOL_HEADER_FILE_HASH(bf2a99993f1ad2c3e1ebbe9d6d29a507)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/ldpc_H_matrix_python.cc
+++ b/gr-fec/python/fec/bindings/ldpc_H_matrix_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(ldpc_H_matrix.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(68956287d34e6a1208c0d84fda0d8af4)                     */
+/* BINDTOOL_HEADER_FILE_HASH(aeff2a97ade352d218316adfe97a4b6d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
This adds some missing `<algorithm>` and `<string>` headers that are used but not explicitly included (presumably included somewhere else so it hasn't been a problem). This fixes compilation with MSVC on conda-forge, although why this wasn't needed earlier is a mystery.