### PR TITLE
Remove #include <boost/format.hpp> from logger.h

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -28,7 +28,6 @@ typedef int mode_t;
 // buffer.cc, then only include it there
 #include <gnuradio/api.h>
 #include <log4cpp/Category.hh>
-#include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <cassert>
 #include <memory>

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -15,6 +15,7 @@
 #include <gnuradio/buffer.h>
 #include <gnuradio/integer_math.h>
 #include <gnuradio/math.h>
+#include <boost/format.hpp>
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc
@@ -10,6 +10,7 @@
 
 #include <gnuradio/rpcserver_booter_thrift.h>
 #include <gnuradio/rpcserver_thrift.h>
+#include <boost/format.hpp>
 
 #include <boost/asio/ip/host_name.hpp>
 

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -27,6 +27,7 @@
 #include <log4cpp/PatternLayout.hh>
 #include <log4cpp/PropertyConfigurator.hh>
 #include <log4cpp/RollingFileAppender.hh>
+#include <boost/format.hpp>
 #include <boost/thread.hpp>
 
 #include <algorithm>

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -14,6 +14,7 @@
 
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 
 #include "pagesize.h"
 #include <unistd.h>

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -20,6 +20,7 @@
 #include <sched.h>
 #endif
 
+#include <boost/format.hpp>
 #include <algorithm>
 #include <cerrno>
 #include <cmath>

--- a/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
+++ b/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
@@ -14,6 +14,7 @@
 
 #include <gnuradio/logger.h>
 #include <gnuradio/thread/thread_body_wrapper.h>
+#include <boost/format.hpp>
 
 #ifdef HAVE_SIGNAL_H
 #include <csignal>

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -15,6 +15,7 @@
 #include "tpb_thread_body.h"
 #include <gnuradio/prefs.h>
 #include <pmt/pmt.h>
