### PR TITLE
Get rid of Qt compilation deprecation warnings

### DIFF
--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -44,7 +44,7 @@ DisplayPlot::DisplayPlot(int nplots, QWidget* parent)
 
     d_panner = new QwtPlotPanner(canvas());
     d_panner->setAxisEnabled(QwtPlot::yRight, false);
-    d_panner->setMouseButton(Qt::MidButton, Qt::ControlModifier);
+    d_panner->setMouseButton(Qt::MiddleButton, Qt::ControlModifier);
 
     // emit the position of clicks on widget
     d_picker = new QwtDblClickPlotPicker(canvas());

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -123,7 +123,7 @@ public:
 
             // scale for units tag
             x_label /= d_ten_scale;
-            return QwtText(QString("").sprintf("%.3f%s", x_label, d_units.c_str()));
+            return QwtText(QString("").asprintf("%.3f%s", x_label, d_units.c_str()));
         }
     }
 
@@ -205,7 +205,7 @@ public:
     {
         if (d_start_value == d_end_value) {
             // no scale was provided.  Default to row number.
-            return QwtText(QString("").sprintf("%.0f", value));
+            return QwtText(QString("").asprintf("%.0f", value));
         } else {
             // User-defined scale provided.
             double y_label =
@@ -213,7 +213,7 @@ public:
 
             // scale for units tag
             y_label /= d_ten_scale;
-            return QwtText(QString("").sprintf("%.3f%s", y_label, d_units.c_str()));
+            return QwtText(QString("").asprintf("%.3f%s", y_label, d_units.c_str()));
         }
     }
 
@@ -351,10 +351,10 @@ protected:
 
             double x_label = d_x_start_value + x / (double)d_cols * d_x_delta_value;
             if ((d_y_delta_value > 999.0) or (d_y_delta_value <= 1.0)) {
-                QwtText t(QString(QString("").sprintf("%.2f, %.2e", x_label, y)));
+                QwtText t(QString(QString("").asprintf("%.2f, %.2e", x_label, y)));
                 return t;
             } else {
-                QwtText t(QString(QString("").sprintf("%.2f, %.0f", x_label, y)));
+                QwtText t(QString(QString("").asprintf("%.2f, %.0f", x_label, y)));
                 return t;
             }
         }

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -418,7 +418,7 @@ TimeRasterDisplayPlot::TimeRasterDisplayPlot(
     setAlpha(0, 255);
 
     // LeftButton for the zooming
-    // MidButton for the panning
+    // MiddleButton for the panning
     // RightButton: zoom out by 1
     // Ctrl+RighButton: zoom out to full size
     d_zoomer = new TimeRasterZoomer(canvas(),

--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -158,7 +158,7 @@ WaterfallDisplayPlot::WaterfallDisplayPlot(int nplots, QWidget* parent)
     setAlpha(0, 255);
 
     // LeftButton for the zooming
-    // MidButton for the panning
+    // MiddleButton for the panning
     // RightButton: zoom out by 1
     // Ctrl+RighButton: zoom out to full size
     d_zoomer = new WaterfallZoomer(canvas(), 0);

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -147,7 +147,7 @@ DisplayForm::~DisplayForm()
 void DisplayForm::mousePressEvent(QMouseEvent* e)
 {
     bool ctrloff = Qt::ControlModifier != QApplication::keyboardModifiers();
-    if ((e->button() == Qt::MidButton) && ctrloff && (d_menu_on)) {
+    if ((e->button() == Qt::MiddleButton) && ctrloff && (d_menu_on)) {
         if (d_stop_state == false)
             d_stop_act->setText(tr("Stop"));
         else

--- a/gr-qtgui/lib/eyedisplaysform.cc
+++ b/gr-qtgui/lib/eyedisplaysform.cc
@@ -155,7 +155,7 @@ void EyeDisplaysForm::resizeEvent(QResizeEvent* e)
 void EyeDisplaysForm::mousePressEvent(QMouseEvent* e)
 {
     bool ctrloff = Qt::ControlModifier != QApplication::keyboardModifiers();
-    if ((e->button() == Qt::MidButton) && ctrloff && (d_menu_on)) {
+    if ((e->button() == Qt::MiddleButton) && ctrloff && (d_menu_on)) {
         if (d_stop_state == false)
             d_stop_act->setText(tr("Stop"));
         else

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -157,7 +157,7 @@ NumberDisplayForm::~NumberDisplayForm()
 void NumberDisplayForm::mousePressEvent(QMouseEvent* e)
 {
     bool ctrloff = Qt::ControlModifier != QApplication::keyboardModifiers();
-    if ((e->button() == Qt::MidButton) && ctrloff && (d_menu_on)) {
+    if ((e->button() == Qt::MiddleButton) && ctrloff && (d_menu_on)) {
         if (d_stop_state == false)
             d_stop_act->setText(tr("Stop"));
         else


### PR DESCRIPTION
This requires >= Qt5.5, which is available everywhere.