### PR TITLE
soapy: added message support for SoapySDR 0.8 API (backport to maint-3.9)

### DIFF
--- a/gr-soapy/lib/block_impl.cc
+++ b/gr-soapy/lib/block_impl.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include "block_impl.h"
+#include "setting_string_conversion.h"
 #include <gnuradio/io_signature.h>
 #include <SoapySDR/Formats.h>
 #include <SoapySDR/Version.hpp>
@@ -106,13 +107,43 @@ static void check_abi(void)
     }
 }
 
-// TODO: messages for full 0.8 support
 const pmt::pmt_t CMD_CHAN_KEY = pmt::mp("chan");
 const pmt::pmt_t CMD_FREQ_KEY = pmt::mp("freq");
 const pmt::pmt_t CMD_GAIN_KEY = pmt::mp("gain");
 const pmt::pmt_t CMD_ANTENNA_KEY = pmt::mp("antenna");
 const pmt::pmt_t CMD_RATE_KEY = pmt::mp("rate");
 const pmt::pmt_t CMD_BW_KEY = pmt::mp("bandwidth");
+const pmt::pmt_t CMD_GAINMODE_KEY = pmt::mp("gain_mode");
+const pmt::pmt_t CMD_FREQCORR_KEY = pmt::mp("freq_corr");
+const pmt::pmt_t CMD_DCOFFSETMODE_KEY = pmt::mp("dc_offset_mode");
+const pmt::pmt_t CMD_DCOFFSET_KEY = pmt::mp("dc_offset");
+const pmt::pmt_t CMD_IQBAL_KEY = pmt::mp("iq_bal");
+const pmt::pmt_t CMD_IQBALMODE_KEY = pmt::mp("iq_bal_mode");
+const pmt::pmt_t CMD_MCR_KEY = pmt::mp("master_clock_rate");
+const pmt::pmt_t CMD_REFCLOCKRATE_KEY = pmt::mp("ref_clock_rate");
+const pmt::pmt_t CMD_CLOCKSRC_KEY = pmt::mp("clock_src");
+const pmt::pmt_t CMD_TIMESRC_KEY = pmt::mp("time_src");
+const pmt::pmt_t CMD_HWTIME_KEY = pmt::mp("hw_time");
+const pmt::pmt_t CMD_REG_KEY = pmt::mp("reg");
+const pmt::pmt_t CMD_REGS_KEY = pmt::mp("regs");
+const pmt::pmt_t CMD_SETTING_KEY = pmt::mp("setting");
+const pmt::pmt_t CMD_GPIO_KEY = pmt::mp("gpio");
+const pmt::pmt_t CMD_GPIODIR_KEY = pmt::mp("gpio_dir");
+const pmt::pmt_t CMD_I2C_KEY = pmt::mp("i2c");
+const pmt::pmt_t CMD_UART_KEY = pmt::mp("uart");
+
+const pmt::pmt_t CMD_NAME_KEY = pmt::mp("name");
+const pmt::pmt_t CMD_KEY_KEY = pmt::mp("key");
+const pmt::pmt_t CMD_VALUE_KEY = pmt::mp("value");
+const pmt::pmt_t CMD_ADDR_KEY = pmt::mp("addr");
+const pmt::pmt_t CMD_MASK_KEY = pmt::mp("mask");
+const pmt::pmt_t CMD_TIME_KEY = pmt::mp("time");
+const pmt::pmt_t CMD_BANK_KEY = pmt::mp("bank");
+const pmt::pmt_t CMD_DATA_KEY = pmt::mp("data");
+
+// Common default values for pmt::dict_ref
+const pmt::pmt_t PMT_EMPTYSTR = pmt::mp("");
+const pmt::pmt_t PMT_ZERO = pmt::mp(0);
 
 /*
  * The private constructor
@@ -267,6 +298,65 @@ block_impl::block_impl(int direction,
     });
     register_msg_cmd_handler(CMD_ANTENNA_KEY, [this](pmt::pmt_t val, size_t channel) {
         this->cmd_handler_antenna(val, channel);
+    });
+    register_msg_cmd_handler(CMD_GAINMODE_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_gain_mode(val, channel);
+    });
+    register_msg_cmd_handler(CMD_FREQCORR_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_frequency_correction(val, channel);
+    });
+    register_msg_cmd_handler(CMD_FREQCORR_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_frequency_correction(val, channel);
+    });
+    register_msg_cmd_handler(CMD_DCOFFSETMODE_KEY,
+                             [this](pmt::pmt_t val, size_t channel) {
+                                 this->cmd_handler_dc_offset_mode(val, channel);
+                             });
+    register_msg_cmd_handler(CMD_DCOFFSET_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_dc_offset(val, channel);
+    });
+    register_msg_cmd_handler(CMD_IQBAL_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_iq_balance(val, channel);
+    });
+    register_msg_cmd_handler(CMD_IQBALMODE_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_iq_balance_mode(val, channel);
+    });
+    register_msg_cmd_handler(CMD_MCR_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_master_clock_rate(val, channel);
+    });
+    register_msg_cmd_handler(CMD_REFCLOCKRATE_KEY,
+                             [this](pmt::pmt_t val, size_t channel) {
+                                 this->cmd_handler_reference_clock_rate(val, channel);
+                             });
+    register_msg_cmd_handler(CMD_CLOCKSRC_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_clock_source(val, channel);
+    });
+    register_msg_cmd_handler(CMD_TIMESRC_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_time_source(val, channel);
+    });
+    register_msg_cmd_handler(CMD_HWTIME_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_hardware_time(val, channel);
+    });
+    register_msg_cmd_handler(CMD_REG_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_register(val, channel);
+    });
+    register_msg_cmd_handler(CMD_REGS_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_registers(val, channel);
+    });
+    register_msg_cmd_handler(CMD_SETTING_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_setting(val, channel);
+    });
+    register_msg_cmd_handler(CMD_GPIO_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_gpio(val, channel);
+    });
+    register_msg_cmd_handler(CMD_GPIODIR_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_gpio_dir(val, channel);
+    });
+    register_msg_cmd_handler(CMD_I2C_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_i2c(val, channel);
+    });
+    register_msg_cmd_handler(CMD_UART_KEY, [this](pmt::pmt_t val, size_t channel) {
+        this->cmd_handler_uart(val, channel);
     });
 }
 
@@ -514,9 +604,9 @@ void block_impl::set_gain(size_t channel, double gain)
     range_t rGain = d_device->getGainRange(d_direction, channel);
 
     if (!value_in_range(rGain, gain)) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("Gain out of range: %d <= gain <= %d") %
-                        rGain.minimum() % rGain.maximum());
+        GR_LOG_ERROR(d_logger,
+                     boost::format("Gain out of range: %d <= gain <= %d") %
+                         rGain.minimum() % rGain.maximum());
         return;
     }
 
@@ -537,9 +627,9 @@ void block_impl::set_gain(size_t channel, const std::string& name, double gain)
     /* Validate gain value */
     range_t rGain = d_device->getGainRange(d_direction, channel, name);
     if (!value_in_range(rGain, gain)) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("Gain %s out of range: %d <= gain <= %d") % name %
