### PR TITLE
gr-iio: grc: Fix source/sink throttle/python flags

### DIFF
--- a/gr-iio/grc/iio_device_sink.block.yml
+++ b/gr-iio/grc/iio_device_sink.block.yml
@@ -1,6 +1,6 @@
 id: iio_device_sink
 label: IIO Device Sink
-flags: [ python ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri

--- a/gr-iio/grc/iio_device_source.block.yml
+++ b/gr-iio/grc/iio_device_source.block.yml
@@ -1,6 +1,6 @@
 id: iio_device_source
 label: IIO Device Source
-flags: [ python ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri

--- a/gr-iio/grc/iio_fmcomms2_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_sink.block.yml
@@ -1,6 +1,6 @@
 id: iio_fmcomms2_sink
 label: FMComms2/3/4 Sink
-flags: [ python ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri

--- a/gr-iio/grc/iio_fmcomms5_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms5_sink.block.yml
@@ -1,6 +1,6 @@
 id: iio_fmcomms5_sink
 label: FMComms5 Sink
-flags: [ python ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri

--- a/gr-iio/grc/iio_fmcomms5_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms5_source.block.yml
@@ -1,6 +1,6 @@
 id: iio_fmcomms5_source
 label: FMComms5 Source
-flags: [ throttle ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri

--- a/gr-iio/grc/iio_pluto_sink.block.yml
+++ b/gr-iio/grc/iio_pluto_sink.block.yml
@@ -1,6 +1,6 @@
 id: iio_pluto_sink
 label: PlutoSDR Sink
-flags: [ python ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri

--- a/gr-iio/grc/iio_pluto_source.block.yml
+++ b/gr-iio/grc/iio_pluto_source.block.yml
@@ -1,6 +1,6 @@
 id: iio_pluto_source
 label: PlutoSDR Source
-flags: [ throttle ]
+flags: [ python, throttle ]
 
 parameters:
 -   id: uri


### PR DESCRIPTION
This commit fixes the flags for hardware connected blocks to include
"throttle", which prevents the following warning from being emitted
erroneously:

>>> Warning: This flow graph may not have flow control: no audio or RF
hardware blocks found. Add a Misc->Throttle block to your flow graph to
avoid CPU congestion.

Additionally, the python flag is added to all blocks for consistency.