### PR TITLE
modtool: Fix find_package_handle_standard_args warning in gr_modtool … (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/cmake/Modules/howtoConfig.cmake
+++ b/gr-utils/modtool/templates/gr-newmod/cmake/Modules/howtoConfig.cmake
@@ -1,4 +1,6 @@
-INCLUDE(FindPkgConfig)
+if(NOT PKG_CONFIG_FOUND)
+    INCLUDE(FindPkgConfig)
+endif()
 PKG_CHECK_MODULES(PC_HOWTO howto)
 
 FIND_PATH(


### PR DESCRIPTION
…newmod

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 4605af69fa8b1a366d49c6c4aea2f4a80bb611f5)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4125/commits