### PR TITLE
[v7] grc: Make exception for epy in blacklist id

### DIFF
--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -70,6 +70,7 @@ class EPyBlock(Block):
 
     key = 'epy_block'
     label = 'Python Block'
+    exempt_from_id_validation = True  # Exempt epy block from blacklist id validation
     documentation = {'': DOC}
 
     parameters_data = build_params(
@@ -201,6 +202,7 @@ class EPyBlock(Block):
 class EPyModule(Block):
     key = 'epy_module'
     label = 'Python Module'
+    exempt_from_id_validation = True  # Exempt epy module from blacklist id validation
     documentation = {'': dedent("""
         This block lets you embed a python module in your flowgraph.
 

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -40,10 +40,13 @@ class ValidateError(Exception):
 def validate_block_id(param,black_listed_ids):
     value = param.value
     # Can python use this as a variable?
+
     if not re.match(r'^[a-z|A-Z]\w*$', value):
         raise ValidateError('ID "{}" must begin with a letter and may contain letters, numbers, '
                             'and underscores.'.format(value))
-    if value in (black_listed_ids + ID_BLACKLIST):
+    if value in (black_listed_ids + ID_BLACKLIST) and \
+        not getattr(param.parent_block, 'exempt_from_id_validation', False):
+        # Grant blacklist exemption to epy blocks and modules
         raise ValidateError('ID "{}" is blacklisted.'.format(value))
     block_names = [block.name for block in param.parent_flowgraph.iter_enabled_blocks()]
     # Id should only appear once, or zero times if block is disabled


### PR DESCRIPTION
I refer to the mailing list thread on May 8 2021 regarding "Embedded
Python Block Tutorial Param ID Error".

The bug is caused by #4522 as names of embedded python blocks
such as `epy_block_0` are blacklisted because of "blocks" in the
argument `black_listed_ids`. It affects both embedded python blocks and
modules. This commit fixes the bug by granting exemption for these two
types of blocks from id validation.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>