### PR TITLE
docs: remove six

### DIFF
--- a/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -10,8 +10,6 @@ import sys
 from xml.dom import minidom
 from xml.dom import Node
 
-import six
-
 #
 # User methods
 #
@@ -66,7 +64,7 @@ def showIndent(outfile, level):
         outfile.write('    ')
 
 def quote_xml(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -74,7 +72,7 @@ def quote_xml(inStr):
     return s1
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')

--- a/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -10,8 +10,6 @@ import sys
 from xml.dom import minidom
 from xml.dom import Node
 
-import six
-
 #
 # User methods
 #
@@ -66,7 +64,7 @@ def showIndent(outfile, level):
         outfile.write('    ')
 
 def quote_xml(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -74,7 +72,7 @@ def quote_xml(inStr):
     return s1
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')

--- a/gr-utils/modtool/templates/gr-newmod/docs/doxygen/doxyxml/generated/compoundsuper.py
+++ b/gr-utils/modtool/templates/gr-newmod/docs/doxygen/doxyxml/generated/compoundsuper.py
@@ -10,9 +10,6 @@ import sys
 from xml.dom import minidom
 from xml.dom import Node
 
-import six
-
-
 #
 # User methods
 #
@@ -67,7 +64,7 @@ def showIndent(outfile, level):
         outfile.write('    ')
 
 def quote_xml(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -75,7 +72,7 @@ def quote_xml(inStr):
     return s1
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')

--- a/gr-utils/modtool/templates/gr-newmod/docs/doxygen/doxyxml/generated/indexsuper.py
+++ b/gr-utils/modtool/templates/gr-newmod/docs/doxygen/doxyxml/generated/indexsuper.py
@@ -10,8 +10,6 @@ import sys
 from xml.dom import minidom
 from xml.dom import Node
 
-import six
-
 #
 # User methods
 #
@@ -66,7 +64,7 @@ def showIndent(outfile, level):
         outfile.write('    ')
 
 def quote_xml(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')
@@ -74,7 +72,7 @@ def quote_xml(inStr):
     return s1
 
 def quote_attrib(inStr):
-    s1 = (isinstance(inStr, six.string_types) and inStr or
+    s1 = (isinstance(inStr, str) and inStr or
           '%s' % inStr)
     s1 = s1.replace('&', '&amp;')
     s1 = s1.replace('<', '&lt;')


### PR DESCRIPTION
Partially resolves #3446.

I'm not quite sure how these docs work, but the dependency on six can be easily removed so I've done so here.

The headers suggest these files were auto-generated, but they've been subsequently edited by hand.

Together with #3808 and #3809 the dependency on six will be removed, after which the cmake references can be removed:

https://github.com/gnuradio/gnuradio/blob/4b402404e152ede29cfaa5c0648bdfb5d327038b/CMakeLists.txt#L322
https://github.com/gnuradio/gnuradio/blob/4b402404e152ede29cfaa5c0648bdfb5d327038b/CMakeLists.txt#L347-L352
