### PR TITLE
logging: log message conversion to remove <iostream> includes

### DIFF
--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -19,9 +19,6 @@
 #include <sstream>
 #include <stdexcept>
 
-// TODO: Replace with GNU Radio logging
-#include <iostream>
-
 namespace gr {
 
 constexpr bool HIER_BLOCK2_DETAIL_DEBUG = false;
@@ -48,6 +45,8 @@ hier_block2_detail::hier_block2_detail(hier_block2* owner)
 
     d_max_output_buffer = std::vector<size_t>(std::max(max_outputs, 1), 0);
     d_min_output_buffer = std::vector<size_t>(std::max(max_outputs, 1), 0);
+
+    gr::configure_default_loggers(d_logger, d_debug_logger, "hier_block2_detail");
 }
 
 hier_block2_detail::~hier_block2_detail()
@@ -76,8 +75,9 @@ void hier_block2_detail::connect(basic_block_sptr block)
 
     if (hblock && hblock.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "connect: block is hierarchical, setting parent to " << this
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("connect: block is hierarchical, setting parent to %s")
+                    % this));
         hblock->d_detail->d_parent_detail = this;
     }
 
@@ -92,9 +92,9 @@ void hier_block2_detail::connect(basic_block_sptr src,
     std::stringstream msg;
 
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "connecting: " << endpoint(src, src_port) << " -> "
-                  << endpoint(dst, dst_port) << std::endl;
-
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format("connecting: %s -> %s")
+                % endpoint(src, src_port) % endpoint(dst, dst_port)));
     if (src.get() == dst.get())
         throw std::invalid_argument(
             "connect: src and destination blocks cannot be the same");
@@ -104,15 +104,17 @@ void hier_block2_detail::connect(basic_block_sptr src,
 
     if (src_block && src.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "connect: src is hierarchical, setting parent to " << this
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("connect: src is hierarchical, setting parent to %s")
+                    % this));
         src_block->d_detail->d_parent_detail = this;
     }
 
     if (dst_block && dst.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "connect: dst is hierarchical, setting parent to " << this
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("connect: dst is hierarchical, setting parent to %s")
+                    % this));
         dst_block->d_detail->d_parent_detail = this;
     }
 
@@ -150,7 +152,7 @@ void hier_block2_detail::msg_connect(basic_block_sptr src,
                                      pmt::pmt_t dstport)
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "connecting message port..." << std::endl;
+        GR_LOG_INFO(d_logger, "connecting message port...");
 
     // add block uniquely to list to internal blocks
     if (std::find(d_blocks.begin(), d_blocks.end(), dst) == d_blocks.end()) {
@@ -175,22 +177,25 @@ void hier_block2_detail::msg_connect(basic_block_sptr src,
 
     if (src_block && src.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "msg_connect: src is hierarchical, setting parent to " << this
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("connect: src is hierarchical, setting parent to %s")
+                    % this));
         src_block->d_detail->d_parent_detail = this;
     }
 
     if (dst_block && dst.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "msg_connect: dst is hierarchical, setting parent to " << this
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("connect: dst is hierarchical, setting parent to %s")
+                    % this));
         dst_block->d_detail->d_parent_detail = this;
     }
 
     // add edge for this message connection
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << boost::format("msg_connect( (%s, %s, %d), (%s, %s, %d) )\n") % src %
-                         srcport % hier_out % dst % dstport % hier_in;
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format("msg_connect( (%s, %s, %d), (%s, %s, %d) )\n")
+                % src % srcport % hier_out % dst % dstport % hier_in));
     d_fg->connect(msg_endpoint(src, srcport, hier_out),
                   msg_endpoint(dst, dstport, hier_in));
 }
@@ -201,7 +206,7 @@ void hier_block2_detail::msg_disconnect(basic_block_sptr src,
                                         pmt::pmt_t dstport)
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "disconnecting message port..." << std::endl;
+        GR_LOG_INFO(d_logger, "disconnecting message port...");
 
     // remove edge for this message connection
     bool hier_in = false, hier_out = false;
@@ -258,8 +263,7 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
             hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
             if (block && block.get() != d_owner) {
                 if (HIER_BLOCK2_DETAIL_DEBUG)
-                    std::cout << "disconnect: block is hierarchical, clearing parent"
-                              << std::endl;
+                    GR_LOG_INFO(d_logger, "disconnect: block is hierarchical, clearing parent");
                 hblock->d_detail->d_parent_detail = 0;
             }
 
@@ -275,7 +279,7 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
             edges.push_back(*p);
 
             if (HIER_BLOCK2_DETAIL_DEBUG)
-                std::cout << "disconnect: block found in edge " << (*p) << std::endl;
+                GR_LOG_INFO(d_logger, "disconnect: block is hierarchical, clearing parent");
         }
     }
 
@@ -297,8 +301,9 @@ void hier_block2_detail::disconnect(basic_block_sptr src,
                                     int dst_port)
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "disconnecting: " << endpoint(src, src_port) << " -> "
-                  << endpoint(dst, dst_port) << std::endl;
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format("disconnecting: %s -> %s")
+                % endpoint(src, src_port) % endpoint(dst, dst_port)));
 
     if (src.get() == dst.get())
         throw std::invalid_argument(
@@ -309,13 +314,13 @@ void hier_block2_detail::disconnect(basic_block_sptr src,
 
     if (src_block && src.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "disconnect: src is hierarchical, clearing parent" << std::endl;
+            GR_LOG_INFO(d_logger, "disconnect: src is hierarchical, clearing parent");
         src_block->d_detail->d_parent_detail = 0;
     }
 
     if (dst_block && dst.get() != d_owner) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "disconnect: dst is hierarchical, clearing parent" << std::endl;
+            GR_LOG_INFO(d_logger, "disconnect: dst is hierarchical, clearing parent");
         dst_block->d_detail->d_parent_detail = 0;
     }
 
@@ -449,9 +454,9 @@ endpoint_vector_t hier_block2_detail::resolve_port(int port, bool is_input)
     std::stringstream msg;
 
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "Resolving port " << port << " as an "
-                  << (is_input ? "input" : "output") << " of " << d_owner->name()
-                  << std::endl;
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format("Resolving port %i as an %s of %s")
+                % port % (is_input ? "input" : "output") % d_owner->name()));
 
     endpoint_vector_t result;
 
