### PR TITLE
Remove unused gru imports

### DIFF
--- a/gnuradio-runtime/examples/mp-sched/wfm_rcv_pll_to_wav.py
+++ b/gnuradio-runtime/examples/mp-sched/wfm_rcv_pll_to_wav.py
@@ -8,7 +8,7 @@
 #
 #
 
-from gnuradio import gr, gru, eng_notation, filter
+from gnuradio import gr, eng_notation, filter
 from gnuradio import audio
 from gnuradio import analog
 from gnuradio import blocks

--- a/gr-digital/python/digital/crc.py
+++ b/gr-digital/python/digital/crc.py
@@ -7,7 +7,6 @@
 #
 #
 
-from gnuradio import gru
 from . import digital_python as digital
 import struct
 


### PR DESCRIPTION
This is a continuation of the gru cleanup (#1591).

Neither of these files use the gru module anymore. I've tested that they work correctly after removing the unused imports.