### PR TITLE
qtgui: remove spurious volk includes (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -14,7 +14,6 @@
 
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
-#include <volk/volk.h>
 #include <QColor>
 #include <cmath>
 #include <iostream>

--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/math.h>
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
-#include <volk/volk.h>
 #include <boost/math/special_functions/round.hpp>
 #include <QColor>
 #include <cmath>

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -15,7 +15,6 @@
 
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
-#include <volk/volk.h>
 #include <QColor>
 #include <cmath>
 #include <iostream>

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/prefs.h>
 
 #include <qwt_symbol.h>
-#include <volk/volk.h>
 
 #include <cstring>
 


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 29ebb4085e689043e14b95e1b8d16b517cc52000)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4777