### PR TITLE
grc: allow short and byte as valid types in an enum (backport to maint-3.8)

### DIFF
--- a/gr-analog/grc/analog_const_source_x.block.yml
+++ b/gr-analog/grc/analog_const_source_x.block.yml
@@ -8,7 +8,7 @@ parameters:
     dtype: enum
     options: [complex, float, int, short, byte]
     option_attributes:
-        const_type: [complex, real, int, short, gr.sizeof_char]
+        const_type: [complex, real, int, short, byte]
         fcn: [c, f, i, s, b]
     hide: part
 -   id: const

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -58,7 +58,7 @@ HIER_BLOCK_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP
 
 PARAM_TYPE_NAMES = {
     'raw', 'enum',
-    'complex', 'real', 'float', 'int',
+    'complex', 'real', 'float', 'int', 'short', 'byte',
     'complex_vector', 'real_vector', 'float_vector', 'int_vector',
     'hex', 'string', 'bool',
     'file_open', 'file_save', '_multiline', '_multiline_python_external',

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -218,7 +218,7 @@ class Param(Element):
         #########################
         # Numeric Types
         #########################
-        elif dtype in ('raw', 'complex', 'real', 'float', 'int', 'hex', 'bool'):
+        elif dtype in ('raw', 'complex', 'real', 'float', 'int', 'short', 'byte', 'hex', 'bool'):
             if expr:
                 try:
                     if isinstance(expr, str) and self.is_float(expr[:-1]):


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 256953bebab151c50fd9a32156f75d2aabc14c17)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4876