### PR TITLE
pmt: use to_string for char string_refs

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt_unv.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_unv.cc
@@ -140,7 +140,7 @@ uint8_t* u8vector_writable_elements(pmt_t vector, size_t& len)
 const std::string pmt_u8vector::string_ref(size_t k) const
 {
     const auto& ch = ref(k);
-    return std::string(&ch, &ch + 1);
+    return std::to_string(ch);
 }
 
 } /* namespace pmt */
@@ -263,7 +263,7 @@ int8_t* s8vector_writable_elements(pmt_t vector, size_t& len)
 const std::string pmt_s8vector::string_ref(size_t k) const
 {
     const auto& ch = ref(k);
-    return std::string(&ch, &ch + 1);
+    return std::to_string(ch);
 }
 
 } /* namespace pmt */


### PR DESCRIPTION
The current method of converting pmt char values to strings results in non-unicode characters - looks like it was using the pointer value in the string reference.  This just uses std::to_string on the char values

Fixes #3398 