### PR TITLE
gr_filter_sign: bessel bandpass calculation always fails

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -6,7 +6,6 @@
 #
 #
 
-
 import sys
 import os
 import re
@@ -894,15 +893,15 @@ class gr_plot_filter(QtGui.QMainWindow):
             if iirbtype == "Low Pass" or iirbtype == "High Pass":
                 besselparams.append(float(self.gui.iirbesselcritEdit1.text()))
             else:
-                besselparams.append(getfloat(self.gui.iirbesselcritEdit1.text()))
-                besselparams.append(getfloat(self.gui.iirbesselcritEdit2.text()))
+                besselparams.append(float(self.gui.iirbesselcritEdit1.text()))
+                besselparams.append(float(self.gui.iirbesselcritEdit2.text()))
 
             order = int(self.gui.besselordEdit.text())
 
             try:
                 (self.b, self.a) = signal.iirfilter(order, besselparams, btype=iirbtype.replace(' ', '').lower(),
                                                     analog=sanalog[atype], ftype=iirft[iirftype], output='ba')
-            except StandardError as e:
+            except Exception as e:
                 reply = QtGui.QMessageBox.information(self, "IIR design error", e.args[0],
                                                       QtGui.QMessageBox.Ok)
 
@@ -914,7 +913,7 @@ class gr_plot_filter(QtGui.QMainWindow):
             try:
                 (self.b, self.a) = signal.iirdesign(params[0], params[1], params[2], params[3],
                                                     analog=sanalog[atype], ftype=iirft[iirftype], output='ba')
-            except StandardError as e:
+            except Exception as e:
                 reply = QtGui.QMessageBox.information(self, "IIR design error", e.args[0],
                                                       QtGui.QMessageBox.Ok)
 
@@ -2166,7 +2165,7 @@ class gr_plot_filter(QtGui.QMainWindow):
             self.gui.iirfilterTypeComboBox.setCurrentIndex(iirft[params["filttype"]])
             self.gui.iirfilterBandComboBox.setCurrentIndex(bandpos[params["bandtype"]])
             if params["filttype"] == "bessel":
-                critfreq = map(float, params["critfreq"][1:-1].split(','))
+                critfreq = [float(x) for x in params["critfreq"][1:-1].split(',')]
                 self.gui.besselordEdit.setText(str(params["filtord"]))
                 self.gui.iirbesselcritEdit1.setText(str(critfreq[0]))
                 self.gui.iirbesselcritEdit2.setText(str(critfreq[1]))

--- a/gr-filter/python/filter/design/fir_design.py
+++ b/gr-filter/python/filter/design/fir_design.py
@@ -27,7 +27,7 @@ def design_win_lpf(fs, gain, wintype, mainwin):
         try:
             taps = filter.firdes.low_pass_2(gain, fs, pb, tb,
                                             atten, wintype)
-        except RuntimeError as e:
+        except (RuntimeError, IndexError)  as e:
             reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
                                                   e.args[0], QtGui.QMessageBox.Ok)
             return ([], [], ret)


### PR DESCRIPTION
bessel bandpass calculation always fails as a wrong str to float
conversion is used. Using the same conversion as in lowpass calculation
fixes this problem.

StandardError is not valid in python 3. It was replaced by Exception.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>