### PR TITLE
qtgui: Make check_set_qss public

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/utils.h
+++ b/gr-qtgui/include/gnuradio/qtgui/utils.h
@@ -54,6 +54,6 @@ public:
     transition(const QwtEventPattern& eventPattern, const QEvent* e) override;
 };
 
-void check_set_qss(QApplication* app);
+QTGUI_API void check_set_qss(QApplication* app);
 
 #endif /* INCLUDED_QTGUI_UTILS_H */


### PR DESCRIPTION
`check_set_qss` is part of the public qtgui headers, but hasn't been
declared part of the public API as of now. This is unfortunate, because
when bootstrapping a Qt application, this function should be called to
apply a qt gui stylesheet as defined in the config.

This commit adds that function to the public api to allow external Qt
GUI widgets to behave in a manner that's compatible with the in-tree
widgets.