### PR TITLE
gnuradio-runtime: missing <algorithm> header for std:sort

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tag_checker.h
+++ b/gnuradio-runtime/include/gnuradio/tag_checker.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_RUNTIME_TAG_CHECKER_H
 
 #include <gnuradio/tags.h>
+#include <algorithm>
 #include <vector>
 
 namespace gr {


### PR DESCRIPTION
MSVC is looking for <algorithm> header to have sort be part of the std namespace