@@ -520,8 +525,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
     // Check if endpoint is a leaf node
     if (cast_to_block_sptr(endp.block())) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "Block " << endp.block() << " is a leaf node, returning."
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("Block %s is a leaf node, returning.")
+                    % endp.block()));
         result.push_back(endp);
         return result;
     }
@@ -530,8 +536,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
     hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(endp.block()));
     if (hier_block2) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "Resolving endpoint " << endp << " as an "
-                      << (is_input ? "input" : "output") << ", recursing" << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("Resolving endpoint %s as an %s, recursing")
+                    % endp % (is_input ? "input" : "output")));
         return hier_block2->d_detail->resolve_port(endp.port(), is_input);
     }
 
@@ -543,8 +550,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
 void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << " ** Flattening " << d_owner->name()
-                  << " parent: " << d_parent_detail << std::endl;
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format(" ** Flattening %s parent: %s")
+                % d_owner->name() % d_parent_detail));
     bool is_top_block = (d_parent_detail == NULL);
 
     // Add my edges to the flow graph, resolving references to actual endpoints
@@ -564,14 +572,16 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     // Get the min and max buffer length
     if (set_all_min_buff) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "Getting (" << (d_owner->alias()).c_str() << ") min buffer"
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("Getting (%s) min buffer")
+                    % d_owner->alias()));
         min_buff = d_owner->min_output_buffer();
     }
     if (set_all_max_buff) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "Getting (" << (d_owner->alias()).c_str() << ") max buffer"
-                      << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("Getting (%s) max buffer")
+                    % d_owner->alias()));
         max_buff = d_owner->max_output_buffer();
     }
 
@@ -588,8 +598,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
-                            std::cout << "Block (" << (bb->alias()).c_str()
-                                      << ") min_buff (" << min_buff << ")" << std::endl;
+                            GR_LOG_INFO(d_logger,
+                                boost::str(boost::format("Block (%s) min_buff (%s)")
+                                    % bb->alias() % min_buff));
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
@@ -597,9 +608,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
-                                std::cout << "HBlock (" << (hh->alias()).c_str()
-                                          << ") min_buff (" << min_buff << ")"
-                                          << std::endl;
+                                GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("HBlock (%s) min_buff (%s)")
+                                        % hh->alias() % min_buff));
                             hh->set_min_output_buffer(min_buff);
                         }
                     }
@@ -613,8 +624,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
-                            std::cout << "Block (" << (bb->alias()).c_str()
-                                      << ") max_buff (" << max_buff << ")" << std::endl;
+                            GR_LOG_INFO(d_logger,
+                                boost::str(boost::format("Block (%s) max_buff (%s)")
+                                    % bb->alias() % max_buff));
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
@@ -622,9 +634,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
-                                std::cout << "HBlock (" << (hh->alias()).c_str()
-                                          << ") max_buff (" << max_buff << ")"
-                                          << std::endl;
+                                GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("HBlock (%s) max_buff (%s)")
+                                        % hh->alias() % max_buff));
                             hh->set_max_output_buffer(max_buff);
                         }
                     }
@@ -640,8 +652,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
-                            std::cout << "Block (" << (bb->alias()).c_str()
-                                      << ") min_buff (" << min_buff << ")" << std::endl;
+                            GR_LOG_INFO(d_logger,
+                                boost::str(boost::format("Block (%s) min_buff (%s)")
+                                    % bb->alias() % min_buff));
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
@@ -649,9 +662,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
-                                std::cout << "HBlock (" << (hh->alias()).c_str()
-                                          << ") min_buff (" << min_buff << ")"
-                                          << std::endl;
+                                GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("HBlock (%s) min_buff (%s)")
+                                        % hh->alias() % min_buff));
                             hh->set_min_output_buffer(min_buff);
                         }
                     }
@@ -665,8 +678,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
                         if (HIER_BLOCK2_DETAIL_DEBUG)
-                            std::cout << "Block (" << (bb->alias()).c_str()
-                                      << ") max_buff (" << max_buff << ")" << std::endl;
+                            GR_LOG_INFO(d_logger,
+                                boost::str(boost::format("Block (%s) max_buff (%s)")
+                                    % bb->alias() % max_buff));
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
@@ -674,9 +688,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
                             if (HIER_BLOCK2_DETAIL_DEBUG)
-                                std::cout << "HBlock (" << (hh->alias()).c_str()
-                                          << ") max_buff (" << max_buff << ")"
-                                          << std::endl;
+                                GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("HBlock (%s) max_buff (%s)")
+                                        % hh->alias() % max_buff));
                             hh->set_max_output_buffer(max_buff);
                         }
                     }
@@ -686,11 +700,13 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     }
 
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "Flattening stream connections: " << std::endl;
+        GR_LOG_INFO(d_logger, "Flattening stream connections: ");
 
     for (p = edges.begin(); p != edges.end(); p++) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "Flattening edge " << (*p) << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("Flattening edge %s")
+                    % (*p)));
 
         endpoint_vector_t src_endps = resolve_endpoint(p->src(), false);
         endpoint_vector_t dst_endps = resolve_endpoint(p->dst(), true);
@@ -699,7 +715,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         for (s = src_endps.begin(); s != src_endps.end(); s++) {
             for (d = dst_endps.begin(); d != dst_endps.end(); d++) {
                 if (HIER_BLOCK2_DETAIL_DEBUG)
-                    std::cout << (*s) << "->" << (*d) << std::endl;
+                    GR_LOG_INFO(d_logger,
+                        boost::str(boost::format("%s -> %s")
+                            % (*s) % (*d)));
                 sfg->connect(*s, *d);
             }
         }
