### PR TITLE
cmake: Move swath of add_definitions to gnuradio-runtime target. (backport to maint-3.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,9 +165,6 @@ include(GrMiscUtils) #compiler flag check
 
 include(TestBigEndian)
 TEST_BIG_ENDIAN(GR_IS_BIG_ENDIAN)
-if(GR_IS_BIG_ENDIAN)
-    add_definitions(-DGR_IS_BIG_ENDIAN)
-endif(GR_IS_BIG_ENDIAN)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -183,26 +180,10 @@ endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
 
 if(MSVC)
     include_directories(${CMAKE_SOURCE_DIR}/cmake/msvc) #missing headers
-    add_definitions(-D_USE_MATH_DEFINES) #enables math constants on all supported versions of MSVC
-    add_definitions(-D_WIN32_WINNT=0x0502) #Minimum version: "Windows Server 2003 with SP1, Windows XP with SP2"
-    add_definitions(-DNOMINMAX) #disables stupidity and enables std::min and std::max
-    add_definitions( #stop all kinds of compatibility warnings
-        -D_SCL_SECURE_NO_WARNINGS
-        -D_CRT_SECURE_NO_WARNINGS
-        -D_CRT_SECURE_NO_DEPRECATE
-        -D_CRT_NONSTDC_NO_DEPRECATE
-    )
     add_definitions(-DHAVE_CONFIG_H)
     add_compile_options(/MP) #build with multiple processors
     add_compile_options(/bigobj) #allow for larger object files
 endif(MSVC)
-
-if(WIN32)
-    add_definitions(-D_USE_MATH_DEFINES)
-    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-        add_definitions(-DMS_WIN64)
-    endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-endif(WIN32)
 
 # Record Compiler Info for record
 STRING(TOUPPER ${CMAKE_BUILD_TYPE} GRCBTU)
@@ -274,7 +255,6 @@ OPTION(ENABLE_PERFORMANCE_COUNTERS "Enable block performance counters" ON)
 if(ENABLE_PERFORMANCE_COUNTERS)
   message(STATUS "ADDING PERF COUNTERS")
   SET(GR_PERFORMANCE_COUNTERS True)
-  add_definitions(-DGR_PERFORMANCE_COUNTERS)
 else(ENABLE_PERFORMANCE_COUNTERS)
   SET(GR_PERFORMANCE_COUNTERS False)
   message(STATUS "NO PERF COUNTERS")
@@ -456,7 +436,6 @@ list(APPEND GR_TEST_PYTHON_DIRS
 # multiprecision arithmetic library header to include
 include(FindPkgConfig)
 find_package(MPLIB)
-add_definitions(${MPLIB_DEFINITIONS})
 
 ########################################################################
 # Post-Install tasks are tasks that are usually not executed during
@@ -492,7 +471,6 @@ add_subdirectory(gr-network)
 # Defining GR_CTRLPORT for gnuradio/config.h
 if(ENABLE_GR_CTRLPORT)
   SET(GR_CTRLPORT True)
-  add_definitions(-DGR_CTRLPORT)
 
   if(CTRLPORT_BACKENDS GREATER 0)
     SET(GR_RPCSERVER_ENABLED True)

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -122,6 +122,42 @@ target_sources(gnuradio-runtime PRIVATE
   ${MATH_SINE_TABLE_HEADER}
   )
 
+target_link_libraries(gnuradio-runtime PUBLIC
+  gnuradio-pmt
+  Volk::volk
+  Boost::program_options
+  Boost::filesystem
+  Boost::system
+  Boost::regex
+  Boost::thread
+  Log4Cpp::log4cpp
+  MPLib::mplib
+  ${libunwind_LIBRARIES}
+  # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
+  # (importantly, extension modules can avoid linking against Python and resolve
+  #  their own Python symbols at runtime through the Python interpreter's linking)
+  INTERFACE
+    Python::Module
+  PRIVATE
+    Python::Python
+  )
+
+target_include_directories(gnuradio-runtime
+  PUBLIC
+    ${PYTHON_NUMPY_INCLUDE_DIR}
+    ${pybind11_INCLUDE_DIR}
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+target_compile_definitions(gnuradio-runtime PUBLIC ${MPLIB_DEFINITIONS})
+
+########################################################################
+# Add controlport stuff to gnuradio-runtime
+########################################################################
 # Controlport
 if(ENABLE_GR_CTRLPORT)
 
@@ -178,6 +214,8 @@ target_link_libraries(gnuradio-runtime PUBLIC
   Thrift::thrift
   )
 
+target_compile_definitions(gnuradio-runtime PUBLIC GR_CTRLPORT)
+
 # Add install rule to move example Thrift configuration file into a
 # documentation directory
 install(
@@ -188,10 +226,6 @@ install(
 endif(THRIFT_FOUND)
 endif(ENABLE_CTRLPORT_THRIFT)
 
-########################################################################
-# Add controlport stuff to gnuradio-runtime
-########################################################################
-
 # Save the number of backends for testing against later
 set(
   CTRLPORT_BACKENDS ${CTRLPORT_BACKENDS}
@@ -200,41 +234,38 @@ set(
 
 endif(ENABLE_GR_CTRLPORT)
 
-target_link_libraries(gnuradio-runtime PUBLIC
-  gnuradio-pmt
-  Volk::volk
-  Boost::program_options
-  Boost::filesystem
-  Boost::system
-  Boost::regex
-  Boost::thread
-  Log4Cpp::log4cpp
-  MPLib::mplib
-  ${libunwind_LIBRARIES}
-  # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
-  # (importantly, extension modules can avoid linking against Python and resolve
-  #  their own Python symbols at runtime through the Python interpreter's linking)
-  INTERFACE
-    Python::Module
-  PRIVATE
-    Python::Python
+########################################################################
+# Add misc conditional includes/definitions to gnuradio-runtime
+########################################################################
+
+if(ENABLE_PERFORMANCE_COUNTERS)
+  target_compile_definitions(gnuradio-runtime PUBLIC -DGR_PERFORMANCE_COUNTERS)
+endif()
+
+if(GR_IS_BIG_ENDIAN)
+  target_compile_definitions(gnuradio-runtime PUBLIC -DGR_IS_BIG_ENDIAN)
+endif(GR_IS_BIG_ENDIAN)
+
+if(MSVC)
+  target_compile_definitions(gnuradio-runtime PUBLIC
+    # Minimum version: "Windows Server 2003 with SP1, Windows XP with SP2"
+    -D_WIN32_WINNT=0x0502
+    # disables stupidity and enables std::min and std::max
+    -DNOMINMAX
+    # stop all kinds of compatibility warnings
+    -D_SCL_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_DEPRECATE
+    -D_CRT_NONSTDC_NO_DEPRECATE
   )
+endif(MSVC)
 
-target_include_directories(gnuradio-runtime
-  PUBLIC
-    ${PYTHON_NUMPY_INCLUDE_DIR}
-    ${pybind11_INCLUDE_DIR}
-    $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
-  if(ENABLE_GR_CTRLPORT)
-    target_compile_definitions(gnuradio-runtime PUBLIC GR_CTRLPORT)
-  endif()
-
+if(WIN32)
+  target_compile_definitions(gnuradio-runtime PUBLIC -D_USE_MATH_DEFINES)
+  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    target_compile_definitions(gnuradio-runtime PUBLIC -DMS_WIN64)
+  endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+endif(WIN32)
 
 if(WIN32)
     target_compile_definitions(gnuradio-runtime PUBLIC -DWIN32_LEAN_AND_MEAN)


### PR DESCRIPTION
Besides being a more modern CMake style, this has the benefit of
propagating the public definitions to any consumers of the
gnuradio-runtime library, which includes OOT modules. For example, OOT
modules would previously have to know to define "NOMINMAX" on MSVC, but
now that happens transitively.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
Patch pulled directly from ryanvolz tree.
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4477