### PR TITLE
GRC: Supersede Constants, color.py with Theming engine

### DIFF
--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -109,6 +109,15 @@ class Config(CoreConfig):
         self._gr_prefs.set_string("qtgui", "qss", value)
         self._gr_prefs.save()
 
+    @property
+    def theme_file(self):
+        return self._gr_prefs.get_string('grc', 'theme_file', '')
+
+    @theme_file.setter
+    def theme_file(self, value):
+        return self._gr_prefs.set_string('grc', 'theme_file', value)
+        self._gr_prefs.save()
+
     ##### Originally from Preferences.py #####
     def main_window_size(self, size=None):
         if size is None:

--- a/grc/gui/Constants.py
+++ b/grc/gui/Constants.py
@@ -6,7 +6,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 """
 
-
+import gi
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
 
 from ..core.Constants import *

--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -9,9 +9,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 from gi.repository import Gtk, Gdk
 
-from .canvas.colors import FLOWGRAPH_BACKGROUND_COLOR
 from . import Constants
 from . import Actions
+from .Theme import Theme
 
 
 class DrawingArea(Gtk.DrawingArea):
@@ -188,7 +188,8 @@ class DrawingArea(Gtk.DrawingArea):
         width = widget.get_allocated_width()
         height = widget.get_allocated_height()
 
-        cr.set_source_rgba(*FLOWGRAPH_BACKGROUND_COLOR)
+        cr.set_source_rgba(
+            *Theme.get_property("background-color", "Flowgraph"))
         cr.rectangle(0, 0, width, height)
         cr.fill()
 

--- a/grc/gui/Platform.py
+++ b/grc/gui/Platform.py
@@ -11,13 +11,14 @@ import sys
 import os
 
 from .Config import Config
+from .Theme import Theme
 from . import canvas
 from ..core.platform import Platform as CorePlatform
 from ..core.utils.backports import ChainMap
 
 
 class Platform(CorePlatform):
-
+    Theme = Theme
     def __init__(self, *args, **kwargs):
         CorePlatform.__init__(self, *args, **kwargs)
 
@@ -27,6 +28,12 @@ class Platform(CorePlatform):
             os.mkdir(os.path.dirname(gui_prefs_file))
 
         self._move_old_pref_file()
+
+        theme_file = self.config.theme_file
+        if len(theme_file):
+            import yaml
+            data = yaml.safe_load(open(theme_file))
+            self.Theme.load(data)
 
     def get_prefs_file(self):
         return self.config.gui_prefs_file

--- a/grc/gui/Theme.py
+++ b/grc/gui/Theme.py
@@ -39,6 +39,12 @@ class State(Flag):
 
 
 DEFAULT_THEME = {
+    "Element": {
+        "default": {
+            "font-family": "Sans",
+            "font-size": 8,
+        },
+    },
     "Flowgraph": {
         "default": {
             "background-color": "#FFFFFF"
@@ -48,7 +54,10 @@ DEFAULT_THEME = {
         "default": {
             "border-color": "#616161",
             "color": "#000000",
-            "background-color": "#F1ECFF"
+            "background-color": "#F1ECFF",
+            "font-family": "Sans",
+            "font-size": 8,
+            "padding": 7,
         },
         "disabled": {
             "background-color": "#CCCCCC",
@@ -78,7 +87,24 @@ DEFAULT_THEME = {
     },
     "Port": {
         "default": {
-            "background-color": "#FFFFFF"
+            "background-color": "#FFFFFF",
+            "font-size": 8,
+            "padding": 2
+        }
+    },
+    "Param": {
+        "default": {
+            "font-size": 7.5,
+        }
+    },
+    "Comment": {
+        "default": {
+            "color": "#404040",
+            "font-size": 8,
+            "font-family": "Sans",
+        },
+        "disabled": {
+            "color": "#808080"
         }
     }
 }
@@ -168,6 +194,11 @@ class ThemeEngine(object):
         """
 
         type_specific = None
+        if isinstance(objtype, str):
+            try:
+                type_specific = self.dict[objtype]
+            except KeyError:
+                return default
         if isinstance(objtype, Element):
             objtype = type(objtype)
         if isinstance(objtype, type):
@@ -178,7 +209,7 @@ class ThemeEngine(object):
                         break
                     type_specific = self.dict[classname]
                     break
