### PR TITLE
gr-iio: Add packetized transfer support using stream tags

### DIFF
--- a/gr-iio/grc/iio_device_sink.block.yml
+++ b/gr-iio/grc/iio_device_sink.block.yml
@@ -43,6 +43,11 @@ parameters:
     dtype: raw
     default: []
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    hide: ${( 'part' )}
+
 inputs:
 -   domain: stream
     dtype: short
@@ -52,7 +57,9 @@ asserts:
 - ${ len(channels) > 0 }
 
 templates:
-    imports: from gnuradio import iio
-    make: iio.device_sink(${uri}, ${device}, ${channels}, ${device_phy}, ${params}, ${buffer_size}, ${interpolation} - 1, ${cyclic})
+  imports: from gnuradio import iio
+  make: |
+    iio.device_sink(${uri}, ${device}, ${channels}, ${device_phy}, ${params}, ${buffer_size}, ${interpolation} - 1, ${cyclic})
+    self.${id}.set_len_tag_key(${len_tag_key})
 
 file_format: 1

--- a/gr-iio/grc/iio_device_source.block.yml
+++ b/gr-iio/grc/iio_device_source.block.yml
@@ -36,6 +36,12 @@ parameters:
     dtype: raw
     default: []
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    default: packet_len
+    hide: part
+
 outputs:
 -   domain: stream
     dtype: short
@@ -45,7 +51,9 @@ outputs:
     optional: true
 
 templates:
-    imports: from gnuradio import iio
-    make: iio.device_source(${uri}, ${device}, ${channels}, ${device_phy}, ${params}, ${buffer_size}, ${decimation} - 1)
+  imports: from gnuradio import iio
+  make: |
+    iio.device_source(${uri}, ${device}, ${channels}, ${device_phy}, ${params}, ${buffer_size}, ${decimation} - 1)
+    self.${id}.set_len_tag_key(${len_tag_key})
 
 file_format: 1

--- a/gr-iio/grc/iio_pluto_sink.block.yml
+++ b/gr-iio/grc/iio_pluto_sink.block.yml
@@ -35,6 +35,11 @@ parameters:
     dtype: float
     default: 10.0
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    hide: ${( 'part' )}
+
 -   id: filter_source
     category: Filter
     label: Filter Configuration
@@ -81,14 +86,15 @@ asserts:
 - ${ ((samplerate<=61440000) and (samplerate>=65105)) }
 - ${ ((bandwidth<=40000000) and (bandwidth>=200000)) }
 - ${ ((frequency<=6000000000) and (frequency>=47000000)) }
-- ${ ((filter_source!="'Design'")  or (fpass<=samplerate)) }
-- ${ ((filter_source!="'Design'")  or (fstop<=samplerate)) }
-- ${ ((filter_source!="'Design'")  or (fstop>fpass)) }
+- ${ ((filter_source!="'Design'") or (fpass<=samplerate)) }
+- ${ ((filter_source!="'Design'") or (fstop<=samplerate)) }
+- ${ ((filter_source!="'Design'") or (fstop>fpass)) }
 
 templates:
     imports: from gnuradio import iio
-    make: | 
+    make: |
         iio.pluto_sink(${uri}, ${buffer_size}, ${cyclic})
+        self.${id}.set_len_tag_key(${len_tag_key})
         self.${id}.set_bandwidth(${bandwidth})
         self.${id}.set_frequency(${frequency})
         self.${id}.set_samplerate(${samplerate})

--- a/gr-iio/grc/iio_pluto_source.block.yml
+++ b/gr-iio/grc/iio_pluto_source.block.yml
@@ -57,6 +57,12 @@ parameters:
     default: 64
     hide: ${ ('none' if gain1 == "'manual'" else 'all') }
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    default: packet_len
+    hide: part
+
 -   id: filter_source
     category: Filter
     label: Filter Configuration
@@ -103,14 +109,15 @@ asserts:
 - ${ ((samplerate<=61440000) and (samplerate>=65105)) }
 - ${ ((bandwidth<=52000000) and (bandwidth>=200000)) }
 - ${ ((frequency<=6000000000) and (frequency>=70000000)) }
-- ${ ((filter_source!="'Design'")  or (fpass<=samplerate)) }
-- ${ ((filter_source!="'Design'")  or (fstop<=samplerate)) }
-- ${ ((filter_source!="'Design'")  or (fstop>fpass)) }
+- ${ ((filter_source!="'Design'") or (fpass<=samplerate)) }
+- ${ ((filter_source!="'Design'") or (fstop<=samplerate)) }
+- ${ ((filter_source!="'Design'") or (fstop>fpass)) }
 
 templates:
     imports: from gnuradio import iio
