### PR TITLE
Implement grcc --output switch for hierarchical blocks

### DIFF
--- a/grc/compiler.py
+++ b/grc/compiler.py
@@ -45,7 +45,7 @@ def main(args=None):
     output_dir = args.output if not args.user_lib_dir else platform.config.hier_block_lib_dir
     try:
         # recursive mkdir: os.makedirs doesn't work with .. paths, resolve with realpath
-        os.makedirs(os.path.realpath(output_dir), exists_ok=True)
+        os.makedirs(os.path.realpath(output_dir), exist_ok=True)
     except Exception as e:
         exit(str(e))
 

--- a/grc/compiler.py
+++ b/grc/compiler.py
@@ -43,8 +43,11 @@ def main(args=None):
     platform.build_library()
 
     output_dir = args.output if not args.user_lib_dir else platform.config.hier_block_lib_dir
-    if not os.path.exists(output_dir):
-        exit('Error: Invalid output directory')
+    try:
+        # recursive mkdir: os.makedirs doesn't work with .. paths, resolve with realpath
+        os.makedirs(os.path.realpath(output_dir), exists_ok=True)
+    except Exception as e:
+        exit(str(e))
 
     Messages.send_init(platform)
     flow_graph = file_path = None

--- a/grc/compiler.py
+++ b/grc/compiler.py
@@ -42,12 +42,8 @@ def main(args=None):
     )
     platform.build_library()
 
-    out_dir = args.output if not args.user_lib_dir else platform.config.hier_block_lib_dir
-    if os.path.exists(out_dir):
-        pass  # all is well
-    elif args.save_to_lib:
-        os.mkdir(out_dir)  # create missing hier_block lib directory
-    else:
+    output_dir = args.output if not args.user_lib_dir else platform.config.hier_block_lib_dir
+    if not os.path.exists(output_dir):
         exit('Error: Invalid output directory')
 
     Messages.send_init(platform)
@@ -57,7 +53,7 @@ def main(args=None):
         Messages.send('\n')
 
         flow_graph, file_path = platform.load_and_generate_flow_graph(
-            os.path.abspath(grc_file), os.path.abspath(out_dir))
+            os.path.abspath(grc_file), os.path.abspath(output_dir))
         if not file_path:
             exit('Compilation error')
     if file_path and args.run:

--- a/grc/core/generator/Generator.py
+++ b/grc/core/generator/Generator.py
@@ -15,14 +15,14 @@ from .cpp_hier_block import CppHierBlockGenerator
 class Generator(object):
     """Adaptor for various generators (uses generate_options)"""
 
-    def __init__(self, flow_graph, file_path):
+    def __init__(self, flow_graph, output_dir):
         """
         Initialize the generator object.
         Determine the file to generate.
 
         Args:
             flow_graph: the flow graph object
-            file_path: the path to the grc file
+            output_dir: the output path for generated files
         """
         self.generate_options = flow_graph.get_option('generate_options')
         self.output_language = flow_graph.get_option('output_language')
@@ -45,7 +45,7 @@ class Generator(object):
             else:
                 generator_cls = CppTopBlockGenerator
 
-        self._generator = generator_cls(flow_graph, file_path)
+        self._generator = generator_cls(flow_graph, output_dir)
 
     def __getattr__(self, item):
         """get all other attrib from actual generator object"""

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -28,31 +28,6 @@ cmake_template = Template(filename=CMAKE_TEMPLATE)
 
 class CppTopBlockGenerator(TopBlockGenerator):
 
-    def __init__(self, flow_graph, file_path):
-        """
-        Initialize the C++ top block generator object.
-
-        Args:
-            flow_graph: the flow graph object
-            file_path: the path where we want to create
-                a new directory with C++ files
-        """
-
-        self._flow_graph = FlowGraphProxy(flow_graph)
-        self._generate_options = self._flow_graph.get_option('generate_options')
-
-        self._mode = TOP_BLOCK_FILE_MODE
-        # Handle the case where the directory is read-only
-        # In this case, use the system's temp directory
-        if not os.access(file_path, os.W_OK):
-            file_path = tempfile.gettempdir()
-
-        # When generating C++ code, we create a new directory
-        # (file_path) and generate the files inside that directory
-        filename = self._flow_graph.get_option('id')
-        self.file_path = os.path.join(file_path, filename)
-        self._dirname = file_path
-
     def write(self):
         """create directory, generate output and write it to files"""
         self._warnings()

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -26,8 +26,29 @@ source_template = Template(filename=SOURCE_TEMPLATE)
 cmake_template = Template(filename=CMAKE_TEMPLATE)
 
 
