### PR TITLE
digital: remove non-existing msg output from chunks_to_symbols block yaml (backport to maint-3.8)

### DIFF
--- a/gr-digital/grc/digital_chunks_to_symbols.block.yml
+++ b/gr-digital/grc/digital_chunks_to_symbols.block.yml
@@ -43,9 +43,6 @@ outputs:
 -   domain: stream
     dtype: ${ out_type }
     multiplicity: ${ num_ports }
--   domain: message
-    id: set_symbol_table
-    optional: true
 
 asserts:
 - ${ num_ports > 0 }


### PR DESCRIPTION
digital: remove non-existing msg output from chunks_to_symbols block yaml

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 3a1e6e689bccb6016e5129cd1a3c8f6da6b11424)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4903