-    make: | 
+    make: |
         iio.pluto_source(${uri}, ${buffer_size})
+        self.${id}.set_len_tag_key(${len_tag_key})
         self.${id}.set_frequency(${frequency})
         self.${id}.set_samplerate(${samplerate})
         self.${id}.set_gain_mode(${gain1})

--- a/gr-iio/include/gnuradio/iio/device_sink.h
+++ b/gr-iio/include/gnuradio/iio/device_sink.h
@@ -14,6 +14,8 @@
 #include <gnuradio/iio/api.h>
 #include <gnuradio/sync_block.h>
 
+#include <string>
+
 #define DEFAULT_BUFFER_SIZE 0x8000
 
 extern "C" {
@@ -71,6 +73,18 @@ public:
                           unsigned int buffer_size = DEFAULT_BUFFER_SIZE,
                           unsigned int interpolation = 0,
                           bool cyclic = false);
+
+    /*!
+     * The key of the tag that indicates packet length.
+     * When not empty, samples are expected as "packets" and
+     * must be tagged as such, i.e. the first sample of a packet needs to be
+     * tagged with the corresponding length of that packet.
+     * Note, packet size MUST be equal to buffer_size / (1+interpolation),
+     * otherwise a runtime_error will be thrown. This is a deliberate design
+     * choice, because all other options would result in potentially unexpected
+     * behavior.
+     */
+    virtual void set_len_tag_key(const std::string& len_tag_key) = 0;
 };
 
 } // namespace iio

--- a/gr-iio/include/gnuradio/iio/device_source.h
+++ b/gr-iio/include/gnuradio/iio/device_source.h
@@ -67,7 +67,17 @@ public:
                           unsigned int buffer_size = DEFAULT_BUFFER_SIZE,
                           unsigned int decimation = 0);
 
+    /*!
+     * \brief Key of the packet length tag. If empty no tag will be emitted
+     */
+    virtual void set_len_tag_key(const std::string& len_tag_key) = 0;
+
+    /*!
+     * \brief Number of samples to be put into each IIO
+     *        buffered passed to hardware.
+     */
     virtual void set_buffer_size(unsigned int buffer_size) = 0;
+
     virtual void set_timeout_ms(unsigned long timeout) = 0;
 };
 

--- a/gr-iio/include/gnuradio/iio/fmcomms2_sink.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_sink.h
@@ -39,6 +39,18 @@ public:
                      unsigned long buffer_size,
                      bool cyclic);
 
+    /*!
+     * The key of the tag that indicates packet length.
+     * When not empty, samples are expected as "packets" and
+     * must be tagged as such, i.e. the first sample of a packet needs to be
+     * tagged with the corresponding length of that packet.
+     * Note, packet size MUST be equal to buffer_size / (1+interpolation),
+     * otherwise a runtime_error will be thrown. This is a deliberate design
+     * choice, because all other options would result in potentially unexpected
+     * behavior.
+     */
+    virtual void set_len_tag_key(const std::string& val = "") = 0;
+
     virtual void set_bandwidth(unsigned long bandwidth) = 0;
     virtual void set_rf_port_select(const std::string& rf_port_select) = 0;
     virtual void set_frequency(unsigned long long frequency) = 0;

--- a/gr-iio/include/gnuradio/iio/fmcomms2_sink_fc32.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_sink_fc32.h
@@ -39,6 +39,8 @@ public:
                      const std::vector<bool>& ch_en,
                      unsigned long buffer_size,
                      bool cyclic);
+
+    virtual void set_len_tag_key(const std::string& len_tag_key);
     virtual void set_bandwidth(unsigned long bandwidth);
     virtual void set_frequency(unsigned long long frequency);
     virtual void set_samplerate(unsigned long samplerate);

--- a/gr-iio/include/gnuradio/iio/fmcomms2_source.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_source.h
@@ -38,6 +38,11 @@ public:
                      const std::vector<bool>& ch_en,
                      unsigned long buffer_size);
 
+    /*!
+     * \brief Key of the packet length tag. If empty no tag will be emitted
+     */
+    virtual void set_len_tag_key(const std::string& len_tag_key = "packet_len") = 0;
+
     virtual void set_frequency(unsigned long long frequency) = 0;
     virtual void set_samplerate(unsigned long samplerate) = 0;
     virtual void set_gain_mode(size_t chan, const std::string& mode) = 0;

