### PR TITLE
grc: update disabled blocks if they depend on others (backport to maint-3.9)

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -216,7 +216,7 @@ class FlowGraph(Element):
         return elements
 
     def children(self):
-        return itertools.chain(self.iter_enabled_blocks(), self.connections)
+        return itertools.chain(self.blocks, self.connections)
 
     def rewrite(self):
         """
@@ -227,6 +227,7 @@ class FlowGraph(Element):
 
     def renew_namespace(self):
         namespace = {}
+        self.namespace.clear()
         # Load imports
         for expr in self.imports():
             try:


### PR DESCRIPTION
If we want disabled blocks to be updated properly,
we have to consider all blocks when updating the fg not only the enabled.

This does the patch of Flowgraph.py and fixes #4788.

But a problem remains.
If you use the example in #4788 and disable the symbol_rate block,
only the samp_rate block 'turns to red'.
The other blocks don't change.
Only if you open and close an arbitrary block, the other blocks are updated.

This is fixed by clearing the namespace in renew_namespace in FlowGraph.py.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>

grc: update disabled blocks

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit fbab6c383d6f86ab0de42a90a9182d22637a5b96)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4851