### PR TITLE
fix header file install

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/CMakeLists.txt
+++ b/gr-qtgui/include/gnuradio/qtgui/CMakeLists.txt
@@ -11,7 +11,6 @@
 install(FILES
   api.h
   ber_sink_b.h
-  CMakeLists.txt
   constellationdisplayform.h
   ConstellationDisplayPlot.h
   const_sink_c.h


### PR DESCRIPTION
That CMakeLists.txt does not belong installed under /usr/include/...
