### PR TITLE
cmake: Pass extra arguments to GR_PYTHON_INSTALL to install command.

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -168,6 +168,7 @@ function(GR_PYTHON_INSTALL)
     install(
       FILES ${GR_PYTHON_INSTALL_FILES}
       DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
+      ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS}
     )
 
         #create a list of all generated files
@@ -228,6 +229,7 @@ function(GR_PYTHON_INSTALL)
     install(
       DIRECTORY ${GR_PYTHON_INSTALL_DIRECTORY}
       DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
+      ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS}
     )
 
 
@@ -334,6 +336,7 @@ function(GR_PYTHON_INSTALL)
 
             install(PROGRAMS ${pyexefile} RENAME ${pyfile_name}
                 DESTINATION ${GR_PYTHON_INSTALL_DESTINATION}
+                ${GR_PYTHON_INSTALL_UNPARSED_ARGUMENTS}
             )
         endforeach(pyfile)
 


### PR DESCRIPTION
GRC already does a few GR_PYTHON_INSTALLs with extra FILES_MATCHING
REGEX arguments, so this will actually pass these through.

This was necessary in an earlier version of #4671, but isn't anymore and has thus been moved to a separate PR.