### PR TITLE
add homebrew installation on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@
 [![Docs](https://img.shields.io/badge/docs-doxygen-orange.svg)](https://www.gnuradio.org/doc/doxygen/)
 [![Packaging status](https://repology.org/badge/tiny-repos/gnuradio.svg)](https://repology.org/project/gnuradio/badges)
 
-GNU Radio is a free & open-source software development toolkit that 
-provides signal processing blocks to implement software radios. It can 
-be used with readily-available, low-cost external RF hardware to create 
-software-defined radios, or without hardware in a simulation-like 
-environment. It is widely used in hobbyist, academic, and commercial 
-environments to support both wireless communications research and real-world 
+GNU Radio is a free & open-source software development toolkit that
+provides signal processing blocks to implement software radios. It can
+be used with readily-available, low-cost external RF hardware to create
+software-defined radios, or without hardware in a simulation-like
+environment. It is widely used in hobbyist, academic, and commercial
+environments to support both wireless communications research and real-world
 radio systems.
 
-Please visit the GNU Radio website at https://www.gnuradio.org/ and the 
-wiki at https://wiki.gnuradio.org/. Bugs and feature requests are 
-tracked on GitHub's [Issue Tracker](https://github.com/gnuradio/gnuradio/issues). 
-If you have questions about GNU Radio, please search the **discuss-gnuradio** 
-mailing list [archive](https://lists.gnu.org/archive/html/discuss-gnuradio/), 
-as many questions have already been asked and answered. Please also 
-[subscribe](https://lists.gnu.org/mailman/listinfo/discuss-gnuradio) to 
+Please visit the GNU Radio website at https://www.gnuradio.org/ and the
+wiki at https://wiki.gnuradio.org/. Bugs and feature requests are
+tracked on GitHub's [Issue Tracker](https://github.com/gnuradio/gnuradio/issues).
+If you have questions about GNU Radio, please search the **discuss-gnuradio**
+mailing list [archive](https://lists.gnu.org/archive/html/discuss-gnuradio/),
+as many questions have already been asked and answered. Please also
+[subscribe](https://lists.gnu.org/mailman/listinfo/discuss-gnuradio) to
 the mailing list and post your new questions there.
 
 
@@ -30,11 +30,15 @@ the mailing list and post your new questions there.
 
 ### Prebuilt Binaries
 
-The recommended way to install GNU Radio on most platforms is using available binary package distributions. 
+The recommended way to install GNU Radio on most platforms is using available binary package distributions.
 
 The following command is for Debian, Ubuntu, and derivatives. Consult your distribution information to obtain the version of GNU Radio which is included.
 
     sudo apt install gnuradio
+
+For MacOS, install the latest release version of GNU Radio with [homebrew](https://brew.sh)
+
+    brew install gnuradio
 
 For other operating systems and versions, see [Installing from Binaries](https://wiki.gnuradio.org/index.php/InstallingGR#From_Binaries)
 
@@ -59,14 +63,14 @@ Complete PyBOMBS instructions are in the [PyBOMBS README](https://github.com/gnu
 
 ### From Source
 
-Complete instructions for building Gnuradio from source code are detailed in 
-[Installing GR From Source](https://wiki.gnuradio.org/index.php/InstallingGR#From_Source). 
+Complete instructions for building Gnuradio from source code are detailed in
+[Installing GR From Source](https://wiki.gnuradio.org/index.php/InstallingGR#From_Source).
 
 ## Legal Matters
 
-Some files have been changed many times throughout the years. Copyright 
-notices at the top of source files list which years changes have been 
-made. For some files, changes have occurred in many consecutive years. 
-These files may often have the format of a year range (e.g., "2006 - 2011"), 
-which indicates that these files have had copyrightable changes made 
+Some files have been changed many times throughout the years. Copyright
+notices at the top of source files list which years changes have been
+made. For some files, changes have occurred in many consecutive years.
+These files may often have the format of a year range (e.g., "2006 - 2011"),
+which indicates that these files have had copyrightable changes made
 during each year in the range, inclusive.


### PR DESCRIPTION
I added all the necessary dependencies on homebrew and now it installs perfectly with version 3.9.2 and includes gr_soapy and the prerequisites of soapysdr and soapyrtlsdr.

Signed-off-by: NeuroForLunch <neuro.for.lunch@gmail.com>