### PR TITLE
Fix rational resampler yml

### DIFF
--- a/gr-filter/grc/filter_rational_resampler_xxx.block.yml
+++ b/gr-filter/grc/filter_rational_resampler_xxx.block.yml
@@ -52,7 +52,7 @@ templates:
         % else:
                 taps=[],
         % endif
-        % if float(fbw) != 0:
+        % if fbw:
                 fractional_bw=${fbw})
         % else:
                 fractional_bw=-1.0)


### PR DESCRIPTION
Hi

I reported an issue on the mailing list for this flowgraph  [test_fbw.grc.txt](https://github.com/gnuradio/gnuradio/files/6316290/test_fbw.grc.txt)
used in GR 3.8 and 3.9. This flowgraph is only used to demonstrate the issue.

The issue appears when I'm defining a fractional bandwidth (fbw) as "1/sps" calculated from a variable instead of a float value.
during making the template, this error is raised
```
Generating: '/home/seguinot/desktop/test_grc/test_fbw.py'
Generate Error: (ValueError("could not convert string to float: '1/sps'"), 'filter.rational_resampler_${type}(\n        interpolation=${interp},\n        decimation=${decim},\n% if taps:\n        taps=${taps},\n% else:\n        taps=None,\n% endif\n% if float(fbw) != 0:\n        fractional_bw=${fbw})\n% else:\n        fractional_bw=None)\n% endif')
>>> Failure
```
The problem comes from `if float(fbw) != 0` which can't be evaluated when fbw is a string. 
Replacing this by `if float:` solve the issue. 
Surprinsingly, it also solves the issue if parameter fbw is a string evaluated to 0 (example fbw='0.4*my_fbw' with my fbw set to 0 which indicates that using fbw=-1 seems not required! 

I tried to investigates the rational_resampler_impl.cc code, however it states that fbw must be within 0<fbw<0.5

Regards Christophe 