-                        rGain.minimum() % rGain.maximum());
+        GR_LOG_ERROR(d_logger,
+                     boost::format("Gain %s out of range: %d <= gain <= %d") % name %
+                         rGain.minimum() % rGain.maximum());
     }
 
     d_device->setGain(d_direction, channel, name, gain);
@@ -1157,7 +1247,7 @@ std::string block_impl::read_uart(const std::string& which, long timeout_us) con
 void block_impl::cmd_handler_frequency(pmt::pmt_t val, size_t channel)
 {
     if (!(val->is_number() && !val->is_complex())) {
-        GR_LOG_WARN(d_logger, "soapy: freq must be float/int");
+        GR_LOG_ERROR(d_logger, "soapy: freq must be float/int");
         return;
     }
     set_frequency(channel, pmt::to_double(val));
@@ -1165,17 +1255,35 @@ void block_impl::cmd_handler_frequency(pmt::pmt_t val, size_t channel)
 
 void block_impl::cmd_handler_gain(pmt::pmt_t val, size_t channel)
 {
-    if (!(val->is_number() && !val->is_complex())) {
-        GR_LOG_WARN(d_logger, "soapy: gain must be float/int");
+    // For compatibility, accept either a numeric value for setting the
+    // overall gain or a dict with a gain element and element-specific
+    // value.
+    if (!(val->is_number() && !val->is_complex()) && !val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: gain must be float/int or a dict");
         return;
     }
-    set_gain(channel, pmt::to_double(val));
+
+    if (val->is_dict()) {
+        if (!pmt::dict_has_key(val, CMD_GAIN_KEY)) {
+            GR_LOG_ERROR(d_logger, "soapy: gain dict must contain key \"gain\"");
+            return;
+        }
+
+        // Accept no name, falls back to default argument ""
+        const auto name =
+            pmt::symbol_to_string(pmt::dict_ref(val, CMD_NAME_KEY, PMT_EMPTYSTR));
+        const auto gain = pmt::to_double(pmt::dict_ref(val, CMD_GAIN_KEY, PMT_ZERO));
+
+        set_gain(channel, name, gain);
+    } else {
+        set_gain(channel, pmt::to_double(val));
+    }
 }
 
 void block_impl::cmd_handler_samp_rate(pmt::pmt_t val, size_t channel)
 {
     if (!(val->is_number() && !val->is_complex())) {
-        GR_LOG_WARN(d_logger, "soapy: rate must be float/int");
+        GR_LOG_ERROR(d_logger, "soapy: rate must be float/int");
         return;
     }
     set_sample_rate(channel, pmt::to_double(val));
@@ -1184,7 +1292,7 @@ void block_impl::cmd_handler_samp_rate(pmt::pmt_t val, size_t channel)
 void block_impl::cmd_handler_bw(pmt::pmt_t val, size_t channel)
 {
     if (!(val->is_number() && !val->is_complex())) {
-        GR_LOG_WARN(d_logger, "soapy: bw must be float/int");
+        GR_LOG_ERROR(d_logger, "soapy: bw must be float/int");
         return;
     }
     set_bandwidth(channel, pmt::to_double(val));
@@ -1193,10 +1301,284 @@ void block_impl::cmd_handler_bw(pmt::pmt_t val, size_t channel)
 void block_impl::cmd_handler_antenna(pmt::pmt_t val, size_t channel)
 {
     if (!val->is_symbol()) {
-        GR_LOG_WARN(d_logger, "soapy: ant must be string");
+        GR_LOG_ERROR(d_logger, "soapy: ant must be string");
         return;
     }
     set_antenna(channel, pmt::symbol_to_string(val));
+}
+
+void block_impl::cmd_handler_gain_mode(pmt::pmt_t val, size_t channel)
+{
+    if (!val->is_bool()) {
+        GR_LOG_ERROR(d_logger, "soapy: gain mode must be bool");
+        return;
+    }
+    set_gain_mode(channel, pmt::to_bool(val));
+}
+
+void block_impl::cmd_handler_frequency_correction(pmt::pmt_t val, size_t channel)
+{
+    if (!(val->is_number() && !val->is_complex())) {
+        GR_LOG_ERROR(d_logger, "soapy: frequency correction must be float/int");
+        return;
+    }
+    set_frequency_correction(channel, pmt::to_double(val));
+}
+
+void block_impl::cmd_handler_dc_offset_mode(pmt::pmt_t val, size_t channel)
+{
+    if (!val->is_bool()) {
+        GR_LOG_ERROR(d_logger, "soapy: DC offset mode must be bool");
+        return;
+    }
+    set_dc_offset_mode(channel, pmt::to_bool(val));
+}
+
+void block_impl::cmd_handler_dc_offset(pmt::pmt_t val, size_t channel)
+{
+    if (!val->is_number()) {
+        GR_LOG_ERROR(d_logger, "soapy: DC offset must be numeric");
+        return;
+    }
+    set_dc_offset(channel, pmt::to_complex(val));
+}
+
+void block_impl::cmd_handler_iq_balance(pmt::pmt_t val, size_t channel)
+{
+    if (!val->is_number()) {
+        GR_LOG_ERROR(d_logger, "soapy: IQ balance must be numeric");
+        return;
+    }
+    set_iq_balance(channel, pmt::to_complex(val));
+}
+
+void block_impl::cmd_handler_iq_balance_mode(pmt::pmt_t val, size_t channel)
+{
+    if (!val->is_bool()) {
+        GR_LOG_ERROR(d_logger, "soapy: IQ balance mode must be bool");
+        return;
+    }
+    set_iq_balance_mode(channel, pmt::to_bool(val));
+}
+
+void block_impl::cmd_handler_master_clock_rate(pmt::pmt_t val, size_t)
+{
+    if (!(val->is_number() && !val->is_complex())) {
+        GR_LOG_ERROR(d_logger, "soapy: master clock rate must be float/int");
+        return;
+    }
+    set_master_clock_rate(pmt::to_double(val));
+}
+
+void block_impl::cmd_handler_reference_clock_rate(pmt::pmt_t val, size_t)
+{
+    if (!(val->is_number() && !val->is_complex())) {
+        GR_LOG_ERROR(d_logger, "soapy: reference clock rate must be float/int");
+        return;
+    }
+    set_reference_clock_rate(pmt::to_double(val));
+}
+
+void block_impl::cmd_handler_clock_source(pmt::pmt_t val, size_t)
+{
+    if (!val->is_symbol()) {
+        GR_LOG_ERROR(d_logger, "soapy: clock source must be string");
+        return;
+    }
+    set_clock_source(pmt::symbol_to_string(val));
+}
+
+void block_impl::cmd_handler_time_source(pmt::pmt_t val, size_t)
+{
+    if (!val->is_symbol()) {
+        GR_LOG_ERROR(d_logger, "soapy: time source must be string");
+        return;
+    }
+    set_time_source(pmt::symbol_to_string(val));
+}
+
+void block_impl::cmd_handler_hardware_time(pmt::pmt_t val, size_t)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: hardware time must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_TIME_KEY)) {
+        GR_LOG_ERROR(d_logger, "soapy: hardware time dict must contain key \"time\"");
+        return;
+    }
+
+    // Accept no name, falls back to default argument ""
+    const auto name =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_NAME_KEY, PMT_EMPTYSTR));
+    const auto time = pmt::to_long(pmt::dict_ref(val, CMD_TIME_KEY, PMT_ZERO));
+
+    set_hardware_time(static_cast<long long>(time), name);
+}
+
+void block_impl::cmd_handler_register(pmt::pmt_t val, size_t)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: register write param must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_NAME_KEY) || !pmt::dict_has_key(val, CMD_ADDR_KEY) ||
+        !pmt::dict_has_key(val, CMD_VALUE_KEY)) {
+        GR_LOG_ERROR(
+            d_logger,
+            "soapy: register write dict must contain keys \"name\", \"addr\", \"value\"");
+        return;
+    }
+
+    const auto name =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_NAME_KEY, PMT_EMPTYSTR));
+    const auto addr = pmt::to_uint64(pmt::dict_ref(val, CMD_ADDR_KEY, PMT_ZERO));
+    const auto value = pmt::to_uint64(pmt::dict_ref(val, CMD_VALUE_KEY, PMT_ZERO));
+
+    write_register(name, static_cast<unsigned>(addr), static_cast<unsigned>(value));
+}
+
+void block_impl::cmd_handler_registers(pmt::pmt_t val, size_t)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: multi-register write param must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_NAME_KEY) || !pmt::dict_has_key(val, CMD_ADDR_KEY) ||
+        !pmt::dict_has_key(val, CMD_VALUE_KEY)) {
+        GR_LOG_ERROR(d_logger,
+                     "soapy: multi-register write dict must contain keys \"name\", "
+                     "\"addr\", \"value\"");
+        return;
+    }
+
+    const auto name =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_NAME_KEY, PMT_EMPTYSTR));
+    const auto addr = pmt::to_uint64(pmt::dict_ref(val, CMD_ADDR_KEY, PMT_ZERO));
+    const auto value = pmt::u32vector_elements(
+        pmt::dict_ref(val, CMD_VALUE_KEY, pmt::make_u32vector(0, 0)));
+
+    write_registers(name, static_cast<unsigned>(addr), value);
+}
+
+// TODO: any way to call channel-less version?
+void block_impl::cmd_handler_setting(pmt::pmt_t val, size_t channel)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: GPIO must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_KEY_KEY) || !pmt::dict_has_key(val, CMD_VALUE_KEY)) {
+        GR_LOG_ERROR(d_logger, "soapy: GPIO must contain keys \"key\", \"value\"");
+        return;
+    }
+
+    const auto key = pmt::symbol_to_string(pmt::dict_ref(val, CMD_KEY_KEY, PMT_EMPTYSTR));
+    const auto value_pmt = pmt::dict_ref(val, CMD_VALUE_KEY, PMT_EMPTYSTR);
+
+    std::string value;
+    if (pmt::is_bool(val)) {
+        write_setting(channel, key, setting_to_string(pmt::to_bool(value_pmt)));
+    } else if (pmt::is_number(val)) {
+        write_setting(channel, key, setting_to_string(pmt::to_double(value_pmt)));
+    } else {
+        write_setting(channel, key, pmt::symbol_to_string(value_pmt));
+    }
+}
+
+void block_impl::cmd_handler_gpio(pmt::pmt_t val, size_t)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: setting must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_BANK_KEY) || !pmt::dict_has_key(val, CMD_VALUE_KEY)) {
+        GR_LOG_ERROR(d_logger, "soapy: GPIO must contain keys \"bank\", \"value\"");
+        return;
+    }
+
+    const auto bank =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_BANK_KEY, PMT_EMPTYSTR));
+    const auto value = pmt::to_uint64(pmt::dict_ref(val, CMD_VALUE_KEY, PMT_ZERO));
+
+    if (pmt::dict_has_key(val, CMD_MASK_KEY)) {
+        const auto mask = pmt::to_uint64(pmt::dict_ref(val, CMD_MASK_KEY, PMT_ZERO));
+
+        write_gpio(bank, static_cast<unsigned>(value), static_cast<unsigned>(mask));
+    } else {
+        write_gpio(bank, static_cast<unsigned>(value));
+    }
+}
+
+void block_impl::cmd_handler_gpio_dir(pmt::pmt_t val, size_t)
+{
+    static const pmt::pmt_t CMD_DIR_KEY = pmt::mp("dir");
+
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: GPIO dir must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_BANK_KEY) || !pmt::dict_has_key(val, CMD_DIR_KEY)) {
+        GR_LOG_ERROR(d_logger, "soapy: GPIO dir must contain keys \"bank\", \"dir\"");
+        return;
+    }
+
+    const auto bank =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_BANK_KEY, PMT_EMPTYSTR));
+    const auto dir = pmt::to_uint64(pmt::dict_ref(val, CMD_DIR_KEY, PMT_ZERO));
+
+    if (pmt::dict_has_key(val, CMD_MASK_KEY)) {
+        const auto mask = pmt::to_uint64(pmt::dict_ref(val, CMD_MASK_KEY, PMT_ZERO));
+
+        write_gpio_dir(bank, static_cast<unsigned>(dir), static_cast<unsigned>(mask));
+    } else {
+        write_gpio_dir(bank, static_cast<unsigned>(dir));
+    }
+}
+
+void block_impl::cmd_handler_i2c(pmt::pmt_t val, size_t)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: I2C must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_ADDR_KEY) || !pmt::dict_has_key(val, CMD_DATA_KEY)) {
+        GR_LOG_ERROR(d_logger, "soapy: I2C must contain keys \"addr\", \"data\"");
+        return;
+    }
+
+    const auto addr = pmt::to_long(pmt::dict_ref(val, CMD_ADDR_KEY, PMT_ZERO));
+    const auto data =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_DATA_KEY, PMT_EMPTYSTR));
+
+    write_i2c(static_cast<int>(addr), data);
+}
+
+void block_impl::cmd_handler_uart(pmt::pmt_t val, size_t)
+{
+    if (!val->is_dict()) {
+        GR_LOG_ERROR(d_logger, "soapy: UART must be a dict");
+        return;
+    }
+
+    if (!pmt::dict_has_key(val, CMD_NAME_KEY) || !pmt::dict_has_key(val, CMD_DATA_KEY)) {
+        GR_LOG_ERROR(d_logger, "soapy: UART must contain keys \"name\", \"data\"");
+        return;
+    }
+
+    const auto name =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_NAME_KEY, PMT_EMPTYSTR));
+    const auto data =
+        pmt::symbol_to_string(pmt::dict_ref(val, CMD_DATA_KEY, PMT_EMPTYSTR));
+
+    write_uart(name, data);
 }
 
 void block_impl::msg_handler_cmd(pmt::pmt_t msg)
