### PR TITLE
uhd: Remove (almost all) occurrences of Boost

### DIFF
--- a/gr-uhd/examples/c++/tag_source_demo.h
+++ b/gr-uhd/examples/c++/tag_source_demo.h
@@ -9,7 +9,6 @@
 
 #include <gnuradio/io_signature.h>
 #include <gnuradio/sync_block.h>
-#include <boost/format.hpp>
 #include <complex>
 #include <iostream>
 

--- a/gr-uhd/examples/c++/tags_demo.cc
+++ b/gr-uhd/examples/c++/tags_demo.cc
@@ -13,13 +13,15 @@
 #include <gnuradio/uhd/usrp_sink.h>
 #include <gnuradio/uhd/usrp_source.h>
 #include <uhd/utils/safe_main.hpp>
-#include <boost/make_shared.hpp>
+#include <boost/format.hpp>
 #include <boost/program_options.hpp>
-#include <boost/thread/thread.hpp> //sleep
+#include <chrono>
 #include <csignal>
 #include <iostream>
+#include <thread>
 
 namespace po = boost::program_options;
+using namespace std::chrono_literals;
 
 /***********************************************************************
  * Signal handlers
@@ -127,8 +129,8 @@ int UHD_SAFE_MAIN(int argc, char* argv[])
     //------------------------------------------------------------------
     std::signal(SIGINT, &sig_int_handler);
     std::cout << "press ctrl + c to exit" << std::endl;
-    while (not stop_signal_called) {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(100));
+    while (!stop_signal_called) {
+        std::this_thread::sleep_for(100ms);
     }
 
     //------------------------------------------------------------------

--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -14,6 +14,7 @@
 #include <gnuradio/sync_block.h>
 #include <gnuradio/uhd/api.h>
 #include <uhd/usrp/multi_usrp.hpp>
+#include <cstdint>
 
 namespace gr {
 namespace uhd {
@@ -582,8 +583,8 @@ public:
      */
     virtual void set_gpio_attr(const std::string& bank,
                                const std::string& attr,
-                               const boost::uint32_t value,
-                               const boost::uint32_t mask = 0xffffffff,
+                               const uint32_t value,
+                               const uint32_t mask = 0xffffffff,
                                const size_t mboard = 0) = 0;
 
     /*!
@@ -602,9 +603,9 @@ public:
      * \param mboard the motherboard index 0 to M-1
      * \return the value set for this attribute
      */
