### PR TITLE
runtime: tags can be compared with < instead of offset_compare (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/tag_checker.h
+++ b/gnuradio-runtime/include/gnuradio/tag_checker.h
@@ -29,7 +29,7 @@ public:
     tag_checker(std::vector<tag_t>& tags) : d_has_next_tag(false), d_next_tag_index(0)
     {
         d_tags = tags;
-        std::sort(d_tags.begin(), d_tags.end(), &gr::tag_t::offset_compare);
+        std::sort(d_tags.begin(), d_tags.end());
         if (!d_tags.empty()) {
             d_has_next_tag = true;
             d_next_tag = tags[0];

--- a/gnuradio-runtime/include/gnuradio/tags.h
+++ b/gnuradio-runtime/include/gnuradio/tags.h
@@ -33,15 +33,15 @@ struct GR_RUNTIME_API tag_t {
     //! ignore this.
     std::vector<long> marked_deleted;
 
-    /*!
-     * Comparison function to test which tag, \p x or \p y, came
-     * first in time
-     */
-    static inline bool offset_compare(const tag_t& x, const tag_t& y)
+    //! Comparison function to test which tag, \p x or \p y, came first in time
+    friend inline bool operator<(const tag_t& x, const tag_t& y)
     {
         return x.offset < y.offset;
     }
+    //! Comparison function to test which tag, \p x or \p y, came first in time
+    static inline bool offset_compare(const tag_t& x, const tag_t& y) { return x < y; }
 
+    //! equality comparison. Compares all details, except marked_delete
     inline bool operator==(const tag_t& t) const
     {
         return (t.key == key) && (t.value == value) && (t.srcid == srcid) &&
@@ -56,6 +56,7 @@ struct GR_RUNTIME_API tag_t {
     {
     }
 
+    //! Copy constructor; constructs identical tag, but doesn't copy marked_delete
     tag_t(const tag_t& rhs)
         : offset(rhs.offset), key(rhs.key), value(rhs.value), srcid(rhs.srcid)
     {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tag_checker_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tag_checker_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tag_checker.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e602a721975a2c2c15dbbb419eb57c15)                     */
+/* BINDTOOL_HEADER_FILE_HASH(9ffac9df4d29f09b0c8506584e6f1f75)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tags_python.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -14,10 +15,11 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tags.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(73eb73e445943e224cdbae24b0b0ab76)                     */
+/* BINDTOOL_HEADER_FILE_HASH(25435955fa46de2924e0b648c4f8dd43)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -43,6 +45,8 @@ void bind_tags(py::module& m)
                     py::arg("x"),
                     py::arg("y"),
                     D(tag_t, offset_compare))
+
+        .def(py::self < py::self, D(tag_t, offset_compare))
 
         .def_readwrite("offset", &tag_t::offset)
         .def_readwrite("key", &tag_t::key)

--- a/gnuradio-runtime/python/gnuradio/gr/qa_tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_tag_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2007,2010 Free Software Foundation, Inc.
+# Copyright 2021 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -31,6 +32,24 @@ class test_tag_utils (gr_unittest.TestCase):
         self.assertEqual(pt.key, 'key')
         self.assertEqual(pt.value, 23)
         self.assertEqual(pt.offset, 10)
+
+    def test_comparison(self):
+        t = gr.tag_t()
+        t.offset = 10
+        t.key = pmt.string_to_symbol('key')
+        t.value = pmt.from_long(23)
+        t.srcid = pmt.from_bool(False)
+
+        t2 = gr.tag_t()
+        t2.offset = 100
+        t2.key = pmt.string_to_symbol('aaa')
+        t2.value = pmt.from_long(230)
+        t2.srcid = pmt.from_bool(True)
+        self.assertTrue(t < t2)
+        self.assertTrue(t == t)
+        self.assertTrue(t != t2)
+        self.assertFalse(t > t2)
+        self.assertFalse(t < t)
 
     def test_002(self):
         offset = 10
@@ -75,20 +94,19 @@ class test_tag_utils (gr_unittest.TestCase):
             t.srcid = srcid
             tags.append(t)
 
-        for k, t in zip(sorted(offsets),
-                        sorted(tags, key=gr.tag_t_offset_compare_key())):
+        for k, t in zip(sorted(offsets), sorted(tags)):
             self.assertEqual(t.offset, k)
             self.assertTrue(pmt.equal(t.key, key))
             self.assertTrue(pmt.equal(t.value, pmt.from_long(k)))
             self.assertTrue(pmt.equal(t.srcid, srcid))
 
-        tmin = min(tags, key=gr.tag_t_offset_compare_key())
+        tmin = min(tags)
         self.assertEqual(tmin.offset, min(offsets))
         self.assertTrue(pmt.equal(tmin.key, key))
         self.assertTrue(pmt.equal(tmin.value, pmt.from_long(min(offsets))))
         self.assertTrue(pmt.equal(tmin.srcid, srcid))
 
-        tmax = max(tags, key=gr.tag_t_offset_compare_key())
+        tmax = max(tags)
         self.assertEqual(tmax.offset, max(offsets))
         self.assertTrue(pmt.equal(tmax.key, key))
         self.assertTrue(pmt.equal(tmax.value, pmt.from_long(max(offsets))))
@@ -96,5 +114,4 @@ class test_tag_utils (gr_unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('hi')
     gr_unittest.run(test_tag_utils)

--- a/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
+++ b/gnuradio-runtime/python/gnuradio/gr/tag_utils.py
@@ -99,36 +99,3 @@ def python_to_tag(tag_struct):
         return tag
     else:
         return None
-
-def tag_t_offset_compare_key():
-    """
-    Convert a tag_t.offset_compare function into a key=function
-    This method is modeled after functools.cmp_to_key(_func_).
-    It can be used by functions that accept a key function, such as
-    sorted(), min(), max(), etc. to compare tags by their offsets,
-    e.g., sorted(tag_list, key=gr.tag_t.offset_compare_key()).
-    """
-    class K(object):
-        def __init__(self, obj, *args):
-            self.obj = obj
-        def __lt__(self, other):
-            # x.offset < y.offset
-            return gr.tag_t.offset_compare(self.obj, other.obj)
-        def __gt__(self, other):
-            # y.offset < x.offset
-            return gr.tag_t.offset_compare(other.obj, self.obj)
-        def __eq__(self, other):
-            # not (x.offset < y.offset) and not (y.offset < x.offset)
-            return not gr.tag_t.offset_compare(self.obj, other.obj) and \
-                   not gr.tag_t.offset_compare(other.obj, self.obj)
-        def __le__(self, other):
-            # not (y.offset < x.offset)
-            return not gr.tag_t.offset_compare(other.obj, self.obj)
-        def __ge__(self, other):
-            # not (x.offset < y.offset)
-            return not gr.tag_t.offset_compare(self.obj, other.obj)
-        def __ne__(self, other):
-            # (x.offset < y.offset) or (y.offset < x.offset)
-            return gr.tag_t.offset_compare(self.obj, other.obj) or \
-                   gr.tag_t.offset_compare(other.obj, self.obj)
-    return K

--- a/gr-digital/python/digital/qa_burst_shaper.py
+++ b/gr-digital/python/digital/qa_burst_shaper.py
@@ -362,8 +362,7 @@ class qa_burst_shaper (gr_unittest.TestCase):
 
         # checks
         self.assertFloatTuplesAlmostEqual(sink.data(), expected, 6)
-        for x, y in zip(sorted(sink.tags(), key=gr.tag_t_offset_compare_key()),
-                        sorted(etags, key=gr.tag_t_offset_compare_key())):
+        for x, y in zip(sorted(sink.tags()), sorted(etags)):
             self.assertTrue(compare_tags(x, y))
 
 


### PR DESCRIPTION
runtime: tags can be compared with < instead of offset_compare    
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit ae586c92d7ccb945fb994c29571c257d02e5f6ee)

runtime: use < instead of compare_offset, remove Python comparison class
Since the introduction of the comparison operator obsoletes the comparison class, remove it.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 078d40ddeab957fcc91060131a4b3a1dfe9df676)

Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4760
