### PR TITLE
gr-iio: Fix wrong hint for include dir

### DIFF
--- a/cmake/Modules/Findlibad9361.cmake
+++ b/cmake/Modules/Findlibad9361.cmake
@@ -52,7 +52,7 @@ pkg_check_modules(PC_libad9361 QUIET libad9361)
 
 find_path(libad9361_INCLUDE_DIR
   NAMES ad9361.h
-  HINTS ${PC_libiio_INCLUDE_DIRS}
+  HINTS ${PC_libad9361_INCLUDE_DIRS}
   PATHS /usr/include
         /usr/local/include
         /opt/local/include


### PR DESCRIPTION
    Fix wrong hint for inlcude dirs
    
    Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
