### PR TITLE
Fix drag n' drop issue with Quartz (macOS) backend (backport to maint-3.8)

### DIFF
--- a/grc/gui/Constants.py
+++ b/grc/gui/Constants.py
@@ -52,7 +52,8 @@ PARAM_FONT = "Sans 7.5"
 STATE_CACHE_SIZE = 42
 
 # Shared targets for drag and drop of blocks
-DND_TARGETS = [('STRING', Gtk.TargetFlags.SAME_APP, 0)]
+DND_TARGETS = [Gtk.TargetEntry.new('STRING', Gtk.TargetFlags.SAME_APP, 0),
+               Gtk.TargetEntry.new('UTF8_STRING', Gtk.TargetFlags.SAME_APP, 1)]
 
 # label constraint dimensions
 LABEL_SEPARATION = 3


### PR DESCRIPTION
(cherry picked from commit 518dc7eda3a2575292dc67374cad62c887f83d12)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3980