### PR TITLE
gr-uhd: ALL_LOS binding

### DIFF
--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -23,6 +23,7 @@ void bind_usrp_block(py::module& m)
     using usrp_block = ::gr::uhd::usrp_block;
 
     m.attr("ALL_MBOARDS") = py::int_(::uhd::usrp::multi_usrp::ALL_MBOARDS);
+    m.attr("ALL_LOS") = py::str(::uhd::usrp::multi_usrp::ALL_LOS);
 
     py::class_<usrp_block,
                gr::sync_block,


### PR DESCRIPTION
This is a patch to prevent the following issue, when using GNU Radio (master) to configure USRP LO sharing.
```
  File "/home/user/n321_rx.py", line 125, in __init__
    self.uhd_usrp_source_0.set_lo_source('external', uhd.ALL_LOS, 0)
AttributeError: module 'gnuradio.uhd' has no attribute 'ALL_LOS'
```