-                except KeyError as key_err:
+                except KeyError:
                     continue
 
         if not type_specific:

--- a/grc/gui/Theme.py
+++ b/grc/gui/Theme.py
@@ -7,7 +7,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 from ..core.base import Element
 from .defaulttheme import DEFAULT_THEME
-from .Config import Config
 
 from enum import Flag, auto
 from typing import Union, Iterable, Tuple

--- a/grc/gui/Theme.py
+++ b/grc/gui/Theme.py
@@ -1,0 +1,204 @@
+"""
+Copyright 2021 Marcus Müller
+This file is part of GNU Radio
+
+SPDX-License-Identifier: GPL-2.0-or-later
+"""
+
+from enum import Flag, auto
+from functools import cache
+from typing import Union, Iterable
+from ..core.base import Element
+from .canvas.colors import get_color
+
+
+class State(Flag):
+    """
+    State to query for
+    """
+    DEFAULT = auto()
+    DISABLED = auto()
+    SELECTED = auto()
+    BYPASSED = auto()
+    DEPRECATED = auto()
+    INVALID_PARAMETERS = auto()
+    INVALID_CONNECTION = auto()
+    MISSING = auto()
+    UNSPECIFIED_ERROR = auto()
+    PROBLEM = (DEPRECATED | INVALID_PARAMETERS | INVALID_CONNECTION
+               | UNSPECIFIED_ERROR | MISSING)
+
+    @staticmethod
+    def reduce(iter: Iterable):
+        if not iter:
+            return State.DEFAULT
+        sumstate = iter[0]
+        for state in iter:
+            sumstate = sumstate | state
+        return sumstate
+
+
+DEFAULT_THEME = {
+    "Flowgraph": {
+        "default": {
+            "background-color": "#FFFFFF"
+        }
+    },
+    "Block": {
+        "default": {
+            "border-color": "#616161",
+            "color": "#000000",
+            "background-color": "#F1ECFF"
+        },
+        "disabled": {
+            "background-color": "#CCCCCC",
+            "border-color": "#888888",
+            "color": "#333333"
+        },
+        "bypassed": {
+            "background-color": "#F4FF81"
+        },
+        "selected": {
+            "border-color": "#00FFFF"
+        },
+        "missing": {
+            "background-color": "#F4FF81"
+        }
+    },
+    "Connection": {
+        "default": {
+            "color": "#000000"
+        },
+        "disabled": {
+            "color": "#BBBBBB"
+        },
+        "invalid_connection": {
+            "color": "#FF0000"
+        }
+    },
+    "Port": {
+        "default": {
+            "background-color": "#FFFFFF"
+        }
+    }
+}
+
+
+class ThemeEngine(object):
+    """
+    Theming Engine.
+
+    Able to load themes, categorize them hierarchically:
+
+    - Object Type 1:
+      - Default:
+        - Property1: ValueA
+        - Property2: ValueB
+      - Single state selector:
+        - Property1: ValueC
+        - Property2: ValueD
+      - Space-joined combination of state selectors:
+        - Property1: ValueE
+        - Property3: ValueF
+
+    Note that the more specific a state selector is, i.e. the more elements
+    in the selector list, the higher its priority.
+
+    To give an example how that would be encoded in JSON:
+    ```
+    {
+    "Block": {
+        "default": {
+            "border-color": "#000000",
+            "background-color": "#DEDEDE",
+            "border-width": "3"
+        },
+        "selected": {
+            "border-color": "#0000FF"
+        },
+        "disabled": {
+            "background-color": "#CCCCCC",
+            "border-color": "#444444"
+        },
+        "selected disabled": {
+            "border-color": "#4444DE"
+        }
+        }
+    }
+    ```
+    """
+    def __init__(self):
+        self.dict = {}
+
+    def load(self, dictlike):
+        """
+        updates the internal dict with new values from dictlike
+        """
+        for typename, typedict in dictlike.items():
+            if typename not in self.dict:
+                self.dict[typename] = {}
+            for statestring, stateprops in typedict.items():
+                states = statestring.split(" ")
+                statecomb = []
+                for state in states:
+                    if not state.upper() in State.__members__.keys():
+                        # raise Exception(f"{typename}: Unknown state {state}")
+                        print(f"Unknown state {state}, ignoring")
+                        print("possible states: " +
+                              ", ".join(State.__members__.keys()))
+                        continue
+                    statecomb.append(State.__members__[state.upper()])
+                if not statecomb:
+                    print(f"{typename}: statestring \"{statestring}\"" +
+                          " contained no states")
+                    continue
+                sumstate = State.reduce(statecomb)
+                self.dict[typename][sumstate] = stateprops
+
+        self.get_property.cache_clear()
+
+    @cache
+    def get_property(self,
+                     property: str,
+                     objtype: Union[Element, type, str],
+                     state: State = State.DEFAULT,
+                     default=None):
+        """
+        Get the property
+        """
+
+        type_specific = None
+        if isinstance(objtype, Element):
+            objtype = type(objtype)
+        if isinstance(objtype, type):
+            for type_candidate in objtype.mro():
+                try:
+                    classname = type_candidate.__name__
+                    if classname == "object":
+                        break
+                    type_specific = self.dict[classname]
+                    break
+                except KeyError as key_err:
+                    continue
+
+        if not type_specific:
+            return default
+
+        # select the most specific specification
+        # Due to our construction of binary flags,
+        # the state with the most 1 set is the most specific
+        max_bit_count, to_apply = -1, default
+        for statecomb, props in type_specific.items():
+            if statecomb == State.DEFAULT or statecomb in state:
+                if property in props:
+                    count_of_ones = bin(state.value).count("1")
+                    if count_of_ones >= max_bit_count:
+                        to_apply = props[property]
+
+        if isinstance(to_apply, str) and "color" in property:
+            return get_color(to_apply)
+        return to_apply
+
+
+Theme = ThemeEngine()
+Theme.load(DEFAULT_THEME)

