### PR TITLE
filter: Fix polyphase_filterbank for MSVC, w/ default move constructor.

### DIFF
--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -87,6 +87,15 @@ public:
      */
     fft_filter_fff(int decimation, const std::vector<float>& taps, int nthreads = 1);
 
+    // Disallow copy.
+    //
+    // This prevents accidentally doing needless copies, not just of fft_filter_xxx,
+    // but every block that contains one.
+    fft_filter_fff(const fft_filter_fff&) = delete;
+    fft_filter_fff& operator=(const fft_filter_fff&) = delete;
+    fft_filter_fff(fft_filter_fff&&) = default;
+    fft_filter_fff& operator=(fft_filter_fff&&) = default;
+
     /*!
      * \brief Set new taps for the filter.
      *
@@ -191,6 +200,15 @@ public:
      */
     fft_filter_ccc(int decimation, const std::vector<gr_complex>& taps, int nthreads = 1);
 
+    // Disallow copy.
+    //
+    // This prevents accidentally doing needless copies, not just of fft_filter_xxx,
+    // but every block that contains one.
+    fft_filter_ccc(const fft_filter_ccc&) = delete;
+    fft_filter_ccc& operator=(const fft_filter_ccc&) = delete;
+    fft_filter_ccc(fft_filter_ccc&&) = default;
+    fft_filter_ccc& operator=(fft_filter_ccc&&) = default;
+
     /*!
      * \brief Set new taps for the filter.
      *
@@ -294,6 +312,15 @@ public:
      * \param nthreads   The number of threads for the FFT to use (int)
      */
     fft_filter_ccf(int decimation, const std::vector<float>& taps, int nthreads = 1);
+
+    // Disallow copy.
+    //
+    // This prevents accidentally doing needless copies, not just of fft_filter_xxx,
+    // but every block that contains one.
+    fft_filter_ccf(const fft_filter_ccf&) = delete;
+    fft_filter_ccf& operator=(const fft_filter_ccf&) = delete;
+    fft_filter_ccf(fft_filter_ccf&&) = default;
+    fft_filter_ccf& operator=(fft_filter_ccf&&) = default;
 
     /*!
      * \brief Set new taps for the filter.

--- a/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
+++ b/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
@@ -106,6 +106,8 @@ public:
      */
     polyphase_filterbank(unsigned int nfilts, const std::vector<float>& taps);
 
+    polyphase_filterbank(polyphase_filterbank&&) = default;
+
     /*!
      * Update the filterbank's filter taps from a prototype
      * filter.

--- a/gr-filter/python/filter/bindings/fft_filter_python.cc
+++ b/gr-filter/python/filter/bindings/fft_filter_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fft_filter.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(ba4bcb2a6271a7c9db0b1fc2c39f00ee)                     */
+/* BINDTOOL_HEADER_FILE_HASH(69cbae029e98a78bebb18c73fb73366e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polyphase_filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(107cf4797045f9c8e227c2c741e2ed4d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(eddfa9a8852378220a937bc1e3bc7a39)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Because of the deleted copy constructor (previously implicit, now made explicit in this commit to match fir_filter.h), polyphase_filterbank.cc fails to compile with MSVC trying to use the fft_filter_ccf copy constructor. Explicitly declaring a default move constructor fixes this by allowing it to use the move constuctor instead, which is the behavior we want. It's a mystery why MSVC requires this and other compilers don't, but it works.

See #3892 for similar discussion and change for other filter classes. (This one wasn't caught there because changes from other PRs came in parallel.)

This was needed to get MSVC compilation to work for my [3.9.0.0-rc2 conda package](https://github.com/conda-forge/gnuradio-feedstock/runs/1669068304).

It will also need a backport to 3.9 that I can push when approved.