### PR TITLE
pfb.py: fix variable in static function

### DIFF
--- a/gr-filter/python/filter/pfb.py
+++ b/gr-filter/python/filter/pfb.py
@@ -66,7 +66,7 @@ class channelizer_ccf(gr.hier_block2):
         ripple = 0.1
         while True:
             try:
-                taps = optfir.low_pass(1, self._nchans, bw, bw+tb, ripple, atten)
+                taps = optfir.low_pass(1, numchans, bw, bw+tb, ripple, atten)
                 return taps
             except RuntimeError:
                 ripple += 0.01


### PR DESCRIPTION
When create_taps() was moved to a static function, a _self reference
tagged along. Use function parameter as intended.

Note: this was found while looking at Issue #4015, but it does not fix the issue.

Signed-off-by: Jeff Long <willcode4@gmail.com>