### PR TITLE
numpy: Fix fftpack references (backport maint-3.8)

### DIFF
--- a/gr-digital/examples/example_timing.py
+++ b/gr-digital/examples/example_timing.py
@@ -39,8 +39,6 @@ except ImportError:
     print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
-from numpy.fft import fftpack
-
 class example_timing(gr.top_block):
     def __init__(self, N, sps, rolloff, ntaps, bw, noise,
                  foffset, toffset, poffset, mode=0):
@@ -194,7 +192,7 @@ def main():
         s32.set_title("FFT of Differential Filters")
 
         for i,d in enumerate(diff_taps):
-            D = 20.0*numpy.log10(1e-20+abs(numpy.fft.fftshift(fftpack.fft(d, 10000))))
+            D = 20.0*numpy.log10(1e-20+abs(numpy.fft.fftshift(numpy.fft.fft(d, 10000))))
             s31.plot(t[i::nfilts].real, d, "-o")
             s32.plot(D)
         s32.set_ylim([-120, 10])
@@ -241,4 +239,3 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         pass
-

--- a/gr-dtv/examples/atsc_ctrlport_monitor.py
+++ b/gr-dtv/examples/atsc_ctrlport_monitor.py
@@ -31,7 +31,6 @@ from gnuradio.ctrlport.GNURadioControlPortClient import (
     GNURadioControlPortClient, TTransportException,
 )
 import numpy
-from numpy.fft import fftpack
 
 """
 If a host is running the ATSC receiver chain with ControlPort
@@ -120,7 +119,7 @@ class atsc_ctrlport_monitor(object):
 
         fs = 6.25e6
         freq = numpy.linspace(-fs / 2, fs / 2, 10000)
-        H = numpy.fft.fftshift(fftpack.fft(eqdata.value, 10000))
+        H = numpy.fft.fftshift(numpy.fft.fft(eqdata.value, 10000))
         HdB = 20.0*numpy.log10(abs(H))
         psd.set_ydata(HdB)
         psd.set_xdata(freq)

--- a/gr-utils/python/utils/plot_fft_base.py
+++ b/gr-utils/python/utils/plot_fft_base.py
@@ -25,7 +25,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import numpy
-from numpy.fft import fftpack
 
 try:
     from pylab import Button, connect, draw, figure, figtext, get_current_fig_manager, show, rcParams, ceil
@@ -100,7 +99,7 @@ class plot_fft_base(object):
 
     def dofft(self, iq):
         N = len(iq)
-        iq_fft = numpy.fft.fftshift(fftpack.fft(iq))       # fft and shift axis
+        iq_fft = numpy.fft.fftshift(numpy.fft.fft(iq))       # fft and shift axis
         iq_fft = 20*numpy.log10(abs((iq_fft+1e-15) / N)) # convert to decibels, adjust power
         # adding 1e-15 (-300 dB) to protect against value errors if an item in iq_fft is 0
         return iq_fft


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/4245 to maint-3.8.