### PR TITLE
gr-utils: improve usefulness of blocktool exceptions

### DIFF
--- a/gr-utils/blocktool/core/parseheader.py
+++ b/gr-utils/blocktool/core/parseheader.py
@@ -56,7 +56,7 @@ class BlockHeaderParser(BlockTool):
         if (include_paths):
             self.include_paths = [p.strip() for p in include_paths.split(',')]
         if not os.path.isfile(file_path):
-            raise BlockToolException('file does not exist')
+            raise BlockToolException('file', file_path, 'does not exist')
         file_path = os.path.abspath(file_path)
         self.target_file = file_path
         self.initialize()

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -59,7 +59,7 @@ class GenericHeaderParser(BlockTool):
         if (include_paths):
             self.include_paths = [p.strip() for p in include_paths.split(',')]
         if not os.path.isfile(file_path):
-            raise BlockToolException('file does not exist')
+            raise BlockToolException('file', file_path, 'does not exist')
         file_path = os.path.abspath(file_path)
         self.target_file = file_path
 


### PR DESCRIPTION
When binding blocks using `gr_modtool bind` if a file is missing a fairly useless error is now printed that 'file does not exist'. This actually prints the file that was attempted to be accessed.

This should also be backported to maint-3.9.