### PR TITLE
filter: fix out of bound access in qa_fir_filter_with_buffer, add length check

### DIFF
--- a/gr-filter/lib/fir_filter_with_buffer.cc
+++ b/gr-filter/lib/fir_filter_with_buffer.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
 namespace gr {
 namespace filter {
@@ -35,6 +36,9 @@ fir_filter_with_buffer_fff::fir_filter_with_buffer_fff(const std::vector<float>&
 void fir_filter_with_buffer_fff::set_taps(const std::vector<float>& taps)
 {
     d_ntaps = (int)taps.size();
+    if (d_ntaps < 1) {
+        throw std::runtime_error("Need at least 1 tap");
+    }
     d_taps = taps;
     std::reverse(d_taps.begin(), d_taps.end());
 
@@ -140,6 +144,9 @@ fir_filter_with_buffer_ccc::fir_filter_with_buffer_ccc(
 void fir_filter_with_buffer_ccc::set_taps(const std::vector<gr_complex>& taps)
 {
     d_ntaps = (int)taps.size();
+    if (d_ntaps < 1) {
+        throw std::runtime_error("Need at least 1 tap");
+    }
     d_taps = taps;
     std::reverse(d_taps.begin(), d_taps.end());
 
@@ -244,6 +251,9 @@ fir_filter_with_buffer_ccf::fir_filter_with_buffer_ccf(const std::vector<float>&
 void fir_filter_with_buffer_ccf::set_taps(const std::vector<float>& taps)
 {
     d_ntaps = (int)taps.size();
+    if (d_ntaps < 1) {
+        throw std::runtime_error("Need at least 1 tap");
+    }
     d_taps = taps;
     std::reverse(d_taps.begin(), d_taps.end());
 

--- a/gr-filter/lib/qa_fir_filter_with_buffer.cc
+++ b/gr-filter/lib/qa_fir_filter_with_buffer.cc
@@ -87,8 +87,8 @@ void test_decimate(unsigned int decimate)
     volk::vector<o_type> actual_output(OUTPUT_LEN);
     volk::vector<tap_type> taps(MAX_TAPS);
 
-    for (int n = 0; n <= MAX_TAPS; n++) {
-        for (int ol = 0; ol <= OUTPUT_LEN; ol++) {
+    for (int n = 1; n < MAX_TAPS; n++) {
+        for (int ol = 1; ol <= OUTPUT_LEN; ol++) {
 
             // build random test case
             random_floats(input.data(), INPUT_LEN);
@@ -107,7 +107,7 @@ void test_decimate(unsigned int decimate)
             }
 
             // build filter
-            vector<tap_type> f1_taps(&taps[0], &taps[n]);
+            vector<tap_type> f1_taps(taps.data(), taps.data() + n);
             kernel::fir_filter_with_buffer_fff f1(f1_taps);
 
             // zero the output, then do the filtering
@@ -178,8 +178,8 @@ void test_decimate(unsigned int decimate)
     volk::vector<o_type> actual_output(OUTPUT_LEN);
     volk::vector<tap_type> taps(MAX_TAPS);
 
-    for (int n = 0; n <= MAX_TAPS; n++) {
-        for (int ol = 0; ol <= OUTPUT_LEN; ol++) {
+    for (int n = 1; n < MAX_TAPS; n++) {
+        for (int ol = 1; ol <= OUTPUT_LEN; ol++) {
 
             // build random test case
             random_complex(input.data(), INPUT_LEN);
@@ -267,8 +267,8 @@ void test_decimate(unsigned int decimate)
     volk::vector<o_type> actual_output(OUTPUT_LEN);
     volk::vector<tap_type> taps(MAX_TAPS);
 
-    for (int n = 0; n <= MAX_TAPS; n++) {
-        for (int ol = 0; ol <= OUTPUT_LEN; ol++) {
+    for (int n = 1; n < MAX_TAPS; n++) {
+        for (int ol = 1; ol <= OUTPUT_LEN; ol++) {
 
             // build random test case
             random_complex(input.data(), INPUT_LEN);


### PR DESCRIPTION
Did a build with `export CXXFLAGS=-D_GLIBCXX_ASSERTIONS`, was screamed at by libcxx. Fun times!