### PR TITLE
qtgui:Added Time Raster Sink Control Axis Configuration

### DIFF
--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -31,6 +31,36 @@ parameters:
     label: Num. Cols
     dtype: int
     default: 256
+-   id: x_label
+    label: X-Axis Label
+    dtype: string
+    default: '""'
+    hide: part
+-   id: x_start_value
+    label: X-Axis Start Value
+    dtype: float
+    default: 0.0
+    hide: part
+-   id: x_end_value
+    label: X-Axis End Value
+    dtype: float
+    default: 0.0
+    hide: part
+-   id: y_label
+    label: Y-Axis Label
+    dtype: string
+    default: '""'
+    hide: part
+-   id: y_start_value
+    label: Y-Axis Start Value
+    dtype: float
+    default: 0.0
+    hide: part
+-   id: y_end_value
+    label: Y-Axis End Value
+    dtype: float
+    default: 0.0
+    hide: part
 -   id: grid
     label: Grid
     dtype: enum
@@ -243,6 +273,10 @@ templates:
         self.${id}.set_intensity_range(${zmin}, ${zmax})
         self.${id}.enable_grid(${grid})
         self.${id}.enable_axis_labels(${axislabels})
+        self.${id}.set_x_label(${x_label})
+        self.${id}.set_x_range(${x_start_value}, ${x_end_value})
+        self.${id}.set_y_label(${y_label})
+        self.${id}.set_y_range(${y_start_value}, ${y_end_value})
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]
@@ -264,5 +298,7 @@ templates:
 
 documentation: |-
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.
+    
+    Note that for user-defined axis values, numbers will be scaled to their power of 10 3-unit grouping (e.g. Giga, Mega, Kilo, milli, nano (u), pico) and appended with the first letter descriptor for a more concise display. 
 
 file_format: 1

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -50,6 +50,10 @@ public:
     void setNumCols(double cols);
     void setAlpha(unsigned int which, int alpha);
     void setSampleRate(double samprate);
+    void setXLabel(const std::string& label);
+    void setXAxis(double start, double end);
+    void setYLabel(const std::string& label);
+    void setYAxis(double start, double end);
 
     double numRows() const;
     double numCols() const;
@@ -100,6 +104,13 @@ private:
     QColor d_high_intensity;
 
     int d_color_bar_title_font_size;
+
+    std::string d_x_label;
+    double d_x_start_value;
+    double d_x_end_value;
+    std::string d_y_label;
+    double d_y_start_value;
+    double d_y_end_value;
 };
 
 #endif /* TIMERASTER_DISPLAY_PLOT_H */

--- a/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_b.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_b.h
@@ -84,6 +84,10 @@ public:
     virtual void* pyqwidget() = 0;
 #endif
 
+    virtual void set_x_label(const std::string& label) = 0;
+    virtual void set_x_range(double start, double end) = 0;
+    virtual void set_y_label(const std::string& label) = 0;
+    virtual void set_y_range(double start, double end) = 0;
     virtual void set_update_time(double t) = 0;
     virtual void set_title(const std::string& title) = 0;
     virtual void set_line_label(unsigned int which, const std::string& label) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_f.h
@@ -80,6 +80,10 @@ public:
     virtual void* pyqwidget() = 0;
 #endif
 
+    virtual void set_x_label(const std::string& label) = 0;
+    virtual void set_x_range(double start, double end) = 0;
+    virtual void set_y_label(const std::string& label) = 0;
+    virtual void set_y_range(double start, double end) = 0;
     virtual void set_update_time(double t) = 0;
     virtual void set_title(const std::string& title) = 0;
     virtual void set_line_label(unsigned int which, const std::string& label) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/timerasterdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timerasterdisplayform.h
@@ -58,6 +58,11 @@ public slots:
     void setSampleRate(const double samprate);
     void setSampleRate(const QString& rate) override;
 
+    void setXAxis(double min, double max);
+    void setXLabel(const std::string& label);
+    void setYAxis(double min, double max);
+    void setYLabel(const std::string& label);
+
     void setIntensityRange(const double minIntensity, const double maxIntensity);
     void setMaxIntensity(const QString& m);
     void setMinIntensity(const QString& m);

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -155,6 +155,26 @@ PyObject* time_raster_sink_b_impl::pyqwidget()
 void* time_raster_sink_b_impl::pyqwidget() { return NULL; }
 #endif
 
+void time_raster_sink_b_impl::set_x_label(const std::string& label)
+{
+    d_main_gui->setXLabel(label);
+}
+
+void time_raster_sink_b_impl::set_x_range(double start, double end)
+{
+    d_main_gui->setXAxis(start, end);
+}
+
+void time_raster_sink_b_impl::set_y_label(const std::string& label)
+{
+    d_main_gui->setYLabel(label);
+}
+
+void time_raster_sink_b_impl::set_y_range(double start, double end)
+{
+    d_main_gui->setYAxis(start, end);
+}
+
 void time_raster_sink_b_impl::set_update_time(double t)
 {
     // convert update time to ticks

--- a/gr-qtgui/lib/time_raster_sink_b_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.h
@@ -76,6 +76,10 @@ public:
     void* pyqwidget();
 #endif
 
+    void set_x_label(const std::string& label);
+    void set_x_range(double start, double end);
+    void set_y_label(const std::string& label);
+    void set_y_range(double start, double end);
     void set_update_time(double t) override;
     void set_title(const std::string& title) override;
     void set_line_label(unsigned int which, const std::string& label) override;

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -153,6 +153,26 @@ PyObject* time_raster_sink_f_impl::pyqwidget()
 void* time_raster_sink_f_impl::pyqwidget() { return NULL; }
 #endif
 
+void time_raster_sink_f_impl::set_x_label(const std::string& label)
+{
+    d_main_gui->setXLabel(label);
+}
+
+void time_raster_sink_f_impl::set_x_range(double start, double end)
+{
+    d_main_gui->setXAxis(start, end);
+}
+
+void time_raster_sink_f_impl::set_y_label(const std::string& label)
+{
+    d_main_gui->setYLabel(label);
+}
+
+void time_raster_sink_f_impl::set_y_range(double start, double end)
+{
+    d_main_gui->setYAxis(start, end);
+}
+
 void time_raster_sink_f_impl::set_update_time(double t)
 {
     // convert update time to ticks

--- a/gr-qtgui/lib/time_raster_sink_f_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.h
@@ -75,6 +75,10 @@ public:
     void* pyqwidget();
 #endif
 
+    void set_x_label(const std::string& label);
+    void set_x_range(double start, double end);
+    void set_y_label(const std::string& label);
+    void set_y_range(double start, double end);
     void set_update_time(double t) override;
     void set_title(const std::string& title) override;
     void set_line_label(unsigned int which, const std::string& label) override;

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -177,6 +177,30 @@ void TimeRasterDisplayForm::customEvent(QEvent* e)
     }
 }
 
