### PR TITLE
Modify template to cast Python pointer correctly

### DIFF
--- a/gr-utils/bindtool/templates/generic_python_cc.mako
+++ b/gr-utils/bindtool/templates/generic_python_cc.mako
@@ -58,7 +58,19 @@ if overloaded:
   overloaded_str = '({} ({}::*)({}))'.format(fcn['return_type'],cls_name,', '.join([f['dtype'] for f in fcn_args]))
 %>\
 % if fcn['name'] != filter_val:
-        ${modvar if isfree else ""}${".def_static" if has_static and not isfree else ".def"}("${fcn['name']}",${overloaded_str}&${cls_name}::${fcn['name']},
+%       if fcn['return_type'] == 'PyObject *': 
+<%
+func = '\n\
+            [](std::shared_ptr<'+cls_name+'> p) {\n\
+               return PyLong_AsLongLong(p->'+fcn_name+'());\n\
+        }'
+%>
+%       else: ## No PyObject pointer 
+<%
+func = overloaded_str+'&'+cls_name+'::'+fcn_name
+%>        
+%       endif                    
+        ${modvar if isfree else ""}${".def_static" if has_static and not isfree else ".def"}("${fcn['name']}",${func},       
 % for arg in fcn_args:
             py::arg("${arg['name']}")${" = " + arg['default'] if arg['default'] else ''},
 % endfor ## args 


### PR DESCRIPTION
The mako template creates code fo PyObject * that must be hand edited.
For instance see the comments for qtgui widgets:

        // .def("pyqwidget",&sink_f::pyqwidget,
        //     D(sink_f,pyqwidget)
        // )
        // For the sip conversion to python to work, the widget object
        // needs to be explicitly converted to long long.
This modification does this cast for PyObject *  . So no more hand editing is needed