### PR TITLE
python: bindings: Use nullptr instead of nonstandard __null.

### DIFF
--- a/gr-digital/python/digital/bindings/header_buffer_python.cc
+++ b/gr-digital/python/digital/bindings/header_buffer_python.cc
@@ -37,7 +37,7 @@ void bind_header_buffer(py::module& m)
         m, "header_buffer", D(header_buffer))
 
         .def(py::init<uint8_t*>(),
-             py::arg("buffer") = __null,
+             py::arg("buffer") = nullptr,
              D(header_buffer, header_buffer, 0))
         .def(py::init<gr::digital::header_buffer const&>(),
              py::arg("arg0"),

--- a/gr-qtgui/python/qtgui/bindings/ber_sink_b_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/ber_sink_b_python.cc
@@ -48,7 +48,7 @@ void bind_ber_sink_b(py::module& m)
              py::arg("berminerrors") = 100,
              py::arg("berLimit") = -7.,
              py::arg("curvenames") = std::vector<std::string>(),
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(ber_sink_b, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/const_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/const_sink_c_python.cc
@@ -49,7 +49,7 @@ void bind_const_sink_c(py::module& m)
              py::arg("size"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(const_sink_c, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/edit_box_msg_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/edit_box_msg_python.cc
@@ -49,7 +49,7 @@ void bind_edit_box_msg(py::module& m)
              py::arg("is_pair") = true,
              py::arg("is_static") = true,
              py::arg("key") = "",
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(edit_box_msg, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/eye_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/eye_sink_c_python.cc
@@ -53,7 +53,7 @@ void bind_eye_sink_c(py::module& m)
              py::arg("samp_rate"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(eye_sink_c, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/eye_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/eye_sink_f_python.cc
@@ -50,7 +50,7 @@ void bind_eye_sink_f(py::module& m)
              py::arg("samp_rate"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(eye_sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/freq_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/freq_sink_c_python.cc
@@ -52,7 +52,7 @@ void bind_freq_sink_c(py::module& m)
              py::arg("bw"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(freq_sink_c, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/freq_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/freq_sink_f_python.cc
@@ -52,7 +52,7 @@ void bind_freq_sink_f(py::module& m)
              py::arg("bw"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(freq_sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/histogram_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/histogram_sink_f_python.cc
@@ -53,7 +53,7 @@ void bind_histogram_sink_f(py::module& m)
              py::arg("xmax"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(histogram_sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
@@ -50,7 +50,7 @@ void bind_number_sink(py::module& m)
              py::arg("average") = 0,
              py::arg("graph_type") = ::gr::qtgui::graph_t::NUM_GRAPH_HORIZ,
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(number_sink, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/sink_f_python.cc
@@ -52,7 +52,7 @@ void bind_sink_f(py::module& m)
              py::arg("plotwaterfall"),
              py::arg("plottime"),
              py::arg("plotconst"),
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/time_raster_sink_b_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_raster_sink_b_python.cc
@@ -54,7 +54,7 @@ void bind_time_raster_sink_b(py::module& m)
              py::arg("offset"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(time_raster_sink_b, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/time_raster_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_raster_sink_f_python.cc
@@ -54,7 +54,7 @@ void bind_time_raster_sink_f(py::module& m)
              py::arg("offset"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(time_raster_sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/time_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_sink_c_python.cc
@@ -53,7 +53,7 @@ void bind_time_sink_c(py::module& m)
              py::arg("samp_rate"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(time_sink_c, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/time_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_sink_f_python.cc
@@ -50,7 +50,7 @@ void bind_time_sink_f(py::module& m)
              py::arg("samp_rate"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(time_sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/vector_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/vector_sink_f_python.cc
@@ -53,7 +53,7 @@ void bind_vector_sink_f(py::module& m)
              py::arg("y_axis_label"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(vector_sink_f, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/waterfall_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/waterfall_sink_c_python.cc
@@ -53,7 +53,7 @@ void bind_waterfall_sink_c(py::module& m)
              py::arg("bw"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(waterfall_sink_c, make))
 
 

--- a/gr-qtgui/python/qtgui/bindings/waterfall_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/waterfall_sink_f_python.cc
@@ -53,7 +53,7 @@ void bind_waterfall_sink_f(py::module& m)
              py::arg("bw"),
              py::arg("name"),
              py::arg("nconnections") = 1,
-             py::arg("parent") = __null,
+             py::arg("parent") = nullptr,
              D(waterfall_sink_f, make))
 
 


### PR DESCRIPTION
This is a compilation fix for MSVC.