### PR TITLE
qtgui: Use pmt.from_double() instead of pmt.from_float() (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/python/qtgui/dialcontrol.py
+++ b/gr-qtgui/python/qtgui/dialcontrol.py
@@ -135,7 +135,7 @@ class GrDialControl(gr.sync_block, LabeledDialControl):
 
         if self.isFloat:
             self.message_port_pub(pmt.intern("value"), pmt.cons(pmt.intern(self.outputmsgname),
-                                                                pmt.from_float(new_value)))
+                                                                pmt.from_double(new_value)))
         else:
             self.message_port_pub(pmt.intern("value"), pmt.cons(pmt.intern(self.outputmsgname),
                                                                 pmt.from_long(new_value)))

--- a/gr-qtgui/python/qtgui/digitalnumbercontrol.py
+++ b/gr-qtgui/python/qtgui/digitalnumbercontrol.py
@@ -354,12 +354,12 @@ class MsgDigitalNumberControl(gr.sync_block, LabeledDigitalNumberControl):
     def click_callback(self, new_value):
         self.call_var_callback(new_value)
 
-        self.message_port_pub(pmt.intern("valueout"), pmt.cons(pmt.intern(self.outputmsgname), pmt.from_float(float(new_value))))
+        self.message_port_pub(pmt.intern("valueout"), pmt.cons(pmt.intern(self.outputmsgname), pmt.from_double(float(new_value))))
 
     def setValue(self, new_val):
         self.setFrequency(new_val)
 
-        self.message_port_pub(pmt.intern("valueout"), pmt.cons(pmt.intern(self.outputmsgname), pmt.from_float(float(self.getFrequency()))))
+        self.message_port_pub(pmt.intern("valueout"), pmt.cons(pmt.intern(self.outputmsgname), pmt.from_double(float(self.getFrequency()))))
 
     def getValue(self):
         self.getFrequency()

--- a/gr-qtgui/python/qtgui/msgcheckbox.py
+++ b/gr-qtgui/python/qtgui/msgcheckbox.py
@@ -93,7 +93,7 @@ class MsgCheckBox(gr.sync_block, QFrame):
             elif type(self.pressReleasedDict['Pressed']) == float:
                 self.message_port_pub(pmt.intern("state"),
                     pmt.cons(pmt.intern(self.outputmsgname),
-                    pmt.from_float(self.pressReleasedDict['Pressed'])))
+                    pmt.from_double(self.pressReleasedDict['Pressed'])))
             else:
                 self.message_port_pub(pmt.intern("state"),
                     pmt.cons(pmt.intern(self.outputmsgname),
@@ -112,7 +112,7 @@ class MsgCheckBox(gr.sync_block, QFrame):
             elif type(self.pressReleasedDict['Released']) == float:
                 self.message_port_pub(pmt.intern("state"),
                     pmt.cons(pmt.intern(self.outputmsgname),
-                    pmt.from_float(self.pressReleasedDict['Released'])))
+                    pmt.from_double(self.pressReleasedDict['Released'])))
             else:
                 self.message_port_pub(pmt.intern("state"),
                     pmt.cons(pmt.intern(self.outputmsgname),

--- a/gr-qtgui/python/qtgui/msgpushbutton.py
+++ b/gr-qtgui/python/qtgui/msgpushbutton.py
@@ -47,7 +47,7 @@ class MsgPushButton(gr.sync_block, Qt.QPushButton):
                 pmt.cons(pmt.intern(self.msgName), pmt.from_long(self.msgValue)))
         elif type(self.msgValue) == float:
             self.message_port_pub(pmt.intern("pressed"),
-                pmt.cons(pmt.intern(self.msgName), pmt.from_float(self.msgValue)))
+                pmt.cons(pmt.intern(self.msgName), pmt.from_double(self.msgValue)))
         elif type(self.msgValue) == str:
             self.message_port_pub(pmt.intern("pressed"),
                 pmt.cons(pmt.intern(self.msgName), pmt.intern(self.msgValue)))

--- a/gr-qtgui/python/qtgui/togglebutton.py
+++ b/gr-qtgui/python/qtgui/togglebutton.py
@@ -98,7 +98,7 @@ class ToggleButton(gr.sync_block, Qt.QPushButton):
             elif type(self.pressReleasedDict['Pressed']) == float:
                 self.message_port_pub(pmt.intern("state"),
                                     pmt.cons(pmt.intern(self.outputmsgname),
-                                    pmt.from_float(self.pressReleasedDict['Pressed'])))
+                                    pmt.from_double(self.pressReleasedDict['Pressed'])))
             else:
                 self.message_port_pub(pmt.intern("state"),
                                     pmt.cons(pmt.intern(self.outputmsgname),
@@ -115,7 +115,7 @@ class ToggleButton(gr.sync_block, Qt.QPushButton):
             elif type(self.pressReleasedDict['Released']) == float:
                 self.message_port_pub(pmt.intern("state"),
                                     pmt.cons(pmt.intern(self.outputmsgname),
-                                    pmt.from_float(self.pressReleasedDict['Released'])))
+                                    pmt.from_double(self.pressReleasedDict['Released'])))
             else:
                 self.message_port_pub(pmt.intern("state"),
                                     pmt.cons(pmt.intern(self.outputmsgname),

--- a/gr-qtgui/python/qtgui/toggleswitch.py
+++ b/gr-qtgui/python/qtgui/toggleswitch.py
@@ -186,7 +186,7 @@ class GrToggleSwitch(gr.sync_block, LabeledToggleSwitch):
             elif type(self.pressReleasedDict['Pressed']) == float:
                 self.message_port_pub(pmt.intern("state"),
                             pmt.cons(pmt.intern(self.outputmsgname),
-                            pmt.from_float(self.pressReleasedDict['Pressed'])))
+                            pmt.from_double(self.pressReleasedDict['Pressed'])))
             else:
                 self.message_port_pub(pmt.intern("state"),
                             pmt.cons(pmt.intern(self.outputmsgname),
@@ -203,7 +203,7 @@ class GrToggleSwitch(gr.sync_block, LabeledToggleSwitch):
             elif type(self.pressReleasedDict['Released']) == float:
                 self.message_port_pub(pmt.intern("state"),
                             pmt.cons(pmt.intern(self.outputmsgname),
-                            pmt.from_float(self.pressReleasedDict['Released'])))
+                            pmt.from_double(self.pressReleasedDict['Released'])))
             else:
                 self.message_port_pub(pmt.intern("state"),
                             pmt.cons(pmt.intern(self.outputmsgname),


### PR DESCRIPTION
Messages should be constructed using double values instead of float
to avoid loss of precision.

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 9e32ef0ffab29efe4c52f2e574016cd3d6453484)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4567