### PR TITLE
Run clang-tidy with deprecated headers check enabled on C++17 codebase

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert,readability-container-size-empty,modernize-use-override,modernize-make-unique'
+Checks:          '-*,misc-throw-by-value-catch-by-reference,misc-static-assert,readability-container-size-empty,modernize-use-override,modernize-make-unique,modernize-deprecated-headers'
 # Not in here: modernize-use-emplace, since that basically broke all things it touched
 WarningsAsErrors: ''
 HeaderFilterRegex: '\.(cc|c|cpp|h|hpp)$'

--- a/gnuradio-runtime/include/gnuradio/fxpt.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/types.h>
-#include <stdint.h>
+#include <cstdint>
 
 namespace gr {
 

--- a/gnuradio-runtime/include/gnuradio/fxpt_nco.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt_nco.h
@@ -14,7 +14,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/fxpt.h>
 #include <gnuradio/gr_complex.h>
-#include <stdint.h>
+#include <cstdint>
 
 namespace gr {
 

--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -24,7 +24,6 @@ typedef int mode_t;
 #endif
 
 #include <gnuradio/api.h>
-#include <assert.h>
 #include <log4cpp/Category.hh>
 #include <log4cpp/FileAppender.hh>
 #include <log4cpp/OstreamAppender.hh>
@@ -32,10 +31,11 @@ typedef int mode_t;
 #include <log4cpp/PropertyConfigurator.hh>
 #include <log4cpp/RollingFileAppender.hh>
 #include <pmt/pmt.h>
-#include <time.h>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
+#include <cassert>
+#include <ctime>
 #include <iostream>
 #include <memory>
 

--- a/gnuradio-runtime/include/gnuradio/messages/msg_accepter_msgq.h
+++ b/gnuradio-runtime/include/gnuradio/messages/msg_accepter_msgq.h
@@ -29,7 +29,7 @@ protected:
 
 public:
     msg_accepter_msgq(msg_queue_sptr msgq);
-    ~msg_accepter_msgq();
+    virtual ~msg_accepter_msgq();
 
     virtual void post(pmt::pmt_t msg);
 

--- a/gnuradio-runtime/include/gnuradio/random.h
+++ b/gnuradio-runtime/include/gnuradio/random.h
@@ -14,7 +14,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/gr_complex.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <ctime>
 #include <random>
 

--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -15,7 +15,7 @@
 #include <gnuradio/rpcserver_base.h>
 #include <gnuradio/rpcserver_booter_base.h>
 #include <gnuradio/rpcserver_selector.h>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <sstream>
 

--- a/gnuradio-runtime/include/gnuradio/types.h
+++ b/gnuradio-runtime/include/gnuradio/types.h
@@ -12,13 +12,13 @@
 #define INCLUDED_GR_TYPES_H
 
 #include <gnuradio/api.h>
-#include <stddef.h> // size_t
+#include <cstddef> // size_t
 #include <memory>
 #include <vector>
 
 #include <gnuradio/gr_complex.h>
 
-#include <stdint.h>
+#include <cstdint>
 
 typedef std::vector<int> gr_vector_int;
 typedef std::vector<unsigned int> gr_vector_uint;

--- a/gnuradio-runtime/include/gnuradio/xoroshiro128p.h
+++ b/gnuradio-runtime/include/gnuradio/xoroshiro128p.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 /*! \brief rotating left shift helper
  * According to the original authors, this will on most platforms reduce to a single

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -12,10 +12,10 @@
 #define INCLUDED_PMT_H
 
 #include <pmt/api.h>
-#include <stdint.h>
 #include <boost/any.hpp>
 #include <boost/noncopyable.hpp>
 #include <complex>
+#include <cstdint>
 #include <iosfwd>
 #include <memory>
 #include <stdexcept>

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -17,11 +17,11 @@
 #include <gnuradio/buffer.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
-#include <assert.h>
 #include <block_executor.h>
-#include <stdio.h>
 #include <boost/format.hpp>
 #include <boost/thread.hpp>
+#include <cassert>
+#include <cstdio>
 #include <iostream>
 #include <limits>
 

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -13,7 +13,7 @@
 #include <gnuradio/block_detail.h>
 #include <gnuradio/block_registry.h>
 #include <gnuradio/tpb_detail.h>
-#include <stdio.h>
+#include <cstdio>
 
 gr::block_registry global_block_registry;
 

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -15,8 +15,8 @@
 #include <gnuradio/buffer.h>
 #include <gnuradio/integer_math.h>
 #include <gnuradio/math.h>
-#include <assert.h>
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 

--- a/gnuradio-runtime/lib/local_sighandler.cc
+++ b/gnuradio-runtime/lib/local_sighandler.cc
@@ -13,9 +13,9 @@
 #endif
 
 #include "local_sighandler.h"
-#include <stdio.h>
-#include <string.h>
 #include <boost/format.hpp>
+#include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 namespace gr {

--- a/gnuradio-runtime/lib/local_sighandler.h
+++ b/gnuradio-runtime/lib/local_sighandler.h
@@ -12,7 +12,7 @@
 #define INCLUDED_GR_LOCAL_SIGHANDLER_H
 
 #ifdef HAVE_SIGNAL_H
-#include <signal.h>
+#include <csignal>
 #endif
 
 #include <gnuradio/api.h>

--- a/gnuradio-runtime/lib/math/qa_fxpt.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt.cc
@@ -14,10 +14,10 @@
 
 #include <gnuradio/fxpt.h>
 #include <gnuradio/math.h>
-#include <math.h>
-#include <stdio.h>
 #include <unistd.h>
 #include <boost/test/unit_test.hpp>
+#include <cmath>
+#include <cstdio>
 #include <iostream>
 
 static const float SIN_COS_TOLERANCE = 1e-5;

--- a/gnuradio-runtime/lib/math/qa_fxpt_nco.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt_nco.cc
@@ -14,10 +14,10 @@
 
 #include <gnuradio/fxpt_nco.h>
 #include <gnuradio/nco.h>
-#include <math.h>
-#include <stdio.h>
 #include <unistd.h>
 #include <boost/test/unit_test.hpp>
+#include <cmath>
+#include <cstdio>
 #include <iostream>
 
 static const float SIN_COS_TOLERANCE = 1e-5;

--- a/gnuradio-runtime/lib/math/qa_fxpt_vco.cc
+++ b/gnuradio-runtime/lib/math/qa_fxpt_vco.cc
@@ -14,10 +14,10 @@
 
 #include "vco.h"
 #include <gnuradio/fxpt_vco.h>
-#include <math.h>
-#include <stdio.h>
 #include <unistd.h>
 #include <boost/test/unit_test.hpp>
+#include <cmath>
+#include <cstdio>
 #include <iostream>
 
 static const float SIN_COS_TOLERANCE = 1e-5;

--- a/gnuradio-runtime/lib/math/qa_math.cc
+++ b/gnuradio-runtime/lib/math/qa_math.cc
@@ -8,9 +8,9 @@
  */
 
 #include <gnuradio/math.h>
-#include <stdio.h>
 #include <boost/test/unit_test.hpp>
 #include <cmath>
+#include <cstdio>
 
 BOOST_AUTO_TEST_CASE(test_binary_slicer1)
 {

--- a/gnuradio-runtime/lib/message.cc
+++ b/gnuradio-runtime/lib/message.cc
@@ -13,8 +13,8 @@
 #endif
 
 #include <gnuradio/message.h>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -16,8 +16,8 @@
 #include <gnuradio/prefs.h>
 
 #include "pagesize.h"
-#include <stdio.h>
 #include <unistd.h>
+#include <cstdio>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -16,8 +16,8 @@
 #include <gnuradio/messages/msg_accepter.h>
 #include <pmt/pmt.h>
 #include <pmt/pmt_pool.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <functional>
 #include <vector>
 

--- a/gnuradio-runtime/lib/pmt/pmt_pool.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_pool.cc
@@ -13,8 +13,8 @@
 #endif
 
 #include <pmt/pmt_pool.h>
-#include <stdint.h>
 #include <algorithm>
+#include <cstdint>
 
 namespace pmt {
 

--- a/gnuradio-runtime/lib/qa_buffer.cc
+++ b/gnuradio-runtime/lib/qa_buffer.cc
@@ -15,8 +15,8 @@
 
 #include <gnuradio/buffer.h>
 #include <gnuradio/random.h>
-#include <stdlib.h>
 #include <boost/test/unit_test.hpp>
+#include <cstdlib>
 
 
 static void leak_check(void f())

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -20,11 +20,11 @@
 #include <sched.h>
 #endif
 
-#include <errno.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
 #include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
 
 #include <iostream>
 

--- a/gnuradio-runtime/lib/test.cc
+++ b/gnuradio-runtime/lib/test.cc
@@ -14,7 +14,7 @@
 
 #include "test.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 

--- a/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
+++ b/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
@@ -16,10 +16,10 @@
 #include <gnuradio/thread/thread_body_wrapper.h>
 
 #ifdef HAVE_SIGNAL_H
-#include <signal.h>
+#include <csignal>
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace thread {

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -20,9 +20,9 @@
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
 
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 

--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -15,10 +15,10 @@
 #include "local_sighandler.h"
 #include "vmcircbuf.h"
 #include "vmcircbuf_prefs.h"
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
 #include <boost/format.hpp>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
 #include <stdexcept>
 #include <vector>
 

--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
@@ -12,9 +12,9 @@
 #include "config.h"
 #endif
 
-#include <assert.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cassert>
 #include <stdexcept>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -24,9 +24,9 @@
 #endif
 #include "pagesize.h"
 #include "vmcircbuf_createfilemapping.h"
-#include <errno.h>
-#include <stdio.h>
 #include <boost/format.hpp>
+#include <cerrno>
+#include <cstdio>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
@@ -13,9 +13,9 @@
 #endif
 
 #include "vmcircbuf_mmap_shm_open.h"
-#include <assert.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cassert>
 #include <stdexcept>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -25,9 +25,9 @@
 #endif
 #include "pagesize.h"
 #include <gnuradio/sys_paths.h>
-#include <errno.h>
-#include <stdio.h>
 #include <boost/format.hpp>
+#include <cerrno>
+#include <cstdio>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.cc
@@ -13,9 +13,9 @@
 #endif
 
 #include "vmcircbuf_mmap_tmpfile.h"
-#include <assert.h>
-#include <stdlib.h>
 #include <unistd.h>
+#include <cassert>
+#include <cstdlib>
 #include <stdexcept>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -25,11 +25,11 @@
 #endif
 #include "pagesize.h"
 #include <gnuradio/sys_paths.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
 #include <boost/format.hpp>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -15,12 +15,12 @@
 #include "vmcircbuf.h"
 #include "vmcircbuf_prefs.h"
 #include <gnuradio/sys_paths.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
@@ -13,10 +13,10 @@
 #endif
 
 #include "vmcircbuf_sysv_shm.h"
-#include <assert.h>
 #include <fcntl.h>
-#include <stdlib.h>
 #include <unistd.h>
+#include <cassert>
+#include <cstdlib>
 #include <stdexcept>
 #ifdef HAVE_SYS_IPC_H
 #include <sys/ipc.h>
@@ -25,8 +25,8 @@
 #include <sys/shm.h>
 #endif
 #include "pagesize.h"
-#include <errno.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstdio>
 
 #define MAX_SYSV_SHM_ATTEMPTS 3
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_nco_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_nco_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fxpt_nco.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a464f7bdf49d3dfafc989a2b3f4d7b94)                     */
+/* BINDTOOL_HEADER_FILE_HASH(e3506eb8121ca9e030103d44633b8a4c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fxpt.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2299d7b3bd19eed3eb2e59c8075cfdb3)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f6f6a6028a7944b8a1032337bba08124)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(5e612fbda6f51ed261021bd090eb95c1)                     */
+/* BINDTOOL_HEADER_FILE_HASH(92bf454f642caf2a1de6cdf3cbda722e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/random_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/random_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(random.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(7f6d1465c630113ffe56d12f0e8b65a8)                     */
+/* BINDTOOL_HEADER_FILE_HASH(95215055c6ad6f78b88d532d3994d29a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/rpcregisterhelpers_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/rpcregisterhelpers_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rpcregisterhelpers.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e709e094b601d2ad985ce55b438cc0e2)                     */
+/* BINDTOOL_HEADER_FILE_HASH(824d93e3a111258aafa88e46b1eb4e4b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/include/gnuradio/analog/agc2.h
+++ b/gr-analog/include/gnuradio/analog/agc2.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/analog/api.h>
 #include <gnuradio/gr_complex.h>
-#include <math.h>
+#include <cmath>
 
 namespace gr {
 namespace analog {

--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -12,7 +12,7 @@
 #include "config.h"
 #endif
 
-#include <float.h>
+#include <cfloat>
 #include <vector>
 
 #include "agc3_cc_impl.h"

--- a/gr-analog/lib/phase_modulator_fc_impl.cc
+++ b/gr-analog/lib/phase_modulator_fc_impl.cc
@@ -15,7 +15,7 @@
 #include "phase_modulator_fc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/sincos.h>
-#include <math.h>
+#include <cmath>
 
 namespace gr {
 namespace analog {

--- a/gr-analog/lib/pll_refout_cc_impl.cc
+++ b/gr-analog/lib/pll_refout_cc_impl.cc
@@ -15,7 +15,7 @@
 #include "pll_refout_cc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/sincos.h>
-#include <math.h>
+#include <cmath>
 
 namespace gr {
 namespace analog {

--- a/gr-audio/lib/alsa/alsa_impl.h
+++ b/gr-audio/lib/alsa/alsa_impl.h
@@ -12,7 +12,7 @@
 #define INCLUDED_ALSA_IMPL_H
 
 #include <alsa/asoundlib.h>
-#include <stdio.h>
+#include <cstdio>
 
 void gri_alsa_dump_hw_params(snd_pcm_t* pcm, snd_pcm_hw_params_t* hwparams, FILE* fp);
 

--- a/gr-audio/lib/alsa/alsa_source.cc
+++ b/gr-audio/lib/alsa/alsa_source.cc
@@ -17,7 +17,7 @@
 #include "alsa_source.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-audio/lib/jack/jack_impl.h
+++ b/gr-audio/lib/jack/jack_impl.h
@@ -11,6 +11,6 @@
 #ifndef INCLUDED_AUDIO_JACK_IMPL_H
 #define INCLUDED_AUDIO_JACK_IMPL_H
 
-#include <stdio.h>
+#include <cstdio>
 
 #endif /* INCLUDED_AUDIO_JACK_IMPL_H */

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -17,7 +17,7 @@
 #include "jack_sink.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -17,8 +17,8 @@
 #include "jack_source.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
 #include <type_traits>
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-audio/lib/oss/oss_sink.cc
+++ b/gr-audio/lib/oss/oss_sink.cc
@@ -17,12 +17,12 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/ioctl.h>
 #include <sys/soundcard.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-audio/lib/oss/oss_source.cc
+++ b/gr-audio/lib/oss/oss_source.cc
@@ -17,12 +17,12 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/ioctl.h>
 #include <sys/soundcard.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstdio>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-audio/lib/portaudio/portaudio_impl.cc
+++ b/gr-audio/lib/portaudio/portaudio_impl.cc
@@ -14,7 +14,7 @@
 
 #include "portaudio_impl.h"
 #include <portaudio.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace audio {

--- a/gr-audio/lib/portaudio/portaudio_impl.h
+++ b/gr-audio/lib/portaudio/portaudio_impl.h
@@ -12,7 +12,7 @@
 #define INCLUDED_AUDIO_PORTAUDIO_IMPL_H
 
 #include <portaudio.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace audio {

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -21,9 +21,9 @@
 #include "portaudio_sink.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstring>
 #include <future>
 #include <iostream>
 #include <stdexcept>

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -21,9 +21,9 @@
 #include "portaudio_source.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 #ifdef _MSC_VER

--- a/gr-blocks/include/gnuradio/blocks/head.h
+++ b/gr-blocks/include/gnuradio/blocks/head.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/sync_block.h>
-#include <stddef.h> // size_t
+#include <cstddef> // size_t
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/include/gnuradio/blocks/nop.h
+++ b/gr-blocks/include/gnuradio/blocks/nop.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/api.h>
-#include <stddef.h> // size_t
+#include <cstddef> // size_t
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/include/gnuradio/blocks/null_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/null_sink.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/sync_block.h>
-#include <stddef.h> // size_t
+#include <cstddef> // size_t
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/include/gnuradio/blocks/skiphead.h
+++ b/gr-blocks/include/gnuradio/blocks/skiphead.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/sync_block.h>
-#include <stddef.h> // size_t
+#include <cstddef> // size_t
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_1to1_impl.cc
+++ b/gr-blocks/lib/annotator_1to1_impl.cc
@@ -14,7 +14,7 @@
 
 #include "annotator_1to1_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 

--- a/gr-blocks/lib/annotator_alltoall_impl.cc
+++ b/gr-blocks/lib/annotator_alltoall_impl.cc
@@ -14,7 +14,7 @@
 
 #include "annotator_alltoall_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 

--- a/gr-blocks/lib/annotator_raw_impl.cc
+++ b/gr-blocks/lib/annotator_raw_impl.cc
@@ -14,7 +14,7 @@
 
 #include "annotator_raw_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <stdexcept>

--- a/gr-blocks/lib/burst_tagger_impl.cc
+++ b/gr-blocks/lib/burst_tagger_impl.cc
@@ -14,7 +14,7 @@
 
 #include "burst_tagger_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/check_lfsr_32k_s_impl.cc
+++ b/gr-blocks/lib/check_lfsr_32k_s_impl.cc
@@ -14,8 +14,8 @@
 
 #include "check_lfsr_32k_s_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/copy_impl.cc
+++ b/gr-blocks/lib/copy_impl.cc
@@ -14,7 +14,7 @@
 
 #include "copy_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/delay_impl.cc
+++ b/gr-blocks/lib/delay_impl.cc
@@ -14,7 +14,7 @@
 
 #include "delay_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/file_descriptor_sink_impl.cc
+++ b/gr-blocks/lib/file_descriptor_sink_impl.cc
@@ -14,11 +14,10 @@
 
 #include "file_descriptor_sink_impl.h"
 #include <gnuradio/io_signature.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cerrno>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-blocks/lib/file_descriptor_source_impl.cc
+++ b/gr-blocks/lib/file_descriptor_source_impl.cc
@@ -14,13 +14,12 @@
 
 #include "file_descriptor_source_impl.h"
 #include <gnuradio/io_signature.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 #ifdef HAVE_IO_H

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -15,7 +15,6 @@
 #include "file_meta_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cstdio>

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -15,7 +15,6 @@
 #include "file_meta_source_impl.h"
 #include <gnuradio/io_signature.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cstdio>

--- a/gr-blocks/lib/file_sink_base.cc
+++ b/gr-blocks/lib/file_sink_base.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/thread/thread.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cstdio>

--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cstdio>

--- a/gr-blocks/lib/float_array_to_int.cc
+++ b/gr-blocks/lib/float_array_to_int.cc
@@ -14,7 +14,7 @@
 
 #define _ISOC9X_SOURCE
 #include "float_array_to_int.h"
-#include <math.h>
+#include <cmath>
 #if __cplusplus >= 201103L
 #include <cstdint>
 using std::int64_t;

--- a/gr-blocks/lib/float_array_to_uchar.cc
+++ b/gr-blocks/lib/float_array_to_uchar.cc
@@ -14,7 +14,7 @@
 
 #define _ISOC9X_SOURCE
 #include "float_array_to_uchar.h"
-#include <math.h>
+#include <cmath>
 
 static const int MIN_UCHAR = 0;
 static const int MAX_UCHAR = 255;

--- a/gr-blocks/lib/head_impl.cc
+++ b/gr-blocks/lib/head_impl.cc
@@ -14,7 +14,7 @@
 
 #include "head_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -14,12 +14,12 @@
 
 #include "message_strobe_impl.h"
 #include <gnuradio/io_signature.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-blocks/lib/mute_impl.cc
+++ b/gr-blocks/lib/mute_impl.cc
@@ -15,8 +15,8 @@
 
 #include "mute_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/null_source_impl.cc
+++ b/gr-blocks/lib/null_source_impl.cc
@@ -14,7 +14,7 @@
 
 #include "null_source_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/packed_to_unpacked_impl.cc
+++ b/gr-blocks/lib/packed_to_unpacked_impl.cc
@@ -15,7 +15,7 @@
 
 #include "packed_to_unpacked_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
+++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "peak_detector2_fb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <limits>
 
 namespace gr {

--- a/gr-blocks/lib/peak_detector_impl.cc
+++ b/gr-blocks/lib/peak_detector_impl.cc
@@ -14,8 +14,8 @@
 
 #include "peak_detector_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
 #include <type_traits>
+#include <cstring>
 #include <limits>
 
 namespace gr {

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -14,7 +14,7 @@
 
 #include "selector_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/skiphead_impl.cc
+++ b/gr-blocks/lib/skiphead_impl.cc
@@ -14,7 +14,7 @@
 
 #include "skiphead_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/stream_to_streams_impl.cc
+++ b/gr-blocks/lib/stream_to_streams_impl.cc
@@ -14,7 +14,7 @@
 
 #include "stream_to_streams_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/tag_debug_impl.h
+++ b/gr-blocks/lib/tag_debug_impl.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/blocks/tag_debug.h>
 #include <gnuradio/thread/thread.h>
-#include <stddef.h>
+#include <cstddef>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -14,10 +14,10 @@
 
 #include "tagged_file_sink_impl.h"
 #include <gnuradio/io_signature.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cerrno>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-blocks/lib/tags_strobe_impl.cc
+++ b/gr-blocks/lib/tags_strobe_impl.cc
@@ -14,12 +14,12 @@
 
 #include "tags_strobe_impl.h"
 #include <gnuradio/io_signature.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-blocks/lib/tcp_server_sink_impl.cc
+++ b/gr-blocks/lib/tcp_server_sink_impl.cc
@@ -15,12 +15,12 @@
 #include "tcp_server_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
-#include <stdio.h>
-#include <string.h>
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
 #include <algorithm>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -15,8 +15,8 @@
 #include "test_tag_variable_rate_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <stdexcept>

--- a/gr-blocks/lib/udp_sink_impl.cc
+++ b/gr-blocks/lib/udp_sink_impl.cc
@@ -15,11 +15,11 @@
 #include "udp_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
-#include <stdio.h>
-#include <string.h>
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 

--- a/gr-blocks/lib/udp_source_impl.cc
+++ b/gr-blocks/lib/udp_source_impl.cc
@@ -16,9 +16,9 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <gnuradio/prefs.h>
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 

--- a/gr-blocks/lib/unpacked_to_packed_impl.cc
+++ b/gr-blocks/lib/unpacked_to_packed_impl.cc
@@ -15,7 +15,7 @@
 
 #include "unpacked_to_packed_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/vco_c_impl.cc
+++ b/gr-blocks/lib/vco_c_impl.cc
@@ -14,7 +14,7 @@
 
 #include "vco_c_impl.h"
 #include <gnuradio/io_signature.h>
-#include <math.h>
+#include <cmath>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/vco_f_impl.cc
+++ b/gr-blocks/lib/vco_f_impl.cc
@@ -14,7 +14,7 @@
 
 #include "vco_f_impl.h"
 #include <gnuradio/io_signature.h>
-#include <math.h>
+#include <cmath>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/vector_insert_impl.cc
+++ b/gr-blocks/lib/vector_insert_impl.cc
@@ -16,8 +16,8 @@
 #include "vector_insert_impl.h"
 #include <gnuradio/block.h>
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
 #include <algorithm>
+#include <cstdio>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/vector_map_impl.cc
+++ b/gr-blocks/lib/vector_map_impl.cc
@@ -14,7 +14,7 @@
 
 #include "vector_map_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/python/blocks/bindings/head_python.cc
+++ b/gr-blocks/python/blocks/bindings/head_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(head.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a84eb75af0a93ad008abf4fd915a3c41)                     */
+/* BINDTOOL_HEADER_FILE_HASH(d0c0087ad00f1b1d3f09273ba0dcb7d6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/bindings/nop_python.cc
+++ b/gr-blocks/python/blocks/bindings/nop_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(nop.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c206b7435a51013204b4c6ef82caf92e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ff387f469b6a04fae6124034ea3bb399)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/bindings/null_sink_python.cc
+++ b/gr-blocks/python/blocks/bindings/null_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(null_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8e09529f4c20a55974e648e7cff8e8b7)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f3d81a0f6f4dd8272f550d742d0abf49)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/bindings/skiphead_python.cc
+++ b/gr-blocks/python/blocks/bindings/skiphead_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(skiphead.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(f323e03d857174538fe9bfe4f0128205)                     */
+/* BINDTOOL_HEADER_FILE_HASH(7e569f2f33544fdc21963c5b4dc69972)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-channels/lib/flat_fader_impl.h
+++ b/gr-channels/lib/flat_fader_impl.h
@@ -15,7 +15,7 @@
 #include <gnuradio/fxpt.h>
 #include <gnuradio/io_signature.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <random>
 
 // FASTSINCOS:  0 = slow native,  1 = gr::fxpt impl,  2 = sincostable.h

--- a/gr-digital/include/gnuradio/digital/adaptive_algorithm.h
+++ b/gr-digital/include/gnuradio/digital/adaptive_algorithm.h
@@ -14,8 +14,8 @@
 #include <gnuradio/digital/api.h>
 #include <gnuradio/digital/constellation.h>
 #include <gnuradio/math.h>
-#include <math.h>
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 namespace gr {

--- a/gr-digital/include/gnuradio/digital/header_buffer.h
+++ b/gr-digital/include/gnuradio/digital/header_buffer.h
@@ -11,8 +11,8 @@
 #define INCLUDED_DIGITAL_HEADER_BUFFER_H
 
 #include <gnuradio/digital/api.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 namespace gr {

--- a/gr-digital/include/gnuradio/digital/lfsr.h
+++ b/gr-digital/include/gnuradio/digital/lfsr.h
@@ -12,7 +12,7 @@
 #define INCLUDED_DIGITAL_LFSR_H
 
 #include <gnuradio/digital/api.h>
-#include <stdint.h>
+#include <cstdint>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -15,7 +15,7 @@
 #include "chunks_to_symbols_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/tag_checker.h>
-#include <assert.h>
+#include <cassert>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/constellation_encoder_bc_impl.h
+++ b/gr-digital/lib/constellation_encoder_bc_impl.h
@@ -23,11 +23,11 @@ private:
 
 public:
     constellation_encoder_bc_impl(constellation_sptr constellation);
-    ~constellation_encoder_bc_impl();
+    ~constellation_encoder_bc_impl() override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items);
+             gr_vector_void_star& output_items) override;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/decision_feedback_equalizer_impl.cc
+++ b/gr-digital/lib/decision_feedback_equalizer_impl.cc
@@ -82,7 +82,7 @@ decision_feedback_equalizer_impl::decision_feedback_equalizer_impl(
     // not reversed at this point
     d_new_taps[0] = gr_complex(1.0, 0.0); // help things along with initialized taps
 
-    if (training_start_tag == "" || training_sequence.empty()) {
+    if (training_start_tag.empty() || training_sequence.empty()) {
         d_training_state = equalizer_state_t::DD;
     } else {
         d_training_state = equalizer_state_t::IDLE;
@@ -206,7 +206,7 @@ int decision_feedback_equalizer_impl::equalize(
         if (state)
             state[i] = (unsigned short)d_training_state;
 
-        if (training_start_samples.size() > 0 &&
+        if (!training_start_samples.empty() &&
             tag_index < training_start_samples.size()) {
             int tag_sample = training_start_samples[tag_index];
             if (tag_sample >= j && tag_sample < (j + (int)decimation())) {

--- a/gr-digital/lib/header_buffer.cc
+++ b/gr-digital/lib/header_buffer.cc
@@ -12,9 +12,9 @@
 #endif
 
 #include <gnuradio/digital/header_buffer.h>
-#include <string.h>
 #include <volk/volk.h>
 #include <algorithm>
+#include <cstring>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/header_format_base.cc
+++ b/gr-digital/lib/header_format_base.cc
@@ -13,8 +13,8 @@
 
 #include <gnuradio/digital/header_format_base.h>
 #include <gnuradio/math.h>
-#include <string.h>
 #include <volk/volk.h>
+#include <cstring>
 #include <iostream>
 
 namespace gr {

--- a/gr-digital/lib/header_format_counter.cc
+++ b/gr-digital/lib/header_format_counter.cc
@@ -14,8 +14,8 @@
 #include <gnuradio/digital/header_buffer.h>
 #include <gnuradio/digital/header_format_counter.h>
 #include <gnuradio/math.h>
-#include <string.h>
 #include <volk/volk_alloc.hh>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 

--- a/gr-digital/lib/header_format_crc.cc
+++ b/gr-digital/lib/header_format_crc.cc
@@ -13,8 +13,8 @@
 
 #include <gnuradio/digital/header_buffer.h>
 #include <gnuradio/digital/header_format_crc.h>
-#include <string.h>
 #include <volk/volk_alloc.hh>
+#include <cstring>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_default.cc
+++ b/gr-digital/lib/header_format_default.cc
@@ -13,8 +13,8 @@
 
 #include <gnuradio/digital/header_format_default.h>
 #include <gnuradio/math.h>
-#include <string.h>
 #include <volk/volk_alloc.hh>
+#include <cstring>
 #include <iostream>
 
 namespace gr {

--- a/gr-digital/lib/header_format_ofdm.cc
+++ b/gr-digital/lib/header_format_ofdm.cc
@@ -14,8 +14,8 @@
 #include <gnuradio/digital/header_buffer.h>
 #include <gnuradio/digital/header_format_ofdm.h>
 #include <gnuradio/digital/lfsr.h>
-#include <string.h>
 #include <volk/volk.h>
+#include <cstring>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/linear_equalizer_impl.cc
+++ b/gr-digital/lib/linear_equalizer_impl.cc
@@ -66,7 +66,7 @@ linear_equalizer_impl::linear_equalizer_impl(unsigned num_taps,
       d_updated(false),
       d_training_sample(0)
 {
-    if (training_start_tag == "" || training_sequence.empty()) {
+    if (training_start_tag.empty() || training_sequence.empty()) {
         d_training_state = equalizer_state_t::DD;
     } else {
         d_training_state = equalizer_state_t::IDLE;
@@ -134,7 +134,7 @@ int linear_equalizer_impl::equalize(const gr_complex* input_samples,
             state[i] = (unsigned short)d_training_state;
         }
 
-        if (training_start_samples.size() > 0 &&
+        if (!training_start_samples.empty() &&
             tag_index < training_start_samples.size()) {
             unsigned int tag_sample = training_start_samples[tag_index];
             if (tag_sample >= j && tag_sample < (j + decimation())) {

--- a/gr-digital/lib/packet_header_default.cc
+++ b/gr-digital/lib/packet_header_default.cc
@@ -12,7 +12,7 @@
 #endif
 
 #include <gnuradio/digital/packet_header_default.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/packet_sink_impl.cc
+++ b/gr-digital/lib/packet_sink_impl.cc
@@ -15,12 +15,12 @@
 #include "packet_sink_impl.h"
 #include <gnuradio/blocks/count_bits.h>
 #include <gnuradio/io_signature.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/protocol_formatter_async_impl.cc
+++ b/gr-digital/lib/protocol_formatter_async_impl.cc
@@ -14,8 +14,8 @@
 
 #include "protocol_formatter_async_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
 #include <volk/volk_alloc.hh>
+#include <cstdio>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/protocol_formatter_bb_impl.cc
+++ b/gr-digital/lib/protocol_formatter_bb_impl.cc
@@ -14,8 +14,8 @@
 
 #include "protocol_formatter_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
 #include <volk/volk.h>
+#include <cstdio>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/qa_header_buffer.cc
+++ b/gr-digital/lib/qa_header_buffer.cc
@@ -14,9 +14,9 @@
 
 #include <gnuradio/attributes.h>
 #include <gnuradio/digital/header_buffer.h>
-#include <stdio.h>
 #include <volk/volk_alloc.hh>
 #include <boost/test/unit_test.hpp>
+#include <cstdio>
 
 BOOST_AUTO_TEST_CASE(test_add8)
 {

--- a/gr-digital/lib/qa_header_format.cc
+++ b/gr-digital/lib/qa_header_format.cc
@@ -18,10 +18,10 @@
 #include <gnuradio/digital/header_format_default.h>
 #include <gnuradio/expj.h>
 #include <gnuradio/xoroshiro128p.h>
-#include <stdio.h>
 #include <volk/volk_alloc.hh>
 #include <boost/test/unit_test.hpp>
 #include <cmath>
+#include <cstdio>
 
 static void
 xoroshiro_fill_buffer(uint8_t* buffer, unsigned int length, uint64_t seed = 42)

--- a/gr-digital/lib/simple_correlator_impl.cc
+++ b/gr-digital/lib/simple_correlator_impl.cc
@@ -16,9 +16,9 @@
 #include <gnuradio/blocks/count_bits.h>
 #include <gnuradio/digital/simple_framer_sync.h>
 #include <gnuradio/io_signature.h>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/simple_framer_impl.cc
+++ b/gr-digital/lib/simple_framer_impl.cc
@@ -15,7 +15,7 @@
 #include "simple_framer_impl.h"
 #include <gnuradio/digital/simple_framer_sync.h>
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <string>
 
 namespace gr {

--- a/gr-digital/python/digital/bindings/adaptive_algorithm_python.cc
+++ b/gr-digital/python/digital/bindings/adaptive_algorithm_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(adaptive_algorithm.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(33c5f79e6e5a87ff26075b7aa45a61c4)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a13b47b8abd39d82742a594477210648)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/header_buffer_python.cc
+++ b/gr-digital/python/digital/bindings/header_buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_buffer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(fa6a18f60473f6981e632c4cf3005793)                     */
+/* BINDTOOL_HEADER_FILE_HASH(22afb7f4d4128f03a2a8f67f1e6ea6e0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/lfsr_python.cc
+++ b/gr-digital/python/digital/bindings/lfsr_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(lfsr.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a9c9bd5cfce2d712fcbd9401773e8621)                     */
+/* BINDTOOL_HEADER_FILE_HASH(6ad566b46874d5852d96814797e67bc4)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-dtv/lib/atsc/atsc_basic_trellis_encoder.cc
+++ b/gr-dtv/lib/atsc/atsc_basic_trellis_encoder.cc
@@ -7,7 +7,7 @@
  */
 
 #include "atsc_basic_trellis_encoder.h"
-#include <assert.h>
+#include <cassert>
 
 namespace gr {
 namespace dtv {

--- a/gr-dtv/lib/atsc/atsc_fpll_impl.h
+++ b/gr-dtv/lib/atsc/atsc_fpll_impl.h
@@ -15,7 +15,7 @@
 #include <gnuradio/dtv/atsc_fpll.h>
 #include <gnuradio/filter/single_pole_iir.h>
 #include <gnuradio/nco.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace dtv {

--- a/gr-dtv/lib/atsc/atsc_single_viterbi.cc
+++ b/gr-dtv/lib/atsc/atsc_single_viterbi.cc
@@ -9,7 +9,7 @@
  */
 
 #include "atsc_single_viterbi.h"
-#include <math.h>
+#include <cmath>
 
 namespace gr {
 namespace dtv {

--- a/gr-dtv/lib/atsc/atsc_trellis_encoder_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_trellis_encoder_impl.cc
@@ -12,7 +12,7 @@
 
 #include "atsc_trellis_encoder_impl.h"
 #include "gnuradio/dtv/atsc_consts.h"
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace dtv {

--- a/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc
@@ -12,7 +12,7 @@
 
 #include "dvbt_inner_coder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 
 namespace gr {
 namespace dtv {

--- a/gr-dtv/lib/dvbt/dvbt_map_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_map_impl.cc
@@ -12,7 +12,7 @@
 
 #include "dvbt_map_impl.h"
 #include <gnuradio/io_signature.h>
-#include <math.h>
+#include <cmath>
 #include <complex>
 
 namespace gr {

--- a/gr-dtv/lib/dvbt2/dvbt2_p1insertion_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_p1insertion_cc_impl.cc
@@ -12,8 +12,8 @@
 
 #include "dvbt2_p1insertion_cc_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
 #include <algorithm>
+#include <cstdio>
 
 namespace gr {
 namespace dtv {

--- a/gr-fec/include/gnuradio/fec/alist.h
+++ b/gr-fec/include/gnuradio/fec/alist.h
@@ -23,7 +23,7 @@
 #define ALIST_H
 
 #include <gnuradio/fec/api.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/gr-fec/include/gnuradio/fec/gf2vec.h
+++ b/gr-fec/include/gnuradio/fec/gf2vec.h
@@ -11,7 +11,7 @@
 #ifndef GF2VEC_H
 #define GF2VEC_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 class GF2Vec

--- a/gr-fec/include/gnuradio/fec/polar_common.h
+++ b/gr-fec/include/gnuradio/fec/polar_common.h
@@ -16,8 +16,8 @@
 
 #include <gnuradio/blocks/unpack_k_bits.h>
 #include <gnuradio/fec/api.h>
-#include <stdint.h>
 #include <volk/volk_alloc.hh>
+#include <cstdint>
 #include <vector>
 
 // Forward declaration for those objects. SWIG doesn't like them to be #include'd.

--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -14,8 +14,8 @@
 
 #include "async_decoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
 #include <volk/volk.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -14,8 +14,8 @@
 
 #include "async_encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
 #include <volk/volk.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/ber_bf_impl.cc
+++ b/gr-fec/lib/ber_bf_impl.cc
@@ -14,8 +14,8 @@
 
 #include "ber_bf_impl.h"
 #include <gnuradio/io_signature.h>
-#include <math.h>
 #include <volk/volk.h>
+#include <cmath>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -13,10 +13,10 @@
 #endif
 
 #include "cc_decoder_impl.h"
-#include <math.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -15,11 +15,11 @@
 #include "cc_encoder_impl.h"
 #include <gnuradio/fec/cc_common.h>
 #include <gnuradio/fec/generic_encoder.h>
-#include <math.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <volk/volk_typedefs.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/conv_bit_corr_bb_impl.cc
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.cc
@@ -15,7 +15,7 @@
 #include "conv_bit_corr_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/messages/msg_passing.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/decoder_impl.cc
+++ b/gr-fec/lib/decoder_impl.cc
@@ -14,7 +14,7 @@
 
 #include "decoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/depuncture_bb_impl.cc
+++ b/gr-fec/lib/depuncture_bb_impl.cc
@@ -15,9 +15,9 @@
 #include "depuncture_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/bind.hpp>
+#include <cstdio>
 #include <string>
 
 namespace gr {

--- a/gr-fec/lib/dummy_decoder_impl.cc
+++ b/gr-fec/lib/dummy_decoder_impl.cc
@@ -13,10 +13,10 @@
 #endif
 
 #include "dummy_decoder_impl.h"
-#include <math.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/encoder_impl.cc
+++ b/gr-fec/lib/encoder_impl.cc
@@ -14,7 +14,7 @@
 
 #include "encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/fec_mtrx_impl.cc
+++ b/gr-fec/lib/fec_mtrx_impl.cc
@@ -11,8 +11,8 @@
 #endif
 
 #include "fec_mtrx_impl.h"
-#include <math.h>
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/gr-fec/lib/generic_decoder.cc
+++ b/gr-fec/lib/generic_decoder.cc
@@ -14,7 +14,7 @@
 
 #include <gnuradio/fec/generic_decoder.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -14,7 +14,7 @@
 
 #include <gnuradio/fec/generic_encoder.h>
 #include <gnuradio/prefs.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -10,7 +10,7 @@
 #endif
 
 #include "ldpc_G_matrix_impl.h"
-#include <math.h>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/gr-fec/lib/ldpc_H_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_H_matrix_impl.cc
@@ -10,7 +10,7 @@
 #endif
 
 #include "ldpc_H_matrix_impl.h"
-#include <math.h>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
@@ -11,10 +11,10 @@
 #endif
 
 #include "ldpc_bit_flip_decoder_impl.h"
-#include <math.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/ldpc_decoder.cc
+++ b/gr-fec/lib/ldpc_decoder.cc
@@ -11,12 +11,12 @@
 #include <gnuradio/fec/decoder.h>
 #include <gnuradio/fec/ldpc_decoder.h>
 #include <gnuradio/fec/maxstar.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h> // for memcpy
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
+#include <cmath>
+#include <cstdio>
+#include <cstring> // for memcpy
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/ldpc_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_encoder_impl.cc
@@ -9,11 +9,11 @@
  */
 
 #include "ldpc_encoder_impl.h"
-#include <stdio.h>
-#include <string.h> // for memcpy
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
+#include <cstdio>
+#include <cstring> // for memcpy
 #include <sstream>
 
 namespace gr {

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -9,12 +9,12 @@
  */
 
 #include "ldpc_par_mtrx_encoder_impl.h"
-#include <math.h>
-#include <stdio.h>
-#include <string.h> // for memcpy
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
+#include <cmath>
+#include <cstdio>
+#include <cstring> // for memcpy
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/puncture_bb_impl.cc
+++ b/gr-fec/lib/puncture_bb_impl.cc
@@ -15,9 +15,9 @@
 #include "puncture_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/bind.hpp>
+#include <cstdio>
 #include <string>
 
 namespace gr {

--- a/gr-fec/lib/puncture_ff_impl.cc
+++ b/gr-fec/lib/puncture_ff_impl.cc
@@ -15,9 +15,9 @@
 #include "puncture_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/bind.hpp>
+#include <cstdio>
 #include <string>
 
 namespace gr {

--- a/gr-fec/lib/repetition_decoder_impl.cc
+++ b/gr-fec/lib/repetition_decoder_impl.cc
@@ -13,10 +13,10 @@
 #endif
 
 #include "repetition_decoder_impl.h"
-#include <math.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/tagged_decoder_impl.cc
+++ b/gr-fec/lib/tagged_decoder_impl.cc
@@ -14,7 +14,7 @@
 
 #include "tagged_decoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/tagged_encoder_impl.cc
+++ b/gr-fec/lib/tagged_encoder_impl.cc
@@ -14,7 +14,7 @@
 
 #include "tagged_encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
+#include <cstdio>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/tpc_decoder.cc
+++ b/gr-fec/lib/tpc_decoder.cc
@@ -12,14 +12,14 @@
 #include <gnuradio/fec/tpc_decoder.h>
 #include <volk/volk.h>
 
-#include <math.h>
-#include <stdio.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 
-#include <string.h>  // for memcpy
 #include <algorithm> // for std::reverse
+#include <cstring>   // for memcpy
 
 #include <gnuradio/fec/maxstar.h>
 

--- a/gr-fec/lib/tpc_encoder.cc
+++ b/gr-fec/lib/tpc_encoder.cc
@@ -12,15 +12,15 @@
 #include <gnuradio/fec/tpc_common.h>
 #include <gnuradio/fec/tpc_encoder.h>
 
-#include <math.h>
-#include <stdio.h>
 #include <volk/volk.h>
 #include <boost/assign/list_of.hpp>
+#include <cmath>
+#include <cstdio>
 #include <sstream>
 #include <vector>
 
-#include <string.h>  // for memcpy
 #include <algorithm> // for std::reverse
+#include <cstring>   // for memcpy
 
 namespace gr {
 namespace fec {

--- a/gr-fec/python/fec/bindings/polar_common_python.cc
+++ b/gr-fec/python/fec/bindings/polar_common_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polar_common.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(09bd7cfed21a2597f5c0ea5c21093054)                     */
+/* BINDTOOL_HEADER_FILE_HASH(9ebf708c1ab88b66055a5aa54159d6b1)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -32,9 +32,9 @@ static int my_fftw_read_char(void* f) { return fgetc((FILE*)f); }
 #define O_NONBLOCK 0
 #endif //_WIN32
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 
 #include <boost/filesystem/operations.hpp>

--- a/gr-fft/lib/fft_v_fftw.cc
+++ b/gr-fft/lib/fft_v_fftw.cc
@@ -13,9 +13,9 @@
 #endif
 
 #include "fft_v_fftw.h"
-#include <math.h>
-#include <string.h>
 #include <volk/volk.h>
+#include <cmath>
+#include <cstring>
 
 namespace gr {
 namespace fft {

--- a/gr-fft/lib/fft_v_fftw.h
+++ b/gr-fft/lib/fft_v_fftw.h
@@ -33,7 +33,7 @@ public:
                bool shift,
                int nthreads = 1);
 
-    ~fft_v_fftw() {}
+    ~fft_v_fftw() override {}
 
     void set_nthreads(int n) override;
     int nthreads() const override;

--- a/gr-filter/lib/fft_filter_ccc_impl.cc
+++ b/gr-filter/lib/fft_filter_ccc_impl.cc
@@ -15,8 +15,8 @@
 #include "fft_filter_ccc_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <assert.h>
-#include <math.h>
+#include <cassert>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-filter/lib/fft_filter_ccf_impl.cc
+++ b/gr-filter/lib/fft_filter_ccf_impl.cc
@@ -15,8 +15,8 @@
 #include "fft_filter_ccf_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <assert.h>
-#include <math.h>
+#include <cassert>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-filter/lib/fft_filter_fff_impl.cc
+++ b/gr-filter/lib/fft_filter_fff_impl.cc
@@ -15,8 +15,8 @@
 #include "fft_filter_fff_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <assert.h>
-#include <math.h>
+#include <cassert>
+#include <cmath>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -14,7 +14,7 @@
 
 #include "filterbank_vcvcf_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 namespace gr {

--- a/gr-filter/lib/pfb_channelizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_channelizer_ccf_impl.cc
@@ -14,7 +14,7 @@
 
 #include "pfb_channelizer_ccf_impl.h"
 #include <gnuradio/io_signature.h>
-#include <stdio.h>
+#include <cstdio>
 
 #ifdef _MSC_VER
 #define round(number) number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5)

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -31,7 +31,7 @@
 
 #include <gnuradio/filter/pm_remez.h>
 #include <gnuradio/logger.h>
-#include <assert.h>
+#include <cassert>
 #include <cmath>
 #include <iostream>
 

--- a/gr-filter/lib/qa_firdes.cc
+++ b/gr-filter/lib/qa_firdes.cc
@@ -10,9 +10,9 @@
 
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/gr_complex.h>
-#include <stdio.h>
-#include <string.h>
 #include <boost/test/unit_test.hpp>
+#include <cstdio>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 

--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -114,13 +114,13 @@ rational_resampler_impl<IN_T, OUT_T, TAP_T>::rational_resampler_impl(
     }
 
     // If taps are not specified, we need to design them based on fractional_bw
-    if (taps.size() == 0 && fractional_bw <= 0) {
+    if (taps.empty() && fractional_bw <= 0) {
         fractional_bw = 0.4;
     }
 
     auto d = GR_GCD(interpolation, decimation);
 
-    if (taps.size() && (d > 1)) {
+    if (!taps.empty() && (d > 1)) {
         GR_LOG_INFO(
             d_logger,
             boost::format(
@@ -131,7 +131,7 @@ rational_resampler_impl<IN_T, OUT_T, TAP_T>::rational_resampler_impl(
     }
 
     std::vector<TAP_T> staps;
-    if (taps.size() == 0) {
+    if (taps.empty()) {
         if (fractional_bw <= 0) {
             fractional_bw = 0.4;
         }

--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -224,7 +224,7 @@ int udp_source_impl::work(int noutput_items,
     unsigned int num_requested = noutput_items * d_block_size;
 
     // quick exit if nothing to do
-    if ((bytes_available == 0) && (d_localqueue->size() == 0)) {
+    if ((bytes_available == 0) && (d_localqueue->empty())) {
         underrun_counter++;
         d_partial_frame_counter = 0;
         if (d_source_zeros) {
@@ -288,7 +288,7 @@ int udp_source_impl::work(int noutput_items,
             // This is just a safety to clear in the case there's a hanging partial
             // packet. If we've lingered through a number of calls and we still don't
             // have any data, clear the stale data.
-            while (d_localqueue->size() > 0)
+            while (!d_localqueue->empty())
                 d_localqueue->pop_front();
 
             d_partial_frame_counter = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
@@ -12,7 +12,7 @@
 #define CONSTELLATION_DISPLAY_PLOT_H
 
 #include <gnuradio/qtgui/DisplayPlot.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -24,7 +24,7 @@
 #include <qwt_scale_engine.h>
 #include <qwt_scale_widget.h>
 #include <qwt_symbol.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
@@ -12,7 +12,7 @@
 
 #include <gnuradio/qtgui/DisplayPlot.h>
 #include <gnuradio/tags.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/FrequencyDisplayPlot.h
@@ -12,7 +12,7 @@
 #define FREQUENCY_DISPLAY_PLOT_HPP
 
 #include <gnuradio/qtgui/DisplayPlot.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
@@ -12,7 +12,7 @@
 #define HISTOGRAM_DISPLAY_PLOT_H
 
 #include <gnuradio/qtgui/DisplayPlot.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/qtgui/DisplayPlot.h>
 #include <gnuradio/tags.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -16,7 +16,7 @@
 #include <gnuradio/qtgui/plot_raster.h>
 #include <gnuradio/qtgui/timeRasterGlobalData.h>
 #include <qwt_plot_rasteritem.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
@@ -12,7 +12,7 @@
 #define VECTOR_DISPLAY_PLOT_HPP
 
 #include <gnuradio/qtgui/DisplayPlot.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -15,7 +15,7 @@
 #include <gnuradio/qtgui/DisplayPlot.h>
 #include <gnuradio/qtgui/waterfallGlobalData.h>
 #include <qwt_plot_spectrogram.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 

--- a/gr-qtgui/include/gnuradio/qtgui/spectrumUpdateEvents.h
+++ b/gr-qtgui/include/gnuradio/qtgui/spectrumUpdateEvents.h
@@ -14,10 +14,10 @@
 #include <gnuradio/high_res_timer.h>
 #include <gnuradio/qtgui/api.h>
 #include <gnuradio/tags.h>
-#include <stdint.h>
 #include <QEvent>
 #include <QString>
 #include <complex>
+#include <cstdint>
 #include <vector>
 
 static constexpr int SpectrumUpdateEventType = 10005;

--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -11,8 +11,8 @@
 #ifndef TIMERASTER_GLOBAL_DATA_HPP
 #define TIMERASTER_GLOBAL_DATA_HPP
 
-#include <inttypes.h>
 #include <qwt_raster_data.h>
+#include <cinttypes>
 
 #if QWT_VERSION >= 0x060000
 #include <qwt_compat.h>

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -11,8 +11,8 @@
 #ifndef WATERFALL_GLOBAL_DATA_HPP
 #define WATERFALL_GLOBAL_DATA_HPP
 
-#include <inttypes.h>
 #include <qwt_raster_data.h>
+#include <cinttypes>
 
 #if QWT_VERSION >= 0x060000
 #include <qwt_compat.h>

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -17,8 +17,8 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <qwt_symbol.h>
-#include <string.h>
 #include <volk/volk.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -21,8 +21,8 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -22,7 +22,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -23,8 +23,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/numeric.hpp>
 
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -23,7 +23,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/numeric.hpp>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -20,7 +20,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -20,8 +20,8 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
 #include <cmath>
+#include <cstring>
 
 #ifdef _MSC_VER
 #define isfinite _finite

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -19,7 +19,7 @@
 
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -20,7 +20,7 @@
 
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -19,7 +19,7 @@
 
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/time_raster_sink_b_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.h
@@ -76,10 +76,10 @@ public:
     void* pyqwidget();
 #endif
 
-    void set_x_label(const std::string& label);
-    void set_x_range(double start, double end);
-    void set_y_label(const std::string& label);
-    void set_y_range(double start, double end);
+    void set_x_label(const std::string& label) override;
+    void set_x_range(double start, double end) override;
+    void set_y_label(const std::string& label) override;
+    void set_y_range(double start, double end) override;
     void set_update_time(double t) override;
     void set_title(const std::string& title) override;
     void set_line_label(unsigned int which, const std::string& label) override;

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -19,7 +19,7 @@
 
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/time_raster_sink_f_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.h
@@ -75,10 +75,10 @@ public:
     void* pyqwidget();
 #endif
 
-    void set_x_label(const std::string& label);
-    void set_x_range(double start, double end);
-    void set_y_label(const std::string& label);
-    void set_y_range(double start, double end);
+    void set_x_label(const std::string& label) override;
+    void set_x_range(double start, double end) override;
+    void set_y_label(const std::string& label) override;
+    void set_y_range(double start, double end) override;
     void set_update_time(double t) override;
     void set_title(const std::string& title) override;
     void set_line_label(unsigned int which, const std::string& label) override;

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -21,8 +21,8 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -23,7 +23,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -20,7 +20,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -20,8 +20,8 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 
 namespace gr {

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -19,7 +19,7 @@
 
 #include <volk/volk.h>
 
-#include <string.h>
+#include <cstring>
 #include <iostream>
 
 namespace gr {

--- a/gr-trellis/lib/calc_metric.cc
+++ b/gr-trellis/lib/calc_metric.cc
@@ -9,7 +9,7 @@
  */
 
 #include <gnuradio/trellis/calc_metric.h>
-#include <float.h>
+#include <cfloat>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-trellis/lib/constellation_metrics_cf_impl.cc
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.cc
@@ -14,7 +14,7 @@
 
 #include "constellation_metrics_cf_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-trellis/lib/fsm.cc
+++ b/gr-trellis/lib/fsm.cc
@@ -11,8 +11,8 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/trellis/base.h>
 #include <gnuradio/trellis/fsm.h>
-#include <stdlib.h>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <stdexcept>
 #include <string>

--- a/gr-trellis/lib/metrics_impl.cc
+++ b/gr-trellis/lib/metrics_impl.cc
@@ -15,7 +15,7 @@
 
 #include "metrics_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-trellis/lib/permutation_impl.cc
+++ b/gr-trellis/lib/permutation_impl.cc
@@ -14,7 +14,7 @@
 
 #include "permutation_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 #include <iostream>
 
 namespace gr {

--- a/gr-trellis/lib/siso_combined_f_impl.cc
+++ b/gr-trellis/lib/siso_combined_f_impl.cc
@@ -14,7 +14,7 @@
 
 #include "siso_combined_f_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-trellis/lib/siso_f_impl.cc
+++ b/gr-trellis/lib/siso_f_impl.cc
@@ -14,7 +14,7 @@
 
 #include "siso_f_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -15,11 +15,11 @@
 #include "sink_s_impl.h"
 #include <gnuradio/io_signature.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -15,11 +15,11 @@
 #include "sink_uc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <stdexcept>
 

--- a/gr-vocoder/lib/alaw_decode_bs_impl.cc
+++ b/gr-vocoder/lib/alaw_decode_bs_impl.cc
@@ -14,7 +14,7 @@
 
 #include "alaw_decode_bs_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/alaw_encode_sb_impl.cc
+++ b/gr-vocoder/lib/alaw_encode_sb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "alaw_encode_sb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/codec2_decode_ps_impl.cc
+++ b/gr-vocoder/lib/codec2_decode_ps_impl.cc
@@ -19,7 +19,7 @@ extern "C" {
 #include "codec2_decode_ps_impl.h"
 
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/cvsd_decode_bs_impl.cc
+++ b/gr-vocoder/lib/cvsd_decode_bs_impl.cc
@@ -14,7 +14,7 @@
 
 #include "cvsd_decode_bs_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/cvsd_encode_sb_impl.cc
+++ b/gr-vocoder/lib/cvsd_encode_sb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "cvsd_encode_sb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -15,7 +15,7 @@
 #include "freedv_rx_ss_impl.h"
 
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/g721_decode_bs_impl.cc
+++ b/gr-vocoder/lib/g721_decode_bs_impl.cc
@@ -14,7 +14,7 @@
 
 #include "g721_decode_bs_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/g721_encode_sb_impl.cc
+++ b/gr-vocoder/lib/g721_encode_sb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "g721_encode_sb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/g723_24_decode_bs_impl.cc
+++ b/gr-vocoder/lib/g723_24_decode_bs_impl.cc
@@ -14,7 +14,7 @@
 
 #include "g723_24_decode_bs_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/g723_24_encode_sb_impl.cc
+++ b/gr-vocoder/lib/g723_24_encode_sb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "g723_24_encode_sb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/g723_40_decode_bs_impl.cc
+++ b/gr-vocoder/lib/g723_40_decode_bs_impl.cc
@@ -14,7 +14,7 @@
 
 #include "g723_40_decode_bs_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/g723_40_encode_sb_impl.cc
+++ b/gr-vocoder/lib/g723_40_encode_sb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "g723_40_encode_sb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/gsm_fr_decode_ps_impl.cc
+++ b/gr-vocoder/lib/gsm_fr_decode_ps_impl.cc
@@ -15,7 +15,7 @@
 #define GSM_SAMPLES_PER_FRAME 160
 #include "gsm_fr_decode_ps_impl.h"
 #include <gnuradio/io_signature.h>
-#include <assert.h>
+#include <cassert>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/ulaw_decode_bs_impl.cc
+++ b/gr-vocoder/lib/ulaw_decode_bs_impl.cc
@@ -14,7 +14,7 @@
 
 #include "ulaw_decode_bs_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-vocoder/lib/ulaw_encode_sb_impl.cc
+++ b/gr-vocoder/lib/ulaw_encode_sb_impl.cc
@@ -14,7 +14,7 @@
 
 #include "ulaw_encode_sb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <limits.h>
+#include <climits>
 
 namespace gr {
 namespace vocoder {

--- a/gr-wavelet/lib/wavelet_ff_impl.cc
+++ b/gr-wavelet/lib/wavelet_ff_impl.cc
@@ -16,7 +16,7 @@
 #include <gnuradio/io_signature.h>
 #include <stdexcept>
 
-#include <stdio.h>
+#include <cstdio>
 
 // NB in this version, only Daubechies wavelets
 // order is wavelet length, even, 2...20

--- a/gr-wavelet/lib/wvps_ff_impl.cc
+++ b/gr-wavelet/lib/wvps_ff_impl.cc
@@ -14,7 +14,7 @@
 
 #include "wvps_ff_impl.h"
 #include <gnuradio/io_signature.h>
-#include <string.h>
+#include <cstring>
 
 namespace gr {
 namespace wavelet {

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -88,7 +88,7 @@ int base_sink_impl::send_message(const void* in_buf,
                                  const uint64_t in_offset)
 {
     /* Send key if it exists */
-    if (d_key.size() > 0) {
+    if (!d_key.empty()) {
         zmq::message_t key_message(d_key.size());
         memcpy(key_message.data(), d_key.data(), d_key.size());
 #if USE_NEW_CPPZMQ_SEND_RECV
@@ -217,7 +217,7 @@ bool base_source_impl::load_message(bool wait)
 
     /* Throw away key and get the first message. Avoid blocking if a multi-part
      * message is not sent */
-    if (d_key.size() > 0 && !more) {
+    if (!d_key.empty() && !more) {
         int64_t is_multipart;
         d_socket.getsockopt(ZMQ_RCVMORE, &is_multipart, &more_len);
 


### PR DESCRIPTION
closes #4115