### PR TITLE
qtgui: Remove more manual memory management

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ConstellationDisplayPlot.h
@@ -52,8 +52,8 @@ public slots:
 private:
     void _autoScale(double bottom, double top);
 
-    std::vector<double*> d_real_data;
-    std::vector<double*> d_imag_data;
+    std::vector<std::vector<double>> d_real_data;
+    std::vector<std::vector<double>> d_imag_data;
 
     int64_t d_pen_size;
 };

--- a/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/EyeDisplayPlot.h
@@ -34,6 +34,12 @@ public:
     EyeDisplayPlot(unsigned int nplots, unsigned int curve_index, QWidget* parent);
     ~EyeDisplayPlot() override;
 
+    // Disable copy&move because of raw QT pointers.
+    EyeDisplayPlot(const EyeDisplayPlot&) = delete;
+    EyeDisplayPlot(EyeDisplayPlot&&) = delete;
+    EyeDisplayPlot& operator=(const EyeDisplayPlot&) = delete;
+    EyeDisplayPlot& operator=(EyeDisplayPlot&&) = delete;
+
     void plotNewData(const std::vector<double*> dataPoints,
                      const int64_t numDataPoints,
                      int d_sps,
@@ -82,16 +88,15 @@ private:
     void _resetXAxisPoints();
     void _autoScale(double bottom, double top);
 
-    std::vector<double*> d_ydata;
+    std::vector<std::vector<double>> d_ydata;
 
-    double* d_xdata;
+    std::vector<double> d_xdata;
 
     double d_sample_rate;
 
     unsigned int d_curve_index;
-    unsigned int nplots;
-    int d_sps;
-    unsigned int d_numPointsPerPeriod;
+    int d_sps = 4;
+    unsigned int d_numPointsPerPeriod = 2 * d_sps + 1;
     unsigned int d_numPeriods;
 
     bool d_autoscale_shot;

--- a/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
+++ b/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
@@ -40,6 +40,13 @@ public:
                      const double newStartFrequency,
                      const double newStopFrequency);
     ~SpectrumGUIClass();
+
+    // Disable copy/move because of raw QT pointers.
+    SpectrumGUIClass(const SpectrumGUIClass&) = delete;
+    SpectrumGUIClass(SpectrumGUIClass&&) = delete;
+    SpectrumGUIClass& operator=(const SpectrumGUIClass&) = delete;
+    SpectrumGUIClass& operator=(SpectrumGUIClass&&) = delete;
+
     void reset();
 
     void openSpectrumWindow(QWidget*,
@@ -105,27 +112,26 @@ public:
 protected:
 private:
     gr::thread::mutex d_mutex;
-    int64_t _dataPoints;
+    const int64_t _dataPoints;
     std::string _title;
     double _centerFrequency;
     double _startFrequency;
     double _stopFrequency;
-    float _powerValue;
-    bool _windowOpennedFlag;
-    int _windowType;
+    float _powerValue = 1;
+    bool _windowOpennedFlag = false;
+    int _windowType = 5;
     int64_t _lastDataPointCount;
     int _fftSize;
-    gr::high_res_timer_type _lastGUIUpdateTime;
-    unsigned int _pendingGUIUpdateEventsCount;
-    int _droppedEntriesCount;
-    bool _fftBuffersCreatedFlag;
+    gr::high_res_timer_type _lastGUIUpdateTime = 0;
+    unsigned int _pendingGUIUpdateEventsCount = 0;
+    int _droppedEntriesCount = 0;
     double _updateTime;
 
-    SpectrumDisplayForm* _spectrumDisplayForm;
+    SpectrumDisplayForm* _spectrumDisplayForm = nullptr; // Deleted by QT.
 
-    float* _fftPoints;
-    double* _realTimeDomainPoints;
-    double* _imagTimeDomainPoints;
+    std::vector<float> _fftPoints;
+    std::vector<double> _realTimeDomainPoints;
+    std::vector<double> _imagTimeDomainPoints;
 };
 
 #endif /* SPECTRUM_GUI_CLASS_HPP */

--- a/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeDomainDisplayPlot.h
@@ -35,6 +35,12 @@ public:
     TimeDomainDisplayPlot(int nplots, QWidget*);
     ~TimeDomainDisplayPlot() override;
 
