### PR TITLE
runtime: dereference symlink in gr::prefix()

### DIFF
--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -28,9 +28,15 @@ const std::string prefix()
 
     boost::filesystem::path prefix_rel_lib = "@prefix_relative_to_lib@";
     boost::filesystem::path gr_runtime_lib_path = boost::dll::this_line_location();
-    // Normalize before decomposing path so result is reliable
+    // Ensure that the lib path is absolute to avoid built-in current_path()
+    // call in canonical
+    if (gr_runtime_lib_path.is_relative())
+        gr_runtime_lib_path = boost::filesystem::absolute(gr_runtime_lib_path);
+    // Canonize before decomposing path so result is reliable and without symlinks
+    boost::filesystem::path canonical_lib_path =
+        boost::filesystem::canonical(gr_runtime_lib_path, "/");
     boost::filesystem::path prefix_path =
-        gr_runtime_lib_path.lexically_normal().parent_path() / prefix_rel_lib;
+        canonical_lib_path.parent_path() / prefix_rel_lib;
     return prefix_path.lexically_normal().string();
 }
 


### PR DESCRIPTION
Signed-off-by: Ed Beroset <beroset@ieee.org>
(adapted from 0f851bd06 for maint-3.9 using boost::filesystem)
Signed-off-by: Jeff Long <willcode4@gmail.com>
Signed-off-by: Ryan Volz <ryan.volz@gmail.com>