@@ -707,34 +725,40 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 
     // loop through flattening hierarchical connections
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "Flattening msg connections: " << std::endl;
+        GR_LOG_INFO(d_logger, "Flattening msg connections: ");
 
     std::vector<std::pair<msg_endpoint, bool>> resolved_endpoints;
     for (q = msg_edges.begin(); q != msg_edges.end(); q++) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << boost::format(
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format(
                              " flattening edge ( %s, %s, %d) -> ( %s, %s, %d)\n") %
                              q->src().block() % q->src().port() % q->src().is_hier() %
-                             q->dst().block() % q->dst().port() % q->dst().is_hier();
+                             q->dst().block() % q->dst().port() % q->dst().is_hier()));
 
 
         if (q->src().is_hier() && q->src().block().get() == d_owner) {
             // connection into this block ..
             if (HIER_BLOCK2_DETAIL_DEBUG)
-                std::cout << "hier incoming port: " << q->src() << std::endl;
+                GR_LOG_INFO(d_logger,
+                    boost::str(boost::format("hier incoming port: %s")
+                        % q->src()));
             sfg->replace_endpoint(q->src(), q->dst(), false);
             resolved_endpoints.push_back(std::pair<msg_endpoint, bool>(q->src(), false));
         } else if (q->dst().is_hier() && q->dst().block().get() == d_owner) {
             // connection out of this block
             if (HIER_BLOCK2_DETAIL_DEBUG)
-                std::cout << "hier outgoing port: " << q->dst() << std::endl;
+                GR_LOG_INFO(d_logger,
+                    boost::str(boost::format("hier outgoing port: %s")
+                        % q->dst()));
             sfg->replace_endpoint(q->dst(), q->src(), true);
             resolved_endpoints.push_back(std::pair<msg_endpoint, bool>(q->dst(), true));
         } else {
             // internal connection only
             if (HIER_BLOCK2_DETAIL_DEBUG)
-                std::cout << "internal msg connection: " << q->src() << "-->" << q->dst()
-                          << std::endl;
+                GR_LOG_INFO(d_logger,
+                    boost::str(boost::format("internal msg connection: %s-->%s")
+                        % q->src() % q->dst()));
             sfg->connect(q->src(), q->dst());
         }
     }
@@ -744,8 +768,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
          it != resolved_endpoints.end();
          it++) {
         if (HIER_BLOCK2_DETAIL_DEBUG)
-            std::cout << "sfg->clear_endpoint(" << (*it).first << ", " << (*it).second
-                      << ") " << std::endl;
+            GR_LOG_INFO(d_logger,
+                boost::str(boost::format("sfg->clear_endpoint(%s, %s)")
+                    % (*it).first % (*it).second));
         sfg->clear_endpoint((*it).first, (*it).second);
     }
 
@@ -756,7 +781,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         sfg->connect(q->src(), q->dst());
       }
       else {
-        std::cout << "not connecting hier connection!" << std::endl;
+        GR_LOG_INFO(d_logger, "not connecting hier connection!");
       }
     }
     */
@@ -800,18 +825,18 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
                     if (HIER_BLOCK2_DETAIL_DEBUG)
-                        std::cout << "Block (" << (bb->alias()).c_str() << ") Port ("
-                                  << bb_src_port << ") min_buff (" << min_buff << ")"
-                                  << std::endl;
+                        GR_LOG_INFO(d_logger,
+                            boost::str(boost::format("Block (%s) Port (%s) min_buff (%s)")
+                                % bb->alias() % bb_src_port % min_buff));
                     bb->set_min_output_buffer(bb_src_port, min_buff);
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
                         if (HIER_BLOCK2_DETAIL_DEBUG)
-                            std::cout << "HBlock (" << (hh->alias()).c_str() << ") Port ("
-                                      << hh_src_port << ") min_buff (" << min_buff << ")"
-                                      << std::endl;
+                            GR_LOG_INFO(d_logger,
+                                boost::str(boost::format("HBlock (%s) Port (%s) min_buff (%s)")
+                                    % hh->alias() % hh_src_port % min_buff));
                         hh->set_min_output_buffer(hh_src_port, min_buff);
                     }
                 }
@@ -824,18 +849,18 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
                     if (HIER_BLOCK2_DETAIL_DEBUG)
-                        std::cout << "Block (" << (bb->alias()).c_str() << ") Port ("
-                                  << bb_src_port << ") max_buff (" << max_buff << ")"
-                                  << std::endl;
+                        GR_LOG_INFO(d_logger,
+                            boost::str(boost::format("Block (%s) Port (%s) max_buff (%s)")
+                                % bb->alias() % bb_src_port % max_buff));
                     bb->set_max_output_buffer(bb_src_port, max_buff);
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
                         if (HIER_BLOCK2_DETAIL_DEBUG)
-                            std::cout << "HBlock (" << (hh->alias()).c_str() << ") Port ("
-                                      << hh_src_port << ") max_buff (" << max_buff << ")"
-                                      << std::endl;
+                            GR_LOG_INFO(d_logger,
+                                boost::str(boost::format("HBlock (%s) Port (%s) max_buff (%s)")
+                                    % hh->alias() % hh_src_port % max_buff));
                         hh->set_max_output_buffer(hh_src_port, max_buff);
                     }
                 }
@@ -853,8 +878,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(*p));
         if (hier_block2 && (hier_block2.get() != d_owner)) {
             if (HIER_BLOCK2_DETAIL_DEBUG)
-                std::cout << "flatten_aux: recursing into hierarchical block "
-                          << hier_block2->alias() << std::endl;
+                GR_LOG_INFO(d_logger,
+                    boost::str(boost::format("flatten_aux: recursing into hierarchical block %s")
+                        % hier_block2->alias()));
             hier_block2->d_detail->flatten_aux(sfg);
         }
     }
@@ -868,7 +894,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 
     // print all primitive connections at exit
     if (HIER_BLOCK2_DETAIL_DEBUG && is_top_block) {
-        std::cout << "flatten_aux finished in top_block" << std::endl;
+        GR_LOG_INFO(d_logger, "flatten_aux finished in top_block");
         sfg->dump();
     }
 
@@ -886,7 +912,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 void hier_block2_detail::lock()
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "lock: entered in " << this << std::endl;
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format("lock: entered in %s")
+                % this));
 
     if (d_parent_detail)
         d_parent_detail->lock();
