### PR TITLE
gr-fft: window cleanup - remove nuttal (sic) windows

### DIFF
--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -214,21 +214,11 @@ public:
     static std::vector<float> nuttall(int ntaps);
 
     /*!
-     * Deprecated: use nuttall window instead.
-     */
-    static std::vector<float> nuttal(int ntaps);
-
-    /*!
      * \brief Alias to the Nuttall window.
      *
      * \param ntaps Number of coefficients in the window.
      */
     static std::vector<float> blackman_nuttall(int ntaps);
-
-    /*!
-     * Deprecated: use blackman_nuttall window instead.
-     */
-    static std::vector<float> blackman_nuttal(int ntaps);
 
     /*!
      * \brief Build a Nuttall 4-term continuous first derivative window, referred to by
@@ -247,11 +237,6 @@ public:
      * \param ntaps Number of coefficients in the window.
      */
     static std::vector<float> nuttall_cfd(int ntaps);
-
-    /*!
-     * Deprecated: use nuttall_cfd window instead.
-     */
-    static std::vector<float> nuttal_cfd(int ntaps);
 
     /*!
      * \brief Build a flat top window per the SRS specification

--- a/gr-fft/lib/window.cc
+++ b/gr-fft/lib/window.cc
@@ -211,19 +211,12 @@ std::vector<float> window::blackmanharris(int ntaps, int atten)
     return blackman_harris(ntaps, atten);
 }
 
-std::vector<float> window::nuttal(int ntaps) { return nuttall(ntaps); }
-
 std::vector<float> window::nuttall(int ntaps)
 {
     return coswindow(ntaps, 0.3635819, 0.4891775, 0.1365995, 0.0106411);
 }
 
-std::vector<float> window::blackman_nuttal(int ntaps) { return nuttall(ntaps); }
-
 std::vector<float> window::blackman_nuttall(int ntaps) { return nuttall(ntaps); }
-
-std::vector<float> window::nuttal_cfd(int ntaps) { return nuttall_cfd(ntaps); }
-
 std::vector<float> window::nuttall_cfd(int ntaps)
 {
     return coswindow(ntaps, 0.355768, 0.487396, 0.144232, 0.012604);

--- a/gr-fft/python/fft/bindings/docstrings/window_pydoc_template.h
+++ b/gr-fft/python/fft/bindings/docstrings/window_pydoc_template.h
@@ -69,19 +69,10 @@ static const char* __doc_gr_fft_window_blackmanharris = R"doc()doc";
 static const char* __doc_gr_fft_window_nuttall = R"doc()doc";
 
 
-static const char* __doc_gr_fft_window_nuttal = R"doc()doc";
-
-
 static const char* __doc_gr_fft_window_blackman_nuttall = R"doc()doc";
 
 
-static const char* __doc_gr_fft_window_blackman_nuttal = R"doc()doc";
-
-
 static const char* __doc_gr_fft_window_nuttall_cfd = R"doc()doc";
-
-
-static const char* __doc_gr_fft_window_nuttal_cfd = R"doc()doc";
 
 
 static const char* __doc_gr_fft_window_flattop = R"doc()doc";

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(window.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(a44a323c53d5dd52382d240afdd4b984)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4de3c97757728a4acfbd8b1c29181431)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -142,27 +142,14 @@ void bind_window(py::module& m)
         .def_static("nuttall", &window::nuttall, py::arg("ntaps"), D(window, nuttall))
 
 
-        .def_static("nuttal", &window::nuttal, py::arg("ntaps"), D(window, nuttal))
-
-
         .def_static("blackman_nuttall",
                     &window::blackman_nuttall,
                     py::arg("ntaps"),
                     D(window, blackman_nuttall))
 
 
-        .def_static("blackman_nuttal",
-                    &window::blackman_nuttal,
-                    py::arg("ntaps"),
-                    D(window, blackman_nuttal))
-
-
         .def_static(
             "nuttall_cfd", &window::nuttall_cfd, py::arg("ntaps"), D(window, nuttall_cfd))
-
-
-        .def_static(
-            "nuttal_cfd", &window::nuttal_cfd, py::arg("ntaps"), D(window, nuttal_cfd))
 
 
         .def_static("flattop", &window::flattop, py::arg("ntaps"), D(window, flattop))


### PR DESCRIPTION
These have been deprecated for over 6 years in b2e6c0f247784ba4119cd6aa32998e7fcfa43f77, looks like Tom intended to have them removed in 3.8.

This is a misspelling of Nuttall / Blackman-Nuttall which are of course still in the code.