### PR TITLE
Backport 3.8: uhd: Update possible master_clock_rate

### DIFF
--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -71,8 +71,8 @@ parameters:
     label: Clock Rate (Hz)
     dtype: real
     default: 0e0
-    options: [0e0, 200e6, 184.32e6, 120e6, 30.72e6]
-    option_labels: [Default, 200 MHz, 184.32 MHz, 120 MHz, 30.72 MHz]
+    options: [0e0, 200e6, 184.32e6, 153.6e6, 125.0e6, 122.88e6, 120e6, 30.72e6]
+    option_labels: [Default, 200 MHz, 184.32 MHz, 153.6 MHz, 125 MHz, 122.88 MHz, 120 MHz, 30.72 MHz]
     hide: ${'$'}{ 'none' if clock_rate else 'part' }
 -   id: num_mboards
     label: Num Mboards
@@ -135,7 +135,11 @@ templates:
         import time
     make: |
         uhd.usrp_${sourk}(
+            ${'%'} if clock_rate():
+            ",".join((${'$'}{dev_addr}, ${'$'}{dev_args}, "master_clock_rate=${'$'}{clock_rate}")),
+            ${'%'} else:
             ",".join((${'$'}{dev_addr}, ${'$'}{dev_args})),
+            ${'%'} endif
             uhd.stream_args(
                 cpu_format="${'$'}{type}",
                 ${'%'} if otw:
@@ -204,9 +208,6 @@ templates:
         ${'%'} endif
         ${'%'} endif
         % endfor
-        ${'%'} if clock_rate():
-        self.${'$'}{id}.set_clock_rate(${'$'}{clock_rate}, uhd.ALL_MBOARDS)
-        ${'%'} endif
         self.${'$'}{id}.set_samp_rate(${'$'}{samp_rate})
         ${'%'} if sync == 'sync':
         self.${'$'}{id}.set_time_unknown_pps(uhd.time_spec())

--- a/gr-uhd/grc/gen_uhd_usrp_blocks.py
+++ b/gr-uhd/grc/gen_uhd_usrp_blocks.py
@@ -71,8 +71,8 @@ parameters:
     label: Clock Rate (Hz)
     dtype: real
     default: 0e0
-    options: [0e0, 200e6, 184.32e6, 153.6e6, 125.0e6, 122.88e6, 120e6, 30.72e6]
-    option_labels: [Default, 200 MHz, 184.32 MHz, 153.6 MHz, 125 MHz, 122.88 MHz, 120 MHz, 30.72 MHz]
+    options: [0e0, 200e6, 184.32e6, 153.6e6, 125.0e6, 122.88e6, 120e6, 61.44e6, 56.0e6, 30.72e6]
+    option_labels: [Default, 200 MHz, 184.32 MHz, 153.6 MHz, 125 MHz, 122.88 MHz, 120 MHz, 61.44 MHz, 56 MHz, 30.72 MHz]
     hide: ${'$'}{ 'none' if clock_rate else 'part' }
 -   id: num_mboards
     label: Num Mboards


### PR DESCRIPTION
Backport of #3667 from @jdemel - any reason for this to not go on maint-3.8?

A USRP block offers the option to set a `clock_rate` which in turn sets
`master_clock_rate` in UHD. There were some common options
(153.6MHz, 125MHz, 122.88MHz) missing for N310s. Now these options are added.

Instead of a separate call to `set_clock_rate`, `master_clock_rate` is
now set as part of the device address string. This behavior makes it
more consistent with UHD examples. Flowgraphs that set MCR as part of
their `device_args` option, are currently overruled if clock rate is set
too. This behavior may easily be reversed.

According to the UHD manual, X300s don't support
`set_master_clock_rate`, thus in this case it is strictly necessary to
set MCR as part of the device address string.