### PR TITLE
digital: remove six

### DIFF
--- a/gr-digital/python/digital/packet_utils.py
+++ b/gr-digital/python/digital/packet_utils.py
@@ -11,7 +11,6 @@
 import struct
 
 import numpy
-import six
 
 from gnuradio import gru
 from . import crc
@@ -19,20 +18,19 @@ from . import crc
 
 def conv_packed_binary_string_to_1_0_string(s):
     """
-    '\xAF' --> '10101111'
+    b'\xAF' --> '10101111'
     """
     r = []
     for ch in s:
-        x = ord(ch)
         for i in range(7,-1,-1):
-            t = (x >> i) & 0x1
+            t = (ch >> i) & 0x1
             r.append(t)
 
     return ''.join([chr(x + ord('0')) for x in r])
 
 def conv_1_0_string_to_packed_binary_string(s):
     """
-    '10101111' -> ('\xAF', False)
+    '10101111' -> (b'\xAF', False)
 
     Basically the inverse of conv_packed_binary_string_to_1_0_string,
     but also returns a flag indicating if we had to pad with leading zeros
@@ -57,15 +55,15 @@ def conv_1_0_string_to_packed_binary_string(s):
         t = 0
         for j in range(8):
             t = (t << 1) | (ord(s[i + j]) - ord('0'))
-        r.append(chr(t))
+        r.append(t)
         i += 8
-    return (''.join(r), padded)
+    return (bytes(r), padded)
 
 
 default_access_code = \
-  conv_packed_binary_string_to_1_0_string('\xAC\xDD\xA4\xE2\xF2\x8C\x20\xFC')
+  conv_packed_binary_string_to_1_0_string(b'\xAC\xDD\xA4\xE2\xF2\x8C\x20\xFC')
 default_preamble = \
-  conv_packed_binary_string_to_1_0_string('\xA4\xF2')
+  conv_packed_binary_string_to_1_0_string(b'\xA4\xF2')
 
 def is_1_0_string(s):
     if not isinstance(s, str):

--- a/gr-digital/python/digital/qa_packet_format.py
+++ b/gr-digital/python/digital/qa_packet_format.py
@@ -9,7 +9,6 @@
 #
 
 import time, struct
-import six
 
 import pmt
 from gnuradio import gr, gr_unittest, digital, blocks
@@ -35,10 +34,10 @@ class test_packet_format_fb(gr_unittest.TestCase):
         self.tb.msg_connect(formatter, 'payload', snk_pld, 'store')
 
 
-        send_str = "Hello World"
-        send_pmt = pmt.make_u8vector(len(send_str), ord(' '))
+        send_str = b"Hello World"
+        send_pmt = pmt.make_u8vector(len(send_str), 0)
         for i in range(len(send_str)):
-            pmt.u8vector_set(send_pmt, i, ord(send_str[i]))
+            pmt.u8vector_set(send_pmt, i, send_str[i])
         msg = pmt.cons(pmt.PMT_NIL, send_pmt)
 
         port = pmt.intern("in")
@@ -56,14 +55,14 @@ class test_packet_format_fb(gr_unittest.TestCase):
 
         result_hdr = pmt.u8vector_elements(result_hdr_pmt)
         result_pld = pmt.u8vector_elements(result_pld_pmt)
-        header = "".join(chr(r) for r in result_hdr)
-        payload = "".join(chr(r) for r in result_pld)
+        header = bytes(result_hdr)
+        payload = bytes(result_pld)
 
         access_code = packet_utils.conv_1_0_string_to_packed_binary_string(packet_utils.default_access_code)[0]
         rx_access_code = header[0:len(access_code)]
 
         length = len(send_str)
-        rx_length = struct.unpack_from(b"!H", six.b(header), len(access_code))[0]
+        rx_length = struct.unpack_from(b"!H", header, len(access_code))[0]
 
         self.assertEqual(access_code, rx_access_code)
         self.assertEqual(length, rx_length)
@@ -129,10 +128,10 @@ class test_packet_format_fb(gr_unittest.TestCase):
         self.tb.msg_connect(formatter, 'payload', snk_pld, 'store')
 
 
-        send_str = "Hello World" + 1000*"xxx"
-        send_pmt = pmt.make_u8vector(len(send_str), ord(' '))
+        send_str = b"Hello World" + 1000*b"xxx"
+        send_pmt = pmt.make_u8vector(len(send_str), 0)
         for i in range(len(send_str)):
-            pmt.u8vector_set(send_pmt, i, ord(send_str[i]))
+            pmt.u8vector_set(send_pmt, i, send_str[i])
         msg = pmt.cons(pmt.PMT_NIL, send_pmt)
 
         port = pmt.intern("in")
@@ -149,16 +148,16 @@ class test_packet_format_fb(gr_unittest.TestCase):
 
         result_hdr = pmt.u8vector_elements(result_hdr_pmt)
         result_pld = pmt.u8vector_elements(result_pld_pmt)
-        header = "".join(chr(r) for r in result_hdr)
-        payload = "".join(chr(r) for r in result_pld)
+        header = bytes(result_hdr)
+        payload = bytes(result_pld)
 
         access_code = packet_utils.conv_1_0_string_to_packed_binary_string(packet_utils.default_access_code)[0]
         rx_access_code = header[0:len(access_code)]
 
         length = len(send_str)
-        rx_length = struct.unpack_from(b"!H", six.b(header), len(access_code))[0]
-        rx_bps = struct.unpack_from(b"!H", six.b(header), len(access_code)+4)[0]
-        rx_counter = struct.unpack_from(b"!H", six.b(header), len(access_code)+6)[0]
+        rx_length = struct.unpack_from(b"!H", header, len(access_code))[0]
+        rx_bps = struct.unpack_from(b"!H", header, len(access_code)+4)[0]
+        rx_counter = struct.unpack_from(b"!H", header, len(access_code)+6)[0]
 
         self.assertEqual(access_code, rx_access_code)
         self.assertEqual(length, rx_length)


### PR DESCRIPTION
Partially resolves #3446.

gr-digital still had a few usages of `six.b`. They were only needed because bytes were incorrectly stored in stings. I've updated the code to use bytes where appropriate.