### PR TITLE
qtgui: only one definition of (internal) TimePrecisionClass (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -10,6 +10,7 @@
 #ifndef EYE_DISPLAY_PLOT_C
 #define EYE_DISPLAY_PLOT_C
 
+#include "TimePrecisionClass.h"
 #include <gnuradio/qtgui/EyeDisplayPlot.h>
 
 #include <qwt_legend.h>
@@ -19,23 +20,6 @@
 #include <cmath>
 #include <iostream>
 
-class TimePrecisionClass
-{
-public:
-    TimePrecisionClass(const int timePrecision) { d_timePrecision = timePrecision; }
-
-    virtual ~TimePrecisionClass() {}
-
-    virtual unsigned int getTimePrecision() const { return d_timePrecision; }
-
-    virtual void setTimePrecision(const unsigned int newPrecision)
-    {
-        d_timePrecision = newPrecision;
-    }
-
-protected:
-    unsigned int d_timePrecision;
-};
 
 class EyeDisplayZoomer : public QwtPlotZoomer, public TimePrecisionClass
 {

--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -11,6 +11,7 @@
 #ifndef HISTOGRAM_DISPLAY_PLOT_C
 #define HISTOGRAM_DISPLAY_PLOT_C
 
+#include "TimePrecisionClass.h"
 #include <gnuradio/qtgui/HistogramDisplayPlot.h>
 
 #include <gnuradio/math.h>
@@ -25,25 +26,6 @@
 #ifdef _MSC_VER
 #define copysign _copysign
 #endif
-
-class TimePrecisionClass
-{
-public:
-    TimePrecisionClass(const int timeprecision) { d_time_precision = timeprecision; }
-
-    virtual ~TimePrecisionClass() {}
-
-    virtual unsigned int getTimePrecision() const { return d_time_precision; }
-
-    virtual void setTimePrecision(const unsigned int newprecision)
-    {
-        d_time_precision = newprecision;
-    }
-
-protected:
-    unsigned int d_time_precision;
-};
-
 
 class HistogramDisplayZoomer : public QwtPlotZoomer, public TimePrecisionClass
 {

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -11,6 +11,7 @@
 #ifndef TIME_DOMAIN_DISPLAY_PLOT_C
 #define TIME_DOMAIN_DISPLAY_PLOT_C
 
+#include "TimePrecisionClass.h"
 #include <gnuradio/qtgui/TimeDomainDisplayPlot.h>
 
 #include <qwt_legend.h>
@@ -19,25 +20,6 @@
 #include <QColor>
 #include <cmath>
 #include <iostream>
-
-class TimePrecisionClass
-{
-public:
-    TimePrecisionClass(const int timePrecision) { d_timePrecision = timePrecision; }
-
-    virtual ~TimePrecisionClass() {}
-
-    virtual unsigned int getTimePrecision() const { return d_timePrecision; }
-
-    virtual void setTimePrecision(const unsigned int newPrecision)
-    {
-        d_timePrecision = newPrecision;
-    }
-
-protected:
-    unsigned int d_timePrecision;
-};
-
 
 class TimeDomainDisplayZoomer : public QwtPlotZoomer, public TimePrecisionClass
 {

--- a/gr-qtgui/lib/TimePrecisionClass.h
+++ b/gr-qtgui/lib/TimePrecisionClass.h
@@ -1,0 +1,23 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+class TimePrecisionClass
+{
+public:
+    TimePrecisionClass(const int timePrecision) { d_timePrecision = timePrecision; }
+    virtual ~TimePrecisionClass() = default;
+    virtual unsigned int getTimePrecision() const { return d_timePrecision; }
+    virtual void setTimePrecision(const unsigned int newPrecision)
+    {
+        d_timePrecision = newPrecision;
+    }
+
+protected:
+    unsigned int d_timePrecision;
+};

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -11,6 +11,7 @@
 #ifndef TIMERASTER_DISPLAY_PLOT_C
 #define TIMERASTER_DISPLAY_PLOT_C
 
+#include "TimePrecisionClass.h"
 #include <gnuradio/qtgui/TimeRasterDisplayPlot.h>
 
 #include <gnuradio/qtgui/qtgui_types.h>
@@ -234,24 +235,6 @@ private:
     double d_delta_value;
     double d_ten_scale;
     std::string d_units;
-};
-
-class TimePrecisionClass
-{
-public:
-    TimePrecisionClass(const int timePrecision) { d_timePrecision = timePrecision; }
-
-    virtual ~TimePrecisionClass() {}
-
-    virtual unsigned int getTimePrecision() const { return d_timePrecision; }
-
-    virtual void setTimePrecision(const unsigned int newPrecision)
-    {
-        d_timePrecision = newPrecision;
-    }
-
-protected:
-    unsigned int d_timePrecision;
 };
 
 /***********************************************************************


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit e1b633a95047fce266e575cbc66a314d31c24491)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4776