### PR TITLE
grc: Remove global_blocks_path preference and use prefix path

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -168,6 +168,7 @@ function(GR_PYTHON_INSTALL)
     install(
       FILES ${GR_PYTHON_INSTALL_FILES}
       DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
+      ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS}
     )
 
         #create a list of all generated files
@@ -228,6 +229,7 @@ function(GR_PYTHON_INSTALL)
     install(
       DIRECTORY ${GR_PYTHON_INSTALL_DIRECTORY}
       DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
+      ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS}
     )
 
 
@@ -334,6 +336,7 @@ function(GR_PYTHON_INSTALL)
 
             install(PROGRAMS ${pyexefile} RENAME ${pyfile_name}
                 DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
+                ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS}
             )
         endforeach(pyfile)
 

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -80,14 +80,8 @@ GR_REGISTER_COMPONENT("gnuradio-companion" ENABLE_GRC
 if(ENABLE_GRC)
 
 ########################################################################
-# Create and install the grc and grc-docs conf file
+# Create and install the grc and grc-docs conf files and constants YAML
 ########################################################################
-file(TO_NATIVE_PATH ${CMAKE_INSTALL_PREFIX}/${GRC_BLOCKS_DIR} blocksdir)
-if(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-    # linux binary installs: append blocks dir with prefix /usr/local
-    set(blocksdir ${blocksdir}:/usr/local/${GRC_BLOCKS_DIR})
-endif(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
-
 if(UNIX)
     find_program(GRC_XTERM_EXE
         NAMES xterminal-emulator gnome-terminal konsole xterm
@@ -119,6 +113,13 @@ configure_file(
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/00-grc-docs.conf
     DESTINATION ${GR_PREFSDIR}
+)
+
+configure_file(core/constants.yml.in core/constants.yml @ONLY)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/core/constants.yml"
+    DESTINATION "${GR_PYTHON_DIR}/gnuradio/grc/core"
 )
 
 ########################################################################

--- a/grc/compiler.py
+++ b/grc/compiler.py
@@ -38,7 +38,8 @@ def main(args=None):
         name='GNU Radio Companion Compiler',
         prefs=gr.prefs(),
         version=gr.version(),
-        version_parts=(gr.major_version(), gr.api_version(), gr.minor_version())
+        version_parts=(gr.major_version(), gr.api_version(), gr.minor_version()),
+        install_prefix=gr.prefix(),
     )
     platform.build_library()
 

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -12,13 +12,25 @@ import numbers
 import stat
 
 import numpy
+import yaml
 
+
+DATA_DIR = os.path.dirname(__file__)
+
+try:
+    with open(os.path.join(DATA_DIR, "constants.yml"), "r") as f:
+        _yaml_constants = yaml.safe_load(f)
+except (OSError, yaml.YAMLError):
+    _yaml_constants = {}
 
 # Data files
-DATA_DIR = os.path.dirname(__file__)
 BLOCK_DTD = os.path.join(DATA_DIR, 'block.dtd')
 DEFAULT_FLOW_GRAPH = os.path.join(DATA_DIR, 'default_flow_graph.grc')
 DEFAULT_HIER_BLOCK_LIB_DIR = os.path.expanduser('~/.grc_gnuradio')
+GRC_BLOCKS_DIR = os.path.normpath(
+    _yaml_constants.get("GRC_BLOCKS_DIR", os.path.join(DATA_DIR, "..", "blocks"))
+)
+
 
 CACHE_FILE = os.path.expanduser('~/.cache/grc_gnuradio/cache.json')
 

--- a/grc/core/constants.yml.in
+++ b/grc/core/constants.yml.in
@@ -1,0 +1,8 @@
+# Copyright 2021 Ryan Volz
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# For constants to be loaded by Constants.py that are configured at build time
+GRC_BLOCKS_DIR: "@GRC_BLOCKS_DIR@"

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -179,7 +179,20 @@ class Platform(Element):
 
         self._docstring_extractor.finish()
         # self._docstring_extractor.wait()
-        utils.hide_bokeh_gui_options_if_not_installed(self.blocks['options'])
+        if 'options' not in self.blocks:
+            # we didn't find one of the built-in blocks ("options")
+            # which probably means the GRC blocks path is bad
+            errstr = (
+                "Failed to find built-in GRC blocks (specifically, the "
+                "'options' block). Ensure your GRC block paths are correct "
+                "and at least one points to your prefix installation:"
+            )
+            errstr = "\n".join([errstr] + (path or self.config.block_paths))
+            raise RuntimeError(errstr)
+        else:
+            # might have some cleanup to do on the options block in particular
+            utils.hide_bokeh_gui_options_if_not_installed(self.blocks['options'])
+
 
     def _iter_files_in_block_path(self, path=None, ext='yml'):
         """Iterator for block descriptions and category trees"""

--- a/grc/grc.conf.in
+++ b/grc/grc.conf.in
@@ -3,7 +3,6 @@
 # ~/.gnuradio/config.conf
 
 [grc]
-global_blocks_path = @blocksdir@
 local_blocks_path =
 default_flow_graph =
 xterm_executable = @GRC_XTERM_EXE@

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -30,9 +30,8 @@ class Config(CoreConfig):
     gui_prefs_file = os.environ.get(
         'GRC_PREFS_PATH', os.path.expanduser('~/.gnuradio/grc.conf'))
 
-    def __init__(self, install_prefix, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         CoreConfig.__init__(self, *args, **kwargs)
-        self.install_prefix = install_prefix
         Constants.update_font_size(self.font_size)
 
         self.parser = configparser.ConfigParser()

--- a/grc/tests/CMakeLists.txt
+++ b/grc/tests/CMakeLists.txt
@@ -15,7 +15,6 @@ if(ENABLE_TESTING)
     )
 
     if(PYTEST_FOUND)
-        set(GR_TEST_ENVIRONS "GRC_BLOCKS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/../blocks\"")
         GR_ADD_TEST(grc_tests ${QA_PYTHON_EXECUTABLE} -B -m pytest ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
 endif(ENABLE_TESTING)

--- a/grc/tests/test_generator.py
+++ b/grc/tests/test_generator.py
@@ -26,6 +26,7 @@ def test_generator():
         name='GNU Radio Companion Compiler',
         prefs=None,
         version='0.0.0',
+        install_prefix='',
     )
     platform.build_library(block_paths)
 


### PR DESCRIPTION
Addresses #2763.

Instead of storing the default (built-in) blocks path in the preferences, store the path relative to the prefix (`GRC_BLOCKS_DIR`) in a `constants.yml` file and evaluate the full blocks path at runtime by joining with the installation prefix. This should make it easier to switch between different versions by making it so the user preference for `global_blocks_path` doesn't interfere. Users still have `local_blocks_path` preference and the `GRC_BLOCKS_PATH` environment variable for pointing to additional blocks.

This PR also includes a CMake tweak to `GR_PYTHON_INSTALL` that is no longer necessary for this PR to work but adds what looks to be expected functionality for `FILES_MATCHING REGEX`. It also includes a commit to make the cause of the `KeyError: 'options'` error more clear (even though the removal of `global_blocks_path` should do a lot to prevent that error from happening).

I tested running `gnuradio-companion` on both Linux and Windows and the blocks load fine, avoiding a bad or empty `global_blocks_path` preference as intended. It would be great for someone more familiar with this part of the code to double-check to make sure I haven't broken anything unintentionally.