+#include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <iostream>
 

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
@@ -15,6 +15,7 @@
 #include "vmcircbuf_sysv_shm.h"
 #include <fcntl.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdlib>
 #include <stdexcept>
 #ifdef HAVE_SYS_IPC_H

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(eaf28bcaeb7c34dc0fca3fdd4a9860c0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(42bcfdc0723030de15907521dac6e6f2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-audio/lib/alsa/alsa_impl.cc
+++ b/gr-audio/lib/alsa/alsa_impl.cc
@@ -16,6 +16,8 @@
 #include <gnuradio/logger.h>
 
 #include "alsa_impl.h"
+
+#include <boost/format.hpp>
 #include <algorithm>
 
 static snd_pcm_access_t access_types[] = { SND_PCM_ACCESS_MMAP_INTERLEAVED,

--- a/gr-audio/lib/alsa/alsa_sink.cc
+++ b/gr-audio/lib/alsa/alsa_sink.cc
@@ -17,6 +17,7 @@
 #include "alsa_sink.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <future>
 #include <stdexcept>

--- a/gr-audio/lib/alsa/alsa_source.cc
+++ b/gr-audio/lib/alsa/alsa_source.cc
@@ -17,6 +17,7 @@
 #include "alsa_source.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-audio/lib/audio_registry.cc
+++ b/gr-audio/lib/audio_registry.cc
@@ -10,6 +10,7 @@
 #include "audio_registry.h"
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 #include <vector>
 

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -17,6 +17,7 @@
 #include "jack_sink.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -18,6 +18,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <type_traits>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-audio/lib/oss/oss_sink.cc
+++ b/gr-audio/lib/oss/oss_sink.cc
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-audio/lib/oss/oss_source.cc
+++ b/gr-audio/lib/oss/oss_source.cc
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-audio/lib/osx/osx_common.h
+++ b/gr-audio/lib/osx/osx_common.h
@@ -12,6 +12,7 @@
 #define INCLUDED_AUDIO_OSX_COMMON_H
 
 #include <gnuradio/audio/osx_impl.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace audio {

--- a/gr-audio/lib/osx/osx_sink.cc
+++ b/gr-audio/lib/osx/osx_sink.cc
@@ -18,6 +18,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/osx/osx_source.cc
+++ b/gr-audio/lib/osx/osx_source.cc
@@ -17,6 +17,7 @@
 
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -22,6 +22,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <future>

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -22,6 +22,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>

--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cctype>
 #include <sstream>
 #include <stdexcept>

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -22,6 +22,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <boost/format.hpp>
 #include <cctype>
 #include <sstream>
 #include <stdexcept>

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.cc
@@ -14,6 +14,7 @@
 
 #include "ctrlport_probe2_b_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.cc
@@ -14,6 +14,7 @@
 
 #include "ctrlport_probe2_c_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.h
@@ -14,6 +14,7 @@
 #include <gnuradio/blocks/ctrlport_probe2_c.h>
 #include <gnuradio/rpcbufferedget.h>
 #include <gnuradio/rpcregisterhelpers.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.cc
@@ -14,6 +14,7 @@
 
 #include "ctrlport_probe2_f_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.cc
@@ -14,6 +14,7 @@
 
 #include "ctrlport_probe2_i_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.cc
@@ -14,6 +14,7 @@
 
 #include "ctrlport_probe2_s_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/file_descriptor_source_impl.cc
+++ b/gr-blocks/lib/file_descriptor_source_impl.cc
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-blocks/lib/file_sink_base.cc
+++ b/gr-blocks/lib/file_sink_base.cc
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 

--- a/gr-blocks/lib/keep_m_in_n_impl.cc
+++ b/gr-blocks/lib/keep_m_in_n_impl.cc
@@ -14,6 +14,7 @@
 
 #include "keep_m_in_n_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/multiply_by_tag_value_cc_impl.cc
+++ b/gr-blocks/lib/multiply_by_tag_value_cc_impl.cc
@@ -15,6 +15,7 @@
 #include "multiply_by_tag_value_cc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/packed_to_unpacked_impl.cc
+++ b/gr-blocks/lib/packed_to_unpacked_impl.cc
@@ -15,6 +15,7 @@
 
 #include "packed_to_unpacked_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <cerrno>
 #include <iostream>
 #include <stdexcept>

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -15,6 +15,7 @@
 #include "test_tag_variable_rate_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
+#include <boost/format.hpp>
 #include <cstdint>
 
 using namespace pmt;

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -15,6 +15,7 @@
 #include "wavfile_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
+#include <boost/format.hpp>
 #include <cstring>
 #include <stdexcept>
 

--- a/gr-blocks/lib/wavfile_source_impl.cc
+++ b/gr-blocks/lib/wavfile_source_impl.cc
@@ -15,6 +15,7 @@
 #include "wavfile_source_impl.h"
 #include <gnuradio/io_signature.h>
 #include <sys/types.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/framer_sink_1_impl.cc
+++ b/gr-digital/lib/framer_sink_1_impl.cc
@@ -14,6 +14,7 @@
 
 #include "framer_sink_1_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/packet_sink_impl.cc
+++ b/gr-digital/lib/packet_sink_impl.cc
@@ -15,6 +15,7 @@
 #include "packet_sink_impl.h"
 #include <gnuradio/blocks/count_bits.h>
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <cstring>
 
 namespace gr {

--- a/gr-digital/lib/protocol_formatter_bb_impl.cc
+++ b/gr-digital/lib/protocol_formatter_bb_impl.cc
@@ -15,6 +15,7 @@
 #include "protocol_formatter_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cstdio>
 
 namespace gr {

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/integer_math.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/integer_math.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-fec/include/gnuradio/fec/generic_encoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_encoder.h
@@ -31,7 +31,7 @@ public:
     int my_id;
     int unique_id();
     std::string d_name;
-    std::string alias() { return (boost::format("%s%d") % d_name % unique_id()).str(); }
+    std::string alias();
 
 public:
     typedef std::shared_ptr<generic_encoder> sptr;

--- a/gr-fec/lib/ber_bf_impl.cc
+++ b/gr-fec/lib/ber_bf_impl.cc
@@ -15,6 +15,7 @@
 #include "ber_bf_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cmath>
 
 namespace gr {

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "cc_decoder_impl.h"
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -17,6 +17,7 @@
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
 #include <volk/volk_typedefs.h>
+#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/ccsds_encoder_impl.cc
+++ b/gr-fec/lib/ccsds_encoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "ccsds_encoder_impl.h"
 #include <gnuradio/fec/generic_encoder.h>
+#include <boost/format.hpp>
 #include <cstdio>
 
 #include <gnuradio/fec/viterbi.h>

--- a/gr-fec/lib/depuncture_bb_impl.cc
+++ b/gr-fec/lib/depuncture_bb_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 

--- a/gr-fec/lib/dummy_decoder_impl.cc
+++ b/gr-fec/lib/dummy_decoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "dummy_decoder_impl.h"
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/dummy_encoder_impl.cc
+++ b/gr-fec/lib/dummy_encoder_impl.cc
@@ -15,6 +15,7 @@
 #include "dummy_encoder_impl.h"
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <sstream>
 
 namespace gr {

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -13,6 +13,7 @@
 #endif
 
 #include <gnuradio/fec/generic_encoder.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace fec {
@@ -27,6 +28,10 @@ generic_encoder::generic_encoder(std::string name)
 
 generic_encoder::~generic_encoder() {}
 
+std::string generic_encoder::alias()
+{
+    return (boost::format("%s%d") % d_name % unique_id()).str();
+}
 const char* generic_encoder::get_input_conversion() { return "none"; }
 
 const char* generic_encoder::get_output_conversion() { return "none"; }

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
@@ -12,6 +12,7 @@
 
 #include "ldpc_bit_flip_decoder_impl.h"
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/ldpc_decoder.cc
+++ b/gr-fec/lib/ldpc_decoder.cc
@@ -12,6 +12,7 @@
 #include <gnuradio/fec/ldpc_decoder.h>
 #include <gnuradio/fec/maxstar.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <algorithm> // for std::reverse
 #include <cmath>
 #include <cstdio>

--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
@@ -11,7 +11,7 @@
 #endif
 
 #include "ldpc_gen_mtrx_encoder_impl.h"
-#include <sstream>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace fec {

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -10,11 +10,11 @@
 
 #include "ldpc_par_mtrx_encoder_impl.h"
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <algorithm> // for std::reverse
 #include <cmath>
 #include <cstdio>
 #include <cstring> // for memcpy
-#include <sstream>
 #include <vector>
 
 namespace gr {

--- a/gr-fec/lib/puncture_bb_impl.cc
+++ b/gr-fec/lib/puncture_bb_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 

--- a/gr-fec/lib/puncture_ff_impl.cc
+++ b/gr-fec/lib/puncture_ff_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 

--- a/gr-fec/lib/repetition_decoder_impl.cc
+++ b/gr-fec/lib/repetition_decoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "repetition_decoder_impl.h"
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>

--- a/gr-fec/lib/repetition_encoder_impl.cc
+++ b/gr-fec/lib/repetition_encoder_impl.cc
@@ -15,6 +15,7 @@
 #include "repetition_encoder_impl.h"
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <sstream>
 
 namespace gr {

--- a/gr-fec/lib/tagged_decoder_impl.cc
+++ b/gr-fec/lib/tagged_decoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "tagged_decoder_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <cstdio>
 
 namespace gr {

--- a/gr-fec/lib/tagged_encoder_impl.cc
+++ b/gr-fec/lib/tagged_encoder_impl.cc
@@ -14,6 +14,7 @@
 
 #include "tagged_encoder_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <cstdio>
 
 namespace gr {

--- a/gr-fec/python/fec/bindings/generic_encoder_python.cc
+++ b/gr-fec/python/fec/bindings/generic_encoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(generic_encoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(063421e47a4e75e4a2e1aa1e4f86016a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8f2010dc3c6371720e76fe7c2903bd84)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -12,7 +12,7 @@
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/sys_paths.h>
 #include <fftw3.h>
-#include <volk/volk.h>
+#include <boost/format.hpp>
 
 #ifdef _WIN32 // http://www.fftw.org/install/windows.html#DLLwisdom
 static void my_fftw_write_char(char c, void* f) { fputc(c, (FILE*)f); }

--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -17,7 +17,7 @@
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/integer_math.h>
 #include <gnuradio/io_signature.h>
-#include <volk/volk.h>
+#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-iio/python/iio/bindings/fmcomms2_sink_python.cc
+++ b/gr-iio/python/iio/bindings/fmcomms2_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fmcomms2_sink.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(8d538776355ec633d4c0e70b075af87d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(1ca54fa74c12834cae56b0832dd5c3f3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-iio/python/iio/bindings/fmcomms2_source_f32c_python.cc
+++ b/gr-iio/python/iio/bindings/fmcomms2_source_f32c_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fmcomms2_source_fc32.h)                                    */
-/* BINDTOOL_HEADER_FILE_HASH(ac7fd629916d34fa7785ef97b2d1d1ef)                     */
+/* BINDTOOL_HEADER_FILE_HASH(dde70331e3284513f54d0d26df960535)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-iio/python/iio/bindings/fmcomms2_source_python.cc
+++ b/gr-iio/python/iio/bindings/fmcomms2_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fmcomms2_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d42f0dcf19e3ece400da638d3d95e61c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(79999a9f1335aa4bc5043ddf033a0e38)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -15,6 +15,7 @@
 #include "tcp_sink_impl.h"
 #include <gnuradio/io_signature.h>
 
+#include <boost/format.hpp>
 #include <chrono>
 #include <sstream>
 #include <thread>

--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -15,6 +15,7 @@
 #include "udp_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <boost/array.hpp>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace network {

--- a/gr-pdu/lib/time_delta_impl.cc
+++ b/gr-pdu/lib/time_delta_impl.cc
@@ -14,6 +14,7 @@
 #include "time_delta_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/pdu.h>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace pdu {

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -14,6 +14,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <volk/volk.h>
+#include <boost/format.hpp>
 #include <cmath>
 
 #ifdef HAVE_CONFIG_H

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -17,6 +17,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/qtgui/utils.h>
+#include <boost/format.hpp>
 #include <sstream>
 
 namespace gr {

--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -21,6 +21,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
+#include <boost/format.hpp>
 #include <algorithm>
 #include <cstring>
 

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -22,6 +22,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
+#include <boost/format.hpp>
 #include <cstring>
 
 namespace gr {

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -21,6 +21,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
+#include <boost/format.hpp>
 #include <algorithm>
 #include <cstring>
 

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -23,6 +23,7 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
+#include <boost/format.hpp>
 #include <cstring>
 
 namespace gr {

--- a/gr-soapy/lib/sink_impl.cc
+++ b/gr-soapy/lib/sink_impl.cc
@@ -12,6 +12,7 @@
 
 #include "sink_impl.h"
 #include <SoapySDR/Errors.hpp>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace soapy {

--- a/gr-soapy/lib/source_impl.cc
+++ b/gr-soapy/lib/source_impl.cc
@@ -12,6 +12,7 @@
 
 #include "source_impl.h"
 #include <SoapySDR/Errors.hpp>
+#include <boost/format.hpp>
 
 namespace gr {
 namespace soapy {

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -9,6 +9,7 @@
  */
 
 #include "usrp_block_impl.h"
+#include <boost/format.hpp>
 #include <chrono>
 #include <thread>
 

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -12,6 +12,7 @@
 #include "usrp_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <boost/thread/thread.hpp>
 #include <chrono>
 #include <climits>


### PR DESCRIPTION
depends on #4778 

This is a bigger cleanup, as it requires including <boost/format.hpp> wherever it was actually used, but will be necessary sooner or later when we replace the logging subsystem.