### PR TITLE
gr-blocks: Add missing pybind11 binding for Phase Shift block. (backport to maint-3.9)

### DIFF
--- a/gr-blocks/python/blocks/bindings/python_bindings.cc
+++ b/gr-blocks/python/blocks/bindings/python_bindings.cc
@@ -299,6 +299,7 @@ PYBIND11_MODULE(blocks_python, m)
     bind_pdu_to_tagged_stream(m);
     bind_peak_detector(m);
     bind_peak_detector2_fb(m);
+    bind_phase_shift(m);
     bind_plateau_detector_fb(m);
     bind_probe_rate(m);
     bind_probe_signal(m);


### PR DESCRIPTION
Signed-off-by: Ron Economos <w6rz@comcast.net>
(cherry picked from commit 885f9587d22e5f294e1012be56402601831d369a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4708