### PR TITLE
global: remove iostream from all files not use cout|cerr|cin|clog (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/basic_block.h>
 #include <gnuradio/block_registry.h>
 #include <gnuradio/logger.h>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/block_detail.h>
 #include <gnuradio/buffer.h>
 #include <gnuradio/logger.h>
-#include <iostream>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/block_gateway_impl.cc
+++ b/gnuradio-runtime/lib/block_gateway_impl.cc
@@ -11,7 +11,6 @@
 #include <pybind11/embed.h>
 
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/math.h>
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gnuradio-runtime/lib/controlport/rpcmanager.cc
+++ b/gnuradio-runtime/lib/controlport/rpcmanager.cc
@@ -10,7 +10,6 @@
 
 #include <gnuradio/rpcmanager.h>
 #include <cassert>
-#include <iostream>
 #include <stdexcept>
 
 rpcmanager::rpcmanager() { ; }

--- a/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
+++ b/gnuradio-runtime/lib/controlport/rpcserver_aggregator.cc
@@ -11,7 +11,6 @@
 #include <gnuradio/rpcserver_aggregator.h>
 #include <gnuradio/rpcserver_booter_base.h>
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 

--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -12,7 +12,6 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <boost/assign/ptr_map_inserter.hpp>
-#include <iostream>
 
 GNURadio::Knob rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
 {

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -17,9 +17,12 @@
 #include <sstream>
 #include <stdexcept>
 
+// TODO: Replace with GNU Radio logging
+#include <iostream>
+
 namespace gr {
 
-#define FLOWGRAPH_DEBUG 0
+constexpr bool FLOWGRAPH_DEBUG = false;
 
 edge::~edge() {}
 

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/flowgraph.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <memory>
 
 namespace gr {

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -19,9 +19,12 @@
 #include <sstream>
 #include <stdexcept>
 
+// TODO: Replace with GNU Radio logging
+#include <iostream>
+
 namespace gr {
 
-#define HIER_BLOCK2_DETAIL_DEBUG 0
+constexpr bool HIER_BLOCK2_DETAIL_DEBUG = false;
 
 hier_block2_detail::hier_block2_detail(hier_block2* owner)
     : d_owner(owner), d_parent_detail(0), d_fg(make_flowgraph())

--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/io_signature.h>
 #include <algorithm>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -21,6 +21,7 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -19,8 +19,18 @@
 #endif
 
 #include <gnuradio/logger.h>
+
 #include <gnuradio/prefs.h>
+
+#include <log4cpp/FileAppender.hh>
+#include <log4cpp/OstreamAppender.hh>
+#include <log4cpp/PatternLayout.hh>
+#include <log4cpp/PropertyConfigurator.hh>
+#include <log4cpp/RollingFileAppender.hh>
+#include <boost/thread.hpp>
+
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <stdexcept>

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -18,7 +18,6 @@
 #include <pmt/pmt_pool.h>
 #include <cstdio>
 #include <cstring>
-#include <functional>
 #include <vector>
 
 namespace pmt {

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -26,7 +26,6 @@
 #include <cstdio>
 #include <cstring>
 
-#include <iostream>
 
 #if defined(HAVE_PTHREAD_SETSCHEDPARAM) || defined(HAVE_SCHED_SETSCHEDULER)
 #include <pthread.h>

--- a/gnuradio-runtime/lib/test.cc
+++ b/gnuradio-runtime/lib/test.cc
@@ -15,7 +15,6 @@
 #include "test.h"
 #include <gnuradio/io_signature.h>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gnuradio-runtime/lib/top_block.cc
+++ b/gnuradio-runtime/lib/top_block.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
 #include <unistd.h>
-#include <iostream>
 #include <memory>
 
 namespace gr {

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -23,7 +23,6 @@
 #include <unistd.h>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/alsa/alsa_sink.cc
+++ b/gr-audio/lib/alsa/alsa_sink.cc
@@ -19,7 +19,6 @@
 #include <gnuradio/prefs.h>
 #include <cstdio>
 #include <future>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/alsa/alsa_source.cc
+++ b/gr-audio/lib/alsa/alsa_source.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/audio_registry.cc
+++ b/gr-audio/lib/audio_registry.cc
@@ -10,7 +10,6 @@
 #include "audio_registry.h"
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
-#include <iostream>
 #include <stdexcept>
 #include <vector>
 

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 #ifndef NO_PTHREAD

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -19,7 +19,6 @@
 #include <gnuradio/prefs.h>
 #include <type_traits>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 #ifndef NO_PTHREAD

--- a/gr-audio/lib/oss/oss_sink.cc
+++ b/gr-audio/lib/oss/oss_sink.cc
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/oss/oss_source.cc
+++ b/gr-audio/lib/oss/oss_source.cc
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-audio/lib/osx/circular_buffer.h
+++ b/gr-audio/lib/osx/circular_buffer.h
@@ -13,7 +13,6 @@
 
 #include <gnuradio/logger.h>
 #include <gnuradio/thread/thread.h>
-#include <iostream>
 #include <stdexcept>
 
 #ifndef DO_DEBUG

--- a/gr-audio/lib/osx/osx_impl.cc
+++ b/gr-audio/lib/osx/osx_impl.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/logger.h>
 
 #include <algorithm>
-#include <iostream>
 #include <locale>
 #include <stdexcept>
 

--- a/gr-audio/lib/portaudio/portaudio_sink.cc
+++ b/gr-audio/lib/portaudio/portaudio_sink.cc
@@ -25,7 +25,6 @@
 #include <cstdio>
 #include <cstring>
 #include <future>
-#include <iostream>
 #include <stdexcept>
 #ifdef _MSC_VER
 #include <io.h>

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -24,7 +24,6 @@
 #include <unistd.h>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 #ifdef _MSC_VER
 #include <io.h>

--- a/gr-audio/lib/windows/windows_sink.cc
+++ b/gr-audio/lib/windows/windows_sink.cc
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <cctype>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <cctype>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 

--- a/gr-blocks/lib/annotator_1to1_impl.cc
+++ b/gr-blocks/lib/annotator_1to1_impl.cc
@@ -15,7 +15,7 @@
 #include "annotator_1to1_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cstring>
-#include <iomanip>
+#include <sstream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_1to1_impl.cc
+++ b/gr-blocks/lib/annotator_1to1_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_alltoall_impl.cc
+++ b/gr-blocks/lib/annotator_alltoall_impl.cc
@@ -15,7 +15,6 @@
 #include "annotator_alltoall_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cstring>
-#include <iomanip>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_alltoall_impl.cc
+++ b/gr-blocks/lib/annotator_alltoall_impl.cc
@@ -14,7 +14,7 @@
 
 #include "annotator_alltoall_impl.h"
 #include <gnuradio/io_signature.h>
-#include <cstring>
+#include <sstream>
 
 namespace gr {
 namespace blocks {
@@ -60,7 +60,7 @@ int annotator_alltoall_impl::work(int noutput_items,
 
     // Source ID and key for any tag that might get applied from this block
     pmt::pmt_t srcid = pmt::string_to_symbol(str.str());
-    pmt::pmt_t key = pmt::string_to_symbol("seq");
+    static pmt::pmt_t key = pmt::string_to_symbol("seq");
 
     // Work does nothing to the data stream; just copy all inputs to
     // outputs Adds a new tag when the number of items read is a

--- a/gr-blocks/lib/annotator_alltoall_impl.cc
+++ b/gr-blocks/lib/annotator_alltoall_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/annotator_raw_impl.cc
+++ b/gr-blocks/lib/annotator_raw_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 #include <stdexcept>
 
 using namespace pmt;

--- a/gr-blocks/lib/annotator_raw_impl.cc
+++ b/gr-blocks/lib/annotator_raw_impl.cc
@@ -15,7 +15,6 @@
 #include "annotator_raw_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cstring>
-#include <iomanip>
 #include <stdexcept>
 
 using namespace pmt;

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -20,7 +20,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/pack_k_bits.cc
+++ b/gr-blocks/lib/pack_k_bits.cc
@@ -13,7 +13,6 @@
 #endif
 
 #include <gnuradio/blocks/pack_k_bits.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/qa_block_tags.cc
+++ b/gr-blocks/lib/qa_block_tags.cc
@@ -22,6 +22,8 @@
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
 
+// FIXME use logging
+#include <iostream>
 
 // ----------------------------------------------------------------
 

--- a/gr-blocks/lib/qa_set_msg_handler.cc
+++ b/gr-blocks/lib/qa_set_msg_handler.cc
@@ -20,7 +20,6 @@
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/thread/thread.hpp>
-#include <iostream>
 
 /*
  * The gr::block::nop block has been instrumented so that it counts

--- a/gr-blocks/lib/socket_pdu_impl.cc
+++ b/gr-blocks/lib/socket_pdu_impl.cc
@@ -212,8 +212,9 @@ void socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection,
         new_connection->start(this);
         d_tcp_connections.push_back(new_connection);
         start_tcp_accept();
-    } else
-        std::cout << error << std::endl;
+    } else {
+        GR_LOG_ERROR(d_logger, error);
+    }
 }
 
 void socket_pdu_impl::tcp_client_send(pmt::pmt_t msg)

--- a/gr-blocks/lib/tag_debug_impl.cc
+++ b/gr-blocks/lib/tag_debug_impl.cc
@@ -14,7 +14,6 @@
 
 #include "tag_debug_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iomanip>
 #include <iostream>
 
 namespace gr {

--- a/gr-blocks/lib/tags_strobe_impl.cc
+++ b/gr-blocks/lib/tags_strobe_impl.cc
@@ -20,7 +20,6 @@
 #include <sys/types.h>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -16,9 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
 #include <cstdint>
-#include <cstring>
-#include <iomanip>
-#include <stdexcept>
 
 using namespace pmt;
 

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 #include <stdexcept>
 
 using namespace pmt;

--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -73,13 +73,13 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
     }
 
 
-    std::cout << boost::format("Allocated virtual ethernet interface: %s\n"
+    GR_LOG_WARN(d_logger,
+                (boost::format("Allocated virtual ethernet interface: %s\n"
                                "You must now use ifconfig to set its IP address. E.g.,\n"
                                "  $ sudo ifconfig %s 192.168.200.1\n"
                                "Be sure to use a different address in the same subnet "
                                "for each machine.\n") %
-                     dev % dev
-              << std::endl;
+                 dev % dev));
 
     // set up output message port
     message_port_register_out(pdu::pdu_port_id());

--- a/gr-blocks/lib/unpack_k_bits.cc
+++ b/gr-blocks/lib/unpack_k_bits.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/blocks/unpack_k_bits.h>
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/unpack_k_bits_bb_impl.cc
+++ b/gr-blocks/lib/unpack_k_bits_bb_impl.cc
@@ -14,7 +14,6 @@
 
 #include "unpack_k_bits_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-blocks/lib/vector_sink_impl.cc
+++ b/gr-blocks/lib/vector_sink_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
 #include <algorithm>
-#include <iostream>
 
 namespace gr {
 namespace blocks {

--- a/gr-channels/lib/cfo_model_impl.cc
+++ b/gr-channels/lib/cfo_model_impl.cc
@@ -11,7 +11,6 @@
 #include "cfo_model_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <iostream>
 
 namespace gr {
 namespace channels {

--- a/gr-channels/lib/channel_model2_impl.cc
+++ b/gr-channels/lib/channel_model2_impl.cc
@@ -11,7 +11,6 @@
 #include "channel_model2_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <iostream>
 
 namespace gr {
 namespace channels {

--- a/gr-channels/lib/channel_model_impl.cc
+++ b/gr-channels/lib/channel_model_impl.cc
@@ -10,7 +10,6 @@
 
 #include "channel_model_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace channels {

--- a/gr-channels/lib/dynamic_channel_model_impl.cc
+++ b/gr-channels/lib/dynamic_channel_model_impl.cc
@@ -10,7 +10,6 @@
 
 #include "dynamic_channel_model_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace channels {

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <gnuradio/prefs.h>
-#include <iomanip>
 #include <sstream>
 #include <stdexcept>
 

--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -21,7 +21,6 @@
 
 #include <cfloat>
 #include <cstdlib>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -17,7 +17,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -18,7 +18,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -17,7 +17,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -18,7 +18,6 @@
 #include <volk/volk.h>
 #include <boost/format.hpp>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-digital/lib/hdlc_framer_pb_impl.cc
+++ b/gr-digital/lib/hdlc_framer_pb_impl.cc
@@ -15,7 +15,6 @@
 #include "hdlc_framer_pb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/tags.h>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_base.cc
+++ b/gr-digital/lib/header_format_base.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/math.h>
 #include <volk/volk.h>
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_counter.cc
+++ b/gr-digital/lib/header_format_counter.cc
@@ -17,7 +17,6 @@
 #include <volk/volk_alloc.hh>
 #include <cstring>
 #include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_counter.cc
+++ b/gr-digital/lib/header_format_counter.cc
@@ -15,8 +15,7 @@
 #include <gnuradio/digital/header_format_counter.h>
 #include <gnuradio/math.h>
 #include <volk/volk_alloc.hh>
-#include <cstring>
-#include <iomanip>
+#include <string>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/header_format_default.cc
+++ b/gr-digital/lib/header_format_default.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/math.h>
 #include <volk/volk_alloc.hh>
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/probe_density_b_impl.cc
+++ b/gr-digital/lib/probe_density_b_impl.cc
@@ -12,7 +12,6 @@
 
 #include "probe_density_b_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace digital {

--- a/gr-digital/lib/protocol_parser_b_impl.cc
+++ b/gr-digital/lib/protocol_parser_b_impl.cc
@@ -15,7 +15,6 @@
 #include "protocol_parser_b_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-dtv/lib/dvbt/dvbt_configure.cc
+++ b/gr-dtv/lib/dvbt/dvbt_configure.cc
@@ -12,7 +12,6 @@
 
 #include "dvbt_configure.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace dtv {

--- a/gr-fec/lib/alist.cc
+++ b/gr-fec/lib/alist.cc
@@ -9,6 +9,11 @@
  */
 
 #include <gnuradio/fec/alist.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 alist::alist(const char* fname) : data_ok(false) { read(fname); }
 

--- a/gr-fec/lib/cldpc.cc
+++ b/gr-fec/lib/cldpc.cc
@@ -9,6 +9,7 @@
  */
 
 #include <gnuradio/fec/cldpc.h>
+#include <iostream>
 #include <stdexcept>
 
 cldpc::cldpc(const GF2Mat X)

--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -12,7 +12,6 @@
 #include "ldpc_G_matrix_impl.h"
 #include <cmath>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <vector>
 

--- a/gr-fec/lib/polar_decoder_common.cc
+++ b/gr-fec/lib/polar_decoder_common.cc
@@ -17,6 +17,7 @@
 #include <volk/volk.h>
 
 #include <cstdio>
+#include <iostream>
 
 namespace gr {
 namespace fec {
@@ -166,6 +167,7 @@ void polar_decoder_common::extract_info_bits(unsigned char* output,
 void polar_decoder_common::print_pretty_llr_vector(const float* llr_vec) const
 {
     for (int row = 0; row < block_size(); row++) {
+        // FIXME this is an interesting mixture of iostream and stdio
         std::cout << row << "->" << int(bit_reverse(row, block_power())) << ":\t";
         for (int stage = 0; stage < block_power() + 1; stage++) {
             printf("%+4.2f, ", llr_vec[(stage * block_size()) + row]);

--- a/gr-fec/lib/scl_list.cc
+++ b/gr-fec/lib/scl_list.cc
@@ -12,7 +12,6 @@
 #include <volk/volk.h>
 #include <algorithm>
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace fec {

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/logger.h>
 #include <volk/volk.h>
 #include <cstring>
-#include <iostream>
 #include <memory>
 
 namespace gr {

--- a/gr-filter/lib/filterbank.cc
+++ b/gr-filter/lib/filterbank.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/filter/filterbank.h>
 #include <cstdio>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -15,7 +15,6 @@
 #include "filterbank_vcvcf_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cstdio>
-#include <iostream>
 
 namespace gr {
 namespace filter {

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -33,7 +33,6 @@
 #include <gnuradio/logger.h>
 #include <cassert>
 #include <cmath>
-#include <iostream>
 
 #ifndef LOCAL_BUFFER
 #include <vector>

--- a/gr-filter/lib/qa_firdes.cc
+++ b/gr-filter/lib/qa_firdes.cc
@@ -9,12 +9,7 @@
  */
 
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/gr_complex.h>
 #include <boost/test/unit_test.hpp>
-#include <cstdio>
-#include <cstring>
-#include <iomanip>
-#include <iostream>
 
 namespace gr {
 namespace filter {

--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
+++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
@@ -16,7 +16,6 @@
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
-#include <iostream>
 
 class ConstellationDisplayZoomer : public QwtPlotZoomer
 {

--- a/gr-qtgui/lib/DisplayPlot.cc
+++ b/gr-qtgui/lib/DisplayPlot.cc
@@ -15,7 +15,6 @@
 #include <QColor>
 #include <QDebug>
 #include <cmath>
-#include <iostream>
 #include <stdexcept>
 
 DisplayPlot::DisplayPlot(int nplots, QWidget* parent)

--- a/gr-qtgui/lib/EyeDisplayPlot.cc
+++ b/gr-qtgui/lib/EyeDisplayPlot.cc
@@ -18,7 +18,6 @@
 #include <volk/volk.h>
 #include <QColor>
 #include <cmath>
-#include <iostream>
 
 
 class EyeDisplayZoomer : public QwtPlotZoomer, public TimePrecisionClass

--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
+++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/qtgui/qtgui_types.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
-#include <iostream>
 
 
 /***********************************************************************

--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -21,7 +21,6 @@
 #include <boost/math/special_functions/round.hpp>
 #include <QColor>
 #include <cmath>
-#include <iostream>
 
 #ifdef _MSC_VER
 #define copysign _copysign

--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
@@ -19,7 +19,6 @@
 #include <volk/volk.h>
 #include <QColor>
 #include <cmath>
-#include <iostream>
 
 class TimeDomainDisplayZoomer : public QwtPlotZoomer, public TimePrecisionClass
 {

--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -21,7 +21,6 @@
 #include <qwt_scale_draw.h>
 #include <QColor>
 #include <cmath>
-#include <iostream>
 
 #if QWT_VERSION < 0x060100
 #include <qwt_legend_item.h>

--- a/gr-qtgui/lib/VectorDisplayPlot.cc
+++ b/gr-qtgui/lib/VectorDisplayPlot.cc
@@ -17,7 +17,6 @@
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
-#include <iostream>
 
 #if QWT_VERSION < 0x060100
 #include <qwt_legend_item.h>

--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
+++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
@@ -19,7 +19,6 @@
 #include <qwt_plot_layout.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
-#include <iostream>
 
 #if QWT_VERSION < 0x060100
 #include <qwt_legend_item.h>

--- a/gr-qtgui/lib/constellationdisplayform.cc
+++ b/gr-qtgui/lib/constellationdisplayform.cc
@@ -12,7 +12,6 @@
 
 #include <QMessageBox>
 #include <cmath>
-#include <iostream>
 
 ConstellationDisplayForm::ConstellationDisplayForm(int nplots, QWidget* parent)
     : DisplayForm(nplots, parent)

--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -12,7 +12,6 @@
 
 #include <QFileDialog>
 #include <QPixmap>
-#include <iostream>
 
 DisplayForm::DisplayForm(int nplots, QWidget* parent)
     : QWidget(parent), d_nplots(nplots), d_system_specified_flag(false)

--- a/gr-qtgui/lib/eyedisplayform.cc
+++ b/gr-qtgui/lib/eyedisplayform.cc
@@ -16,7 +16,6 @@
 #include <QSpacerItem>
 
 #include <cmath>
-#include <iostream>
 
 EyeDisplayForm::EyeDisplayForm(int nplots, bool cmplx, QWidget* parent)
     : EyeDisplaysForm(nplots, parent)

--- a/gr-qtgui/lib/eyedisplaysform.cc
+++ b/gr-qtgui/lib/eyedisplaysform.cc
@@ -11,7 +11,6 @@
 
 #include <QFileDialog>
 #include <QPixmap>
-#include <iostream>
 
 EyeDisplaysForm::EyeDisplaysForm(int nplots, QWidget* parent)
     : QWidget(parent), d_nplots(nplots), d_system_specified_flag(false)

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -14,7 +14,6 @@
 #include <QMessageBox>
 #include <QSpacerItem>
 #include <cmath>
-#include <iostream>
 
 FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
     : DisplayForm(nplots, parent)

--- a/gr-qtgui/lib/histogramdisplayform.cc
+++ b/gr-qtgui/lib/histogramdisplayform.cc
@@ -13,7 +13,6 @@
 #include <QMessageBox>
 
 #include <cmath>
-#include <iostream>
 
 HistogramDisplayForm::HistogramDisplayForm(int nplots, QWidget* parent)
     : DisplayForm(nplots, parent)

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -15,7 +15,6 @@
 #include <QMessageBox>
 
 #include <cmath>
-#include <iostream>
 
 NumberDisplayForm::NumberDisplayForm(int nplots, gr::qtgui::graph_t type, QWidget* parent)
     : QWidget(parent)

--- a/gr-qtgui/lib/plot_raster.cc
+++ b/gr-qtgui/lib/plot_raster.cc
@@ -17,7 +17,6 @@
 #include <qpainter.h>
 #include <qpen.h>
 
-#include <iostream>
 
 #if QWT_VERSION < 0x060000
 #include "qwt_double_interval.h"

--- a/gr-qtgui/lib/timeRasterGlobalData.cc
+++ b/gr-qtgui/lib/timeRasterGlobalData.cc
@@ -15,7 +15,6 @@
 
 #include <cmath>
 #include <cstdio>
-#include <iostream>
 
 TimeRasterData::TimeRasterData(const double rows, const double cols)
 #if QWT_VERSION < 0x060000

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -16,7 +16,6 @@
 #include <QSpacerItem>
 
 #include <cmath>
-#include <iostream>
 
 
 TimeDisplayForm::TimeDisplayForm(int nplots, QWidget* parent)

--- a/gr-qtgui/lib/vectordisplayform.cc
+++ b/gr-qtgui/lib/vectordisplayform.cc
@@ -13,7 +13,6 @@
 #include <QMessageBox>
 
 #include <cmath>
-#include <iostream>
 
 VectorDisplayForm::VectorDisplayForm(int nplots, QWidget* parent)
     : DisplayForm(nplots, parent)

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -20,7 +20,6 @@
 #include <volk/volk.h>
 
 #include <cstring>
-#include <iostream>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -14,7 +14,6 @@
 #include <QMessageBox>
 
 #include <cmath>
-#include <iostream>
 
 WaterfallDisplayForm::WaterfallDisplayForm(int nplots, QWidget* parent)
     : DisplayForm(nplots, parent)

--- a/gr-trellis/lib/constellation_metrics_cf_impl.cc
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.cc
@@ -15,7 +15,6 @@
 #include "constellation_metrics_cf_impl.h"
 #include <gnuradio/io_signature.h>
 #include <cassert>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-trellis/lib/encoder_impl.cc
+++ b/gr-trellis/lib/encoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/metrics_impl.cc
+++ b/gr-trellis/lib/metrics_impl.cc
@@ -16,7 +16,6 @@
 #include "metrics_impl.h"
 #include <gnuradio/io_signature.h>
 #include <assert.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-trellis/lib/pccc_decoder_blk_impl.cc
+++ b/gr-trellis/lib/pccc_decoder_blk_impl.cc
@@ -16,7 +16,6 @@
 #include "pccc_decoder_blk_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/trellis/core_algorithms.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/pccc_decoder_combined_blk_impl.cc
+++ b/gr-trellis/lib/pccc_decoder_combined_blk_impl.cc
@@ -15,7 +15,6 @@
 #include "pccc_decoder_combined_blk_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/trellis/core_algorithms.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/pccc_encoder_impl.cc
+++ b/gr-trellis/lib/pccc_encoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "pccc_encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/sccc_decoder_blk_impl.cc
+++ b/gr-trellis/lib/sccc_decoder_blk_impl.cc
@@ -16,7 +16,6 @@
 #include "sccc_decoder_blk_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/trellis/core_algorithms.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/sccc_decoder_combined_blk_impl.cc
+++ b/gr-trellis/lib/sccc_decoder_combined_blk_impl.cc
@@ -15,7 +15,6 @@
 #include "sccc_decoder_combined_blk_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/trellis/core_algorithms.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/sccc_encoder_impl.cc
+++ b/gr-trellis/lib/sccc_encoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "sccc_encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/siso_combined_f_impl.cc
+++ b/gr-trellis/lib/siso_combined_f_impl.cc
@@ -15,7 +15,6 @@
 #include "siso_combined_f_impl.h"
 #include <gnuradio/io_signature.h>
 #include <assert.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-trellis/lib/siso_f_impl.cc
+++ b/gr-trellis/lib/siso_f_impl.cc
@@ -15,7 +15,6 @@
 #include "siso_f_impl.h"
 #include <gnuradio/io_signature.h>
 #include <assert.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-trellis/lib/viterbi_combined_impl.cc
+++ b/gr-trellis/lib/viterbi_combined_impl.cc
@@ -14,7 +14,6 @@
 
 #include "viterbi_combined_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-trellis/lib/viterbi_impl.cc
+++ b/gr-trellis/lib/viterbi_impl.cc
@@ -15,7 +15,6 @@
 
 #include "viterbi_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 
 namespace gr {
 namespace trellis {

--- a/gr-uhd/examples/c++/tag_sink_demo.h
+++ b/gr-uhd/examples/c++/tag_sink_demo.h
@@ -12,7 +12,6 @@
 #include <gnuradio/sync_block.h>
 #include <boost/format.hpp>
 #include <complex>
-#include <iostream>
 
 class tag_sink_demo : public gr::sync_block
 {

--- a/gr-uhd/examples/c++/tag_source_demo.h
+++ b/gr-uhd/examples/c++/tag_source_demo.h
@@ -10,7 +10,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/sync_block.h>
 #include <complex>
-#include <iostream>
 
 class tag_source_demo : public gr::sync_block
 {

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -21,7 +21,6 @@
 #include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -21,7 +21,6 @@
 #include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/codec2_encode_sp_impl.cc
+++ b/gr-vocoder/lib/codec2_encode_sp_impl.cc
@@ -20,7 +20,6 @@ extern "C" {
 
 #include <gnuradio/io_signature.h>
 #include <iomanip>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/codec2_encode_sp_impl.cc
+++ b/gr-vocoder/lib/codec2_encode_sp_impl.cc
@@ -19,7 +19,6 @@ extern "C" {
 #include "codec2_encode_sp_impl.h"
 
 #include <gnuradio/io_signature.h>
-#include <iomanip>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/freedv_tx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.cc
@@ -16,7 +16,6 @@
 
 #include <gnuradio/io_signature.h>
 #include <iomanip>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {

--- a/gr-vocoder/lib/freedv_tx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.cc
@@ -15,7 +15,6 @@
 #include "freedv_tx_ss_impl.h"
 
 #include <gnuradio/io_signature.h>
-#include <iomanip>
 #include <stdexcept>
 
 namespace gr {

--- a/grc/core/generator/cpp_templates/flow_graph.hpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.hpp.mako
@@ -32,7 +32,6 @@ ${inc}
 % endif
 
 % if parameters:
-#include <iostream>
 #include <boost/program_options.hpp>
 % endif
 


### PR DESCRIPTION
Modified original PR to omit changes to public headers.

Backport https://github.com/gnuradio/gnuradio/pull/4764