### PR TITLE
cmake: use certain relative paths in Win64 and stick to cmake paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,7 @@ SET(GR_THEMES_DIR      ${GR_PKG_DATA_DIR}/themes CACHE PATH "Path to install QTG
 # Special exception if prefix is /usr so we don't make a /usr/etc.
 SET(GR_CONF_DIR etc CACHE PATH "Path to install config files")
 string(COMPARE EQUAL "${CMAKE_INSTALL_PREFIX}" "/usr" isusr)
-if(isusr)
+if(isusr OR MSVC)
   SET(SYSCONFDIR "/${GR_CONF_DIR}" CACHE PATH "System configuration directory")
 else(isusr)
   SET(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/${GR_CONF_DIR}" CACHE PATH "System configuration directory" FORCE)
@@ -322,8 +322,8 @@ file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
 file(TO_NATIVE_PATH "\${prefix}"                        exec_prefix)
 file(TO_NATIVE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
 file(TO_NATIVE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
-file(TO_NATIVE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
-file(TO_NATIVE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+file(TO_CMAKE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
+file(TO_CMAKE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
 
 ########################################################################
 # On Apple only, set install name and use rpath correctly, if not already set


### PR DESCRIPTION
Currently by default in a Win64 build, SYSCONFDIR is set to the absolute path.  This results in the installers retaining a reference to whatever path was used to build the installer, which is now irrelevant.  So applied the same logic from "isusr" when it's an MSVC build.  For those building themselves with MSVC to use vs. create an installer, it still works fine as well.

Then later the scripts change those paths to native paths instead of cmake.  This changes the slashes to backslashes on windows, which is fine outside of cmake, but unfortunately other GNURadio components reference these values using cmake, and so the back slashes cause build issues.  Since windows can natively handles slashes in either direction, there really is no value is switching to backslash so might as well just leave them as forward slashes.  I am open to changing the others as well for consistency (as I believe Windows is the only case where TO_CMAKE_PATH and TO_NATIVE_PATH differ???) if desired but throw that out for consideration.

Signed-off-by: gnieboer <gnieboer@corpcomm.net>