### PR TITLE
runtime: install xoroshiro128p.h

### DIFF
--- a/gnuradio-runtime/include/gnuradio/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/CMakeLists.txt
@@ -68,6 +68,7 @@ install(FILES
   rpcserver_booter_aggregator.h
   rpcserver_booter_base.h
   rpcserver_selector.h
+  xoroshiro128p.h
   DESTINATION ${GR_INCLUDE_DIR}/gnuradio
 )
 


### PR DESCRIPTION
As of eb91fb0 this is required for anything linking against gr::random
which broke at least one OOT (gr-pdu_utils)