### PR TITLE
grc: generating a simple cpp qt-gui flowgraph fails (backport to maint-3.9)

### DIFF
--- a/gr-analog/grc/analog_agc2_xx.block.yml
+++ b/gr-analog/grc/analog_agc2_xx.block.yml
@@ -63,6 +63,6 @@ cpp_templates:
     - set_reference(${reference})
     - set_gain(${gain})
     - set_max_gain(${max_gain})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_agc3_xx.block.yml
+++ b/gr-analog/grc/analog_agc3_xx.block.yml
@@ -67,6 +67,6 @@ cpp_templates:
     - set_reference(${reference})
     - set_gain(${gain})
     - set_max_gain(${max_gain})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_agc_xx.block.yml
+++ b/gr-analog/grc/analog_agc_xx.block.yml
@@ -57,6 +57,6 @@ cpp_templates:
     - set_reference(${reference})
     - set_gain(${gain})
     - set_max_gain(${max_gain})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_const_source_x.block.yml
+++ b/gr-analog/grc/analog_const_source_x.block.yml
@@ -32,6 +32,6 @@ cpp_templates:
     make: 'this->${id} = analog::sig_source_${type.fcn}::make(0, analog::GR_CONST_WAVE, 0, 0, ${const});'
     callbacks:
     - set_offset(${const})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_cpfsk_bc.block.yml
+++ b/gr-analog/grc/analog_cpfsk_bc.block.yml
@@ -34,7 +34,7 @@ cpp_templates:
     make: 'this->${id} = analog::cpfsk_bc::make(${k}, ${amplitude}, ${samples_per_symbol});'
     callbacks:
     - set_amplitude(${amplitude})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 
 file_format: 1

--- a/gr-analog/grc/analog_ctcss_squelch_ff.block.yml
+++ b/gr-analog/grc/analog_ctcss_squelch_ff.block.yml
@@ -49,7 +49,7 @@ cpp_templates:
     callbacks:
     - set_level(${level})
     - set_frequency(${freq})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-analog/grc/analog_dpll_bb.block.yml
+++ b/gr-analog/grc/analog_dpll_bb.block.yml
@@ -29,6 +29,6 @@ cpp_templates:
     make: 'this->${id} = analog::dpll_bb::make(${period}, ${gain});'
     callbacks:
     - set_gain(${gain})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_fastnoise_source_x.block.yml
+++ b/gr-analog/grc/analog_fastnoise_source_x.block.yml
@@ -46,7 +46,7 @@ cpp_templates:
     callbacks:
     - set_type(${noise_type})
     - set_amplitude(${amp})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
     translations:
         analog.: 'analog::'
 

--- a/gr-analog/grc/analog_feedforward_agc_cc.block.yml
+++ b/gr-analog/grc/analog_feedforward_agc_cc.block.yml
@@ -27,6 +27,6 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/analog/feedforward_agc_cc.h>']
     make: 'this->${id} = analog::feedforward_agc_cc::make(${num_samples}, ${reference});'
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_frequency_modulator_fc.block.yml
+++ b/gr-analog/grc/analog_frequency_modulator_fc.block.yml
@@ -27,6 +27,6 @@ cpp_templates:
     make: 'this->${id} = analog::frequency_modulator_fc::make(${sensitivity});'
     callbacks:
     - set_sensitivity(${sensitivity})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_noise_source_x.block.yml
+++ b/gr-analog/grc/analog_noise_source_x.block.yml
@@ -42,7 +42,7 @@ cpp_templates:
     callbacks:
     - set_type(${noise_type})
     - set_amplitude(${amp})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
     translations:
         analog.: 'analog::'
 

--- a/gr-analog/grc/analog_phase_modulator_fc.block.yml
+++ b/gr-analog/grc/analog_phase_modulator_fc.block.yml
@@ -24,7 +24,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/analog/phase_modulator_fc.h>']
     make: 'this->${id} = analog::phase_modulator_fc::make(${sensitivity});'
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
     callbacks:
     - set_sensitivity(${sensitivity})
 

--- a/gr-analog/grc/analog_pll_carriertracking_cc.block.yml
+++ b/gr-analog/grc/analog_pll_carriertracking_cc.block.yml
@@ -36,6 +36,6 @@ cpp_templates:
     - set_loop_bandwidth(${w})
     - set_max_freq(${max_freq})
     - set_min_freq(${min_freq})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_pll_freqdet_cf.block.yml
+++ b/gr-analog/grc/analog_pll_freqdet_cf.block.yml
@@ -36,7 +36,7 @@ cpp_templates:
     - set_loop_bandwidth(${w})
     - set_max_freq(${max_freq})
     - set_min_freq(${min_freq})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 
 file_format: 1

--- a/gr-analog/grc/analog_pll_refout_cc.block.yml
+++ b/gr-analog/grc/analog_pll_refout_cc.block.yml
@@ -36,6 +36,6 @@ cpp_templates:
     - set_loop_bandwidth(${w})
     - set_max_freq(${max_freq})
     - set_min_freq(${min_freq})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_pwr_squelch_xx.block.yml
+++ b/gr-analog/grc/analog_pwr_squelch_xx.block.yml
@@ -48,7 +48,7 @@ cpp_templates:
     callbacks:
     - set_threshold(${threshold})
     - set_alpha(${alpha})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
     translations:
         True: true
         False: false

--- a/gr-analog/grc/analog_rail_ff.block.yml
+++ b/gr-analog/grc/analog_rail_ff.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     callbacks:
     - set_lo(${lo})
     - set_hi(${hi})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_random_uniform_source_x.block.yml
+++ b/gr-analog/grc/analog_random_uniform_source_x.block.yml
@@ -33,6 +33,6 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/analog/random_uniform_source.h>']
     make: 'this->${id} = analog.random_uniform_source_${type.fcn}(${minimum}, ${maximum}, ${seed});'
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_sig_source_x.block.yml
+++ b/gr-analog/grc/analog_sig_source_x.block.yml
@@ -75,7 +75,7 @@ cpp_templates:
     - set_amplitude(${amp})
     - set_offset(${offset})
     - set_phase(${phase})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
     translations:
         analog\.: 'analog::'
 

--- a/gr-analog/grc/analog_simple_squelch_cc.block.yml
+++ b/gr-analog/grc/analog_simple_squelch_cc.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     callbacks:
     - set_threshold(${threshold})
     - set_alpha(${alpha})
-    link: ['gnuradio-analog']
+    link: ['gnuradio::gnuradio-analog']
 
 file_format: 1

--- a/gr-analog/grc/analog_wfm_tx.block.yml
+++ b/gr-analog/grc/analog_wfm_tx.block.yml
@@ -42,6 +42,6 @@ cpp_templates:
     includes: [ '#include <gnuradio/analog/frequency_modulator_fc.h>', '#include <boost/math/constants/constants.hpp>' ]
     declarations: gr::analog::frequency_modulator_fc::sptr ${id};
     make: this->${id} = gr::analog::frequency_modulator_fc::make(2 * boost::math::constants::pi<double>() * ${max_dev} / ${quad_rate});
-    link: ['gnuradio-analog']          
+    link: ['gnuradio::gnuradio-analog']          
       
 file_format: 1

--- a/gr-audio/grc/audio_sink.block.yml
+++ b/gr-audio/grc/audio_sink.block.yml
@@ -43,7 +43,7 @@ cpp_templates:
     includes: [ '#include <gnuradio/audio/sink.h>' ]
     declarations: 'audio::sink::sptr ${id};'
     make: 'this->${id} = audio::sink::make(${samp_rate}, ${device_name}, ${ok_to_block});'
-    link: ['gnuradio-audio']
+    link: ['gnuradio::gnuradio-audio']
     translations:
         "'": '"'
         'True': 'true'

--- a/gr-audio/grc/audio_source.block.yml
+++ b/gr-audio/grc/audio_source.block.yml
@@ -43,7 +43,7 @@ cpp_templates:
     includes: [ '#include <gnuradio/audio/source.h>' ]
     declarations: 'audio::source::sptr ${id};'
     make: 'this->${id} = audio::source::make(${samp_rate}, ${device_name}, ${ok_to_block});'
