### PR TITLE
grc: match data type aliases as well as types (backport to maint-3.9)

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -8,6 +8,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 
 from .base import Element
+from .Constants import ALIAS_OF
 from .utils.descriptors import lazy_property
 
 
@@ -92,7 +93,7 @@ class Connection(Element):
 
         source_dtype = self.source_port.dtype
         sink_dtype = self.sink_port.dtype
-        if source_dtype != sink_dtype:
+        if source_dtype != sink_dtype and source_dtype != ALIAS_OF.get(sink_dtype):
             self.add_error_message('Source IO type "{}" does not match sink IO type "{}".'.format(source_dtype, sink_dtype))
 
         source_size = self.source_port.item_size

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -115,5 +115,21 @@ ALIAS_TYPES = {
     'bits':    (1, GRC_COLOR_PURPLE_A100),
 }
 
+ALIAS_OF = {
+    'complex': 'fc32',
+    'float': 'f32',
+    'int': 's32',
+    'short': 's16',
+    'byte': 's8',
+    'bits': 'bit',
+
+    'fc32': 'complex',
+    'f32': 'float',
+    's32': 'int',
+    's16': 'short',
+    's8': 'byte',
+    'bit': 'bits',
+}
+
 TYPE_TO_SIZEOF = {key: sizeof for name, key, sizeof, color in CORE_TYPES}
 TYPE_TO_SIZEOF.update((key, sizeof) for key, (sizeof, _) in ALIAS_TYPES.items())


### PR DESCRIPTION
A recent fix to validate connections by type, rather than by sizeof(type), exposed the fact that GRC did not
handle type aliases.

Fixes #4514

Signed-off-by: Jeff Long willcode4@gmail.com

Backport #4516