### PR TITLE
pmt: remove tag_to_pmt method (unused) (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -19,15 +19,6 @@ def tag_to_python(tag):
     newtag.srcid = pmt.to_python(tag.srcid)
     return newtag
 
-def tag_to_pmt(tag):
-    """ Convert a Python-readable object to a stream tag """
-    newtag = gr.tag_t()
-    newtag.offset = tag.offset
-    newtag.key = pmt.to_python(tag.key)
-    newtag.value = pmt.from_python(tag.value)
-    newtag.srcid = pmt.from_python(tag.srcid)
-    return newtag
-
 def python_to_tag(tag_struct):
     """
     Convert a Python list/tuple/dictionary to a stream tag.


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@perspectalabs.com>
(cherry picked from commit da3d208956f165c54ed86351ecede88fdd6a4c05)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4459