--- a/gr-iio/include/gnuradio/iio/fmcomms2_source_fc32.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_source_fc32.h
@@ -38,6 +38,8 @@ public:
     static sptr make(const std::string& uri,
                      const std::vector<bool>& ch_en,
                      unsigned long buffer_size);
+
+    virtual void set_len_tag_key(const std::string& len_tag_key);
     virtual void set_frequency(unsigned long long frequency);
     virtual void set_samplerate(unsigned long samplerate);
     virtual void set_gain_mode(size_t chan, const std::string& mode);

--- a/gr-iio/include/gnuradio/iio/pluto_sink.h
+++ b/gr-iio/include/gnuradio/iio/pluto_sink.h
@@ -31,10 +31,21 @@ public:
      *
      * \param uri  String of the context uri
      * \param buffer_size  Long of number of samples in buffer to send to device
-     * \param cyclic Boolean when True sends first buffer_size number of samples
+     * \param cyclic Boolean, the first packet is repeated indefinitely when set
      */
     static sptr make(const std::string& uri, unsigned long buffer_size, bool cyclic);
 
+    /*!
+     * The key of the tag that indicates packet length.
+     * When not empty, samples are expected as "packets" and
+     * must be tagged as such, i.e. the first sample of a packet needs to be
+     * tagged with the corresponding length of that packet.
+     * Note, packet size MUST be equal to buffer_size / (1+interpolation),
+     * otherwise a runtime_error will be thrown. This is a deliberate design
+     * choice, because all other options would result in potentially unexpected
+     * behavior.
+     */
+    virtual void set_len_tag_key(const std::string& val) = 0;
     virtual void set_frequency(unsigned long long frequency) = 0;
     virtual void set_bandwidth(unsigned long bandwidth) = 0;
     virtual void set_samplerate(unsigned long samplerate) = 0;

--- a/gr-iio/include/gnuradio/iio/pluto_source.h
+++ b/gr-iio/include/gnuradio/iio/pluto_source.h
@@ -28,6 +28,11 @@ public:
 
     static sptr make(const std::string& uri, unsigned long buffer_size);
 
+    /*!
+     * \brief Key of the packet length tag. If empty no tag will be emitted
+     */
+    virtual void set_len_tag_key(const std::string& val) = 0;
+
     virtual void set_frequency(unsigned long long frequency) = 0;
     virtual void set_samplerate(unsigned long samplerate) = 0;
     virtual void set_gain_mode(const std::string& mode) = 0;

--- a/gr-iio/lib/device_sink_impl.h
+++ b/gr-iio/lib/device_sink_impl.h
@@ -24,6 +24,7 @@ class device_sink_impl : public device_sink
 {
 private:
     void channel_write(const struct iio_channel* chn, const void* src, size_t len);
+    std::vector<tag_t> d_tags;
 
 protected:
     struct iio_context* ctx;
@@ -33,6 +34,7 @@ protected:
     unsigned int interpolation;
     unsigned int buffer_size;
     bool destroy_ctx;
+    pmt::pmt_t d_len_tag_key;
 
 public:
     device_sink_impl(struct iio_context* ctx,
@@ -44,9 +46,12 @@ public:
                      unsigned int buffer_size = DEFAULT_BUFFER_SIZE,
                      unsigned int interpolation = 0,
                      bool cyclic = false);
+
     ~device_sink_impl();
 
     void set_params(const std::vector<std::string>& params);
+
+    void set_len_tag_key(const std::string& len_tag_key) override;
 
     // Where all the action really happens
     int work(int noutput_items,

--- a/gr-iio/lib/device_source_impl.h
+++ b/gr-iio/lib/device_source_impl.h
@@ -50,6 +50,8 @@ private:
 
     unsigned long timeout;
 
+    pmt::pmt_t d_len_tag_key;
+
     void refill_thread();
 
 protected:
@@ -72,10 +74,13 @@ public:
                        const std::vector<std::string>& params,
                        unsigned int buffer_size = DEFAULT_BUFFER_SIZE,
                        unsigned int decimation = 0);
+
     ~device_source_impl();
 
     static void set_params(struct iio_device* phy,
                            const std::vector<std::string>& params);
+
+    void set_len_tag_key(const std::string& len_tag_key) override;
 
     void set_params(const std::vector<std::string>& params);
     void set_buffer_size(unsigned int buffer_size);

--- a/gr-iio/lib/fmcomms2_sink_fc32_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_fc32_impl.cc
@@ -58,6 +58,11 @@ fmcomms2_sink_f32c::sptr fmcomms2_sink_f32c::make(const std::string& uri,
         (ch_en.size() > 0 && ch_en[0]), (ch_en.size() > 1 && ch_en[1]), block));
 }
 