+    // Disable move/delete because of raw QT pointers.
+    TimeDomainDisplayPlot(const TimeDomainDisplayPlot&) = delete;
+    TimeDomainDisplayPlot(TimeDomainDisplayPlot&&) = delete;
+    TimeDomainDisplayPlot& operator=(const TimeDomainDisplayPlot&) = delete;
+    TimeDomainDisplayPlot& operator=(TimeDomainDisplayPlot&&) = delete;
+
     void plotNewData(const std::vector<double*> dataPoints,
                      const int64_t numDataPoints,
                      const double timeInterval,
@@ -77,8 +83,8 @@ private:
     void _resetXAxisPoints();
     void _autoScale(double bottom, double top);
 
-    std::vector<double*> d_ydata;
-    double* d_xdata;
+    std::vector<std::vector<double>> d_ydata;
+    std::vector<double> d_xdata;
 
     double d_sample_rate;
 
@@ -89,9 +95,9 @@ private:
     std::vector<std::vector<QwtPlotMarker*>> d_tag_markers;
     std::vector<bool> d_tag_markers_en;
 
-    QColor d_tag_text_color;
-    QColor d_tag_background_color;
-    Qt::BrushStyle d_tag_background_style;
+    QColor d_tag_text_color = Qt::black;
+    QColor d_tag_background_color = Qt::white;
+    Qt::BrushStyle d_tag_background_style = Qt::NoBrush;
 
     QwtPlotMarker* d_trigger_lines[2];
 };

--- a/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/VectorDisplayPlot.h
@@ -45,6 +45,12 @@ public:
     VectorDisplayPlot(int nplots, QWidget*);
     ~VectorDisplayPlot() override;
 
+    // Disable move/copy because of raw QT pointers.
+    VectorDisplayPlot(const VectorDisplayPlot&) = delete;
+    VectorDisplayPlot(VectorDisplayPlot&&) = delete;
+    VectorDisplayPlot& operator=(const VectorDisplayPlot&) = delete;
+    VectorDisplayPlot& operator=(VectorDisplayPlot&&) = delete;
+
     void setXAxisValues(const double start, const double step = 1.0);
 
     void plotNewData(const std::vector<double*> dataPoints,
@@ -105,7 +111,7 @@ private:
     void _resetXAxisPoints();
     void _autoScale(double bottom, double top);
 
-    std::vector<double*> d_ydata;
+    std::vector<std::vector<double>> d_ydata;
 
     QwtPlotCurve* d_min_vec_plot_curve;
     QwtPlotCurve* d_max_vec_plot_curve;
@@ -120,24 +126,24 @@ private:
     QColor d_marker_ref_level_color;
     bool d_marker_ref_level_visible;
 
-    double d_x_axis_start;
-    double d_x_axis_step;
+    double d_x_axis_start = 0;
+    double d_x_axis_step = 1.0;
 
-    double d_ymax;
-    double d_ymin;
+    double d_ymax = 10;
+    double d_ymin = -10;
 
     QwtPlotMarker* d_lower_intensity_marker;
     QwtPlotMarker* d_upper_intensity_marker;
 
     QwtPlotMarker* d_marker_ref_level;
 
-    double* d_xdata;
+    std::vector<double> d_xdata;
 
     QString d_x_axis_label;
     QString d_y_axis_label;
 
-    double* d_min_vec_data;
-    double* d_max_vec_data;
+    std::vector<double> d_min_vec_data;
+    std::vector<double> d_max_vec_data;
 
     double d_ref_level;
 };

--- a/gr-qtgui/include/gnuradio/qtgui/spectrumdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/spectrumdisplayform.h
@@ -33,6 +33,12 @@ public:
     SpectrumDisplayForm(QWidget* parent = 0);
     ~SpectrumDisplayForm() override;
 
+    // Disable copy/move because of QT raw pointers.
+    SpectrumDisplayForm(const SpectrumDisplayForm&) = delete;
+    SpectrumDisplayForm(SpectrumDisplayForm&&) = delete;
+    SpectrumDisplayForm& operator=(const SpectrumDisplayForm&) = delete;
+    SpectrumDisplayForm& operator=(SpectrumDisplayForm&&) = delete;
+
     void setSystem(SpectrumGUIClass* newSystem,
                    const uint64_t numFFTDataPoints,
                    const uint64_t numTimeDomainDataPoints);
