### PR TITLE
modtool: Fix TypeError (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/core/rm.py
+++ b/gr-utils/modtool/core/rm.py
@@ -15,7 +15,7 @@ import sys
 import glob
 import logging
 
-from ..tools import remove_pattern_from_file, CMakeFileEditor, CPPFileEditor
+from ..tools import remove_pattern_from_file, CMakeFileEditor, CPPFileEditor, get_block_names
 from .base import ModTool, ModToolException
 
 logger = logging.getLogger(__name__)
@@ -88,11 +88,6 @@ class ModToolRemove(ModTool):
             ed.remove_double_newlines()
 
         # Go, go, go!
-        if not self.skip_subdirs['lib']:
-            self._run_subdir('lib', ('*.cc', '*.h'), ('add_library', 'list'),
-                             cmakeedit_func=_remove_cc_test_case)
-        if not self.skip_subdirs['include']:
-            incl_files_deleted = self._run_subdir(self.info['includedir'], ('*.h',), ('install',))
         if not self.skip_subdirs['python']:
             py_files_deleted = self._run_subdir('python', ('*.py',), ('GR_PYTHON_INSTALL',),
                                                 cmakeedit_func=_remove_py_test_case)
@@ -105,13 +100,28 @@ class ModToolRemove(ModTool):
             pbdoc_files_deleted = self._run_subdir('python/bindings/docstrings', ('*.h',), ('',))
 
             # Update python_bindings.cc
-            ed = CPPFileEditor(self._file['ccpybind'])
-            ed.remove_value('// BINDING_FUNCTION_PROTOTYPES(', '// ) END BINDING_FUNCTION_PROTOTYPES', 
-                'void bind_' + self.info['blockname'] + '(py::module& m);')
-            ed.remove_value('// BINDING_FUNCTION_CALLS(', '// ) END BINDING_FUNCTION_CALLS', 
-                'bind_' + self.info['blockname'] + '(m);')
-            ed.write()
+            blocknames_to_delete = []
+            if self.info['blockname']:
+                # A complete block name was given
+                blocknames_to_delete.append(self.info['blockname'])
+            elif self.info['pattern']:
+                # A regex resembling one or several blocks were given
+                blocknames_to_delete = get_block_names(self.info['pattern'], self.info['modname']) 
+            else:
+                raise ModToolException("No block name or regex was specified!")
+            for blockname in blocknames_to_delete:
+                ed = CPPFileEditor(self._file['ccpybind'])
+                ed.remove_value('// BINDING_FUNCTION_PROTOTYPES(', '// ) END BINDING_FUNCTION_PROTOTYPES', 
+                    'void bind_' + blockname + '(py::module& m);')
+                ed.remove_value('// BINDING_FUNCTION_CALLS(', '// ) END BINDING_FUNCTION_CALLS', 
+                    'bind_' + blockname + '(m);')
+                ed.write()
 
+        if not self.skip_subdirs['lib']:
+            self._run_subdir('lib', ('*.cc', '*.h'), ('add_library', 'list'),
+                             cmakeedit_func=_remove_cc_test_case)
+        if not self.skip_subdirs['include']:
+            incl_files_deleted = self._run_subdir(self.info['includedir'], ('*.h',), ('install',))
         if not self.skip_subdirs['grc']:
             self._run_subdir('grc', ('*.yml',), ('install',))
 

--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -117,6 +117,20 @@ def get_modname():
     except AttributeError:
         return None
 
+def get_block_names(pattern, modname):
+    """ Return a list of block names belonging to modname that matches the regex pattern. """
+    blocknames = []
+    reg = re.compile(pattern)
+    fname_re = re.compile(r'[a-zA-Z]\w+\.\w{1,5}$')
+    with open(f'include/{modname}/CMakeLists.txt', 'r') as f:
+        for line in f.read().splitlines():
+            if len(line.strip()) == 0 or line.strip()[0] == '#':
+                continue
+            for word in re.split('[ /)(\t\n\r\f\v]', line):
+                if fname_re.match(word) and reg.search(word):
+                    blocknames.append(word.strip('.h'))
+    return blocknames
+
 def is_number(s):
     """ Return True if the string s contains a number. """
     try:


### PR DESCRIPTION
Fixes #4682, a bug triggered in the `rm` and `bind` commands when the
block name (or regex) is entered as stdin rather than an argument.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit b285dc3dbd8369805e2c2e612dbf88983faf1353)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4686