### PR TITLE
Phase continuity for freq_xlating_fir_filter

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/rotator.h
+++ b/gr-blocks/include/gnuradio/blocks/rotator.h
@@ -29,6 +29,7 @@ private:
 public:
     rotator() : d_phase(1), d_phase_incr(1), d_counter(0) {}
 
+    gr_complex phase() { return d_phase; }
     void set_phase(gr_complex phase) { d_phase = phase / std::abs(phase); }
     void set_phase_incr(gr_complex incr) { d_phase_incr = incr / std::abs(incr); }
 

--- a/gr-blocks/python/blocks/bindings/rotator_python.cc
+++ b/gr-blocks/python/blocks/bindings/rotator_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rotator.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(00766f91fe492a48d5f40aa2082f31ff)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5d52f019c659d77040b16ad7541e4fd2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -39,6 +39,9 @@ void bind_rotator(py::module& m)
         .def(py::init<gr::blocks::rotator const&>(),
              py::arg("arg0"),
              D(rotator, rotator, 1))
+
+
+        .def("phase", &rotator::phase)
 
 
         .def("set_phase", &rotator::set_phase, py::arg("phase"), D(rotator, set_phase))

--- a/gr-filter/lib/freq_xlating_fir_filter_impl.h
+++ b/gr-filter/lib/freq_xlating_fir_filter_impl.h
@@ -28,6 +28,7 @@ protected:
     kernel::fir_filter<IN_T, OUT_T, gr_complex> d_composite_fir;
     blocks::rotator d_r;
     double d_center_freq;
+    double d_prev_center_freq;
     double d_sampling_freq;
     bool d_updated;
     const int d_decim;

--- a/gr-filter/python/filter/qa_freq_xlating_fir_filter.py
+++ b/gr-filter/python/filter/qa_freq_xlating_fir_filter.py
@@ -39,8 +39,9 @@ def sig_source_c(samp_rate, freq, amp, N):
     return y
 
 
-def mix(lo, data):
-    y = [lo_i * data_i for lo_i, data_i in zip(lo, data)]
+def mix(lo, data, phase=0.0):
+    cphase = cmath.exp(1j * phase)
+    y = [lo_i * data_i * cphase for lo_i, data_i in zip(lo, data)]
     return y
 
 
@@ -114,7 +115,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 1
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_c(self.src_data)
@@ -132,7 +134,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 4
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_c(self.src_data)
@@ -149,7 +152,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 1
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_c(self.src_data)
@@ -166,7 +170,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 4
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_c(self.src_data)
@@ -183,7 +188,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 1
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_f(self.src_data)
@@ -200,7 +206,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 4
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_f(self.src_data)
@@ -217,7 +224,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 1
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_f(self.src_data)
@@ -234,7 +242,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
         decim = 4
         lo = sig_source_c(self.fs, -self.fc, 1, len(self.src_data))
-        despun = mix(lo, self.src_data)
+        phase = -cmath.pi * self.fc / self.fs * (len(self.taps)-1)
+        despun = mix(lo, self.src_data, phase=phase)
         expected_data = fir_filter(despun, self.taps, decim)
 
         src = blocks.vector_source_f(self.src_data)


### PR DESCRIPTION
Retuning the freq_xlating_fir_filter result in arbitrary phase jumps, which can affect phase-sensitive demodulators.

https://github.com/gnuradio/gnuradio/issues/3877

This PR
- adds rotator::phase() to allow access to the internal state of a rotator object
- adjusts the rotator used by the xlating filter to keep phase constant during retune

The algorithm here works for FIR filters with a constant phase delay over the passband, and having an odd number of taps.

It is unlikely that anyone depends on the current behavior (arbitrary phase jump).

Tested using https://gist.github.com/willcode/f32e905bc268eeebd0cf4cb95bb4b4f1.