### PR TITLE
global: remove unused boost includes

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -16,7 +16,6 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/weak_ptr.hpp>
 #include <map>
 #include <memory>
 

--- a/gnuradio-runtime/include/gnuradio/high_res_timer.h
+++ b/gnuradio-runtime/include/gnuradio/high_res_timer.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GNURADIO_HIGH_RES_TIMER_H
 
 #include <gnuradio/api.h>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 ////////////////////////////////////////////////////////////////////////
 // Use architecture defines to determine the implementation
@@ -123,8 +124,6 @@ inline gr::high_res_timer_type gr::high_res_timer_tps(void)
 
 ////////////////////////////////////////////////////////////////////////
 #ifdef GNURADIO_HRT_USE_MICROSEC_CLOCK
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 inline gr::high_res_timer_type gr::high_res_timer_now(void)
 {
     static const boost::posix_time::ptime epoch(boost::posix_time::from_time_t(0));
@@ -143,8 +142,6 @@ inline gr::high_res_timer_type gr::high_res_timer_tps(void)
 #endif
 
 ////////////////////////////////////////////////////////////////////////
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 inline gr::high_res_timer_type gr::high_res_timer_epoch(void)
 {
     static const double hrt_ticks_per_utc_ticks =

--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -17,9 +17,10 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
+#include <boost/any.hpp>
+#include <boost/core/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/utility.hpp>
 #include <memory>
 
 namespace gr {

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -14,7 +14,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/hier_block2.h>
 #include <flat_flowgraph.h>
-#include <boost/utility.hpp>
+#include <boost/core/noncopyable.hpp>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -11,9 +11,7 @@
 #define INCLUDED_PMT_INT_H
 
 #include <pmt/pmt.h>
-#include <boost/atomic.hpp>
-#include <boost/utility.hpp>
-#include <boost/version.hpp>
+#include <boost/any.hpp>
 
 /*
  * EVERYTHING IN THIS FILE IS PRIVATE TO THE IMPLEMENTATION!

--- a/gnuradio-runtime/lib/scheduler.h
+++ b/gnuradio-runtime/lib/scheduler.h
@@ -14,7 +14,7 @@
 #include "flat_flowgraph.h"
 #include <gnuradio/api.h>
 #include <gnuradio/block.h>
-#include <boost/utility.hpp>
+#include <boost/core/noncopyable.hpp>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/scheduler_tpb.cc
+++ b/gnuradio-runtime/lib/scheduler_tpb.cc
@@ -15,7 +15,6 @@
 #include "scheduler_tpb.h"
 #include "tpb_thread_body.h"
 #include <gnuradio/thread/thread_body_wrapper.h>
-#include <boost/make_shared.hpp>
 #include <sstream>
 
 namespace gr {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(825bd18ddcab10552de6f9162a6aae3e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(69b17e66fac6e29f860466846a64feab)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/high_res_timer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/high_res_timer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(high_res_timer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(07d128321042e69a0ce418de407ceaf4)                     */
+/* BINDTOOL_HEADER_FILE_HASH(65bfb20df6b18709a817ce85f90e9e06)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/include/gnuradio/blocks/ctrlport_probe_c.h
+++ b/gr-blocks/include/gnuradio/blocks/ctrlport_probe_c.h
@@ -14,7 +14,6 @@
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/rpcregisterhelpers.h>
 #include <gnuradio/sync_block.h>
-#include <boost/thread/shared_mutex.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/python/blocks/bindings/ctrlport_probe_c_python.cc
+++ b/gr-blocks/python/blocks/bindings/ctrlport_probe_c_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(ctrlport_probe_c.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(953e3c69bfcbde28327778d11ce02638)                     */
+/* BINDTOOL_HEADER_FILE_HASH(984a7510b6724f3bc0f28224541ec937)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-channels/CMakeLists.txt
+++ b/gr-channels/CMakeLists.txt
@@ -8,7 +8,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 
 ########################################################################
 # Register component
@@ -16,7 +15,6 @@ include(GrBoost)
 include(GrComponent)
 
 GR_REGISTER_COMPONENT("gr-channels" ENABLE_GR_CHANNELS
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_BLOCKS
     ENABLE_GR_FFT

--- a/gr-channels/lib/CMakeLists.txt
+++ b/gr-channels/lib/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(gnuradio-channels PUBLIC
     gnuradio-filter
     gnuradio-analog
     gnuradio-blocks
-    Boost::boost
 )
 
 target_include_directories(gnuradio-channels

--- a/gr-digital/include/gnuradio/digital/header_format_ofdm.h
+++ b/gr-digital/include/gnuradio/digital/header_format_ofdm.h
@@ -13,7 +13,6 @@
 #include <gnuradio/digital/api.h>
 #include <gnuradio/digital/header_format_crc.h>
 #include <pmt/pmt.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -17,8 +17,8 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 
-#include <boost/format.hpp>
 
+#include <cassert>
 #include <cfloat>
 #include <cstdlib>
 #include <stdexcept>

--- a/gr-digital/lib/correlate_access_code_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_impl.cc
@@ -15,7 +15,6 @@
 #include "correlate_access_code_bb_impl.h"
 #include <gnuradio/blocks/count_bits.h>
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-digital/lib/costas_loop_cc_impl.cc
+++ b/gr-digital/lib/costas_loop_cc_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <gnuradio/sincos.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.h
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.h
@@ -14,7 +14,6 @@
 #include <gnuradio/digital/msk_timing_recovery_cc.h>
 #include <gnuradio/filter/fir_filter_with_buffer.h>
 #include <gnuradio/filter/mmse_fir_interpolator_cc.h>
-#include <boost/circular_buffer.hpp>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -19,8 +19,6 @@
 #include "pfb_clock_sync_ccf_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <boost/format.hpp>
-#include <boost/math/special_functions/round.hpp>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/python/digital/bindings/header_format_ofdm_python.cc
+++ b/gr-digital/python/digital/bindings/header_format_ofdm_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_format_ofdm.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(498bdcfe4bd8bf2202fecec7e1fef6bf)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4ec4c2872c64bdae4088678b3b0310fe)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
@@ -16,6 +16,8 @@
 #include "gnuradio/dtv/atsc_consts.h"
 #include <gnuradio/io_signature.h>
 
+#include <boost/format.hpp>
+
 namespace gr {
 namespace dtv {
 

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
@@ -13,6 +13,8 @@
 #include "dvbt_bit_inner_deinterleaver_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <boost/format.hpp>
+
 #define MAX_MODULATION_ORDER 6
 #define INTERLEAVER_BLOCK_SIZE 126
 

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
@@ -13,6 +13,8 @@
 #include "dvbt_bit_inner_interleaver_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <boost/format.hpp>
+
 #define MAX_MODULATION_ORDER 6
 #define INTERLEAVER_BLOCK_SIZE 126
 

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "cc_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -119,8 +118,8 @@ cc_decoder_impl::cc_decoder_impl(int frame_size,
         d_SUBSHIFT = 0;
     }
 
-    std::map<std::string, conv_kernel> yp_kernel =
-        boost::assign::map_list_of("k=7r=2", volk_8u_x4_conv_k7_r2_8u);
+    std::map<std::string, conv_kernel> yp_kernel = { { "k=7r=2",
+                                                       volk_8u_x4_conv_k7_r2_8u } };
 
     std::string k_ = "k=";
     std::string r_ = "r=";

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
 #include <volk/volk_typedefs.h>
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/dummy_decoder_impl.cc
+++ b/gr-fec/lib/dummy_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "dummy_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
@@ -12,7 +12,6 @@
 
 #include "ldpc_bit_flip_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/ldpc_decoder.cc
+++ b/gr-fec/lib/ldpc_decoder.cc
@@ -12,7 +12,6 @@
 #include <gnuradio/fec/ldpc_decoder.h>
 #include <gnuradio/fec/maxstar.h>
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
 #include <cmath>
 #include <cstdio>

--- a/gr-fec/lib/ldpc_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_encoder_impl.cc
@@ -10,7 +10,6 @@
 
 #include "ldpc_encoder_impl.h"
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
 #include <cstdio>
 #include <cstring> // for memcpy

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -10,7 +10,6 @@
 
 #include "ldpc_par_mtrx_encoder_impl.h"
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <algorithm> // for std::reverse
 #include <cmath>
 #include <cstdio>

--- a/gr-fec/lib/repetition_decoder_impl.cc
+++ b/gr-fec/lib/repetition_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "repetition_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/tpc_decoder.cc
+++ b/gr-fec/lib/tpc_decoder.cc
@@ -12,7 +12,6 @@
 #include <gnuradio/fec/tpc_decoder.h>
 #include <volk/volk.h>
 
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/tpc_encoder.cc
+++ b/gr-fec/lib/tpc_encoder.cc
@@ -13,7 +13,6 @@
 #include <gnuradio/fec/tpc_encoder.h>
 
 #include <volk/volk.h>
-#include <boost/assign/list_of.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-pdu/lib/random_pdu_impl.h
+++ b/gr-pdu/lib/random_pdu_impl.h
@@ -12,7 +12,6 @@
 #define INCLUDED_PDU_RANDOM_PDU_IMPL_H
 
 #include <gnuradio/pdu/random_pdu.h>
-#include <boost/generator_iterator.hpp>
 
 #include <random>
 

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -20,8 +20,6 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/numeric.hpp>
 
 #include <algorithm>
 #include <cstring>

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -20,8 +20,6 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/numeric.hpp>
 
 #include <cstring>
 

--- a/gr-trellis/lib/fsm.cc
+++ b/gr-trellis/lib/fsm.cc
@@ -11,6 +11,7 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/trellis/base.h>
 #include <gnuradio/trellis/fsm.h>
+#include <boost/format.hpp>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -18,10 +18,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
-
 
 namespace gr {
 namespace video_sdl {

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -18,10 +18,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
-
 
 namespace gr {
 namespace video_sdl {

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -15,6 +15,7 @@
 #include "freedv_rx_ss_impl.h"
 
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-wavelet/CMakeLists.txt
+++ b/gr-wavelet/CMakeLists.txt
@@ -8,8 +8,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
-
 find_package(GSL)
 
 ########################################################################
@@ -18,7 +16,6 @@ find_package(GSL)
 include(GrComponent)
 
 GR_REGISTER_COMPONENT("gr-wavelet" ENABLE_GR_WAVELET
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_BLOCKS
     ENABLE_GR_ANALOG


### PR DESCRIPTION
used command:

    sed -i '/^#include.*boost.*$/d' $(ag -L '(boost::|BOOST)' $(ag --cpp -l '#include <boost'))


With this changeset, channels and wavelet don't use boost internally anymore; a boost-free GNU Radio: it *is* possible.