### PR TITLE
blocks: use VOLK popcnt implementations for count_bits (backport to maint-3.9)

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/count_bits.h
+++ b/gr-blocks/include/gnuradio/blocks/count_bits.h
@@ -13,6 +13,8 @@
 
 #include <gnuradio/blocks/api.h>
 
+#include <cstdint>
+
 namespace gr {
 namespace blocks {
 
@@ -26,7 +28,7 @@ BLOCKS_API unsigned int count_bits16(unsigned int x);
 BLOCKS_API unsigned int count_bits32(unsigned int x);
 
 //! return number of set bits in a 64-bit word
-BLOCKS_API unsigned int count_bits64(unsigned long long int x);
+BLOCKS_API unsigned int count_bits64(uint64_t x);
 
 } /* namespace blocks */
 } /* namespace gr */

--- a/gr-blocks/lib/count_bits.cc
+++ b/gr-blocks/lib/count_bits.cc
@@ -10,11 +10,7 @@
 
 #include <gnuradio/blocks/count_bits.h>
 
-/*
- * these are slow and obvious.  If you need something faster, fix these
- *
- * Can probably replace with VOLK's popcount
- */
+#include <volk/volk.h>
 
 namespace gr {
 namespace blocks {
@@ -45,16 +41,18 @@ unsigned int count_bits16(unsigned int x)
 
 unsigned int count_bits32(unsigned int x)
 {
-    unsigned res = (x & 0x55555555) + ((x >> 1) & 0x55555555);
-    res = (res & 0x33333333) + ((res >> 2) & 0x33333333);
-    res = (res & 0x0F0F0F0F) + ((res >> 4) & 0x0F0F0F0F);
-    res = (res & 0x00FF00FF) + ((res >> 8) & 0x00FF00FF);
-    return (res & 0x0000FFFF) + ((res >> 16) & 0x0000FFFF);
+    unsigned res = 0;
+    volk_32u_popcnt(&res, x);
+
+    return res;
 }
 
-unsigned int count_bits64(unsigned long long x)
+unsigned int count_bits64(uint64_t x)
 {
-    return count_bits32((x >> 32) & 0xffffffff) + count_bits32(x & 0xffffffff);
+    uint64_t res_as_u64 = 0;
+    volk_64u_popcnt(&res_as_u64, x);
+
+    return static_cast<unsigned int>(res_as_u64);
 }
 
 } /* namespace blocks */

--- a/gr-blocks/python/blocks/bindings/count_bits_python.cc
+++ b/gr-blocks/python/blocks/bindings/count_bits_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2020-2021 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(count_bits.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(da855d7f097f40a02197ebb030104cfc)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b999075adec115941653f24e8e41f18b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
* Changed count_bits64 input parameter type to uint64_t

Signed-off-by: Nicholas Corgan <n.corgan@gmail.com>
(cherry picked from commit e1dfa8c62b31661d249f3d0f6a0395b01a2e21f9)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4569