### PR TITLE
modtool: Remove -Wcomment warnings in python_bindings.cc template.

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/python_bindings.cc
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/python_bindings.cc
@@ -16,9 +16,9 @@ namespace py = pybind11;
 
 // Headers for binding functions
 /**************************************/
-/* The following comment block is used for
-/* gr_modtool to insert function prototypes
-/* Please do not delete
+// The following comment block is used for
+// gr_modtool to insert function prototypes
+// Please do not delete
 /**************************************/
 // BINDING_FUNCTION_PROTOTYPES(
 // ) END BINDING_FUNCTION_PROTOTYPES
@@ -44,9 +44,9 @@ PYBIND11_MODULE(howto_python, m)
     py::module::import("gnuradio.gr");
 
     /**************************************/
-    /* The following comment block is used for
-    /* gr_modtool to insert binding function calls
-    /* Please do not delete
+    // The following comment block is used for
+    // gr_modtool to insert binding function calls
+    // Please do not delete
     /**************************************/
     // BINDING_FUNCTION_CALLS(
     // ) END BINDING_FUNCTION_CALLS


### PR DESCRIPTION
Occurs if -Wall is enabled in OOT.

Signed-off-by: Ron Economos <w6rz@comcast.net>