### PR TITLE
gnuradio-runtime: configurable buffer size

### DIFF
--- a/gnuradio-runtime/gnuradio-runtime.conf.in
+++ b/gnuradio-runtime/gnuradio-runtime.conf.in
@@ -9,6 +9,8 @@ verbose = False
 # the queue by popping messages from the front.
 max_messages = 8192
 
+# Block output buffer size in bytes.
+#buffer_size = 32768
 
 [LOG]
 # Levels can be (case insensitive):

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -27,7 +27,8 @@ namespace gr {
 // 32Kbyte buffer size between blocks
 #define GR_FIXED_BUFFER_SIZE (32 * (1L << 10))
 
-static const unsigned int s_fixed_buffer_size = GR_FIXED_BUFFER_SIZE;
+static const unsigned int s_fixed_buffer_size =
+    prefs::singleton()->get_long("DEFAULT", "buffer_size", GR_FIXED_BUFFER_SIZE);
 
 flat_flowgraph_sptr make_flat_flowgraph()
 {


### PR DESCRIPTION
Currently block output buffers are limited to 32768 bytes in size, although smaller buffers can be configured using `set_max_output_buffer` functionality. This patch allows increasing the 32768 byte limitation from the configuration file. Increasing the buffer size is useful in rare cases and this patch greatly simplifies doing so. Or at least it simplifies experimenting with different buffer sizes.

https://github.com/gnuradio/gnuradio/blob/63cd1cd0570b387d5b0ccdfbbf92a093a6494fc1/gnuradio-runtime/lib/flat_flowgraph.cc#L28

This patch was originally proposed in [discuss-gnuradio](https://lists.gnu.org/archive/html/discuss-gnuradio/2016-02/msg00404.html) by @marcusmueller. I found it useful.