### PR TITLE
grc: Fix vector length bug (backport to maint-3.8)

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -224,6 +224,7 @@ class Block(Element):
         for port in ports:
             if hasattr(port, 'master_port'):  # Not a master port and no left-over clones
                 port.dtype = port.master_port.dtype
+                port.vlen = port.master_port.vlen
                 continue
             nports = port.multiplicity
             for clone in port.clones[nports-1:]:

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -561,7 +561,7 @@ class Application(Gtk.Application):
                     response = self.dialog.run()
                     if response in (Gtk.ResponseType.APPLY, Gtk.ResponseType.ACCEPT):
                         page.state_cache.save_new_state(flow_graph.export_data())
-                        ### Following  lines force an complete update of io ports
+                        ### Following lines force an complete update of io ports
                         n = page.state_cache.get_current_state()
                         flow_graph.import_data(n)
                         flow_graph_update()


### PR DESCRIPTION
Make all ports follow the `vlen` of their master port the same way it is
for `dtype`. Fixes #4634.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit 6f5803963c56d454564ba2ee2e5f2607689b3c43)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4637