### PR TITLE
gr_filter_design: save wintype as int instead of str (backport to maint-3.9)

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -802,7 +802,7 @@ class gr_plot_filter(QtGui.QMainWindow):
                         "Half Band" : design_win_hb,
                         "Root Raised Cosine" :  design_win_rrc,
                         "Gaussian" :  design_win_gaus}
-            wintype = self.filterWindows[winstr]
+            wintype = int(self.filterWindows[winstr])
             taps,params,r = designer[ftype](fs, gain, wintype, self)
         if(r):
             if self.gridview:


### PR DESCRIPTION
Original author: Volker Schroer
Manually backported - just adding an int()

Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4444