### PR TITLE
Fix default parameters in Stream_Mux block

### DIFF
--- a/gr-blocks/grc/blocks_stream_demux.block.yml
+++ b/gr-blocks/grc/blocks_stream_demux.block.yml
@@ -14,7 +14,7 @@ parameters:
 -   id: lengths
     label: Lengths
     dtype: int_vector
-    default: 1, 1
+    default: (1, 1)
 -   id: num_outputs
     label: Num Outputs
     dtype: int

--- a/gr-blocks/grc/blocks_stream_mux.block.yml
+++ b/gr-blocks/grc/blocks_stream_mux.block.yml
@@ -14,7 +14,7 @@ parameters:
 -   id: lengths
     label: Lengths
     dtype: int_vector
-    default: 1, 1
+    default: (1, 1)
 -   id: num_inputs
     label: Num Inputs
     dtype: int


### PR DESCRIPTION
fix default parameter 'Length' in Stream Mux block. Cannot connect in the flowgraph otherwise. Stream mux block example is OK as it uses '[3, 2]'.