### PR TITLE
audio: fix lcm calculation (backport to maint-3.8)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gru/mathmisc.py
+++ b/gnuradio-runtime/python/gnuradio/gru/mathmisc.py
@@ -29,7 +29,7 @@ def gcd(a,b):
     return a
 
 def lcm(a,b):
-    return a * b / gcd(a, b)
+    return a * b // gcd(a, b)
 
 def log2(x):
     return math.log(x) / math.log(2)

--- a/gr-audio/examples/python/test_resampler.py
+++ b/gr-audio/examples/python/test_resampler.py
@@ -57,8 +57,8 @@ class my_top_block(gr.top_block):
         input_rate = int(args.input_rate)
         output_rate = int(args.output_rate)
 
-        interp = gru.lcm(input_rate / output_rate, input_rate)
-        decim = gru.lcm(input_rate / output_rate, output_rate)
+        interp = gru.lcm(input_rate, output_rate) // input_rate
+        decim = gru.lcm(input_rate, output_rate) // output_rate
 
         print("interp =", interp)
         print("decim  =", decim)


### PR DESCRIPTION
(cherry picked from commit a613e6def09729c47cdfc9d2037a7c40b4ffb0c8)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3810