### PR TITLE
cmake: manual override to ignore pybind hash checking

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -182,7 +182,9 @@ foreach(file ${files})
 
     # message(STATUS ${file} ":" ${flag_auto} ":" ${flag_pygccxml} ":" ${header_filename} ":" ${header_file_hash})
 
-    if (NOT ${header_filename} STREQUAL "None")  # If no header filename is specified, don't bother checking for a rebuild
+    # If no header filename is specified (set to empty or "None")
+    #  OR If hash is set to 0, then ignore the check as well
+    if (NOT ${header_filename} STREQUAL "None" AND NOT ${header_file_hash} STREQUAL "0")  
         set(header_full_path ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include/${name}/${header_filename})  # NOTE OOT version does not have gnuradio/ here
         file(MD5 ${header_full_path} calc_hash)
         # message(STATUS ${ii} " " ${calc_hash} " " ${saved_hash})


### PR DESCRIPTION
This permits an OOT to override the hash checking

putting a 0 for BINDTOOL_HEADER_FILE_HASH will ignore the hash checking.
This would:
1) Not be the default behavior
2) only for OOTs
3) Use at your own risk

/***********************************************************************************/
/* This file is automatically generated using bindtool and can be manually edited  */
/* The following lines can be configured to regenerate this file during cmake      */
/* If manual edits are made, the following tags should be modified accordingly.    */
/* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
/* BINDTOOL_USE_PYGCCXML(0)                                                        */
/* BINDTOOL_HEADER_FILE(foo.h)                                                     */
/* BINDTOOL_HEADER_FILE_HASH(0)                                                    */
/***********************************************************************************/