### PR TITLE
grc: indent multiline connections in py flowgraph generation

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -217,7 +217,7 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         # Connections
         ${'##################################################'}
         % for connection in connections:
-        ${ connection.rstrip() }
+        ${ indent(connection.rstrip()) }
         % endfor
         % endif
 


### PR DESCRIPTION
This fixes flowgraph generation when using connection templates with
multiple lines. Previously it would only indent the first line and
subsequent lines would have no indentation, causing a python error.