### PR TITLE
cppgen: Use correct required version in CMakeLists

### DIFF
--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -13,7 +13,7 @@
 
 <%
 class_name = flow_graph.get_option('id')
-version_list = config.version.split(".")
+version_list = config.version_parts
 short_version = '.'.join(version_list[0:2])
 %>\
 


### PR DESCRIPTION
Looks like config.version changed at some point.

Fixes following error:
```
CMake Error at CMakeLists.txt:13 (find_package):
  find_package called with invalid argument "v3.10"
```

caused by
```
find_package(Gnuradio "v3.10" COMPONENTS
```