### PR TITLE
grc: order blocks with GUI Hint first (backport to maint-3.9)

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -196,6 +196,14 @@ class TopBlockGenerator(object):
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
+
+        # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
+        def without_gui_hint(block):
+            hint = block.params.get('gui_hint')
+            return hint is None or not hint.get_value()
+
+        blocks.sort(key=without_gui_hint)
+
         blocks_make = []
         for block in blocks:
             make = block.templates.render('make')

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -392,7 +392,10 @@ class Param(Element):
             else:
                 layout = '{tab}_grid_layout_{index}'.format(tab=tab, index=index)
         else:
-            layout = 'top_grid_layout'
+            if not pos:
+                layout = 'top_layout'
+            else:
+                layout = 'top_grid_layout'
 
         widget = '%s'  # to be fill-out in the mail template
 


### PR DESCRIPTION
(cherry picked from commit 9a25928a621081fae49b81ed4b2eb221cded9d1b)
grc: validate gui hints
(cherry picked from commit a53bb7a76047414eeae611f9d1fdcca4c6e2fa53)
grc: validate gui hints
(cherry picked from commit f45c82436c2a19fa1e5ff15177fbc4cc591017cb)
grc: fix widget whitout GUI_hint may  superpose to other
(cherry picked from commit 21b4eb156fa9a5dd85668c0ca019a1cf7882e6e0)

Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4271