+
+void fmcomms2_sink_f32c::set_len_tag_key(const std::string& len_tag_key)
+{
+    fmcomms2_block->set_len_tag_key(len_tag_key);
+}
 void fmcomms2_sink_f32c::set_bandwidth(unsigned long bandwidth)
 {
     fmcomms2_block->set_bandwidth(bandwidth);

--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -101,6 +101,11 @@ fmcomms2_sink_impl::~fmcomms2_sink_impl()
     underflow_thd.join();
 }
 
+void fmcomms2_sink_impl::set_len_tag_key(const std::string& str)
+{
+    device_sink_impl::set_len_tag_key(str);
+}
+
 void fmcomms2_sink_impl::check_underflow(void)
 {
     uint32_t status;

--- a/gr-iio/lib/fmcomms2_sink_impl.h
+++ b/gr-iio/lib/fmcomms2_sink_impl.h
@@ -47,6 +47,7 @@ public:
              gr_vector_void_star& output_items);
 
     void update_dependent_params();
+    virtual void set_len_tag_key(const std::string& len_tag_key);
     virtual void set_bandwidth(unsigned long bandwidth);
     virtual void set_rf_port_select(const std::string& rf_port_select);
     virtual void set_frequency(unsigned long long frequency);

--- a/gr-iio/lib/fmcomms2_source_fc32_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_fc32_impl.cc
@@ -57,6 +57,10 @@ fmcomms2_source_f32c::sptr fmcomms2_source_f32c::make(const std::string& uri,
         (ch_en.size() > 0 && ch_en[0]), (ch_en.size() > 1 && ch_en[1]), block));
 }
 
+void fmcomms2_source_f32c::set_len_tag_key(const std::string& len_tag_key)
+{
+    fmcomms2_block->set_len_tag_key(len_tag_key);
+}
 void fmcomms2_source_f32c::set_frequency(unsigned long long frequency)
 {
     fmcomms2_block->set_frequency(frequency);

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -163,6 +163,11 @@ void fmcomms2_source_impl::update_dependent_params()
     }
 }
 
