### PR TITLE
gr-uhd: fix command tuning

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/usrp_block.h
+++ b/gr-uhd/include/gnuradio/uhd/usrp_block.h
@@ -38,8 +38,8 @@ GR_UHD_API const pmt::pmt_t cmd_tag_key();
 GR_UHD_API const pmt::pmt_t cmd_gpio_key();
 GR_UHD_API const pmt::pmt_t cmd_pc_clock_resync_key();
 
-GR_UHD_API const pmt::pmt_t ant_direction_rx();
-GR_UHD_API const pmt::pmt_t ant_direction_tx();
+GR_UHD_API const pmt::pmt_t direction_rx();
+GR_UHD_API const pmt::pmt_t direction_tx();
 
 /*! Base class for USRP blocks.
  * \ingroup uhd_blk

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -122,12 +122,12 @@ const pmt::pmt_t gr::uhd::cmd_gpio_key()
     return val;
 }
 
-const pmt::pmt_t gr::uhd::ant_direction_rx()
+const pmt::pmt_t gr::uhd::direction_rx()
 {
     static const pmt::pmt_t val = pmt::mp("RX");
     return val;
 }
-const pmt::pmt_t gr::uhd::ant_direction_tx()
+const pmt::pmt_t gr::uhd::direction_tx()
 {
     static const pmt::pmt_t val = pmt::mp("TX");
     return val;
@@ -291,14 +291,14 @@ void usrp_block_impl::_set_center_freq_from_internals_allchans()
     while (_rx_chans_to_tune.any()) {
         // This resets() bits, so this loop should not run indefinitely
         chan = _rx_chans_to_tune.find_first();
-        _set_center_freq_from_internals(chan, ant_direction_rx());
+        _set_center_freq_from_internals(chan, direction_rx());
         _rx_chans_to_tune.reset(chan);
     }
 
     while (_tx_chans_to_tune.any()) {
         // This resets() bits, so this loop should not run indefinitely
         chan = _tx_chans_to_tune.find_first();
-        _set_center_freq_from_internals(chan, ant_direction_tx());
+        _set_center_freq_from_internals(chan, direction_tx());
         _tx_chans_to_tune.reset(chan);
     }
 }
@@ -581,7 +581,7 @@ void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req,
         return;
     }
 
-    if (pmt::eqv(direction, ant_direction_rx())) {
+    if (pmt::eqv(direction, direction_rx())) {
         if (tune_req.target_freq != _curr_rx_tune_req[chan].target_freq ||
             tune_req.rf_freq_policy != _curr_rx_tune_req[chan].rf_freq_policy ||
             tune_req.rf_freq != _curr_rx_tune_req[chan].rf_freq ||
@@ -637,7 +637,7 @@ void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t& lo_offset,
 
     double lo_offs = pmt::to_double(lo_offset);
     ::uhd::tune_request_t new_tune_request;
-    if (pmt::eqv(direction, ant_direction_rx())) {
+    if (pmt::eqv(direction, direction_rx())) {
         new_tune_request = _curr_rx_tune_req[chan];
     } else {
         new_tune_request = _curr_tx_tune_req[chan];
@@ -845,7 +845,7 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
     }
 
     ::uhd::tune_request_t new_tune_request;
-    if (pmt::eqv(direction, ant_direction_rx())) {
+    if (pmt::eqv(direction, direction_rx())) {
         new_tune_request = _curr_rx_tune_req[chan];
     } else {
         new_tune_request = _curr_tx_tune_req[chan];
@@ -882,7 +882,7 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
     }
 
     ::uhd::tune_request_t new_tune_request;
-    if (pmt::eqv(direction, ant_direction_rx())) {
+    if (pmt::eqv(direction, direction_rx())) {
         new_tune_request = _curr_rx_tune_req[chan];
     } else {
         new_tune_request = _curr_tx_tune_req[chan];
@@ -902,7 +902,7 @@ usrp_block_impl::get_cmd_or_default_direction(const pmt::pmt_t& cmd) const
 
     // if the direction key exists and is either "TX" or "RX", return that
     if (pmt::is_symbol(dir) &&
-        (pmt::eqv(dir, ant_direction_rx()) || pmt::eqv(dir, ant_direction_tx()))) {
+        (pmt::eqv(dir, direction_rx()) || pmt::eqv(dir, direction_tx()))) {
         return dir;
     }
     // otherwise return the direction key for the block that received the cmd

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -298,8 +298,7 @@ void usrp_block_impl::_set_center_freq_from_internals_allchans()
     while (_tx_chans_to_tune.any()) {
         // This resets() bits, so this loop should not run indefinitely
         chan = _tx_chans_to_tune.find_first();
-        _set_center_freq_from_internals(_tx_chans_to_tune.find_first(),
-                                        ant_direction_tx());
+        _set_center_freq_from_internals(chan, ant_direction_tx());
         _tx_chans_to_tune.reset(chan);
     }
 }
@@ -528,16 +527,8 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
                                               pmt::from_long(-1) // Default to all chans
                                               )));
 
-    /// 3) See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
-    // if the a direction symbol was provided, force a tune
-    _force_tune = pmt::is_symbol(direction);
-
+    /// 3) If a direction key was specified, force the block to tune - see issue #1814
+    _force_tune = pmt::dict_has_key(msg, cmd_direction_key());
 
     /// 4) Loop through all the values
     GR_LOG_DEBUG(d_debug_logger, boost::format("Processing command message %s") % msg);
@@ -618,13 +609,8 @@ void usrp_block_impl::_cmd_handler_freq(const pmt::pmt_t& freq_,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     double freq = pmt::to_double(freq_);
     ::uhd::tune_request_t new_tune_request(freq);
@@ -641,13 +627,8 @@ void usrp_block_impl::_cmd_handler_looffset(const pmt::pmt_t& lo_offset,
                                             int chan,
                                             const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX" will default to the
-                                   // messaged block direction
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     if (pmt::dict_has_key(msg, cmd_freq_key())) {
         // Then it's already taken care of
@@ -673,13 +654,8 @@ void usrp_block_impl::_cmd_handler_gain(const pmt::pmt_t& gain_,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     double gain = pmt::to_double(gain_);
     if (chan == -1) {
@@ -780,13 +756,8 @@ void usrp_block_impl::_cmd_handler_tune(const pmt::pmt_t& tune,
                                         int chan,
                                         const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX" will default to the
-                                   // messaged block direction
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     double freq = pmt::to_double(pmt::car(tune));
     double lo_offset = pmt::to_double(pmt::cdr(tune));
@@ -798,13 +769,8 @@ void usrp_block_impl::_cmd_handler_mtune(const pmt::pmt_t& tune,
                                          int chan,
                                          const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX" will default to the
-                                   // messaged block direction
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     ::uhd::tune_request_t new_tune_request;
     if (pmt::dict_has_key(tune, pmt::mp("dsp_freq"))) {
@@ -868,13 +834,8 @@ void usrp_block_impl::_cmd_handler_lofreq(const pmt::pmt_t& lofreq,
                                           int chan,
                                           const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     if (chan == -1) {
         for (size_t i = 0; i < _nchan; i++) {
@@ -905,13 +866,8 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
                                            int chan,
                                            const pmt::pmt_t& msg)
 {
-    // See if a direction was specified
-    pmt::pmt_t direction =
-        pmt::dict_ref(msg,
-                      cmd_direction_key(),
-                      pmt::PMT_NIL // Anything except "TX" or "RX will default to the
-                                   // messaged block direction"
-        );
+    // Get the direction key
+    const pmt::pmt_t direction = get_cmd_or_default_direction(msg);
 
     if (pmt::dict_has_key(msg, cmd_lo_freq_key())) {
         // Then it's already dealt with
@@ -937,4 +893,18 @@ void usrp_block_impl::_cmd_handler_dspfreq(const pmt::pmt_t& dspfreq,
     new_tune_request.dsp_freq_policy = ::uhd::tune_request_t::POLICY_MANUAL;
 
     _update_curr_tune_req(new_tune_request, chan, direction);
+}
+
+const pmt::pmt_t
+usrp_block_impl::get_cmd_or_default_direction(const pmt::pmt_t& cmd) const
+{
+    const pmt::pmt_t dir = pmt::dict_ref(cmd, cmd_direction_key(), pmt::PMT_NIL);
+
+    // if the direction key exists and is either "TX" or "RX", return that
+    if (pmt::is_symbol(dir) &&
+        (pmt::eqv(dir, ant_direction_rx()) || pmt::eqv(dir, ant_direction_tx()))) {
+        return dir;
+    }
+    // otherwise return the direction key for the block that received the cmd
+    return _direction();
 }

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -227,6 +227,12 @@ protected:
 
     //! Stores the individual command handlers
     ::uhd::dict<pmt::pmt_t, cmd_handler_t> _msg_cmd_handlers;
+
+    //! Will check a command for a direction key, if it does not exist this will use
+    // the default value for the block via _direction() defined below
+    const pmt::pmt_t get_cmd_or_default_direction(const pmt::pmt_t& cmd) const;
+    //! Block direction overloaded by block impl to return "RX"/"TX" for source/sink
+    virtual const pmt::pmt_t _direction() const = 0;
 };
 
 } /* namespace uhd */

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -98,7 +98,7 @@ usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size_t
 ::uhd::tune_result_t usrp_sink_impl::_set_center_freq_from_internals(size_t chan,
                                                                      pmt::pmt_t direction)
 {
-    if (pmt::eqv(direction, ant_direction_rx())) {
+    if (pmt::eqv(direction, direction_rx())) {
         // TODO: what happens if the RX device is not instantiated? Catch error?
         _rx_chans_to_tune.reset(chan);
         return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
@@ -123,7 +123,7 @@ double usrp_sink_impl::get_center_freq(size_t chan)
 void usrp_sink_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
 {
     chan = _stream_args.channels[chan];
-    if (pmt::eqv(direction, ant_direction_rx())) {
+    if (pmt::eqv(direction, direction_rx())) {
         return _dev->set_rx_gain(gain, chan);
     } else {
         return _dev->set_tx_gain(gain, chan);

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -142,6 +142,8 @@ private:
     bool _async_event_loop_running;
     void async_event_loop();
     gr::thread::thread _async_event_thread;
+
+    const pmt::pmt_t _direction() const override { return ant_direction_tx(); };
 };
 
 } /* namespace uhd */

--- a/gr-uhd/lib/usrp_sink_impl.h
+++ b/gr-uhd/lib/usrp_sink_impl.h
@@ -143,7 +143,7 @@ private:
     void async_event_loop();
     gr::thread::thread _async_event_thread;
 
-    const pmt::pmt_t _direction() const override { return ant_direction_tx(); };
+    const pmt::pmt_t _direction() const override { return direction_tx(); };
 };
 
 } /* namespace uhd */

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -112,7 +112,7 @@ usrp_source_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size
 ::uhd::tune_result_t
 usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direction)
 {
-    if (pmt::eqv(direction, ant_direction_tx())) {
+    if (pmt::eqv(direction, direction_tx())) {
         // TODO: what happens if the TX device is not instantiated? Catch error?
         _tx_chans_to_tune.reset(chan);
         return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
@@ -137,7 +137,7 @@ double usrp_source_impl::get_center_freq(size_t chan)
 void usrp_source_impl::set_gain(double gain, size_t chan, pmt::pmt_t direction)
 {
     chan = _stream_args.channels[chan];
-    if (pmt::eqv(direction, ant_direction_tx())) {
+    if (pmt::eqv(direction, direction_tx())) {
         return _dev->set_tx_gain(gain, chan);
     } else {
         return _dev->set_rx_gain(gain, chan);

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -146,6 +146,8 @@ private:
     double _samp_rate;
 
     std::recursive_mutex d_mutex;
+
+    const pmt::pmt_t _direction() const override { return ant_direction_rx(); };
 };
 
 } /* namespace uhd */

--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -147,7 +147,7 @@ private:
 
     std::recursive_mutex d_mutex;
 
-    const pmt::pmt_t _direction() const override { return ant_direction_rx(); };
+    const pmt::pmt_t _direction() const override { return direction_rx(); };
 };
 
 } /* namespace uhd */

--- a/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/usrp_block_pydoc_template.h
@@ -246,7 +246,7 @@ static const char* __doc_gr_uhd_cmd_direction_key = R"doc()doc";
 static const char* __doc_gr_uhd_cmd_tag_key = R"doc()doc";
 
 
-static const char* __doc_gr_uhd_ant_direction_rx = R"doc()doc";
+static const char* __doc_gr_uhd_direction_rx = R"doc()doc";
 
 
-static const char* __doc_gr_uhd_ant_direction_tx = R"doc()doc";
+static const char* __doc_gr_uhd_direction_tx = R"doc()doc";

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -476,8 +476,8 @@ void bind_usrp_block(py::module& m)
     m.def("cmd_tag_key", &::gr::uhd::cmd_tag_key, D(cmd_tag_key));
 
 
-    m.def("ant_direction_rx", &::gr::uhd::ant_direction_rx, D(ant_direction_rx));
+    m.def("direction_rx", &::gr::uhd::direction_rx, D(direction_rx));
 
 
-    m.def("ant_direction_tx", &::gr::uhd::ant_direction_tx, D(ant_direction_tx));
+    m.def("direction_tx", &::gr::uhd::direction_tx, D(direction_tx));
 }


### PR DESCRIPTION
Command tuning has seen several updates recently and incomplete regression testing. One issue introduced is that when tuning without a direction key will result in the tune applied in the TX direction instead of the block direction (intended). This fixes that by adding member getters for block direction as well as a number of minor updates to how this logic is handled internally.

Here is a flowgraph to test tuning: [usrp_cmd_tuning.grc.txt](https://github.com/gnuradio/gnuradio/files/6224941/usrp_cmd_tuning.grc.txt)
