### PR TITLE
soapy: custom source/sink freq defaults must be quoted (backport to maint-3.9)

### DIFF
--- a/gr-soapy/grc/soapy_custom_sink.block.yml
+++ b/gr-soapy/grc/soapy_custom_sink.block.yml
@@ -71,7 +71,7 @@ parameters:
     label: 'Ch0: Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction0
     label: 'Ch0: Frequency Correction'
@@ -134,7 +134,7 @@ parameters:
     label: 'Ch1: Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
     hide: ${ 'none' if nchan > 1 else 'all' }
 
   - id: freq_correction1

--- a/gr-soapy/grc/soapy_custom_source.block.yml
+++ b/gr-soapy/grc/soapy_custom_source.block.yml
@@ -71,7 +71,7 @@ parameters:
     label: 'Ch0: Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction0
     label: 'Ch0: Frequency Correction'
@@ -148,7 +148,7 @@ parameters:
     label: 'Ch1: Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
     hide: ${ 'none' if nchan > 1 else 'all' }
 
   - id: freq_correction1


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit e881a24e8c191f782dab902fb453ed4c10a53a2d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4662