### PR TITLE
utils: modtool: Improve exception handling for import error

### DIFF
--- a/gr-utils/modtool/cli/base.py
+++ b/gr-utils/modtool/cli/base.py
@@ -59,8 +59,8 @@ class CommandCLI(click.Group):
         """
         try:
             mod = import_module('gnuradio.modtool.cli.' + cmd_name)
-        except ImportError:
-            logging.error(ImportError)
+        except ImportError as ex:
+            logging.error(str(ex))
             return self.commands.get(cmd_name)
         return mod.cli
 


### PR DESCRIPTION
If an import error happens in get_command(), the error is now logged.