### PR TITLE
Remove boost::bind where trivial

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thrift_application_base.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_application_base.h
@@ -202,8 +202,8 @@ void thrift_application_base<TserverBase, TserverClass>::start_application()
             "thrift", "init_attempts", d_default_max_init_attempts));
 
     if (!p_impl->d_application_initialized) {
-        p_impl->d_start_thrift_thread.reset(
-            (new gr::thread::thread([app = d_application] { app->start_thrift(); })));
+        p_impl->d_start_thrift_thread = std::make_shared<gr::thread::thread>(
+            [app = d_application] { app->start_thrift(); });
 
         bool app_started(false);
         for (unsigned int attempts(0); (!app_started && attempts < max_init_attempts);

--- a/gnuradio-runtime/include/gnuradio/thrift_application_base.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_application_base.h
@@ -202,8 +202,8 @@ void thrift_application_base<TserverBase, TserverClass>::start_application()
             "thrift", "init_attempts", d_default_max_init_attempts));
 
     if (!p_impl->d_application_initialized) {
-        p_impl->d_start_thrift_thread.reset((new gr::thread::thread(
-            boost::bind(&thrift_application_base::start_thrift, d_application))));
+        p_impl->d_start_thrift_thread.reset(
+            (new gr::thread::thread([app = d_application] { app->start_thrift(); })));
 
         bool app_started(false);
         for (unsigned int attempts(0); (!app_started && attempts < max_init_attempts);

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/thrift_application_base_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/thrift_application_base_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(thrift_application_base.h) */
-/* BINDTOOL_HEADER_FILE_HASH(6308813ad7a4fccf1d2baa9ab79a8634)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a27f23a8d3fc9fff2ecc054d43abbcaa)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -41,7 +41,7 @@ message_strobe_impl::~message_strobe_impl() {}
 bool message_strobe_impl::start()
 {
     d_finished = false;
-    d_thread = gr::thread::thread(std::bind(&message_strobe_impl::run, this));
+    d_thread = gr::thread::thread([this] { run(); });
 
     return block::start();
 }

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -50,7 +50,7 @@ message_strobe_random_impl::message_strobe_random_impl(
 {
     // set up ports
     message_port_register_out(d_port);
-    d_thread = gr::thread::thread(std::bind(&message_strobe_random_impl::run, this));
+    d_thread = gr::thread::thread([this] { run(); });
 
     message_port_register_in(pmt::mp("set_msg"));
     set_msg_handler(pmt::mp("set_msg"), [this](pmt::pmt_t msg) { this->set_msg(msg); });

--- a/gr-network/lib/socket_pdu_impl.cc
+++ b/gr-network/lib/socket_pdu_impl.cc
@@ -136,7 +136,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
     } else
         throw std::runtime_error("gr::pdu:socket_pdu: unknown socket type");
 
-    d_thread = gr::thread::thread(boost::bind(&socket_pdu_impl::run_io_service, this));
+    d_thread = gr::thread::thread([this] { run_io_service(); });
     d_started = true;
 }
 

--- a/gr-network/lib/stream_pdu_base.cc
+++ b/gr-network/lib/stream_pdu_base.cc
@@ -44,7 +44,7 @@ void stream_pdu_base::start_rxthread(basic_block* blk, pmt::pmt_t port)
 {
     d_blk = blk;
     d_port = port;
-    d_thread = gr::thread::thread(std::bind(&stream_pdu_base::run, this));
+    d_thread = gr::thread::thread([this] { run(); });
     d_started = true;
 }
 

--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -98,8 +98,7 @@ tcp_sink_impl::tcp_sink_impl(
         // In this mode, we're starting a local port listener and waiting
         // for inbound connections.
         d_start_new_listener = true;
-        d_listener_thread =
-            new boost::thread(boost::bind(&tcp_sink_impl::run_listener, this));
+        d_listener_thread = new boost::thread([this] { run_listener(); });
     }
 }
 

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -61,8 +61,7 @@ pull_msg_source_impl::~pull_msg_source_impl() {}
 bool pull_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>(
-        boost::bind(&pull_msg_source_impl::readloop, this));
+    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -58,8 +58,7 @@ rep_msg_sink_impl::~rep_msg_sink_impl() {}
 bool rep_msg_sink_impl::start()
 {
     d_finished = false;
-    d_thread =
-        std::make_unique<boost::thread>(boost::bind(&rep_msg_sink_impl::readloop, this));
+    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -15,7 +15,6 @@
 #include "req_msg_source_impl.h"
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
-#include <boost/bind.hpp>
 #include <boost/thread/thread.hpp>
 #include <chrono>
 #include <memory>
@@ -62,8 +61,7 @@ req_msg_source_impl::~req_msg_source_impl() {}
 bool req_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>(
-        boost::bind(&req_msg_source_impl::readloop, this));
+    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -15,7 +15,6 @@
 #include "sub_msg_source_impl.h"
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
-#include <boost/bind.hpp>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -60,8 +59,7 @@ sub_msg_source_impl::~sub_msg_source_impl() {}
 bool sub_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>(
-        boost::bind(&sub_msg_source_impl::readloop, this));
+    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
     return true;
 }
 


### PR DESCRIPTION
That being everywhere where boost::asio isn't involved.

The boost::asio error placeholders for some reason don't play nicely with lambdas, I can't really figure out what's going wrong there, so let's leave it at this for now. This leaves boost::bind in place where boost::asio is used.