### PR TITLE
blocks: message_debug: mutex getting the stored message count (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -101,7 +101,11 @@ void message_debug_impl::print_pdu(pmt::pmt_t pdu)
     std::cout << sout.str();
 }
 
-int message_debug_impl::num_messages() { return (int)d_messages.size(); }
+int message_debug_impl::num_messages()
+{
+    gr::thread::scoped_lock guard(d_mutex);
+    return (int)d_messages.size();
+}
 
 pmt::pmt_t message_debug_impl::get_message(int i)
 {


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 3e4e7feffb29f54364b370594ee953d1c2d53327)
Backported mutex-related hunk only.
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport part of https://github.com/gnuradio/gnuradio/pull/4418