### PR TITLE
cmake: correct minimum version checking for Mako

### DIFF
--- a/gr-utils/CMakeLists.txt
+++ b/gr-utils/CMakeLists.txt
@@ -10,7 +10,11 @@
 ########################################################################
 include(GrPython)
 
-GR_PYTHON_CHECK_MODULE("Mako >= ${GR_MAKO_MIN_VERSION}" mako "mako.__version__ >= '${GR_MAKO_MIN_VERSION}'" MAKO_FOUND)
+GR_PYTHON_CHECK_MODULE(
+  "Mako >= ${GR_MAKO_MIN_VERSION}"
+  mako
+  "LooseVersion(mako.__version__) >= LooseVersion('${GR_MAKO_MIN_VERSION}')"
+  MAKO_FOUND)
 
 GR_PYTHON_CHECK_MODULE_RAW(
   "click"

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -18,9 +18,10 @@ GR_PYTHON_CHECK_MODULE_RAW(
     PYYAML_FOUND
 )
 
-GR_PYTHON_CHECK_MODULE_RAW(
+GR_PYTHON_CHECK_MODULE(
     "mako >= ${GR_MAKO_MIN_VERSION}"
-    "import mako; assert mako.__version__ >= '${GR_MAKO_MIN_VERSION}'"
+    mako
+    "LooseVersion(mako.__version__) >= LooseVersion('${GR_MAKO_MIN_VERSION}')"
     MAKO_FOUND
 )
 


### PR DESCRIPTION
A string-based '>=" only works for single digit version numbers. It turns out that there is already a macro set up to do correct version checking - it was just not being used.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Fixes https://github.com/gnuradio/gnuradio/issues/4727