### PR TITLE
grc: Fix multiple 'Apply' in modify block parameters dialog box

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -544,11 +544,8 @@ class Application(Gtk.Application):
                     response = self.dialog.run()
                     if response in (Gtk.ResponseType.APPLY, Gtk.ResponseType.ACCEPT):
                         page.state_cache.save_new_state(flow_graph.export_data())
-                        ### Following  lines force an complete update of io ports
-                        n = page.state_cache.get_current_state()
-                        flow_graph.import_data(n)
+                        ### Following  line forces a complete update of io ports
                         flow_graph_update()
-
                         page.saved = False
                     else:  # restore the current state
                         n = page.state_cache.get_current_state()


### PR DESCRIPTION
When the modify parameters dialog block is constructed, the instance of
the block to be modified, is passed in. When the apply button is clicked
there is an extraenous flowgraph.import_data() call that re-creates all
blocks in the flowgraph. The consequence is that the block instance
passed to the dialog box is no longer the one in the flowgraph, and so
subsequent Applies have no effect. This change simply removes this call.

Fixes: #3914 
