### PR TITLE
pybind: add implicit conversion from int to enum

### DIFF
--- a/gr-analog/python/analog/bindings/cpm_python.cc
+++ b/gr-analog/python/analog/bindings/cpm_python.cc
@@ -51,4 +51,6 @@ void bind_cpm(py::module& m)
                          py::arg("L"),
                          py::arg("beta") = 0.3,
                          D(cpm, phase_response));
+
+    py::implicitly_convertible<int, gr::analog::cpm::cpm_type>();
 }

--- a/gr-analog/python/analog/bindings/noise_type_python.cc
+++ b/gr-analog/python/analog/bindings/noise_type_python.cc
@@ -34,4 +34,6 @@ void bind_noise_type(py::module& m)
         .value("GR_LAPLACIAN", gr::analog::GR_LAPLACIAN) // 202
         .value("GR_IMPULSE", gr::analog::GR_IMPULSE)     // 203
         .export_values();
+
+    py::implicitly_convertible<int, gr::analog::noise_type_t>();
 }

--- a/gr-analog/python/analog/bindings/sig_source_waveform_python.cc
+++ b/gr-analog/python/analog/bindings/sig_source_waveform_python.cc
@@ -36,4 +36,6 @@ void bind_sig_source_waveform(py::module& m)
         .value("GR_TRI_WAVE", gr::analog::GR_TRI_WAVE)     // 104
         .value("GR_SAW_WAVE", gr::analog::GR_SAW_WAVE)     // 105
         .export_values();
+
+    py::implicitly_convertible<int, gr::analog::gr_waveform_t>();
 }

--- a/gr-blocks/python/blocks/bindings/file_meta_sink_python.cc
+++ b/gr-blocks/python/blocks/bindings/file_meta_sink_python.cc
@@ -42,6 +42,8 @@ void bind_file_meta_sink(py::module& m)
         .value("GR_FILE_DOUBLE", gr::blocks::GR_FILE_DOUBLE)       // 6
         .export_values();
 
+    py::implicitly_convertible<int, gr::blocks::gr_file_types>();
+
     py::class_<file_meta_sink,
                gr::sync_block,
                gr::block,

--- a/gr-blocks/python/blocks/bindings/message_strobe_random_python.cc
+++ b/gr-blocks/python/blocks/bindings/message_strobe_random_python.cc
@@ -90,4 +90,6 @@ void bind_message_strobe_random(py::module& m)
         .value("STROBE_GAUSSIAN", ::gr::blocks::STROBE_GAUSSIAN) // 2
         .value("STROBE_UNIFORM", ::gr::blocks::STROBE_UNIFORM)   // 3
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::blocks::message_strobe_random_distribution_t>();
 }

--- a/gr-blocks/python/blocks/bindings/pdu_python.cc
+++ b/gr-blocks/python/blocks/bindings/pdu_python.cc
@@ -41,6 +41,7 @@ void bind_pdu(py::module& m)
         .value("complex_t", ::gr::blocks::pdu::complex_t) // 2
         .export_values();
 
+    py::implicitly_convertible<int, ::gr::blocks::pdu::vector_type>();
 
     m_pdu.def("pdu_port_id", &::gr::blocks::pdu::pdu_port_id, D(pdu, pdu_port_id));
 

--- a/gr-blocks/python/blocks/bindings/wavfile_python.cc
+++ b/gr-blocks/python/blocks/bindings/wavfile_python.cc
@@ -56,4 +56,7 @@ void bind_wavfile(py::module& m)
         .value("FORMAT_DOUBLE", ::gr::blocks::FORMAT_DOUBLE) // 7
         .value("FORMAT_VORBIS", ::gr::blocks::FORMAT_VORBIS) // 96
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::blocks::wavfile_format_t>();
+    py::implicitly_convertible<int, ::gr::blocks::wavfile_subformat_t>();
 }

--- a/gr-digital/python/digital/bindings/adaptive_algorithm_python.cc
+++ b/gr-digital/python/digital/bindings/adaptive_algorithm_python.cc
@@ -84,4 +84,6 @@ void bind_adaptive_algorithm(py::module& m)
         .value("NLMS", ::gr::digital::adaptive_algorithm_t::NLMS) // 1
         .value("CMA", ::gr::digital::adaptive_algorithm_t::CMA)   // 2
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::digital::adaptive_algorithm_t>();
 }

