### PR TITLE
modtool: add default .gitignore

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/.gitignore
+++ b/gr-utils/modtool/templates/gr-newmod/.gitignore
@@ -1,0 +1,5 @@
+*~
+*.pyc
+*.pyo
+build*/
+examples/grc/*.py


### PR DESCRIPTION
Every time I create a new OOT, have to remember to not check in the build dir and create a .gitignore

This adds a .gitignore to remove that step from the process