### PR TITLE
qtgui: toggle label&icon on plot play/stop button

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/eyecontrolpanel.h
+++ b/gr-qtgui/include/gnuradio/qtgui/eyecontrolpanel.h
@@ -35,6 +35,7 @@ public slots:
     void toggleTriggerMode(gr::qtgui::trigger_mode mode);
     void toggleTriggerSlope(gr::qtgui::trigger_slope slope);
     void toggleStopButton();
+    void updateStopLabel(bool on);
 
 signals:
     void signalToggleStopButton();

--- a/gr-qtgui/include/gnuradio/qtgui/freqcontrolpanel.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqcontrolpanel.h
@@ -45,6 +45,7 @@ public slots:
     void toggleTriggerMode(gr::qtgui::trigger_mode mode);
 
     void toggleStopButton();
+    void updateStopLabel(bool on);
 
 signals:
     void signalAvgSlider(float val);

--- a/gr-qtgui/include/gnuradio/qtgui/timecontrolpanel.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timecontrolpanel.h
@@ -36,6 +36,7 @@ public slots:
     void toggleTriggerMode(gr::qtgui::trigger_mode mode);
     void toggleTriggerSlope(gr::qtgui::trigger_slope slope);
     void toggleStopButton();
+    void updateStopLabel(bool on);
 
 signals:
     void signalToggleStopButton();

--- a/gr-qtgui/lib/eyecontrolpanel.cc
+++ b/gr-qtgui/lib/eyecontrolpanel.cc
@@ -76,7 +76,7 @@ EyeControlPanel::EyeControlPanel(EyeDisplayForm* form) : QVBoxLayout(), d_parent
     d_extras_box = new QGroupBox("Extras");
     d_extras_layout = new QVBoxLayout;
     d_autoscale_button = new QPushButton("Autoscale");
-    d_stop_button = new QPushButton("Stop");
+    d_stop_button = new QPushButton(QApplication::style()->standardIcon(QStyle::SP_MediaStop),"Stop");
     d_stop_button->setCheckable(true);
 
     // Set up the boxes into the layout
@@ -141,7 +141,13 @@ EyeControlPanel::EyeControlPanel(EyeDisplayForm* form) : QVBoxLayout(), d_parent
 
     connect(
         d_autoscale_button, SIGNAL(pressed(void)), d_parent, SLOT(autoScaleShot(void)));
+
+    // Handle the start/stop button
+    //Call the base class' stop function when they press the button
     connect(d_stop_button, SIGNAL(pressed(void)), d_parent, SLOT(setStop(void)));
+    //Updated the button state regardless of who changed it
+    connect(
+        d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
     connect(
         this, SIGNAL(signalToggleStopButton(void)), d_stop_button, SLOT(toggle(void)));
 }
@@ -173,3 +179,14 @@ void EyeControlPanel::toggleTriggerSlope(gr::qtgui::trigger_slope slope)
 }
 
 void EyeControlPanel::toggleStopButton() { emit signalToggleStopButton(); }
+
+void EyeControlPanel::updateStopLabel(bool on) {
+    if( on) {
+    d_stop_button->setText("Start");
+    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaPlay) );
+    }
+    else {
+    d_stop_button->setText("Stop");
+    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaStop) );
+    }
+}

--- a/gr-qtgui/lib/eyecontrolpanel.cc
+++ b/gr-qtgui/lib/eyecontrolpanel.cc
@@ -76,7 +76,8 @@ EyeControlPanel::EyeControlPanel(EyeDisplayForm* form) : QVBoxLayout(), d_parent
     d_extras_box = new QGroupBox("Extras");
     d_extras_layout = new QVBoxLayout;
     d_autoscale_button = new QPushButton("Autoscale");
-    d_stop_button = new QPushButton(QApplication::style()->standardIcon(QStyle::SP_MediaStop),"Stop");
+    d_stop_button = new QPushButton(
+        QApplication::style()->standardIcon(QStyle::SP_MediaStop), "Stop");
     d_stop_button->setCheckable(true);
 
     // Set up the boxes into the layout
@@ -143,11 +144,10 @@ EyeControlPanel::EyeControlPanel(EyeDisplayForm* form) : QVBoxLayout(), d_parent
         d_autoscale_button, SIGNAL(pressed(void)), d_parent, SLOT(autoScaleShot(void)));
 
     // Handle the start/stop button
-    //Call the base class' stop function when they press the button
+    // Call the base class' stop function when they press the button
     connect(d_stop_button, SIGNAL(pressed(void)), d_parent, SLOT(setStop(void)));
