### PR TITLE
gr-uhd: adding a bool to force tune request

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -120,6 +120,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
       _nchan(stream_args.channels.size()),
       _stream_now(_nchan == 1 and ts_tag_name.empty()),
       _start_time_set(false),
+      _force_tune(false),
       _curr_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
       _chans_to_tune(stream_args.channels.size())
 {
@@ -544,7 +545,18 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
                                               pmt::from_long(-1) // Default to all chans
                                               )));
 
-    /// 3) Loop through all the values
+    /// 3) See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+    // if the a direction symbol was provided, force a tune
+    _force_tune = pmt::is_symbol(direction);
+
+
+    /// 4) Loop through all the values
     GR_LOG_DEBUG(d_debug_logger, boost::format("Processing command message %s") % msg);
     pmt::pmt_t msg_items = pmt::dict_items(msg);
     for (size_t i = 0; i < pmt::length(msg_items); i++) {
@@ -561,17 +573,9 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
             break;
         }
     }
-
-    /// 4) See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
-
     /// 5) Check if we need to re-tune
     _set_center_freq_from_internals_allchans(direction);
+    _force_tune = false;
 }
 
 
@@ -604,7 +608,7 @@ void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req, int
         tune_req.rf_freq_policy != _curr_tune_req[chan].rf_freq_policy ||
         tune_req.rf_freq != _curr_tune_req[chan].rf_freq ||
         tune_req.dsp_freq != _curr_tune_req[chan].dsp_freq ||
-        tune_req.dsp_freq_policy != _curr_tune_req[chan].dsp_freq_policy) {
+        tune_req.dsp_freq_policy != _curr_tune_req[chan].dsp_freq_policy || _force_tune) {
         _curr_tune_req[chan] = tune_req;
         _chans_to_tune.set(chan);
     }

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -212,6 +212,7 @@ protected:
     bool _stream_now;
     ::uhd::time_spec_t _start_time;
     bool _start_time_set;
+    bool _force_tune;
 
     /****** Command interface related **********/
     //! Stores a list of commands for later execution


### PR DESCRIPTION
This is used if a 'direction' key is provided with the tune command.
This fixes an issue when the 'TX' and 'RX' directions are tuned
explicitly to the same frequency; prior to this fix the second tune
request is dropped.