### PR TITLE
Change "top_block" to "default" to find options_block in GRC create hier

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -324,7 +324,7 @@ class Application(Gtk.Application):
             flow_graph.move_selected(coords)
 
             # Set flow graph to heir block type
-            top_block  = flow_graph.get_block("top_block")
+            top_block  = flow_graph.get_block("default")
             top_block.params['generate_options'].set_value('hb')
 
             # this needs to be a unique name


### PR DESCRIPTION
The default name in the flowgraph options_block seems to have changed from "top_block" to "default". This PR changes the flowgraph block search term while creating a hierarchical block from the GRC UI. Prior to this change, hierarchical block creation would fail, failing to find the "top_block" block in the flow_graph.get_block method. 

This change enables creation of hierarchical blocks in the GRC interface again. There appears to be some need to refactor / rewrite a bit of the code that performs the creation (e.g. the rest of the code opts for flow_graph.options_block vs. flow_graph.get_block(...) ).

```bash
$ gnuradio-config-info --version
3.8.2.0
$ python3 --version
Python 3.8.6
$ 
```