### PR TITLE
Adding optional parameter addl_includes to gr_modtool bind

### DIFF
--- a/gr-utils/modtool/cli/bind.py
+++ b/gr-utils/modtool/cli/bind.py
@@ -28,6 +28,8 @@ from .base import common_params, block_name, run, cli_input
 @click.command('bind', short_help=ModToolGenBindings.description)
 @click.option('-o', '--output', is_flag=True,
               help='If given, a file with desired output format will be generated')
+@click.option('--addl_includes',default ="",
+              help = 'comma separated list of additional include directories (default "")')
 @common_params
 @block_name
 def cli(**kwargs):

--- a/gr-utils/modtool/core/bind.py
+++ b/gr-utils/modtool/core/bind.py
@@ -37,6 +37,7 @@ class ModToolGenBindings(ModTool):
     def __init__(self, blockname=None, **kwargs):
         ModTool.__init__(self, blockname, **kwargs)
         self.info['pattern'] = blockname
+        self.info['addl_includes'] = kwargs['addl_includes']
 
     def validate(self):
         """ Validates the arguments """
@@ -58,5 +59,5 @@ class ModToolGenBindings(ModTool):
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             file_to_process = os.path.join(self.dir, self.info['includedir'], self.info['blockname'] + '.h')
             bg = BindingGenerator(prefix=gr.prefix(), namespace=[
-                                  'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'))
+                                  'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'), addl_includes=self.info['addl_includes'])
             bg.gen_file_binding(file_to_process)


### PR DESCRIPTION
gr_modtool bind fails if the module references external packages like qt.
In such a case you see something like:

INFO Parsing source file "/home/schroer/gnuradiocomponents/gr-display/include/display/display_text_msg.h" ... 
/home/schroer/gnuradiocomponents/gr-display/include/display/display_text_msg.h:33:10: fatal error: 
      'qapplication.h' file not found
#include <qapplication.h>
         ^~~~~~~~~~~~~~~~
1 error generated.
Error occurred while running CASTXML:  status:1

So I propose to add an optional parameter --addl_includes to gr_modtool bind to tell where to find the required includes.
This addresses #3759 
