### PR TITLE
modtool: Fix #2672 for `rm`, `disable`, `rename` and `makeyml`

### DIFF
--- a/gr-utils/modtool/core/disable.py
+++ b/gr-utils/modtool/core/disable.py
@@ -67,7 +67,7 @@ class ModToolDisable(ModTool):
                 ed.write()
                 self.scm.mark_file_updated(self._file['qalib'])
             elif self.info['version'] == '38':
-                fname_qa_cc = f'qa_{self._info["blockname"]}.cc'
+                fname_qa_cc = f'qa_{self.info["blockname"]}.cc'
                 cmake.comment_out_lines(fname_qa_cc)
             elif self.info['version'] == '36':
                 cmake.comment_out_lines('add_executable.*'+fname)
@@ -97,7 +97,24 @@ class ModToolDisable(ModTool):
             except IOError:
                 continue
             logger.info(f"Traversing {subdir}...")
-            filenames = cmake.find_filenames_match(self.info['pattern'])
+            filenames = []
+            if self.info['blockname']:
+                if subdir == 'python':
+                    blockname_pattern = f"^(qa_)?{self.info['blockname']}.py$"
+                elif subdir == 'python/bindings':
+                    blockname_pattern = f"^{self.info['blockname']}_python.cc$"
+                elif subdir == 'python/bindings/docstrings':
+                    blockname_pattern = f"^{self.info['blockname']}_pydoc_template.h$"
+                elif subdir == 'lib':
+                    blockname_pattern = f"^{self.info['blockname']}_impl(\\.h|\\.cc)$"
+                elif subdir == self.info['includedir']:
+                    blockname_pattern = f"^{self.info['blockname']}.h$"
+                elif subdir == 'grc':
+                    blockname_pattern = f"^{self.info['modname']}_{self.info['blockname']}.block.yml$"
+                if blockname_pattern:
+                    filenames = cmake.find_filenames_match(blockname_pattern)
+            elif self.info['pattern']:
+                filenames = cmake.find_filenames_match(self.info['pattern'])
             yes = self.info['yes']
             for fname in filenames:
                 file_disabled = False

--- a/gr-utils/modtool/core/makeyaml.py
+++ b/gr-utils/modtool/core/makeyaml.py
@@ -93,9 +93,29 @@ class ModToolMakeYAML(ModTool):
         files = sorted(glob.glob(f"{path}/{path_glob}"))
         files_filt = []
         logger.info(f"Searching for matching files in {path}/:")
-        for f in files:
-            if re.search(self.info['pattern'], os.path.basename(f)) is not None:
-                files_filt.append(f)
+        if self.info['blockname']:
+            # ensure the blockname given is not confused with similarly named blocks
+            blockname_pattern = ''
+            if path == 'python':
+                blockname_pattern = f"^(qa_)?{self.info['blockname']}.py$"
+            elif path == 'python/bindings':
+                blockname_pattern = f"^{self.info['blockname']}_python.cc$"
+            elif path == 'python/bindings/docstrings':
+                blockname_pattern = f"^{self.info['blockname']}_pydoc_template.h$"
+            elif path == 'lib':
+                blockname_pattern = f"^{self.info['blockname']}_impl(\\.h|\\.cc)$"
+            elif path == self.info['includedir']:
+                blockname_pattern = f"^{self.info['blockname']}.h$"
+            elif path == 'grc':
+                blockname_pattern = f"^{self.info['modname']}_{self.info['blockname']}.block.yml$"
+            for f in files:
+                if re.search(blockname_pattern, os.path.basename(f)) is not None:
+                    files_filt.append(f)
+        elif self.info['pattern']:
+            # search for block names matching a given regex pattern
+            for f in files:
+                if re.search(self.info['pattern'], os.path.basename(f)) is not None:
+                    files_filt.append(f)
         if len(files_filt) == 0:
             logger.info("None found.")
         return files_filt

--- a/gr-utils/modtool/core/rm.py
+++ b/gr-utils/modtool/core/rm.py
@@ -131,9 +131,29 @@ class ModToolRemove(ModTool):
             files = files + sorted(glob.glob(f"{path}/{g}"))
         files_filt = []
         logger.info(f"Searching for matching files in {path}/:")
-        for f in files:
-            if re.search(self.info['pattern'], os.path.basename(f)) is not None:
-                files_filt.append(f)
+        if self.info['blockname']:
+            # Ensure the blockname given is not confused with similarly named blocks
+            blockname_pattern = ''
+            if path == 'python':
+                blockname_pattern = f"^(qa_)?{self.info['blockname']}.py$"
+            elif path == 'python/bindings':
+                blockname_pattern = f"^{self.info['blockname']}_python.cc$"
+            elif path == 'python/bindings/docstrings':
+                blockname_pattern = f"^{self.info['blockname']}_pydoc_template.h$"
+            elif path == 'lib':
+                blockname_pattern = f"^{self.info['blockname']}_impl(\\.h|\\.cc)$"
+            elif path == self.info['includedir']:
+                blockname_pattern = f"^{self.info['blockname']}.h$"
+            elif path == 'grc':
+                blockname_pattern = f"^{self.info['modname']}_{self.info['blockname']}.block.yml$"
+            for f in files:
+                if re.search(blockname_pattern, os.path.basename(f)) is not None:
+                    files_filt.append(f)
+        elif self.info['pattern']:
+            # A regex resembling one or several blocks were given as stdin
+            for f in files:
+                if re.search(self.info['pattern'], os.path.basename(f)) is not None:
+                    files_filt.append(f)
         if len(files_filt) == 0:
             logger.info("None found.")
             return []


### PR DESCRIPTION
Fixes #2672 

When a block name is entered as an argument to a modtool command, (e.g. `gr_modtool rm my_block`), the user expects _only_ that specific block (ie `my_block`) to be acted upon. Issue #2672 is caused when similarly named block names are also acted upon (e.g. `my_block_1` or `temp_my_block`). This issue affects the four commands stated in the title. PR fixes said issue.

Edit:
PR also fixes two other seemingly unreported issues:
1. A minor AttributeError affecting the `disable` command OOT version 38 due to what I believe is a spelling error: `self._info` should be `self.info`. 
2. Failure of the `rename` command to rename the binding function in `python_bindings.cc`. 