### PR TITLE
cmake: Fix finding libunwind (backport to maint-3.9)

### DIFF
--- a/cmake/Modules/Findlibunwind.cmake
+++ b/cmake/Modules/Findlibunwind.cmake
@@ -25,7 +25,7 @@ find_library(libunwind_LIBRARY
 
 # Set the include dir variables and the libraries and let libfind_process do the rest.
 # NOTE: Singular variables for this library, plural for libraries this this lib depends on.
-set(libunwind_PROCESS_INCLUDES ${libunwind_INCLUDE_DIR})
+set(libunwind_PROCESS_INCLUDES libunwind_INCLUDE_DIR)
 set(libunwind_PROCESS_LIBS libunwind_LIBRARY)
 libfind_process(libunwind)
 


### PR DESCRIPTION
The libfind_process macro expects <lib>_PROCESS_INCLUDES to be set to
the names of variables containing the include paths, not the include
paths themselves.  This was causing find_package(libunwind) to always
fail, even when the necessary files were correctly found by find_path
and find_library.

Signed-off-by: Pavon <pavon@protonmail.com>
(cherry picked from commit cd4a47de989ca83e31a48661673b1e12ca417502)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4904