### PR TITLE
Make additional includes and defines available in the bind process

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -209,7 +209,9 @@ foreach(file ${files})
                 message(STATUS "Regenerating Bindings in-place for " ${header_filename})
 
                 file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${file}.regen_status)
-                # Automatically regenerate the bindings               
+                # Automatically regenerate the bindings
+                string(REPLACE ";" ","  extra_include_list "${extra_includes}")  #Convert ';' separated extra_includes to ',' separated list format
+                string(REPLACE ";" ","  defines "${define_symbols}")  #Convert ';' separated define_symbols to ',' separated list format
                 add_custom_command( 
                     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}}/${file}
                     COMMAND  "${PYTHON_EXECUTABLE}"
@@ -222,7 +224,8 @@ foreach(file ${files})
                     "--status" ${CMAKE_CURRENT_BINARY_DIR}/${file}.regen_status 
                     "--flag_automatic" ${flag_auto}
                     "--flag_pygccxml" ${flag_pygccxml}
-                    # "--include" "$<INSTALL_INTERFACE:include>"  #FIXME: Make the pygccxml generation use the source tree headers
+                    "--defines" ${defines} #Add preprocessor defines
+                    "--include" ${extra_include_list} #Some oots may require additional includes
                     COMMENT "Automatic generation of pybind11 bindings for " ${header_full_path})
                 add_custom_target(${file}_regen_bindings ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}}/${file})
                 list(APPEND regen_targets ${file}_regen_bindings)

--- a/gr-utils/bindtool/core/generator.py
+++ b/gr-utils/bindtool/core/generator.py
@@ -20,7 +20,7 @@ import hashlib
 
 class BindingGenerator:
 
-    def __init__(self, prefix, namespace, prefix_include_root, output_dir="", addl_includes="", 
+    def __init__(self, prefix, namespace, prefix_include_root, output_dir="", define_symbols=None, addl_includes= None, 
                     match_include_structure=False, catch_exceptions=True, write_json_output=False, status_output=None,
                     flag_automatic=False, flag_pygccxml=False):
         """Initialize BindingGenerator
@@ -31,6 +31,7 @@ class BindingGenerator:
 
         Keyword arguments:
         output_dir -- path where bindings will be placed
+        define_symbols -- comma separated tuple of defines
         addl_includes -- comma separated list of additional include directories (default "")
         match_include_structure -- 
             If set to False, a bindings/ dir will be placed directly under the specified output_dir
@@ -38,6 +39,7 @@ class BindingGenerator:
         """
 
         self.header_extensions = ['.h', '.hh', '.hpp']
+        self.define_symbols=define_symbols
         self.addl_include = addl_includes
         self.prefix = prefix
         self.namespace = namespace
@@ -151,7 +153,7 @@ class BindingGenerator:
             include_paths = ','.join((include_paths, self.addl_include))
 
         parser = GenericHeaderParser(
-            include_paths=include_paths, file_path=file_to_process)
+            define_symbols = self.define_symbols, include_paths=include_paths, file_path=file_to_process)
         try:
             header_info = parser.get_header_info(self.namespace)
             

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -47,11 +47,14 @@ class GenericHeaderParser(BlockTool):
     name = 'Block Parse Header'
     description = 'Create a parsed output from a block header file'
 
-    def __init__(self, file_path=None, blocktool_comments=False, include_paths=None, **kwargs):
+    def __init__(self, file_path=None, blocktool_comments=False, define_symbols=None,  include_paths=None, **kwargs):
         """ __init__ """
         BlockTool.__init__(self, **kwargs)
         self.parsed_data = {}
         self.addcomments = blocktool_comments
+        self.define_symbols = ('BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC',)
+        if(define_symbols):
+            self.define_symbols += define_symbols
         self.include_paths = None
         if (include_paths):
             self.include_paths = [p.strip() for p in include_paths.split(',')]
@@ -270,7 +273,7 @@ class GenericHeaderParser(BlockTool):
         module = self.modname.split('-')[-1]
         self.parsed_data['module_name'] = module
         self.parsed_data['filename'] = self.filename