-    //Updated the button state regardless of who changed it
-    connect(
-        d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
+    // Updated the button state regardless of who changed it
+    connect(d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
     connect(
         this, SIGNAL(signalToggleStopButton(void)), d_stop_button, SLOT(toggle(void)));
 }
@@ -180,13 +180,13 @@ void EyeControlPanel::toggleTriggerSlope(gr::qtgui::trigger_slope slope)
 
 void EyeControlPanel::toggleStopButton() { emit signalToggleStopButton(); }
 
-void EyeControlPanel::updateStopLabel(bool on) {
-    if( on) {
-    d_stop_button->setText("Start");
-    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaPlay) );
-    }
-    else {
-    d_stop_button->setText("Stop");
-    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaStop) );
+void EyeControlPanel::updateStopLabel(bool on)
+{
+    if (on) {
+        d_stop_button->setText("Start");
+        d_stop_button->setIcon(QApplication::style()->standardIcon(QStyle::SP_MediaPlay));
+    } else {
+        d_stop_button->setText("Stop");
+        d_stop_button->setIcon(QApplication::style()->standardIcon(QStyle::SP_MediaStop));
     }
 }

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -111,7 +111,8 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     // Set up the box for other items
     d_extras_box = new QGroupBox("Extras");
     d_extras_layout = new QVBoxLayout;
-    d_stop_button = new QPushButton(QApplication::style()->standardIcon(QStyle::SP_MediaStop),"Stop");
+    d_stop_button = new QPushButton(
+        QApplication::style()->standardIcon(QStyle::SP_MediaStop), "Stop");
     d_stop_button->setCheckable(true);
 
     // Set up the boxes into the layout
@@ -189,12 +190,11 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
             SLOT(notifyTriggerLevelMinus()));
 
     // Handle the start/stop button
-    //Call the base class' stop function when they press the button
+    // Call the base class' stop function when they press the button
     connect(d_stop_button, SIGNAL(pressed(void)), d_parent, SLOT(setStop(void)));
-    //Updated the button state regardless of who changed it
-    connect(
-        d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
-    //Update the button if someone else changes it
+    // Updated the button state regardless of who changed it
+    connect(d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
+    // Update the button if someone else changes it
     connect(
         this, SIGNAL(signalToggleStopButton(void)), d_stop_button, SLOT(toggle(void)));
 }
@@ -273,13 +273,13 @@ void FreqControlPanel::toggleTriggerMode(gr::qtgui::trigger_mode mode)
 
 void FreqControlPanel::toggleStopButton() { emit signalToggleStopButton(); }
 
-void FreqControlPanel::updateStopLabel(bool on) {
-    if( on) {
-    d_stop_button->setText("Start");
-    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaPlay) );
-    }
-    else {
-    d_stop_button->setText("Stop");
-    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaStop) );
+void FreqControlPanel::updateStopLabel(bool on)
+{
+    if (on) {
+        d_stop_button->setText("Start");
+        d_stop_button->setIcon(QApplication::style()->standardIcon(QStyle::SP_MediaPlay));
+    } else {
+        d_stop_button->setText("Stop");
+        d_stop_button->setIcon(QApplication::style()->standardIcon(QStyle::SP_MediaStop));
     }
 }

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -111,7 +111,7 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     // Set up the box for other items
     d_extras_box = new QGroupBox("Extras");
     d_extras_layout = new QVBoxLayout;
-    d_stop_button = new QPushButton("Stop");
+    d_stop_button = new QPushButton(QApplication::style()->standardIcon(QStyle::SP_MediaStop),"Stop");
     d_stop_button->setCheckable(true);
 
     // Set up the boxes into the layout
@@ -188,7 +188,13 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
             d_parent,
             SLOT(notifyTriggerLevelMinus()));
 
+    // Handle the start/stop button
+    //Call the base class' stop function when they press the button
     connect(d_stop_button, SIGNAL(pressed(void)), d_parent, SLOT(setStop(void)));
+    //Updated the button state regardless of who changed it
+    connect(
+        d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
+    //Update the button if someone else changes it
     connect(
         this, SIGNAL(signalToggleStopButton(void)), d_stop_button, SLOT(toggle(void)));
 }
@@ -266,3 +272,14 @@ void FreqControlPanel::toggleTriggerMode(gr::qtgui::trigger_mode mode)
 }
 
 void FreqControlPanel::toggleStopButton() { emit signalToggleStopButton(); }
+
+void FreqControlPanel::updateStopLabel(bool on) {
+    if( on) {
+    d_stop_button->setText("Start");
+    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaPlay) );
+    }
+    else {
+    d_stop_button->setText("Stop");
+    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaStop) );
+    }
+}

