### PR TITLE
numpy: Fix fftpack references (backport to maint-3.9)

### DIFF
--- a/gr-digital/examples/example_timing.py
+++ b/gr-digital/examples/example_timing.py
@@ -24,8 +24,6 @@ except ImportError:
     print("Error: could not from matplotlib import pyplot (http://matplotlib.sourceforge.net/)")
     sys.exit(1)
 
-from numpy.fft import fftpack
-
 class example_timing(gr.top_block):
     def __init__(self, N, sps, rolloff, ntaps, bw, noise,
                  foffset, toffset, poffset, mode=0):
@@ -179,7 +177,7 @@ def main():
         s32.set_title("FFT of Differential Filters")
 
         for i,d in enumerate(diff_taps):
-            D = 20.0*numpy.log10(1e-20+abs(numpy.fft.fftshift(fftpack.fft(d, 10000))))
+            D = 20.0*numpy.log10(1e-20+abs(numpy.fft.fftshift(numpy.fft.fft(d, 10000))))
             s31.plot(t[i::nfilts].real, d, "-o")
             s32.plot(D)
         s32.set_ylim([-120, 10])
@@ -226,4 +224,3 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         pass
-

--- a/gr-dtv/examples/atsc_ctrlport_monitor.py
+++ b/gr-dtv/examples/atsc_ctrlport_monitor.py
@@ -15,7 +15,6 @@ from gnuradio.ctrlport.GNURadioControlPortClient import (
     GNURadioControlPortClient, TTransportException,
 )
 import numpy
-from numpy.fft import fftpack
 
 """
 If a host is running the ATSC receiver chain with ControlPort
@@ -104,7 +103,7 @@ class atsc_ctrlport_monitor(object):
 
         fs = 6.25e6
         freq = numpy.linspace(-fs / 2, fs / 2, 10000)
-        H = numpy.fft.fftshift(fftpack.fft(eqdata.value, 10000))
+        H = numpy.fft.fftshift(numpy.fft.fft(eqdata.value, 10000))
         HdB = 20.0*numpy.log10(abs(H))
         psd.set_ydata(HdB)
         psd.set_xdata(freq)

--- a/gr-utils/plot_tools/plot_fft_base.py
+++ b/gr-utils/plot_tools/plot_fft_base.py
@@ -10,7 +10,6 @@
 
 
 import numpy
-from numpy.fft import fftpack
 
 try:
     from pylab import Button, connect, draw, figure, figtext, get_current_fig_manager, show, rcParams, ceil
@@ -85,7 +84,7 @@ class plot_fft_base(object):
 
     def dofft(self, iq):
         N = len(iq)
-        iq_fft = numpy.fft.fftshift(fftpack.fft(iq))       # fft and shift axis
+        iq_fft = numpy.fft.fftshift(numpy.fft.fft(iq))       # fft and shift axis
         iq_fft = 20*numpy.log10(abs((iq_fft+1e-15) / N)) # convert to decibels, adjust power
         # adding 1e-15 (-300 dB) to protect against value errors if an item in iq_fft is 0
         return iq_fft


### PR DESCRIPTION
Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>
(cherry picked from commit 80d96134f29bd90eaa9df62989365d095bbfc302)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4245.