--- a/grc/gui/Theme.py
+++ b/grc/gui/Theme.py
@@ -5,17 +5,25 @@ This file is part of GNU Radio
 SPDX-License-Identifier: GPL-2.0-or-later
 """
 
-from enum import Flag, auto
-from functools import cache
-from typing import Union, Iterable
 from ..core.base import Element
-from typing import Tuple
 from .defaulttheme import DEFAULT_THEME
+from .Config import Config
 
+from enum import Flag, auto
+from typing import Union, Iterable, Tuple
 # TODO: Don't import Gdk to parse non-#C0FFEE colors
 import gi
 gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk
+try:
+    from functools import cache
+except ImportError:
+    # We'd prefer cache, but that's only available in Python > 3.9
+    # lru_cache is pretty similar
+    from functools import lru_cache
+
+    def cache(userfunction):
+        return lru_cache(userfunction, maxsize=None)
 
 
 def get_color(color_code: str):

--- a/grc/gui/Theme.py
+++ b/grc/gui/Theme.py
@@ -9,9 +9,41 @@ from enum import Flag, auto
 from functools import cache
 from typing import Union, Iterable
 from ..core.base import Element
-from .canvas.colors import get_color
-
+from typing import Tuple
 from .defaulttheme import DEFAULT_THEME
+
+# TODO: Don't import Gdk to parse non-#C0FFEE colors
+import gi
+gi.require_version('Gdk', '3.0')
+from gi.repository import Gdk
+
+
+def get_color(color_code: str):
+    if not color_code.startswith("#"):
+        color = Gdk.RGBA()
+        color.parse(color_code)
+        return color.red, color.green, color.blue, color.alpha
+
+    color_code = color_code[1:]
+    a = 0xFF
+    if len(color_code) == 8:
+        a = int(color_code[-2], 16)
+        color_code = color_code[:-2]
+    if len(color_code) == 6:
+        r = int(color_code[0:2], 16)
+        g = int(color_code[2:4], 16)
+        b = int(color_code[4:6], 16)
+        return r / 255, g / 255, b / 255, a / 255
+    raise Exception(f"invalid color: {color_code}")
+
+
+def get_hexcolor(color_tuple: Tuple[float, float, float]):
+    """
+    Converts a tuple (r,g,b)∈[0,1]³ to an RGB hexcode #000000…#FFFFFF
+    """
+    r, g, b, *rest = (int(val * 0xFF) for val in color_tuple)
+    assert len(rest) <= 1
+    return f"#{r:02X}{b:02X}{g:02X}"
 
 
 class State(Flag):

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -6,6 +6,15 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 """
 