@@ -97,31 +103,30 @@ signals:
     void plotPointSelected(const QPointF p, int type);
 
 private:
-    void _averageHistory(const double* newBuffer);
+    void _averageHistory(const std::vector<double>& newBuffer);
 
-    int _historyEntryCount;
-    int _historyEntry;
-    std::vector<double*>* _historyVector;
-    double* _averagedValues;
-    uint64_t _numRealDataPoints;
-    double* _realFFTDataPoints;
-    QIntValidator* _intValidator;
+    int _historyEntryCount = 0;
+    int _historyEntry = 0;
+    std::deque<std::vector<double>> _historyVector;
+    std::vector<double> _averagedValues;
+    std::vector<double> _realFFTDataPoints;
+    QIntValidator _intValidator;
     FrequencyDisplayPlot* _frequencyDisplayPlot;
     WaterfallDisplayPlot* _waterfallDisplayPlot;
     TimeDomainDisplayPlot* _timeDomainDisplayPlot;
     ConstellationDisplayPlot* _constellationDisplayPlot;
     SpectrumGUIClass* _system;
-    bool _systemSpecifiedFlag;
+    bool _systemSpecifiedFlag = false;
     double _centerFrequency;
     double _startFrequency;
     double _noiseFloorAmplitude;
-    double _peakFrequency;
+    double _peakFrequency = 0;
     double _peakAmplitude;
     double _stopFrequency;
 
     double d_units;
-    bool d_clicked;
-    double d_clicked_freq;
+    bool d_clicked = false;
+    double d_clicked_freq = 0;
 
     // SpectrumUpdateEvent _lastSpectrumEvent;
 
@@ -131,7 +136,7 @@ private:
     int d_plot_time;
     int d_plot_constellation;
 
-    QTimer* displayTimer;
+    QTimer displayTimer;
     double d_update_time;
 };
 

--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -47,10 +47,10 @@ public:
     void incrementResidual();
 
 protected:
-    double* d_data;
+    std::vector<double> d_data;
     double d_rows, d_cols;
     double d_resid;
-    int d_nitems, d_totalitems, d_data_size;
+    int d_nitems, d_totalitems;
 
 #if QWT_VERSION < 0x060000
     QwtDoubleInterval d_intensityRange;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -43,7 +43,7 @@ public:
     virtual uint64_t getNumFFTPoints() const;
     virtual void addFFTData(const double*, const uint64_t, const int);
 
-    virtual double* getSpectrumDataBuffer() const;
+    virtual const double* getSpectrumDataBuffer() const;
     virtual void setSpectrumDataBuffer(const double*);
 
     virtual int getNumLinesToUpdate() const;
@@ -51,7 +51,7 @@ public:
     virtual void incrementNumLinesToUpdate();
 
 protected:
-    double* _spectrumData;
+    std::vector<double> _spectrumData;
     uint64_t _fftPoints;
     uint64_t _historyLength;
     int _numLinesToUpdate;

--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -235,11 +235,9 @@ void EyeDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
                 // New data structure and data
                 for (unsigned int i = 0; i < d_numPeriods; ++i) {
                     int64_t time_index = i * (d_numPointsPerPeriod - 1);
-                    d_ydata.emplace_back(d_numPointsPerPeriod);
-                    // TODO: init copy.
-                    memcpy(d_ydata[i].data(),
-                           &(dataPoints[d_curve_index][time_index]),
-                           d_numPointsPerPeriod * sizeof(double));
+                    d_ydata.emplace_back(
+                        &dataPoints[d_curve_index][time_index],
+                        &dataPoints[d_curve_index][time_index + d_numPointsPerPeriod]);
                     d_plot_curve.push_back(
                         new QwtPlotCurve(QString("Eye [Data %1]").arg(d_curve_index)));
                     d_plot_curve[i]->attach(this);

--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -126,9 +126,7 @@ void SpectrumGUIClass::setDisplayTitle(const std::string newString)
 bool SpectrumGUIClass::getWindowOpenFlag()
 {
     gr::thread::scoped_lock lock(d_mutex);
-    bool returnFlag = false;
-    returnFlag = _windowOpennedFlag;
-    return returnFlag;
+    return _windowOpennedFlag;
 }
 
 

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -90,20 +90,13 @@ private:
     std::string d_yUnitType;
 };
 
