### PR TITLE
gr-fec / trellis: include <string> to allow windows to build

### DIFF
--- a/gr-fec/include/gnuradio/fec/fec_mtrx.h
+++ b/gr-fec/include/gnuradio/fec/fec_mtrx.h
@@ -24,6 +24,7 @@
 #include <gnuradio/fec/api.h>
 #include <boost/shared_ptr.hpp>
 #include <cstdlib>
+#include <string>
 
 namespace gr {
 namespace fec {

--- a/gr-trellis/include/gnuradio/trellis/fsm.h
+++ b/gr-trellis/include/gnuradio/trellis/fsm.h
@@ -26,6 +26,7 @@
 #include <gnuradio/trellis/api.h>
 #include <iosfwd>
 #include <vector>
+#include <string>
 
 namespace gr {
 namespace trellis {


### PR DESCRIPTION
MSVC is looking for <string> to be included to get needed std::string namespace items

The fsm.h change also applies to maint-3.9