### PR TITLE
Blacklist audio

### DIFF
--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -13,7 +13,7 @@ from .. import Constants
 
 
 # Blacklist certain ids, its not complete, but should help
-ID_BLACKLIST = ['self', 'options', 'gr', 'math', 'firdes', 'default'] + dir(builtins)
+ID_BLACKLIST = ['self', 'options', 'gr', 'math', 'firdes', 'default', 'audio'] + dir(builtins)
 try:
     from gnuradio import gr
     ID_BLACKLIST.extend(attr for attr in dir(gr.top_block()) if not attr.startswith('_'))


### PR DESCRIPTION
The id audio should be blacklisted , too
This fixes the attribute error in #4475 
Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>