### PR TITLE
runtime: constants: modernized #include, structure (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -13,48 +13,48 @@
 #endif
 
 #include <gnuradio/constants.h>
-#include <stdlib.h>
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/filesystem/path.hpp>
+#include <cstdlib>
+
+using boost::filesystem::path;
 
 namespace gr {
 
 const std::string prefix()
 {
     // Use "GR_PREFIX" environment variable when specified
-    const char* prefix = getenv("GR_PREFIX");
+    const char* prefix = std::getenv("GR_PREFIX");
     if (prefix != NULL)
         return prefix;
 
-    boost::filesystem::path prefix_rel_lib = "@prefix_relative_to_lib@";
-    boost::filesystem::path gr_runtime_lib_path = boost::dll::this_line_location();
+    path prefix_rel_lib = "@prefix_relative_to_lib@";
+    path gr_runtime_lib_path = boost::dll::this_line_location();
     // Ensure that the lib path is absolute (see next comment)
     if (gr_runtime_lib_path.is_relative())
         gr_runtime_lib_path = boost::filesystem::absolute(gr_runtime_lib_path);
     // Canonize before decomposing path so result is reliable and without symlinks
     // Since we know lib path is absolute, pass "/" to avoid implicit current_path()
     // which fails when working dir is deleted (this happens in CI testing)
-    boost::filesystem::path canonical_lib_path =
-        boost::filesystem::canonical(gr_runtime_lib_path, "/");
-    boost::filesystem::path prefix_path =
-        canonical_lib_path.parent_path() / prefix_rel_lib;
+    path canonical_lib_path = boost::filesystem::canonical(gr_runtime_lib_path, "/");
+    path prefix_path = canonical_lib_path.parent_path() / prefix_rel_lib;
     return prefix_path.lexically_normal().string();
 }
 
 const std::string sysconfdir()
 {
-    boost::filesystem::path sysconfdir_rel_prefix = "@SYSCONFDIR_relative_to_prefix@";
-    boost::filesystem::path prefix_path = prefix();
-    boost::filesystem::path sysconfdir_path = prefix_path / sysconfdir_rel_prefix;
+    path sysconfdir_rel_prefix = "@SYSCONFDIR_relative_to_prefix@";
+    path prefix_path = prefix();
+    path sysconfdir_path = prefix_path / sysconfdir_rel_prefix;
 
     return sysconfdir_path.lexically_normal().string();
 }
 
 const std::string prefsdir()
 {
-    boost::filesystem::path prefsdir_rel_prefix = "@GR_PREFSDIR_relative_to_prefix@";
-    boost::filesystem::path prefix_path = prefix();
-    boost::filesystem::path prefsdir_path = prefix_path / prefsdir_rel_prefix;
+    path prefsdir_rel_prefix = "@GR_PREFSDIR_relative_to_prefix@";
+    path prefix_path = prefix();
+    path prefsdir_path = prefix_path / prefsdir_rel_prefix;
 
     return prefsdir_path.lexically_normal().string();
 }


### PR DESCRIPTION
Backport 311a983 (manual)
Backport https://github.com/gnuradio/gnuradio/pull/4739

This is not super important, but make the code more readable.