### PR TITLE
runtime: lib: Don't use hard-coded absolute path constants.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,12 +279,20 @@ endif(ENABLE_PERFORMANCE_COUNTERS)
 ########################################################################
 # Variables replaced when configuring the package config files
 ########################################################################
-file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
-file(TO_NATIVE_PATH "\${prefix}"                        exec_prefix)
-file(TO_NATIVE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
-file(TO_NATIVE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
-file(TO_NATIVE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
-file(TO_NATIVE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
+file(TO_CMAKE_PATH "\${prefix}"                        exec_prefix)
+file(TO_CMAKE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
+file(TO_CMAKE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
+file(TO_CMAKE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
+file(TO_CMAKE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+
+if(WIN32)
+    file(RELATIVE_PATH prefix_relative_to_lib "${prefix}/${GR_RUNTIME_DIR}" "${prefix}")
+else(WIN32)
+    file(RELATIVE_PATH prefix_relative_to_lib "${prefix}/${GR_LIBRARY_DIR}" "${prefix}")
+endif(WIN32)
+file(RELATIVE_PATH SYSCONFDIR_relative_to_prefix "${prefix}" "${SYSCONFDIR}")
+file(RELATIVE_PATH GR_PREFSDIR_relative_to_prefix "${prefix}" "${GR_PREFSDIR}")
 
 ########################################################################
 # On Apple only, set install name and use rpath correctly, if not already set

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -23,10 +23,6 @@ string(TIMESTAMP BUILD_DATE "%a, %d %b %Y %H:%M:%S" UTC)
 message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
-#double escape for windows backslash path separators
-string(REPLACE "\\" "\\\\" prefix "${prefix}")
-string(REPLACE "\\" "\\\\" SYSCONFDIR "${SYSCONFDIR}")
-string(REPLACE "\\" "\\\\" GR_PREFSDIR "${GR_PREFSDIR}")
 
 #Generate the constants file, now that we actually know which components will be enabled.
 configure_file(

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -14,6 +14,8 @@
 
 #include <gnuradio/constants.h>
 #include <stdlib.h>
+#include <boost/dll/runtime_symbol_info.hpp>
+#include <boost/filesystem/path.hpp>
 
 namespace gr {
 
@@ -24,29 +26,30 @@ const std::string prefix()
     if (prefix != NULL)
         return prefix;
 
-    return "@prefix@";
+    boost::filesystem::path prefix_rel_lib = "@prefix_relative_to_lib@";
+    boost::filesystem::path gr_runtime_lib_path = boost::dll::this_line_location();
+    // Normalize before decomposing path so result is reliable
+    boost::filesystem::path prefix_path =
+        gr_runtime_lib_path.lexically_normal().parent_path() / prefix_rel_lib;
+    return prefix_path.lexically_normal().string();
 }
 
 const std::string sysconfdir()
 {
-    // Provide the sysconfdir in terms of prefix()
-    // when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL) {
-        return prefix() + "/@GR_CONF_DIR@";
-    }
+    boost::filesystem::path sysconfdir_rel_prefix = "@SYSCONFDIR_relative_to_prefix@";
+    boost::filesystem::path prefix_path = prefix();
+    boost::filesystem::path sysconfdir_path = prefix_path / sysconfdir_rel_prefix;
 
-    return "@SYSCONFDIR@";
+    return sysconfdir_path.lexically_normal().string();
 }
 
 const std::string prefsdir()
 {
-    // Provide the prefsdir in terms of sysconfdir()
-    // when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL) {
-        return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
-    }
+    boost::filesystem::path prefsdir_rel_prefix = "@GR_PREFSDIR_relative_to_prefix@";
+    boost::filesystem::path prefix_path = prefix();
+    boost::filesystem::path prefsdir_path = prefix_path / prefsdir_rel_prefix;
 
-    return "@GR_PREFSDIR@";
+    return prefsdir_path.lexically_normal().string();
 }
 
 const std::string build_date() { return "@BUILD_DATE@"; }


### PR DESCRIPTION
This replaces the path constants for the prefix, system configuration, and preferences directories with a runtime prefix lookup based on the gnuradio-runtime library location and relative paths from that. Boost >= 1.61 is required, but this is now compatible with the minimum version required by GNU Radio overall.

I'm still using `boost::filesystem` here since that's currently what is used elsewhere, but with C++17 there is no reason that this and elsewhere couldn't be `std::filesystem` with the `<filesystem>` header.

Also use cmake-style paths instead of native paths for substitution to avoid unescaped character problems. Windows is able to use the forward-slash paths just fine, and this also has external benefits (e.g. conda will do path replacement during installation and it substitutes forward-slash paths, so this avoids mixed-slash paths).

I also ran clang-format on `constants.cc.in` and that makes the diff bigger since (being a .in file) it evidently had not been clang-formatted prior to this.

Side-note: I've been using a version of this patch for the entirety of GNU Radio's life as a conda package. Since conda installs to a different prefix than the one it is compiled for, something like this has always been necessary. With the bump in Boost version and others running into similar issues (#4123), it was clear to me that another attempt at upstreaming was necessary.