### PR TITLE
Remove things marked as deprecated to be removed in 3.8

### DIFF
--- a/docs/usage-manual/(exported from wiki) GNURadioCompanion.txt
+++ b/docs/usage-manual/(exported from wiki) GNURadioCompanion.txt
@@ -185,7 +185,7 @@ Note: Most blocks with a taps parameter automatically import the firdes module. 
 Enter the following into the taps parameter of a filter block:
 
 <pre>
-firdes.low_pass(1.0, samp_rate, 1000, 100, firdes.WIN_HAMMING)
+firdes.low_pass(1.0, samp_rate, 1000, 100, fft.window.WIN_HAMMING)
 </pre>
 === Use Taps from a File ===
 

--- a/docs/usage-manual/(exported from wiki) Polyphase Filterbanks.txt
+++ b/docs/usage-manual/(exported from wiki) Polyphase Filterbanks.txt
@@ -49,7 +49,7 @@ filter that is then split up between the N channels of the PFB.
     self._M = 9              # Number of channels to channelize
     self._taps = filter.firdes.low_pass_2(1, self._fs, 475.50, 50,
                                           attenuation_dB=100,
-                                          window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                          window=fft.window.WIN_BLACKMAN_hARRIS)
 
 In this example, the signal into the channelizer is sampled at 9 ksps
 (complex, so 9 kHz of bandwidth). The filter uses 9 channels, so each

--- a/gnuradio-runtime/python/gnuradio/ctrlport/GrDataPlotter.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/GrDataPlotter.py
@@ -11,7 +11,7 @@
 
 from gnuradio import gr
 from gnuradio import blocks
-from gnuradio import filter
+from gnuradio import filter, fft
 from gnuradio.ctrlport.GNURadio import ControlPort
 import sys, time, struct
 

--- a/gnuradio-runtime/python/gnuradio/ctrlport/GrDataPlotter.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/GrDataPlotter.py
@@ -280,7 +280,7 @@ class GrDataPlotterPsdC(GrDataPlotParent):
         self._iscomplex = True
 
         self._npts = 2048
-        self._wintype = filter.firdes.WIN_BLACKMAN_hARRIS
+        self._wintype = fft.window.WIN_BLACKMAN_hARRIS
         self._fc = 0
 
         self._setup(1)
@@ -313,7 +313,7 @@ class GrDataPlotterPsdF(GrDataPlotParent):
         self._iscomplex = False
 
         self._npts = 2048
-        self._wintype = filter.firdes.WIN_BLACKMAN_hARRIS
+        self._wintype = fft.window.WIN_BLACKMAN_hARRIS
         self._fc = 0
 
         self._setup(1)

--- a/gr-analog/examples/USRP_FM_stereo.grc
+++ b/gr-analog/examples/USRP_FM_stereo.grc
@@ -229,7 +229,7 @@ blocks:
     samp_rate: samp_rate
     type: ccc
     width: '20000'
-    win: fft.window.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
     bus_sink: false
     bus_source: false
@@ -258,7 +258,7 @@ blocks:
     showports: 'False'
     showrf: 'True'
     type: complex
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-analog/examples/USRP_FM_stereo.grc
+++ b/gr-analog/examples/USRP_FM_stereo.grc
@@ -229,7 +229,7 @@ blocks:
     samp_rate: samp_rate
     type: ccc
     width: '20000'
-    win: firdes.WIN_HAMMING
+    win: fft.window.WIN_HAMMING
   states:
     bus_sink: false
     bus_source: false
@@ -258,7 +258,7 @@ blocks:
     showports: 'False'
     showrf: 'True'
     type: complex
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-analog/examples/fm_demod.py
+++ b/gr-analog/examples/fm_demod.py
@@ -14,6 +14,7 @@ from gnuradio import filter
 from gnuradio import analog
 from gnuradio import audio
 from gnuradio.filter import firdes
+from gnuradio.fft import window
 import sys, math
 
 # Create a top_block
@@ -49,7 +50,7 @@ class build_graph(gr.top_block):
                                         15e3,               # low pass cutoff freq
                                         1e3,                # width of trans. band
                                         60,                 # stop band attenuaton
-                                        firdes.WIN_KAISER)
+                                        window.WIN_KAISER)
 
         # Build the resampler and filter
         resamp_filter = filter.pfb_arb_resampler_fff(resamp_rate,

--- a/gr-analog/examples/fm_rx.grc
+++ b/gr-analog/examples/fm_rx.grc
@@ -201,7 +201,7 @@ blocks:
     nfilts: nfilts
     rrate: resamp_rate
     samp_delay: '0'
-    taps: firdes.low_pass_2(volume*nfilts, nfilts*in_rate, 15e3, 1e3, 60, fft.window.WIN_KAISER)
+    taps: firdes.low_pass_2(volume*nfilts, nfilts*in_rate, 15e3, 1e3, 60, window.WIN_KAISER)
     type: fff
   states:
     bus_sink: false
@@ -280,7 +280,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -360,7 +360,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -440,7 +440,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-analog/examples/fm_rx.grc
+++ b/gr-analog/examples/fm_rx.grc
@@ -201,7 +201,7 @@ blocks:
     nfilts: nfilts
     rrate: resamp_rate
     samp_delay: '0'
-    taps: firdes.low_pass_2(volume*nfilts, nfilts*in_rate, 15e3, 1e3, 60, firdes.WIN_KAISER)
+    taps: firdes.low_pass_2(volume*nfilts, nfilts*in_rate, 15e3, 1e3, 60, fft.window.WIN_KAISER)
     type: fff
   states:
     bus_sink: false
@@ -280,7 +280,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -360,7 +360,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -440,7 +440,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-analog/examples/fm_tx.grc
+++ b/gr-analog/examples/fm_tx.grc
@@ -274,7 +274,7 @@ blocks:
     nfilts: nfilts
     rrate: resamp_rate
     samp_delay: '0'
-    taps: firdes.low_pass_2(nfilts, nfilts*in_rate, 20e3, 2e3, 60, fft.window.WIN_KAISER)
+    taps: firdes.low_pass_2(nfilts, nfilts*in_rate, 20e3, 2e3, 60, window.WIN_KAISER)
     type: fff
   states:
     bus_sink: false
@@ -353,7 +353,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -433,7 +433,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-analog/examples/fm_tx.grc
+++ b/gr-analog/examples/fm_tx.grc
@@ -274,7 +274,7 @@ blocks:
     nfilts: nfilts
     rrate: resamp_rate
     samp_delay: '0'
-    taps: firdes.low_pass_2(nfilts, nfilts*in_rate, 20e3, 2e3, 60, firdes.WIN_KAISER)
+    taps: firdes.low_pass_2(nfilts, nfilts*in_rate, 20e3, 2e3, 60, fft.window.WIN_KAISER)
     type: fff
   states:
     bus_sink: false
@@ -353,7 +353,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -433,7 +433,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-analog/examples/fmtest.py
+++ b/gr-analog/examples/fmtest.py
@@ -11,6 +11,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
+from gnuradio.fft import window
 from gnuradio import analog
 from gnuradio import channels
 import sys, math, time
@@ -82,7 +83,7 @@ class fmtest(gr.top_block):
         self._chan_rate = self._if_rate / self._M
         self._taps = filter.firdes.low_pass_2(1, self._if_rate, bw, t_bw,
                                               attenuation_dB=100,
-                                              window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                              window=window.WIN_BLACKMAN_hARRIS)
         tpc = math.ceil(float(len(self._taps)) / float(self._M))
 
         print("Number of taps:     ", len(self._taps))

--- a/gr-analog/python/analog/nbfm_rx.py
+++ b/gr-analog/python/analog/nbfm_rx.py
@@ -66,7 +66,7 @@ class nbfm_rx(gr.hier_block2):
                                             quad_rate,      # sampling rate
                                             2.7e3,          # Audio LPF cutoff
                                             0.5e3,          # Transition band
-                                            filter.firdes.WIN_HAMMING)  # filter type
+                                            fft.window.WIN_HAMMING)  # filter type
 
         print("len(audio_taps) =", len(audio_taps))
 

--- a/gr-analog/python/analog/nbfm_rx.py
+++ b/gr-analog/python/analog/nbfm_rx.py
@@ -11,7 +11,7 @@
 import math
 
 from gnuradio import gr
-from gnuradio import filter
+from gnuradio import filter, fft
 
 from . import analog_python as analog
 from .fm_emph import fm_deemph

--- a/gr-analog/python/analog/wfm_rcv.py
+++ b/gr-analog/python/analog/wfm_rcv.py
@@ -57,7 +57,7 @@ class wfm_rcv(gr.hier_block2):
                                               quad_rate,      # sampling rate
                                               audio_rate / 2 - width_of_transition_band,
                                               width_of_transition_band,
-                                              filter.firdes.WIN_HAMMING)
+                                              fft.window.WIN_HAMMING)
         # input: float; output: float
         self.audio_filter = filter.fir_filter_fff(audio_decimation, audio_coeffs)
 

--- a/gr-analog/python/analog/wfm_rcv.py
+++ b/gr-analog/python/analog/wfm_rcv.py
@@ -10,7 +10,7 @@
 
 import math
 
-from gnuradio import gr, filter
+from gnuradio import gr, filter, fft
 
 from . import analog_python as analog
 from .fm_emph import fm_deemph

--- a/gr-analog/python/analog/wfm_rcv_fmdet.py
+++ b/gr-analog/python/analog/wfm_rcv_fmdet.py
@@ -60,7 +60,7 @@ class wfm_rcv_fmdet(gr.hier_block2):
                                               demod_rate,   # sampling rate
                                               15000 ,
                                               width_of_transition_band,
-                                              filter.firdes.WIN_HAMMING)
+                                              fft.window.WIN_HAMMING)
 
         # input: float; output: float
         self.audio_filter = filter.fir_filter_fff(audio_decimation, audio_coeffs)
@@ -78,7 +78,7 @@ class wfm_rcv_fmdet(gr.hier_block2):
                                                 -19020,
                                                 -18980,
                                                 width_of_transition_band,
-                                                filter.firdes.WIN_HAMMING)
+                                                fft.window.WIN_HAMMING)
 
             #print "len stereo carrier filter = ",len(stereo_carrier_filter_coeffs)
             #print "stereo carrier filter ", stereo_carrier_filter_coeffs
@@ -94,7 +94,7 @@ class wfm_rcv_fmdet(gr.hier_block2):
                                                 38000-15000 / 2,
                                                 38000+15000 / 2,
                                                 width_of_transition_band,
-                                                filter.firdes.WIN_HAMMING)
+                                                fft.window.WIN_HAMMING)
             #print "len stereo dsbsc filter = ",len(stereo_dsbsc_filter_coeffs)
             #print "stereo dsbsc filter ", stereo_dsbsc_filter_coeffs
 
@@ -115,7 +115,7 @@ class wfm_rcv_fmdet(gr.hier_block2):
                                                 57000 - 1500,
                                                 57000 + 1500,
                                                 width_of_transition_band,
-                                                filter.firdes.WIN_HAMMING)
+                                                fft.window.WIN_HAMMING)
             #print "len stereo dsbsc filter = ",len(stereo_dsbsc_filter_coeffs)
             #print "stereo dsbsc filter ", stereo_dsbsc_filter_coeffs
             # construct overlap add filter system from coefficients for stereo carrier

--- a/gr-analog/python/analog/wfm_rcv_fmdet.py
+++ b/gr-analog/python/analog/wfm_rcv_fmdet.py
@@ -12,7 +12,7 @@ import math
 
 from gnuradio import gr
 from gnuradio import blocks
-from gnuradio import filter
+from gnuradio import filter, fft
 
 from . import analog_python as analog
 from .fm_emph import fm_deemph

--- a/gr-analog/python/analog/wfm_rcv_pll.py
+++ b/gr-analog/python/analog/wfm_rcv_pll.py
@@ -42,10 +42,10 @@ class wfm_rcv_pll(gr.hier_block2):
         self.samp_rate = samp_rate = 3840000
         self.rf_decim = rf_decim = 10
         self.demod_rate = demod_rate = (int)(samp_rate/rf_decim)
-        self.stereo_carrier_filter_coeffs_0 = stereo_carrier_filter_coeffs_0 = firdes.band_pass(1.0, demod_rate, 37600, 38400, 400, firdes.WIN_HAMMING, 6.76)
-        self.stereo_carrier_filter_coeffs = stereo_carrier_filter_coeffs = firdes.complex_band_pass(1.0, demod_rate, 18980, 19020, 1500, firdes.WIN_HAMMING, 6.76)
+        self.stereo_carrier_filter_coeffs_0 = stereo_carrier_filter_coeffs_0 = firdes.band_pass(1.0, demod_rate, 37600, 38400, 400, fft.window.WIN_HAMMING, 6.76)
+        self.stereo_carrier_filter_coeffs = stereo_carrier_filter_coeffs = firdes.complex_band_pass(1.0, demod_rate, 18980, 19020, 1500, fft.window.WIN_HAMMING, 6.76)
         self.deviation = deviation = 75000
