### PR TITLE
uhd: Control of frequency and gain in both directions at the same moment (backport to maint-3.9)

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -145,8 +145,11 @@ public:
      *
      * \param gain the gain in dB
      * \param chan the channel index 0 to N-1
+     * \param direction TX or RX. This is mostly used by the internal message
+     *        handling.
      */
-    virtual void set_gain(double gain, size_t chan = 0) = 0;
+    virtual void
+    set_gain(double gain, size_t chan = 0, pmt::pmt_t direction = pmt::PMT_NIL) = 0;
 
     /*!
      * Set the named gain on the dboard.

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -125,8 +125,10 @@ usrp_block_impl::usrp_block_impl(const ::uhd::device_addr_t& device_addr,
       _stream_now(_nchan == 1 and ts_tag_name.empty()),
       _start_time_set(false),
       _force_tune(false),
-      _curr_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
-      _chans_to_tune(stream_args.channels.size())
+      _curr_tx_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
+      _curr_rx_tune_req(stream_args.channels.size(), ::uhd::tune_request_t()),
+      _tx_chans_to_tune(stream_args.channels.size()),
+      _rx_chans_to_tune(stream_args.channels.size())
 {
     _dev = ::uhd::usrp::multi_usrp::make(device_addr);
 
@@ -264,11 +266,22 @@ bool usrp_block_impl::_check_mboard_sensors_locked()
     return clocks_locked;
 }
 
-void usrp_block_impl::_set_center_freq_from_internals_allchans(pmt::pmt_t direction)
+void usrp_block_impl::_set_center_freq_from_internals_allchans()
 {
-    while (_chans_to_tune.any()) {
+    unsigned int chan;
+    while (_rx_chans_to_tune.any()) {
         // This resets() bits, so this loop should not run indefinitely
-        _set_center_freq_from_internals(_chans_to_tune.find_first(), direction);
+        chan = _rx_chans_to_tune.find_first();
+        _set_center_freq_from_internals(chan, ant_direction_rx());
+        _rx_chans_to_tune.reset(chan);
+    }
+
+    while (_tx_chans_to_tune.any()) {
+        // This resets() bits, so this loop should not run indefinitely
+        chan = _tx_chans_to_tune.find_first();
+        _set_center_freq_from_internals(_tx_chans_to_tune.find_first(),
+                                        ant_direction_tx());
+        _tx_chans_to_tune.reset(chan);
     }
 }
 
@@ -540,8 +553,9 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
             break;
         }
     }
+
     /// 5) Check if we need to re-tune
-    _set_center_freq_from_internals_allchans(direction);
+    _set_center_freq_from_internals_allchans();
     _force_tune = false;
 }
 
@@ -562,22 +576,37 @@ void usrp_block_impl::register_msg_cmd_handler(const pmt::pmt_t& cmd,
     _msg_cmd_handlers[cmd] = handler;
 }
 
-void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req, int chan)
+void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req,
+                                            int chan,
+                                            pmt::pmt_t direction)
 {
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
-            _update_curr_tune_req(tune_req, int(i));
+            _update_curr_tune_req(tune_req, int(i), direction);
         }
         return;
     }
 
-    if (tune_req.target_freq != _curr_tune_req[chan].target_freq ||
-        tune_req.rf_freq_policy != _curr_tune_req[chan].rf_freq_policy ||
-        tune_req.rf_freq != _curr_tune_req[chan].rf_freq ||
-        tune_req.dsp_freq != _curr_tune_req[chan].dsp_freq ||
-        tune_req.dsp_freq_policy != _curr_tune_req[chan].dsp_freq_policy || _force_tune) {
-        _curr_tune_req[chan] = tune_req;
-        _chans_to_tune.set(chan);
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        if (tune_req.target_freq != _curr_rx_tune_req[chan].target_freq ||
+            tune_req.rf_freq_policy != _curr_rx_tune_req[chan].rf_freq_policy ||
+            tune_req.rf_freq != _curr_rx_tune_req[chan].rf_freq ||
+            tune_req.dsp_freq != _curr_rx_tune_req[chan].dsp_freq ||
+            tune_req.dsp_freq_policy != _curr_rx_tune_req[chan].dsp_freq_policy ||
+            _force_tune) {
+            _curr_rx_tune_req[chan] = tune_req;
+            _rx_chans_to_tune.set(chan);
+        }
+    } else {
+        if (tune_req.target_freq != _curr_tx_tune_req[chan].target_freq ||
+            tune_req.rf_freq_policy != _curr_tx_tune_req[chan].rf_freq_policy ||
+            tune_req.rf_freq != _curr_tx_tune_req[chan].rf_freq ||
+            tune_req.dsp_freq != _curr_tx_tune_req[chan].dsp_freq ||
+            tune_req.dsp_freq_policy != _curr_tx_tune_req[chan].dsp_freq_policy ||
+            _force_tune) {
+            _curr_tx_tune_req[chan] = tune_req;
+            _tx_chans_to_tune.set(chan);
+        }
     }
 }
 
@@ -586,6 +615,14 @@ void usrp_block_impl::_cmd_handler_freq(const pmt::pmt_t& freq_,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     double freq = pmt::to_double(freq_);
     ::uhd::tune_request_t new_tune_request(freq);
     if (pmt::dict_has_key(msg, cmd_lo_offset_key())) {
@@ -594,40 +631,62 @@ void usrp_block_impl::_cmd_handler_freq(const pmt::pmt_t& freq_,
         new_tune_request = ::uhd::tune_request_t(freq, lo_offset);
     }
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t& lo_offset,
                                             int chan,
                                             const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX" will default to the
+                                   // messaged block direction
+        );
+
     if (pmt::dict_has_key(msg, cmd_freq_key())) {
         // Then it's already taken care of
         return;
     }
 
     double lo_offs = pmt::to_double(lo_offset);
-    ::uhd::tune_request_t new_tune_request = _curr_tune_req[chan];
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        new_tune_request = _curr_rx_tune_req[chan];
+    } else {
+        new_tune_request = _curr_tx_tune_req[chan];
+    }
+
     new_tune_request.rf_freq = new_tune_request.target_freq + lo_offs;
     new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_AUTO;
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t& gain_,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     double gain = pmt::to_double(gain_);
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
-            set_gain(gain, i);
+            set_gain(gain, i, direction);
         }
         return;
     }
 
-    set_gain(gain, chan);
+    set_gain(gain, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_power(const pmt::pmt_t& power_dbm_,
@@ -670,10 +729,18 @@ void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     double freq = pmt::to_double(pmt::car(tune));
     double lo_offset = pmt::to_double(pmt::cdr(tune));
     ::uhd::tune_request_t new_tune_request(freq, lo_offset);
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_bw(const pmt::pmt_t& bw,
@@ -695,6 +762,14 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
                                           int chan,
                                           const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
             _cmd_handler_lofreq(lofreq, int(i), msg);
@@ -702,7 +777,13 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
         return;
     }
 
-    ::uhd::tune_request_t new_tune_request = _curr_tune_req[chan];
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        new_tune_request = _curr_rx_tune_req[chan];
+    } else {
+        new_tune_request = _curr_tx_tune_req[chan];
+    }
+
     new_tune_request.rf_freq = pmt::to_double(lofreq);
     if (pmt::dict_has_key(msg, cmd_dsp_freq_key())) {
         new_tune_request.dsp_freq =
@@ -711,13 +792,21 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
     new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }
 
 void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
                                            int chan,
                                            const pmt::pmt_t& msg)
 {
+    // See if a direction was specified
+    pmt::pmt_t direction =
+        pmt::dict_ref(msg,
+                      cmd_direction_key(),
+                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
+                                   // messaged block direction"
+        );
+
     if (pmt::dict_has_key(msg, cmd_lo_freq_key())) {
         // Then it's already dealt with
         return;
@@ -730,10 +819,16 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
         return;
     }
 
-    ::uhd::tune_request_t new_tune_request = _curr_tune_req[chan];
+    ::uhd::tune_request_t new_tune_request;
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        new_tune_request = _curr_rx_tune_req[chan];
+    } else {
+        new_tune_request = _curr_tx_tune_req[chan];
+    }
+
     new_tune_request.dsp_freq = pmt::to_double(dspfreq);
     new_tune_request.rf_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
 
-    _update_curr_tune_req(new_tune_request, chan);
+    _update_curr_tune_req(new_tune_request, chan, direction);
 }

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -134,7 +134,9 @@ protected:
     void _update_stream_args(const ::uhd::stream_args_t& stream_args_);
 
     // should be const, doesn't work though 'cause missing operator=() for tune_request_t
-    void _update_curr_tune_req(::uhd::tune_request_t& tune_req, int chan);
+    void _update_curr_tune_req(::uhd::tune_request_t& tune_req,
+                               int chan,
+                               pmt::pmt_t direction = pmt::PMT_NIL);
 
     /*! \brief Wait until a timeout or a sensor returns 'locked'.
      *
@@ -197,7 +199,7 @@ protected:
     _set_center_freq_from_internals(size_t chan, pmt::pmt_t direction) = 0;
 
     //! Calls _set_center_freq_from_internals() on all channels
-    void _set_center_freq_from_internals_allchans(pmt::pmt_t direction);
+    void _set_center_freq_from_internals_allchans();
 
     /**********************************************************************
      * Members
@@ -217,8 +219,10 @@ protected:
     std::vector<pmt::pmt_t> _pending_cmds;
     //! Shadows the last value we told the USRP to tune to for every channel
     // (this is not necessarily the true value the USRP is currently tuned to!).
-    std::vector<::uhd::tune_request_t> _curr_tune_req;
-    boost::dynamic_bitset<> _chans_to_tune;
+    std::vector<::uhd::tune_request_t> _curr_tx_tune_req;
+    std::vector<::uhd::tune_request_t> _curr_rx_tune_req;
+    boost::dynamic_bitset<> _tx_chans_to_tune;
+    boost::dynamic_bitset<> _rx_chans_to_tune;
 
     //! Stores the individual command handlers
     ::uhd::dict<pmt::pmt_t, cmd_handler_t> _msg_cmd_handlers;

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -87,7 +87,7 @@ double usrp_sink_impl::get_samp_rate(void)
 ::uhd::tune_result_t
 usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size_t chan)
 {
-    _curr_tune_req[chan] = tune_request;
+    _curr_tx_tune_req[chan] = tune_request;
     chan = _stream_args.channels[chan];
     return _dev->set_tx_freq(tune_request, chan);
 }
@@ -95,12 +95,13 @@ usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size_t
 ::uhd::tune_result_t usrp_sink_impl::_set_center_freq_from_internals(size_t chan,
                                                                      pmt::pmt_t direction)
 {
-    _chans_to_tune.reset(chan);
     if (pmt::eqv(direction, ant_direction_rx())) {
         // TODO: what happens if the RX device is not instantiated? Catch error?
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _rx_chans_to_tune.reset(chan);
+        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _tx_chans_to_tune.reset(chan);
+        return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     }
 }
 
@@ -116,10 +117,14 @@ double usrp_sink_impl::get_center_freq(size_t chan)
     return _dev->get_tx_freq_range(chan);
 }
 
-void usrp_sink_impl::set_gain(double gain, size_t chan)
+void usrp_sink_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
 {
     chan = _stream_args.channels[chan];
-    return _dev->set_tx_gain(gain, chan);
+    if (pmt::eqv(direction, ant_direction_rx())) {
+        return _dev->set_rx_gain(gain, chan);
+    } else {
+        return _dev->set_tx_gain(gain, chan);
+    }
 }
 
 void usrp_sink_impl::set_gain(double gain, const std::string& name, size_t chan)

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -87,7 +87,7 @@ public:
     void set_samp_rate(double rate) override;
     ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan) override;
-    void set_gain(double gain, size_t chan) override;
+    void set_gain(double gain, size_t chan, pmt::pmt_t direction) override;
     void set_gain(double gain, const std::string& name, size_t chan) override;
     void set_normalized_gain(double gain, size_t chan) override;
     void set_power_reference(double power_dbm, size_t chan) override;

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -112,12 +112,13 @@ usrp_source_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size
 ::uhd::tune_result_t
 usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
 {
-    _chans_to_tune.reset(chan);
     if (pmt::eqv(direction, ant_direction_tx())) {
         // TODO: what happens if the TX device is not instantiated? Catch error?
-        return _dev->set_tx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _tx_chans_to_tune.reset(chan);
+        return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        return _dev->set_rx_freq(_curr_tune_req[chan], _stream_args.channels[chan]);
+        _rx_chans_to_tune.reset(chan);
+        return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
     }
 }
 
@@ -133,10 +134,14 @@ double usrp_source_impl::get_center_freq(size_t chan)
     return _dev->get_rx_freq_range(chan);
 }
 
-void usrp_source_impl::set_gain(double gain, size_t chan)
+void usrp_source_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
 {
     chan = _stream_args.channels[chan];
-    return _dev->set_rx_gain(gain, chan);
+    if (pmt::eqv(direction, ant_direction_tx())) {
+        return _dev->set_tx_gain(gain, chan);
+    } else {
+        return _dev->set_rx_gain(gain, chan);
+    }
 }
 
 void usrp_source_impl::set_gain(double gain, const std::string& name, size_t chan)

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -77,7 +77,8 @@ public:
     void set_samp_rate(double rate) override;
     ::uhd::tune_result_t set_center_freq(const ::uhd::tune_request_t tune_request,
                                          size_t chan) override;
-    void set_gain(double gain, size_t chan) override;
+    void
+    set_gain(double gain, size_t chan = 0, pmt::pmt_t direction = pmt::PMT_NIL) override;
     void set_gain(double gain, const std::string& name, size_t chan) override;
     void set_rx_agc(const bool enable, size_t chan) override;
     void set_normalized_gain(double gain, size_t chan) override;

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -91,9 +91,10 @@ void bind_usrp_block(py::module& m)
 
 
         .def("set_gain",
-             (void (usrp_block::*)(double, size_t)) & usrp_block::set_gain,
+             (void (usrp_block::*)(double, size_t, pmt::pmt_t)) & usrp_block::set_gain,
              py::arg("gain"),
              py::arg("chan") = 0,
+             py::arg("direction") = pmt::PMT_NIL,
              D(usrp_block, set_gain, 0))
 
 


### PR DESCRIPTION
It implements the ability to control frequency and gain in both
directions (Tx and Rx) with use of a single UHD source or sink - in the
same moment. It is possible to do that in separate moments with current
UHD blocks but this way it is not possible to change both Rx and Tx
settings for the same burst. Now, a single message can do that.

Note that there is a bit of an oddity here: The GNU Radio USRP blocks
are either Rx or Tx (source or sink). However, they all encapsulate an
underlying multi_usrp object. That means that under the hood, a USRP
source or a USRP sink potentially has access to the "other" direction.
This is made use in this patch.

To use this feature, add a direction key to the message dictionary going
to the block.

Signed-off-by: Martin Braun <martin@gnuradio.org>
(cherry picked from commit f17a453de62681141641f1da414bdbed56a2e5a9)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4093