### PR TITLE
clang-tidy: run-clang-tidy with default checks on gr-soapy (Manual Rebase)

### DIFF
--- a/gr-soapy/lib/block_impl.cc
+++ b/gr-soapy/lib/block_impl.cc
@@ -457,7 +457,7 @@ void block_impl::set_antenna(const size_t channel, const std::string& name)
     std::vector<std::string> antennas = d_device->listAntennas(d_direction, channel);
 
     // Ignore call if there are no antennas.
-    if (antennas.size() == 0) {
+    if (antennas.empty()) {
         return;
     }
 


### PR DESCRIPTION
Manual rebase of #4741 

Second change in that PR was made obsolete by 16d1b0215d59c52009b09867fbfce0b4c3585add

* use empty() on antenna vector

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>