-        self.audio_filter = audio_filter = firdes.low_pass(1, demod_rate, 15000,1500, firdes.WIN_HAMMING, 6.76)
+        self.audio_filter = audio_filter = firdes.low_pass(1, demod_rate, 15000,1500, fft.window.WIN_HAMMING, 6.76)
         self.audio_decim = audio_decim = (int)(demod_rate/48000)
 
         ##################################################

--- a/gr-analog/python/analog/wfm_rcv_pll.py
+++ b/gr-analog/python/analog/wfm_rcv_pll.py
@@ -12,7 +12,7 @@ import math
 
 from gnuradio import gr
 from gnuradio import blocks
-from gnuradio import filter
+from gnuradio import filter, fft
 from gnuradio.filter import firdes
 from gnuradio import analog
 

--- a/gr-audio/examples/grc/cvsd_sweep.grc
+++ b/gr-audio/examples/grc/cvsd_sweep.grc
@@ -243,7 +243,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -320,7 +320,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -397,7 +397,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-audio/examples/grc/cvsd_sweep.grc
+++ b/gr-audio/examples/grc/cvsd_sweep.grc
@@ -243,7 +243,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -320,7 +320,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -397,7 +397,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-blocks/examples/ctrlport/usrp_source_control.grc
+++ b/gr-blocks/examples/ctrlport/usrp_source_control.grc
@@ -108,7 +108,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-blocks/examples/ctrlport/usrp_source_control.grc
+++ b/gr-blocks/examples/ctrlport/usrp_source_control.grc
@@ -108,7 +108,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-channels/examples/channel_tone_response.grc
+++ b/gr-channels/examples/channel_tone_response.grc
@@ -335,7 +335,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -398,7 +398,7 @@ blocks:
     showports: 'False'
     type: complex
     update_time: '0.10'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-channels/examples/channel_tone_response.grc
+++ b/gr-channels/examples/channel_tone_response.grc
@@ -335,7 +335,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -398,7 +398,7 @@ blocks:
     showports: 'False'
     type: complex
     update_time: '0.10'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-channels/examples/demo_quantization.grc
+++ b/gr-channels/examples/demo_quantization.grc
@@ -205,7 +205,7 @@ blocks:
     samp_rate: samp_rate
     type: fir_filter_fff
     width: bw/5.0
-    win: fft.window.WIN_HANN
+    win: window.WIN_HANN
   states:
     coordinate: [192, 196.0]
     rotation: 0
@@ -349,7 +349,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-channels/examples/demo_quantization.grc
+++ b/gr-channels/examples/demo_quantization.grc
@@ -205,7 +205,7 @@ blocks:
     samp_rate: samp_rate
     type: fir_filter_fff
     width: bw/5.0
-    win: firdes.WIN_HANN
+    win: fft.window.WIN_HANN
   states:
     coordinate: [192, 196.0]
     rotation: 0
@@ -349,7 +349,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-channels/examples/demo_spec_an.grc
+++ b/gr-channels/examples/demo_spec_an.grc
@@ -286,7 +286,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_FLATTOP
+    wintype: fft.window.WIN_FLATTOP
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-channels/examples/demo_spec_an.grc
+++ b/gr-channels/examples/demo_spec_an.grc
@@ -286,7 +286,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_FLATTOP
+    wintype: window.WIN_FLATTOP
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-channels/examples/demo_two_tone.grc
+++ b/gr-channels/examples/demo_two_tone.grc
@@ -450,7 +450,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-channels/examples/demo_two_tone.grc
+++ b/gr-channels/examples/demo_two_tone.grc
@@ -450,7 +450,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/demod/digital_freq_lock.grc
+++ b/gr-digital/examples/demod/digital_freq_lock.grc
@@ -298,7 +298,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-20'
     ymin: '-120'
   states:
@@ -375,7 +375,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-20'
     ymin: '-120'
   states:

--- a/gr-digital/examples/demod/digital_freq_lock.grc
+++ b/gr-digital/examples/demod/digital_freq_lock.grc
@@ -298,7 +298,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-20'
     ymin: '-120'
   states:
@@ -375,7 +375,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-20'
     ymin: '-120'
   states:

--- a/gr-digital/examples/demod/pam_sync.grc
+++ b/gr-digital/examples/demod/pam_sync.grc
@@ -454,7 +454,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -531,7 +531,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/demod/pam_sync.grc
+++ b/gr-digital/examples/demod/pam_sync.grc
@@ -454,7 +454,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -531,7 +531,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/ofdm/ofdm_loopback.grc
+++ b/gr-digital/examples/ofdm/ofdm_loopback.grc
@@ -315,7 +315,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/ofdm/ofdm_loopback.grc
+++ b/gr-digital/examples/ofdm/ofdm_loopback.grc
@@ -315,7 +315,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/ofdm/tx_ofdm.grc
+++ b/gr-digital/examples/ofdm/tx_ofdm.grc
@@ -639,7 +639,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/ofdm/tx_ofdm.grc
+++ b/gr-digital/examples/ofdm/tx_ofdm.grc
@@ -639,7 +639,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/burst_tagger.grc
+++ b/gr-digital/examples/packet/burst_tagger.grc
@@ -100,7 +100,7 @@ blocks:
     post_padding: '20'
     pre_padding: '0'
     type: complex
-    window: firdes.window(fft.window.WIN_HANN, 50, 0)
+    window: firdes.window(window.WIN_HANN, 50, 0)
   states:
     coordinate: [696, 75]
     rotation: 0
@@ -118,7 +118,7 @@ blocks:
     post_padding: '20'
     pre_padding: '0'
     type: complex
-    window: firdes.window(fft.window.WIN_HANN, 50, 0)
+    window: firdes.window(window.WIN_HANN, 50, 0)
   states:
     coordinate: [696, 203]
     rotation: 0

--- a/gr-digital/examples/packet/burst_tagger.grc
+++ b/gr-digital/examples/packet/burst_tagger.grc
@@ -100,7 +100,7 @@ blocks:
     post_padding: '20'
     pre_padding: '0'
     type: complex
-    window: firdes.window(firdes.WIN_HANN, 50, 0)
+    window: firdes.window(fft.window.WIN_HANN, 50, 0)
   states:
     coordinate: [696, 75]
     rotation: 0
@@ -118,7 +118,7 @@ blocks:
     post_padding: '20'
     pre_padding: '0'
     type: complex
-    window: firdes.window(firdes.WIN_HANN, 50, 0)
+    window: firdes.window(fft.window.WIN_HANN, 50, 0)
   states:
     coordinate: [696, 203]
     rotation: 0

--- a/gr-digital/examples/packet/packet_loopback_hier.grc
+++ b/gr-digital/examples/packet/packet_loopback_hier.grc
@@ -770,7 +770,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -847,7 +847,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/packet_loopback_hier.grc
+++ b/gr-digital/examples/packet/packet_loopback_hier.grc
@@ -770,7 +770,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -847,7 +847,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/packet_tx.grc
+++ b/gr-digital/examples/packet/packet_tx.grc
@@ -194,7 +194,7 @@ blocks:
     post_padding: filt_delay
     pre_padding: '0'
     type: complex
-    window: firdes.window(firdes.WIN_HANN, 20, 0)
+    window: firdes.window(fft.window.WIN_HANN, 20, 0)
   states:
     bus_sink: false
     bus_source: false

--- a/gr-digital/examples/packet/packet_tx.grc
+++ b/gr-digital/examples/packet/packet_tx.grc
@@ -194,7 +194,7 @@ blocks:
     post_padding: filt_delay
     pre_padding: '0'
     type: complex
-    window: firdes.window(fft.window.WIN_HANN, 20, 0)
+    window: firdes.window(window.WIN_HANN, 20, 0)
   states:
     bus_sink: false
     bus_source: false

--- a/gr-digital/examples/packet/simple_bpsk_tx.grc
+++ b/gr-digital/examples/packet/simple_bpsk_tx.grc
@@ -476,7 +476,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/simple_bpsk_tx.grc
+++ b/gr-digital/examples/packet/simple_bpsk_tx.grc
@@ -476,7 +476,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/transmitter_sim_hier.grc
+++ b/gr-digital/examples/packet/transmitter_sim_hier.grc
@@ -593,7 +593,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/transmitter_sim_hier.grc
+++ b/gr-digital/examples/packet/transmitter_sim_hier.grc
@@ -593,7 +593,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage4.grc
+++ b/gr-digital/examples/packet/tx_stage4.grc
@@ -449,7 +449,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage4.grc
+++ b/gr-digital/examples/packet/tx_stage4.grc
@@ -449,7 +449,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage5.grc
+++ b/gr-digital/examples/packet/tx_stage5.grc
@@ -262,7 +262,7 @@ blocks:
     post_padding: '10'
     pre_padding: '10'
     type: complex
-    window: firdes.window(fft.window.WIN_HANN, 50, 0)
+    window: firdes.window(window.WIN_HANN, 50, 0)
   states:
     bus_sink: false
     bus_source: false
@@ -470,7 +470,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage5.grc
+++ b/gr-digital/examples/packet/tx_stage5.grc
@@ -262,7 +262,7 @@ blocks:
     post_padding: '10'
     pre_padding: '10'
     type: complex
-    window: firdes.window(firdes.WIN_HANN, 50, 0)
+    window: firdes.window(fft.window.WIN_HANN, 50, 0)
   states:
     bus_sink: false
     bus_source: false
@@ -470,7 +470,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage6.grc
+++ b/gr-digital/examples/packet/tx_stage6.grc
@@ -338,7 +338,7 @@ blocks:
     post_padding: '10'
     pre_padding: '10'
     type: complex
-    window: firdes.window(fft.window.WIN_HANN, 50, 0)
+    window: firdes.window(window.WIN_HANN, 50, 0)
   states:
     bus_sink: false
     bus_source: false
@@ -567,7 +567,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage6.grc
+++ b/gr-digital/examples/packet/tx_stage6.grc
@@ -338,7 +338,7 @@ blocks:
     post_padding: '10'
     pre_padding: '10'
     type: complex
-    window: firdes.window(firdes.WIN_HANN, 50, 0)
+    window: firdes.window(fft.window.WIN_HANN, 50, 0)
   states:
     bus_sink: false
     bus_source: false
@@ -567,7 +567,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage6a.grc
+++ b/gr-digital/examples/packet/tx_stage6a.grc
@@ -354,7 +354,7 @@ blocks:
     post_padding: '10'
     pre_padding: '10'
     type: complex
-    window: firdes.window(firdes.WIN_HANN, 50, 0)
+    window: firdes.window(fft.window.WIN_HANN, 50, 0)
   states:
     bus_sink: false
     bus_source: false
@@ -602,7 +602,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/tx_stage6a.grc
+++ b/gr-digital/examples/packet/tx_stage6a.grc
@@ -354,7 +354,7 @@ blocks:
     post_padding: '10'
     pre_padding: '10'
     type: complex
-    window: firdes.window(fft.window.WIN_HANN, 50, 0)
+    window: firdes.window(window.WIN_HANN, 50, 0)
   states:
     bus_sink: false
     bus_source: false
@@ -602,7 +602,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/uhd_packet_tx.grc
+++ b/gr-digital/examples/packet/uhd_packet_tx.grc
@@ -557,7 +557,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/uhd_packet_tx.grc
+++ b/gr-digital/examples/packet/uhd_packet_tx.grc
@@ -557,7 +557,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/uhd_packet_tx_tun.grc
+++ b/gr-digital/examples/packet/uhd_packet_tx_tun.grc
@@ -542,7 +542,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-digital/examples/packet/uhd_packet_tx_tun.grc
+++ b/gr-digital/examples/packet/uhd_packet_tx_tun.grc
@@ -542,7 +542,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/catv_tx_256qam.grc
+++ b/gr-dtv/examples/catv_tx_256qam.grc
@@ -434,7 +434,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/catv_tx_256qam.grc
+++ b/gr-dtv/examples/catv_tx_256qam.grc
@@ -434,7 +434,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/catv_tx_64qam.grc
+++ b/gr-dtv/examples/catv_tx_64qam.grc
@@ -434,7 +434,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/catv_tx_64qam.grc
+++ b/gr-dtv/examples/catv_tx_64qam.grc
@@ -434,7 +434,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/dvbs2_tx.grc
+++ b/gr-dtv/examples/dvbs2_tx.grc
@@ -446,7 +446,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/dvbs2_tx.grc
+++ b/gr-dtv/examples/dvbs2_tx.grc
@@ -446,7 +446,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/dvbs_tx.grc
+++ b/gr-dtv/examples/dvbs_tx.grc
@@ -389,7 +389,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/dvbs_tx.grc
+++ b/gr-dtv/examples/dvbs_tx.grc
@@ -389,7 +389,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/dvbt_rx_8k.grc
+++ b/gr-dtv/examples/dvbt_rx_8k.grc
@@ -556,7 +556,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-10'
     ymin: '-170'
   states:

