### PR TITLE
soapy: yaml - use always-valid defaults for second channel (backport to maint-3.9)

### DIFF
--- a/gr-soapy/grc/soapy_airspyhf_source.block.yml
+++ b/gr-soapy/grc/soapy_airspyhf_source.block.yml
@@ -20,13 +20,13 @@ parameters:
   - id: samp_rate
     label: Sample Rate
     dtype: float
-    default: samp_rate
+    default: 'samp_rate'
 
   - id: center_freq
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'

--- a/gr-soapy/grc/soapy_bladerf_sink.block.yml
+++ b/gr-soapy/grc/soapy_bladerf_sink.block.yml
@@ -33,7 +33,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'

--- a/gr-soapy/grc/soapy_bladerf_source.block.yml
+++ b/gr-soapy/grc/soapy_bladerf_source.block.yml
@@ -33,7 +33,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'

--- a/gr-soapy/grc/soapy_custom_sink.block.yml
+++ b/gr-soapy/grc/soapy_custom_sink.block.yml
@@ -127,14 +127,14 @@ parameters:
     label: 'Ch1: Antenna'
     category: RF Options
     dtype: string
-    default: 'TX'
+    default: ''
     hide: ${ 'part' if nchan > 1 else 'all' }
 
   - id: center_freq1
     label: 'Ch1: Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: 'freq'
+    default: '0'
     hide: ${ 'none' if nchan > 1 else 'all' }
 
   - id: freq_correction1
@@ -148,7 +148,7 @@ parameters:
     label: 'Ch1: Overall Gain Value'
     category: RF Options
     dtype: real
-    default: '10'
+    default: '0'
     hide: ${ 'part' if nchan > 1 else 'all' }
 
   - id: dc_offset1

--- a/gr-soapy/grc/soapy_custom_source.block.yml
+++ b/gr-soapy/grc/soapy_custom_source.block.yml
@@ -141,14 +141,14 @@ parameters:
     label: 'Ch1: Antenna'
     category: RF Options
     dtype: string
-    default: 'RX'
+    default: ''
     hide: ${ 'part' if nchan > 1 else 'all' }
 
   - id: center_freq1
     label: 'Ch1: Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: 'freq'
+    default: '0'
     hide: ${ 'none' if nchan > 1 else 'all' }
 
   - id: freq_correction1
@@ -169,7 +169,7 @@ parameters:
     label: 'Ch1: Overall Gain Value'
     category: RF Options
     dtype: real
-    default: '10'
+    default: '0'
     hide: ${ 'part' if nchan > 1 and not agc1 else 'all' }
 
   - id: dc_removal1

--- a/gr-soapy/grc/soapy_hackrf_sink.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_sink.block.yml
@@ -26,14 +26,14 @@ parameters:
     label: Bandwidth (0=auto)
     category: RF Options
     dtype: float
-    default: 0
+    default: '0'
     hide: part
 
   - id: center_freq
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: amp
     label: 'Amp On (+14 dB)'

--- a/gr-soapy/grc/soapy_hackrf_source.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_source.block.yml
@@ -26,14 +26,14 @@ parameters:
     label: Bandwidth (0=auto)
     category: RF Options
     dtype: float
-    default: 0
+    default: '0'
     hide: part
 
   - id: center_freq
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: amp
     label: 'Amp On (+14 dB)'

--- a/gr-soapy/grc/soapy_limesdr_sink.block.yml
+++ b/gr-soapy/grc/soapy_limesdr_sink.block.yml
@@ -20,7 +20,7 @@ parameters:
   - id: samp_rate
     label: Sample Rate
     dtype: float
-    default: samp_rate
+    default: 'samp_rate'
 
   - id: bandwidth
     label: Bandwidth
@@ -33,7 +33,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'

--- a/gr-soapy/grc/soapy_limesdr_source.block.yml
+++ b/gr-soapy/grc/soapy_limesdr_source.block.yml
@@ -33,7 +33,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'

--- a/gr-soapy/grc/soapy_plutosdr_sink.block.yml
+++ b/gr-soapy/grc/soapy_plutosdr_sink.block.yml
@@ -33,7 +33,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: gain
     label: 'RF Gain (0dB - 89dB)'

--- a/gr-soapy/grc/soapy_plutosdr_source.block.yml
+++ b/gr-soapy/grc/soapy_plutosdr_source.block.yml
@@ -33,7 +33,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: agc
     label: 'AGC'

--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -26,7 +26,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'

--- a/gr-soapy/grc/soapy_sdrplay_source.block.yml
+++ b/gr-soapy/grc/soapy_sdrplay_source.block.yml
@@ -20,7 +20,7 @@ parameters:
   - id: samp_rate
     label: Sample Rate
     dtype: float
-    default: samp_rate
+    default: 'samp_rate'
 
   - id: bandwidth
     label: Bandwidth
@@ -39,7 +39,7 @@ parameters:
     label: 'Center Freq (Hz)'
     category: RF Options
     dtype: real
-    default: freq
+    default: 'freq'
 
   - id: freq_correction
     label: 'Frequency Correction (PPM)'


### PR DESCRIPTION
Also made defaults quoted to be consistent, but this turned out not
to be the problem.

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 44152d6c3fb19ab56ef6f839f63fbfb26650b46a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4664