### PR TITLE
Update the repository to reflect the requirement to sign the DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,22 @@ list, answers on Stack Overflow, Wiki page edits, examples... We very much
 appreciate those. However, this document is specifically about contributing
 code.
 
-## CLA filed?
+## DCO Signed?
 
-The GNU Radio codebase's copyright belongs to the Free Software Foundation. Any
-submission that gets merged must therefore be assigned to the FSF. Exceptions
-are small or obvious changes (< 10 lines, typically) or documentation changes.
-See also [What's this Copyright Assignment?][cla].
+Any code contributions going into GNU Radio will become part of a GPL-licensed,
+open source repository. It is therefore imperative that code submissions belong
+to the authors, and that submitters have the authority to merge that code into
+the public GNU Radio codebase.
+
+For that purpose, we use the [Developer's Certificate of Origin](DCO.txt). It
+is the same document used by other projects. Signing the DCO states that there
+are no legal reasons to not merge your code.
+
+To sign the DCO, suffix your git commits with a "Signed-off-by" line. When
+using the command line, you can use `git commit -s` to automatically add this
+line. If there were multiple authors of the code, or other types of
+stakeholders, make sure that all are listed, each with a separate Signed-off-by
+line.
 
 ## Coding Guidelines
 
@@ -79,6 +89,5 @@ please follow existing examples regarding their command line arguments, and
 reuse them.
 
 [grep1]: https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md
-[cla]: https://wiki.gnuradio.org/index.php/Development#What.27s_this_Copyright_Assignment.3F
 [wikicontrib]: https://wiki.gnuradio.org/index.php/Development
 [gr-devs]: https://github.com/orgs/gnuradio/teams/gr-devs

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Going forward, we will be requiring contributors to sign the DCO. This
commit adds the DCO text itself and updates the contribution guidelines.