### PR TITLE
pybind: remove forecast from python bindings

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -66,13 +66,6 @@ void bind_block(py::module& m)
         .def("fixed_rate", &block::fixed_rate, D(block, fixed_rate))
 
 
-        .def("forecast",
-             &block::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(block, forecast))
-
-
         .def("general_work",
              &block::general_work,
              py::arg("noutput_items"),

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/sync_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/sync_block_python.cc
@@ -45,13 +45,6 @@ void bind_sync_block(py::module& m)
              D(sync_block, work))
 
 
-        .def("forecast",
-             &sync_block::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(sync_block, forecast))
-
-
         .def("general_work",
              &sync_block::general_work,
              py::arg("noutput_items"),

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/sync_decimator_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/sync_decimator_python.cc
@@ -49,13 +49,6 @@ void bind_sync_decimator(py::module& m)
              D(sync_decimator, set_decimation))
 
 
-        .def("forecast",
-             &sync_decimator::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(sync_decimator, forecast))
-
-
         .def("general_work",
              &sync_decimator::general_work,
              py::arg("noutput_items"),

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/sync_interpolator_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/sync_interpolator_python.cc
@@ -52,13 +52,6 @@ void bind_sync_interpolator(py::module& m)
              D(sync_interpolator, set_interpolation))
 
 
-        .def("forecast",
-             &sync_interpolator::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(sync_interpolator, forecast))
-
-
         .def("general_work",
              &sync_interpolator::general_work,
              py::arg("noutput_items"),

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tagged_stream_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tagged_stream_block_python.cc
@@ -40,13 +40,6 @@ void bind_tagged_stream_block(py::module& m)
         m, "tagged_stream_block", D(tagged_stream_block))
 
 
-        .def("forecast",
-             &tagged_stream_block::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(tagged_stream_block, forecast))
-
-
         .def("check_topology",
              &tagged_stream_block::check_topology,
              py::arg("ninputs"),

--- a/gr-fec/python/fec/bindings/decoder_python.cc
+++ b/gr-fec/python/fec/bindings/decoder_python.cc
@@ -63,12 +63,5 @@ void bind_decoder(py::module& m)
              py::arg("noutput"),
              D(decoder, fixed_rate_noutput_to_ninput))
 
-
-        .def("forecast",
-             &decoder::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(decoder, forecast))
-
         ;
 }

--- a/gr-fec/python/fec/bindings/encoder_python.cc
+++ b/gr-fec/python/fec/bindings/encoder_python.cc
@@ -63,12 +63,5 @@ void bind_encoder(py::module& m)
              py::arg("noutput"),
              D(encoder, fixed_rate_noutput_to_ninput))
 
-
-        .def("forecast",
-             &encoder::forecast,
-             py::arg("noutput_items"),
-             py::arg("ninput_items_required"),
-             D(encoder, forecast))
-
         ;
 }


### PR DESCRIPTION
There is no scenario that a block or app should be calling forecast over
the python interface.  This is only called by the scheduler, and for
python blocks would pass through the gateway interface.

There may be more we want to remove from the pybind interface at the block level as well