### PR TITLE
runtime: remove unused HAVE_SNPRINTF macro

### DIFF
--- a/gnuradio-runtime/ConfigChecks.cmake
+++ b/gnuradio-runtime/ConfigChecks.cmake
@@ -29,14 +29,6 @@ GR_CHECK_HDR_N_DEF(malloc.h HAVE_MALLOC_H)
 
 ########################################################################
 CHECK_CXX_SOURCE_COMPILES("
-    #include <stdio.h>
-    int main(){snprintf(0, 0, 0); return 0;}
-    " HAVE_SNPRINTF
-)
-GR_ADD_COND_DEF(HAVE_SNPRINTF)
-
-########################################################################
-CHECK_CXX_SOURCE_COMPILES("
     #include <signal.h>
     int main(){sigaction(0, 0, 0); return 0;}
     " HAVE_SIGACTION


### PR DESCRIPTION
The last reference to `HAVE_SNPRINTF` was removed in a75f0c40fe0912535fe102792f27c13d01df8e3e so it should now be safe to remove it.

Together with #3817 and #3832, this resolves #2875.