### PR TITLE
grc: restore pre-3.8 block id behavior

### DIFF
--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -171,7 +171,7 @@ class PropsDialog(Gtk.Dialog):
 
                 for param in self._block.params.values():
                     if force_show_id and param.dtype == 'id':
-                        param.hide = 'none'
+                        param.hide = 'part'
                     # todo: why do we even rebuild instead of really hiding params?
                     if param.category != category or param.hide == 'all':
                         continue

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -157,8 +157,8 @@ class Block(CoreBlock, Drawable):
 
         # update the params layout
         if not self.is_dummy_block:
-            markups = [param.format_block_surface_markup()
-                       for param in self.params.values() if (param.hide not in ('all', 'part') or (param.dtype == 'id' and force_show_id))]
+            markups = [param.format_block_surface_markup() for param in self.params.values()
+                       if (param.hide not in ('all', 'part'))]
         else:
             markups = ['<span font_desc="{font}"><b>key: </b>{key}</span>'.format(font=PARAM_FONT, key=self.key)]
 


### PR DESCRIPTION
Prior to 3.8 block IDs were shown in the properties dialogue for every block as these are important for function of some GR features. #2795 brought this back as an option for 3.8+, however it forces the `hide` value to effectively be `none` instead of `part` (not visible on the block canvas but visible in the properties dialogue) for all blocks. This changes this back to the pre-3.8 behavior where the ID value is not shown on the canvas but is shown in the properties dialogue.

I realize this was a deliberate change by @mormj but most block IDs add little value on the canvas and the exceptions to this are explicit in their yaml files (e.g.: variables). I also realize that the change to the PropsDialog.py does not actually change anything, but it matches the intention.