### PR TITLE
runtime: lib: Fix terminate_handler compilation with MSVC

### DIFF
--- a/gnuradio-runtime/lib/terminate_handler.cc
+++ b/gnuradio-runtime/lib/terminate_handler.cc
@@ -14,10 +14,9 @@
 #include <regex>
 #include <stdexcept>
 
-#include <cxxabi.h>
-
 #ifdef HAVE_LIBUNWIND
 #define UNW_LOCAL_ONLY
+#include <cxxabi.h>
 #include <libunwind.h>
 #include <cstdio>
 #include <cstdlib>

--- a/gnuradio-runtime/lib/terminate_handler.h
+++ b/gnuradio-runtime/lib/terminate_handler.h
@@ -13,7 +13,7 @@
 #include <gnuradio/api.h>
 
 namespace gr {
-void install_terminate_handler() GR_RUNTIME_API;
+GR_RUNTIME_API void install_terminate_handler();
 }
 
 #endif /* INCLUDED_TERMINATE_HANDLER_H */


### PR DESCRIPTION
Two simple commits here to fix compiling terminate_handler.cc with MSVC, one correcting the location for the GR_RUNTIME_API macro and one correcting for a non-existent header with MSVC. I think these would have been fixed by #4012 and/or #4013, but it's hard to tell in the current state. Anyway, this gets it compiling for me.

This was needed to get MSVC compilation to work for my [3.9.0.0-rc2 conda package](https://github.com/conda-forge/gnuradio-feedstock/runs/1669068304).

It will also need a backport to 3.9 that I can push when approved.