### PR TITLE
portaudio: fix unintentionally synchronous std::async

### DIFF
--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -114,7 +114,7 @@ int portaudio_sink_callback(const void* inputBuffer,
     }
 
     else { // underrun
-        std::async(&portaudio_underrun_notification, self->d_logger);
+        auto future_local = std::async(&portaudio_underrun_notification, self->d_logger);
         // FIXME we should transfer what we've got and pad the rest
         memset(outputBuffer, 0, nreqd_samples * sizeof(sample_t));
 


### PR DESCRIPTION
Note this classic (which I didn't do in ALSA back in the day, 'doh):

If you don't assign your future coming from std::async to something, its
destructor is instantly called, leading to the call effectively being
blocking.