### PR TITLE
iio: lib: Add missing gnuradio-iio.rc.in Windows DLL resource file

### DIFF
--- a/gr-iio/lib/gnuradio-iio.rc.in
+++ b/gr-iio/lib/gnuradio-iio.rc.in
@@ -1,0 +1,43 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include <afxres.h>
+
+VS_VERSION_INFO VERSIONINFO
+  FILEVERSION @MAJOR_VERSION@,@API_COMPAT@,@RC_MINOR_VERSION@,@RC_MAINT_VERSION@
+  PRODUCTVERSION @MAJOR_VERSION@,@API_COMPAT@,@RC_MINOR_VERSION@,@RC_MAINT_VERSION@
+  FILEFLAGSMASK 0x3fL
+#ifndef NDEBUG
+  FILEFLAGS 0x0L
+#else
+  FILEFLAGS 0x1L
+#endif
+  FILEOS VOS__WINDOWS32
+  FILETYPE VFT_DLL
+  FILESUBTYPE VFT2_DRV_INSTALLABLE
+  BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+      BLOCK "040904b0"
+      BEGIN
+        VALUE "FileDescription", "gnuradio-iio"
+        VALUE "FileVersion", "@VERSION@"
+        VALUE "InternalName", "gnuradio-iio.dll"
+        VALUE "LegalCopyright", "Licensed under GPLv3 or any later version"
+        VALUE "OriginalFilename", "gnuradio-iio.dll"
+        VALUE "ProductName", "gnuradio-iio"
+        VALUE "ProductVersion", "@VERSION@"
+      END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+      VALUE "Translation", 0x409, 1200
+    END
+  END


### PR DESCRIPTION
Fixes #4772.