### PR TITLE
channels: Clean up the hardware impairments block (backport to maint-3.9)

### DIFF
--- a/gr-channels/grc/channels_impairments.block.yml
+++ b/gr-channels/grc/channels_impairments.block.yml
@@ -3,7 +3,7 @@ label: HW Impairments
 
 parameters:
 -   id: phase_noise_mag
-    label: Phase Noise Mag.
+    label: Phase Noise Mag. (dB)
     dtype: float
     default: '0'
 -   id: magbal

--- a/gr-channels/python/channels/distortion_2_gen.py
+++ b/gr-channels/python/channels/distortion_2_gen.py
@@ -59,5 +59,3 @@ class distortion_2_gen(gr.hier_block2):
     def set_beta(self, beta):
         self.beta = beta
         self.blocks_multiply_const_vxx_0.set_k((self.beta, ))
-
-

--- a/gr-channels/python/channels/impairments.py
+++ b/gr-channels/python/channels/impairments.py
@@ -6,11 +6,11 @@
 # Generated: Thu Aug  1 12:46:10 2013
 ##################################################
 
+import math
 from gnuradio import analog
 from gnuradio import blocks
 from gnuradio import gr
 from gnuradio.filter import firdes
-import math
 
 #Import locally
 from .phase_noise_gen import phase_noise_gen
@@ -20,7 +20,15 @@ from .distortion_3_gen import distortion_3_gen
 
 class impairments(gr.hier_block2):
 