-
 /***********************************************************************
  * Main Time domain plotter widget
  **********************************************************************/
 TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
-    : DisplayPlot(nplots, parent)
+    : DisplayPlot(nplots, parent), d_xdata(1024)
 {
-    d_numPoints = 1024;
-    d_xdata = new double[d_numPoints];
-    memset(d_xdata, 0x0, d_numPoints * sizeof(double));
-
-    d_tag_text_color = Qt::black;
-    d_tag_background_color = Qt::white;
-    d_tag_background_style = Qt::NoBrush;
+    d_numPoints = d_xdata.size();
 
     d_zoomer = new TimeDomainDisplayZoomer(canvas(), 0);
 
@@ -147,8 +140,7 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
     // Setup dataPoints and plot vectors
     // Automatically deleted when parent is deleted
     for (unsigned int i = 0; i < d_nplots; ++i) {
-        d_ydata.push_back(new double[d_numPoints]);
-        memset(d_ydata[i], 0x0, d_numPoints * sizeof(double));
+        d_ydata.emplace_back(d_numPoints);
 
         d_plot_curve.push_back(new QwtPlotCurve(QString("Data %1").arg(i)));
         d_plot_curve[i]->attach(this);
@@ -159,10 +151,10 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
             QwtSymbol::NoSymbol, QBrush(colors[i]), QPen(colors[i]), QSize(7, 7));
 
 #if QWT_VERSION < 0x060000
-        d_plot_curve[i]->setRawData(d_xdata, d_ydata[i], d_numPoints);
+        d_plot_curve[i]->setRawData(d_xdata.data(), d_ydata[i].data(), d_numPoints);
         d_plot_curve[i]->setSymbol(*symbol);
 #else
-        d_plot_curve[i]->setRawSamples(d_xdata, d_ydata[i], d_numPoints);
+        d_plot_curve[i]->setRawSamples(d_xdata.data(), d_ydata[i].data(), d_numPoints);
         d_plot_curve[i]->setSymbol(symbol);
 #endif
     }
@@ -191,10 +183,6 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
 
 TimeDomainDisplayPlot::~TimeDomainDisplayPlot()
 {
-    for (unsigned int i = 0; i < d_nplots; ++i)
-        delete[] d_ydata[i];
-    delete[] d_xdata;
-
     // d_zoomer and _panner deleted when parent deleted
 }
 
@@ -210,17 +198,17 @@ void TimeDomainDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
             if (numDataPoints != d_numPoints) {
                 d_numPoints = numDataPoints;
 
-                delete[] d_xdata;
-                d_xdata = new double[d_numPoints];
+                d_xdata.resize(d_numPoints);
 
                 for (unsigned int i = 0; i < d_nplots; ++i) {
-                    delete[] d_ydata[i];
-                    d_ydata[i] = new double[d_numPoints];
+                    d_ydata[i].resize(d_numPoints);
 
 #if QWT_VERSION < 0x060000
-                    d_plot_curve[i]->setRawData(d_xdata, d_ydata[i], d_numPoints);
+                    d_plot_curve[i]->setRawData(
+                        d_xdata.data(), d_ydata[i].data(), d_numPoints);
 #else
-                    d_plot_curve[i]->setRawSamples(d_xdata, d_ydata[i], d_numPoints);
+                    d_plot_curve[i]->setRawSamples(
+                        d_xdata.data(), d_ydata[i].data(), d_numPoints);
 #endif
                 }
 
@@ -232,7 +220,8 @@ void TimeDomainDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
                     for (int n = 0; n < numDataPoints; n++)
                         d_ydata[i][n] = fabs(dataPoints[i][n]);
                 } else {
-                    memcpy(d_ydata[i], dataPoints[i], numDataPoints * sizeof(double));
+                    memcpy(
+                        d_ydata[i].data(), dataPoints[i], numDataPoints * sizeof(double));
                 }
             }
 

