### PR TITLE
pmt: stop treating all pairs like they are dicts (backport to maint-3.8)

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -654,8 +654,12 @@ c64vector_writable_elements(pmt_t v, size_t& len); //< len is in elements
  * ------------------------------------------------------------------------
  */
 
-//! Return true if \p obj is a dictionary (warning: also returns true for a pair)
+//! Return true if \p obj is a dictionary
 PMT_API bool is_dict(const pmt_t& obj);
+
+//! Return a newly allocated dict whose car is a key-value pair \p x and whose cdr is a
+//! dict \p y.
+PMT_API pmt_t dcons(const pmt_t& x, const pmt_t& y);
 
 //! Make an empty dictionary
 PMT_API pmt_t make_dict();
@@ -725,6 +729,14 @@ PMT_API boost::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt
  *			  General functions
  * ------------------------------------------------------------------------
  */
+
+/*!
+ * Returns true if the object is a PDU meaning:
+ *   the object is a pair
+ *   the car is a dictionary type object (including an empty dict)
+ *   the cdr is a uniform vector of any type
+ */
+PMT_API bool is_pdu(const pmt_t& obj);
 
 //! Return true if x and y are the same object; otherwise return false.
 PMT_API bool eq(const pmt_t& x, const pmt_t& y);
@@ -813,7 +825,7 @@ PMT_API pmt_t reverse_x(pmt_t list);
 /*!
  * \brief (acons x y a) == (cons (cons x y) a)
  */
-inline static pmt_t acons(pmt_t x, pmt_t y, pmt_t a) { return cons(cons(x, y), a); }
+inline static pmt_t acons(pmt_t x, pmt_t y, pmt_t a) { return dcons(cons(x, y), a); }
 
 /*!
  * \brief locates \p nth element of \n list where the car is the 'zeroth' element.

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -94,6 +94,8 @@ static pmt_any* _any(pmt_t x) { return dynamic_cast<pmt_any*>(x.get()); }
 //                           Globals
 ////////////////////////////////////////////////////////////////////////////
 
+pmt_null::pmt_null() {}
+
 pmt_t get_PMT_NIL()
 {
     static pmt_t _NIL = pmt_t(new pmt_null());
@@ -326,7 +328,6 @@ std::complex<double> to_complex(pmt_t x)
 //                              Pairs
 ////////////////////////////////////////////////////////////////////////////
 
-pmt_null::pmt_null() {}
 pmt_pair::pmt_pair(const pmt_t& car, const pmt_t& cdr) : d_car(car), d_cdr(cdr) {}
 
 bool is_null(const pmt_t& x) { return x == PMT_NIL; }
@@ -670,9 +671,22 @@ void* uniform_vector_writable_elements(pmt_t vector, size_t& len)
  * Chris Okasaki, 1998, section 3.3.
  */
 
-bool is_dict(const pmt_t& obj) { return is_null(obj) || is_pair(obj); }
+pmt_dict::pmt_dict(const pmt_t& car, const pmt_t& cdr) : pmt_pair::pmt_pair(car, cdr) {}
+
+bool is_dict(const pmt_t& obj) { return is_null(obj) || obj->is_dict(); }
 
 pmt_t make_dict() { return PMT_NIL; }
+
+pmt_t dcons(const pmt_t& x, const pmt_t& y)
+{
+    // require arguments to be a PMT pair and PMT dictionary respectively
+    if (!is_pair(x))
+        throw wrong_type("pmt_dcons: not a pair", x);
+    if (!is_dict(y))
+        throw wrong_type("pmt_dcons: not a dict", y);
+
+    return pmt_t(new pmt_dict(x, y));
+}
 
 pmt_t dict_add(const pmt_t& dict, const pmt_t& key, const pmt_t& value)
 {
@@ -705,7 +719,7 @@ pmt_t dict_delete(const pmt_t& dict, const pmt_t& key)
     if (eqv(caar(dict), key))
         return cdr(dict);
 
-    return cons(car(dict), dict_delete(cdr(dict), key));
+    return dcons(car(dict), dict_delete(cdr(dict), key));
 }
 
 pmt_t dict_ref(const pmt_t& dict, const pmt_t& key, const pmt_t& not_found)
@@ -826,6 +840,11 @@ size_t blob_length(pmt_t blob)
 //                          General Functions
 ////////////////////////////////////////////////////////////////////////////
 
+bool is_pdu(const pmt_t& obj)
+{
+    return is_pair(obj) && is_dict(car(obj)) && is_uniform_vector(cdr(obj));
+}
+
 bool eq(const pmt_t& x, const pmt_t& y) { return x == y; }
 
 bool eqv(const pmt_t& x, const pmt_t& y)
@@ -916,6 +935,7 @@ size_t length(const pmt_t& x)
     if (x->is_null())
         return 0;
 
+    // also returns correct result for dictionaries
     if (x->is_pair()) {
         size_t length = 1;
         pmt_t it = cdr(x);
@@ -929,8 +949,6 @@ size_t length(const pmt_t& x)
         // not a proper list
         throw wrong_type("pmt_length", x);
     }
