### PR TITLE
grc cpp generation: Establish the possibility to add find packages

### DIFF
--- a/grc/core/blocks/_build.py
+++ b/grc/core/blocks/_build.py
@@ -57,6 +57,7 @@ def build(id, label='', category='', flags='', documentation='',
         callbacks=cpp_templates.get('callbacks', []),
         var_make=cpp_templates.get('var_make', ''),
         link=cpp_templates.get('link', []),
+        packages=cpp_templates.get('packages', []),
         translations=cpp_templates.get('translations', []),
         declarations=cpp_templates.get('declarations', ''),
     )

--- a/grc/core/generator/FlowGraphProxy.py
+++ b/grc/core/generator/FlowGraphProxy.py
@@ -148,6 +148,15 @@ class FlowGraphProxy(object):  # TODO: move this in a refactored Generator
         """
         return [block.cpp_templates.render('link') for block in self.iter_enabled_blocks() if not (block.is_virtual_sink() or block.is_virtual_source())]
 
+    def packages(self):
+        """
+        Get a set of all packages  to find (C++) ( especially for oot modules ) in this flow graph namespace.
+
+        Returns:
+            a list of required packages
+        """
+        return [block.cpp_templates.render('packages') for block in self.iter_enabled_blocks() if not (block.is_virtual_sink() or block.is_virtual_source())]
+
 def get_hier_block_io(flow_graph, direction, domain=None):
     """
     Get a list of io ports for this flow graph.

--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -22,7 +22,6 @@ set(CMAKE_CXX_STANDARD 14)
 
 project(${class_name})
 
-
 find_package(Gnuradio "${short_version}" COMPONENTS
     % for component in config.enabled_components.split(";"):
     % if component.startswith("gr-"):
@@ -50,6 +49,11 @@ set(CMAKE_EXE_LINKER_FLAGS " -static")
 set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 % endif
 
+% for package in packages:
+% if package:
+find_package(${package})
+% endif
+% endfor
 add_executable(${class_name} ${class_name}.cpp)
 target_link_libraries(${class_name}
     gnuradio::gnuradio-blocks

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -175,6 +175,7 @@ class CppTopBlockGenerator(TopBlockGenerator):
             connections=self._connections(),
             links=self._links(),
             cmake_tuples=cmake_tuples,
+            packages=self._packages(),
             **self.namespace
         )
         # strip trailing white-space
@@ -187,12 +188,23 @@ class CppTopBlockGenerator(TopBlockGenerator):
         fg = self._flow_graph
         links = fg.links()
         seen = set()
-        output = []
 
         for link_list in links:
             if link_list:
                 for link in link_list:
                     seen.add(link)
+
+        return list(seen)
+
+    def _packages(self):
+        fg = self._flow_graph
+        packages = fg.packages()
+        seen = set()
+
+        for package_list in packages:
+            if package_list:
+                for package in package_list:
+                    seen.add(package)
 
         return list(seen)
 

--- a/grc/core/schema_checker/block.py
+++ b/grc/core/schema_checker/block.py
@@ -42,6 +42,7 @@ CPP_TEMPLATES_SCHEME = expand(
     var_make=str,
     callbacks=list,
     link=list,
+    packages=list,
     translations=dict,
 )
 BLOCK_SCHEME = expand(


### PR DESCRIPTION
Flowgraphs may use oot modules. When generating cpp code an oot module
may require a package that is not provided by gnuradio.
So I propose to add an additional entry parameters in the cpp template
to provide a list of package names and add the corresponding find package calls to CMakeLists.txt

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>