### PR TITLE
cmake: Format numpy include path in CMake style for consistency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,9 @@ execute_process(
     COMMAND "${PYTHON_EXECUTABLE}" -c
     "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
     OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR)
+# format path in CMake-style for consistency with other path variables
+# (a consistent style helps conda builds by using the same path separators)
+file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_DIR)
 
 include(GrComponent)
 GR_REGISTER_COMPONENT("python-support" ENABLE_PYTHON

--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -124,6 +124,9 @@ execute_process(
     COMMAND "${PYTHON_EXECUTABLE}" -c
     "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
     OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR)
+# format path in CMake-style for consistency with other path variables
+# (a consistent style helps conda builds by using the same path separators)
+file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_DIR)
 
 ########################################################################
 # Setup doxygen option


### PR DESCRIPTION
GNU Radio builds done with conda do path subsitution to replace the build prefix with the installed prefix, but it struggles when multiple path separator styles are used in the same file. This makes it so that all of the paths that would be subsitituted use the same style (forward slash separators) so that build prefix replacement happens correctly.

Using this in conda-forge now after https://github.com/conda-forge/gnuradio-feedstock/pull/45. The fix allowed us to get OOTs (in this case, gr-satellites) compiling against GR 3.9 where it was unknowingly broken before.