### PR TITLE
pmt: remove extra, mis-named pmt::pmt_ functions

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -594,20 +594,6 @@ PMT_API const std::vector<double> f64vector_elements(pmt_t v);
 PMT_API const std::vector<std::complex<float>> c32vector_elements(pmt_t v);
 PMT_API const std::vector<std::complex<double>> c64vector_elements(pmt_t v);
 
-// len is in elements
-PMT_API const std::vector<uint8_t> pmt_u8vector_elements(pmt_t v);
-PMT_API const std::vector<int8_t> pmt_s8vector_elements(pmt_t v);
-PMT_API const std::vector<uint16_t> pmt_u16vector_elements(pmt_t v);
-PMT_API const std::vector<int16_t> pmt_s16vector_elements(pmt_t v);
-PMT_API const std::vector<uint32_t> pmt_u32vector_elements(pmt_t v);
-PMT_API const std::vector<int32_t> pmt_s32vector_elements(pmt_t v);
-PMT_API const std::vector<uint64_t> pmt_u64vector_elements(pmt_t v);
-PMT_API const std::vector<int64_t> pmt_s64vector_elements(pmt_t v);
-PMT_API const std::vector<float> pmt_f32vector_elements(pmt_t v);
-PMT_API const std::vector<double> pmt_f64vector_elements(pmt_t v);
-PMT_API const std::vector<std::complex<float>> pmt_c32vector_elements(pmt_t v);
-PMT_API const std::vector<std::complex<double>> pmt_c64vector_elements(pmt_t v);
-
 // Return non-const pointers to the elements
 
 PMT_API void*

--- a/gnuradio-runtime/python/pmt/bindings/docstrings/pmt_pydoc_template.h
+++ b/gnuradio-runtime/python/pmt/bindings/docstrings/pmt_pydoc_template.h
@@ -648,42 +648,6 @@ static const char* __doc_pmt_c32vector_elements_1 = R"doc()doc";
 static const char* __doc_pmt_c64vector_elements_1 = R"doc()doc";
 
 
-static const char* __doc_pmt_pmt_u8vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_s8vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_u16vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_s16vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_u32vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_s32vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_u64vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_s64vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_f32vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_f64vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_c32vector_elements = R"doc()doc";
-
-
-static const char* __doc_pmt_pmt_c64vector_elements = R"doc()doc";
-
-
 static const char* __doc_pmt_uniform_vector_writable_elements = R"doc()doc";
 
 

--- a/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_python.cc
@@ -1221,43 +1221,6 @@ void bind_pmt(py::module& m)
           py::arg("v"),
           D(c64vector_elements, 1));
 
-    // The following functions are not implemented in pmt.cc
-    // m.def("pmt_u8vector_elements",&pmt::pmt_u8vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_s8vector_elements",&pmt::pmt_s8vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_u16vector_elements",&pmt::pmt_u16vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_s16vector_elements",&pmt::pmt_s16vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_u32vector_elements",&pmt::pmt_u32vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_s32vector_elements",&pmt::pmt_s32vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_u64vector_elements",&pmt::pmt_u64vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_s64vector_elements",&pmt::pmt_s64vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_f32vector_elements",&pmt::pmt_f32vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_f64vector_elements",&pmt::pmt_f64vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_c32vector_elements",&pmt::pmt_c32vector_elements,
-    //     py::arg("v")
-    // );
-    // m.def("pmt_c64vector_elements",&pmt::pmt_c64vector_elements,
-    //     py::arg("v")
-    // );
     m.def("uniform_vector_writable_elements",
           &::pmt::uniform_vector_writable_elements,
           py::arg("v"),


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>

Fixes https://github.com/gnuradio/gnuradio/issues/4619