### PR TITLE
testing: rm dependencies from disabled components in blocks/runtime tests

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
+++ b/gnuradio-runtime/python/gnuradio/gr/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright 2012 Free Software Foundation, Inc.
+# Copyright 2021 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -32,9 +33,25 @@ if(ENABLE_TESTING)
     )
   include(GrTest)
   file(GLOB py_qa_test_files "qa_*.py")
+  set(py_qa_test_files
+    qa_flowgraph.py
+    qa_prefs.py
+    qa_random.py
+    qa_tag_utils.py
+    )
+  # This is a check for whether gr-blocks is enabled
+  if(ENABLE_DEFAULT OR ENABLE_GR_BLOCKS)
+    list(APPEND py_qa_test_files
+      qa_hier_block2.py
+      qa_uncaught_exception.py
+      )
+  else()
+    message(STATUS "gr-blocks not enabled: Disabling hier block and uncaught exception test")
+  endif()
+
   foreach(py_qa_test_file ${py_qa_test_files})
     get_filename_component(py_qa_test_name ${py_qa_test_file} NAME_WE)
-    GR_ADD_TEST(${py_qa_test_name} ${QA_PYTHON_EXECUTABLE} -B ${py_qa_test_file})
+    GR_ADD_TEST(${py_qa_test_name} ${QA_PYTHON_EXECUTABLE} -B ${CMAKE_CURRENT_SOURCE_DIR}/${py_qa_test_file})
   endforeach(py_qa_test_file)
 endif(ENABLE_TESTING)
 

--- a/gnuradio-runtime/python/gnuradio/gr/qa_flowgraph.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_flowgraph.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2016 Free Software Foundation, Inc.
+# Copyright 2021 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -9,9 +10,7 @@
 #
 
 
-import time
-import pmt
-from gnuradio import gr, gr_unittest, blocks, pdu
+from gnuradio import gr, gr_unittest
 
 
 class test_flowgraph (gr_unittest.TestCase):
@@ -22,27 +21,9 @@ class test_flowgraph (gr_unittest.TestCase):
     def tearDown(self):
         self.tb = None
 
-    def test_000(self):
-
+    def test_000_empty_fg(self):
         self.tb.start()
-        self.tb.lock()
-
-        rem = pdu.pdu_remove(pmt.intern('foo'))
-        dbg = blocks.message_debug()
-        self.tb.msg_connect((rem, 'pdus'), (dbg, 'store'))
-
-        self.tb.unlock()
-
-        msg = pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(3, (1, 2, 3)))
-        rem.to_basic_block()._post(pmt.intern('pdus'), msg)
-        time.sleep(0.2)
-
         self.tb.stop()
-
-        self.assertEqual(dbg.num_messages(), 1)
-        data = pmt.u8vector_elements(pmt.cdr(dbg.get_message(0)))
-        self.assertEqual([1, 2, 3], data)
-
 
 if __name__ == '__main__':
     gr_unittest.run(test_flowgraph)

--- a/gnuradio-runtime/python/gnuradio/gr/qa_hier_block2.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_hier_block2.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2014 Free Software Foundation, Inc.
+# Copyright 2021 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -9,7 +10,7 @@
 
 import time
 
-from gnuradio import gr_unittest, blocks, gr, analog
+from gnuradio import gr_unittest, blocks, gr
 from gnuradio.gr.hier_block2 import _multiple_endpoints, _optional_endpoints
 import pmt
 
@@ -102,40 +103,43 @@ class test_hier_block2(gr_unittest.TestCase):
         with self.assertRaises(ValueError):
             self.multi(self.Block(), 5)
 
-    def test_010(self):
-        s, h, k = analog.sig_source_c(44100, analog.GR_COS_WAVE, 440, 1.0, 0.0), blocks.head(
-            gr.sizeof_gr_complex, 1000), test_hblk([gr.sizeof_gr_complex], 0)
+    def test_010_end_with_head(self):
+        import math
+        exp = 1j * 440 / 44100
+        src = blocks.vector_source_c([math.e**(exp*n) for n in range(10**6)])
+        head = blocks.head(gr.sizeof_gr_complex, 1000)
+        test = test_hblk([gr.sizeof_gr_complex], 0)
         tb = gr.top_block()
-        tb.connect(s, h, k)
+        tb.connect(src, head, test)
         tb.run()
 
-    def test_011(self):
-        s, st, h, k = analog.sig_source_c(
-            44100, analog.GR_COS_WAVE, 440, 1.0, 0.0), blocks.message_strobe(
-            pmt.PMT_NIL, 100), blocks.head(
-            gr.sizeof_gr_complex, 1000), test_hblk(
-                [
-                    gr.sizeof_gr_complex], 1)
+    def test_011_test_message_connect(self):
+        import math
+        exp = 1j * 440 / 44100
+        src = blocks.vector_source_c([math.e**(exp*n) for n in range(10**6)])
+        strobe = blocks.message_strobe(pmt.PMT_NIL, 100)
+        head = blocks.head(gr.sizeof_gr_complex, 1000)
+        test = test_hblk([gr.sizeof_gr_complex], 1)
         tb = gr.top_block()
-        tb.connect(s, h, k)
-        tb.msg_connect(st, "strobe", k, "msg_in")
+        tb.connect(src, head, test)
+        tb.msg_connect(strobe, "strobe", test, "msg_in")
         tb.start()
-        time.sleep(1)
+        time.sleep(0.5)
         tb.stop()
         tb.wait()
 
     def test_012(self):
-        s, st, h, k = analog.sig_source_c(
-            44100, analog.GR_COS_WAVE, 440, 1.0, 0.0), blocks.message_strobe(
-            pmt.PMT_NIL, 100), blocks.head(
-            gr.sizeof_gr_complex, 1000), test_hblk(
-                [
-                    gr.sizeof_gr_complex], 16)
+        import math
+        exp = 1j * 440 / 44100
+        src = blocks.vector_source_c([math.e**(exp*n) for n in range(10**6)])
+        strobe = blocks.message_strobe(pmt.PMT_NIL, 100)
+        head = blocks.head(gr.sizeof_gr_complex, 1000)
+        test = test_hblk([gr.sizeof_gr_complex], 16)
         tb = gr.top_block()
-        tb.connect(s, h, k)
-        tb.msg_connect(st, "strobe", k, "msg_in")
+        tb.connect(src, head, test)
+        tb.msg_connect(strobe, "strobe", test, "msg_in")
         tb.start()
-        time.sleep(1)
+        time.sleep(0.5)
         tb.stop()
         tb.wait()
 

--- a/gr-blocks/python/blocks/__init__.py
+++ b/gr-blocks/python/blocks/__init__.py
@@ -37,4 +37,8 @@ multiply_vii = multiply_ii
 multiply_vss = multiply_ss
 
 # Compatibility layer for transition to gr-pdu. Scheduled for removal in 3.11.
-from .pdu_compatibility import *
+# This can fail if we're not building PDU tools
+try:
+    from .pdu_compatibility import *
+except ImportError:
+    pass


### PR DESCRIPTION
This included shifting of the PDU test from runtime to gr-pdu, and
making the tests that actually require blocks conditional on whether
there's going to be gr-blocks. Also, don't use gr-analog just because
you need data.