### PR TITLE
grc: Fix option_attributes check on inherited type (backport to maint-3.8)

### DIFF
--- a/grc/core/blocks/_build.py
+++ b/grc/core/blocks/_build.py
@@ -128,12 +128,12 @@ def build_params(params_raw, have_inputs, have_outputs, flags, block_id):
         if param_id in params:
             raise Exception('Param id "{}" is not unique'.format(param_id))
 
-        if 'option_attributes' in param_data:
-            _validate_option_attributes(param_data, block_id)
-
         base_key = param_data.get('base_key', None)
         param_data_ext = base_params_n.get(base_key, {}).copy()
         param_data_ext.update(param_data)
+
+        if 'option_attributes' in param_data:
+            _validate_option_attributes(param_data_ext, block_id)
 
         add_param(**param_data_ext)
         base_params_n[param_id] = param_data_ext


### PR DESCRIPTION
Run the option_attributes validation routine on the extended dictionary,
i.e., after inheriting the properties from the base_key parameter. By
doing so, if the dtype property is inherited, the
_validate_option_attributes still sees it and does not throw a key
error.

Signed-off-by: Igor Freire <igor@blockstream.com>
(cherry picked from commit 0b3dc1b157b709fcd64a80f13ec604bda3f86e66)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4520