### PR TITLE
zmq: Handle the PMT exceptions (backport to maint-3.8)

### DIFF
--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -108,8 +108,12 @@ void pull_msg_source_impl::readloop()
 
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
-            pmt::pmt_t m = pmt::deserialize(sb);
-            message_port_pub(d_port, m);
+            try {
+                pmt::pmt_t m = pmt::deserialize(sb);
+                message_port_pub(d_port, m);
+            } catch (pmt::exception& e) {
+                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+            }
 
         } else {
             boost::this_thread::sleep(boost::posix_time::microseconds(100));

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -126,8 +126,12 @@ void req_msg_source_impl::readloop()
 
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
-            pmt::pmt_t m = pmt::deserialize(sb);
-            message_port_pub(d_port, m);
+            try {
+                pmt::pmt_t m = pmt::deserialize(sb);
+                message_port_pub(d_port, m);
+            } catch (pmt::exception& e) {
+                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+            }
 
         } else {
             boost::this_thread::sleep(boost::posix_time::microseconds(100));

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -106,9 +106,12 @@ void sub_msg_source_impl::readloop()
 #endif
             std::string buf(static_cast<char*>(msg.data()), msg.size());
             std::stringbuf sb(buf);
-            pmt::pmt_t m = pmt::deserialize(sb);
-
-            message_port_pub(d_port, m);
+            try {
+                pmt::pmt_t m = pmt::deserialize(sb);
+                message_port_pub(d_port, m);
+            } catch (pmt::exception& e) {
+                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+            }
         } else {
             boost::this_thread::sleep(boost::posix_time::microseconds(100));
         }


### PR DESCRIPTION
Handle the PMT exceptions when deserializing the received ZMQ messages,
log an error message and continue the execution.

Previously the unhandled exceptions were aborting the process:

terminate called after throwing an instance of 'pmt::exception'
  what():  pmt::deserialize: malformed input stream, tag value = : 50
Aborted (core dumped)

Original Author: Vasil Velichkov
(cherry picked from commit ff9b489dee9293e1837910990bd2f2b60f5e7fde)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3230
QA code (a565c806ef3a5e8e057a7eb4257721f4b88ab62f) omitted because `int.from_bytes()` is not Python2-friendly.
Avoiding a crash on an invalid PMT over ZMQ is worth foregoing the QA code.