### PR TITLE
soapy: use "bandwidth" and "antenna" instead of "bw" and "ant" msgs

### DIFF
--- a/gr-soapy/lib/block_impl.cc
+++ b/gr-soapy/lib/block_impl.cc
@@ -110,9 +110,9 @@ static void check_abi(void)
 const pmt::pmt_t CMD_CHAN_KEY = pmt::mp("chan");
 const pmt::pmt_t CMD_FREQ_KEY = pmt::mp("freq");
 const pmt::pmt_t CMD_GAIN_KEY = pmt::mp("gain");
-const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("ant");
+const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("antenna");
 const pmt::pmt_t CMD_RATE_KEY = pmt::mp("rate");
-const pmt::pmt_t CMD_BW_KEY = pmt::mp("bw");
+const pmt::pmt_t CMD_BW_KEY = pmt::mp("bandwidth");
 
 /*
  * The private constructor


### PR DESCRIPTION
Tried to save a few characters, but matching uhd is a better goal.

Signed-off-by: Jeff Long <willcode4@gmail.com>