--- a/gr-dtv/examples/dvbt_rx_8k.grc
+++ b/gr-dtv/examples/dvbt_rx_8k.grc
@@ -556,7 +556,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-10'
     ymin: '-170'
   states:

--- a/gr-dtv/examples/file_atsc_tx.grc
+++ b/gr-dtv/examples/file_atsc_tx.grc
@@ -337,7 +337,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/file_atsc_tx.grc
+++ b/gr-dtv/examples/file_atsc_tx.grc
@@ -337,7 +337,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/uhd_atsc_capture.grc
+++ b/gr-dtv/examples/uhd_atsc_capture.grc
@@ -567,7 +567,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-20'
     ymin: '-100'
   states:

--- a/gr-dtv/examples/uhd_atsc_capture.grc
+++ b/gr-dtv/examples/uhd_atsc_capture.grc
@@ -567,7 +567,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-20'
     ymin: '-100'
   states:

--- a/gr-dtv/examples/uhd_atsc_rx.grc
+++ b/gr-dtv/examples/uhd_atsc_rx.grc
@@ -855,7 +855,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/uhd_atsc_rx.grc
+++ b/gr-dtv/examples/uhd_atsc_rx.grc
@@ -855,7 +855,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/uhd_atsc_tx.grc
+++ b/gr-dtv/examples/uhd_atsc_tx.grc
@@ -435,7 +435,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-dtv/examples/uhd_atsc_tx.grc
+++ b/gr-dtv/examples/uhd_atsc_tx.grc
@@ -435,7 +435,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/channelize.py
+++ b/gr-filter/examples/channelize.py
@@ -11,6 +11,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
+from gnuradio.fft import window
 import sys, time
 import numpy
 
@@ -39,7 +40,7 @@ class pfb_top_block(gr.top_block):
         # Create a set of taps for the PFB channelizer
         self._taps = filter.firdes.low_pass_2(1, self._ifs, 475.50, 50,
                                               attenuation_dB=100,
-                                              window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                              window=window.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
         tpc = numpy.ceil(float(len(self._taps)) / float(self._M))

--- a/gr-filter/examples/chirp_channelize.py
+++ b/gr-filter/examples/chirp_channelize.py
@@ -11,6 +11,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
+from gnuradio.fft import window
 import sys, time
 import numpy
 
@@ -38,7 +39,7 @@ class pfb_top_block(gr.top_block):
         # Create a set of taps for the PFB channelizer
         self._taps = filter.firdes.low_pass_2(1, self._fs, 500, 20,
                                               attenuation_dB=10,
-                                              window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                              window=window.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
         tpc = numpy.ceil(float(len(self._taps)) / float(self._M))

--- a/gr-filter/examples/decimate.py
+++ b/gr-filter/examples/decimate.py
@@ -11,6 +11,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
+from gnuradio.fft import window
 import sys, time
 import numpy
 
@@ -40,7 +41,7 @@ class pfb_top_block(gr.top_block):
         self._taps = filter.firdes.low_pass_2(1, self._fs,
                                               200, 150,
                                               attenuation_dB=120,
-                                              window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                              window=window.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
         tpc = numpy.ceil(float(len(self._taps)) / float(self._decim))

--- a/gr-filter/examples/filter_taps.grc
+++ b/gr-filter/examples/filter_taps.grc
@@ -58,7 +58,7 @@ blocks:
     samp_rate: samp_rate
     type: band_pass
     width: transition
-    win: fft.window.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
     coordinate: [696, 35]
     rotation: 0
@@ -73,7 +73,7 @@ blocks:
     low_cutoff_freq: bp_low
     samp_rate: samp_rate
     width: transition
-    win: fft.window.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
     coordinate: [872, 36.0]
     rotation: 0
@@ -105,7 +105,7 @@ blocks:
     gain: '1.0'
     samp_rate: samp_rate
     width: transition
-    win: fft.window.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
     coordinate: [536, 35]
     rotation: 0
@@ -128,7 +128,7 @@ blocks:
     gain: '1.0'
     samp_rate: samp_rate
     width: transition
-    win: fft.window.WIN_HAMMING
+    win: window.WIN_HAMMING
   states:
     coordinate: [376, 35]
     rotation: 0
@@ -333,7 +333,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/filter_taps.grc
+++ b/gr-filter/examples/filter_taps.grc
@@ -58,7 +58,7 @@ blocks:
     samp_rate: samp_rate
     type: band_pass
     width: transition
-    win: firdes.WIN_HAMMING
+    win: fft.window.WIN_HAMMING
   states:
     coordinate: [696, 35]
     rotation: 0
@@ -73,7 +73,7 @@ blocks:
     low_cutoff_freq: bp_low
     samp_rate: samp_rate
     width: transition
-    win: firdes.WIN_HAMMING
+    win: fft.window.WIN_HAMMING
   states:
     coordinate: [872, 36.0]
     rotation: 0
@@ -105,7 +105,7 @@ blocks:
     gain: '1.0'
     samp_rate: samp_rate
     width: transition
-    win: firdes.WIN_HAMMING
+    win: fft.window.WIN_HAMMING
   states:
     coordinate: [536, 35]
     rotation: 0
@@ -128,7 +128,7 @@ blocks:
     gain: '1.0'
     samp_rate: samp_rate
     width: transition
-    win: firdes.WIN_HAMMING
+    win: fft.window.WIN_HAMMING
   states:
     coordinate: [376, 35]
     rotation: 0
@@ -333,7 +333,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/filter_taps_loader.grc
+++ b/gr-filter/examples/filter_taps_loader.grc
@@ -198,7 +198,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/filter_taps_loader.grc
+++ b/gr-filter/examples/filter_taps_loader.grc
@@ -198,7 +198,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/gr_filtdes_live_upd.py
+++ b/gr-filter/examples/gr_filtdes_live_upd.py
@@ -10,6 +10,7 @@
 
 from gnuradio.filter import filter_design
 from gnuradio import gr, filter
+from gnuradio.fft import window
 from gnuradio import blocks
 import sys
 
@@ -60,7 +61,7 @@ class my_top_block(gr.top_block):
         channel = channels.channel_model(0.01)
         self.filt = filter.fft_filter_ccc(1, self.filt_taps)
         thr = blocks.throttle(gr.sizeof_gr_complex, 100*npts)
-        self.snk1 = qtgui.freq_sink_c(npts, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.freq_sink_c(npts, window.WIN_BLACKMAN_hARRIS,
                                       0, Rs,
                                       "Complex Freq Example", 1)
 

--- a/gr-filter/examples/interpolate.py
+++ b/gr-filter/examples/interpolate.py
@@ -11,6 +11,7 @@
 from gnuradio import gr
 from gnuradio import blocks
 from gnuradio import filter
+from gnuradio.fft import window
 import sys, time
 import numpy
 
@@ -46,7 +47,7 @@ class pfb_top_block(gr.top_block):
                                               self._interp*self._fs,
                                               freq2+50, 50,
                                               attenuation_dB=120,
-                                              window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                              window=window.WIN_BLACKMAN_hARRIS)
 
         # Create a set of taps for the PFB arbitrary resampler
         # The filter size is the number of filters in the filterbank; 32 will give very low side-lobes,
@@ -58,7 +59,7 @@ class pfb_top_block(gr.top_block):
                                                flt_size*self._fs,
                                                freq2+50, 150,
                                                attenuation_dB=120,
-                                               window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                               window=window.WIN_BLACKMAN_hARRIS)
 
         # Calculate the number of taps per channel for our own information
         tpc = numpy.ceil(float(len(self._taps)) / float(self._interp))

--- a/gr-filter/examples/polyphase_channelizer_demo.grc
+++ b/gr-filter/examples/polyphase_channelizer_demo.grc
@@ -259,7 +259,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -339,7 +339,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -419,7 +419,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -499,7 +499,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/polyphase_channelizer_demo.grc
+++ b/gr-filter/examples/polyphase_channelizer_demo.grc
@@ -259,7 +259,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -339,7 +339,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -419,7 +419,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -499,7 +499,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/reconstruction.py
+++ b/gr-filter/examples/reconstruction.py
@@ -11,6 +11,7 @@
 from gnuradio import gr, digital
 from gnuradio import filter
 from gnuradio import blocks
+from gnuradio.fft import window
 import sys
 import numpy
 
@@ -43,7 +44,7 @@ def main():
     tb = 400
     proto_taps = filter.firdes.low_pass_2(1, nchans*fs,
                                           bw, tb, 80,
-                                          filter.firdes.WIN_BLACKMAN_hARRIS)
+                                          window.WIN_BLACKMAN_hARRIS)
     print("Filter length: ", len(proto_taps))
 
 

--- a/gr-filter/examples/resampler_demo.grc
+++ b/gr-filter/examples/resampler_demo.grc
@@ -230,7 +230,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -307,7 +307,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/resampler_demo.grc
+++ b/gr-filter/examples/resampler_demo.grc
@@ -230,7 +230,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -307,7 +307,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-filter/examples/test_ichar_decim.grc
+++ b/gr-filter/examples/test_ichar_decim.grc
@@ -252,7 +252,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '20'
     ymin: '-120'
   states:

--- a/gr-filter/examples/test_ichar_decim.grc
+++ b/gr-filter/examples/test_ichar_decim.grc
@@ -252,7 +252,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '20'
     ymin: '-120'
   states:

--- a/gr-filter/grc/filter_band_pass_filter.block.yml
+++ b/gr-filter/grc/filter_band_pass_filter.block.yml
@@ -51,9 +51,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_band_pass_filter.block.yml
+++ b/gr-filter/grc/filter_band_pass_filter.block.yml
@@ -51,9 +51,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_band_reject_filter.block.yml
+++ b/gr-filter/grc/filter_band_reject_filter.block.yml
@@ -48,9 +48,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_band_reject_filter.block.yml
+++ b/gr-filter/grc/filter_band_reject_filter.block.yml
@@ -48,9 +48,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_fft_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_fft_low_pass_filter.block.yml
@@ -37,9 +37,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_fft_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_fft_low_pass_filter.block.yml
@@ -37,9 +37,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_high_pass_filter.block.yml
+++ b/gr-filter/grc/filter_high_pass_filter.block.yml
@@ -40,9 +40,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_high_pass_filter.block.yml
+++ b/gr-filter/grc/filter_high_pass_filter.block.yml
@@ -40,9 +40,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_hilbert_fc.block.yml
+++ b/gr-filter/grc/filter_hilbert_fc.block.yml
@@ -10,9 +10,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_BLACKMAN_hARRIS,
-        firdes.WIN_RECTANGULAR, firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_BLACKMAN_hARRIS,
+        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Blackman-harris, Rectangular, Kaiser]
     hide: part
 -   id: beta

--- a/gr-filter/grc/filter_hilbert_fc.block.yml
+++ b/gr-filter/grc/filter_hilbert_fc.block.yml
@@ -10,9 +10,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_BLACKMAN_hARRIS,
-        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_BLACKMAN_hARRIS,
+        window.WIN_RECTANGULAR, window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Blackman-harris, Rectangular, Kaiser]
     hide: part
 -   id: beta

--- a/gr-filter/grc/filter_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_filter.block.yml
@@ -40,9 +40,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_filter.block.yml
@@ -40,9 +40,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
@@ -41,9 +41,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_xlating_filter.block.yml
@@ -41,9 +41,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -28,9 +28,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -28,9 +28,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -28,9 +28,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -28,9 +28,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -20,9 +20,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -20,9 +20,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -20,9 +20,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: firdes.WIN_HAMMING
-    options: [firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN, firdes.WIN_RECTANGULAR,
-        firdes.WIN_KAISER]
+    default: fft.window.WIN_HAMMING
+    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
+        fft.window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -20,9 +20,9 @@ parameters:
 -   id: win
     label: Window
     dtype: raw
-    default: fft.window.WIN_HAMMING
-    options: [fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN, fft.window.WIN_RECTANGULAR,
-        fft.window.WIN_KAISER]
+    default: window.WIN_HAMMING
+    options: [window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN, window.WIN_RECTANGULAR,
+        window.WIN_KAISER]
     option_labels: [Hamming, Hann, Blackman, Rectangular, Kaiser]
 -   id: beta
     label: Beta