-    virtual boost::uint32_t get_gpio_attr(const std::string& bank,
-                                          const std::string& attr,
-                                          const size_t mboard = 0) = 0;
+    virtual uint32_t get_gpio_attr(const std::string& bank,
+                                   const std::string& attr,
+                                   const size_t mboard = 0) = 0;
 
     /*!
      * Enumerate the available filters in the signal path.

--- a/gr-uhd/lib/amsg_source_impl.cc
+++ b/gr-uhd/lib/amsg_source_impl.cc
@@ -10,7 +10,6 @@
 
 #include "amsg_source_impl.h"
 #include "gr_uhd_common.h"
-#include <boost/bind.hpp>
 
 namespace gr {
 namespace uhd {
@@ -32,7 +31,7 @@ amsg_source_impl::amsg_source_impl(const ::uhd::device_addr_t& device_addr,
     : _msgq(msgq), _running(true)
 {
     _dev = ::uhd::usrp::multi_usrp::make(device_addr);
-    _amsg_thread = gr::thread::thread(boost::bind(&amsg_source_impl::recv_loop, this));
+    _amsg_thread = gr::thread::thread([this]() { this->recv_loop(); });
 }
 
 amsg_source_impl::~amsg_source_impl()

--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -16,7 +16,6 @@
 #include <uhd/rfnoc/mb_controller.hpp>
 #include <uhd/rfnoc_graph.hpp>
 #include <unordered_map>
-#include <boost/make_shared.hpp>
 #include <atomic>
 #include <stdexcept>
 
@@ -105,7 +104,7 @@ public:
         return streamer;
     }
 
-    void commit()
+    void commit() override
     {
         if (!_commit_called.exchange(true)) {
             _graph->commit();
@@ -114,14 +113,14 @@ public:
 
     std::string get_block_id(const std::string& block_name,
                              const int device_select,
-                             const int block_select)
+                             const int block_select) override
     {
         std::string block_hint = block_name;
         if (device_select >= 0) {
-            block_hint = str(boost::format("%d/%s") % device_select % block_hint);
+            block_hint = std::to_string(device_select) + "/" + block_hint;
         }
         if (block_select >= 0) {
-            block_hint = str(boost::format("%s#%d") % block_hint % block_select);
+            block_hint = block_hint + "#" + std::to_string(block_select);
         }
 
         auto block_ids = _graph->find_blocks(block_hint);

--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/io_signature.h>
 #include <uhd/convert.hpp>
 #include <uhd/rfnoc/node.hpp>
+#include <boost/format.hpp>
 
 const pmt::pmt_t EOB_KEY = pmt::string_to_symbol("rx_eob");
 const pmt::pmt_t CMD_TIME_KEY = pmt::mp("time");

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -10,10 +10,14 @@
 
 #include "usrp_block_impl.h"
 #include <chrono>
+#include <thread>
 
 using namespace gr::uhd;
+using namespace std::chrono_literals;
 
-const double usrp_block_impl::LOCK_TIMEOUT = 1.5;
+namespace {
+constexpr auto LOCK_TIMEOUT = 1.5s;
+}
 
 /**********************************************************************
  * Structors
@@ -198,36 +202,23 @@ bool usrp_block_impl::_wait_for_locked_sensor(std::vector<std::string> sensor_na
                                               get_sensor_fn_t get_sensor_fn)
 {
     if (std::find(sensor_names.begin(), sensor_names.end(), sensor_name) ==
-        sensor_names.end())
+        sensor_names.end()) {
         return true;
-
-    boost::system_time start = boost::get_system_time();
-    boost::system_time first_lock_time;
-
-    while (true) {
-        if ((not first_lock_time.is_not_a_date_time()) and
-            (boost::get_system_time() >
-             (first_lock_time +
-              boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT))))) {
-            break;
-        }
-
-        if (get_sensor_fn(sensor_name).to_bool()) {
-            if (first_lock_time.is_not_a_date_time())
-                first_lock_time = boost::get_system_time();
-        } else {
-            first_lock_time = boost::system_time(); // reset to 'not a date time'
-
-            if (boost::get_system_time() >
-                (start + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT)))) {
-                return false;
-            }
-        }
-
-        boost::this_thread::sleep(boost::posix_time::milliseconds(100));
     }
 
-    return true;
+    const auto start = std::chrono::steady_clock::now();
+    const auto timeout = start + LOCK_TIMEOUT;
+
+    while (std::chrono::steady_clock::now() < timeout) {
+        if (get_sensor_fn(sensor_name).to_bool()) {
+            return true;
+        }
+
+        std::this_thread::sleep_for(100ms);
+    }
+
+    // One last try:
+    return get_sensor_fn(sensor_name).to_bool();
 }
 
 bool usrp_block_impl::_unpack_chan_command(std::string& command,
@@ -374,9 +365,9 @@ std::vector<std::string> usrp_block_impl::get_gpio_banks(const size_t mboard)
 #endif
 }
 
-boost::uint32_t usrp_block_impl::get_gpio_attr(const std::string& bank,
-                                               const std::string& attr,
-                                               const size_t mboard)
+uint32_t usrp_block_impl::get_gpio_attr(const std::string& bank,
+                                        const std::string& attr,
+                                        const size_t mboard)
 {
 #ifdef UHD_USRP_MULTI_USRP_GPIO_API
     return _dev->get_gpio_attr(bank, attr, mboard);
@@ -447,8 +438,8 @@ void usrp_block_impl::set_user_register(const uint8_t addr,
 
 void usrp_block_impl::set_gpio_attr(const std::string& bank,
                                     const std::string& attr,
-                                    const boost::uint32_t value,
-                                    const boost::uint32_t mask,
+                                    const uint32_t value,
+                                    const uint32_t mask,
                                     const size_t mboard)
 {
 #ifdef UHD_USRP_MULTI_USRP_GPIO_API

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -34,8 +34,6 @@ public:
     typedef std::function<::uhd::sensor_value_t(const std::string&)> get_sensor_fn_t;
     typedef std::function<void(const pmt::pmt_t&, int, const pmt::pmt_t&)> cmd_handler_t;
 
-    static const double LOCK_TIMEOUT;
-
     /**********************************************************************
      * Public API calls (see usrp_block.h for docs)
      **********************************************************************/
