### PR TITLE
digital: packed<->unpacked: check chunk sizes, incl. NDBEBUG builds (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/packed_to_unpacked_impl.h
+++ b/gr-blocks/lib/packed_to_unpacked_impl.h
@@ -24,7 +24,7 @@ private:
     const unsigned int d_bits_per_chunk;
     const endianness_t d_endianness;
     unsigned int d_index;
-    static constexpr unsigned int d_bits_per_type = sizeof(T) * 8;
+    static constexpr unsigned int bits_per_type() { return (sizeof(T) * 8); }
     static unsigned int log2_l_type();
     unsigned int get_bit_le(const T* in_vector, unsigned int bit_addr);
     unsigned int get_bit_be(const T* in_vector, unsigned int bit_addr);

--- a/gr-blocks/lib/unpacked_to_packed_impl.h
+++ b/gr-blocks/lib/unpacked_to_packed_impl.h
@@ -24,7 +24,7 @@ private:
     const unsigned int d_bits_per_chunk;
     const endianness_t d_endianness;
     unsigned int d_index;
-    static constexpr unsigned int d_bits_per_type = sizeof(T) * 8;
+    static constexpr unsigned int bits_per_type() { return (sizeof(T) * 8); }
     unsigned int
     get_bit_be1(const T* in_vector, unsigned int bit_addr, unsigned int bits_per_chunk);
 


### PR DESCRIPTION
Also, get rid of impossible asserts(), and throw exceptions instead of
assert(0)-aborting, as we now have facilities to handle failed
block::work().

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit c5a1be2e93186df3c20ed2c0512dfd2e1ce7799e)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4255