### PR TITLE
blocks: zero-output, zero-copy Head mode

### DIFF
--- a/gr-blocks/grc/blocks_head.block.yml
+++ b/gr-blocks/grc/blocks_head.block.yml
@@ -30,6 +30,7 @@ outputs:
 -   domain: stream
     dtype: ${ type }
     vlen: ${ vlen }
+    optional: true
 
 asserts:
 - ${ vlen > 0 }

--- a/gr-blocks/include/gnuradio/blocks/head.h
+++ b/gr-blocks/include/gnuradio/blocks/head.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2009,2012,2013 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -19,11 +20,17 @@ namespace gr {
 namespace blocks {
 
 /*!
- * \brief copies the first N items to the output then signals done
+ * \brief stop after processing the first N items
  * \ingroup misc_blk
  *
  * \details
- * Useful for building test cases
+ * Useful for building test cases, this block consumes only N items from its input, and
+ * copies them to its output, if that is connected.
+ *
+ * You can hence use this block in series with your sample flow if you want a block
+ * downstream of it to be tested with an exact number of input items; or you can put it in
+ * parallel to your data path, so that it stops at most one buffer size after the
+ * specified number of items has been produced upstream.
  */
 class BLOCKS_API head : virtual public sync_block
 {

--- a/gr-blocks/lib/head_impl.cc
+++ b/gr-blocks/lib/head_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2009,2013 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -27,7 +28,7 @@ head::sptr head::make(size_t sizeof_stream_item, uint64_t nitems)
 head_impl::head_impl(size_t sizeof_stream_item, uint64_t nitems)
     : sync_block("head",
                  io_signature::make(1, 1, sizeof_stream_item),
-                 io_signature::make(1, 1, sizeof_stream_item)),
+                 io_signature::make(0, 1, sizeof_stream_item)),
       d_nitems(nitems),
       d_ncopied_items(0)
 {
@@ -47,7 +48,12 @@ int head_impl::work(int noutput_items,
     if (n == 0)
         return 0;
 
-    memcpy(output_items[0], input_items[0], n * input_signature()->sizeof_stream_item(0));
+    // can have zero or one output port, if zero, don't copy
+    if (!output_items.empty()) {
+        memcpy(output_items[0],
+               input_items[0],
+               n * input_signature()->sizeof_stream_item(0));
+    }
     d_ncopied_items += n;
 
     return n;

--- a/gr-blocks/python/blocks/bindings/head_python.cc
+++ b/gr-blocks/python/blocks/bindings/head_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(head.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d0c0087ad00f1b1d3f09273ba0dcb7d6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(eef877add2d06c4e1e1a3ba48f498ad3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
If you don't want to test a stream with an exact number of input, but
just want your flow graph to terminate after a given number of items,
having a head block without an output enables you to do that without
copying the data from Head's in- to its output.