### PR TITLE
gr-blocks: Fix control loop set_frequency() bounds check. (backport maint-3.8)

### DIFF
--- a/gr-blocks/lib/control_loop.cc
+++ b/gr-blocks/lib/control_loop.cc
@@ -117,9 +117,9 @@ void control_loop::set_beta(float beta)
 void control_loop::set_frequency(float freq)
 {
     if (freq > d_max_freq)
-        d_freq = d_min_freq;
-    else if (freq < d_min_freq)
         d_freq = d_max_freq;
+    else if (freq < d_min_freq)
+        d_freq = d_min_freq;
     else
         d_freq = freq;
 }


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/4212 to maint-3.8.

Signed-off-by: David Pi <david.pinho@gmail.com>
(cherry picked from commit 369cec2383df5f4d18c0be8bd26ed7ad553ada0a)
Signed-off-by: Jeff Long <willcode4@gmail.com>