### PR TITLE
filterbanks: Use virtual destructor in superclasses

### DIFF
--- a/gr-filter/include/gnuradio/filter/filterbank.h
+++ b/gr-filter/include/gnuradio/filter/filterbank.h
@@ -57,6 +57,7 @@ public:
      */
     filterbank(const std::vector<std::vector<float>>& taps);
     filterbank(filterbank&&) = default;
+    virtual ~filterbank() = default;
 
     /*!
      * Update the filterbank's filter taps.

--- a/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
+++ b/gr-filter/include/gnuradio/filter/polyphase_filterbank.h
@@ -108,6 +108,8 @@ public:
 
     polyphase_filterbank(polyphase_filterbank&&) = default;
 
+    virtual ~polyphase_filterbank() = default;
+
     /*!
      * Update the filterbank's filter taps from a prototype
      * filter.

--- a/gr-filter/python/filter/bindings/filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e57eee381c9c8a096d6ee5976be9287e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4d60cd35615f6bf0c8446169f1af7ece)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
+++ b/gr-filter/python/filter/bindings/polyphase_filterbank_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(polyphase_filterbank.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(eddfa9a8852378220a937bc1e3bc7a39)                     */
+/* BINDTOOL_HEADER_FILE_HASH(29e70e9f09508967c171c029d5f7529c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Makes compilation less warning intense, too.