### PR TITLE
Qt compass

### DIFF
--- a/gr-audio/lib/alsa/gr-audio-alsa.conf
+++ b/gr-audio/lib/alsa/gr-audio-alsa.conf
@@ -9,5 +9,5 @@ default_output_device = default
 # period time in seconds
 period_time = 0.010
 # total buffering = period_time * nperiods
-nperiods = 4
+nperiods = 16
 verbose = false

--- a/gr-audio/lib/alsa/gr-audio-alsa.conf
+++ b/gr-audio/lib/alsa/gr-audio-alsa.conf
@@ -9,5 +9,5 @@ default_output_device = default
 # period time in seconds
 period_time = 0.010
 # total buffering = period_time * nperiods
-nperiods = 16
+nperiods = 32
 verbose = false

--- a/gr-qtgui/grc/qtgui_compass.block.yml
+++ b/gr-qtgui/grc/qtgui_compass.block.yml
@@ -95,10 +95,7 @@ templates:
 documentation: |-
     This block takes angle in degrees as input and displays it on a compass.
     Args:
-    update_time: Time-interval between GUI update.
-    min_val: Min. value displayed on the compass.
-    max_val: Max. value displayed on the compass.
-    step: Step-size.
-    arc_bias: Clockwise rotation applied to dial.
-    usemsg: Use the message instead of the stream input.
+    Update Period: Time-interval between GUI updates.
+    Min Size (px): Min. size of the compass.
+    Input Type: Use the message instead of the stream input.
 file_format: 1


### PR DESCRIPTION
qtgui_compass.block.yml contains parameters in the "documentation" section which are not used in the implementation.