### PR TITLE
filter: remove needless empty destructors and problematic const

### DIFF
--- a/gr-filter/include/gnuradio/filter/filterbank.h
+++ b/gr-filter/include/gnuradio/filter/filterbank.h
@@ -56,8 +56,7 @@ public:
      *             Populates the filters.
      */
     filterbank(const std::vector<std::vector<float>>& taps);
-
-    ~filterbank();
+    filterbank(filterbank&&) = default;
 
     /*!
      * Update the filterbank's filter taps.

--- a/gr-filter/include/gnuradio/filter/fir_filter.h
+++ b/gr-filter/include/gnuradio/filter/fir_filter.h
@@ -26,15 +26,14 @@ class FILTER_API fir_filter
 {
 public:
     fir_filter(int decimation, const std::vector<TAP_T>& taps);
-    ~fir_filter();
 
     // Disallow copy.
     //
     // This prevents accidentally doing needless copies, not just of fir_filter,
     // but every block that contains one.
     fir_filter(const fir_filter&) = delete;
-    fir_filter(fir_filter&&) = default;
     fir_filter& operator=(const fir_filter&) = delete;
+    fir_filter(fir_filter&&) = default;
     fir_filter& operator=(fir_filter&&) = default;
 
     void set_taps(const std::vector<TAP_T>& taps);

--- a/gr-filter/include/gnuradio/filter/fir_filter_with_buffer.h
+++ b/gr-filter/include/gnuradio/filter/fir_filter_with_buffer.h
@@ -55,8 +55,6 @@ public:
     fir_filter_with_buffer_fff(fir_filter_with_buffer_fff&&) = default;
     fir_filter_with_buffer_fff& operator=(fir_filter_with_buffer_fff&&) = default;
 
-    ~fir_filter_with_buffer_fff();
-
     // MANIPULATORS
 
     /*!
@@ -157,8 +155,6 @@ public:
     fir_filter_with_buffer_ccc(fir_filter_with_buffer_ccc&&) = default;
     fir_filter_with_buffer_ccc& operator=(fir_filter_with_buffer_ccc&&) = default;
 
-    ~fir_filter_with_buffer_ccc();
-
     // MANIPULATORS
 
     /*!
@@ -258,8 +254,6 @@ public:
     fir_filter_with_buffer_ccf& operator=(const fir_filter_with_buffer_ccf&) = delete;
     fir_filter_with_buffer_ccf(fir_filter_with_buffer_ccf&&) = default;
     fir_filter_with_buffer_ccf& operator=(fir_filter_with_buffer_ccf&&) = default;
-
-    ~fir_filter_with_buffer_ccf();
 
     // MANIPULATORS
 

--- a/gr-filter/include/gnuradio/filter/iir_filter.h
+++ b/gr-filter/include/gnuradio/filter/iir_filter.h
@@ -115,8 +115,6 @@ public:
 
     iir_filter() : d_latest_n(0), d_latest_m(0) {}
 
-    ~iir_filter() {}
-
     /*!
      * \brief compute a single output value.
      * \returns the filtered input value.

--- a/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_cc.h
+++ b/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_cc.h
@@ -39,7 +39,7 @@ class FILTER_API mmse_fir_interpolator_cc
 {
 public:
     mmse_fir_interpolator_cc();
-    ~mmse_fir_interpolator_cc();
+    mmse_fir_interpolator_cc(mmse_fir_interpolator_cc&&) = default;
 
     unsigned ntaps() const;
     unsigned nsteps() const;
@@ -58,7 +58,7 @@ public:
     gr_complex interpolate(const gr_complex input[], float mu) const;
 
 protected:
-    const std::vector<kernel::fir_filter_ccf> filters;
+    std::vector<kernel::fir_filter_ccf> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_ff.h
+++ b/gr-filter/include/gnuradio/filter/mmse_fir_interpolator_ff.h
@@ -39,7 +39,7 @@ class FILTER_API mmse_fir_interpolator_ff
 {
 public:
     mmse_fir_interpolator_ff();
-    ~mmse_fir_interpolator_ff();
+    mmse_fir_interpolator_ff(mmse_fir_interpolator_ff&&) = default;
 
     unsigned ntaps() const;
     unsigned nsteps() const;
@@ -56,7 +56,7 @@ public:
     float interpolate(const float input[], float mu) const;
 
 protected:
-    const std::vector<kernel::fir_filter_fff> filters;
+    std::vector<kernel::fir_filter_fff> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_cc.h
+++ b/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_cc.h
@@ -38,7 +38,7 @@ class FILTER_API mmse_interp_differentiator_cc
 {
 public:
     mmse_interp_differentiator_cc();
-    ~mmse_interp_differentiator_cc();
+    mmse_interp_differentiator_cc(mmse_interp_differentiator_cc&&) = default;
 
     unsigned ntaps() const;
     unsigned nsteps() const;
@@ -59,7 +59,7 @@ public:
     gr_complex differentiate(const gr_complex input[], float mu) const;
 
 protected:
-    const std::vector<kernel::fir_filter_ccf> filters;
+    std::vector<kernel::fir_filter_ccf> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_ff.h
+++ b/gr-filter/include/gnuradio/filter/mmse_interp_differentiator_ff.h
@@ -37,7 +37,7 @@ class FILTER_API mmse_interp_differentiator_ff
 {
 public:
     mmse_interp_differentiator_ff();
-    ~mmse_interp_differentiator_ff();
+    mmse_interp_differentiator_ff(mmse_interp_differentiator_ff&&) = default;
 
     unsigned ntaps() const;
     unsigned nsteps() const;
@@ -58,7 +58,7 @@ public:
     float differentiate(const float input[], float mu) const;
 
 protected:
-    const std::vector<kernel::fir_filter_fff> filters;
+    std::vector<kernel::fir_filter_fff> filters;
 };
 
 } /* namespace filter */

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
@@ -131,7 +131,9 @@ public:
                           const std::vector<float>& taps,
                           unsigned int filter_size);
 
