### PR TITLE
digital: ofdm_equalizer_simpledfe: add output_exact_syms option

### DIFF
--- a/gr-digital/include/gnuradio/digital/ofdm_equalizer_simpledfe.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_equalizer_simpledfe.h
@@ -44,9 +44,12 @@ namespace digital {
  * channel state is estimated incorrectly during equalization; after that,
  * all subsequent symbols will be completely wrong.
  *
- * Note that the equalized symbols are *exact points* on the constellation.
- * This means soft information of the modulation symbols is lost after the
+ * Note that, by default, the equalized symbols are *exact points* on the
+ * constellation.
+ * This means that soft information of the modulation symbols is lost after the
  * equalization, which is suboptimal for channel codes that use soft decision.
+ * If this behaviour is not desired, set the `enable_soft_output` parameter to
+ * true.
  *
  */
 class DIGITAL_API ofdm_equalizer_simpledfe : public ofdm_equalizer_1d_pilots
@@ -64,7 +67,8 @@ public:
                                  std::vector<std::vector<gr_complex>>(),
                              int symbols_skipped = 0,
                              float alpha = 0.1,
-                             bool input_is_shifted = true);
+                             bool input_is_shifted = true,
+                             bool enable_soft_output = false);
 
     ~ofdm_equalizer_simpledfe();
 
@@ -97,6 +101,9 @@ public:
      *                         the first input items is on the DC carrier.
      *                         Note that a lot of the OFDM receiver blocks operate on
      * shifted signals!
+     * \param enable_soft_output Output noisy equalized symbols instead of exact
+     *                           constellation symbols.
+     *                           This is useful for soft demodulation and decoding.
      */
     static sptr make(int fft_len,
                      const gr::digital::constellation_sptr& constellation,
@@ -108,12 +115,15 @@ public:
                          std::vector<std::vector<gr_complex>>(),
                      int symbols_skipped = 0,
                      float alpha = 0.1,
-                     bool input_is_shifted = true);
+                     bool input_is_shifted = true,
+                     bool enable_soft_output = false);
 
 private:
     gr::digital::constellation_sptr d_constellation;
     //! Averaging coefficient
     float d_alpha;
+    //! Do not output exact constellation symbols
+    bool d_enable_soft_output;
 };
 
 } /* namespace digital */

--- a/gr-digital/python/digital/bindings/ofdm_equalizer_simpledfe_python.cc
+++ b/gr-digital/python/digital/bindings/ofdm_equalizer_simpledfe_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(ofdm_equalizer_simpledfe.h) */
-/* BINDTOOL_HEADER_FILE_HASH(8091e37dbba4afc0b7a2fd9441996144)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e484906ff9740a46f83b999ec69f511e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -47,6 +47,7 @@ void bind_ofdm_equalizer_simpledfe(py::module& m)
              py::arg("symbols_skipped") = 0,
              py::arg("alpha") = 0.10000000000000001,
              py::arg("input_is_shifted") = true,
+             py::arg("enable_soft_output") = false,
              D(ofdm_equalizer_simpledfe, make))
 
 


### PR DESCRIPTION
This should solve a limitation in [`ofdm_equalizer_simpledfe`](https://www.gnuradio.org/doc/doxygen/classgr_1_1digital_1_1ofdm__equalizer__simpledfe.html):
> Note that the equalized symbols are exact points on the constellation. This means soft information of the modulation symbols is lost after the equalization, which is suboptimal for channel codes that use soft decision.

Hopefully, this simple fix has no downsides... (it seemed *too* obvious to me)

Here is a grc flowgraph based upon the rx_ofdm example: https://gist.github.com/japm48/4ce310709702bb84d12c980cc0ed2330

I can add this to the examples folder, or maybe create a testbench (but I'm not really sure how properly do that in this case).

Here is the relevant result:

![screenshot](https://user-images.githubusercontent.com/1911407/96547598-abbe9180-12ac-11eb-9c12-3bd0740a64c1.png)


