### PR TITLE
grc: fixing build order for blocks with gui hints

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -198,10 +198,10 @@ class TopBlockGenerator(object):
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
 
         # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
+        # The block must have a GUI HINT, but the hint may be empty
         def without_gui_hint(block):
-            hint = block.params.get('gui_hint')
-            return hint is None or not hint.get_value()
-
+            return block.params.get('gui_hint') is None
+ 
         blocks.sort(key=without_gui_hint)
 
         blocks_make = []


### PR DESCRIPTION
In some cases the build order of blocks with gui hints is wrong,
which leads to errors.

See #4631.
This pr fixes #4631

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>