### PR TITLE
gr-iio: pluto source /sink fails to set paramter if german locale is used

### DIFF
--- a/gr-iio/lib/device_source_impl.cc
+++ b/gr-iio/lib/device_source_impl.cc
@@ -92,7 +92,8 @@ void device_source_impl::set_params(struct iio_device* phy,
             ret = iio_device_debug_attr_write(phy, attr, val.c_str());
         if (ret < 0) {
             GR_LOG_WARN(logger,
-                        boost::format("Unable to write attribute %s: %d") % key % ret);
+                        boost::format("Unable to write attribute %s: %d %s") % key % ret %
+                            val);
         }
     }
 }

--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -185,9 +185,11 @@ void fmcomms2_sink_impl::set_attenuation(size_t chan, double attenuation)
         throw std::runtime_error("Channel out of range for this device");
     }
     std::vector<std::string> params;
-
-    params.push_back("out_voltage" + std::to_string(chan) +
-                     "_hardwaregain=" + std::to_string(-attenuation));
+    std::string att_value = std::to_string(-attenuation);
+    std::string::size_type idx = att_value.find(',');
+    if (idx != std::string::npos) // found , as decimal separator, so change to .
+        att_value.replace(idx, 1, ".");
+    params.push_back("out_voltage" + std::to_string(chan) + "_hardwaregain=" + att_value);
 
 
     device_source_impl::set_params(this->phy, params);

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -220,10 +220,12 @@ void fmcomms2_source_impl::set_gain(size_t chan, double gain_value)
     std::vector<std::string> params;
 
     if (d_gain_mode[chan].compare("manual") == 0) {
-        // params.push_back("in_voltage" + std::to_string(chan) +
-        //                  "_gain_control_mode=" + d_gain_mode[chan]);
+        std::string gain_string = std::to_string(gain_value);
+        std::string::size_type idx = gain_string.find(',');
+        if (idx != std::string::npos) // found , as decimal separator, so change to .
+            gain_string.replace(idx, 1, ".");
         params.push_back("in_voltage" + std::to_string(chan) +
-                         "_hardwaregain=" + std::to_string(gain_value));
+                         "_hardwaregain=" + gain_string);
     }
     device_source_impl::set_params(params);
     d_gain_value[chan] = gain_value;


### PR DESCRIPTION
pluto source / sink fails to set hardwaregain with

gr::log :WARN: iio::device::set_params - Unable to write attribute in_voltage0_hardwaregain: -22
gr::log :WARN: iio::device::set_params - Unable to write attribute out_voltage0_hardwaregain: -22

gain values are treated as double. The conversion std::to_string() uses the locale setting.
So in the US std::to_string(10.) leads to "10.0" while in Germany the result is "10,0" which the pluto handles as error.
Forcing LC_NUMERIC to "C" fixes this issue.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>