### PR TITLE
[backport 3.9] runtime: lib: Don't use hard-coded absolute path constants and clang-format .cc.in

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         source: '.'
         exclude: './volk'
-        extensions: 'h,hpp,cpp,cc'
+        extensions: 'h,hpp,cpp,cc,cc.in'
   # All of these shall depend on the formatting check (needs: check-formatting)
   ubuntu-20_04:
     name: Ubuntu 20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,12 +279,20 @@ endif(ENABLE_PERFORMANCE_COUNTERS)
 ########################################################################
 # Variables replaced when configuring the package config files
 ########################################################################
-file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
-file(TO_NATIVE_PATH "\${prefix}"                        exec_prefix)
-file(TO_NATIVE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
-file(TO_NATIVE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
-file(TO_NATIVE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
-file(TO_NATIVE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}"           prefix)
+file(TO_CMAKE_PATH "\${prefix}"                        exec_prefix)
+file(TO_CMAKE_PATH "\${exec_prefix}/${GR_LIBRARY_DIR}" libdir)
+file(TO_CMAKE_PATH "\${prefix}/${GR_INCLUDE_DIR}"      includedir)
+file(TO_CMAKE_PATH "${SYSCONFDIR}"                     SYSCONFDIR)
+file(TO_CMAKE_PATH "${GR_PREFSDIR}"                    GR_PREFSDIR)
+
+if(WIN32)
+    file(RELATIVE_PATH prefix_relative_to_lib "${prefix}/${GR_RUNTIME_DIR}" "${prefix}")
+else(WIN32)
+    file(RELATIVE_PATH prefix_relative_to_lib "${prefix}/${GR_LIBRARY_DIR}" "${prefix}")
+endif(WIN32)
+file(RELATIVE_PATH SYSCONFDIR_relative_to_prefix "${prefix}" "${SYSCONFDIR}")
+file(RELATIVE_PATH GR_PREFSDIR_relative_to_prefix "${prefix}" "${GR_PREFSDIR}")
 
 ########################################################################
 # On Apple only, set install name and use rpath correctly, if not already set

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -23,10 +23,6 @@ string(TIMESTAMP BUILD_DATE "%a, %d %b %Y %H:%M:%S" UTC)
 message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
-#double escape for windows backslash path separators
-string(REPLACE "\\" "\\\\" prefix "${prefix}")
-string(REPLACE "\\" "\\\\" SYSCONFDIR "${SYSCONFDIR}")
-string(REPLACE "\\" "\\\\" GR_PREFSDIR "${GR_PREFSDIR}")
 
 #Generate the constants file, now that we actually know which components will be enabled.
 configure_file(

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -12,99 +12,59 @@
 #include <config.h>
 #endif
 
-#include <stdlib.h>
 #include <gnuradio/constants.h>
+#include <stdlib.h>
 
 namespace gr {
 
-  const std::string
-  prefix()
-  {
-    //Use "GR_PREFIX" environment variable when specified
-    const char *prefix = getenv("GR_PREFIX");
-    if (prefix != NULL) return prefix;
+const std::string prefix()
+{
+    // Use "GR_PREFIX" environment variable when specified
+    const char* prefix = getenv("GR_PREFIX");
+    if (prefix != NULL)
+        return prefix;
 
     return "@prefix@";
-  }
+}
 
-  const std::string
-  sysconfdir()
-  {
-    //Provide the sysconfdir in terms of prefix()
-    //when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL)
-    {
-      return prefix() + "/@GR_CONF_DIR@";
+const std::string sysconfdir()
+{
+    // Provide the sysconfdir in terms of prefix()
+    // when the "GR_PREFIX" environment var is specified.
+    if (getenv("GR_PREFIX") != NULL) {
+        return prefix() + "/@GR_CONF_DIR@";
     }
 
     return "@SYSCONFDIR@";
-  }
+}
 
-  const std::string
-  prefsdir()
-  {
-    //Provide the prefsdir in terms of sysconfdir()
-    //when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL)
-    {
-      return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
+const std::string prefsdir()
+{
+    // Provide the prefsdir in terms of sysconfdir()
+    // when the "GR_PREFIX" environment var is specified.
+    if (getenv("GR_PREFIX") != NULL) {
+        return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
     }
 
     return "@GR_PREFSDIR@";
-  }
+}
 
-  const std::string
-  build_date()
-  {
-    return "@BUILD_DATE@";
-  }
+const std::string build_date() { return "@BUILD_DATE@"; }
 
-  const std::string
-  version()
-  {
-    return "@VERSION@";
-  }
+const std::string version() { return "@VERSION@"; }
 
-  // Return individual parts of the version
-  const std::string
-  major_version()
-  {
-    return "@MAJOR_VERSION@";
-  }
+// Return individual parts of the version
+const std::string major_version() { return "@MAJOR_VERSION@"; }
 
-  const std::string
-  api_version()
-  {
-    return "@API_COMPAT@";
-  }
+const std::string api_version() { return "@API_COMPAT@"; }
 
-  const std::string
-  minor_version()
-  {
-    return "@MINOR_VERSION@";
-  }
+const std::string minor_version() { return "@MINOR_VERSION@"; }
 
-  const std::string
-  c_compiler()
-  {
-    return "@cmake_c_compiler_version@";
-  }
+const std::string c_compiler() { return "@cmake_c_compiler_version@"; }
 
-  const std::string
-  cxx_compiler()
-  {
-    return "@cmake_cxx_compiler_version@";
-  }
+const std::string cxx_compiler() { return "@cmake_cxx_compiler_version@"; }
 
-  const std::string
-  compiler_flags()
-  {
-    return "@COMPILER_INFO@";
-  }
+const std::string compiler_flags() { return "@COMPILER_INFO@"; }
 
-  const std::string
-  build_time_enabled_components()
-  {
-    return "@_gr_enabled_components@";
-  }
+const std::string build_time_enabled_components() { return "@_gr_enabled_components@"; }
 } /* namespace gr */

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -14,6 +14,8 @@
 
 #include <gnuradio/constants.h>
 #include <stdlib.h>
+#include <boost/dll/runtime_symbol_info.hpp>
+#include <boost/filesystem/path.hpp>
 
 namespace gr {
 
@@ -24,29 +26,30 @@ const std::string prefix()
     if (prefix != NULL)
         return prefix;
 
-    return "@prefix@";
+    boost::filesystem::path prefix_rel_lib = "@prefix_relative_to_lib@";
+    boost::filesystem::path gr_runtime_lib_path = boost::dll::this_line_location();
+    // Normalize before decomposing path so result is reliable
+    boost::filesystem::path prefix_path =
+        gr_runtime_lib_path.lexically_normal().parent_path() / prefix_rel_lib;
+    return prefix_path.lexically_normal().string();
 }
 
 const std::string sysconfdir()
 {
-    // Provide the sysconfdir in terms of prefix()
-    // when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL) {
-        return prefix() + "/@GR_CONF_DIR@";
-    }
+    boost::filesystem::path sysconfdir_rel_prefix = "@SYSCONFDIR_relative_to_prefix@";
+    boost::filesystem::path prefix_path = prefix();
+    boost::filesystem::path sysconfdir_path = prefix_path / sysconfdir_rel_prefix;
 
-    return "@SYSCONFDIR@";
+    return sysconfdir_path.lexically_normal().string();
 }
 
 const std::string prefsdir()
 {
-    // Provide the prefsdir in terms of sysconfdir()
-    // when the "GR_PREFIX" environment var is specified.
-    if (getenv("GR_PREFIX") != NULL) {
-        return sysconfdir() + "/@CMAKE_PROJECT_NAME@/conf.d";
-    }
+    boost::filesystem::path prefsdir_rel_prefix = "@GR_PREFSDIR_relative_to_prefix@";
+    boost::filesystem::path prefix_path = prefix();
+    boost::filesystem::path prefsdir_path = prefix_path / prefsdir_rel_prefix;
 
-    return "@GR_PREFSDIR@";
+    return prefsdir_path.lexically_normal().string();
 }
 
 const std::string build_date() { return "@BUILD_DATE@"; }


### PR DESCRIPTION
Backport of #4129 and #4127 to maint-3.9.