@@ -1204,7 +1586,7 @@ void block_impl::msg_handler_cmd(pmt::pmt_t msg)
     const long CHANNEL_ALL = 0x12345678; // arbitrary
 
     if (!pmt::is_dict(msg)) {
-        GR_LOG_WARN(d_logger, "soapy: commands must be pmt::dict");
+        GR_LOG_ERROR(d_logger, "soapy: commands must be pmt::dict");
         return;
     }
 
@@ -1213,9 +1595,9 @@ void block_impl::msg_handler_cmd(pmt::pmt_t msg)
     size_t channel = pmt::to_long(pmt::dict_ref(msg, CMD_CHAN_KEY, channel_all_pmt));
 
     if (channel != CHANNEL_ALL && channel >= d_nchan) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("soapy: ignoring command for invalid channel %d") %
-                        channel);
+        GR_LOG_ERROR(d_logger,
+                     boost::format("soapy: ignoring command for invalid channel %d") %
+                         channel);
         return;
     }
 
@@ -1230,9 +1612,9 @@ void block_impl::msg_handler_cmd(pmt::pmt_t msg)
         // Find command handler
         auto it = d_cmd_handlers.find(key);
         if (it == d_cmd_handlers.end()) {
-            GR_LOG_WARN(d_logger,
-                        boost::format("soapy: ignoring unknown command key '%s'") %
-                            pmt::symbol_to_string(key));
+            GR_LOG_ERROR(d_logger,
+                         boost::format("soapy: ignoring unknown command key '%s'") %
+                             pmt::symbol_to_string(key));
             continue;
         }
         cmd_handler_t handler = it->second;

