### PR TITLE
GRC: Make deprecated blocks appear in orange on Canvas

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -1,5 +1,6 @@
 """
 Copyright 2008-2020 Free Software Foundation, Inc.
+Copyright 2021 GNU Radio contributors
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-2.0-or-later
@@ -37,7 +38,7 @@ class Block(Element):
 
     key = ''
     label = ''
-    category = ''
+    category = []
     vtype = '' # This is only used for variables when we want C++ output
     flags = Flags('')
     documentation = {'': ''}
@@ -74,6 +75,7 @@ class Block(Element):
 
         self.states = {'state': True, 'bus_source': False, 'bus_sink': False, 'bus_structure': None}
         self.block_namespace = {}
+        self.deprecated = self.is_deprecated()
 
         if Flags.HAS_CPP in self.flags and self.enabled and not (self.is_virtual_source() or self.is_virtual_sink()):
             # This is a workaround to allow embedded python blocks/modules to load as there is
@@ -434,8 +436,8 @@ class Block(Element):
                 if _vtype == None:
                     _vtype = type(evaluated)
             except ValueError or SyntaxError as excp:
-                    if _vtype == None:
-                        print(excp)
+                if _vtype == None:
+                    print(excp)
 
             if _vtype in [int, float, bool, list, dict, str, complex]:
                 if _vtype == (int or long):
@@ -511,8 +513,8 @@ class Block(Element):
                 val_str += self.get_cpp_value(element) + ', '
 
             if len(val_str) > 1:
-              # truncate to trim superfluous ', ' from the end
-              val_str = val_str[0:-2]
+                # truncate to trim superfluous ', ' from the end
+                val_str = val_str[0:-2]
 
             return val_str + '}'
 
@@ -523,8 +525,8 @@ class Block(Element):
                 val_str += '{' + self.get_cpp_value(key) + ', ' + self.get_cpp_value(pyval[key]) + '}, '
 
             if len(val_str) > 1:
-              # truncate to trim superfluous ', ' from the end
-              val_str = val_str[0:-2]
+                # truncate to trim superfluous ', ' from the end
+                val_str = val_str[0:-2]
 
             return val_str + '}'
 
@@ -538,6 +540,26 @@ class Block(Element):
 
     def is_virtual_source(self):
         return self.key == 'virtual_source'
+
+    def is_deprecated(self):
+        """
+        Check whether the block is deprecated.
+
+        For now, we just check the category name for presence of "deprecated".
+
+        As it might be desirable in the future to have such "tags" be stored
+        explicitly, we're taking the detour of introducing a property.
+        """
+        if not self.category:
+            return False
+
+        try:
+            return any("deprecated".casefold() in cat.casefold()
+                       for cat in self.category)
+        except Exception as exception:
+            print(exception.message)
+        return False
+
 
     # Block bypassing
     def get_bypassed(self):

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -1,5 +1,6 @@
 """
 Copyright 2007, 2008, 2009 Free Software Foundation, Inc.
+Copyright 2020-2021 GNU Radio Contributors
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-2.0-or-later
@@ -95,17 +96,38 @@ class Block(CoreBlock, Drawable):
         self.states['rotation'] = rot
 
     def _update_colors(self):
-        self._bg_color = (
-            colors.MISSING_BLOCK_BACKGROUND_COLOR if self.is_dummy_block else
-            colors.BLOCK_BYPASSED_COLOR if self.state == 'bypassed' else
-            colors.BLOCK_ENABLED_COLOR if self.state == 'enabled' else
-            colors.BLOCK_DISABLED_COLOR
-        )
+        def get_bg():
+            """
+            Get the background color for this block
+
+            Explicit is better than a chain of if/else expressions,
+            so this was extracted into a nested function.
+            """
+            if self.is_dummy_block:
+                return colors.MISSING_BLOCK_BACKGROUND_COLOR
+            if self.state == 'bypassed':
+                return colors.BLOCK_BYPASSED_COLOR
+            if self.state == 'enabled':
+                if self.deprecated:
+                    return colors.BLOCK_DEPRECATED_BACKGROUND_COLOR
+                return colors.BLOCK_ENABLED_COLOR
+            return colors.BLOCK_DISABLED_COLOR
+
+        def get_border():
+            """
+            Get the border color for this block
+            """
+            if self.is_dummy_block:
+                return colors.MISSING_BLOCK_BORDER_COLOR
+            if self.deprecated:
+                return colors.BLOCK_DEPRECATED_BORDER_COLOR
+            if self.state == 'enabled':
+                return colors.BORDER_COLOR
+            return colors.BORDER_COLOR_DISABLED
+
+        self._bg_color = get_bg()
         self._font_color[-1] = 1.0 if self.state == 'enabled' else 0.4
-        self._border_color = (
-            colors.MISSING_BLOCK_BORDER_COLOR if self.is_dummy_block else
-            colors.BORDER_COLOR_DISABLED if not self.state == 'enabled' else colors.BORDER_COLOR
-        )
+        self._border_color = get_border()
 
     def create_shapes(self):
         """Update the block, parameters, and ports when a change occurs."""

--- a/grc/gui/canvas/colors.py
+++ b/grc/gui/canvas/colors.py
@@ -34,6 +34,12 @@ FONT_COLOR = get_color('#000000')
 MISSING_BLOCK_BACKGROUND_COLOR = get_color('#FFF2F2')
 MISSING_BLOCK_BORDER_COLOR = get_color('#FF0000')
 
+# Deprecated blocks
+# a light warm yellow
+BLOCK_DEPRECATED_BACKGROUND_COLOR = get_color('#FED86B')
+# orange
+BLOCK_DEPRECATED_BORDER_COLOR = get_color('#FF540B')
+
 # Flow graph color constants
 FLOWGRAPH_BACKGROUND_COLOR = get_color('#FFFFFF')
 COMMENT_BACKGROUND_COLOR = get_color('#F3F3F3')


### PR DESCRIPTION
To make it clear that a block is deprecated, blocks appear with an orange
border on the canvas, and, if enabled, with a light warm yellow background.

![deprecated](https://user-images.githubusercontent.com/958972/115152350-045ec380-a071-11eb-986f-7e504f5ebeae.png)


I hope this reduces the effort needed to spot problems in flow graphs.

For this to work, I gave the core block (not the GUI block) a property
"deprecated". For now, this just searches (case-normalized) categories for the
string "deprecated", but in case we'd want to make that a tag (like
"throttling/hardware"), separating logic from rendering seemed wise.