### PR TITLE
vocoder: add text message output to FreeDV demodulator

### DIFF
--- a/gr-vocoder/examples/grfreedv.grc
+++ b/gr-vocoder/examples/grfreedv.grc
@@ -1,6 +1,7 @@
 options:
   parameters:
     author: A. Maitland Bottoms
+    catch_exceptions: 'True'
     category: Custom
     cmake_opt: ''
     comment: ''
@@ -22,9 +23,11 @@ options:
     sizing_mode: fixed
     thread_safe_setters: ''
     title: GNU Radio FreeDV
-    window_size: ''
   states:
-    coordinate: [8, 8]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 4.0]
     rotation: 0
     state: enabled
 
@@ -35,7 +38,10 @@ blocks:
     comment: ''
     value: '8000'
   states:
-    coordinate: [8, 160]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 164.0]
     rotation: 0
     state: enabled
 - name: squelch
@@ -45,7 +51,7 @@ blocks:
     gui_hint: ''
     label: squelch slider
     min_len: '256'
-    orient: Qt.Horizontal
+    orient: QtCore.Qt.Horizontal
     rangeType: float
     start: '-127'
     step: '1'
@@ -53,7 +59,10 @@ blocks:
     value: '-120'
     widget: counter_slider
   states:
-    coordinate: [232, 16]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 4.0]
     rotation: 0
     state: enabled
 - name: audio_sink_0
@@ -67,7 +76,10 @@ blocks:
     ok_to_block: 'True'
     samp_rate: samp_rate
   states:
-    coordinate: [1152, 220.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1192, 204.0]
     rotation: 0
     state: enabled
 - name: audio_source_0
@@ -83,6 +95,9 @@ blocks:
     ok_to_block: 'True'
     samp_rate: '48000'
   states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
     coordinate: [8, 300.0]
     rotation: 0
     state: enabled
@@ -97,9 +112,25 @@ blocks:
     scale: '32768'
     vlen: '1'
   states:
-    coordinate: [456, 220.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [416, 220.0]
     rotation: 0
     state: enabled
+- name: blocks_message_debug_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1104, 288.0]
+    rotation: 0
+    state: true
 - name: blocks_short_to_float_0
   id: blocks_short_to_float
   parameters:
@@ -111,7 +142,10 @@ blocks:
     scale: '32768'
     vlen: '1'
   states:
-    coordinate: [1008, 220.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1024, 204.0]
     rotation: 0
     state: enabled
 - name: blocks_wavfile_source_0
@@ -126,7 +160,10 @@ blocks:
     nchan: '1'
     repeat: 'True'
   states:
-    coordinate: [120, 164.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [176, 164.0]
     rotation: 0
     state: disabled
 - name: rational_resampler_xxx_0
@@ -143,7 +180,10 @@ blocks:
     taps: ''
     type: fff
   states:
-    coordinate: [232, 276.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [200, 276.0]
     rotation: 0
     state: enabled
 - name: vocoder_freedv_rx_ss_0
@@ -159,7 +199,10 @@ blocks:
     squelch_enable: 'True'
     squelch_thresh: squelch
   states:
-    coordinate: [816, 196.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [808, 196.0]
     rotation: 0
     state: enabled
 - name: vocoder_freedv_tx_ss_0
@@ -176,7 +219,10 @@ blocks:
     tx_bpf_val: 'True'
     txt_msg: '''GNU Radio'''
   states:
-    coordinate: [608, 188.0]
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [584, 188.0]
     rotation: 0
     state: enabled
 
@@ -187,6 +233,7 @@ connections:
 - [blocks_wavfile_source_0, '0', blocks_float_to_short_0, '0']
 - [rational_resampler_xxx_0, '0', blocks_float_to_short_0, '0']
 - [vocoder_freedv_rx_ss_0, '0', blocks_short_to_float_0, '0']
+- [vocoder_freedv_rx_ss_0, text, blocks_message_debug_0, print]
 - [vocoder_freedv_tx_ss_0, '0', vocoder_freedv_rx_ss_0, '0']
 
 metadata:

--- a/gr-vocoder/grc/vocoder_freedv_rx_ss.block.yml
+++ b/gr-vocoder/grc/vocoder_freedv_rx_ss.block.yml
@@ -29,6 +29,9 @@ inputs:
 outputs:
 -   domain: stream
     dtype: short
+-   domain: message
+    id: text
+    optional: true
 
 templates:
     imports: |-

--- a/gr-vocoder/lib/freedv_rx_ss_impl.h
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.h
@@ -13,16 +13,6 @@
 
 #include <gnuradio/vocoder/freedv_rx_ss.h>
 
-extern "C" {
-struct freedv_rx_callback_state {
-    FILE* ftxt;
-};
-static void put_next_rx_char(void* callback_state, char c);
-void put_next_rx_proto(void* callback_state, char* proto_bits);
-void datarx(void* callback_state, unsigned char* packet, size_t size);
-void datatx(void* callback_state, unsigned char* packet, size_t* size);
-}
-
 namespace gr {
 namespace vocoder {
 
@@ -33,7 +23,9 @@ private:
     short* d_demod_in;
     struct freedv* d_freedv;
     int d_nin, d_nout, d_frame;
-    struct freedv_rx_callback_state d_cb_state;
+    std::string d_rx_str;
+    static void put_next_rx_char(void* callback_state, char c);
+    const pmt::pmt_t d_port;
     struct MODEM_STATS d_stats;
     int d_mode;
     int d_sync;


### PR DESCRIPTION
Fixes #2929.

The FreeDV protocol includes a low bit rate text stream which is used to 
transmit information such as call sign and location. GNU Radio's FreeDV 
demodulator block sets up a callback to receive this text data, but the 
callback currently does nothing.

Here I've added an optional message output to the block. It collects 
characters until a carriage return is encountered, then outputs a 
string. I've updated the sample flow graph to print these messages using 
the Message Debug block.