### PR TITLE
modtool: Change handled exception to ModuleNotFoundError

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/__init__.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/__init__.py
@@ -16,7 +16,7 @@ import os
 try:
     # this might fail if the module is python-only
     from .howto_python import *
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 # import any pure python here


### PR DESCRIPTION
Change the pass on exception to pass only on ModuleNotFoundError, not any ImportError

This should make the behavior as follows:
1) Python only module should import without error (by passing at ModuleNotFoundError)
2) C++ module with missing symbol should be caught and displayed

Tested 2) by creating a block with a dummy function in the header with no implementation.  Then call that implementation from another function.  Compiles ok, but will cause undefined symbol error at import.

Fixes #3884