### PR TITLE
cmake: Remove absolute paths and private links from exported targets. (backport to maint-3.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,14 +333,6 @@ IF(${pybind11_VERSION} VERSION_LESS ${PYBIND11_MIN_VERSION})
     message(FATAL_ERROR "pybind11 version ${pybind11_VERSION} < ${PYBIND11_MIN_VERSION}")
 ENDIF()
 
-execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c
-    "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
-    OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR)
-# format path in CMake-style for consistency with other path variables
-# (a consistent style helps conda builds by using the same path separators)
-file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_DIR)
-
 include(GrComponent)
 GR_REGISTER_COMPONENT("python-support" ENABLE_PYTHON
     PYTHONLIBS_FOUND

--- a/cmake/Modules/Findlibunwind.cmake
+++ b/cmake/Modules/Findlibunwind.cmake
@@ -4,6 +4,7 @@
 #  libunwind_FOUND - system has libunwind
 #  libunwind_INCLUDE_DIRS - the libunwind include directories
 #  libunwind_LIBRARIES - link these to use libunwind
+#  libunwind::libunwind target
 
 include(LibFindMacros)
 
@@ -27,3 +28,14 @@ find_library(libunwind_LIBRARY
 set(libunwind_PROCESS_INCLUDES ${libunwind_INCLUDE_DIR})
 set(libunwind_PROCESS_LIBS libunwind_LIBRARY)
 libfind_process(libunwind)
+
+add_library(libunwind::libunwind INTERFACE IMPORTED)
+# Only add properties if libunwind was found, so target can be used even
+# when libunwind was not found
+if(libunwind_FOUND)
+  set_target_properties(libunwind::libunwind PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS HAVE_LIBUNWIND
+    INTERFACE_INCLUDE_DIRECTORIES "${libunwind_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${libunwind_LIBRARIES}"
+  )
+endif()

--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -1,5 +1,7 @@
 include(GrPython)
 
+find_package(pybind11 REQUIRED)
+
 macro(GR_PYBIND_MAKE name updir filter files) 
 
 configure_file(${CMAKE_SOURCE_DIR}/docs/doxygen/pydoc_macros.h ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
@@ -32,14 +34,12 @@ else(ENABLE_DOXYGEN)
     add_custom_target(${name}_docstrings ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/docstring_status)
 endif(ENABLE_DOXYGEN)
 
-target_include_directories(${name}_python PUBLIC
+target_include_directories(${name}_python PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
-    ${pybind11_INCLUDE_DIR}
 )
-target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
+target_link_libraries(${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module Python::NumPy gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${name}_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates
@@ -149,14 +149,12 @@ else(ENABLE_DOXYGEN)
     add_custom_target(${name}_docstrings ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/docstring_status)
 endif(ENABLE_DOXYGEN)
 
-target_include_directories(${name}_python PUBLIC
+target_include_directories(${name}_python PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
-    ${pybind11_INCLUDE_DIR}
 )
-target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
+target_link_libraries(${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module Python::NumPy gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${name}_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates
@@ -282,14 +280,12 @@ else(ENABLE_DOXYGEN)
     add_custom_target(${name}_docstrings ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/docstring_status)
 endif(ENABLE_DOXYGEN)
 
-target_include_directories(${name}_python PUBLIC
+target_include_directories(${name}_python PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${PYTHON_NUMPY_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/${updir}/include
-    ${pybind11_INCLUDE_DIR}
 )
-target_link_libraries(${name}_python PUBLIC ${Boost_LIBRARIES} Python::Module gnuradio-${MODULE_NAME})
+target_link_libraries(${name}_python PRIVATE ${Boost_LIBRARIES} pybind11::pybind11 Python::Module Python::NumPy gnuradio-${MODULE_NAME})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
    CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${name}_python PRIVATE -Wno-unused-variable) # disable warnings for docstring templates

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -80,6 +80,26 @@ else()
     endif(APPLE)
 endif(WIN32)
 
+# Find NumPy but duplicate behavior/variable names of FindPython in CMake 3.14+
+# (to facilitate a future transition)
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" -c
+    "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
+    OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
+)
+# advanced cache variable that the user should set to override the numpy include dir
+set(Python_NumPy_INCLUDE_DIR ${NUMPY_INCLUDE_DIR} CACHE FILEPATH "NumPy include directory")
+mark_as_advanced(Python_NumPy_INCLUDE_DIR)
+# output used by modern FindPython, duplicate the behavior
+set(Python_NumPy_INCLUDE_DIRS ${Python_NumPy_INCLUDE_DIR})
+
+# target for building with NumPy
+add_library(Python::NumPy INTERFACE IMPORTED)
+set_target_properties(Python::NumPy PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Python_NumPy_INCLUDE_DIRS}"
+)
+target_link_libraries(Python::NumPy INTERFACE Python::Module)
+
 
 ########################################################################
 # Check for the existence of a python module:

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -12,9 +12,6 @@ gr_check_hdr_n_def(sys/resource.h HAVE_SYS_RESOURCE_H)
 # Look for libunwind
 ########################################################################
 find_package(libunwind)
-if(libunwind_FOUND)
-    add_definitions(-DHAVE_LIBUNWIND)
-endif(libunwind_FOUND)
 
 ########################################################################
 # Handle the generated constants
@@ -132,7 +129,6 @@ target_link_libraries(gnuradio-runtime PUBLIC
   Boost::thread
   Log4Cpp::log4cpp
   MPLib::mplib
-  ${libunwind_LIBRARIES}
   # INTERFACE/PRIVATE split so users of the library can choose how to link to Python
   # (importantly, extension modules can avoid linking against Python and resolve
   #  their own Python symbols at runtime through the Python interpreter's linking)
@@ -140,12 +136,12 @@ target_link_libraries(gnuradio-runtime PUBLIC
     Python::Module
   PRIVATE
     Python::Python
+    libunwind::libunwind
+    pybind11::pybind11
   )
 
 target_include_directories(gnuradio-runtime
   PUBLIC
-    ${PYTHON_NUMPY_INCLUDE_DIR}
-    ${pybind11_INCLUDE_DIR}
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>

--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -116,19 +116,6 @@ endif(APPLE)
 find_package(Doxygen)
 
 ########################################################################
-# PyBind11 Related
-########################################################################
-
-find_package(pybind11 REQUIRED)
-execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" -c
-    "try:\n import numpy\n import os\n inc_path = numpy.get_include()\n if os.path.exists(os.path.join(inc_path, 'numpy', 'arrayobject.h')):\n  print(inc_path, end='')\nexcept:\n pass"
-    OUTPUT_VARIABLE PYTHON_NUMPY_INCLUDE_DIR)
-# format path in CMake-style for consistency with other path variables
-# (a consistent style helps conda builds by using the same path separators)
-file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_DIR)
-
-########################################################################
 # Setup doxygen option
 ########################################################################
 if(DOXYGEN_FOUND)


### PR DESCRIPTION
This transitions to using Python::NumPy, pybind11::pybind11, and
libunwind::libunwind targets for building with the include
directories/libraries of NumPy, pybind11, and libunwind. The
Python::NumPy target matches what is available with the FindPython
module in CMake 3.14+ (and can be transitioned to such when the minimum
CMake version is past that). These changes have the effect of cleaning
up the include_directory paths added to the gnuradio-runtime target so
that no absolute paths are used, which is helpful for relocatable
installations (e.g. conda).

Part of this change involves moving some link targets to PRIVATE since
they are not actually part of the public interface. In the case of the
python bindings, these are not exported and have no public interface for
consumption by other C++ libraries, so the switch from PUBLIC to PRIVATE
has no practical effect but could still help avoid future confusion.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit caf0f1e28be1f62ff9fdd48f2333f6068ccfa74d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4617