### PR TITLE
Update parameter background colours realtime

### DIFF
--- a/grc/blocks/parameter.block.yml
+++ b/grc/blocks/parameter.block.yml
@@ -7,10 +7,6 @@ parameters:
     label: Label
     dtype: string
     hide: ${ ('none' if label else 'part') }
--   id: value
-    label: Value
-    dtype: ${ type.type }
-    default: '0'
 -   id: type
     label: Type
     dtype: enum
@@ -19,6 +15,10 @@ parameters:
     option_attributes:
         type: [raw, complex, real, int, int, string]
     hide: ${ ('none' if type else 'part') }
+-   id: value
+    label: Value
+    dtype: ${ type.type }
+    default: '0'
 -   id: short_id
     label: Short ID
     dtype: string


### PR DESCRIPTION
If you change the type of a variable in the Properties Parameter editor the background colour of the parameter value is not updated.
You have to reload the editor for this parameter block to see the background colour according to the parameter type.

Fixes #3487 

This happens because the value box is evaluated before the type box.
Changing the order of the entries to type before value in the parameter.block.yml file fixes this issue.