### PR TITLE
digital: Fix documentation for corr_est 'threshold' paramter (backport to maint-3.9)

### DIFF
--- a/gr-digital/include/gnuradio/digital/corr_est_cc.h
+++ b/gr-digital/include/gnuradio/digital/corr_est_cc.h
@@ -89,10 +89,22 @@ public:
      * \param sps               Samples per symbol
      * \param mark_delay        tag marking delay in samples after the
      *                          corr_start tag
-     * \param threshold         Threshold of correlator, relative to a 100%
-     *                          correlation (1.0). Default is 0.9.
+     * \param threshold         Threshold of correlator.
+     *                          The meaning of this parameter depends on the threshold
+     *                          method used. For DYNAMIC threshold method, this
+     *                          parameter is actually 1 - Probability of False
+     *                          Alarm (under some inaccurate assumptions). The
+     *                          code performs the check
+     *                          |r[k]|^2 + |r[k+1]|^2 <> -log(1-threshold)*2*E,
+     *                          where r[k] is the correlated incoming signal,
+     *                          and E is the average sample energy of the
+     *                          correlated signal. For ABSOLUTE threshold method,
+     *                          this parameter sets the threshold to a fraction
+     *                          of the maximum squared autocorrelation.  The code
+     *                          performs the check |r[k]|^2 <> threshold * R^2,
+     *                          where R is the precomputed max autocorrelation
+     *                          of the given sync word. Default is 0.9
      * \param threshold_method  Method for computing threshold.
-     *
      */
     static sptr make(const std::vector<gr_complex>& symbols,
                      float sps,

--- a/gr-digital/python/digital/bindings/corr_est_cc_python.cc
+++ b/gr-digital/python/digital/bindings/corr_est_cc_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(corr_est_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(bc2913cc6c389d7d0eecd401f081f6f1)                     */
+/* BINDTOOL_HEADER_FILE(corr_est_cc.h)                                             */
+/* BINDTOOL_HEADER_FILE_HASH(9f1bed2a780e7f84a05da2a0eb5fe345)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Signed-off-by: Ipsit <mmkipsit@gmail.com>
Signed-off-by: Martin Braun <martin@gnuradio.org>
(cherry picked from commit 51fcd60d3f170ee992b960c4623797c945fadc0d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4274