### PR TITLE
RPC fixes to allow using Thrift-0.13

### DIFF
--- a/cmake/Modules/FindTHRIFT.cmake
+++ b/cmake/Modules/FindTHRIFT.cmake
@@ -72,7 +72,19 @@ ENDIF  (CMAKE_CROSSCOMPILING)
 
 # Set to found if we've made it this far
 if(THRIFT_INCLUDE_DIRS AND THRIFT_LIBRARIES AND PYTHON_THRIFT_FOUND)
-  set(THRIFT_FOUND TRUE CACHE BOOL "If Thift has been found")
+  set(THRIFT_FOUND TRUE CACHE BOOL "If Thrift has been found")
+
+  find_file(THRIFT_HAS_VERSION_H thrift/version.h
+    PATH ${THRIFT_INCLUDE_DIRS} NO_DEFAULT_PATH)
+  if(THRIFT_HAS_VERSION_H-FOUND)
+    set(THRIFT_HAS_VERSION_H TRUE CACHE BOOL "If Thrift has thrift/version.h")
+  endif()
+
+  find_file(THRIFT_HAS_THREADFACTORY_H thrift/concurrency/ThreadFactory.h
+    PATH ${THRIFT_INCLUDE_DIRS} NO_DEFAULT_PATH)
+  if(THRIFT_HAS_THREADFACTORY_H-FOUND)
+    set(THRIFT_HAS_THREADFACTORY_H TRUE CACHE BOOL "If Thrift has thrift/concurrency/ThreadFactory.h")
+  endif()
 endif(THRIFT_INCLUDE_DIRS AND THRIFT_LIBRARIES AND PYTHON_THRIFT_FOUND)
 
 

--- a/config.h.in
+++ b/config.h.in
@@ -24,6 +24,12 @@
 #ifndef GR_RPCSERVER_THRIFT
 #cmakedefine GR_RPCSERVER_THRIFT
 #endif
+#ifndef THRIFT_HAS_VERSION_H
+#cmakedefine THRIFT_HAS_VERSION_H
+#endif
+#ifndef THRIFT_HAS_THREADFACTORY_H
+#cmakedefine THRIFT_HAS_THREADFACTORY_H
+#endif
 #ifndef GR_MPLIB_GMP
 #cmakedefine GR_MPLIB_GMP
 #endif

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -30,9 +30,6 @@
 class rpcserver_thrift : public virtual rpcserver_base, public GNURadio::ControlPortIf
 {
 public:
-    gr::logger_ptr d_logger;
-    gr::logger_ptr d_debug_logger;
-
     rpcserver_thrift();
     virtual ~rpcserver_thrift();
 
@@ -82,6 +79,9 @@ public:
     virtual void shutdown();
 
 private:
+    static gr::logger_ptr d_logger;
+    static gr::logger_ptr d_debug_logger;
+
     boost::mutex d_callback_map_lock;
 
     typedef std::map<std::string, configureCallback_t> ConfigureCallbackMap_t;
@@ -108,7 +108,7 @@ private:
             msg << _handlerCallback.description
                 << " requires PRIVLVL <= " << _handlerCallback.priv
                 << " to set, currently at: " << cur_priv;
-            GR_LOG_ERROR(logger, msg.str());
+            GR_LOG_ERROR(d_logger, msg.str());
         }
     }
 
@@ -133,7 +133,7 @@ private:
                     msg << "Key " << p.first
                         << " requires PRIVLVL <= " << iter->second.priv
                         << " to set, currently at: " << cur_priv;
-                    GR_LOG_ERROR(logger, msg.str());
+                    GR_LOG_ERROR(d_logger, msg.str());
                 }
             } else {
                 throw apache::thrift::TApplicationException(__FILE__ " " S__LINE__);
@@ -165,12 +165,12 @@ private:
                     msg << "Key " << iter->first
                         << " requires PRIVLVL: <= " << iter->second.priv
                         << " to get, currently at: " << cur_priv;
-                    GR_LOG_ERROR(logger, msg.str());
+                    GR_LOG_ERROR(d_logger, msg.str());
                 }
             } else {
                 std::ostringstream smsgs;
-                msg << "Ctrlport Key called with unregistered key (" << p << ")\n";
-                GR_LOG_ERROR(logger, ss.str());
+                smsgs << "Ctrlport Key called with unregistered key (" << p << ")\n";
+                GR_LOG_ERROR(d_logger, smsgs.str());
                 throw apache::thrift::TApplicationException(__FILE__ " " S__LINE__);
             }
         }
