### PR TITLE
grc: order blocks with GUI Hint first

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -196,11 +196,12 @@ class TopBlockGenerator(object):
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
 
         # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
-        for block in blocks:
+        def without_gui_hint(block):
             hint = block.params.get('gui_hint')
-            block.without_gui_hint = not hint # (hint == None) or (not hint.get_value())
+            Messages.send('>>> name =: {} without_gui_hint={} hint={}\n'.format(block.name, hint,type(hint)))
+            return hint is None or not hint.get_value()
 
-        blocks = sorted(blocks, key=lambda block: block.without_gui_hint)
+        blocks.sort(key=without_gui_hint)
 
         blocks_make = []
         for block in blocks:

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -198,7 +198,6 @@ class TopBlockGenerator(object):
         # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
         def without_gui_hint(block):
             hint = block.params.get('gui_hint')
-            Messages.send('>>> name =: {} without_gui_hint={} hint={}\n'.format(block.name, hint,type(hint)))
             return hint is None or not hint.get_value()
 
         blocks.sort(key=without_gui_hint)

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -194,6 +194,17 @@ class TopBlockGenerator(object):
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
+
+        # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
+        for block in blocks:
+            try:
+                block.without_gui_hint = (block.params['gui_hint'].get_value()=='')
+            except KeyError:
+                # No gui hint
+                block.without_gui_hint = True
+                pass
+        blocks = sorted(blocks, key=lambda block: block.without_gui_hint)
+
         blocks_make = []
         for block in blocks:
             make = block.templates.render('make')
@@ -307,7 +318,7 @@ class TopBlockGenerator(object):
                 porta = con.source_port
                 portb = con.sink_port
                 fg = self._flow_graph
-                             
+
                 if porta.dtype == 'bus' and portb.dtype == 'bus':
                     # which bus port is this relative to the bus structure
                     if len(porta.bus_structure) == len(portb.bus_structure):
@@ -318,8 +329,8 @@ class TopBlockGenerator(object):
                                 parent=self, source=hidden_porta, sink=hidden_portb)
                             code = template.render(make_port_sig=make_port_sig, source=hidden_porta, sink=hidden_portb)
                             rendered.append(code)
-                            
 
-            
+
+
 
         return rendered

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -197,12 +197,9 @@ class TopBlockGenerator(object):
 
         # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
         for block in blocks:
-            try:
-                block.without_gui_hint = (block.params['gui_hint'].get_value()=='')
-            except KeyError:
-                # No gui hint
-                block.without_gui_hint = True
-                pass
+            hint = block.params.get('gui_hint')
+            block.without_gui_hint = not hint # (hint == None) or (not hint.get_value())
+
         blocks = sorted(blocks, key=lambda block: block.without_gui_hint)
 
         blocks_make = []


### PR DESCRIPTION
Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>

This PR add ordering of block in a flowgraph before the .py code is generated.
This prevent PyQT5 from superposing blocks as explained in issue #3371, by simpling drawing first those blocks having a GUI Hint.