### PR TITLE
gr-blocks: Standardize Vector parameter name

### DIFF
--- a/gr-blocks/grc/blocks_abs_xx.block.yml
+++ b/gr-blocks/grc/blocks_abs_xx.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_add_const_vxx.block.yml
+++ b/gr-blocks/grc/blocks_add_const_vxx.block.yml
@@ -17,7 +17,7 @@ parameters:
     dtype: ${ type.const_type if vlen == 1 else type.vconst_type }
     default: '0'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_add_xx.block.yml
+++ b/gr-blocks/grc/blocks_add_xx.block.yml
@@ -16,7 +16,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_argmax_xx.block.yml
+++ b/gr-blocks/grc/blocks_argmax_xx.block.yml
@@ -16,7 +16,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_char_to_float.block.yml
+++ b/gr-blocks/grc/blocks_char_to_float.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_char_to_short.block.yml
+++ b/gr-blocks/grc/blocks_char_to_short.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_arg.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_arg.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_float.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_float.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_imag.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_imag.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_mag.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_mag.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_mag_squared.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_mag_squared.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_magphase.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_magphase.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_complex_to_real.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_real.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_copy.block.yml
+++ b/gr-blocks/grc/blocks_copy.block.yml
@@ -18,7 +18,7 @@ parameters:
     options: ['True', 'False']
     option_labels: [Enabled, Disabled]
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_deinterleave.block.yml
+++ b/gr-blocks/grc/blocks_deinterleave.block.yml
@@ -22,7 +22,7 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_delay.block.yml
+++ b/gr-blocks/grc/blocks_delay.block.yml
@@ -21,7 +21,7 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_divide_XX.block.yml
+++ b/gr-blocks/grc/blocks_divide_XX.block.yml
@@ -11,7 +11,7 @@ parameters:
         fcn: [cc, ff, ii, ss]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_exponentiate_const_cci.block.yml
+++ b/gr-blocks/grc/blocks_exponentiate_const_cci.block.yml
@@ -9,7 +9,7 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_file_descriptor_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_descriptor_sink.block.yml
@@ -15,7 +15,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_file_descriptor_source.block.yml
+++ b/gr-blocks/grc/blocks_file_descriptor_source.block.yml
@@ -21,7 +21,7 @@ parameters:
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_file_meta_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_meta_sink.block.yml
@@ -26,7 +26,7 @@ parameters:
     dtype: real
     default: '1'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_file_meta_source.block.yml
+++ b/gr-blocks/grc/blocks_file_meta_source.block.yml
@@ -30,7 +30,7 @@ parameters:
     label: Header File
     dtype: file_open
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_file_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_sink.block.yml
@@ -15,7 +15,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_file_source.block.yml
+++ b/gr-blocks/grc/blocks_file_source.block.yml
@@ -21,7 +21,7 @@ parameters:
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_float_to_char.block.yml
+++ b/gr-blocks/grc/blocks_float_to_char.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_float_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_float_to_complex.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_float_to_int.block.yml
+++ b/gr-blocks/grc/blocks_float_to_int.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_float_to_short.block.yml
+++ b/gr-blocks/grc/blocks_float_to_short.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_head.block.yml
+++ b/gr-blocks/grc/blocks_head.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: int
     default: '1024'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_int_to_float.block.yml
+++ b/gr-blocks/grc/blocks_int_to_float.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_integrate_xx.block.yml
+++ b/gr-blocks/grc/blocks_integrate_xx.block.yml
@@ -14,7 +14,7 @@ parameters:
     label: Decimation
     dtype: int
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_interleave.block.yml
+++ b/gr-blocks/grc/blocks_interleave.block.yml
@@ -22,7 +22,7 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_keep_one_in_n.block.yml
+++ b/gr-blocks/grc/blocks_keep_one_in_n.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_magphase_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_magphase_to_complex.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_max_xx.block.yml
+++ b/gr-blocks/grc/blocks_max_xx.block.yml
@@ -16,12 +16,12 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Input Vec Length
+    label: Input Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: vlen_out
-    label: Output Vec Length
+    label: Output Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_min_xx.block.yml
+++ b/gr-blocks/grc/blocks_min_xx.block.yml
@@ -16,12 +16,12 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Input Vec Length
+    label: Input Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: vlen_out
-    label: Output Vec Length
+    label: Output Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_multiply_by_tag_value_cc.block.yml
+++ b/gr-blocks/grc/blocks_multiply_by_tag_value_cc.block.yml
@@ -7,7 +7,7 @@ parameters:
     label: Tag Name
     dtype: string
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
 