--- a/gr-soapy/lib/block_impl.h
+++ b/gr-soapy/lib/block_impl.h
@@ -269,6 +269,25 @@ protected:
      */
     void cmd_handler_antenna(pmt::pmt_t val, size_t channel);
 
+    void cmd_handler_gain_mode(pmt::pmt_t val, size_t channel);
+    void cmd_handler_frequency_correction(pmt::pmt_t val, size_t channel);
+    void cmd_handler_dc_offset_mode(pmt::pmt_t val, size_t channel);
+    void cmd_handler_dc_offset(pmt::pmt_t val, size_t channel);
+    void cmd_handler_iq_balance(pmt::pmt_t val, size_t channel);
+    void cmd_handler_iq_balance_mode(pmt::pmt_t val, size_t channel);
+    void cmd_handler_master_clock_rate(pmt::pmt_t val, size_t);
+    void cmd_handler_reference_clock_rate(pmt::pmt_t val, size_t);
+    void cmd_handler_clock_source(pmt::pmt_t val, size_t);
+    void cmd_handler_time_source(pmt::pmt_t val, size_t);
+    void cmd_handler_hardware_time(pmt::pmt_t val, size_t);
+    void cmd_handler_register(pmt::pmt_t val, size_t);
+    void cmd_handler_registers(pmt::pmt_t val, size_t);
+    void cmd_handler_setting(pmt::pmt_t val, size_t channel);
+    void cmd_handler_gpio(pmt::pmt_t val, size_t);
+    void cmd_handler_gpio_dir(pmt::pmt_t val, size_t);
+    void cmd_handler_i2c(pmt::pmt_t val, size_t);
+    void cmd_handler_uart(pmt::pmt_t val, size_t);
+
     /*** End message handlers ***/
 };
 

