### PR TITLE
grc: Allow func prob args to be changed dynamically

### DIFF
--- a/grc/blocks/variable_function_probe.block.yml
+++ b/grc/blocks/variable_function_probe.block.yml
@@ -35,7 +35,13 @@ templates:
         def _${id}_probe():
           while True:
             <% obj = 'self' + ('.' + block_id if block_id else '') %>
-            val = ${obj}.${function_name}(${function_args})
+            <%
+            if function_args:
+                function_args_impr = ','.join(list('self.' + function_arg.strip() for function_arg in function_args.split(',')))
+            else:
+                function_args_impr = ''
+            %>
+            val = ${obj}.${function_name}(${function_args_impr})
             try:
               try:
                 self.doc.add_next_tick_callback(functools.partial(self.set_${id},val))


### PR DESCRIPTION
When the func prob block is used to run a function defined in a epy
block to accept any number of arguments, it is impossible to dynamically
change the value of the argument during runtime despite a callback
function setting its value. This is because it is missing a 'self.' prefix.

An example GRC is [in this link](https://pastebin.com/raw/fu9KFtQi). Without the patch, one cannot change the value of the arguments, `Test` and `Test2` during runtime. This is made possible with this patch.

Fixes #4942 

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>