--- a/gr-blocks/grc/blocks_multiply_conjugate_cc.block.yml
+++ b/gr-blocks/grc/blocks_multiply_conjugate_cc.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_multiply_const_vxx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_const_vxx.block.yml
@@ -17,7 +17,7 @@ parameters:
     dtype: ${ type.const_type if vlen == 1 else type.vconst_type }
     default: '1'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_multiply_const_xx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_const_xx.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: ${ type.const_type }
     default: '0'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_multiply_xx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_xx.block.yml
@@ -16,7 +16,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_nlog10_ff.block.yml
+++ b/gr-blocks/grc/blocks_nlog10_ff.block.yml
@@ -13,7 +13,7 @@ parameters:
     dtype: real
     default: '0'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_nop.block.yml
+++ b/gr-blocks/grc/blocks_nop.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_null_sink.block.yml
+++ b/gr-blocks/grc/blocks_null_sink.block.yml
@@ -12,7 +12,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_null_source.block.yml
+++ b/gr-blocks/grc/blocks_null_source.block.yml
@@ -12,7 +12,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_patterned_interleaver.block.yml
+++ b/gr-blocks/grc/blocks_patterned_interleaver.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '[0,0,1,2]'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_probe_rate.block.yml
+++ b/gr-blocks/grc/blocks_probe_rate.block.yml
@@ -12,7 +12,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_probe_signal_vx.block.yml
+++ b/gr-blocks/grc/blocks_probe_signal_vx.block.yml
@@ -11,7 +11,7 @@ parameters:
         fcn: [c, f, i, s, b]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_repeat.block.yml
+++ b/gr-blocks/grc/blocks_repeat.block.yml
@@ -15,7 +15,7 @@ parameters:
     label: Interpolation
     dtype: int
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_selector.block.yml
+++ b/gr-blocks/grc/blocks_selector.block.yml
@@ -34,7 +34,7 @@ parameters:
     dtype: int
     default: 0
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_short_to_char.block.yml
+++ b/gr-blocks/grc/blocks_short_to_char.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_short_to_float.block.yml
+++ b/gr-blocks/grc/blocks_short_to_float.block.yml
@@ -4,7 +4,7 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_skiphead.block.yml
+++ b/gr-blocks/grc/blocks_skiphead.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: int
     default: '1024'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_stream_demux.block.yml
+++ b/gr-blocks/grc/blocks_stream_demux.block.yml
@@ -21,7 +21,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_stream_mux.block.yml
+++ b/gr-blocks/grc/blocks_stream_mux.block.yml
@@ -21,7 +21,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_stream_to_streams.block.yml
+++ b/gr-blocks/grc/blocks_stream_to_streams.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_stream_to_vector.block.yml
+++ b/gr-blocks/grc/blocks_stream_to_vector.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '2'
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_stream_to_vector_decimator.block.yml
+++ b/gr-blocks/grc/blocks_stream_to_vector_decimator.block.yml
@@ -16,11 +16,11 @@ parameters:
     dtype: real
     default: samp_rate
 -   id: vec_rate
-    label: Vec Rate
+    label: Vector Rate
     dtype: real
     default: '30'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1024'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_streams_to_stream.block.yml
+++ b/gr-blocks/grc/blocks_streams_to_stream.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_streams_to_vector.block.yml
+++ b/gr-blocks/grc/blocks_streams_to_vector.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_sub_xx.block.yml
+++ b/gr-blocks/grc/blocks_sub_xx.block.yml
@@ -11,7 +11,7 @@ parameters:
         fcn: [cc, ff, ii, ss]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_tag_debug.block.yml
+++ b/gr-blocks/grc/blocks_tag_debug.block.yml
@@ -24,7 +24,7 @@ parameters:
     default: '1'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_tag_gate.block.yml
+++ b/gr-blocks/grc/blocks_tag_gate.block.yml
@@ -12,7 +12,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_tag_share.block.yml
+++ b/gr-blocks/grc/blocks_tag_share.block.yml
@@ -20,7 +20,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: part

--- a/gr-blocks/grc/blocks_tagged_file_sink.block.yml
+++ b/gr-blocks/grc/blocks_tagged_file_sink.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: int
     default: samp_rate
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_tags_strobe.block.yml
+++ b/gr-blocks/grc/blocks_tags_strobe.block.yml
@@ -24,7 +24,7 @@ parameters:
     dtype: int
     default: '1000'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_throttle.block.yml