--- a/gr-digital/python/digital/bindings/corr_est_cc_python.cc
+++ b/gr-digital/python/digital/bindings/corr_est_cc_python.cc
@@ -37,6 +37,8 @@ void bind_corr_est_cc(py::module& m)
         .value("THRESHOLD_ABSOLUTE", gr::digital::THRESHOLD_ABSOLUTE) // 1
         .export_values();
 
+    py::implicitly_convertible<int, gr::digital::tm_type>();
+
     py::class_<corr_est_cc,
                gr::sync_block,
                gr::block,

--- a/gr-digital/python/digital/bindings/interpolating_resampler_type_python.cc
+++ b/gr-digital/python/digital/bindings/interpolating_resampler_type_python.cc
@@ -36,4 +36,6 @@ void bind_interpolating_resampler_type(py::module& m)
         .value("IR_PFB_NO_MF", gr::digital::IR_PFB_NO_MF) // 1
         .value("IR_PFB_MF", gr::digital::IR_PFB_MF)       // 2
         .export_values();
+
+    py::implicitly_convertible<int, gr::digital::ir_type>();
 }

--- a/gr-digital/python/digital/bindings/meas_evm_cc_python.cc
+++ b/gr-digital/python/digital/bindings/meas_evm_cc_python.cc
@@ -37,6 +37,8 @@ void bind_meas_evm_cc(py::module& m)
         .value("EVM_DB", ::gr::digital::evm_measurement_t::EVM_DB)           // 1
         .export_values();
 
+    py::implicitly_convertible<int, ::gr::digital::evm_measurement_t>();
+
     py::class_<meas_evm_cc,
                gr::sync_block,
                gr::block,

--- a/gr-digital/python/digital/bindings/metric_type_python.cc
+++ b/gr-digital/python/digital/bindings/metric_type_python.cc
@@ -36,4 +36,6 @@ void bind_metric_type(py::module& m)
         .value("TRELLIS_HARD_SYMBOL", ::gr::digital::TRELLIS_HARD_SYMBOL) // 201
         .value("TRELLIS_HARD_BIT", ::gr::digital::TRELLIS_HARD_BIT)       // 202
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::digital::trellis_metric_type_t>();
 }

--- a/gr-digital/python/digital/bindings/mpsk_snr_est_python.cc
+++ b/gr-digital/python/digital/bindings/mpsk_snr_est_python.cc
@@ -204,4 +204,6 @@ void bind_mpsk_snr_est(py::module& m)
         .value("SNR_EST_M2M4", ::gr::digital::SNR_EST_M2M4)     // 2
         .value("SNR_EST_SVR", ::gr::digital::SNR_EST_SVR)       // 3
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::digital::snr_est_type_t>();
 }

--- a/gr-digital/python/digital/bindings/timing_error_detector_type_python.cc
+++ b/gr-digital/python/digital/bindings/timing_error_detector_type_python.cc
@@ -46,4 +46,6 @@ void bind_timing_error_detector_type(py::module& m)
         .value("TED_MENGALI_AND_DANDREA_GMSK",
                ::gr::digital::TED_MENGALI_AND_DANDREA_GMSK) // 9
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::digital::ted_type>();
 }

--- a/gr-dtv/python/dtv/bindings/catv_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_config_python.cc
@@ -35,4 +35,6 @@ void bind_catv_config(py::module& m)
         .value("CATV_MOD_64QAM", ::gr::dtv::CATV_MOD_64QAM)   // 0
         .value("CATV_MOD_256QAM", ::gr::dtv::CATV_MOD_256QAM) // 1
         .export_values();
+
+    py::implicitly_convertible<int, gr::dtv::catv_constellation_t>();
 }

--- a/gr-dtv/python/dtv/bindings/dvb_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvb_config_python.cc
@@ -124,4 +124,11 @@ void bind_dvb_config(py::module& m)
         .value("GI_19_128", ::gr::dtv::GI_19_128) // 5
         .value("GI_19_256", ::gr::dtv::GI_19_256) // 6
         .export_values();
+
+    // This will allow enum values to be passed int values
+    py::implicitly_convertible<int, gr::dtv::dvb_standard_t>();
+    py::implicitly_convertible<int, gr::dtv::dvb_code_rate_t>();
+    py::implicitly_convertible<int, gr::dtv::dvb_framesize_t>();
+    py::implicitly_convertible<int, gr::dtv::dvb_constellation_t>();
+    py::implicitly_convertible<int, gr::dtv::dvb_guardinterval_t>();
 }

