### PR TITLE
grc: Fix drag n' drop issue with Quartz (macOS) backend

### DIFF
--- a/grc/gui/Constants.py
+++ b/grc/gui/Constants.py
@@ -38,7 +38,8 @@ PARAM_FONT = "Sans 7.5"
 STATE_CACHE_SIZE = 42
 
 # Shared targets for drag and drop of blocks
-DND_TARGETS = [('STRING', Gtk.TargetFlags.SAME_APP, 0)]
+DND_TARGETS = [Gtk.TargetEntry.new('STRING', Gtk.TargetFlags.SAME_APP, 0),
+               Gtk.TargetEntry.new('UTF8_STRING', Gtk.TargetFlags.SAME_APP, 1)]
 
 # label constraint dimensions
 LABEL_SEPARATION = 3


### PR DESCRIPTION
This resolves an exception thrown when performing a drag and drop from the block list to the flow graph on macOS.

See discussion in #2727 in which @eblot proposed this patch more than a year ago, but as far as I know was not put forward as a pull request.

The patch has already been in use for the last 6 months when installing GNU Radio on macOS via conda.