### PR TITLE
gr-iio: add iio GnuradioConfig.cmake.in

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -84,6 +84,7 @@ set(GR_COMPONENTS
   audio
   channels
   pdu
+  iio
   qtgui
   trellis
   uhd


### PR DESCRIPTION
If gr-iio is part of gnuradio, the module should be mentioned here.