### PR TITLE
gr-uhd: Add command uhd handler for mtune ("manual tune")

### DIFF
--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -92,6 +92,7 @@ Command name | Value Type   | Description
 `freq`       | double       | Sets the Tx or Rx frequency. Defaults to all channels. If specified without `lo_offset`, it will set the LO offset to zero.
 `lo_offset`  | double       | Sets an LO offset. Defaults to all channels. Note this does not affect the effective center frequency.
 `tune`       | tune_request | Like freq, but sets a full tune request (i.e. center frequency and DSP offset). Defaults to all channels.
+`mtune`      | tune_request_t | Like tune, but supports a full manual tune request as uhd::tune_request_t. Defaults to all channels.
 `lo_freq`    | double       | For fully manual tuning: Set the LO frequency (RF frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
 `dsp_freq`   | double       | For fully manual tuning: Set the DSP frequency (CORDIC frequency). Conflicts with `freq`, `lo_offset`, and `tune`.
 `direction`  | string       | Used for timed transceiver tuning to ensure tuning order is maintained. Values other than 'TX' or 'RX' will be ignored.
@@ -105,8 +106,30 @@ Command name | Value Type   | Description
 Special types:
 
 - tune_request: Like a uhd::tune_request_t, but always uses POLICY_AUTO. This is a pair, composed of (target_frequency, lo_offset)
+- tune_request_t: Exact copy of uhd::tune_request_t, allowing full control. See details below.
+  It supports fully customized tunings with all policies and integer-N tuning. The policies are strings A, N, M for automatic, none and manual tuning.
 - timestamp: A pair composed of (long full_secs, double frac_secs). Similar to uhd::time_spec_t
 - gpio: This is a PMT dictionary with four key/value pairs: bank (string), attr (string), value (double) and mask (double). The `gpio` command calls `set_gpio_attr` with the elements from the dictionary as arguments. Can optionally contain `mboard` to specify the mainboard. Defaults to `0` (first mboard).
+
+Further notes on command `mtune`:
+
+The object is of type pmt::dict and has the same fields as uhd::tune_request_t:
+- `dsp_freq`: the dsp frequency as pmt double type.
+- `dsp_freq_policy`: policy for DSP tuning. Should be a string "A" (automatic), "M" (manual) or "N" (none). If not set, defaults to "A".
+- `rf_freq`: the rf frequency as pmt double type.
+- `rf_freq_policy`: policy for RF tuning. Should be a string "A" (automatic), "M" (manual) or "N" (none). If not set, defaults to "A".
+- `target_freq`: target frequency (for automatic runing) as pmt double type
+- `args`: string containing additional arguments, for example for integer N tuning.
+
+Example:
+
+\code
+tune_rx = pmt.make_dict()
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('rf_freq'), pmt.to_pmt(rf_freq))
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('rf_freq_policy'), pmt.to_pmt('M'))
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('dsp_freq_policy'), pmt.to_pmt('N'))
+tune_rx = pmt.dict_add(tune_rx, pmt.to_pmt('args'), pmt.to_pmt('mode_n=integer,int_n_step=1000e3'))
+\endcode
 
 \b Note: Not all commands are affected by `time`. See the UHD manual for details on timed commands.
 

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -24,6 +24,7 @@ GR_UHD_API const pmt::pmt_t cmd_power_key();
 GR_UHD_API const pmt::pmt_t cmd_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_offset_key();
 GR_UHD_API const pmt::pmt_t cmd_tune_key();
+GR_UHD_API const pmt::pmt_t cmd_mtune_key();
 GR_UHD_API const pmt::pmt_t cmd_lo_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_dsp_freq_key();
 GR_UHD_API const pmt::pmt_t cmd_rate_key();

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -56,6 +56,11 @@ const pmt::pmt_t gr::uhd::cmd_tune_key()
     static const pmt::pmt_t val = pmt::mp("tune");
     return val;
 }