@@ -897,7 +925,9 @@ void hier_block2_detail::lock()
 void hier_block2_detail::unlock()
 {
     if (HIER_BLOCK2_DETAIL_DEBUG)
-        std::cout << "unlock: entered in " << this << std::endl;
+        GR_LOG_INFO(d_logger,
+            boost::str(boost::format("unlock: entered in %s")
+                % this));
 
     if (d_parent_detail)
         d_parent_detail->unlock();

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -21,8 +21,6 @@
 
 namespace gr {
 
-constexpr bool HIER_BLOCK2_DETAIL_DEBUG = false;
-
 hier_block2_detail::hier_block2_detail(hier_block2* owner)
     : d_owner(owner), d_parent_detail(0), d_fg(make_flowgraph())
 {
@@ -74,10 +72,11 @@ void hier_block2_detail::connect(basic_block_sptr block)
     hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
 
     if (hblock && hblock.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("connect: block is hierarchical, setting parent to %s")
-                    % this));
+        GR_LOG_INFO(
+            d_logger,
+            boost::str(
+                boost::format("connect: block is hierarchical, setting parent to %s") %
+                this));
         hblock->d_detail->d_parent_detail = this;
     }
 
@@ -91,10 +90,9 @@ void hier_block2_detail::connect(basic_block_sptr src,
 {
     std::stringstream msg;
 
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format("connecting: %s -> %s")
-                % endpoint(src, src_port) % endpoint(dst, dst_port)));
+    GR_LOG_INFO(d_logger,
+                boost::str(boost::format("connecting: %s -> %s") %
+                           endpoint(src, src_port) % endpoint(dst, dst_port)));
     if (src.get() == dst.get())
         throw std::invalid_argument(
             "connect: src and destination blocks cannot be the same");
@@ -103,18 +101,18 @@ void hier_block2_detail::connect(basic_block_sptr src,
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if (src_block && src.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("connect: src is hierarchical, setting parent to %s")
-                    % this));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format(
+                                   "connect: src is hierarchical, setting parent to %s") %
+                               this));
         src_block->d_detail->d_parent_detail = this;
     }
 
     if (dst_block && dst.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("connect: dst is hierarchical, setting parent to %s")
-                    % this));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format(
+                                   "connect: dst is hierarchical, setting parent to %s") %
+                               this));
         dst_block->d_detail->d_parent_detail = this;
     }
 
@@ -151,8 +149,7 @@ void hier_block2_detail::msg_connect(basic_block_sptr src,
                                      basic_block_sptr dst,
                                      pmt::pmt_t dstport)
 {
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger, "connecting message port...");
+    GR_LOG_INFO(d_logger, "connecting message port...");
 
     // add block uniquely to list to internal blocks
     if (std::find(d_blocks.begin(), d_blocks.end(), dst) == d_blocks.end()) {
@@ -176,26 +173,25 @@ void hier_block2_detail::msg_connect(basic_block_sptr src,
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if (src_block && src.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("connect: src is hierarchical, setting parent to %s")
-                    % this));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format(
+                                   "connect: src is hierarchical, setting parent to %s") %
+                               this));
         src_block->d_detail->d_parent_detail = this;
     }
 
     if (dst_block && dst.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("connect: dst is hierarchical, setting parent to %s")
-                    % this));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format(
+                                   "connect: dst is hierarchical, setting parent to %s") %
+                               this));
         dst_block->d_detail->d_parent_detail = this;
     }
 
     // add edge for this message connection
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format("msg_connect( (%s, %s, %d), (%s, %s, %d) )\n")
-                % src % srcport % hier_out % dst % dstport % hier_in));
+    GR_LOG_INFO(d_logger,
+                boost::str(boost::format("msg_connect( (%s, %s, %d), (%s, %s, %d) )\n") %
+                           src % srcport % hier_out % dst % dstport % hier_in));
     d_fg->connect(msg_endpoint(src, srcport, hier_out),
                   msg_endpoint(dst, dstport, hier_in));
 }
@@ -205,8 +201,7 @@ void hier_block2_detail::msg_disconnect(basic_block_sptr src,
                                         basic_block_sptr dst,
                                         pmt::pmt_t dstport)
 {
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger, "disconnecting message port...");
+    GR_LOG_INFO(d_logger, "disconnecting message port...");
 
     // remove edge for this message connection
     bool hier_in = false, hier_out = false;
@@ -262,8 +257,8 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
 
             hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
             if (block && block.get() != d_owner) {
-                if (HIER_BLOCK2_DETAIL_DEBUG)
-                    GR_LOG_INFO(d_logger, "disconnect: block is hierarchical, clearing parent");
+                GR_LOG_INFO(d_logger,
+                            "disconnect: block is hierarchical, clearing parent");
                 hblock->d_detail->d_parent_detail = 0;
             }
 
@@ -278,8 +273,7 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
         if ((*p).src().block() == block || (*p).dst().block() == block) {
             edges.push_back(*p);
 
-            if (HIER_BLOCK2_DETAIL_DEBUG)
-                GR_LOG_INFO(d_logger, "disconnect: block is hierarchical, clearing parent");
+            GR_LOG_INFO(d_logger, "disconnect: block is hierarchical, clearing parent");
         }
     }
 
@@ -300,10 +294,9 @@ void hier_block2_detail::disconnect(basic_block_sptr src,
                                     basic_block_sptr dst,
                                     int dst_port)
 {
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format("disconnecting: %s -> %s")
-                % endpoint(src, src_port) % endpoint(dst, dst_port)));
+    GR_LOG_INFO(d_logger,
+                boost::str(boost::format("disconnecting: %s -> %s") %
+                           endpoint(src, src_port) % endpoint(dst, dst_port)));
 
     if (src.get() == dst.get())
         throw std::invalid_argument(
@@ -313,14 +306,12 @@ void hier_block2_detail::disconnect(basic_block_sptr src,
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if (src_block && src.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger, "disconnect: src is hierarchical, clearing parent");
+        GR_LOG_INFO(d_logger, "disconnect: src is hierarchical, clearing parent");
         src_block->d_detail->d_parent_detail = 0;
     }
 
     if (dst_block && dst.get() != d_owner) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger, "disconnect: dst is hierarchical, clearing parent");
+        GR_LOG_INFO(d_logger, "disconnect: dst is hierarchical, clearing parent");
         dst_block->d_detail->d_parent_detail = 0;
     }
 
@@ -453,10 +444,9 @@ endpoint_vector_t hier_block2_detail::resolve_port(int port, bool is_input)
 {
     std::stringstream msg;
 
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format("Resolving port %i as an %s of %s")
-                % port % (is_input ? "input" : "output") % d_owner->name()));
+    GR_LOG_INFO(d_logger,
+                boost::str(boost::format("Resolving port %i as an %s of %s") % port %
+                           (is_input ? "input" : "output") % d_owner->name()));
 
     endpoint_vector_t result;
 
@@ -524,10 +514,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
 
     // Check if endpoint is a leaf node
     if (cast_to_block_sptr(endp.block())) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("Block %s is a leaf node, returning.")
-                    % endp.block()));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format("Block %s is a leaf node, returning.") %
+                               endp.block()));
         result.push_back(endp);
         return result;
     }