-        
+
         import hashlib
         hasher = hashlib.md5()
         with open(self.target_file, 'rb') as file_in:
@@ -322,11 +325,11 @@ class GenericHeaderParser(BlockTool):
                 include_paths=self.include_paths,
                 compiler='gcc',
                 undefine_symbols=['__PIE__'],
-                #define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC', '__PIC__'],
-                define_symbols=['BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC'],
+                define_symbols=self.define_symbols,
                 cflags='-std=c++11 -fPIC')
             decls = parser.parse(
                 [self.target_file], xml_generator_config)
+
             global_namespace = declarations.get_global_namespace(decls)
 
             # namespace

--- a/gr-utils/modtool/cli/bind.py
+++ b/gr-utils/modtool/cli/bind.py
@@ -27,9 +27,11 @@ from .base import common_params, block_name, run, cli_input
 
 @click.command('bind', short_help=ModToolGenBindings.description)
 @click.option('-o', '--output', is_flag=True,
-              help='If given, a file with desired output format will be generated')
-@click.option('--addl_includes',default ="",
-              help = 'comma separated list of additional include directories (default "")')
+              help = 'If given, a file with desired output format will be generated')
+@click.option('--addl_includes', default = None,
+              help = 'Comma separated list of additional include directories (default None)')
+@click.option('-D', '--define_symbols', multiple=True, default=None,
+              help = 'Set precompiler defines')
 @common_params
 @block_name
 def cli(**kwargs):

--- a/gr-utils/modtool/core/bind.py
+++ b/gr-utils/modtool/core/bind.py
@@ -38,6 +38,7 @@ class ModToolGenBindings(ModTool):
         ModTool.__init__(self, blockname, **kwargs)
         self.info['pattern'] = blockname
         self.info['addl_includes'] = kwargs['addl_includes']
+        self.info['define_symbols'] = kwargs['define_symbols']
 
     def validate(self):
         """ Validates the arguments """
@@ -58,6 +59,8 @@ class ModToolGenBindings(ModTool):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             file_to_process = os.path.join(self.dir, self.info['includedir'], self.info['blockname'] + '.h')
+
             bg = BindingGenerator(prefix=gr.prefix(), namespace=[
-                                  'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'), addl_includes=self.info['addl_includes'])
+                                  'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'),
+                                   define_symbols=self.info['define_symbols'], addl_includes=self.info['addl_includes'])
             bg.gen_file_binding(file_to_process)

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
@@ -19,7 +19,9 @@ parser.add_argument(
     '--filename', help="File to be parsed")
 
 parser.add_argument(
-    '--include', help='Additional Include Dirs, separated', default=(), nargs='+')
+    '--defines', help='Set additional defines for precompiler',default=(), nargs='*')
+parser.add_argument(
+    '--include', help='Additional Include Dirs, separated', default=(), nargs='*')
 
 parser.add_argument(
     '--status', help='Location of output file for general status (used during cmake)', default=None
@@ -35,7 +37,8 @@ args = parser.parse_args()
 
 prefix = args.prefix
 output_dir = args.output_dir
-includes = args.include
+defines = tuple(','.join(args.defines).split(','))
+includes = ','.join(args.include)
 name = args.module
 
 namespace = ['gr', name]
@@ -46,7 +49,8 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
 
     bg = BindingGenerator(prefix, namespace,
-                          prefix_include_root, output_dir, addl_includes=','.join(args.include), catch_exceptions=False, write_json_output=False, status_output=args.status,
+                          prefix_include_root, output_dir, define_symbols=defines, addl_includes=includes,
+                          catch_exceptions=False, write_json_output=False, status_output=args.status,
                           flag_automatic=True if args.flag_automatic.lower() in [
                               '1', 'true'] else False,
                           flag_pygccxml=True if args.flag_pygccxml.lower() in ['1', 'true'] else False)


### PR DESCRIPTION
At the moment neither gr_modtool bind nor the GR_PYBIND_MAKE_OOT macro consider additional ( required ) includes like QWidgets or consider defines like ENABLE_PYTHON.

So bind may fail or generate wrong bind code.

This pr fixes this issue and includes #3629 