### PR TITLE
modtool: Fix `rm`, `disable`, `rename` and `makeyml` similar naming (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/core/disable.py
+++ b/gr-utils/modtool/core/disable.py
@@ -67,7 +67,7 @@ class ModToolDisable(ModTool):
                 ed.write()
                 self.scm.mark_file_updated(self._file['qalib'])
             elif self.info['version'] == '38':
-                fname_qa_cc = f'qa_{self._info["blockname"]}.cc'
+                fname_qa_cc = f'qa_{self.info["blockname"]}.cc'
                 cmake.comment_out_lines(fname_qa_cc)
             elif self.info['version'] == '36':
                 cmake.comment_out_lines('add_executable.*'+fname)
@@ -97,7 +97,24 @@ class ModToolDisable(ModTool):
             except IOError:
                 continue
             logger.info(f"Traversing {subdir}...")
-            filenames = cmake.find_filenames_match(self.info['pattern'])
+            filenames = []
+            if self.info['blockname']:
+                if subdir == 'python':
+                    blockname_pattern = f"^(qa_)?{self.info['blockname']}.py$"
+                elif subdir == 'python/bindings':
+                    blockname_pattern = f"^{self.info['blockname']}_python.cc$"
+                elif subdir == 'python/bindings/docstrings':
+                    blockname_pattern = f"^{self.info['blockname']}_pydoc_template.h$"
+                elif subdir == 'lib':
+                    blockname_pattern = f"^{self.info['blockname']}_impl(\\.h|\\.cc)$"
+                elif subdir == self.info['includedir']:
+                    blockname_pattern = f"^{self.info['blockname']}.h$"
+                elif subdir == 'grc':
+                    blockname_pattern = f"^{self.info['modname']}_{self.info['blockname']}.block.yml$"
+                if blockname_pattern:
+                    filenames = cmake.find_filenames_match(blockname_pattern)
+            elif self.info['pattern']:
+                filenames = cmake.find_filenames_match(self.info['pattern'])
             yes = self.info['yes']
             for fname in filenames:
                 file_disabled = False

--- a/gr-utils/modtool/core/makeyaml.py
+++ b/gr-utils/modtool/core/makeyaml.py
@@ -93,9 +93,29 @@ class ModToolMakeYAML(ModTool):
         files = sorted(glob.glob(f"{path}/{path_glob}"))
         files_filt = []
         logger.info(f"Searching for matching files in {path}/:")
-        for f in files:
-            if re.search(self.info['pattern'], os.path.basename(f)) is not None:
-                files_filt.append(f)
+        if self.info['blockname']:
+            # ensure the blockname given is not confused with similarly named blocks
+            blockname_pattern = ''
+            if path == 'python':
+                blockname_pattern = f"^(qa_)?{self.info['blockname']}.py$"
+            elif path == 'python/bindings':
+                blockname_pattern = f"^{self.info['blockname']}_python.cc$"
+            elif path == 'python/bindings/docstrings':
+                blockname_pattern = f"^{self.info['blockname']}_pydoc_template.h$"
+            elif path == 'lib':
+                blockname_pattern = f"^{self.info['blockname']}_impl(\\.h|\\.cc)$"
+            elif path == self.info['includedir']:
+                blockname_pattern = f"^{self.info['blockname']}.h$"
+            elif path == 'grc':
+                blockname_pattern = f"^{self.info['modname']}_{self.info['blockname']}.block.yml$"
+            for f in files:
+                if re.search(blockname_pattern, os.path.basename(f)) is not None:
+                    files_filt.append(f)
+        elif self.info['pattern']:
+            # search for block names matching a given regex pattern
+            for f in files:
+                if re.search(self.info['pattern'], os.path.basename(f)) is not None:
+                    files_filt.append(f)
         if len(files_filt) == 0:
             logger.info("None found.")
         return files_filt

--- a/gr-utils/modtool/core/rm.py
+++ b/gr-utils/modtool/core/rm.py
@@ -141,9 +141,29 @@ class ModToolRemove(ModTool):
             files = files + sorted(glob.glob(f"{path}/{g}"))
         files_filt = []
         logger.info(f"Searching for matching files in {path}/:")
-        for f in files:
-            if re.search(self.info['pattern'], os.path.basename(f)) is not None:
-                files_filt.append(f)
+        if self.info['blockname']:
+            # Ensure the blockname given is not confused with similarly named blocks
+            blockname_pattern = ''
+            if path == 'python':
+                blockname_pattern = f"^(qa_)?{self.info['blockname']}.py$"
+            elif path == 'python/bindings':
+                blockname_pattern = f"^{self.info['blockname']}_python.cc$"
+            elif path == 'python/bindings/docstrings':
+                blockname_pattern = f"^{self.info['blockname']}_pydoc_template.h$"
+            elif path == 'lib':
+                blockname_pattern = f"^{self.info['blockname']}_impl(\\.h|\\.cc)$"
+            elif path == self.info['includedir']:
+                blockname_pattern = f"^{self.info['blockname']}.h$"
+            elif path == 'grc':
+                blockname_pattern = f"^{self.info['modname']}_{self.info['blockname']}.block.yml$"
+            for f in files:
+                if re.search(blockname_pattern, os.path.basename(f)) is not None:
+                    files_filt.append(f)
+        elif self.info['pattern']:
+            # A regex resembling one or several blocks were given as stdin
+            for f in files:
+                if re.search(self.info['pattern'], os.path.basename(f)) is not None:
+                    files_filt.append(f)
         if len(files_filt) == 0:
             logger.info("None found.")
             return []


### PR DESCRIPTION
* modtool: Fix issue #2672 for `rm`

In the event that the user specifies only one specific block to delete,
this PR ensures that the files for said block is not confused with files
of similarly named blocks.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>

* modtool: Fix issue #2672 for `rename` and more

This commit fixes the following for the `rename` command.
1. Issue #2672 that also affects `rename`
2. Fixes errorneous replacement of similarly named blocks in CMakeLists
3. Replaced the file search in `_run_file_rename` from `file.find` to
`re.search` so that block names will not be confused with names with one
or two prefix characters (e.g. "decoder" vs "adecoder").
4. Renames the bind function in `python_bindings.cc` as well.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>

* modtool: Fix Issue #2672 for `disable` & more

When the user specifies a block name, only the block with that specific
blockname should be disabled. Prior to this PR, all blocks matching said
specified block name are disabled. This PR fixes it.

This PR also fixes what appears to be a spelling error `self._info`. The
error is thrown for OOT module version 38:
Attribute error `'ModToolDisable' object has no attribute '_info'`

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>

* modtool: Fix Issue #2672 for `makeyaml`

This PR fixes issue #2672 which also affects the `makeyaml` command.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit ac738e2a6db48f13929c780d89a87ba5e916e2d3)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4709