### PR TITLE
gr-digital: fixes name error in chunks_to_symbols cpp_templates logic

### DIFF
--- a/gr-digital/grc/digital_chunks_to_symbols.block.yml
+++ b/gr-digital/grc/digital_chunks_to_symbols.block.yml
@@ -61,7 +61,7 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/chunks_to_symbols.h>']
     declarations: 'digital::chunks_to_symbols_${in_type.fcn}${out_type.fcn}::sptr ${id};'
     make: |-
-        % if str(out_type.table)=="float_vector":
+        % if str(out_type.table)=="real_vector":
         std::vector<float> symbol_table = {${str(symbol_table)[1:-1]}};
         % else:
         std::vector<gr_complex> symbol_table = {${str(symbol_table)[1:-1]}};

--- a/gr-digital/grc/digital_chunks_to_symbols.block.yml
+++ b/gr-digital/grc/digital_chunks_to_symbols.block.yml
@@ -16,7 +16,7 @@ parameters:
     options: [complex, float]
     option_attributes:
         fcn: [c, f]
-        table: [complex_vector, real_vector]
+        table: [complex_vector, float_vector]
     hide: part
 -   id: symbol_table
     label: Symbol Table
@@ -61,7 +61,7 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/chunks_to_symbols.h>']
     declarations: 'digital::chunks_to_symbols_${in_type.fcn}${out_type.fcn}::sptr ${id};'
     make: |-
-        % if str(out_type.table)=="real_vector":
+        % if str(out_type.table)=="float_vector":
         std::vector<float> symbol_table = {${str(symbol_table)[1:-1]}};
         % else:
         std::vector<gr_complex> symbol_table = {${str(symbol_table)[1:-1]}};


### PR DESCRIPTION
Fixes a name error in the cpp_templates logic that results in invalid C++ code being generated.