### PR TITLE
iio: Remove cstdio/iostream and log using GR_LOG

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -61,12 +61,18 @@ typedef log4cpp::Category* logger_ptr;
 
 #define GR_LOG_ASSIGN_LOGPTR(logger, name) logger = gr::logger_get_logger(name)
 
+#define GR_LOG_ASSIGN_CONFIGURED_LOGPTR(logger, name) \
+    logger = gr::logger_get_configured_logger(name)
+
 #define GR_CONFIG_LOGGER(config) gr::logger_config::load_config(config)
 
 #define GR_CONFIG_AND_WATCH_LOGGER(config, period) \
     gr::logger_config::load_config(config, period)
 
 #define GR_LOG_GETLOGGER(logger, name) gr::logger_ptr logger = gr::logger_get_logger(name)
+
+#define GR_LOG_GET_CONFIGURED_LOGGER(logger, name) \
+    gr::logger_ptr logger = gr::logger_get_configured_logger(name)
 
 #define GR_SET_LEVEL(name, level)                            \
     {                                                        \
@@ -377,6 +383,19 @@ public:
  * \param name Name of the logger for which a pointer is requested
  */
 GR_RUNTIME_API logger_ptr logger_get_logger(std::string name);
+
+/*!
+ * \brief Retrieve a pointer to a fully configured logger by name
+ *
+ * Retrieves a logger pointer.
+ * This method differs from logger_get_logger in that it configures the logger to
+ * reflect the current gnuradio configuration, including log level and log output file.
+ *
+ * \p name.
+ *
+ * \param name Name of the logger for which a pointer is requested
+ */
+GR_RUNTIME_API logger_ptr logger_get_configured_logger(const std::string& name);
 
 /*!
  * \brief Load logger's configuration file.

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -153,6 +153,31 @@ logger_ptr logger_get_logger(std::string name)
     }
 }
 
+logger_ptr logger_get_configured_logger(const std::string& name)
+{
+    if (log4cpp::Category::exists(name))
+        return &log4cpp::Category::getInstance(name);
+
+    prefs* p = prefs::singleton();
+    std::string config_file = p->get_string("LOG", "log_config", "");
+    std::string log_level = p->get_string("LOG", "log_level", "off");
+    std::string log_file = p->get_string("LOG", "log_file", "");
+
+    GR_LOG_GETLOGGER(LOG, "gr_log." + name);
+    GR_LOG_SET_LEVEL(LOG, log_level);
+
+    if (!log_file.empty()) {
+        if (log_file == "stdout") {
+            GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
+        } else if (log_file == "stderr") {
+            GR_LOG_SET_CONSOLE_APPENDER(LOG, "stderr", "gr::log :%p: %c{1} - %m%n");
+        } else {
+            GR_LOG_SET_FILE_APPENDER(LOG, log_file, true, "%r :%p: %c{1} - %m%n");
+        }
+    }
+    return LOG;
+}
+
 bool logger_load_config(const std::string& config_filename)
 {
     if (!config_filename.empty()) {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(b071f4deb18875805b73952a7aa43389)                     */
+/* BINDTOOL_HEADER_FILE(logger.h)                                                  */
+/* BINDTOOL_HEADER_FILE_HASH(eaf28bcaeb7c34dc0fca3fdd4a9860c0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -100,6 +100,9 @@ void bind_logger(py::module& m)
           py::arg("name"),
           py::arg("alias"));
     m.def("logger_get_logger", &gr::logger_get_logger, py::arg("name"));
+    m.def("logger_get_configured_logger",
+          &gr::logger_get_configured_logger,
+          py::arg("name"));
     m.def("logger_load_config", &gr::logger_load_config, py::arg("config_filename") = "");
     m.def("gr_logger_reset_config", &gr_logger_reset_config);
     m.def("logger_set_level",

--- a/gr-fec/lib/generic_decoder.cc
+++ b/gr-fec/lib/generic_decoder.cc
@@ -13,8 +13,6 @@
 #endif
 
 #include <gnuradio/fec/generic_decoder.h>
-#include <gnuradio/prefs.h>
-#include <cstdio>
 
 namespace gr {
 namespace fec {
@@ -24,26 +22,7 @@ generic_decoder::generic_decoder(std::string name)
     d_name = name;
     my_id = base_unique_id++;
 
-    prefs* p = prefs::singleton();
-    std::string config_file = p->get_string("LOG", "log_config", "");
-    std::string log_level = p->get_string("LOG", "log_level", "off");
-    std::string log_file = p->get_string("LOG", "log_file", "");
-
-    GR_CONFIG_LOGGER(config_file);
-
-    GR_LOG_GETLOGGER(LOG, "gr_log." + alias());
-    GR_LOG_SET_LEVEL(LOG, log_level);
-    if (!log_file.empty()) {
-        if (log_file == "stdout") {
-            GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
-        } else if (log_file == "stderr") {
-            GR_LOG_SET_CONSOLE_APPENDER(LOG, "stderr", "gr::log :%p: %c{1} - %m%n");
-        } else {
-            GR_LOG_SET_FILE_APPENDER(LOG, log_file, true, "%r :%p: %c{1} - %m%n");
-        }
-    }
-
-    d_logger = LOG;
+    GR_LOG_ASSIGN_CONFIGURED_LOGPTR(d_logger, alias());
 }
 
 generic_decoder::~generic_decoder() {}

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -13,8 +13,6 @@
 #endif
 
 #include <gnuradio/fec/generic_encoder.h>
-#include <gnuradio/prefs.h>
-#include <cstdio>
 
 namespace gr {
 namespace fec {
@@ -24,26 +22,7 @@ generic_encoder::generic_encoder(std::string name)
     d_name = name;
     my_id = base_unique_id++;
 
-    prefs* p = prefs::singleton();
-    std::string config_file = p->get_string("LOG", "log_config", "");
-    std::string log_level = p->get_string("LOG", "log_level", "off");
-    std::string log_file = p->get_string("LOG", "log_file", "");
-
-    GR_CONFIG_LOGGER(config_file);
-
-    GR_LOG_GETLOGGER(LOG, "gr_log." + alias());
-    GR_LOG_SET_LEVEL(LOG, log_level);
-    if (!log_file.empty()) {
-        if (log_file == "stdout") {
-            GR_LOG_SET_CONSOLE_APPENDER(LOG, "stdout", "gr::log :%p: %c{1} - %m%n");
-        } else if (log_file == "stderr") {
-            GR_LOG_SET_CONSOLE_APPENDER(LOG, "stderr", "gr::log :%p: %c{1} - %m%n");
-        } else {
-            GR_LOG_SET_FILE_APPENDER(LOG, log_file, true, "%r :%p: %c{1} - %m%n");
-        }
-    }
-
-    d_logger = LOG;
+    GR_LOG_ASSIGN_CONFIGURED_LOGPTR(d_logger, alias());
 }
 
 generic_encoder::~generic_encoder() {}

--- a/gr-iio/lib/attr_sink_impl.cc
+++ b/gr-iio/lib/attr_sink_impl.cc
@@ -15,8 +15,6 @@
 #include <gnuradio/io_signature.h>
 #include <boost/lexical_cast.hpp>
 
-#include <cstdio>
-#include <iostream>
 #include <string>
 
 namespace gr {
@@ -114,7 +112,7 @@ void attr_sink_impl::write_attribute(pmt::pmt_t pdu)
                 uint32_t value32 = boost::lexical_cast<uint32_t>(value);
                 ret = iio_device_reg_write(dev, address, value32);
             } catch (const boost::bad_lexical_cast& e) {
-                std::cerr << e.what() << '\n';
+                GR_LOG_WARN(d_logger, e.what());
             }
             break;
         }

--- a/gr-iio/lib/attr_source_impl.cc
+++ b/gr-iio/lib/attr_source_impl.cc
@@ -13,10 +13,10 @@
 
 #include "attr_source_impl.h"
 #include <gnuradio/io_signature.h>
+#include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <chrono>
-#include <cstdio>
 #include <string>
 #include <thread>
 #include <vector>
@@ -130,7 +130,7 @@ attr_source_impl::~attr_source_impl() {}
 void attr_source_impl::check(int ret)
 {
     if (ret < 0)
-        std::cerr << "Reading parameter failed: " << ret << std::endl;
+        GR_LOG_WARN(d_logger, boost::format("Reading parameter failed: %d") % ret);
 }
 
 void attr_source_impl::get_register_data(uint32_t address, int* value)

--- a/gr-iio/lib/attr_source_impl.h
+++ b/gr-iio/lib/attr_source_impl.h
@@ -13,7 +13,6 @@
 #include "device_source_impl.h"
 #include <gnuradio/iio/attr_source.h>
 
-#include <cstdio>
 #include <string>
 
 namespace gr {

--- a/gr-iio/lib/dds_control_impl.cc
+++ b/gr-iio/lib/dds_control_impl.cc
@@ -14,8 +14,8 @@
 #include "dds_control_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <cstdio>
-#include <iostream>
+#include <boost/format.hpp>
+
 #include <string>
 #include <vector>
 
@@ -122,25 +122,28 @@ void dds_control_impl::set_dds_confg(std::vector<long> frequencies,
             ret = iio_channel_attr_write_longlong(
                 chan, "frequency", d_frequencies[dds_indx]);
             if (ret < 0)
-                std::cerr << "Unable to set DDS frequency: " << d_frequencies[dds_indx]
-                          << std::endl;
+                GR_LOG_WARN(d_logger,
+                            boost::format("Unable to set DDS frequency: %ld") %
+                                d_frequencies[dds_indx]);
 
             ret = iio_channel_attr_write_longlong(chan, "phase", d_phases[dds_indx]);
             if (ret < 0)
-                std::cerr << "Unable to set DDS phase: " << d_phases[dds_indx]
-                          << std::endl;
+                GR_LOG_WARN(d_logger,
+                            boost::format("Unable to set DDS phase: %f") %
+                                d_phases[dds_indx]);
 
             if (d_enabled[enable_indx])
                 ret = iio_channel_attr_write_double(chan, "scale", d_scales[dds_indx]);
             else
                 ret = iio_channel_attr_write_double(chan, "scale", 0);
             if (ret < 0)
-                std::cerr << "Unable to set DDS scale: " << d_scales[dds_indx]
-                          << std::endl;
+                GR_LOG_WARN(d_logger,
+                            boost::format("Unable to set DDS scale: %f") %
+                                d_scales[dds_indx]);
 
             ret = iio_channel_attr_write_longlong(chan, "raw", enable);
             if (ret < 0)
-                std::cerr << "Unable to set DDS: " << ret << std::endl;
+                GR_LOG_WARN(d_logger, boost::format("Unable to set DDS: %d") % ret);
 
             dds_indx++;
             if ((dds_indx % 4) == 0)

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -15,7 +15,8 @@
 #include "device_source_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <cstdio>
+#include <boost/format.hpp>
+
 #include <string>
 #include <vector>
 
@@ -219,8 +220,8 @@ int device_sink_impl::work(int noutput_items,
         iio_strerror(-ret, buf, sizeof(buf));
         std::string error(buf);
 
-        std::cerr << "Unable to push buffer: " << error << std::endl;
-        return WORK_DONE;
+        GR_LOG_WARN(d_logger, boost::format("Unable to push buffer: %d") % error);
+        return WORK_DONE; /* EOF */
     }
 
     consume_each(buffer_size / (interpolation + 1));

