### PR TITLE
digital/chunks to symbols: be less inefficient

### DIFF
--- a/gr-digital/include/gnuradio/digital/chunks_to_symbols.h
+++ b/gr-digital/include/gnuradio/digital/chunks_to_symbols.h
@@ -51,9 +51,9 @@ public:
      * \param symbol_table: list that maps chunks to symbols.
      * \param D: dimension of table.
      */
-    static sptr make(const std::vector<OUT_T>& symbol_table, const int D = 1);
+    static sptr make(const std::vector<OUT_T>& symbol_table, const unsigned int D = 1);
 
-    virtual int D() const = 0;
+    virtual unsigned int D() const = 0;
     virtual std::vector<OUT_T> symbol_table() const = 0;
     virtual void set_symbol_table(const std::vector<OUT_T>& symbol_table) = 0;
 };

--- a/gr-digital/lib/chunks_to_symbols_impl.h
+++ b/gr-digital/lib/chunks_to_symbols_impl.h
@@ -12,6 +12,7 @@
 #define CHUNKS_TO_SYMBOLS_IMPL_H
 
 #include <gnuradio/digital/chunks_to_symbols.h>
+#include <pmt/pmt.h>
 
 namespace gr {
 namespace digital {
@@ -20,18 +21,20 @@ template <class IN_T, class OUT_T>
 class chunks_to_symbols_impl : public chunks_to_symbols<IN_T, OUT_T>
 {
 private:
-    const int d_D;
+    const unsigned int d_D;
     std::vector<OUT_T> d_symbol_table;
+    const pmt::pmt_t symbol_table_key;
 
 public:
-    chunks_to_symbols_impl(const std::vector<OUT_T>& symbol_table, const int D = 1);
+    chunks_to_symbols_impl(const std::vector<OUT_T>& symbol_table,
+                           const unsigned int D = 1);
 
     ~chunks_to_symbols_impl() override;
 
-    void handle_set_symbol_table(pmt::pmt_t symbol_table_pmt);
+    void handle_set_symbol_table(const pmt::pmt_t& symbol_table_pmt);
     void set_symbol_table(const std::vector<OUT_T>& symbol_table) override;
 
-    int D() const override { return d_D; }
+    unsigned int D() const override { return d_D; }
     std::vector<OUT_T> symbol_table() const override { return d_symbol_table; }
 
     int work(int noutput_items,

--- a/gr-digital/python/digital/bindings/chunks_to_symbols_python.cc
+++ b/gr-digital/python/digital/bindings/chunks_to_symbols_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(chunks_to_symbols.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(92d3e85da4622d93c34d8226cbaaecf0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a7e4da5deb77580b19fd40a649ee11a8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/qa_chunks_to_symbols.py
+++ b/gr-digital/python/digital/qa_chunks_to_symbols.py
@@ -56,6 +56,50 @@ class test_chunks_to_symbols(gr_unittest.TestCase):
         actual_result = dst.data()
         self.assertEqual(expected_result, actual_result)
 
+    def test_bf_2d(self):
+        maxval = 4
+        dimensions = 2
+        const = list(range(maxval * dimensions))
+        src_data = [v * 13 % maxval for v in range(maxval)]
+        expected_result = []
+        for data in src_data:
+            for i in range(dimensions):
+                expected_result += [const[data * dimensions + i]]
+
+        self.assertEqual(len(src_data) * dimensions, len(expected_result))
+        src = blocks.vector_source_b(src_data)
+        op = digital.chunks_to_symbols_bf(const, dimensions)
+
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
+    def test_bf_3d(self):
+        maxval = 48
+        dimensions = 3
+        const = list(range(maxval * dimensions))
+        src_data = [v * 13 % maxval for v in range(maxval)]
+        expected_result = []
+        for data in src_data:
+            for i in range(dimensions):
+                expected_result += [const[data * dimensions + i]]
+
+        self.assertEqual(len(src_data) * dimensions, len(expected_result))
+        src = blocks.vector_source_b(src_data)
+        op = digital.chunks_to_symbols_bf(const, dimensions)
+
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
     def test_ic_003(self):
         const = [1 + 0j, 0 + 1j,
                  -1 + 0j, 0 - 1j]

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -12,6 +12,7 @@
 import random
 import math
 from cmath import exp, pi, log, sqrt
+import numpy
 
 from gnuradio import gr, gr_unittest, digital, blocks
 from gnuradio.digital.utils import mod_codes
@@ -195,7 +196,19 @@ class test_constellation(gr_unittest.TestCase):
                 data = dst.data()
                 # Don't worry about cut off data for now.
                 first = constellation.bits_per_symbol()
-                self.assertEqual(self.src_data[first:len(data)], data[first:])
+                equality = all(numpy.equal(self.src_data[first:len(data)],
+                                           data[first:]))
+                if not equality:
+                    msg = "Constellations mismatched. " + \
+                        f"{type(constellation)}; " + \
+                        f"Differential? {differential}; " + \
+                        f"{len(constellation.points())} " +\
+                        "Constellation points: " + \
+                        f"{constellation.points()};"
+                    self.assertEqual(self.src_data[first:len(data)],
+                                     data[first:],
+                                     msg=msg)
+
 
     def test_soft_qpsk_gen(self):
         prec = 8


### PR DESCRIPTION
The block formerly took the tags from `get_tags_in_range` (which are sorted),
gave them to `tag_checker`, which sorted them, and then went through every
input sample, checking its index against the next tag.

Removed the tag_checker; that saves us a sorting of a sorted vector per work call.

The other optimization is to not dispatch any tag encountered to the own
message handler; instead, the handler is called directly.

Found #4898 while doing this.