### PR TITLE
usrp_block: pybind: add missing bind for cmd_power_key

### DIFF
--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
@@ -207,6 +207,9 @@ static const char* __doc_gr_uhd_cmd_chan_key = R"doc()doc";
 static const char* __doc_gr_uhd_cmd_gain_key = R"doc()doc";
 
 
+static const char* __doc_gr_uhd_cmd_power_key = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_cmd_freq_key = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -433,6 +433,9 @@ void bind_usrp_block(py::module& m)
     m.def("cmd_gain_key", &::gr::uhd::cmd_gain_key, D(cmd_gain_key));
 
 
+    m.def("cmd_power_key", &::gr::uhd::cmd_power_key, D(cmd_power_key));
+
+
     m.def("cmd_freq_key", &::gr::uhd::cmd_freq_key, D(cmd_freq_key));
 
 


### PR DESCRIPTION
When I try to fix the problem in https://github.com/gnuradio/gnuradio/pull/3887, I found that it seems missing cmd_power_key python binding.