--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -66,22 +66,22 @@ private:
     QString d_y_units; //!< Units on y-Axis (e.g. V)
 };
 
+namespace {
+constexpr int default_numpoints = 1024;
+}
 
 /***********************************************************************
  * Main frequency display plotter widget
  **********************************************************************/
 VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
-    : DisplayPlot(nplots, parent), d_x_axis_label("x"), d_y_axis_label("y")
+    : DisplayPlot(nplots, parent),
+      d_xdata(default_numpoints),
+      d_x_axis_label("x"),
+      d_y_axis_label("y"),
+      d_min_vec_data(default_numpoints),
+      d_max_vec_data(default_numpoints)
 {
-    d_numPoints = 1024;
-    d_x_axis_start = 0;
-    d_x_axis_step = 1.0;
-    d_ymin = -10;
-    d_ymax = 10;
-
-    d_min_vec_data = new double[d_numPoints];
-    d_max_vec_data = new double[d_numPoints];
-    d_xdata = new double[d_numPoints];
+    d_numPoints = default_numpoints;
 
     setAxisTitle(QwtPlot::xBottom, d_x_axis_label);
     setAxisScale(QwtPlot::xBottom, d_x_axis_start, d_numPoints - 1);
@@ -100,8 +100,7 @@ VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
     // Create a curve for each input
     // Automatically deleted when parent is deleted
     for (unsigned int i = 0; i < d_nplots; ++i) {
-        d_ydata.push_back(new double[d_numPoints]);
-        memset(d_ydata[i], 0x0, d_numPoints * sizeof(double));
+        d_ydata.emplace_back(d_numPoints);
 
         d_plot_curve.push_back(new QwtPlotCurve(QString("Data %1").arg(i)));
         d_plot_curve[i]->attach(this);
@@ -112,10 +111,10 @@ VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
                                           QSize(7, 7));
 
 #if QWT_VERSION < 0x060000
-        d_plot_curve[i]->setRawData(d_xdata, d_ydata[i], d_numPoints);
+        d_plot_curve[i]->setRawData(d_xdata.data(), d_ydata[i].data(), d_numPoints);
         d_plot_curve[i]->setSymbol(*symbol);
 #else
-        d_plot_curve[i]->setRawSamples(d_xdata, d_ydata[i], d_numPoints);
+        d_plot_curve[i]->setRawSamples(d_xdata.data(), d_ydata[i].data(), d_numPoints);
         d_plot_curve[i]->setSymbol(symbol);
 #endif
         setLineColor(i, default_colors[i]);
@@ -127,9 +126,10 @@ VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
     const QColor default_min_fft_color = Qt::magenta;
     setMinVecColor(default_min_fft_color);
 #if QWT_VERSION < 0x060000
-    d_min_vec_plot_curve->setRawData(d_xdata, d_min_vec_data, d_numPoints);
+    d_min_vec_plot_curve->setRawData(d_xdata.data(), d_min_vec_data.data(), d_numPoints);
 #else
-    d_min_vec_plot_curve->setRawSamples(d_xdata, d_min_vec_data, d_numPoints);
+    d_min_vec_plot_curve->setRawSamples(
+        d_xdata.data(), d_min_vec_data.data(), d_numPoints);
 #endif
     d_min_vec_plot_curve->setVisible(false);
     d_min_vec_plot_curve->setZ(0);
@@ -139,9 +139,10 @@ VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
     QColor default_max_fft_color = Qt::darkYellow;
     setMaxVecColor(default_max_fft_color);
 #if QWT_VERSION < 0x060000
-    d_max_vec_plot_curve->setRawData(d_xdata, d_max_vec_data, d_numPoints);
+    d_max_vec_plot_curve->setRawData(d_xdata.data(), d_max_vec_data.data(), d_numPoints);
 #else
-    d_max_vec_plot_curve->setRawSamples(d_xdata, d_max_vec_data, d_numPoints);
+    d_max_vec_plot_curve->setRawSamples(
+        d_xdata.data(), d_max_vec_data.data(), d_numPoints);
 #endif
     d_max_vec_plot_curve->setVisible(false);
     d_max_vec_plot_curve->setZ(0);
@@ -158,7 +159,7 @@ VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
     setMarkerUpperIntensityColor(default_marker_upper_intensity_color);
     d_upper_intensity_marker->attach(this);
 
-    memset(d_xdata, 0x0, d_numPoints * sizeof(double));
+    std::fill(std::begin(d_xdata), std::end(d_xdata), 0.0);
 
     for (int64_t number = 0; number < d_numPoints; number++) {
         d_min_vec_data[number] = 1e6;
@@ -209,14 +210,7 @@ VectorDisplayPlot::VectorDisplayPlot(int nplots, QWidget* parent)
     replot();
 }
 
-VectorDisplayPlot::~VectorDisplayPlot()
-{
-    for (unsigned int i = 0; i < d_nplots; ++i)
-        delete[] d_ydata[i];
-    delete[] d_max_vec_data;
-    delete[] d_min_vec_data;
-    delete[] d_xdata;
-}
+VectorDisplayPlot::~VectorDisplayPlot() {}
 
 void VectorDisplayPlot::setYaxis(double min, double max)
 {
@@ -294,29 +288,31 @@ void VectorDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
             if (numDataPoints != d_numPoints) {
                 d_numPoints = numDataPoints;
 
-                delete[] d_min_vec_data;
-                delete[] d_max_vec_data;
-                delete[] d_xdata;
-                d_xdata = new double[d_numPoints];
-                d_min_vec_data = new double[d_numPoints];
-                d_max_vec_data = new double[d_numPoints];
+                d_xdata.resize(d_numPoints);
+                d_min_vec_data.resize(d_numPoints);
+                d_max_vec_data.resize(d_numPoints);
 
                 for (unsigned int i = 0; i < d_nplots; ++i) {
-                    delete[] d_ydata[i];
-                    d_ydata[i] = new double[d_numPoints];
+                    d_ydata[i].resize(d_numPoints);
 
 #if QWT_VERSION < 0x060000
-                    d_plot_curve[i]->setRawData(d_xdata, d_ydata[i], d_numPoints);
+                    d_plot_curve[i]->setRawData(
+                        d_xdata.data(), d_ydata[i].data(), d_numPoints);
 #else
-                    d_plot_curve[i]->setRawSamples(d_xdata, d_ydata[i], d_numPoints);
+                    d_plot_curve[i]->setRawSamples(
+                        d_xdata.data(), d_ydata[i].data(), d_numPoints);
 #endif
                 }
 #if QWT_VERSION < 0x060000
-                d_min_vec_plot_curve->setRawData(d_xdata, d_min_vec_data, d_numPoints);
-                d_max_vec_plot_curve->setRawData(d_xdata, d_max_vec_data, d_numPoints);
+                d_min_vec_plot_curve->setRawData(
+                    d_xdata.data(), d_min_vec_data.data(), d_numPoints);
+                d_max_vec_plot_curve->setRawData(
+                    d_xdata.data(), d_max_vec_data.data(), d_numPoints);
 #else
-                d_min_vec_plot_curve->setRawSamples(d_xdata, d_min_vec_data, d_numPoints);
-                d_max_vec_plot_curve->setRawSamples(d_xdata, d_max_vec_data, d_numPoints);
+                d_min_vec_plot_curve->setRawSamples(
+                    d_xdata.data(), d_min_vec_data.data(), d_numPoints);
+                d_max_vec_plot_curve->setRawSamples(
+                    d_xdata.data(), d_max_vec_data.data(), d_numPoints);
 #endif
                 _resetXAxisPoints();
                 clearMaxData();
@@ -326,7 +322,7 @@ void VectorDisplayPlot::plotNewData(const std::vector<double*> dataPoints,
             double bottom = 1e20, top = -1e20;
             for (unsigned int n = 0; n < d_nplots; ++n) {
 
-                memcpy(d_ydata[n], dataPoints[n], numDataPoints * sizeof(double));
+                memcpy(d_ydata[n].data(), dataPoints[n], numDataPoints * sizeof(double));
 
                 for (int64_t point = 0; point < numDataPoints; point++) {
                     if (dataPoints[n][point] < d_min_vec_data[point]) {


### PR DESCRIPTION
I want to do some more testing today.

I'm not sure why `EyeDisplayPlot` was only freeing the `d_curve_index` `d_ydata`. Was that a mistake, or am I missing something?