@@ -535,10 +524,10 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
     // Check if endpoint is a hierarchical block
     hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(endp.block()));
     if (hier_block2) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("Resolving endpoint %s as an %s, recursing")
-                    % endp % (is_input ? "input" : "output")));
+        GR_LOG_INFO(
+            d_logger,
+            boost::str(boost::format("Resolving endpoint %s as an %s, recursing") % endp %
+                       (is_input ? "input" : "output")));
         return hier_block2->d_detail->resolve_port(endp.port(), is_input);
     }
 
@@ -549,10 +538,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
 
 void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 {
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format(" ** Flattening %s parent: %s")
-                % d_owner->name() % d_parent_detail));
+    GR_LOG_INFO(d_logger,
+                boost::str(boost::format(" ** Flattening %s parent: %s") %
+                           d_owner->name() % d_parent_detail));
     bool is_top_block = (d_parent_detail == NULL);
 
     // Add my edges to the flow graph, resolving references to actual endpoints
@@ -571,17 +559,15 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     bool set_all_max_buff = d_owner->all_max_output_buffer_p();
     // Get the min and max buffer length
     if (set_all_min_buff) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("Getting (%s) min buffer")
-                    % d_owner->alias()));
+        GR_LOG_INFO(
+            d_logger,
+            boost::str(boost::format("Getting (%s) min buffer") % d_owner->alias()));
         min_buff = d_owner->min_output_buffer();
     }
     if (set_all_max_buff) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("Getting (%s) max buffer")
-                    % d_owner->alias()));
+        GR_LOG_INFO(
+            d_logger,
+            boost::str(boost::format("Getting (%s) max buffer") % d_owner->alias()));
         max_buff = d_owner->max_output_buffer();
     }
 
@@ -597,20 +583,19 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
-                        if (HIER_BLOCK2_DETAIL_DEBUG)
-                            GR_LOG_INFO(d_logger,
-                                boost::str(boost::format("Block (%s) min_buff (%s)")
-                                    % bb->alias() % min_buff));
+                        GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("Block (%s) min_buff (%s)") %
+                                               bb->alias() % min_buff));
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
-                            if (HIER_BLOCK2_DETAIL_DEBUG)
-                                GR_LOG_INFO(d_logger,
-                                    boost::str(boost::format("HBlock (%s) min_buff (%s)")
-                                        % hh->alias() % min_buff));
+                            GR_LOG_INFO(
+                                d_logger,
+                                boost::str(boost::format("HBlock (%s) min_buff (%s)") %
+                                           hh->alias() % min_buff));
                             hh->set_min_output_buffer(min_buff);
                         }
                     }
@@ -623,20 +608,19 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
-                        if (HIER_BLOCK2_DETAIL_DEBUG)
-                            GR_LOG_INFO(d_logger,
-                                boost::str(boost::format("Block (%s) max_buff (%s)")
-                                    % bb->alias() % max_buff));
+                        GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("Block (%s) max_buff (%s)") %
+                                               bb->alias() % max_buff));
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
-                            if (HIER_BLOCK2_DETAIL_DEBUG)
-                                GR_LOG_INFO(d_logger,
-                                    boost::str(boost::format("HBlock (%s) max_buff (%s)")
-                                        % hh->alias() % max_buff));
+                            GR_LOG_INFO(
+                                d_logger,
+                                boost::str(boost::format("HBlock (%s) max_buff (%s)") %
+                                           hh->alias() % max_buff));
                             hh->set_max_output_buffer(max_buff);
                         }
                     }
@@ -651,20 +635,19 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
-                        if (HIER_BLOCK2_DETAIL_DEBUG)
-                            GR_LOG_INFO(d_logger,
-                                boost::str(boost::format("Block (%s) min_buff (%s)")
-                                    % bb->alias() % min_buff));
+                        GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("Block (%s) min_buff (%s)") %
+                                               bb->alias() % min_buff));
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
-                            if (HIER_BLOCK2_DETAIL_DEBUG)
-                                GR_LOG_INFO(d_logger,
-                                    boost::str(boost::format("HBlock (%s) min_buff (%s)")
-                                        % hh->alias() % min_buff));
+                            GR_LOG_INFO(
+                                d_logger,
+                                boost::str(boost::format("HBlock (%s) min_buff (%s)") %
+                                           hh->alias() % min_buff));
                             hh->set_min_output_buffer(min_buff);
                         }
                     }
@@ -677,20 +660,19 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
-                        if (HIER_BLOCK2_DETAIL_DEBUG)
-                            GR_LOG_INFO(d_logger,
-                                boost::str(boost::format("Block (%s) max_buff (%s)")
-                                    % bb->alias() % max_buff));
+                        GR_LOG_INFO(d_logger,
+                                    boost::str(boost::format("Block (%s) max_buff (%s)") %
+                                               bb->alias() % max_buff));
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
-                            if (HIER_BLOCK2_DETAIL_DEBUG)
-                                GR_LOG_INFO(d_logger,
-                                    boost::str(boost::format("HBlock (%s) max_buff (%s)")
-                                        % hh->alias() % max_buff));
+                            GR_LOG_INFO(
+                                d_logger,
+                                boost::str(boost::format("HBlock (%s) max_buff (%s)") %
+                                           hh->alias() % max_buff));
                             hh->set_max_output_buffer(max_buff);
                         }
                     }
@@ -699,14 +681,10 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         }
     }
 
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger, "Flattening stream connections: ");
+    GR_LOG_INFO(d_logger, "Flattening stream connections: ");
 
     for (p = edges.begin(); p != edges.end(); p++) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("Flattening edge %s")
-                    % (*p)));
+        GR_LOG_INFO(d_logger, boost::str(boost::format("Flattening edge %s") % (*p)));
 
         endpoint_vector_t src_endps = resolve_endpoint(p->src(), false);
         endpoint_vector_t dst_endps = resolve_endpoint(p->dst(), true);
