### PR TITLE
gr-digital: improved performance and capability of scramblers to 64-bit

### DIFF
--- a/gr-digital/CMakeLists.txt
+++ b/gr-digital/CMakeLists.txt
@@ -30,6 +30,11 @@ SET(GR_PKG_DIGITAL_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/digital)
 ########################################################################
 if(ENABLE_GR_DIGITAL)
 
+# Set HAVE_BUILTIN_PARITYL for use in scrambler if compiler is GNU
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_definitions(-DHAVE_BUILTIN_PARITYL)
+endif()
+
 ########################################################################
 # Add subdirectories
 ########################################################################

--- a/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/additive_scrambler_bb.h
@@ -55,18 +55,18 @@ public:
      * \param reset_tag_key When a tag with this key is detected, the shift register is
      * reset (when this is set, count is ignored!)
      */
-    static sptr make(int mask,
-                     int seed,
-                     int len,
-                     int count = 0,
-                     int bits_per_byte = 1,
+    static sptr make(uint64_t mask,
+                     uint64_t seed,
+                     uint8_t len,
+                     int64_t count = 0,
+                     uint8_t bits_per_byte = 1,
                      const std::string& reset_tag_key = "");
 
-    virtual int mask() const = 0;
-    virtual int seed() const = 0;
-    virtual int len() const = 0;
-    virtual int count() const = 0;
-    virtual int bits_per_byte() = 0;
+    virtual uint64_t mask() const = 0;
+    virtual uint64_t seed() const = 0;
+    virtual uint8_t len() const = 0;
+    virtual int64_t count() const = 0;
+    virtual uint8_t bits_per_byte() = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/descrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/descrambler_bb.h
@@ -39,7 +39,7 @@ public:
      * \param seed     Initial shift register contents
      * \param len      Shift register length
      */
-    static sptr make(int mask, int seed, int len);
+    static sptr make(uint64_t mask, uint64_t seed, uint8_t len);
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr.h
+++ b/gr-digital/include/gnuradio/digital/glfsr.h
@@ -23,26 +23,27 @@ namespace digital {
  *
  * \details
  * Generates a maximal length pseudo-random sequence of length 2^degree-1
+ * if given a primitive polynomial.
  */
 class DIGITAL_API glfsr
 {
 private:
-    uint32_t d_shift_register;
-    uint32_t d_mask;
+    uint64_t d_shift_register;
+    uint64_t d_mask;
 
 public:
-    glfsr(uint32_t mask, uint32_t seed)
+    glfsr(uint64_t mask, uint64_t seed)
     {
         d_shift_register = seed;
         d_mask = mask;
     }
     ~glfsr();
 
-    static uint32_t glfsr_mask(unsigned int degree);
+    static uint64_t glfsr_mask(unsigned int degree);
 
     uint8_t next_bit();
 
-    uint32_t mask() const { return d_mask; }
+    uint64_t mask() const { return d_mask; }
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr_source_b.h
+++ b/gr-digital/include/gnuradio/digital/glfsr_source_b.h
@@ -40,11 +40,11 @@ public:
      */
     static sptr make(unsigned int degree,
                      bool repeat = true,
-                     uint32_t mask = 0x0,
-                     uint32_t seed = 0x1);
+                     uint64_t mask = 0x0,
+                     uint64_t seed = 0x1);
 
-    virtual uint32_t period() const = 0;
-    virtual uint32_t mask() const = 0;
+    virtual uint64_t period() const = 0;
+    virtual uint64_t mask() const = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/glfsr_source_f.h
+++ b/gr-digital/include/gnuradio/digital/glfsr_source_f.h
@@ -30,7 +30,7 @@ public:
     /*!
      * Make a Galois LFSR pseudo-random source block.
      *
-     * \param degree Degree of shift register must be in [1, 32]. If mask
+     * \param degree Degree of shift register must be in [1, 64]. If mask
      *               is 0, the degree determines a default mask (see
      *               digital_impl_glfsr.cc for the mapping).
      * \param repeat Set to repeat sequence.
@@ -39,10 +39,10 @@ public:
      * \param seed   Initial setting for values in shift register.
      */
     static sptr
-    make(unsigned int degree, bool repeat = true, uint32_t mask = 0, uint32_t seed = 1);
+    make(unsigned int degree, bool repeat = true, uint64_t mask = 0, uint64_t seed = 1);
 
-    virtual uint32_t period() const = 0;
-    virtual uint32_t mask() const = 0;
+    virtual uint64_t period() const = 0;
+    virtual uint64_t mask() const = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/scrambler_bb.h
+++ b/gr-digital/include/gnuradio/digital/scrambler_bb.h
@@ -39,7 +39,7 @@ public:
      * \param seed     Initial shift register contents
      * \param len      Shift register length
      */
-    static sptr make(int mask, int seed, int len);
+    static sptr make(uint64_t mask, uint64_t seed, uint8_t len);
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/additive_scrambler_bb_impl.cc
+++ b/gr-digital/lib/additive_scrambler_bb_impl.cc
@@ -18,22 +18,22 @@
 namespace gr {
 namespace digital {
 
-additive_scrambler_bb::sptr additive_scrambler_bb::make(int mask,
-                                                        int seed,
-                                                        int len,
-                                                        int count,
-                                                        int bits_per_byte,
+additive_scrambler_bb::sptr additive_scrambler_bb::make(uint64_t mask,
+                                                        uint64_t seed,
+                                                        uint8_t len,
+                                                        int64_t count,
+                                                        uint8_t bits_per_byte,
                                                         const std::string& reset_tag_key)
 {
     return gnuradio::make_block_sptr<additive_scrambler_bb_impl>(
         mask, seed, len, count, bits_per_byte, reset_tag_key);
 }
 
-additive_scrambler_bb_impl::additive_scrambler_bb_impl(int mask,
-                                                       int seed,
-                                                       int len,
-                                                       int count,
-                                                       int bits_per_byte,
+additive_scrambler_bb_impl::additive_scrambler_bb_impl(uint64_t mask,
+                                                       uint64_t seed,
+                                                       uint8_t len,
+                                                       int64_t count,
+                                                       uint8_t bits_per_byte,
                                                        const std::string& reset_tag_key)
     : sync_block("additive_scrambler_bb",
                  io_signature::make(1, 1, sizeof(unsigned char)),
@@ -56,25 +56,26 @@ additive_scrambler_bb_impl::additive_scrambler_bb_impl(int mask,
 
 additive_scrambler_bb_impl::~additive_scrambler_bb_impl() {}
 
-int additive_scrambler_bb_impl::mask() const { return d_lfsr.mask(); }
+uint64_t additive_scrambler_bb_impl::mask() const { return d_lfsr.mask(); }
 
-int additive_scrambler_bb_impl::seed() const { return d_seed; }
+uint64_t additive_scrambler_bb_impl::seed() const { return d_seed; }
 
-int additive_scrambler_bb_impl::len() const { return d_len; }
+uint8_t additive_scrambler_bb_impl::len() const { return d_len; }
 
-int additive_scrambler_bb_impl::count() const { return d_count; }
+int64_t additive_scrambler_bb_impl::count() const { return d_count; }
 
-int additive_scrambler_bb_impl::_get_next_reset_index(int noutput_items,
-                                                      int last_reset_index /* = -1 */)
+int64_t
+additive_scrambler_bb_impl::_get_next_reset_index(int64_t noutput_items,
+                                                  int64_t last_reset_index /* = -1 */)
 {
-    int reset_index =
+    int64_t reset_index =
         noutput_items; // This is a value that gets never reached in the for loop
     if (d_count == -1) {
         std::vector<gr::tag_t> tags;
         get_tags_in_range(
             tags, 0, nitems_read(0), nitems_read(0) + noutput_items, d_reset_tag_key);
         for (unsigned i = 0; i < tags.size(); i++) {
-            int reset_pos = tags[i].offset - nitems_read(0);
+            int64_t reset_pos = tags[i].offset - nitems_read(0);
             if (reset_pos < reset_index && reset_pos > last_reset_index) {
                 reset_index = reset_pos;
             }

--- a/gr-digital/lib/additive_scrambler_bb_impl.h
+++ b/gr-digital/lib/additive_scrambler_bb_impl.h
@@ -21,29 +21,29 @@ class additive_scrambler_bb_impl : public additive_scrambler_bb
 {
 private:
     digital::lfsr d_lfsr;
-    int d_count; //!< Reset the LFSR after this many bytes (not bits)
-    int d_bytes; //!< Count the processed bytes
-    int d_len;
-    int d_seed;
-    int d_bits_per_byte;
+    int64_t d_count;  //!< Reset the LFSR after this many bytes (not bits)
+    uint64_t d_bytes; //!< Count the processed bytes
+    uint8_t d_len;
+    uint64_t d_seed;
+    uint8_t d_bits_per_byte;
     pmt::pmt_t d_reset_tag_key; //!< Reset the LFSR when this tag is received
 
-    int _get_next_reset_index(int noutput_items, int last_reset_index = -1);
+    int64_t _get_next_reset_index(int64_t noutput_items, int64_t last_reset_index = -1);
 
 public:
-    additive_scrambler_bb_impl(int mask,
-                               int seed,
-                               int len,
-                               int count = 0,
-                               int bits_per_byte = 1,
+    additive_scrambler_bb_impl(uint64_t mask,
+                               uint64_t seed,
+                               uint8_t len,
+                               int64_t count = 0,
+                               uint8_t bits_per_byte = 1,
                                const std::string& reset_tag_key = "");
     ~additive_scrambler_bb_impl() override;
 
-    int mask() const override;
-    int seed() const override;
-    int len() const override;
-    int count() const override;
-    int bits_per_byte() override { return d_bits_per_byte; };
+    uint64_t mask() const override;
+    uint64_t seed() const override;
+    uint8_t len() const override;
+    int64_t count() const override;
+    uint8_t bits_per_byte() override { return d_bits_per_byte; };
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/descrambler_bb_impl.cc
+++ b/gr-digital/lib/descrambler_bb_impl.cc
@@ -18,12 +18,12 @@
 namespace gr {
 namespace digital {
 
-descrambler_bb::sptr descrambler_bb::make(int mask, int seed, int len)
+descrambler_bb::sptr descrambler_bb::make(uint64_t mask, uint64_t seed, uint8_t len)
 {
     return gnuradio::make_block_sptr<descrambler_bb_impl>(mask, seed, len);
 }
 
-descrambler_bb_impl::descrambler_bb_impl(int mask, int seed, int len)
+descrambler_bb_impl::descrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len)
     : sync_block("descrambler_bb",
                  io_signature::make(1, 1, sizeof(unsigned char)),
                  io_signature::make(1, 1, sizeof(unsigned char))),

--- a/gr-digital/lib/descrambler_bb_impl.h
+++ b/gr-digital/lib/descrambler_bb_impl.h
@@ -23,8 +23,8 @@ private:
     digital::lfsr d_lfsr;
 
 public:
-    descrambler_bb_impl(int mask, int seed, int len);
-    ~descrambler_bb_impl() override;
+    descrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len);
+    ~descrambler_bb_impl();
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr.cc
+++ b/gr-digital/lib/glfsr.cc
@@ -14,7 +14,7 @@
 namespace gr {
 namespace digital {
 
-static uint32_t s_polynomial_masks[] = {
+static uint64_t s_polynomial_masks[] = {
     0x00000000,
     0x00000001, // x^1 + 1
     0x00000003, // x^2 + x^1 + 1
@@ -52,11 +52,10 @@ static uint32_t s_polynomial_masks[] = {
 
 glfsr::~glfsr() {}
 
-uint32_t glfsr::glfsr_mask(unsigned int degree)
+uint64_t glfsr::glfsr_mask(unsigned int degree)
 {
-    if (degree < 1 || degree > 32)
-        throw std::runtime_error(
-            "glfsr::glfsr_mask(): degree must be between 1 and 32 inclusive");
+    if (degree < 1 || degree > 64)
+        throw std::runtime_error("glfsr::glfsr_mask(): must be 1 <= degree <= 64");
     return s_polynomial_masks[degree];
 }
 

--- a/gr-digital/lib/glfsr_source_b_impl.cc
+++ b/gr-digital/lib/glfsr_source_b_impl.cc
@@ -1,4 +1,3 @@
-/* -*- c++ -*- */
 /*
  * Copyright 2007,2010,2012,2016 Free Software Foundation, Inc.
  *
@@ -20,31 +19,30 @@ namespace gr {
 namespace digital {
 
 glfsr_source_b::sptr
-glfsr_source_b::make(unsigned int degree, bool repeat, uint32_t mask, uint32_t seed)
+glfsr_source_b::make(unsigned int degree, bool repeat, uint64_t mask, uint64_t seed)
 {
     return gnuradio::make_block_sptr<glfsr_source_b_impl>(degree, repeat, mask, seed);
 }
 
 glfsr_source_b_impl::glfsr_source_b_impl(unsigned int degree,
                                          bool repeat,
-                                         uint32_t mask,
-                                         uint32_t seed)
+                                         uint64_t mask,
+                                         uint64_t seed)
     : sync_block("glfsr_source_b",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(unsigned char))),
       d_glfsr(mask ? mask : glfsr::glfsr_mask(degree), seed),
       d_repeat(repeat),
       d_index(0),
-      d_length((((uint32_t)1) << degree) - 1)
+      d_length((1ULL << degree) - 1)
 {
-    if (degree < 1 || degree > 32)
-        throw std::runtime_error(
-            "glfsr_source_b_impl: degree must be between 1 and 32 inclusive");
+    if (degree < 1 || degree > 64)
+        throw std::runtime_error("glfsr_source_b_impl: must be 1 <= degree <= 64");
 }
 
 glfsr_source_b_impl::~glfsr_source_b_impl() {}
 
-uint32_t glfsr_source_b_impl::mask() const { return d_glfsr.mask(); }
+uint64_t glfsr_source_b_impl::mask() const { return d_glfsr.mask(); }
 
 int glfsr_source_b_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr_source_b_impl.h
+++ b/gr-digital/lib/glfsr_source_b_impl.h
@@ -23,22 +23,22 @@ private:
     glfsr d_glfsr;
 
     bool d_repeat;
-    uint32_t d_index;
-    uint32_t d_length;
+    uint64_t d_index;
+    uint64_t d_length;
 
 public:
     glfsr_source_b_impl(unsigned int degree,
                         bool repeat = true,
-                        uint32_t mask = 0,
-                        uint32_t seed = 0x1);
-    ~glfsr_source_b_impl() override;
+                        uint64_t mask = 0,
+                        uint64_t seed = 0x1);
+    ~glfsr_source_b_impl();
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;
 
-    uint32_t period() const override { return d_length; }
-    uint32_t mask() const override;
+    uint64_t period() const { return d_length; }
+    uint64_t mask() const;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/glfsr_source_f_impl.cc
+++ b/gr-digital/lib/glfsr_source_f_impl.cc
@@ -21,31 +21,30 @@ namespace gr {
 namespace digital {
 
 glfsr_source_f::sptr
-glfsr_source_f::make(unsigned int degree, bool repeat, uint32_t mask, uint32_t seed)
+glfsr_source_f::make(unsigned int degree, bool repeat, uint64_t mask, uint64_t seed)
 {
     return gnuradio::make_block_sptr<glfsr_source_f_impl>(degree, repeat, mask, seed);
 }
 
 glfsr_source_f_impl::glfsr_source_f_impl(unsigned int degree,
                                          bool repeat,
-                                         uint32_t mask,
-                                         uint32_t seed)
+                                         uint64_t mask,
+                                         uint64_t seed)
     : sync_block("glfsr_source_f",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(float))),
       d_glfsr(mask ? mask : glfsr::glfsr_mask(degree), seed),
       d_repeat(repeat),
       d_index(0),
-      d_length((((uint32_t)1) << degree) - 1)
+      d_length((1ULL << degree) - 1)
 {
-    if (degree < 1 || degree > 32)
-        throw std::runtime_error(
-            "glfsr_source_f_impl: degree must be between 1 and 32 inclusive");
+    if (degree < 1 || degree > 64)
+        throw std::runtime_error("glfsr_source_f_impl: must be 1 <= degree <= 64");
 }
 
 glfsr_source_f_impl::~glfsr_source_f_impl() {}
 
-uint32_t glfsr_source_f_impl::mask() const { return d_glfsr.mask(); }
+uint64_t glfsr_source_f_impl::mask() const { return d_glfsr.mask(); }
 
 int glfsr_source_f_impl::work(int noutput_items,
                               gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/glfsr_source_f_impl.h
+++ b/gr-digital/lib/glfsr_source_f_impl.h
@@ -23,22 +23,22 @@ private:
     glfsr d_glfsr;
 
     bool d_repeat;
-    uint32_t d_index;
-    uint32_t d_length;
+    uint64_t d_index;
+    uint64_t d_length;
 
 public:
     glfsr_source_f_impl(unsigned int degree,
                         bool repeat = true,
-                        uint32_t mask = 0,
-                        uint32_t seed = 0x1);
-    ~glfsr_source_f_impl() override;
+                        uint64_t mask = 0,
+                        uint64_t seed = 0x1);
+    ~glfsr_source_f_impl();
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;
 
-    uint32_t period() const override { return d_length; }
-    uint32_t mask() const override;
+    uint64_t period() const { return d_length; }
+    uint64_t mask() const;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/scrambler_bb_impl.cc
+++ b/gr-digital/lib/scrambler_bb_impl.cc
@@ -18,12 +18,12 @@
 namespace gr {
 namespace digital {
 
-scrambler_bb::sptr scrambler_bb::make(int mask, int seed, int len)
+scrambler_bb::sptr scrambler_bb::make(uint64_t mask, uint64_t seed, uint8_t len)
 {
     return gnuradio::make_block_sptr<scrambler_bb_impl>(mask, seed, len);
 }
 
-scrambler_bb_impl::scrambler_bb_impl(int mask, int seed, int len)
+scrambler_bb_impl::scrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len)
     : sync_block("scrambler_bb",
                  io_signature::make(1, 1, sizeof(unsigned char)),
                  io_signature::make(1, 1, sizeof(unsigned char))),

--- a/gr-digital/lib/scrambler_bb_impl.h
+++ b/gr-digital/lib/scrambler_bb_impl.h
@@ -24,8 +24,8 @@ private:
     digital::lfsr d_lfsr;
 
 public:
-    scrambler_bb_impl(int mask, int seed, int len);
-    ~scrambler_bb_impl() override;
+    scrambler_bb_impl(uint64_t mask, uint64_t seed, uint8_t len);
+    ~scrambler_bb_impl();
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/python/digital/CMakeLists.txt
+++ b/gr-digital/python/digital/CMakeLists.txt
@@ -37,6 +37,7 @@ GR_PYTHON_INSTALL(
     FILES
     utils/__init__.py
     utils/gray_code.py
+    utils/lfsr.py
     utils/mod_codes.py
     utils/alignment.py
     utils/tagged_streams.py

--- a/gr-digital/python/digital/bindings/additive_scrambler_bb_python.cc
+++ b/gr-digital/python/digital/bindings/additive_scrambler_bb_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(additive_scrambler_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a35bcdbbc4e320dd37c13a0adb156c57)                     */
+/* BINDTOOL_HEADER_FILE(additive_scrambler_bb.h)                                   */
+/* BINDTOOL_HEADER_FILE_HASH(526b44ff08fc8ae301bc1e7a3508c540)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/descrambler_bb_python.cc
+++ b/gr-digital/python/digital/bindings/descrambler_bb_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(descrambler_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d630c5081c027a198e21e0622963b40b)                     */
+/* BINDTOOL_HEADER_FILE(descrambler_bb.h)                                          */
+/* BINDTOOL_HEADER_FILE_HASH(af9fc52c6846ef88340101d3c6bbacc7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/glfsr_python.cc
+++ b/gr-digital/python/digital/bindings/glfsr_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(glfsr.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4299ef7303d0f404e97b16abb6de32ee)                     */
+/* BINDTOOL_HEADER_FILE(glfsr.h)                                                   */
+/* BINDTOOL_HEADER_FILE_HASH(0a9a03db1fc3d6a7b81b009e620c41c2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -35,7 +35,7 @@ void bind_glfsr(py::module& m)
 
     py::class_<glfsr, std::shared_ptr<glfsr>>(m, "glfsr", D(glfsr))
 
-        .def(py::init<uint32_t, uint32_t>(),
+        .def(py::init<uint64_t, uint64_t>(),
              py::arg("mask"),
              py::arg("seed"),
              D(glfsr, glfsr, 0))

--- a/gr-digital/python/digital/bindings/glfsr_source_b_python.cc
+++ b/gr-digital/python/digital/bindings/glfsr_source_b_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(glfsr_source_b.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(7b6d09b85b54ce73f4e3c80b1809bed7)                     */
+/* BINDTOOL_HEADER_FILE(glfsr_source_b.h)                                          */
+/* BINDTOOL_HEADER_FILE_HASH(d5e395b769198beb82a644f02b11f443)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/glfsr_source_f_python.cc
+++ b/gr-digital/python/digital/bindings/glfsr_source_f_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(glfsr_source_f.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(fefa5e006f5c5c49a91ff379b1c571d4)                     */
+/* BINDTOOL_HEADER_FILE(glfsr_source_f.h)                                          */
+/* BINDTOOL_HEADER_FILE_HASH(2e85e8ef0b1f9d6585364f2342f14ad1)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/lfsr_python.cc
+++ b/gr-digital/python/digital/bindings/lfsr_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(lfsr.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(6ad566b46874d5852d96814797e67bc4)                     */
+/* BINDTOOL_HEADER_FILE(lfsr.h)                                                    */
+/* BINDTOOL_HEADER_FILE_HASH(ae0c3aeb06a21a60a4415fe89135120e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -35,7 +35,7 @@ void bind_lfsr(py::module& m)
 
     py::class_<lfsr, std::shared_ptr<lfsr>>(m, "lfsr", D(lfsr))
 
-        .def(py::init<uint32_t, uint32_t, uint32_t>(),
+        .def(py::init<uint64_t, uint64_t, uint32_t>(),
              py::arg("mask"),
              py::arg("seed"),
              py::arg("reg_len"),

--- a/gr-digital/python/digital/bindings/scrambler_bb_python.cc
+++ b/gr-digital/python/digital/bindings/scrambler_bb_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(scrambler_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(857ba8ebaf0d0a1080493edc410b3aea)                     */
+/* BINDTOOL_HEADER_FILE(scrambler_bb.h)                                            */
+/* BINDTOOL_HEADER_FILE_HASH(83d0f3673216d2c2d68b1833512e01e2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/qa_glfsr_source.py
+++ b/gr-digital/python/digital/qa_glfsr_source.py
@@ -29,7 +29,7 @@ class test_glfsr_source(gr_unittest.TestCase):
         self.assertRaises(RuntimeError,
                           lambda: digital.glfsr_source_b(0))
         self.assertRaises(RuntimeError,
-                          lambda: digital.glfsr_source_b(33))
+                          lambda: digital.glfsr_source_b(65))
 
     def test_002_correlation_b(self):
         for degree in range(
@@ -59,8 +59,8 @@ class test_glfsr_source(gr_unittest.TestCase):
         self.assertRaises(RuntimeError,
                           lambda: digital.glfsr_source_f(0))
         self.assertRaises(RuntimeError,
-                          lambda: digital.glfsr_source_f(33))
-
+                          lambda: digital.glfsr_source_f(65))
+        
     def test_005_correlation_f(self):
         for degree in range(
                 1, 11):                # Higher degrees take too long to correlate

--- a/gr-digital/python/digital/qa_lfsr.py
+++ b/gr-digital/python/digital/qa_lfsr.py
@@ -10,9 +10,9 @@
 
 
 import math
-
+import numpy as np
 from gnuradio import gr, gr_unittest, digital
-
+from gnuradio.digital.utils import lfsr_args
 
 class test_lfsr(gr_unittest.TestCase):
 
@@ -25,7 +25,6 @@ class test_lfsr(gr_unittest.TestCase):
     def test_lfsr_001(self):
         reglen = 8
         l = digital.lfsr(1, 1, reglen)
-
         result_data = []
         for i in range(4 * (reglen + 1)):
             result_data.append(l.next_bit())
@@ -33,6 +32,20 @@ class test_lfsr(gr_unittest.TestCase):
         expected_result = 4 * ([1, ] + reglen * [0, ])
         self.assertFloatTuplesAlmostEqual(expected_result, result_data, 5)
 
+    def test_lfsr_002(self):
+        l = digital.lfsr(*lfsr_args(0b1,5,3,0))
+        result_data = [l.next_bit() for _ in range(2*(2**5-1))]
+        
+        expected_result = [1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0,
+                           0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0]*2
+        self.assertEqual(expected_result, result_data)
+
+        seq1 = [l.next_bit() for _ in range(2**5-1)]
+        seq2 = [l.next_bit() for _ in range(2**5-1)]
+        self.assertEqual(seq1,seq2)
+
+        res = (np.convolve(seq1,[1,0,1,0,0,1])%2)
+        self.assertTrue(sum(res[5:-5])==0,"LRS not generated properly")
 
 if __name__ == '__main__':
     gr_unittest.run(test_lfsr)

--- a/gr-digital/python/digital/qa_scrambler.py
+++ b/gr-digital/python/digital/qa_scrambler.py
@@ -8,8 +8,9 @@
 #
 #
 
-
 from gnuradio import gr, gr_unittest, digital, blocks
+from gnuradio.digital.utils import lfsr_args
+import numpy as np
 import pmt
 
 # See gr-digital/lib/additive_scrambler_bb_impl.cc for reference.
@@ -25,7 +26,6 @@ def additive_scramble_lfsr(mask, seed, reglen, bpb, data):
         out.append(d ^ scramble_word)
     return out
 
-
 class test_scrambler(gr_unittest.TestCase):
 
     def setUp(self):
@@ -33,6 +33,83 @@ class test_scrambler(gr_unittest.TestCase):
 
     def tearDown(self):
         self.tb = None
+
+
+    def test_lfsr_002(self):
+        _a = lfsr_args(1,51,3,0)
+        l = digital.lfsr(*_a)
+        seq = [l.next_bit() for _ in range(2**10)]
+        reg = np.zeros(52,np.int8)
+        reg[::-1][(51,3,0),] = 1
+        res = (np.convolve(seq,reg)%2)
+        self.assertTrue(sum(res[52:-52])==0,"LRS not generated properly")
+
+    def test_scrambler_descrambler_001(self):
+        src_data = np.random.randint(0,2,500,dtype=np.int8)
+        src = blocks.vector_source_b(src_data, False)
+        scrambler = digital.scrambler_bb(*lfsr_args(0b1,7,2,0))     # p(x) = x^7 + x^2 + 1
+        descrambler = digital.descrambler_bb(*lfsr_args(0b111,7,2,0)) # we can use any seed here, it is descrambling.
+        m_tap = blocks.vector_sink_b()
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, scrambler, descrambler, dst)
+        self.tb.connect(scrambler, m_tap)
+        self.tb.run()
+        self.assertEqual(src_data[:-7].tolist(), dst.data()[7:]) # skip garbage during synchronization
+        self.assertEqual(tuple(np.convolve(m_tap.data(),[1,0,0,0,0,1,0,1])%2)[7:-10],
+                tuple(src_data[:-10])) # manual descrambling test
+
+    def test_scrambler_descrambler_002(self):
+        _a = lfsr_args(0b1,51,6,0) #p(x) = x^51+x^6+1
+        src_data = np.random.randint(0,2,1000,dtype=np.int8)
+        src = blocks.vector_source_b(src_data, False)
+        scrambler = digital.scrambler_bb(*_a)
+        m_tap = blocks.vector_sink_b()
+        descrambler = digital.descrambler_bb(*_a)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, scrambler, descrambler, dst)
+        self.tb.connect(scrambler, m_tap)
+        self.tb.run()
+        self.assertTrue(np.all(src_data[:-51]==dst.data()[51:])) # skip garbage during synchronization
+        reg = np.zeros(52,np.int8)
+        reg[::-1][(51,6,0),] = 1
+        self.assertTrue(np.all( np.convolve(m_tap.data(),reg)[51:-60]%2 
+            == src_data[:-60])) # manual descrambling test
+
+    def test_scrambler_descrambler_003(self):
+        src_data = np.random.randint(0,2,1000,dtype=np.int8)
+        src = blocks.vector_source_b(src_data, False)
+        scrambler = digital.scrambler_bb(*lfsr_args(1,12,10,3,2,0)) # this is the product of the other two
+        descrambler1 = digital.descrambler_bb(*lfsr_args(1,5,3,0))
+        descrambler2 = digital.descrambler_bb(*lfsr_args(1,7,2,0))
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, scrambler, descrambler1, descrambler2, dst)
+        self.tb.run()
+        self.assertTrue(np.all(src_data[:-12]==dst.data()[12:])) # skip garbage during synchronization
+
+    def test_additive_scrambler_001(self):
+        _a = lfsr_args(1,51,3,0) #i p(x) = x^51+x^3+1, seed 0x1
+        src_data = np.random.randint(0,2,1000,dtype=np.int8).tolist()
+        src = blocks.vector_source_b(src_data, False)
+        scrambler = digital.additive_scrambler_bb(*_a)
+        descrambler = digital.additive_scrambler_bb(*_a)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, scrambler, descrambler, dst)
+        self.tb.run()
+        self.assertEqual(tuple(src_data), tuple(dst.data()))
+
+    def test_additive_scrambler_002(self):
+        _a = lfsr_args(1,51,3,0) #i p(x) = x^51+x^3+1, seed 0x1
+        src_data = [1,]*1000
+        src = blocks.vector_source_b(src_data, False)
+        scrambler = digital.additive_scrambler_bb(*_a)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, scrambler, dst)
+        self.tb.run()
+        reg = np.zeros(52,np.int8)
+        reg[::-1][(51,3,0),] = 1
+        res = (np.convolve(dst.data(),reg)%2)[52:-52]
+        self.assertEqual(len(res), sum(res)) # when convolved with mask, 
+                                             # after sync, only 1's would be returned.
 
     def test_scrambler_descrambler(self):
         src_data = [1, ] * 1000

--- a/gr-digital/python/digital/utils/__init__.py
+++ b/gr-digital/python/digital/utils/__init__.py
@@ -7,3 +7,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # 
+
+from .lfsr import lfsr_args

--- a/gr-digital/python/digital/utils/lfsr.py
+++ b/gr-digital/python/digital/utils/lfsr.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+#
+# Copyright 2020 Free Software Foundation, Inc.
+# 
+# This file is part of GNU Radio
+# 
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# 
+
+def lfsr_args(seed, *exp):
+    """
+    Produce arguments to create scrambler objects from exponent polynomial expressions.
+     seed: start-value of register
+    *exp: exponents of desired polynomial.
+     Example:
+    >>> l = digital.lfsr(*lfrs_args(0b11001,7,1,0))
+    Creates an lfsr object with seed 0b11001, mask 0b1000011, K=6
+    """
+    from functools import reduce
+    return reduce(int.__xor__, map(lambda x:2**x, exp)), seed, max(exp)-1


### PR DESCRIPTION
registers. Use __builtin_parity or volk popcnt. qa was also enhanced to detect errors.

See this thread for reference: https://github.com/gnuradio/gnuradio/pull/3968