### PR TITLE
audio: fix lcm calculation

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gru/mathmisc.py
+++ b/gnuradio-runtime/python/gnuradio/gru/mathmisc.py
@@ -15,7 +15,7 @@ def gcd(a,b):
     return a
 
 def lcm(a,b):
-    return a * b / gcd(a, b)
+    return a * b // gcd(a, b)
 
 def log2(x):
     return math.log(x) / math.log(2)

--- a/gr-audio/examples/python/test_resampler.py
+++ b/gr-audio/examples/python/test_resampler.py
@@ -42,8 +42,8 @@ class my_top_block(gr.top_block):
         input_rate = int(args.input_rate)
         output_rate = int(args.output_rate)
 
-        interp = gru.lcm(input_rate / output_rate, input_rate)
-        decim = gru.lcm(input_rate / output_rate, output_rate)
+        interp = gru.lcm(input_rate, output_rate) // input_rate
+        decim = gru.lcm(input_rate, output_rate) // output_rate
 
         print("interp =", interp)
         print("decim  =", decim)


### PR DESCRIPTION
While working on #3809, I noticed that `gnuradio.digital.packet_utils.make_packet` is broken because `gnuradio.gru.lcm` returns a float instead of an integer. I've fixed that here, and `make_packet` now executes.

I also checked where `lcm` is used, and found that test_resampler.py was also broken; the LCM calculations were broken in https://github.com/gnuradio/gnuradio/commit/9e625c4821f4c63421b3d3747c0c4f358fef6c5f#diff-da129366a03c0bb69563f36127facf1d. I've restored them to their previous form here, except using Python 3's integer division operator `//`. After this change, test_resampler.py works again.