### PR TITLE
uhd: Fix filter API

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -610,35 +610,34 @@ public:
                                    const std::string& attr,
                                    const size_t mboard = 0) = 0;
 
-    /*!
-     * Enumerate the available filters in the signal path.
-     * \param search_mask
-     * \parblock
-     * Select only certain filter names by specifying this search mask.
+    /*! Enumerate the available filters in the signal path.
      *
-     * E.g. if search mask is set to "rx_frontends/A" only filter names including
-     * that string will be returned. \endparblock \return a vector of strings
-     * representing the selected filter names.
+     * \param chan Channel index
+     *
+     * \return a vector of strings representing the selected filter names.
      */
-    virtual std::vector<std::string>
-    get_filter_names(const std::string& search_mask = "") = 0;
+    virtual std::vector<std::string> get_filter_names(const size_t chan = 0) = 0;
 
-    /*!
-     * Write back a filter obtained by get_filter() to the signal path.
+    /*! Write back a filter obtained by get_filter() to the signal path.
+     *
      * This filter can be a modified version of the originally returned one.
      * The information about Rx or Tx is contained in the path parameter.
      * \param path the name of the filter as returned from get_filter_names().
      * \param filter the filter_info_base::sptr of the filter object to be written
+     * \param chan Channel index
      */
     virtual void set_filter(const std::string& path,
-                            ::uhd::filter_info_base::sptr filter) = 0;
+                            ::uhd::filter_info_base::sptr filter,
+                            const size_t chan = 0) = 0;
 
-    /*!
-     * Return the filter object for the given name.
-     * @param path the name of the filter as returned from get_filter_names()
-     * @return the filter object
+    /*! Return the filter object for the given name.
+     *
+     * \param path the name of the filter as returned from get_filter_names()
+     * \param chan Channel index
+     * \return the filter object
      */
-    virtual ::uhd::filter_info_base::sptr get_filter(const std::string& path) = 0;
+    virtual ::uhd::filter_info_base::sptr get_filter(const std::string& path,
+                                                     const size_t chan = 0) = 0;
 
     /*!
      * Returns identifying information about this USRP's configuration.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -381,22 +381,6 @@ uint32_t usrp_block_impl::get_gpio_attr(const std::string& bank,
     throw std::runtime_error("not implemented in this version");
 }
 
-std::vector<std::string> usrp_block_impl::get_filter_names(const std::string& search_mask)
-{
-    return _dev->get_filter_names(search_mask);
-}
-
-::uhd::filter_info_base::sptr usrp_block_impl::get_filter(const std::string& path)
-{
-    return _dev->get_filter(path);
-}
-
-void usrp_block_impl::set_filter(const std::string& path,
-                                 ::uhd::filter_info_base::sptr filter)
-{
-    _dev->set_filter(path, filter);
-}
-
 void usrp_block_impl::set_time_now(const ::uhd::time_spec_t& time_spec, size_t mboard)
 {
     return _dev->set_time_now(time_spec, mboard);

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -54,8 +54,6 @@ public:
                            const std::string& attr,
                            const size_t mboard = 0) override;
     size_t get_num_mboards() override;
-    std::vector<std::string> get_filter_names(const std::string& search_mask) override;
-    ::uhd::filter_info_base::sptr get_filter(const std::string& path) override;
 
     // Setters
     void set_time_source(const std::string& source, const size_t mboard) override;
@@ -73,8 +71,6 @@ public:
                        const uint32_t value,
                        const uint32_t mask,
                        const size_t mboard) override;
-    void set_filter(const std::string& path,
-                    ::uhd::filter_info_base::sptr filter) override;
 
     // RPC
     void setup_rpc() override;

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -392,6 +392,44 @@ std::vector<std::string> usrp_sink_impl::get_sensor_names(size_t chan)
     return _dev->get_tx_dboard_iface(chan);
 }
 
+#if UHD_VERSION >= 4000000
+std::vector<std::string> usrp_sink_impl::get_filter_names(const size_t chan)
+{
+    return _dev->get_tx_filter_names(chan);
+}
+
+::uhd::filter_info_base::sptr usrp_sink_impl::get_filter(const std::string& path,
+                                                         const size_t chan)
+{
+    return _dev->get_tx_filter(path, chan);
+}
+
+void usrp_sink_impl::set_filter(const std::string& path,
+                                ::uhd::filter_info_base::sptr filter,
+                                const size_t chan)
+{
+    _dev->set_tx_filter(path, filter, chan);
+}
+#else
+std::vector<std::string> usrp_sink_impl::get_filter_names(const size_t /*chan*/)
+{
+    return _dev->get_filter_names("tx");
+}
+
+::uhd::filter_info_base::sptr usrp_sink_impl::get_filter(const std::string& path,
+                                                         const size_t /*chan*/)
+{
+    return _dev->get_filter(path);
+}
+
+void usrp_sink_impl::set_filter(const std::string& path,
+                                ::uhd::filter_info_base::sptr filter,
+                                const size_t /*chan*/)
+{
+    _dev->set_filter(path, filter);
+}
+#endif
+
 void usrp_sink_impl::set_stream_args(const ::uhd::stream_args_t& stream_args)
 {
     _update_stream_args(stream_args);

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -81,6 +81,9 @@ public:
     bool get_lo_export_enabled(const std::string& name, size_t chan) override;
     double get_lo_freq(const std::string& name, size_t chan) override;
     ::uhd::freq_range_t get_lo_freq_range(const std::string& name, size_t chan) override;
+    std::vector<std::string> get_filter_names(const size_t chan) override;
+    ::uhd::filter_info_base::sptr get_filter(const std::string& path,
+                                             const size_t chan) override;
 
     void set_subdev_spec(const std::string& spec, size_t mboard) override;
     std::string get_subdev_spec(size_t mboard) override;
@@ -106,6 +109,9 @@ public:
                                const std::string& name = ALL_LOS,
                                size_t chan = 0) override;
     double set_lo_freq(double freq, const std::string& name, size_t chan) override;
