### PR TITLE
dtv/atsc: create separate plinfo stream ports

### DIFF
--- a/gr-dtv/examples/uhd_atsc_rx.grc
+++ b/gr-dtv/examples/uhd_atsc_rx.grc
@@ -189,7 +189,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [872, 556.0]
+    coordinate: [904, 556.0]
     rotation: 0
     state: enabled
 - name: dc_blocker_xx_0
@@ -222,7 +222,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [144, 576.0]
+    coordinate: [120, 576.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_depad_0
@@ -237,7 +237,7 @@ blocks:
     bus_sink: false
     bus_source: false
     bus_structure: null
-    coordinate: [736, 576.0]
+    coordinate: [752, 588.0]
     rotation: 0
     state: enabled
 - name: dtv_atsc_derandomizer_0
@@ -870,14 +870,19 @@ connections:
 - [agc, '0', dtv_atsc_sync_0, '0']
 - [dc_blocker_xx_0, '0', agc, '0']
 - [dtv_atsc_deinterleaver_0, '0', dtv_atsc_rs_decoder_0, '0']
+- [dtv_atsc_deinterleaver_0, '1', dtv_atsc_rs_decoder_0, '1']
 - [dtv_atsc_depad_0, '0', blocks_file_sink_0, '0']
 - [dtv_atsc_derandomizer_0, '0', dtv_atsc_depad_0, '0']
 - [dtv_atsc_equalizer_0, '0', dtv_atsc_viterbi_decoder_0, '0']
+- [dtv_atsc_equalizer_0, '1', dtv_atsc_viterbi_decoder_0, '1']
 - [dtv_atsc_fpll_0, '0', dc_blocker_xx_0, '0']
 - [dtv_atsc_fs_checker_0, '0', dtv_atsc_equalizer_0, '0']
+- [dtv_atsc_fs_checker_0, '1', dtv_atsc_equalizer_0, '1']
 - [dtv_atsc_rs_decoder_0, '0', dtv_atsc_derandomizer_0, '0']
+- [dtv_atsc_rs_decoder_0, '1', dtv_atsc_derandomizer_0, '1']
 - [dtv_atsc_sync_0, '0', dtv_atsc_fs_checker_0, '0']
 - [dtv_atsc_viterbi_decoder_0, '0', dtv_atsc_deinterleaver_0, '0']
+- [dtv_atsc_viterbi_decoder_0, '1', dtv_atsc_deinterleaver_0, '1']
 - [filter_fft_rrc_filter_0, '0', dtv_atsc_fpll_0, '0']
 - [filter_fft_rrc_filter_0, '0', usrp_freq_sink, '1']
 - [u, '0', filter_fft_rrc_filter_0, '0']

--- a/gr-dtv/grc/dtv_atsc_deinterleaver.block.yml
+++ b/gr-dtv/grc/dtv_atsc_deinterleaver.block.yml
@@ -6,11 +6,19 @@ inputs:
 -   domain: stream
     dtype: byte
     vlen: 207
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
 
 outputs:
 -   domain: stream
     dtype: byte
     vlen: 207
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
 
 templates:
     imports: from gnuradio import dtv

--- a/gr-dtv/grc/dtv_atsc_derandomizer.block.yml
+++ b/gr-dtv/grc/dtv_atsc_derandomizer.block.yml
@@ -6,7 +6,11 @@ inputs:
 -   domain: stream
     dtype: byte
     vlen: 188
-
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
+    
 outputs:
 -   domain: stream
     dtype: byte

--- a/gr-dtv/grc/dtv_atsc_equalizer.block.yml
+++ b/gr-dtv/grc/dtv_atsc_equalizer.block.yml
@@ -6,11 +6,19 @@ inputs:
 -   domain: stream
     dtype: float
     vlen: 832
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
 
 outputs:
 -   domain: stream
     dtype: float
     vlen: 832
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
 
 templates:
     imports: from gnuradio import dtv

--- a/gr-dtv/grc/dtv_atsc_fs_checker.block.yml
+++ b/gr-dtv/grc/dtv_atsc_fs_checker.block.yml
@@ -12,6 +12,11 @@ outputs:
     dtype: float
     vlen: 832
 
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
+
 templates:
     imports: from gnuradio import dtv
     make: dtv.atsc_fs_checker()

--- a/gr-dtv/grc/dtv_atsc_rs_decoder.block.yml
+++ b/gr-dtv/grc/dtv_atsc_rs_decoder.block.yml
@@ -6,11 +6,19 @@ inputs:
 -   domain: stream
     dtype: byte
     vlen: 207
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
 
 outputs:
 -   domain: stream
     dtype: byte
     vlen: 188
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2
 
 templates:
     imports: from gnuradio import dtv

--- a/gr-dtv/grc/dtv_atsc_viterbi_decoder.block.yml
+++ b/gr-dtv/grc/dtv_atsc_viterbi_decoder.block.yml
@@ -6,11 +6,19 @@ inputs:
 -   domain: stream
     dtype: float 
     vlen: 832
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2    
 
 outputs:
 -   domain: stream
     dtype: byte
     vlen: 207
+-   domain: stream
+    label: plinfo
+    dtype: short
+    vlen: 2    
 
 templates:
     imports: from gnuradio import dtv

--- a/gr-dtv/include/gnuradio/dtv/atsc_plinfo.h
+++ b/gr-dtv/include/gnuradio/dtv/atsc_plinfo.h
@@ -12,8 +12,8 @@
 #define DTV_INCLUDED_ATSC_PLINFO_H
 
 #include <gnuradio/dtv/atsc_consts.h>
-#include <boost/endian/conversion.hpp>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 
 #include <gnuradio/dtv/api.h>
@@ -37,20 +37,6 @@ public:
      *
      */
     void reset();
-
-    /**
-     * @brief Load the flags and segno from an endian safe value that came over the tags
-     *
-     * @param tag_value
-     */
-    void from_tag_value(uint32_t tag_value);
-
-    /**
-     * @brief Return an endian safe value containing the flags and segno
-     *
-     * @return uint32_t
-     */
-    uint32_t get_tag_value() const;
 
     // accessors
     bool field_sync1_p() const;

--- a/gr-dtv/lib/atsc/atsc_derandomizer_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_derandomizer_impl.cc
@@ -26,11 +26,11 @@ atsc_derandomizer::sptr atsc_derandomizer::make()
 
 atsc_derandomizer_impl::atsc_derandomizer_impl()
     : gr::sync_block("dtv_atsc_derandomizer",
-                     io_signature::make(1, 1, ATSC_MPEG_PKT_LENGTH * sizeof(uint8_t)),
+                     io_signature::make2(
+                         2, 2, ATSC_MPEG_PKT_LENGTH * sizeof(uint8_t), sizeof(plinfo)),
                      io_signature::make(1, 1, ATSC_MPEG_PKT_LENGTH * sizeof(uint8_t)))
 {
     d_rand.reset();
-    set_tag_propagation_policy(TPP_DONT);
 }
 
 int atsc_derandomizer_impl::work(int noutput_items,
@@ -39,20 +39,12 @@ int atsc_derandomizer_impl::work(int noutput_items,
 {
     auto in = static_cast<const uint8_t*>(input_items[0]);
     auto out = static_cast<uint8_t*>(output_items[0]);
+    auto plin = static_cast<const plinfo*>(input_items[1]);
 
-    std::vector<tag_t> tags;
-    auto tag_pmt = pmt::intern("plinfo");
     for (int i = 0; i < noutput_items; i++) {
-        plinfo pli_in;
-        get_tags_in_window(tags, 0, i, i + 1, tag_pmt);
-        if (tags.size() > 0) {
-            pli_in.from_tag_value(pmt::to_uint64(tags[0].value));
-        } else {
-            throw std::runtime_error("Atsc Derandomizer: Plinfo Tag not found on sample");
-        }
-        assert(pli_in.regular_seg_p());
+        assert(plin[i].regular_seg_p());
 
-        if (pli_in.first_regular_seg_p())
+        if (plin[i].first_regular_seg_p())
             d_rand.reset();
 
         d_rand.derandomize(&out[i * ATSC_MPEG_PKT_LENGTH], &in[i * ATSC_MPEG_PKT_LENGTH]);
@@ -60,7 +52,7 @@ int atsc_derandomizer_impl::work(int noutput_items,
         // Check the pipeline info for error status and and set the
         // corresponding bit in transport packet header.
 
-        if (pli_in.transport_error_p())
+        if (plin[i].transport_error_p())
             out[i * ATSC_MPEG_PKT_LENGTH + 1] |= MPEG_TRANSPORT_ERROR_BIT;
         else
             out[i * ATSC_MPEG_PKT_LENGTH + 1] &= ~MPEG_TRANSPORT_ERROR_BIT;

--- a/gr-dtv/lib/atsc/atsc_equalizer_impl.h
+++ b/gr-dtv/lib/atsc/atsc_equalizer_impl.h
@@ -44,7 +44,7 @@ private:
     unsigned short d_flags;
     short d_segno;
 
-    bool d_buff_not_filled;
+    bool d_buff_not_filled = true;
 
 public:
     atsc_equalizer_impl();

--- a/gr-dtv/lib/atsc/atsc_plinfo.cc
+++ b/gr-dtv/lib/atsc/atsc_plinfo.cc
@@ -22,18 +22,6 @@ void plinfo::reset()
     d_segno = 0;
 }
 
-void plinfo::from_tag_value(uint32_t tag_value)
-{
-    auto native_val = boost::endian::big_to_native(tag_value);
-    d_flags = (native_val >> 16) & 0xFFFF;
-    d_segno = native_val & 0xFFFF;
-}
-
-uint32_t plinfo::get_tag_value() const
-{
-    return boost::endian::native_to_big(((d_flags & 0xFFFF) << 16) | (d_segno & 0xFFFF));
-}
-
 // accessors
 bool plinfo::field_sync1_p() const { return (d_flags & fl_field_sync1) != 0; }
 bool plinfo::field_sync2_p() const { return (d_flags & fl_field_sync2) != 0; }

--- a/gr-dtv/python/dtv/atsc_rx.py
+++ b/gr-dtv/python/dtv/atsc_rx.py
@@ -66,5 +66,16 @@ class atsc_rx(gr.hier_block2):
         dep = dtv.atsc_depad()
 
         # Connect pipeline
-        self.connect(self, rx_filt, pll, dcr, agc, btl, fsc, equ)
-        self.connect(equ, vit, dei, rsd, der, dep, self)
+        self.connect(self, rx_filt, pll, dcr, agc, btl, fsc)
+        self.connect((fsc,0),(equ,0))
+        self.connect((fsc,1),(equ,1))
+        self.connect((equ,0),(vit,0))
+        self.connect((equ,1),(vit,1))
+        self.connect((vit,0),(dei,0))
+        self.connect((vit,1),(dei,1))
+        self.connect((dei,0),(rsd,0))
+        self.connect((dei,1),(rsd,1))
+        self.connect((rsd,0),(der,0))
+        self.connect((rsd,1),(der,1))
+        self.connect((der,0),(dep,0))
+        self.connect((dep,0),(self,0))


### PR DESCRIPTION
Rather than adding/searching for tags, just put plinfo on its own
streaming port.  This should be more efficient than putting tags on
every item and easier to inspect/debug.

So now, the receive chain looks like this:
![image](https://user-images.githubusercontent.com/34754695/111187152-1fc64280-858a-11eb-957d-fe7ea561d5d6.png)
