### PR TITLE
Replace deprecated getargspec function

### DIFF
--- a/gr-digital/python/digital/modulation_utils.py
+++ b/gr-digital/python/digital/modulation_utils.py
@@ -69,9 +69,9 @@ def extract_kwargs_from_options(function, excluded_args, options):
     """
     
     # Try this in C++ ;)
-    args, varargs, varkw, defaults = inspect.getargspec(function)
+    spec = inspect.getfullargspec(function)
     d = {}
-    for kw in [a for a in args if a not in excluded_args]:
+    for kw in [a for a in spec.args if a not in excluded_args]:
         if hasattr(options, kw):
             if getattr(options, kw) is not None:
                 d[kw] = getattr(options, kw)

--- a/grc/core/utils/epy_block_io.py
+++ b/grc/core/utils/epy_block_io.py
@@ -52,7 +52,7 @@ def extract(cls):
     if not inspect.isclass(cls):
         cls = _find_block_class(cls, gr.gateway.gateway_block)
 
-    spec = inspect.getargspec(cls.__init__)
+    spec = inspect.getfullargspec(cls.__init__)
     init_args = spec.args[1:]
     defaults = [repr(arg) for arg in (spec.defaults or ())]
     doc = cls.__doc__ or cls.__init__.__doc__ or ''


### PR DESCRIPTION
Embedded python modules give the following warning:
```
/share/gnuradio/grdev/lib/python3/dist-packages/gnuradio/grc/core/utils/epy_block_io.py:55: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
```
Replacement of getargspec with getfullargspec is a straightforward swap

Fixes #3676