### PR TITLE
gr-analog: Fixed orientation of L and R audio in wfm_rcv_pll. Changed gain of multiply_const_ff blocks from 5.5 to 1.0.

### DIFF
--- a/gr-analog/grc/analog_wfm_rcv_pll.block.yml
+++ b/gr-analog/grc/analog_wfm_rcv_pll.block.yml
@@ -9,6 +9,10 @@ parameters:
 -   id: audio_decimation
     label: Audio Decimation
     dtype: int
+-   id: deemph_tau
+    label: Deemphasis Tau
+    dtype: real
+    default: 75e-6
 
 inputs:
 -   domain: stream
@@ -24,7 +28,7 @@ outputs:
 
 templates:
     imports: from gnuradio import analog
-    make: "analog.wfm_rcv_pll(\n\tdemod_rate=${quad_rate},\n\taudio_decimation=${audio_decimation},\n\
+    make: "analog.wfm_rcv_pll(\n\tdemod_rate=${quad_rate},\n\taudio_decimation=${audio_decimation},\n\tdeemph_tau=${deemph_tau},\n\
         )"
 
 file_format: 1

--- a/gr-analog/python/analog/wfm_rcv_pll.py
+++ b/gr-analog/python/analog/wfm_rcv_pll.py
@@ -26,7 +26,7 @@ class wfm_rcv_pll(gr.hier_block2):
 
         Args:
             demod_rate: input sample rate of complex baseband input. (float)
