### PR TITLE
grc: Update flowgraph vars controlled by vars

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -557,7 +557,7 @@ class Application(Gtk.Application):
                         ### Following line forces a complete update of io ports
                         flow_graph_update()
                         page.saved = False
-                    else:  # restore the current state
+                    if response in (Gtk.ResponseType.REJECT, Gtk.ResponseType.ACCEPT):
                         n = page.state_cache.get_current_state()
                         flow_graph.import_data(n)
                         flow_graph_update()


### PR DESCRIPTION
Fixes #4781. When a variable is controlled by another variable,
updating the latter does not update the former in the flowgraph when
`Ok` is pressed. Caused by commit c4f46bf. This commit patches the bug.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>