### PR TITLE
runtime: Prefs cleanup (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/prefs.h
+++ b/gnuradio-runtime/include/gnuradio/prefs.h
@@ -154,7 +154,7 @@ protected:
     void set_general(const std::string& section, const std::string& option, const T& val);
 
 private:
-    // TODO: add back and actually use: gr::thread::mutex d_mutex;
+    std::mutex d_mutex;
     config_map_t d_config_map;
 };
 

--- a/gnuradio-runtime/include/gnuradio/prefs.h
+++ b/gnuradio-runtime/include/gnuradio/prefs.h
@@ -83,75 +83,78 @@ public:
     /*!
      * \brief Does \p section exist?
      */
-    virtual bool has_section(const std::string& section);
+    bool has_section(const std::string& section);
 
     /*!
      * \brief Does \p option exist?
      */
-    virtual bool has_option(const std::string& section, const std::string& option);
+    bool has_option(const std::string& section, const std::string& option);
 
     /*!
      * \brief If option exists return associated value; else
      * default_val.
      */
-    virtual const std::string get_string(const std::string& section,
-                                         const std::string& option,
-                                         const std::string& default_val);
+    const std::string get_string(const std::string& section,
+                                 const std::string& option,
+                                 const std::string& default_val);
 
     /*!
      * \brief Set or add a string \p option to \p section with value
      * \p val.
      */
-    virtual void set_string(const std::string& section,
-                            const std::string& option,
-                            const std::string& val);
+    void set_string(const std::string& section,
+                    const std::string& option,
+                    const std::string& val);
 
     /*!
      * \brief If option exists and value can be converted to bool,
      * return it; else default_val.
      */
-    virtual bool
+    bool
     get_bool(const std::string& section, const std::string& option, bool default_val);
 
     /*!
      * \brief Set or add a bool \p option to \p section with value \p val.
      */
-    virtual void
-    set_bool(const std::string& section, const std::string& option, bool val);
+    void set_bool(const std::string& section, const std::string& option, bool val);
 
     /*!
      * \brief If option exists and value can be converted to long,
      * return it; else default_val.
      */
-    virtual long
+    long
     get_long(const std::string& section, const std::string& option, long default_val);
 
     /*!
      * \brief Set or add a long \p option to \p section with value \p val.
      */
-    virtual void
-    set_long(const std::string& section, const std::string& option, long val);
+    void set_long(const std::string& section, const std::string& option, long val);
 
     /*!
      * \brief If option exists and value can be converted to double,
      * return it; else default_val.
      */
-    virtual double
+    double
     get_double(const std::string& section, const std::string& option, double default_val);
 
     /*!
      * \brief Set or add a double \p option to \p section with value \p val.
      */
-    virtual void
-    set_double(const std::string& section, const std::string& option, double val);
+    void set_double(const std::string& section, const std::string& option, double val);
 
 protected:
-    virtual std::vector<std::string> _sys_prefs_filenames();
-    virtual void _read_files(const std::vector<std::string>& filenames);
-    virtual char* option_to_env(std::string section, std::string option);
+    std::vector<std::string> _sys_prefs_filenames();
+    void _read_files(const std::vector<std::string>& filenames);
+    char* option_to_env(std::string section, std::string option);
+    template <typename T>
+    T get_general(const std::string& section,
+                  const std::string& option,
+                  const T& default_val);
+    template <typename T>
+    void set_general(const std::string& section, const std::string& option, const T& val);
 
 private:
-    gr::thread::mutex d_mutex;
+    // TODO: add back and actually use: gr::thread::mutex d_mutex;
     config_map_t d_config_map;
 };
 

--- a/gnuradio-runtime/include/gnuradio/prefs.h
+++ b/gnuradio-runtime/include/gnuradio/prefs.h
@@ -14,15 +14,10 @@
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
 #include <map>
