### PR TITLE
MSVC 2019 fixes

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tag_checker.h
+++ b/gnuradio-runtime/include/gnuradio/tag_checker.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_RUNTIME_TAG_CHECKER_H
 
 #include <gnuradio/tags.h>
+#include <algorithm>
 #include <vector>
 
 namespace gr {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tag_checker_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tag_checker_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tag_checker.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4f4bad08f4f039dbd5150a36e29d365c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e602a721975a2c2c15dbbb419eb57c15)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-trellis/include/gnuradio/trellis/fsm.h
+++ b/gr-trellis/include/gnuradio/trellis/fsm.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/trellis/api.h>
 #include <iosfwd>
+#include <string>
 #include <vector>
 
 namespace gr {

--- a/gr-trellis/python/trellis/bindings/fsm_python.cc
+++ b/gr-trellis/python/trellis/bindings/fsm_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fsm.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(55ea410fe82d117d20ec1c63ac3df824)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b9d1dcdec11c0bd17a33e91782c30663)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Updating to MSVC 2019 and GNURadio 3.9. So far several minor build issues have come up. This pull fixes missing includes in public header files and an interesting bug with gr-filter and copy assign. The commits are separated to make them easy to cherry-pick.