### PR TITLE
Doxygen: Remove warnings from gr-soapy and gr-iio. (backport to maint-3.9)

### DIFF
--- a/gr-soapy/include/gnuradio/soapy/block.h
+++ b/gr-soapy/include/gnuradio/soapy/block.h
@@ -351,7 +351,6 @@ public:
 
     /*!
      * Does the device support automatic frontend IQ balance correction?
-     * \param direction the channel direction RX or TX
      * \param channel an available channel on the device
      * \return true if IQ balance corrections are supported
      */

--- a/gr-soapy/include/gnuradio/soapy/sink.h
+++ b/gr-soapy/include/gnuradio/soapy/sink.h
@@ -35,8 +35,7 @@ namespace soapy {
  * Antenna and clock source can be left empty and default values
  * will be used.
  * This block has a message port, which consumes PMT messages.
- * For a description of the command syntax , see \ref cmd_handler.
- * \image html sink_params.png "Figure 2"
+ * For a description of the command syntax, see \ref cmd_handler_t.
  */
 class SOAPY_API sink : virtual public block
 {

--- a/gr-soapy/include/gnuradio/soapy/source.h
+++ b/gr-soapy/include/gnuradio/soapy/source.h
@@ -35,8 +35,7 @@ namespace soapy {
  * Antenna and clock source can be left empty and default values
  * will be used.
  * This block has a message port, which consumes PMT messages.
- * For a description of the command syntax , see \ref cmd_handler.
- * \image html source_params.png "Figure 2"
+ * For a description of the command syntax, see \ref cmd_handler_t.
  */
 class SOAPY_API source : virtual public block
 {

--- a/gr-soapy/python/soapy/bindings/block_python.cc
+++ b/gr-soapy/python/soapy/bindings/block_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(4de2fe0c995edc3d14d7f4dde4bbb1db)                     */
+/* BINDTOOL_HEADER_FILE_HASH(6326cce2f22e30ab332ef966343f4a50)                     */
 /***********************************************************************************/
 
 #include "soapy_common.h"

--- a/gr-soapy/python/soapy/bindings/sink_python.cc
+++ b/gr-soapy/python/soapy/bindings/sink_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(sink.h)                                                    */
-/* BINDTOOL_HEADER_FILE_HASH(9d2a52df7aac70fba9497554fc13c9a8)                     */
+/* BINDTOOL_HEADER_FILE_HASH(07be73e41abcd1f8a128bd1ba153ab32)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-soapy/python/soapy/bindings/source_python.cc
+++ b/gr-soapy/python/soapy/bindings/source_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(source.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(f451db37bf5a066dda6a1c9a1e3a4835)                     */
+/* BINDTOOL_HEADER_FILE_HASH(2ae3163aea8bce7c6a687dda4356f09e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Signed-off-by: Ron Economos <w6rz@comcast.net>
(cherry picked from commit 3fe76f88d5585b62a286180265718beac5b1fb9b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4774