--- a/gr-filter/include/gnuradio/filter/firdes.h
+++ b/gr-filter/include/gnuradio/filter/firdes.h
@@ -28,23 +28,7 @@ namespace filter {
 class FILTER_API firdes
 {
 public:
-    // WARNING: deprecated, now located in gr::fft::window.
-    // We will be removing this in 3.8.
-    enum win_type {
-        WIN_NONE = -1,       //!< don't use a window
-        WIN_HAMMING = 0,     //!< Hamming window; max attenuation 53 dB
-        WIN_HANN = 1,        //!< Hann window; max attenuation 44 dB
-        WIN_BLACKMAN = 2,    //!< Blackman window; max attenuation 74 dB
-        WIN_RECTANGULAR = 3, //!< Basic rectangular window
-        WIN_KAISER = 4, //!< Kaiser window; max attenuation a function of beta, google it
-        WIN_BLACKMAN_hARRIS = 5, //!< Blackman-harris window
-        WIN_BLACKMAN_HARRIS =
-            5,            //!< alias to WIN_BLACKMAN_hARRIS for capitalization consistency
-        WIN_BARTLETT = 6, //!< Barlett (triangular) window
-        WIN_FLATTOP = 7,  //!< flat top window; useful in FFTs
-    };
-
-    static std::vector<float> window(win_type type, int ntaps, double beta);
+    static std::vector<float> window(fft::window::win_type type, int ntaps, double beta);
 
     // ... class methods ...
 
@@ -58,7 +42,7 @@ public:
      * \param sampling_freq       sampling freq (Hz)
      * \param cutoff_freq	        center of transition band (Hz)
      * \param transition_width	width of transition band (Hz)
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -66,7 +50,7 @@ public:
              double sampling_freq,
              double cutoff_freq,      // Hz center of transition band
              double transition_width, // Hz width of transition band
-             win_type window = WIN_HAMMING,
+             fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
              double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -81,7 +65,7 @@ public:
      * \param cutoff_freq         beginning of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      required stopband attenuation
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta		        parameter for Kaiser window
      */
     static std::vector<float>
@@ -90,7 +74,7 @@ public:
                double cutoff_freq,      // Hz beginning transition band
                double transition_width, // Hz width of transition band
                double attenuation_dB,   // out of band attenuation dB
-               win_type window = WIN_HAMMING,
+               fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -103,7 +87,7 @@ public:
      * \param sampling_freq       sampling freq (Hz)
      * \param cutoff_freq         center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -111,7 +95,7 @@ public:
               double sampling_freq,
               double cutoff_freq,      // Hz center of transition band
               double transition_width, // Hz width of transition band
-              win_type window = WIN_HAMMING,
+              fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
               double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -126,7 +110,7 @@ public:
      * \param cutoff_freq         center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -135,7 +119,7 @@ public:
                 double cutoff_freq,      // Hz center of transition band
                 double transition_width, // Hz width of transition band
                 double attenuation_dB,   // out of band attenuation dB
-                win_type window = WIN_HAMMING,
+                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                 double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -149,7 +133,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -158,7 +142,7 @@ public:
               double low_cutoff_freq,  // Hz center of transition band
               double high_cutoff_freq, // Hz center of transition band
               double transition_width, // Hz width of transition band
-              win_type window = WIN_HAMMING,
+              fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
               double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -174,7 +158,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -184,7 +168,7 @@ public:
                 double high_cutoff_freq, // Hz beginning transition band
                 double transition_width, // Hz width of transition band
                 double attenuation_dB,   // out of band attenuation dB
-                win_type window = WIN_HAMMING,
+                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                 double beta = 6.76); // used only with Kaiser
     /*!
      * \brief Use the "window method" to design a complex band-reject FIR
@@ -197,7 +181,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<gr_complex>
@@ -206,7 +190,7 @@ public:
                         double low_cutoff_freq,
                         double high_cutoff_freq,
                         double transition_width, // Hz width of transition band
-                        win_type window = WIN_HAMMING,
+                        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                         double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -222,18 +206,18 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
-    static std::vector<gr_complex>
-    complex_band_reject_2(double gain,
-                          double sampling_freq,
-                          double low_cutoff_freq,  // Hz beginning transition band
-                          double high_cutoff_freq, // Hz beginning transition band
-                          double transition_width, // Hz width of transition band
-                          double attenuation_dB,   // out of band attenuation dB
-                          win_type window = WIN_HAMMING,
-                          double beta = 6.76); // used only with Kaiser
+    static std::vector<gr_complex> complex_band_reject_2(
+        double gain,
+        double sampling_freq,
+        double low_cutoff_freq,  // Hz beginning transition band
+        double high_cutoff_freq, // Hz beginning transition band
+        double transition_width, // Hz width of transition band
+        double attenuation_dB,   // out of band attenuation dB
+        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        double beta = 6.76); // used only with Kaiser
 
     /*!
      * \brief Use the "window method" to design a complex band-pass FIR
@@ -246,7 +230,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<gr_complex>
@@ -255,7 +239,7 @@ public:
                       double low_cutoff_freq,  // Hz center of transition band
                       double high_cutoff_freq, // Hz center of transition band
                       double transition_width, // Hz width of transition band
-                      win_type window = WIN_HAMMING,
+                      fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                       double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -271,7 +255,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<gr_complex>
@@ -281,7 +265,7 @@ public:
                         double high_cutoff_freq, // Hz beginning transition band
                         double transition_width, // Hz width of transition band
                         double attenuation_dB,   // out of band attenuation dB
-                        win_type window = WIN_HAMMING,
+                        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                         double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -295,7 +279,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -304,7 +288,7 @@ public:
                 double low_cutoff_freq,  // Hz center of transition band
                 double high_cutoff_freq, // Hz center of transition band
                 double transition_width, // Hz width of transition band
-                win_type window = WIN_HAMMING,
+                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                 double beta = 6.76); // used only with Kaiser
 
     /*!
@@ -320,7 +304,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of firdes::win_type
+     * \param window              one of fft::window::win_type
      * \param beta                parameter for Kaiser window
      */
     static std::vector<float>
@@ -330,18 +314,19 @@ public:
                   double high_cutoff_freq, // Hz beginning transition band
                   double transition_width, // Hz width of transition band
                   double attenuation_dB,   // out of band attenuation dB
-                  win_type window = WIN_HAMMING,
+                  fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                   double beta = 6.76); // used only with Kaiser
 
     /*!\brief design a Hilbert Transform Filter
      *
      * \param ntaps           number of taps, must be odd
-     * \param windowtype      one kind of firdes::win_type
+     * \param windowtype      one kind of fft::window::win_type
      * \param beta            parameter for Kaiser window
      */
