### PR TITLE
Propagate to the user, errors making new grc blocks.

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -308,11 +308,8 @@ class FlowGraph(Element):
         """
         if block_id == 'options':
             return self.options_block
-        try:
-            block = self.parent_platform.make_block(self, block_id, **kwargs)
-            self.blocks.append(block)
-        except KeyError:
-            block = None
+        block = self.parent_platform.make_block(self, block_id, **kwargs)
+        self.blocks.append(block)
         return block
 
     def connect(self, porta, portb):


### PR DESCRIPTION
Otherwise, when the None return value is used later, the user sees a misleading error.

The misleading error is thrown here: https://github.com/gnuradio/gnuradio/blob/master/grc/gui/canvas/flowgraph.py#L162

This the same issue as #4672 .

The problem was that I had duplicate option ids specified for an enum parameter.  I wanted to handle signed and unsigned int64s differently, but was using gnuradio's types as id names, and gnuradio doesn't differentiate between them. 