### PR TITLE
gnuradio-runtime: configurable buffer size (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/gnuradio-runtime.conf.in
+++ b/gnuradio-runtime/gnuradio-runtime.conf.in
@@ -9,6 +9,8 @@ verbose = False
 # the queue by popping messages from the front.
 max_messages = 8192
 
+# Block output buffer size in bytes.
+#buffer_size = 32768
 
 [LOG]
 # Levels can be (case insensitive):

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -27,7 +27,8 @@ namespace gr {
 // 32Kbyte buffer size between blocks
 #define GR_FIXED_BUFFER_SIZE (32 * (1L << 10))
 
-static const unsigned int s_fixed_buffer_size = GR_FIXED_BUFFER_SIZE;
+static const unsigned int s_fixed_buffer_size =
+    prefs::singleton()->get_long("DEFAULT", "buffer_size", GR_FIXED_BUFFER_SIZE);
 
 flat_flowgraph_sptr make_flat_flowgraph()
 {


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/4244.

Low risk and could be useful.