@@ -714,51 +692,42 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         endpoint_viter_t s, d;
         for (s = src_endps.begin(); s != src_endps.end(); s++) {
             for (d = dst_endps.begin(); d != dst_endps.end(); d++) {
-                if (HIER_BLOCK2_DETAIL_DEBUG)
-                    GR_LOG_INFO(d_logger,
-                        boost::str(boost::format("%s -> %s")
-                            % (*s) % (*d)));
+                GR_LOG_INFO(d_logger,
+                            boost::str(boost::format("%s -> %s") % (*s) % (*d)));
                 sfg->connect(*s, *d);
             }
         }
     }
 
     // loop through flattening hierarchical connections
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger, "Flattening msg connections: ");
+    GR_LOG_INFO(d_logger, "Flattening msg connections: ");
 
     std::vector<std::pair<msg_endpoint, bool>> resolved_endpoints;
     for (q = msg_edges.begin(); q != msg_edges.end(); q++) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format(
-                             " flattening edge ( %s, %s, %d) -> ( %s, %s, %d)\n") %
-                             q->src().block() % q->src().port() % q->src().is_hier() %
-                             q->dst().block() % q->dst().port() % q->dst().is_hier()));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format(
+                                   " flattening edge ( %s, %s, %d) -> ( %s, %s, %d)\n") %
+                               q->src().block() % q->src().port() % q->src().is_hier() %
+                               q->dst().block() % q->dst().port() % q->dst().is_hier()));
 
 
         if (q->src().is_hier() && q->src().block().get() == d_owner) {
             // connection into this block ..
-            if (HIER_BLOCK2_DETAIL_DEBUG)
-                GR_LOG_INFO(d_logger,
-                    boost::str(boost::format("hier incoming port: %s")
-                        % q->src()));
+            GR_LOG_INFO(d_logger,
+                        boost::str(boost::format("hier incoming port: %s") % q->src()));
             sfg->replace_endpoint(q->src(), q->dst(), false);
             resolved_endpoints.push_back(std::pair<msg_endpoint, bool>(q->src(), false));
         } else if (q->dst().is_hier() && q->dst().block().get() == d_owner) {
             // connection out of this block
-            if (HIER_BLOCK2_DETAIL_DEBUG)
-                GR_LOG_INFO(d_logger,
-                    boost::str(boost::format("hier outgoing port: %s")
-                        % q->dst()));
+            GR_LOG_INFO(d_logger,
+                        boost::str(boost::format("hier outgoing port: %s") % q->dst()));
             sfg->replace_endpoint(q->dst(), q->src(), true);
             resolved_endpoints.push_back(std::pair<msg_endpoint, bool>(q->dst(), true));
         } else {
             // internal connection only
-            if (HIER_BLOCK2_DETAIL_DEBUG)
-                GR_LOG_INFO(d_logger,
-                    boost::str(boost::format("internal msg connection: %s-->%s")
-                        % q->src() % q->dst()));
+            GR_LOG_INFO(d_logger,
+                        boost::str(boost::format("internal msg connection: %s-->%s") %
+                                   q->src() % q->dst()));
             sfg->connect(q->src(), q->dst());
         }
     }
@@ -767,10 +736,9 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
              resolved_endpoints.begin();
          it != resolved_endpoints.end();
          it++) {
-        if (HIER_BLOCK2_DETAIL_DEBUG)
-            GR_LOG_INFO(d_logger,
-                boost::str(boost::format("sfg->clear_endpoint(%s, %s)")
-                    % (*it).first % (*it).second));
+        GR_LOG_INFO(d_logger,
+                    boost::str(boost::format("sfg->clear_endpoint(%s, %s)") %
+                               (*it).first % (*it).second));
         sfg->clear_endpoint((*it).first, (*it).second);
     }
 
@@ -824,19 +792,20 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(blk);
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
-                    if (HIER_BLOCK2_DETAIL_DEBUG)
-                        GR_LOG_INFO(d_logger,
-                            boost::str(boost::format("Block (%s) Port (%s) min_buff (%s)")
-                                % bb->alias() % bb_src_port % min_buff));
+                    GR_LOG_INFO(
+                        d_logger,
+                        boost::str(boost::format("Block (%s) Port (%s) min_buff (%s)") %
+                                   bb->alias() % bb_src_port % min_buff));
                     bb->set_min_output_buffer(bb_src_port, min_buff);
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
-                        if (HIER_BLOCK2_DETAIL_DEBUG)
-                            GR_LOG_INFO(d_logger,
-                                boost::str(boost::format("HBlock (%s) Port (%s) min_buff (%s)")
-                                    % hh->alias() % hh_src_port % min_buff));
+                        GR_LOG_INFO(
+                            d_logger,
+                            boost::str(
+                                boost::format("HBlock (%s) Port (%s) min_buff (%s)") %
+                                hh->alias() % hh_src_port % min_buff));
                         hh->set_min_output_buffer(hh_src_port, min_buff);
                     }
                 }
@@ -848,19 +817,20 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(blk);
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
-                    if (HIER_BLOCK2_DETAIL_DEBUG)
-                        GR_LOG_INFO(d_logger,
-                            boost::str(boost::format("Block (%s) Port (%s) max_buff (%s)")
-                                % bb->alias() % bb_src_port % max_buff));
+                    GR_LOG_INFO(
+                        d_logger,
+                        boost::str(boost::format("Block (%s) Port (%s) max_buff (%s)") %
+                                   bb->alias() % bb_src_port % max_buff));
                     bb->set_max_output_buffer(bb_src_port, max_buff);
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
-                        if (HIER_BLOCK2_DETAIL_DEBUG)
-                            GR_LOG_INFO(d_logger,
-                                boost::str(boost::format("HBlock (%s) Port (%s) max_buff (%s)")
-                                    % hh->alias() % hh_src_port % max_buff));
+                        GR_LOG_INFO(
+                            d_logger,
+                            boost::str(
+                                boost::format("HBlock (%s) Port (%s) max_buff (%s)") %
+                                hh->alias() % hh_src_port % max_buff));
                         hh->set_max_output_buffer(hh_src_port, max_buff);
                     }
                 }
@@ -877,10 +847,11 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     for (basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
         hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(*p));
         if (hier_block2 && (hier_block2.get() != d_owner)) {
-            if (HIER_BLOCK2_DETAIL_DEBUG)
-                GR_LOG_INFO(d_logger,
-                    boost::str(boost::format("flatten_aux: recursing into hierarchical block %s")
-                        % hier_block2->alias()));
+            GR_LOG_INFO(
+                d_logger,
+                boost::str(
+                    boost::format("flatten_aux: recursing into hierarchical block %s") %
+                    hier_block2->alias()));
             hier_block2->d_detail->flatten_aux(sfg);
         }
     }
@@ -893,7 +864,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     }
 
     // print all primitive connections at exit
