### PR TITLE
grc: handle variables of type raw correctly (backport to maint-3.8)

### DIFF
--- a/grc/core/base.py
+++ b/grc/core/base.py
@@ -34,8 +34,6 @@ class Element(object):
         Validate this element and call validate on all children.
         Call this base method before adding error messages in the subclass.
         """
-        del self._error_messages[:]
-
         for child in self.children():
             child.validate()
 
@@ -88,6 +86,7 @@ class Element(object):
         Rewrite this element and call rewrite on all children.
         Call this base method before rewriting the element.
         """
+        del self._error_messages[:]
         for child in self.children():
             child.rewrite()
 

--- a/grc/core/ports/port.py
+++ b/grc/core/ports/port.py
@@ -104,6 +104,7 @@ class Port(Element):
         return not self.dtype
 
     def validate(self):
+        del self._error_messages[:]
         Element.validate(self)
         platform = self.parent_platform
 

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -192,18 +192,7 @@ class VariableEditor(Gtk.VBox):
             else:
                 # Evaluate and show the value (if it is a variable)
                 if block.is_variable:
-                    # Evaluate the params
-                    for key in block.params :
-                        evaluated = str(block.params[key].evaluate())
-                        self.set_tooltip_text(evaluated)
-
-                    # Evaluate the block value
-                    try:
-                        evaluated = str( eval(block.value,block.parent.namespace,block.namespace))
-                        self.set_tooltip_text(evaluated)
-                    except Exception as error:
-                        self.set_tooltip_text(str(error))
-                        pass
+                    value = str(block.evaluate(block.value))
 
         # Always set the text value.
         sp('text', value)


### PR DESCRIPTION
At the moment grc does not validate variables, as they are of type raw.
So they are always treated as valid, which leads to some problems, see: #4519.

A approach to fix #4519 is #4531.
This approach improves the situation, but has still some problems.

param.py provides a validator function for dtype raw, but this is not used, as dtypes.py provides no validator function for dtype raw.

This fix clears the error messages in base.rewrite not in base.elements.validate, so the error messages are kept.

In addition this makes it possible, to make the code in VariableEditor.py smoother.

The error messages are kept on switching the different tabs in VariableEditor.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit e562d6b3c82a30f12b4e8e2585447dddeb88e93d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4629