### PR TITLE
gr-qtgui: fix invalid pointer

### DIFF
--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -146,7 +146,6 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
 
 edit_box_msg_impl::~edit_box_msg_impl()
 {
-    delete d_argv;
     delete d_group;
     delete d_hlayout;
     delete d_vlayout;

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -67,13 +67,7 @@ number_sink_impl::number_sink_impl(
     initialize();
 }
 
-number_sink_impl::~number_sink_impl()
-{
-    // if(!d_main_gui->isClosed())
-    //  d_main_gui->close();
-
-    delete d_argv;
-}
+number_sink_impl::~number_sink_impl() {}
 
 bool number_sink_impl::check_topology(int ninputs, int noutputs)
 {


### PR DESCRIPTION
Closing an flowgraph that contains an qt edit_box_msg or  a number_sink fails with a core dump
free() invaldi pointer.

This pr fixes these issues and fixes #4679 

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>