### PR TITLE
Prevent Windows CRLF conversion for files subject to pybind hash comparisons

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,11 @@
 *.m4	-crlf
 *.ac	-crlf
 *.scm	-crlf
+#
+# In GNURadio 3.9, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf


### PR DESCRIPTION
In GNURadio 3.9, pybind11 compares hash values of headers and source files against knowns values.  Conversion of values to CRLF on checkout break those checks so keep LF values when files are subject to said checks.

I only saw code doing hashing for C source and header files.  Are there any other file types where this is used I didn't see?
Also, does these hash checks serve additional purposes after build that we need to be aware of?