### PR TITLE
Do not disable boost, if only the unit_test_framework is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,14 @@ SET(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 message(STATUS "Build type set to ${CMAKE_BUILD_TYPE}.")
 
 include(GrComponent)
-GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING)
+########################################################################
+# Setup Boost for global use (within this build)
+# Do this before enabling testing support, as it depends
+# on unit_test_framework
+########################################################################
+include(GrBoost)
+GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING
+         Boost_unit_test_framework_FOUND )
 
 # Set the version information here
 SET(VERSION_MAJOR 3)
@@ -309,11 +316,6 @@ configure_file(
 add_custom_target(uninstall
     ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 )
-
-########################################################################
-# Setup Boost for global use (within this build)
-########################################################################
-include(GrBoost)
 
 ########################################################################
 # Enable python component

--- a/cmake/Modules/GrBoost.cmake
+++ b/cmake/Modules/GrBoost.cmake
@@ -23,10 +23,6 @@ set(BOOST_REQUIRED_COMPONENTS
     thread
 )
 
-if(ENABLE_TESTING)
-    list(APPEND BOOST_REQUIRED_COMPONENTS unit_test_framework)
-endif(ENABLE_TESTING)
-
 if(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
     list(APPEND BOOST_LIBRARYDIR "/usr/lib64") #fedora 64-bit fix
 endif(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
@@ -73,7 +69,8 @@ set(Boost_ADDITIONAL_VERSIONS
     "1.71.0" "1.71"
 )
 
-find_package(Boost ${GR_BOOST_MIN_VERSION} COMPONENTS ${BOOST_REQUIRED_COMPONENTS})
+find_package(Boost ${GR_BOOST_MIN_VERSION} REQUIRED ${BOOST_REQUIRED_COMPONENTS}
+                                           OPTIONAL_COMPONENTS unit_test_framework)
 
 # Boost 1.52 disabled, see https://svn.boost.org/trac/boost/ticket/7669
 # Similar problems with Boost 1.46 and 1.47.


### PR DESCRIPTION
Boost will be disabled even all required components besides unit_test_framework are available.
It would suffice to  disable testing. 