### PR TITLE
gr-uhd: adding a bool to force tune request

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -222,6 +222,7 @@ protected:
     bool _stream_now;
     ::uhd::time_spec_t _start_time;
     bool _start_time_set;
+    bool _force_tune;
 
     /****** Command interface related **********/
     //! Stores a list of commands for later execution


### PR DESCRIPTION
This is used if a 'direction' key is provided with the tune command.
This fixes an issue when the 'TX' and 'RX' directions are tuned
explicitly to the same frequency; prior to this fix the second tune
request is dropped.