### PR TITLE
github: Add Centos 7 to GH-A, separate Doxygen

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - maint-3.8
+      - gh-a-centos7-3.8
 jobs:
   check-formatting:
     name: Check C++ Formatting
@@ -17,6 +18,22 @@ jobs:
         source: '.'
         exclude: './volk'
         extensions: 'h,hpp,cpp,cc'
+  doxygen:
+    name: Doxygen
+    runs-on: ubuntu-20.04 # This can run on whatever
+    container:
+      image: 'gnuradio/ci-ubuntu-18.04-3.8:0.2'
+      volumes:
+        - build_data:/build
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout Project
+      with:
+        submodules: 'recursive'
+    - name: CMake
+      run: 'cd /build && cmake ${GITHUB_WORKSPACE}'
+    - name: Make Docs
+      run: 'cd /build && make doxygen_target'
   # All of these shall depend on the formatting check (needs: check-formatting)
   ubuntu-18_04:
     name: Ubuntu 18.04
@@ -33,7 +50,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: CMake
-      run: 'cd /build && cmake ${GITHUB_WORKSPACE}'
+      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
     - name: Make
       run: 'cd /build && make -j2'
     - name: Make Test
@@ -58,3 +75,24 @@ jobs:
       run: 'cd /build && make -j2'
     - name: Make Test
       run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui"'
+  centos7:
+    name: Centos 7.6
+    needs: check-formatting
+    runs-on: ubuntu-20.04 # This can run on whatever
+    container:
+      image: 'gnuradio/ci-centos-7.6-3.8:0.2'
+      volumes:
+        - build_data:/build
+      options: --cpus 2
+    steps:
+    # Note: We don't checkout the submodule here, because we already have VOLK
+    # in this container, the installed git version is too old for GitHub Actions
+    # to checkout a submodule.
+    - uses: actions/checkout@v2
+      name: Checkout Project
+    - name: CMake
+      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF -DENABLE_INTERNAL_VOLK=OFF'
+    - name: Make
+      run: 'cd /build && make -j2'
+    - name: Make Test
+      run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui|volk"'


### PR DESCRIPTION
- This adds another worker for compiling on Centos7. So far, only Python
  3 works there.
- The Doxygen build step is farmed into its own worker.