### PR TITLE
[Backport] gr-uhd/lib/usrp_block_impl.cc: fix compile error using boost>=1.73

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -140,9 +140,11 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
                     boost::bind(&usrp_block_impl::msg_handler_command, this, _1));
 
 // cuz we lazy:
-#define REGISTER_CMD_HANDLER(key, _handler) \
-    register_msg_cmd_handler(key,           \
-                             boost::bind(&usrp_block_impl::_handler, this, _1, _2, _3))
+#define REGISTER_CMD_HANDLER(key, _handler)                                   \
+    register_msg_cmd_handler(                                                 \
+        key, [this](const pmt::pmt_t& var, int chan, const pmt::pmt_t& msg) { \
+            this->_handler(var, chan, msg);                                   \
+        })
     // Register default command handlers:
     REGISTER_CMD_HANDLER(cmd_freq_key(), _cmd_handler_freq);
     REGISTER_CMD_HANDLER(cmd_gain_key(), _cmd_handler_gain);
@@ -257,11 +259,13 @@ bool usrp_block_impl::_check_mboard_sensors_locked()
         } else if (_dev->get_clock_source(mboard_index) == "mimo") {
             sensor_name = "mimo_locked";
         }
-        if (not _wait_for_locked_sensor(
-                get_mboard_sensor_names(mboard_index),
-                sensor_name,
-                boost::bind(
-                    &usrp_block_impl::get_mboard_sensor, this, _1, mboard_index))) {
+        if (not _wait_for_locked_sensor(get_mboard_sensor_names(mboard_index),
+                                        sensor_name,
+                                        [this, mboard_index](const std::string& name) {
+                                            return static_cast<::uhd::sensor_value_t>(
+                                                this->get_mboard_sensor(name,
+                                                                        mboard_index));
+                                        })) {
             GR_LOG_WARN(
                 d_logger,
                 boost::format(

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -26,8 +26,8 @@
 #include <gnuradio/uhd/usrp_block.h>
 #include <pmt/pmt.h>
 #include <uhd/usrp/multi_usrp.hpp>
-#include <boost/bind.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <functional>
 
 
 namespace gr {
@@ -43,9 +43,8 @@ static const std::string ALL_LOS;
 class usrp_block_impl : virtual public usrp_block
 {
 public:
-    typedef boost::function<::uhd::sensor_value_t(const std::string&)> get_sensor_fn_t;
-    typedef boost::function<void(const pmt::pmt_t&, int, const pmt::pmt_t&)>
-        cmd_handler_t;
+    typedef std::function<::uhd::sensor_value_t(const std::string&)> get_sensor_fn_t;
+    typedef std::function<void(const pmt::pmt_t&, int, const pmt::pmt_t&)> cmd_handler_t;
 
     static const double LOCK_TIMEOUT;
 

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -58,7 +58,9 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
     _samp_rate = this->get_samp_rate();
     _samps_per_packet = 1;
     register_msg_cmd_handler(cmd_tag_key(),
-                             boost::bind(&usrp_source_impl::_cmd_handler_tag, this, _1));
+                             [this](const pmt::pmt_t& tag, const int, const pmt::pmt_t&) {
+                                 this->_cmd_handler_tag(tag);
+                             });
 }
 
 usrp_source_impl::~usrp_source_impl() {}


### PR DESCRIPTION
When using boost>=1.73 and compile with uhd, it always have errors.
Fix the compile error when using uhd and gcc10: error: ‘_1’ was not declared
Bug: https://bugs.gentoo.org/751259

usrp_source_impl.cc: use lambdas instead of boost::bind
usrp_block_impl.cc:use lambdas instead of boost::bind
usrp_block_impl.h: Switch from boost::function to std::function

https://github.com/gnuradio/gnuradio/pull/3441
https://github.com/gnuradio/gnuradio/pull/3887

usrp_source_impl: fix parameter bug of original code

The usrp_block_impl::register_msg_cmd_handler uses cmd_handler_t as
handler type, but it have 3 parameters.
Fix the parameter mismatch bug and change the signature as cmd_handler_t

Signed-off-by: Huang Rui <vowstar@gmail.com>