### PR TITLE
digital: Changed soft decision LUT to scale off maximum point in constellation

### DIFF
--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -247,10 +247,11 @@ void constellation::gen_soft_dec_lut(int precision, float npwr)
     // Search for the largest coordinate
     max_min_axes();
     float step = (2.0f * d_re_max) / (d_lut_scale - 1);
+    float step_2 = step / 2;
     float y = -d_re_max;
-    while (y < d_re_max + step) {
+    while (y < d_re_max + step_2) {
         float x = -d_re_max;
-        while (x < d_re_max + step) {
+        while (x < d_re_max + step_2) {
             gr_complex pt = gr_complex(x, y);
             d_soft_dec_lut.push_back(calc_soft_dec(pt, npwr));
             x += step;

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -117,8 +117,8 @@ def slicer(x):
     for xi in x:
         if(xi < 0):
             ret.append(0.0)
-    else:
-        ret.append(1.0)
+        else:
+            ret.append(1.0)
     return ret
 
 

--- a/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
+++ b/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
@@ -29,10 +29,10 @@ class test_constellation_soft_decoder(gr_unittest.TestCase):
         lut = digital.soft_dec_table_generator(const_sd_gen, prec, Es)
         expected_result = list()
         for s in src_data:
-            res = digital.calc_soft_dec_from_table(s, lut, prec, sqrt(2.0))
+            res = digital.calc_soft_dec_from_table(s, lut, prec, Es)
             expected_result += res
 
-        cnst = digital.constellation_calcdist(cnst_pts, code, 2, 1)
+        cnst = digital.constellation_calcdist(cnst_pts, code, 2, 1, digital.constellation.NO_NORMALIZATION)
         cnst.set_soft_dec_lut(lut, int(prec))
         src = blocks.vector_source_c(src_data)
         op = digital.constellation_soft_decoder_cf(cnst.base())

--- a/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
+++ b/gr-digital/python/digital/qa_constellation_soft_decoder_cf.py
@@ -25,7 +25,7 @@ class test_constellation_soft_decoder(gr_unittest.TestCase):
 
     def helper_with_lut(self, prec, src_data, const_gen, const_sd_gen):
         cnst_pts, code = const_gen()
-        Es = max([abs(c) for c in cnst_pts])
+        Es = max([abs(c) if c.real != c else abs(c)*sqrt(2) for c in cnst_pts])
         lut = digital.soft_dec_table_generator(const_sd_gen, prec, Es)
         expected_result = list()
         for s in src_data:

--- a/gr-digital/python/digital/soft_dec_lut_gen.py
+++ b/gr-digital/python/digital/soft_dec_lut_gen.py
@@ -147,7 +147,7 @@ def calc_soft_dec_from_table(sample, table, prec, Es=1.0):
     maxd = Es*numpy.sqrt(2.0)/2.0
     scale = (lut_scale) / (2.0*maxd)
 
-    alpha = 0.99 # to keep index within bounds
+    alpha = 0.999 # to keep index within bounds
     xre = sample.real
     xim = sample.imag
     xre = ((maxd + min(alpha*maxd, max(-alpha*maxd, xre))) * scale)


### PR DESCRIPTION
The constellation can have points with coordinates larger than 1, even if normalized for 64-QAM and above.
Therefore, the LUT should be calculated for the largest coordinate.

Partially fixes #4892