--- a/gr-dtv/python/dtv/bindings/dvbs2_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbs2_config_python.cc
@@ -48,4 +48,8 @@ void bind_dvbs2_config(py::module& m)
         .value("INTERPOLATION_OFF", ::gr::dtv::INTERPOLATION_OFF) // 0
         .value("INTERPOLATION_ON", ::gr::dtv::INTERPOLATION_ON)   // 1
         .export_values();
+
+    py::implicitly_convertible<int, gr::dtv::dvbs2_rolloff_factor_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbs2_pilots_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbs2_interpolation_t>();
 }

--- a/gr-dtv/python/dtv/bindings/dvbt2_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_config_python.cc
@@ -125,4 +125,22 @@ void bind_dvbt2_config(py::module& m)
         .value("BANDWIDTH_8_0_MHZ", ::gr::dtv::BANDWIDTH_8_0_MHZ)   // 4
         .value("BANDWIDTH_10_0_MHZ", ::gr::dtv::BANDWIDTH_10_0_MHZ) // 5
         .export_values();
+
+    py::implicitly_convertible<int, gr::dtv::dvbt2_rotation_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_streamtype_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_inputmode_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_extended_carrier_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_preamble_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_fftsize_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_papr_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_l1constellation_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_pilotpattern_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_version_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_reservedbiasbits_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_l1scrambled_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_misogroup_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_showlevels_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_inband_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_equalization_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt2_bandwidth_t>();
 }

--- a/gr-dtv/python/dtv/bindings/dvbt_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_config_python.cc
@@ -41,4 +41,7 @@ void bind_dvbt_config(py::module& m)
         .value("T2k", ::gr::dtv::T2k) // 0
         .value("T8k", ::gr::dtv::T8k) // 1
         .export_values();
+
+    py::implicitly_convertible<int, gr::dtv::dvbt_hierarchy_t>();
+    py::implicitly_convertible<int, gr::dtv::dvbt_transmission_mode_t>();
 }

--- a/gr-fec/python/fec/bindings/cc_common_python.cc
+++ b/gr-fec/python/fec/bindings/cc_common_python.cc
@@ -27,4 +27,6 @@ void bind_cc_common(py::module& m)
         .value("CC_TRUNCATED", ::CC_TRUNCATED)   // 2
         .value("CC_TAILBITING", ::CC_TAILBITING) // 3
         .export_values();
+
+    py::implicitly_convertible<int, ::_cc_mode_t>();
 }

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -193,4 +193,6 @@ void bind_window(py::module& m)
         .value("WIN_BARTLETT", gr::fft::window::WIN_BARTLETT)               // 6
         .value("WIN_FLATTOP", gr::fft::window::WIN_FLATTOP)                 // 7
         .export_values();
+
+    py::implicitly_convertible<int, gr::fft::window::win_type>();
 }

--- a/gr-filter/python/filter/bindings/firdes_python.cc
+++ b/gr-filter/python/filter/bindings/firdes_python.cc
@@ -46,6 +46,7 @@ void bind_firdes(py::module& m)
         .value("WIN_FLATTOP", gr::filter::firdes::WIN_FLATTOP)                 // 7
         .export_values();
 
