### PR TITLE
network: lib: Fixes to get network to compile with MSVC

### DIFF
--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -15,7 +15,9 @@
 #include "tcp_sink_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <chrono>
 #include <sstream>
+#include <thread>
 
 namespace gr {
 namespace network {
@@ -112,7 +114,7 @@ void tcp_sink_impl::run_listener()
             connect(d_initial_connection);
             d_initial_connection = false;
         } else
-            usleep(10);
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
 
     d_thread_running = false;
@@ -208,7 +210,7 @@ bool tcp_sink_impl::stop()
 
     if (d_listener_thread) {
         while (d_thread_running)
-            usleep(5);
+            std::this_thread::sleep_for(std::chrono::microseconds(5));
 
         delete d_listener_thread;
         d_listener_thread = NULL;

--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -118,11 +118,11 @@ udp_sink_impl::udp_sink_impl(size_t itemsize,
 
     d_udpsocket = new boost::asio::ip::udp::socket(d_io_service);
 
-    std::string s_port = (boost::format("%d") % port).str();
-    std::string s_host = host.empty() ? std::string("localhost") : host;
+    std::string str_port = (boost::format("%d") % port).str();
+    std::string str_host = host.empty() ? std::string("localhost") : host;
     boost::asio::ip::udp::resolver resolver(d_io_service);
     boost::asio::ip::udp::resolver::query query(
-        s_host, s_port, boost::asio::ip::resolver_query_base::passive);
+        str_host, str_port, boost::asio::ip::resolver_query_base::passive);
 
     boost::system::error_code err;
     d_endpoint = *resolver.resolve(query, err);


### PR DESCRIPTION
This includes using functions from the standard library to sleep instead of `usleep`, and a weird error where MSVC barfed on the variable name `s_host`.