### PR TITLE
gr-fft: Expand window enum - backport 3.9

### DIFF
--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -26,6 +26,7 @@ public:
         WIN_NONE = -1,       //!< don't use a window
         WIN_HAMMING = 0,     //!< Hamming window; max attenuation 53 dB
         WIN_HANN = 1,        //!< Hann window; max attenuation 44 dB
+        WIN_HANNING = 1,     //!< alias to WIN_HANN
         WIN_BLACKMAN = 2,    //!< Blackman window; max attenuation 74 dB
         WIN_RECTANGULAR = 3, //!< Basic rectangular window; max attenuation 21 dB
         WIN_KAISER = 4, //!< Kaiser window; max attenuation see window::max_attenuation
@@ -34,27 +35,51 @@ public:
             5,            //!< alias to WIN_BLACKMAN_hARRIS for capitalization consistency
         WIN_BARTLETT = 6, //!< Barlett (triangular) window; max attenuation 26 dB
         WIN_FLATTOP = 7,  //!< flat top window; useful in FFTs; max attenuation 93 dB
+        WIN_NUTTALL = 8,  //!< Nuttall window; max attenuation 114 dB
+        WIN_BLACKMAN_NUTTALL = 8, //!< Nuttall window; max attenuation 114 dB
+        WIN_NUTTALL_CFD =
+            9, //!< Nuttall continuous-first-derivative window; max attenuation 112 dB
+        WIN_WELCH = 10,  //!< Welch window; max attenuation 31 dB
+        WIN_PARZEN = 11, //!< Parzen window; max attenuation 56 dB
+        WIN_EXPONENTIAL =
+            12, //!< Exponential window; max attenuation see window::max_attenuation
+        WIN_RIEMANN = 13, //!< Riemann window; max attenuation 39 dB
+        WIN_GAUSSIAN =
+            14,         //!< Gaussian window; max attenuation see window::max_attenuation
+        WIN_TUKEY = 15, //!< Tukey window; max attenuation see window::max_attenuation
     };
 
     /*!
      * \brief Given a window::win_type, this tells you the maximum
-     * attenuation you can expect.
+     * attenuation (really the maximum approximation error) you can expect.
      *
      * \details
-     * For most windows, this is a set value. For the Kaiser window,
-     * the attenuation is based on the value of beta. The actual
-     * relationship is a piece-wise exponential relationship to
-     * calculate beta from the desired attenuation and can be found
-     * on page 542 of Oppenheim and Schafer (Discrete-Time Signal
-     * Processing, 3rd edition). To simplify this function to solve
-     * for A given beta, we use a linear form that is exact for
-     * attenuation >= 50 dB.
+     * For most windows, this is a set value. For the Kaiser, Exponential, Gaussian, and
+     * Tukey windows, the attenuation is based on the value of a provided parameter.
      *
-     * For an attenuation of 50 dB, beta = 4.55.
-     * For an attenuation of 70 dB, beta = 6.76.
+     * For the Kaiser window the actual relationship is a piece-wise exponential
+     * relationship to calculate beta from the desired attenuation and can be found on
+     * page 542 of Oppenheim and Schafer (Discrete-Time Signal Processing, 3rd edition).
+     * To simplify this function to solve for A given beta, we use a linear form that is
+     * exact for attenuation >= 50 dB. For an attenuation of 50 dB, beta = 4.55; for an
+     * attenuation of 70 dB, beta = 6.76.
+     *
+     * Exponential attenuation is complicated to measure due to the irregular error ripple
+     * structure, but it ranges between 23 and 26 dB depending on the decay factor; 26 dB
+     * is a good bound.
+     *
+     * The Gaussian window should not be used for window based filter construction;
+     * instead there is a dedicated gaussian filter construction fuction. There is no
+     * meaningful way to measure approximation error 'delta' as shown in Fig 7.23 of
+     * Oppenheim and Schafer (Discrete-Time Signal Processing, 3rd edition).
+     *
+     * Tukey windows provide attenuation that varies non-linearily between Rectangular (21
+     * dB) and Hann (44 dB) windows.
      *
      * \param type The window::win_type enumeration of the window type.
-     * \param beta Beta value only used for the Kaiser window.
+     * \param beta Parameter value used for Kaiser (beta), Exponential (d), Gaussian
+     * (sigma) and Tukey (alpha) window creation. The name `beta` is still used for API
+     * compatibility reasons but will be changed to `param` in 3.10.
      */
     static double max_attenuation(win_type type, double beta = 6.76);
 
