### PR TITLE
Remove iostream remnants

### DIFF
--- a/gr-blocks/lib/annotator_1to1_impl.cc
+++ b/gr-blocks/lib/annotator_1to1_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_alltoall_impl.cc
+++ b/gr-blocks/lib/annotator_alltoall_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_raw_impl.cc
+++ b/gr-blocks/lib/annotator_raw_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 #include <stdexcept>
 
 using namespace pmt;

--- a/gr-blocks/lib/message_debug_impl.cc
+++ b/gr-blocks/lib/message_debug_impl.cc
@@ -15,7 +15,6 @@
 #include "message_debug_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cstdio>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/pack_k_bits.cc
+++ b/gr-blocks/lib/pack_k_bits.cc
@@ -13,7 +13,6 @@
 #endif
 
 #include <gnuradio/blocks/pack_k_bits.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/pack_k_bits_bb_impl.cc
+++ b/gr-blocks/lib/pack_k_bits_bb_impl.cc
@@ -14,7 +14,6 @@
 
 #include "pack_k_bits_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/qa_gr_top_block.cc
+++ b/gr-blocks/lib/qa_gr_top_block.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/blocks/null_source.h>
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
-#include <iostream>
 
 #define VERBOSE 0
 

--- a/gr-blocks/lib/qa_set_msg_handler.cc
+++ b/gr-blocks/lib/qa_set_msg_handler.cc
@@ -20,7 +20,6 @@
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/thread/thread.hpp>
-#include <iostream>
 
 /*
  * The gr::block::nop block has been instrumented so that it counts

--- a/gr-blocks/lib/tag_debug_impl.cc
+++ b/gr-blocks/lib/tag_debug_impl.cc
@@ -15,7 +15,6 @@
 #include "tag_debug_impl.h"
 #include <gnuradio/io_signature.h>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -18,7 +18,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cerrno>
-#include <iostream>
 #include <stdexcept>
 
 #ifdef HAVE_IO_H

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 #include <stdexcept>
 
 using namespace pmt;

--- a/gr-blocks/lib/unpack_k_bits.cc
+++ b/gr-blocks/lib/unpack_k_bits.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/blocks/unpack_k_bits.h>
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/unpack_k_bits_bb_impl.cc
+++ b/gr-blocks/lib/unpack_k_bits_bb_impl.cc
@@ -14,7 +14,6 @@
 
 #include "unpack_k_bits_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/vector_sink_impl.cc
+++ b/gr-blocks/lib/vector_sink_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
 #include <algorithm>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -21,7 +21,6 @@
 
 #include <cfloat>
 #include <cstdlib>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -17,7 +17,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -18,7 +18,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -17,7 +17,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -18,7 +18,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/hdlc_framer_pb_impl.cc
+++ b/gr-digital/lib/hdlc_framer_pb_impl.cc
@@ -15,7 +15,6 @@
 #include "hdlc_framer_pb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/tags.h>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_base.cc
+++ b/gr-digital/lib/header_format_base.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/math.h>
 #include <volk/volk.h>
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_counter.cc
+++ b/gr-digital/lib/header_format_counter.cc
@@ -17,7 +17,6 @@
 #include <volk/volk_alloc.hh>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_default.cc
+++ b/gr-digital/lib/header_format_default.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/math.h>
 #include <volk/volk_alloc.hh>
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/probe_density_b_impl.cc
+++ b/gr-digital/lib/probe_density_b_impl.cc
@@ -12,7 +12,6 @@
 
 #include "probe_density_b_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/protocol_parser_b_impl.cc
+++ b/gr-digital/lib/protocol_parser_b_impl.cc
@@ -15,7 +15,6 @@
 #include "protocol_parser_b_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {


### PR DESCRIPTION
I think we've converted all stdout / stderr to logging. so we shouldn't have need these headers anymore.