### PR TITLE
gr-blocks: Sanitize the Print PDU input of the message_debug block

### DIFF
--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -52,6 +52,11 @@ void message_debug_impl::store(pmt::pmt_t msg)
 
 void message_debug_impl::print_pdu(pmt::pmt_t pdu)
 {
+    if (pmt::is_null(pdu) || !pmt::is_pair(pdu)) {
+        GR_LOG_WARN(d_logger, "Non PDU type message received. Dropping.");
+        return;
+    }
+
     pmt::pmt_t meta = pmt::car(pdu);
     pmt::pmt_t vector = pmt::cdr(pdu);
     std::cout << "* MESSAGE DEBUG PRINT PDU VERBOSE *\n";


### PR DESCRIPTION
No message received on this port should cause the block to crash, currently a non-pair message will.

Fixes #4191

This is not a backport as this is not an issue in 3.9/3.10