### PR TITLE
runtime: remove snprintf

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt_unv.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_unv.cc
@@ -17,6 +17,7 @@
 #include "pmt_int.h"
 #include "pmt_unv_int.h"
 #include <pmt/pmt.h>
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -1146,9 +1147,9 @@ float* f32vector_writable_elements(pmt_t vector, size_t& len)
 
 const std::string pmt_f32vector::string_ref(size_t k) const
 {
-    char buf[128];
-    snprintf(buf, sizeof(buf), "%.*f", std::numeric_limits<float>::digits10, ref(k));
-    return buf;
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(std::numeric_limits<float>::digits10) << ref(k);
+    return ss.str();
 }
 
 } /* namespace pmt */
@@ -1273,9 +1274,10 @@ double* f64vector_writable_elements(pmt_t vector, size_t& len)
 
 const std::string pmt_f64vector::string_ref(size_t k) const
 {
-    char buf[128];
-    snprintf(buf, sizeof(buf), "%.*f", std::numeric_limits<double>::digits10, ref(k));
-    return buf;
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(std::numeric_limits<double>::digits10)
+       << ref(k);
+    return ss.str();
 }
 
 } /* namespace pmt */

--- a/gnuradio-runtime/lib/pmt/qa_pmt_unv.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_unv.cc
@@ -324,6 +324,8 @@ BOOST_AUTO_TEST_CASE(test_f32vector)
     BOOST_CHECK_EQUAL(float(0), wr[0]);
     BOOST_CHECK_EQUAL(s1, wr[1]);
     BOOST_CHECK_EQUAL(s2, wr[2]);
+
+    BOOST_CHECK_EQUAL(pmt::write_string(v1), "#[0.000000 20.000000 30.000000]");
 }
 BOOST_AUTO_TEST_CASE(test_f64vector)
 {
@@ -358,6 +360,9 @@ BOOST_AUTO_TEST_CASE(test_f64vector)
     BOOST_CHECK_EQUAL(double(0), wr[0]);
     BOOST_CHECK_EQUAL(s1, wr[1]);
     BOOST_CHECK_EQUAL(s2, wr[2]);
+
+    BOOST_CHECK_EQUAL(pmt::write_string(v1),
+                      "#[0.000000000000000 20.000000000000000 30.000000000000000]");
 }
 BOOST_AUTO_TEST_CASE(test_c32vector)
 {


### PR DESCRIPTION
Partially resolves #2875.

This removes the last usage of `snprintf` from gnuradio-runtime. I also added tests to verify that the behaviour of `string_ref` is the same before & after the change.