### PR TITLE
pybind11: remove debug message

### DIFF
--- a/docs/doxygen/update_pydoc.py
+++ b/docs/doxygen/update_pydoc.py
@@ -295,8 +295,6 @@ def sub_docstring_in_pydoc_h(pydoc_files, docstrings_dict, output_dir, filter_st
                     file_in = file_in_tmp
 
             output_pathname = os.path.join(output_dir, os.path.basename(pydoc_file).replace('_template.h','.h'))
-            # FIXME: Remove this debug print
-            print('output docstrings to {}'.format(output_pathname))
             with open(output_pathname,'w') as file_out:
                 file_out.write(file_in)
 
@@ -305,8 +303,6 @@ def copy_docstring_templates(pydoc_files, output_dir):
         for pydoc_file in pydoc_files:
             file_in = open(pydoc_file,'r').read()
             output_pathname = os.path.join(output_dir, os.path.basename(pydoc_file).replace('_template.h','.h'))
-            # FIXME: Remove this debug print
-            print('copy docstrings to {}'.format(output_pathname))
             with open(output_pathname,'w') as file_out:
                 file_out.write(file_in)
         status_file.write("DONE")

--- a/gr-utils/modtool/templates/gr-newmod/docs/doxygen/update_pydoc.py
+++ b/gr-utils/modtool/templates/gr-newmod/docs/doxygen/update_pydoc.py
@@ -295,8 +295,6 @@ def sub_docstring_in_pydoc_h(pydoc_files, docstrings_dict, output_dir, filter_st
                     file_in = file_in_tmp
 
             output_pathname = os.path.join(output_dir, os.path.basename(pydoc_file).replace('_template.h','.h'))
-            # FIXME: Remove this debug print
-            print('output docstrings to {}'.format(output_pathname))
             with open(output_pathname,'w') as file_out:
                 file_out.write(file_in)
 
@@ -305,8 +303,6 @@ def copy_docstring_templates(pydoc_files, output_dir):
         for pydoc_file in pydoc_files:
             file_in = open(pydoc_file,'r').read()
             output_pathname = os.path.join(output_dir, os.path.basename(pydoc_file).replace('_template.h','.h'))
-            # FIXME: Remove this debug print
-            print('copy docstrings to {}'.format(output_pathname))
             with open(output_pathname,'w') as file_out:
                 file_out.write(file_in)
         status_file.write("DONE")


### PR DESCRIPTION
Remove the annoying 'output docstrings to {path}' message.
Hopefully, this is no longer needed, otherwise, I'll try to make a 'verbose' compile-time option.