### PR TITLE
cmake: python: Fix linking when runtime py interpreter != build time.

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -39,7 +39,7 @@ target_include_directories(${name}_python PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
     ${PYBIND11_INCLUDE_DIR}
 )
-target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} gnuradio-${MODULE_NAME})
+target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${name}_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates
@@ -156,7 +156,7 @@ target_include_directories(${name}_python PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
     ${PYBIND11_INCLUDE_DIR}
 )
-target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} gnuradio-${MODULE_NAME})
+target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${name}_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates
@@ -289,7 +289,7 @@ target_include_directories(${name}_python PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
     ${PYBIND11_INCLUDE_DIR}
 )
-target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} gnuradio-${MODULE_NAME})
+target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${name}_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -37,14 +37,9 @@ set(PYTHON_EXECUTABLE ${PYTHON_EXECUTABLE} CACHE FILEPATH "python interpreter")
 set(QA_PYTHON_EXECUTABLE ${QA_PYTHON_EXECUTABLE} CACHE FILEPATH "python interpreter for QA tests")
 
 add_library(Python::Python INTERFACE IMPORTED)
-if(APPLE)
-    set_target_properties(Python::Python PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "-undefined dynamic_lookup"
-      )
 # Need to handle special cases where both debug and release
 # libraries are available (in form of debug;A;optimized;B) in PYTHON_LIBRARIES
-elseif(PYTHON_LIBRARY_DEBUG AND PYTHON_LIBRARY_RELEASE)
+if(PYTHON_LIBRARY_DEBUG AND PYTHON_LIBRARY_RELEASE)
     set_target_properties(Python::Python PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
       INTERFACE_LINK_LIBRARIES "$<$<NOT:$<CONFIG:Debug>>:${PYTHON_LIBRARY_RELEASE}>;$<$<CONFIG:Debug>:${PYTHON_LIBRARY_DEBUG}>"
@@ -55,6 +50,35 @@ else()
       INTERFACE_LINK_LIBRARIES "${PYTHON_LIBRARIES}"
       )
 endif()
+
+# separate target when linking to make an extension module, which should not
+# link explicitly to the python library on Unix-like platforms
+add_library(Python::Module INTERFACE IMPORTED)
+if(WIN32)
+    # identical to Python::Python, cannot be an alias because Python::Python is imported
+    # Need to handle special cases where both debug and release
+    # libraries are available (in form of debug;A;optimized;B) in PYTHON_LIBRARIES
+    if(PYTHON_LIBRARY_DEBUG AND PYTHON_LIBRARY_RELEASE)
+        set_target_properties(Python::Module PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
+          INTERFACE_LINK_LIBRARIES "$<$<NOT:$<CONFIG:Debug>>:${PYTHON_LIBRARY_RELEASE}>;$<$<CONFIG:Debug>:${PYTHON_LIBRARY_DEBUG}>"
+        )
+    else()
+        set_target_properties(Python::Module PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
+          INTERFACE_LINK_LIBRARIES "${PYTHON_LIBRARIES}"
+        )
+    endif()
+else()
+    set_target_properties(Python::Module PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${PYTHON_INCLUDE_DIRS}"
+    )
+    if(APPLE)
+        set_target_properties(Python::Module PROPERTIES
+            INTERFACE_LINK_OPTIONS "LINKER:-undefined,dynamic_lookup"
+        )
+    endif(APPLE)
+endif(WIN32)
 
 
 ########################################################################

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -203,13 +203,18 @@ target_link_libraries(gnuradio-runtime PUBLIC
   Boost::thread
   Log4Cpp::log4cpp
   MPLib::mplib
-  ${PYTHON_LIBRARIES}
   ${libunwind_LIBRARIES}
+  # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
+  # (importantly, extension modules can avoid linking against Python and resolve
+  #  their own Python symbols at runtime through the Python interpreter's linking)
+  INTERFACE
+    Python::Module
+  PRIVATE
+    Python::Python
   )
 
 target_include_directories(gnuradio-runtime
   PUBLIC
-    ${PYTHON_INCLUDE_DIR}
     ${PYTHON_NUMPY_INCLUDE_DIR}
     ${pybind11_INCLUDE_DIR}
     $<INSTALL_INTERFACE:include>

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -86,8 +86,12 @@ endif(WIN32)
 include(GrPython)
 if(ENABLE_PYTHON)
   target_compile_definitions(gnuradio-qtgui PUBLIC -DENABLE_PYTHON)
-  target_link_libraries(gnuradio-qtgui PUBLIC
-    Python::Python
+  # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
+  # (importantly, extension modules can avoid linking against Python and resolve
+  #  their own Python symbols at runtime through the Python interpreter's linking)
+  target_link_libraries(gnuradio-qtgui
+    INTERFACE Python::Module
+    PRIVATE Python::Python
   )
 endif(ENABLE_PYTHON)
 


### PR DESCRIPTION
I've been using this for a little while in my conda packages, and it's about time some version of it got upstream. In light of possibly requiring CMake 3.16 for 3.10 development, this could probably be simplified. (By requiring CMake 3.16+, it would be possible to use the `Python::Python` and `Python::Module` targets defined by the builtin CMake FindPython module that was added for 3.12 and drop that part of GrPython.cmake.) But I'd rather trigger a discussion before going off and changing things, and at least maint-3.9 would require something closer to this. I can send that PR once this has had a few eyes on it.

So the description of the fix:

This fixes a segmentation fault with the Pybind11 bindings when trying to load any Python module on OSX with a different interpreter than was used at build time (relevant to at least conda and homebrew). This fix was already in place for the prior Swig bindings, but the Pybind11 changes do not incorporate it since they link with ${PYTHON_LIBRARIES} instead of the (fixed) Python::Python target.

For clearer separation and to adopt the approach used by the new-ish (3.12) builtin CMake FindPython module, this commit creates a separate Python::Module target to be used when creating a Python extension module (which includes "-undefined" and "dynamic_lookup" for macOS instead of linking directly to the Python library). The Python::Python target that does link to the Python library is still necessary for use as a PRIVATE target (e.g. for runtime and qtgui).

For future reference and a general description of best practices for linking Python extension modules, see https://blog.tim-smith.us/2015/09/python-extension-modules-os-x.