### PR TITLE
grc: Check connection types, whether they match

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -90,6 +90,11 @@ class Connection(Element):
             self.add_error_message('No connection known between domains "{}" and "{}"'
                                    ''.format(*self.type))
 
+        source_dtype = self.source_port.dtype
+        sink_dtype = self.sink_port.dtype
+        if source_dtype != sink_dtype:
+            self.add_error_message('Source IO type "{}" does not match sink IO type "{}".'.format(source_dtype, sink_dtype))
+
         source_size = self.source_port.item_size
         sink_size = self.sink_port.item_size
         if source_size != sink_size:


### PR DESCRIPTION
At the moment grc treats a connection int -> float as valid as the itemsizes match. See #4475 
This patch checks the dtype of a port. Connections are only valid if the dtype's match

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>