-    link: ['gnuradio-audio']
+    link: ['gnuradio::gnuradio-audio']
     translations:
         "'": '"'
         'True': 'true'

--- a/gr-digital/grc/digital_additive_scrambler_bb.block.yml
+++ b/gr-digital/grc/digital_additive_scrambler_bb.block.yml
@@ -52,6 +52,6 @@ cpp_templates:
             count=${count},
             bits_per_byte=${bits_per_byte},
             reset_tag_key=${reset_tag_key});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_binary_slicer_fb.block.yml
+++ b/gr-digital/grc/digital_binary_slicer_fb.block.yml
@@ -19,6 +19,6 @@ cpp_templates:
     declarations: 'digital::binary_slicer_fb::sptr ${id};'
     make: |-
         this->${id} = digital::binary_slicer_fb::make();
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_burst_shaper.block.yml
+++ b/gr-digital/grc/digital_burst_shaper.block.yml
@@ -63,7 +63,7 @@ cpp_templates:
             ${post_padding},
             ${insert_phasing},
             ${length_tag_name});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_chunks_to_symbols.block.yml
+++ b/gr-digital/grc/digital_chunks_to_symbols.block.yml
@@ -69,7 +69,7 @@ cpp_templates:
         this->${id} = digital::chunks_to_symbols_${in_type.fcn}${out_type.fcn}::make(
             symbol_table,
             ${dimension});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_symbol_table(symbol_table)
 

--- a/gr-digital/grc/digital_clock_recovery_mm_xx.block.yml
+++ b/gr-digital/grc/digital_clock_recovery_mm_xx.block.yml
@@ -60,7 +60,7 @@ cpp_templates:
             ${mu},
             ${gain_mu},
             ${omega_relative_limit});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_omega(${omega})
     - set_gain_omega(${gain_omega})

--- a/gr-digital/grc/digital_constellation.block.yml
+++ b/gr-digital/grc/digital_constellation.block.yml
@@ -82,6 +82,6 @@ cpp_templates:
         % elif str(soft_dec_lut) != "None":
         this->${id}.set_soft_dec_lut(${soft_dec_lut}, ${precision});
         % endif
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_decoder_cb.block.yml
+++ b/gr-digital/grc/digital_constellation_decoder_cb.block.yml
@@ -23,6 +23,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/constellation_decoder_cb.h>']
     declarations: 'digital::constellation_decoder_cb::sptr ${id};'
     make: 'this->${id} = digital::constellation_decoder_cb::make(${constellation});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_encoder_bc.block.yml
+++ b/gr-digital/grc/digital_constellation_encoder_bc.block.yml
@@ -23,6 +23,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/constellation_encoder_bc.h>']
     declarations: 'digital::constellation_encoder_bc::sptr ${id};'
     make: 'this->${id} = digital::constellation_encoder_bc::make(${constellation});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_receiver_cb.block.yml
+++ b/gr-digital/grc/digital_constellation_receiver_cb.block.yml
@@ -67,6 +67,6 @@ cpp_templates:
             ${loop_bw},
             ${fmin},
             ${fmax}));
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_soft_decoder_cf.block.yml
+++ b/gr-digital/grc/digital_constellation_soft_decoder_cf.block.yml
@@ -24,6 +24,6 @@ cpp_templates:
     declarations: 'digital::constellation_soft_decoder_cf::sptr ${id};'
     make: |-
         this->${id} = digital::constellation_soft_decoder_cf::make(${constellation});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_corr_est_cc.block.yml
+++ b/gr-digital/grc/digital_corr_est_cc.block.yml
@@ -52,7 +52,7 @@ cpp_templates:
             ${mark_delay},
             ${threshold},
             ${threshold_method});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_mark_delay(${mark_delay})
     - set_threshold(${threshold})

--- a/gr-digital/grc/digital_correlate_access_code_tag_xx.block.yml
+++ b/gr-digital/grc/digital_correlate_access_code_tag_xx.block.yml
@@ -46,7 +46,7 @@ cpp_templates:
             ${access_code},
             ${threshold},
             ${tagname});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_access_code(${access_code})
     - set_threshold(${threshold})

--- a/gr-digital/grc/digital_correlate_access_code_xx_ts.block.yml
+++ b/gr-digital/grc/digital_correlate_access_code_xx_ts.block.yml
@@ -43,6 +43,6 @@ cpp_templates:
             ${access_code},
             ${threshold},
             ${tagname});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_costas_loop_cc.block.yml
+++ b/gr-digital/grc/digital_costas_loop_cc.block.yml
@@ -54,7 +54,7 @@ cpp_templates:
             ${w},
             ${order},
             ${use_snr});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_loop_bandwidth(${w})
     translations:

--- a/gr-digital/grc/digital_cpmmod_bc.block.yml
+++ b/gr-digital/grc/digital_cpmmod_bc.block.yml
@@ -48,7 +48,7 @@ cpp_templates:
             ${samples_per_symbol},
             ${L},
             ${beta});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         analog.cpm.: 'analog::cpm::'
 

--- a/gr-digital/grc/digital_crc32_async_bb.block.yml
+++ b/gr-digital/grc/digital_crc32_async_bb.block.yml
@@ -29,7 +29,7 @@ cpp_templates:
     make: |-
         this->${id} = digital::crc32_async_bb::make(
             ${check});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_crc32_bb.block.yml
+++ b/gr-digital/grc/digital_crc32_bb.block.yml
@@ -39,7 +39,7 @@ cpp_templates:
             ${check},
             ${lengthtagname},
             ${packed});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_descrambler_bb.block.yml
+++ b/gr-digital/grc/digital_descrambler_bb.block.yml
@@ -36,6 +36,6 @@ cpp_templates:
             ${mask},
             ${seed},
             ${len});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_diff_decoder_bb.block.yml
+++ b/gr-digital/grc/digital_diff_decoder_bb.block.yml
@@ -34,7 +34,7 @@ cpp_templates:
     declarations: 'digital::diff_decoder_bb::sptr ${id};'
     make: |-
         this->${id} = digital::diff_decoder_bb::make(${modulus if coding.force_modulus == '-1' else coding.force_modulus}, ${coding});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         digital.DIFF: 'digital::DIFF'
 

--- a/gr-digital/grc/digital_diff_encoder_bb.block.yml
+++ b/gr-digital/grc/digital_diff_encoder_bb.block.yml
@@ -34,7 +34,7 @@ cpp_templates:
     declarations: 'digital::diff_encoder_bb::sptr ${id};'
     make: |-
         this->${id} = digital::diff_encoder_bb::make(${modulus if coding.force_modulus == '-1' else coding.force_modulus}, ${coding});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         digital.DIFF: 'digital::DIFF'
 

--- a/gr-digital/grc/digital_diff_phasor_cc.block.yml
+++ b/gr-digital/grc/digital_diff_phasor_cc.block.yml
@@ -19,6 +19,6 @@ cpp_templates:
     declarations: 'digital::diff_phasor_cc::sptr ${id};'
     make: |-
         this->${id} = digital::diff_phasor_cc::make();
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_fll_band_edge_cc.block.yml
+++ b/gr-digital/grc/digital_fll_band_edge_cc.block.yml
@@ -60,7 +60,7 @@ cpp_templates:
             ${rolloff},
             ${filter_size},
             ${w});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_loop_bandwidth(${w})
 

--- a/gr-digital/grc/digital_framer_sink_1.block.yml
+++ b/gr-digital/grc/digital_framer_sink_1.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     declarations: 'digital::framer_sink_1::sptr ${id};'
     make: |-
         this->${id} = digital::framer_sink_1::make(${target_queue});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_glfsr_source_x.block.yml
+++ b/gr-digital/grc/digital_glfsr_source_x.block.yml
@@ -44,7 +44,7 @@ cpp_templates:
             ${repeat},
             ${mask},
             ${seed});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_hdlc_deframer_bp.block.yml
+++ b/gr-digital/grc/digital_hdlc_deframer_bp.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
         this->${id} = digital::hdlc_deframer_bp::make(
             ${min},
             ${max});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_hdlc_framer_pb.block.yml
