### PR TITLE
Update qa_qtgui.py

### DIFF
--- a/gr-qtgui/python/qtgui/qa_qtgui.py
+++ b/gr-qtgui/python/qtgui/qa_qtgui.py
@@ -72,10 +72,10 @@ class test_qtgui(gr_unittest.TestCase):
         self.qtsnk = qtgui.histogram_sink_f(1024, 100, -1, 1, "Test", 1, None)
 
     def test13(self):
-        self.qtsnk = qtgui.eye_sink_c(1024, 1, "Test", 1, None)
+        self.qtsnk = qtgui.eye_sink_f(1024, 1, 1, None)
 
-    def test13(self):
-        self.qtsnk = qtgui.eye_sink_c(1024, 1, "Test", 1, None)
+    def test14(self):
+        self.qtsnk = qtgui.eye_sink_c(1024, 1, 1, None)
 
 if __name__ == '__main__':
     gr_unittest.run(test_qtgui, "test_qtgui.xml")


### PR DESCRIPTION
Test fails with
  File "/home/schroer/gnuradiocomponents/gnuradio-volker/gr-qtgui/python/qtgui/qa_qtgui.py", line 78, in test13
    self.qtsnk = qtgui.eye_sink_c(1024, 1, "Test", 1, None)
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. gnuradio.qtgui.qtgui_python.eye_sink_c(size: int, samp_rate: float, nconnections: int = 1, parent: gnuradio.qtgui.qtgui_python.QWidget = None)

Invoked with: 1024, 1, 'Test', 1, None

eye_sink_f/c has no string parameter

And eye_sink_c and eye_sink_f should be tested