### PR TITLE
Fix various typos

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -321,7 +321,7 @@ public:
 
     /*!
      * \brief return a reference to the multiple precision rational
-     * represntation of the approximate output rate / input rate
+     * representation of the approximate output rate / input rate
      */
     mpq_class& mp_relative_rate() { return d_mp_relative_rate; }
 

--- a/gnuradio-runtime/include/gnuradio/flowgraph.h
+++ b/gnuradio-runtime/include/gnuradio/flowgraph.h
@@ -243,7 +243,7 @@ public:
     basic_block_vector_t topological_sort(basic_block_vector_t& blocks);
 
     /*!
-     * \brief Calculate vector of disjoint graph partions
+     * \brief Calculate vector of disjoint graph partitions
      * \return vector of disjoint vectors of topologically sorted blocks
      */
     std::vector<basic_block_vector_t> partition();

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -76,7 +76,7 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
         gr::thread::set_thread_priority(d->thread, block->thread_priority());
     }
 
-    // make sure our block isnt finished
+    // make sure our block isn't finished
     block->clear_finished();
 
     start_sync->wait();

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(block.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3e181f6028976ba3727d29f45ebaa6cf)                     */
+/* BINDTOOL_HEADER_FILE(block.h)                                                   */
+/* BINDTOOL_HEADER_FILE_HASH(ee3b6013487881ab1dac5105e9fd55c7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/flowgraph_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/flowgraph_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(flowgraph.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a019dfc2f7380e37ef8eaa0ee96c39c0)                     */
+/* BINDTOOL_HEADER_FILE(flowgraph.h)                                               */
+/* BINDTOOL_HEADER_FILE_HASH(3ab08834070348db57c720795b8de826)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/include/gnuradio/blocks/phase_shift.h
+++ b/gr-blocks/include/gnuradio/blocks/phase_shift.h
@@ -19,7 +19,7 @@ namespace blocks {
 
 /*!
  * \brief This block will shift the incoming signal by the specified amount.
- * Shift can be specified in either radians or degress which is configurable
+ * Shift can be specified in either radians or degrees which is configurable
  * in the constructor.
  *
  * This block functions like a multiply const, but with the const limited to

--- a/gr-blocks/include/gnuradio/blocks/sample_and_hold.h
+++ b/gr-blocks/include/gnuradio/blocks/sample_and_hold.h
@@ -25,7 +25,7 @@ namespace blocks {
  *
  * \details
  * Samples the data stream (input stream 0) and holds the value if
- * the control signal is 1 (intput stream 1).
+ * the control signal is 1 (input stream 1).
  */
 template <class T>
 class BLOCKS_API sample_and_hold : virtual public sync_block

