### PR TITLE
block_executor: invalid states log errors without debug build (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -19,11 +19,8 @@
 #include <gnuradio/prefs.h>
 #include <assert.h>
 #include <block_executor.h>
-#include <stdio.h>
-#include <boost/format.hpp>
-#include <boost/thread.hpp>
-#include <iostream>
 #include <limits>
+#include <sstream>
 
 namespace gr {
 
@@ -246,7 +243,7 @@ block_executor::state block_executor::run_one_iteration()
     max_noutput_items = round_down(d_max_noutput_items, m->output_multiple());
 
     if (d->done()) {
-        assert(0);
+        GR_LOG_ERROR(d_logger, "unexpected done() in run_one_iteration");
         return DONE;
     }
 
@@ -565,7 +562,7 @@ block_executor::state block_executor::run_one_iteration()
         // Have the caller try again...
         return READY_NO_OUTPUT;
     }
-    assert(0);
+    GR_LOG_ERROR(d_logger, "invalid state while going through iteration state machine");
 
 were_done:
     LOG(GR_LOG_INFO(d_debug_logger, "we're done"););


### PR DESCRIPTION
Clean up includes on the way.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit cedc95ad7d7aa983b2047650c3eebdf4eedda043)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4254
Minor merge conflict on include files.