### PR TITLE
add_blk: only memcpy for exactly 1 input, complex specialization

### DIFF
--- a/gr-blocks/lib/add_blk_impl.cc
+++ b/gr-blocks/lib/add_blk_impl.cc
@@ -27,6 +27,7 @@ typename add_blk<T>::sptr add_blk<T>::make(size_t vlen)
 }
 
 
+// Float implementation
 template <>
 add_blk_impl<float>::add_blk_impl(size_t vlen)
     : sync_block("add_ff",
@@ -43,12 +44,25 @@ int add_blk_impl<float>::work(int noutput_items,
                               gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
-    float* out = (float*)output_items[0];
+    float* out = static_cast<float*>(output_items[0]);
     int noi = d_vlen * noutput_items;
 
-    memcpy(out, input_items[0], noi * sizeof(float));
-    for (size_t i = 1; i < input_items.size(); i++)
-        volk_32f_x2_add_32f(out, out, (const float*)input_items[i], noi);
+    // strange single-input add case
+    if (input_items.size() == 1) {
+        memcpy(out, input_items[0], noi * sizeof(float));
+        return noutput_items;
+    }
+
+    // for two inputs, add up the two inputs into the output
+    volk_32f_x2_add_32f(out,
+                        static_cast<const float*>(input_items[0]),
+                        static_cast<const float*>(input_items[1]),
+                        noi);
+
+    // for more inputs, add the rest on top
+    for (size_t i = 2; i < input_items.size(); i++) {
+        volk_32f_x2_add_32f(out, out, static_cast<const float*>(input_items[i]), noi);
+    }
     return noutput_items;
 }
 

--- a/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
+++ b/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
@@ -301,10 +301,11 @@ class qa_ofdm_chanest_vcvc (gr_unittest.TestCase):
 
         def run_flow_graph(sync_sym1, sync_sym2, data_sym):
             top_block = gr.top_block()
-            carr_offset = random.randint(-max_offset / 2, max_offset / 2) * 2
+            carr_offset = random.randint(-max_offset // 2, max_offset // 2) * 2
             tx_data = shift_tuple(sync_sym1, carr_offset) + \
                 shift_tuple(sync_sym2, carr_offset) + \
-                shift_tuple(data_sym, carr_offset)
+                shift_tuple(data_sym, carr_offset) + \
+                tuple((0,) * fft_len)
             channel = [
                 rand_range(
                     min_chan_ampl,


### PR DESCRIPTION
fixes #986

This is ... kinda obvious.