### PR TITLE
grc: Be more informative when missing "options" block. (backport to maint-3.9)

### DIFF
--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -180,7 +180,20 @@ class Platform(Element):
 
         self._docstring_extractor.finish()
         # self._docstring_extractor.wait()
-        utils.hide_bokeh_gui_options_if_not_installed(self.blocks['options'])
+        if 'options' not in self.blocks:
+            # we didn't find one of the built-in blocks ("options")
+            # which probably means the GRC blocks path is bad
+            errstr = (
+                "Failed to find built-in GRC blocks (specifically, the "
+                "'options' block). Ensure your GRC block paths are correct "
+                "and at least one points to your prefix installation:"
+            )
+            errstr = "\n".join([errstr] + (path or self.config.block_paths))
+            raise RuntimeError(errstr)
+        else:
+            # might have some cleanup to do on the options block in particular
+            utils.hide_bokeh_gui_options_if_not_installed(self.blocks['options'])
+
 
     def _iter_files_in_block_path(self, path=None, ext='yml'):
         """Iterator for block descriptions and category trees"""


### PR DESCRIPTION
This raises an RuntimeError describing that GRC could not find the
built-in blocks rather than raising a KeyError on "options", which
left users with little to go on. This error has come up in various
situations involving an incorrect blocks path (due to mixing GR
versions causing the configuration files to point to the wrong
installation) or simply the blocks not being installed.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit 6a8fc29d0a6244a1c4624500e853fb23d17ceb86)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4683