### PR TITLE
grc: fix dark theme on ParamWidgets

### DIFF
--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -29,9 +29,9 @@ def have_dark_theme():
     config.read(os.path.expanduser(Constants.GTK_SETTINGS_INI_PATH))
     prefer_dark = config.get(
         'Settings', Constants.GTK_INI_PREFER_DARK_KEY, fallback=None)
-    if prefer_dark in ('1', 'yes', 'true', 'on'):
-        theme_name = config.get(
-            'Settings', Constants.GTK_INI_THEME_NAME_KEY, fallback=None)
+    theme_name = config.get(
+        'Settings', Constants.GTK_INI_THEME_NAME_KEY, fallback=None)
+    if prefer_dark in ('1', 'yes', 'true', 'on') or is_dark_theme(theme_name):
         return True
     try:
         theme = subprocess.check_output(

--- a/grc/gui/ParamWidgets.py
+++ b/grc/gui/ParamWidgets.py
@@ -32,7 +32,7 @@ def have_dark_theme():
     if prefer_dark in ('1', 'yes', 'true', 'on'):
         theme_name = config.get(
             'Settings', Constants.GTK_INI_THEME_NAME_KEY, fallback=None)
-        return is_dark_theme(theme_name)
+        return True
     try:
         theme = subprocess.check_output(
             ["gsettings", "get", "org.gnome.desktop.interface", "gtk-theme"],


### PR DESCRIPTION
Fix `gtk-application-prefer-dark-theme` not affecting the color displayed.

For example, when you have a `~/.config/gtk-3.0/settings.ini` like this, the background color of the input box will still be white.

```
gtk-application-prefer-dark-theme=true
gtk-theme-name=Breeze
```

This also fixes #2374.