### PR TITLE
Output a message when a missing block is created.

### DIFF
--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -159,6 +159,9 @@ class FlowGraph(CoreFlowgraph, Drawable):
         )
         # get the new block
         block = self.new_block(key)
+        if block is None:
+            Messages.send('>>> No block found with key "' + key + '".\n')
+            return None
         block.coordinate = coor
         block.params['id'].set_value(id)
         Actions.ELEMENT_CREATE()


### PR DESCRIPTION
This PR is onto the maint-3.9 branch, since I have that cloned locally.  Not certain what's normal here.

Since the `new_block` function absorbs errors, missing blocks cause errors that hide the underlying issue and what the wrong key is.  I ran into this when I had failed to rename a block everywhere.

I'm a little worried that this message I added can't be caught by code like an exception would be, but I saw another message was output to handle an issue elsewhere in the file, so copied the pattern.