### PR TITLE
 gr-uhd: fix directional tune commands being dropped when TX and RX are the same frequency

### DIFF
--- a/gr-uhd/apps/uhd_app.py
+++ b/gr-uhd/apps/uhd_app.py
@@ -325,7 +325,7 @@ class UHDApp:
                 treq = uhd.tune_request(
                     target_freq=freq,
                     rf_freq=freq,
-                    rf_freq_policy=uhd.tune_reqest.POLICY_MANUAL,
+                    rf_freq_policy=uhd.tune_request.POLICY_MANUAL,
                     dsp_freq=tune_resp.actual_dsp_freq,
                     dsp_freq_policy=uhd.tune_request.POLICY_MANUAL)
             for chan in self.channels:

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -612,14 +612,14 @@ void usrp_block_impl::_cmd_handler_freq(const pmt::pmt_t& freq_,
                                         const pmt::pmt_t& msg)
 {
     double freq = pmt::to_double(freq_);
-    ::uhd::tune_request_t new_tune_reqest(freq);
+    ::uhd::tune_request_t new_tune_request(freq);
     if (pmt::dict_has_key(msg, cmd_lo_offset_key())) {
         double lo_offset =
             pmt::to_double(pmt::dict_ref(msg, cmd_lo_offset_key(), pmt::PMT_NIL));
-        new_tune_reqest = ::uhd::tune_request_t(freq, lo_offset);
+        new_tune_request = ::uhd::tune_request_t(freq, lo_offset);
     }
 
-    _update_curr_tune_req(new_tune_reqest, chan);
+    _update_curr_tune_req(new_tune_request, chan);
 }
 
 void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t& lo_offset,
@@ -697,8 +697,8 @@ void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,
 {
     double freq = pmt::to_double(pmt::car(tune));
     double lo_offset = pmt::to_double(pmt::cdr(tune));
-    ::uhd::tune_request_t new_tune_reqest(freq, lo_offset);
-    _update_curr_tune_req(new_tune_reqest, chan);
+    ::uhd::tune_request_t new_tune_request(freq, lo_offset);
+    _update_curr_tune_req(new_tune_request, chan);
 }
 
 void usrp_block_impl::_cmd_handler_bw(const pmt::pmt_t& bw,

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -120,6 +120,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
       _nchan(stream_args.channels.size()),
       _stream_now(_nchan == 1 and ts_tag_name.empty()),
       _start_time_set(false),
+      _force_tune(false),
       _curr_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
       _chans_to_tune(stream_args.channels.size())
 {
@@ -540,7 +541,18 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
                                               pmt::from_long(-1) // Default to all chans
                                               )));
 
-    /// 3) Loop through all the values
+    /// 3) See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+    // if the a direction symbol was provided, force a tune
+    _force_tune = pmt::is_symbol(direction);
+
+
+    /// 4) Loop through all the values
     GR_LOG_DEBUG(d_debug_logger, boost::format("Processing command message %s") % msg);
     pmt::pmt_t msg_items = pmt::dict_items(msg);
     for (size_t i = 0; i < pmt::length(msg_items); i++) {
@@ -557,17 +569,9 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
             break;
         }
     }
-
-    /// 4) See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
-
     /// 5) Check if we need to re-tune
     _set_center_freq_from_internals_allchans(direction);
+    _force_tune = false;
 }
 
 
@@ -600,7 +604,7 @@ void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req, int
         tune_req.rf_freq_policy != _curr_tune_req[chan].rf_freq_policy ||
         tune_req.rf_freq != _curr_tune_req[chan].rf_freq ||
         tune_req.dsp_freq != _curr_tune_req[chan].dsp_freq ||
-        tune_req.dsp_freq_policy != _curr_tune_req[chan].dsp_freq_policy) {
+        tune_req.dsp_freq_policy != _curr_tune_req[chan].dsp_freq_policy || _force_tune) {
         _curr_tune_req[chan] = tune_req;
         _chans_to_tune.set(chan);
     }

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -210,6 +210,7 @@ protected:
     bool _stream_now;
     ::uhd::time_spec_t _start_time;
     bool _start_time_set;
+    bool _force_tune;
 
     /****** Command interface related **********/
     //! Stores a list of commands for later execution


### PR DESCRIPTION
This is a [long overdue] fix for #1814 which adds a class member bool which will force a tune to occur if the 'direction' key is provided, and the value of that key is a symbol.

This PR also includes a commit fixing some misspellings in gr-uhd.

This should be backported all the way back to 3.7 in my opinion, but first I would like to see if this is acceptable.