### PR TITLE
filter: filter_delay_fc documentation used to be unclear about delay (backport to maint-3.9)

### DIFF
--- a/gr-filter/include/gnuradio/filter/filter_delay_fc.h
+++ b/gr-filter/include/gnuradio/filter/filter_delay_fc.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2012 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -18,33 +19,41 @@ namespace gr {
 namespace filter {
 
 /*!
- * \brief Filter-Delay Combination Block.
+ * \brief Filter-Delay Combination Block
  * \ingroup filter_blk
  *
  * \details
- * The block takes one or two float stream and outputs a complex
- * stream.
+ * The purpose of this block is to compensate the delay that a linear-phase filter
+ * introduces.
  *
- * If only one float stream is input, the real output is a delayed
- * version of this input and the imaginary output is the filtered
- * output.
+ * It does that by introducing a delay of half the length of the FIR tap vector on
+ * passed-through samples.
  *
- * If two floats are connected to the input, then the real output
- * is the delayed version of the first input, and the imaginary
- * output is the filtered output.
+ * The block takes one or two float stream and outputs a stream composed of pairs of
+ * floats. (In GNU Radio, pairs of floats are identical to complex numbers, where the real
+ * and imaginary parts are the first and second element, respectively.)
  *
- * The delay in the real path accounts for the group delay
- * introduced by the filter in the imaginary path. The filter taps
- * needs to be calculated before initializing this block.
+ * If only one float stream is input, the first element of each output item is a delayed
+ * version of this input and the second element is the filtered output.
+ *
+ * If two floats are connected to the input, then the first element of each output item is
+ * the delayed version of the first input, and the second element is the filtered second
+ * input.
+ *
+ * The delay in the first elements of the output accounts for the group delay introduced
+ * by the filter in the second elements path under the assumption of linear-phase
+ * filtering. The filter taps need to be calculated before initializing this block.
  */
 class FILTER_API filter_delay_fc : virtual public sync_block
 {
 public:
-    // gr::filter::filter_delay_fc::sptr
     typedef std::shared_ptr<filter_delay_fc> sptr;
 
     /*!
      * Build a filter with delay block.
+     *
+     * \param taps the vector of real-valued tags. Half of the length of this vector is
+     * the delay introduced by this block.
      */
     static sptr make(const std::vector<float>& taps);
 };

--- a/gr-filter/python/filter/bindings/filter_delay_fc_python.cc
+++ b/gr-filter/python/filter/bindings/filter_delay_fc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(filter_delay_fc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(eea88abd944cadd21cdfdb0211654fcc)                     */
+/* BINDTOOL_HEADER_FILE_HASH(318340909cbdad8f966383445fdec0f4)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
This clarifies that the block does not, indeed, construct a
delay-compensating all-pass, but just takes half the length of the
passed taps vector and uses that as delay.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 8f9c66bf0b4099cd824745bbbdcde2285db78cf9)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4542