### PR TITLE
fft: Use explicit extension when adding test (backport to maint-3.8)

### DIFF
--- a/gr-fft/lib/CMakeLists.txt
+++ b/gr-fft/lib/CMakeLists.txt
@@ -70,7 +70,7 @@ if(ENABLE_TESTING)
   include(GrTest)
 
   list(APPEND test_gr_fft_sources
-    qa_fft_shift
+    qa_fft_shift.cc
   )
   list(APPEND GR_TEST_TARGET_DEPS gnuradio-fft)
 


### PR DESCRIPTION
Signed-off-by: Håkon Vågsether <hauk142@gmail.com>
(cherry picked from commit d84df80edaf1e8491a1b4fc208b407b7e5c5198c)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4719