### PR TITLE
github: Add -Werror for Ubuntu workers

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - maint-3.9
+      - werror-39
 jobs:
   check-formatting:
     name: Check C++ Formatting
@@ -45,9 +46,11 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Project
     - name: CMake
+      env:
+        CXXFLAGS: -Werror
       run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
     - name: Make
-      run: 'cd /build && make -j2'
+      run: 'cd /build && make -j2 -k'
     - name: Make Test
       run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui"'
   ubuntu-18_04:
@@ -63,9 +66,11 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout Project
     - name: CMake
+      env:
+        CXXFLAGS: -Werror
       run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
     - name: Make
-      run: 'cd /build && make -j2'
+      run: 'cd /build && make -j2 -k'
     - name: Make Test
       run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui"'
   fedora33:

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -37,7 +37,7 @@ int pagesize()
 #elif defined(HAVE_SYSCONF)
         s_pagesize = sysconf(_SC_PAGESIZE);
         if (s_pagesize == -1) {
-            GR_LOG_ERROR(logger, boost::format("_SC_PAGESIZE: %s") strerror(errno));
+            GR_LOG_ERROR(logger, boost::format("_SC_PAGESIZE: %s") % strerror(errno));
             s_pagesize = 4096;
         }
 #else


### PR DESCRIPTION
Ubuntu 18 and 20 on maint-3.9 are now warning-free. We will add -Werror
to the CI builds to keep it that way.