@@ -52,9 +50,9 @@ public:
     ::uhd::time_spec_t get_time_last_pps(size_t mboard) override;
     ::uhd::usrp::multi_usrp::sptr get_device(void) override;
     std::vector<std::string> get_gpio_banks(const size_t mboard) override;
-    boost::uint32_t get_gpio_attr(const std::string& bank,
-                                  const std::string& attr,
-                                  const size_t mboard = 0) override;
+    uint32_t get_gpio_attr(const std::string& bank,
+                           const std::string& attr,
+                           const size_t mboard = 0) override;
     size_t get_num_mboards() override;
     std::vector<std::string> get_filter_names(const std::string& search_mask) override;
     ::uhd::filter_info_base::sptr get_filter(const std::string& path) override;
@@ -72,8 +70,8 @@ public:
     void clear_command_time(size_t mboard) override;
     void set_gpio_attr(const std::string& bank,
                        const std::string& attr,
-                       const boost::uint32_t value,
-                       const boost::uint32_t mask,
+                       const uint32_t value,
+                       const uint32_t mask,
                        const size_t mboard) override;
     void set_filter(const std::string& path,
                     ::uhd::filter_info_base::sptr filter) override;

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -11,6 +11,7 @@
 #include "gr_uhd_common.h"
 #include "usrp_sink_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/thread/thread.hpp>
 #include <climits>
 #include <stdexcept>
 

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -10,10 +10,8 @@
 
 #include "gr_uhd_common.h"
 #include "usrp_source_impl.h"
-#include <boost/format.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/thread/thread.hpp>
-#include <iostream>
+#include <mutex>
 #include <stdexcept>
 
 namespace gr {
@@ -481,7 +479,7 @@ void usrp_source_impl::set_recv_timeout(const double timeout, const bool one_pac
 
 bool usrp_source_impl::start(void)
 {
-    boost::recursive_mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::recursive_mutex> lock(d_mutex);
     if (not _rx_stream) {
         _rx_stream = _dev->get_rx_stream(_stream_args);
         _samps_per_packet = _rx_stream->get_max_num_samps();
@@ -527,7 +525,7 @@ void usrp_source_impl::flush(void)
 
 bool usrp_source_impl::stop(void)
 {
-    boost::recursive_mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::recursive_mutex> lock(d_mutex);
     this->issue_stream_cmd(::uhd::stream_cmd_t::STREAM_MODE_STOP_CONTINUOUS);
     this->flush();
 
@@ -587,7 +585,7 @@ int usrp_source_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)
 {
-    boost::recursive_mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::recursive_mutex> lock(d_mutex);
     boost::this_thread::disable_interruption disable_interrupt;
     // In order to allow for low-latency:
     // We receive all available packets without timeout.
@@ -629,11 +627,8 @@ int usrp_source_impl::work(int noutput_items,
         return work(noutput_items, input_items, output_items);
 
     default:
-        // GR_LOG_WARN(d_logger, boost::format("USRP Source Block caught rx error: %d") %
-        // _metadata.strerror());
         GR_LOG_WARN(d_logger,
-                    boost::format("USRP Source Block caught rx error code: %d") %
-                        _metadata.error_code);
+                    "USRP Source Block caught rx error: " + _metadata.strerror());
         return num_samps;
     }
 

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -11,7 +11,7 @@
 #include "usrp_block_impl.h"
 #include <gnuradio/uhd/usrp_source.h>
 #include <uhd/convert.hpp>
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 static const pmt::pmt_t TIME_KEY = pmt::string_to_symbol("rx_time");
 static const pmt::pmt_t RATE_KEY = pmt::string_to_symbol("rx_rate");
@@ -130,7 +130,7 @@ private:
     // tag shadows
     double _samp_rate;
 
-    boost::recursive_mutex d_mutex;
+    std::recursive_mutex d_mutex;
 };
 
 } /* namespace uhd */


### PR DESCRIPTION
The following usages of Boost remain:
- boost::format
- boost::program_options for the examples
- Boost thread interruption directives to interact with GNU Radio
  runtime

Note: The async message queue is currently non-functional in GRC and
I will do something about that later.