### PR TITLE
grc: Fix option_attributes check on inherited type

### DIFF
--- a/grc/core/blocks/_build.py
+++ b/grc/core/blocks/_build.py
@@ -116,12 +116,12 @@ def build_params(params_raw, have_inputs, have_outputs, flags, block_id):
         if param_id in params:
             raise Exception('Param id "{}" is not unique'.format(param_id))
 
-        if 'option_attributes' in param_data:
-            _validate_option_attributes(param_data, block_id)
-
         base_key = param_data.get('base_key', None)
         param_data_ext = base_params_n.get(base_key, {}).copy()
         param_data_ext.update(param_data)
+
+        if 'option_attributes' in param_data:
+            _validate_option_attributes(param_data_ext, block_id)
 
         add_param(**param_data_ext)
         base_params_n[param_id] = param_data_ext


### PR DESCRIPTION
Run the `option_attributes` validation routine on the extended dictionary, i.e., after inheriting the properties from the `base_key` parameter. By doing so, if the `dtype` property is inherited, the `_validate_option_attributes` still sees it and does not throw a key error.

For example, the following would break without this patch:
```
-   id: param1
    label: label
    dtype: enum
    options: ...
    option_labels: ...
    option_attributes:
        key: ...
-   id: param2
    base_key: param1
    options: ...
    option_labels: ...
    option_attributes:
        key: ...
```

@haakov Does this make sense? I see the validation was added in 99b8ef09b954c69492be95b68989d6d75b0446ee. 