### PR TITLE
gr-uhd: Generate tags when frequency changed from message port.

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -118,7 +118,7 @@ usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direct
         return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
     } else {
         return set_center_freq(_curr_tune_req[chan], chan);
-   }
+    }
 }
 
 double usrp_source_impl::get_center_freq(size_t chan)

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -117,8 +117,8 @@ usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direct
         // TODO: what happens if the TX device is not instantiated? Catch error?
         return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
-    }
+        return set_center_freq(_curr_tune_req[chan], chan);
+   }
 }
 
 double usrp_source_impl::get_center_freq(size_t chan)


### PR DESCRIPTION
Call set_center_freq() rather _dev->set_rx_freq() so that _tag_now is set on the change.

The end result is that the tags are generated as needed when changes are directed from the message port. set_center_freq() performs the same functionality as the original code with the addition of properly setting the _tag_now flag.

Signed-off-by: Steve Lunsford <seldad8@gmail.com>

fixes #1357 
fixes #4204.