### PR TITLE
soapy: less surprising bool cast

### DIFF
--- a/gr-soapy/python/soapy/bindings/soapy_common.cc
+++ b/gr-soapy/python/soapy/bindings/soapy_common.cc
@@ -11,6 +11,8 @@
 
 #include <SoapySDR/Types.hpp>
 #include <SoapySDR/Version.h>
+#include <stdexcept>
+#include <string>
 
 // SoapySDR doesn't have an API define for SettingToString, so we need
 // to check the version. 0.8 is the first tagged version to have this
@@ -49,22 +51,20 @@ static inline T string_to_setting(const std::string& str)
 }
 
 // Copied from SoapySDR 0.8
+//! convert empty and "false" strings to false, integers to their truthness
 template <>
 inline bool string_to_setting<bool>(const std::string& str)
 {
-    if (str == SOAPY_SDR_TRUE)
+    if (str.empty() || str == SOAPY_SDR_FALSE) {
+        return false;
+    }
+    if (str == SOAPY_SDR_TRUE) {
         return true;
-    if (str == SOAPY_SDR_FALSE)
-        return false;
-
-    // zeros and empty strings are false
-    if (str == "0")
-        return false;
-    if (str == "0.0")
-        return false;
-    if (str == "")
-        return false;
-
+    }
+    try {
+        return static_cast<bool>(std::stod(str));
+    } catch (std::invalid_argument& e) {
+    }
     // other values are true
     return true;
 }


### PR DESCRIPTION
Soapy has its own way of casting strings to bools, and it special-cases
"0" and "0.0" and misses out on the opportunity to be consistent with
many other ways of specifying 0 as number.

I'm trying to upstream the same change to SoapSDR, in order to keep
things consistent. But this is worth having in GNU Radio, either way,
since GNU Radio has its own user expectations, which might even differ a
bit from these of SoapySDR users.

Fixes #4742

References https://github.com/pothosware/SoapySDR/pull/313