### PR TITLE
grc: update the "Get Involved" dialog

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -338,11 +338,11 @@ def show_keyboard_shortcuts(parent):
 def show_get_involved(parent):
     """Get Involved Instructions"""
     markup = textwrap.dedent("""\
-    <tt><b>Welcome to GNU Radio Community!</b></tt>
+    <b>Welcome to GNU Radio Community!</b>
     \n\
-    <tt>For more details on contributing to GNU Radio and getting engaged with our great community visit </tt><a href="https://www.gnuradio.org/get-involved">here</a>.     
+    For more details on contributing to GNU Radio and getting engaged with our great community visit <a href="https://wiki.gnuradio.org/index.php/HowToGetInvolved">here</a>.
     \n\
-    <tt>You can also join our <a href="https://slack.gnuradio.org/">Slack Channel</a>, IRC Channel (#gnuradio) or contact through our <a href="https://lists.gnu.org/mailman/listinfo/discuss-gnuradio">mailing list(discuss-gnuradio)</a></tt>. 
+    You can also join our <a href="https://chat.gnuradio.org/">Matrix chat server</a>, IRC Channel (#gnuradio) or contact through our <a href="https://lists.gnu.org/mailman/listinfo/discuss-gnuradio">mailing list (discuss-gnuradio)</a>.
     \
     """)
     


### PR DESCRIPTION
The Help -> Get Involved dialog in GRC is out of date: the "Get Involved" link is broken, and it still references Slack. I've refreshed it here.

Before:

![Screenshot from 2020-10-03 14-42-34](https://user-images.githubusercontent.com/583749/94999353-c099e600-0586-11eb-854b-88ac0a743cbe.png)

After:

![Screenshot from 2020-10-03 14-41-59](https://user-images.githubusercontent.com/583749/94999354-c68fc700-0586-11eb-8579-c1afe7f4bd85.png)
