### PR TITLE
gr-blocks: Update message debug error handling on Print PDU port

### DIFF
--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -60,7 +60,8 @@ void message_debug_impl::store(pmt::pmt_t msg)
 
 void message_debug_impl::print_pdu(pmt::pmt_t pdu)
 {
-    if (pmt::is_null(pdu) || !pmt::is_pair(pdu)) {
+    if (!pmt::is_pdu(pdu)) {
+        GR_LOG_WARN(d_logger, "Non PDU type message received. Dropping.");
         return;
     }
 


### PR DESCRIPTION
Currently non PDU messages get silently dropped. This can mask connection issues; given this is a debug block a WARNing messages seems appropriate. 

Suggestion from #4191

Not sure this should be backported to 3.9 or not; it does slightly change the conditions under which data is dropped - let me know.