+++ b/gr-digital/grc/digital_hdlc_framer_pb.block.yml
@@ -23,6 +23,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/hdlc_framer_pb.h>']
     declarations: 'digital::hdlc_framer_pb::sptr ${id};'
     make: 'this->${id} = digital::hdlc_framer_pb::make(${frame_tag_name});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_header_payload_demux.block.yml
+++ b/gr-digital/grc/digital_header_payload_demux.block.yml
@@ -107,7 +107,7 @@ cpp_templates:
             ${samp_rate},
             ${special_tags},
             ${header_padding});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_map_bb.block.yml
+++ b/gr-digital/grc/digital_map_bb.block.yml
@@ -26,6 +26,6 @@ cpp_templates:
     make: |-
         std::vector<int> map = {${str(map)[1:-1]}};
         this->${id} = digital::map_bb::make(map);
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_modulate_vector.block.yml
+++ b/gr-digital/grc/digital_modulate_vector.block.yml
@@ -28,6 +28,6 @@ cpp_templates:
         std::vector<float> taps = {${str(taps)[1:-1]}};
         this->${id} = ${id} = digital::modulate_vector_bc(${mod}.to_basic_block(),
         data, taps);
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_mpsk_snr_est_cc.block.yml
+++ b/gr-digital/grc/digital_mpsk_snr_est_cc.block.yml
@@ -41,7 +41,7 @@ cpp_templates:
             ${type},
             ${tag_nsamples},
             ${alpha});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_type(${type})
     - set_tag_nsamples(${tag_nsamples})

--- a/gr-digital/grc/digital_msk_timing_recovery_cc.block.yml
+++ b/gr-digital/grc/digital_msk_timing_recovery_cc.block.yml
@@ -50,7 +50,7 @@ cpp_templates:
             ${gain},
             ${limit},
             ${osps});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_gain(${gain})
     - set_sps(${sps})

--- a/gr-digital/grc/digital_ofdm_carrier_allocator_cvc.block.yml
+++ b/gr-digital/grc/digital_ofdm_carrier_allocator_cvc.block.yml
@@ -61,7 +61,7 @@ cpp_templates:
             ${sync_words},
             ${len_tag_key},
             ${output_is_shifted});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_ofdm_chanest_vcvc.block.yml
+++ b/gr-digital/grc/digital_ofdm_chanest_vcvc.block.yml
@@ -64,7 +64,7 @@ cpp_templates:
             ${eq_noise_red_len},
             ${max_carr_offset},
             ${force_one_symbol});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_ofdm_cyclic_prefixer.block.yml
+++ b/gr-digital/grc/digital_ofdm_cyclic_prefixer.block.yml
@@ -56,6 +56,6 @@ cpp_templates:
         % endif
             ${rolloff},
             ${tagname});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_ofdm_frame_equalizer_vcvc.block.yml
+++ b/gr-digital/grc/digital_ofdm_frame_equalizer_vcvc.block.yml
@@ -54,7 +54,7 @@ cpp_templates:
             ${len_tag_key},
             ${propagate_channel_state},
             ${fixed_frame_len});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_ofdm_serializer_vcc.block.yml
+++ b/gr-digital/grc/digital_ofdm_serializer_vcc.block.yml
@@ -61,7 +61,7 @@ cpp_templates:
             ${symbols_skipped},
             ${carr_offset_key},
             ${input_is_shifted});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-digital/grc/digital_ofdm_sync_sc_cfb.block.yml
+++ b/gr-digital/grc/digital_ofdm_sync_sc_cfb.block.yml
@@ -52,7 +52,7 @@ cpp_templates:
             ${cp_len},
             ${use_even_carriers},
             ${threshold});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_threshold(${threshold})
     translations:

--- a/gr-digital/grc/digital_packet_headergenerator_bb.block.yml
+++ b/gr-digital/grc/digital_packet_headergenerator_bb.block.yml
@@ -32,7 +32,7 @@ cpp_templates:
         this->${id} = digital::packet_headergenerator_bb::make(
             ${header_len},
             ${len_tag_key});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_header_formatter(${header_formatter})
 

--- a/gr-digital/grc/digital_packet_headergenerator_bb_default.block.yml
+++ b/gr-digital/grc/digital_packet_headergenerator_bb_default.block.yml
@@ -30,6 +30,6 @@ cpp_templates:
         this->${id} = digital::packet_headergenerator_bb::make(
             ${header_len},
             ${len_tag_key});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_packet_headerparser_b.block.yml
+++ b/gr-digital/grc/digital_packet_headerparser_b.block.yml
@@ -22,6 +22,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/packet_headerparser_b.h>']
     declarations: 'digital::packet_headerparser_b::sptr ${id};'
     make: 'this->${id} = digital::packet_headerparser_b::make(${header_formatter});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_packet_headerparser_b_default.block.yml
+++ b/gr-digital/grc/digital_packet_headerparser_b_default.block.yml
@@ -30,6 +30,6 @@ cpp_templates:
         this->${id} = digital::packet_headerparser_b::make(
             ${header_len},
             ${len_tag_key});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_packet_sink.block.yml
+++ b/gr-digital/grc/digital_packet_sink.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
             sync_vector,
             ${target_queue},
             ${threshold});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_pfb_clock_sync.block.yml
+++ b/gr-digital/grc/digital_pfb_clock_sync.block.yml
@@ -81,7 +81,7 @@ cpp_templates:
             ${init_phase},
             ${max_dev},
             ${osps});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - update_taps(taps)
     - set_loop_bandwidth(${loop_bw})

--- a/gr-digital/grc/digital_pn_correlator_cc.block.yml
+++ b/gr-digital/grc/digital_pn_correlator_cc.block.yml
@@ -35,6 +35,6 @@ cpp_templates:
             ${degree},
             ${mask},
             ${seed});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_probe_density_b.block.yml
+++ b/gr-digital/grc/digital_probe_density_b.block.yml
@@ -26,7 +26,7 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/probe_density_b.h>']
     declarations: 'digital::probe_density_b::sptr ${id};'
     make: 'this->${id} = digital::probe_density_b::make(${alpha});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_alpha(${alpha})
 

--- a/gr-digital/grc/digital_probe_mpsk_snr_est_c.block.yml
+++ b/gr-digital/grc/digital_probe_mpsk_snr_est_c.block.yml
@@ -48,7 +48,7 @@ cpp_templates:
             ${type},
             ${msg_nsamples},
             ${alpha});
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_type(${type})
     - set_msg_nsample(${msg_nsamples})

--- a/gr-digital/grc/digital_protocol_formatter_async.block.yml
+++ b/gr-digital/grc/digital_protocol_formatter_async.block.yml
@@ -28,6 +28,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/protocol_formatter_async.h>']
     declarations: 'digital::protocol_formatter_async::sptr ${id};'
     make: 'this->${id} = digital::protocol_formatter_async::make(${format});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_protocol_formatter_bb.block.yml
+++ b/gr-digital/grc/digital_protocol_formatter_bb.block.yml
@@ -27,6 +27,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/protocol_formatter_bb.h>']
     declarations: 'digital::protocol_formatter_bb::sptr ${id};'
     make: 'this->${id} = digital::protocol_formatter_bb::make(${format}, ${len_tag_key});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_protocol_parser_b.block.yml
+++ b/gr-digital/grc/digital_protocol_parser_b.block.yml
@@ -24,6 +24,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/protocol_parser_b.h>']
     declarations: 'digital::protocol_parser_b::sptr ${id};'
     make: 'this->${id} = fft::ctrlport_probe_psd::make(${format});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_scrambler_bb.block.yml
+++ b/gr-digital/grc/digital_scrambler_bb.block.yml
@@ -32,6 +32,6 @@ cpp_templates:
     includes: ['#include <gnuradio/digital/scrambler_bb.h>']
     declarations: 'digital::scrambler_bb::sptr ${id};'
     make: 'this->${id} = digital::scrambler_bb::make(${mask}, ${seed}, ${len});'
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -133,7 +133,7 @@ cpp_templates:
             ${resamp_type}, 
             ${nfilters},
             pfb_mf_taps);
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
     callbacks:
     - set_loop_bandwidth(${loop_bw})
     - set_damping_factor(${damping})

