### PR TITLE
qtgui: bugfix - display tags on the last sample (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -576,7 +576,7 @@ int time_sink_c_impl::work(int noutput_items,
 
         uint64_t nr = nitems_read(n);
         std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, n, nr, nr + nitems);
+        get_tags_in_range(tags, n, nr, nr + nitems + 1);
         for (size_t t = 0; t < tags.size(); t++) {
             tags[t].offset = tags[t].offset - nr + (d_index - d_start - 1);
         }

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -566,7 +566,7 @@ int time_sink_f_impl::work(int noutput_items,
 
         uint64_t nr = nitems_read(idx);
         std::vector<gr::tag_t> tags;
-        get_tags_in_range(tags, idx, nr, nr + nitems);
+        get_tags_in_range(tags, idx, nr, nr + nitems + 1);
         for (size_t t = 0; t < tags.size(); t++) {
             tags[t].offset = tags[t].offset - nr + (d_index - d_start - 1);
         }


### PR DESCRIPTION
3.9 backport of https://github.com/gnuradio/gnuradio/pull/4873
