### PR TITLE
Fix find_package_handle_standard_args warning in gr_modtool newmod

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/cmake/Modules/howtoConfig.cmake
+++ b/gr-utils/modtool/templates/gr-newmod/cmake/Modules/howtoConfig.cmake
@@ -1,4 +1,6 @@
-INCLUDE(FindPkgConfig)
+if(NOT PKG_CONFIG_FOUND)
+    INCLUDE(FindPkgConfig)
+endif()
 PKG_CHECK_MODULES(PC_HOWTO howto)
 
 FIND_PATH(


### PR DESCRIPTION
Buillding gnuradio led to a lot warnings. See #3581 which was fixed with #3781.
But the template used in   
gr_modtool newmod
needs this fix, too.
