### PR TITLE
gr-filter: cpp code genration fails for root raised cosine filter

### DIFF
--- a/gr-filter/grc/filter_root_raised_cosine_filter.block.yml
+++ b/gr-filter/grc/filter_root_raised_cosine_filter.block.yml
@@ -75,7 +75,7 @@ cpp_templates:
     make: |-
         this->${id} = filter::${type}::make(
             ${ interp if str(type).startswith('interp') else decim },
-            firdes.${type.fcn}(
+            firdes::root_raised_cosine(
                 ${gain},
                 ${samp_rate},
                 ${sym_rate},


### PR DESCRIPTION
The rrc block has no parameter type.fcn, which is wrongly  used in cpp code generation
but not in python code generation.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>