-            audio_decimation: how much to decimate demod_rate to get to audio. (integer) FIXME: Not actually implemented!
+            audio_decimation: how much to decimate demod_rate to get to audio. (integer)
         """
         gr.hier_block2.__init__(self, "wfm_rcv_pll",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex), # Input signature
@@ -39,14 +39,13 @@ class wfm_rcv_pll(gr.hier_block2):
         ##################################################
         # Variables
         ##################################################
-        self.samp_rate = samp_rate = 3840000
-        self.rf_decim = rf_decim = 10
-        self.demod_rate = demod_rate = (int)(samp_rate/rf_decim)
-        self.stereo_carrier_filter_coeffs_0 = stereo_carrier_filter_coeffs_0 = firdes.band_pass(1.0, demod_rate, 37600, 38400, 400, fft.window.WIN_HAMMING, 6.76)
+        self.demod_rate = demod_rate
+        self.stereo_carrier_filter_coeffs_0 = stereo_carrier_filter_coeffs_0 = firdes.band_pass(-2.0, demod_rate, 37600, 38400, 400, fft.window.WIN_HAMMING, 6.76)
         self.stereo_carrier_filter_coeffs = stereo_carrier_filter_coeffs = firdes.complex_band_pass(1.0, demod_rate, 18980, 19020, 1500, fft.window.WIN_HAMMING, 6.76)
         self.deviation = deviation = 75000
         self.audio_filter = audio_filter = firdes.low_pass(1, demod_rate, 15000,1500, fft.window.WIN_HAMMING, 6.76)
-        self.audio_decim = audio_decim = (int)(demod_rate/48000)
+        self.audio_decim = audio_decim = audio_decimation
+        self.samp_delay = samp_delay = (len(stereo_carrier_filter_coeffs) - 1) // 2 + (len(stereo_carrier_filter_coeffs_0) - 1) // 2
 
         ##################################################
         # Blocks
@@ -61,15 +60,14 @@ class wfm_rcv_pll(gr.hier_block2):
         self.fft_filter_xxx_1.declare_sample_delay(0)
         self.blocks_multiply_xx_2 = blocks.multiply_vff(1)
         self.blocks_multiply_xx_0 = blocks.multiply_vcc(1)
-        self.blocks_multiply_const_vxx_0_1 = blocks.multiply_const_ff(5.5)
-        self.blocks_multiply_const_vxx_0 = blocks.multiply_const_ff(-5.5)
         self.blocks_complex_to_imag_0 = blocks.complex_to_imag(1)
-        self.blocks_add_xx_0_0 = blocks.add_vff(1)
+        self.blocks_sub_xx_0 = blocks.sub_ff(1)
         self.blocks_add_xx_0 = blocks.add_vff(1)
         self.analog_quadrature_demod_cf_0 = analog.quadrature_demod_cf(demod_rate/(2*math.pi*deviation))
         self.analog_pll_refout_cc_0 = analog.pll_refout_cc(0.001, 2*math.pi * 19200 / demod_rate, 2*math.pi * 18800 / demod_rate)
-        self.analog_fm_deemph_0_0 = analog.fm_deemph(fs=48000, tau=75e-6)
-        self.analog_fm_deemph_0 = analog.fm_deemph(fs=48000, tau=75e-6)
+        self.analog_fm_deemph_0_0 = analog.fm_deemph(fs=demod_rate//audio_decim, tau=75e-6)
+        self.analog_fm_deemph_0 = analog.fm_deemph(fs=demod_rate//audio_decim, tau=75e-6)
+        self.blocks_delay_0 = blocks.delay(gr.sizeof_float*1, samp_delay)
 
         ##################################################
         # Connections
@@ -78,20 +76,19 @@ class wfm_rcv_pll(gr.hier_block2):
         self.connect((self.analog_fm_deemph_0_0, 0), (self, 1))
         self.connect((self.analog_pll_refout_cc_0, 0), (self.blocks_multiply_xx_0, 1))
         self.connect((self.analog_pll_refout_cc_0, 0), (self.blocks_multiply_xx_0, 0))
-        self.connect((self.analog_quadrature_demod_cf_0, 0), (self.blocks_multiply_xx_2, 0))
-        self.connect((self.analog_quadrature_demod_cf_0, 0), (self.fft_filter_xxx_1, 0))
+        self.connect((self.analog_quadrature_demod_cf_0, 0), (self.blocks_delay_0, 0))
+        self.connect((self.blocks_delay_0, 0), (self.blocks_multiply_xx_2, 0))
+        self.connect((self.blocks_delay_0, 0), (self.fft_filter_xxx_1, 0))
         self.connect((self.analog_quadrature_demod_cf_0, 0), (self.fir_filter_xxx_1, 0))
         self.connect((self.blocks_add_xx_0, 0), (self.analog_fm_deemph_0, 0))
-        self.connect((self.blocks_add_xx_0_0, 0), (self.analog_fm_deemph_0_0, 0))
+        self.connect((self.blocks_sub_xx_0, 0), (self.analog_fm_deemph_0_0, 0))
         self.connect((self.blocks_complex_to_imag_0, 0), (self.fft_filter_xxx_3, 0))
-        self.connect((self.blocks_multiply_const_vxx_0, 0), (self.blocks_add_xx_0, 0))
-        self.connect((self.blocks_multiply_const_vxx_0_1, 0), (self.blocks_add_xx_0_0, 0))
         self.connect((self.blocks_multiply_xx_0, 0), (self.blocks_complex_to_imag_0, 0))
-        self.connect((self.blocks_multiply_xx_2, 0), (self.fft_filter_xxx_2, 0))
+        self.connect((self.blocks_multiply_xx_2, 0), (self.fft_filter_xxx_2, 0)) # L - R path
         self.connect((self.fft_filter_xxx_1, 0), (self.blocks_add_xx_0, 1))
-        self.connect((self.fft_filter_xxx_1, 0), (self.blocks_add_xx_0_0, 1))
-        self.connect((self.fft_filter_xxx_2, 0), (self.blocks_multiply_const_vxx_0, 0))
-        self.connect((self.fft_filter_xxx_2, 0), (self.blocks_multiply_const_vxx_0_1, 0))
+        self.connect((self.fft_filter_xxx_1, 0), (self.blocks_sub_xx_0, 0))
+        self.connect((self.fft_filter_xxx_2, 0), (self.blocks_add_xx_0, 0))
+        self.connect((self.fft_filter_xxx_2, 0), (self.blocks_sub_xx_0, 1))
         self.connect((self.fft_filter_xxx_3, 0), (self.blocks_multiply_xx_2, 1))
         self.connect((self.fir_filter_xxx_1, 0), (self.analog_pll_refout_cc_0, 0))
         self.connect((self, 0), (self.analog_quadrature_demod_cf_0, 0))


### PR DESCRIPTION
This change resolves two issues:

1. L and R audio were reversed. Negation should occur in the R audio path - refer to [this](https://cdn.rohde-schwarz.com/pws/dl_downloads/dl_application/application_notes/7bm105/7BM105_0E.pdf) R&S app note for details.
2. Gain of multiply_const_ff block should be 1. In this case, the demodulated audio can be multiplied by the max_deviation parameter of the quadrature demodulator (75 kHz) to give the L and R deviation values.