### PR TITLE
cmake: Update VERSION_PATCH so that correct versioning is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING)
 SET(VERSION_MAJOR 3)
 SET(VERSION_API   8)
 SET(VERSION_ABI   2)
-SET(VERSION_PATCH 0)
+SET(VERSION_PATCH git)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:


### PR DESCRIPTION
i.e. version - commit number from last tag - last commit hash.

Signed-off-by: Ron Economos <w6rz@comcast.net>