### PR TITLE
grc: update disabled blocks if they depend on others

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -216,7 +216,7 @@ class FlowGraph(Element):
         return elements
 
     def children(self):
-        return itertools.chain(self.iter_enabled_blocks(), self.connections)
+        return itertools.chain(self.blocks, self.connections)
 
     def rewrite(self):
         """
@@ -227,6 +227,7 @@ class FlowGraph(Element):
 
     def renew_namespace(self):
         namespace = {}
+        self.namespace.clear()
         # Load imports
         for expr in self.imports():
             try:


### PR DESCRIPTION
If we want disabled blocks to be updated properly,
we have to consider all blocks when updating the fg not only the enabled.

This does the patch of Flowgraph.py and fixes #4788.

But a problem remains.
If you use the example in #4788 and disable the symbol_rate block,
only the samp_rate block 'turns to red'.
The other blocks don't change.
Only if you open and close arbitrary block, the other blocks are updated.

This is fixed by the patch of Application.py.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>