-    if (HIER_BLOCK2_DETAIL_DEBUG && is_top_block) {
+    if (is_top_block) {
         GR_LOG_INFO(d_logger, "flatten_aux finished in top_block");
         sfg->dump();
     }
@@ -911,10 +882,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 
 void hier_block2_detail::lock()
 {
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format("lock: entered in %s")
-                % this));
+    GR_LOG_INFO(d_logger, boost::str(boost::format("lock: entered in %s") % this));
 
     if (d_parent_detail)
         d_parent_detail->lock();
@@ -924,10 +892,7 @@ void hier_block2_detail::lock()
 
 void hier_block2_detail::unlock()
 {
-    if (HIER_BLOCK2_DETAIL_DEBUG)
-        GR_LOG_INFO(d_logger,
-            boost::str(boost::format("unlock: entered in %s")
-                % this));
+    GR_LOG_INFO(d_logger, boost::str(boost::format("unlock: entered in %s") % this));
 
     if (d_parent_detail)
         d_parent_detail->unlock();

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -55,6 +55,9 @@ public:
     std::vector<size_t> d_max_output_buffer;
     std::vector<size_t> d_min_output_buffer;
 
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
+
 private:
     // Private implementation data
     hier_block2* d_owner;

--- a/gr-blocks/lib/qa_block_tags.cc
+++ b/gr-blocks/lib/qa_block_tags.cc
@@ -22,9 +22,6 @@
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
 
-// FIXME use logging
-#include <iostream>
-
 // ----------------------------------------------------------------
 
 // set to 1 to turn on debug output
@@ -113,6 +110,10 @@ BOOST_AUTO_TEST_CASE(t1)
     BOOST_REQUIRE_EQUAL(tags4.size(), (size_t)8);
 
 #if QA_TAGS_DEBUG
+    gr::logger_ptr logger;
+    gr::logger_ptr debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "qa_block_tags_t1");
+
     // Kludge together the tags that we know should result from the above graph
     std::stringstream str0, str1, str2;
     str0 << ann0->name() << ann0->unique_id();
@@ -139,20 +140,22 @@ BOOST_AUTO_TEST_CASE(t1)
     expected_tags4[6] = make_tag(30000, pmt::mp(str2.str()), pmt::mp("seq"), pmt::mp(3));
     expected_tags4[7] = make_tag(30000, pmt::mp(str0.str()), pmt::mp("seq"), pmt::mp(7));
 
-    std::cout << std::endl << "qa_block_tags::t1" << std::endl;
+    GR_LOG_INFO(logger, "qa_block_tags::t1");
 
     // For annotator 3, we know it gets tags from ann0 and ann1, test this
     for (size_t i = 0; i < tags3.size(); i++) {
-        std::cout << "tags3[" << i << "] = " << tags3[i] << "\t\t" << expected_tags3[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags3[%i] = %s\t\t%s") % i % tags3[i] %
+                               expected_tags3[i]));
         BOOST_REQUIRE_EQUAL(tags3[i], expected_tags3[i]);
     }
 
     // For annotator 4, we know it gets tags from ann0 and ann2, test this
-    std::cout << std::endl;
+    GR_LOG_INFO(logger, "qa_block_tags::t1");
     for (size_t i = 0; i < tags4.size(); i++) {
-        std::cout << "tags4[" << i << "] = " << tags4[i] << "\t\t" << expected_tags4[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags4[%i] = %s\t\t%s") % i % tags4[i] %
+                               expected_tags4[i]));
         BOOST_REQUIRE_EQUAL(tags4[i], expected_tags4[i]);
     }
 #endif
@@ -210,6 +213,10 @@ BOOST_AUTO_TEST_CASE(t2)
 
 
 #if QA_TAGS_DEBUG
+    gr::logger_ptr logger;
+    gr::logger_ptr debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "qa_block_tags_t2");
+
     // Kludge together the tags that we know should result from the above graph
     std::stringstream str0, str1;
     str0 << ann0->name() << ann0->unique_id();
@@ -243,22 +250,24 @@ BOOST_AUTO_TEST_CASE(t2)
     expected_tags4[10] = make_tag(30000, pmt::mp(str0.str()), pmt::mp("seq"), pmt::mp(6));
     expected_tags4[11] = make_tag(30000, pmt::mp(str0.str()), pmt::mp("seq"), pmt::mp(7));
 
-    std::cout << std::endl << "qa_block_tags::t2" << std::endl;
+    GR_LOG_INFO(logger, "qa_block_tags::t2");
 
     // For annotator[2-4], we know it gets tags from ann0 and ann1
     // but the tags from the different outputs of ann1 are different for each.
     // Just testing ann2 and ann4; if they are correct it would be
     // inconceivable for ann3 to have it wrong.
     for (size_t i = 0; i < tags2.size(); i++) {
-        std::cout << "tags2[" << i << "] = " << tags2[i] << "\t\t" << expected_tags2[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags2[%i] = %s\t\t%s") % i % tags2[i] %
+                               expected_tags2[i]));
         BOOST_REQUIRE_EQUAL(tags2[i], expected_tags2[i]);
     }
 
-    std::cout << std::endl;
+    GR_LOG_INFO(logger, "");
     for (size_t i = 0; i < tags4.size(); i++) {
-        std::cout << "tags2[" << i << "] = " << tags4[i] << "\t\t" << expected_tags4[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags4[%i] = %s\t\t%s") % i % tags4[i] %
+                               expected_tags4[i]));
         BOOST_REQUIRE_EQUAL(tags4[i], expected_tags4[i]);
     }
 #endif
@@ -309,6 +318,10 @@ BOOST_AUTO_TEST_CASE(t3)
     BOOST_REQUIRE_EQUAL(tags4.size(), (size_t)8);
 
 #if QA_TAGS_DEBUG
+    gr::logger_ptr logger;
+    gr::logger_ptr debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "qa_block_tags_t3");
+
     // Kludge together the tags that we know should result from the above graph
     std::stringstream str0, str1, str2;
     str0 << ann0->name() << ann0->unique_id();
@@ -335,20 +348,22 @@ BOOST_AUTO_TEST_CASE(t3)
     expected_tags4[6] = make_tag(30000, pmt::mp(str2.str()), pmt::mp("seq"), pmt::mp(3));
     expected_tags4[7] = make_tag(30000, pmt::mp(str0.str()), pmt::mp("seq"), pmt::mp(7));
 
