### PR TITLE
cmake: removes cmake_prefix_path from hints list in FindQWT.cmake

### DIFF
--- a/cmake/Modules/FindQwt.cmake
+++ b/cmake/Modules/FindQwt.cmake
@@ -13,7 +13,7 @@ find_path(QWT_INCLUDE_DIRS
   HINTS
   ${PC_QWT_INCLUDEDIR}
   ${CMAKE_INSTALL_PREFIX}/include/qwt
-  ${CMAKE_PREFIX_PATH}/include/qwt
+  /include/qwt
   PATHS
   /usr/local/include/qwt-${QWT_QT_VERSION}
   /usr/local/include/qwt
@@ -34,7 +34,7 @@ find_library (QWT_LIBRARIES
   ${PC_QWT_LIBDIR}
   ${CMAKE_INSTALL_PREFIX}/lib
   ${CMAKE_INSTALL_PREFIX}/lib64
-  ${CMAKE_PREFIX_PATH}/lib
+  /lib
   PATHS
   /usr/local/lib
   /usr/lib


### PR DESCRIPTION
So this is an odd one... when vcpkg integration is enabled (which is what the latest win scripts are using), it adds a value to the CMAKE_PREFIX_PATH, which apparently make it a list instead of a single value.  So this causes one and only one failure... FindQWT is unable to find QWT because when it appends the /include/qwt to the CMAKE_PREFIX_PATH value, it's not appending it to both values.  

This is the only module that uses CMAKE_PREFIX_PATH in the HINTS, and I suspect that syntax is unnecessary as CMake uses the PREFIX_PATH(s) as a root anyways, so removal of the reference fixes the issue for me.

An alternate fix was to change the first line to "list(APPEND ${CMAKE_PREFIX_PATH} /include/qwt)" but that seems quite a bit more awkward and unnecessary.

I am open to syntax tweaks to make it more "standard" cmake format.

Signed-off-by: gnieboer <gnieboer@corpcomm.net>