### PR TITLE
Disable metainfo_test until we've decided how to proceed

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -79,4 +79,4 @@ jobs:
     - name: Make
       run: 'cd /build && make -j2 -k'
     - name: Make Test
-      run: 'cd /build && ctest --output-on-failure -E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+      run: 'cd /build && ctest --output-on-failure -E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|metainfo_test"'


### PR DESCRIPTION
see issue https://github.com/gnuradio/gnuradio/issues/4918 ; it's not really our fault this test fails, but it's our problem.