### PR TITLE
digital: fix yaml and bindings for constellation

### DIFF
--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -31,7 +31,7 @@ parameters:
     hide: ${ ( 'none' if str(type) == "calcdist" else 'all') }
 -   id: normalization
     label: Normalization Type
-    dtype: int
+    dtype: raw
     default: digital.constellation.AMPLITUDE_NORMALIZATION
     options: [digital.constellation.NO_NORMALIZATION, digital.constellation.POWER_NORMALIZATION, digital.constellation.AMPLITUDE_NORMALIZATION]
     option_labels: [None, Power, Amplitude]
@@ -46,6 +46,7 @@ parameters:
     dtype: raw
     default: None
     hide: ${ ('part' if str(soft_dec_lut) == 'None' else 'none') }
+
 value: ${ digital.constellation_calcdist(const_points, sym_map, rot_sym, dims, normalization) if (str(type) == "calcdist") else getattr(digital,'constellation_'+str(type))()  }
 
 
@@ -54,7 +55,7 @@ templates:
     var_make: |-
         % if str(type) == "calcdist":
         self.${id} = ${id} = digital.constellation_calcdist(${const_points}, ${sym_map},
-        ${rot_sym}, ${dims}).base()
+        ${rot_sym}, ${dims}, ${normalization}).base()
         % else:
         self.${id} = ${id} = digital.constellation_${type}().base()
         % endif

--- a/gr-digital/python/digital/bindings/constellation_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_python.cc
@@ -52,22 +52,9 @@ void bind_constellation(py::module& m)
         .value("AMPLITUDE_NORMALIZATION", constellation::AMPLITUDE_NORMALIZATION)
         .export_values();
 
+    py::implicitly_convertible<int, gr::digital::constellation::normalization_t>();
+
     constellation_class
-        // .def(py::init<std::vector<std::complex<float>,
-        // std::allocator<std::complex<float> > >,std::vector<int, std::allocator<int>
-        // >,unsigned int,unsigned int,bool>(),           py::arg("constell"),
-        //    py::arg("pre_diff_code"),
-        //    py::arg("rotational_symmetry"),
-        //    py::arg("dimensionality"),
-        //    py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
-        //    D(constellation,constellation,0)
-        // )
-        // .def(py::init<>(),D(constellation,constellation,1))
-        // .def(py::init<gr::digital::constellation const &>(),           py::arg("arg0"),
-        //    D(constellation,constellation,2)
-        // )
-
-
         .def("map_to_points",
              &constellation::map_to_points,
              py::arg("value"),
@@ -235,20 +222,6 @@ void bind_constellation(py::module& m)
                std::shared_ptr<constellation_sector>>(
         m, "constellation_sector", D(constellation_sector))
 
-        // .def(py::init<std::vector<std::complex<float>,
-        // std::allocator<std::complex<float> > >,std::vector<int, std::allocator<int>
-        // >,unsigned int,unsigned int,unsigned int>(),           py::arg("constell"),
-        //    py::arg("pre_diff_code"),
-        //    py::arg("rotational_symmetry"),
-        //    py::arg("dimensionality"),
-        //    py::arg("n_sectors"),
-        //    D(constellation_sector,constellation_sector,0)
-        // )
-        // .def(py::init<gr::digital::constellation_sector const &>(), py::arg("arg0"),
-        //    D(constellation_sector,constellation_sector,1)
-        // )
-
-
         .def("decision_maker",
              &constellation_sector::decision_maker,
              py::arg("sample"),
@@ -271,10 +244,7 @@ void bind_constellation(py::module& m)
              py::arg("width_real_sectors"),
              py::arg("width_imag_sectors"),
              py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
-             D(constellation_rect, make))
-
-
-        ;
+             D(constellation_rect, make));
 
 
     py::class_<constellation_expl_rect,
@@ -291,10 +261,7 @@ void bind_constellation(py::module& m)
              py::arg("width_real_sectors"),
              py::arg("width_imag_sectors"),
              py::arg("sector_values"),
-             D(constellation_expl_rect, make))
-
-
-        ;
+             D(constellation_expl_rect, make));
 
 
     py::class_<constellation_psk,
@@ -306,10 +273,7 @@ void bind_constellation(py::module& m)
              py::arg("constell"),
              py::arg("pre_diff_code"),
              py::arg("n_sectors"),
-             D(constellation_psk, make))
-
-
-        ;
+             D(constellation_psk, make));
 
 
     py::class_<constellation_bpsk,
@@ -323,9 +287,7 @@ void bind_constellation(py::module& m)
         .def("decision_maker",
              &constellation_bpsk::decision_maker,
              py::arg("sample"),
-             D(constellation_bpsk, decision_maker))
-
-        ;
+             D(constellation_bpsk, decision_maker));
 
 
     py::class_<constellation_qpsk,
@@ -339,9 +301,7 @@ void bind_constellation(py::module& m)
         .def("decision_maker",
              &constellation_qpsk::decision_maker,
              py::arg("sample"),
-             D(constellation_qpsk, decision_maker))
-
-        ;
+             D(constellation_qpsk, decision_maker));
 
 
     py::class_<constellation_dqpsk,
@@ -355,9 +315,7 @@ void bind_constellation(py::module& m)
         .def("decision_maker",
              &constellation_dqpsk::decision_maker,
              py::arg("sample"),
-             D(constellation_dqpsk, decision_maker))
-
-        ;
+             D(constellation_dqpsk, decision_maker));
 
 
     py::class_<constellation_8psk,
@@ -371,9 +329,7 @@ void bind_constellation(py::module& m)
         .def("decision_maker",
              &constellation_8psk::decision_maker,
              py::arg("sample"),
-             D(constellation_8psk, decision_maker))
-
-        ;
+             D(constellation_8psk, decision_maker));
 
 
     py::class_<constellation_8psk_natural,
@@ -388,9 +344,7 @@ void bind_constellation(py::module& m)
         .def("decision_maker",
              &constellation_8psk_natural::decision_maker,
              py::arg("sample"),
-             D(constellation_8psk_natural, decision_maker))
-
-        ;
+             D(constellation_8psk_natural, decision_maker));
 
 
     py::class_<constellation_16qam,
@@ -404,7 +358,5 @@ void bind_constellation(py::module& m)
         .def("decision_maker",
              &constellation_16qam::decision_maker,
              py::arg("sample"),
-             D(constellation_16qam, decision_maker))
-
-        ;
+             D(constellation_16qam, decision_maker));
 }


### PR DESCRIPTION
Adds implicit conversion to the enum type
Cleans up the binding code a bit (remove some dead code)
Change the dropdown from int to enum (as in other places)

Fixes #4007 