### PR TITLE
uhd: Remove ifdefs for older UHD versions

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -371,50 +371,30 @@ void usrp_block_impl::set_clock_rate(double rate, size_t mboard)
 
 std::vector<std::string> usrp_block_impl::get_gpio_banks(const size_t mboard)
 {
-#ifdef UHD_USRP_MULTI_USRP_GPIO_API
     return _dev->get_gpio_banks(mboard);
-#else
-    throw std::runtime_error("not implemented in this version");
-#endif
 }
 
 uint32_t usrp_block_impl::get_gpio_attr(const std::string& bank,
                                         const std::string& attr,
                                         const size_t mboard)
 {
-#ifdef UHD_USRP_MULTI_USRP_GPIO_API
-    return _dev->get_gpio_attr(bank, attr, mboard);
-#else
     throw std::runtime_error("not implemented in this version");
-#endif
 }
 
 std::vector<std::string> usrp_block_impl::get_filter_names(const std::string& search_mask)
 {
-#ifdef UHD_USRP_MULTI_FILTER_API
     return _dev->get_filter_names(search_mask);
-#else
-    throw std::runtime_error("not implemented in this version");
-#endif
 }
 
 ::uhd::filter_info_base::sptr usrp_block_impl::get_filter(const std::string& path)
 {
-#ifdef UHD_USRP_MULTI_FILTER_API
     return _dev->get_filter(path);
-#else
-    throw std::runtime_error("not implemented in this version");
-#endif
 }
 
 void usrp_block_impl::set_filter(const std::string& path,
                                  ::uhd::filter_info_base::sptr filter)
 {
-#ifdef UHD_USRP_MULTI_FILTER_API
     _dev->set_filter(path, filter);
-#else
-    throw std::runtime_error("not implemented in this version");
-#endif
 }
 
 void usrp_block_impl::set_time_now(const ::uhd::time_spec_t& time_spec, size_t mboard)
@@ -455,11 +435,7 @@ void usrp_block_impl::set_gpio_attr(const std::string& bank,
                                     const uint32_t mask,
                                     const size_t mboard)
 {
-#ifdef UHD_USRP_MULTI_USRP_GPIO_API
     return _dev->set_gpio_attr(bank, attr, value, mask, mboard);
-#else
-    throw std::runtime_error("not implemented in this version");
-#endif
 }
 
 ::uhd::usrp::multi_usrp::sptr usrp_block_impl::get_device(void) { return _dev; }

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -133,17 +133,7 @@ void usrp_sink_impl::set_gain(double gain, const std::string& name, size_t chan)
 
 void usrp_sink_impl::set_normalized_gain(double norm_gain, size_t chan)
 {
-#ifdef UHD_USRP_MULTI_USRP_NORMALIZED_GAIN
     _dev->set_normalized_tx_gain(norm_gain, chan);
-#else
-    if (norm_gain > 1.0 || norm_gain < 0.0) {
-        throw std::runtime_error("Normalized gain out of range, must be in [0, 1].");
-    }
-    ::uhd::gain_range_t gain_range = get_gain_range(chan);
-    double abs_gain =
-        (norm_gain * (gain_range.stop() - gain_range.start())) + gain_range.start();
-    set_gain(abs_gain, chan);
-#endif
 }
 
 double usrp_sink_impl::get_gain(size_t chan)
@@ -160,19 +150,7 @@ double usrp_sink_impl::get_gain(const std::string& name, size_t chan)
 
 double usrp_sink_impl::get_normalized_gain(size_t chan)
 {
-#ifdef UHD_USRP_MULTI_USRP_NORMALIZED_GAIN
     return _dev->get_normalized_tx_gain(chan);
-#else
-    ::uhd::gain_range_t gain_range = get_gain_range(chan);
-    double norm_gain =
-        (get_gain(chan) - gain_range.start()) / (gain_range.stop() - gain_range.start());
-    // Avoid rounding errors:
-    if (norm_gain > 1.0)
-        return 1.0;
-    if (norm_gain < 0.0)
-        return 0.0;
-    return norm_gain;
-#endif
 }
 
 std::vector<std::string> usrp_sink_impl::get_gain_names(size_t chan)


### PR DESCRIPTION
GNU Radio now requires UHD 3.9.7. This obviates the need for certain
ifdefs to check for older features.

This fixes one bug in particular: Newer versions of UHD no longer define
INCLUDED_UHD_UTILS_MSG_TASK_HPP, which would lead UHD 4.0 + GNU Radio
using deprecated APIs within UHD.

Closes  #3956