### PR TITLE
grc: Make exception for epy in blacklist id (backport to maint-3.8)

### DIFF
--- a/grc/core/blocks/embedded_python.py
+++ b/grc/core/blocks/embedded_python.py
@@ -81,6 +81,7 @@ class EPyBlock(Block):
 
     key = 'epy_block'
     label = 'Python Block'
+    exempt_from_id_validation = True  # Exempt epy block from blacklist id validation
     documentation = {'': DOC}
 
     parameters_data = build_params(
@@ -209,6 +210,7 @@ class EPyBlock(Block):
 class EPyModule(Block):
     key = 'epy_module'
     label = 'Python Module'
+    exempt_from_id_validation = True  # Exempt epy module from blacklist id validation
     documentation = {'': dedent("""
         This block lets you embed a python module in your flowgraph.
 

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -53,10 +53,13 @@ class ValidateError(Exception):
 def validate_block_id(param,black_listed_ids):
     value = param.value
     # Can python use this as a variable?
+
     if not re.match(r'^[a-z|A-Z]\w*$', value):
         raise ValidateError('ID "{}" must begin with a letter and may contain letters, numbers, '
                             'and underscores.'.format(value))
-    if value in (black_listed_ids + ID_BLACKLIST):
+    if value in (black_listed_ids + ID_BLACKLIST) and \
+        not getattr(param.parent_block, 'exempt_from_id_validation', False):
+        # Grant blacklist exemption to epy blocks and modules
         raise ValidateError('ID "{}" is blacklisted.'.format(value))
     block_names = [block.name for block in param.parent_flowgraph.iter_enabled_blocks()]
     # Id should only appear once, or zero times if block is disabled


### PR DESCRIPTION
I refer to the mailing list thread on May 8 2021 regarding "Embedded
Python Block Tutorial Param ID Error".

The bug is caused by #4522 as names of embedded python blocks
such as `epy_block_0` are blacklisted because of "blocks" in the
argument `black_listed_ids`. It affects both embedded python blocks and
modules. This commit fixes the bug by granting exemption for these two
types of blocks from id validation.

This commit makes the regex more strictly follow the naming convention
of epy blocks and modules so that only these will be fast-tracked
through the id validation. The naming convention appears to be a "epy"
prefix, followed by "block" or "module", and a number suffix.

This regex also takes into account the user copying-and-pasting the epy
blocks resulting in id names like `epy_block_0_0` and `epy_block_0_0_0`.

Instead of checking for epy blocks or modules using the naming
convention in the id like commit ac383d1 does, this commit checks by
looking at the block's key. All epy blocks and modules are identified
with the key `epy_block` and `epy_module` respectively.

This commit fixes the bug by changing the import name such that it does
not coincide with the generated id for epy blocks and modules. This
means that there no longer needs to be an exception case in the
validation id function for epy blocks and modules.

This commit fixes the bug by giving epy blocks and modules a new
attribute that grants them exemption from blacklist id validation.
Unlike v1, v2 and v3, this does not depend on the naming convention of
the block ids or block keys, which could change in the future, making
the code less of a hassle to maintain.

Improved on v5 (commit b85da80) with the following changes.
1. Changed `exempt_from_id_validation` from an instance variable to a
class variable since all instances of epy blocks and modules are
affected by the bug mentioned in v5.
2. Changed `hasattr` to `getattr` to prevent the bug where a block is
exempted from id validation when `exempt_from_id_validation=False`.

Improved from v6 (commit e66ed85). This grants the exemption to
blocks/modules only after they are marked for blacklist. This change
makes sure that the id exemption is used only to prevent the
blacklisting bug. The blocks/modules will still go through other forms
of id validation such as the naming convention check.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit 4870dcf68941194d16618887effd95fa32f99ba6)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4604