--- a/gr-digital/grc/variable_header_format_default.block.yml
+++ b/gr-digital/grc/variable_header_format_default.block.yml
@@ -39,6 +39,6 @@ cpp_templates:
         this->${id} = ${id} = digital::header_format_default(${access_code},\
         ${threshold}, ${bps});
         % endif
-    link: ['gnuradio-digital']
+    link: ['gnuradio::gnuradio-digital']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_deinterleaver.block.yml
+++ b/gr-dtv/grc/dtv_atsc_deinterleaver.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_deinterleaver.h>']
     declarations: 'dtv::atsc_deinterleaver::sptr ${id};'
     make: 'this->${id} = dtv::atsc_deinterleaver::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_depad.block.yml
+++ b/gr-dtv/grc/dtv_atsc_depad.block.yml
@@ -19,6 +19,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_depad.h>']
     declarations: 'dtv::atsc_depad::sptr ${id};'
     make: 'this->${id} = dtv::atsc_depad::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_derandomizer.block.yml
+++ b/gr-dtv/grc/dtv_atsc_derandomizer.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_derandomizer.h>']
     declarations: 'dtv::atsc_derandomizer::sptr ${id};'
     make: 'this->${id} = dtv::atsc_derandomizer::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_equalizer.block.yml
+++ b/gr-dtv/grc/dtv_atsc_equalizer.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_equalizer.h>']
     declarations: 'dtv::atsc_equalizer::sptr ${id};'
     make: 'this->${id} = dtv::atsc_equalizer::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_field_sync_mux.block.yml
+++ b/gr-dtv/grc/dtv_atsc_field_sync_mux.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_field_sync_mux.h>']
     declarations: 'dtv::atsc_field_sync_mux::sptr ${id};'
     make: 'this->${id} = dtv::atsc_field_sync_mux::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_fpll.block.yml
+++ b/gr-dtv/grc/dtv_atsc_fpll.block.yml
@@ -23,6 +23,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_fpll.h>']
     declarations: 'dtv::atsc_fpll::sptr ${id};'
     make: 'this->${id} = dtv::atsc_fpll::make(${rate});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_fs_checker.block.yml
+++ b/gr-dtv/grc/dtv_atsc_fs_checker.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_fs_checker.h>']
     declarations: 'dtv::atsc_fs_checker::sptr ${id};'
     make: 'this->${id} = dtv::atsc_fs_checker::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_interleaver.block.yml
+++ b/gr-dtv/grc/dtv_atsc_interleaver.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_interleaver.h>']
     declarations: 'dtv::atsc_interleaver::sptr ${id};'
     make: 'this->${id} = dtv::atsc_interleaver::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_pad.block.yml
+++ b/gr-dtv/grc/dtv_atsc_pad.block.yml
@@ -19,6 +19,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_pad.h>']
     declarations: 'dtv::atsc_pad::sptr ${id};'
     make: 'this->${id} = dtv::atsc_pad::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_randomizer.block.yml
+++ b/gr-dtv/grc/dtv_atsc_randomizer.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_randomizer.h>']
     declarations: 'dtv::atsc_randomizer::sptr ${id};'
     make: 'this->${id} = dtv::atsc_randomizer::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_rs_decoder.block.yml
+++ b/gr-dtv/grc/dtv_atsc_rs_decoder.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_rs_decoder.h>']
     declarations: 'dtv::atsc_rs_decoder::sptr ${id};'
     make: 'this->${id} = dtv::atsc_rs_decoder::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_rs_encoder.block.yml
+++ b/gr-dtv/grc/dtv_atsc_rs_encoder.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_rs_encoder.h>']
     declarations: 'dtv::atsc_rs_encoder::sptr ${id};'
     make: 'this->${id} = dtv::atsc_rs_encoder::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_sync.block.yml
+++ b/gr-dtv/grc/dtv_atsc_sync.block.yml
@@ -24,6 +24,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_sync.h>']
     declarations: 'dtv::atsc_sync::sptr ${id};'
     make: 'this->{id} = dtv::atsc_sync::make(${rate});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_trellis_encoder.block.yml
+++ b/gr-dtv/grc/dtv_atsc_trellis_encoder.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_trellis_encoder.h>']
     declarations: 'dtv::atsc_trellis_encoder::sptr ${id};'
     make: 'this->${id} = dtv::atsc_trellis_encoder::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_atsc_viterbi_decoder.block.yml
+++ b/gr-dtv/grc/dtv_atsc_viterbi_decoder.block.yml
@@ -20,6 +20,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/atsc_viterbi_decoder.h>']
     declarations: 'dtv::atsc_viterbi_decoder::sptr ${id};'
     make: 'this->${id} = dtv::atsc_viterbi_decoder::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_catv_frame_sync_enc_bb.block.yml
+++ b/gr-dtv/grc/dtv_catv_frame_sync_enc_bb.block.yml
@@ -31,7 +31,7 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/catv_frame_sync_enc_bb.h>']
     declarations: 'dtv::catv_frame_sync_enc_bb::sptr ${id};'
     make: 'this->${id} = dtv::catv_frame_sync_enc_bb::make(${constellation.val}, ${ctrlword});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: "dtv::"
 

--- a/gr-dtv/grc/dtv_catv_randomizer_bb.block.yml
+++ b/gr-dtv/grc/dtv_catv_randomizer_bb.block.yml
@@ -27,7 +27,7 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/catv_randomizer_bb.h>']
     declarations: 'dtv::catv_randomizer_bb::sptr ${id};'
     make: 'this->${id} = dtv::catv_randomizer_bb::make(${constellation.val});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: "dtv::"
 

--- a/gr-dtv/grc/dtv_catv_reed_solomon_enc_bb.block.yml
+++ b/gr-dtv/grc/dtv_catv_reed_solomon_enc_bb.block.yml
@@ -18,6 +18,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/catv_reed_solomon_enc_bb.h>']
     declarations: 'dtv::catv_reed_solomon_enc_bb::sptr ${id};'
     make: 'this->${id} = dtv::catv_reed_solomon_enc_bb::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_catv_transport_framing_enc_bb.block.yml
+++ b/gr-dtv/grc/dtv_catv_transport_framing_enc_bb.block.yml
@@ -18,6 +18,6 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/catv_transport_framing_enc_bb.h>']
     declarations: 'dtv::catv_transport_framing_enc_bb::sptr ${id};'
     make: 'this->${id} = dtv::catv_transport_framing_enc_bb::make();'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_catv_trellis_enc_bb.block.yml
+++ b/gr-dtv/grc/dtv_catv_trellis_enc_bb.block.yml
@@ -27,7 +27,7 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/catv_trellis_enc_bb.h>']
     declarations: 'dtv::catv_trellis_enc_bb::sptr ${id};'
     make: 'dtv::catv_trellis_enc_bb::make(${constellation.val});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: "dtv::"
 

--- a/gr-dtv/grc/dtv_dvb_bbheader_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_bbheader_bb.block.yml
@@ -204,7 +204,7 @@ cpp_templates:
             ${inband.val},
             ${fecblocks},
             ${tsrate});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvb_bbscrambler_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_bbscrambler_bb.block.yml
