### PR TITLE
gr-blocks: remove indexing in file source cpp template

### DIFF
--- a/gr-blocks/grc/blocks_file_source.block.yml
+++ b/gr-blocks/grc/blocks_file_source.block.yml
@@ -60,7 +60,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/file_source.h>']
     declarations: 'blocks::file_source::sptr ${id};'
-    make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, "${file[1:-1]}", ${repeat}, ${offset}, ${length});'
+    make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length});'
     callbacks:
     - open(${file}, ${repeat})
     translations:


### PR DESCRIPTION
`"${file[1:-1]}"` results in the file name becoming `NotImplemented`. This seems to be the only place where such indexing is being tried. Otherwise, `${file}` is used everywhere (file sink etc). This patch makes the code across all such blocks consistent and fixes the `NotImplemented` issue for file source block (when generating C++ output).

However, the original issue, which I believe was being targeted by indexing and double quotes, is still not solved. When simply using `${file}`, the file name is passed to C++ code in single quotes, which results in an error. A solution to that is to enclose the file name in double quotes in the respective GRC block, for example.