+from .drawable import Drawable
+from .. import Actions, Utils
+from ..Theme import Theme, State, get_hexcolor
+from ..Constants import (
+    PORT_SPACING, PORT_SEPARATION, LABEL_SEPARATION,
+    PORT_BORDER_SEPARATION
+)
+from ...core import utils
+from ...core.blocks import Block as CoreBlock
 
 import math
 
@@ -13,17 +22,6 @@ import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('PangoCairo', '1.0')
 from gi.repository import Gtk, Pango, PangoCairo
-
-from .drawable import Drawable
-from .. import Actions, Utils
-from ..Theme import Theme, State
-from .colors import get_hexcolor
-from ..Constants import (
-    PORT_SPACING, PORT_SEPARATION, LABEL_SEPARATION,
-    PORT_BORDER_SEPARATION
-)
-from ...core import utils
-from ...core.blocks import Block as CoreBlock
 
 
 class Block(CoreBlock, Drawable):

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -94,6 +94,8 @@ class Block(CoreBlock, Drawable):
         """
         self.states['rotation'] = rot
 
+    def notify(self):
+        self._update_colors()
     def _update_colors(self):
         self._bg_color = (
             colors.MISSING_BLOCK_BACKGROUND_COLOR if self.is_dummy_block else

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -9,6 +9,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 import math
 
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('PangoCairo', '1.0')
 from gi.repository import Gtk, Pango, PangoCairo
 
 from .drawable import Drawable

--- a/grc/gui/canvas/block.py
+++ b/grc/gui/canvas/block.py
@@ -47,11 +47,6 @@ class Block(CoreBlock, Drawable):
 
         self._area = []
 
-        def theme(prop, *args, **kwargs):
-            return Theme.get_property(prop, self, *args, **kwargs)
-
-        self._theme = theme
-        self._update_theming()
 
     @property
     def coordinate(self):
@@ -101,9 +96,9 @@ class Block(CoreBlock, Drawable):
         self.states['rotation'] = rot
 
     def notify(self):
-        self._update_theming()
+        self.update_theming()
 
-    def _update_theming(self):
+    def update_theming(self):
         statecomb = []
         if self.is_dummy_block:
             statecomb.append(State.MISSING)
@@ -202,7 +197,7 @@ class Block(CoreBlock, Drawable):
         width = label_width + 2 * self._padding
         height = label_height + 2 * self._padding
 
-        self._update_theming()
+        self.update_theming()
         self.create_port_labels()
 
         def get_min_height_for_ports(ports):

--- a/grc/gui/canvas/colors.py
+++ b/grc/gui/canvas/colors.py
@@ -12,6 +12,8 @@ from gi.repository import Gtk, Gdk, cairo
 
 from .. import Constants
 
+from typing import Tuple
+
 
 def get_color(color_code):
     color = Gdk.RGBA()
@@ -20,6 +22,16 @@ def get_color(color_code):
     # chars_per_color = 2 if len(color_code) > 4 else 1
     # offsets = range(1, 3 * chars_per_color + 1, chars_per_color)
     # return tuple(int(color_code[o:o + 2], 16) / 255.0 for o in offsets)
+
+
+def get_hexcolor(color_tuple: Tuple[float, float, float]):
+    """
+    Converts a tuple (r,g,b)∈[0,1]³ to an RGB hexcode #000000…#FFFFFF
+    """
+    r, g, b, *rest = (int(val * 0xFF) for val in color_tuple)
+    assert len(rest) <= 1
+    return f"#{r:02X}{b:02X}{g:02X}"
+
 
 #################################################################################
 # fg colors

--- a/grc/gui/canvas/colors.py
+++ b/grc/gui/canvas/colors.py
@@ -8,41 +8,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 """
 
-
-from gi.repository import Gdk
-
 from .. import Constants
