### PR TITLE
grc: introduce gui_hint for cpp code generation

### DIFF
--- a/gr-analog/grc/analog_noise_source_x.block.yml
+++ b/gr-analog/grc/analog_noise_source_x.block.yml
@@ -38,12 +38,13 @@ templates:
 
 cpp_templates:
     includes: ['#include <gnuradio/analog/noise_source.h>']
+    declarations: 'analog::noise_source_${type.fcn}::sptr ${id};'
     make: 'this->${id} = analog::noise_source_${type.fcn}::make(${noise_type}, ${amp}, ${seed});'
     callbacks:
     - set_type(${noise_type})
     - set_amplitude(${amp})
     link: ['gnuradio::gnuradio-analog']
     translations:
-        analog.: 'analog::'
+        analog\.: 'analog::'
 
 file_format: 1

--- a/gr-qtgui/examples/c++/Number_Sink.grc
+++ b/gr-qtgui/examples/c++/Number_Sink.grc
@@ -1,0 +1,173 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: Number_Sink
+    max_nouts: '0'
+    output_language: cpp
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Number_Sink demo
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 12.0]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: freq
+  id: variable_qtgui_label
+  parameters:
+    comment: ''
+    formatter: None
+    gui_hint: 0,0
+    label: Frequency
+    type: real
+    value: '0.1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 12.0]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '32000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [192, 12.0]
+    rotation: 0
+    state: enabled
+- name: analog_sig_source_x_0
+  id: analog_sig_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: '1'
+    comment: ''
+    freq: freq
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: '0'
+    phase: '0'
+    samp_rate: samp_rate
+    type: float
+    waveform: analog.GR_COS_WAVE
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [40, 148.0]
+    rotation: 0
+    state: true
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [256, 188.0]
+    rotation: 0
+    state: true
+- name: qtgui_number_sink_0
+  id: qtgui_number_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    autoscale: 'False'
+    avg: '0'
+    color1: ("black", "black")
+    color10: ("black", "black")
+    color2: ("black", "black")
+    color3: ("black", "black")
+    color4: ("black", "black")
+    color5: ("black", "black")
+    color6: ("black", "black")
+    color7: ("black", "black")
+    color8: ("black", "black")
+    color9: ("black", "black")
+    comment: ''
+    factor1: '1'
+    factor10: '1'
+    factor2: '1'
+    factor3: '1'
+    factor4: '1'
+    factor5: '1'
+    factor6: '1'
+    factor7: '1'
+    factor8: '1'
+    factor9: '1'
+    graph_type: qtgui.NUM_GRAPH_VERT
+    gui_hint: ''
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    max: '1'
+    min: '-1'
+    name: '""'
+    nconnections: '1'
+    type: float
+    unit1: ''
+    unit10: ''
+    unit2: ''
+    unit3: ''
+    unit4: ''
+    unit5: ''
+    unit6: ''
+    unit7: ''
+    unit8: ''
+    unit9: ''
+    update_time: '0.10'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [432, 172.0]
+    rotation: 0
+    state: true
+
+connections:
+- [analog_sig_source_x_0, '0', blocks_throttle_0, '0']
+- [blocks_throttle_0, '0', qtgui_number_sink_0, '0']
+
+metadata:
+  file_format: 1

