### PR TITLE
grc: Fix message port show/hide problem due to bus logic update (backport to maint-3.8)

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -214,8 +214,9 @@ class Block(Element):
 
                 # Re-enable the hidden property of the ports
                 for port in ports:
-                    port.hidden = port.stored_hidden_state
-                    port.stored_hidden_state = None
+                    if (port.stored_hidden_state is not None):
+                        port.hidden = port.stored_hidden_state
+                        port.stored_hidden_state = None
 
 
 
@@ -664,6 +665,8 @@ class Block(Element):
             cnt = 0
             idx = 0
             for p in ports:
+                if p.domain == 'message':
+                    continue
                 if cnt > 0:
                     cnt -= 1
                     continue


### PR DESCRIPTION
update_bus_logic() is called when disabling a bus, it doesn't check if
it's been previously enabled. This causes it to restore port.hidden with
a None which ultimately is converted to False. So it never hides the
message ports.
Also, filter message ports from buses.

(cherry picked from commit 176e86980b3eeb9795c7a217fba9eb205c7a5adf)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3934