### PR TITLE
gr-qtgui number sink: Honor block setting of 'avg' in GUI

### DIFF
--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -241,6 +241,7 @@ templates:
         import sip
     callbacks:
     - set_update_time(${update_time})
+    - set_average(${avg})
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -99,6 +99,7 @@ void number_sink_impl::initialize()
     }
 
     d_main_gui = new NumberDisplayForm(d_nconnections, d_type, d_parent);
+    d_main_gui->setAverage(d_average);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -135,6 +136,7 @@ void number_sink_impl::set_average(const float avg)
         d_avg_value[n] = 0;
         d_iir[n].set_taps(d_average);
     }
+    d_main_gui->setAverage(avg);
 }
 
 void number_sink_impl::set_graph_type(const graph_t type)


### PR DESCRIPTION
GUI was overriding block parameter (setting to 0) at init.
- Use block parameter for 'avg'
- Add callback for 'avg' to yml

It is still possible to set the avg from the GUI middle click. The menu
value is not updated when avg is set from a block parameter (there is no
slot in the widget to do this). If the user creates a GRC file with a
widget (e.g., entry) to set avg, and also sets it via the menu, the
values shown will not match. However, the value can be successfully set
either way.

Fixes https://github.com/gnuradio/gnuradio/issues/4034
Should be backported to 3.9 and 3.8.

Signed-off-by: Jeff Long <willcode4@gmail.com>