### PR TITLE
grc: add top_block.py to .gitignore (backport to maint-3.9)

### DIFF
--- a/grc/tests/.gitignore
+++ b/grc/tests/.gitignore
@@ -1,1 +1,2 @@
 .pytest_cache
+resources/top_block.py


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@perspectalabs.com>
(cherry picked from commit 08f188579761aa5300457ad2083405833174b223)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4309