--- a/gr-qtgui/examples/c++/gui_sink.grc
+++ b/gr-qtgui/examples/c++/gui_sink.grc
@@ -1,0 +1,194 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: GUI Sink demo
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: gui_sink
+    max_nouts: '0'
+    output_language: cpp
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: QT GUI Sink
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [16, 20.0]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: check_box
+  id: variable_qtgui_check_box
+  parameters:
+    comment: ''
+    'false': '0'
+    gui_hint: 1,0
+    label: Add noise
+    'true': '1'
+    type: int
+    value: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [304, 20.0]
+    rotation: 0
+    state: true
+- name: freq
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: 0,0
+    label: Frequency
+    type: int
+    value: '800'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [480, 20.0]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '100000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [192, 20.0]
+    rotation: 0
+    state: enabled
+- name: analog_noise_source_x_0
+  id: analog_noise_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: check_box
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    noise_type: analog.GR_GAUSSIAN
+    seed: '0'
+    type: complex
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [264, 300.0]
+    rotation: 0
+    state: true
+- name: analog_sig_source_x_0
+  id: analog_sig_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: '1'
+    comment: ''
+    freq: freq
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: '0'
+    phase: '0'
+    samp_rate: samp_rate
+    type: complex
+    waveform: analog.GR_COS_WAVE
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [64, 172.0]
+    rotation: 0
+    state: true
+- name: blocks_add_xx_0
+  id: blocks_add_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_inputs: '2'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [496, 216.0]
+    rotation: 0
+    state: true
+- name: blocks_throttle_0
+  id: blocks_throttle
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    ignoretag: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samples_per_second: samp_rate
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [296, 212.0]
+    rotation: 0
+    state: true
+- name: qtgui_sink_x_0
+  id: qtgui_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    bw: samp_rate
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    gui_hint: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: QT GUI Sink demo
+    plotconst: 'True'
+    plotfreq: 'True'
+    plottime: 'True'
+    plotwaterfall: 'True'
+    rate: '10'
+    showports: 'False'
+    showrf: 'False'
+    type: complex
+    wintype: window.WIN_BLACKMAN_hARRIS
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [616, 212.0]
+    rotation: 0
+    state: true
+
+connections:
+- [analog_noise_source_x_0, '0', blocks_add_xx_0, '1']
+- [analog_sig_source_x_0, '0', blocks_throttle_0, '0']
+- [blocks_add_xx_0, '0', qtgui_sink_x_0, '0']
+- [blocks_throttle_0, '0', blocks_add_xx_0, '0']
+
+metadata:
+  file_format: 1

--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_check_box
 label: QT GUI Check Box
