### PR TITLE
runtime: remove ready message receiver queue remnant from basic_block (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -52,8 +52,6 @@ private:
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator> msg_queue_map_t;
     typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator>::iterator
         msg_queue_map_itr;
-    std::map<pmt::pmt_t, std::shared_ptr<boost::condition_variable>, pmt::comparator>
-        msg_queue_ready;
 
     gr::thread::mutex mutex; //< protects all vars
 

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -75,8 +75,6 @@ void basic_block::message_port_register_in(pmt::pmt_t port_id)
         throw std::runtime_error("message_port_register_in: bad port id");
     }
     msg_queue[port_id] = msg_queue_t();
-    msg_queue_ready[port_id] =
-        std::shared_ptr<boost::condition_variable>(new boost::condition_variable());
 }
 
 pmt::pmt_t basic_block::message_ports_in()
@@ -176,8 +174,7 @@ void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
 {
     gr::thread::scoped_lock guard(mutex);
 
-    if ((msg_queue.find(which_port) == msg_queue.end()) ||
-        (msg_queue_ready.find(which_port) == msg_queue_ready.end())) {
+    if (msg_queue.find(which_port) == msg_queue.end()) {
         GR_LOG_ERROR(d_logger,
                      std::string("attempted insertion on invalid queue ") +
                          pmt::symbol_to_string(which_port));
@@ -185,7 +182,6 @@ void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
     }
 
     msg_queue[which_port].push_back(msg);
-    msg_queue_ready[which_port]->notify_one();
 
     // wake up thread if BLKD_IN or BLKD_OUT
     global_block_registry.notify_blk(d_symbol_name);

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -173,15 +173,15 @@ void basic_block::_post(pmt::pmt_t which_port, pmt::pmt_t msg)
 void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
 {
     gr::thread::scoped_lock guard(mutex);
-
-    if (msg_queue.find(which_port) == msg_queue.end()) {
+    const auto& queue = msg_queue.find(which_port);
+    if (queue == msg_queue.end()) {
         GR_LOG_ERROR(d_logger,
                      std::string("attempted insertion on invalid queue ") +
                          pmt::symbol_to_string(which_port));
         throw std::runtime_error("attempted to insert_tail on invalid queue!");
     }
 
-    msg_queue[which_port].push_back(msg);
+    queue->second.push_back(msg);
 
     // wake up thread if BLKD_IN or BLKD_OUT
     global_block_registry.notify_blk(d_symbol_name);

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(basic_block.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(26ded167bb79b740fd37685f86fd553e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(9239cc3381582f5f44010485cd48fa72)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
runtime: remove ready message receiver queue remnant from basic_block
runtime: don't do two lookups to verify existence and get msg handler

Backport https://github.com/gnuradio/gnuradio/pull/4426