### PR TITLE
cmake: remove check for six module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,6 @@ include(GrBoost)
 # Enable python component
 ########################################################################
 include(GrPython)
-GR_PYTHON_CHECK_MODULE("six - python 2 and 3 compatibility library" six "True" SIX_FOUND)
 GR_PYTHON_CHECK_MODULE(
     "numpy"
     numpy
@@ -347,7 +346,6 @@ include(GrComponent)
 GR_REGISTER_COMPONENT("python-support" ENABLE_PYTHON
     PYTHONLIBS_FOUND
     pybind11_FOUND
-    SIX_FOUND
     NUMPY_FOUND
 )
 


### PR DESCRIPTION
Resolves #3446.
Depends on #3808, #3809, and #3811.

Once the pull requests above are merged, GNU Radio will have no dependence on the six module, so we no longer need to check for it in cmake.