+void fmcomms2_source_impl::set_len_tag_key(const std::string& len_tag_key)
+{
+    device_source_impl::set_len_tag_key(len_tag_key);
+}
+
 void fmcomms2_source_impl::set_frequency(unsigned long long frequency)
 {
     std::vector<std::string> params;

--- a/gr-iio/lib/fmcomms2_source_impl.h
+++ b/gr-iio/lib/fmcomms2_source_impl.h
@@ -36,6 +36,7 @@ public:
 
     ~fmcomms2_source_impl();
 
+    virtual void set_len_tag_key(const std::string& len_tag_key);
     virtual void set_frequency(unsigned long long frequency);
     virtual void set_samplerate(unsigned long samplerate);
     virtual void set_gain_mode(size_t chan, const std::string& mode);

--- a/gr-iio/lib/pluto_sink_impl.cc
+++ b/gr-iio/lib/pluto_sink_impl.cc
@@ -36,6 +36,10 @@ pluto_sink_impl::pluto_sink_impl(fmcomms2_sink::sptr block)
 {
 }
 
+void pluto_sink_impl::set_len_tag_key(const std::string& len_tag_key)
+{
+    fmcomms2_sink_f32c::set_len_tag_key(len_tag_key);
+}
 void pluto_sink_impl::set_frequency(unsigned long long frequency)
 {
     fmcomms2_sink_f32c::set_frequency(frequency);

--- a/gr-iio/lib/pluto_sink_impl.h
+++ b/gr-iio/lib/pluto_sink_impl.h
@@ -22,6 +22,7 @@ class pluto_sink_impl : public pluto_sink, public fmcomms2_sink_f32c
 public:
     explicit pluto_sink_impl(fmcomms2_sink::sptr block);
 
+    virtual void set_len_tag_key(const std::string& len_tag_key) override;
     virtual void set_frequency(unsigned long long frequency);
     virtual void set_bandwidth(unsigned long bandwidth);
     virtual void set_samplerate(unsigned long samplerate);

--- a/gr-iio/lib/pluto_source_impl.cc
+++ b/gr-iio/lib/pluto_source_impl.cc
@@ -73,6 +73,10 @@ pluto_source_impl::pluto_source_impl(fmcomms2_source::sptr block)
 {
 }
 
+void pluto_source_impl::set_len_tag_key(const std::string& len_tag_key)
+{
+    fmcomms2_source_f32c::set_len_tag_key(len_tag_key);
+}
 void pluto_source_impl::set_frequency(unsigned long long frequency)
 {
     fmcomms2_source_f32c::set_frequency(frequency);

--- a/gr-iio/lib/pluto_source_impl.h
+++ b/gr-iio/lib/pluto_source_impl.h
@@ -28,6 +28,7 @@ public:
 
     static std::string get_uri();
 
+    virtual void set_len_tag_key(const std::string& len_tag_key) override;
     virtual void set_frequency(unsigned long long frequency);
     virtual void set_samplerate(unsigned long samplerate);
     virtual void set_gain_mode(const std::string& mode);

--- a/gr-iio/python/iio/bindings/device_sink_python.cc
+++ b/gr-iio/python/iio/bindings/device_sink_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(device_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a18ca2be4b936386305f32fb9ea40ade)                     */
+/* BINDTOOL_HEADER_FILE(device_sink.h)                                             */
+/* BINDTOOL_HEADER_FILE_HASH(cc567f6efacc47c8e6dd89985dd33c3f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -49,6 +49,11 @@ void bind_device_sink(py::module& m)
              py::arg("interpolation") = 0,
              py::arg("cyclic") = false,
              D(device_sink, make))
+
+        .def(
+            "set_len_tag_key",
+            [](device_sink& sink, const std::string& str) { sink.set_len_tag_key(str); },
+            py::arg("len_tag_key") = "")
 
         ;
 }

--- a/gr-iio/python/iio/bindings/device_source_python.cc
+++ b/gr-iio/python/iio/bindings/device_source_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(device_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(09eb30139a946becee62a26128da7dc7)                     */
+/* BINDTOOL_HEADER_FILE(device_source.h)                                           */
+/* BINDTOOL_HEADER_FILE_HASH(b7f9efa65ce300b5fd707cfb59d62529)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -58,6 +58,11 @@ void bind_device_source(py::module& m)
              &device_source::set_timeout_ms,
              py::arg("timeout"),
              D(device_source, set_timeout_ms))
+
+        .def(
+            "set_len_tag_key",
+            [](device_source& src, const std::string& str) { src.set_len_tag_key(str); },
+            py::arg("len_tag_key") = "")
 
         ;
 }

--- a/gr-iio/python/iio/bindings/docstrings/device_sink_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/device_sink_pydoc_template.h
@@ -17,3 +17,5 @@
 static const char* __doc_gr_iio_device_sink = R"doc()doc";
 
 static const char* __doc_gr_iio_device_sink_make = R"doc()doc";
+
+static const char* __doc_gr_iio_device_sink_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/device_source_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/device_source_pydoc_template.h
@@ -21,3 +21,5 @@ static const char* __doc_gr_iio_device_source_make = R"doc()doc";
 static const char* __doc_gr_iio_device_source_set_buffer_size = R"doc()doc";
 
 static const char* __doc_gr_iio_device_source_set_timeout_ms = R"doc()doc";
+
+static const char* __doc_gr_iio_device_source_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/fmcomms2_sink_f32c_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/fmcomms2_sink_f32c_pydoc_template.h
@@ -19,3 +19,5 @@ static const char* __doc_gr_iio_fmcomms2_sink_f32c = R"doc()doc";
 static const char* __doc_gr_iio_fmcomms2_sink_f32c_make = R"doc()doc";
 
 static const char* __doc_gr_iio_fmcomms2_sink_f32c_set_params = R"doc()doc";
+
+static const char* __doc_gr_iio_fmcomms2_sink_f32c_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/fmcomms2_sink_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/fmcomms2_sink_pydoc_template.h
@@ -19,3 +19,5 @@ static const char* __doc_gr_iio_fmcomms2_sink = R"doc()doc";
 static const char* __doc_gr_iio_fmcomms2_sink_make = R"doc()doc";
 
 static const char* __doc_gr_iio_fmcomms2_sink_set_params = R"doc()doc";
+
+static const char* __doc_gr_iio_fmcomms2_sink_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/fmcomms2_source_f32c_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/fmcomms2_source_f32c_pydoc_template.h
@@ -19,3 +19,5 @@ static const char* __doc_gr_iio_fmcomms2_source_f32c = R"doc()doc";
 static const char* __doc_gr_iio_fmcomms2_source_f32c_make = R"doc()doc";
 
 static const char* __doc_gr_iio_fmcomms2_source_f32c_set_params = R"doc()doc";
+
+static const char* __doc_gr_iio_fmcomms2_source_f32c_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/fmcomms2_source_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/fmcomms2_source_pydoc_template.h
@@ -19,3 +19,5 @@ static const char* __doc_gr_iio_fmcomms2_source = R"doc()doc";
 static const char* __doc_gr_iio_fmcomms2_source_make = R"doc()doc";
 
 static const char* __doc_gr_iio_fmcomms2_source_set_params = R"doc()doc";
+
+static const char* __doc_gr_iio_fmcomms2_source_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/pluto_sink_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/pluto_sink_pydoc_template.h
@@ -19,3 +19,5 @@ static const char* __doc_gr_iio_pluto_sink = R"doc()doc";
 static const char* __doc_gr_iio_pluto_sink_make = R"doc()doc";
 
 static const char* __doc_gr_iio_pluto_sink_set_params = R"doc()doc";
+
+static const char* __doc_gr_iio_pluto_sink_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/docstrings/pluto_source_pydoc_template.h
+++ b/gr-iio/python/iio/bindings/docstrings/pluto_source_pydoc_template.h
@@ -19,3 +19,5 @@ static const char* __doc_gr_iio_pluto_source = R"doc()doc";
 static const char* __doc_gr_iio_pluto_source_make = R"doc()doc";
 
 static const char* __doc_gr_iio_pluto_source_set_params = R"doc()doc";
+
+static const char* __doc_gr_iio_pluto_source_set_len_tag_key = R"doc()doc";

--- a/gr-iio/python/iio/bindings/fmcomms2_sink_f32c_python.cc
+++ b/gr-iio/python/iio/bindings/fmcomms2_sink_f32c_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fmcomms2_sink_fc32.h)                                      */
-/* BINDTOOL_HEADER_FILE_HASH(d38c940efb3bb6408ddd0cd6b09c57ef)                     */
+/* BINDTOOL_HEADER_FILE_HASH(22973a1c4b186c5b8363b99d601da6b5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-iio/python/iio/bindings/pluto_sink_python.cc
+++ b/gr-iio/python/iio/bindings/pluto_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pluto_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a2f3444638fe8507d7b91ae6f895eda7)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4315d0abebcaff67b262aee785fb2c49)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -45,5 +45,7 @@ void bind_pluto_sink(py::module& m)
         .def("set_frequency", &pluto_sink::set_frequency, py::arg("longfrequency"))
         .def("set_samplerate", &pluto_sink::set_samplerate, py::arg("samplerate"))
         .def("set_attenuation", &pluto_sink::set_attenuation, py::arg("attenuation"))
-        .def("set_filter_params", &pluto_sink::set_filter_params);
+        .def("set_filter_params", &pluto_sink::set_filter_params)
+        .def(
+            "set_len_tag_key", &pluto_sink::set_len_tag_key, py::arg("len_tag_key") = "");
 }

--- a/gr-iio/python/iio/bindings/pluto_source_python.cc
+++ b/gr-iio/python/iio/bindings/pluto_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pluto_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(bdb6a1ffc20099440210c3ac917cc008)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f73fc3ad843eb6f61c8a520ee3d68f8f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -50,6 +50,6 @@ void bind_pluto_source(py::module& m)
         .def("set_rfdc", &pluto_source::set_rfdc, py::arg("rfdc"))
         .def("set_bbdc", &pluto_source::set_bbdc, py::arg("bbdc"))
         .def("set_filter_params", &pluto_source::set_filter_params)
-
-        ;
+        .def("set_len_tag_key", &pluto_source::set_len_tag_key, py::arg("len_tag_key"));
+    ;
 }


### PR DESCRIPTION
This PR adds stream tagging support to the device_source and device_sink
blocks, and thus also deriviates like the fmcomms2 and pluto.

The important bits are:

* The source block now tags buffer boundaries
* When tagged_input is enabled on the device sink, it enforces that all input packet sizes match buffer_size / (1 + interpolation). 

This isn't very flexible, but can be understood as a safeguard against unexpected behavior.

(Continuation of #4684)