### PR TITLE
Backports to 3.9

### DIFF
--- a/gr-blocks/grc/blocks_stream_demux.block.yml
+++ b/gr-blocks/grc/blocks_stream_demux.block.yml
@@ -14,7 +14,7 @@ parameters:
 -   id: lengths
     label: Lengths
     dtype: int_vector
-    default: 1, 1
+    default: (1, 1)
 -   id: num_outputs
     label: Num Outputs
     dtype: int

--- a/gr-blocks/grc/blocks_stream_mux.block.yml
+++ b/gr-blocks/grc/blocks_stream_mux.block.yml
@@ -14,7 +14,7 @@ parameters:
 -   id: lengths
     label: Lengths
     dtype: int_vector
-    default: 1, 1
+    default: (1, 1)
 -   id: num_inputs
     label: Num Inputs
     dtype: int

--- a/grc/converter/xml.py
+++ b/grc/converter/xml.py
@@ -50,8 +50,11 @@ def load_lxml(filename, document_type_def=None):
 def load_stdlib(filename, document_type_def=None):
     """Load block description from xml file"""
 
-    with open(filename, 'rb') as xml_file:
-        data = xml_file.read().decode('utf-8')
+    if isinstance(filename, str):
+        with open(filename, 'rb') as xml_file:
+            data = xml_file.read().decode('utf-8')
+    else: # Already opened
+        data = filename.read().decode('utf-8')
 
     try:
         element = etree.fromstring(data)

--- a/grc/tests/test_expr_utils.py
+++ b/grc/tests/test_expr_utils.py
@@ -8,7 +8,6 @@ id_getter = operator.itemgetter(0)
 expr_getter = operator.itemgetter(1)
 
 
-@pytest.mark.xfail(reason="core/utils/expr_utils.py:97: TypeError: '<' not supported between instances of 'NoneType' and 'str'")
 def test_simple():
     objects = [
         ['c', '2 * a + b'],
@@ -18,26 +17,24 @@ def test_simple():
     ]
 
     expected = [
-        ['a', '1'],
         ['d', '5'],
+        ['a', '1'],
         ['b', '2 * a + unknown * d'],
         ['c', '2 * a + b'],
     ]
 
-    out = expr_utils.sort_objects2(objects, id_getter, expr_getter)
+    out = expr_utils.sort_objects(objects, id_getter, expr_getter)
 
     assert out == expected
 
 
-@pytest.mark.xfail(reason="core/utils/expr_utils.py:97: TypeError: '<' not supported between instances of 'NoneType' and 'str'")
-def test_other():
+def test_circular():
     test = [
         ['c', '2 * a + b'],
         ['a', '1'],
         ['b', '2 * c + unknown'],
     ]
 
-    expr_utils.sort_objects2(test, id_getter, expr_getter, check_circular=False)
-
-    with pytest.raises(RuntimeError):
-        expr_utils.sort_objects2(test, id_getter, expr_getter)
+    # Should fail due to circular dependency
+    with pytest.raises(Exception):
+        expr_utils.sort_objects(test, id_getter, expr_getter)

--- a/grc/tests/test_generator.py
+++ b/grc/tests/test_generator.py
@@ -15,16 +15,19 @@ from grc.core.platform import Platform
 
 def test_generator():
     # c&p form compiler code.
-    # todo: make this independent from installed GR
     grc_file = path.join(path.dirname(__file__), 'resources', 'test_compiler.grc')
     out_dir = tempfile.gettempdir()
+    block_paths = [
+        path.join(path.dirname(__file__), '../../grc/blocks'),
+        path.join(path.dirname(__file__), '../../gr-blocks/grc')
+    ]
 
     platform = Platform(
         name='GNU Radio Companion Compiler',
         prefs=None,
         version='0.0.0',
     )
-    platform.build_library()
+    platform.build_library(block_paths)
 
     flow_graph = platform.make_flow_graph(grc_file)
     flow_graph.rewrite()

--- a/grc/tests/test_xml_parser.py
+++ b/grc/tests/test_xml_parser.py
@@ -21,7 +21,7 @@ def test_flow_graph_converter():
 def test_flow_graph_converter_with_fp():
     filename = path.join(path.dirname(__file__), 'resources', 'test_compiler.grc')
 
-    with open(filename) as fp:
+    with open(filename, 'rb') as fp:
         data = flow_graph.from_xml(fp)
 
     flow_graph.dump(data, sys.stdout)


### PR DESCRIPTION
Changes:

71bece9b9 (Adrien Michel, 6 days ago)
   gr-blocks: fix default length with list in Stream Mux and Demux yml

   Signed-off-by: Adrien Michel <adriengit@users.noreply.github.com>

0f90c7309 (Håkon Vågsether, 8 days ago)
   grc: Accept file pointer in load_stdlib() (converter/xml.py)

   Fixes test_xml_parser.py failing in the absence of lxml

   Signed-off-by: Håkon Vågsether <hauk142@gmail.com>

4e2ef66f0 (Håkon Vågsether, 8 days ago)
   grc: Clean up test_expr_utils.py

   Signed-off-by: Håkon Vågsether <hauk142@gmail.com>

d0da6fe02 (Håkon Vågsether, 8 days ago)
   grc: Let test_generator.py know where to find blocks

   Signed-off-by: Håkon Vågsether <hauk142@gmail.com>