### PR TITLE
cmake: Move swath of add_definitions to gnuradio-runtime target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,9 +167,6 @@ include(GrMiscUtils) #compiler flag check
 
 include(TestBigEndian)
 TEST_BIG_ENDIAN(GR_IS_BIG_ENDIAN)
-if(GR_IS_BIG_ENDIAN)
-    add_definitions(-DGR_IS_BIG_ENDIAN)
-endif(GR_IS_BIG_ENDIAN)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -185,25 +182,9 @@ endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
 
 if(MSVC)
     include_directories(${CMAKE_SOURCE_DIR}/cmake/msvc) #missing headers
-    add_definitions(-D_USE_MATH_DEFINES) #enables math constants on all supported versions of MSVC
-    add_definitions(-D_WIN32_WINNT=0x0502) #Minimum version: "Windows Server 2003 with SP1, Windows XP with SP2"
-    add_definitions(-DNOMINMAX) #disables stupidity and enables std::min and std::max
-    add_definitions( #stop all kinds of compatibility warnings
-        -D_SCL_SECURE_NO_WARNINGS
-        -D_CRT_SECURE_NO_WARNINGS
-        -D_CRT_SECURE_NO_DEPRECATE
-        -D_CRT_NONSTDC_NO_DEPRECATE
-    )
     add_compile_options(/MP) #build with multiple processors
     add_compile_options(/bigobj) #allow for larger object files
 endif(MSVC)
-
-if(WIN32)
-    add_definitions(-D_USE_MATH_DEFINES)
-    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-        add_definitions(-DMS_WIN64)
-    endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-endif(WIN32)
 
 # Record Compiler Info for record
 STRING(TOUPPER ${CMAKE_BUILD_TYPE} GRCBTU)
@@ -276,7 +257,6 @@ OPTION(ENABLE_PERFORMANCE_COUNTERS "Enable block performance counters" ON)
 if(ENABLE_PERFORMANCE_COUNTERS)
   message(STATUS "ADDING PERF COUNTERS")
   SET(GR_PERFORMANCE_COUNTERS True)
-  add_definitions(-DGR_PERFORMANCE_COUNTERS)
 else(ENABLE_PERFORMANCE_COUNTERS)
   SET(GR_PERFORMANCE_COUNTERS False)
   message(STATUS "NO PERF COUNTERS")