-class CppTopBlockGenerator(TopBlockGenerator):
+class CppTopBlockGenerator(object):
 
+    def __init__(self, flow_graph, output_dir):
+        """
+        Initialize the top block generator object.
+
+        Args:
+            flow_graph: the flow graph object
+            output_dir: the path for written files
+        """
+
+        self._flow_graph = FlowGraphProxy(flow_graph)
+        self._generate_options = self._flow_graph.get_option('generate_options')
+
+        self._mode = TOP_BLOCK_FILE_MODE
+        # Handle the case where the directory is read-only
+        # In this case, use the system's temp directory
+        if not os.access(output_dir, os.W_OK):
+            output_dir = tempfile.gettempdir()
+        filename = self._flow_graph.get_option('id')
+        self.file_path = os.path.join(output_dir, filename)
+        self.output_dir = output_dir
+        
     def write(self):
         """create directory, generate output and write it to files"""
         self._warnings()

--- a/grc/core/generator/hier_block.py
+++ b/grc/core/generator/hier_block.py
@@ -12,15 +12,17 @@ from ..io import yaml
 class HierBlockGenerator(TopBlockGenerator):
     """Extends the top block generator to also generate a block YML file"""
 
-    def __init__(self, flow_graph, _):
+    def __init__(self, flow_graph, output_dir=None):
         """
         Initialize the hier block generator object.
 
         Args:
             flow_graph: the flow graph object
+            output_dir: the path for written files
         """
-        platform = flow_graph.parent
-        output_dir = platform.config.hier_block_lib_dir
+        if output_dir is None:
+            platform = flow_graph.parent
+            output_dir = platform.config.hier_block_lib_dir
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 

--- a/grc/core/generator/top_block.py
+++ b/grc/core/generator/top_block.py
@@ -26,7 +26,7 @@ class TopBlockGenerator(object):
 
         Args:
             flow_graph: the flow graph object
-            output_dir: the path to write the file to
+            output_dir: the path for written files
         """
 
         self._flow_graph = FlowGraphProxy(flow_graph)

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -73,7 +73,7 @@ class Platform(Element):
             if os.path.exists(os.path.normpath(file_path)):
                 return file_path
 
-    def load_and_generate_flow_graph(self, file_path, out_path=None, hier_only=False):
+    def load_and_generate_flow_graph(self, file_path, out_dir=None, hier_only=False):
         """Loads a flow graph from file and generates it"""
         Messages.set_indent(len(self._auto_hier_block_generate_chain))
         Messages.send('>>> Loading: {}\n'.format(file_path))
@@ -101,17 +101,16 @@ class Platform(Element):
             Messages.set_indent(len(self._auto_hier_block_generate_chain))
 
         try:
-            generator = self.Generator(flow_graph, out_path or file_path)
+            if flow_graph.get_option('generate_options').startswith('hb'):
+                generator = self.Generator(flow_graph, out_dir)
+            else:
+                generator = self.Generator(flow_graph, out_dir or file_path)
             Messages.send('>>> Generating: {}\n'.format(generator.file_path))
             generator.write()
         except Exception as e:
             Messages.send('>>> Generate Error: {}: {}\n'.format(file_path, str(e)))
             return None, None
 
-        if flow_graph.get_option('generate_options').startswith('hb'):
-            # self.load_block_xml(generator.file_path_xml)
-            # TODO: implement yml output for hier blocks
-            pass
         return flow_graph, generator.file_path
 
     def build_library(self, path=None):


### PR DESCRIPTION
Reference Issue #2799.

This commit adjusts some logic and code to enable the --output switch
for grcc. Prior to this commit, grcc would only output to the GRC_HIER_PATH.

The commit adjusts the various Generators in grc/core/generator to
consistently use output_dir for the output directory.

If output_dir is None, then take from the platform.config.hier_block_lib_dir
attribute which can be set via the GRC_HIER_PATH env var.

The cpp_top_block generator was also modified to remote its __init__ function
which appeared identical to its base TopBlockGenerator.

I did not test c++ GRC output.