### PR TITLE
clang-tidy: run-clang-tidy with default checks on gr-soapy (backport to maint-3.9)

### DIFF
--- a/gr-soapy/lib/block_impl.cc
+++ b/gr-soapy/lib/block_impl.cc
@@ -457,7 +457,7 @@ void block_impl::set_antenna(const size_t channel, const std::string& name)
     std::vector<std::string> antennas = d_device->listAntennas(d_direction, channel);
 
     // Ignore call if there are no antennas.
-    if (antennas.size() == 0) {
+    if (antennas.empty()) {
         return;
     }
 


### PR DESCRIPTION
* use empty() on antenna vector

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 7b21032dea9d4d8ead09178fa2fa99fb37d7f9a2)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4831