--- a/gr-soapy/lib/setting_string_conversion.h
+++ b/gr-soapy/lib/setting_string_conversion.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Nicholas Corgan
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef INCLUDED_GR_SOAPY_SETTING_STRING_CONVERSION_H
+#define INCLUDED_GR_SOAPY_SETTING_STRING_CONVERSION_H
+
+#include <SoapySDR/Types.hpp>
+#include <SoapySDR/Version.h>
+
+#include <sstream>
+
+namespace gr {
+namespace soapy {
+
+// SoapySDR doesn't have an API define for SettingToString, so we need
+// to check the version. 0.8 is the first tagged version to have this
+// functionality.
+#if SOAPY_SDR_API_VERSION >= 0x080000
+
+template <typename T>
+static inline T string_to_setting(const std::string& str)
+{
+    return SoapySDR::StringToSetting<T>(str);
+}
+
+template <typename T>
+static inline std::string setting_to_string(const T& setting)
+{
+    return SoapySDR::SettingToString<T>(setting);
+}
+
+#else
+
+// Copied from SoapySDR 0.8
+#define SOAPY_SDR_TRUE "true"
+#define SOAPY_SDR_FALSE "false"
+
+template <typename T>
+static inline T string_to_setting(const std::string& str)
+{
+    std::stringstream sstream(str);
+    T setting;
+
+    sstream >> setting;
+
+    return setting;
+}
+
+// Copied from SoapySDR 0.8
+//! convert empty and "false" strings to false, integers to their truthness
+template <>
+inline bool string_to_setting<bool>(const std::string& str)
+{
+    if (str.empty() || str == SOAPY_SDR_FALSE) {
+        return false;
+    }
+    if (str == SOAPY_SDR_TRUE) {
+        return true;
+    }
+    try {
+        return static_cast<bool>(std::stod(str));
+    } catch (std::invalid_argument& e) {
+    }
+    // other values are true
+    return true;
+}
+
+template <typename T>
+static inline std::string setting_to_string(const T& setting)
+{
+    return std::to_string(setting);
+}
+
+template <>
+inline std::string setting_to_string<bool>(const bool& setting)
+{
+    return setting ? SOAPY_SDR_TRUE : SOAPY_SDR_FALSE;
+}
+
+#endif
+
+} // namespace soapy
+} // namespace gr
+
+#endif /* INCLUDED_GR_SOAPY_SETTING_STRING_CONVERSION_H */

--- a/gr-soapy/python/soapy/bindings/CMakeLists.txt
+++ b/gr-soapy/python/soapy/bindings/CMakeLists.txt
@@ -11,6 +11,9 @@ include(GrPybind)
 # Python Bindings
 ########################################################################
 
+# For setting string conversions
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../lib)
+
 list(APPEND soapy_python_files
     block_python.cc
     soapy_common.cc


### PR DESCRIPTION
* Moved string <-> setting conversion to common header
* Closes https://github.com/gnuradio/gnuradio/issues/4571

Signed-off-by: Nicholas Corgan <n.corgan@gmail.com>
(cherry picked from commit a152662f8536a1f389f7f799f588a0e4623a7bea)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4835