### PR TITLE
gr-qtgui: Fix deprecated use of QPixmap::grabWidget()

### DIFF
--- a/gr-qtgui/lib/eyedisplaysform.cc
+++ b/gr-qtgui/lib/eyedisplaysform.cc
@@ -332,7 +332,7 @@ void EyeDisplaysForm::setAxisLabels(bool en)
 
 void EyeDisplaysForm::saveFigure()
 {
-    QPixmap qpix = QPixmap::grabWidget(this);
+    QPixmap qpix = grab();
 
     QString types = QString(tr("JPEG file (*.jpg);;Portable Network Graphics file "
                                "(*.png);;Bitmap file (*.bmp);;TIFF file (*.tiff)"));


### PR DESCRIPTION
Use QWidget::grab() instead (which was introduced in Qt 5).

Signed-off-by: Zackery Spytz <zspytz@gmail.com>