### PR TITLE
modtool: use prefix path for modtool instead of prefs (backport to maint-3.8)

### DIFF
--- a/gr-utils/python/modtool/cli/newmod.py
+++ b/gr-utils/python/modtool/cli/newmod.py
@@ -33,7 +33,6 @@ from gnuradio import gr
 from ..core import ModToolNewModule
 from .base import common_params, run, cli_input, ModToolException
 
-
 @click.command('newmod', short_help=ModToolNewModule.description)
 @click.option('--srcdir',
               help="Source directory for the module template.")
@@ -57,8 +56,7 @@ def cli(**kwargs):
     else:
         raise ModToolException('The given directory exists.')
     if self.srcdir is None:
-        self.srcdir = '/usr/local/share/gnuradio/modtool/templates/gr-newmod'
-    self.srcdir = gr.prefs().get_string('modtool', 'newmod_path', self.srcdir)
+        self.srcdir = os.path.join(gr.prefix(),'share','gnuradio','modtool','templates','gr-newmod')
     if not os.path.isdir(self.srcdir):
         raise ModToolException('Could not find gr-newmod source dir.')
     run(self)

--- a/gr-utils/python/modtool/core/newmod.py
+++ b/gr-utils/python/modtool/core/newmod.py
@@ -35,7 +35,6 @@ from .base import ModTool, ModToolException
 
 logger = logging.getLogger(__name__)
 
-
 class ModToolNewModule(ModTool):
     """ Create a new out-of-tree module """
     name = 'newmod'
@@ -49,8 +48,7 @@ class ModToolNewModule(ModTool):
     def assign(self):
         self.dir = os.path.join(self.directory, 'gr-{}'.format(self.info['modname']))
         if self.srcdir is None:
-            self.srcdir = '/usr/local/share/gnuradio/modtool/templates/gr-newmod'
-        self.srcdir = gr.prefs().get_string('modtool', 'newmod_path', self.srcdir)
+            self.srcdir = os.path.join(gr.prefix(),'share','gnuradio','modtool','templates','gr-newmod')
 
     def validate(self):
         """ Validates the arguments """


### PR DESCRIPTION
When a prefix gets installed, the [modtool] section in prefs hardcodes
the path to the templates in the newly installed prefix as a global path
for all modtools.  This creates major problems when bouncing between
prefixes, especially when newmod changes between releases

Why not just use the prefix as the root of where to look for the
templates

(cherry picked from commit 82262753a56d15cfa6343044c726cf0035c38d9c)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3266
Old one we missed.