+void TimeRasterDisplayForm::setXAxis(double min, double max)
+{
+    getPlot()->setXAxis(min, max);
+    getPlot()->replot();
+}
+
+void TimeRasterDisplayForm::setXLabel(const std::string& label)
+{
+    getPlot()->setXLabel(label);
+    getPlot()->replot();
+}
+
+void TimeRasterDisplayForm::setYAxis(double min, double max)
+{
+    getPlot()->setYAxis(min, max);
+    getPlot()->replot();
+}
+
+void TimeRasterDisplayForm::setYLabel(const std::string& label)
+{
+    getPlot()->setYLabel(label);
+    getPlot()->replot();
+}
+
 void TimeRasterDisplayForm::setNumRows(double rows)
 {
     getPlot()->setNumRows(rows);

--- a/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_b_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_b_pydoc_template.h
@@ -36,6 +36,18 @@ static const char* __doc_gr_qtgui_time_raster_sink_b_qwidget = R"doc()doc";
 static const char* __doc_gr_qtgui_time_raster_sink_b_pyqwidget = R"doc()doc";
 
 
+static const char* __doc_gr_qtgui_time_raster_sink_b_set_x_label = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_time_raster_sink_b_set_x_range = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_time_raster_sink_b_set_y_label = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_time_raster_sink_b_set_y_range = R"doc()doc";
+
+
 static const char* __doc_gr_qtgui_time_raster_sink_b_set_update_time = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_f_pydoc_template.h
@@ -36,6 +36,18 @@ static const char* __doc_gr_qtgui_time_raster_sink_f_qwidget = R"doc()doc";
 static const char* __doc_gr_qtgui_time_raster_sink_f_pyqwidget = R"doc()doc";
 
 
+static const char* __doc_gr_qtgui_time_raster_sink_f_set_x_label = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_time_raster_sink_f_set_x_range = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_time_raster_sink_f_set_y_label = R"doc()doc";
+
+
+static const char* __doc_gr_qtgui_time_raster_sink_f_set_y_range = R"doc()doc";
+
+
 static const char* __doc_gr_qtgui_time_raster_sink_f_set_update_time = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/time_raster_sink_b_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_raster_sink_b_python.cc
@@ -76,6 +76,31 @@ void bind_time_raster_sink_b(py::module& m)
             },
             D(time_raster_sink_b, pyqwidget))
 
+        .def("set_x_range",
+             &time_raster_sink_b::set_x_range,
+             py::arg("min"),
+             py::arg("max"),
+             D(time_raster_sink_b, set_x_range))
+
+
+        .def("set_x_label",
+             &time_raster_sink_b::set_x_label,
+             py::arg("label"),
+             D(time_raster_sink_b, set_x_label))
+
+
+        .def("set_y_range",
+             &time_raster_sink_b::set_y_range,
+             py::arg("min"),
+             py::arg("max"),
+             D(time_raster_sink_b, set_y_range))
+
+
+        .def("set_y_label",
+             &time_raster_sink_b::set_y_label,
+             py::arg("label"),
+             D(time_raster_sink_b, set_y_label))
+
 
         .def("set_update_time",
              &time_raster_sink_b::set_update_time,

--- a/gr-qtgui/python/qtgui/bindings/time_raster_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_raster_sink_f_python.cc
@@ -76,6 +76,32 @@ void bind_time_raster_sink_f(py::module& m)
             },
             D(time_raster_sink_f, pyqwidget))
 
+        .def("set_x_range",
+             &time_raster_sink_f::set_x_range,
+             py::arg("min"),
+             py::arg("max"),
+             D(time_raster_sink_f, set_x_range))
+
+
+        .def("set_x_label",
+             &time_raster_sink_f::set_x_label,
+             py::arg("label"),
+             D(time_raster_sink_f, set_x_label))
+
+
+        .def("set_y_range",
+             &time_raster_sink_f::set_y_range,
+             py::arg("min"),
+             py::arg("max"),
+             D(time_raster_sink_f, set_y_range))
+
+
+        .def("set_y_label",
+             &time_raster_sink_f::set_y_label,
+             py::arg("label"),
+             D(time_raster_sink_f, set_y_label))
+
+
         .def("set_update_time",
              &time_raster_sink_f::set_update_time,
              py::arg("t"),


### PR DESCRIPTION
This update allows a time raster sink's axis minimum, maximum,
and label to now be specified in the block configuration options.
This allows the block to be formatted to match a waterfall plot
in terms of having frequency on the lower axis.

Based on PR from ghostop14 <ghostop14@gmail.com>

Signed-off-by: Jeff Long <willcode4@gmail.com>