### PR TITLE
gfsk: Make packed_to_unpacked optional (backport to maint-3.9)

### DIFF
--- a/gr-digital/grc/digital_gfsk_mod.block.yml
+++ b/gr-digital/grc/digital_gfsk_mod.block.yml
@@ -29,6 +29,13 @@ parameters:
     options: ['True', 'False']
     option_labels: ['On', 'Off']
     hide: ${ ('part' if str(log) == 'False' else 'none') }
+-   id: do_unpack
+    label: Unpack
+    dtype: bool
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['On', 'Off']
+    hide: ${ ('part' if do_unpack else 'none') }
 
 inputs:
 -   domain: stream
@@ -46,6 +53,7 @@ templates:
             sensitivity=${sensitivity},
             bt=${bt},
             verbose=${verbose},
-            log=${log})
+            log=${log},
+            do_unpack=${do_unpack})
 
 file_format: 1


### PR DESCRIPTION
Provide the option to not use the packed_to_unpacked block in the gfsk
mod hier block so that the latter can be used to modulate
non-byte-aligned bit stream.

The option enables packed_to_unpacked by default for backward
compatibility.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit 9c388da6571ca7605b78f519c23778b0d604abfc)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4940