### PR TITLE
fft: Use explicit extension when adding test

### DIFF
--- a/gr-fft/lib/CMakeLists.txt
+++ b/gr-fft/lib/CMakeLists.txt
@@ -60,7 +60,7 @@ if(ENABLE_TESTING)
   include(GrTest)
 
   list(APPEND test_gr_fft_sources
-    qa_fft_shift
+    qa_fft_shift.cc
   )
   list(APPEND GR_TEST_TARGET_DEPS gnuradio-fft)
 


### PR DESCRIPTION
Fixes the following warning (Arch Linux, CMake 3.20.3):

```
CMake Warning (dev) at cmake/Modules/GrTest.cmake:151 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    /home/hkon/gnuradio/gr-fft/lib/qa_fft_shift.cc
Call Stack (most recent call first):
  gr-fft/lib/CMakeLists.txt:68 (GR_ADD_CPP_TEST)
This warning is for project developers.  Use -Wno-dev to suppress it.
```