### PR TITLE
MSVC 2019 fixes

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcserver_aggregator.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_aggregator.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/rpcmanager_base.h>
 #include <gnuradio/rpcserver_base.h>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -42,7 +43,7 @@ public:
 
 private:
     template <class T, typename Tcallback>
-    struct registerConfigureCallback_f : public std::unary_function<T, void> {
+    struct registerConfigureCallback_f : public std::function<void(T)> {
         registerConfigureCallback_f(const std::string& _id, const Tcallback _callback)
             : id(_id), callback(_callback)
         {
@@ -55,7 +56,7 @@ private:
     };
 
     template <class T, typename Tcallback>
-    struct unregisterConfigureCallback_f : public std::unary_function<T, void> {
+    struct unregisterConfigureCallback_f : public std::function<void(T)> {
         unregisterConfigureCallback_f(const std::string& _id) : id(_id) { ; }
 
         void operator()(T& x) { x->i()->unregisterConfigureCallback(id); }
@@ -63,7 +64,7 @@ private:
     };
 
     template <class T, typename Tcallback>
-    struct registerQueryCallback_f : public std::unary_function<T, void> {
+    struct registerQueryCallback_f : public std::function<void(T)> {
         registerQueryCallback_f(const std::string& _id, const Tcallback _callback)
             : id(_id), callback(_callback)
         {
@@ -76,7 +77,7 @@ private:
     };
 
     template <class T, typename Tcallback>
-    struct unregisterQueryCallback_f : public std::unary_function<T, void> {
+    struct unregisterQueryCallback_f : public std::function<void(T)> {
         unregisterQueryCallback_f(const std::string& _id) : id(_id) { ; }
 
         void operator()(T& x) { x->i()->unregisterQueryCallback(id); }
@@ -85,7 +86,7 @@ private:
 
 
     template <class T, typename Tcallback>
-    struct registerHandlerCallback_f : public std::unary_function<T, void> {
+    struct registerHandlerCallback_f : public std::function<void(T)> {
         registerHandlerCallback_f(const std::string& _id, const Tcallback _callback)
             : id(_id), callback(_callback)
         {
@@ -98,7 +99,7 @@ private:
     };
 
     template <class T, typename Tcallback>
-    struct unregisterHandlerCallback_f : public std::unary_function<T, void> {
+    struct unregisterHandlerCallback_f : public std::function<void(T)> {
         unregisterHandlerCallback_f(const std::string& _id) : id(_id) { ; }
 
         void operator()(T& x) { x->i()->unregisterHandlerCallback(id); }

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -43,10 +43,11 @@ add_subdirectory(pmt)
 #Generate sine table header file for Math part of library
 set(MATH_SINE_TABLE_HEADER ${CMAKE_CURRENT_BINARY_DIR}/math/generated/sine_table.h)
 set(MATH_SINE_TABLE_GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/math/gen_sine_table.py)
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/math/generated")
 add_custom_command(
   DEPENDS ${MATH_SINE_TABLE_GENERATOR}
   OUTPUT ${MATH_SINE_TABLE_HEADER}
-  COMMAND ${PYTHON_EXECUTABLE} ${MATH_SINE_TABLE_GENERATOR} | install -D /dev/stdin ${MATH_SINE_TABLE_HEADER}
+  COMMAND ${PYTHON_EXECUTABLE} ${MATH_SINE_TABLE_GENERATOR} > ${MATH_SINE_TABLE_HEADER}
 )
 
 add_library(gnuradio-runtime

--- a/gnuradio-runtime/python/gnuradio/__init__.py
+++ b/gnuradio-runtime/python/gnuradio/__init__.py
@@ -13,6 +13,19 @@ GNU Radio is licensed under the GNU General Public License (GPL) version 3. All 
 
 import os
 
+# python3.8 and up need to have the dll search path set
+# https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+if os.name == 'nt' and hasattr(os, 'add_dll_directory'):
+    root_dir = __file__
+    for i in range(5): #limit search depth
+        root_dir = os.path.dirname(root_dir)
+        bin_dir = os.path.join(root_dir, 'bin')
+        if os.path.exists(bin_dir):
+            try: os.add_dll_directory(bin_dir)
+            except Exception as ex:
+                print('add_dll_directory(%s): %s'%(bin_dir, ex))
+            break
+
 # Check if the gnuradio package is installed or whether we're attempting to import it from
 # the build directory.
 path_ending = os.path.join('gnuradio-runtime', 'python', 'gnuradio', '__init__.py')

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -350,7 +350,7 @@ protected:
             }
 
             double x_label = d_x_start_value + x / (double)d_cols * d_x_delta_value;
-            if ((d_y_delta_value > 999.0) or (d_y_delta_value <= 1.0)) {
+            if ((d_y_delta_value > 999.0) || (d_y_delta_value <= 1.0)) {
                 QwtText t(QString(QString("").sprintf("%.2f, %.2e", x_label, y)));
                 return t;
             } else {


### PR DESCRIPTION
I have built gnuradio under MSVC 2019 with python3.9 and I now have GRC up and running. The following fixes were required to both compile and run. Please let me know if I need to adjust any of the commits. The patches are split into multiple functional commits so they can be easily cherry picked. I am interested in building patch free in the future.

Screen shot here: gnuradio-companion launcher working as well as launching generated qtgui apps from GRC itself. Note that gr-osmosdr is still missing, and does need some help to get python bindings ported to 3.9

![grc_msvc2019](https://user-images.githubusercontent.com/184117/105567494-daa73200-5cf7-11eb-82e2-e70677996e3e.png)

And further, because I was unable to simply pip install pygtk for GRC, I created a installable wheel file for Python3.9 AMD64, should that be of interest to anyone: https://downloads.myriadrf.org/binaries/python39_amd64/PothosSDRPyGTK-2021.1.21-cp39-cp39-win_amd64.whl

# Changes in the pull request

## runtime: replace use of std::unary_function

std::unary_function is deprecated of as c++11 and removed in c++17
https://en.cppreference.com/w/cpp/utility/functional/unary_function
The solution was to replace unary_function with std::function.

## qtgui: replace use of `or` macro with `||` 

This macro is not defined without including ciso646
https://www.cplusplus.com/reference/ciso646/
gnuradio otherwise does not use these macros

## runtime: replace /dev/stdin in sine table generator

/dev/stdin does not exist and was replaced by directing stdout to the
file rather than piping stdout to the stdin of an install command

## python: add the dll runtime path in __init__.py

python3.8 and up needs to have the dll search path set explicitly before importing.
More details can be found here: https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew

Without the fix, python libraries will fail to import regardless of how PATH is configured.
The solution searches for the runtime path for gnuradio dlls and calls add_dll_directory() before imports.
As a precedent, a similar behaviour is implemented in the gi/__init__.py module used with pygtk.