--- a/gr-iio/lib/device_sink_impl.h
+++ b/gr-iio/lib/device_sink_impl.h
@@ -13,7 +13,6 @@
 #include <gnuradio/iio/device_sink.h>
 #include <iio.h>
 
-#include <cstdio>
 #include <string>
 #include <vector>
 

--- a/gr-iio/lib/device_source_impl.h
+++ b/gr-iio/lib/device_source_impl.h
@@ -14,7 +14,6 @@
 #include <iio.h>
 
 #include <condition_variable>
-#include <cstdio>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <ad9361.h>
 
-#include <cstdio>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/io_signature.h>
 #include <ad9361.h>
 
-#include <cstdio>
 #include <string>
 #include <thread>
 #include <vector>

--- a/gr-iio/lib/fmcomms5_sink_impl.cc
+++ b/gr-iio/lib/fmcomms5_sink_impl.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/io_signature.h>
 #include <ad9361.h>
 
-#include <cstdio>
 #include <string>
 #include <vector>
 

--- a/gr-iio/lib/fmcomms5_source_impl.cc
+++ b/gr-iio/lib/fmcomms5_source_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/io_signature.h>
 #include <ad9361.h>
 
-#include <cstdio>
 #include <string>
 #include <vector>
 

--- a/gr-iio/lib/pluto_source_impl.cc
+++ b/gr-iio/lib/pluto_source_impl.cc
@@ -10,7 +10,6 @@
 #include "pluto_source_impl.h"
 #include <iio.h>
 
-#include <cstdio>
 #include <string>
 
 namespace gr {


### PR DESCRIPTION
This commit cleans up unused headers (cstdio) and replaces all instances
of std::cout and std::cerr with the corresponding GR_LOG_* invocation.

Additionally, a helper is added to gr/lib/logger.cc to facilitate the
allocation of loggers which are automatically configured according to the
gnuradio configuration settings.

(I had some issues getting the logger to work in static contexts (As such no access to d_logger), so i created a new helper that does the logger configuration for me. I'm still not sure if that should be something global, but it is certainly not very iio specific.)