### PR TITLE
clang-format .cc.in

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         source: '.'
         exclude: './volk'
-        extensions: 'h,hpp,cpp,cc'
+        extensions: 'h,hpp,cpp,cc,cc.in'
   # All of these shall depend on the formatting check (needs: check-formatting)
   ubuntu-20_04:
     name: Ubuntu 20.04

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -12,99 +12,59 @@
 #include <config.h>
 #endif
 
-#include <stdlib.h>
 #include <gnuradio/constants.h>
+#include <stdlib.h>
 
 namespace gr {
 
-  const std::string
-  prefix()
-  {
-    //Use "GR_PREFIX" environment variable when specified
-    const char *prefix = getenv("GR_PREFIX");
-    if (prefix != NULL) return prefix;
+const std::string prefix()
+{
+    // Use "GR_PREFIX" environment variable when specified
+    const char* prefix = getenv("GR_PREFIX");
+    if (prefix != NULL)
+        return prefix;
 
     return "@prefix@";
-  }
+}
 
-  const std::string
-  sysconfdir()
-  {
-    //Provide the sysconfdir in terms of prefix()
-    //when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL)
-    {
-      return prefix() + "/@GR_CONF_DIR@";
+const std::string sysconfdir()
+{
+    // Provide the sysconfdir in terms of prefix()
+    // when the "GR_PREFIX" environment var is specified.
+    if (getenv("GR_PREFIX") != NULL) {
+        return prefix() + "/@GR_CONF_DIR@";
     }
 
     return "@SYSCONFDIR@";
-  }
+}
 
-  const std::string
-  prefsdir()
-  {
-    //Provide the prefsdir in terms of sysconfdir()
-    //when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL)
-    {
-      return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
+const std::string prefsdir()
+{
+    // Provide the prefsdir in terms of sysconfdir()
+    // when the "GR_PREFIX" environment var is specified.
+    if (getenv("GR_PREFIX") != NULL) {
+        return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
     }
 
     return "@GR_PREFSDIR@";
-  }
+}
 
-  const std::string
-  build_date()
-  {
-    return "@BUILD_DATE@";
-  }
+const std::string build_date() { return "@BUILD_DATE@"; }
 
-  const std::string
-  version()
-  {
-    return "@VERSION@";
-  }
+const std::string version() { return "@VERSION@"; }
 
-  // Return individual parts of the version
-  const std::string
-  major_version()
-  {
-    return "@MAJOR_VERSION@";
-  }
+// Return individual parts of the version
+const std::string major_version() { return "@MAJOR_VERSION@"; }
 
-  const std::string
-  api_version()
-  {
-    return "@API_COMPAT@";
-  }
+const std::string api_version() { return "@API_COMPAT@"; }
 
-  const std::string
-  minor_version()
-  {
-    return "@MINOR_VERSION@";
-  }
+const std::string minor_version() { return "@MINOR_VERSION@"; }
 
-  const std::string
-  c_compiler()
-  {
-    return "@cmake_c_compiler_version@";
-  }
+const std::string c_compiler() { return "@cmake_c_compiler_version@"; }
 
-  const std::string
-  cxx_compiler()
-  {
-    return "@cmake_cxx_compiler_version@";
-  }
+const std::string cxx_compiler() { return "@cmake_cxx_compiler_version@"; }
 
-  const std::string
-  compiler_flags()
-  {
-    return "@COMPILER_INFO@";
-  }
+const std::string compiler_flags() { return "@COMPILER_INFO@"; }
 
-  const std::string
-  build_time_enabled_components()
-  {
-    return "@_gr_enabled_components@";
-  }
+const std::string build_time_enabled_components() { return "@_gr_enabled_components@"; }
 } /* namespace gr */


### PR DESCRIPTION
```
commit 7b380c37ee182336d1214ee196f1eed8089ece43 (HEAD -> clang-format-cc-in, mb/clang-format-cc-in)
Author: Martin Braun <martin@gnuradio.org>
Date:   Wed Jan 20 15:35:52 2021 +0100

lib: Clang-format constants.cc.in

Because we always used globs to find the files we re-format, this
slipped under the clang-format-radar.

commit 19e29abc868becb9f493a08bdd29b28428ab4048
Author: Martin Braun <martin@gnuradio.org>
Date:   Wed Jan 20 15:35:03 2021 +0100

GitHub Actions: Also check .cc.in files

These files are templates that get expanded to C++ during CMake time.
They also need to follow our .clang-format, so let's check for them
during CI.
```