### PR TITLE
Fastnoise_source: when picking indices from random pool, avoid modulo operation when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
   - requires MSVC 1914 (Microsoft VS 2017 15.7)
 - Windows build: removed unnecessary MSVC-specific system include overrides
 
+#### gr-analog
+
+- `fastnoise_source`: Use `uint64_t` seed API, use `size_t` for vector length/indices
+- `fastnoise_source`: Use a simple bitmask if the random pool length is a power
+  of 2 to determine indices, instead of `%`, which consumed considerable CPU
+
 ### Added
 
 - New in-tree module gr-pdu

--- a/gr-analog/include/gnuradio/analog/fastnoise_source.h
+++ b/gr-analog/include/gnuradio/analog/fastnoise_source.h
@@ -46,7 +46,8 @@ public:
      * \param seed seed for random generators. Note that for uniform
      *        and Gaussian distributions, this should be a negative
      *        number.
-     * \param samples Number of samples to pre-generate
+     * \param samples Number of samples to pre-generate. For performance
+     *        reasons, prefer a power of 2.
      */
     static sptr
     make(noise_type_t type, float ampl, uint64_t seed = 0, size_t samples = 1024 * 16);

--- a/gr-analog/include/gnuradio/analog/fastnoise_source.h
+++ b/gr-analog/include/gnuradio/analog/fastnoise_source.h
@@ -49,7 +49,7 @@ public:
      * \param samples Number of samples to pre-generate
      */
     static sptr
-    make(noise_type_t type, float ampl, long seed = 0, long samples = 1024 * 16);
+    make(noise_type_t type, float ampl, uint64_t seed = 0, size_t samples = 1024 * 16);
     virtual T sample() = 0;
     virtual T sample_unbiased() = 0;
     virtual const std::vector<T>& samples() const = 0;

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -24,7 +24,7 @@ namespace analog {
 
 template <class T>
 typename fastnoise_source<T>::sptr
-fastnoise_source<T>::make(noise_type_t type, float ampl, long seed, long samples)
+fastnoise_source<T>::make(noise_type_t type, float ampl, uint64_t seed, size_t samples)
 {
     return gnuradio::make_block_sptr<fastnoise_source_impl<T>>(type, ampl, seed, samples);
 }
@@ -32,16 +32,16 @@ fastnoise_source<T>::make(noise_type_t type, float ampl, long seed, long samples
 template <>
 void fastnoise_source_impl<gr_complex>::generate()
 {
-    int noutput_items = d_samples.size();
+    size_t noutput_items = d_samples.size();
     switch (d_type) {
     case GR_UNIFORM:
-        for (int i = 0; i < noutput_items; i++)
+        for (size_t i = 0; i < noutput_items; i++)
             d_samples[i] = gr_complex(d_ampl * ((d_rng.ran1() * 2.0) - 1.0),
                                       d_ampl * ((d_rng.ran1() * 2.0) - 1.0));
         break;
 
     case GR_GAUSSIAN:
-        for (int i = 0; i < noutput_items; i++)
+        for (size_t i = 0; i < noutput_items; i++)
             d_samples[i] = d_ampl * d_rng.rayleigh_complex();
         break;
     default:
@@ -52,8 +52,8 @@ void fastnoise_source_impl<gr_complex>::generate()
 template <class T>
 fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
                                                 float ampl,
-                                                long seed,
-                                                long samples)
+                                                uint64_t seed,
+                                                size_t samples)
     : sync_block("fastnoise_source",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(T))),
@@ -62,7 +62,7 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
       d_rng(seed)
 {
     d_samples.resize(samples);
-    xoroshiro128p_seed(d_state, (uint64_t)seed);
+    xoroshiro128p_seed(d_state, seed);
     generate();
 }
 
@@ -70,8 +70,8 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
 template <>
 fastnoise_source_impl<gr_complex>::fastnoise_source_impl(noise_type_t type,
                                                          float ampl,
-                                                         long seed,
-                                                         long samples)
+                                                         uint64_t seed,
+                                                         size_t samples)
     : sync_block("fastnoise_source",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(gr_complex))),
