### PR TITLE
GRC Fix Date String in About dialog (backport to maint-3.9)

### DIFF
--- a/grc/core/Config.py
+++ b/grc/core/Config.py
@@ -1,8 +1,7 @@
-"""Copyright 2016 Free Software Foundation, Inc.
+"""Copyright 2021 The GNU Radio Contributors
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-2.0-or-later
-
 """
 
 


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit f070efd62d08649d7628e3905a67c60c38bdca3a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4451