### PR TITLE
modtool: improve the 'invalid name' error message (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/cli/add.py
+++ b/gr-utils/modtool/cli/add.py
@@ -15,7 +15,7 @@ import getpass
 
 import click
 
-from ..core import ModToolAdd
+from ..core import ModToolAdd, validate_name
 from ..tools import SequenceCompleter, ask_yes_no
 from .base import common_params, block_name, run, cli_input, ModToolException
 
@@ -90,8 +90,7 @@ def get_blockname(self):
     if not self.info['blockname'] or self.info['blockname'].isspace():
         while not self.info['blockname'] or self.info['blockname'].isspace():
             self.info['blockname'] = cli_input("Enter name of block/code (without module name prefix): ")
-    if not re.match('^[a-zA-Z0-9_]+$', self.info['blockname']):
-        raise ModToolException('Invalid block name.')
+    validate_name('block', self.info['blockname'])
     self.info['fullblockname'] = self.info['modname'] + '_' + self.info['blockname']
     fname_grc = self.info['fullblockname'] + '.block.yml'
     for block in os.scandir('./grc/'):

--- a/gr-utils/modtool/cli/newmod.py
+++ b/gr-utils/modtool/cli/newmod.py
@@ -15,7 +15,7 @@ import os
 import click
 
 from gnuradio import gr
-from ..core import ModToolNewModule
+from ..core import ModToolNewModule, validate_name
 from .base import common_params, run, cli_input, ModToolException
 
 @click.command('newmod', short_help=ModToolNewModule.description)
@@ -51,5 +51,4 @@ def get_modname(self):
     if self.info['modname'] is None:
         while not self.info['modname'] or self.info['modname'].isspace():
             self.info['modname'] = cli_input('Name of the new module: ')
-    if not re.match('[a-zA-Z0-9_]+$', self.info['modname']):
-        raise ModToolException('Invalid module name.')
+    validate_name('module', self.info['modname'])

--- a/gr-utils/modtool/cli/rename.py
+++ b/gr-utils/modtool/cli/rename.py
@@ -13,7 +13,7 @@ import re
 
 import click
 
-from ..core import get_block_candidates, ModToolRename
+from ..core import get_block_candidates, ModToolRename, validate_name
 from ..tools import SequenceCompleter
 from .base import common_params, block_name, run, cli_input, ModToolException
 
@@ -55,8 +55,7 @@ def get_oldname(self):
         if len(choices) > 0:
             click.secho("Suggested alternatives: "+str(choices), fg='yellow')
         raise ModToolException("Blockname for renaming does not exists!")
-    if not re.match('[a-zA-Z0-9_]+', self.info['oldname']):
-        raise ModToolException('Invalid block name.')
+    validate_name('block', self.info['oldname'])
 
 def get_newname(self):
     """ Get the new block name """
@@ -64,5 +63,4 @@ def get_newname(self):
         while not self.info['newname'] or self.info['newname'].isspace():
             self.info['newname'] = cli_input("Enter name of block/code "+
                                              "(without module name prefix): ")
-    if not re.match('[a-zA-Z0-9_]+', self.info['newname']):
-        raise ModToolException('Invalid block name.')
+    validate_name('block', self.info['newname'])

--- a/gr-utils/modtool/core/__init__.py
+++ b/gr-utils/modtool/core/__init__.py
@@ -8,7 +8,7 @@
 #
 
 
-from .base import ModTool, ModToolException, get_block_candidates
+from .base import ModTool, ModToolException, get_block_candidates, validate_name
 from .add import ModToolAdd
 from .bind import ModToolGenBindings
 from .disable import ModToolDisable

--- a/gr-utils/modtool/core/add.py
+++ b/gr-utils/modtool/core/add.py
@@ -16,7 +16,7 @@ import subprocess
 
 from ..tools import render_template, append_re_line_sequence, CMakeFileEditor, CPPFileEditor, code_generator
 from ..templates import Templates
-from .base import ModTool, ModToolException
+from .base import ModTool, ModToolException, validate_name
 from gnuradio.bindtool import BindingGenerator
 from gnuradio import gr
 
@@ -72,8 +72,7 @@ class ModToolAdd(ModTool):
             raise ModToolException('Tagged Stream Blocks for Python currently unsupported')            
         if self.info['blockname'] is None:
             raise ModToolException('Blockname not specified.')
-        if not re.match('^[a-zA-Z0-9_]+$', self.info['blockname']):
-            raise ModToolException('Invalid block name.')
+        validate_name('block', self.info['blockname'])
         if not isinstance(self.add_py_qa, bool):
             raise ModToolException('Expected a boolean value for add_python_qa.')
         if not isinstance(self.add_cc_qa, bool):

--- a/gr-utils/modtool/core/base.py
+++ b/gr-utils/modtool/core/base.py
@@ -44,6 +44,12 @@ class ModToolException(Exception):
     pass
 
 
+def validate_name(kind, name):
+    """ Checks that block, module etc names are alphanumeric. """
+    if not re.fullmatch('[a-zA-Z0-9_]+', name):
+        raise ModToolException("Invalid {} name '{}': names can only contain letters, numbers and underscores".format(kind, name))
+
+
 class ModTool(object):
     """ Base class for all modtool command classes. """
     name = 'base'

--- a/gr-utils/modtool/core/newmod.py
+++ b/gr-utils/modtool/core/newmod.py
@@ -16,7 +16,7 @@ import logging
 
 from gnuradio import gr
 from ..tools import SCMRepoFactory
-from .base import ModTool, ModToolException
+from .base import ModTool, ModToolException, validate_name
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,7 @@ class ModToolNewModule(ModTool):
         """ Validates the arguments """
         if not self.info['modname']:
             raise ModToolException('Module name not specified.')
-        if not re.match('[a-zA-Z0-9_]+$', self.info['modname']):
-            raise ModToolException('Invalid module name.')
+        validate_name('module', self.info['modname'])
         try:
             os.stat(self.dir)
         except OSError:

--- a/gr-utils/modtool/core/rename.py
+++ b/gr-utils/modtool/core/rename.py
@@ -13,7 +13,7 @@ import os
 import re
 import logging
 
-from .base import get_block_candidates, ModTool, ModToolException
+from .base import get_block_candidates, ModTool, ModToolException, validate_name
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,7 @@ class ModToolRename(ModTool):
         ModTool._validate(self)
         if not self.info['oldname']:
             raise ModToolException('Old block name (blockname) not specified.')
-        if not re.match('[a-zA-Z0-9_]+', self.info['oldname']):
-            raise ModToolException('Invalid block name.')
+        validate_name('old block', self.info['oldname'])
         block_candidates = get_block_candidates()
         if self.info['oldname'] not in block_candidates:
             choices = [x for x in block_candidates if self.info['oldname'] in x]
@@ -43,8 +42,7 @@ class ModToolRename(ModTool):
             raise ModToolException("Blockname for renaming does not exists!")
         if not self.info['newname']:
             raise ModToolException('New blockname (new_name) not specified.')
-        if not re.match('[a-zA-Z0-9_]+', self.info['newname']):
-            raise ModToolException('Invalid new block name.')
+        validate_name('new block', self.info['newname'])
 
     def assign(self):
         self.info['fullnewname'] = self.info['modname'] + '_' + self.info['newname']

--- a/gr-utils/modtool/tests/test_modtool.py
+++ b/gr-utils/modtool/tests/test_modtool.py
@@ -239,12 +239,20 @@ class TestModToolCore(unittest.TestCase):
         test_dict['directory'] = module_dir
         # Missing 2 arguments blockname, new_name
         self.assertRaises(ModToolException, ModToolRename(**test_dict).run)
+
         test_dict['blockname'] = 'square_ff'
         # Missing argument new_name
         self.assertRaises(ModToolException, ModToolRename(**test_dict).run)
+
         test_dict['new_name'] = '//#'
         # Invalid new block name!
+        expected_message = "Invalid new block name '//#': names can only contain letters, numbers and underscores"
+        self.assertRaisesRegex(ModToolException, expected_message, ModToolRename(**test_dict).run)
+
+        test_dict['new_name'] = 'non-alpha-chars-like-hyphen-are-not-allowed'
+        # Invalid new block name!
         self.assertRaises(ModToolException, ModToolRename(**test_dict).run)
+
         test_dict['new_name'] = None
         # New Block name not specified
         self.assertRaises(ModToolException, ModToolRename(**test_dict).run)


### PR DESCRIPTION
also fix some validations which checked a prefix instead of the whole name

Signed-off-by: Ferenc Gerlits <fgerlits@gmail.com>
(cherry picked from commit faf786d57f48bc516c530bfd76e478b3748cd582)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4555