### PR TITLE
Fix typos

### DIFF
--- a/gnuradio-runtime/lib/terminate_handler.cc
+++ b/gnuradio-runtime/lib/terminate_handler.cc
@@ -88,7 +88,7 @@ void terminate_handler_impl()
         std::cerr << "Got std::logic_error" << std::endl;
         std::cerr << e.what() << std::endl;
     } catch (const std::ios_base::failure& e) {
-        std::cerr << "Got std::ios_base::falure" << std::endl;
+        std::cerr << "Got std::ios_base::failure" << std::endl;
         std::cerr << e.what() << std::endl;
     } catch (const std::system_error& e) {
         std::cerr << "Got std::system_error" << std::endl;

--- a/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
@@ -572,7 +572,7 @@ int dvbt_pilot_gen::get_current_tpilot() const { return d_tps_carriers[d_tpilot_
 
 gr_complex dvbt_pilot_gen::get_tpilot_value(int tpilot)
 {
-    // TODO - it can be calculated at the beginnning
+    // TODO - it can be calculated at the beginning
     if (d_symbol_index == 0) {
         d_tps_carriers_val[d_tpilot_index] = gr_complex(2 * (0.5 - d_wk[tpilot]), 0);
     } else {

--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -72,7 +72,7 @@ public:
      * is a good bound.
      *
      * The Gaussian window should not be used for window based filter construction;
-     * instead there is a dedicated gaussian filter construction fuction. There is no
+     * instead there is a dedicated gaussian filter construction function. There is no
      * meaningful way to measure approximation error 'delta' as shown in Fig 7.23 of
      * Oppenheim and Schafer (Discrete-Time Signal Processing, 3rd edition).
      *

--- a/gr-fft/lib/window.cc
+++ b/gr-fft/lib/window.cc
@@ -87,7 +87,7 @@ double window::max_attenuation(win_type type, double param)
         // value not meaningful for gaussian windows, but return something reasonable
         return 100;
     case WIN_TUKEY:
-        // low end is a rectangular window, attenuation exponentialy approaches Hann
+        // low end is a rectangular window, attenuation exponentially approaches Hann
         // piecewise linear estimate, determined empirically via curve fitting, median
         // error is less than 0.5dB and maximum error is 2.5dB; the returned value will
         // never be less than expected attenuation to ensure that window designed filters

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -536,7 +536,7 @@ static void freq_sample(int N, double A[], double h[], int symm)
  *
  * INPUT:
  * ------
- * int    r     - 1/2 the number of filter coeffiecients
+ * int    r     - 1/2 the number of filter coefficients
  * int    Ext[] - Indexes to extremal frequencies [r+1]
  * double E[]   - Error function on the dense grid [gridsize]
  *

--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -58,7 +58,7 @@ templates:
 documentation: |-
     This block creates a variable check box. Leave the label blank to use the variable id as the label.
 
-    A check box selects between two values of similar type. Te values do not necessarily need to be of boolean type.
+    A check box selects between two values of similar type. The values do not necessarily need to be of boolean type.
 
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.
 

--- a/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
@@ -27,7 +27,7 @@ class QwtColorMap;
  * \ingroup qtgui_blk
  *
  * \details
- * A time raster displays three-dimenional data, where the 3rd dimension
+ * A time raster displays three-dimensional data, where the 3rd dimension
  * (the intensity) is displayed using colors. The colors are calculated
  * from the values using a color map.
  *

--- a/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
@@ -27,7 +27,7 @@ class QwtColorMap;
  * \ingroup qtgui_blk
  *
  * \details
- * A waterfall displays three-dimenional data, where the 3rd dimension
+ * A waterfall displays three-dimensional data, where the 3rd dimension
  * (the intensity) is displayed using colors. The colors are calculated
  * from the values using a color map.
  *

--- a/gr-trellis/docs/test_viterbi_equalization1.py.xml
+++ b/gr-trellis/docs/test_viterbi_equalization1.py.xml
@@ -29,7 +29,7 @@
  27
  28      # CHANNEL
  29      isi = filter.fir_filter_fff(1,channel)
- 30      add = blocs.add_ff()
+ 30      add = blocks.add_ff()
  31      noise = analog.noise_source_f(analog.GR_GAUSSIAN,math.sqrt(N0/2),seed)
  32
  33      # RX

--- a/gr-uhd/docs/uhd.dox
+++ b/gr-uhd/docs/uhd.dox
@@ -118,7 +118,7 @@ The object is of type pmt::dict and has the same fields as uhd::tune_request_t:
 - `dsp_freq_policy`: policy for DSP tuning. Should be a string "A" (automatic), "M" (manual) or "N" (none). If not set, defaults to "A".
 - `rf_freq`: the rf frequency as pmt double type.
 - `rf_freq_policy`: policy for RF tuning. Should be a string "A" (automatic), "M" (manual) or "N" (none). If not set, defaults to "A".
-- `target_freq`: target frequency (for automatic runing) as pmt double type
+- `target_freq`: target frequency (for automatic running) as pmt double type
 - `args`: string containing additional arguments, for example for integer N tuning.
 
 Example:

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -723,7 +723,7 @@ class Application(Gtk.Application):
                             Dialogs.show_missing_xterm(main, xterm)
                         self.config.xterm_missing(xterm)
                     if page.saved and page.file_path:
-                        # Save config before exection
+                        # Save config before execution
                         self.config.save()
                         Executor.ExecFlowGraphThread(
                             flow_graph_page=page,

--- a/grc/tests/resources/file3.block.yml
+++ b/grc/tests/resources/file3.block.yml
@@ -59,7 +59,7 @@ templates:
 documentation: |-
     This block creates a variable check box. Leave the label blank to use the variable id as the label.
 
-    A check box selects between two values of similar type. Te values do not necessarily need to be of boolean type.
+    A check box selects between two values of similar type. The values do not necessarily need to be of boolean type.
 
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.
 


### PR DESCRIPTION
Found via `codespell v2.1.dev0`  
`codespell -q 3 -L ans,fo,hist,inout,ist,ith,nd,sinc,uint -S ./volk`