### PR TITLE
grc: remove gnuradio prefix from linked libraries (backport to maint-3.9)

### DIFF
--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -55,7 +55,7 @@ target_link_libraries(${class_name}
     gnuradio::gnuradio-blocks
     % for link in links:
     % if link:
-    ${link.replace("gnuradio-", "gnuradio::gnuradio-")}
+    ${link}
     % endif
     % endfor
 


### PR DESCRIPTION
this allows OOT modules to be linked, as those will not link with the prefix

Signed-off-by: karel <5636152+karel@users.noreply.github.com>
(cherry picked from commit 78dc0d8b5b289b108deebce3567b69902d65d202)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4263