### PR TITLE
runtime: buffer factories use size_t

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf.h
+++ b/gnuradio-runtime/lib/vmcircbuf.h
@@ -72,7 +72,7 @@ public:
      *
      * Call this to create a doubly mapped circular buffer.
      */
-    virtual vmcircbuf* make(int size) = 0;
+    virtual vmcircbuf* make(size_t size) = 0;
 };
 
 /*
@@ -90,7 +90,7 @@ public:
     static vmcircbuf_factory* get_default_factory();
 
     static int granularity() { return get_default_factory()->granularity(); }
-    static vmcircbuf* make(int size) { return get_default_factory()->make(size); }
+    static vmcircbuf* make(size_t size) { return get_default_factory()->make(size); }
 
     // N.B. not all factories are guaranteed to work.
     // It's too hard to check everything at config time, so we check at runtime

--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
@@ -49,7 +49,8 @@ static void werror(char* where, DWORD last_error)
 #endif
 
 
-vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(int size) : gr::vmcircbuf(size)
+vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(size_t size)
+    : gr::vmcircbuf(size)
 {
     gr::configure_default_loggers(
         d_logger, d_debug_logger, "vmcircbuf_createfilemapping");
@@ -195,7 +196,7 @@ int vmcircbuf_createfilemapping_factory::granularity()
 #endif
 }
 
-gr::vmcircbuf* vmcircbuf_createfilemapping_factory::make(int size)
+gr::vmcircbuf* vmcircbuf_createfilemapping_factory::make(size_t size)
 {
     try {
         return new vmcircbuf_createfilemapping(size);

--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.h
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.h
@@ -28,7 +28,7 @@ class GR_RUNTIME_API vmcircbuf_createfilemapping : public gr::vmcircbuf
 {
 public:
     // CREATORS
-    vmcircbuf_createfilemapping(int size);
+    vmcircbuf_createfilemapping(size_t size);
     ~vmcircbuf_createfilemapping() override;
 #ifdef HAVE_CREATEFILEMAPPING
 private:
@@ -64,7 +64,7 @@ public:
      *
      * Call this to create a doubly mapped circular buffer.
      */
-    gr::vmcircbuf* make(int size) override;
+    gr::vmcircbuf* make(size_t size) override;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.cc
@@ -30,7 +30,7 @@
 
 namespace gr {
 
-vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(int size) : gr::vmcircbuf(size)
+vmcircbuf_mmap_shm_open::vmcircbuf_mmap_shm_open(size_t size) : gr::vmcircbuf(size)
 {
 #if !defined(HAVE_MMAP) || !defined(HAVE_SHM_OPEN)
     std::stringstream error_msg;
@@ -178,7 +178,7 @@ gr::vmcircbuf_factory* vmcircbuf_mmap_shm_open_factory::singleton()
 
 int vmcircbuf_mmap_shm_open_factory::granularity() { return gr::pagesize(); }
 
-gr::vmcircbuf* vmcircbuf_mmap_shm_open_factory::make(int size)
+gr::vmcircbuf* vmcircbuf_mmap_shm_open_factory::make(size_t size)
 {
     try {
         return new vmcircbuf_mmap_shm_open(size);

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.h
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_shm_open.h
@@ -23,7 +23,7 @@ namespace gr {
 class GR_RUNTIME_API vmcircbuf_mmap_shm_open : public gr::vmcircbuf
 {
 public:
-    vmcircbuf_mmap_shm_open(int size);
+    vmcircbuf_mmap_shm_open(size_t size);
     ~vmcircbuf_mmap_shm_open() override;
 };
 
@@ -50,7 +50,7 @@ public:
      *
      * Call this to create a doubly mapped circular buffer.
      */
-    gr::vmcircbuf* make(int size) override;
+    gr::vmcircbuf* make(size_t size) override;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.cc
@@ -32,7 +32,7 @@
 
 namespace gr {
 
-vmcircbuf_mmap_tmpfile::vmcircbuf_mmap_tmpfile(int size) : gr::vmcircbuf(size)
+vmcircbuf_mmap_tmpfile::vmcircbuf_mmap_tmpfile(size_t size) : gr::vmcircbuf(size)
 {
 #if !defined(HAVE_MMAP)
     GR_LOG_ERROR(d_logger, "mmap or mkstemp is not available");
@@ -170,7 +170,7 @@ gr::vmcircbuf_factory* vmcircbuf_mmap_tmpfile_factory::singleton()
 
 int vmcircbuf_mmap_tmpfile_factory::granularity() { return gr::pagesize(); }
 
-gr::vmcircbuf* vmcircbuf_mmap_tmpfile_factory::make(int size)
+gr::vmcircbuf* vmcircbuf_mmap_tmpfile_factory::make(size_t size)
 {
     try {
         return new vmcircbuf_mmap_tmpfile(size);

--- a/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.h
+++ b/gnuradio-runtime/lib/vmcircbuf_mmap_tmpfile.h
@@ -23,7 +23,7 @@ namespace gr {
 class GR_RUNTIME_API vmcircbuf_mmap_tmpfile : public gr::vmcircbuf
 {
 public:
-    vmcircbuf_mmap_tmpfile(int size);
+    vmcircbuf_mmap_tmpfile(size_t size);
     ~vmcircbuf_mmap_tmpfile() override;
 };
 
@@ -50,7 +50,7 @@ public:
      *
      * Call this to create a doubly mapped circular buffer.
      */
-    gr::vmcircbuf* make(int size) override;
+    gr::vmcircbuf* make(size_t size) override;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
@@ -31,7 +31,7 @@
 
 namespace gr {
 
-vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(int size) : gr::vmcircbuf(size)
+vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
 {
 #if !defined(HAVE_SYS_SHM_H)
     GR_LOG_ERROR(d_logger, "sysv shared memory is not available");
@@ -178,7 +178,7 @@ gr::vmcircbuf_factory* vmcircbuf_sysv_shm_factory::singleton()
 
 int vmcircbuf_sysv_shm_factory::granularity() { return gr::pagesize(); }
 
-gr::vmcircbuf* vmcircbuf_sysv_shm_factory::make(int size)
+gr::vmcircbuf* vmcircbuf_sysv_shm_factory::make(size_t size)
 {
     try {
         return new vmcircbuf_sysv_shm(size);

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.h
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.h
@@ -23,7 +23,7 @@ namespace gr {
 class GR_RUNTIME_API vmcircbuf_sysv_shm : public gr::vmcircbuf
 {
 public:
-    vmcircbuf_sysv_shm(int size);
+    vmcircbuf_sysv_shm(size_t size);
     ~vmcircbuf_sysv_shm() override;
 };
 
@@ -50,7 +50,7 @@ public:
      *
      * Call this to create a doubly mapped circular buffer.
      */
-    gr::vmcircbuf* make(int size) override;
+    gr::vmcircbuf* make(size_t size) override;
 };
 
 } /* namespace gr */


### PR DESCRIPTION
Addresses the issue where large buffer size requests get converted back
and forth to signed/unsigned and can cause an overflow and the buffer
allocation to fail

Addresses #1541