### PR TITLE
gr-qtgui: fix invalid pointer (backport to maint-3.8)

### DIFF
--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -163,7 +163,6 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
 
 edit_box_msg_impl::~edit_box_msg_impl()
 {
-    delete d_argv;
     delete d_group;
     delete d_hlayout;
     delete d_vlayout;

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -89,13 +89,7 @@ number_sink_impl::number_sink_impl(
     initialize();
 }
 
-number_sink_impl::~number_sink_impl()
-{
-    // if(!d_main_gui->isClosed())
-    //  d_main_gui->close();
-
-    delete d_argv;
-}
+number_sink_impl::~number_sink_impl() {}
 
 bool number_sink_impl::check_topology(int ninputs, int noutputs)
 {


### PR DESCRIPTION
Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit ac9eb756cc1d9dd414dbd166a99f1488f14385f2)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4685