+#include <mutex>
 #include <string>
 
 namespace gr {
-
-typedef std::map<std::string, std::map<std::string, std::string>> config_map_t;
-typedef std::map<std::string, std::map<std::string, std::string>>::iterator
-    config_map_itr;
-typedef std::map<std::string, std::string> config_map_elem_t;
-typedef std::map<std::string, std::string>::iterator config_map_elem_itr;
 
 /*!
  * \brief Base class for representing user preferences a la windows INI files.
@@ -51,8 +46,6 @@ public:
      * \endcode
      */
     prefs();
-
-    virtual ~prefs();
 
     /*!
      * If specifying a file name, this opens that specific
@@ -155,7 +148,7 @@ protected:
 
 private:
     std::mutex d_mutex;
-    config_map_t d_config_map;
+    std::map<std::string, std::map<std::string, std::string>> d_config_map;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <mutex>
 
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -51,11 +50,6 @@ prefs* prefs::singleton()
 }
 
 prefs::prefs() { _read_files(_sys_prefs_filenames()); }
-
-prefs::~prefs()
-{
-    // nop
-}
 
 std::vector<std::string> prefs::_sys_prefs_filenames()
 {
@@ -130,16 +124,13 @@ void prefs::add_config_file(const std::string& configfile)
 
 std::string prefs::to_string()
 {
-    config_map_itr sections;
-    config_map_elem_itr options;
     std::stringstream s;
     std::lock_guard<std::mutex> lk(d_mutex);
 
-    for (sections = d_config_map.begin(); sections != d_config_map.end(); sections++) {
-        s << "[" << sections->first << "]" << std::endl;
-        for (options = sections->second.begin(); options != sections->second.end();
-             options++) {
-            s << options->first << " = " << options->second << std::endl;
+    for (const auto& sections : d_config_map) {
+        s << "[" << sections.first << "]" << std::endl;
+        for (const auto& options : sections.second) {
+            s << options.first << " = " << options.second << std::endl;
         }
         s << std::endl;
     }
@@ -172,7 +163,7 @@ bool prefs::has_section(const std::string& section)
     std::string s = section;
     stolower(s);
     std::lock_guard<std::mutex> lk(d_mutex);
-    return d_config_map.count(s) > 0;
+    return d_config_map.find(s) != d_config_map.end();
 }
 
 bool prefs::has_option(const std::string& section, const std::string& option)
@@ -190,8 +181,8 @@ bool prefs::has_option(const std::string& section, const std::string& option)
     stolower(o);
 
     std::lock_guard<std::mutex> lk(d_mutex);
-    config_map_itr sec = d_config_map.find(s);
-    return sec->second.count(o) > 0;
+    const auto& sec = d_config_map[s];
+    return sec.find(o) != sec.end();
 }
 
 // get_string needs specialization because it can have spaces.
@@ -214,9 +205,7 @@ const std::string prefs::get_string(const std::string& section,
     stolower(o);
 
     std::lock_guard<std::mutex> lk(d_mutex);
-    config_map_itr sec = d_config_map.find(s);
-    config_map_elem_itr opt = sec->second.find(o);
-    return opt->second;
+    return d_config_map[s][o];
 }
 
 // get_bool() needs specialization because there are multiple text strings for true/false

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -140,14 +140,31 @@ std::string prefs::to_string()
 
 void prefs::save()
 {
-    // TODO: write the settings in an error-safe way, by writing to a tempfile and
-    // atomically renaming.
-    std::string conf = to_string();
-    fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
-    fs::ofstream fout(userconf);
+    const std::string conf = to_string();
+
+    // Write temp file.
+    const fs::path tmp = fs::path(gr::userconf_path()) / "config.conf.tmp";
+    std::ofstream fout(tmp);
     fout << conf;
     fout.close();
-    // TODO: throw on error?
+    if (!fout.good()) {
+        const std::string write_err = strerror(errno);
+        {
+            std::error_code err;
+            fs::remove(tmp, err);
+            if (err) {
+                std::cerr << "Failed to remove temp file: " << err << std::endl;
+            }
+        }
+        throw std::runtime_error("failed to write updated config: " + write_err);
+    }
+
+    // Atomic rename.
+    const fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
+    fs::rename(tmp, userconf);
+    // If fs::rename() fails, we'll leak the tempfile and throw. That's fine.
+    // If the user wants it (it was written successfully) they can have it.
+    // Or it'll be overwritten on the next save.
 }
 
 char* prefs::option_to_env(std::string section, std::string option)
@@ -163,7 +180,7 @@ bool prefs::has_section(const std::string& section)
     std::string s = section;
     stolower(s);
     std::lock_guard<std::mutex> lk(d_mutex);
-    return d_config_map.find(s) != d_config_map.end();
+    return d_config_map.count(s) > 0;
 }
 
 bool prefs::has_option(const std::string& section, const std::string& option)

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -109,6 +110,7 @@ void prefs::_read_files(const std::vector<std::string>& filenames)
                 // value of a basic_option is always a std::vector<string>; we only
                 // allow single values, so:
                 std::string value = o.value[0];
+                std::lock_guard<std::mutex> lk(d_mutex);
                 d_config_map[section][key] = value;
             }
         } catch (std::exception& e) {
@@ -131,6 +133,7 @@ std::string prefs::to_string()
     config_map_itr sections;
     config_map_elem_itr options;
     std::stringstream s;
+    std::lock_guard<std::mutex> lk(d_mutex);
 
     for (sections = d_config_map.begin(); sections != d_config_map.end(); sections++) {
         s << "[" << sections->first << "]" << std::endl;
@@ -168,6 +171,7 @@ bool prefs::has_section(const std::string& section)
 {
     std::string s = section;
     stolower(s);
+    std::lock_guard<std::mutex> lk(d_mutex);
     return d_config_map.count(s) > 0;
 }
 
@@ -185,6 +189,7 @@ bool prefs::has_option(const std::string& section, const std::string& option)
     std::string o = option;
     stolower(o);
 
+    std::lock_guard<std::mutex> lk(d_mutex);
     config_map_itr sec = d_config_map.find(s);
     return sec->second.count(o) > 0;
 }
@@ -208,6 +213,7 @@ const std::string prefs::get_string(const std::string& section,
     std::string o = option;
     stolower(o);
 
+    std::lock_guard<std::mutex> lk(d_mutex);
     config_map_itr sec = d_config_map.find(s);
     config_map_elem_itr opt = sec->second.find(o);
     return opt->second;
@@ -261,12 +267,12 @@ void prefs::set_general(const std::string& section,
     stolower(s);
     std::string o = option;
     stolower(o);
-    std::map<std::string, std::string> opt_map = d_config_map[s];
 
     std::stringstream sstr;
     sstr << val;
-    opt_map[o] = sstr.str();
-    d_config_map[s] = opt_map;
+
+    std::lock_guard<std::mutex> lk(d_mutex);
+    d_config_map[s][o] = sstr.str();
 }
 
 void prefs::set_bool(const std::string& section, const std::string& option, bool val)

--- a/gnuradio-runtime/lib/prefs.cc
+++ b/gnuradio-runtime/lib/prefs.cc
@@ -30,10 +30,22 @@ typedef std::ifstream::char_type char_t;
 
 namespace gr {
 
+namespace {
+
+void stolower(std::string& s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+}
+void stoupper(std::string& s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+}
+
+} // namespace
+
 prefs* prefs::singleton()
 {
-    static prefs instance; // Guaranteed to be destroyed.
-                           // Instantiated on first use.
+    static prefs instance;
     return &instance;
 }
 
@@ -50,11 +62,9 @@ std::vector<std::string> prefs::_sys_prefs_filenames()
 
     fs::path dir = prefsdir();
     if (fs::is_directory(dir)) {
-        fs::directory_iterator diritr(dir);
-        while (diritr != fs::directory_iterator()) {
-            fs::path p = *diritr++;
-            if (p.extension() == ".conf")
-                fnames.push_back(p.string());
+        for (const auto& p : fs::directory_iterator(dir)) {
+            if (p.path().extension() == ".conf")
+                fnames.push_back(p.path());
         }
         std::sort(fnames.begin(), fnames.end());
     }
@@ -74,48 +84,45 @@ void prefs::_read_files(const std::vector<std::string>& filenames)
 {
     for (const auto& fname : filenames) {
         std::ifstream infile(fname.c_str());
-        if (infile.good()) {
-            try {
-                po::basic_parsed_options<char_t> parsed =
-                    po::parse_config_file(infile, po::options_description(), true);
-                for (const auto& o : parsed.options) {
-                    std::string okey = o.string_key;
-                    size_t pos = okey.find(".");
-                    std::string section, key;
-                    if (pos != std::string::npos) {
-                        section = okey.substr(0, pos);
-                        key = okey.substr(pos + 1);
-                    } else {
-                        section = "default";
-                        key = okey;
-                    }
-                    std::transform(
-                        section.begin(), section.end(), section.begin(), ::tolower);
-                    std::transform(key.begin(), key.end(), key.begin(), ::tolower);
-                    // value of a basic_option is always a std::vector<string>; we only
-                    // allow single values, so:
-                    std::string value = o.value[0];
-                    d_config_map[section][key] = value;
-                }
-            } catch (std::exception& e) {
-                std::cerr << "WARNING: Config file '" << fname
-                          << "' failed to parse:" << std::endl;
-                std::cerr << e.what() << std::endl;
-                std::cerr << "Skipping it" << std::endl;
-            }
-        } else { // infile.good();
+        if (!infile.good()) {
             std::cerr << "WARNING: Config file '" << fname
                       << "' could not be opened for reading." << std::endl;
+            continue;
+        }
+
+        try {
+            po::basic_parsed_options<char_t> parsed =
+                po::parse_config_file(infile, po::options_description(), true);
+            for (const auto& o : parsed.options) {
+                std::string okey = o.string_key;
+                size_t pos = okey.find(".");
+                std::string section, key;
+                if (pos != std::string::npos) {
+                    section = okey.substr(0, pos);
+                    key = okey.substr(pos + 1);
+                } else {
+                    section = "default";
+                    key = okey;
+                }
+                stolower(section);
+                stolower(key);
+                // value of a basic_option is always a std::vector<string>; we only
+                // allow single values, so:
+                std::string value = o.value[0];
+                d_config_map[section][key] = value;
+            }
+        } catch (std::exception& e) {
+            std::cerr << "WARNING: Config file '" << fname
+                      << "' failed to parse:" << std::endl;
+            std::cerr << e.what() << std::endl;
+            std::cerr << "Skipping it" << std::endl;
         }
     }
 }
 
 void prefs::add_config_file(const std::string& configfile)
 {
-    std::vector<std::string> filenames;
-    filenames.push_back(configfile);
-
-    _read_files(filenames);
+    _read_files(std::vector<std::string>{ configfile });
 }
 
 
@@ -139,29 +146,28 @@ std::string prefs::to_string()
 
 void prefs::save()
 {
+    // TODO: write the settings in an error-safe way, by writing to a tempfile and
+    // atomically renaming.
     std::string conf = to_string();
     fs::path userconf = fs::path(gr::userconf_path()) / "config.conf";
     fs::ofstream fout(userconf);
     fout << conf;
     fout.close();
+    // TODO: throw on error?
 }
 
 char* prefs::option_to_env(std::string section, std::string option)
 {
-    std::stringstream envname;
-    std::string secname = section, optname = option;
-
-    std::transform(section.begin(), section.end(), secname.begin(), ::toupper);
-    std::transform(option.begin(), option.end(), optname.begin(), ::toupper);
-    envname << "GR_CONF_" << secname << "_" << optname;
-
-    return getenv(envname.str().c_str());
+    stoupper(section);
+    stoupper(option);
+    const auto envname = "GR_CONF_" + section + "_" + option;
+    return getenv(envname.c_str());
 }
 
 bool prefs::has_section(const std::string& section)
 {
     std::string s = section;
-    std::transform(section.begin(), section.end(), s.begin(), ::tolower);
+    stolower(s);
     return d_config_map.count(s) > 0;
 }
 
@@ -170,20 +176,20 @@ bool prefs::has_option(const std::string& section, const std::string& option)
     if (option_to_env(section, option))
         return true;
 
-    if (has_section(section)) {
-        std::string s = section;
-        std::transform(section.begin(), section.end(), s.begin(), ::tolower);
-
-        std::string o = option;
-        std::transform(option.begin(), option.end(), o.begin(), ::tolower);
-
-        config_map_itr sec = d_config_map.find(s);
-        return sec->second.count(o) > 0;
-    } else {
+    if (!has_section(section)) {
         return false;
     }
+
+    std::string s = section;
+    stolower(s);
+    std::string o = option;
+    stolower(o);
+
+    config_map_itr sec = d_config_map.find(s);
+    return sec->second.count(o) > 0;
 }
 
+// get_string needs specialization because it can have spaces.
 const std::string prefs::get_string(const std::string& section,
                                     const std::string& option,
                                     const std::string& default_val)
@@ -192,144 +198,112 @@ const std::string prefs::get_string(const std::string& section,
     if (env)
         return std::string(env);
 
-    if (has_option(section, option)) {
-        std::string s = section;
-        std::transform(section.begin(), section.end(), s.begin(), ::tolower);
-
-        std::string o = option;
-        std::transform(option.begin(), option.end(), o.begin(), ::tolower);
-
-        config_map_itr sec = d_config_map.find(s);
-        config_map_elem_itr opt = sec->second.find(o);
-        return opt->second;
-    } else {
+    if (!has_option(section, option)) {
         return default_val;
     }
-}
 
-void prefs::set_string(const std::string& section,
-                       const std::string& option,
-                       const std::string& val)
-{
     std::string s = section;
-    std::transform(section.begin(), section.end(), s.begin(), ::tolower);
+    stolower(s);
 
     std::string o = option;
-    std::transform(option.begin(), option.end(), o.begin(), ::tolower);
+    stolower(o);
 
-    std::map<std::string, std::string> opt_map = d_config_map[s];
-
-    opt_map[o] = val;
-
-    d_config_map[s] = opt_map;
+    config_map_itr sec = d_config_map.find(s);
+    config_map_elem_itr opt = sec->second.find(o);
+    return opt->second;
 }
 
+// get_bool() needs specialization because there are multiple text strings for true/false
 bool prefs::get_bool(const std::string& section,
                      const std::string& option,
                      bool default_val)
 {
-    if (has_option(section, option)) {
-        std::string str = get_string(section, option, "");
-        if (str.empty()) {
-            return default_val;
-        }
-        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
-        if ((str == "true") || (str == "on") || (str == "1"))
-            return true;
-        else if ((str == "false") || (str == "off") || (str == "0"))
-            return false;
-        else
-            return default_val;
-    } else {
+    if (!has_option(section, option)) {
         return default_val;
     }
+    std::string str = get_string(section, option, "");
+    if (str.empty()) {
+        return default_val;
+    }
+    stolower(str);
+    if ((str == "true") || (str == "on") || (str == "1"))
+        return true;
+    if ((str == "false") || (str == "off") || (str == "0"))
+        return false;
+    return default_val;
+}
+
+template <typename T>
+T prefs::get_general(const std::string& section,
+                     const std::string& option,
+                     const T& default_val)
+{
+    if (!has_option(section, option)) {
+        return default_val;
+    }
+
+    std::string str = get_string(section, option, "");
+    if (str.empty()) {
+        return default_val;
+    }
+    std::stringstream sstr(str);
+    T n;
+    sstr >> n;
+    return n;
+}
+
+template <typename T>
+void prefs::set_general(const std::string& section,
+                        const std::string& option,
+                        const T& val)
+{
+    std::string s = section;
+    stolower(s);
+    std::string o = option;
+    stolower(o);
+    std::map<std::string, std::string> opt_map = d_config_map[s];
+
+    std::stringstream sstr;
+    sstr << val;
+    opt_map[o] = sstr.str();
+    d_config_map[s] = opt_map;
 }
 
 void prefs::set_bool(const std::string& section, const std::string& option, bool val)
 {
-    std::string s = section;
-    std::transform(section.begin(), section.end(), s.begin(), ::tolower);
-
-    std::string o = option;
-    std::transform(option.begin(), option.end(), o.begin(), ::tolower);
-
-    std::map<std::string, std::string> opt_map = d_config_map[s];
-
-    std::stringstream sstr;
-    sstr << (val == true);
-    opt_map[o] = sstr.str();
-
-    d_config_map[s] = opt_map;
+    return set_general(section, option, val);
 }
 
 long prefs::get_long(const std::string& section,
                      const std::string& option,
                      long default_val)
 {
-    if (has_option(section, option)) {
-        std::string str = get_string(section, option, "");
-        if (str.empty()) {
-            return default_val;
-        }
-        std::stringstream sstr(str);
-        long n;
-        sstr >> n;
-        return n;
-    } else {
-        return default_val;
-    }
+    return get_general(section, option, default_val);
 }
 
 void prefs::set_long(const std::string& section, const std::string& option, long val)
 {
-    std::string s = section;
-    std::transform(section.begin(), section.end(), s.begin(), ::tolower);
-
-    std::string o = option;
-    std::transform(option.begin(), option.end(), o.begin(), ::tolower);
-
-    std::map<std::string, std::string> opt_map = d_config_map[s];
-
-    std::stringstream sstr;
-    sstr << val;
-    opt_map[o] = sstr.str();
-
-    d_config_map[s] = opt_map;
+    return set_general(section, option, val);
 }
 
 double prefs::get_double(const std::string& section,
                          const std::string& option,
                          double default_val)
 {
-    if (has_option(section, option)) {
-        std::string str = get_string(section, option, "");
-        if (str.empty()) {
-            return default_val;
-        }
-        std::stringstream sstr(str);
-        double n;
-        sstr >> n;
-        return n;
-    } else {
-        return default_val;
-    }
+    return get_general(section, option, default_val);
 }
 
 void prefs::set_double(const std::string& section, const std::string& option, double val)
 {
-    std::string s = section;
-    std::transform(section.begin(), section.end(), s.begin(), ::tolower);
-
-    std::string o = option;
-    std::transform(option.begin(), option.end(), o.begin(), ::tolower);
-
-    std::map<std::string, std::string> opt_map = d_config_map[s];
-
-    std::stringstream sstr;
-    sstr << val;
-    opt_map[o] = sstr.str();
-
-    d_config_map[s] = opt_map;
+    return set_general(section, option, val);
 }
+
+void prefs::set_string(const std::string& section,
+                       const std::string& option,
+                       const std::string& val)
+{
+    return set_general(section, option, val);
+}
+
 
 } /* namespace gr */

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/prefs_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/prefs_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(prefs.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(59ed43a1f982f3c7da3f0f6b51941294)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4d5fd75bdefb15004e9f86e1ddec95fc)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/prefs_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/prefs_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(prefs.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c461d885bc4fd82aa0301248e9f1e958)                     */
+/* BINDTOOL_HEADER_FILE_HASH(59ed43a1f982f3c7da3f0f6b51941294)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/prefs_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/prefs_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(prefs.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4d5fd75bdefb15004e9f86e1ddec95fc)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f9d239804a24578ed1abfd735b31ca6b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Cleanup of the code.
Actually using the mutex.
Safer preference writing using atomic rename.

Backport https://github.com/gnuradio/gnuradio/pull/4504
