### PR TITLE
grc: remove gnuradio prefix from linked libraries

### DIFF
--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -55,7 +55,7 @@ target_link_libraries(${class_name}
     gnuradio::gnuradio-blocks
     % for link in links:
     % if link:
-    ${link.replace("gnuradio-", "gnuradio::gnuradio-")}
+    ${link}
     % endif
     % endfor
 


### PR DESCRIPTION
This allows out-of-tree modules to be linked, as those will not link with the prefix. In-tree modules link still. Or are there some cases where the in-tree modules will not link with this approach?