-    ~pfb_arb_resampler_ccf();
+    // Don't allow copy.
+    pfb_arb_resampler_ccf(const pfb_arb_resampler_ccf&) = delete;
+    pfb_arb_resampler_ccf& operator=(const pfb_arb_resampler_ccf&) = delete;
 
     /*!
      * Resets the filterbank's filter taps with the new prototype filter
@@ -259,7 +261,9 @@ public:
                           const std::vector<gr_complex>& taps,
                           unsigned int filter_size);
 
-    ~pfb_arb_resampler_ccc();
+    // Don't allow copy.
+    pfb_arb_resampler_ccc(const pfb_arb_resampler_ccc&) = delete;
+    pfb_arb_resampler_ccc& operator=(const pfb_arb_resampler_ccc&) = delete;
 
     /*!
      * Resets the filterbank's filter taps with the new prototype filter
@@ -448,7 +452,10 @@ public:
                           const std::vector<float>& taps,
                           unsigned int filter_size);
 
-    ~pfb_arb_resampler_fff();
+    // Don't allow copy.
+    pfb_arb_resampler_fff(const pfb_arb_resampler_fff&) = delete;
+    pfb_arb_resampler_fff& operator=(const pfb_arb_resampler_fff&) = delete;
+
 
     /*!
      * Resets the filterbank's filter taps with the new prototype filter

--- a/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
+++ b/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
@@ -108,8 +108,6 @@ public:
                          const std::vector<float>& taps,
                          bool fft_forward = false);
 
-    ~polyphase_filterbank();
-
     /*!
      * Update the filterbank's filter taps from a prototype
      * filter.

--- a/gr-filter/lib/dc_blocker_cc_impl.cc
+++ b/gr-filter/lib/dc_blocker_cc_impl.cc
@@ -29,8 +29,6 @@ moving_averager_c::moving_averager_c(int D)
 {
 }
 
-moving_averager_c::~moving_averager_c() {}
-
 gr_complex moving_averager_c::filter(gr_complex x)
 {
     d_out_d1 = d_out;
@@ -66,8 +64,6 @@ dc_blocker_cc_impl::dc_blocker_cc_impl(int D, bool long_form)
         d_delay_line = std::deque<gr_complex>(d_length - 1, gr_complex(0, 0));
     }
 }
-
-dc_blocker_cc_impl::~dc_blocker_cc_impl() {}
 
 int dc_blocker_cc_impl::group_delay()
 {

--- a/gr-filter/lib/dc_blocker_cc_impl.h
+++ b/gr-filter/lib/dc_blocker_cc_impl.h
@@ -22,7 +22,6 @@ class moving_averager_c
 {
 public:
     moving_averager_c(int D);
-    ~moving_averager_c();
 
     gr_complex filter(gr_complex x);
     gr_complex delayed_sig() { return d_out; }
@@ -46,8 +45,6 @@ private:
 
 public:
     dc_blocker_cc_impl(int D, bool long_form);
-
-    ~dc_blocker_cc_impl() override;
 
     int group_delay() override;
 

--- a/gr-filter/lib/dc_blocker_ff_impl.cc
+++ b/gr-filter/lib/dc_blocker_ff_impl.cc
@@ -25,8 +25,6 @@ moving_averager_f::moving_averager_f(int D)
 {
 }
 
-moving_averager_f::~moving_averager_f() {}
-
 float moving_averager_f::filter(float x)
 {
     d_out_d1 = d_out;
@@ -61,8 +59,6 @@ dc_blocker_ff_impl::dc_blocker_ff_impl(int D, bool long_form)
         d_delay_line = std::deque<float>(d_length - 1, 0);
     }
 }
-
-dc_blocker_ff_impl::~dc_blocker_ff_impl() {}
 
 int dc_blocker_ff_impl::group_delay()
 {

--- a/gr-filter/lib/dc_blocker_ff_impl.h
+++ b/gr-filter/lib/dc_blocker_ff_impl.h
@@ -22,7 +22,6 @@ class moving_averager_f
 {
 public:
     moving_averager_f(int D);
-    ~moving_averager_f();
 
     float filter(float x);
     float delayed_sig() { return d_out; }
@@ -46,8 +45,6 @@ private:
 
 public:
     dc_blocker_ff_impl(int D, bool long_form);
-
-    ~dc_blocker_ff_impl() override;
 
     int group_delay() override;
 

--- a/gr-filter/lib/filter_delay_fc_impl.cc
+++ b/gr-filter/lib/filter_delay_fc_impl.cc
@@ -38,8 +38,6 @@ filter_delay_fc_impl::filter_delay_fc_impl(const std::vector<float>& taps)
     set_alignment(std::max(1, alignment_multiple));
 }
 
-filter_delay_fc_impl::~filter_delay_fc_impl() {}
-
 std::vector<float> filter_delay_fc_impl::taps() { return d_fir.taps(); }
 
 void filter_delay_fc_impl::set_taps(const std::vector<float>& taps)

--- a/gr-filter/lib/filter_delay_fc_impl.h
+++ b/gr-filter/lib/filter_delay_fc_impl.h
@@ -28,7 +28,6 @@ private:
 
 public:
     filter_delay_fc_impl(const std::vector<float>& taps);
-    ~filter_delay_fc_impl() override;
 
     std::vector<float> taps();
     void set_taps(const std::vector<float>& taps);

--- a/gr-filter/lib/filterbank.cc
+++ b/gr-filter/lib/filterbank.cc
@@ -38,8 +38,6 @@ filterbank::filterbank(const std::vector<std::vector<float>>& taps)
     set_taps(d_taps);
 }
 
-filterbank::~filterbank() {}
-
 void filterbank::set_taps(const std::vector<std::vector<float>>& taps)
 {
     // Check that the number of filters is correct.

--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -34,8 +34,6 @@ filterbank_vcvcf_impl::filterbank_vcvcf_impl(const std::vector<std::vector<float
     set_history(d_ntaps + 1);
 }
 
-filterbank_vcvcf_impl::~filterbank_vcvcf_impl() {}
-
 void filterbank_vcvcf_impl::set_taps(const std::vector<std::vector<float>>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);

--- a/gr-filter/lib/filterbank_vcvcf_impl.h
+++ b/gr-filter/lib/filterbank_vcvcf_impl.h
@@ -27,7 +27,6 @@ private:
 
 public:
     filterbank_vcvcf_impl(const std::vector<std::vector<float>>& taps);
-    ~filterbank_vcvcf_impl() override;
 
     void set_taps(const std::vector<std::vector<float>>& taps) override;
     void print_taps() override;

--- a/gr-filter/lib/fir_filter.cc
+++ b/gr-filter/lib/fir_filter.cc
@@ -28,11 +28,6 @@ fir_filter<IN_T, OUT_T, TAP_T>::fir_filter(int decimation, const std::vector<TAP
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-fir_filter<IN_T, OUT_T, TAP_T>::~fir_filter()
-{
-}
-
-template <class IN_T, class OUT_T, class TAP_T>
 void fir_filter<IN_T, OUT_T, TAP_T>::set_taps(const std::vector<TAP_T>& taps)
 {
     d_ntaps = (int)taps.size();

--- a/gr-filter/lib/fir_filter_blk_impl.cc
+++ b/gr-filter/lib/fir_filter_blk_impl.cc
@@ -45,11 +45,6 @@ fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::fir_filter_blk_impl(
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::~fir_filter_blk_impl()
-{
-}
-
-template <class IN_T, class OUT_T, class TAP_T>
 void fir_filter_blk_impl<IN_T, OUT_T, TAP_T>::set_taps(const std::vector<TAP_T>& taps)
 {
     gr::thread::scoped_lock l(this->d_setlock);

--- a/gr-filter/lib/fir_filter_blk_impl.h
+++ b/gr-filter/lib/fir_filter_blk_impl.h
@@ -27,8 +27,6 @@ private:
 public:
     fir_filter_blk_impl(int decimation, const std::vector<TAP_T>& taps);
 
-    ~fir_filter_blk_impl() override;
-
     void set_taps(const std::vector<TAP_T>& taps) override;
     std::vector<TAP_T> taps() const override;
 

--- a/gr-filter/lib/fir_filter_with_buffer.cc
+++ b/gr-filter/lib/fir_filter_with_buffer.cc
@@ -32,8 +32,6 @@ fir_filter_with_buffer_fff::fir_filter_with_buffer_fff(const std::vector<float>&
     set_taps(taps);
 }
 
-fir_filter_with_buffer_fff::~fir_filter_with_buffer_fff() {}
-
 void fir_filter_with_buffer_fff::set_taps(const std::vector<float>& taps)
 {
     d_ntaps = (int)taps.size();
@@ -139,8 +137,6 @@ fir_filter_with_buffer_ccc::fir_filter_with_buffer_ccc(
     set_taps(taps);
 }
 
-fir_filter_with_buffer_ccc::~fir_filter_with_buffer_ccc() {}
-
 void fir_filter_with_buffer_ccc::set_taps(const std::vector<gr_complex>& taps)
 {
     d_ntaps = (int)taps.size();
@@ -244,8 +240,6 @@ fir_filter_with_buffer_ccf::fir_filter_with_buffer_ccf(const std::vector<float>&
 {
     set_taps(taps);
 }
-
-fir_filter_with_buffer_ccf::~fir_filter_with_buffer_ccf() {}
 
 void fir_filter_with_buffer_ccf::set_taps(const std::vector<float>& taps)
 {

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.cc
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.cc
@@ -57,11 +57,6 @@ freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::freq_xlating_fir_filter_impl(
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::~freq_xlating_fir_filter_impl()
-{
-}
-
-template <class IN_T, class OUT_T, class TAP_T>
 void freq_xlating_fir_filter_impl<IN_T, OUT_T, TAP_T>::build_composite_fir()
 {
     std::vector<gr_complex> ctaps(d_proto_taps.size());

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.h
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.h
@@ -39,7 +39,6 @@ public:
                                  const std::vector<TAP_T>& taps,
                                  double center_freq,
                                  double sampling_freq);
-    ~freq_xlating_fir_filter_impl() override;
 
     void set_center_freq(double center_freq) override;
     double center_freq() const override;

--- a/gr-filter/lib/hilbert_fc_impl.cc
+++ b/gr-filter/lib/hilbert_fc_impl.cc
@@ -38,8 +38,6 @@ hilbert_fc_impl::hilbert_fc_impl(unsigned int ntaps, firdes::win_type window, do
     set_alignment(std::max(1, alignment_multiple));
 }
 
-hilbert_fc_impl::~hilbert_fc_impl() {}
-
 int hilbert_fc_impl::work(int noutput_items,
                           gr_vector_const_void_star& input_items,
                           gr_vector_void_star& output_items)

--- a/gr-filter/lib/hilbert_fc_impl.h
+++ b/gr-filter/lib/hilbert_fc_impl.h
@@ -29,8 +29,6 @@ public:
                     firdes::win_type window = firdes::WIN_HAMMING,
                     double beta = 6.76);
 
-    ~hilbert_fc_impl() override;
-
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;

--- a/gr-filter/lib/iir_filter_ccc_impl.cc
+++ b/gr-filter/lib/iir_filter_ccc_impl.cc
@@ -37,8 +37,6 @@ iir_filter_ccc_impl::iir_filter_ccc_impl(const std::vector<gr_complex>& fftaps,
 {
 }
 
-iir_filter_ccc_impl::~iir_filter_ccc_impl() {}
-
 void iir_filter_ccc_impl::set_taps(const std::vector<gr_complex>& fftaps,
                                    const std::vector<gr_complex>& fbtaps)
 {

--- a/gr-filter/lib/iir_filter_ccc_impl.h
+++ b/gr-filter/lib/iir_filter_ccc_impl.h
@@ -29,7 +29,6 @@ public:
     iir_filter_ccc_impl(const std::vector<gr_complex>& fftaps,
                         const std::vector<gr_complex>& fbtaps,
                         bool oldstyle = true);
-    ~iir_filter_ccc_impl() override;
 
     void set_taps(const std::vector<gr_complex>& fftaps,
                   const std::vector<gr_complex>& fbtaps) override;

--- a/gr-filter/lib/iir_filter_ccd_impl.cc
+++ b/gr-filter/lib/iir_filter_ccd_impl.cc
@@ -37,8 +37,6 @@ iir_filter_ccd_impl::iir_filter_ccd_impl(const std::vector<double>& fftaps,
 {
 }
 
-iir_filter_ccd_impl::~iir_filter_ccd_impl() {}
-
 void iir_filter_ccd_impl::set_taps(const std::vector<double>& fftaps,
                                    const std::vector<double>& fbtaps)
 {

--- a/gr-filter/lib/iir_filter_ccd_impl.h
+++ b/gr-filter/lib/iir_filter_ccd_impl.h
@@ -29,7 +29,6 @@ public:
     iir_filter_ccd_impl(const std::vector<double>& fftaps,
                         const std::vector<double>& fbtaps,
                         bool oldstyle = true);
-    ~iir_filter_ccd_impl() override;
 
     void set_taps(const std::vector<double>& fftaps,
                   const std::vector<double>& fbtaps) override;

--- a/gr-filter/lib/iir_filter_ccf_impl.cc
+++ b/gr-filter/lib/iir_filter_ccf_impl.cc
@@ -37,8 +37,6 @@ iir_filter_ccf_impl::iir_filter_ccf_impl(const std::vector<float>& fftaps,
 {
 }
 
-iir_filter_ccf_impl::~iir_filter_ccf_impl() {}
-
 void iir_filter_ccf_impl::set_taps(const std::vector<float>& fftaps,
                                    const std::vector<float>& fbtaps)
 {

--- a/gr-filter/lib/iir_filter_ccf_impl.h
+++ b/gr-filter/lib/iir_filter_ccf_impl.h
@@ -29,7 +29,6 @@ public:
     iir_filter_ccf_impl(const std::vector<float>& fftaps,
                         const std::vector<float>& fbtaps,
                         bool oldstyle = true);
-    ~iir_filter_ccf_impl() override;
 
     void set_taps(const std::vector<float>& fftaps,
                   const std::vector<float>& fbtaps) override;

--- a/gr-filter/lib/iir_filter_ccz_impl.cc
+++ b/gr-filter/lib/iir_filter_ccz_impl.cc
@@ -37,8 +37,6 @@ iir_filter_ccz_impl::iir_filter_ccz_impl(const std::vector<gr_complexd>& fftaps,
 {
 }
 
-iir_filter_ccz_impl::~iir_filter_ccz_impl() {}
-
 void iir_filter_ccz_impl::set_taps(const std::vector<gr_complexd>& fftaps,
                                    const std::vector<gr_complexd>& fbtaps)
 {

--- a/gr-filter/lib/iir_filter_ccz_impl.h
+++ b/gr-filter/lib/iir_filter_ccz_impl.h
@@ -29,7 +29,6 @@ public:
     iir_filter_ccz_impl(const std::vector<gr_complexd>& fftaps,
                         const std::vector<gr_complexd>& fbtaps,
                         bool oldstyle = true);
-    ~iir_filter_ccz_impl() override;
 
     void set_taps(const std::vector<gr_complexd>& fftaps,
                   const std::vector<gr_complexd>& fbtaps) override;

--- a/gr-filter/lib/iir_filter_ffd_impl.cc
+++ b/gr-filter/lib/iir_filter_ffd_impl.cc
@@ -37,8 +37,6 @@ iir_filter_ffd_impl::iir_filter_ffd_impl(const std::vector<double>& fftaps,
 {
 }
 
-iir_filter_ffd_impl::~iir_filter_ffd_impl() {}
-
 void iir_filter_ffd_impl::set_taps(const std::vector<double>& fftaps,
                                    const std::vector<double>& fbtaps)
 {

--- a/gr-filter/lib/iir_filter_ffd_impl.h
+++ b/gr-filter/lib/iir_filter_ffd_impl.h
@@ -29,7 +29,6 @@ public:
     iir_filter_ffd_impl(const std::vector<double>& fftaps,
                         const std::vector<double>& fbtaps,
                         bool oldstyle = true);
-    ~iir_filter_ffd_impl() override;
 
     void set_taps(const std::vector<double>& fftaps,
                   const std::vector<double>& fbtaps) override;

--- a/gr-filter/lib/interp_fir_filter_impl.cc
+++ b/gr-filter/lib/interp_fir_filter_impl.cc
@@ -58,11 +58,6 @@ interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::interp_fir_filter_impl(
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::~interp_fir_filter_impl()
-{
-}
-
-template <class IN_T, class OUT_T, class TAP_T>
 void interp_fir_filter_impl<IN_T, OUT_T, TAP_T>::set_taps(const std::vector<TAP_T>& taps)
 {
     d_new_taps = taps;

--- a/gr-filter/lib/interp_fir_filter_impl.h
+++ b/gr-filter/lib/interp_fir_filter_impl.h
@@ -32,8 +32,6 @@ private:
 public:
     interp_fir_filter_impl(unsigned interpolation, const std::vector<TAP_T>& taps);
 
-    ~interp_fir_filter_impl() override;
-
     void set_taps(const std::vector<TAP_T>& taps) override;
     std::vector<TAP_T> taps() const override;
 

--- a/gr-filter/lib/ival_decimator_impl.cc
+++ b/gr-filter/lib/ival_decimator_impl.cc
@@ -43,11 +43,6 @@ ival_decimator_impl::ival_decimator_impl(int decimation, int data_size)
     gr::block::set_output_multiple(2);
 }
 
-/*
- * Our virtual destructor.
- */
-ival_decimator_impl::~ival_decimator_impl() {}
-
 int ival_decimator_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)

