### PR TITLE
gr-audio: Check CreateEvent() for failure (backport to maint-3.8)

### DIFF
--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -101,6 +101,10 @@ windows_sink::windows_sink(int sampling_freq,
         (wave_format.wBitsPerSample / 8); // room for 16-bit audio on two channels.
 
     d_wave_write_event = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (!d_wave_write_event) {
+        GR_LOG_ERROR(d_logger, "CreateEvent() failed");
+        throw std::runtime_error("CreateEvent() failed");
+    }
     if (open_waveout_device() < 0) {
         perror("audio_windows_sink:open_waveout_device() failed\n");
         throw std::runtime_error("audio_windows_sink:open_waveout_device() failed");


### PR DESCRIPTION
CreateEvent() should be checked for failure.  An access violation
could occur if it is not.

Signed-off-by: Zackery Spytz <zspytz@gmail.com>
(cherry picked from commit eb444b21b1022a2c7de346af24f8c457a184a7de)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4457