### PR TITLE
Backport Remove hardcoded GR_PYTHON_DIR 

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -47,7 +47,6 @@ find_dependency(Volk)
 set(ENABLE_PYTHON @ENABLE_PYTHON@ CACHE BOOL "Enable Python & SWIG")
 if(${ENABLE_PYTHON})
   set(PYTHON_EXECUTABLE @PYTHON_EXECUTABLE@)
-  set(GR_PYTHON_DIR @GR_PYTHON_DIR@ CACHE STRING "Custom OOT Python installation directory")
   include(GrPython)
 endif()
 


### PR DESCRIPTION
This was fixed on master a long time ago and should also have gone in a backport for 3.8 at least. Meantime another attempt to address the issue with installing OOT's to a custom install prefix was made in https://github.com/gnuradio/gnuradio/pull/3944, but this is an improper fix as it requires the user to specify yet another variable at configure time.

This pull request backports the original pull request from master https://github.com/gnuradio/gnuradio/pull/3730 to maint-3.8. This is also available in maint-3.9.