@@ -161,7 +161,7 @@ cpp_templates:
             % endif
             % endif
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvb_bch_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_bch_bb.block.yml
@@ -161,7 +161,7 @@ cpp_templates:
             % endif
             % endif
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvb_ldpc_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvb_ldpc_bb.block.yml
@@ -169,7 +169,7 @@ cpp_templates:
             % endif
             % endif
             ${constellation.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbs2_interleaver_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvbs2_interleaver_bb.block.yml
@@ -106,7 +106,7 @@ cpp_templates:
             ${rate3.val},
             % endif
             ${constellation.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbs2_modulator_bc.block.yml
+++ b/gr-dtv/grc/dtv_dvbs2_modulator_bc.block.yml
@@ -124,7 +124,7 @@ cpp_templates:
             % endif
             ${constellation.val},
             ${interpolation.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbs2_physical_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbs2_physical_cc.block.yml
@@ -121,7 +121,7 @@ cpp_templates:
             ${constellation.val},
             ${pilots.val},
             ${goldcode});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_cellinterleaver_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_cellinterleaver_cc.block.yml
@@ -44,7 +44,7 @@ cpp_templates:
     declarations: 'dtv::dvbt2_cellinterleaver_cc::sptr ${id};'
     make: 'this->${id} = dtv::dvbt2_cellinterleaver_cc::make(${framesize.val},
         ${constellation.val}, ${fecblocks}, ${tiblocks});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_framemapper_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_framemapper_cc.block.yml
@@ -271,7 +271,7 @@ cpp_templates:
             ${reservedbiasbits.val},
             ${l1scrambled.val},
             ${inband.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_freqinterleaver_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_freqinterleaver_cc.block.yml
@@ -138,7 +138,7 @@ cpp_templates:
             ${preamble2.val}
             % endif
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_interleaver_bb.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_interleaver_bb.block.yml
@@ -42,7 +42,7 @@ cpp_templates:
     includes: ['#include <gnuradio/dtv/dvbt2_interleaver_bb.h>']
     declarations: 'dtv::dvbt2_interleaver_bb::sptr ${id};'
     make: 'this->${id} = dtv::dvbt2_interleaver_bb::make(${framesize.val}, ${rate.val}, ${constellation.val});'
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_miso_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_miso_cc.block.yml
@@ -110,7 +110,7 @@ cpp_templates:
             ${paprmode2.val}
             % endif
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_modulator_bc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_modulator_bc.block.yml
@@ -42,7 +42,7 @@ cpp_templates:
     declarations: 'dtv::dvbt2_modulator_bc::sptr ${id};'
     make: |-
         this->${id} = dtv::dvbt2_modulator_bc::make(${framesize.val}, ${constellation.val}, ${rotation.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_p1insertion_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_p1insertion_cc.block.yml
@@ -145,7 +145,7 @@ cpp_templates:
             ${showlevels.val},
             ${vclip}
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_paprtr_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_paprtr_cc.block.yml
@@ -135,7 +135,7 @@ cpp_templates:
             ${iterations},
             ${fftsize.vlength}
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt2_pilotgenerator_cc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt2_pilotgenerator_cc.block.yml
@@ -178,7 +178,7 @@ cpp_templates:
             ${bandwidth.val},
             ${fftsize.vlength}
             );
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_bit_inner_deinterleaver.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_bit_inner_deinterleaver.block.yml
@@ -53,7 +53,7 @@ cpp_templates:
             ${constellation.val},
             ${hierarchy.val},
             ${transmission_mode.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_bit_inner_interleaver.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_bit_inner_interleaver.block.yml
@@ -53,7 +53,7 @@ cpp_templates:
             ${constellation.val},
             ${hierarchy.val},
             ${transmission_mode.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_convolutional_deinterleaver.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_convolutional_deinterleaver.block.yml
@@ -40,6 +40,6 @@ cpp_templates:
     declarations: 'dtv::dvbt_convolutional_deinterleaver::sptr ${id};'
     make: |-
         this->${id} = dtv::dvbt_convolutional_deinterleaver::make(${blocks}, ${I}, ${M});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_convolutional_interleaver.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_convolutional_interleaver.block.yml
@@ -40,6 +40,6 @@ cpp_templates:
     declarations: 'dtv::dvbt_convolutional_interleaver::sptr ${id};'
     make: |-
         this->${id} = dtv::dvbt_convolutional_interleaver::make(${blocks}, ${I}, ${M});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_demap.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_demap.block.yml
@@ -55,7 +55,7 @@ cpp_templates:
             ${hierarchy.val},
             ${transmission_mode.val},
             ${gain});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_demod_reference_signals.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_demod_reference_signals.block.yml
@@ -108,7 +108,7 @@ cpp_templates:
             ${transmission_mode.val},
             ${include_cell_id.val},
             ${cell_id});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_energy_descramble.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_energy_descramble.block.yml
@@ -30,6 +30,6 @@ cpp_templates:
     declarations: 'dtv::dvbt_energy_descramble::sptr ${id};'
     make: |-
         this->${id} = dtv::dvbt_energy_descramble::make(${nsize});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_energy_dispersal.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_energy_dispersal.block.yml
@@ -30,6 +30,6 @@ cpp_templates:
     declarations: 'dtv::dvbt_energy_dispersal::sptr ${id};'
     make: |-
         this->${id} = dtv::dvbt_energy_dispersal::make(${nsize});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_inner_coder.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_inner_coder.block.yml
@@ -63,7 +63,7 @@ cpp_templates:
             ${constellation.val},
             ${hierarchy.val},
             ${code_rate.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_map.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_map.block.yml
@@ -55,7 +55,7 @@ cpp_templates:
             ${hierarchy.val},
             ${transmission_mode.val},
             ${gain});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_ofdm_sym_acquisition.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_ofdm_sym_acquisition.block.yml
@@ -52,6 +52,6 @@ cpp_templates:
             ${occupied_tones},
             ${cp_length},
             ${snr});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_reed_solomon_dec.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_reed_solomon_dec.block.yml
@@ -64,6 +64,6 @@ cpp_templates:
             ${t},
             ${s},
             ${blocks});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_reed_solomon_enc.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_reed_solomon_enc.block.yml
@@ -64,6 +64,6 @@ cpp_templates:
             ${t},
             ${s},
             ${blocks});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
 
 file_format: 1

--- a/gr-dtv/grc/dtv_dvbt_reference_signals.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_reference_signals.block.yml
@@ -108,7 +108,7 @@ cpp_templates:
             ${transmission_mode.val},
             ${include_cell_id.val},
             ${cell_id});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_symbol_inner_interleaver.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_symbol_inner_interleaver.block.yml
@@ -42,7 +42,7 @@ cpp_templates:
             ${transmission_mode.payload_length},
             ${transmission_mode.val},
             ${direction.val});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-dtv/grc/dtv_dvbt_viterbi_decoder.block.yml
+++ b/gr-dtv/grc/dtv_dvbt_viterbi_decoder.block.yml
@@ -58,7 +58,7 @@ cpp_templates:
             ${hierarchy.val},
             ${code_rate.val},
             ${block_size});
-    link: ['gnuradio-dtv']
+    link: ['gnuradio::gnuradio-dtv']
     translations:
         dtv\.: 'dtv::'
 

--- a/gr-fft/grc/fft_ctrlport_probe_psd.block.yml
+++ b/gr-fft/grc/fft_ctrlport_probe_psd.block.yml
@@ -30,7 +30,7 @@ cpp_templates:
     includes: [ '#include <gnuradio/fft/ctrlport_probe_psd.h>' ]
     declarations: 'fft::ctrlport_probe_psd::sptr ${id};'
     make: 'this->${id} = fft::ctrlport_probe_psd::make(${name}, ${desc}, ${len});'
-    link: ['gnuradio-fft']
+    link: ['gnuradio::gnuradio-fft']
     callbacks:
     - set_length(${len})
 

--- a/gr-fft/grc/fft_fft_vxx.block.yml
+++ b/gr-fft/grc/fft_fft_vxx.block.yml
@@ -65,7 +65,7 @@ cpp_templates:
         % else:
         this->${id} = fft::fft_vfc::make(${fft_size}, ${forward}, ${window}, ${shift}, ${nthreads});
         % endif
-    link: ['gnuradio-fft']
+    link: ['gnuradio::gnuradio-fft']
     callbacks:
     - set_nthreads(${nthreads})
     translations:

--- a/gr-fft/grc/fft_goertzel_fc.block.yml
+++ b/gr-fft/grc/fft_goertzel_fc.block.yml
@@ -35,7 +35,7 @@ cpp_templates:
     includes: [ '#include <gnuradio/fft/goertzel_fc.h>' ]
     declarations: 'fft::goertzel_fc::sptr ${id};'
     make: 'this->${id} = fft::goertzel_fc::make(${rate}, ${len}, ${freq});'
-    link: ['gnuradio-fft']
+    link: ['gnuradio::gnuradio-fft']
     callbacks:
     - set_freq(${freq})
     - set_rate(${rate})

