### PR TITLE
If GSL not found exclude modules requiring GSL from python bindings

### DIFF
--- a/gr-fec/python/fec/__init__.py
+++ b/gr-fec/python/fec/__init__.py
@@ -64,14 +64,18 @@ ldpc_decoder_make = ldpc_decoder.make
 tpc_encoder_make = tpc_encoder.make
 tpc_decoder_make = tpc_decoder.make
 
-ldpc_H_matrix = code.ldpc_H_matrix
-ldpc_G_matrix = code.ldpc_G_matrix
-ldpc_par_mtrx_encoder = code.ldpc_par_mtrx_encoder
-ldpc_par_mtrx_encoder_make = ldpc_par_mtrx_encoder.make
-ldpc_par_mtrx_encoder_make_H = ldpc_par_mtrx_encoder.make_H
-ldpc_gen_mtrx_encoder = code.ldpc_gen_mtrx_encoder
-ldpc_gen_mtrx_encoder_make = code.ldpc_gen_mtrx_encoder.make
-ldpc_bit_flip_decoder = code.ldpc_bit_flip_decoder
+try:
+    ldpc_H_matrix = code.ldpc_H_matrix
+    ldpc_G_matrix = code.ldpc_G_matrix
+    ldpc_par_mtrx_encoder = code.ldpc_par_mtrx_encoder
+    ldpc_par_mtrx_encoder_make = ldpc_par_mtrx_encoder.make
+    ldpc_par_mtrx_encoder_make_H = ldpc_par_mtrx_encoder.make_H
+    ldpc_gen_mtrx_encoder = code.ldpc_gen_mtrx_encoder
+    ldpc_gen_mtrx_encoder_make = code.ldpc_gen_mtrx_encoder.make
+    ldpc_bit_flip_decoder = code.ldpc_bit_flip_decoder
+except AttributeError:
+    pass    
+
 polar_decoder_sc = code.polar_decoder_sc
 polar_decoder_sc_list = code.polar_decoder_sc_list
 polar_decoder_sc_systematic = code.polar_decoder_sc_systematic

--- a/gr-fec/python/fec/bindings/CMakeLists.txt
+++ b/gr-fec/python/fec/bindings/CMakeLists.txt
@@ -70,5 +70,7 @@ GR_PYBIND_MAKE_CHECK_HASH(fec
    "${fec_python_files}") 
 
 target_link_libraries(fec_python PUBLIC gnuradio-runtime gnuradio-blocks)
-
+if(GSL_FOUND)
+    target_compile_definitions(fec_python PUBLIC -DHAVE_GSL)
+endif(GSL_FOUND)
 install(TARGETS fec_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/fec COMPONENT pythonapi)

--- a/gr-fec/python/fec/bindings/python_bindings.cc
+++ b/gr-fec/python/fec/bindings/python_bindings.cc
@@ -33,18 +33,20 @@ void bind_dummy_decoder(py::module&);
 void bind_dummy_encoder(py::module&);
 void bind_encode_ccsds_27_bb(py::module&);
 void bind_encoder(py::module&);
-void bind_fec_mtrx(py::module&);
 void bind_generic_decoder(py::module&);
 void bind_generic_encoder(py::module&);
 void bind_gf2mat(py::module&);
 void bind_gf2vec(py::module&);
+#ifdef HAVE_GSL
+void bind_fec_mtrx(py::module&);
 void bind_ldpc_G_matrix(py::module&);
 void bind_ldpc_H_matrix(py::module&);
 void bind_ldpc_bit_flip_decoder(py::module&);
-void bind_ldpc_decoder(py::module&);
-void bind_ldpc_encoder(py::module&);
 void bind_ldpc_gen_mtrx_encoder(py::module&);
 void bind_ldpc_par_mtrx_encoder(py::module&);
+#endif
+void bind_ldpc_decoder(py::module&);
+void bind_ldpc_encoder(py::module&);
 void bind_maxstar(py::module&);
 void bind_polar_common(py::module&);
 void bind_polar_decoder_common(py::module&);
@@ -104,16 +106,18 @@ PYBIND11_MODULE(fec_python, m)
     bind_dummy_decoder(m);
     bind_dummy_encoder(m);
     bind_encode_ccsds_27_bb(m);
-    bind_fec_mtrx(m);
     // bind_gf2mat(m);
     // bind_gf2vec(m);
+#ifdef HAVE_GSL
+    bind_fec_mtrx(m);
     bind_ldpc_G_matrix(m);
     bind_ldpc_H_matrix(m);
     bind_ldpc_bit_flip_decoder(m);
-    bind_ldpc_decoder(m);
-    bind_ldpc_encoder(m);
     bind_ldpc_gen_mtrx_encoder(m);
     bind_ldpc_par_mtrx_encoder(m);
+#endif
+    bind_ldpc_decoder(m);
+    bind_ldpc_encoder(m);
     // bind_maxstar(m);
     bind_polar_common(m);
     bind_polar_decoder_common(m);


### PR DESCRIPTION
If gnuradio was build without GSL test  105 -117 fail with 
    from gnuradio import gr, gr_unittest, blocks, fec
  File "/home/schroer/gnuradiocomponents/gnuradio-volker/gr-fec/python/fec/__init__.py", line 21, in <module>
    from .fec_python import *
ImportError: /home/schroer/gnuradiocomponents/gnuradio-volker/build/gr-fec/python/fec/bindings/fec_python.cpython-39-x86_64-linux-gnu.so: undefined symbol: _Z18bind_ldpc_G_matrixRN8pybind117module_E

Some modules depend on GSL_FOUND. So they should be excluded in the python bindings, if GSL was not found.
Other way to check than running the tests:
Run in python 
from gnuradio import fec

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>