### PR TITLE
digital: remove non-existing msg output from chunks_to_symbols block yaml

### DIFF
--- a/gr-digital/grc/digital_chunks_to_symbols.block.yml
+++ b/gr-digital/grc/digital_chunks_to_symbols.block.yml
@@ -43,9 +43,6 @@ outputs:
 -   domain: stream
     dtype: ${ out_type }
     multiplicity: ${ num_ports }
--   domain: message
-    id: set_symbol_table
-    optional: true
 
 asserts:
 - ${ num_ports > 0 }


### PR DESCRIPTION
Before:

![benchmark_chunks_to_symbols](https://user-images.githubusercontent.com/958972/126005759-1e382660-e84c-4687-8320-4da7c09e60ec.png)

After:

![benchmark_chunks_to_symbols_new](https://user-images.githubusercontent.com/958972/126005775-ae90b299-13b3-4b81-abe8-c7720509d5d2.png)

The block doesn't have a message output port.