--- a/gr-filter/grc/filter_band_pass_filter.block.yml
+++ b/gr-filter/grc/filter_band_pass_filter.block.yml
@@ -105,7 +105,7 @@ cpp_templates:
                 ${width},
                 ${win},
                 ${beta}));
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(firdes::${type.fcn}(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq},
         ${width}, ${win}, ${beta}))

--- a/gr-filter/grc/filter_band_reject_filter.block.yml
+++ b/gr-filter/grc/filter_band_reject_filter.block.yml
@@ -102,7 +102,7 @@ cpp_templates:
                 ${width},
                 ${win},
                 ${beta}));
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(firdes::${type.fcn}(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq},
         ${width}, ${win}, ${beta}))

--- a/gr-filter/grc/filter_dc_blocker_xx.block.yml
+++ b/gr-filter/grc/filter_dc_blocker_xx.block.yml
@@ -37,7 +37,7 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/dc_blocker_${type}.h>']
     declarations: 'filter::dc_blocker_${type}::sptr ${id};'
     make: 'this->${id} = filter::dc_blocker_${type}::make(${length}, ${long_form});'
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-filter/grc/filter_fft_filter_xxx.block.yml
+++ b/gr-filter/grc/filter_fft_filter_xxx.block.yml
@@ -64,7 +64,7 @@ cpp_templates:
             taps,
             ${nthreads});
         this->${id}.declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
     - set_nthreads(${nthreads})

--- a/gr-filter/grc/filter_filter_delay_fc.block.yml
+++ b/gr-filter/grc/filter_filter_delay_fc.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
         std::vector<float> taps = {${str(taps)[1:-1]}};
         this->${id} = filter::fft_filter_${type}::make(
             taps);
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 file_format: 1

--- a/gr-filter/grc/filter_filterbank_vcvcf.block.yml
+++ b/gr-filter/grc/filter_filterbank_vcvcf.block.yml
@@ -30,7 +30,7 @@ cpp_templates:
     make: |-
         this->${id} = filter::filterbank_vcvcf::make( 
             ${taps});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(${taps})
 

--- a/gr-filter/grc/filter_fir_filter_xxx.block.yml
+++ b/gr-filter/grc/filter_fir_filter_xxx.block.yml
@@ -60,7 +60,7 @@ cpp_templates:
             ${decim}, 
             taps);
         this->${id}.declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
 

--- a/gr-filter/grc/filter_high_pass_filter.block.yml
+++ b/gr-filter/grc/filter_high_pass_filter.block.yml
@@ -88,7 +88,7 @@ cpp_templates:
                 ${width},
                 ${win},
                 ${beta}));
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(firdes::high_pass(${gain}, ${samp_rate}, ${cutoff_freq}, ${width}, ${win},
         ${beta}))

--- a/gr-filter/grc/filter_hilbert_fc.block.yml
+++ b/gr-filter/grc/filter_hilbert_fc.block.yml
@@ -41,6 +41,6 @@ cpp_templates:
             ${num_taps},
             ${win},
             ${beta});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 file_format: 1

--- a/gr-filter/grc/filter_iir_filter_xxx.block.yml
+++ b/gr-filter/grc/filter_iir_filter_xxx.block.yml
@@ -57,7 +57,7 @@ cpp_templates:
             fftaps,
             fbtaps,
             ${oldstyle});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(fftaps, fbtaps)
     translations:

--- a/gr-filter/grc/filter_interp_fir_filter_xxx.block.yml
+++ b/gr-filter/grc/filter_interp_fir_filter_xxx.block.yml
@@ -56,7 +56,7 @@ cpp_templates:
         std::vector<int> taps = {${str(taps)[1:-1]}};
         % endif
         this->${id} = filter::interp_fir_filter_${type}::make(${interp}, taps);
-  link: ['gnuradio-filter']
+  link: ['gnuradio::gnuradio-filter']
   callbacks:
     - set_taps(${taps})
 

--- a/gr-filter/grc/filter_low_pass_filter.block.yml
+++ b/gr-filter/grc/filter_low_pass_filter.block.yml
@@ -88,7 +88,7 @@ cpp_templates:
                 ${width},
                 ${win.replace('firdes.', 'gr::filter::firdes::')},
                 ${beta}));
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(gr::filter::firdes::low_pass(${gain}, ${samp_rate}, ${cutoff_freq}, ${width}, ${win.replace('firdes.', 'gr::filter::firdes::')},
         ${beta}))

--- a/gr-filter/grc/filter_mmse_resampler_xx.block.yml
+++ b/gr-filter/grc/filter_mmse_resampler_xx.block.yml
@@ -45,7 +45,7 @@ cpp_templates:
         this->${id} = filter::mmse_resampler_${type.fcn}::make(
             ${phase_shift},
             ${resamp_ratio});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_resamp_ratio(${resamp_ratio})
 

--- a/gr-filter/grc/filter_pfb_arb_resampler.block.yml
+++ b/gr-filter/grc/filter_pfb_arb_resampler.block.yml
@@ -93,7 +93,7 @@ cpp_templates:
             taps,
             ${nfilts});
         this->${id}->declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
     - set_rate(${rrate})

--- a/gr-filter/grc/filter_pfb_channelizer.block.yml
+++ b/gr-filter/grc/filter_pfb_channelizer.block.yml
@@ -71,7 +71,7 @@ cpp_templates:
             ${atten});
         this->${id}.set_channel_map(${ch_map});
         this->${id}.declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
     - set_channel_map(${ch_map})

--- a/gr-filter/grc/filter_pfb_decimator.block.yml
+++ b/gr-filter/grc/filter_pfb_decimator.block.yml
@@ -73,7 +73,7 @@ cpp_templates:
             ${fft_rot},
             ${fft_filts});
         this->${id}.declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
     - set_channel(int(${channel}))

--- a/gr-filter/grc/filter_pfb_interpolator.block.yml
+++ b/gr-filter/grc/filter_pfb_interpolator.block.yml
@@ -50,7 +50,7 @@ cpp_templates:
             taps,
             ${atten});
         this->${id}.declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
 

--- a/gr-filter/grc/filter_pfb_synthesizer.block.yml
+++ b/gr-filter/grc/filter_pfb_synthesizer.block.yml
@@ -70,7 +70,7 @@ cpp_templates:
             ${twox});
         this->${id}->set_channel_map(ch_map);
         this->${id}->declare_sample_delay(${samp_delay});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)
     - set_channel_map(ch_map)

--- a/gr-filter/grc/filter_rational_resampler_xxx.block.yml
+++ b/gr-filter/grc/filter_rational_resampler_xxx.block.yml
@@ -89,7 +89,7 @@ cpp_templates:
             ${decim},
             taps,
             ${fbw});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(${taps})
 

--- a/gr-filter/grc/filter_root_raised_cosine_filter.block.yml
+++ b/gr-filter/grc/filter_root_raised_cosine_filter.block.yml
@@ -81,7 +81,7 @@ cpp_templates:
                 ${sym_rate},
                 ${alpha},
                 ${ntaps}));
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(firdes::root_raised_cosine(${gain}, ${samp_rate}, ${sym_rate}, ${alpha},
         ${ntaps}))

--- a/gr-filter/grc/filter_single_pole_iir_filter_xx.block.yml
+++ b/gr-filter/grc/filter_single_pole_iir_filter_xx.block.yml
@@ -40,7 +40,7 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/single_pole_iir_filter_${type.fcn}.h>']
     declarations: 'filter::single_pole_iir_filter_${type.fcn}::sptr ${id};'
     make: 'this->${id} = filter::single_pole_iir_filter_${type.fcn}::make(${alpha}, ${vlen});'
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(${alpha})
 

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -53,7 +53,7 @@ cpp_templates:
     var_make: |-
         this->${id} = ${id} = firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, \
         ${high_cutoff_freq}, ${width}, ${win}, ${beta});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 documentation: |-
     This is a convenience wrapper for calling firdes.band_pass() or firdes.complex_band_pass()

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -53,7 +53,7 @@ cpp_templates:
     var_make: |-
         this->${id} = ${id} = firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq},\
         ${high_cutoff_freq}, ${width}, ${win}, ${beta});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 documentation: |-
     This is a convenience wrapper for calling firdes.band_reject() or firdes.complex_band_reject().

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -44,7 +44,7 @@ cpp_templates:
     var_make: |-
         this->${id} = ${id} = firdes.high_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
         ${width}, ${win}, ${beta});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 documentation: |-
     This variable is a convenience wrapper around a call to firdes.high_pass(...).

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -44,7 +44,7 @@ cpp_templates:
     var_make: |-
         this->${id} = ${id} = firdes.low_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
         ${width}, ${win}, ${beta});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 documentation: |-
     This variable is a convenience wrapper around a call to firdes.low_pass(...).

