### PR TITLE
gr_filter : fix variable filter taps blocks

### DIFF
--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -44,6 +44,8 @@ templates:
     var_make: |-
         self.${id} = ${id} = firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, \
         ${high_cutoff_freq}, ${width}, ${win}, ${beta})
+    callbacks:
+    - self.set_${id}(firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq}, ${width}, ${win}, ${beta}))
 
 cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -44,6 +44,8 @@ templates:
     var_make: |-
         self.${id} = ${id} = firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq},\
         ${high_cutoff_freq}, ${width}, ${win}, ${beta})
+    callbacks:
+    - self.set_${id}(firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq}, ${width}, ${win}, ${beta}))
 
 cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -35,6 +35,8 @@ templates:
     var_make: |-
         self.${id} = ${id} = firdes.high_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
         ${width}, ${win}, ${beta})
+    callbacks:
+    - self.set_${id}(firdes.high_pass(${gain}, ${samp_rate}, ${cutoff_freq}, ${width}, ${win}, ${beta}))
 
 cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -35,6 +35,8 @@ templates:
     var_make: |-
         self.${id} = ${id} = firdes.low_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
         ${width}, ${win}, ${beta})
+    callbacks:
+    - self.set_${id}(firdes.low_pass(${gain}, ${samp_rate}, ${cutoff_freq}, ${width}, ${win}, ${beta}))
 
 cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']

--- a/gr-filter/grc/variable_rrc_filter_taps.block.yml
+++ b/gr-filter/grc/variable_rrc_filter_taps.block.yml
@@ -29,6 +29,8 @@ templates:
     var_make: |-
         self.${id} = ${id} = firdes.root_raised_cosine(${gain}, ${samp_rate},\
         ${sym_rate}, ${alpha}, ${ntaps})
+    callbacks:
+    - self.set_${id}(firdes.root_raised_cosine(${gain}, ${samp_rate}, ${sym_rate}, ${alpha}, ${ntaps}))
 
 cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']


### PR DESCRIPTION
Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>

This partly fix an issue reported in [discuss gnuradio](https://lists.gnu.org/archive/html/discuss-gnuradio/2021-03/msg00008.html) and in #4317
It appears that the following variable taps blocks do not had callbacks : 
- /gnuradio/gr-filter/grc/variable_band_pass_filter_taps.block.yml
- /gnuradio/gr-filter/grc/variable_band_reject_filter_taps.block.yml
- /gnuradio/gr-filter/grc/variable_high_pass_filter_taps.block.yml
- /gnuradio/gr-filter/grc/variable_low_pass_filter_taps.block.yml
- /gnuradio/gr-filter/grc/variable_rrc_filter_taps.block.yml 

The fix has been tested under GR 3.8.2 and 3.9 using flowgraph 
[filter_taps_test.grc.txt](https://github.com/gnuradio/gnuradio/files/6100586/filter_taps_test.grc.txt). 

However, as I don't know what are cpp_templates callbacks , when they are used/needed ... I did not add any cpp_template callbacks. May be this need more work ?

All this can be backported to maint-3.9 and 3.8 excepted in one case described below

**Attention when backporting to 3.8** 
	${type} variable is used in band_pass and band_reject filters in master branch but
	${type} was introduced for band_pass in maint-3.8
	${type} was introduced for band_reject in maint-3.9

So when backporting to 3.8 replace  `${type}` by `band_reject` FOR band_reject filter NOT FOR band_pass
maint-3.8 call back for variable_band_reject_filter_taps.block.yml
   ` - self.set_${id}(firdes.band_reject(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq}, ${width}, ${win}, ${beta}))`
maint-3.9 and master  call back for variable_band_reject_filter_taps.block.yml
  `  - self.set_${id}(firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq}, ${width}, ${win}, ${beta}))`


