### PR TITLE
Qt shutdown cleanup

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -44,6 +44,34 @@ ${imp}
 % endfor
 
 ########################################################
+##Prepare snippets
+########################################################
+% for snip in flow_graph.get_snippets_dict():
+
+${indent(snip['def'])}
+% for line in snip['lines']:
+    ${indent(line)}
+% endfor
+% endfor
+\
+<%
+snippet_sections = ['main_after_init', 'main_after_start', 'main_after_stop']
+snippets = {}
+for section in snippet_sections:
+    snippets[section] = flow_graph.get_snippets_dict(section)
+%>
+\
+%for section in snippet_sections:
+%if snippets[section]:
+
+def snippets_${section}(tb):
+    % for snip in snippets[section]:
+    ${indent(snip['call'])}
+    % endfor
+%endif
+%endfor
+
+########################################################
 ##Create Class
 ##  Write the class declaration for a top or hier block.
 ##  The parameter names are the arguments to __init__.
@@ -269,30 +297,6 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         % endif
     % endfor
 \
-% for snip in flow_graph.get_snippets_dict():
-
-${indent(snip['def'])}
-% for line in snip['lines']:
-    ${indent(line)}
-% endfor
-% endfor
-\
-<%
-snippet_sections = ['main_after_init', 'main_after_start', 'main_after_stop']
-snippets = {}
-for section in snippet_sections:
-    snippets[section] = flow_graph.get_snippets_dict(section)
-%>
-\
-%for section in snippet_sections:
-%if snippets[section]:
-
-def snippets_${section}(tb):
-    % for snip in snippets[section]:
-    ${indent(snip['call'])}
-    % endfor
-%endif
-%endfor
 
 ########################################################
 ##Create Main

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -257,6 +257,9 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
     def closeEvent(self, event):
         self.settings = Qt.QSettings("GNU Radio", "${class_name}")
         self.settings.setValue("geometry", self.saveGeometry())
+        self.stop()
+        self.wait()
+        ${'snippets_main_after_stop(self)' if snippets['main_after_stop'] else ''}
         event.accept()
     % if flow_graph.get_option('qt_qss_theme'):
 
@@ -371,6 +374,9 @@ def main(top_block_cls=${class_name}, options=None):
     tb.show()
 
     def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+        ${'snippets_main_after_stop(tb)' if snippets['main_after_stop'] else ''}
         Qt.QApplication.quit()
 
     signal.signal(signal.SIGINT, sig_handler)
@@ -380,11 +386,6 @@ def main(top_block_cls=${class_name}, options=None):
     timer.start(500)
     timer.timeout.connect(lambda: None)
 
-    def quitting():
-        tb.stop()
-        tb.wait()
-        ${'snippets_main_after_stop(tb)' if snippets['main_after_stop'] else ''}
-    qapp.aboutToQuit.connect(quitting)
     % for m in monitors:
     % if m.params['en'].get_value() == 'True':
     tb.${m.name}.start()


### PR DESCRIPTION
So originally I introduced the aboutToQuit() stuff in the hope to cleanly shutdown the flow graph, including the Qt widgets blocks before the Qt stuff is torn down.
    
Turns out that in aboutToQuit some stuff is already invalid, especially in OpenGL and so causes SegFault on exit.
    
Instead this patch modify the logic so that we stop the flow graph before Qt even begin disabling things.
    
The two shutdown path that exits are :
     - The sig_handler in case we get TERM or INT signals
     - The closeEvent() of the main window
    
This makes sure that both path call tb.stop() tb.wait() and also any snippet 'main_after_stop'.
