### PR TITLE
GR-UHD: Support for stream_mode_t 

### DIFF
--- a/gr-uhd/python/uhd/bindings/uhd_types_python.cc
+++ b/gr-uhd/python/uhd/bindings/uhd_types_python.cc
@@ -95,9 +95,22 @@ void bind_uhd_types(py::module& m)
     py::class_<stream_cmd_t>(m, "stream_cmd_t")
         .def(py::init<stream_cmd_t::stream_mode_t>())
         // Properties
+        .def_readwrite("stream_mode", &stream_cmd_t::stream_mode)
         .def_readwrite("num_samps", &stream_cmd_t::num_samps)
         .def_readwrite("time_spec", &stream_cmd_t::time_spec)
         .def_readwrite("stream_now", &stream_cmd_t::stream_now);
+
+    // ::uhd::stream_cmd_t::stream_mode_t
+    py::enum_<stream_cmd_t::stream_mode_t>(m, "stream_mode_t")
+        .value("STREAM_MODE_START_CONTINUOUS",
+               stream_cmd_t::stream_mode_t::STREAM_MODE_START_CONTINUOUS)
+        .value("STREAM_MODE_STOP_CONTINUOUS",
+               stream_cmd_t::stream_mode_t::STREAM_MODE_STOP_CONTINUOUS)
+        .value("STREAM_MODE_NUM_SAMPS_AND_DONE",
+               stream_cmd_t::stream_mode_t::STREAM_MODE_NUM_SAMPS_AND_DONE)
+        .value("STREAM_MODE_NUM_SAMPS_AND_MORE",
+               stream_cmd_t::stream_mode_t::STREAM_MODE_NUM_SAMPS_AND_MORE)
+        .export_values();
 
     // ::uhd::meta_range_t
     using meta_range_t = ::uhd::meta_range_t;


### PR DESCRIPTION
Add support for stream_mode_t, partially fixing #4177.

This may be invoked within python using something along the lines of;

```
cmd = uhd.stream_cmd_t(uhd.stream_mode_t.STREAM_MODE_NUM_SAMPS_AND_DONE)
cmd.num_samps = frame[1]
cmd.stream_now = False
cmd.time_spec = uhd.time_spec(frame[0])
csrc.issue_stream_cmd(cmd)
```

This behaviour is slightly different than what was in place with previous (swig) versions of gnuradio. When using pybind, the result we replace old instances of  "uhd.stream_cmd_t" with "uhd.stream_mode_t".

This has been tested on hardware.

Still pending a fix for "tune_request_t::policy_t".