### PR TITLE
gr-digital: improved performance and capability to 63-bit registers. …

### DIFF
--- a/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
@@ -67,18 +67,18 @@ public:
      * \param reset_tag_key When a tag with this key is detected, the shift register is
      * reset (when this is set, count is ignored!)
      */
-    static sptr make(int mask,
-                     int seed,
-                     int len,
-                     int count = 0,
-                     int bits_per_byte = 1,
+    static sptr make(uint64_t mask,
+                     uint64_t seed,
+                     uint8_t len,
+                     int64_t count = 0,
+                     uint8_t bits_per_byte = 1,
                      const std::string& reset_tag_key = "");
 
-    virtual int mask() const = 0;
-    virtual int seed() const = 0;
-    virtual int len() const = 0;
-    virtual int count() const = 0;
-    virtual int bits_per_byte() = 0;
+    virtual uint64_t mask() const = 0;
+    virtual uint64_t seed() const = 0;
+    virtual uint8_t len() const = 0;
+    virtual int64_t count() const = 0;
+    virtual uint8_t bits_per_byte() = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/descrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/descrambler_bb.h
@@ -51,7 +51,7 @@ public:
      * \param seed     Initial shift register contents
      * \param len      Shift register length
      */
-    static sptr make(int mask, int seed, int len);
+    static sptr make(uint64_t mask, uint64_t seed, uint8_t len);
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr.h
+++ b/gr-digital/include/gnuradio/digital/glfsr.h
@@ -35,26 +35,27 @@ namespace digital {
  *
  * \details
  * Generates a maximal length pseudo-random sequence of length 2^degree-1
+ * if given a primitive polynomial.
  */
 class DIGITAL_API glfsr
 {
 private:
-    uint32_t d_shift_register;
-    uint32_t d_mask;
+    uint64_t d_shift_register;
+    uint64_t d_mask;
 
 public:
-    glfsr(uint32_t mask, uint32_t seed)
+    glfsr(uint64_t mask, uint64_t seed)
     {
         d_shift_register = seed;
         d_mask = mask;
     }
     ~glfsr();
 
-    static uint32_t glfsr_mask(unsigned int degree);
+    static uint64_t glfsr_mask(unsigned int degree);
 
     uint8_t next_bit();
 
-    uint32_t mask() const { return d_mask; }
+    uint64_t mask() const { return d_mask; }
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr_source_b.h
+++ b/gr-digital/include/gnuradio/digital/glfsr_source_b.h
@@ -52,11 +52,11 @@ public:
      */
     static sptr make(unsigned int degree,
                      bool repeat = true,
-                     uint32_t mask = 0x0,
-                     uint32_t seed = 0x1);
+                     uint64_t mask = 0x0,
+                     uint64_t seed = 0x1);
 
-    virtual uint32_t period() const = 0;
-    virtual uint32_t mask() const = 0;
+    virtual uint64_t period() const = 0;
+    virtual uint64_t mask() const = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr_source_f.h
+++ b/gr-digital/include/gnuradio/digital/glfsr_source_f.h
@@ -42,7 +42,7 @@ public:
     /*!
      * Make a Galois LFSR pseudo-random source block.
      *
-     * \param degree Degree of shift register must be in [1, 32]. If mask
+     * \param degree Degree of shift register must be in [1, 64]. If mask
      *               is 0, the degree determines a default mask (see
      *               digital_impl_glfsr.cc for the mapping).
      * \param repeat Set to repeat sequence.
@@ -51,10 +51,10 @@ public:
      * \param seed   Initial setting for values in shift register.
      */
     static sptr
-    make(unsigned int degree, bool repeat = true, uint32_t mask = 0, uint32_t seed = 1);
+    make(unsigned int degree, bool repeat = true, uint64_t mask = 0, uint64_t seed = 1);
 
-    virtual uint32_t period() const = 0;
-    virtual uint32_t mask() const = 0;
+    virtual uint64_t period() const = 0;
+    virtual uint64_t mask() const = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/lfsr.h
+++ b/gr-digital/include/gnuradio/digital/lfsr.h
@@ -37,7 +37,7 @@ namespace digital {
  *
  * \details
  * Generates a maximal length pseudo-random sequence of length
- * 2^degree-1
+ * 2^degree-1, if supplied with a primitive polynomial.
  *
  * Constructor: digital::lfsr(int mask, int seed, int reg_len);
  *
@@ -47,9 +47,9 @@ namespace digital {
  *             order bit.
  *
  *             Some common masks might be:
- *              x^4 + x^3 + x^0 = 0x19
- *              x^5 + x^3 + x^0 = 0x29
- *              x^6 + x^5 + x^0 = 0x61
+ *              x^4 + x^3 + x^0 = 0x19, K=3
+ *              x^5 + x^3 + x^0 = 0x29, K=4
+ *              x^6 + x^5 + x^0 = 0x61, K=5
  *
  * \param seed - the initialization vector placed into the
  *             register during initialization. Low order bit
@@ -90,32 +90,26 @@ namespace digital {
 class lfsr
 {
 private:
-    uint32_t d_shift_register;
-    uint32_t d_mask;
-    uint32_t d_seed;
-    uint32_t d_shift_register_length; // less than 32
-
-    static uint32_t popCount(uint32_t x)
-    {
-        uint32_t r = x - ((x >> 1) & 033333333333) - ((x >> 2) & 011111111111);
-        return ((r + (r >> 3)) & 030707070707) % 63;
-    }
+    uint64_t d_shift_register;
+    uint64_t d_mask;
+    uint64_t d_seed;
+    uint64_t d_shift_register_length; // less than 32
 
 public:
-    lfsr(uint32_t mask, uint32_t seed, uint32_t reg_len)
+    lfsr(uint64_t mask, uint64_t seed, uint64_t reg_len)
         : d_shift_register(seed),
           d_mask(mask),
           d_seed(seed),
           d_shift_register_length(reg_len)
     {
-        if (reg_len > 31)
-            throw std::invalid_argument("reg_len must be <= 31");
+        if (reg_len > 63)
+            throw std::invalid_argument("reg_len must be <= 63");
     }
 
     unsigned char next_bit()
     {
         unsigned char output = d_shift_register & 1;
-        unsigned char newbit = popCount(d_shift_register & d_mask) % 2;
+        unsigned char newbit = __builtin_parityl(d_shift_register & d_mask);
         d_shift_register =
             ((d_shift_register >> 1) | (newbit << d_shift_register_length));
         return output;
@@ -124,7 +118,7 @@ public:
     unsigned char next_bit_scramble(unsigned char input)
     {
         unsigned char output = d_shift_register & 1;
-        unsigned char newbit = (popCount(d_shift_register & d_mask) % 2) ^ (input & 1);
+        uint64_t newbit = __builtin_parityl(d_shift_register & d_mask) ^ (input & 1);
         d_shift_register =
             ((d_shift_register >> 1) | (newbit << d_shift_register_length));
         return output;
@@ -132,8 +126,8 @@ public:
 
     unsigned char next_bit_descramble(unsigned char input)
     {
-        unsigned char output = (popCount(d_shift_register & d_mask) % 2) ^ (input & 1);
-        unsigned char newbit = input & 1;
+        unsigned char output = __builtin_parityl(d_shift_register & d_mask) ^ (input & 1);
+        uint64_t newbit = input & 1;
         d_shift_register =
             ((d_shift_register >> 1) | (newbit << d_shift_register_length));
         return output;
@@ -155,7 +149,7 @@ public:
         }
     }
 
-    int mask() const { return d_mask; }
+    uint64_t mask() const { return d_mask; }
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/scrambler_bb.h
@@ -51,7 +51,7 @@ public:
      * \param seed     Initial shift register contents
      * \param len      Shift register length
      */
-    static sptr make(int mask, int seed, int len);
+    static sptr make(uint64_t mask, uint64_t seed, uint8_t len);
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/additive_scrambler_bb_impl.cc
+++ b/gr-digital/lib/additive_scrambler_bb_impl.cc
@@ -30,22 +30,22 @@
 namespace gr {
 namespace digital {
 
-additive_scrambler_bb::sptr additive_scrambler_bb::make(int mask,
-                                                        int seed,
-                                                        int len,
-                                                        int count,
-                                                        int bits_per_byte,
+additive_scrambler_bb::sptr additive_scrambler_bb::make(uint64_t mask,
+                                                        uint64_t seed,
+                                                        uint8_t len,
+                                                        int64_t count,
+                                                        uint8_t bits_per_byte,
                                                         const std::string& reset_tag_key)
 {
     return gnuradio::get_initial_sptr(new additive_scrambler_bb_impl(
         mask, seed, len, count, bits_per_byte, reset_tag_key));
 }
 
-additive_scrambler_bb_impl::additive_scrambler_bb_impl(int mask,
-                                                       int seed,
-                                                       int len,
-                                                       int count,
-                                                       int bits_per_byte,
+additive_scrambler_bb_impl::additive_scrambler_bb_impl(uint64_t mask,
+                                                       uint64_t seed,
+                                                       uint8_t len,
+                                                       int64_t count,
+                                                       uint8_t bits_per_byte,
                                                        const std::string& reset_tag_key)
     : sync_block("additive_scrambler_bb",
                  io_signature::make(1, 1, sizeof(unsigned char)),
@@ -68,25 +68,26 @@ additive_scrambler_bb_impl::additive_scrambler_bb_impl(int mask,
 
 additive_scrambler_bb_impl::~additive_scrambler_bb_impl() {}
 
-int additive_scrambler_bb_impl::mask() const { return d_lfsr.mask(); }
+uint64_t additive_scrambler_bb_impl::mask() const { return d_lfsr.mask(); }
 
-int additive_scrambler_bb_impl::seed() const { return d_seed; }
+uint64_t additive_scrambler_bb_impl::seed() const { return d_seed; }
 
-int additive_scrambler_bb_impl::len() const { return d_len; }
+uint8_t additive_scrambler_bb_impl::len() const { return d_len; }
 
-int additive_scrambler_bb_impl::count() const { return d_count; }
+int64_t additive_scrambler_bb_impl::count() const { return d_count; }
 
-int additive_scrambler_bb_impl::_get_next_reset_index(int noutput_items,
-                                                      int last_reset_index /* = -1 */)
+int64_t
+additive_scrambler_bb_impl::_get_next_reset_index(int64_t noutput_items,
+                                                  int64_t last_reset_index /* = -1 */)
 {
-    int reset_index =
+    int64_t reset_index =
         noutput_items; // This is a value that gets never reached in the for loop
     if (d_count == -1) {
         std::vector<gr::tag_t> tags;
         get_tags_in_range(
             tags, 0, nitems_read(0), nitems_read(0) + noutput_items, d_reset_tag_key);
         for (unsigned i = 0; i < tags.size(); i++) {
-            int reset_pos = tags[i].offset - nitems_read(0);
+            int64_t reset_pos = tags[i].offset - nitems_read(0);
             if (reset_pos < reset_index && reset_pos > last_reset_index) {
                 reset_index = reset_pos;
             }

--- a/gr-digital/lib/additive_scrambler_bb_impl.h
+++ b/gr-digital/lib/additive_scrambler_bb_impl.h
@@ -33,29 +33,29 @@ class additive_scrambler_bb_impl : public additive_scrambler_bb
 {
 private:
     digital::lfsr d_lfsr;
-    int d_count; //!< Reset the LFSR after this many bytes (not bits)
-    int d_bytes; //!< Count the processed bytes
-    int d_len;
-    int d_seed;
-    int d_bits_per_byte;
+    int64_t d_count;  //!< Reset the LFSR after this many bytes (not bits)
+    uint64_t d_bytes; //!< Count the processed bytes
+    uint8_t d_len;
+    uint64_t d_seed;
+    uint8_t d_bits_per_byte;
     pmt::pmt_t d_reset_tag_key; //!< Reset the LFSR when this tag is received
 
-    int _get_next_reset_index(int noutput_items, int last_reset_index = -1);
+    int64_t _get_next_reset_index(int64_t noutput_items, int64_t last_reset_index = -1);
 
 public:
-    additive_scrambler_bb_impl(int mask,
-                               int seed,
-                               int len,
-                               int count = 0,
-                               int bits_per_byte = 1,
+    additive_scrambler_bb_impl(uint64_t mask,
+                               uint64_t seed,
+                               uint8_t len,
+                               int64_t count = 0,
+                               uint8_t bits_per_byte = 1,
                                const std::string& reset_tag_key = "");
     ~additive_scrambler_bb_impl();
 
-    int mask() const;
-    int seed() const;
-    int len() const;
-    int count() const;
-    int bits_per_byte() { return d_bits_per_byte; };
+    uint64_t mask() const;
+    uint64_t seed() const;
+    uint8_t len() const;
+    int64_t count() const;
+    uint8_t bits_per_byte() { return d_bits_per_byte; };
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/descrambler_bb_impl.cc
+++ b/gr-digital/lib/descrambler_bb_impl.cc
@@ -30,12 +30,12 @@
 namespace gr {
 namespace digital {
 
-descrambler_bb::sptr descrambler_bb::make(int mask, int seed, int len)
+descrambler_bb::sptr descrambler_bb::make(uint64_t mask, uint64_t seed, uint8_t len)
 {
     return gnuradio::get_initial_sptr(new descrambler_bb_impl(mask, seed, len));
 }
 
-descrambler_bb_impl::descrambler_bb_impl(int mask, int seed, int len)
+descrambler_bb_impl::descrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len)
     : sync_block("descrambler_bb",
                  io_signature::make(1, 1, sizeof(unsigned char)),
                  io_signature::make(1, 1, sizeof(unsigned char))),

--- a/gr-digital/lib/descrambler_bb_impl.h
+++ b/gr-digital/lib/descrambler_bb_impl.h
@@ -35,7 +35,7 @@ private:
     digital::lfsr d_lfsr;
 
 public:
-    descrambler_bb_impl(int mask, int seed, int len);
+    descrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len);
     ~descrambler_bb_impl();
 
     int work(int noutput_items,

--- a/gr-digital/lib/glfsr.cc
+++ b/gr-digital/lib/glfsr.cc
@@ -26,7 +26,7 @@
 namespace gr {
 namespace digital {
 
-static uint32_t s_polynomial_masks[] = {
+static uint64_t s_polynomial_masks[] = {
     0x00000000,
     0x00000001, // x^1 + 1
     0x00000003, // x^2 + x^1 + 1
@@ -64,9 +64,9 @@ static uint32_t s_polynomial_masks[] = {
 
 glfsr::~glfsr() {}
 
-uint32_t glfsr::glfsr_mask(unsigned int degree)
+uint64_t glfsr::glfsr_mask(unsigned int degree)
 {
-    if (degree < 1 || degree > 32)
+    if (degree < 1 || degree > 64)
         throw std::runtime_error(
             "glfsr::glfsr_mask(): degree must be between 1 and 32 inclusive");
     return s_polynomial_masks[degree];

--- a/gr-digital/lib/glfsr_source_b_impl.cc
+++ b/gr-digital/lib/glfsr_source_b_impl.cc
@@ -32,7 +32,7 @@ namespace gr {
 namespace digital {
 
 glfsr_source_b::sptr
-glfsr_source_b::make(unsigned int degree, bool repeat, uint32_t mask, uint32_t seed)
+glfsr_source_b::make(unsigned int degree, bool repeat, uint64_t mask, uint64_t seed)
 {
     return gnuradio::get_initial_sptr(
         new glfsr_source_b_impl(degree, repeat, mask, seed));
@@ -40,16 +40,16 @@ glfsr_source_b::make(unsigned int degree, bool repeat, uint32_t mask, uint32_t s
 
 glfsr_source_b_impl::glfsr_source_b_impl(unsigned int degree,
                                          bool repeat,
-                                         uint32_t mask,
-                                         uint32_t seed)
+                                         uint64_t mask,
+                                         uint64_t seed)
     : sync_block("glfsr_source_b",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(unsigned char))),
       d_repeat(repeat),
       d_index(0),
-      d_length((((uint32_t)1) << degree) - 1)
+      d_length((1L << degree) - 1)
 {
-    if (degree < 1 || degree > 32)
+    if (degree < 1 || degree > 64)
         throw std::runtime_error(
             "glfsr_source_b_impl: degree must be between 1 and 32 inclusive");
 
@@ -60,7 +60,7 @@ glfsr_source_b_impl::glfsr_source_b_impl(unsigned int degree,
 
 glfsr_source_b_impl::~glfsr_source_b_impl() { delete d_glfsr; }
 
-uint32_t glfsr_source_b_impl::mask() const { return d_glfsr->mask(); }
+uint64_t glfsr_source_b_impl::mask() const { return d_glfsr->mask(); }
 
 int glfsr_source_b_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr_source_b_impl.h
+++ b/gr-digital/lib/glfsr_source_b_impl.h
@@ -35,22 +35,22 @@ private:
     glfsr* d_glfsr;
 
     bool d_repeat;
-    uint32_t d_index;
-    uint32_t d_length;
+    uint64_t d_index;
+    uint64_t d_length;
 
 public:
     glfsr_source_b_impl(unsigned int degree,
                         bool repeat = true,
-                        uint32_t mask = 0,
-                        uint32_t seed = 0x1);
+                        uint64_t mask = 0,
+                        uint64_t seed = 0x1);
     ~glfsr_source_b_impl();
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items);
 
-    uint32_t period() const { return d_length; }
-    uint32_t mask() const;
+    uint64_t period() const { return d_length; }
+    uint64_t mask() const;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/glfsr_source_f_impl.cc
+++ b/gr-digital/lib/glfsr_source_f_impl.cc
@@ -33,7 +33,7 @@ namespace gr {
 namespace digital {
 
 glfsr_source_f::sptr
-glfsr_source_f::make(unsigned int degree, bool repeat, uint32_t mask, uint32_t seed)
+glfsr_source_f::make(unsigned int degree, bool repeat, uint64_t mask, uint64_t seed)
 {
     return gnuradio::get_initial_sptr(
         new glfsr_source_f_impl(degree, repeat, mask, seed));
@@ -41,16 +41,16 @@ glfsr_source_f::make(unsigned int degree, bool repeat, uint32_t mask, uint32_t s
 
 glfsr_source_f_impl::glfsr_source_f_impl(unsigned int degree,
                                          bool repeat,
-                                         uint32_t mask,
-                                         uint32_t seed)
+                                         uint64_t mask,
+                                         uint64_t seed)
     : sync_block("glfsr_source_f",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(float))),
       d_repeat(repeat),
       d_index(0),
-      d_length((((uint32_t)1) << degree) - 1)
+      d_length((1L << degree) - 1)
 {
-    if (degree < 1 || degree > 32)
+    if (degree < 1 || degree > 64)
         throw std::runtime_error(
             "glfsr_source_f_impl: degree must be between 1 and 32 inclusive");
 
@@ -61,7 +61,7 @@ glfsr_source_f_impl::glfsr_source_f_impl(unsigned int degree,
 
 glfsr_source_f_impl::~glfsr_source_f_impl() { delete d_glfsr; }
 
-uint32_t glfsr_source_f_impl::mask() const { return d_glfsr->mask(); }
+uint64_t glfsr_source_f_impl::mask() const { return d_glfsr->mask(); }
 
 int glfsr_source_f_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr_source_f_impl.h
+++ b/gr-digital/lib/glfsr_source_f_impl.h
@@ -35,22 +35,22 @@ private:
     glfsr* d_glfsr;
 
     bool d_repeat;
-    uint32_t d_index;
-    uint32_t d_length;
+    uint64_t d_index;
+    uint64_t d_length;
 
 public:
     glfsr_source_f_impl(unsigned int degree,
                         bool repeat = true,
-                        uint32_t mask = 0,
-                        uint32_t seed = 0x1);
+                        uint64_t mask = 0,
+                        uint64_t seed = 0x1);
     ~glfsr_source_f_impl();
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items);
 
-    uint32_t period() const { return d_length; }
-    uint32_t mask() const;
+    uint64_t period() const { return d_length; }
+    uint64_t mask() const;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/scrambler_bb_impl.cc
+++ b/gr-digital/lib/scrambler_bb_impl.cc
@@ -30,12 +30,12 @@
 namespace gr {
 namespace digital {
 
-scrambler_bb::sptr scrambler_bb::make(int mask, int seed, int len)
+scrambler_bb::sptr scrambler_bb::make(uint64_t mask, uint64_t seed, uint8_t len)
 {
     return gnuradio::get_initial_sptr(new scrambler_bb_impl(mask, seed, len));
 }
 
-scrambler_bb_impl::scrambler_bb_impl(int mask, int seed, int len)
+scrambler_bb_impl::scrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len)
     : sync_block("scrambler_bb",
                  io_signature::make(1, 1, sizeof(unsigned char)),
                  io_signature::make(1, 1, sizeof(unsigned char))),

--- a/gr-digital/lib/scrambler_bb_impl.h
+++ b/gr-digital/lib/scrambler_bb_impl.h
@@ -36,7 +36,7 @@ private:
     digital::lfsr d_lfsr;
 
 public:
-    scrambler_bb_impl(int mask, int seed, int len);
+    scrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len);
     ~scrambler_bb_impl();
 
     int work(int noutput_items,

--- a/gr-digital/python/digital/qa_glfsr_source.py
+++ b/gr-digital/python/digital/qa_glfsr_source.py
@@ -40,7 +40,7 @@ class test_glfsr_source(gr_unittest.TestCase):
         self.assertRaises(RuntimeError,
                           lambda: digital.glfsr_source_b(0))
         self.assertRaises(RuntimeError,
-                          lambda: digital.glfsr_source_b(33))
+                          lambda: digital.glfsr_source_b(65))
 
     def test_002_correlation_b(self):
         for degree in range(1,11):                # Higher degrees take too long to correlate
@@ -67,7 +67,7 @@ class test_glfsr_source(gr_unittest.TestCase):
         self.assertRaises(RuntimeError,
                           lambda: digital.glfsr_source_f(0))
         self.assertRaises(RuntimeError,
-                          lambda: digital.glfsr_source_f(33))
+                          lambda: digital.glfsr_source_f(65))
     def test_005_correlation_f(self):
         for degree in range(1,11):                # Higher degrees take too long to correlate
             src = digital.glfsr_source_f(degree, False)

--- a/gr-digital/python/digital/qa_lfsr.py
+++ b/gr-digital/python/digital/qa_lfsr.py
@@ -36,11 +36,7 @@ class test_lfsr(gr_unittest.TestCase):
     def test_lfsr_001(self):
         reglen = 8
         l = digital.lfsr(1, 1, reglen)
-
-        result_data = []
-        for i in range(4*(reglen+1)):
-            result_data.append(l.next_bit())
-
+        result_data = [l.next_bit() for _ in range(4*(reglen+1))]
         expected_result = 4*([1,] + reglen*[0,])
         self.assertFloatTuplesAlmostEqual(expected_result, result_data, 5)
 


### PR DESCRIPTION
gr-digital: improved performance and capability to 64-bit registers (up to polynomials of degree 63). Now uses __builtin_parityl (a compiler built-in function?) to check for parity to determine the next bit.

I would also like to change the way masks are entered in GRC, it is quite easy to convert from exponent list to integer register, as can be seen in the qa_scramblers.py: make_mask-function.

I do have concerns, I'm not sure this will work on a raspberry pie, can I get help to test this?