### PR TITLE
modtool: update of cli block name checking

### DIFF
--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -44,6 +44,7 @@ def cli(**kwargs):
     kwargs['cli'] = True
     self = ModToolAdd(**kwargs)
     click.secho("GNU Radio module name identified: " + self.info['modname'], fg='green')
+    get_blockname(self)
     get_blocktype(self)
     get_lang(self)
     info_lang = {'cpp': 'C++', 'python': 'Python'}[self.info['lang']]
@@ -51,7 +52,6 @@ def cli(**kwargs):
     if ((self.skip_subdirs['lib'] and self.info['lang'] == 'cpp')
             or (self.skip_subdirs['python'] and self.info['lang'] == 'python')):
         raise ModToolException('Missing or skipping relevant subdir.')
-    get_blockname(self)
     click.secho("Block/code identifier: " + self.info['blockname'], fg='green')
     if not self.license_file:
         get_copyrightholder(self)

--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -53,7 +53,6 @@ def cli(**kwargs):
         raise ModToolException('Missing or skipping relevant subdir.')
     get_blockname(self)
     click.secho("Block/code identifier: " + self.info['blockname'], fg='green')
-    self.info['fullblockname'] = self.info['modname'] + '_' + self.info['blockname']
     if not self.license_file:
         get_copyrightholder(self)
     self.info['license'] = self.setup_choose_license()
@@ -93,11 +92,12 @@ def get_blockname(self):
             self.info['blockname'] = cli_input("Enter name of block/code (without module name prefix): ")
     if not re.match('^[a-zA-Z0-9_]+$', self.info['blockname']):
         raise ModToolException('Invalid block name.')
+    self.info['fullblockname'] = self.info['modname'] + '_' + self.info['blockname']
+    fname_grc = self.info['fullblockname'] + '.block.yml'
     for block in os.scandir('./grc/'):
         if block.is_file():
             s = block.name
-            present_block = self.info['modname'] + "_" + self.info['blockname'] + ".block.yml"
-            if s == present_block:
+            if s == fname_grc:
                 raise ModToolException('Block Already Present.')
                 
 def get_copyrightholder(self):


### PR DESCRIPTION
This updates the logic of the modtool checking for duplicate block names to be consistent with what is on maint-3.8 (#3387 - which was a more recent PR and got updated with feedback). 

There is no functional change here, just a cleanup of the code by @alekhgupta1441 to be consistent with the 3.8 branch.