--- a/gr-filter/lib/ival_decimator_impl.h
+++ b/gr-filter/lib/ival_decimator_impl.h
@@ -24,7 +24,6 @@ private:
 
 public:
     ival_decimator_impl(int decimation, int data_size);
-    ~ival_decimator_impl() override;
 
     // Where all the action really happens
     int work(int noutput_items,

--- a/gr-filter/lib/mmse_fir_interpolator_cc.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_cc.cc
@@ -34,8 +34,6 @@ std::vector<kernel::fir_filter_ccf> build_filters()
 
 mmse_fir_interpolator_cc::mmse_fir_interpolator_cc() : filters(build_filters()) {}
 
-mmse_fir_interpolator_cc::~mmse_fir_interpolator_cc() {}
-
 unsigned mmse_fir_interpolator_cc::ntaps() const { return NTAPS; }
 
 unsigned mmse_fir_interpolator_cc::nsteps() const { return NSTEPS; }

--- a/gr-filter/lib/mmse_fir_interpolator_ff.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_ff.cc
@@ -34,8 +34,6 @@ std::vector<kernel::fir_filter_fff> build_filters()
 
 mmse_fir_interpolator_ff::mmse_fir_interpolator_ff() : filters(build_filters()) {}
 
-mmse_fir_interpolator_ff::~mmse_fir_interpolator_ff() {}
-
 unsigned mmse_fir_interpolator_ff::ntaps() const { return NTAPS; }
 
 unsigned mmse_fir_interpolator_ff::nsteps() const { return NSTEPS; }

--- a/gr-filter/lib/mmse_interp_differentiator_cc.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_cc.cc
@@ -37,8 +37,6 @@ mmse_interp_differentiator_cc::mmse_interp_differentiator_cc() : filters(build_f
 {
 }
 
-mmse_interp_differentiator_cc::~mmse_interp_differentiator_cc() {}
-
 unsigned mmse_interp_differentiator_cc::ntaps() const { return DNTAPS; }
 
 unsigned mmse_interp_differentiator_cc::nsteps() const { return DNSTEPS; }

--- a/gr-filter/lib/mmse_interp_differentiator_ff.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_ff.cc
@@ -36,8 +36,6 @@ mmse_interp_differentiator_ff::mmse_interp_differentiator_ff() : filters(build_f
 {
 }
 
-mmse_interp_differentiator_ff::~mmse_interp_differentiator_ff() {}
-
 unsigned mmse_interp_differentiator_ff::ntaps() const { return DNTAPS; }
 
 unsigned mmse_interp_differentiator_ff::nsteps() const { return DNSTEPS; }

--- a/gr-filter/lib/mmse_interpolator_cc_impl.cc
+++ b/gr-filter/lib/mmse_interpolator_cc_impl.cc
@@ -45,8 +45,6 @@ mmse_interpolator_cc_impl::mmse_interpolator_cc_impl(float phase_shift,
     set_inverse_relative_rate(d_mu_inc);
 }
 
-mmse_interpolator_cc_impl::~mmse_interpolator_cc_impl() {}
-
 void mmse_interpolator_cc_impl::forecast(int noutput_items,
                                          gr_vector_int& ninput_items_required)
 {

--- a/gr-filter/lib/mmse_interpolator_cc_impl.h
+++ b/gr-filter/lib/mmse_interpolator_cc_impl.h
@@ -26,7 +26,6 @@ private:
 
 public:
     mmse_interpolator_cc_impl(float phase_shift, float interp_ratio);
-    ~mmse_interpolator_cc_impl() override;
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
     int general_work(int noutput_items,

--- a/gr-filter/lib/mmse_interpolator_ff_impl.cc
+++ b/gr-filter/lib/mmse_interpolator_ff_impl.cc
@@ -45,8 +45,6 @@ mmse_interpolator_ff_impl::mmse_interpolator_ff_impl(float phase_shift,
     set_inverse_relative_rate(d_mu_inc);
 }
 
-mmse_interpolator_ff_impl::~mmse_interpolator_ff_impl() {}
-
 void mmse_interpolator_ff_impl::forecast(int noutput_items,
                                          gr_vector_int& ninput_items_required)
 {

--- a/gr-filter/lib/mmse_interpolator_ff_impl.h
+++ b/gr-filter/lib/mmse_interpolator_ff_impl.h
@@ -26,7 +26,6 @@ private:
 
 public:
     mmse_interpolator_ff_impl(float phase_shift, float interp_ratio);
-    ~mmse_interpolator_ff_impl() override;
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
     int general_work(int noutput_items,

--- a/gr-filter/lib/mmse_resampler_cc_impl.cc
+++ b/gr-filter/lib/mmse_resampler_cc_impl.cc
@@ -42,8 +42,6 @@ mmse_resampler_cc_impl::mmse_resampler_cc_impl(float phase_shift, float resamp_r
                     [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
-mmse_resampler_cc_impl::~mmse_resampler_cc_impl() {}
-
 void mmse_resampler_cc_impl::handle_msg(pmt::pmt_t msg)
 {
     if (!pmt::is_dict(msg))

--- a/gr-filter/lib/mmse_resampler_cc_impl.h
+++ b/gr-filter/lib/mmse_resampler_cc_impl.h
@@ -26,7 +26,6 @@ private:
 
 public:
     mmse_resampler_cc_impl(float phase_shift, float resamp_ratio);
-    ~mmse_resampler_cc_impl() override;
 
     void handle_msg(pmt::pmt_t msg);
 

--- a/gr-filter/lib/mmse_resampler_ff_impl.cc
+++ b/gr-filter/lib/mmse_resampler_ff_impl.cc
@@ -43,8 +43,6 @@ mmse_resampler_ff_impl::mmse_resampler_ff_impl(float phase_shift, float resamp_r
                     [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 }
 
-mmse_resampler_ff_impl::~mmse_resampler_ff_impl() {}
-
 void mmse_resampler_ff_impl::handle_msg(pmt::pmt_t msg)
 {
     if (!pmt::is_dict(msg))

--- a/gr-filter/lib/mmse_resampler_ff_impl.h
+++ b/gr-filter/lib/mmse_resampler_ff_impl.h
@@ -26,7 +26,6 @@ private:
 
 public:
     mmse_resampler_ff_impl(float phase_shift, float resamp_ratio);
-    ~mmse_resampler_ff_impl() override;
 
     void handle_msg(pmt::pmt_t msg);
 

--- a/gr-filter/lib/pfb_arb_resampler.cc
+++ b/gr-filter/lib/pfb_arb_resampler.cc
@@ -75,8 +75,6 @@ pfb_arb_resampler_ccf::pfb_arb_resampler_ccf(float rate,
     d_est_phase_change = d_last_filter - (end_filter + accum_frac);
 }
 
-pfb_arb_resampler_ccf::~pfb_arb_resampler_ccf() {}
-
 void pfb_arb_resampler_ccf::create_taps(const std::vector<float>& newtaps,
                                         std::vector<std::vector<float>>& ourtaps,
                                         std::vector<fir_filter_ccf>& ourfilter)
@@ -266,8 +264,6 @@ pfb_arb_resampler_ccc::pfb_arb_resampler_ccc(float rate,
 
     d_est_phase_change = d_last_filter - (end_filter + accum_frac);
 }
-
-pfb_arb_resampler_ccc::~pfb_arb_resampler_ccc() {}
 
 void pfb_arb_resampler_ccc::create_taps(const std::vector<gr_complex>& newtaps,
                                         std::vector<std::vector<gr_complex>>& ourtaps,
@@ -461,8 +457,6 @@ pfb_arb_resampler_fff::pfb_arb_resampler_fff(float rate,
 
     d_est_phase_change = d_last_filter - (end_filter + accum_frac);
 }
-
-pfb_arb_resampler_fff::~pfb_arb_resampler_fff() {}
 
 void pfb_arb_resampler_fff::create_taps(const std::vector<float>& newtaps,
                                         std::vector<std::vector<float>>& ourtaps,

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
@@ -39,8 +39,6 @@ pfb_arb_resampler_ccc_impl::pfb_arb_resampler_ccc_impl(
     set_relative_rate(rate);
 }
 
-pfb_arb_resampler_ccc_impl::~pfb_arb_resampler_ccc_impl() {}
-
 void pfb_arb_resampler_ccc_impl::forecast(int noutput_items,
                                           gr_vector_int& ninput_items_required)
 {

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
@@ -31,8 +31,6 @@ public:
                                const std::vector<gr_complex>& taps,
                                unsigned int filter_size);
 
-    ~pfb_arb_resampler_ccc_impl() override;
-
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 
     void set_taps(const std::vector<gr_complex>& taps) override;

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
@@ -41,8 +41,6 @@ pfb_arb_resampler_ccf_impl::pfb_arb_resampler_ccf_impl(float rate,
     set_relative_rate(rate);
 }
 
-pfb_arb_resampler_ccf_impl::~pfb_arb_resampler_ccf_impl() {}
-
 void pfb_arb_resampler_ccf_impl::forecast(int noutput_items,
                                           gr_vector_int& ninput_items_required)
 {

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
@@ -31,8 +31,6 @@ public:
                                const std::vector<float>& taps,
                                unsigned int filter_size);
 
-    ~pfb_arb_resampler_ccf_impl() override;
-
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 
     void set_taps(const std::vector<float>& taps) override;

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
@@ -41,8 +41,6 @@ pfb_arb_resampler_fff_impl::pfb_arb_resampler_fff_impl(float rate,
     set_relative_rate(rate);
 }
 
-pfb_arb_resampler_fff_impl::~pfb_arb_resampler_fff_impl() {}
-
 void pfb_arb_resampler_fff_impl::forecast(int noutput_items,
                                           gr_vector_int& ninput_items_required)
 {

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.h
@@ -31,8 +31,6 @@ public:
                                const std::vector<float>& taps,
                                unsigned int filter_size);
 
-    ~pfb_arb_resampler_fff_impl() override;
-
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 
     void set_taps(const std::vector<float>& taps) override;

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.cc
@@ -91,8 +91,6 @@ pfb_channelizer_ccf_impl::pfb_channelizer_ccf_impl(unsigned int nfilts,
     set_tag_propagation_policy(TPP_ONE_TO_ONE);
 }
 
-pfb_channelizer_ccf_impl::~pfb_channelizer_ccf_impl() {}
-
 void pfb_channelizer_ccf_impl::set_taps(const std::vector<float>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.h
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.h
@@ -37,8 +37,6 @@ public:
                              const std::vector<float>& taps,
                              float oversample_rate);
 
-    ~pfb_channelizer_ccf_impl() override;
-
     void set_taps(const std::vector<float>& taps) override;
     void print_taps() override;
     std::vector<std::vector<float>> taps() const override;

--- a/gr-filter/lib/pfb_decimator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.cc
@@ -72,8 +72,6 @@ bool pfb_decimator_ccf_impl::start()
 
 bool pfb_decimator_ccf_impl::stop() { return block::stop(); }
 
-pfb_decimator_ccf_impl::~pfb_decimator_ccf_impl() {}
-
 void pfb_decimator_ccf_impl::set_taps(const std::vector<float>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);

--- a/gr-filter/lib/pfb_decimator_ccf_impl.h
+++ b/gr-filter/lib/pfb_decimator_ccf_impl.h
@@ -53,8 +53,6 @@ public:
                            bool use_fft_rotator = true,
                            bool use_fft_filters = true);
 
-    ~pfb_decimator_ccf_impl() override;
-
     // No copy because d_tmp.
     pfb_decimator_ccf_impl(const pfb_decimator_ccf_impl&) = delete;
     pfb_decimator_ccf_impl& operator=(const pfb_decimator_ccf_impl&) = delete;

--- a/gr-filter/lib/pfb_interpolator_ccf_impl.cc
+++ b/gr-filter/lib/pfb_interpolator_ccf_impl.cc
@@ -38,8 +38,6 @@ pfb_interpolator_ccf_impl::pfb_interpolator_ccf_impl(unsigned int interp,
     set_history(d_taps_per_filter);
 }
 
-pfb_interpolator_ccf_impl::~pfb_interpolator_ccf_impl() {}
-
 void pfb_interpolator_ccf_impl::set_taps(const std::vector<float>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);

--- a/gr-filter/lib/pfb_interpolator_ccf_impl.h
+++ b/gr-filter/lib/pfb_interpolator_ccf_impl.h
@@ -32,8 +32,6 @@ private:
 public:
     pfb_interpolator_ccf_impl(unsigned int interp, const std::vector<float>& taps);
 
-    ~pfb_interpolator_ccf_impl() override;
-
     void set_taps(const std::vector<float>& taps) override;
     void print_taps() override;
     std::vector<std::vector<float>> taps() const override;

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -66,8 +66,6 @@ pfb_synthesizer_ccf_impl::pfb_synthesizer_ccf_impl(unsigned int numchans,
     set_output_multiple(d_numchans);
 }
 
-pfb_synthesizer_ccf_impl::~pfb_synthesizer_ccf_impl() {}
-
 void pfb_synthesizer_ccf_impl::set_taps(const std::vector<float>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.h
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.h
@@ -53,8 +53,6 @@ public:
     pfb_synthesizer_ccf_impl(unsigned int numchans,
                              const std::vector<float>& taps,
                              bool twox);
-    ~pfb_synthesizer_ccf_impl() override;
-
     void set_taps(const std::vector<float>& taps) override;
     std::vector<std::vector<float>> taps() const override;
     void print_taps() override;

--- a/gr-filter/lib/polyphase_filterbank.cc
+++ b/gr-filter/lib/polyphase_filterbank.cc
@@ -40,8 +40,6 @@ polyphase_filterbank::polyphase_filterbank(unsigned int nfilts,
     d_fft = new fft::fft_complex_rev(d_nfilts);
 }
 
-polyphase_filterbank::~polyphase_filterbank() {}
-
 void polyphase_filterbank::set_taps(const std::vector<float>& taps)
 {
     unsigned int i, j;

--- a/gr-filter/lib/rational_resampler_base_impl.cc
+++ b/gr-filter/lib/rational_resampler_base_impl.cc
@@ -61,11 +61,6 @@ rational_resampler_base_impl<IN_T, OUT_T, TAP_T>::rational_resampler_base_impl(
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-rational_resampler_base_impl<IN_T, OUT_T, TAP_T>::~rational_resampler_base_impl()
-{
-}
-
-template <class IN_T, class OUT_T, class TAP_T>
 void rational_resampler_base_impl<IN_T, OUT_T, TAP_T>::set_taps(
     const std::vector<TAP_T>& taps)
 {

--- a/gr-filter/lib/rational_resampler_base_impl.h
+++ b/gr-filter/lib/rational_resampler_base_impl.h
@@ -36,8 +36,6 @@ public:
                                  unsigned decimation,
                                  const std::vector<TAP_T>& taps);
 
-    ~rational_resampler_base_impl() override;
-
     unsigned history() const { return d_history; }
     void set_history(unsigned history) { d_history = history; }
 

--- a/gr-filter/lib/single_pole_iir_filter_cc_impl.cc
+++ b/gr-filter/lib/single_pole_iir_filter_cc_impl.cc
@@ -36,8 +36,6 @@ single_pole_iir_filter_cc_impl::single_pole_iir_filter_cc_impl(double alpha,
     set_taps(alpha);
 }
 
-single_pole_iir_filter_cc_impl::~single_pole_iir_filter_cc_impl() {}
-
 void single_pole_iir_filter_cc_impl::set_taps(double alpha)
 {
     for (unsigned int i = 0; i < d_vlen; i++) {

--- a/gr-filter/lib/single_pole_iir_filter_cc_impl.h
+++ b/gr-filter/lib/single_pole_iir_filter_cc_impl.h
@@ -28,7 +28,6 @@ private:
 
 public:
     single_pole_iir_filter_cc_impl(double alpha, unsigned int vlen);
-    ~single_pole_iir_filter_cc_impl() override;
 
     void set_taps(double alpha) override;
 

--- a/gr-filter/lib/single_pole_iir_filter_ff_impl.cc
+++ b/gr-filter/lib/single_pole_iir_filter_ff_impl.cc
@@ -35,8 +35,6 @@ single_pole_iir_filter_ff_impl::single_pole_iir_filter_ff_impl(double alpha,
     set_taps(alpha);
 }
 
-single_pole_iir_filter_ff_impl::~single_pole_iir_filter_ff_impl() {}
-
 void single_pole_iir_filter_ff_impl::set_taps(double alpha)
 {
     for (unsigned int i = 0; i < d_vlen; i++) {

--- a/gr-filter/lib/single_pole_iir_filter_ff_impl.h
+++ b/gr-filter/lib/single_pole_iir_filter_ff_impl.h
@@ -27,7 +27,6 @@ private:
 
 public:
     single_pole_iir_filter_ff_impl(double alpha, unsigned int vlen);
-    ~single_pole_iir_filter_ff_impl() override;
 
     void set_taps(double alpha) override;
 

--- a/gr-filter/python/filter/bindings/filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(be850101db6157f52549d1616dc228a0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e57eee381c9c8a096d6ee5976be9287e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/fir_filter_python.cc
+++ b/gr-filter/python/filter/bindings/fir_filter_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fir_filter.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(48049333c1cea0b522a397159553f186)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7c2f5f583b22ffa30bb7cc803bc4fbec)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/fir_filter_with_buffer_python.cc
+++ b/gr-filter/python/filter/bindings/fir_filter_with_buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fir_filter_with_buffer.h) */
-/* BINDTOOL_HEADER_FILE_HASH(fc7229741eab002c302113309e5fcaed)                     */
+/* BINDTOOL_HEADER_FILE_HASH(867fb3442793a11d1d1833c21c086002)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/iir_filter_python.cc
+++ b/gr-filter/python/filter/bindings/iir_filter_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(iir_filter.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1d61e54feed01fda0c8badd2c19d566d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(13dec42f09e2dd232a8c7872db83c6a8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/mmse_fir_interpolator_cc_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_fir_interpolator_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_fir_interpolator_cc.h) */
-/* BINDTOOL_HEADER_FILE_HASH(c618917f7ba9048d2b73da399ca5cf60)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0490610d46f74dce45c062d4aa295314)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/mmse_fir_interpolator_ff_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_fir_interpolator_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_fir_interpolator_ff.h) */
-/* BINDTOOL_HEADER_FILE_HASH(a5230c4b6ad2c4241956c24184a499c5)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0bba83011a10ac652b4b4e900eaf77bf)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/mmse_interp_differentiator_cc_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_interp_differentiator_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_interp_differentiator_cc.h) */
-/* BINDTOOL_HEADER_FILE_HASH(7aceb77ae6aefbaff71960b27310ffe1)                     */
+/* BINDTOOL_HEADER_FILE_HASH(963926ec98344bc64362fcdd3c71060d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/mmse_interp_differentiator_ff_python.cc
+++ b/gr-filter/python/filter/bindings/mmse_interp_differentiator_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(mmse_interp_differentiator_ff.h) */
-/* BINDTOOL_HEADER_FILE_HASH(8f07bad55ded4360fdf5b74807e0635b)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7b1847b569d6e106905d152901e5cb8c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_arb_resampler.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(7cc3fce37ee5e8d755875d6741d1bac5)                     */
+/* BINDTOOL_HEADER_FILE_HASH(20d30db553c5a0baf55e49dcb9fd7f47)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polyphase_filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8dc0395542b870d22b4d596530e6fc7d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(74cd61e5d733f0b33073025d04d5e48e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
You can't move from a const object, so unfortunately it's not possible
to keep constness on these.

This should fix #3757