### PR TITLE
grc: fix gnome-terminal deprecation warning

### DIFF
--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -56,7 +56,10 @@ class ExecFlowGraphThread(threading.Thread):
         # When in no gui mode on linux, use a graphical terminal (looks nice)
         xterm_executable = find_executable(self.xterm_executable)
         if generator.generate_options == 'no_gui' and xterm_executable:
-            run_command_args = [xterm_executable, '-e', run_command]
+            if ('gnome-terminal' in xterm_executable):
+                run_command_args = [xterm_executable, '--'] + run_command_args
+            else:
+                run_command_args = [xterm_executable, '-e', run_command]
 
         # this does not reproduce a shell executable command string, if a graphical
         # terminal is used. Passing run_command though shlex_quote would do it but


### PR DESCRIPTION
When running a "No GUI" flowgraph from GRC, it gives the following deprecation warning:
```
    Option “-e” is deprecated and might be removed in a later version of gnome-terminal.
    Use “-- ” to terminate the options and put the command line to execute after it.
```
This follows the suggested fix to update the deprecation