-    std::cout << std::endl << "qa_block_tags::t3" << std::endl;
+    GR_LOG_INFO(logger, "qa_block_tags::t3");
 
     // For annotator 3, we know it gets tags from ann0 and ann1, test this
     for (size_t i = 0; i < tags3.size(); i++) {
-        std::cout << "tags3[" << i << "] = " << tags3[i] << "\t\t" << expected_tags3[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags3[%i] = %s\t\t%s") % i % tags3[i] %
+                               expected_tags3[i]));
         BOOST_REQUIRE_EQUAL(tags3[i], expected_tags3[i]);
     }
 
     // For annotator 4, we know it gets tags from ann0 and ann2, test this
-    std::cout << std::endl;
+    GR_LOG_INFO(logger, "");
     for (size_t i = 0; i < tags4.size(); i++) {
-        std::cout << "tags4[" << i << "] = " << tags4[i] << "\t\t" << expected_tags4[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags4[%i] = %s\t\t%s") % i % tags4[i] %
+                               expected_tags4[i]));
         BOOST_REQUIRE_EQUAL(tags4[i], expected_tags4[i]);
     }
 #endif
@@ -357,6 +372,10 @@ BOOST_AUTO_TEST_CASE(t3)
 
 BOOST_AUTO_TEST_CASE(t4)
 {
+    gr::logger_ptr logger;
+    gr::logger_ptr debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "qa_block_tags_t4");
+
     int N = 40000;
     gr::top_block_sptr tb = gr::make_top_block("top");
     gr::block_sptr src(gr::blocks::null_source::make(sizeof(int)));
@@ -379,9 +398,8 @@ BOOST_AUTO_TEST_CASE(t4)
     tb->connect(ann1, 0, snk0, 0);
     tb->connect(ann2, 0, snk1, 0);
 
-    std::cerr << std::endl
-              << "NOTE: This is supposed to produce an error from block_executor"
-              << std::endl;
+    GR_LOG_ERROR(logger,
+                 "NOTE: This is supposed to produce an error from block_executor");
     tb->run();
 }
 
@@ -424,6 +442,10 @@ BOOST_AUTO_TEST_CASE(t5)
 
 
 #if QA_TAGS_DEBUG
+    gr::logger_ptr logger;
+    gr::logger_ptr debug_logger;
+    gr::configure_default_loggers(logger, debug_logger, "qa_block_tags_t5");
+
     // Kludge together the tags that we know should result from the above graph
     std::stringstream str0, str1, str2;
     str0 << ann0->name() << ann0->unique_id();
@@ -448,22 +470,24 @@ BOOST_AUTO_TEST_CASE(t5)
     expected_tags2[8] = make_tag(4000, pmt::mp(str1.str()), pmt::mp("seq"), pmt::mp(4));
     expected_tags2[9] = make_tag(4000, pmt::mp(str0.str()), pmt::mp("seq"), pmt::mp(4));
 
-    std::cout << std::endl << "qa_block_tags::t5" << std::endl;
+    GR_LOG_INFO(logger, "qa_block_tags::t5");
 
     // annotator 1 gets tags from annotator 0
-    std::cout << "tags1.size(): " << tags1.size() << std::endl;
+    GR_LOG_INFO(logger, boost::str(boost::format("tags1.size(): %i") % tags1.size()));
     for (size_t i = 0; i < tags1.size(); i++) {
-        std::cout << "tags1[" << i << "] = " << tags1[i] << "\t\t" << expected_tags1[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags1[%i] = %s\t\t%s") % i % tags1[i] %
+                               expected_tags1[i]));
         BOOST_REQUIRE_EQUAL(tags1[i], expected_tags1[i]);
     }
 
     // annotator 2 gets tags from annotators 0 and 1
-    std::cout << std::endl;
-    std::cout << "tags2.size(): " << tags2.size() << std::endl;
+    GR_LOG_INFO(logger, "");
+    GR_LOG_INFO(logger, boost::str(boost::format("tags2.size(): %i") % tags2.size()));
     for (size_t i = 0; i < tags2.size(); i++) {
-        std::cout << "tags2[" << i << "] = " << tags2[i] << "\t\t" << expected_tags2[i]
-                  << std::endl;
+        GR_LOG_INFO(logger,
+                    boost::str(boost::format("tags2[%i] = %s\t\t%s") % i % tags2[i] %
+                               expected_tags2[i]));
         BOOST_REQUIRE_EQUAL(tags2[i], expected_tags2[i]);
     }
 #endif

--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -17,7 +17,6 @@
 #include <volk/volk.h>
 
 #include <cstdio>
-#include <iostream>
 
 namespace gr {
 namespace fec {
@@ -167,12 +166,13 @@ void polar_decoder_common::extract_info_bits(unsigned char* output,
 void polar_decoder_common::print_pretty_llr_vector(const float* llr_vec) const
 {
     for (int row = 0; row < block_size(); row++) {
-        // FIXME this is an interesting mixture of iostream and stdio
-        std::cout << row << "->" << int(bit_reverse(row, block_power())) << ":\t";
+        std::ostringstream msg;
+        msg << row << "->" << int(bit_reverse(row, block_power())) << ":\t";
         for (int stage = 0; stage < block_power() + 1; stage++) {
-            printf("%+4.2f, ", llr_vec[(stage * block_size()) + row]);
+            msg << boost::format("%+4.2f, ") % llr_vec[(stage * block_size()) + row];
         }
-        std::cout << std::endl;
+        msg << "\n";
+        GR_LOG_INFO(d_logger, msg.str().c_str());
     }
 }
 


### PR DESCRIPTION
This PR is related to Issue #4765 ("Convert remaining code to logging")

Filename: hier_block2_detail
 - [x] Create d_logger and d_debug_logger pointers and configure them
 - [x] Convert cout to use GR_LOG_INFO
 - [x] Remove <iostream> header
 - [x] Remove debug flag and associated if statements

Filename: qa_blocks_tags.cc
 - [x] Create d_logger and d_debug_logger pointers and configure them (for each tag)
 - [x] Convert cout to use GR_LOG_INFO
 - [x] Remove <iostream> header

Filename: polar_decoder_common.cc
 - [x] Settle on use of ostringstring (rather than printf)
 - [x] Convert cout to use GR_LOG_INFO
 - [x] Remove <iostream> header