--- a/gr-blocks/include/gnuradio/blocks/threshold_ff.h
+++ b/gr-blocks/include/gnuradio/blocks/threshold_ff.h
@@ -23,7 +23,7 @@ namespace blocks {
  *
  * \details
  * Test the incoming signal against a threshold. If the signal
- * excedes the \p hi value, it will output a 1 until the signal
+ * exceeds the \p hi value, it will output a 1 until the signal
  * falls below the \p lo value.
  */
 class BLOCKS_API threshold_ff : virtual public sync_block

--- a/gr-blocks/python/blocks/bindings/phase_shift_python.cc
+++ b/gr-blocks/python/blocks/bindings/phase_shift_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(phase_shift.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(5657bd1fe7366cf279f6b1e29ee4df6b)                     */
+/* BINDTOOL_HEADER_FILE(phase_shift.h)                                             */
+/* BINDTOOL_HEADER_FILE_HASH(1664568abb8b7440216e8565354ffd7f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/bindings/sample_and_hold_python.cc
+++ b/gr-blocks/python/blocks/bindings/sample_and_hold_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(sample_and_hold.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e2112809d670e502f4b8621039111a9f)                     */
+/* BINDTOOL_HEADER_FILE(sample_and_hold.h)                                         */
+/* BINDTOOL_HEADER_FILE_HASH(143913f78329444b1cdda20cbe1d7a7c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/bindings/threshold_ff_python.cc
+++ b/gr-blocks/python/blocks/bindings/threshold_ff_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(threshold_ff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c84062668a3f19f25cfde9bd7b70e3ec)                     */
+/* BINDTOOL_HEADER_FILE(threshold_ff.h)                                            */
+/* BINDTOOL_HEADER_FILE_HASH(50555a585be0d02b5c3eddc195f8b018)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/qa_file_source.py
+++ b/gr-blocks/python/blocks/qa_file_source.py
@@ -49,7 +49,7 @@ class test_file_source(gr_unittest.TestCase):
 
     def test_file_source_no_such_file(self):
         """
-        Try to open a non-existant file and verify exception is thrown.
+        Try to open a non-existent file and verify exception is thrown.
         """
         try:
             _ = blocks.file_source(gr.sizeof_float, "___no_such_file___")

--- a/gr-digital/include/gnuradio/digital/cma_equalizer_cc.h
+++ b/gr-digital/include/gnuradio/digital/cma_equalizer_cc.h
@@ -43,7 +43,7 @@ public:
     /*!
      * Make a CMA Equalizer block
      *
-     * \param num_taps Numer of taps in the equalizer (channel size)
+     * \param num_taps Number of taps in the equalizer (channel size)
      * \param modulus Modulus of the modulated signals
      * \param mu Gain of the update loop
      * \param sps Number of samples per symbol of the input signal

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -212,7 +212,7 @@ protected:
 /*                                                          */
 /************************************************************/
 
-/*! \brief Calculate Euclidian distance for any constellation
+/*! \brief Calculate Euclidean distance for any constellation
  *  \ingroup digital
  *
  * \details

--- a/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_cc.h
@@ -224,7 +224,7 @@ public:
      *
      * Damping factor of the 2nd order loop transfer function.
      * When a new damping factor is set, the gains, alpha and beta,
-     * of the loop are automatcally recalculated.
+     * of the loop are automatically recalculated.
      *
      * \param zeta    loop damping factor
      */
@@ -243,7 +243,7 @@ public:
      * properly from the desired input loop bandwidth and damping factor.
      *
      * When a new ted_gain is set, the gains, alpha and beta,
-     * of the loop are automatcally recalculated.
+     * of the loop are automatically recalculated.
      *
      * \param ted_gain    expected gain of the timing error detector
      */

--- a/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
+++ b/gr-digital/include/gnuradio/digital/symbol_sync_ff.h
@@ -224,7 +224,7 @@ public:
      *
      * Damping factor of the 2nd order loop transfer function.
      * When a new damping factor is set, the gains, alpha and beta,
-     * of the loop are automatcally recalculated.
+     * of the loop are automatically recalculated.
      *
      * \param zeta    loop damping factor
      */
@@ -243,7 +243,7 @@ public:
      * properly from the desired input loop bandwidth and damping factor.
      *
      * When a new ted_gain is set, the gains, alpha and beta,
-     * of the loop are automatcally recalculated.
+     * of the loop are automatically recalculated.
      *
      * \param ted_gain    expected gain of the timing error detector
      */

--- a/gr-digital/lib/clock_tracking_loop.h
+++ b/gr-digital/lib/clock_tracking_loop.h
@@ -526,7 +526,7 @@ public:
      * properly from the desired input loop bandwidth and damping factor.
      *
      * When a new ted_gain is set, the gains, alpha and beta,
-     * of the loop are automatcally recalculated.
+     * of the loop are automatically recalculated.
      *
      * \param ted_gain    expected gain of the timing error detector
      */

--- a/gr-digital/lib/constellation_receiver_cb_impl.h
+++ b/gr-digital/lib/constellation_receiver_cb_impl.h
@@ -57,7 +57,7 @@ private:
      * Message handler port to update the phase of the rotator. The
      * phase should be a real number (float or double) that is added
      * to the current phase. So we can rotate the constellation by
-     * 90 degress by passing a value of pmt::from_double(GR_M_PI/2).
+     * 90 degrees by passing a value of pmt::from_double(GR_M_PI/2).
      */
     void handle_rotate_phase(pmt::pmt_t rotation);
 

--- a/gr-digital/python/digital/bindings/cma_equalizer_cc_python.cc
+++ b/gr-digital/python/digital/bindings/cma_equalizer_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(cma_equalizer_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(75c10b4e338f162c2d71d137f0836689)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3d7ebc78bf6a6c712f19f13f3e20648a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/constellation_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(constellation.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(88a9804617d38b7414a38c6bb77199ae)                     */
+/* BINDTOOL_HEADER_FILE(constellation.h)                                           */
+/* BINDTOOL_HEADER_FILE_HASH(a4bdcaf2db30bfe32e518f4f4b62bafa)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/symbol_sync_cc_python.cc
+++ b/gr-digital/python/digital/bindings/symbol_sync_cc_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(symbol_sync_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(6031664528c8f0fb0834ad9d79b65553)                     */
+/* BINDTOOL_HEADER_FILE(symbol_sync_cc.h)                                          */
+/* BINDTOOL_HEADER_FILE_HASH(a6425f9904862a6d1eac5e8f884e14cd)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/symbol_sync_ff_python.cc
+++ b/gr-digital/python/digital/bindings/symbol_sync_ff_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(symbol_sync_ff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8fecc2546d8c4e383b70c824b2cbfaf8)                     */
+/* BINDTOOL_HEADER_FILE(symbol_sync_ff.h)                                          */
+/* BINDTOOL_HEADER_FILE_HASH(be3b845025900d5a510daf14508add97)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/grc/filter_fft_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_fft_low_pass_filter.block.yml
@@ -74,6 +74,6 @@ documentation: |-
 
     Sample rate, cutoff frequency, and transition width are in Hertz.
 
-    The beta paramater only applies to the Kaiser window.
+    The beta parameter only applies to the Kaiser window.
 
 file_format: 1

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -299,7 +299,7 @@ static double compute_A(double freq, int r, double ad[], double x[], double y[])
  * int gridsize  - Number of elements in the dense frequency grid
  * double Grid[] - Frequencies on the dense grid [gridsize]
  * double D[]    - Desired response on the dense grid [gridsize]
- * double W[]    - Weight function on the desnse grid [gridsize]
+ * double W[]    - Weight function on the dense grid [gridsize]
  *
  * OUTPUT:
  * -------

--- a/gr-qtgui/grc/qtgui_compass.block.yml
+++ b/gr-qtgui/grc/qtgui_compass.block.yml
@@ -34,7 +34,7 @@ parameters:
     options: ['False', 'True']
     option_labels: ['Stream', 'Message']
 -   id: backgroundColor
-    label: Backround Color
+    label: Background Color
     dtype: enum
     default: 'default'
     options: ['default', 'silver', 'gray', 'black', 'white', 'red', 'green', 'blue', 'navy', 'yellow', 'orange', 'purple', 'lime', 'aqua', 'teal']

--- a/gr-qtgui/grc/qtgui_graphicitem.block.yml
+++ b/gr-qtgui/grc/qtgui_graphicitem.block.yml
@@ -50,6 +50,6 @@ templates:
         ${gui_hint() % win}
 
 documentation: |-
-    This block displays the selected graphic item.  You can pass a filename as a string in a message to change the image on the fly.  overlays can also be added by passing in a message with a dictionary of a list of dictionaries in the car portion of the message.  Each dicationary should have the following keys: 'filename','x','y', and an optional 'scalefactor'.  Setting the x/y attributes to -1,-1 will remove an overlay.  Otherwise items are indexed by filename and can be animated throughout the backgound image.
+    This block displays the selected graphic item.  You can pass a filename as a string in a message to change the image on the fly.  overlays can also be added by passing in a message with a dictionary of a list of dictionaries in the car portion of the message.  Each dictionary should have the following keys: 'filename','x','y', and an optional 'scalefactor'.  Setting the x/y attributes to -1,-1 will remove an overlay.  Otherwise items are indexed by filename and can be animated throughout the background image.
 
 file_format: 1

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -86,8 +86,8 @@ public:
      * \param wintype type of window to apply (see gr::fft::window::win_type).
      *        By setting bit 16 to one, this block will normalize the window
      *        before applying it. This allows switching between windows without
-     *        sacrifying signal power due to tapering, but it will also amplify
-     *        some samples. See also set_fft_window_normalized().
+     *        sacrificing signal power due to tapering, but it will also 
+     *        amplify some samples. See also set_fft_window_normalized().
      * \param fc center frequency of signal (use for x-axis labels)
      * \param bw bandwidth of signal (used to set x-axis labels)
      * \param name title for the plot

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -86,7 +86,7 @@ public:
      * \param wintype type of window to apply (see gr::fft::window::win_type).
      *        By setting bit 16 to one, this block will normalize the window
      *        before applying it. This allows switching between windows without
-     *        sacrificing signal power due to tapering, but it will also 
+     *        sacrificing signal power due to tapering, but it will also
      *        amplify some samples. See also set_fft_window_normalized().
      * \param fc center frequency of signal (use for x-axis labels)
      * \param bw bandwidth of signal (used to set x-axis labels)

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -86,8 +86,8 @@ public:
      * \param wintype type of window to apply (see gr::fft::window::win_type).
      *        By setting bit 16 to one, this block will normalize the window
      *        before applying it. This allows switching between windows without
-     *        sacrifying signal power due to tapering, but it will also amplify
-     *        some samples. See also set_fft_window_normalized().
+     *        sacrificing signal power due to tapering, but it will also 
+     *        amplify some samples. See also set_fft_window_normalized().
      * \param fc center frequency of signal (use for x-axis labels)
      * \param bw bandwidth of signal (used to set x-axis labels)
      * \param name title for the plot

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -86,7 +86,7 @@ public:
      * \param wintype type of window to apply (see gr::fft::window::win_type).
      *        By setting bit 16 to one, this block will normalize the window
      *        before applying it. This allows switching between windows without
-     *        sacrificing signal power due to tapering, but it will also 
+     *        sacrificing signal power due to tapering, but it will also
      *        amplify some samples. See also set_fft_window_normalized().
      * \param fc center frequency of signal (use for x-axis labels)
      * \param bw bandwidth of signal (used to set x-axis labels)

--- a/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
@@ -27,7 +27,7 @@ class QwtColorMap;
  * \ingroup qtgui_blk
  *
  * \details
- * A time raster displays threedimenional data, where the 3rd dimension
+ * A time raster displays three-dimenional data, where the 3rd dimension
  * (the intensity) is displayed using colors. The colors are calculated
  * from the values using a color map.
  *

--- a/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
@@ -27,7 +27,7 @@ class QwtColorMap;
  * \ingroup qtgui_blk
  *
  * \details
- * A waterfall displays threedimenional data, where the 3rd dimension
+ * A waterfall displays three-dimenional data, where the 3rd dimension
  * (the intensity) is displayed using colors. The colors are calculated
  * from the values using a color map.
  *

--- a/gr-qtgui/python/qtgui/digitalnumbercontrol.py
+++ b/gr-qtgui/python/qtgui/digitalnumbercontrol.py
@@ -260,7 +260,7 @@ class DigitalNumberControl(QFrame):
 
     def setFrequencyNow(self, new_freq):
         # This setFrequency differs from setFrequency() in that it
-        # it updates the display immediately rather than emiting
+        # it updates the display immediately rather than emitting
         # to the message queue as required during msg handling
         if (new_freq >= self.min_freq) and (new_freq <= self.max_freq):
             self.cur_freq = int(new_freq)

--- a/gr-qtgui/python/qtgui/graphicitem.py
+++ b/gr-qtgui/python/qtgui/graphicitem.py
@@ -26,11 +26,11 @@ class GrGraphicItem(gr.sync_block, QLabel):
     filename as a string in a message to change the image on the fly.
     overlays can also be added by passing in a message with a
     dictionary of a list of dictionaries in the car portion of the
-    message.  Each dicationary should have the following keys:
+    message.  Each dictionary should have the following keys:
     'filename','x','y', and an optional 'scalefactor'.
     Setting the x/y attributes to -1,-1 will remove an overlay.
     Otherwise items are indexed by filename and can be animated
-    throughout the backgound image.
+    throughout the background image.
     """
     def __init__(self, image_file, scaleImage=True, fixedSize=False, setWidth=0, setHeight=0):
         gr.sync_block.__init__(self, name="GrGraphicsItem", in_sig=None, out_sig=None)

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
@@ -34,7 +34,7 @@ public:
 
     //! Factory function to create a UHD block controller reference
     //
-    // \param graph Refernce to the flowgraph's RFNoC graph
+    // \param graph Reference to the flowgraph's RFNoC graph
     // \param block_args Block args
     // \param block_name Block name (e.g. "DDC")
     // \param device_select Device index (motherboard index)

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_rx_radio.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_rx_radio.h
@@ -19,7 +19,7 @@ namespace uhd {
 /*! RFNoC RX Radio
  *
  * This wraps a radio block into GNU Radio. Note: When doing TX and RX in the
- * same flow graph, simply crate an rfnoc_rx_radio and an rfnoc_tx_radio with
+ * same flow graph, simply create an rfnoc_rx_radio and an rfnoc_tx_radio with
  * the same block ID.
  *
  * \ingroup uhd_blk

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_tx_radio.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_tx_radio.h
@@ -19,7 +19,7 @@ namespace uhd {
 /*! RFNoC TX Radio
  *
  * This wraps a radio block into GNU Radio. Note: When doing TX and RX in the
- * same flow graph, simply crate an rfnoc_rx_radio and an rfnoc_tx_radio with
+ * same flow graph, simply create an rfnoc_rx_radio and an rfnoc_tx_radio with
  * the same block ID.
  *
  * \ingroup uhd_blk

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -494,7 +494,7 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     // End of legacy backward compat code.
 
     // pmt_dict is a subclass of pmt_pair. Make sure we use pmt_pair!
-    // Old behavior was that these checks were interchangably. Be aware of this change!
+    // Old behavior was that these checks were interchangeable. Be aware of this change!
     if (!(pmt::is_dict(msg)) && pmt::is_pair(msg)) {
         GR_LOG_DEBUG(
             d_logger,

--- a/gr-utils/blocktool/core/iosignature.py
+++ b/gr-utils/blocktool/core/iosignature.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger(__name__)
 def io_signature(impl_file):
     """
     function to generate the io_signature of the block
-    : returns the io parmaters
+    : returns the io parameters
     """
     parsed_io = {
         "input": {

--- a/gr-utils/blocktool/core/parseheader.py
+++ b/gr-utils/blocktool/core/parseheader.py
@@ -42,7 +42,7 @@ class BlockHeaderParser(BlockTool):
         : returns the parsed header data in python dict
         : return dict keys: namespace, class, io_signature, make,
                        properties, methods
-    : Can be used as an CLI command or an extenal API
+    : Can be used as an CLI command or an external API
     """
     name = 'Block Parse Header'
     description = 'Create a parsed output from a block header file'
@@ -95,7 +95,7 @@ class BlockHeaderParser(BlockTool):
         : returns the parsed header data in python dict
         : return dict keys: namespace, class, io_signature, make,
                        properties, methods
-        : Can be used as an CLI command or an extenal API
+        : Can be used as an CLI command or an external API
         """
         gr = self.modname.split('-')[0]
         module = self.modname.split('-')[-1]

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -42,7 +42,7 @@ class GenericHeaderParser(BlockTool):
         : returns the parsed header data in python dict
         : return dict keys: namespace, class, io_signature, make,
                        properties, methods
-    : Can be used as an CLI command or an extenal API
+    : Can be used as an CLI command or an external API
     """
     name = 'Block Parse Header'
     description = 'Create a parsed output from a block header file'
@@ -265,7 +265,7 @@ class GenericHeaderParser(BlockTool):
         : returns the parsed header data in python dict
         : return dict keys: namespace, class, io_signature, make,
                        properties, methods
-        : Can be used as an CLI command or an extenal API
+        : Can be used as an CLI command or an external API
         """
         module = self.modname.split('-')[-1]
         self.parsed_data['module_name'] = module

--- a/gr-utils/blocktool/tests/sample_yaml/analog_agc2_cc.yml
+++ b/gr-utils/blocktool/tests/sample_yaml/analog_agc2_cc.yml
@@ -40,7 +40,7 @@ outputs:
   dtype: sizeof(gr_complex)
 cpp_templates:
   includes: '#include <gnuradio/analog/agc2_cc.h>'
-  declartions: analog::agc2_cc::sptr ${id}
+  declarations: analog::agc2_cc::sptr ${id}
   make: this->${id} = analog::agc2_cc::make(${attack_rate}, ${decay_rate}, ${reference},
     ${gain}, ${max_gain})
   callbacks: !!python/tuple

--- a/gr-utils/blocktool/tests/sample_yaml/digital_additive_scrambler_bb.yml
+++ b/gr-utils/blocktool/tests/sample_yaml/digital_additive_scrambler_bb.yml
@@ -34,7 +34,7 @@ outputs:
   dtype: sizeof(unsigned char)
 cpp_templates:
   includes: '#include <gnuradio/digital/additive_scrambler_bb.h>'
-  declartions: digital::additive_scrambler_bb::sptr ${id}
+  declarations: digital::additive_scrambler_bb::sptr ${id}
   make: this->${id} = digital::additive_scrambler_bb::make(${mask}, ${seed}, ${len},
     ${count}, ${bits_per_byte})
   link: gnuradio-digital

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -255,8 +255,8 @@ class FlowGraph(Element):
                 variable_block.rewrite()
                 value = eval(variable_block.value, namespace, variable_block.namespace)
                 namespace[variable_block.name] = value
-                self.namespace.update(namespace) # rewrite on subsequent blocks depends on an updated self.namespace
-            except TypeError: #Type Errors may happen, but that desn't matter as they are displayed in the gui
+                self.namespace.update(namespace) # rewrite on subsequent blocks depends on an updated self.namespace 
+            except TypeError: #Type Errors may happen, but that doesn't matter as they are displayed in the gui
                 pass
             except Exception:
                 log.exception('Failed to evaluate variable block {0}'.format(variable_block.name), exc_info=True)

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -275,8 +275,8 @@ class CppTopBlockGenerator(TopBlockGenerator):
         # Create an executable fragment of code containing all 'raw' variables in
         # order to infer the lvalue types.
         #
-        # Note that this differs from using ast.literal_eval() as literal_eval evaluates one
-        # variable at a time. The code fragment below evaluates all varaibles together which
+        # Note that this differs from using ast.literal_eval() as literal_eval evaluates one 
+        # variable at a time. The code fragment below evaluates all variables together which 
         # allows the variables to reference each other (i.e. a = b * c).
         prog = 'def get_decl_types():\n'
         prog += '\tvar_types = {}\n'

--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -360,8 +360,8 @@ class DirectoryParam(FileParam):
         dir_dialog.set_current_folder(dirname)
         dir_dialog.set_local_only(True)
         dir_dialog.set_select_multiple(False)
-
-        # Show dialog and update paramter on success
+        
+        # Show dialog and update parameter on success
         if Gtk.ResponseType.OK == dir_dialog.run():
             path = dir_dialog.get_filename()
             self._input.set_text(path)


### PR DESCRIPTION
Found via `codespell v2.0.dev`  
`codespell -q 3 -L ans,fo,hist,inout,ist,ith,nd,sinc,uint -S ./volk`