### PR TITLE
Cmake: accept orocos-log4cpp as acceptable alternative name 

### DIFF
--- a/cmake/Modules/FindLOG4CPP.cmake
+++ b/cmake/Modules/FindLOG4CPP.cmake
@@ -17,7 +17,7 @@ find_path(LOG4CPP_INCLUDE_DIR log4cpp/Category.hh
   /opt/local/include
 )
 
-set(LOG4CPP_NAMES log4cpp)
+set(LOG4CPP_NAMES log4cpp orocos-log4cpp)
 find_library(LOG4CPP_LIBRARY
   NAMES ${LOG4CPP_NAMES}
   PATHS /usr/lib /usr/lib64 /usr/local/lib  /usr/local/lib64 /opt/local/lib /opt/local/lib64

--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -13,7 +13,7 @@ find_path(QWT_INCLUDE_DIRS
   HINTS
   ${PC_QWT_INCLUDEDIR}
   ${CMAKE_INSTALL_PREFIX}/include/qwt
-  ${CMAKE_PREFIX_PATH}/include/qwt
+  list(APPEND ${CMAKE_PREFIX_PATH} /include/qwt)
   PATHS
   /usr/local/include/qwt-${QWT_QT_VERSION}
   /usr/local/include/qwt


### PR DESCRIPTION
VCPkg uses the orocos log4cpp package as it is maintained, so this allows vcpkg compatibility