### PR TITLE
Fix for #3678

### DIFF
--- a/gr-digital/lib/timing_error_detector.cc
+++ b/gr-digital/lib/timing_error_detector.cc
@@ -311,8 +311,8 @@ float ted_generalized_msk::compute_error_cf()
 {
     gr_complex u;
 
-    u = (d_input[0] * d_input[0] * conj(d_input[2] * d_input[2])) -
-        (d_input[1] * d_input[1] * conj(d_input[3] * d_input[3]));
+    u = (d_input[1] * d_input[1] * conj(d_input[5] * d_input[5])) -
+        (d_input[3] * d_input[3] * conj(d_input[7] * d_input[7]));
 
     return gr::branchless_clip(u.real(), 3.0f);
 }
@@ -321,8 +321,8 @@ float ted_generalized_msk::compute_error_ff()
 {
     float u;
 
-    u = (d_input[0].real() * d_input[0].real() * d_input[2].real() * d_input[2].real()) -
-        (d_input[1].real() * d_input[1].real() * d_input[3].real() * d_input[3].real());
+    u = (d_input[1].real() * d_input[1].real() * d_input[5].real() * d_input[5].real()) -
+        (d_input[3].real() * d_input[3].real() * d_input[7].real() * d_input[7].real());
 
     return gr::branchless_clip(u, 3.0f);
 }

--- a/gr-digital/lib/timing_error_detector.h
+++ b/gr-digital/lib/timing_error_detector.h
@@ -379,7 +379,7 @@ public:
      */
     ted_generalized_msk()
         : timing_error_detector(
-              TED_DANDREA_AND_MENGALI_GEN_MSK, 2, 4, false, false, constellation_sptr())
+              TED_DANDREA_AND_MENGALI_GEN_MSK, 4, 8, false, false, constellation_sptr())
     {
     }
     ~ted_generalized_msk() override{};


### PR DESCRIPTION
This fixes #3678 (MSK timing error detector) for the "MSK Gen TED". The fix can be cherry-picked onto maint-3.8 and maint-3.9 as it is not an API change.

It does not change the "GMSK TED", which should be deprecated as it is redundant and does not work for its intended application, confusing users.