### PR TITLE
Bump dependency versions to match these of 3.9; might increase further

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,16 +52,17 @@ SET(VERSION_PATCH git)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:
-set(GR_BOOST_MIN_VERSION "1.58")
-set(GR_CMAKE_MIN_VERSION "3.8.0")
-set(GR_MAKO_MIN_VERSION "0.4.2")
-set(GR_PYTHON_MIN_VERSION "3.6.5")
-set(GR_NUMPY_MIN_VERSION "1.13.0")
-set(GCC_MIN_VERSION "5.0.0")
-set(CLANG_MIN_VERSION "3.4.0")
-set(APPLECLANG_MIN_VERSION "500")
-set(MSVC_MIN_VERSION "1900")
-set(VOLK_MIN_VERSION "2.1.0")
+
+set(GR_BOOST_MIN_VERSION "1.65")      ## Version in Ubuntu 18.04LTS
+set(GR_CMAKE_MIN_VERSION "3.10.2")    ## Version in Ubuntu 18.04LTS
+set(GR_MAKO_MIN_VERSION "1.0.7")      ## debian buster, 18.04LTS
+set(GR_PYTHON_MIN_VERSION "3.6.5")    ## Version in Ubuntu 18.04LTS
+set(GR_NUMPY_MIN_VERSION "1.13.3")    ## Version in Ubuntu 18.04LTS
+set(GCC_MIN_VERSION "8.3.0")          ## debian buster
+set(CLANG_MIN_VERSION "11.0.0")       ## debian bullseye, Fedora 33
+set(APPLECLANG_MIN_VERSION "1100")    ## same as clang 11.0.0, in Xcode11
+set(MSVC_MIN_VERSION "1910")          ## VS2017 15.0, for full-ish C++14 support
+set(VOLK_MIN_VERSION "2.4.1")         ## first version with CPU features
 set(PYBIND11_MIN_VERSION "2.4") # pybind11 sets versions like 2.4.dev4, which compares < 2.4.3
 
 # Enable generation of compile_commands.json for code completion engines


### PR DESCRIPTION
This is the minimum we'll do anyways.

Bumping to C++17 seems relatively well-discussed, will be done in a separate commit, nevertheless.