### PR TITLE
cmake: Fix codec2 and MPIR find modules for Windows (conda).

### DIFF
--- a/cmake/Modules/FindCodec2.cmake
+++ b/cmake/Modules/FindCodec2.cmake
@@ -17,17 +17,16 @@ INCLUDE(FindPackageHandleStandardArgs)
 pkg_check_modules(LIBCODEC2_PKG QUIET codec2)
 
 find_path(LIBCODEC2_INCLUDE_DIR NAMES codec2.h
+  HINTS ${LIBCODEC2_PKG_INCLUDE_DIRS}
   PATHS
-  ${LIBCODEC2_PKG_INCLUDE_DIRS}
-  /usr/include/codec2
   /usr/include
-  /usr/local/include/codec2
   /usr/local/include
+  PATH_SUFFIXES codec2
   )
 
-find_library(LIBCODEC2_LIBRARIES NAMES codec2
+find_library(LIBCODEC2_LIBRARIES NAMES codec2 libcodec2
+  HINTS ${LIBCODEC2_PKG_LIBRARY_DIRS}
   PATHS
-  ${LIBCODEC2_PKG_LIBRARY_DIRS}
   /usr/lib
   /usr/local/lib
   )

--- a/cmake/Modules/FindMPIR.cmake
+++ b/cmake/Modules/FindMPIR.cmake
@@ -18,7 +18,8 @@ set(MPIR_PC_ADD_CFLAGS "-I${MPIR_INCLUDE_DIR}")
 
 find_library(
     MPIRXX_LIBRARY
-    NAMES mpirxx
+    # mpirxx is bundled into mpir.lib with MSVC
+    NAMES mpirxx mpir.lib
     HINTS ${PC_MPIR_LIBDIR}
     PATHS ${CMAKE_INSTALL_PREFIX}/lib
           ${CMAKE_INSTALL_PREFIX}/lib64


### PR DESCRIPTION
Tweak the CMake find modules for codec2 and MPIR so that they work on Windows (at least when using conda packages). Previously it was necessary to specify paths to these libraries/headers with the cmake command so that they could be used.