### PR TITLE
allow oot override of gr python dir

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -47,7 +47,7 @@ find_dependency(Volk)
 set(ENABLE_PYTHON @ENABLE_PYTHON@ CACHE BOOL "Enable Python & SWIG")
 if(${ENABLE_PYTHON})
   set(PYTHON_EXECUTABLE @PYTHON_EXECUTABLE@)
-  set(GR_PYTHON_DIR @GR_PYTHON_DIR@)
+  set(GR_PYTHON_DIR @GR_PYTHON_DIR@ CACHE STRING "Custom OOT Python installation directory")
   include(GrPython)
 endif()
 


### PR DESCRIPTION
Fixes: GNU Radio 3.8 installed with a package manager
       hard codes GR_PYTHON_DIR #2856