### PR TITLE
grc: Clean up test_expr_utils.py

### DIFF
--- a/grc/tests/test_expr_utils.py
+++ b/grc/tests/test_expr_utils.py
@@ -8,7 +8,6 @@ id_getter = operator.itemgetter(0)
 expr_getter = operator.itemgetter(1)
 
 
-@pytest.mark.xfail(reason="core/utils/expr_utils.py:97: TypeError: '<' not supported between instances of 'NoneType' and 'str'")
 def test_simple():
     objects = [
         ['c', '2 * a + b'],
@@ -18,26 +17,24 @@ def test_simple():
     ]
 
     expected = [
-        ['a', '1'],
         ['d', '5'],
+        ['a', '1'],
         ['b', '2 * a + unknown * d'],
         ['c', '2 * a + b'],
     ]
 
-    out = expr_utils.sort_objects2(objects, id_getter, expr_getter)
+    out = expr_utils.sort_objects(objects, id_getter, expr_getter)
 
     assert out == expected
 
 
-@pytest.mark.xfail(reason="core/utils/expr_utils.py:97: TypeError: '<' not supported between instances of 'NoneType' and 'str'")
-def test_other():
+def test_circular():
     test = [
         ['c', '2 * a + b'],
         ['a', '1'],
         ['b', '2 * c + unknown'],
     ]
 
-    expr_utils.sort_objects2(test, id_getter, expr_getter, check_circular=False)
-
-    with pytest.raises(RuntimeError):
-        expr_utils.sort_objects2(test, id_getter, expr_getter)
+    # Should fail due to circular dependency
+    with pytest.raises(Exception):
+        expr_utils.sort_objects(test, id_getter, expr_getter)


### PR DESCRIPTION
The tests are xfail-marked, but the marked error was fixed in https://github.com/gnuradio/gnuradio/pull/2679. 

Another error remains, `test_simple()` randomly passes or fails with the error shown below. It also appears that `sort_objects2()` is not used anywhere. `sort_objects()`is used instead, and should be tested.

Note: I also had to rearrange the two first elements of the `expected` list but from what I can see the order of these two elements are unimportant to the correctness of the function

@skoslowski Should `sort_objects2()` be removed?


Error:
```python
____________________________________________________________________________ test_simple _____________________________________________________________________________

    def test_simple():
        objects = [
            ['c', '2 * a + b'],
            ['a', '1'],
            ['b', '2 * a + unknown * d'],
            ['d', '5'],
        ]

        expected = [
            ['a', '1'],
            ['d', '5'],
            ['b', '2 * a + unknown * d'],
            ['c', '2 * a + b'],
        ]

>       out = expr_utils.sort_objects2(objects, id_getter, expr_getter)

test_expr_utils.py:26:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

objects = [['a', '1'], ['d', '5'], ['c', '2 * a + b'], ['b', '2 * a + unknown * d']], id_getter = operator.itemgetter(0), expr_getter = operator.itemgetter(1)
check_circular = True

    def sort_objects2(objects, id_getter, expr_getter, check_circular=True):
        known_ids = {id_getter(obj) for obj in objects}

        def dependent_ids(obj):
            deps = dependencies(expr_getter(obj))
            return [id_ if id_ in deps else '' for id_ in known_ids]

        objects = sorted(objects, key=dependent_ids)

        if check_circular:  # walk var defines step by step
            defined_ids = set()  # variables defined so far
            for obj in objects:
                deps = dependencies(expr_getter(obj), known_ids)
                if not defined_ids.issuperset(deps):  # can't have an undefined dep
>                   raise RuntimeError(obj, deps, defined_ids)
E                   RuntimeError: (['c', '2 * a + b'], frozenset({'b', 'a'}), {'d', 'a'})

../core/utils/expr_utils.py:90: RuntimeError
```