### PR TITLE
block_executor: invalid states log errors without debug build

### DIFF
--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -18,12 +18,8 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <block_executor.h>
-#include <boost/format.hpp>
-#include <boost/thread.hpp>
-#include <cassert>
-#include <cstdio>
-#include <iostream>
 #include <limits>
+#include <sstream>
 
 namespace gr {
 
@@ -246,7 +242,7 @@ block_executor::state block_executor::run_one_iteration()
     max_noutput_items = round_down(d_max_noutput_items, m->output_multiple());
 
     if (d->done()) {
-        assert(0);
+        GR_LOG_ERROR(d_logger, "unexpected done() in run_one_iteration");
         return DONE;
     }
 
@@ -565,7 +561,7 @@ block_executor::state block_executor::run_one_iteration()
         // Have the caller try again...
         return READY_NO_OUTPUT;
     }
-    assert(0);
+    GR_LOG_ERROR(d_logger, "invalid state while going through iteration state machine");
 
 were_done:
     LOG(GR_LOG_INFO(d_debug_logger, "we're done"););


### PR DESCRIPTION
Clean up includes on the way.

This rescues a reasonable change from #4152.