--- a/gr-filter/grc/variable_rrc_filter_taps.block.yml
+++ b/gr-filter/grc/variable_rrc_filter_taps.block.yml
@@ -38,7 +38,7 @@ cpp_templates:
     var_make: |-
         this->${id} = ${id} = firdes.root_raised_cosine(${gain}, ${samp_rate},\
         ${sym_rate}, ${alpha}, ${ntaps});
-    link: ['gnuradio-filter']
+    link: ['gnuradio::gnuradio-filter']
 
 documentation: |-
     This is a convenience wrapper for calling firdes.root_raised_cosine(...).

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -69,7 +69,11 @@ cpp_templates:
         QObject::connect(this->_${id}_line_edit, &QLineEdit::returnPressed, this, [this] () {this->set_${id}(this->_${id}_line_edit->text().toInt());});
 
         this->top_layout->addWidget(this->_${id}_tool_bar);
-
+        % if  len(gui_hint) > 0:
+        this->top_grid_layout->addWidget(this->_${id}_tool_bar,${gui_hint});
+        % else:
+        this->top_layout->addWidget(this->_${id}_tool_bar);
+        % endif
 documentation: |-
     This block creates a variable with a text entry box. Leave the label blank to use the variable id as the label.
 

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -59,7 +59,7 @@ cpp_templates:
     - set_${id}(${value})
     - QMetaObject::invokeMethod(this->_${id}_line_edit, "setText", Q_ARG(QString,
         QString::number(${id})))
