### PR TITLE
grc: fix Wrong order in the generated .py caused by uncorrect function without_gui_hint(block)

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -196,14 +196,6 @@ class TopBlockGenerator(object):
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
-
-        # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
-        def without_gui_hint(block):
-            hint = block.params.get('gui_hint')
-            return hint is None or not hint.get_value()
-
-        blocks.sort(key=without_gui_hint)
-
         blocks_make = []
         for block in blocks:
             make = block.templates.render('make')


### PR DESCRIPTION
Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>

This fix #4557 
I tested it under GR 3.9.1 using different flowgraph combining widgets with/without GUI_hint positioned Inside /outside tabs. 

Note: I =was not able to reproduce errror  in  #4557 first message ( https://github.com/bastibl/gr-rds/blob/3a80121f0858adf4ebd2f5f9f36ff1e4bb18b7a4/examples/rds_rx.grc (maint-3.9 branch) 
Thank to @kaushiksv for proposing this fix