### PR TITLE
gr-qtgui: remove erroneous parameters in compass.block.yml

### DIFF
--- a/gr-qtgui/grc/qtgui_compass.block.yml
+++ b/gr-qtgui/grc/qtgui_compass.block.yml
@@ -95,10 +95,7 @@ templates:
 documentation: |-
     This block takes angle in degrees as input and displays it on a compass.
     Args:
-    update_time: Time-interval between GUI update.
-    min_val: Min. value displayed on the compass.
-    max_val: Max. value displayed on the compass.
-    step: Step-size.
-    arc_bias: Clockwise rotation applied to dial.
-    usemsg: Use the message instead of the stream input.
+    Update Period: Time-interval between GUI update.
+    Min Size (px): Min. size of the compass.
+    Input Type: Use the message instead of the stream input.
 file_format: 1


### PR DESCRIPTION
there are parameters in the 'documentation' section of the yml file which do not match the implementation