### PR TITLE
Fix qt gui vector margin for non-frequency data

### DIFF
--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -369,9 +369,10 @@ void VectorDisplayPlot::clearMinData()
 
 void VectorDisplayPlot::_autoScale(double bottom, double top)
 {
-    // Auto scale the y-axis with a margin of 10 dB on either side.
-    d_ymin = bottom - 10;
-    d_ymax = top + 10;
+    // Auto scale the y-axis with a margin of 1% on either side
+    double margin = (top - bottom) / 100;
+    d_ymin = bottom - margin;
+    d_ymax = top + margin;
     setYaxis(d_ymin, d_ymax);
 }
 


### PR DESCRIPTION
This is why I was running into #4675 .  My data was on the range 0.0-0.01 and was invisible with a total hardcoded margin of 20.

It looks like the margin of 10 on either side might have been unreviewed code copied from the gui frequency sink.  This change updates the margin to be 1% of the range of the data.