### PR TITLE
gr-blocks qa for peak_detector2: fix result type in test5

### DIFF
--- a/gr-blocks/python/blocks/qa_peak_detector2.py
+++ b/gr-blocks/python/blocks/qa_peak_detector2.py
@@ -139,8 +139,8 @@ class test_peak_detector2(gr_unittest.TestCase):
         dst_data = dst.data()
         dst_avg = avg.data()
 
-        self.assertEqual(tuple(expected_result_peak), dst_data)
-        self.assertFloatTuplesAlmostEqual(tuple(expected_result_average[1:]), dst_avg)
+        self.assertEqual(expected_result_peak, dst_data)
+        self.assertFloatTuplesAlmostEqual(expected_result_average[1:], dst_avg)
 
 if __name__ == '__main__':
     gr_unittest.run(test_peak_detector2)


### PR DESCRIPTION
Compare of tuple vs list was failing.

Fixes issue noted after merge of https://github.com/gnuradio/gnuradio/pull/3356

Signed-off-by: Jeff Long <willcode4@gmail.com>