### PR TITLE
Add ZMQ_Linger of 1000ms to ZMQ socket creation to prevent infinite block in top_block.stop()

### DIFF
--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -16,6 +16,10 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 
+namespace {
+constexpr int LINGER_DEFAULT = 1000; // 1 second.
+}
+
 namespace gr {
 namespace zeromq {
 
@@ -71,6 +75,9 @@ base_sink_impl::base_sink_impl(int type,
         d_socket.setsockopt(ZMQ_HWM, &tmp, sizeof(tmp));
 #endif
     }
+
+    /* Set ZMQ_LINGER so socket won't infinitely block during teardown */
+    d_socket.setsockopt(ZMQ_LINGER, &LINGER_DEFAULT, sizeof(LINGER_DEFAULT));
 
     /* Bind */
     d_socket.bind(address);
@@ -142,6 +149,9 @@ base_source_impl::base_source_impl(int type,
         d_socket.setsockopt(ZMQ_HWM, &tmp, sizeof(tmp));
 #endif
     }
+
+    /* Set ZMQ_LINGER so socket won't infinitely block during teardown */
+    d_socket.setsockopt(ZMQ_LINGER, &LINGER_DEFAULT, sizeof(LINGER_DEFAULT));
 
     /* Connect */
     d_socket.connect(address);


### PR DESCRIPTION
Re: #1132 the default value of ZMQ_Linger was incorrect in the ZMQ docs, and is currently -1, which causes sockets with pending messages to block indefinitely during tear down, causing flow graphs to lock up indefinitely during top_block.stop() if outbound data is pending on the ZMQ socket.

It's challenging to reliably reproduce this condition so I don't have code for that, but in my code that uses ZMQ pub/sub sinks/sources to pass data around, it regularly locks up at least once about every 8 hours in top_block.stop()

It might make more sense for ZMQ_Linger to be configurable, but that is beyond my C++ abilities, and I think a ZMQ_LINGER of 0 is sensible since it really only effects data during tear down.