### PR TITLE
gr-blocks: (un)pack-k-bits tag propagation Bugfix #1111 (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/pack_k_bits_bb_impl.cc
+++ b/gr-blocks/lib/pack_k_bits_bb_impl.cc
@@ -14,7 +14,6 @@
 
 #include "pack_k_bits_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <iostream>
 #include <stdexcept>
 
 namespace gr {
@@ -32,6 +31,8 @@ pack_k_bits_bb_impl::pack_k_bits_bb_impl(unsigned k)
                      k),
       d_pack(k)
 {
+    d_k = k;
+    set_tag_propagation_policy(TPP_CUSTOM);
 }
 
 int pack_k_bits_bb_impl::work(int noutput_items,
@@ -41,7 +42,21 @@ int pack_k_bits_bb_impl::work(int noutput_items,
     const unsigned char* in = (const unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
+    std::vector<tag_t> wintags; // Temp variable to store tags for prop
+
+    // GR_LOG_DEBUG(d_logger, boost::format("Packing Outputs"));
     d_pack.pack(out, in, noutput_items);
+
+    // Propagate tags
+    get_tags_in_range(wintags, 0, nitems_read(0), nitems_read(0) + (noutput_items * d_k));
+
+    // GR_LOG_DEBUG(d_logger, boost::format("Propagating tags"));
+    std::vector<tag_t>::iterator t;
+    for (t = wintags.begin(); t != wintags.end(); t++) {
+        tag_t new_tag = *t;
+        new_tag.offset = std::floor((double)new_tag.offset / d_k);
+        add_item_tag(0, new_tag);
+    }
 
     return noutput_items;
 }

--- a/gr-blocks/lib/pack_k_bits_bb_impl.h
+++ b/gr-blocks/lib/pack_k_bits_bb_impl.h
@@ -22,6 +22,8 @@ class pack_k_bits_bb_impl : public pack_k_bits_bb
 private:
     const kernel::pack_k_bits d_pack;
 
+    unsigned d_k;
+
 public:
     pack_k_bits_bb_impl(unsigned k);
 

--- a/gr-blocks/python/blocks/qa_pack_k_bits.py
+++ b/gr-blocks/python/blocks/qa_pack_k_bits.py
@@ -12,7 +12,7 @@
 import random
 
 from gnuradio import gr, gr_unittest, blocks
-
+import pmt
 
 class test_pack(gr_unittest.TestCase):
 
@@ -41,7 +41,6 @@ class test_pack(gr_unittest.TestCase):
         dst = blocks.vector_sink_b()
         self.tb.connect(src, op, dst)
         self.tb.run()
-        #self.assertEqual(expected_results, dst.data())
         self.assertEqual(expected_results, dst.data())
 
     def test_003(self):
@@ -53,6 +52,45 @@ class test_pack(gr_unittest.TestCase):
         self.tb.connect(src, unpack, pack, snk)
         self.tb.run()
         self.assertEqual(list(expected_results), list(snk.data()))
+
+    def test_004(self):
+        # Test tags propagation
+
+        #Tags on the incoming bits
+        src_data = [1, 0, 1, 1, 0, 0, 0, 1]
+        #src_tag_offsets = [1, 2, 3, 5, 6]
+        src_tag_offsets = [1, 2, 3, 5, 6, 7]
+
+        #Ground Truth
+        expected_data= [2, 3, 0, 1]
+        expected_tag_offsets = [0, 1, 1, 2, 3, 3]
+
+        test_tags = list()
+        tag_indexs = range(len(src_tag_offsets))
+        for src_tag in tag_indexs:
+            test_tags.append(
+                      gr.tag_utils.python_to_tag(( src_tag_offsets[src_tag],
+                                                   pmt.intern('tag_byte'),
+                                                   pmt.from_long(src_tag),
+                                                   None
+                                                ))
+                        )
+
+        src = blocks.vector_source_b(src_data, False,1, test_tags )
+        op = blocks.pack_k_bits_bb(2)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+
+        # Check the data
+        self.assertEqual(expected_data, dst.data())
+
+        # Check the tag values
+        self.assertEqual( list(tag_indexs), [ pmt.to_python(x.value) for x in dst.tags()])
+
+        # Check the tag offsets
+        self.assertEqual( expected_tag_offsets, [ x.offset for x in dst.tags()])
+
 
 
 if __name__ == '__main__':

--- a/gr-blocks/python/blocks/qa_unpack_k_bits.py
+++ b/gr-blocks/python/blocks/qa_unpack_k_bits.py
@@ -12,6 +12,7 @@
 from gnuradio import gr, gr_unittest, blocks
 
 import random
+import pmt
 
 
 class test_unpack(gr_unittest.TestCase):
@@ -43,6 +44,41 @@ class test_unpack(gr_unittest.TestCase):
         self.tb.run()
         self.assertEqual(expected_results, dst.data())
 
+    def test_003(self):
+
+        #Tags on the incoming bytes
+        src_data= [2, 3, 0, 1]
+        src_tag_offsets = [0, 1, 1, 2, 3]
+
+        #Ground Truth
+        expected_data = [1, 0, 1, 1, 0, 0, 0, 1]
+        expected_tag_offsets = [0, 2, 2, 4, 6]
+
+        test_tags = list()
+        tag_indexs = range(len(src_tag_offsets))
+        for src_tag in tag_indexs:
+            test_tags.append(
+                      gr.tag_utils.python_to_tag(( src_tag_offsets[src_tag],
+                                                   pmt.intern('tag_byte'),
+                                                   pmt.from_long(src_tag),
+                                                   None
+                                                ))
+                        )
+
+        src = blocks.vector_source_b(src_data, False,1, test_tags )
+        op = blocks.unpack_k_bits_bb(2)
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, op, dst)
+        self.tb.run()
+
+        # Check the data
+        self.assertEqual(expected_data, dst.data())
+
+        # Check the tag values
+        self.assertEqual( list(tag_indexs), [ pmt.to_python(x.value) for x in dst.tags()])
+
+        # Check the tag offsets
+        self.assertEqual( expected_tag_offsets, [ x.offset for x in dst.tags()])
 
 if __name__ == '__main__':
     gr_unittest.run(test_unpack)


### PR DESCRIPTION
backport to 3.9 from https://github.com/gnuradio/gnuradio/pull/4863