### PR TITLE
digital: ofdm: Fix whitespace in OFDM chanest block

### DIFF
--- a/gr-digital/include/gnuradio/digital/ofdm_chanest_vcvc.h
+++ b/gr-digital/include/gnuradio/digital/ofdm_chanest_vcvc.h
@@ -17,10 +17,9 @@
 namespace gr {
 namespace digital {
 
-/*!
- * \brief Estimate channel and coarse frequency offset for OFDM from preambles
+/*! Estimate channel and coarse frequency offset for OFDM from preambles
  * \ingroup ofdm_blk
- * \ingroup syncronizers_blk
+ * \ingroup synchronizers_blk
  *
  * Input: OFDM symbols (in frequency domain). The first one (or two) symbols are expected
  *        to be synchronisation symbols, which are used to estimate the coarse freq offset
@@ -33,14 +32,14 @@ namespace digital {
  * synchronisation symbols are attached to the first data symbol. All other tags are
  * propagated as expected.
  *
- * Note: The vector on ofdm_sync_eq_taps is already frequency-corrected, whereas the rest
- * is not.
+ * Note: The vector on ofdm_sync_eq_taps is already frequency-corrected, whereas
+ * the rest is not.
  *
  * This block assumes the frequency offset is even (i.e. an integer multiple of 2).
  *
- * [1] Schmidl, T.M. and Cox, D.C., "Robust frequency and timing synchronization for
- * OFDM", Communications, IEEE Transactions on, 1997. [2] K.D. Kammeyer,
- * "Nachrichtenuebertragung," Chapter. 16.3.2.
+ * [1] Schmidl, T.M. and Cox, D.C., "Robust frequency and timing synchronization
+ *     for OFDM", Communications, IEEE Transactions on, 1997.
+ * [2] K.D. Kammeyer, "Nachrichtenuebertragung," Chapter. 16.3.2.
  */
 class DIGITAL_API ofdm_chanest_vcvc : virtual public block
 {
@@ -48,23 +47,31 @@ public:
     typedef std::shared_ptr<ofdm_chanest_vcvc> sptr;
 
     /*!
-     * \param sync_symbol1 First synchronisation symbol in the frequency domain. Its
-     * length must be the FFT length. For Schmidl & Cox synchronisation, every second
-     * sub-carrier has to be zero. \param sync_symbol2 Second synchronisation symbol in
-     * the frequency domain. Must be equal to the FFT length, or zero length if only one
-     * synchronisation symbol is used. Using this symbol is how synchronisation is
-     * described in [1]. Leaving this empty forces us to interpolate the equalizer taps.
-     *                     If you are using an unusual sub-carrier configuration (e.g.
-     * because of OFDMA), this sync symbol is used to identify the active sub-carriers. If
-     * you only have one synchronisation symbol, set the active sub-carriers to a non-zero
-     *                     value in here, and also set \p force_one_sync_symbol parameter
-     * to true. \param n_data_symbols The number of data symbols following each set of
-     * synchronisation symbols. Must be at least 1. \param eq_noise_red_len If non-zero,
-     * noise reduction for the equalizer taps is done according to [2]. In this case, it
-     * is the channel influence time in number of samples. A good value is usually the
-     * length of the cyclic prefix. \param max_carr_offset Limit the number of
-     * sub-carriers the frequency offset can maximally be. Leave this zero to try all
-     * possibilities. \param force_one_sync_symbol See \p sync_symbol2.
+     * \param sync_symbol1 First synchronisation symbol in the frequency domain.
+     *                     Its length must be the FFT length. For Schmidl & Cox
+     *                     synchronisation, every second sub-carrier has to be zero.
+     * \param sync_symbol2 Second synchronisation symbol in the frequency domain.
+     *                     Must be equal to the FFT length, or zero length if
+     *                     only one synchronisation symbol is used. Using this
+     *                     symbol is how synchronisation is described in [1].
+     *                     Leaving this empty forces us to interpolate the
+     *                     equalizer taps.
+     *                     If you are using an unusual sub-carrier configuration
+     *                     (e.g.  because of OFDMA), this sync symbol is used to
+     *                     identify the active sub-carriers. If you only have
+     *                     one synchronisation symbol, set the active sub-carriers
+     *                     to a non-zero value in here, and set \p force_one_sync_symbol
+     *                     parameter to true.
+     * \param n_data_symbols The number of data symbols following each set of
+     *                       synchronisation symbols. Must be at least 1.
+     * \param eq_noise_red_len If non-zero, noise reduction for the equalizer
+     *                         taps is done according to [2]. In this case, it
+     *                         is the channel influence time in number of samples.
+     *                         A good value is usually the length of the cyclic prefix.
+     * \param max_carr_offset Limit the number of sub-carriers the frequency
+     *                        offset can maximally be. Leave this zero to try
+     *                        all possibilities.
+     * \param force_one_sync_symbol See \p sync_symbol2.
      */
     static sptr make(const std::vector<gr_complex>& sync_symbol1,
                      const std::vector<gr_complex>& sync_symbol2,

--- a/gr-digital/python/digital/bindings/ofdm_chanest_vcvc_python.cc
+++ b/gr-digital/python/digital/bindings/ofdm_chanest_vcvc_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(ofdm_chanest_vcvc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(82caca03752b79f24d3d33c573cf570b)                     */
+/* BINDTOOL_HEADER_FILE(ofdm_chanest_vcvc.h)                                       */
+/* BINDTOOL_HEADER_FILE_HASH(a4f2516ae6c6cc38e9cf81673542ef76)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Both the C++ and Python files have really weird whitespace issues,
making them hard to read. This makes the whitespace usage for consistent
with usual formatting, and fixes some Doxygen issues.