### PR TITLE
grc/cmake: Align Python and Mako versions (3.8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ include(GrVersion) #setup version info
 set(GR_BOOST_MIN_VERSION "1.53")
 set(GR_SWIG_MIN_VERSION "3.0.8")
 set(GR_CMAKE_MIN_VERSION "3.5.1")
-set(GR_MAKO_MIN_VERSION "0.4.2")
+set(GR_MAKO_MIN_VERSION "0.9.1")
 set(GR_PYTHON_MIN_VERSION "2.7.6")
 set(GR_PYTHON3_MIN_VERSION "3.6.5")
 set(GCC_MIN_VERSION "4.8.4")

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -25,22 +25,22 @@ include(GrPython)
 message(STATUS "")
 
 GR_PYTHON_CHECK_MODULE_RAW(
-    "python2 >= 2.7.6 or python3 >= 3.6.5"
+    "python2 >= ${GR_PYTHON_MIN_VERSION} or python3 >= ${GR_PYTHON3_MIN_VERSION}"
     "import sys; \
-     requirement = (3, 6, 5) if sys.version_info.major >= 3 else (2, 7, 6); \
+    requirement = tuple(int(x) for x in '${GR_PYTHON3_MIN_VERSION}'.split('.')) if sys.version_info.major >= 3 else tuple(int(x) for x in '${GR_PYTHON_MIN_VERSION}'.split('.')); \
      assert sys.version_info[:3] >= requirement"
     PYTHON_MIN_VER_FOUND
 )
 
 GR_PYTHON_CHECK_MODULE_RAW(
-    "PyYAML >= 3.10"
+    "PyYAML >= 3.11"
     "import yaml; assert yaml.__version__ >= '3.11'"
     PYYAML_FOUND
 )
 
 GR_PYTHON_CHECK_MODULE_RAW(
-    "mako >= 0.9.1"
-    "import mako; assert mako.__version__ >= '0.9.1'"
+    "mako >= ${GR_MAKO_MIN_VERSION}"
+    "import mako; assert mako.__version__ >= '${GR_MAKO_MIN_VERSION}'"
     MAKO_FOUND
 )
 


### PR DESCRIPTION
GRC has its own check for Python modules, and Python itself. It
shouldn't be enforcing its own versions though. Therefore, we change the
CMake to use the same Mako and Python min versions for GRC and the rest
of GNU Radio.

This has the side effect of modifing GR_MAKO_MIN_VERSION, which seems
counter to what we may do within the 3.8 release cycle. However, GRC had
already snuck in the new Mako requirement a long time ago, therefore
we're now adapting CMake to the reality.