-
-from typing import Tuple
-
-
-def get_color(color_code: str):
-    if not color_code.startswith("#"):
-        color = Gdk.RGBA()
-        color.parse(color_code)
-        return color.red, color.green, color.blue, color.alpha
-
-    color_code = color_code[1:]
-    a = 0xFF
-    if len(color_code) == 8:
-        a = int(color_code[-2], 16)
-        color_code = color_code[:-2]
-    if len(color_code) == 6:
-        r = int(color_code[0:2], 16)
-        g = int(color_code[2:4], 16)
-        b = int(color_code[4:6], 16)
-        return r / 255, g / 255, b / 255, a / 255
-    raise Exception(f"invalid color: {color_code}")
-
-
-def get_hexcolor(color_tuple: Tuple[float, float, float]):
-    """
-    Converts a tuple (r,g,b)∈[0,1]³ to an RGB hexcode #000000…#FFFFFF
-    """
-    r, g, b, *rest = (int(val * 0xFF) for val in color_tuple)
-    assert len(rest) <= 1
-    return f"#{r:02X}{b:02X}{g:02X}"
-
+from ..Theme import get_color
 
 #################################################################################
 # fg colors
@@ -74,14 +41,16 @@ CONNECTION_ERROR_COLOR = get_color('#FF0000')
 
 DEFAULT_DOMAIN_COLOR = get_color('#777777')
 
-
 #################################################################################
 # port colors
 #################################################################################
 
-PORT_TYPE_TO_COLOR = {key: get_color(color) for name, key, sizeof, color in Constants.CORE_TYPES}
-PORT_TYPE_TO_COLOR.update((key, get_color(color)) for key, (_, color) in Constants.ALIAS_TYPES.items())
-
+PORT_TYPE_TO_COLOR = {
+    key: get_color(color)
+    for name, key, sizeof, color in Constants.CORE_TYPES
+}
+PORT_TYPE_TO_COLOR.update((key, get_color(color))
+                          for key, (_, color) in Constants.ALIAS_TYPES.items())
 
 #################################################################################
 # param box colors

--- a/grc/gui/canvas/colors.py
+++ b/grc/gui/canvas/colors.py
@@ -1,5 +1,7 @@
 """
 Copyright 2008,2013 Free Software Foundation, Inc.
+Copyright 2021 Marcus Müller
+
 This file is part of GNU Radio
 
 SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,21 +9,30 @@ SPDX-License-Identifier: GPL-2.0-or-later
 """
 
 
-from gi.repository import Gtk, Gdk, cairo
-# import pycairo
+from gi.repository import Gdk
 
 from .. import Constants
 
 from typing import Tuple
 
 
-def get_color(color_code):
-    color = Gdk.RGBA()
-    color.parse(color_code)
-    return color.red, color.green, color.blue, color.alpha
-    # chars_per_color = 2 if len(color_code) > 4 else 1
-    # offsets = range(1, 3 * chars_per_color + 1, chars_per_color)
-    # return tuple(int(color_code[o:o + 2], 16) / 255.0 for o in offsets)
+def get_color(color_code: str):
+    if not color_code.startswith("#"):
+        color = Gdk.RGBA()
+        color.parse(color_code)
+        return color.red, color.green, color.blue, color.alpha
+
+    color_code = color_code[1:]
+    a = 0xFF
+    if len(color_code) == 8:
+        a = int(color_code[-2], 16)
+        color_code = color_code[:-2]
+    if len(color_code) == 6:
+        r = int(color_code[0:2], 16)
+        g = int(color_code[2:4], 16)
+        b = int(color_code[4:6], 16)
+        return r / 255, g / 255, b / 255, a / 255
+    raise Exception(f"invalid color: {color_code}")
 
 
 def get_hexcolor(color_tuple: Tuple[float, float, float]):
@@ -115,4 +126,3 @@ LIGHT_THEME_STYLES = b"""
 
                         #enum_custom           { background-color: #EEEEEE; }
                     """
-

--- a/grc/gui/canvas/connection.py
+++ b/grc/gui/canvas/connection.py
@@ -152,9 +152,11 @@ class Connection(CoreConnection, Drawable):
             statecombination.append(State.SELECTED)
         state = State.reduce(statecombination)
 
-        color1 = self._color1 if state == State.DEFAULT else self._theme("color", state)
-        color2 = self._color2 if state == State.DEFAULT else self._theme("color", state)
-
+        color1, color2 = self._color1, self._color2
+        if color1 is not None and state != State.DEFAULT:
+            color1 = self._theme("color", state)
+        if color2 is not None and state != State.DEFAULT:
+            color2 = self._theme("color", state)
 
         cr.translate(*self.coordinate)
         cr.set_line_width(self._line_width_factor * cr.get_line_width())

