### PR TITLE
blocks: tcp_server_sink QA: sequence compare failed because list!=tuple

### DIFF
--- a/gr-blocks/python/blocks/qa_tcp_server_sink.py
+++ b/gr-blocks/python/blocks/qa_tcp_server_sink.py
@@ -47,7 +47,7 @@ class test_tcp_sink(gr_unittest.TestCase):
             blocks.file_descriptor_source(
                 self.itemsize, fd), dst)
         self.tb_rcv.run()
-        self.assertEqual(self.data, dst.data())
+        self.assertSequenceEqual(self.data, dst.data())
 
     def test_001(self):
         self.addr = '127.0.0.1'


### PR DESCRIPTION
Although the contained values are the same, this unit test failed on me.

Using Python's unittest assertSequenceEqual solves that, it seems.