### PR TITLE
Remove sorting of tag vectors where already sorted

### DIFF
--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -75,9 +75,6 @@ int tagged_file_sink_impl::work(int noutput_items,
 
     std::vector<tag_t> all_tags;
     get_tags_in_range(all_tags, 0, start_N, end_N);
-
-    std::sort(all_tags.begin(), all_tags.end(), tag_t::offset_compare);
-
     std::vector<tag_t>::iterator vitr = all_tags.begin();
 
     // Look for a time tag and initialize d_timeval.

--- a/gr-digital/lib/burst_shaper_impl.cc
+++ b/gr-digital/lib/burst_shaper_impl.cc
@@ -114,7 +114,8 @@ int burst_shaper_impl<T>::general_work(int noutput_items,
 
     std::vector<tag_t> length_tags;
     this->get_tags_in_window(length_tags, 0, 0, ninput_items[0], d_length_tag_key);
-    std::sort(length_tags.rbegin(), length_tags.rend(), tag_t::offset_compare);
+    auto tags_start = length_tags.begin();
+    const auto tags_end = length_tags.end();
 
     while (nwritten < noutput_items) {
         // Only check the nread condition if we are actually reading
@@ -133,11 +134,11 @@ int burst_shaper_impl<T>::general_work(int noutput_items,
         nspace = noutput_items - nwritten;
         switch (d_state) {
         case (STATE_WAIT):
-            if (!length_tags.empty()) {
-                d_length_tag_offset = length_tags.back().offset;
+            if (tags_start != tags_end) {
+                d_length_tag_offset = tags_start->offset;
                 curr_tag_index = (int)(d_length_tag_offset - this->nitems_read(0));
-                d_ncopy = pmt::to_long(length_tags.back().value);
-                length_tags.pop_back();
+                d_ncopy = pmt::to_long(tags_start->value);
+                tags_start++;
                 nskip = curr_tag_index - nread;
                 add_length_tag(nwritten);
                 propagate_tags(curr_tag_index, nwritten, 1, false);

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -380,7 +380,6 @@ int header_payload_demux_impl::find_trigger_signal(int skip_items,
                           base_offset + max_rel_offset,
                           d_trigger_tag_key);
         if (!tags.empty()) {
-            std::sort(tags.begin(), tags.end(), tag_t::offset_compare);
             const int tag_rel_offset = tags[0].offset - base_offset;
             if (tag_rel_offset < rel_offset) {
                 rel_offset = tag_rel_offset;
@@ -521,7 +520,6 @@ void header_payload_demux_impl::update_special_tags(uint64_t range_start,
         std::vector<tag_t> tags;
         get_tags_in_range(tags, PORT_INPUTDATA, range_start, range_end, d_timing_key);
         if (!tags.empty()) {
-            std::sort(tags.begin(), tags.end(), tag_t::offset_compare);
             d_last_time = tags.back().value;
             d_last_time_offset = tags.back().offset;
         }
@@ -536,7 +534,8 @@ void header_payload_demux_impl::update_special_tags(uint64_t range_start,
                           range_start,
                           range_end,
                           d_special_tags[i]);
-        std::sort(tags.begin(), tags.end(), tag_t::offset_compare);
+        // TODO / FIXME this loop seems lacking reason (just use the last value)
+        // However, not fixing this on the fly without understanding it.
         for (size_t t = 0; t < tags.size(); t++) {
             d_special_tags_last_value[i] = tags[t].value;
         }

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -174,7 +174,6 @@ void symbol_sync_cc_impl::collect_tags(uint64_t nitems_rd, int count)
     // d_tags is used for manual tag propagation.
     d_new_tags.clear();
     get_tags_in_range(d_new_tags, 0, nitems_rd, nitems_rd + count);
-    std::sort(d_new_tags.begin(), d_new_tags.end(), tag_t::offset_compare);
     d_tags.insert(d_tags.end(), d_new_tags.begin(), d_new_tags.end());
     std::sort(d_tags.begin(), d_tags.end(), tag_t::offset_compare);
 }

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -177,7 +177,6 @@ void symbol_sync_ff_impl::collect_tags(uint64_t nitems_rd, int count)
     // d_tags is used for manual tag propagation.
     d_new_tags.clear();
     get_tags_in_range(d_new_tags, 0, nitems_rd, nitems_rd + count);
-    std::sort(d_new_tags.begin(), d_new_tags.end(), tag_t::offset_compare);
     d_tags.insert(d_tags.end(), d_new_tags.begin(), d_new_tags.end());
     std::sort(d_tags.begin(), d_tags.end(), tag_t::offset_compare);
 }

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -516,7 +516,7 @@ int usrp_sink_impl::work(int noutput_items,
 void usrp_sink_impl::tag_work(int& ninput_items)
 {
     // the for loop below assumes tags sorted by count low -> high
-    std::sort(_tags.begin(), _tags.end(), tag_t::offset_compare);
+    // This is OK since get_tags_in_range returns sorted tags
 
     // extract absolute sample counts
     const uint64_t samp0_count = this->nitems_read(0);


### PR DESCRIPTION
this is mostly a reminder from a time long gone, when tags didn't come out of `get_tags_in_range` sorted.