### PR TITLE
digital: Fix output type in GRC bindings of chunks_to_symbols

### DIFF
--- a/gr-digital/grc/digital_chunks_to_symbols.block.yml
+++ b/gr-digital/grc/digital_chunks_to_symbols.block.yml
@@ -16,7 +16,7 @@ parameters:
     options: [complex, float]
     option_attributes:
         fcn: [c, f]
-        table: [complex_vector, real_vector]
+        table: [complex_vector, float_vector]
     hide: part
 -   id: symbol_table
     label: Symbol Table


### PR DESCRIPTION
Type was flagged as 'real_vector', which would mean vector<double>. We
want vector<float>, thus this fix.
This would cause an error when creating CPP code from GRC.

Signed-off-by: Terry May <terrydmay@gmail.com>
Signed-off-by: Martin Braun <martin@gnuradio.org>

Same as https://github.com/gnuradio/gnuradio/pull/4136, but with fixed history.