### PR TITLE
Revert " grc: restore pre-3.8 block id behavior" (backport to maint-3.9)

### DIFF
--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -175,7 +175,7 @@ class PropsDialog(Gtk.Dialog):
 
                 for param in self._block.params.values():
                     if force_show_id and param.dtype == 'id':
-                        param.hide = 'part'
+                        param.hide = 'none'
                     # todo: why do we even rebuild instead of really hiding params?
                     if param.category != category or param.hide == 'all':
                         continue

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -157,8 +157,8 @@ class Block(CoreBlock, Drawable):
 
         # update the params layout
         if not self.is_dummy_block:
-            markups = [param.format_block_surface_markup() for param in self.params.values()
-                       if (param.hide not in ('all', 'part'))]
+            markups = [param.format_block_surface_markup()
+                       for param in self.params.values() if (param.hide not in ('all', 'part') or (param.dtype == 'id' and force_show_id))]
         else:
             markups = ['<span font_desc="{font}"><b>key: </b>{key}</span>'.format(font=PARAM_FONT, key=self.key)]
 


### PR DESCRIPTION
This reverts commit 1fbf9ba89c643f478024d6af797e0a0dbbdf5ba3.

Signed-off-by: Josh Morman <jmorman@perspectalabs.com>
(cherry picked from commit 8ba9c53d8ec95c9453cb92ab81a19bde9b03c719)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4327