### PR TITLE
c++ generation: escape "." in translations

### DIFF
--- a/gr-analog/grc/analog_fastnoise_source_x.block.yml
+++ b/gr-analog/grc/analog_fastnoise_source_x.block.yml
@@ -48,7 +48,7 @@ cpp_templates:
     - set_amplitude(${amp})
     link: ['gnuradio::gnuradio-analog']
     translations:
-        analog.: 'analog::'
+        analog\.: 'analog::'
 
 documentation: |-
     The fast noise source works by pre-generating a pool of random variates taken from the specified distribution.  At runtime, samples are then uniform randomly chosen from this pool which is a very fast operation.

--- a/gr-blocks/grc/blocks_ctrlport_probe2_c.block.yml
+++ b/gr-blocks/grc/blocks_ctrlport_probe2_c.block.yml
@@ -40,7 +40,7 @@ cpp_templates:
     callbacks:
     - set_length(${len})
     translations:
-        gr.: ''
+        gr\.: ''
 
 
 documentation: |-

--- a/gr-blocks/grc/blocks_ctrlport_probe2_x.block.yml
+++ b/gr-blocks/grc/blocks_ctrlport_probe2_x.block.yml
@@ -47,7 +47,7 @@ cpp_templates:
     callbacks:
     - set_length(${len})
     translations:
-        gr.: ''
+        gr\.: ''
 
 
 documentation: |-

--- a/gr-blocks/grc/blocks_packed_to_unpacked_xx.block.yml
+++ b/gr-blocks/grc/blocks_packed_to_unpacked_xx.block.yml
@@ -48,6 +48,6 @@ cpp_templates:
     declarations: 'blocks::packed_to_unpacked_${type.fcn}::sptr ${id};'
     make: 'this->${id} = blocks::packed_to_unpacked_${type.fcn}::make(${bits_per_chunk}, ${endianness});'
     translations:
-        gr.: ''
+        gr\.: ''
 
 file_format: 1

--- a/gr-blocks/grc/blocks_repack_bits_bb.block.yml
+++ b/gr-blocks/grc/blocks_repack_bits_bb.block.yml
@@ -52,7 +52,7 @@ cpp_templates:
     callbacks:
     - set_k_and_l(${k},${l})
     translations:
-        gr.: ''
+        gr\.: ''
         'True': 'true'
         'False': 'false'
 file_format: 1

--- a/gr-digital/grc/digital_corr_est_cc.block.yml
+++ b/gr-digital/grc/digital_corr_est_cc.block.yml
@@ -57,6 +57,6 @@ cpp_templates:
     - set_mark_delay(${mark_delay})
     - set_threshold(${threshold})
     translations:
-        digital.: 'digital::'
+        digital\.: 'digital::'
 
 file_format: 1

--- a/gr-digital/grc/digital_cpmmod_bc.block.yml
+++ b/gr-digital/grc/digital_cpmmod_bc.block.yml
@@ -50,6 +50,6 @@ cpp_templates:
             ${beta});
     link: ['gnuradio::gnuradio-digital']
     translations:
-        analog.cpm.: 'analog::cpm::'
+        analog\.cpm\.: 'analog::cpm::'
 
 file_format: 1

--- a/gr-digital/grc/digital_diff_decoder_bb.block.yml
+++ b/gr-digital/grc/digital_diff_decoder_bb.block.yml
@@ -36,6 +36,6 @@ cpp_templates:
         this->${id} = digital::diff_decoder_bb::make(${modulus if coding.force_modulus == '-1' else coding.force_modulus}, ${coding});
     link: ['gnuradio::gnuradio-digital']
     translations:
-        digital.DIFF: 'digital::DIFF'
+        digital\.DIFF: 'digital::DIFF'
 
 file_format: 1

--- a/gr-digital/grc/digital_diff_encoder_bb.block.yml
+++ b/gr-digital/grc/digital_diff_encoder_bb.block.yml
@@ -36,6 +36,6 @@ cpp_templates:
         this->${id} = digital::diff_encoder_bb::make(${modulus if coding.force_modulus == '-1' else coding.force_modulus}, ${coding});
     link: ['gnuradio::gnuradio-digital']
     translations:
-        digital.DIFF: 'digital::DIFF'
+        digital\.DIFF: 'digital::DIFF'
 
 file_format: 1

--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -139,6 +139,6 @@ cpp_templates:
     - set_damping_factor(${damping})
     - set_ted_gain(${ted_gain})
     translations:
-        digital.: 'digital::'
+        digital\.: 'digital::'
 
 file_format: 1

--- a/gr-fft/grc/fft_fft_vxx.block.yml
+++ b/gr-fft/grc/fft_fft_vxx.block.yml
@@ -71,6 +71,6 @@ cpp_templates:
     translations:
         'True': 'true'
         'False': 'false'
-        'window.': 'fft::window::'
+        'window\.': 'fft::window::'
 
 file_format: 1

--- a/gr-pdu/grc/pdu_pdu_to_tagged_stream.block.yml
+++ b/gr-pdu/grc/pdu_pdu_to_tagged_stream.block.yml
@@ -32,6 +32,6 @@ cpp_templates:
     declarations: 'pdu::pdu_to_tagged_stream::sptr ${id};'
     make: 'this->${id} = pdu::pdu_to_tagged_stream::make(${type.tv}, ${tag});'
     translations:
-        pdu.: 'pdu::'
+        pdu\.: 'pdu::'
 
 file_format: 1


### PR DESCRIPTION
Translations are a regex, so "." needs to be escaped. Fix the
remaining unescaped strings.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Fixes https://github.com/gnuradio/gnuradio/issues/4754