### PR TITLE
Make message_debug::store/num_messages thread-safe

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/message_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/message_debug.h
@@ -52,7 +52,7 @@ public:
     /*!
      * \brief Reports the number of messages received by this block.
      */
-    virtual int num_messages() = 0;
+    virtual size_t num_messages() = 0;
 
     /*!
      * \brief Get a message (as a PMT) from the message vector at index \p i.
@@ -67,7 +67,7 @@ public:
      *
      * \return a message at index \p i as a pmt_t.
      */
-    virtual pmt::pmt_t get_message(int i) = 0;
+    virtual pmt::pmt_t get_message(size_t i) = 0;
 
     /*!
      * \brief Enables or disables printing of PDU uniform vector data.

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -102,13 +102,13 @@ void message_debug_impl::print_pdu(pmt::pmt_t pdu)
     }
 }
 
-int message_debug_impl::num_messages() { return (int)d_messages.size(); }
+size_t message_debug_impl::num_messages() { return d_messages.size(); }
 
-pmt::pmt_t message_debug_impl::get_message(int i)
+pmt::pmt_t message_debug_impl::get_message(size_t i)
 {
     gr::thread::scoped_lock guard(d_mutex);
 
-    if ((size_t)i >= d_messages.size()) {
+    if (i >= d_messages.size()) {
         throw std::runtime_error("message_debug: index for message out of bounds.");
     }
 

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -30,25 +30,27 @@ message_debug_impl::message_debug_impl(bool en_uvec)
       d_en_uvec(en_uvec)
 {
     message_port_register_in(pmt::mp("print"));
-    set_msg_handler(pmt::mp("print"), [this](pmt::pmt_t msg) { this->print(msg); });
+    set_msg_handler(pmt::mp("print"),
+                    [this](const pmt::pmt_t& msg) { this->print(msg); });
 
     message_port_register_in(pmt::mp("store"));
-    set_msg_handler(pmt::mp("store"), [this](pmt::pmt_t msg) { this->store(msg); });
+    set_msg_handler(pmt::mp("store"),
+                    [this](const pmt::pmt_t& msg) { this->store(msg); });
 
     message_port_register_in(pmt::mp("print_pdu"));
     set_msg_handler(pmt::mp("print_pdu"),
-                    [this](pmt::pmt_t msg) { this->print_pdu(msg); });
+                    [this](const pmt::pmt_t& msg) { this->print_pdu(msg); });
 }
 
 message_debug_impl::~message_debug_impl() {}
 
-void message_debug_impl::print(pmt::pmt_t msg)
+void message_debug_impl::print(const pmt::pmt_t& msg)
 {
     std::stringstream sout;
 
     if (pmt::is_pdu(msg)) {
-        pmt::pmt_t meta = pmt::car(msg);
-        pmt::pmt_t vector = pmt::cdr(msg);
+        const auto& meta = pmt::car(msg);
+        const auto& vector = pmt::cdr(msg);
 
         sout << "***** VERBOSE PDU DEBUG PRINT ******" << std::endl
              << pmt::write_string(meta) << std::endl;
@@ -82,14 +84,14 @@ void message_debug_impl::print(pmt::pmt_t msg)
     std::cout << sout.str();
 }
 
-void message_debug_impl::store(pmt::pmt_t msg)
+void message_debug_impl::store(const pmt::pmt_t& msg)
 {
     gr::thread::scoped_lock guard(d_mutex);
     d_messages.push_back(msg);
 }
 
 // ! DEPRECATED as of 3.10 use print() for all printing!
-void message_debug_impl::print_pdu(pmt::pmt_t pdu)
+void message_debug_impl::print_pdu(const pmt::pmt_t& pdu)
 {
     if (pmt::is_pdu(pdu)) {
         GR_LOG_INFO(d_logger,

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -104,7 +104,11 @@ void message_debug_impl::print_pdu(const pmt::pmt_t& pdu)
     }
 }
 
-size_t message_debug_impl::num_messages() { return d_messages.size(); }
+size_t message_debug_impl::num_messages()
+{
+    gr::thread::scoped_lock guard(d_mutex);
+    return d_messages.size();
+}
 
 pmt::pmt_t message_debug_impl::get_message(size_t i)
 {

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -71,8 +71,8 @@ public:
     message_debug_impl(bool en_uvec);
     ~message_debug_impl() override;
 
-    int num_messages() override;
-    pmt::pmt_t get_message(int i) override;
+    size_t num_messages() override;
+    pmt::pmt_t get_message(size_t i) override;
     void set_vector_print(bool en) override { d_en_uvec = en; };
 };
 

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -35,7 +35,7 @@ private:
      *
      * \param msg A pmt message passed from the scheduler's message handling.
      */
-    void print(pmt::pmt_t msg);
+    void print(const pmt::pmt_t& msg);
 
     /*!
      * \brief PDU formatted messages received in this port are printed to stdout.
@@ -49,7 +49,7 @@ private:
      *
      * \param pdu A PDU message passed from the scheduler's message handling.
      */
-    void print_pdu(pmt::pmt_t pdu);
+    void print_pdu(const pmt::pmt_t& pdu);
 
     /*!
      * \brief Messages received in this port are stored in a vector.
@@ -62,7 +62,7 @@ private:
      *
      * \param msg A pmt message passed from the scheduler's message handling.
      */
-    void store(pmt::pmt_t msg);
+    void store(const pmt::pmt_t& msg);
 
     gr::thread::mutex d_mutex;
     std::vector<pmt::pmt_t> d_messages;

--- a/gr-blocks/python/blocks/bindings/message_debug_python.cc
+++ b/gr-blocks/python/blocks/bindings/message_debug_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(message_debug.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(27c3ba26dd33d2ecd535857d5ea26ed8)                     */
+/* BINDTOOL_HEADER_FILE_HASH(23b39e92e05151acfe9f9c5ed93c3c43)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Only needs a mutex. This was found while trying to figure out the headerparser mystery #4348.

On the way, use the native `size_t` for messgae index handling.

Backport: 3.7-3.9, only the mutexing in 4464766fa .