### PR TITLE
digital/chunks to symbols: be less inefficient (backport to maint-3.9)

### DIFF
--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -105,26 +105,49 @@ int chunks_to_symbols_impl<IN_T, OUT_T>::work(int noutput_items,
 
         // per tag: all the samples leading up to this tag can be handled straightforward
         // with the current settings
-        for (const auto& tag : tags) {
-            for (; in_count < tag.offset; ++in_count) {
+        if (d_D == 1) {
+            for (const auto& tag : tags) {
+                for (; in_count < tag.offset; ++in_count) {
+                    auto key = static_cast<unsigned int>(*in);
+                    *out = d_symbol_table[key];
+                    ++out;
+                    ++in;
+                }
+                if (tag.key == symbol_table_key) {
+                    handle_set_symbol_table(tag.value);
+                }
+            }
+
+            // after the last tag, continue working on the remaining items
+            for (; in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items;
+                 ++in) {
+                auto key = static_cast<unsigned int>(*in);
+                *out = d_symbol_table[key];
+                ++out;
+            }
+        } else { // the multi-dimensional case
+            for (const auto& tag : tags) {
+                for (; in_count < tag.offset; ++in_count) {
+                    auto key = static_cast<unsigned int>(*in) * d_D;
+                    for (unsigned int idx = 0; idx < d_D; ++idx) {
+                        *out = d_symbol_table[key + idx];
+                        ++out;
+                    }
+                    ++in;
+                }
+                if (tag.key == symbol_table_key) {
+                    handle_set_symbol_table(tag.value);
+                }
+            }
+
+            // after the last tag, continue working on the remaining items
+            for (; in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items;
+                 ++in) {
                 auto key = static_cast<unsigned int>(*in) * d_D;
                 for (unsigned int idx = 0; idx < d_D; ++idx) {
                     *out = d_symbol_table[key + idx];
                     ++out;
                 }
-                ++in;
-            }
-            if (tag.key == symbol_table_key) {
-                handle_set_symbol_table(tag.value);
-            }
-        }
-
-        // after the last tag, continue working on the remaining items
-        for (; in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items; ++in) {
-            auto key = static_cast<unsigned int>(*in) * d_D;
-            for (unsigned int idx = 0; idx < d_D; ++idx) {
-                *out = d_symbol_table[key + idx];
-                ++out;
             }
         }
     }

--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -14,7 +14,7 @@
 
 #include "chunks_to_symbols_impl.h"
 #include <gnuradio/io_signature.h>
-#include <gnuradio/tag_checker.h>
+#include <pmt/pmt.h>
 #include <cassert>
 
 namespace gr {
@@ -22,14 +22,15 @@ namespace digital {
 
 
 void set_vector_from_pmt(std::vector<gr_complex>& symbol_table,
-                         pmt::pmt_t& symbol_table_pmt)
+                         const pmt::pmt_t& symbol_table_pmt)
 {
     size_t length;
     const gr_complex* elements = pmt::c32vector_elements(symbol_table_pmt, length);
     symbol_table.assign(elements, elements + length);
 }
 
-void set_vector_from_pmt(std::vector<float>& symbol_table, pmt::pmt_t& symbol_table_pmt)
+void set_vector_from_pmt(std::vector<float>& symbol_table,
+                         const pmt::pmt_t& symbol_table_pmt)
 {
     size_t length;
     const float* elements = pmt::f32vector_elements(symbol_table_pmt, length);
@@ -52,11 +53,13 @@ chunks_to_symbols_impl<IN_T, OUT_T>::chunks_to_symbols_impl(
                         io_signature::make(1, -1, sizeof(OUT_T)),
                         D),
       d_D(D),
-      d_symbol_table(symbol_table)
+      d_symbol_table(symbol_table),
+      symbol_table_key(pmt::mp("set_symbol_table"))
 {
-    this->message_port_register_in(pmt::mp("set_symbol_table"));
-    this->set_msg_handler(pmt::mp("set_symbol_table"),
-                          [this](pmt::pmt_t msg) { this->handle_set_symbol_table(msg); });
+    this->message_port_register_in(symbol_table_key);
+    this->set_msg_handler(symbol_table_key, [this](const pmt::pmt_t& msg) {
+        this->handle_set_symbol_table(msg);
+    });
 }
 
 template <class IN_T, class OUT_T>
@@ -66,7 +69,7 @@ chunks_to_symbols_impl<IN_T, OUT_T>::~chunks_to_symbols_impl()
 
 template <class IN_T, class OUT_T>
 void chunks_to_symbols_impl<IN_T, OUT_T>::handle_set_symbol_table(
-    pmt::pmt_t symbol_table_pmt)
+    const pmt::pmt_t& symbol_table_pmt)
 {
     set_vector_from_pmt(d_symbol_table, symbol_table_pmt);
 }
@@ -86,31 +89,43 @@ int chunks_to_symbols_impl<IN_T, OUT_T>::work(int noutput_items,
                                               gr_vector_void_star& output_items)
 {
     gr::thread::scoped_lock lock(this->d_setlock);
-    assert(noutput_items % d_D == 0);
-    assert(input_items.size() == output_items.size());
-    int nstreams = input_items.size();
+    auto nstreams = input_items.size();
+    for (unsigned int m = 0; m < nstreams; m++) {
+        const auto* in = reinterpret_cast<const IN_T*>(input_items[m]);
+        // NB: The compiler can't know whether all specializations of `chunks_to_symbol`
+        // are subclasses of gr::block. Hence the "this->" hoop we have to jump through to
+        // access members of parent classes.
+        size_t in_count = this->nitems_read(m);
 
-    for (int m = 0; m < nstreams; m++) {
-        const IN_T* in = (IN_T*)input_items[m];
-        OUT_T* out = (OUT_T*)output_items[m];
+        auto out = reinterpret_cast<OUT_T*>(output_items[m]);
 
         std::vector<tag_t> tags;
         this->get_tags_in_range(
             tags, m, this->nitems_read(m), this->nitems_read(m) + noutput_items / d_D);
-        tag_checker tchecker(tags);
 
-        // per stream processing
-        for (int i = 0; i < noutput_items / d_D; i++) {
-
-            std::vector<tag_t> tags_now;
-            tchecker.get_tags(tags_now, i + this->nitems_read(m));
-            for (unsigned int j = 0; j < tags_now.size(); j++) {
-                tag_t tag = tags_now[j];
-                this->dispatch_msg(tag.key, tag.value);
+        // per tag: all the samples leading up to this tag can be handled straightforward
+        // with the current settings
+        for (const auto& tag : tags) {
+            for (; in_count < tag.offset; ++in_count) {
+                auto key = static_cast<unsigned int>(*in) * d_D;
+                for (unsigned int idx = 0; idx < d_D; ++idx) {
+                    *out = d_symbol_table[key + idx];
+                    ++out;
+                }
+                ++in;
             }
-            assert(((unsigned int)in[i] * d_D + d_D) <= d_symbol_table.size());
-            memcpy(out, &d_symbol_table[(unsigned int)in[i] * d_D], d_D * sizeof(OUT_T));
-            out += d_D;
+            if (tag.key == symbol_table_key) {
+                handle_set_symbol_table(tag.value);
+            }
+        }
+
+        // after the last tag, continue working on the remaining items
+        for (; in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items; ++in) {
+            auto key = static_cast<unsigned int>(*in) * d_D;
+            for (unsigned int idx = 0; idx < d_D; ++idx) {
+                *out = d_symbol_table[key + idx];
+                ++out;
+            }
         }
     }
     return noutput_items;

--- a/gr-digital/lib/chunks_to_symbols_impl.h
+++ b/gr-digital/lib/chunks_to_symbols_impl.h
@@ -12,6 +12,7 @@
 #define CHUNKS_TO_SYMBOLS_IMPL_H
 
 #include <gnuradio/digital/chunks_to_symbols.h>
+#include <pmt/pmt.h>
 
 namespace gr {
 namespace digital {
@@ -20,15 +21,16 @@ template <class IN_T, class OUT_T>
 class chunks_to_symbols_impl : public chunks_to_symbols<IN_T, OUT_T>
 {
 private:
-    const int d_D;
+    const unsigned int d_D;
     std::vector<OUT_T> d_symbol_table;
+    const pmt::pmt_t symbol_table_key;
 
 public:
     chunks_to_symbols_impl(const std::vector<OUT_T>& symbol_table, const int D = 1);
 
     ~chunks_to_symbols_impl() override;
 
-    void handle_set_symbol_table(pmt::pmt_t symbol_table_pmt);
+    void handle_set_symbol_table(const pmt::pmt_t& symbol_table_pmt);
     void set_symbol_table(const std::vector<OUT_T>& symbol_table) override;
 
     int D() const override { return d_D; }

--- a/gr-digital/python/digital/qa_chunks_to_symbols.py
+++ b/gr-digital/python/digital/qa_chunks_to_symbols.py
@@ -56,6 +56,50 @@ class test_chunks_to_symbols(gr_unittest.TestCase):
         actual_result = dst.data()
         self.assertEqual(expected_result, actual_result)
 
+    def test_bf_2d(self):
+        maxval = 4
+        dimensions = 2
+        const = list(range(maxval * dimensions))
+        src_data = [v * 13 % maxval for v in range(maxval)]
+        expected_result = []
+        for data in src_data:
+            for i in range(dimensions):
+                expected_result += [const[data * dimensions + i]]
+
+        self.assertEqual(len(src_data) * dimensions, len(expected_result))
+        src = blocks.vector_source_b(src_data)
+        op = digital.chunks_to_symbols_bf(const, dimensions)
+
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
+    def test_bf_3d(self):
+        maxval = 48
+        dimensions = 3
+        const = list(range(maxval * dimensions))
+        src_data = [v * 13 % maxval for v in range(maxval)]
+        expected_result = []
+        for data in src_data:
+            for i in range(dimensions):
+                expected_result += [const[data * dimensions + i]]
+
+        self.assertEqual(len(src_data) * dimensions, len(expected_result))
+        src = blocks.vector_source_b(src_data)
+        op = digital.chunks_to_symbols_bf(const, dimensions)
+
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
     def test_ic_003(self):
         const = [1 + 0j, 0 + 1j,
                  -1 + 0j, 0 - 1j]

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -12,6 +12,7 @@
 import random
 import math
 from cmath import exp, pi, log, sqrt
+import numpy
 
 from gnuradio import gr, gr_unittest, digital, blocks
 from gnuradio.digital.utils import mod_codes
@@ -216,7 +217,19 @@ class test_constellation(gr_unittest.TestCase):
                 data = dst.data()
                 # Don't worry about cut off data for now.
                 first = constellation.bits_per_symbol()
-                self.assertEqual(self.src_data[first:len(data)], data[first:])
+                equality = all(numpy.equal(self.src_data[first:len(data)],
+                                           data[first:]))
+                if not equality:
+                    msg = "Constellations mismatched. " + \
+                        f"{type(constellation)}; " + \
+                        f"Differential? {differential}; " + \
+                        f"{len(constellation.points())} " +\
+                        "Constellation points: " + \
+                        f"{constellation.points()};"
+                    self.assertEqual(self.src_data[first:len(data)],
+                                     data[first:],
+                                     msg=msg)
+
 
     def test_soft_qpsk_gen(self):
         prec = 8


### PR DESCRIPTION
This is essentially an exact replication of the patchset from #4901, but does not change the exported signature in the public header.