### PR TITLE
PMT: replace custom hash implementation with std::hash and increase hash table size

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -18,6 +18,7 @@
 #include <pmt/pmt_pool.h>
 #include <stdio.h>
 #include <string.h>
+#include <functional>
 #include <vector>
 
 namespace pmt {
@@ -150,27 +151,11 @@ static std::vector<pmt_t>* get_symbol_hash_table()
 pmt_symbol::pmt_symbol(const std::string& name) : d_name(name) {}
 
 
-static unsigned int hash_string(const std::string& s)
-{
-    unsigned int h = 0;
-    unsigned int g = 0;
-
-    for (std::string::const_iterator p = s.begin(); p != s.end(); ++p) {
-        h = (h << 4) + (*p & 0xff);
-        g = h & 0xf0000000;
-        if (g) {
-            h = h ^ (g >> 24);
-            h = h ^ g;
-        }
-    }
-    return h;
-}
-
 bool is_symbol(const pmt_t& obj) { return obj->is_symbol(); }
 
 pmt_t string_to_symbol(const std::string& name)
 {
-    unsigned hash = hash_string(name) % get_symbol_hash_table_size();
+    unsigned hash = std::hash<std::string>()(name) % get_symbol_hash_table_size();
 
     // Does a symbol with this name already exist?
     for (pmt_t sym = (*get_symbol_hash_table())[hash]; sym; sym = _symbol(sym)->next()) {

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -138,7 +138,7 @@ bool to_bool(pmt_t val)
 
 static const unsigned int get_symbol_hash_table_size()
 {
-    static const unsigned int SYMBOL_HASH_TABLE_SIZE = 701;
+    static const unsigned int SYMBOL_HASH_TABLE_SIZE = 8192;
     return SYMBOL_HASH_TABLE_SIZE;
 }
 


### PR DESCRIPTION
Some of libpmt's features and behaviors have been a bit of a sore spot over the years; the hashtable being one of them. While replacing PMT with another serialization library is on the roadmap, we are stuck with them for now, so we might as well make them work for us.

Two annoying things I have noticed are the custom hash algorithm, and the small hash table size; I view both of these changes as suggestions for discussion. While this PR addresses both, they are separate changes and can be split up if necessary.

---

The hashing algorithm has been updated to use `std::hash<std::string>` which is very slightly faster (~3% on my ubuntu system), but more importantly not a homebrew undocumented algorithm. I did verify uniformity of the output of both algorithms:

![image](https://user-images.githubusercontent.com/7121282/95660043-2122a900-0ada-11eb-890d-b8171067f283.png)

![image](https://user-images.githubusercontent.com/7121282/95660059-38619680-0ada-11eb-8464-f269fa5efef7.png)

The hash table size is a more convoluted and https://github.com/gnuradio/gnuradio/pull/1448 has some good information about this. The increased memory use seems negligible given GR's memory footprint, and improved my test code (`pmt::eq()` comparison against 15k unique random strings) by a factor of ~8.5x.