### PR TITLE
blocks: message_debug: mutex getting the stored message count (backport to maint-3.8)

### DIFF
--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -78,7 +78,11 @@ void message_debug_impl::print_pdu(pmt::pmt_t pdu)
     std::cout << "***********************************\n";
 }
 
-int message_debug_impl::num_messages() { return (int)d_messages.size(); }
+int message_debug_impl::num_messages()
+{
+    gr::thread::scoped_lock guard(d_mutex);
+    return (int)d_messages.size();
+}
 
 pmt::pmt_t message_debug_impl::get_message(int i)
 {


### PR DESCRIPTION
Manual backport of mutex portion only
Original author: Marcus Müller mmueller@gnuradio.org

Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport part of https://github.com/gnuradio/gnuradio/pull/4418