### PR TITLE
CMake: remove unused compile/header checks (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/ConfigChecks.cmake
+++ b/gnuradio-runtime/ConfigChecks.cmake
@@ -13,18 +13,11 @@ IF(MSVC) #add this directory for our provided headers
 LIST(APPEND CMAKE_REQUIRED_INCLUDES ${CMAKE_SOURCE_DIR}/msvc)
 ENDIF(MSVC)
 
-GR_CHECK_HDR_N_DEF(sys/time.h HAVE_SYS_TIME_H)
 GR_CHECK_HDR_N_DEF(sys/types.h HAVE_SYS_TYPES_H)
-GR_CHECK_HDR_N_DEF(sys/socket.h HAVE_SYS_SOCKET_H)
-GR_CHECK_HDR_N_DEF(io.h HAVE_IO_H)
 GR_CHECK_HDR_N_DEF(sys/mman.h HAVE_SYS_MMAN_H)
 GR_CHECK_HDR_N_DEF(sys/ipc.h HAVE_SYS_IPC_H)
 GR_CHECK_HDR_N_DEF(sys/shm.h HAVE_SYS_SHM_H)
 GR_CHECK_HDR_N_DEF(signal.h HAVE_SIGNAL_H)
-GR_CHECK_HDR_N_DEF(netinet/in.h HAVE_NETINET_IN_H)
-GR_CHECK_HDR_N_DEF(arpa/inet.h HAVE_ARPA_INET_H)
-GR_CHECK_HDR_N_DEF(unistd.h HAVE_UNISTD_H)
-GR_CHECK_HDR_N_DEF(malloc.h HAVE_MALLOC_H)
 
 
 ########################################################################
@@ -49,37 +42,6 @@ CHECK_CXX_SOURCE_COMPILES("
     " HAVE_GETPAGESIZE
 )
 GR_ADD_COND_DEF(HAVE_GETPAGESIZE)
-
-
-########################################################################
-CHECK_CXX_SOURCE_COMPILES("
-    #include <Winbase.h>
-    int main(){Sleep(0); return 0;}
-    " HAVE_SSLEEP
-)
-GR_ADD_COND_DEF(HAVE_SSLEEP)
-
-########################################################################
-CHECK_CXX_SOURCE_COMPILES("
-    #include <stdlib.h>
-    int main(){posix_memalign(0, 0, 0); return 0;}
-    " HAVE_POSIX_MEMALIGN
-)
-GR_ADD_COND_DEF(HAVE_POSIX_MEMALIGN)
-
-CHECK_CXX_SOURCE_COMPILES("
-    #include <malloc.h>
-    int main(){valloc(0); return 0;}
-    " HAVE_VALLOC
-)
-GR_ADD_COND_DEF(HAVE_VALLOC)
-
-if(APPLE)
-    # Apple's malloc has been 16 byte aligned since at least 10.4
-    ADD_DEFINITIONS(-DALIGNED_MALLOC=16)
-else()
-    ADD_DEFINITIONS(-DALIGNED_MALLOC=0)
-endif()
 
 ########################################################################
 SET(CMAKE_REQUIRED_LIBRARIES -lpthread)

--- a/gr-blocks/lib/ConfigChecks.cmake
+++ b/gr-blocks/lib/ConfigChecks.cmake
@@ -13,18 +13,7 @@ IF(MSVC) #add this directory for our provided headers
 LIST(APPEND CMAKE_REQUIRED_INCLUDES ${CMAKE_SOURCE_DIR}/msvc)
 ENDIF(MSVC)
 
-GR_CHECK_HDR_N_DEF(sys/time.h HAVE_SYS_TIME_H)
-GR_CHECK_HDR_N_DEF(sys/types.h HAVE_SYS_TYPES_H)
-GR_CHECK_HDR_N_DEF(sys/socket.h HAVE_SYS_SOCKET_H)
 GR_CHECK_HDR_N_DEF(io.h HAVE_IO_H)
-GR_CHECK_HDR_N_DEF(sys/mman.h HAVE_SYS_MMAN_H)
-GR_CHECK_HDR_N_DEF(sys/ipc.h HAVE_SYS_IPC_H)
-GR_CHECK_HDR_N_DEF(sys/shm.h HAVE_SYS_SHM_H)
-GR_CHECK_HDR_N_DEF(signal.h HAVE_SIGNAL_H)
-GR_CHECK_HDR_N_DEF(netinet/in.h HAVE_NETINET_IN_H)
-GR_CHECK_HDR_N_DEF(arpa/inet.h HAVE_ARPA_INET_H)
-GR_CHECK_HDR_N_DEF(unistd.h HAVE_UNISTD_H)
-GR_CHECK_HDR_N_DEF(malloc.h HAVE_MALLOC_H)
 
 ########################################################################
 CHECK_INCLUDE_FILE_CXX(windows.h HAVE_WINDOWS_H)
@@ -33,34 +22,3 @@ IF(HAVE_WINDOWS_H)
     MESSAGE(STATUS "Adding windows libs to gr blocks libs...")
     LIST(APPEND blocks_libs ws2_32 wsock32)
 ENDIF(HAVE_WINDOWS_H)
-
-########################################################################
-CHECK_CXX_SOURCE_COMPILES("
-    #define _GNU_SOURCE
-    #include <math.h>
-    int main(){double x, sin, cos; sincos(x, &sin, &cos); return 0;}
-    " HAVE_SINCOS
-)
-GR_ADD_COND_DEF(HAVE_SINCOS)
-
-CHECK_CXX_SOURCE_COMPILES("
-    #define _GNU_SOURCE
-    #include <math.h>
-    int main(){float x, sin, cos; sincosf(x, &sin, &cos); return 0;}
-    " HAVE_SINCOSF
-)
-GR_ADD_COND_DEF(HAVE_SINCOSF)
-
-CHECK_CXX_SOURCE_COMPILES("
-    #include <math.h>
-    int main(){sinf(0); return 0;}
-    " HAVE_SINF
-)
-GR_ADD_COND_DEF(HAVE_SINF)
-
-CHECK_CXX_SOURCE_COMPILES("
-    #include <math.h>
-    int main(){cosf(0); return 0;}
-    " HAVE_COSF
-)
-GR_ADD_COND_DEF(HAVE_COSF)


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 6c93722c546a25bd1e310497a38af410f973c3f1)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4256