### PR TITLE
fec: lib: Remove use of FEC_API for function definitions.

### DIFF
--- a/gr-fec/lib/reed-solomon/decode_rs.h
+++ b/gr-fec/lib/reed-solomon/decode_rs.h
@@ -3,8 +3,6 @@
  * May be used under the terms of the GNU General Public License (GPL)
  */
 
-#include <gnuradio/fec/api.h>
-
 #ifdef DEBUG
 #include <stdio.h>
 #endif
@@ -17,7 +15,7 @@
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-FEC_API int DECODE_RS(
+int DECODE_RS(
 #ifndef FIXED
     void* p,
 #endif

--- a/gr-fec/lib/reed-solomon/decode_rs_ccsds.c
+++ b/gr-fec/lib/reed-solomon/decode_rs_ccsds.c
@@ -8,9 +8,7 @@
 #include "ccsds.h"
 #include "fixed.h"
 
-#include <gnuradio/fec/api.h>
-
-FEC_API int decode_rs_ccsds(unsigned char* data, int* eras_pos, int no_eras)
+int decode_rs_ccsds(unsigned char* data, int* eras_pos, int no_eras)
 {
     int i, r;
     unsigned char cdata[NN];

--- a/gr-fec/lib/reed-solomon/encode_rs.h
+++ b/gr-fec/lib/reed-solomon/encode_rs.h
@@ -3,11 +3,9 @@
  * May be used under the terms of the GNU General Public License (GPL)
  */
 
-#include <gnuradio/fec/api.h>
-
 #include <string.h>
 
-FEC_API void ENCODE_RS(
+void ENCODE_RS(
 #ifndef FIXED
     void* p,
 #endif

--- a/gr-fec/lib/reed-solomon/encode_rs_ccsds.c
+++ b/gr-fec/lib/reed-solomon/encode_rs_ccsds.c
@@ -8,9 +8,7 @@
 #include "ccsds.h"
 #include "fixed.h"
 
-#include <gnuradio/fec/api.h>
-
-FEC_API void encode_rs_ccsds(unsigned char* data, unsigned char* parity)
+void encode_rs_ccsds(unsigned char* data, unsigned char* parity)
 {
     int i;
     unsigned char cdata[NN - NROOTS];


### PR DESCRIPTION
This fixes building with MSVC. Since these files first get built into an object that is *not* a shared library, `FEC_API` was resolving to `__declspec(dllimport)`, which should never be used for function definitions. Warnings still occur about inconsistent dll linkage because the `gr_fec_rs` target is built into an object library that doesn't define `gnuradio_fec_EXPORTS`, but the end result works. These warnings have always existed previously.