### PR TITLE
vocoder: allow input & output rates to differ

### DIFF
--- a/gr-vocoder/include/gnuradio/vocoder/freedv_tx_ss.h
+++ b/gr-vocoder/include/gnuradio/vocoder/freedv_tx_ss.h
@@ -22,12 +22,12 @@ namespace vocoder {
  * \brief FreeDV modulator
  * \ingroup audio_blk
  *
- * Input: Speech (audio) signal as 16-bit shorts, sampling rate 8 kHz.
+ * Input: Speech (audio) signal as 16-bit shorts.
  *
- * Output: Signal (audio) as 16-bit shorts, sampling rate 8 kHz.
+ * Output: Signal (audio) as 16-bit shorts.
  *
  */
-class VOCODER_API freedv_tx_ss : virtual public gr::sync_block
+class VOCODER_API freedv_tx_ss : virtual public gr::block
 {
 public:
     typedef std::shared_ptr<freedv_tx_ss> sptr;

--- a/gr-vocoder/lib/freedv_tx_ss_impl.h
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.h
@@ -50,9 +50,12 @@ public:
     void set_tx_bpf(int val);
 
     // Where all the action really happens
-    int work(int noutput_items,
-             gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+
+    int general_work(int noutput_items,
+                     gr_vector_int& ninput_items,
+                     gr_vector_const_void_star& input_items,
+                     gr_vector_void_star& output_items);
 };
 
 } /* namespace vocoder */

--- a/gr-vocoder/python/vocoder/bindings/freedv_tx_ss_python.cc
+++ b/gr-vocoder/python/vocoder/bindings/freedv_tx_ss_python.cc
@@ -25,11 +25,8 @@ void bind_freedv_tx_ss(py::module& m)
     using freedv_tx_ss = ::gr::vocoder::freedv_tx_ss;
 
 
-    py::class_<freedv_tx_ss,
-               gr::sync_block,
-               gr::block,
-               gr::basic_block,
-               std::shared_ptr<freedv_tx_ss>>(m, "freedv_tx_ss", D(freedv_tx_ss))
+    py::class_<freedv_tx_ss, gr::block, gr::basic_block, std::shared_ptr<freedv_tx_ss>>(
+        m, "freedv_tx_ss", D(freedv_tx_ss))
 
         .def(py::init(&freedv_tx_ss::make),
              py::arg("mode") = gr::vocoder::freedv_api::MODE_1600,


### PR DESCRIPTION
Fixes #2932.

The input & output rates of the FreeDV modulator aren't necessarily the same. In particular, the 2400A and 2400B modes have an input rate of 8000 sps and an output rate of 48000 sps. To allow for arbitrary input & output rates, I've changed `freedv_tx_ss` from `sync_block` to `block`.