### PR TITLE
Fix gnuradio/gnuradio#4639 by dereferencing symlink in gr::prefix().

### DIFF
--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -28,13 +28,9 @@ const std::string prefix()
 
     std::filesystem::path prefix_rel_lib = "@prefix_relative_to_lib@";
     std::filesystem::path gr_runtime_lib_path = boost::dll::this_line_location().string();
-    // Normalize before decomposing path so result is reliable
-    std::filesystem::path partial_path = gr_runtime_lib_path.lexically_normal().parent_path();
-    // If this is a symlink, dereference (/bin ==> /usr/bin on some systems)
-    if (std::filesystem::is_symlink(partial_path)) {
-        partial_path = partial_path.parent_path() / std::filesystem::read_symlink(partial_path);
-    }
-    std::filesystem::path prefix_path = partial_path / prefix_rel_lib;
+    // Canonize before decomposing path so result is reliable and without symlinks
+    std::filesystem::path canonical_lib_path = std::filesystem::canonical(gr_runtime_lib_path);
+    std::filesystem::path prefix_path = canonical_lib_path.parent_path() / prefix_rel_lib;
     return prefix_path.lexically_normal().string();
 }
 

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -29,8 +29,12 @@ const std::string prefix()
     std::filesystem::path prefix_rel_lib = "@prefix_relative_to_lib@";
     std::filesystem::path gr_runtime_lib_path = boost::dll::this_line_location().string();
     // Normalize before decomposing path so result is reliable
-    std::filesystem::path prefix_path =
-        gr_runtime_lib_path.lexically_normal().parent_path() / prefix_rel_lib;
+    std::filesystem::path partial_path = gr_runtime_lib_path.lexically_normal().parent_path();
+    // If this is a symlink, dereference (/bin ==> /usr/bin on some systems)
+    if (std::filesystem::is_symlink(partial_path)) {
+        partial_path = partial_path.parent_path() / std::filesystem::read_symlink(partial_path);
+    }
+    std::filesystem::path prefix_path = partial_path / prefix_rel_lib;
     return prefix_path.lexically_normal().string();
 }
 


### PR DESCRIPTION
Signed-off-by: Ed Beroset <beroset@ieee.org>