### PR TITLE
docs: Exclude gr-newmod from Doxygen

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -736,8 +736,8 @@ EXCLUDE                = @abs_top_builddir@/cmake/msvc \
                          @abs_top_builddir@/grc \
                          @abs_top_builddir@/_CPack_Packages \
                          @abs_top_srcdir@/cmake \
-                         @abs_top_srcdir@/gr-utils/python/modtool/gr-newmod \
-                         @abs_top_builddir@/gr-utils/python/modtool/gr-newmod \
+                         @abs_top_srcdir@/gr-utils/modtool/templates/gr-newmod \
+                         @abs_top_builddir@/gr-utils/modtool/templates/gr-newmod \
                          @abs_top_srcdir@/docs/doxygen/doxyxml/example \
                          @abs_top_srcdir@/gnuradio-runtime/lib \
                          @abs_top_builddir@/gnuradio-runtime/lib \


### PR DESCRIPTION
Moving newmod templates to a new directory in the modtool overhaul caused the files now to be visible to Doxygen. Fixed that.