### PR TITLE
cmake: Thrift min version is set at top level, raise min Thrift to 0.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,8 @@ set(CLANG_MIN_VERSION "11.0.0")       ## debian bullseye, Fedora 33
 set(APPLECLANG_MIN_VERSION "1100")    ## same as clang 11.0.0, in Xcode11
 set(MSVC_MIN_VERSION "1914")          ## VS2017 15.7, for full-ish C++17 support
 set(VOLK_MIN_VERSION "2.4.1")         ## first version with CPU features
-set(PYBIND11_MIN_VERSION "2.4") # pybind11 sets versions like 2.4.dev4, which compares < 2.4.3
+set(PYBIND11_MIN_VERSION "2.4")       # pybind11 sets versions like 2.4.dev4, which compares < 2.4.3
+set(GR_THRIFT_MIN_VERSION "0.13")
 
 # Enable generation of compile_commands.json for code completion engines
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/Modules/FindTHRIFT.cmake
+++ b/cmake/Modules/FindTHRIFT.cmake
@@ -3,7 +3,8 @@ if(NOT PKG_CONFIG_FOUND)
 endif()
 PKG_CHECK_MODULES(PC_THRIFT thrift)
 
-set(THRIFT_REQ_VERSION "0.9.2")
+set(THRIFT_REQ_VERSION ${THRIFT_FIND_VERSION})
+message(STATUS "thrift looking for version ${THRIFT_REQ_VERSION}")
 
 # If pkg-config found Thrift and it doesn't meet our version
 # requirement, warn and exit -- does not cause an error; just doesn't

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -138,7 +138,7 @@ OPTION(ENABLE_CTRLPORT_THRIFT "Enable ControlPort Thrift support" ON)
 
 if(ENABLE_CTRLPORT_THRIFT)
 # Look if Thrift is installed and use it as a ControlPort backend.
-FIND_PACKAGE(THRIFT)
+FIND_PACKAGE(THRIFT ${GR_THRIFT_MIN_VERSION})
 
 if(THRIFT_FOUND)
 list(APPEND EXTRA_DEPS "THRIFT")


### PR DESCRIPTION
- Modifies top-level CMake to set the min Thrift version
- Modifies FindThrift.cmake to use a version argument

Closes https://github.com/gnuradio/gnuradio/issues/3920