### PR TITLE
runtime: fix gr::random API to be fixed-width 64 bit, use XOROSHIRO128+ (manual rebase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Older Logs can be found in `docs/RELEASE-NOTES-*`.
 - `fastnoise_source`: Use a simple bitmask if the random pool length is a power
   of 2 to determine indices, instead of `%`, which consumed considerable CPU
 
+#### gnuradio-runtime
+
+- `gr::random` uses xoroshiro128+ internally, takes `uint64_t` seed
+
 ### Added
 
 - New in-tree module gr-pdu

--- a/gnuradio-runtime/lib/math/random.cc
+++ b/gnuradio-runtime/lib/math/random.cc
@@ -35,13 +35,12 @@
 
 namespace gr {
 
-random::random(unsigned int seed, int min_integer, int max_integer)
-    : d_rng(), d_integer_dis(0, 1)
+random::random(uint64_t seed, int64_t min_integer, int64_t max_integer)
+    : d_rng(seed), d_integer_dis(0, 1)
 {
     d_gauss_stored = false; // set gasdev (gauss distributed numbers) on calculation state
 
     // Setup random number generators
-    reseed(seed); // set seed for random number generator
     set_integer_limits(min_integer, max_integer);
 }
 
@@ -51,7 +50,7 @@ random::~random() {}
  * Seed is initialized with time if the given seed is 0. Otherwise the seed is taken
  * directly. Sets the seed for the random number generator.
  */
-void random::reseed(unsigned int seed)
+void random::reseed(uint64_t seed)
 {
     d_seed = seed;
     if (d_seed == 0) {
@@ -63,17 +62,17 @@ void random::reseed(unsigned int seed)
     }
 }
 
-void random::set_integer_limits(const int minimum, const int maximum)
+void random::set_integer_limits(int64_t minimum, int64_t maximum)
 {
     // boost expects integer limits defined as [minimum, maximum] which is unintuitive.
     // use the expected half open interval behavior! [minimum, maximum)!
-    d_integer_dis = std::uniform_int_distribution<>(minimum, maximum - 1);
+    d_integer_dis = std::uniform_int_distribution<int64_t>(minimum, maximum - 1);
 }
 
 /*!
  * Uniform random integers in the range set by 'set_integer_limits' [min, max).
  */
-int random::ran_int() { return d_integer_dis(d_rng); }
+int64_t random::ran_int() { return d_integer_dis(d_rng); }
 
 /*
  * Returns uniformly distributed numbers in [0,1) taken from boost.random using a Mersenne

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/random_pydoc_template.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/random_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2021 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -13,6 +13,24 @@
   Do not edit! These were automatically extracted during the binding process
   and will be overwritten during the build process
  */
+
+
+static const char* __doc_gr_xoroshiro128p_prng = R"doc()doc";
+
+
+static const char* __doc_gr_xoroshiro128p_prng_xoroshiro128p_prng_0 = R"doc()doc";
+
+
+static const char* __doc_gr_xoroshiro128p_prng_xoroshiro128p_prng_1 = R"doc()doc";
+
+
+static const char* __doc_gr_xoroshiro128p_prng_min = R"doc()doc";
+
+
+static const char* __doc_gr_xoroshiro128p_prng_max = R"doc()doc";
+
+
+static const char* __doc_gr_xoroshiro128p_prng_seed = R"doc()doc";
 
 
 static const char* __doc_gr_random = R"doc()doc";

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/random_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/random_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(random.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(95215055c6ad6f78b88d532d3994d29a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(489c2917f344c75e2001d0c670de7784)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -29,8 +29,33 @@ namespace py = pybind11;
 
 void bind_random(py::module& m)
 {
-
+    using xoroshiro128p_prng = ::gr::xoroshiro128p_prng;
     using random = ::gr::random;
+
+
+    py::class_<xoroshiro128p_prng, std::shared_ptr<xoroshiro128p_prng>>(
+        m, "xoroshiro128p_prng", D(xoroshiro128p_prng))
+
+        .def(py::init<uint64_t>(),
+             py::arg("init"),
+             D(xoroshiro128p_prng, xoroshiro128p_prng, 0))
+        .def(py::init<gr::xoroshiro128p_prng const&>(),
+             py::arg("arg0"),
+             D(xoroshiro128p_prng, xoroshiro128p_prng, 1))
+
+
+        .def_static("min", &xoroshiro128p_prng::min, D(xoroshiro128p_prng, min))
+
+
+        .def_static("max", &xoroshiro128p_prng::max, D(xoroshiro128p_prng, max))
+
+
+        .def("seed",
+             &xoroshiro128p_prng::seed,
+             py::arg("seed"),
+             D(xoroshiro128p_prng, seed))
+
+        .def("__call__", &xoroshiro128p_prng::operator());
 
 
     py::class_<random, std::shared_ptr<random>>(m, "random", D(random))

--- a/gnuradio-runtime/python/gnuradio/gr/qa_random.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_random.py
@@ -63,6 +63,42 @@ class test_random(gr_unittest.TestCase):
         self.assertGreaterEqual(minimum, np.min(rnd_vals))
         self.assertLess(np.max(rnd_vals), maximum)
 
+    def test_005_xoroshiro128p_seed_stability(self):
+        """
+        Test that seeding is stable.
+        It's basically an API break if it isn't.
+
+        We simply check for the first value of a sequence
+        being the same as it was when the module was integrated.
+        """
+        rng = gr.xoroshiro128p_prng(42)
+        self.assertEqual(3520422898491873512, rng())
+
+    def test_006_xoroshiro128p_reproducibility(self):
+        """
+        Make sure two RNGs with the same seed yield the same
+        sequence
+        """
+        seed = 123456
+        N = 10000
+        rng1 = gr.xoroshiro128p_prng(123456)
+        rng2 = gr.xoroshiro128p_prng(123456)
+        self.assertSequenceEqual(
+            tuple(rng1() for _ in range(N)),
+            tuple(rng2() for _ in range(N)))
+
+    def test_007_xoroshiro128p_range(self):
+        """
+        Check bounds.
+        Check whether a long sequence of values are within that bounds.
+        """
+        N = 10**6
+
+        self.assertEqual(gr.xoroshiro128p_prng.min(), 0)
+        self.assertEqual(gr.xoroshiro128p_prng.max(), 2**64-1)
+        rng = gr.xoroshiro128p_prng(42)
+        arr = all((0 <= rng() <= 2**64 - 1 for _ in range(N)))
+        self.assertTrue(arr)
 
 if __name__ == '__main__':
     gr_unittest.run(test_random)


### PR DESCRIPTION
Seeding being inconsistent between gr::random and things like fastnoise
source is an outstanding issue (#1559).

Fix that by fixing the API, and pivoting to our built-in XOROSHIRO128+,
which is also substantially faster than MT19937.

For that purpose, introduce, and python-bind, a wrapper class that can
be used with STL distribution shapers.

Add a unit test for the (P)RNG.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>