+    void set_filter(const std::string& path,
+                    ::uhd::filter_info_base::sptr filter,
+                    const size_t chan) override;
 
     bool start(void) override;
     bool stop(void) override;

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -416,6 +416,44 @@ std::vector<std::string> usrp_source_impl::get_sensor_names(size_t chan)
     return _dev->get_rx_dboard_iface(chan);
 }
 
+#if UHD_VERSION >= 4000000
+std::vector<std::string> usrp_source_impl::get_filter_names(const size_t chan)
+{
+    return _dev->get_rx_filter_names(chan);
+}
+
+::uhd::filter_info_base::sptr usrp_source_impl::get_filter(const std::string& path,
+                                                           const size_t chan)
+{
+    return _dev->get_rx_filter(path, chan);
+}
+
+void usrp_source_impl::set_filter(const std::string& path,
+                                  ::uhd::filter_info_base::sptr filter,
+                                  const size_t chan)
+{
+    _dev->set_rx_filter(path, filter, chan);
+}
+#else
+std::vector<std::string> usrp_source_impl::get_filter_names(const size_t /*chan*/)
+{
+    return _dev->get_filter_names("rx");
+}
+
+::uhd::filter_info_base::sptr usrp_source_impl::get_filter(const std::string& path,
+                                                           const size_t /*chan*/)
+{
+    return _dev->get_filter(path);
+}
+
+void usrp_source_impl::set_filter(const std::string& path,
+                                  ::uhd::filter_info_base::sptr filter,
+                                  const size_t /*chan*/)
+{
+    _dev->set_filter(path, filter);
+}
+#endif
+
 void usrp_source_impl::set_stream_args(const ::uhd::stream_args_t& stream_args)
 {
     _update_stream_args(stream_args);

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -66,6 +66,9 @@ public:
     bool get_lo_export_enabled(const std::string& name, size_t chan) override;
     double get_lo_freq(const std::string& name, size_t chan) override;
     ::uhd::freq_range_t get_lo_freq_range(const std::string& name, size_t chan) override;
+    std::vector<std::string> get_filter_names(const size_t chan) override;
+    ::uhd::filter_info_base::sptr get_filter(const std::string& path,
+                                             const size_t chan) override;
 
     // Set Commands
     void set_subdev_spec(const std::string& spec, size_t mboard) override;
@@ -95,6 +98,9 @@ public:
                                const std::string& name = ALL_LOS,
                                size_t chan = 0) override;
     double set_lo_freq(double freq, const std::string& name, size_t chan) override;
+    void set_filter(const std::string& path,
+                    ::uhd::filter_info_base::sptr filter,
+                    const size_t chan) override;
 
     void issue_stream_cmd(const ::uhd::stream_cmd_t& cmd) override;
     void set_recv_timeout(const double timeout, const bool one_packet) override;

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -399,7 +399,7 @@ void bind_usrp_block(py::module& m)
 
         .def("get_filter_names",
              &usrp_block::get_filter_names,
-             py::arg("search_mask") = "",
+             py::arg("chan") = 0,
              D(usrp_block, get_filter_names))
 
 
@@ -407,12 +407,14 @@ void bind_usrp_block(py::module& m)
              &usrp_block::set_filter,
              py::arg("path"),
              py::arg("filter"),
+             py::arg("chan") = 0,
              D(usrp_block, set_filter))
 
 
         .def("get_filter",
              &usrp_block::get_filter,
              py::arg("path"),
+             py::arg("chan") = 0,
              D(usrp_block, get_filter))
 
         .def(


### PR DESCRIPTION
9cdfe5141a exposed a bug in gr-uhd: The filter API was incorrectly
implemented. However, the #ifdef to check for the existence of the
filter API also had a typo, and therefore, the filter API was never
compiled in.

This is an API change, b/c the existing gr-uhd code was actually never
compatible to UHD's filter API. This tells us no one's actually been
using it, so the API change is low-risk.

The change is to adapt gr-uhd's filter API to that in UHD.