### PR TITLE
grc: add tests/resources/top_block.py to .gitignore

### DIFF
--- a/grc/tests/.gitignore
+++ b/grc/tests/.gitignore
@@ -1,1 +1,2 @@
 .pytest_cache
+resources/top_block.py


### PR DESCRIPTION
When `make test` is run from the build dir, `grc/tests/resources/top_block.py` is created in tree. 