### PR TITLE
Fix the gnu-ism in terminite_handler

### DIFF
--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -91,7 +91,7 @@ windows_sink::windows_sink(int sampling_freq,
     d_wave_write_event = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (open_waveout_device() < 0) {
         GR_LOG_ERROR(d_logger,
-                     boost::format("open_waveout_device() failed: %s") % strerror(errno));
+                     boost::format("open_waveout_device() failed: %d") % GetLastError());
         throw std::runtime_error("audio_windows_sink:open_waveout_device() failed");
     } else {
         GR_LOG_INFO(d_debug_logger, "Opened windows waveout device");
@@ -184,8 +184,8 @@ int windows_sink::work(int noutput_items,
                                      d_buffers[i]->dwFlags);
                 }
                 GR_LOG_ERROR(d_logger,
-                             boost::format("no audio buffers available: %s") %
-                                 strerror(errno));
+                             boost::format("no audio buffers available: %d") %
+                                 GetLastError());
                 return -1;
             }
         }
@@ -214,7 +214,7 @@ int windows_sink::work(int noutput_items,
             break;
         }
         if (write_waveout(chosen_header) < 0) {
-            GR_LOG_ERROR(d_logger, boost::format("write failed: %s") % strerror(errno));
+            GR_LOG_ERROR(d_logger, boost::format("write failed: %d") % GetLastError());
         }
         samples_sent += samples_tosend;
     }
@@ -272,8 +272,8 @@ UINT windows_sink::find_device(std::string szDeviceName)
                 if (waveOutGetDevCaps(i, &woc, sizeof(woc)) != MMSYSERR_NOERROR) {
                     GR_LOG_ERROR(d_logger,
                                  boost::format("Could not retrieve wave out device "
-                                               "capabilities for %s device") %
-                                     strerror(errno));
+                                               "capabilities for device: %d") %
+                                     GetLastError());
                     return -1;
                 }
                 if (woc.szPname == szDeviceName) {
@@ -294,8 +294,8 @@ UINT windows_sink::find_device(std::string szDeviceName)
         }
     } else {
         GR_LOG_ERROR(d_logger,
-                     boost::format("No WaveOut devices present or accessible: %s") %
-                         strerror(errno));
+                     boost::format("No WaveOut devices present or accessible: %d") %
+                         GetLastError());
     }
     return result;
 }
@@ -332,8 +332,8 @@ int windows_sink::open_waveout_device(void)
         GR_LOG_INFO(d_debug_logger, boost::format("format error: %s") % err_msg);
         GR_LOG_ERROR(
             d_logger,
-            boost::format("Requested audio format is not supported by device %s driver") %
-                strerror(errno));
+            boost::format("Requested audio format is not supported by device driver: %d") %
+                GetLastError());
         return -1;
     }
 
@@ -347,8 +347,8 @@ int windows_sink::open_waveout_device(void)
 
     if (result) {
         GR_LOG_ERROR(d_logger,
-                     boost::format("Failed to open waveform output device. %s") %
-                         strerror(errno));
+                     boost::format("Failed to open waveform output device: %d") %
+                         GetLastError());
         return -1;
     }
 
@@ -367,16 +367,16 @@ int windows_sink::write_waveout(LPWAVEHDR lp_wave_hdr)
     w_result = waveOutPrepareHeader(d_h_waveout, lp_wave_hdr, sizeof(WAVEHDR));
     if (w_result != 0) {
         GR_LOG_ERROR(d_logger,
-                     boost::format("Failed to waveOutPrepareHeader %s") %
-                         strerror(errno));
+                     boost::format("Failed to waveOutPrepareHeader: %d") %
+                         GetLastError());
         return -1;
     }
 
     w_result = waveOutWrite(d_h_waveout, lp_wave_hdr, sizeof(WAVEHDR));
     if (w_result != 0) {
         GR_LOG_ERROR(d_logger,
-                     boost::format("Failed to write block to device %s") %
-                         strerror(errno));
+                     boost::format("Failed to write block to device: %d") %
+                         GetLastError());
         switch (w_result) {
         case MMSYSERR_INVALHANDLE:
             GR_LOG_ERROR(d_logger, "Specified device handle is invalid");

--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -330,10 +330,10 @@ int windows_sink::open_waveout_device(void)
         char err_msg[50];
         waveOutGetErrorText(supported, err_msg, 50);
         GR_LOG_INFO(d_debug_logger, boost::format("format error: %s") % err_msg);
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format("Requested audio format is not supported by device driver: %d") %
-                GetLastError());
+        GR_LOG_ERROR(d_logger,
+                     boost::format(
+                         "Requested audio format is not supported by device driver: %d") %
+                         GetLastError());
         return -1;
     }
 

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -93,7 +93,7 @@ windows_source::windows_source(int sampling_freq, const std::string device_name)
     gr::logger_ptr logger, debug_logger;
     if (open_wavein_device() < 0) {
         GR_LOG_ERROR(logger,
-                     boost::format("open_wavein_device() failed %s") % strerror(errno));
+                     boost::format("open_wavein_device() failed: %d") % GetLastError());
         throw std::runtime_error("audio_windows_source:open_wavein_device() failed");
     } else {
         GR_LOG_INFO(d_debug_logger, "Opened windows wavein device");
@@ -109,8 +109,8 @@ windows_source::windows_source(int sampling_freq, const std::string device_name)
         MMRESULT w_result = waveInPrepareHeader(d_h_wavein, lp_buffer, sizeof(WAVEHDR));
         if (w_result != 0) {
             GR_LOG_ERROR(logger,
-                         boost::format("Failed to waveInPrepareHeader %s") %
-                             strerror(errno));
+                         boost::format("Failed to waveInPrepareHeader: %d") %
+                             GetLastError());
             throw std::runtime_error("open_wavein_device() failed");
         }
         waveInAddBuffer(d_h_wavein, lp_buffer, sizeof(WAVEHDR));
