### PR TITLE
digital: add int() cast where required (backport to maint-3.9)

### DIFF
--- a/gr-digital/python/digital/generic_mod_demod.py
+++ b/gr-digital/python/digital/generic_mod_demod.py
@@ -135,7 +135,7 @@ class generic_mod(gr.hier_block2):
         # Remove the filter transient at the beginning of the transmission
         if truncate:
             fsps = float(self._samples_per_symbol)
-            len_filt_delay = (ntaps_per_filt*fsps*fsps-fsps)/2.0 # Length of delay through rrc filter
+            len_filt_delay = int((ntaps_per_filt*fsps*fsps-fsps)/2.0) # Length of delay through rrc filter
             self.skiphead = blocks.skiphead(gr.sizeof_gr_complex*1, len_filt_delay)
 
         # Connect


### PR DESCRIPTION
Skiphead requires an integer number of samples, but was being called
with a float parameter.

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 11255ca436e6e3eff56fcc995e1b72cff289c90b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4953