### PR TITLE
Log ImportError exception instance rather than class

### DIFF
--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -59,8 +59,8 @@ class CommandCLI(click.Group):
         """
         try:
             mod = import_module('gnuradio.modtool.cli.' + cmd_name)
-        except ImportError:
-            logging.error(ImportError)
+        except ImportError as e:
+            logging.error(e)
             return self.commands.get(cmd_name)
         return mod.cli
 


### PR DESCRIPTION
This small bit of code simply logs `ImportError` when you want to know `No module named 'gnuradio.blocktool'` is the problem.