@@ -458,7 +438,6 @@ list(APPEND GR_TEST_PYTHON_DIRS
 # multiprecision arithmetic library header to include
 include(FindPkgConfig)
 find_package(MPLIB)
-add_definitions(${MPLIB_DEFINITIONS})
 
 ########################################################################
 # Post-Install tasks are tasks that are usually not executed during
@@ -495,7 +474,6 @@ add_subdirectory(gr-network)
 # Defining GR_CTRLPORT for gnuradio/config.h
 if(ENABLE_GR_CTRLPORT)
   SET(GR_CTRLPORT True)
-  add_definitions(-DGR_CTRLPORT)
 
   if(CTRLPORT_BACKENDS GREATER 0)
     SET(GR_RPCSERVER_ENABLED True)

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -122,6 +122,47 @@ target_sources(gnuradio-runtime PRIVATE
   ${MATH_SINE_TABLE_HEADER}
   )
 
+target_link_libraries(gnuradio-runtime PUBLIC
+  gnuradio-pmt
+  Volk::volk
+  Boost::program_options
+  Boost::system
+  Boost::regex
+  Boost::thread
+  Log4Cpp::log4cpp
+  MPLib::mplib
+  ${libunwind_LIBRARIES}
+  # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
+  # (importantly, extension modules can avoid linking against Python and resolve
+  #  their own Python symbols at runtime through the Python interpreter's linking)
+  INTERFACE
+    Python::Module
+  PRIVATE
+    Python::Python
+  )
+
+# Address linker issues with std::filesystem on Centos 8 and Debian
+target_link_libraries(gnuradio-runtime PUBLIC $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+
+target_include_directories(gnuradio-runtime
+  PUBLIC
+    ${PYTHON_NUMPY_INCLUDE_DIR}
+    ${pybind11_INCLUDE_DIR}
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+target_compile_definitions(gnuradio-runtime PUBLIC ${MPLIB_DEFINITIONS})
+
+# constants.cc includes boost::dll headers, force them to use std::filesystem
+target_compile_definitions(gnuradio-runtime PRIVATE BOOST_DLL_USE_STD_FS)
+
+########################################################################
+# Add controlport stuff to gnuradio-runtime
+########################################################################
 # Controlport
 if(ENABLE_GR_CTRLPORT)
 
@@ -178,6 +219,8 @@ target_link_libraries(gnuradio-runtime PUBLIC
   Thrift::thrift
   )
 
+target_compile_definitions(gnuradio-runtime PUBLIC GR_CTRLPORT)
+
 # Add install rule to move example Thrift configuration file into a
 # documentation directory
 install(
@@ -188,10 +231,6 @@ install(
 endif(THRIFT_FOUND)
 endif(ENABLE_CTRLPORT_THRIFT)
 
-########################################################################
-# Add controlport stuff to gnuradio-runtime
-########################################################################
-
 # Save the number of backends for testing against later
 set(
   CTRLPORT_BACKENDS ${CTRLPORT_BACKENDS}
@@ -200,46 +239,38 @@ set(
 
 endif(ENABLE_GR_CTRLPORT)
 
-target_link_libraries(gnuradio-runtime PUBLIC
-  gnuradio-pmt
-  Volk::volk
-  Boost::program_options
-  Boost::system
-  Boost::regex
-  Boost::thread
-  Log4Cpp::log4cpp
-  MPLib::mplib
-  ${libunwind_LIBRARIES}
-  # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
-  # (importantly, extension modules can avoid linking against Python and resolve
-  #  their own Python symbols at runtime through the Python interpreter's linking)
-  INTERFACE
-    Python::Module
-  PRIVATE
-    Python::Python
+########################################################################
+# Add misc conditional includes/definitions to gnuradio-runtime
+########################################################################
+
+if(ENABLE_PERFORMANCE_COUNTERS)
+  target_compile_definitions(gnuradio-runtime PUBLIC -DGR_PERFORMANCE_COUNTERS)
+endif()
+
+if(GR_IS_BIG_ENDIAN)
+  target_compile_definitions(gnuradio-runtime PUBLIC -DGR_IS_BIG_ENDIAN)
+endif(GR_IS_BIG_ENDIAN)
+
+if(MSVC)
+  target_compile_definitions(gnuradio-runtime PUBLIC
+    # Minimum version: "Windows Server 2003 with SP1, Windows XP with SP2"
+    -D_WIN32_WINNT=0x0502
+    # disables stupidity and enables std::min and std::max
+    -DNOMINMAX
+    # stop all kinds of compatibility warnings
+    -D_SCL_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_DEPRECATE
+    -D_CRT_NONSTDC_NO_DEPRECATE
   )
+endif(MSVC)
 
-# Address linker issues with std::filesystem on Centos 8 and Debian
-target_link_libraries(gnuradio-runtime PUBLIC $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
-
-target_include_directories(gnuradio-runtime
-  PUBLIC
-    ${PYTHON_NUMPY_INCLUDE_DIR}
-    ${pybind11_INCLUDE_DIR}
-    $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
-# constants.cc includes boost::dll headers, force them to use std::filesystem
-target_compile_definitions(gnuradio-runtime PRIVATE BOOST_DLL_USE_STD_FS)
-
-  if(ENABLE_GR_CTRLPORT)
-    target_compile_definitions(gnuradio-runtime PUBLIC GR_CTRLPORT)
-  endif()
-
+if(WIN32)
+  target_compile_definitions(gnuradio-runtime PUBLIC -D_USE_MATH_DEFINES)
+  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    target_compile_definitions(gnuradio-runtime PUBLIC -DMS_WIN64)
+  endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+endif(WIN32)
 
 #Add libraries for winsock2.h on Windows
 check_include_file_cxx(windows.h HAVE_WINDOWS_H)


### PR DESCRIPTION
I think every target affected by the top-level add_definitions links to gnuradio-runtime, so functionally this should be the same. Besides being a more modern CMake style, this has the benefit of propagating the public definitions to any consumers of the gnuradio-runtime library, which includes OOT modules that imported their targets through CMake. For example, OOT modules would previously have to know to define "NOMINMAX" on MSVC, but now that happens transitively. This should make it a little more friendly to build OOT modules, on Windows at least.

This also takes the opportunity to rearrange `gnuradio-runtime/lib/CMakeLists.txt` to what I find is a more logical order, but I can back that out if the diff is deemed too messy.