### PR TITLE
Github CI: enable -Werror on fedora, but don't error on deprecations

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -59,7 +59,7 @@ jobs:
             cxxflags: ''
           - distro: 'Fedora 34'
             containerid: 'gnuradio/ci:fedora-34-3.9'
-            cxxflags: ''
+            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
           - distro: 'CentOS 8.3'
             containerid: 'gnuradio/ci:centos-8.3-3.9'
             cxxflags: ''

--- a/.github/workflows/pkg-debian.yml
+++ b/.github/workflows/pkg-debian.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/.github/workflows/pkg-fedora.yml
+++ b/.github/workflows/pkg-fedora.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - distro: 'Fedora 34'
             containerid: 'ghcr.io/gnuradio/ci:fedora-34-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=deprecated-declarations
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}


### PR DESCRIPTION
This is to keep in lockstep with maint-3.9; this allows to run with
in-tree `[[deprecated]]`-marked functionality, and with current ZMQ,
which otherwise makes Fedora fail.