### PR TITLE
gr-newmod: Set OOT module VERSION_PATCH to 0 instead of git. (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -33,7 +33,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 set(VERSION_MAJOR 1)
 set(VERSION_API   0)
 set(VERSION_ABI   0)
-set(VERSION_PATCH git)
+set(VERSION_PATCH 0)
 
 cmake_policy(SET CMP0011 NEW)
 


### PR DESCRIPTION
This avoids creating multiple copies of the .so file
(each with a different git tag) during development.
The ldconfig command doesn't necessarily set the symlink
properly and the old .so can get loaded after an update.
This can be very confusing for developers and this patch
suppresses that behavior by always creating the .so with
the same name.

Signed-off-by: Ron Economos <w6rz@comcast.net>
(cherry picked from commit 6c36e38ce843476f214b716b25e001e96336fc58)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4839