### PR TITLE
gr-blocks: combine the print and print_pdu port of the message_debug block

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/message_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/message_debug.h
@@ -27,14 +27,13 @@ namespace blocks {
  * The message debug block is used to capture and print or store
  * messages as they are received. Any block that generates a
  * message may connect that message port to one or more of the
- * three message input ports of this debug block. The message
+ * two message input ports of this debug block. The message
  * ports are:
  *
  * \li print: prints the message directly to standard out.
  * \li store: stores the message in an internal vector. May be
  *            access using the get_message function.
- * \li print_pdu: specifically designed to handle formatted PDUs
- *                (see pdu.h).
+ * \li print_pdu: DEPRECATED! use print() for all printing
  */
 class BLOCKS_API message_debug : virtual public block
 {
@@ -43,9 +42,10 @@ public:
     typedef std::shared_ptr<message_debug> sptr;
 
     /*!
-     * \brief Build the message debug block. It takes no parameters
-     * and has three message ports: print, store, and
-     * print_pdu.
+     * \brief Build the message debug block. It takes a single parameter that can be used
+     * to disable PDU vector printing and has two message ports: print and store.
+     *
+     * \param en_uvec Enable PDU Vector Printing.
      */
     static sptr make(bool en_uvec = true);
 

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -30,7 +30,8 @@ private:
      * This port receives messages from the scheduler's message
      * handling mechanism and prints it to stdout. This message
      * handler function is only meant to be used by the scheduler to
-     * handle messages posted to port 'print'.
+     * handle messages posted to port 'print'. If the message is a
+     * PDU, special formatting will be applied.
      *
      * \param msg A pmt message passed from the scheduler's message handling.
      */
@@ -38,6 +39,8 @@ private:
 
     /*!
      * \brief PDU formatted messages received in this port are printed to stdout.
+     *
+     * DEPRECATED as of 3.10 use print() for all printing!
      *
      * This port receives messages from the scheduler's message
      * handling mechanism and prints it to stdout. This message

--- a/gr-blocks/python/blocks/bindings/message_debug_python.cc
+++ b/gr-blocks/python/blocks/bindings/message_debug_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2021 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(message_debug.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(5768fa881c26e7018f934e8997ac36de)                     */
+/* BINDTOOL_HEADER_FILE_HASH(27c3ba26dd33d2ecd535857d5ea26ed8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Having two print ports on this block has confused a number of people, most recently issue #4191, and combining them is straightforward and should make this block easier to use. This PR also updates some out of date documentation in the public header file.

Potentially breaks existing usage of this block so no backport.