### PR TITLE
Backport to 3.9: runtime: lib: Fix terminate_handler compilation with MSVC

### DIFF
--- a/gnuradio-runtime/lib/terminate_handler.cc
+++ b/gnuradio-runtime/lib/terminate_handler.cc
@@ -14,10 +14,9 @@
 #include <regex>
 #include <stdexcept>
 
-#include <cxxabi.h>
-
 #ifdef HAVE_LIBUNWIND
 #define UNW_LOCAL_ONLY
+#include <cxxabi.h>
 #include <libunwind.h>
 #include <cstdio>
 #include <cstdlib>

--- a/gnuradio-runtime/lib/terminate_handler.h
+++ b/gnuradio-runtime/lib/terminate_handler.h
@@ -13,7 +13,7 @@
 #include <gnuradio/api.h>
 
 namespace gr {
-void install_terminate_handler() GR_RUNTIME_API;
+GR_RUNTIME_API void install_terminate_handler();
 }
 
 #endif /* INCLUDED_TERMINATE_HANDLER_H */


### PR DESCRIPTION
Backport of #4056 to maint-3.9.