-    static std::vector<float> hilbert(unsigned int ntaps = 19,
-                                      win_type windowtype = WIN_RECTANGULAR,
-                                      double beta = 6.76);
+    static std::vector<float>
+    hilbert(unsigned int ntaps = 19,
+            fft::window::win_type windowtype = fft::window::win_type::WIN_RECTANGULAR,
+            double beta = 6.76);
 
     /*!
      * \brief design a Root Cosine FIR Filter (do we need a window?)
@@ -384,7 +369,7 @@ private:
 
     static int compute_ntaps(double sampling_freq,
                              double transition_width,
-                             win_type window_type,
+                             fft::window::win_type window_type,
                              double beta);
 
     static int compute_ntaps_windes(double sampling_freq,

--- a/gr-filter/include/gnuradio/filter/hilbert_fc.h
+++ b/gr-filter/include/gnuradio/filter/hilbert_fc.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_FILTER_HILBERT_FC_H
 #define INCLUDED_FILTER_HILBERT_FC_H
 
+#include <gnuradio/fft/window.h>
 #include <gnuradio/filter/api.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/sync_block.h>
@@ -38,11 +39,11 @@ public:
      * Build a Hilbert transformer filter block.
      *
      * \param ntaps The number of taps for the filter.
-     * \param window Window type (see firdes::win_type) to use.
+     * \param window Window type (see fft::window::win_type) to use.
      * \param beta Beta value for a Kaiser window.
      */
     static sptr make(unsigned int ntaps,
-                     firdes::win_type window = firdes::WIN_HAMMING,
+                     fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
                      double beta = 6.76);
 };
 

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler.h
@@ -71,7 +71,7 @@ namespace kernel {
  * interpolation rate (<EM>32</EM>).
  *
  *   <B><EM>self._taps = filter.firdes.low_pass_2(32, 32*fs, BW, TB,
- *      attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *      attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * The theory behind this block can be found in Chapter 7.5 of
  * the following book:
@@ -392,7 +392,7 @@ public:
  * interpolation rate (<EM>32</EM>).
  *
  *   <B><EM>self._taps = filter.firdes.low_pass_2(32, 32*fs, BW, TB,
- *      attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *      attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * The theory behind this block can be found in Chapter 7.5 of
  * the following book:

--- a/gr-filter/include/gnuradio/filter/pfb_arb_resampler_fff.h
+++ b/gr-filter/include/gnuradio/filter/pfb_arb_resampler_fff.h
@@ -71,7 +71,7 @@ namespace filter {
  * rate (<EM>32</EM>).
  *
  *   <B><EM>self._taps = filter.firdes.low_pass_2(32, 32*fs, BW, TB,
- *      attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *      attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * The theory behind this block can be found in Chapter 7.5 of the
  * following book:

--- a/gr-filter/include/gnuradio/filter/pfb_channelizer_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_channelizer_ccf.h
@@ -68,7 +68,7 @@ namespace filter {
  * is the gain of the filter, which we specify here as unity.
  *
  *    <B><EM>self._taps = filter.firdes.low_pass_2(1, fs, BW, TB,
- *       attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *       attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * The filter output can also be oversampled. The oversampling rate
  * is the ratio of the the actual output sampling rate to the normal

--- a/gr-filter/include/gnuradio/filter/pfb_decimator_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_decimator_ccf.h
@@ -58,7 +58,7 @@ namespace filter {
  * unity.
  *
  *   <B><EM>self._taps = filter.firdes.low_pass_2(1, fs, BW, TB,
- *      attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *      attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * The PFB decimator code takes the taps generated above and
  * builds a set of filters. The set contains <EM>decim</EM>

--- a/gr-filter/include/gnuradio/filter/pfb_interpolator_ccf.h
+++ b/gr-filter/include/gnuradio/filter/pfb_interpolator_ccf.h
@@ -45,7 +45,7 @@ namespace filter {
  * overall increase in power).
  *
  *   <B><EM>self._taps = filter.firdes.low_pass_2(interp, interp*fs, BW, TB,
- *      attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *      attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * The PFB interpolator code takes the taps generated above and
  * builds a set of filters. The set contains <EM>interp</EM>

--- a/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
+++ b/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
@@ -75,7 +75,7 @@ namespace kernel {
  * unity.
  *
  *    <B><EM>self._taps = filter.firdes.low_pass_2(1, fs, BW, TB,
- *       attenuation_dB=ATT, window=filter.firdes.WIN_BLACKMAN_hARRIS)</EM></B>
+ *       attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
  *
  * More on the theory of polyphase filterbanks can be found in
  * the following book:

--- a/gr-filter/lib/firdes.cc
+++ b/gr-filter/lib/firdes.cc
@@ -21,9 +21,9 @@ using std::vector;
 namespace gr {
 namespace filter {
 
-std::vector<float> firdes::window(win_type type, int ntaps, double beta)
+std::vector<float> firdes::window(fft::window::win_type type, int ntaps, double beta)
 {
-    return fft::window::build(static_cast<fft::window::win_type>(type), ntaps, beta);
+    return fft::window::build(type, ntaps, beta);
 }
 
 //
@@ -35,7 +35,7 @@ vector<float> firdes::low_pass_2(double gain,
                                  double cutoff_freq,   // Hz BEGINNING of transition band
                                  double transition_width, // Hz width of transition band
                                  double attenuation_dB,   // attenuation dB
-                                 win_type window_type,
+                                 fft::window::win_type window_type,
                                  double beta) // used only with Kaiser
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -78,7 +78,7 @@ vector<float> firdes::low_pass(double gain,
                                double sampling_freq,
                                double cutoff_freq,      // Hz center of transition band
                                double transition_width, // Hz width of transition band
-                               win_type window_type,
+                               fft::window::win_type window_type,
                                double beta) // used only with Kaiser
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -128,7 +128,7 @@ vector<float> firdes::high_pass_2(double gain,
                                   double cutoff_freq,      // Hz center of transition band
                                   double transition_width, // Hz width of transition band
                                   double attenuation_dB,   // attenuation dB
-                                  win_type window_type,
+                                  fft::window::win_type window_type,
                                   double beta) // used only with Kaiser
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -172,7 +172,7 @@ vector<float> firdes::high_pass(double gain,
                                 double sampling_freq,
                                 double cutoff_freq,      // Hz center of transition band
                                 double transition_width, // Hz width of transition band
-                                win_type window_type,
+                                fft::window::win_type window_type,
                                 double beta) // used only with Kaiser
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -221,7 +221,7 @@ vector<float> firdes::band_pass_2(double gain,
                                   double high_cutoff_freq, // Hz center of transition band
                                   double transition_width, // Hz width of transition band
                                   double attenuation_dB,   // attenuation dB
-                                  win_type window_type,
+                                  fft::window::win_type window_type,
                                   double beta) // used only with Kaiser
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -264,7 +264,7 @@ vector<float> firdes::band_pass(double gain,
                                 double low_cutoff_freq,  // Hz center of transition band
                                 double high_cutoff_freq, // Hz center of transition band
                                 double transition_width, // Hz width of transition band
-                                win_type window_type,
+                                fft::window::win_type window_type,
                                 double beta) // used only with Kaiser
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -314,7 +314,7 @@ firdes::complex_band_pass_2(double gain,
                             double high_cutoff_freq, // Hz center of transition band
                             double transition_width, // Hz width of transition band
                             double attenuation_dB,   // attenuation dB
-                            win_type window_type,
+                            fft::window::win_type window_type,
                             double beta) // used only with Kaiser
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -357,7 +357,7 @@ firdes::complex_band_pass(double gain,
                           double low_cutoff_freq,  // Hz center of transition band
                           double high_cutoff_freq, // Hz center of transition band
                           double transition_width, // Hz width of transition band
-                          win_type window_type,
+                          fft::window::win_type window_type,
                           double beta) // used only with Kaiser
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -405,7 +405,7 @@ firdes::complex_band_reject_2(double gain,
                               double high_cutoff_freq, // Hz center of transition band
                               double transition_width, // Hz width of transition band
                               double attenuation_dB,   // attenuation dB
-                              win_type window_type,
+                              fft::window::win_type window_type,
                               double beta) // used only with Kaiser
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -449,7 +449,7 @@ firdes::complex_band_reject(double gain,
                             double low_cutoff_freq,  // Hz center of transition band
                             double high_cutoff_freq, // Hz center of transition band
                             double transition_width, // Hz width of transition band
-                            win_type window_type,
+                            fft::window::win_type window_type,
                             double beta) // used only with Kaiser
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -497,7 +497,7 @@ firdes::band_reject_2(double gain,
                       double high_cutoff_freq, // Hz center of transition band
                       double transition_width, // Hz width of transition band
                       double attenuation_dB,   // attenuation dB
-                      win_type window_type,
+                      fft::window::win_type window_type,
                       double beta) // used only with Kaiser
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -541,7 +541,7 @@ vector<float> firdes::band_reject(double gain,
                                   double low_cutoff_freq,  // Hz center of transition band
                                   double high_cutoff_freq, // Hz center of transition band
                                   double transition_width, // Hz width of transition band
-                                  win_type window_type,
+                                  fft::window::win_type window_type,
                                   double beta) // used only with Kaiser
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -584,7 +584,8 @@ vector<float> firdes::band_reject(double gain,
 // Hilbert Transform
 //
 
-vector<float> firdes::hilbert(unsigned int ntaps, win_type windowtype, double beta)
+vector<float>
+firdes::hilbert(unsigned int ntaps, fft::window::win_type windowtype, double beta)
 {
     if (!(ntaps & 1))
         throw std::out_of_range("Hilbert:  Must have odd number of taps");
@@ -702,11 +703,10 @@ int firdes::compute_ntaps_windes(
 
 int firdes::compute_ntaps(double sampling_freq,
                           double transition_width,
-                          win_type window_type,
+                          fft::window::win_type window_type,
                           double beta)
 {
-    double a = fft::window::max_attenuation(
-        static_cast<fft::window::win_type>(window_type), beta);
+    double a = fft::window::max_attenuation(window_type, beta);
     int ntaps = (int)(a * sampling_freq / (22.0 * transition_width));
     if ((ntaps & 1) == 0) // if even...
         ntaps++;          // ...make odd

--- a/gr-filter/lib/hilbert_fc_impl.cc
+++ b/gr-filter/lib/hilbert_fc_impl.cc
@@ -13,6 +13,7 @@
 #endif
 
 #include "hilbert_fc_impl.h"
+#include <gnuradio/fft/window.h>
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
 
@@ -20,12 +21,14 @@ namespace gr {
 namespace filter {
 
 hilbert_fc::sptr
-hilbert_fc::make(unsigned int ntaps, firdes::win_type window, double beta)
+hilbert_fc::make(unsigned int ntaps, fft::window::win_type window, double beta)
 {
     return gnuradio::make_block_sptr<hilbert_fc_impl>(ntaps, window, beta);
 }
 
-hilbert_fc_impl::hilbert_fc_impl(unsigned int ntaps, firdes::win_type window, double beta)
+hilbert_fc_impl::hilbert_fc_impl(unsigned int ntaps,
+                                 fft::window::win_type window,
+                                 double beta)
     : sync_block("hilbert_fc",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(gr_complex))),

--- a/gr-filter/lib/hilbert_fc_impl.h
+++ b/gr-filter/lib/hilbert_fc_impl.h
@@ -11,6 +11,7 @@
 #ifndef INCLUDED_FILTER_HILBERT_FC_IMPL_H
 #define INCLUDED_FILTER_HILBERT_FC_IMPL_H
 
+#include <gnuradio/fft/window.h>
 #include <gnuradio/filter/fir_filter.h>
 #include <gnuradio/filter/hilbert_fc.h>
 #include <gnuradio/types.h>
@@ -26,7 +27,7 @@ private:
 
 public:
     hilbert_fc_impl(unsigned int ntaps,
-                    firdes::win_type window = firdes::WIN_HAMMING,
+                    fft::window::win_type window = fft::window::WIN_HAMMING,
                     double beta = 6.76);
 
     int work(int noutput_items,

--- a/gr-filter/lib/qa_firdes.cc
+++ b/gr-filter/lib/qa_firdes.cc
@@ -134,7 +134,7 @@ const static float t6_exp[] = { // bandpass
 
 BOOST_AUTO_TEST_CASE(t1)
 {
-    vector<float> taps = firdes::low_pass(1.0, 8000, 1750, 500, firdes::WIN_HAMMING);
+    vector<float> taps = firdes::low_pass(1.0, 8000, 1750, 500, fft::window::WIN_HAMMING);
 
     // std::cout << "ntaps: " << taps.size() << std::endl;
     // print_taps(std::cout, taps);
@@ -148,7 +148,8 @@ BOOST_AUTO_TEST_CASE(t1)
 
 BOOST_AUTO_TEST_CASE(t2)
 {
-    vector<float> taps = firdes::high_pass(1.0, 8000, 1750, 500, firdes::WIN_HAMMING);
+    vector<float> taps =
+        firdes::high_pass(1.0, 8000, 1750, 500, fft::window::WIN_HAMMING);
 
     // std::cout << "ntaps: " << taps.size() << std::endl;
     // print_taps(std::cout, taps);
@@ -168,7 +169,7 @@ BOOST_AUTO_TEST_CASE(t3)
                                            5.75e6 - (5.28e6 / 2),
                                            5.75e6 + (5.28e6 / 2),
                                            0.62e6,
-                                           firdes::WIN_HAMMING);
+                                           fft::window::WIN_HAMMING);
 
     // std::cout << "ntaps: " << taps.size() << std::endl;
     // print_taps(std::cout, taps);
@@ -184,7 +185,7 @@ BOOST_AUTO_TEST_CASE(t3)
 BOOST_AUTO_TEST_CASE(t4)
 {
     vector<float> taps =
-        firdes::low_pass_2(1.0, 8000, 1750, 500, 66, firdes::WIN_HAMMING);
+        firdes::low_pass_2(1.0, 8000, 1750, 500, 66, fft::window::WIN_HAMMING);
 
     // std::cout << "ntaps: " << taps.size() << std::endl;
     // print_taps(std::cout, taps);
@@ -199,7 +200,7 @@ BOOST_AUTO_TEST_CASE(t4)
 BOOST_AUTO_TEST_CASE(t5)
 {
     vector<float> taps =
-        firdes::high_pass_2(1.0, 8000, 1750, 500, 66, firdes::WIN_HAMMING);
+        firdes::high_pass_2(1.0, 8000, 1750, 500, 66, fft::window::WIN_HAMMING);
 
     // std::cout << "ntaps: " << taps.size() << std::endl;
     // print_taps(std::cout, taps);
@@ -220,7 +221,7 @@ BOOST_AUTO_TEST_CASE(t6)
                                              5.75e6 + (5.28e6 / 2),
                                              0.62e6,
                                              66,
-                                             firdes::WIN_HAMMING);
+                                             fft::window::WIN_HAMMING);
 
     // std::cout << "ntaps: " << taps.size() << std::endl;
     // print_taps(std::cout, taps);

--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -13,6 +13,7 @@
 #endif
 
 #include "rational_resampler_impl.h"
+#include <gnuradio/fft/window.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/integer_math.h>
 #include <gnuradio/io_signature.h>
@@ -62,7 +63,7 @@ std::vector<TAP_T> design_resampler_filter(const unsigned interpolation,
                             interpolation,       /* Fs */
                             mid_transition_band, /* trans mid point */
                             trans_width,         /* transition width */
-                            firdes::WIN_KAISER,
+                            fft::window::WIN_KAISER,
                             beta); /* beta*/
 }
 

--- a/gr-filter/python/filter/bindings/firdes_python.cc
+++ b/gr-filter/python/filter/bindings/firdes_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(firdes.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(0b2837cc3e5dcdc4435575d7ce1950df)                     */
+/* BINDTOOL_HEADER_FILE_HASH(afeccb5d25e3c88b1dcfc23d3542ec0b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -33,21 +33,6 @@ void bind_firdes(py::module& m)
 
     py::class_<firdes, std::shared_ptr<firdes>> firdes_class(m, "firdes", D(firdes));
 
-    py::enum_<gr::filter::firdes::win_type>(firdes_class, "win_type")
-        .value("WIN_NONE", gr::filter::firdes::WIN_NONE)                       // -1
-        .value("WIN_HAMMING", gr::filter::firdes::WIN_HAMMING)                 // 0
-        .value("WIN_HANN", gr::filter::firdes::WIN_HANN)                       // 1
-        .value("WIN_BLACKMAN", gr::filter::firdes::WIN_BLACKMAN)               // 2
-        .value("WIN_RECTANGULAR", gr::filter::firdes::WIN_RECTANGULAR)         // 3
-        .value("WIN_KAISER", gr::filter::firdes::WIN_KAISER)                   // 4
-        .value("WIN_BLACKMAN_hARRIS", gr::filter::firdes::WIN_BLACKMAN_hARRIS) // 5
-        .value("WIN_BLACKMAN_HARRIS", gr::filter::firdes::WIN_BLACKMAN_HARRIS) // 5
-        .value("WIN_BARTLETT", gr::filter::firdes::WIN_BARTLETT)               // 6
-        .value("WIN_FLATTOP", gr::filter::firdes::WIN_FLATTOP)                 // 7
-        .export_values();
-
-    py::implicitly_convertible<int, gr::filter::firdes::win_type>();
-
     firdes_class
         .def_static("window",
                     &firdes::window,
@@ -63,7 +48,7 @@ void bind_firdes(py::module& m)
                     py::arg("sampling_freq"),
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, low_pass))
 
@@ -75,7 +60,7 @@ void bind_firdes(py::module& m)
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, low_pass_2))
 
@@ -86,7 +71,7 @@ void bind_firdes(py::module& m)
                     py::arg("sampling_freq"),
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, high_pass))
 
@@ -98,7 +83,7 @@ void bind_firdes(py::module& m)
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, high_pass_2))
 
@@ -110,7 +95,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, band_pass))
 
@@ -123,7 +108,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, band_pass_2))
 
@@ -135,7 +120,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, complex_band_pass))
 
@@ -148,7 +133,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, complex_band_pass_2))
 
@@ -160,7 +145,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, band_reject))
 
@@ -173,7 +158,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, band_reject_2))
 
@@ -185,7 +170,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, complex_band_reject))
 
@@ -198,7 +183,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, complex_band_reject_2))
 
@@ -206,8 +191,7 @@ void bind_firdes(py::module& m)
         .def_static("hilbert",
                     &firdes::hilbert,
                     py::arg("ntaps") = 19,
-                    py::arg("windowtype") =
-                        ::gr::filter::firdes::win_type::WIN_RECTANGULAR,
+                    py::arg("windowtype") = ::gr::fft::window::win_type::WIN_RECTANGULAR,
                     py::arg("beta") = 6.7599999999999998,
                     D(firdes, hilbert))
 

--- a/gr-filter/python/filter/bindings/hilbert_fc_python.cc
+++ b/gr-filter/python/filter/bindings/hilbert_fc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(hilbert_fc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e204e5877a924c21b62513d8e83e952d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3f5ee100c05bf0b167c39a017a65b9eb)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -40,7 +40,7 @@ void bind_hilbert_fc(py::module& m)
 
         .def(py::init(&hilbert_fc::make),
              py::arg("ntaps"),
-             py::arg("window") = ::gr::filter::firdes::win_type::WIN_HAMMING,
+             py::arg("window") = ::gr::fft::window::win_type::WIN_HAMMING,
              py::arg("beta") = 6.7599999999999998,
              D(hilbert_fc, make));
 }

--- a/gr-filter/python/filter/bindings/pfb_arb_resampler_fff_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_arb_resampler_fff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_arb_resampler_fff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c5e898dcdfca7ab572b39fcb3f977449)                     */
+/* BINDTOOL_HEADER_FILE_HASH(01c79a89ea9653af3845ae6feedf7112)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_arb_resampler_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_arb_resampler.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(20d30db553c5a0baf55e49dcb9fd7f47)                     */
+/* BINDTOOL_HEADER_FILE_HASH(575adbe9dca6665e15803cdc1f2fa028)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/pfb_channelizer_ccf_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_channelizer_ccf_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_channelizer_ccf.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(58e2ad3c8033d6b70a93e1210389251a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e5e101f91f9b1d578affd27a80a639b7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/pfb_decimator_ccf_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_decimator_ccf_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_decimator_ccf.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c5b86590e4f51a1b90b5b5464ee0fca1)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b1bbd51a820b07e98a315670a82d4c64)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/pfb_interpolator_ccf_python.cc
+++ b/gr-filter/python/filter/bindings/pfb_interpolator_ccf_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_interpolator_ccf.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(b5d91c997d6fec23021c8c0dd766e535)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0cad2271ae2fb9771ab7a3e89dc95300)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polyphase_filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(00757cfefaac6f0906e8e0643ae0213c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(107cf4797045f9c8e227c2c741e2ed4d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -488,12 +488,12 @@ class gr_plot_filter(QtGui.QMainWindow):
 
         self.gui.nTapsEdit.setText("0")
 
-        self.filterWindows = {"Hamming Window" : filter.firdes.WIN_HAMMING,
-                              "Hann Window" : filter.firdes.WIN_HANN,
-                              "Blackman Window" : filter.firdes.WIN_BLACKMAN,
-                              "Rectangular Window" : filter.firdes.WIN_RECTANGULAR,
-                              "Kaiser Window" : filter.firdes.WIN_KAISER,
-                              "Blackman-harris Window" : filter.firdes.WIN_BLACKMAN_hARRIS}
+        self.filterWindows = {"Hamming Window" : fft.window.WIN_HAMMING,
+                              "Hann Window" : fft.window.WIN_HANN,
+                              "Blackman Window" : fft.window.WIN_BLACKMAN,
+                              "Rectangular Window" : fft.window.WIN_RECTANGULAR,
+                              "Kaiser Window" : fft.window.WIN_KAISER,
+                              "Blackman-harris Window" : fft.window.WIN_BLACKMAN_hARRIS}
         self.EQUIRIPPLE_FILT = 6 # const for equiripple filter window types.
 
 

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -15,7 +15,7 @@ import copy
 import warnings
 from optparse import OptionParser
 
-from gnuradio import filter
+from gnuradio import filter, fft
 
 try:
     import numpy as np

--- a/gr-filter/python/filter/design/fir_design.py
+++ b/gr-filter/python/filter/design/fir_design.py
@@ -156,12 +156,12 @@ def design_win_hb(fs, gain, wintype, mainwin):
     ret = r and ret
     trwidth, r = getfloat(mainwin.gui.firhbtrEdit.text())
     ret = r and ret
-    filtwin = {filter.firdes.WIN_HAMMING: 'hamming',
-               filter.firdes.WIN_HANN: 'hanning',
-               filter.firdes.WIN_BLACKMAN: 'blackman',
-               filter.firdes.WIN_RECTANGULAR: 'boxcar',
-               filter.firdes.WIN_KAISER: ('kaiser', 4.0),
-               filter.firdes.WIN_BLACKMAN_hARRIS: 'blackmanharris'}
+    filtwin = {fft.window.WIN_HAMMING: 'hamming',
+               fft.window.WIN_HANN: 'hanning',
+               fft.window.WIN_BLACKMAN: 'blackman',
+               fft.window.WIN_RECTANGULAR: 'boxcar',
+               fft.window.WIN_KAISER: ('kaiser', 4.0),
+               fft.window.WIN_BLACKMAN_hARRIS: 'blackmanharris'}
 
     if int(filtord) & 1:
         reply = QtGui.QMessageBox.information(mainwin, "Filter order should be even",

--- a/gr-filter/python/filter/design/fir_design.py
+++ b/gr-filter/python/filter/design/fir_design.py
@@ -7,7 +7,7 @@
 #
 
 import scipy
-from gnuradio import filter
+from gnuradio import filter, fft
 from PyQt5 import QtGui
 
 

--- a/gr-filter/python/filter/pfb.py
+++ b/gr-filter/python/filter/pfb.py
@@ -14,7 +14,7 @@ import math
 from gnuradio import gr, fft, blocks
 
 from . import optfir
-from . import filter_python as filter
+from . import filter_python as filter, fft
 
 
 class channelizer_ccf(gr.hier_block2):

--- a/gr-filter/python/filter/pfb.py
+++ b/gr-filter/python/filter/pfb.py
@@ -247,7 +247,7 @@ class arb_resampler_ccf(gr.hier_block2):
             # As we drop the bw factor, the optfir filter has a harder time converging;
             # using the firdes method here for better results.
             return filter.firdes.low_pass_2(flt_size, flt_size, bw, tb, atten,
-                                                  filter.firdes.WIN_BLACKMAN_HARRIS)
+                                                  fft.window.WIN_BLACKMAN_HARRIS)
         else:
             halfband = 0.5
             bw = percent*halfband
@@ -325,7 +325,7 @@ class arb_resampler_fff(gr.hier_block2):
             # As we drop the bw factor, the optfir filter has a harder time converging;
             # using the firdes method here for better results.
             return filter.firdes.low_pass_2(flt_size, flt_size, bw, tb, atten,
-                                                  filter.firdes.WIN_BLACKMAN_HARRIS)
+                                                  fft.window.WIN_BLACKMAN_HARRIS)
         else:
             halfband = 0.5
             bw = percent*halfband

--- a/gr-filter/python/filter/qa_filter_delay_fc.py
+++ b/gr-filter/python/filter/qa_filter_delay_fc.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks
+from gnuradio import gr, gr_unittest, fft, filter, blocks
 
 import math
 

--- a/gr-filter/python/filter/qa_filter_delay_fc.py
+++ b/gr-filter/python/filter/qa_filter_delay_fc.py
@@ -69,7 +69,7 @@ class test_filter_delay_fc(gr_unittest.TestCase):
         dst2 = blocks.vector_sink_c()
 
         # calculate taps
-        taps = filter.firdes.hilbert(ntaps, filter.firdes.WIN_HAMMING)
+        taps = filter.firdes.hilbert(ntaps, fft.window.WIN_HAMMING)
         hd = filter.filter_delay_fc(taps)
 
         expected_result = fir_filter(data, taps, (ntaps - 1) // 2)
@@ -97,7 +97,7 @@ class test_filter_delay_fc(gr_unittest.TestCase):
         dst2 = blocks.vector_sink_c()
 
         # calculate taps
-        taps = filter.firdes.hilbert(ntaps, filter.firdes.WIN_HAMMING)
+        taps = filter.firdes.hilbert(ntaps, fft.window.WIN_HAMMING)
         hd = filter.filter_delay_fc(taps)
 
         expected_result = fir_filter2(data, data, taps, (ntaps - 1) // 2)
@@ -125,7 +125,7 @@ class test_filter_delay_fc(gr_unittest.TestCase):
         src1 = blocks.vector_source_f(data1)
         src2 = blocks.vector_source_f(data2)
 
-        taps = filter.firdes.hilbert(ntaps, filter.firdes.WIN_HAMMING)
+        taps = filter.firdes.hilbert(ntaps, fft.window.WIN_HAMMING)
         hd = filter.filter_delay_fc(taps)
 
         expected_result = fir_filter2(data1, data2, taps, (ntaps - 1) // 2)

--- a/gr-filter/python/filter/qa_firdes.py
+++ b/gr-filter/python/filter/qa_firdes.py
@@ -151,7 +151,7 @@ class test_firdes(gr_unittest.TestCase):
                       0.5732954144477844, 0.0,
                       0.08335155993700027, 0.0,
                       0.010056184604763985)
-        new_taps = filter.firdes.hilbert(11, filter.firdes.WIN_HAMMING)
+        new_taps = filter.firdes.hilbert(11, fft.window.WIN_HAMMING)
         self.assertFloatTuplesAlmostEqual(known_taps, new_taps, 5)
 
     def test_root_raised_cosine(self):

--- a/gr-filter/python/filter/qa_firdes.py
+++ b/gr-filter/python/filter/qa_firdes.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter
+from gnuradio import gr, gr_unittest, fft, filter
 import sys
 
 

--- a/gr-filter/python/filter/qa_hilbert.py
+++ b/gr-filter/python/filter/qa_hilbert.py
@@ -48,7 +48,7 @@ class test_hilbert(gr_unittest.TestCase):
         data = sig_source_f(sampling_freq, sampling_freq * 0.10, 1.0, N)
         src1 = blocks.vector_source_f(data)
 
-        taps = filter.firdes.hilbert(ntaps, filter.firdes.WIN_HAMMING)
+        taps = filter.firdes.hilbert(ntaps, fft.window.WIN_HAMMING)
         expected_result = fir_filter(data, taps)
 
         hilb = filter.hilbert_fc(ntaps)

--- a/gr-filter/python/filter/qa_hilbert.py
+++ b/gr-filter/python/filter/qa_hilbert.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks
+from gnuradio import gr, gr_unittest, fft, filter, blocks
 import math
 
 

--- a/gr-filter/python/filter/qa_pfb_arb_resampler.py
+++ b/gr-filter/python/filter/qa_pfb_arb_resampler.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks
+from gnuradio import gr, gr_unittest, fft, filter, blocks
 import math
 
 

--- a/gr-filter/python/filter/qa_pfb_arb_resampler.py
+++ b/gr-filter/python/filter/qa_pfb_arb_resampler.py
@@ -46,7 +46,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
             fs / 2,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         freq = 121.213
         data = sig_source_f(fs, freq, 1, N)
@@ -88,7 +88,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
             fs / 2,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         freq = 211.123
         data = sig_source_c(fs, freq, 1, N)
@@ -143,7 +143,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
             fs / 4,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         freq = 211.123
         data = sig_source_c(fs, freq, 1, N)
@@ -199,7 +199,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
             400,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         freq = 211.123
         data = sig_source_c(fs, freq, 1, N)
@@ -255,7 +255,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
             400,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         freq = 211.123
         data = sig_source_c(fs, freq, 1, N)

--- a/gr-filter/python/filter/qa_pfb_channelizer.py
+++ b/gr-filter/python/filter/qa_pfb_channelizer.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks, analog
+from gnuradio import gr, gr_unittest, fft, filter, blocks, analog
 import math
 import cmath
 

--- a/gr-filter/python/filter/qa_pfb_channelizer.py
+++ b/gr-filter/python/filter/qa_pfb_channelizer.py
@@ -38,7 +38,7 @@ class test_pfb_channelizer(gr_unittest.TestCase):
         self.taps = filter.firdes.low_pass_2(
             1, self.ifs, self.fs / 2, self.fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         self.Ntest = 50
 

--- a/gr-filter/python/filter/qa_pfb_decimator.py
+++ b/gr-filter/python/filter/qa_pfb_decimator.py
@@ -28,7 +28,7 @@ def run_test(tb, channel, fft_rotate, fft_filter):
 
     taps = filter.firdes.low_pass_2(1, ifs, fs / 2, fs / 10,
                                     attenuation_dB=80,
-                                    window=filter.firdes.WIN_BLACKMAN_hARRIS)
+                                    window=fft.window.WIN_BLACKMAN_hARRIS)
 
     signals = list()
     add = blocks.add_cc()

--- a/gr-filter/python/filter/qa_pfb_decimator.py
+++ b/gr-filter/python/filter/qa_pfb_decimator.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks
+from gnuradio import gr, gr_unittest, fft, filter, blocks
 import math
 
 

--- a/gr-filter/python/filter/qa_pfb_interpolator.py
+++ b/gr-filter/python/filter/qa_pfb_interpolator.py
@@ -41,7 +41,7 @@ class test_pfb_interpolator(gr_unittest.TestCase):
             fs / 4,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         freq = 123.456
         data = sig_source_c(fs, freq, 1, N)

--- a/gr-filter/python/filter/qa_pfb_interpolator.py
+++ b/gr-filter/python/filter/qa_pfb_interpolator.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks
+from gnuradio import gr, gr_unittest, fft, filter, blocks
 
 import math
 

--- a/gr-filter/python/filter/qa_pfb_synthesizer.py
+++ b/gr-filter/python/filter/qa_pfb_synthesizer.py
@@ -9,7 +9,7 @@
 #
 
 
-from gnuradio import gr, gr_unittest, filter, blocks
+from gnuradio import gr, gr_unittest, fft, filter, blocks
 
 import math
 

--- a/gr-filter/python/filter/qa_pfb_synthesizer.py
+++ b/gr-filter/python/filter/qa_pfb_synthesizer.py
@@ -41,7 +41,7 @@ class test_pfb_synthesizer(gr_unittest.TestCase):
             fs / 2,
             fs / 10,
             attenuation_dB=80,
-            window=filter.firdes.WIN_BLACKMAN_hARRIS)
+            window=fft.window.WIN_BLACKMAN_hARRIS)
 
         signals = list()
         freqs = [0, 100, 200, -200, -100]

--- a/gr-network/examples/test_tcp_sink_client.grc
+++ b/gr-network/examples/test_tcp_sink_client.grc
@@ -185,7 +185,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_sink_client.grc
+++ b/gr-network/examples/test_tcp_sink_client.grc
@@ -185,7 +185,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_sink_client_ipv6.grc
+++ b/gr-network/examples/test_tcp_sink_client_ipv6.grc
@@ -185,7 +185,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_sink_client_ipv6.grc
+++ b/gr-network/examples/test_tcp_sink_client_ipv6.grc
@@ -185,7 +185,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_sink_server.grc
+++ b/gr-network/examples/test_tcp_sink_server.grc
@@ -185,7 +185,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_sink_server.grc
+++ b/gr-network/examples/test_tcp_sink_server.grc
@@ -185,7 +185,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_source.grc
+++ b/gr-network/examples/test_tcp_source.grc
@@ -165,7 +165,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_source.grc
+++ b/gr-network/examples/test_tcp_source.grc
@@ -165,7 +165,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_source_client.grc
+++ b/gr-network/examples/test_tcp_source_client.grc
@@ -197,7 +197,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_source_client.grc
+++ b/gr-network/examples/test_tcp_source_client.grc
@@ -197,7 +197,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_source_ipv6.grc
+++ b/gr-network/examples/test_tcp_source_ipv6.grc
@@ -165,7 +165,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_tcp_source_ipv6.grc
+++ b/gr-network/examples/test_tcp_source_ipv6.grc
@@ -165,7 +165,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_sink.grc
+++ b/gr-network/examples/test_udp_sink.grc
@@ -175,7 +175,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_sink.grc
+++ b/gr-network/examples/test_udp_sink.grc
@@ -175,7 +175,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_sink_ipv6.grc
+++ b/gr-network/examples/test_udp_sink_ipv6.grc
@@ -186,7 +186,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_sink_ipv6.grc
+++ b/gr-network/examples/test_udp_sink_ipv6.grc
@@ -186,7 +186,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_sink_seq.grc
+++ b/gr-network/examples/test_udp_sink_seq.grc
@@ -175,7 +175,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_sink_seq.grc
+++ b/gr-network/examples/test_udp_sink_seq.grc
@@ -175,7 +175,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_source.grc
+++ b/gr-network/examples/test_udp_source.grc
@@ -156,7 +156,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_source.grc
+++ b/gr-network/examples/test_udp_source.grc
@@ -156,7 +156,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_source_ipv6.grc
+++ b/gr-network/examples/test_udp_source_ipv6.grc
@@ -168,7 +168,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-60'
   states:

--- a/gr-network/examples/test_udp_source_ipv6.grc
+++ b/gr-network/examples/test_udp_source_ipv6.grc
@@ -168,7 +168,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-30'
     ymin: '-60'
   states:

--- a/gr-network/examples/test_udp_source_seq.grc
+++ b/gr-network/examples/test_udp_source_seq.grc
@@ -156,7 +156,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-network/examples/test_udp_source_seq.grc
+++ b/gr-network/examples/test_udp_source_seq.grc
@@ -156,7 +156,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '0'
     ymin: '-140'
   states:

--- a/gr-qtgui/apps/grc_qt_example.grc
+++ b/gr-qtgui/apps/grc_qt_example.grc
@@ -190,7 +190,7 @@ blocks:
     showports: 'False'
     showrf: 'False'
     type: complex
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/apps/grc_qt_example.grc
+++ b/gr-qtgui/apps/grc_qt_example.grc
@@ -190,7 +190,7 @@ blocks:
     showports: 'False'
     showrf: 'False'
     type: complex
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/apps/uhd_display.py
+++ b/gr-qtgui/apps/uhd_display.py
@@ -182,7 +182,7 @@ class my_top_block(gr.top_block):
         self._fftsize = options.fft_size
 
         self.snk = qtgui.sink_c(options.fft_size,
-                                filter.firdes.WIN_BLACKMAN_hARRIS,
+                                fft.window.WIN_BLACKMAN_hARRIS,
                                 self._freq, self._bandwidth,
                                 "UHD Display",
                                 True, True, True, False)

--- a/gr-qtgui/apps/uhd_display.py
+++ b/gr-qtgui/apps/uhd_display.py
@@ -9,7 +9,7 @@
 #
 
 from gnuradio import gr
-from gnuradio import filter
+from gnuradio import filter, fft
 from gnuradio import blocks
 from gnuradio import uhd
 from gnuradio import eng_notation

--- a/gr-qtgui/examples/gui_sink.grc
+++ b/gr-qtgui/examples/gui_sink.grc
@@ -175,7 +175,7 @@ blocks:
     showports: 'False'
     showrf: 'False'
     type: complex
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/examples/gui_sink.grc
+++ b/gr-qtgui/examples/gui_sink.grc
@@ -175,7 +175,7 @@ blocks:
     showports: 'False'
     showrf: 'False'
     type: complex
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/examples/pyqt_example_c.py
+++ b/gr-qtgui/examples/pyqt_example_c.py
@@ -9,6 +9,7 @@
 #
 
 from gnuradio import gr, filter
+from gnuradio.fft import window
 from gnuradio import blocks
 import sys
 
@@ -144,7 +145,7 @@ class my_top_block(gr.top_block):
         src  = blocks.add_cc()
         channel = channels.channel_model(0.001)
         thr = blocks.throttle(gr.sizeof_gr_complex, 100*fftsize)
-        self.snk1 = qtgui.sink_c(fftsize, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.sink_c(fftsize, window.WIN_BLACKMAN_hARRIS,
                                  0, Rs,
                                  "Complex Signal Example",
                                  True, True, True, False, None)

--- a/gr-qtgui/examples/pyqt_example_f.py
+++ b/gr-qtgui/examples/pyqt_example_f.py
@@ -10,6 +10,7 @@
 
 from gnuradio import gr, filter
 from gnuradio import blocks
+from gnuradio.fft import window
 import sys
 
 try:
@@ -135,7 +136,7 @@ class my_top_block(gr.top_block):
         thr = blocks.throttle(gr.sizeof_float, 100*fftsize)
         noise = analog.noise_source_f(analog.GR_GAUSSIAN, 0.001)
         add = blocks.add_ff()
-        self.snk1 = qtgui.sink_f(fftsize, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.sink_f(fftsize, window.WIN_BLACKMAN_hARRIS,
                                  0, Rs,
                                  "Float Signal Example",
                                  True, True, True, False, None)

--- a/gr-qtgui/examples/pyqt_freq_c.py
+++ b/gr-qtgui/examples/pyqt_freq_c.py
@@ -10,6 +10,7 @@
 
 from gnuradio import gr, filter
 from gnuradio import blocks
+from gnuradio.fft import window
 import sys
 
 try:
@@ -144,7 +145,7 @@ class my_top_block(gr.top_block):
         src  = blocks.add_cc()
         channel = channels.channel_model(0.01)
         thr = blocks.throttle(gr.sizeof_gr_complex, 100*npts)
-        self.snk1 = qtgui.freq_sink_c(npts, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.freq_sink_c(npts, window.WIN_BLACKMAN_hARRIS,
                                       0, Rs,
                                       "Complex Freq Example", 3, None)
 

--- a/gr-qtgui/examples/pyqt_freq_f.py
+++ b/gr-qtgui/examples/pyqt_freq_f.py
@@ -10,6 +10,7 @@
 
 from gnuradio import gr, filter
 from gnuradio import blocks
+from gnuradio.fft import window
 import sys
 
 try:
@@ -134,7 +135,7 @@ class my_top_block(gr.top_block):
         src2 = analog.sig_source_f(Rs, analog.GR_SIN_WAVE, f2, 0.1, 0)
         src  = blocks.add_ff()
         thr = blocks.throttle(gr.sizeof_float, 100*npts)
-        self.snk1 = qtgui.freq_sink_f(npts, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.freq_sink_f(npts, window.WIN_BLACKMAN_hARRIS,
                                       0, Rs,
                                       "Real freq Example", 3, None)
 

--- a/gr-qtgui/examples/pyqt_waterfall_c.py
+++ b/gr-qtgui/examples/pyqt_waterfall_c.py
@@ -10,6 +10,7 @@
 
 from gnuradio import gr, filter
 from gnuradio import blocks
+from gnuradio.fft import window
 import sys
 
 try:
@@ -147,7 +148,7 @@ class my_top_block(gr.top_block):
         channel = channels.channel_model(0.01)
         thr = blocks.throttle(gr.sizeof_gr_complex, 100*npts)
         filt = filter.fft_filter_ccc(1, taps)
-        self.snk1 = qtgui.waterfall_sink_c(npts, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.waterfall_sink_c(npts, window.WIN_BLACKMAN_hARRIS,
                                            0, Rs,
                                            "Complex Waterfall Example", 2, None)
         self.snk1.set_color_map(0, qtgui.INTENSITY_COLOR_MAP_TYPE_COOL)

--- a/gr-qtgui/examples/pyqt_waterfall_f.py
+++ b/gr-qtgui/examples/pyqt_waterfall_f.py
@@ -10,6 +10,7 @@
 
 from gnuradio import gr, filter
 from gnuradio import blocks
+from gnuradio.fft import window
 import sys
 
 try:
@@ -133,7 +134,7 @@ class my_top_block(gr.top_block):
         src2 = analog.sig_source_f(Rs, analog.GR_SIN_WAVE, f2, 0.1, 0)
         src  = blocks.add_ff()
         thr = blocks.throttle(gr.sizeof_float, 100*npts)
-        self.snk1 = qtgui.waterfall_sink_f(npts, filter.firdes.WIN_BLACKMAN_hARRIS,
+        self.snk1 = qtgui.waterfall_sink_f(npts, window.WIN_BLACKMAN_hARRIS,
                                            0, Rs,
                                            "Real Waterfall Example", 2, None)
         self.snk1.set_color_map(0, qtgui.INTENSITY_COLOR_MAP_TYPE_COOL)

--- a/gr-qtgui/examples/qtgui_message_inputs.grc
+++ b/gr-qtgui/examples/qtgui_message_inputs.grc
@@ -407,7 +407,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -484,7 +484,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -870,7 +870,7 @@ blocks:
     showports: 'True'
     type: msg_complex
     update_time: '0.50'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     coordinate: [991, 138]
     rotation: 0
@@ -928,7 +928,7 @@ blocks:
     showports: 'True'
     type: msg_float
     update_time: '0.50'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     coordinate: [968, 435]
     rotation: 0

--- a/gr-qtgui/examples/qtgui_message_inputs.grc
+++ b/gr-qtgui/examples/qtgui_message_inputs.grc
@@ -407,7 +407,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -484,7 +484,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -870,7 +870,7 @@ blocks:
     showports: 'True'
     type: msg_complex
     update_time: '0.50'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     coordinate: [991, 138]
     rotation: 0
@@ -928,7 +928,7 @@ blocks:
     showports: 'True'
     type: msg_float
     update_time: '0.50'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     coordinate: [968, 435]
     rotation: 0

--- a/gr-qtgui/examples/qtgui_multi_input.grc
+++ b/gr-qtgui/examples/qtgui_multi_input.grc
@@ -289,7 +289,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -581,7 +581,7 @@ blocks:
     showports: 'True'
     type: complex
     update_time: '0.10'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     coordinate: [592, 284.0]
     rotation: 0

--- a/gr-qtgui/examples/qtgui_multi_input.grc
+++ b/gr-qtgui/examples/qtgui_multi_input.grc
@@ -289,7 +289,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -581,7 +581,7 @@ blocks:
     showports: 'True'
     type: complex
     update_time: '0.10'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     coordinate: [592, 284.0]
     rotation: 0

--- a/gr-qtgui/examples/test_autocorrelator.grc
+++ b/gr-qtgui/examples/test_autocorrelator.grc
@@ -190,7 +190,7 @@ blocks:
     showports: 'True'
     showrf: 'False'
     type: complex
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/examples/test_autocorrelator.grc
+++ b/gr-qtgui/examples/test_autocorrelator.grc
@@ -190,7 +190,7 @@ blocks:
     showports: 'True'
     showrf: 'False'
     type: complex
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/examples/test_qtgui_msg.grc
+++ b/gr-qtgui/examples/test_qtgui_msg.grc
@@ -224,7 +224,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -287,7 +287,7 @@ blocks:
     showports: 'False'
     type: complex
     update_time: '0.10'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/examples/test_qtgui_msg.grc
+++ b/gr-qtgui/examples/test_qtgui_msg.grc
@@ -224,7 +224,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -287,7 +287,7 @@ blocks:
     showports: 'False'
     type: complex
     update_time: '0.10'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -33,9 +33,9 @@ parameters:
 -   id: wintype
     label: Window Type
     dtype: enum
-    default: firdes.WIN_BLACKMAN_hARRIS
-    options: [firdes.WIN_BLACKMAN_hARRIS, firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN,
-        firdes.WIN_RECTANGULAR, firdes.WIN_KAISER, firdes.WIN_FLATTOP]
+    default: fft.window.WIN_BLACKMAN_hARRIS
+    options: [fft.window.WIN_BLACKMAN_hARRIS, fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN,
+        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER, fft.window.WIN_FLATTOP]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     hide: part

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -33,9 +33,9 @@ parameters:
 -   id: wintype
     label: Window Type
     dtype: enum
-    default: fft.window.WIN_BLACKMAN_hARRIS
-    options: [fft.window.WIN_BLACKMAN_hARRIS, fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN,
-        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER, fft.window.WIN_FLATTOP]
+    default: window.WIN_BLACKMAN_hARRIS
+    options: [window.WIN_BLACKMAN_hARRIS, window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN,
+        window.WIN_RECTANGULAR, window.WIN_KAISER, window.WIN_FLATTOP]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     hide: part

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -22,9 +22,9 @@ parameters:
 -   id: wintype
     label: Window Type
     dtype: enum
-    default: firdes.WIN_BLACKMAN_hARRIS
-    options: [firdes.WIN_BLACKMAN_hARRIS, firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN,
-        firdes.WIN_RECTANGULAR, firdes.WIN_KAISER]
+    default: fft.window.WIN_BLACKMAN_hARRIS
+    options: [fft.window.WIN_BLACKMAN_hARRIS, fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN,
+        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser]
     hide: part
 -   id: fc

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -22,9 +22,9 @@ parameters:
 -   id: wintype
     label: Window Type
     dtype: enum
-    default: fft.window.WIN_BLACKMAN_hARRIS
-    options: [fft.window.WIN_BLACKMAN_hARRIS, fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN,
-        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER]
+    default: window.WIN_BLACKMAN_hARRIS
+    options: [window.WIN_BLACKMAN_hARRIS, window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN,
+        window.WIN_RECTANGULAR, window.WIN_KAISER]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser]
     hide: part
 -   id: fc

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -33,9 +33,9 @@ parameters:
 -   id: wintype
     label: Window Type
     dtype: enum
-    default: firdes.WIN_BLACKMAN_hARRIS
-    options: [firdes.WIN_BLACKMAN_hARRIS, firdes.WIN_HAMMING, firdes.WIN_HANN, firdes.WIN_BLACKMAN,
-        firdes.WIN_RECTANGULAR, firdes.WIN_KAISER, firdes.WIN_FLATTOP]
+    default: fft.window.WIN_BLACKMAN_hARRIS
+    options: [fft.window.WIN_BLACKMAN_hARRIS, fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN,
+        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER, fft.window.WIN_FLATTOP]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     hide: part

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -33,9 +33,9 @@ parameters:
 -   id: wintype
     label: Window Type
     dtype: enum
-    default: fft.window.WIN_BLACKMAN_hARRIS
-    options: [fft.window.WIN_BLACKMAN_hARRIS, fft.window.WIN_HAMMING, fft.window.WIN_HANN, fft.window.WIN_BLACKMAN,
-        fft.window.WIN_RECTANGULAR, fft.window.WIN_KAISER, fft.window.WIN_FLATTOP]
+    default: window.WIN_BLACKMAN_hARRIS
+    options: [window.WIN_BLACKMAN_hARRIS, window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN,
+        window.WIN_RECTANGULAR, window.WIN_KAISER, window.WIN_FLATTOP]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     hide: part

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -61,7 +61,7 @@ sink_c_impl::sink_c_impl(int fftsize,
             io_signature::make(1, -1, sizeof(gr_complex)),
             io_signature::make(0, 0, 0)),
       d_fftsize(fftsize),
-      d_wintype((filter::firdes::win_type)(wintype)),
+      d_wintype((fft::window::win_type)(wintype)),
       d_center_freq(fc),
       d_bandwidth(bw),
       d_name(name),
@@ -239,8 +239,8 @@ void sink_c_impl::fft(float* data_out, const gr_complex* data_in, int size)
 
 void sink_c_impl::windowreset()
 {
-    filter::firdes::win_type newwintype;
-    newwintype = (filter::firdes::win_type)d_main_gui->getWindowType();
+    fft::window::win_type newwintype;
+    newwintype = (fft::window::win_type)d_main_gui->getWindowType();
     if (d_wintype != newwintype) {
         d_wintype = newwintype;
         buildwindow();

--- a/gr-qtgui/lib/sink_c_impl.h
+++ b/gr-qtgui/lib/sink_c_impl.h
@@ -14,6 +14,7 @@
 #include <gnuradio/qtgui/sink_c.h>
 
 #include <gnuradio/fft/fft.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/SpectrumGUIClass.h>
@@ -29,7 +30,7 @@ private:
     void initialize();
 
     int d_fftsize;
-    filter::firdes::win_type d_wintype;
+    fft::window::win_type d_wintype;
     std::vector<float> d_window;
     double d_center_freq;
     double d_bandwidth;

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -14,6 +14,7 @@
 
 #include "sink_f_impl.h"
 
+#include <gnuradio/fft/window.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 
@@ -60,7 +61,7 @@ sink_f_impl::sink_f_impl(int fftsize,
     : block(
           "sink_f", io_signature::make(1, 1, sizeof(float)), io_signature::make(0, 0, 0)),
       d_fftsize(fftsize),
-      d_wintype((filter::firdes::win_type)(wintype)),
+      d_wintype((fft::window::win_type)(wintype)),
       d_center_freq(fc),
       d_bandwidth(bw),
       d_name(name),
@@ -233,8 +234,8 @@ void sink_f_impl::fft(float* data_out, const float* data_in, int size)
 
 void sink_f_impl::windowreset()
 {
-    filter::firdes::win_type newwintype;
-    newwintype = (filter::firdes::win_type)d_main_gui->getWindowType();
+    fft::window::win_type newwintype;
+    newwintype = (fft::window::win_type)d_main_gui->getWindowType();
     if (d_wintype != newwintype) {
         d_wintype = newwintype;
         buildwindow();

--- a/gr-qtgui/lib/sink_f_impl.h
+++ b/gr-qtgui/lib/sink_f_impl.h
@@ -14,6 +14,7 @@
 #include <gnuradio/qtgui/sink_f.h>
 
 #include <gnuradio/fft/fft.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/SpectrumGUIClass.h>
@@ -29,7 +30,7 @@ private:
     void initialize();
 
     int d_fftsize;
-    filter::firdes::win_type d_wintype;
+    fft::window::win_type d_wintype;
     std::vector<float> d_window;
     double d_center_freq;
     double d_bandwidth;

--- a/gr-qtgui/python/qtgui/qa_qtgui.py
+++ b/gr-qtgui/python/qtgui/qa_qtgui.py
@@ -22,7 +22,7 @@ class test_qtgui(gr_unittest.TestCase):
 
     # Tests to make sure we can instantiate the sink.
     # We use '5' in place of fft.window.WIN_BLACKMAN_hARRIS so we
-    # don't have to worry about importing filter just for this one
+    # don't have to worry about importing fft just for this one
     # constant.
     def test01(self):
         self.qtsnk = qtgui.sink_c(1024, 5,

--- a/gr-qtgui/python/qtgui/qa_qtgui.py
+++ b/gr-qtgui/python/qtgui/qa_qtgui.py
@@ -21,7 +21,7 @@ class test_qtgui(gr_unittest.TestCase):
         self.tb = None
 
     # Tests to make sure we can instantiate the sink.
-    # We use '5' in place of filter.firdes.WIN_BLACKMAN_hARRIS so we
+    # We use '5' in place of fft.window.WIN_BLACKMAN_hARRIS so we
     # don't have to worry about importing filter just for this one
     # constant.
     def test01(self):

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -31,6 +31,7 @@ from gnuradio import analog
 from gnuradio import eng_notation
 from gnuradio import qtgui
 from gnuradio import uhd
+from gnuradio import fft
 from gnuradio.filter import firdes
 from gnuradio.qtgui import Range, RangeWidget
 try:

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -292,7 +292,7 @@ class uhd_siggen_gui(Qt.QWidget):
         if self._sg.args.show_freq_sink:
             self.qtgui_freq_sink_x_0 = qtgui.freq_sink_c(
                 1024, #size
-                firdes.WIN_BLACKMAN_hARRIS, #wintype
+                fft.window.WIN_BLACKMAN_hARRIS, #wintype
                 self.freq_coarse + self.freq_fine, #fc
                 self.samp_rate, #bw
                 "", #name

--- a/gr-uhd/examples/grc/rfnoc_radio_ddc.grc
+++ b/gr-uhd/examples/grc/rfnoc_radio_ddc.grc
@@ -178,7 +178,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/rfnoc_radio_ddc.grc
+++ b/gr-uhd/examples/grc/rfnoc_radio_ddc.grc
@@ -178,7 +178,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/uhd_fft.grc
+++ b/gr-uhd/examples/grc/uhd_fft.grc
@@ -395,7 +395,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -555,7 +555,7 @@ blocks:
     showports: 'True'
     type: complex
     update_time: update_rate
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-uhd/examples/grc/uhd_fft.grc
+++ b/gr-uhd/examples/grc/uhd_fft.grc
@@ -395,7 +395,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:
@@ -555,7 +555,7 @@ blocks:
     showports: 'True'
     type: complex
     update_time: update_rate
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
   states:
     bus_sink: false
     bus_source: false

--- a/gr-uhd/examples/grc/uhd_msg_tune.grc
+++ b/gr-uhd/examples/grc/uhd_msg_tune.grc
@@ -245,7 +245,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '-40'
     ymin: '-120'
   states:

--- a/gr-uhd/examples/grc/uhd_msg_tune.grc
+++ b/gr-uhd/examples/grc/uhd_msg_tune.grc
@@ -245,7 +245,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '-40'
     ymin: '-120'
   states:

--- a/gr-uhd/examples/grc/uhd_siggen_gui.grc
+++ b/gr-uhd/examples/grc/uhd_siggen_gui.grc
@@ -428,7 +428,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/uhd_siggen_gui.grc
+++ b/gr-uhd/examples/grc/uhd_siggen_gui.grc
@@ -428,7 +428,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/uhd_two_tone_loopback.grc
+++ b/gr-uhd/examples/grc/uhd_two_tone_loopback.grc
@@ -398,7 +398,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/uhd_two_tone_loopback.grc
+++ b/gr-uhd/examples/grc/uhd_two_tone_loopback.grc
@@ -398,7 +398,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/uhd_wbfm_receive.grc
+++ b/gr-uhd/examples/grc/uhd_wbfm_receive.grc
@@ -291,7 +291,7 @@ blocks:
     samp_rate: samp_rate
     type: fir_filter_ccf
     width: 30e3
-    win: firdes.WIN_HANN
+    win: fft.window.WIN_HANN
   states:
     bus_sink: false
     bus_source: false
@@ -383,7 +383,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-uhd/examples/grc/uhd_wbfm_receive.grc
+++ b/gr-uhd/examples/grc/uhd_wbfm_receive.grc
@@ -291,7 +291,7 @@ blocks:
     samp_rate: samp_rate
     type: fir_filter_ccf
     width: 30e3
-    win: fft.window.WIN_HANN
+    win: window.WIN_HANN
   states:
     bus_sink: false
     bus_source: false
@@ -383,7 +383,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-zeromq/examples/zmq_stream.grc
+++ b/gr-zeromq/examples/zmq_stream.grc
@@ -158,7 +158,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: firdes.WIN_BLACKMAN_hARRIS
+    wintype: fft.window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/gr-zeromq/examples/zmq_stream.grc
+++ b/gr-zeromq/examples/zmq_stream.grc
@@ -158,7 +158,7 @@ blocks:
     width7: '1'
     width8: '1'
     width9: '1'
-    wintype: fft.window.WIN_BLACKMAN_hARRIS
+    wintype: window.WIN_BLACKMAN_hARRIS
     ymax: '10'
     ymin: '-140'
   states:

--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -135,6 +135,7 @@ templates:
     imports: |-
         from gnuradio import gr
         from gnuradio.filter import firdes
+        from gnuradio.fft import window
         import sys
         import signal
         % if generate_options == 'qt_gui':


### PR DESCRIPTION
The win_type in firdes and all its references