-flags: [ show_id, python ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: label
@@ -15,6 +15,7 @@ parameters:
     option_labels: [Float, Integer, String, Boolean, Any]
     option_attributes:
         conv: [float, int, str, bool, eval]
+        cpp_opts: [double,int,std::string,double,double]
     hide: part
 -   id: value
     label: Default Value
@@ -55,6 +56,27 @@ templates:
         ${win}.stateChanged.connect(lambda i: self.set_${id}(self._${id}_choices[bool(i)]))
         ${gui_hint() % win}
 
+cpp_templates:
+  includes: ['#include <QCheckBox>']
+  declarations: |-
+    QCheckBox *_${id};
+    ${type.cpp_opts} _${id}_values[2] = {${false},${true}};
+  var_make: ${id} = ${value};
+  callbacks:
+  - set_${id}(${value})
+
+  make: |-
+      <%
+          win = '_%s'%id
+      %>
+      ${win} = new QCheckBox("${(label.strip("'") if (len(label) - 2 > 0) else repr(id))}");
+      if ( ${value} == ${true} ) {
+          ${win}->setCheckState(Qt::Checked);
+      }
+
+      QObject::connect(${win},&QCheckBox::stateChanged, this, [this] () {this->set_${id}(_${id}_values[${win}->checkState()/2]);});
+
+      ${gui_hint() % win}
 documentation: |-
     This block creates a variable check box. Leave the label blank to use the variable id as the label.
 

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -59,8 +59,11 @@ cpp_templates:
     - set_${id}(${value})
     - QMetaObject::invokeMethod(this->_${id}_line_edit, "setText", Q_ARG(QString,
         QString::number(${id})))
-    link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
+    link: ['gnuradio::gnuradio-qtgui']
     make: |-
+        <%
+            win = 'this->_%s_tool_bar'%id
+        %>
         this->_${id}_tool_bar = new QToolBar();
         this->_${id}_label = new QLabel(QString::fromStdString(std::string("${label.strip("'")}")+ std::string(":")));
         this->_${id}_tool_bar->addWidget(_${id}_label);
@@ -68,12 +71,7 @@ cpp_templates:
         this->_${id}_tool_bar->addWidget(this->_${id}_line_edit);
         QObject::connect(this->_${id}_line_edit, &QLineEdit::returnPressed, this, [this] () {this->set_${id}(this->_${id}_line_edit->text().toInt());});
 
-        this->top_layout->addWidget(this->_${id}_tool_bar);
-        % if  len(gui_hint) > 0:
-        this->top_grid_layout->addWidget(this->_${id}_tool_bar,${gui_hint});
-        % else:
-        this->top_layout->addWidget(this->_${id}_tool_bar);
-        % endif
+        ${gui_hint() % win}
 documentation: |-
     This block creates a variable with a text entry box. Leave the label blank to use the variable id as the label.
 

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -468,9 +468,12 @@ cpp_templates:
     - set_update_time(${update_time})
     - set_y_axis(${ymin}, ${ymax})
     - this->${id}.set_trigger_mode(${tr_mode.cpp_opts}, ${tr_level}, ${tr_chan}, ${tr_tag})
-    link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
+    link: ['gnuradio::gnuradio-qtgui']
     make:  |-
-        this->${id} = qtgui::${type.fcn}::make(
+        <%
+            win = '_%s_win'%id
+        %>\
+        ${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
@@ -479,29 +482,20 @@ cpp_templates:
             ${ 0 if (type == 'msg_complex' or type == 'msg_float') else nconnections } // nconnections
         );
 
-        std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",
-            "${label6.strip("'")}", "${label7.strip("'")}", "${label8.strip("'")}", "${label9.strip("'")}", "${label10.strip("'")}"};
-        int widths[10] = {${width1}, ${width2}, ${width3}, ${width4}, ${width5},
-            ${width6}, ${width7}, ${width8}, ${width9}, ${width10}};
-        std::string colors[10] = {${color1}, ${color2}, ${color3}, ${color4}, ${color5},
-            ${color6}, ${color7}, ${color8}, ${color9}, ${color10}};
-        double alphas[10] = {${alpha1}, ${alpha2}, ${alpha3}, ${alpha4}, ${alpha5},
-            ${alpha6}, ${alpha7}, ${alpha8}, ${alpha9}, ${alpha10}};
-
         QWidget* _${id}_win;
 
-        this->${id}->set_update_time(${update_time});
-        this->${id}->set_y_axis(${ymin}, ${ymax});
-        this->${id}->set_y_label("${label.strip("'")}", "${units.strip("'")}");
-        this->${id}->set_trigger_mode(${tr_mode.replace('qtgui.','gr::qtgui::')}, ${tr_level}, ${tr_chan}, ${tr_tag});
-        this->${id}->enable_autoscale(${autoscale});
-        this->${id}->enable_grid(${grid});
-        this->${id}->set_fft_average(${average});
-        this->${id}->enable_axis_labels(${axislabels});
-        this->${id}->enable_control_panel(${ctrlpanel});
+        ${id}->set_update_time(${update_time});
+        ${id}->set_y_axis(${ymin}, ${ymax});
+        ${id}->set_y_label("${label.strip("'")}", "${units.strip("'")}");
+        ${id}->set_trigger_mode(${tr_mode.replace('qtgui.','gr::qtgui::')}, ${tr_level}, ${tr_chan}, ${tr_tag});
+        ${id}->enable_autoscale(${autoscale});
+        ${id}->enable_grid(${grid});
+        ${id}->set_fft_average(${average});
+        ${id}->enable_axis_labels(${axislabels});
+        ${id}->enable_control_panel(${ctrlpanel});
 
         if (!${legend}) {
-            this->${id}->disable_legend(); // if (!legend)
+            ${id}->disable_legend(); // if (!legend)
         }
 
         /* C++ doesn't have this
@@ -509,23 +503,29 @@ cpp_templates:
             this->${id}->set_plot_pos_half(not ${freqhalf});
         }*/
 
-        for (int i = 0; i < ${ 1 if (type == 'msg_complex' or type == 'msg_float') else nconnections }; i++) {
-            if (sizeof(labels[i]) == 0) {
-                this->${id}->set_line_label(i, "Data " + std::to_string(i));
-            } else {
-                this->${id}->set_line_label(i, labels[i]);
+        {
+            std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",
+                "${label6.strip("'")}", "${label7.strip("'")}", "${label8.strip("'")}", "${label9.strip("'")}", "${label10.strip("'")}"};
+            int widths[10] = {${width1}, ${width2}, ${width3}, ${width4}, ${width5},
+                ${width6}, ${width7}, ${width8}, ${width9}, ${width10}};
+            std::string colors[10] = {${color1}, ${color2}, ${color3}, ${color4}, ${color5},
+                ${color6}, ${color7}, ${color8}, ${color9}, ${color10}};
+            double alphas[10] = {${alpha1}, ${alpha2}, ${alpha3}, ${alpha4}, ${alpha5},
+                ${alpha6}, ${alpha7}, ${alpha8}, ${alpha9}, ${alpha10}};
+            for (int i = 0; i < ${ 1 if (type == 'msg_complex' or type == 'msg_float') else nconnections }; i++) {
+                if (sizeof(labels[i]) == 0) {
+                    ${id}->set_line_label(i, "Data " + std::to_string(i));
+                } else {
+                    ${id}->set_line_label(i, labels[i]);
+                }
+                ${id}->set_line_width(i, widths[i]);
+                ${id}->set_line_color(i, colors[i]);
+                ${id}->set_line_alpha(i, alphas[i]);
             }
-            this->${id}->set_line_width(i, widths[i]);
-            this->${id}->set_line_color(i, colors[i]);
-            this->${id}->set_line_alpha(i, alphas[i]);
         }
-
         _${id}_win = this->${id}->qwidget();
-        % if  len(gui_hint) > 0:
-        this->top_grid_layout->addWidget(_${id}_win,${gui_hint});
-        % else:
-        this->top_layout->addWidget(_${id}_win);
-        % endif
+
+        ${gui_hint() % win}
 
     translations:
         'True': 'true'

--- a/gr-qtgui/grc/qtgui_label.block.yml
+++ b/gr-qtgui/grc/qtgui_label.block.yml
@@ -1,6 +1,6 @@
 id: variable_qtgui_label
 label: QT GUI Label
-flags: [ show_id, python ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: label
@@ -38,9 +38,9 @@ templates:
         from gnuradio import eng_notation
     var_make: self.${id} = ${id} = ${value}
     callbacks:
-    - self.set_${id}(self._${id}_formatter(${value}))
+    - self.set_${id}(${value})
     - Qt.QMetaObject.invokeMethod(self._${id}_label, "setText", Qt.Q_ARG("QString",
-        ${id}))
+        str(self._${id}_formatter(${id}))))
     make: |-
         <%
             win = 'self._%s_tool_bar'%id
@@ -52,9 +52,26 @@ templates:
         else:
             self._${id}_formatter = lambda x: ${type.str}(x)
 
-        ${win}.addWidget(Qt.QLabel(${(label if (len(label) - 2 > 0) else repr(id))} + ": "))
+        ${win}.addWidget(Qt.QLabel(${(label if (len(label) - 2 > 0) else repr(id))}))
         self._${id}_label = Qt.QLabel(str(self._${id}_formatter(self.${id})))
         self._${id}_tool_bar.addWidget(self._${id}_label)
+        ${gui_hint() % win}
+
+cpp_templates:
+    includes: [ '#include <QLabel>','#include <QMetaObject>', '#include <QString>' ]
+    declarations: QLabel *_${id}_label;
+    var_make: ${id} = ${value};
+    callbacks:
+    - set_${id}(${value})
+    - QMetaObject::invokeMethod(this->_${id}_label, "setText", Q_ARG(QString, QString("${label.strip("'")}\%1").arg(${id})))
+    link: ['gnuradio::gnuradio-qtgui']
+    make: |-
+        <%
+            win = 'this->_%s_label'%id
+        %>\
+        // Todo: use formatter
+        this->_${id}_label = new QLabel(QString("${(label.strip("'") if (len(label) - 2 > 0) else repr(id))}") +QString(": ") + QString("%1").arg(${value}));
+
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -1,6 +1,6 @@
 id: qtgui_number_sink
 label: QT GUI Number Sink
-flags: [ python ]
+flags: [ show_id, python, cpp ]
 
 parameters:
 -   id: name
@@ -33,6 +33,8 @@ parameters:
     dtype: enum
     options: [qtgui.NUM_GRAPH_HORIZ, qtgui.NUM_GRAPH_VERT, qtgui.NUM_GRAPH_NONE]
     option_labels: [Horizontal, Vertical, None]
+    option_attributes:
+        cpp_opts: [qtgui::NUM_GRAPH_HORIZ, qtgui::NUM_GRAPH_VERT, qtgui::NUM_GRAPH_NONE]
 -   id: nconnections
     label: Number of Inputs
     category: General
@@ -280,6 +282,56 @@ templates:
         ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
+cpp_templates:
+    includes: ['#include <gnuradio/qtgui/number_sink.h>', '#include <gnuradio/qtgui/qtgui_types.h>' ]
+    declarations: 'qtgui::number_sink::sptr ${id};'
+    callbacks:
+    - set_update_time(${update_time})
+    - set_average(${avg})
+
+    link: ['gnuradio::gnuradio-qtgui']
+    make: |-
+        <%
+            win = '_%s_win'%id
+        %>\
+        ${id} = qtgui::number_sink::make(
+            ${type.size},
+            ${avg},
+            ${graph_type.cpp_opts},
+            ${nconnections},
+            nullptr // parent
+        );
+        ${id}->set_update_time(${update_time});
+        ${id}->set_title(${name});
+        {
+            std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",
+                "${label6.strip("'")}", "${label7.strip("'")}", "${label8.strip("'")}", "${label9.strip("'")}", "${label10.strip("'")}"};
+            std::string colors[10] = {${color1}, ${color2}, ${color3}, ${color4}, ${color5},
+                ${color6}, ${color7}, ${color8}, ${color9}, ${color10}};
+            std::string units[10] ={"${unit1.strip("'")}", "${unit2.strip("'")}", "${unit3.strip("'")}", "${unit4.strip("'")}", "${unit5.strip("'")}",
+                "${unit6.strip("'")}", "${unit7.strip("'")}", "${unit8.strip("'")}", "${unit9.strip("'")}", "${unit10.strip("'")}"};
+            int factor[10] ={${factor1}, ${factor2}, ${factor3}, ${factor4}, ${factor5},
+                             ${factor6}, ${factor7}, ${factor8}, ${factor9}, ${factor10}};
+            for (int i = 0; i < ${nconnections} ; i++ ) {
+                ${id}->set_min(i, ${min});
+                ${id}->set_max(i, ${max});
+                ${id}->set_color(i, colors[i][0], colors[i][1]);
+                if (labels[i].length() == 0)
+                    ${id}->set_label(i, "Data "+std::to_string(i));
+                else
+                    ${id}->set_label(i, labels[i]);
+                ${id}->set_unit(i, units[i]);
+                ${id}->set_factor(i, factor[i]);
+            }
+         }
+         ${id}->enable_autoscale(${autoscale});
+         QWidget* _${id}_win;
+        _${id}_win = this->${id}->qwidget();
+
+        ${gui_hint() % win}
+    translations:
+        'True': 'true'
+        'False': 'false'
 documentation: |-
     The GUI hint can be used to position the widget within the application.     The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span].     Both the tab specification and the grid position are optional.
 

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -146,7 +146,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, //fc
             ${bw}, //bw
-            ${name}, //name
+            "${name.strip("'").strip('"')}", //name
             ${plotfreq}, //plotfreq
             ${plotwaterfall}, //plotwaterfall
             ${plottime}, //plottime

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -138,6 +138,9 @@ cpp_templates:
   includes: ['#include <gnuradio/qtgui/${type.fcn}.h>', '#include <gnuradio/filter/firdes.h>']
   declarations: gr::qtgui::${type.fcn}::sptr ${id};
   make: |-
+    <%
+        win = '_%s_win'%id
+    %>\
     ${id} = gr::qtgui::${type.fcn}::make(
             ${fftsize}, //fftsize
             ${wintype.cpp_opts}, // wintype
@@ -151,14 +154,11 @@ cpp_templates:
         );
     ${id}->set_update_time(1.0/${rate});   
     ${id}->enable_rf_freq(${showrf});
-    ## Attempt to replicate logic of Python gui_hint() method
-    % if  len(gui_hint) > 0:
-    this->top_grid_layout->addWidget(${id + '->qwidget()'},${gui_hint});
-    % else:
-    this->top_layout->addWidget(${id + '->qwidget()'});
-    % endif
-
-  link: ['gnuradio::gnuradio-qtgui', 'Qt5Widgets', 'Qt5Core']
+    QWidget* _${id}_win;
+    _${id}_win = this->${id}->qwidget();
+    ${gui_hint() % win}
+    
+  link: ['gnuradio::gnuradio-qtgui']
   translations:
     'True': 'true'
     'False': 'false'

--- a/gr-qtgui/grc/qtgui_tab_widget.block.yml
+++ b/gr-qtgui/grc/qtgui_tab_widget.block.yml
@@ -1,6 +1,6 @@
 id: qtgui_tab_widget
 label: QT GUI Tab Widget
-flags: [show_id, python ]
+flags: [show_id, python, cpp ]
 
 parameters:
 -   id: num_tabs
@@ -134,6 +134,28 @@ templates:
         % endfor
         ${gui_hint() % win}
 
+cpp_templates:
+  includes: ['#include <QTabWidget>']
+  declarations: QTabWidget *${id};
+  link: ['gnuradio::gnuradio-qtgui']
+  make: |-
+    <%
+        win = '%s'%id
+        all_labels = [label0, label1, label2, label3, label4,
+                      label5, label6, label7, label8, label9,
+                      label10, label11, label12, label13, label14,
+                      label15, label16, label17, label18,label19][:int(num_tabs)]
+    %>\
+    ${id} = new QTabWidget();
+    % for i,label in enumerate(all_labels):
+    QWidget* ${id}_widget_${i} = new QWidget();
+    QBoxLayout* ${id}_layout_${i} =new QBoxLayout(QBoxLayout::TopToBottom,${id}_widget_${i});
+    QGridLayout* ${id}_grid_layout_${i} = new QGridLayout();
+    ${id}_layout_${i}->addLayout(${id}_grid_layout_${i});
+    ${win}->addTab(${id}_widget_${i},"${label.strip("'")}");
+    % endfor
+    ${gui_hint() % win}
+ 
 documentation: |-
     This block creates a tabbed widget to organize other widgets. The ID of this block can be used as the tab_id in the GUI hints of other widgets.
 

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -302,6 +302,7 @@ templates:
         self.${id}.set_intensity_range(${int_min}, ${int_max})
 
         ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+
         ${gui_hint() % win}
 
 cpp_templates:
@@ -310,9 +311,12 @@ cpp_templates:
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
-    link: ['gnuradio::gnuradio-qtgui', 'Qt5::Widgets']
+    link: ['gnuradio::gnuradio-qtgui']
     make: |-
-        this->${id} = qtgui::${type.fcn}::make(
+        <%
+            win = '_%s_win'%id
+        %>\
+        ${id} = qtgui::${type.fcn}::make(
             ${fftsize}, // size
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
@@ -321,18 +325,12 @@ cpp_templates:
             ${ (0 if type.startswith('msg') else nconnections) } // number of inputs
         );
 
-        std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",
-            "${label6.strip("'")}", "${label7.strip("'")}", "${label8.strip("'")}", "${label9.strip("'")}", "${label10.strip("'")}"};
-        int colors[10] = {${color1 or 0}, ${color2 or 0}, ${color3 or 0}, ${color4 or 0}, ${color5 or 0},
-            ${color6 or 0}, ${color7 or 0}, ${color8 or 0}, ${color9 or 0}, ${color10 or 0}};
-        double alphas[10] = {${alpha1 or 1.0}, ${alpha2 or 1.0}, ${alpha3 or 1.0}, ${alpha4 or 1.0}, ${alpha5 or 1.0},
-            ${alpha6 or 1.0}, ${alpha7 or 1.0}, ${alpha8 or 1.0}, ${alpha9 or 1.0}, ${alpha10 or 1.0}};
 
         QWidget* _${id}_win;
 
-        this->${id}->set_update_time(${update_time});
-        this->${id}->enable_grid(${grid});
-        this->${id}->enable_axis_labels(${axislabels});
+        ${id}->set_update_time(${update_time});
+        ${id}->enable_grid(${grid});
+        ${id}->enable_axis_labels(${axislabels});
 
         if (!${legend}) {
             this->${id}->disable_legend(); // if (!legend)
@@ -342,28 +340,32 @@ cpp_templates:
         if ("${type}" == "float" or "${type}" == "msg_float") {
             this->${id}->set_plot_pos_half(not ${freqhalf});
         }*/
+        {
+            std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",
+                "${label6.strip("'")}", "${label7.strip("'")}", "${label8.strip("'")}", "${label9.strip("'")}", "${label10.strip("'")}"};
+            int colors[10] = {${color1 or 0}, ${color2 or 0}, ${color3 or 0}, ${color4 or 0}, ${color5 or 0},
+                ${color6 or 0}, ${color7 or 0}, ${color8 or 0}, ${color9 or 0}, ${color10 or 0}};
+            double alphas[10] = {${alpha1 or 1.0}, ${alpha2 or 1.0}, ${alpha3 or 1.0}, ${alpha4 or 1.0}, ${alpha5 or 1.0},
+                ${alpha6 or 1.0}, ${alpha7 or 1.0}, ${alpha8 or 1.0}, ${alpha9 or 1.0}, ${alpha10 or 1.0}};
 
-        for (int i = 0; i < ${ 1 if (type == 'msg_complex' or type == 'msg_float') else nconnections }; i++) {
-            if (sizeof(labels[i]) == 0) {
-                this->${id}->set_line_label(i, "Data " + std::to_string(i));
-            } else {
-                this->${id}->set_line_label(i, labels[i]);
+            for (int i = 0; i < ${ 1 if (type == 'msg_complex' or type == 'msg_float') else nconnections }; i++) {
+                if (sizeof(labels[i]) == 0) {
+                    ${id}->set_line_label(i, "Data " + std::to_string(i));
+                } else {
+                    ${id}->set_line_label(i, labels[i]);
+                }
+                ${id}->set_color_map(i, colors[i]);
+                ${id}->set_line_alpha(i, alphas[i]);
             }
-            this->${id}->set_color_map(i, colors[i]);
-            this->${id}->set_line_alpha(i, alphas[i]);
         }
 
         this->${id}->set_intensity_range(${int_min}, ${int_max});
 
         _${id}_win = this->${id}->qwidget();
-        % if  len(gui_hint) > 0:
-        this->top_grid_layout->addWidget(_${id}_win,${gui_hint});
-        % else:
-        this->top_layout->addWidget(_${id}_win);
-        % endif
-        
+
+        ${gui_hint() % win}
+
     translations:
-        firdes.: 'filter::firdes::'
         'True': 'true'
         'False': 'false'
 

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_FREQ_SINK_C_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/fft/window.h>

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_FREQ_SINK_F_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/fft/window.h>

--- a/gr-qtgui/include/gnuradio/qtgui/number_sink.h
+++ b/gr-qtgui/include/gnuradio/qtgui/number_sink.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_NUMBER_SINK_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/qtgui/api.h>

--- a/gr-qtgui/include/gnuradio/qtgui/sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/sink_c.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_SINK_C_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/block.h>

--- a/gr-qtgui/include/gnuradio/qtgui/sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/sink_f.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_SINK_F_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/block.h>

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_WATERFALL_SINK_C_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/fft/window.h>

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
@@ -12,7 +12,10 @@
 #define INCLUDED_QTGUI_WATERFALL_SINK_F_H
 
 #ifdef ENABLE_PYTHON
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 #endif
 
 #include <gnuradio/fft/window.h>

--- a/grc/core/generator/cpp_templates/flow_graph.cpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.cpp.mako
@@ -67,7 +67,6 @@ ${class_name}::${class_name} (${param_str}) ${initializer_str} {
 % if blocks:
 // Blocks:
 % for blk, blk_make, declarations in blocks:
-    {
         ${doubleindent(blk_make)}
 ##      % if 'alias' in blk.params and blk.params['alias'].get_evaluated():
 ##      ${blk.name}.set_block_alias("${blk.params['alias'].get_evaluated()}")
@@ -81,7 +80,7 @@ ${class_name}::${class_name} (${param_str}) ${initializer_str} {
 ##      % if len(blk.sources) > 0 and 'maxoutbuf' in blk.params and int(blk.params['maxoutbuf'].get_evaluated()) > 0:
 ##      ${blk.name}.set_max_output_buffer(${blk.params['maxoutbuf'].get_evaluated()})
 ##      % endif
-    }
+
 % endfor
 % endif
 

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -222,9 +222,9 @@ class CppTopBlockGenerator(TopBlockGenerator):
         fg = self._flow_graph
         parameters = fg.get_parameters()
 
-        # List of blocks not including variables and imports and parameters and disabled
+        # List of blocks not including variables and parameters and disabled
         def _get_block_sort_text(block):
-            code = block.cpp_templates.render('make').replace(block.name, ' ')
+            code = block.cpp_templates.render('declarations')
             try:
                 code += block.params['gui_hint'].get_value()  # Newer gui markup w/ qtgui
             except:

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -403,20 +403,40 @@ class Param(Element):
             row, col, row_span, col_span = parse_pos()
             collision_detection(row, col, row_span, col_span)
 
-            widget_str = textwrap.dedent("""
-                self.{layout}.addWidget({widget}, {row}, {col}, {row_span}, {col_span})
-                for r in range({row}, {row_end}):
-                    self.{layout}.setRowStretch(r, 1)
-                for c in range({col}, {col_end}):
-                    self.{layout}.setColumnStretch(c, 1)
-            """.strip('\n')).format(
-                layout=layout, widget=widget,
-                row=row, row_span=row_span, row_end=row+row_span,
-                col=col, col_span=col_span, col_end=col+col_span,
-            )
+            if self.parent_flowgraph.get_option('output_language') == 'python':
+                widget_str = textwrap.dedent("""
+                    self.{layout}.addWidget({widget}, {row}, {col}, {row_span}, {col_span})
+                    for r in range({row}, {row_end}):
+                        self.{layout}.setRowStretch(r, 1)
+                    for c in range({col}, {col_end}):
+                        self.{layout}.setColumnStretch(c, 1)
+                """.strip('\n')).format(
+                    layout=layout, widget=widget,
+                    row=row, row_span=row_span, row_end=row+row_span,
+                    col=col, col_span=col_span, col_end=col+col_span,
+                )
+            elif self.parent_flowgraph.get_option('output_language') == 'cpp':
+                widget_str = textwrap.dedent("""
+                    {layout}->addWidget({widget}, {row}, {col}, {row_span}, {col_span});
+                    for(int r = {row};r < {row_end}; r++)
+                        {layout}->setRowStretch(r, 1);
+                    for(int c = {col}; c <{col_end}; c++)
+                        {layout}->setColumnStretch(c, 1);
+                """.strip('\n')).format(
+                    layout=layout, widget=widget,
+                    row=row, row_span=row_span, row_end=row+row_span,
+                    col=col, col_span=col_span, col_end=col+col_span,
+                )
+            else:
+                widget_str = ''
 
         else:
-            widget_str = 'self.{layout}.addWidget({widget})'.format(layout=layout, widget=widget)
+            if self.parent_flowgraph.get_option('output_language') == 'python':
+                widget_str = 'self.{layout}.addWidget({widget})'.format(layout=layout, widget=widget)
+            elif self.parent_flowgraph.get_option('output_language') == 'cpp':
+                widget_str = '{layout}->addWidget({widget});'.format(layout=layout, widget=widget)
+            else:
+                widget_str = ''
 
         return widget_str
 


### PR DESCRIPTION
At the moment some qtgui windows do support only very simple gui hints, as
the parse_gui_hint in param.py generates only python code independently of the output language.

This is fixed here, so the gui_hint() can be used in cpp code generation.

To test more complex gui hints the qtgui_tab_widget was extended to cpp.

After that compiling the generated cpp code for some examples led to

```
/usr/include/python3.9/object.h:206:23: Fehler: expected unqualified-id before »;« token
 206 |     PyType_Slot *slots; /* terminated by slot==0. */
```
This is a known error and can be fixed by

```
#ifdef ENABLE_PYTHON
#pragma push_macro("slots")
#undef slots
#include "Python.h"
#pragma pop_macro("slots")
#endif
```

instead of simply

```
#ifdef ENABLE_PYTHON
#include "Python.h"
#endif
```

which was applied to the corresponding gr-qtgui header files.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>