### PR TITLE
grc: Accept file pointer in load_stdlib() (converter/xml.py)

### DIFF
--- a/grc/converter/xml.py
+++ b/grc/converter/xml.py
@@ -50,8 +50,11 @@ def load_lxml(filename, document_type_def=None):
 def load_stdlib(filename, document_type_def=None):
     """Load block description from xml file"""
 
-    with open(filename, 'rb') as xml_file:
-        data = xml_file.read().decode('utf-8')
+    if isinstance(filename, str):
+        with open(filename, 'rb') as xml_file:
+            data = xml_file.read().decode('utf-8')
+    else: # Already opened
+        data = filename.read().decode('utf-8')
 
     try:
         element = etree.fromstring(data)

--- a/grc/tests/test_xml_parser.py
+++ b/grc/tests/test_xml_parser.py
@@ -21,7 +21,7 @@ def test_flow_graph_converter():
 def test_flow_graph_converter_with_fp():
     filename = path.join(path.dirname(__file__), 'resources', 'test_compiler.grc')
 
-    with open(filename) as fp:
+    with open(filename, 'rb') as fp:
         data = flow_graph.from_xml(fp)
 
     flow_graph.dump(data, sys.stdout)


### PR DESCRIPTION
Fixes `test_xml_parser.py` failing if lxml is not installed.

**Disclaimer**: Personally, I think the `test_flow_graph_converter_with_fp()` test should be removed, it does not seem like the `from_xml` functions (`load_stdlib()` and `load_lxml()`) are called with file pointer arguments anywhere (please correct me if I'm wrong) and they also do not state clearly that they accept both filenames and file pointers.

https://github.com/gnuradio/gnuradio/blob/0f1ec604f758e28d788ad71283236928d2d82300/grc/tests/test_xml_parser.py#L21-L27

https://github.com/gnuradio/gnuradio/blob/0f1ec604f758e28d788ad71283236928d2d82300/grc/converter/xml.py#L50-L67

Error:

```python
_________________________________________________________________ test_flow_graph_converter_with_fp __________________________________________________________________

    def test_flow_graph_converter_with_fp():
        filename = path.join(path.dirname(__file__), 'resources', 'test_compiler.grc')

        with open(filename) as fp:
>           data = flow_graph.from_xml(fp)

test_xml_parser.py:25:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../converter/flow_graph.py:17: in from_xml
    element, version_info = xml.load(filename, 'flow_graph.dtd')
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

filename = <_io.TextIOWrapper name='/home/hkon/gnuradio/grc/tests/resources/test_compiler.grc' mode='r' encoding='UTF-8'>, document_type_def = 'flow_graph.dtd'

    def load_stdlib(filename, document_type_def=None):
        """Load block description from xml file"""

>       with open(filename, 'rb') as xml_file:
E       TypeError: expected str, bytes or os.PathLike object, not TextIOWrapper

../converter/xml.py:53: TypeError
```