+const pmt::pmt_t gr::uhd::cmd_mtune_key()
+{
+    static const pmt::pmt_t val = pmt::mp("mtune");
+    return val;
+}
 const pmt::pmt_t gr::uhd::cmd_lo_freq_key()
 {
     static const pmt::pmt_t val = pmt::mp("lo_freq");
@@ -151,6 +156,7 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
     REGISTER_CMD_HANDLER(cmd_power_key(), _cmd_handler_power);
     REGISTER_CMD_HANDLER(cmd_lo_offset_key(), _cmd_handler_looffset);
     REGISTER_CMD_HANDLER(cmd_tune_key(), _cmd_handler_tune);
+    REGISTER_CMD_HANDLER(cmd_mtune_key(), _cmd_handler_mtune);
     REGISTER_CMD_HANDLER(cmd_lo_freq_key(), _cmd_handler_lofreq);
     REGISTER_CMD_HANDLER(cmd_dsp_freq_key(), _cmd_handler_dspfreq);
     REGISTER_CMD_HANDLER(cmd_rate_key(), _cmd_handler_rate);
@@ -749,6 +755,53 @@ void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,
     double freq = pmt::to_double(pmt::car(tune));
     double lo_offset = pmt::to_double(pmt::cdr(tune));
     ::uhd::tune_request_t new_tune_request(freq, lo_offset);
+    _update_curr_tune_req(new_tune_request, chan);
+}
+
+void usrp_block_impl::_cmd_handler_mtune(const pmt::pmt_t& tune,
+                                         int chan,
+                                         const pmt::pmt_t& msg)
+{
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::dict_has_key(tune, pmt::mp("dsp_freq"))) {
+        new_tune_request.dsp_freq =
+            pmt::to_double(pmt::dict_ref(tune, pmt::mp("dsp_freq"), 0));
+    }
+    if (pmt::dict_has_key(tune, pmt::mp("rf_freq"))) {
+        new_tune_request.rf_freq =
+            pmt::to_double(pmt::dict_ref(tune, pmt::mp("rf_freq"), 0));
+    }
+    if (pmt::dict_has_key(tune, pmt::mp("target_freq"))) {
+        new_tune_request.target_freq =
+            pmt::to_double(pmt::dict_ref(tune, pmt::mp("target_freq"), 0));
+    }
+    if (pmt::dict_has_key(tune, pmt::mp("dsp_freq_policy"))) {
+        std::string policy = pmt::symbol_to_string(
+            pmt::dict_ref(tune, pmt::mp("dsp_freq_policy"), pmt::mp("A")));
+        if (policy == "M") {
+            new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
+        } else if (policy == "A") {
+            new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_AUTO;
+        } else {
+            new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_NONE;
+        }
+    }
+    if (pmt::dict_has_key(tune, pmt::mp("rf_freq_policy"))) {
+        std::string policy = pmt::symbol_to_string(
+            pmt::dict_ref(tune, pmt::mp("rf_freq_policy"), pmt::mp("A")));
+        if (policy == "M") {
+            new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
+        } else if (policy == "A") {
+            new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_AUTO;
+        } else {
+            new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_NONE;
+        }
+    }
+    if (pmt::dict_has_key(tune, pmt::mp("args"))) {
+        new_tune_request.args = ::uhd::device_addr_t(
+            pmt::symbol_to_string(pmt::dict_ref(tune, pmt::mp("args"), pmt::mp(""))));
+    }
+
     _update_curr_tune_req(new_tune_request, chan);
 }
 

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -124,6 +124,7 @@ protected:
     void _cmd_handler_antenna(const pmt::pmt_t& ant, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_rate(const pmt::pmt_t& rate, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_tune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);
+    void _cmd_handler_mtune(const pmt::pmt_t& tune, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_bw(const pmt::pmt_t& bw, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_lofreq(const pmt::pmt_t& lofreq, int chan, const pmt::pmt_t& msg);
     void _cmd_handler_dspfreq(const pmt::pmt_t& dspfreq, int chan, const pmt::pmt_t& msg);


### PR DESCRIPTION
This command implements uhd::tune_request_t completely (and not just a
subset). Also includes updates to the manual.

Supersedes https://github.com/gnuradio/gnuradio/pull/3485