--- a/grc/gui/canvas/connection.py
+++ b/grc/gui/canvas/connection.py
@@ -13,6 +13,7 @@ from math import pi
 from . import colors
 from .drawable import Drawable
 from .. import Utils
+from ..Theme import State
 from ..Constants import (
     CONNECTOR_ARROW_BASE,
     CONNECTOR_ARROW_HEIGHT,
@@ -142,14 +143,18 @@ class Connection(CoreConnection, Drawable):
             self._make_path(cr)
             self._current_coordinates = new_coordinates
 
-        color1, color2 = (
-            None if color is None else
-            colors.HIGHLIGHT_COLOR if self.highlighted else
-            colors.CONNECTION_DISABLED_COLOR if not self.enabled else
-            colors.CONNECTION_ERROR_COLOR if not self.is_valid() else
-            color
-            for color in (self._color1, self._color2)
-        )
+        statecombination = []
+        if not self.enabled:
+            statecombination.append(State.DISABLED)
+        if not self.is_valid():
+            statecombination.append(State.INVALID_CONNECTION)
+        if self.highlighted:
+            statecombination.append(State.SELECTED)
+        state = State.reduce(statecombination)
+
+        color1 = self._color1 if state == State.DEFAULT else self._theme("color", state)
+        color2 = self._color2 if state == State.DEFAULT else self._theme("color", state)
+
 
         cr.translate(*self.coordinate)
         cr.set_line_width(self._line_width_factor * cr.get_line_width())

--- a/grc/gui/canvas/drawable.py
+++ b/grc/gui/canvas/drawable.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 """
 
 from ..Constants import LINE_SELECT_SENSITIVITY
-
+from ..Theme import Theme
 
 class Drawable(object):
     """
@@ -33,6 +33,12 @@ class Drawable(object):
 
         self._bounding_rects = []
         self._bounding_points = []
+
+        def theme(prop, *args, **kwargs):
+            return Theme.get_property(prop, self, *args, **kwargs)
+
+        self._theme = theme
+        self.update_theming()
 
     def is_horizontal(self, rotation=None):
         """
@@ -172,4 +178,10 @@ class Drawable(object):
         """
         Implement this if you want to be notified when
         Element state changes
+        """
+
+    def update_theming(self):
+        """
+        Implement this if you want to recalculate your theming when anything
+        about the Theme changes.
         """

--- a/grc/gui/canvas/drawable.py
+++ b/grc/gui/canvas/drawable.py
@@ -167,3 +167,9 @@ class Drawable(object):
 
     def mouse_out(self):
         pass
+
+    def notify(self):
+        """
+        Implement this if you want to be notified when
+        Element state changes
+        """

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -469,6 +469,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
         # update highlighting
         for element in elements:
             element.highlighted = element in selected_elements
+            element.notify()
 
     ###########################################################################
     # Draw stuff

--- a/grc/gui/defaulttheme.py
+++ b/grc/gui/defaulttheme.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2021 Marcus Müller
+This file is part of GNU Radio
+
+SPDX-License-Identifier: GPL-2.0-or-later
+"""
+
+DEFAULT_THEME = {
+    "Element": {
+        "default": {
+            "font-family": "Sans",
+            "font-size": 8,
+        },
+    },
+    "Flowgraph": {
+        "default": {
+            "background-color": "#FFFFFF"
+        }
+    },
+    "Block": {
+        "default": {
+            "border-color": "#616161",
+            "color": "#000000",
+            "background-color": "#F1ECFF",
+            "font-family": "Sans",
+            "font-size": 8,
+            "padding": 7,
+        },
+        "disabled": {
+            "background-color": "#CCCCCC",
+            "border-color": "#888888",
+            "color": "#333333"
+        },
+        "bypassed": {
+            "background-color": "#F4FF81"
+        },
+        "selected": {
+            "border-color": "#00FFFF"
+        },
+        "missing": {
+            "background-color": "#F4FF81"
+        }
+    },
+    "Connection": {
+        "default": {
+            "color": "#000000"
+        },
+        "disabled": {
+            "color": "#BBBBBB"
+        },
+        "invalid_connection": {
+            "color": "#FF0000"
+        }
+    },
+    "Port": {
+        "default": {
+            "background-color": "#FFFFFF",
+            "font-size": 8,
+            "padding": 2
+        }
+    },
+    "Param": {
+        "default": {
+            "font-size": 7.5,
+        }
+    },
+    "Comment": {
+        "default": {
+            "color": "#404040",
+            "font-size": 8,
+            "font-family": "Sans",
+        },
+        "disabled": {
+            "color": "#808080"
+        }
+    }
+}

--- a/grc/tests/test_theme.py
+++ b/grc/tests/test_theme.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Marcus Müller
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+
+from grc.gui.Theme import ThemeEngine, State
+from grc.gui.canvas.colors import get_color
+from grc.core.blocks import Block
+import json
+
+
+def test_loading(engine: ThemeEngine = None):
+    """
+    Test whether a simple JSON string can be loaded
+    """
+    jsonstring = """
+    {
+    "Block": {
+        "default": {
+            "border-color": "#000000",
+            "background-color": "#DEDEDE",
+            "border-width": "3"
+        },
+        "selected": {
+            "border-color": "#0000FF"
+        },
+        "disabled": {
+            "background-color": "#CCCCCC",
+            "border-color": "#444444"
+        },
+        "selected disabled": {
+            "border-color": "#4444DE"
+        }
+        }
+    }
+    """
+    dic = json.loads(jsonstring)
+    if not engine:
+        engine = ThemeEngine()
+    engine.load(dic)
+
+
+def test_getting():
+    """
+    Test whether properties can be retrieved in general
+    """
+    engine = ThemeEngine()
+    test_loading(engine)
+
+    prop = engine.get_property("border-color", Block)
+    assert prop == get_color("#000000"), f"default property incorrect: {prop}"
+
+    prop = engine.get_property("border-color",
+                               Block,
+                               state=State.INVALID_CONNECTION)
+    assert prop == get_color("#000000"),\
+        f"default fallthrough property incorrect: {prop}"
+
+    prop = engine.get_property("border-color", Block, State.SELECTED)
+    assert prop == get_color("#0000FF"),\
+        f"selected property incorrect: {prop}"
+
+    prop = engine.get_property("border-color", Block,
+                               State.SELECTED | State.DISABLED)
+    assert prop == get_color("#4444DE"),\
+        f"combined selected property incorrect: {prop}"


### PR DESCRIPTION
This PR adds a ThemeEngine, which applies dict-specified styles to GRC elements.

For now, I only reworked the Block canvas Element, as is probably the most sensible demonstrator for this.

The idea is simple: instead of distributing styling information (fonts, sizes, colors, paddings) throughout the source code, configuration files, and things that are called Constants but get modified at runtime, we just put everything in one  dictionary. We allow the user to override parts of that through their own JSON.

The dictionary structure is hierarchical and simple:

```
---+Block
   |
   ---+Defaults
   |  |
   |  --- property: value
   |  --- property2: value
   |
   ---+Selected state
   |  |
   |  --- property2: different value
   |
   ---+Disabled state
   |  |
   |  --- property2: another different value
   |
   ---+Disabled selected state
      |
      --- property2: yet another different value
---+Port
   |
   ---+Defaults
   |  |
   |  --- property: value
   |  --- property2: value
   |
   ---+Selected state
   |  |
   |  --- property2: different value
   |
   ---+Disabled state
      |
      --- property2: another different value
  ………
```

The trick is that on lookup, the most specific property is selected. This is a bit like CSS, but less convoluted, and doesn't depend on a third-party parser. (the Gtk-integrated parser can't be used, as it doesn't support arbitray object and property types)

In order to not completely break performance, lookup is done through a cache, which gets invalidated on updating the ThemeEngine; that feature allows for live experimentation with themes.

The default theme (which strives to be identical to its hard-coded predecessor) is found in grc/gui/defaulttheme.py.

This PR does *not* already convert all of the canvas to the theming engine, on purpose, to keep the changeset reviewable.
However, on positive review, and after squashing this, porting Flowgraph and the ports should be quick.

Next steps would be:

* Conversion of all Elements to use ThemeEngine instead of hard-coded visual properties
* Adding a minimal RPC / HTTP server (optionally enablable through prefs) so that HTML + JS can live-fiddle with the theme
* Working with the UX experts on what properties to add (maybe something like an "icon" property for blocks? Theming things that aren't themed yet, e.g. the block list?)