### PR TITLE
uhd: Use integer sample rates to fix decimation calculation

### DIFF
--- a/gr-uhd/apps/uhd_rx_nogui
+++ b/gr-uhd/apps/uhd_rx_nogui
@@ -59,9 +59,9 @@ from gnuradio.eng_option import eng_option
 
 # (device_rate, channel_rate, audio_rate, channel_pass, channel_stop, demod)
 DEMOD_PARAMS = {
-                'AM'  : (256e3,  16e3, 16e3,  5000,   8000, analog.demod_10k0a3e_cf),
-                'FM'  : (256e3,  32e3,  8e3,  8000,   9000, analog.demod_20k0f3e_cf),
-                'WFM' : (320e3, 320e3, 32e3, 80000, 115000, analog.demod_200kf3e_cf)
+                'AM'  : (256000,  16000, 16000,  5000,   8000, analog.demod_10k0a3e_cf),
+                'FM'  : (256000,  32000,  8000,  8000,   9000, analog.demod_20k0f3e_cf),
+                'WFM' : (320000, 320000, 32000, 80000, 115000, analog.demod_200kf3e_cf)
                }
 
 class uhd_src(gr.hier_block2):


### PR DESCRIPTION
While working on #3896, I noticed that `uhd_rx_nogui` always fails with the following error:

```
Traceback (most recent call last):
  File "/home/argilo/prefix_39/bin/uhd_rx_nogui", line 255, in <module>
    main()
  File "/home/argilo/prefix_39/bin/uhd_rx_nogui", line 248, in main
    tb = app_top_block(args)
  File "/home/argilo/prefix_39/bin/uhd_rx_nogui", line 146, in __init__
    chan = filter.freq_xlating_fir_filter_ccf(
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. gnuradio.filter.filter_python.freq_xlating_fir_filter_ccf(decimation: int, taps: List[float], center_freq: float, sampling_freq: float)

Invoked with: 1.0, [-0.0028998091913349624, -0.0019897864952883484, 0.00681913596753969, -0.001369043765786086, -0.012918909418688167, 0.012708339901648555, 0.014389730841722823, -0.03482379244255296, 0.0017205613057421781, 0.06343720171449702, -0.058170928902818525, -0.0883602316174735, 0.30016635504946193, 0.5982551815435497, 0.30016635504946193, -0.0883602316174735, -0.058170928902818525, 0.06343720171449702, 0.0017205613057421781, -0.03482379244255296, 0.014389730841722823, 0.012708339901648555, -0.012918909418688167, -0.001369043765786086, 0.00681913596753969, -0.0019897864952883484, -0.0028998091913349624], 0.0, 320000.0
```
This happens because `device_rate` and `channel_rate` are floats here:

https://github.com/gnuradio/gnuradio/blob/2025e70872dcbfa0039ec000ea11d98d34d6cf70/gr-uhd/apps/uhd_rx_nogui#L60-L65

These values are then divided to produce `channel_decim`, which is passed into `freq_xlating_fir_filter_ccf`, which expects an integer:

https://github.com/gnuradio/gnuradio/blob/2025e70872dcbfa0039ec000ea11d98d34d6cf70/gr-uhd/apps/uhd_rx_nogui#L135-L150

To fix this, I changed the floats to integers in `DEMOD_PARAMS`.