### PR TITLE
gr-blocks: Stream Mux C++ improvements

### DIFF
--- a/gr-blocks/lib/stream_mux_impl.cc
+++ b/gr-blocks/lib/stream_mux_impl.cc
@@ -29,8 +29,6 @@ stream_mux_impl::stream_mux_impl(size_t itemsize, const std::vector<int>& length
             io_signature::make(1, -1, itemsize),
             io_signature::make(1, 1, itemsize)),
       d_itemsize(itemsize),
-      d_stream(0),
-      d_residual(0),
       d_lengths(lengths)
 {
     while (d_lengths[d_stream] == 0) {
@@ -52,34 +50,35 @@ void stream_mux_impl::forecast(int noutput_items, gr_vector_int& ninput_items_re
     }
 }
 
-
 int stream_mux_impl::general_work(int noutput_items,
                                   gr_vector_int& ninput_items,
                                   gr_vector_const_void_star& input_items,
                                   gr_vector_void_star& output_items)
 {
-    char* out = (char*)output_items[0];
-    const char* in;
-    int out_index = 0;                              // Items written
-    gr_vector_int input_index(d_lengths.size(), 0); // Items read
-    std::vector<gr::tag_t> stream_t;
+
+    int out_index = 0;                           // Items written
+    gr_vector_int input_index(d_lengths.size()); // Items read
 
     while (out_index < noutput_items) {
         if (ninput_items[d_stream] <= input_index[d_stream]) {
             break;
         }
-        int space_left_in_buffers = std::min(
+        const int space_left_in_buffers = std::min(
             noutput_items - out_index,                     // Space left in output buffer
             ninput_items[d_stream] - input_index[d_stream] // Space left in input buffer
         );
-        int items_to_copy = std::min(space_left_in_buffers, d_residual);
-        in = (const char*)input_items[d_stream] + input_index[d_stream] * d_itemsize;
+        const int items_to_copy = std::min(space_left_in_buffers, d_residual);
+        const char* in = reinterpret_cast<const char*>(input_items[d_stream]) +
+                         input_index[d_stream] * d_itemsize;
+        char* out = reinterpret_cast<char*>(output_items[0]);
         memcpy(&out[out_index * d_itemsize], in, items_to_copy * d_itemsize);
+
+        std::vector<gr::tag_t> stream_t;
         get_tags_in_window(stream_t,
                            d_stream,
                            input_index[d_stream],
                            input_index[d_stream] + items_to_copy);
-        for (auto t : stream_t) {
+        for (auto& t : stream_t) {
             t.offset = t.offset - nitems_read(d_stream) - input_index[d_stream] +
                        nitems_written(0) + out_index;
             add_item_tag(0, t);

--- a/gr-blocks/lib/stream_mux_impl.h
+++ b/gr-blocks/lib/stream_mux_impl.h
@@ -20,9 +20,9 @@ class BLOCKS_API stream_mux_impl : public stream_mux
 {
 private:
     const size_t d_itemsize;
-    unsigned int d_stream;         // index of currently selected stream
-    int d_residual;                // number if items left to put into current stream
-    const gr_vector_int d_lengths; // number if items to pack per stream
+    unsigned int d_stream{ 0 };    // index of currently selected stream
+    int d_residual{ 0 };           // number of items left to put into current stream
+    const gr_vector_int d_lengths; // number of items to pack per stream
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required);
 


### PR DESCRIPTION
- replace C-style cast with reinterpret_cast<>
- make some variables const
- prefer in-class initializers for static data
- avoid copies in for loop by using a reference

These changes stem from review comments made on the new block Stream Demux (PR #3754) which apply to Stream Mux as well.
