### PR TITLE
cmake: Set VERSION_PATH to be only "git", fixing RC_MAINT_VERSION.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING)
 SET(VERSION_MAJOR 3)
 SET(VERSION_API   9)
 SET(VERSION_ABI   0)
-SET(VERSION_PATCH 0-git)
+SET(VERSION_PATCH git)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:


### PR DESCRIPTION
The version parsing in [`GrVersion.cmake`](https://github.com/gnuradio/gnuradio/blob/master/cmake/Modules/GrVersion.cmake#L51-L79) expects exactly the string "git" as either the `MINOR_VERSION` or `MAINT_VERSION` in order to set the dependent variables correctly. Without this fix, Windows builds will fail because `RC_MAINT_VERSION` contains an invalid string.