@@ -329,7 +354,9 @@ public:
      *
      * \param type a gr::fft::win_type index for the type of window.
      * \param ntaps Number of coefficients in the window.
-     * \param beta Used only for building Kaiser windows.
+     * \param beta Parameter value used for Kaiser (beta), Exponential (d), Gaussian
+     * (sigma) and Tukey (alpha) window creation. The name `beta` is still used for API
+     * compatibility reasons but will be changed to `param` in 3.10.
      * \param normalize If true, return a window with unit power
      */
     static std::vector<float>

--- a/gr-fft/include/gnuradio/fft/window.h
+++ b/gr-fft/include/gnuradio/fft/window.h
@@ -195,9 +195,17 @@ public:
     static std::vector<float> blackmanharris(int ntaps, int atten = 92);
 
     /*!
-     * \brief Build a Nuttall (or Blackman-Nuttall) window.
+     * \brief Build a minimum 4-term Nuttall (or Blackman-Nuttall) window, referred to by
+     * Heinzel G. et al. as a Nuttall4c window.
      *
-     * See: http://en.wikipedia.org/wiki/Window_function#Blackman.E2.80.93Nuttall_window
+     * See: A.H. Nuttall: 'Some windows with very good sidelobe behaviour', IEEE Trans. on
+     * Acoustics, Speech and Signal Processing, Vol ASSP-29, figure 15
+     *
+     * See: 'Spectrum and spectral density estimation by the Discrete Fourier transform
+     * (DFT), including a comprehensive list of window functions and some new flat-top
+     * windows', February 15, 2002 https://holometer.fnal.gov/GH_FFT.pdf
+     *
+     * Also: http://en.wikipedia.org/wiki/Window_function#Blackman.E2.80.93Nuttall_window
      *
      * \param ntaps Number of coefficients in the window.
      */
