### PR TITLE
modtool: minor cleanup makeyaml

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -139,12 +139,12 @@ namespace gr {
     if blocktype == 'source':
         inputsig = '0, 0, 0'
     else:
-        inputsig = '1, 1/* min, max nr of inputs */, sizeof(input_type)'
+        inputsig = '1 /* min inputs */, 1 /* max inputs */, sizeof(input_type)'
     endif
     if blocktype == 'sink':
         outputsig = '0, 0, 0'
     else:
-        outputsig = '1, 1/* min, max nr of outputs */, sizeof(output_type)'
+        outputsig = '1 /* min outputs */, 1 /*max outputs */, sizeof(output_type)'
     endif
 %>
     /*

--- a/gr-utils/modtool/tools/grc_yaml_generator.py
+++ b/gr-utils/modtool/tools/grc_yaml_generator.py
@@ -45,7 +45,7 @@ class GRCYAMLGenerator(object):
         str_ = ', '.join(params_list)
         self._header = (('id', f'{modname}_{blockname}'),
                         ('label', blockname.replace('_', ' ')),
-                        (f'category', '[{modname.capitalize()}]')
+                        (f'category', f'[{modname.capitalize()}]')
                        )
         self._templates = (('imports', f'import {modname}'),
                            ('make', f'{modname}.{blockname}({str_})')


### PR DESCRIPTION
Two minor cleanups in makeyaml
1) There was a missing `f` in the recent f-string conversion
2) The new comments int the default grc template caused the makeyaml parsing to create 2 inputs and 2 outputs

To test, create a simple OOT and then run `gr_modtool makeyaml blockname` and look at the generated grc yaml file