+    py::implicitly_convertible<int, gr::filter::firdes::win_type>();
 
     firdes_class
         .def_static("window",

--- a/gr-qtgui/python/qtgui/bindings/qtgui_types_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/qtgui_types_python.cc
@@ -21,8 +21,6 @@ namespace py = pybind11;
 
 void bind_qtgui_types(py::module& m)
 {
-
-
     py::enum_<::gr::qtgui::data_type_t>(m, "data_type_t")
         .value("INT", ::gr::qtgui::INT)                 // 0
         .value("FLOAT", ::gr::qtgui::FLOAT)             // 1
@@ -34,11 +32,13 @@ void bind_qtgui_types(py::module& m)
         .value("DOUBLE_VEC", ::gr::qtgui::DOUBLE_VEC)   // 7
         .value("COMPLEX_VEC", ::gr::qtgui::COMPLEX_VEC) // 8
         .export_values();
+
     py::enum_<::gr::qtgui::graph_t>(m, "graph_t")
         .value("NUM_GRAPH_NONE", ::gr::qtgui::NUM_GRAPH_NONE)   // 0
         .value("NUM_GRAPH_HORIZ", ::gr::qtgui::NUM_GRAPH_HORIZ) // 1
         .value("NUM_GRAPH_VERT", ::gr::qtgui::NUM_GRAPH_VERT)   // 2
         .export_values();
+
     py::enum_<::gr::qtgui::intensity_t>(m, "intensity_t")
         .value("INTENSITY_COLOR_MAP_TYPE_MULTI_COLOR",
                ::gr::qtgui::INTENSITY_COLOR_MAP_TYPE_MULTI_COLOR) // 0
@@ -55,4 +55,8 @@ void bind_qtgui_types(py::module& m)
         .value("INTENSITY_COLOR_MAP_TYPE_COOL",
                ::gr::qtgui::INTENSITY_COLOR_MAP_TYPE_COOL) // 6
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::qtgui::data_type_t>();
+    py::implicitly_convertible<int, ::gr::qtgui::graph_t>();
+    py::implicitly_convertible<int, ::gr::qtgui::intensity_t>();
 }

--- a/gr-qtgui/python/qtgui/bindings/trigger_mode_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/trigger_mode_python.cc
@@ -21,16 +21,18 @@ namespace py = pybind11;
 
 void bind_trigger_mode(py::module& m)
 {
-
-
     py::enum_<::gr::qtgui::trigger_mode>(m, "trigger_mode")
         .value("TRIG_MODE_FREE", ::gr::qtgui::TRIG_MODE_FREE) // 0
         .value("TRIG_MODE_AUTO", ::gr::qtgui::TRIG_MODE_AUTO) // 1
         .value("TRIG_MODE_NORM", ::gr::qtgui::TRIG_MODE_NORM) // 2
         .value("TRIG_MODE_TAG", ::gr::qtgui::TRIG_MODE_TAG)   // 3
         .export_values();
+
     py::enum_<::gr::qtgui::trigger_slope>(m, "trigger_slope")
         .value("TRIG_SLOPE_POS", ::gr::qtgui::TRIG_SLOPE_POS) // 0
         .value("TRIG_SLOPE_NEG", ::gr::qtgui::TRIG_SLOPE_NEG) // 1
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::qtgui::trigger_mode>();
+    py::implicitly_convertible<int, ::gr::qtgui::trigger_slope>();
 }

--- a/gr-trellis/python/trellis/bindings/siso_type_python.cc
+++ b/gr-trellis/python/trellis/bindings/siso_type_python.cc
@@ -29,10 +29,10 @@ namespace py = pybind11;
 
 void bind_siso_type(py::module& m)
 {
-
-
     py::enum_<::gr::trellis::siso_type_t>(m, "siso_type_t")
         .value("TRELLIS_MIN_SUM", ::gr::trellis::TRELLIS_MIN_SUM)         // 200
         .value("TRELLIS_SUM_PRODUCT", ::gr::trellis::TRELLIS_SUM_PRODUCT) // 201
         .export_values();
+
+    py::implicitly_convertible<int, ::gr::trellis::siso_type_t>();
 }

--- a/gr-utils/bindtool/templates/generic_python_cc.mako
+++ b/gr-utils/bindtool/templates/generic_python_cc.mako
@@ -212,6 +212,8 @@ values = en['values']
 % endfor 
         .export_values()
     ;
+
+    py::implicitly_convertible<int, ${namespace['name']}::${en['name']}>();
 % endfor
 % endif
 

--- a/gr-vocoder/python/vocoder/bindings/codec2_python.cc
+++ b/gr-vocoder/python/vocoder/bindings/codec2_python.cc
@@ -46,4 +46,6 @@ void bind_codec2(py::module& m)
         .value("MODE_WB", gr::vocoder::codec2::MODE_WB)
 #endif
         .export_values();
+
+    py::implicitly_convertible<int, gr::vocoder::codec2::bit_rate>();
 }

--- a/gr-vocoder/python/vocoder/bindings/freedv_api_python.cc
+++ b/gr-vocoder/python/vocoder/bindings/freedv_api_python.cc
@@ -53,4 +53,6 @@ void bind_freedv_api(py::module& m)
         .value("SYNC_MANUAL", gr::vocoder::freedv_api::SYNC_MANUAL)
 #endif
         .export_values();
+
+    py::implicitly_convertible<int, gr::vocoder::freedv_api::freedv_modes>();
 }


### PR DESCRIPTION
With swig, there was an automatic conversion from int to enum, so ints could be passed through the python bindings.  This reenables that functionality with pybind11 ~~- if this looks acceptable, I'll do this for all the modules and it as an automatic step in binding enums.~~

UPDATE: propagated for all enums used in block parameters
Also, added to the bindtool so that `modtool bind` will add the implicit conversions

