### PR TITLE
grc: fix Wrong order in the generated .py caused by uncorrect function (backport to maint-3.9)

### DIFF
--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -196,14 +196,6 @@ class TopBlockGenerator(object):
         ]
 
         blocks = expr_utils.sort_objects(blocks, operator.attrgetter('name'), _get_block_sort_text)
-
-        # Ordering blocks : blocks with GUI Hint must be processed first to avoid PyQT5 superposing blocks
-        def without_gui_hint(block):
-            hint = block.params.get('gui_hint')
-            return hint is None or not hint.get_value()
-
-        blocks.sort(key=without_gui_hint)
-
         blocks_make = []
         for block in blocks:
             make = block.templates.render('make')


### PR DESCRIPTION
…n without_gui_hint(block)

Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>

grc: fix Wrong order in the generated .py caused by uncorrect function without_gui_hint(block)

Signed-off-by: Christophe Seguinot <christophe.seguinot@univ-lille.fr>
(cherry picked from commit d3dc106719fa01f6432b3bafc839dc455f61d695)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4609