+++ b/gr-blocks/grc/blocks_throttle.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: real
     default: samp_rate
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_vector_sink_x.block.yml
+++ b/gr-blocks/grc/blocks_vector_sink_x.block.yml
@@ -11,7 +11,7 @@ parameters:
         fcn: [c, f, i, s, b]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_vector_source_x.block.yml
+++ b/gr-blocks/grc/blocks_vector_source_x.block.yml
@@ -26,7 +26,7 @@ parameters:
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_vector_to_stream.block.yml
+++ b/gr-blocks/grc/blocks_vector_to_stream.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '2'
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-blocks/grc/blocks_vector_to_streams.block.yml
+++ b/gr-blocks/grc/blocks_vector_to_streams.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '2'
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-filter/grc/filter_single_pole_iir_filter_xx.block.yml
+++ b/gr-filter/grc/filter_single_pole_iir_filter_xx.block.yml
@@ -15,7 +15,7 @@ parameters:
     dtype: real
     default: '1.0'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-network/grc/network_tcp_sink.block.yml
+++ b/gr-network/grc/network_tcp_sink.block.yml
@@ -28,7 +28,7 @@ parameters:
     dtype: int
     default: '2000'
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-network/grc/network_tcp_source.block.yml
+++ b/gr-network/grc/network_tcp_source.block.yml
@@ -26,7 +26,7 @@ parameters:
     options: ['True', 'False']
     option_labels: [Server, Client]
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-network/grc/network_udp_sink.block.yml
+++ b/gr-network/grc/network_udp_sink.block.yml
@@ -35,7 +35,7 @@ parameters:
     options: ['False', 'True']
     option_labels: ['No', 'Yes']
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-network/grc/network_udp_source.block.yml
+++ b/gr-network/grc/network_udp_source.block.yml
@@ -41,7 +41,7 @@ parameters:
     options: ['False', 'True']
     option_labels: ['No', 'Yes']
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-trellis/grc/trellis_permutation.block.yml
+++ b/gr-trellis/grc/trellis_permutation.block.yml
@@ -21,7 +21,7 @@ parameters:
     label: Symbols per Block
     dtype: int
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-zeromq/grc/zeromq_pub_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_sink.block.yml
@@ -13,7 +13,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-zeromq/grc/zeromq_pull_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_source.block.yml
@@ -13,7 +13,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-zeromq/grc/zeromq_push_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_push_sink.block.yml
@@ -13,7 +13,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-zeromq/grc/zeromq_rep_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_rep_sink.block.yml
@@ -14,7 +14,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-zeromq/grc/zeromq_req_source.block.yml
+++ b/gr-zeromq/grc/zeromq_req_source.block.yml
@@ -13,7 +13,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/gr-zeromq/grc/zeromq_sub_source.block.yml
+++ b/gr-zeromq/grc/zeromq_sub_source.block.yml
@@ -13,7 +13,7 @@ parameters:
             gr.sizeof_char]
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/grc/blocks/pad_sink.block.yml
+++ b/grc/blocks/pad_sink.block.yml
@@ -19,7 +19,7 @@ parameters:
             sizeof(char), sizeof(char), '0', '0']
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/grc/blocks/pad_source.block.yml
+++ b/grc/blocks/pad_source.block.yml
@@ -19,7 +19,7 @@ parameters:
             sizeof(char), sizeof(char), '0', '0']
     hide: part
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }

--- a/grc/tests/resources/file1.block.yml
+++ b/grc/tests/resources/file1.block.yml
@@ -3,13 +3,13 @@ label: testname
 
 parameters:
 -   id: vlen
-    label: Vec Length
+    label: Vector Length
     category: test
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: out_type
-    label: Vec Length
+    label: Vector Length
     dtype: string
     default: complex
     hide: part


### PR DESCRIPTION
Addresses point 1 of Issue #4615. Replaces all label instances of "Vec
Length" to "Vector Length". Also replaces "Vec Rate" to "Vector Rate"
for standardization.

There is no occurrence of "vec size", verified with the command:
`find . -name "*.yml" -exec grep -Hin "vec size" {} ';'` .

All instances of "vec length" were found and replaced with the 
commands:
```
find . -name "*.yml" -exec grep -Hin "vec length" {} ';'
find . -name "*.yml" -exec sed -i 's/Vec Length/Vector Length/g' {} ';'
```

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>