### PR TITLE
cmake: lowercase pkg-config module requires lowercase pybind11_INCLUDE_DIR (backport to maint-3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The SoapySDR framework and Soapy driver modules are not maintained by the GNU Ra
 - In-tree packaging files for DEB and RPM, used with Launchpad and COPR
 - Added man pages for GNU Radio tools
 - Test code generation for all in-tree GRC examples
+- In GrPybind.cmake, `PYBIND11_INCLUDE_DIR` (incorrect) was changed to `pybind11_INCLUDE_DIR`
 
 ### Contributors
 At LEAST the following authors contributed to this release. Note that only authors of commits are included here. A number of people contribute in other ways, including code review, documentation and testing.

--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -37,7 +37,7 @@ target_include_directories(${name}_python PUBLIC
     ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
-    ${PYBIND11_INCLUDE_DIR}
+    ${pybind11_INCLUDE_DIR}
 )
 target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
@@ -154,7 +154,7 @@ target_include_directories(${name}_python PUBLIC
     ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
-    ${PYBIND11_INCLUDE_DIR}
+    ${pybind11_INCLUDE_DIR}
 )
 target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
@@ -287,7 +287,7 @@ target_include_directories(${name}_python PUBLIC
     ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
-    ${PYBIND11_INCLUDE_DIR}
+    ${pybind11_INCLUDE_DIR}
 )
 target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 0705a715dea306c4d53301095f93b0f7077c4a61)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4729