### PR TITLE
runtime: deprecate tag_checker (removal in 3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -53,16 +53,16 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
           - distro: 'Fedora 33'
             containerid: 'gnuradio/ci:fedora-33-3.9'
-            cxxflags: ''
+            cxxflags: -Werror -Wno-error=deprecated-declarations
           - distro: 'CentOS 8.3'
             containerid: 'gnuradio/ci:centos-8.3-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
           - distro: 'Debian 10'
             containerid: 'gnuradio/ci-debian-10-3.9:1.0'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/.github/workflows/pkg-debian.yml
+++ b/.github/workflows/pkg-debian.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/.github/workflows/pkg-fedora.yml
+++ b/.github/workflows/pkg-fedora.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - distro: 'Fedora 33'
             containerid: 'gnuradio/ci:fedora-33-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/gnuradio-runtime/include/gnuradio/tag_checker.h
+++ b/gnuradio-runtime/include/gnuradio/tag_checker.h
@@ -17,7 +17,11 @@
 
 namespace gr {
 
-class tag_checker
+/*!
+ * \brief deprecated class that was used to go through unsorted tag vectors
+ * \deprecated tag_checker serves no purpose and will be removed in 3.10
+ */
+class [[deprecated("tag_checker will be removed in 3.10")]] tag_checker
 {
 private:
     std::vector<tag_t> d_tags;
@@ -26,7 +30,7 @@ private:
     unsigned int d_next_tag_index;
 
 public:
-    tag_checker(std::vector<tag_t>& tags) : d_has_next_tag(false), d_next_tag_index(0)
+    tag_checker(std::vector<tag_t> & tags) : d_has_next_tag(false), d_next_tag_index(0)
     {
         d_tags = tags;
         std::sort(d_tags.begin(), d_tags.end());
@@ -38,7 +42,7 @@ public:
 
     ~tag_checker(){};
 
-    void get_tags(std::vector<tag_t>& tag_list, unsigned int offset)
+    void get_tags(std::vector<tag_t> & tag_list, unsigned int offset)
     {
         while (d_has_next_tag && (offset >= d_next_tag.offset)) {
             if (offset == d_next_tag.offset) {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/tag_checker_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/tag_checker_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tag_checker.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9ffac9df4d29f09b0c8506584e6f1f75)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b5fd75175ff9173ff27ee86729b864f1)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
`tag_checker` used to be meant for cases where you've gotten an unsorted
tag vector (mostly, from `get_tags_in_range`), which you then had to go
through in parallel to your samples, to check which tag applies at what
sample.

For that it sorts the tags; the tags coming from the `get_tags*` functions
are sorted already

The checking pattern (which `chunks_to_symbols` is the last consumer of)
is inefficient: instead of taking the index of the first unprocessed tag
and processing all samples up to that index, a check is performed on
every sample, which includes calls and multiple indirections.

So, since very likely nobody uses this, and because it's a design
anti-pattern, deprecating this.

Together with the actual removal, addresses #4898.

Backport https://github.com/gnuradio/gnuradio/pull/4917 included.