### PR TITLE
grc: order blocks with GUI Hint first

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -196,6 +196,18 @@ class TopBlockGenerator(object):
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
+
+        # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
+        for block in blocks:
+            try:
+                block.without_gui_hint = (block.params['gui_hint'].get_value()=='')
+            except KeyError:
+                # No gui hint
+                block.without_gui_hint = True
+                pass
+
+        blocks = sorted(blocks, key=lambda block: block.without_gui_hint)
+
         blocks_make = []
         for block in blocks:
             make = block.templates.render('make')

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -199,12 +199,8 @@ class TopBlockGenerator(object):
 
         # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
         for block in blocks:
-            try:
-                block.without_gui_hint = (block.params['gui_hint'].get_value()=='')
-            except KeyError:
-                # No gui hint
-                block.without_gui_hint = True
-                pass
+            hint = block.params.get('gui_hint')
+            block.without_gui_hint = (hint == None) or (not hint.get_value())
 
         blocks = sorted(blocks, key=lambda block: block.without_gui_hint)
 


### PR DESCRIPTION
Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>

This PR add ordering of block in a flowgraph before the .py code is generated. 
This prevent PyQT5 from superposing blocks as explained in issue #3371, by simpling drawing first those blocks having a GUI Hint.