-
-    // FIXME dictionary length (number of entries)
 
     throw wrong_type("pmt_length", x);
 }
@@ -998,9 +1016,16 @@ pmt_t reverse(pmt_t listx)
     pmt_t list = listx;
     pmt_t r = PMT_NIL;
 
-    while (is_pair(list)) {
-        r = cons(car(list), r);
-        list = cdr(list);
+    if (is_dict(listx)) {
+        while (is_pair(list)) {
+            r = dcons(car(list), r);
+            list = cdr(list);
+        }
+    } else {
+        while (is_pair(list)) {
+            r = cons(car(list), r);
+            list = cdr(list);
+        }
     }
     if (is_null(list))
         return r;

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -140,6 +140,15 @@ public:
     void set_cdr(pmt_t cdr) { d_cdr = cdr; }
 };
 
+class pmt_dict : public pmt_pair
+{
+public:
+    pmt_dict(const pmt_t& car, const pmt_t& cdr);
+    //~pmt_dict(){};
+
+    bool is_dict() const { return true; }
+};
+
 class pmt_vector : public pmt_base
 {
     std::vector<pmt_t> d_v;

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -395,7 +395,27 @@ BOOST_AUTO_TEST_CASE(test_dict)
     // std::cout << "pmt::dict_keys:   " << pmt::dict_keys(dict) << std::endl;
     // std::cout << "pmt::dict_values: " << pmt::dict_values(dict) << std::endl;
     BOOST_CHECK(pmt::equal(keys, pmt::dict_keys(dict)));
-    BOOST_CHECK(pmt::equal(vals, pmt::dict_values(dict)));
+
+    dict = pmt::dict_delete(dict, k1);
+    BOOST_CHECK(pmt::eqv(pmt::dict_ref(dict, k0, not_found), v0));
+    BOOST_CHECK(pmt::is_dict(dict));
+    dict = pmt::dict_add(dict, k3, v3);
+    dict = pmt::reverse(dict);
+    BOOST_CHECK(pmt::eqv(pmt::dict_ref(dict, k0, not_found), v0));
+    BOOST_CHECK(pmt::is_dict(dict));
+}
+
+BOOST_AUTO_TEST_CASE(test_pdu)
+{
+    pmt::pmt_t dict = pmt::dict_add(pmt::make_dict(), pmt::mp("k0"), pmt::mp("v0"));
+    pmt::pmt_t vec = pmt::make_u8vector(1, 0);
+    BOOST_CHECK(!pmt::is_pdu(pmt::PMT_T));
+    BOOST_CHECK(!pmt::is_pdu(vec));
+    BOOST_CHECK(!pmt::is_pdu(dict));
+    BOOST_CHECK(!pmt::is_pdu(pmt::cons(dict, pmt::PMT_NIL)));
+    BOOST_CHECK(!pmt::is_pdu(pmt::cons(pmt::PMT_F, vec)));
+    BOOST_CHECK(pmt::is_pdu(pmt::cons(pmt::make_dict(), vec)));
+    BOOST_CHECK(pmt::is_pdu(pmt::cons(dict, vec)));
 }
 
 BOOST_AUTO_TEST_CASE(test_io)

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -167,6 +167,7 @@ class test_pmt(unittest.TestCase):
         d = pmt.dict_add(d, min_key, _min)
         s = pmt.serialize_str(d)
         deser = pmt.deserialize_str(s)
+        self.assertTrue(pmt.is_dict(deser))
         self.assertTrue(pmt.equal(d, deser))
         p_dict = pmt.to_python(deser)
         self.assertEqual(self.MAXINT32, p_dict["MAX"])

--- a/gnuradio-runtime/swig/pmt_swig.i
+++ b/gnuradio-runtime/swig/pmt_swig.i
@@ -256,6 +256,7 @@ namespace pmt{
 
   bool is_dict(const pmt_t &obj);
   pmt_t make_dict();
+  pmt_t dcons(const pmt_t& x, const pmt_t& y);
   pmt_t dict_add(const pmt_t &dict, const pmt_t &key, const pmt_t &value);
   pmt_t dict_delete(const pmt_t &dict, const pmt_t &key);
   bool  dict_has_key(const pmt_t &dict, const pmt_t &key);
@@ -274,6 +275,7 @@ namespace pmt{
   pmt_t make_msg_accepter(boost::shared_ptr<gr::messages::msg_accepter> ma);
   boost::shared_ptr<gr::messages::msg_accepter> msg_accepter_ref(const pmt_t &obj);
 
+  bool is_pdu(const pmt_t& obj);
   bool eq(const pmt_t& x, const pmt_t& y);
   bool eqv(const pmt_t& x, const pmt_t& y);
   bool equal(const pmt_t& x, const pmt_t& y);


### PR DESCRIPTION
create a new derived class for pmt dicts so they can be distinguished without complicated try/catch logic, updated QA with a few additional checks. also added an is_pdu() method which returns true if the pmt is a pair of a dict-type PMT and a uniform-vector type, otherwise false

(cherry picked from commit 941c6c895a5724c142cfb0a32220885062373d57)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3389