### PR TITLE
iio: detect not only ad9361.h presence, but suitability

### DIFF
--- a/gr-iio/CMakeLists.txt
+++ b/gr-iio/CMakeLists.txt
@@ -26,7 +26,27 @@ include(GrComponent)
 GR_REGISTER_COMPONENT("gr-iio" ENABLE_GR_IIO ${GR_IIO_DEPENDENCIES})
 
 if(libad9361_FOUND)
-  GR_APPEND_SUBCOMPONENT("libad9361")
+  # Sadly, libad9361 is not reliably versioned (yet?).
+  # Especially Fedora ships an incompatible early version of the ad9361.h header
+  # Let's check whether things compile.
+  set(OLD_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+  set(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+  set(CMAKE_REQUIRED_INCLUDES ${libad9361_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_LIBRARIES ${libad9361_LIBRARIES})
+  CHECK_CXX_SOURCE_COMPILES("
+    #include <ad9361.h>
+    namespace testing
+    {
+      auto test_ad9361_multichip_sync = &::ad9361_multichip_sync;
+      auto test_ad9361_set_bb_rate_custom_filter_manual = &::ad9361_set_bb_rate_custom_filter_manual;
+    };
+    int main() {}"
+    libad9361_SUFFICIENT)
+  if(libad9361_SUFFICIENT)
+    GR_APPEND_SUBCOMPONENT("libad9361")
+  endif()
+  set(CMAKE_REQUIRED_INCLUDES ${OLD_CMAKE_REQUIRED_INCLUDES})
+  set(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
 endif()
 
 SET(GR_PKG_IIO_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/iio)

--- a/gr-iio/include/gnuradio/iio/CMakeLists.txt
+++ b/gr-iio/include/gnuradio/iio/CMakeLists.txt
@@ -17,12 +17,17 @@ install(FILES
   device_sink.h
   device_source.h
   dds_control.h
-  fmcomms2_sink.h
-  fmcomms2_source.h
-  # fmcomms5_sink.h
-  # fmcomms5_source.h
   iio_types.h
-  pluto_sink.h
-  pluto_source.h
   DESTINATION ${GR_INCLUDE_DIR}/gnuradio/iio
 )
+if(libad9361_SUFFICIENT)
+  install(FILES
+    pluto_sink.h
+    pluto_source.h
+    fmcomms2_sink.h
+    fmcomms2_source.h
+    # fmcomms5_sink.h
+    # fmcomms5_source.h
+    DESTINATION ${GR_INCLUDE_DIR}/gnuradio/iio
+    )
+endif()

--- a/gr-iio/lib/CMakeLists.txt
+++ b/gr-iio/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2021 Free Software Foundation, Inc.
+# Copyright 2021 GNU Radio Contributors
 #
 # This file is part of GNU Radio
 #
@@ -31,7 +32,7 @@ target_link_libraries(gnuradio-iio PUBLIC
   gnuradio-blocks
 )
 
-if(libad9361_FOUND)
+if(libad9361_SUFFICIENT)
   target_sources(gnuradio-iio PRIVATE
     fmcomms2_sink_impl.cc
     fmcomms2_source_impl.cc
@@ -43,7 +44,7 @@ if(libad9361_FOUND)
   target_link_libraries(gnuradio-iio PUBLIC libad9361::ad9361)
   target_compile_definitions(gnuradio-iio PUBLIC -DGR_IIO_LIBAD9361)
   list(APPEND iio_deps "libad9361")
-endif(libad9361_FOUND)
+endif(libad9361_SUFFICIENT)
 
 #Add Windows DLL resource file if using MSVC
 if(MSVC)


### PR DESCRIPTION
Hopefully, we can later on absorb that in a version check, so that it's sensible to check this in CMakeLists instead of Findad9361

Fixes #4715