### PR TITLE
grc: Save config before execution and update recent file sub-menu.

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -614,7 +614,7 @@ class Application(Gtk.Application):
                     main.new_page(file_path, show=(i == 0))
                     self.config.add_recent_file(file_path)
                     main.tool_bar.refresh_submenus()
-                    #main.menu_bar.refresh_submenus()
+                    main.menu.refresh_submenus()
         elif action == Actions.FLOW_GRAPH_OPEN_QSS_THEME:
             file_paths = FileDialogs.OpenQSS(main, self.platform.config.install_prefix +
                                              '/share/gnuradio/themes/').run()
@@ -625,7 +625,9 @@ class Application(Gtk.Application):
         elif action == Actions.FLOW_GRAPH_OPEN_RECENT:
             file_path = str(args[0])[1:-1]
             main.new_page(file_path, show=True)
+            self.config.add_recent_file(file_path)
             main.tool_bar.refresh_submenus()
+            main.menu.refresh_submenus()
         elif action == Actions.FLOW_GRAPH_SAVE:
             #read-only or undefined file path, do save-as
             if page.get_read_only() or not page.file_path:
@@ -658,8 +660,7 @@ class Application(Gtk.Application):
                     page.saved = False
                 self.config.add_recent_file(file_path)
                 main.tool_bar.refresh_submenus()
-                #TODO
-                #main.menu_bar.refresh_submenus()
+                main.menu.refresh_submenus()
         elif action == Actions.FLOW_GRAPH_SAVE_COPY:
             try:
                 if not page.file_path:
@@ -725,6 +726,8 @@ class Application(Gtk.Application):
                             Dialogs.show_missing_xterm(main, xterm)
                         self.config.xterm_missing(xterm)
                     if page.saved and page.file_path:
+                        # Save config before exection
+                        self.config.save()
                         Executor.ExecFlowGraphThread(
                             flow_graph_page=page,
                             xterm_executable=xterm,

--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -106,18 +106,13 @@ class SubMenuHelper(object):
     def __init__(self):
         self.submenus = {}
 
-    def build_submenu(self, name, obj, set_func):
+    def build_submenu(self, name, parent_obj, obj_idx, obj, set_func):
         # Get the correct helper function
         create_func = getattr(self, "create_{}".format(name))
         # Save the helper functions for rebuilding the menu later
-        self.submenus[name] = (create_func, obj, set_func)
+        self.submenus[name] = (create_func, parent_obj, obj_idx, obj, set_func)
         # Actually build the menu
         set_func(obj, create_func())
-
-    def refresh_submenus(self):
-        for name in self.submenus:
-            create_func, obj, set_func = self.submenus[name]
-            set_func(obj, create_func())
 
     def create_flow_graph_new_type(self):
         """ Different flowgraph types """
@@ -169,7 +164,8 @@ class MenuHelper(SubMenuHelper):
         SubMenuHelper.__init__(self)
 
     def build_menu(self, actions, menu):
-        for item in actions:
+        for idx, item in enumerate(actions):
+            log.debug("build_menu idx, action: %s, %s", idx, item)
             if isinstance(item, tuple):
                 # Create a new submenu
                 parent, child = (item[0], item[1])
@@ -192,7 +188,7 @@ class MenuHelper(SubMenuHelper):
                     # Child is the name of the submenu to create
                     def set_func(obj, menu):
                         obj.set_submenu(menu)
-                    self.build_submenu(child, menuitem, set_func)
+                    self.build_submenu(child, menu, idx, menuitem, set_func)
                 menu.append_item(menuitem)
 
             elif isinstance(item, list):
@@ -209,6 +205,12 @@ class MenuHelper(SubMenuHelper):
                     menuitem.set_icon(Gio.Icon.new_for_string(item.icon_name))
                 menu.append_item(menuitem)
 
+    def refresh_submenus(self):
+        for name in self.submenus:
+            create_func, parent_obj, obj_idx, obj, set_func = self.submenus[name]
+            set_func(obj, create_func())
+            parent_obj.remove(obj_idx)
+            parent_obj.insert_item(obj_idx, obj)
 
 class ToolbarHelper(SubMenuHelper):
     """
@@ -228,7 +230,7 @@ class ToolbarHelper(SubMenuHelper):
         SubMenuHelper.__init__(self)
 
     def build_toolbar(self, actions, current):
-        for item in actions:
+        for idx, item in enumerate(actions):
             if isinstance(item, list):
                 # Toolbar's don't have sections like menus, so call this function
                 #  recursively with the "section" and just append a separator.
@@ -252,7 +254,7 @@ class ToolbarHelper(SubMenuHelper):
                 def set_func(obj, menu):
                     obj.set_menu(Gtk.Menu.new_from_model(menu))
 
-                self.build_submenu(child, button, set_func)
+                self.build_submenu(child, current, idx, button, set_func)
                 current.insert(button, -1)
 
             elif isinstance(item, Actions.Action):
@@ -264,6 +266,10 @@ class ToolbarHelper(SubMenuHelper):
                 button.set_action_name(target)
                 current.insert(button, -1)
 
+    def refresh_submenus(self):
+        for name in self.submenus:
+            create_func, parent_obj, _, obj, set_func = self.submenus[name]
+            set_func(obj, create_func())
 
 class Menu(Gio.Menu, MenuHelper):
     """ Main Menu """

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -73,7 +73,8 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # This needs to be replaced
         # Have an option for either the application menu or this menu
-        self.menu_bar = Gtk.MenuBar.new_from_model(Bars.Menu())
+        self.menu = Bars.Menu()
+        self.menu_bar = Gtk.MenuBar.new_from_model(self.menu)
         vbox.pack_start(self.menu_bar, False, False, 0)
 
         self.tool_bar = Bars.Toolbar()


### PR DESCRIPTION
Saves the grc prefs before executing a flowgraph to avoid losing them if
anything goes wrong and grc needs to be forcibly closed.

Also fixes recent files sub-menu refresh. When a file is opened, opened
from recent, or saved as, the recent files sub-menu is now updated.

Fixes: #3894