-    def __init__(self, phase_noise_mag=0, magbal=0, phasebal=0, q_ofs=0, i_ofs=0, freq_offset=0, gamma=0, beta=0):
+    def __init__(self,
+                 phase_noise_mag=0,
+                 magbal=0,
+                 phasebal=0,
+                 q_ofs=0,
+                 i_ofs=0,
+                 freq_offset=0,
+                 gamma=0,
+                 beta=0):
         gr.hier_block2.__init__(
             self, "Radio Impairments Model",
             gr.io_signature(1, 1, gr.sizeof_gr_complex*1),
@@ -42,30 +50,34 @@ class impairments(gr.hier_block2):
         ##################################################
         # Blocks
         ##################################################
-        self.channels_phase_noise_gen_0_0 = phase_noise_gen(math.pow(10.0,phase_noise_mag / 20.0), .01)
-        self.channels_iqbal_gen_0 = iqbal_gen(magbal, phasebal)
+        self.phase_noise = phase_noise_gen(10.0**(phase_noise_mag / 20.0), .01)
+        self.iq_imbalance = iqbal_gen(magbal, phasebal)
         self.channels_distortion_3_gen_0 = distortion_3_gen(beta)
         self.channels_distortion_2_gen_0 = distortion_2_gen(gamma)
-        self.blocks_multiply_xx_0_0 = blocks.multiply_vcc(1)
-        self.blocks_multiply_xx_0 = blocks.multiply_vcc(1)
-        self.blocks_conjugate_cc_0 = blocks.conjugate_cc()
-        self.blocks_add_const_vxx_0 = blocks.add_const_vcc((i_ofs + q_ofs* 1j, ))
-        self.analog_sig_source_x_0 = analog.sig_source_c(1.0, analog.GR_COS_WAVE, freq_offset, 1, 0)
+        self.freq_modulator = blocks.multiply_cc()
+        self.freq_offset_gen = analog.sig_source_c(1.0, analog.GR_COS_WAVE, freq_offset, 1, 0)
+        self.freq_modulator_dcoffs = blocks.multiply_cc()
+        self.freq_offset_conj = blocks.conjugate_cc()
+        self.dc_offset = blocks.add_const_vcc((i_ofs + q_ofs* 1j, ))
 
         ##################################################
-        # Connections
-        ##################################################
-        self.connect((self.channels_phase_noise_gen_0_0, 0), (self.channels_distortion_3_gen_0, 0))
-        self.connect((self.blocks_multiply_xx_0, 0), (self, 0))
-        self.connect((self.blocks_add_const_vxx_0, 0), (self.blocks_multiply_xx_0, 1))
-        self.connect((self.analog_sig_source_x_0, 0), (self.blocks_multiply_xx_0, 0))
-        self.connect((self.blocks_multiply_xx_0_0, 0), (self.channels_phase_noise_gen_0_0, 0))
-        self.connect((self.analog_sig_source_x_0, 0), (self.blocks_conjugate_cc_0, 0))
-        self.connect((self, 0), (self.blocks_multiply_xx_0_0, 1))
-        self.connect((self.blocks_conjugate_cc_0, 0), (self.blocks_multiply_xx_0_0, 0))
-        self.connect((self.channels_iqbal_gen_0, 0), (self.blocks_add_const_vxx_0, 0))
-        self.connect((self.channels_distortion_3_gen_0, 0), (self.channels_distortion_2_gen_0, 0))
-        self.connect((self.channels_distortion_2_gen_0, 0), (self.channels_iqbal_gen_0, 0))
+        # Frequency offset
+        self.connect((self, 0), (self.freq_modulator, 1))
+        self.connect((self.freq_offset_gen, 0), (self.freq_offset_conj, 0))
+        self.connect((self.freq_offset_conj, 0), (self.freq_modulator, 0))
+        # Most distortions can be strung in a row
+        self.connect(
+            (self.freq_modulator, 0),
+            (self.phase_noise, 0),
+            (self.channels_distortion_3_gen_0, 0),
+            (self.channels_distortion_2_gen_0, 0),
+            (self.iq_imbalance, 0),
+            (self.dc_offset, 0),
+        )
+        # Frequency offset again
+        self.connect((self.freq_offset_gen, 0), (self.freq_modulator_dcoffs, 0))
+        self.connect((self.dc_offset, 0), (self.freq_modulator_dcoffs, 1))
+        self.connect((self.freq_modulator_dcoffs, 0), (self, 0))
 
 
 # QT sink close method reimplementation
@@ -75,42 +87,45 @@ class impairments(gr.hier_block2):
 
     def set_phase_noise_mag(self, phase_noise_mag):
         self.phase_noise_mag = phase_noise_mag
-        self.channels_phase_noise_gen_0_0.set_noise_mag(math.pow(10.0,self.phase_noise_mag / 20.0))
+        self.phase_noise.set_noise_mag(10**(self.phase_noise_mag / 20.0))
 
     def get_magbal(self):
         return self.magbal
 
     def set_magbal(self, magbal):
         self.magbal = magbal
-        self.channels_iqbal_gen_0.set_magnitude(self.magbal)
+        self.iq_imbalance.set_magnitude(self.magbal)
 
     def get_phasebal(self):
         return self.phasebal
 
     def set_phasebal(self, phasebal):
         self.phasebal = phasebal
-        self.channels_iqbal_gen_0.set_phase(self.phasebal)
+        self.iq_imbalance.set_phase(self.phasebal)
 
     def get_q_ofs(self):
         return self.q_ofs
 
     def set_q_ofs(self, q_ofs):
         self.q_ofs = q_ofs
-        self.blocks_add_const_vxx_0.set_k((self.i_ofs + self.q_ofs* 1j, ))
+        self.dc_offset.set_k((self.i_ofs + self.q_ofs* 1j, ))
 
     def get_i_ofs(self):
         return self.i_ofs
 
     def set_i_ofs(self, i_ofs):
+        """Set inphase part of DC offset"""
         self.i_ofs = i_ofs
-        self.blocks_add_const_vxx_0.set_k((self.i_ofs + self.q_ofs* 1j, ))
+        self.dc_offset.set_k((self.i_ofs + self.q_ofs* 1j, ))
 
     def get_freq_offset(self):
+        """Return frequency offset (normalized to 1.0)"""
         return self.freq_offset
 
     def set_freq_offset(self, freq_offset):
+        """Set frequency offset (normalized to 1.0)"""
         self.freq_offset = freq_offset
-        self.analog_sig_source_x_0.set_frequency(self.freq_offset)
+        self.freq_offset_gen.set_frequency(self.freq_offset)
 
     def get_gamma(self):
         return self.gamma
@@ -125,5 +140,3 @@ class impairments(gr.hier_block2):
     def set_beta(self, beta):
         self.beta = beta
         self.channels_distortion_3_gen_0.set_beta(self.beta)
-
-


### PR DESCRIPTION
- Add missing label docs for the phase noise power
- Fix a bunch of Pylint issues
- Rename blocks in the hier block from their GRC auto-generated names to
  something more readable

Signed-off-by: Martin Braun <martin@gnuradio.org>
(cherry picked from commit b6851218337aca35ace7e9fe80b92a942b7a5c27)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4616