### PR TITLE
gr-qtgui: Add double quotes to cpp_opts keys with colons. (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -15,7 +15,7 @@ parameters:
     option_labels: [Float, Integer, String, Boolean, Any]
     option_attributes:
         conv: [float, int, str, bool, eval]
-        cpp_opts: [double,int,std::string,double,double]
+        cpp_opts: [double,int,"std::string",double,double]
     hide: part
 -   id: value
     label: Default Value

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -39,8 +39,8 @@ parameters:
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     option_attributes:
-        cpp_opts: [fft::window::WIN_BLACKMAN_hARRIS, fft::window::WIN_HAMMING, fft::window::WIN_HANN, fft::window::WIN_BLACKMAN,
-        fft::window::WIN_RECTANGULAR, fft::window::WIN_KAISER, fft::window::WIN_FLATTOP]
+        cpp_opts: ["fft::window::WIN_BLACKMAN_hARRIS", "fft::window::WIN_HAMMING", "fft::window::WIN_HANN", "fft::window::WIN_BLACKMAN",
+        "fft::window::WIN_RECTANGULAR", "fft::window::WIN_KAISER", "fft::window::WIN_FLATTOP"]
     hide: part
 -   id: norm_window
     label: Normalize Window Power
@@ -125,7 +125,7 @@ parameters:
     options: [qtgui.TRIG_MODE_FREE, qtgui.TRIG_MODE_AUTO, qtgui.TRIG_MODE_NORM, qtgui.TRIG_MODE_TAG]
     option_labels: [Free, Auto, Normal, Tag]
     option_attributes:
-        cpp_opts: [qtgui::TRIG_MODE_FREE, qtgui::TRIG_MODE_AUTO, qtgui::TRIG_MODE_NORM, qtgui::TRIG_MODE_TAG]
+        cpp_opts: ["qtgui::TRIG_MODE_FREE", "qtgui::TRIG_MODE_AUTO", "qtgui::TRIG_MODE_NORM", "qtgui::TRIG_MODE_TAG"]
     hide: part
 -   id: tr_level
     label: Trigger Level

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -34,7 +34,7 @@ parameters:
     options: [qtgui.NUM_GRAPH_HORIZ, qtgui.NUM_GRAPH_VERT, qtgui.NUM_GRAPH_NONE]
     option_labels: [Horizontal, Vertical, None]
     option_attributes:
-        cpp_opts: [qtgui::NUM_GRAPH_HORIZ, qtgui::NUM_GRAPH_VERT, qtgui::NUM_GRAPH_NONE]
+        cpp_opts: ["qtgui::NUM_GRAPH_HORIZ", "qtgui::NUM_GRAPH_VERT", "qtgui::NUM_GRAPH_NONE"]
 -   id: nconnections
     label: Number of Inputs
     category: General

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -27,8 +27,8 @@ parameters:
         window.WIN_RECTANGULAR, window.WIN_KAISER]
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser]
     option_attributes:
-        cpp_opts: [fft::window::WIN_BLACKMAN_hARRIS, fft::window::WIN_HAMMING, fft::window::WIN_HANN, fft::window::WIN_BLACKMAN,
-        fft::window::WIN_RECTANGULAR, fft::window::WIN_KAISER]
+        cpp_opts: ["fft::window::WIN_BLACKMAN_hARRIS", "fft::window::WIN_HAMMING", "fft::window::WIN_HANN", "fft::window::WIN_BLACKMAN",
+        "fft::window::WIN_RECTANGULAR", "fft::window::WIN_KAISER"]
     hide: part
 -   id: fc
     label: Center Frequency (Hz)

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -39,8 +39,8 @@ parameters:
     option_labels: [Blackman-harris, Hamming, Hann, Blackman, Rectangular, Kaiser,
         Flat-top]
     option_attributes:
-        cpp_opts: [fft::window::WIN_BLACKMAN_hARRIS, fft::window::WIN_HAMMING, fft::window::WIN_HANN, fft::window::WIN_BLACKMAN,
-        fft::window::WIN_RECTANGULAR, fft::window::WIN_KAISER, fft::window::WIN_FLATTOP]
+        cpp_opts: ["fft::window::WIN_BLACKMAN_hARRIS", "fft::window::WIN_HAMMING", "fft::window::WIN_HANN", "fft::window::WIN_BLACKMAN",
+        "fft::window::WIN_RECTANGULAR", "fft::window::WIN_KAISER", "fft::window::WIN_FLATTOP"]
     hide: part
 -   id: fc
     label: Center Frequency (Hz)


### PR DESCRIPTION
This is required for compatibility with Ubuntu 18.04 LTS.

Signed-off-by: Ron Economos <w6rz@comcast.net>
(cherry picked from commit 0855db230e389c97ce9703b90cf97c2c2e45da9f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4938