### PR TITLE
grc: only rewrite a block if the block is enabled.

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -106,7 +106,8 @@ class Block(Element):
         """
         Add and remove ports to adjust for the nports.
         """
-        Element.rewrite(self)
+        if self.enabled:
+            Element.rewrite(self)
 
         def rekey(ports):
             """Renumber non-message/message ports"""


### PR DESCRIPTION
This fixes #4788. If the disabled block will be reenabled the block is rewriten.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>