### PR TITLE
modtool: Change handled exception to ModuleNotFoundError (backport to maint-3.8)

### DIFF
--- a/gr-utils/python/modtool/templates/gr-newmod/python/__init__.py
+++ b/gr-utils/python/modtool/templates/gr-newmod/python/__init__.py
@@ -24,11 +24,18 @@ description here (python/__init__.py).
 '''
 from __future__ import unicode_literals
 
+# GNU Radio 3.8 is compatible with both Python 2 and 3,
+# which raise different exceptions if a module is not found.
+try:
+    module_not_found_error = ModuleNotFoundError
+except NameError:
+    module_not_found_error = ImportError
+
 # import swig generated symbols into the howto namespace
 try:
     # this might fail if the module is python-only
     from .howto_swig import *
-except ImportError:
+except module_not_found_error:
     pass
 
 # import any pure python here


### PR DESCRIPTION
Backport 08cd88d but maintain compatibility with Python2.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3926
Fixes https://github.com/gnuradio/gnuradio/issues/4761 for v3.8