### PR TITLE
gr-utils: modtool/cli/add: check for arglist inverted

### DIFF
--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -119,7 +119,7 @@ def get_copyrightholder(self):
 
 def get_arglist(self):
     """ Get the argument list of the block to be added """
-    if self.info['arglist'] is not None:
+    if not self.info['arglist']:
         self.info['arglist'] = click.prompt(click.style(
             'Enter valid argument list, including default arguments: \n',
             fg='cyan'),


### PR DESCRIPTION
Bug reported and located by Brandon Smith.

`self.info['arglist']` defaults to `""` so it can never be `None`. And the sense of the check is inverted.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Closes https://github.com/gnuradio/gnuradio/issues/4324