### PR TITLE
gr-blocks: remove indexing in file source cpp template (backport to maint-3.9)

### DIFF
--- a/gr-blocks/grc/blocks_file_source.block.yml
+++ b/gr-blocks/grc/blocks_file_source.block.yml
@@ -60,7 +60,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/file_source.h>']
     declarations: 'blocks::file_source::sptr ${id};'
-    make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, "${file[1:-1]}", ${repeat}, ${offset}, ${length});'
+    make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length});'
     callbacks:
     - open(${file}, ${repeat})
     translations:


### PR DESCRIPTION
file[1:-1] results in file name becoming NotImplemented

Signed-off-by: karel <5636152+karel@users.noreply.github.com>
(cherry picked from commit f3b05ac8e79c20908685f283835f6a2728940b62)
Signed-off-by: Jeff Long <willcode4@gmail.com>