### PR TITLE
fec: If GSL is missing, remove those yml files that require GSL

### DIFF
--- a/gr-fec/grc/CMakeLists.txt
+++ b/gr-fec/grc/CMakeLists.txt
@@ -8,6 +8,18 @@
 ########################################################################
 file(GLOB yml_files "*.yml")
 
+# Without GSL, we don't build some of the LDPC work, so we can't use
+# it in grc
+if(NOT GSL_FOUND)
+    list(REMOVE_ITEM
+         yml_files
+         ${CMAKE_CURRENT_SOURCE_DIR}/variable_ldpc_bit_flip_decoder.block.yml
+         ${CMAKE_CURRENT_SOURCE_DIR}/variable_ldpc_G_matrix_object.block.yml
+         ${CMAKE_CURRENT_SOURCE_DIR}/variable_ldpc_H_matrix_object.block.yml
+         ${CMAKE_CURRENT_SOURCE_DIR}/variable_ldpc_encoder_G.block.yml
+         ${CMAKE_CURRENT_SOURCE_DIR}/variable_ldpc_encoder_H.block.yml
+)
+endif(NOT GSL_FOUND)
 install(FILES
         ${yml_files}
         DESTINATION ${GRC_BLOCKS_DIR}


### PR DESCRIPTION
Some fec require GSL and are not build, if GSL is missing.

In this case, the corresponding yml files should be removed from grc, too. 


Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>