@@ -117,25 +117,25 @@ void fastnoise_source_impl<gr_complex>::set_amplitude(float ampl)
 template <class T>
 void fastnoise_source_impl<T>::generate()
 {
-    int noutput_items = d_samples.size();
+    size_t noutput_items = d_samples.size();
     switch (d_type) {
     case GR_UNIFORM:
-        for (int i = 0; i < noutput_items; i++)
+        for (size_t i = 0; i < noutput_items; i++)
             d_samples[i] = (T)(d_ampl * ((d_rng.ran1() * 2.0) - 1.0));
         break;
 
     case GR_GAUSSIAN:
-        for (int i = 0; i < noutput_items; i++)
+        for (size_t i = 0; i < noutput_items; i++)
             d_samples[i] = (T)(d_ampl * d_rng.gasdev());
         break;
 
     case GR_LAPLACIAN:
-        for (int i = 0; i < noutput_items; i++)
+        for (size_t i = 0; i < noutput_items; i++)
             d_samples[i] = (T)(d_ampl * d_rng.laplacian());
         break;
 
     case GR_IMPULSE: // FIXME changeable impulse settings
-        for (int i = 0; i < noutput_items; i++)
+        for (size_t i = 0; i < noutput_items; i++)
             d_samples[i] = (T)(d_ampl * d_rng.impulse(9));
         break;
     default:

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -24,6 +24,13 @@
 namespace gr {
 namespace analog {
 
+bool constexpr is_pwr_of_two(size_t value)
+{
+    // simple binary trick: an integer x is power of 2 if x-1 is all 1s, but only below
+    // the old 1-position.
+    // also, zero is not a power of two
+    return value && !(value & (value - 1));
+}
 template <class T>
 typename fastnoise_source<T>::sptr
 fastnoise_source<T>::make(noise_type_t type, float ampl, uint64_t seed, size_t samples)
@@ -66,9 +73,7 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
       d_type(type),
       d_ampl(ampl),
       d_rng(seed),
-      // simple binary trick: an integer x is power of 2 if x-1 is all 1s, but only below
-      // the old 1-position
-      d_bitmask((samples && !(samples & (samples - 1))) ? samples - 1 : 0)
+      d_bitmask(is_pwr_of_two(samples) ? samples - 1 : 0)
 {
     if (!d_bitmask) {
         GR_LOG_INFO(this->d_logger,
@@ -93,9 +98,7 @@ fastnoise_source_impl<gr_complex>::fastnoise_source_impl(noise_type_t type,
       d_type(type),
       d_ampl(ampl / sqrtf(2.0f)),
       d_rng(seed),
-      // simple binary trick: an integer x is power of 2 if x-1 is all 1s, but only below
-      // the old 1-position
-      d_bitmask((samples && !(samples & (samples - 1))) ? samples - 1 : 0)
+      d_bitmask(is_pwr_of_two(samples) ? samples - 1 : 0)
 {
     if (!d_bitmask) {
         GR_LOG_INFO(d_logger,

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -42,9 +42,12 @@ template <>
 void fastnoise_source_impl<gr_complex>::generate()
 {
     size_t noutput_items = d_samples.size();
-    GR_LOG_INFO(d_logger,
-                boost::format("Generating %d complex values. This might take a while.") %
-                    noutput_items);
+    if (noutput_items >= 1 << 23) {
+        GR_LOG_INFO(
+            d_logger,
+            boost::format("Generating %d complex values. This might take a while.") %
+                noutput_items);
+    }
 
     switch (d_type) {
     case GR_UNIFORM:
@@ -145,9 +148,11 @@ template <class T>
 void fastnoise_source_impl<T>::generate()
 {
     size_t noutput_items = d_samples.size();
-    GR_LOG_INFO(this->d_logger,
-                boost::format("Generating %d values. This might take a while.") %
-                    noutput_items);
+    if (noutput_items >= 1 << 23) {
+        GR_LOG_INFO(this->d_logger,
+                    boost::format("Generating %d values. This might take a while.") %
+                        noutput_items);
+    }
     switch (d_type) {
     case GR_UNIFORM:
         for (size_t i = 0; i < noutput_items; i++)

--- a/gr-analog/lib/fastnoise_source_impl.h
+++ b/gr-analog/lib/fastnoise_source_impl.h
@@ -30,7 +30,7 @@ private:
     uint64_t d_state[2];
 
 public:
-    fastnoise_source_impl(noise_type_t type, float ampl, long seed, long samples);
+    fastnoise_source_impl(noise_type_t type, float ampl, uint64_t seed, size_t samples);
     ~fastnoise_source_impl() override;
 
     T sample() override;

--- a/gr-analog/lib/fastnoise_source_impl.h
+++ b/gr-analog/lib/fastnoise_source_impl.h
@@ -28,6 +28,7 @@ private:
     gr::random d_rng;
     std::vector<T> d_samples;
     uint64_t d_state[2];
+    size_t d_bitmask;
 
 public:
     fastnoise_source_impl(noise_type_t type, float ampl, uint64_t seed, size_t samples);

--- a/gr-analog/python/analog/bindings/fastnoise_source_python.cc
+++ b/gr-analog/python/analog/bindings/fastnoise_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fastnoise_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1a1a95cd32432f148b324af32f90f9b7)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8e91642118fc23a803672619b185d5cc)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/python/analog/bindings/fastnoise_source_python.cc
+++ b/gr-analog/python/analog/bindings/fastnoise_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fastnoise_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a1bcac8382da0203f011bc01e8f42c98)                     */
+/* BINDTOOL_HEADER_FILE_HASH(1a1a95cd32432f148b324af32f90f9b7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
During an ambulatory encounter with a simulation flowgraph, I benchmarked and found `fastnoise_source` to be surprisingly stuck (ca 15% of time of a 20s execution, which included pool generation!) in the `div` instruction, plus surroundings that also contributed significantly to runtime.


When the pool is power-of-2-sized, index generation can be done using a
simple bitmask. So I did that.

On my private machine, the stats are:

Prior this patch: Standardnormal random variables

* `fastnoise_source`, pool size 2²⁰: 93.5 MS/s
* `noise_source`: 9.7 MS/s (just for comparison)

After the patch:

* `fastnoise_source`, pool size 2²⁰: 251 MS/s
* `fastnoise_source`, pool size 2²⁰-1: 91 MS/s

Since there's usually no reason to use anything but power-of-two sizes for the pool of random numbers that follows the selected distribution, the <2% performance regression is IMHO tolerable.