### PR TITLE
cmake: Fix Boost unit test framework component availability variable

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -75,7 +75,7 @@ jobs:
     - name: CMake
       env:
         CXXFLAGS: ${{ matrix.cxxflags }}
-      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF -DBoost_unit_test_framework_FOUND=ON'
+      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
     - name: Make
       run: 'cd /build && make -j2 -k'
     - name: Make Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2011-2020 Free Software Foundation, Inc.
+# Copyright 2011-2021 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -47,7 +47,7 @@ include(GrComponent)
 ########################################################################
 include(GrBoost)
 GR_REGISTER_COMPONENT("testing-support" ENABLE_TESTING
-         Boost_unit_test_framework_FOUND )
+         Boost_UNIT_TEST_FRAMEWORK_FOUND )
 
 # Set the version information here
 SET(VERSION_MAJOR 3)


### PR DESCRIPTION
This fix enables back 'testing-support' component which has been
disabled by a regression introduced on a3061b8f.

Signed-off-by: Vasilis Tsiligiannis <acinonyx@openwrt.gr>