@@ -248,8 +248,8 @@ UINT windows_source::find_device(std::string szDeviceName)
                 if (waveInGetDevCaps(i, &woc, sizeof(woc)) != MMSYSERR_NOERROR) {
                     GR_LOG_ERROR(logger,
                                  boost::format("Could not retrieve wave out device "
-                                               "capabilities for device %s") %
-                                     strerror(errno));
+                                               "capabilities for device: %d") %
+                                     GetLastError());
                     return -1;
                 }
                 if (woc.szPname == szDeviceName) {
@@ -269,8 +269,8 @@ UINT windows_source::find_device(std::string szDeviceName)
         }
     } else {
         GR_LOG_ERROR(logger,
-                     boost::format("No WaveIn devices present or accessible: %s") %
-                         strerror(errno));
+                     boost::format("No WaveIn devices present or accessible: %d") %
+                         GetLastError());
     }
     return result;
 }
@@ -309,8 +309,8 @@ int windows_source::open_wavein_device(void)
         GR_LOG_INFO(d_debug_logger, boost::format("format error: %s") % err_msg);
         GR_LOG_ERROR(logger,
                      boost::format(
-                         "Requested audio format is not supported by device driver: %s") %
-                         strerror(errno));
+                         "Requested audio format is not supported by device driver: %d") %
+                         GetLastError());
         return -1;
     }
 
@@ -324,8 +324,8 @@ int windows_source::open_wavein_device(void)
 
     if (result) {
         GR_LOG_ERROR(logger,
-                     boost::format("Failed to open waveform output device: %s") %
-                         strerror(errno));
+                     boost::format("Failed to open waveform output device: %d") %
+                         GetLastError());
         return -1;
     }
     return 0;
@@ -339,8 +339,8 @@ static void CALLBACK read_wavein(
         if (!dwInstance) {
             gr::logger_ptr logger;
             GR_LOG_ERROR(logger,
-                         boost::format("callback function missing buffer queue: %s") %
-                             strerror(errno));
+                         boost::format("callback function missing buffer queue: %d") %
+                             GetLastError());
         }
         LPWAVEHDR lp_wave_hdr = (LPWAVEHDR)dwParam1; // The new audio data
         boost::lockfree::spsc_queue<LPWAVEHDR>* q =

--- a/gr-blocks/tests/benchmark_nco.cc
+++ b/gr-blocks/tests/benchmark_nco.cc
@@ -100,7 +100,7 @@ static void benchmark(void test(float* x, float* y), const char* implementation_
 
 void basic_sincos_vec(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -114,7 +114,7 @@ void basic_sincos_vec(float* x, float* y)
 
 void native_sincos_vec(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -125,7 +125,7 @@ void native_sincos_vec(float* x, float* y)
 
 void fxpt_sincos_vec(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -138,7 +138,7 @@ void fxpt_sincos_vec(float* x, float* y)
 
 void native_sincos(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -150,7 +150,7 @@ void native_sincos(float* x, float* y)
 
 void fxpt_sincos(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -164,7 +164,7 @@ void fxpt_sincos(float* x, float* y)
 
 void native_sin(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -176,7 +176,7 @@ void native_sin(float* x, float* y)
 
 void fxpt_sin(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 

--- a/gr-blocks/tests/benchmark_vco.cc
+++ b/gr-blocks/tests/benchmark_vco.cc
@@ -122,7 +122,7 @@ void basic_vco(float* output, const float* input)
 
 void native_vco(float* output, const float* input)
 {
-    gr::blocks::vco<float, float> vco;
+    gr::vco<float, float> vco;
 
     for (int j = 0; j < ITERATIONS / BLOCK_SIZE; j++) {
         vco.cos(output, input, BLOCK_SIZE, K, AMPLITUDE);
@@ -131,7 +131,7 @@ void native_vco(float* output, const float* input)
 
 void fxpt_vco(float* output, const float* input)
 {
-    gr::blocks::fxpt_vco vco;
+    gr::fxpt_vco vco;
 
     for (int j = 0; j < ITERATIONS / BLOCK_SIZE; j++) {
         vco.cos(output, input, BLOCK_SIZE, K, AMPLITUDE);


### PR DESCRIPTION
* `<cxxabi.h>` is for GCC only
* Fix the `dllexport` decoration. Ref. https://github.com/gnuradio/gnuradio/pull/4013 for this. I didn't manage to create 2 changes in one PR in the GitHub's editor.