--- a/gr-qtgui/lib/timecontrolpanel.cc
+++ b/gr-qtgui/lib/timecontrolpanel.cc
@@ -88,7 +88,8 @@ TimeControlPanel::TimeControlPanel(TimeDisplayForm* form) : QVBoxLayout(), d_par
     d_extras_box = new QGroupBox("Extras");
     d_extras_layout = new QVBoxLayout;
     d_autoscale_button = new QPushButton("Autoscale");
-    d_stop_button = new QPushButton(QApplication::style()->standardIcon(QStyle::SP_MediaStop),"Stop");
+    d_stop_button = new QPushButton(
+        QApplication::style()->standardIcon(QStyle::SP_MediaStop), "Stop");
     d_stop_button->setCheckable(true);
 
     // Set up the boxes into the layout
@@ -158,11 +159,10 @@ TimeControlPanel::TimeControlPanel(TimeDisplayForm* form) : QVBoxLayout(), d_par
         d_autoscale_button, SIGNAL(pressed(void)), d_parent, SLOT(autoScaleShot(void)));
 
     // Handle the start/stop button
-    //Call the base class' stop function when they press the button
+    // Call the base class' stop function when they press the button
     connect(d_stop_button, SIGNAL(pressed(void)), d_parent, SLOT(setStop(void)));
-    //Updated the button state regardless of who changed it
-    connect(
-        d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
+    // Updated the button state regardless of who changed it
+    connect(d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
     connect(
         this, SIGNAL(signalToggleStopButton(void)), d_stop_button, SLOT(toggle(void)));
 }
@@ -195,14 +195,13 @@ void TimeControlPanel::toggleTriggerSlope(gr::qtgui::trigger_slope slope)
 
 void TimeControlPanel::toggleStopButton() { emit signalToggleStopButton(); }
 
-void TimeControlPanel::updateStopLabel(bool on) {
-    if( on) {
-    d_stop_button->setText("Start");
-    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaPlay) );
-    }
-    else {
-    d_stop_button->setText("Stop");
-    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaStop) );
+void TimeControlPanel::updateStopLabel(bool on)
+{
+    if (on) {
+        d_stop_button->setText("Start");
+        d_stop_button->setIcon(QApplication::style()->standardIcon(QStyle::SP_MediaPlay));
+    } else {
+        d_stop_button->setText("Stop");
+        d_stop_button->setIcon(QApplication::style()->standardIcon(QStyle::SP_MediaStop));
     }
 }
-

--- a/gr-qtgui/lib/timecontrolpanel.cc
+++ b/gr-qtgui/lib/timecontrolpanel.cc
@@ -88,7 +88,7 @@ TimeControlPanel::TimeControlPanel(TimeDisplayForm* form) : QVBoxLayout(), d_par
     d_extras_box = new QGroupBox("Extras");
     d_extras_layout = new QVBoxLayout;
     d_autoscale_button = new QPushButton("Autoscale");
-    d_stop_button = new QPushButton("Stop");
+    d_stop_button = new QPushButton(QApplication::style()->standardIcon(QStyle::SP_MediaStop),"Stop");
     d_stop_button->setCheckable(true);
 
     // Set up the boxes into the layout
@@ -156,7 +156,13 @@ TimeControlPanel::TimeControlPanel(TimeDisplayForm* form) : QVBoxLayout(), d_par
 
     connect(
         d_autoscale_button, SIGNAL(pressed(void)), d_parent, SLOT(autoScaleShot(void)));
+
+    // Handle the start/stop button
+    //Call the base class' stop function when they press the button
     connect(d_stop_button, SIGNAL(pressed(void)), d_parent, SLOT(setStop(void)));
+    //Updated the button state regardless of who changed it
+    connect(
+        d_stop_button, SIGNAL(toggled(bool)), this, SLOT(updateStopLabel(bool)));
     connect(
         this, SIGNAL(signalToggleStopButton(void)), d_stop_button, SLOT(toggle(void)));
 }
@@ -188,3 +194,15 @@ void TimeControlPanel::toggleTriggerSlope(gr::qtgui::trigger_slope slope)
 }
 
 void TimeControlPanel::toggleStopButton() { emit signalToggleStopButton(); }
+
+void TimeControlPanel::updateStopLabel(bool on) {
+    if( on) {
+    d_stop_button->setText("Start");
+    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaPlay) );
+    }
+    else {
+    d_stop_button->setText("Stop");
+    d_stop_button->setIcon( QApplication::style()->standardIcon(QStyle::SP_MediaStop) );
+    }
+}
+


### PR DESCRIPTION
Makes two changes:
  - First, toggle the label of the 'stop' button depending on the state in
    the same way the context menu does
  - Second, adds a visual 'play' or 'stop' icon based on the action

Signed-off-by: Jason Uher <jason.uher@jhuapl.edu>