### PR TITLE
zeromq: Fix warnings with recv() (backport to maint-3.9)

### DIFF
--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -59,10 +59,15 @@ int rep_sink_impl::work(int noutput_items,
         /* Get and parse the request */
         zmq::message_t request;
 #if USE_NEW_CPPZMQ_SEND_RECV
-        d_socket.recv(request);
+        bool ok = bool(d_socket.recv(request));
 #else
-        d_socket.recv(&request);
+        bool ok = d_socket.recv(&request);
 #endif
+        if (!ok) {
+            // Should not happen, we've checked POLLIN.
+            GR_LOG_ERROR(d_logger, "Failed to receive message.");
+            break;
+        }
 
         int nitems_send = noutput_items - done;
         if (request.size() >= sizeof(uint32_t)) {

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -15,9 +15,10 @@
 #include "sub_msg_source_impl.h"
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/thread/thread.hpp>
+#include <boost/bind.hpp>
+#include <chrono>
 #include <memory>
+#include <thread>
 
 namespace gr {
 namespace zeromq {
@@ -73,6 +74,7 @@ bool sub_msg_source_impl::stop()
 
 void sub_msg_source_impl::readloop()
 {
+    using namespace std::chrono_literals;
     while (!d_finished) {
 
         zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
@@ -84,10 +86,17 @@ void sub_msg_source_impl::readloop()
             // Receive data
             zmq::message_t msg;
 #if USE_NEW_CPPZMQ_SEND_RECV
-            d_socket.recv(msg);
+            const bool ok = bool(d_socket.recv(msg));
 #else
-            d_socket.recv(&msg);
+            const bool ok = d_socket.recv(&msg);
 #endif
+            if (!ok) {
+                // Should not happen, we've checked POLLIN.
+                GR_LOG_ERROR(d_logger, "Failed to receive message.");
+                std::this_thread::sleep_for(100ms);
+                continue;
+            }
+
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
             try {
@@ -97,7 +106,7 @@ void sub_msg_source_impl::readloop()
                 GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
             }
         } else {
-            boost::this_thread::sleep(boost::posix_time::microseconds(100));
+            std::this_thread::sleep_for(100ms);
         }
     }
 }

--- a/gr-zeromq/python/zeromq/qa_zeromq_pull_msg_source.py
+++ b/gr-zeromq/python/zeromq/qa_zeromq_pull_msg_source.py
@@ -48,15 +48,16 @@ class qa_zeromq_pull_msg_source(gr_unittest.TestCase):
         """Test receiving of valid PMT messages"""
         msg = pmt.to_pmt('test_valid_pmt')
         self.zmq_sock.send(pmt.serialize_str(msg))
-
-        time.sleep(0.1)
+        for _ in range(10):
+            if self.message_debug.num_messages() > 0:
+                break
+            time.sleep(0.2)
         self.assertEqual(1, self.message_debug.num_messages())
         self.assertTrue(pmt.equal(msg, self.message_debug.get_message(0)))
 
     def test_invalid_pmt(self):
         """Test receiving of invalid PMT messages"""
         self.zmq_sock.send_string('test_invalid_pmt')
-
         time.sleep(0.1)
         self.assertEqual(0, self.message_debug.num_messages())
 


### PR DESCRIPTION
The recv() call on a ZMQ socket produces a warning if the return value
is not stored. We follow the advice and check the return value, just in
case.

Signed-off-by: Martin Braun <martin.braun@ettus.com>
(cherry picked from commit ec3d116546aa9710b324b1713cea058d80c906a8)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4215