### PR TITLE
filter: use output multiple for pfb arbitrary resampler

### DIFF
--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
@@ -37,6 +37,10 @@ pfb_arb_resampler_ccc_impl::pfb_arb_resampler_ccc_impl(
 
     set_history(d_resamp.taps_per_filter());
     set_relative_rate(rate);
+    if (rate >= 1.0f) {
+        unsigned output_multiple = std::max<int>(rate, filter_size);
+        set_output_multiple(output_multiple);
+    }
 }
 
 void pfb_arb_resampler_ccc_impl::forecast(int noutput_items,

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
@@ -39,6 +39,10 @@ pfb_arb_resampler_ccf_impl::pfb_arb_resampler_ccf_impl(float rate,
 
     set_history(d_resamp.taps_per_filter());
     set_relative_rate(rate);
+    if (rate >= 1.0f) {
+        unsigned output_multiple = std::max<int>(rate, filter_size);
+        set_output_multiple(output_multiple);
+    }
 }
 
 void pfb_arb_resampler_ccf_impl::forecast(int noutput_items,

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
@@ -39,6 +39,10 @@ pfb_arb_resampler_fff_impl::pfb_arb_resampler_fff_impl(float rate,
 
     set_history(d_resamp.taps_per_filter());
     set_relative_rate(rate);
+    if (rate >= 1.0f) {
+        unsigned output_multiple = std::max<int>(rate, filter_size);
+        set_output_multiple(output_multiple);
+    }
 }
 
 void pfb_arb_resampler_fff_impl::forecast(int noutput_items,


### PR DESCRIPTION
When interpolating, the resampler was taking up a full cpu even
at very low rates. This is due to polling when no input items are
available.

For interpolation, this change sets the output multiple to the greater
of the relative rate and the number of pfb filter arms. This is fairly
arbitrary, but results in usable output multiples and good performance.

The output multiple can only be set effectively in the block constructor.
This means that it will not change if the relative rate is set
dynamically. For widely varying rates, this could be a problem. For
rates that vary around 1.0, if the rate is initially set to 0.9 and
then changed to 1.1, performance will be as before (bad) when the rate
goes above 1.0. For this reason, and in hopes that the user will start
with 1.0 in such a case, the output multiple is set for 1.0.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Fixes https://github.com/gnuradio/gnuradio/issues/4561