### PR TITLE
Fix examples that use wavfile_sink

### DIFF
--- a/gnuradio-runtime/examples/mp-sched/wfm_rcv_pll_to_wav.py
+++ b/gnuradio-runtime/examples/mp-sched/wfm_rcv_pll_to_wav.py
@@ -64,7 +64,8 @@ class wfm_rx_block (gr.top_block):
 
         # wave file as final sink
         if 1:
-            sink = blocks.wavfile_sink(args.output_file, 2, int(audio_rate), 16)
+            sink = blocks.wavfile_sink(args.output_file, 2, int(audio_rate),
+                                       blocks.FORMAT_WAV, blocks.FORMAT_PCM_16)
         else:
             sink = audio.sink (int (audio_rate),
                                args.audio_output,

--- a/gr-audio/examples/python/dial_tone_wav.py
+++ b/gr-audio/examples/python/dial_tone_wav.py
@@ -42,7 +42,8 @@ class my_top_block(gr.top_block):
         src1 = analog.sig_source_f(sample_rate, analog.GR_SIN_WAVE, 440, ampl)
         head0 = blocks.head(gr.sizeof_float, int(args.samples))
         head1 = blocks.head(gr.sizeof_float, int(args.samples))
-        dst = blocks.wavfile_sink(args.file_name[0], 2, int(args.sample_rate), 16)
+        dst = blocks.wavfile_sink(args.file_name[0], 2, int(args.sample_rate),
+                                  blocks.FORMAT_WAV, blocks.FORMAT_PCM_16)
 
         self.connect(src0, head0, (dst, 0))
         self.connect(src1, head1, (dst, 1))


### PR DESCRIPTION
The recent libsndfile transition in #3600 changed the API of the `wavfile_sink` block, so the two examples that use it need to be updated.