@@ -221,9 +229,17 @@ public:
     static std::vector<float> blackman_nuttal(int ntaps);
 
     /*!
-     * \brief Build a Nuttall continuous first derivative window.
+     * \brief Build a Nuttall 4-term continuous first derivative window, referred to by
+     * Heinzel G. et al. as a Nuttall4b window
      *
-     * See:
+     * See: A.H. Nuttall: 'Some windows with very good sidelobe behaviour', IEEE Trans. on
+     * Acoustics, Speech and Signal Processing, Vol ASSP-29, figure 12
+     *
+     * See: 'Spectrum and spectral density estimation by the Discrete Fourier transform
+     * (DFT), including a comprehensive list of window functions and some new flat-top
+     * windows', February 15, 2002 https://holometer.fnal.gov/GH_FFT.pdf
+     *
+     * Also:
      * http://en.wikipedia.org/wiki/Window_function#Nuttall_window.2C_continuous_first_derivative
      *
      * \param ntaps Number of coefficients in the window.

--- a/gr-fft/lib/window.cc
+++ b/gr-fft/lib/window.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2002,2007,2008,2012,2013,2018 Free Software Foundation, Inc.
+ * Copyright 2002,2007,2008,2012,2013,2018,2021 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -55,28 +55,21 @@ double window::max_attenuation(win_type type, double param)
     switch (type) {
     case (WIN_HAMMING):
         return 53;
-        break;
     case (WIN_HANN):
         return 44;
-        break;
     case (WIN_BLACKMAN):
         return 74;
-        break;
     case (WIN_RECTANGULAR):
         return 21;
-        break;
     case (WIN_KAISER):
+        // linear approximation
         return (param / 0.1102 + 8.7);
-        break;
     case (WIN_BLACKMAN_hARRIS):
         return 92;
-        break;
     case (WIN_BARTLETT):
         return 27;
-        break;
     case (WIN_FLATTOP):
         return 93;
-        break;
     case WIN_NUTTALL:
         return 114;
     case WIN_NUTTALL_CFD:
@@ -91,7 +84,7 @@ double window::max_attenuation(win_type type, double param)
     case WIN_RIEMANN:
         return 39;
     case WIN_GAUSSIAN:
-        // not meaningful for gaussian windows, but return something reasonable
+        // value not meaningful for gaussian windows, but return something reasonable
         return 100;
     case WIN_TUKEY:
         // low end is a rectangular window, attenuation exponentialy approaches Hann
@@ -345,14 +338,14 @@ std::vector<float> window::riemann(int ntaps)
     return taps;
 }
 
-std::vector<float> window::tukey(int ntaps, float a)
+std::vector<float> window::tukey(int ntaps, float alpha)
 {
-    if ((a < 0) || (a > 1))
+    if ((alpha < 0) || (alpha > 1))
         throw std::out_of_range("window::tukey: alpha must be between 0 and 1");
 
     float N = static_cast<float>(ntaps - 1);
 
-    float aN = a * N;
+    float aN = alpha * N;
     float p1 = aN / 2.0;
     float mid = midn(ntaps);
     std::vector<float> taps(ntaps);

--- a/gr-fft/python/fft/bindings/docstrings/window_pydoc_template.h
+++ b/gr-fft/python/fft/bindings/docstrings/window_pydoc_template.h
@@ -105,4 +105,10 @@ static const char* __doc_gr_fft_window_exponential = R"doc()doc";
 static const char* __doc_gr_fft_window_riemann = R"doc()doc";
 
 
+static const char* __doc_gr_fft_window_tukey = R"doc()doc";
+
+
+static const char* __doc_gr_fft_window_gaussian = R"doc()doc";
+
+
 static const char* __doc_gr_fft_window_build = R"doc()doc";

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2020,2021 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(window.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(73ef06fc08edcb7fd595af5ab8bd2911)                     */
+/* BINDTOOL_HEADER_FILE_HASH(d14efc888c380b1b74cdd63716a3892a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -192,6 +192,17 @@ void bind_window(py::module& m)
 
 
         .def_static("riemann", &window::riemann, py::arg("ntaps"), D(window, riemann))
+
+
+        .def_static(
+            "tukey", &window::tukey, py::arg("ntaps"), py::arg("alpha"), D(window, tukey))
+
+
+        .def_static("gaussian",
+                    &window::gaussian,
+                    py::arg("ntaps"),
+                    py::arg("sigma"),
+                    D(window, gaussian))
 
 
         .def_static("build",

--- a/gr-fft/python/fft/bindings/window_python.cc
+++ b/gr-fft/python/fft/bindings/window_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(window.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(79ff69d65c70259ecd1fc4d7410add8e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(73ef06fc08edcb7fd595af5ab8bd2911)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -34,15 +34,25 @@ void bind_window(py::module& m)
     py::class_<window, std::shared_ptr<window>> window_class(m, "window", D(window));
 
     py::enum_<gr::fft::window::win_type>(window_class, "win_type")
-        .value("WIN_HAMMING", gr::fft::window::WIN_HAMMING)                 // 0
-        .value("WIN_HANN", gr::fft::window::WIN_HANN)                       // 1
-        .value("WIN_BLACKMAN", gr::fft::window::WIN_BLACKMAN)               // 2
-        .value("WIN_RECTANGULAR", gr::fft::window::WIN_RECTANGULAR)         // 3
-        .value("WIN_KAISER", gr::fft::window::WIN_KAISER)                   // 4
-        .value("WIN_BLACKMAN_hARRIS", gr::fft::window::WIN_BLACKMAN_hARRIS) // 5
-        .value("WIN_BLACKMAN_HARRIS", gr::fft::window::WIN_BLACKMAN_HARRIS) // 5
-        .value("WIN_BARTLETT", gr::fft::window::WIN_BARTLETT)               // 6
-        .value("WIN_FLATTOP", gr::fft::window::WIN_FLATTOP)                 // 7
+        .value("WIN_HAMMING", gr::fft::window::WIN_HAMMING)                   // 0
+        .value("WIN_HANN", gr::fft::window::WIN_HANN)                         // 1
+        .value("WIN_HANNING", gr::fft::window::WIN_HANNING)                   // 1
+        .value("WIN_BLACKMAN", gr::fft::window::WIN_BLACKMAN)                 // 2
+        .value("WIN_RECTANGULAR", gr::fft::window::WIN_RECTANGULAR)           // 3
+        .value("WIN_KAISER", gr::fft::window::WIN_KAISER)                     // 4
+        .value("WIN_BLACKMAN_hARRIS", gr::fft::window::WIN_BLACKMAN_hARRIS)   // 5
+        .value("WIN_BLACKMAN_HARRIS", gr::fft::window::WIN_BLACKMAN_HARRIS)   // 5
+        .value("WIN_BARTLETT", gr::fft::window::WIN_BARTLETT)                 // 6
+        .value("WIN_FLATTOP", gr::fft::window::WIN_FLATTOP)                   // 7
+        .value("WIN_NUTTALL", gr::fft::window::WIN_NUTTALL)                   // 8
+        .value("WIN_BLACKMAN_NUTTALL", gr::fft::window::WIN_BLACKMAN_NUTTALL) // 8
+        .value("WIN_NUTTALL_CFD", gr::fft::window::WIN_NUTTALL_CFD)           // 9
+        .value("WIN_WELCH", gr::fft::window::WIN_WELCH)                       // 10
+        .value("WIN_PARZEN", gr::fft::window::WIN_PARZEN)                     // 11
+        .value("WIN_EXPONENTIAL", gr::fft::window::WIN_EXPONENTIAL)           // 12
+        .value("WIN_RIEMANN", gr::fft::window::WIN_RIEMANN)                   // 13
+        .value("WIN_GAUSSIAN", gr::fft::window::WIN_GAUSSIAN)                 // 14
+        .value("WIN_TUKEY", gr::fft::window::WIN_TUKEY)                       // 15
         .export_values();
 
     py::implicitly_convertible<int, gr::fft::window::win_type>();

--- a/gr-filter/include/gnuradio/filter/firdes.h
+++ b/gr-filter/include/gnuradio/filter/firdes.h
@@ -40,10 +40,11 @@ public:
      *
      * \param gain                overall gain of filter (typically 1.0)
      * \param sampling_freq       sampling freq (Hz)
-     * \param cutoff_freq	        center of transition band (Hz)
-     * \param transition_width	width of transition band (Hz)
+     * \param cutoff_freq         center of transition band (Hz)
+     * \param transition_width    width of transition band (Hz)
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     low_pass(double gain,
@@ -51,7 +52,7 @@ public:
              double cutoff_freq,      // Hz center of transition band
              double transition_width, // Hz width of transition band
              fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-             double beta = 6.76); // used only with Kaiser
+             double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a low-pass FIR filter.  The
@@ -66,7 +67,8 @@ public:
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      required stopband attenuation
      * \param window              one of fft::window::win_type
-     * \param beta		        parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     low_pass_2(double gain,
@@ -75,7 +77,7 @@ public:
                double transition_width, // Hz width of transition band
                double attenuation_dB,   // out of band attenuation dB
                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-               double beta = 6.76); // used only with Kaiser
+               double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a high-pass FIR filter.  The
@@ -88,7 +90,8 @@ public:
      * \param cutoff_freq         center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     high_pass(double gain,
@@ -96,7 +99,7 @@ public:
               double cutoff_freq,      // Hz center of transition band
               double transition_width, // Hz width of transition band
               fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-              double beta = 6.76); // used only with Kaiser
+              double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a high-pass FIR filter. The
@@ -111,7 +114,8 @@ public:
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     high_pass_2(double gain,
@@ -120,7 +124,7 @@ public:
                 double transition_width, // Hz width of transition band
                 double attenuation_dB,   // out of band attenuation dB
                 fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                double beta = 6.76); // used only with Kaiser
+                double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a band-pass FIR filter. The
@@ -134,7 +138,8 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     band_pass(double gain,
@@ -143,7 +148,7 @@ public:
               double high_cutoff_freq, // Hz center of transition band
               double transition_width, // Hz width of transition band
               fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-              double beta = 6.76); // used only with Kaiser
+              double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a band-pass FIR filter.  The
@@ -159,7 +164,8 @@ public:
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     band_pass_2(double gain,
@@ -169,7 +175,7 @@ public:
                 double transition_width, // Hz width of transition band
                 double attenuation_dB,   // out of band attenuation dB
                 fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                double beta = 6.76); // used only with Kaiser
+                double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
     /*!
      * \brief Use the "window method" to design a complex band-reject FIR
      * filter.  The normalized width of the transition band is what sets the
@@ -182,16 +188,17 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
-    static std::vector<gr_complex>
-    complex_band_reject(double gain,
-                        double sampling_freq,
-                        double low_cutoff_freq,
-                        double high_cutoff_freq,
-                        double transition_width, // Hz width of transition band
-                        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                        double beta = 6.76); // used only with Kaiser
+    static std::vector<gr_complex> complex_band_reject(
+        double gain,
+        double sampling_freq,
+        double low_cutoff_freq,
+        double high_cutoff_freq,
+        double transition_width, // Hz width of transition band
+        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a complex band-reject FIR filter.
@@ -207,7 +214,8 @@ public:
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      out of band attenuation
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<gr_complex> complex_band_reject_2(
         double gain,
@@ -217,7 +225,7 @@ public:
         double transition_width, // Hz width of transition band
         double attenuation_dB,   // out of band attenuation dB
         fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-        double beta = 6.76); // used only with Kaiser
+        double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use the "window method" to design a complex band-pass FIR
@@ -231,16 +239,17 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
-    static std::vector<gr_complex>
-    complex_band_pass(double gain,
-                      double sampling_freq,
-                      double low_cutoff_freq,  // Hz center of transition band
-                      double high_cutoff_freq, // Hz center of transition band
-                      double transition_width, // Hz width of transition band
-                      fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                      double beta = 6.76); // used only with Kaiser
+    static std::vector<gr_complex> complex_band_pass(
+        double gain,
+        double sampling_freq,
+        double low_cutoff_freq,  // Hz center of transition band
+        double high_cutoff_freq, // Hz center of transition band
+        double transition_width, // Hz width of transition band
+        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a complex band-pass FIR filter.
@@ -256,17 +265,18 @@ public:
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      out of band attenuation
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
-    static std::vector<gr_complex>
-    complex_band_pass_2(double gain,
-                        double sampling_freq,
-                        double low_cutoff_freq,  // Hz beginning transition band
-                        double high_cutoff_freq, // Hz beginning transition band
-                        double transition_width, // Hz width of transition band
-                        double attenuation_dB,   // out of band attenuation dB
-                        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                        double beta = 6.76); // used only with Kaiser
+    static std::vector<gr_complex> complex_band_pass_2(
+        double gain,
+        double sampling_freq,
+        double low_cutoff_freq,  // Hz beginning transition band
+        double high_cutoff_freq, // Hz beginning transition band
+        double transition_width, // Hz width of transition band
+        double attenuation_dB,   // out of band attenuation dB
+        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a band-reject FIR filter.  The
@@ -280,7 +290,8 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     band_reject(double gain,
@@ -289,7 +300,7 @@ public:
                 double high_cutoff_freq, // Hz center of transition band
                 double transition_width, // Hz width of transition band
                 fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                double beta = 6.76); // used only with Kaiser
+                double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
      * \brief Use "window method" to design a band-reject FIR filter.  The
@@ -305,7 +316,8 @@ public:
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
      * \param window              one of fft::window::win_type
-     * \param beta                parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     band_reject_2(double gain,
@@ -315,13 +327,14 @@ public:
                   double transition_width, // Hz width of transition band
                   double attenuation_dB,   // out of band attenuation dB
                   fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
-                  double beta = 6.76); // used only with Kaiser
+                  double beta = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!\brief design a Hilbert Transform Filter
      *
      * \param ntaps           number of taps, must be odd
      * \param windowtype      one kind of fft::window::win_type
-     * \param beta            parameter for Kaiser window
+     * \param beta            parameter for Kaiser, Exp., Gaussian, Tukey windows, the
+     * name `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static std::vector<float>
     hilbert(unsigned int ntaps = 19,
@@ -370,7 +383,7 @@ private:
     static int compute_ntaps(double sampling_freq,
                              double transition_width,
                              fft::window::win_type window_type,
-                             double beta);
+                             double param);
 
     static int compute_ntaps_windes(double sampling_freq,
                                     double transition_width,

--- a/gr-filter/include/gnuradio/filter/hilbert_fc.h
+++ b/gr-filter/include/gnuradio/filter/hilbert_fc.h
@@ -40,7 +40,8 @@ public:
      *
      * \param ntaps The number of taps for the filter.
      * \param window Window type (see fft::window::win_type) to use.
-     * \param beta Beta value for a Kaiser window.
+     * \param beta Parameter value for Kaiser, Exp., Gaussian, Tukey windows, the name
+     * `beta` is used for API compatibility but will be changed to `param` in 3.10.
      */
     static sptr make(unsigned int ntaps,
                      fft::window::win_type window = fft::window::win_type::WIN_HAMMING,

--- a/gr-filter/lib/firdes.cc
+++ b/gr-filter/lib/firdes.cc
@@ -21,9 +21,9 @@ using std::vector;
 namespace gr {
 namespace filter {
 
-std::vector<float> firdes::window(fft::window::win_type type, int ntaps, double beta)
+std::vector<float> firdes::window(fft::window::win_type type, int ntaps, double param)
 {
-    return fft::window::build(type, ntaps, beta);
+    return fft::window::build(type, ntaps, param);
 }
 
 //
@@ -36,7 +36,7 @@ vector<float> firdes::low_pass_2(double gain,
                                  double transition_width, // Hz width of transition band
                                  double attenuation_dB,   // attenuation dB
                                  fft::window::win_type window_type,
-                                 double beta) // used only with Kaiser
+                                 double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
 
@@ -46,7 +46,7 @@ vector<float> firdes::low_pass_2(double gain,
     // [sin(x)/x for the low pass case]
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * cutoff_freq / sampling_freq;
@@ -79,17 +79,16 @@ vector<float> firdes::low_pass(double gain,
                                double cutoff_freq,      // Hz center of transition band
                                double transition_width, // Hz width of transition band
                                fft::window::win_type window_type,
-                               double beta) // used only with Kaiser
+                               double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
-
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
     // construct the truncated ideal impulse response
     // [sin(x)/x for the low pass case]
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * cutoff_freq / sampling_freq;
@@ -129,7 +128,7 @@ vector<float> firdes::high_pass_2(double gain,
                                   double transition_width, // Hz width of transition band
                                   double attenuation_dB,   // attenuation dB
                                   fft::window::win_type window_type,
-                                  double beta) // used only with Kaiser
+                                  double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
 
@@ -138,7 +137,7 @@ vector<float> firdes::high_pass_2(double gain,
     // construct the truncated ideal impulse response times the window function
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * cutoff_freq / sampling_freq;
@@ -173,16 +172,16 @@ vector<float> firdes::high_pass(double gain,
                                 double cutoff_freq,      // Hz center of transition band
                                 double transition_width, // Hz width of transition band
                                 fft::window::win_type window_type,
-                                double beta) // used only with Kaiser
+                                double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
 
     // construct the truncated ideal impulse response times the window function
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * cutoff_freq / sampling_freq;
@@ -222,14 +221,14 @@ vector<float> firdes::band_pass_2(double gain,
                                   double transition_width, // Hz width of transition band
                                   double attenuation_dB,   // attenuation dB
                                   fft::window::win_type window_type,
-                                  double beta) // used only with Kaiser
+                                  double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
     int ntaps = compute_ntaps_windes(sampling_freq, transition_width, attenuation_dB);
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * low_cutoff_freq / sampling_freq;
@@ -265,16 +264,16 @@ vector<float> firdes::band_pass(double gain,
                                 double high_cutoff_freq, // Hz center of transition band
                                 double transition_width, // Hz width of transition band
                                 fft::window::win_type window_type,
-                                double beta) // used only with Kaiser
+                                double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
 
     // construct the truncated ideal impulse response times the window function
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * low_cutoff_freq / sampling_freq;
@@ -315,7 +314,7 @@ firdes::complex_band_pass_2(double gain,
                             double transition_width, // Hz width of transition band
                             double attenuation_dB,   // attenuation dB
                             fft::window::win_type window_type,
-                            double beta) // used only with Kaiser
+                            double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
@@ -323,7 +322,7 @@ firdes::complex_band_pass_2(double gain,
 
     vector<gr_complex> taps(ntaps);
     vector<float> lptaps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     lptaps = low_pass_2(gain,
                         sampling_freq,
@@ -331,7 +330,7 @@ firdes::complex_band_pass_2(double gain,
                         transition_width,
                         attenuation_dB,
                         window_type,
-                        beta);
+                        param);
 
     gr_complex* optr = &taps[0];
     float* iptr = &lptaps[0];
@@ -358,24 +357,24 @@ firdes::complex_band_pass(double gain,
                           double high_cutoff_freq, // Hz center of transition band
                           double transition_width, // Hz width of transition band
                           fft::window::win_type window_type,
-                          double beta) // used only with Kaiser
+                          double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
 
     // construct the truncated ideal impulse response times the window function
 
     vector<gr_complex> taps(ntaps);
     vector<float> lptaps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     lptaps = low_pass(gain,
                       sampling_freq,
                       (high_cutoff_freq - low_cutoff_freq) / 2,
                       transition_width,
                       window_type,
-                      beta);
+                      param);
 
     gr_complex* optr = &taps[0];
     float* iptr = &lptaps[0];
@@ -406,17 +405,17 @@ firdes::complex_band_reject_2(double gain,
                               double transition_width, // Hz width of transition band
                               double attenuation_dB,   // attenuation dB
                               fft::window::win_type window_type,
-                              double beta) // used only with Kaiser
+                              double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
 
     // construct the truncated ideal impulse response times the window function
 
     vector<gr_complex> taps(ntaps);
     vector<float> hptaps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     hptaps = high_pass_2(gain,
                          sampling_freq,
@@ -424,7 +423,7 @@ firdes::complex_band_reject_2(double gain,
                          transition_width,
                          attenuation_dB,
                          window_type,
-                         beta);
+                         param);
 
     gr_complex* optr = &taps[0];
     float* iptr = &hptaps[0];
@@ -450,24 +449,24 @@ firdes::complex_band_reject(double gain,
                             double high_cutoff_freq, // Hz center of transition band
                             double transition_width, // Hz width of transition band
                             fft::window::win_type window_type,
-                            double beta) // used only with Kaiser
+                            double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
 
     // construct the truncated ideal impulse response times the window function
 
     vector<gr_complex> taps(ntaps);
     vector<float> hptaps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     hptaps = high_pass(gain,
                        sampling_freq,
                        (high_cutoff_freq - low_cutoff_freq) / 2,
                        transition_width,
                        window_type,
-                       beta);
+                       param);
 
     gr_complex* optr = &taps[0];
     float* iptr = &hptaps[0];
@@ -498,7 +497,7 @@ firdes::band_reject_2(double gain,
                       double transition_width, // Hz width of transition band
                       double attenuation_dB,   // attenuation dB
                       fft::window::win_type window_type,
-                      double beta) // used only with Kaiser
+                      double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
@@ -507,7 +506,7 @@ firdes::band_reject_2(double gain,
     // construct the truncated ideal impulse response times the window function
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * low_cutoff_freq / sampling_freq;
@@ -542,16 +541,16 @@ vector<float> firdes::band_reject(double gain,
                                   double high_cutoff_freq, // Hz center of transition band
                                   double transition_width, // Hz width of transition band
                                   fft::window::win_type window_type,
-                                  double beta) // used only with Kaiser
+                                  double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
 
-    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, beta);
+    int ntaps = compute_ntaps(sampling_freq, transition_width, window_type, param);
 
     // construct the truncated ideal impulse response times the window function
 
     vector<float> taps(ntaps);
-    vector<float> w = window(window_type, ntaps, beta);
+    vector<float> w = window(window_type, ntaps, param);
 
     int M = (ntaps - 1) / 2;
     double fwT0 = 2 * GR_M_PI * low_cutoff_freq / sampling_freq;
@@ -585,13 +584,13 @@ vector<float> firdes::band_reject(double gain,
 //
 
 vector<float>
-firdes::hilbert(unsigned int ntaps, fft::window::win_type windowtype, double beta)
+firdes::hilbert(unsigned int ntaps, fft::window::win_type windowtype, double param)
 {
     if (!(ntaps & 1))
         throw std::out_of_range("Hilbert:  Must have odd number of taps");
 
     vector<float> taps(ntaps);
-    vector<float> w = window(windowtype, ntaps, beta);
+    vector<float> w = window(windowtype, ntaps, param);
     unsigned int h = (ntaps - 1) / 2;
     float gain = 0;
     for (unsigned int i = 1; i <= h; i++) {
@@ -704,9 +703,9 @@ int firdes::compute_ntaps_windes(
 int firdes::compute_ntaps(double sampling_freq,
                           double transition_width,
                           fft::window::win_type window_type,
-                          double beta)
+                          double param)
 {
-    double a = fft::window::max_attenuation(window_type, beta);
+    double a = fft::window::max_attenuation(window_type, param);
     int ntaps = (int)(a * sampling_freq / (22.0 * transition_width));
     if ((ntaps & 1) == 0) // if even...
         ntaps++;          // ...make odd

--- a/gr-filter/lib/hilbert_fc_impl.cc
+++ b/gr-filter/lib/hilbert_fc_impl.cc
@@ -21,19 +21,19 @@ namespace gr {
 namespace filter {
 
 hilbert_fc::sptr
-hilbert_fc::make(unsigned int ntaps, fft::window::win_type window, double beta)
+hilbert_fc::make(unsigned int ntaps, fft::window::win_type window, double param)
 {
-    return gnuradio::make_block_sptr<hilbert_fc_impl>(ntaps, window, beta);
+    return gnuradio::make_block_sptr<hilbert_fc_impl>(ntaps, window, param);
 }
 
 hilbert_fc_impl::hilbert_fc_impl(unsigned int ntaps,
                                  fft::window::win_type window,
-                                 double beta)
+                                 double param)
     : sync_block("hilbert_fc",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
       d_ntaps(ntaps | 0x1), // ensure ntaps is odd
-      d_hilb(firdes::hilbert(d_ntaps, window, beta))
+      d_hilb(firdes::hilbert(d_ntaps, window, param))
 {
     set_history(d_ntaps);
 

--- a/gr-filter/lib/hilbert_fc_impl.h
+++ b/gr-filter/lib/hilbert_fc_impl.h
@@ -28,7 +28,7 @@ private:
 public:
     hilbert_fc_impl(unsigned int ntaps,
                     fft::window::win_type window = fft::window::WIN_HAMMING,
-                    double beta = 6.76);
+                    double param = 6.76);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-filter/python/filter/bindings/firdes_python.cc
+++ b/gr-filter/python/filter/bindings/firdes_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(firdes.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(afeccb5d25e3c88b1dcfc23d3542ec0b)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b592140ff2b1a9981825b252e6a07018)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/hilbert_fc_python.cc
+++ b/gr-filter/python/filter/bindings/hilbert_fc_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(hilbert_fc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3f5ee100c05bf0b167c39a017a65b9eb)                     */
+/* BINDTOOL_HEADER_FILE(hilbert_fc.h)                                              */
+/* BINDTOOL_HEADER_FILE_HASH(bc1fab779b603f77bfdbc6afd37c9da0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
This is a backport of most of #4139 however the API has been modified to be compatible with 3.9. This essentially means all public methods continue to use the term `beta` (which is syntactically specific to the existing kaiser window) instead of the more generic `param` that is in 3.10. Internally, the code makes use of 'param'. Despite that, this is feature-complete and allows the use of these new windows.