### PR TITLE
uhd: Fix phase relations plot (Qt issue) (backport to maint-3.9)

### DIFF
--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -331,7 +331,8 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
                 1024, #size
                 self.samp_rate, #samp_rate
                 "", #name
-                len(self.channels) - 1
+                len(self.channels) - 1,
+                None # parent
             )
             self.qtgui_phase_plot.set_update_time(self.update_rate)
             self.qtgui_phase_plot.set_y_axis(-3.5, 3.5)


### PR DESCRIPTION
The phase-relations plot didn't specify a handle for the Qt parent,
which used to be OK (it would default to None) but no longer is.

Signed-off-by: Martin Braun <martin@gnuradio.org>
(cherry picked from commit f6fe5280edf78e668f918f6b38f7d59eef7c0a9a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4400