### PR TITLE
gui : fix block can move outside top and left boundary

### DIFF
--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -137,7 +137,7 @@ def make_screenshot(flow_graph, file_path, transparent_bg=False):
 
 def scale(coor, reverse=False):
     factor = Constants.DPI_SCALING if not reverse else 1 / Constants.DPI_SCALING
-    return tuple(int(max(0,x) * factor) for x in coor)
+    return tuple(int(x * factor) for x in coor)
 
 
 def scale_scalar(coor, reverse=False):

--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -137,7 +137,7 @@ def make_screenshot(flow_graph, file_path, transparent_bg=False):
 
 def scale(coor, reverse=False):
     factor = Constants.DPI_SCALING if not reverse else 1 / Constants.DPI_SCALING
-    return tuple(int(x * factor) for x in coor)
+    return tuple(int(max(0,x) * factor) for x in coor)
 
 
 def scale_scalar(coor, reverse=False):

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -362,7 +362,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
         delta_coordinate = (max(delta_coordinate[0],-min_x), max(delta_coordinate[1], -min_y))
 
         # Move selected blocks     
-        for selected_block in self.selected_blocks():
+        for selected_block in blocks:
             selected_block.move(delta_coordinate)
             self.element_moved = True
 

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -347,6 +347,21 @@ class FlowGraph(CoreFlowgraph, Drawable):
         Args:
             delta_coordinate: the change in coordinates
         """
+
+        # Determine selected blocks top left coordinate
+        blocks = list(self.selected_blocks())
+        if not any(blocks):
+            return False
+
+        min_x, min_y  = self.selected_block.coordinate
+        for selected_block in blocks:
+            x, y = selected_block.coordinate
+            min_x, min_y = min(min_x, x), min(min_y, y)
+
+        # Sanitize delta_coordinate so that blocks don't move to negative coordinate
+        delta_coordinate = (max(delta_coordinate[0],-min_x), max(delta_coordinate[1], -min_y))
+
+        # Move selected blocks     
         for selected_block in self.selected_blocks():
             selected_block.move(delta_coordinate)
             self.element_moved = True

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -351,7 +351,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
         # Determine selected blocks top left coordinate
         blocks = list(self.selected_blocks())
         if not blocks:
-            return False
+            return
 
         min_x, min_y  = self.selected_block.coordinate
         for selected_block in blocks:

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -359,7 +359,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
             min_x, min_y = min(min_x, x), min(min_y, y)
 
         # Sanitize delta_coordinate so that blocks don't move to negative coordinate
-        delta_coordinate = (max(delta_coordinate[0],-min_x), max(delta_coordinate[1], -min_y))
+        delta_coordinate = max(delta_coordinate[0],-min_x), max(delta_coordinate[1], -min_y)
 
         # Move selected blocks     
         for selected_block in blocks:

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -350,7 +350,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
 
         # Determine selected blocks top left coordinate
         blocks = list(self.selected_blocks())
-        if not any(blocks):
+        if not blocks:
             return False
 
         min_x, min_y  = self.selected_block.coordinate


### PR DESCRIPTION
Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>

This fixes #4178 
Tested on GR 3.8.2 
If ever a block have been saved with negative coordinate, coordinates are sanitized when opening the flowgraph
This can be backported to maint-3.8 and maint 3.9 
As compared to Derek proposal, the coordinate sanitizing is made inside `scale(coor, reverse=False):` method which is only called in https://github.com/gnuradio/gnuradio/blob/master/grc/gui/canvas/block.py#L61
