### PR TITLE
digital: include control_loop class in child class bindings

### DIFF
--- a/gr-digital/python/digital/bindings/constellation_receiver_cb_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_receiver_cb_python.cc
@@ -36,6 +36,7 @@ void bind_constellation_receiver_cb(py::module& m)
     py::class_<constellation_receiver_cb,
                gr::block,
                gr::basic_block,
+               gr::blocks::control_loop,
                std::shared_ptr<constellation_receiver_cb>>(
         m, "constellation_receiver_cb", D(constellation_receiver_cb))
 

--- a/gr-digital/python/digital/bindings/costas_loop_cc_python.cc
+++ b/gr-digital/python/digital/bindings/costas_loop_cc_python.cc
@@ -37,6 +37,7 @@ void bind_costas_loop_cc(py::module& m)
                gr::sync_block,
                gr::block,
                gr::basic_block,
+               gr::blocks::control_loop,
                std::shared_ptr<costas_loop_cc>>(m, "costas_loop_cc", D(costas_loop_cc))
 
         .def(py::init(&costas_loop_cc::make),

--- a/gr-digital/python/digital/bindings/fll_band_edge_cc_python.cc
+++ b/gr-digital/python/digital/bindings/fll_band_edge_cc_python.cc
@@ -37,6 +37,7 @@ void bind_fll_band_edge_cc(py::module& m)
                gr::sync_block,
                gr::block,
                gr::basic_block,
+               gr::blocks::control_loop,
                std::shared_ptr<fll_band_edge_cc>>(
         m, "fll_band_edge_cc", D(fll_band_edge_cc))
 

--- a/gr-digital/python/digital/bindings/python_bindings.cc
+++ b/gr-digital/python/digital/bindings/python_bindings.cc
@@ -121,6 +121,7 @@ PYBIND11_MODULE(digital_python, m)
 
     // Allow access to base block methods
     py::module::import("gnuradio.gr");
+    py::module::import("gnuradio.blocks");
 
     bind_adaptive_algorithm(m);
     bind_adaptive_algorithm_cma(m);


### PR DESCRIPTION
costas_loop_cc, fll_band_edge_cc, and constellation_receiver_cb all
inherit from gr::blocks::control_loop. Add the class to the bindings so
the control loop methods are available in Python.

Signed-off-by: Jeppe Ledet-Pedersen <jlp@satlab.com>