-    link: ['gnuradio-qtgui', 'Qt5::Widgets']
+    link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
     make: |-
         this->_${id}_tool_bar = new QToolBar();
         this->_${id}_label = new QLabel(QString::fromStdString(std::string("${label.strip("'")}")+ std::string(":")));

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -516,7 +516,12 @@ cpp_templates:
         }
 
         _${id}_win = this->${id}->qwidget();
+        % if  len(gui_hint) > 0:
+        this->top_grid_layout->addWidget(_${id}_win,${gui_hint});
+        % else:
         this->top_layout->addWidget(_${id}_win);
+        % endif
+
     translations:
         firdes.: 'filter::firdes::'
         'True': 'true'

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -38,6 +38,9 @@ parameters:
         window.WIN_RECTANGULAR, window.WIN_KAISER, window.WIN_FLATTOP]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
+    option_attributes:
+        cpp_opts: [fft::window::WIN_BLACKMAN_hARRIS, fft::window::WIN_HAMMING, fft::window::WIN_HANN, fft::window::WIN_BLACKMAN,
+        fft::window::WIN_RECTANGULAR, fft::window::WIN_KAISER, fft::window::WIN_FLATTOP]
     hide: part
 -   id: norm_window
     label: Normalize Window Power
@@ -121,6 +124,8 @@ parameters:
     default: qtgui.TRIG_MODE_FREE
     options: [qtgui.TRIG_MODE_FREE, qtgui.TRIG_MODE_AUTO, qtgui.TRIG_MODE_NORM, qtgui.TRIG_MODE_TAG]
     option_labels: [Free, Auto, Normal, Tag]
+    option_attributes:
+        cpp_opts: [qtgui::TRIG_MODE_FREE, qtgui::TRIG_MODE_AUTO, qtgui::TRIG_MODE_NORM, qtgui::TRIG_MODE_TAG]
     hide: part
 -   id: tr_level
     label: Trigger Level
@@ -462,12 +467,12 @@ cpp_templates:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
     - set_y_axis(${ymin}, ${ymax})
-    - this->${id}.set_trigger_mode(${tr_mode.replace('qtgui.','gr::qtgui::')}, ${tr_level}, ${tr_chan}, ${tr_tag})
+    - this->${id}.set_trigger_mode(${tr_mode.cpp_opts}, ${tr_level}, ${tr_chan}, ${tr_tag})
     link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
     make:  |-
         this->${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
-            gr::fft::${wintype.replace('window.', 'window::')}, //wintype
+            ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
             ${name}, // name
@@ -523,7 +528,6 @@ cpp_templates:
         % endif
 
     translations:
-        firdes.: 'filter::firdes::'
         'True': 'true'
         'False': 'false'
 

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -462,12 +462,12 @@ cpp_templates:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
     - set_y_axis(${ymin}, ${ymax})
-    - this->${id}.set_trigger_mode(${tr_mode}, ${tr_level}, ${tr_chan}, ${tr_tag})
+    - this->${id}.set_trigger_mode(${tr_mode.replace('qtgui.','gr::qtgui::')}, ${tr_level}, ${tr_chan}, ${tr_tag})
     link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
     make:  |-
         this->${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
-            ${wintype}, // wintype
+            gr::fft::${wintype.replace('window.', 'window::')}, //wintype
             ${fc}, // fc
             ${bw}, // bw
             ${name}, // name
@@ -488,7 +488,7 @@ cpp_templates:
         this->${id}->set_update_time(${update_time});
         this->${id}->set_y_axis(${ymin}, ${ymax});
         this->${id}->set_y_label("${label.strip("'")}", "${units.strip("'")}");
-        this->${id}->set_trigger_mode(${tr_mode}, ${tr_level}, ${tr_chan}, ${tr_tag});
+        this->${id}->set_trigger_mode(${tr_mode.replace('qtgui.','gr::qtgui::')}, ${tr_level}, ${tr_chan}, ${tr_tag});
         this->${id}->enable_autoscale(${autoscale});
         this->${id}->enable_grid(${grid});
         this->${id}->set_fft_average(${average});

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -463,7 +463,7 @@ cpp_templates:
     - set_update_time(${update_time})
     - set_y_axis(${ymin}, ${ymax})
     - this->${id}.set_trigger_mode(${tr_mode}, ${tr_level}, ${tr_chan}, ${tr_tag})
-    link: ['gnuradio-qtgui', 'Qt5::Widgets']
+    link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
     make:  |-
         this->${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
@@ -521,7 +521,6 @@ cpp_templates:
         firdes.: 'filter::firdes::'
         'True': 'true'
         'False': 'false'
-        qtgui.: 'qtgui::'
 
 documentation: |-
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -151,7 +151,7 @@ cpp_templates:
     ## Attempt to replicate logic of Python gui_hint() method
     this->top_grid_layout->addWidget(${id + '->qwidget()' + (', ' + str(gui_hint)[1:-1] if len(gui_hint) > 2 else '')});
 
-  link: ['gnuradio-qtgui', 'Qt5Widgets', 'Qt5Core']
+  link: ['gnuradio::gnuradio-qtgui', 'Qt5Widgets', 'Qt5Core']
   translations:
     'True': 'true'
     'False': 'false'

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -149,7 +149,11 @@ cpp_templates:
     ${id}->set_update_time(1.0/${rate});   
     ${id}->enable_rf_freq(${showrf});
     ## Attempt to replicate logic of Python gui_hint() method
-    this->top_grid_layout->addWidget(${id + '->qwidget()' + (', ' + str(gui_hint)[1:-1] if len(gui_hint) > 2 else '')});
+    % if  len(gui_hint) > 0:
+    this->top_grid_layout->addWidget(${id + '->qwidget()'},${gui_hint});
+    % else:
+    this->top_layout->addWidget(${id + '->qwidget()'});
+    % endif
 
   link: ['gnuradio::gnuradio-qtgui', 'Qt5Widgets', 'Qt5Core']
   translations:

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -137,7 +137,7 @@ cpp_templates:
   make: |-
     ${id} = gr::qtgui::${type.fcn}::make(
             ${fftsize}, //fftsize
-            gr::filter::${wintype.replace('.', '::win_type::')}, //wintype
+            gr::fft::${wintype.replace('window.', 'window::')}, //wintype
             ${fc}, //fc
             ${bw}, //bw
             ${name}, //name

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -26,6 +26,9 @@ parameters:
     options: [window.WIN_BLACKMAN_hARRIS, window.WIN_HAMMING, window.WIN_HANN, window.WIN_BLACKMAN,
         window.WIN_RECTANGULAR, window.WIN_KAISER]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser]
+    option_attributes:
+        cpp_opts: [fft::window::WIN_BLACKMAN_hARRIS, fft::window::WIN_HAMMING, fft::window::WIN_HANN, fft::window::WIN_BLACKMAN,
+        fft::window::WIN_RECTANGULAR, fft::window::WIN_KAISER]
     hide: part
 -   id: fc
     label: Center Frequency (Hz)
@@ -137,7 +140,7 @@ cpp_templates:
   make: |-
     ${id} = gr::qtgui::${type.fcn}::make(
             ${fftsize}, //fftsize
-            gr::fft::${wintype.replace('window.', 'window::')}, //wintype
+            ${wintype.cpp_opts}, // wintype
             ${fc}, //fc
             ${bw}, //bw
             ${name}, //name

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -38,6 +38,9 @@ parameters:
         window.WIN_RECTANGULAR, window.WIN_KAISER, window.WIN_FLATTOP]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
+    option_attributes:
+        cpp_opts: [fft::window::WIN_BLACKMAN_hARRIS, fft::window::WIN_HAMMING, fft::window::WIN_HANN, fft::window::WIN_BLACKMAN,
+        fft::window::WIN_RECTANGULAR, fft::window::WIN_KAISER, fft::window::WIN_FLATTOP]
     hide: part
 -   id: fc
     label: Center Frequency (Hz)
@@ -311,7 +314,7 @@ cpp_templates:
     make: |-
         this->${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
-            gr::fft::${wintype.replace('window.', 'window::')}, //wintype
+            ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
             ${name}, // name

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -307,7 +307,7 @@ cpp_templates:
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
-    link: ['gnuradio-qtgui', 'Qt5::Widgets']
+    link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
     make: |-
         this->${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -311,7 +311,7 @@ cpp_templates:
     make: |-
         this->${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
-            ${wintype}, // wintype
+            gr::fft::${wintype.replace('window.', 'window::')}, //wintype
             ${fc}, // fc
             ${bw}, // bw
             ${name}, // name

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -353,7 +353,12 @@ cpp_templates:
         this->${id}->set_intensity_range(${int_min}, ${int_max});
 
         _${id}_win = this->${id}->qwidget();
+        % if  len(gui_hint) > 0:
+        this->top_grid_layout->addWidget(_${id}_win,${gui_hint});
+        % else:
         this->top_layout->addWidget(_${id}_win);
+        % endif
+        
     translations:
         firdes.: 'filter::firdes::'
         'True': 'true'

--- a/gr-video-sdl/grc/video_sdl_sink.block.yml
+++ b/gr-video-sdl/grc/video_sdl_sink.block.yml
@@ -53,7 +53,7 @@ cpp_templates:
     declarations: 'video_sdl::sink_${type.fcn}::sptr ${id};'
     make: 'this->${id} = video_sdl::sink_${type.fcn}::make(${fps}, ${width}, ${height}, 0, ${display_width},
         ${display_height});'
-    link: ['gnuradio-video_sdl']
+    link: ['gnuradio::gnuradio-video_sdl']
 
 documentation: |-
     Provides a rudimentary on-screen video display using libsdl.

--- a/gr-zeromq/grc/zeromq_pub_msg_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_msg_sink.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     includes: [ '#include <gnuradio/zeromq/pub_msg_sink.h>' ]
     declarations: gr::zeromq::pub_msg_sink::sptr ${id};
     make: this->${id} = gr::zeromq::pub_msg_sink::make(const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, ${timeout});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_pub_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_sink.block.yml
@@ -59,7 +59,7 @@ cpp_templates:
         ${timeout}, 
         ${pass_tags}, 
         ${hwm});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_pull_msg_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_msg_source.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     includes: [ '#include <gnuradio/zeromq/pull_msg_source.h>' ]
     declarations: gr::zeromq::pull_msg_source::sptr ${id};
     make: this->${id} = gr::zeromq::pull_msg_source::make(const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, ${timeout});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_pull_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_source.block.yml
@@ -55,7 +55,7 @@ cpp_templates:
               ${timeout}, 
               ${pass_tags}, 
               ${hwm});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_push_msg_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_push_msg_sink.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     includes: [ '#include <gnuradio/zeromq/push_msg_sink.h>' ]
     declarations: gr::zeromq::push_msg_sink::sptr ${id};
     make: this->${id} = gr::zeromq::push_msg_sink::make(const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, ${timeout});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_push_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_push_sink.block.yml
@@ -55,7 +55,7 @@ cpp_templates:
               ${timeout}, 
               ${pass_tags}, 
               ${hwm});
-    link: ['gnuradio-zeromq']          
+    link: ['gnuradio::gnuradio-zeromq']          
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_rep_msg_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_rep_msg_sink.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     includes: [ '#include <gnuradio/zeromq/rep_msg_sink.h>' ]
     declarations: gr::zeromq::rep_msg_sink::sptr ${id};
     make: this->${id} = gr::zeromq::rep_msg_sink::make(const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, ${timeout});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_rep_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_rep_sink.block.yml
@@ -56,7 +56,7 @@ cpp_templates:
         ${timeout}, 
         ${pass_tags}, 
         ${hwm});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_req_msg_source.block.yml
+++ b/gr-zeromq/grc/zeromq_req_msg_source.block.yml
@@ -31,6 +31,6 @@ cpp_templates:
     includes: [ '#include <gnuradio/zeromq/req_msg_source.h>' ]
     declarations: gr::zeromq::req_msg_source::sptr ${id};
     make: this->${id} = gr::zeromq::req_msg_source::make(const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, ${timeout});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_req_source.block.yml
+++ b/gr-zeromq/grc/zeromq_req_source.block.yml
@@ -55,7 +55,7 @@ cpp_templates:
         ${timeout}, 
         ${pass_tags}, 
         ${hwm});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_sub_msg_source.block.yml
+++ b/gr-zeromq/grc/zeromq_sub_msg_source.block.yml
@@ -31,7 +31,7 @@ cpp_templates:
     includes: [ '#include <gnuradio/zeromq/sub_msg_source.h>' ]
     declarations: gr::zeromq::sub_msg_source::sptr ${id};
     make: this->${id} = gr::zeromq::sub_msg_source::make(const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, ${timeout});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
 
 
 file_format: 1

--- a/gr-zeromq/grc/zeromq_sub_source.block.yml
+++ b/gr-zeromq/grc/zeromq_sub_source.block.yml
@@ -60,7 +60,7 @@ cpp_templates:
         ${pass_tags}, 
         ${hwm},
         ${key});
-    link: ['gnuradio-zeromq']      
+    link: ['gnuradio::gnuradio-zeromq']      
     translations:
       'True': 'true'
       'False': 'false'

--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -53,6 +53,9 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 add_executable(${class_name} ${class_name}.cpp)
 target_link_libraries(${class_name}
     gnuradio::gnuradio-blocks
+    % if generate_options == 'qt_gui':
+    gnuradio::gnuradio-qtgui
+    % endif
     % for link in links:
     % if link:
     ${link}

--- a/grc/core/generator/cpp_templates/flow_graph.hpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.hpp.mako
@@ -28,6 +28,7 @@ ${inc}
 #include <QWidget>
 #include <QGridLayout>
 #include <QSettings>
+#include <QApplication>
 % endif
 
 % if parameters:


### PR DESCRIPTION
Generating cpp code for the simple flowgraph described in #2688 fails as
an include statement and a required link lib is missing.

This pr fixes this issue. More complex flowgraphs will still fail.

Signed-off-by: Volker Schroer 3470424+dl1ksv@users.noreply.github.com
(cherry picked from commits bb730ec5f, 4f2da473c, 8093f579e, 06b7d1a8d, 640f737a9)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport #4710