### PR TITLE
fix header file install

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/CMakeLists.txt
+++ b/gr-qtgui/include/gnuradio/qtgui/CMakeLists.txt
@@ -23,7 +23,6 @@
 install(FILES
   api.h
   ber_sink_b.h
-  CMakeLists.txt
   constellationdisplayform.h
   ConstellationDisplayPlot.h
   const_sink_c.h


### PR DESCRIPTION
That CMakeLists.txt does not belong installed under /usr/include/...

This is for the maint-3.8 branch.
Just like 3946 for master.
