### PR TITLE
filter: remove the last reference to __future__

### DIFF
--- a/gr-filter/python/filter/qa_freq_xlating_fft_filter.py
+++ b/gr-filter/python/filter/qa_freq_xlating_fft_filter.py
@@ -8,8 +8,6 @@
 #
 #
 
-from __future__ import division
-
 from gnuradio import gr, gr_unittest, filter, blocks
 
 import cmath, math


### PR DESCRIPTION
a4b7a48f71a059c7410ee3e97aa682361cf22799 removed all references to `__future__` except this one.