@@ -197,7 +197,7 @@ private:
                 std::ostringstream msg;
                 msg << "Key " << p.first << " requires PRIVLVL: <= " << p.second.priv
                     << " to get, currently at: " << cur_priv;
-                GR_LOG_ERROR(logger, msg.str());
+                GR_LOG_ERROR(d_logger, msg.str());
             }
         }
 
@@ -231,7 +231,7 @@ private:
                 std::ostringstream msg;
                 msg << "Key " << p.first << " requires PRIVLVL: <= " << p.second.priv
                     << " to get, currently at: " << cur_priv;
-                GR_LOG_ERROR(logger, msg.str());
+                GR_LOG_ERROR(d_logger, msg.str());
             }
         }
 
@@ -268,7 +268,7 @@ private:
                     msg << "Key " << iter->first
                         << " requires PRIVLVL: <= " << iter->second.priv
                         << " to get, currently at: " << cur_priv;
-                    GR_LOG_ERROR(logger, msg.str());
+                    GR_LOG_ERROR(d_logger, msg.str());
                 }
             } else {
                 throw apache::thrift::TApplicationException(__FILE__ " " S__LINE__);

--- a/gnuradio-runtime/include/gnuradio/thrift_server_template.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_server_template.h
@@ -11,13 +11,18 @@
 #ifndef THRIFT_SERVER_TEMPLATE_H
 #define THRIFT_SERVER_TEMPLATE_H
 
+#include <gnuradio/config.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/thrift_application_base.h>
 #include <iostream>
 
 #include "thrift/ControlPort.h"
+#ifdef THRIFT_HAS_THREADFACTORY_H
+#include <thrift/concurrency/ThreadFactory.h>
+#else
 #include <thrift/concurrency/PlatformThreadFactory.h>
+#endif
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/server/TThreadPoolServer.h>
@@ -124,9 +129,14 @@ thrift_server_template<TserverBase, TserverClass, TImplClass>::thrift_server_tem
         std::shared_ptr<thrift::concurrency::ThreadManager> threadManager(
             thrift::concurrency::ThreadManager::newSimpleThreadManager(nthreads));
 
+#ifdef THRIFT_HAS_THREADFACTORY_H
+        threadManager->threadFactory(std::shared_ptr<thrift::concurrency::ThreadFactory>(
+            new thrift::concurrency::ThreadFactory()));
+#else
         threadManager->threadFactory(
             std::shared_ptr<thrift::concurrency::PlatformThreadFactory>(
                 new thrift::concurrency::PlatformThreadFactory()));
+#endif
 
         threadManager->start();
 

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
@@ -23,9 +23,13 @@
 
 using namespace rpcpmtconverter;
 
+gr::logger_ptr rpcserver_thrift::d_logger;
+gr::logger_ptr rpcserver_thrift::d_debug_logger;
+
+
 rpcserver_thrift::rpcserver_thrift()
 {
-    gr::configure_default_loggers(logger, debug_logger, "rpcserver_thrift");
+    gr::configure_default_loggers(d_logger, d_debug_logger, "rpcserver_thrift");
     // std::cerr << "rpcserver_thrift::ctor" ;
 }
 
@@ -273,7 +277,7 @@ void rpcserver_thrift::shutdown()
 {
     if (DEBUG) {
         std::ostringstream msg;
-        msg << "shutting down... " << id;
+        msg << "shutting down rpcserver_thrift... ";
         GR_LOG_INFO(d_debug_logger, msg.str());
     }
 }


### PR DESCRIPTION
Adds ability for master to build with newer Thrift versions
by checking availability of thrift include files.
(Also spelling fix: Thift -> Thrift)
And fix up logging for rpcserver_thrift class.