### PR TITLE
blocks: Throttle consume-only mode

### DIFF
--- a/gr-blocks/grc/blocks_throttle.block.yml
+++ b/gr-blocks/grc/blocks_throttle.block.yml
@@ -35,6 +35,7 @@ outputs:
 -   domain: stream
     dtype: ${ type }
     vlen: ${ vlen }
+    optional: true
 
 asserts:
 - ${ vlen > 0 }

--- a/gr-blocks/include/gnuradio/blocks/throttle.h
+++ b/gr-blocks/include/gnuradio/blocks/throttle.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2005-2011,2013 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -30,6 +31,13 @@ namespace blocks {
  * precisely controlling the rate of samples. That should be
  * controlled by a source or sink tied to sample clock. E.g., a
  * USRP or audio card.
+ *
+ * You can insert this block "in series" with your sample flow, in which case it  does a
+ * throttled copy of input to output. Alternatively, you can not connect its output and
+ * just connect this block's input in parallel to an existing block in your flow graph. In
+ * that case, Throttle will limit the rate at which samples are consumed; especially at
+ * higher rates, where the copying overhead might be significant, this is functionally not
+ * different to copying at a limited rate.
  */
 class BLOCKS_API throttle : virtual public sync_block
 {

--- a/gr-blocks/python/blocks/bindings/throttle_python.cc
+++ b/gr-blocks/python/blocks/bindings/throttle_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(throttle.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e32468fa73eff1abd796a3fbf4dbb8e0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c3a597508d581cabdc653faaa323232c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
When throttling a sample flow, it's not necessary to produce items at
the desired average rate - consuming them at a limited rate suffices to
slow down the processing of the whole flow graph just as well, and
avoids a copy.