### PR TITLE
cmake: Fix finding libunwind

### DIFF
--- a/cmake/Modules/Findlibunwind.cmake
+++ b/cmake/Modules/Findlibunwind.cmake
@@ -25,7 +25,7 @@ find_library(libunwind_LIBRARY
 
 # Set the include dir variables and the libraries and let libfind_process do the rest.
 # NOTE: Singular variables for this library, plural for libraries this this lib depends on.
-set(libunwind_PROCESS_INCLUDES ${libunwind_INCLUDE_DIR})
+set(libunwind_PROCESS_INCLUDES libunwind_INCLUDE_DIR)
 set(libunwind_PROCESS_LIBS libunwind_LIBRARY)
 libfind_process(libunwind)
 


### PR DESCRIPTION
The `libfind_process macro` expects `<lib>_PROCESS_INCLUDES` to be set to the names of variables containing the include paths, not the include paths themselves. This was causing `find_package(libunwind)` to always fail, even when the necessary files were correctly found by `find_path` and `find_library`.

It looks like this typo has existed since libunwind support was first added in #3051. As such, it is likely that not too many people have exercised the libunwind code, and fixing this may surface other issues. It does compile and successfully links libunwind. I'll go crash some stuff and let you know what I see.