### PR TITLE
FFT window type enums

### DIFF
--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -31,10 +31,23 @@ void bind_window(py::module& m)
 {
     using window = gr::fft::window;
 
+    py::class_<window, std::shared_ptr<window>> window_class(m, "window", D(window));
 
-    py::class_<window, std::shared_ptr<window>>(m, "window", D(window))
+    py::enum_<gr::fft::window::win_type>(window_class, "win_type")
+        .value("WIN_HAMMING", gr::fft::window::WIN_HAMMING)                 // 0
+        .value("WIN_HANN", gr::fft::window::WIN_HANN)                       // 1
+        .value("WIN_BLACKMAN", gr::fft::window::WIN_BLACKMAN)               // 2
+        .value("WIN_RECTANGULAR", gr::fft::window::WIN_RECTANGULAR)         // 3
+        .value("WIN_KAISER", gr::fft::window::WIN_KAISER)                   // 4
+        .value("WIN_BLACKMAN_hARRIS", gr::fft::window::WIN_BLACKMAN_hARRIS) // 5
+        .value("WIN_BLACKMAN_HARRIS", gr::fft::window::WIN_BLACKMAN_HARRIS) // 5
+        .value("WIN_BARTLETT", gr::fft::window::WIN_BARTLETT)               // 6
+        .value("WIN_FLATTOP", gr::fft::window::WIN_FLATTOP)                 // 7
+        .export_values();
 
+    py::implicitly_convertible<int, gr::fft::window::win_type>();
 
+    window_class
         .def_static("max_attenuation",
                     &window::max_attenuation,
                     py::arg("type"),
@@ -180,19 +193,4 @@ void bind_window(py::module& m)
                     D(window, build))
 
         ;
-
-
-    py::enum_<gr::fft::window::win_type>(m, "win_type")
-        .value("WIN_HAMMING", gr::fft::window::WIN_HAMMING)                 // 0
-        .value("WIN_HANN", gr::fft::window::WIN_HANN)                       // 1
-        .value("WIN_BLACKMAN", gr::fft::window::WIN_BLACKMAN)               // 2
-        .value("WIN_RECTANGULAR", gr::fft::window::WIN_RECTANGULAR)         // 3
-        .value("WIN_KAISER", gr::fft::window::WIN_KAISER)                   // 4
-        .value("WIN_BLACKMAN_hARRIS", gr::fft::window::WIN_BLACKMAN_hARRIS) // 5
-        .value("WIN_BLACKMAN_HARRIS", gr::fft::window::WIN_BLACKMAN_HARRIS) // 5
-        .value("WIN_BARTLETT", gr::fft::window::WIN_BARTLETT)               // 6
-        .value("WIN_FLATTOP", gr::fft::window::WIN_FLATTOP)                 // 7
-        .export_values();
-
-    py::implicitly_convertible<int, gr::fft::window::win_type>();
 }

--- a/gr-fft/python/fft/qa_window.py
+++ b/gr-fft/python/fft/qa_window.py
@@ -31,7 +31,7 @@ class test_window(gr_unittest.TestCase):
         Verify window normalization
         """
         win = fft.window.build(
-            fft.win_type.WIN_BLACKMAN_hARRIS,
+            fft.window.WIN_BLACKMAN_hARRIS,
             21,
             normalize=True)
         power = numpy.sum([x * x for x in win]) / len(win)

--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -228,7 +228,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self.top_grid_layout.addWidget(self.display, 0, 0, 1, 4)
         self.qtgui_waterfall_sink_x_0 = qtgui.waterfall_sink_c(
             self.fft_size, #size
-            fft.win_type.WIN_BLACKMAN_hARRIS, #wintype
+            fft.window.WIN_BLACKMAN_hARRIS, #wintype
             self.freq, #fc
             self.samp_rate, #bw
             "", #name
@@ -279,7 +279,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self.display_grid_layout_2.addWidget(self._qtgui_time_sink_x_0_win, 0, 0, 1, 4)
         self.qtgui_freq_sink_x_0 = qtgui.freq_sink_c(
             self.fft_size, #size
-            fft.win_type.WIN_BLACKMAN_hARRIS, #wintype
+            fft.window.WIN_BLACKMAN_hARRIS, #wintype
             self.freq, #fc
             self.samp_rate, #bw
             "", #name


### PR DESCRIPTION
In 3.8 the window enums were placed under fft.window, but in the pybind transition, these got wrapped as fft.win_type.WIN_*

This is an unnecessary departure from the 3.8 API, and this restores the 3.8 API.

This is a subset of #3996 as this is the more critical part of that PR