### PR TITLE
runtime: logging performance improvement

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -156,136 +156,158 @@ typedef log4cpp::Category* logger_ptr;
 #define GR_RESET_CONFIGURATION() gr::logger_config::reset_config();
 
 /* Logger name referenced macros */
-#define GR_DEBUG(name, msg)                                           \
-    {                                                                 \
-        gr::logger_ptr logger = gr::logger_get_logger(name);          \
-        *logger << log4cpp::Priority::DEBUG << (msg) << log4cpp::eol; \
-    }
-
-#define GR_INFO(name, msg)                                           \
-    {                                                                \
-        gr::logger_ptr logger = gr::logger_get_logger(name);         \
-        *logger << log4cpp::Priority::INFO << (msg) << log4cpp::eol; \
-    }
-
-#define GR_NOTICE(name, msg)                                 \
-    {                                                        \
-        gr::logger_ptr logger = gr::logger_get_logger(name); \
-        *logger << log4cpp::Priority::NOTICE << (msg);       \
-    }
-
-#define GR_WARN(name, msg)                                           \
-    {                                                                \
-        gr::logger_ptr logger = gr::logger_get_logger(name);         \
-        *logger << log4cpp::Priority::WARN << (msg) << log4cpp::eol; \
-    }
-
-#define GR_ERROR(name, msg)                                           \
-    {                                                                 \
-        gr::logger_ptr logger = gr::logger_get_logger(name);          \
-        *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
-    }
-
-#define GR_CRIT(name, msg)                                           \
-    {                                                                \
-        gr::logger_ptr logger = gr::logger_get_logger(name);         \
-        *logger << log4cpp::Priority::CRIT << (msg) << log4cpp::eol; \
-    }
-
-#define GR_ALERT(name, msg)                                           \
-    {                                                                 \
-        gr::logger_ptr logger = gr::logger_get_logger(name);          \
-        *logger << log4cpp::Priority::ALERT << (msg) << log4cpp::eol; \
-    }
-
-#define GR_FATAL(name, msg)                                           \
-    {                                                                 \
-        gr::logger_ptr logger = gr::logger_get_logger(name);          \
-        *logger << log4cpp::Priority::FATAL << (msg) << log4cpp::eol; \
-    }
-
-#define GR_EMERG(name, msg)                                           \
-    {                                                                 \
-        gr::logger_ptr logger = gr::logger_get_logger(name);          \
-        *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
-    }
-
-#define GR_ERRORIF(name, cond, msg)                                       \
+#define GR_DEBUG(name, msg)                                               \
     {                                                                     \
-        if ((cond)) {                                                     \
-            gr::logger_ptr logger = gr::logger_get_logger(name);          \
+        gr::logger_ptr logger = gr::logger_get_logger(name);              \
+        if (logger->isPriorityEnabled(log4cpp::Priority::DEBUG))          \
+            *logger << log4cpp::Priority::DEBUG << (msg) << log4cpp::eol; \
+    }
+
+#define GR_INFO(name, msg)                                               \
+    {                                                                    \
+        gr::logger_ptr logger = gr::logger_get_logger(name);             \
+        if (logger->isPriorityEnabled(log4cpp::Priority::INFO))          \
+            *logger << log4cpp::Priority::INFO << (msg) << log4cpp::eol; \
+    }
+
+#define GR_NOTICE(name, msg)                                               \
+    {                                                                      \
+        gr::logger_ptr logger = gr::logger_get_logger(name);               \
+        if (logger->isPriorityEnabled(log4cpp::Priority::NOTICE))          \
+            *logger << log4cpp::Priority::NOTICE << (msg) << log4cpp::eol; \
+    }
+
+#define GR_WARN(name, msg)                                               \
+    {                                                                    \
+        gr::logger_ptr logger = gr::logger_get_logger(name);             \
+        if (logger->isPriorityEnabled(log4cpp::Priority::WARN))          \
+            *logger << log4cpp::Priority::WARN << (msg) << log4cpp::eol; \
+    }
+
+#define GR_ERROR(name, msg)                                               \
+    {                                                                     \
+        gr::logger_ptr logger = gr::logger_get_logger(name);              \
+        if (logger->isPriorityEnabled(log4cpp::Priority::ERROR))          \
             *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
-        }                                                                 \
     }
 
-#define GR_ASSERT(name, cond, msg)                                        \
+#define GR_CRIT(name, msg)                                               \
+    {                                                                    \
+        gr::logger_ptr logger = gr::logger_get_logger(name);             \
+        if (logger->isPriorityEnabled(log4cpp::Priority::CRIT))          \
+            *logger << log4cpp::Priority::CRIT << (msg) << log4cpp::eol; \
+    }
+
+#define GR_ALERT(name, msg)                                               \
     {                                                                     \
-        if (!(cond)) {                                                    \
-            gr::logger_ptr logger = gr::logger_get_logger(name);          \
+        gr::logger_ptr logger = gr::logger_get_logger(name);              \
+        if (logger->isPriorityEnabled(log4cpp::Priority::ALERT))          \
+            *logger << log4cpp::Priority::ALERT << (msg) << log4cpp::eol; \
+    }
+
+#define GR_FATAL(name, msg)                                               \
+    {                                                                     \
+        gr::logger_ptr logger = gr::logger_get_logger(name);              \
+        if (logger->isPriorityEnabled(log4cpp::Priority::FATAL))          \
+            *logger << log4cpp::Priority::FATAL << (msg) << log4cpp::eol; \
+    }
+
+#define GR_EMERG(name, msg)                                               \
+    {                                                                     \
+        gr::logger_ptr logger = gr::logger_get_logger(name);              \
+        if (logger->isPriorityEnabled(log4cpp::Priority::EMERG))          \
             *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
-        }                                                                 \
-        assert(0);                                                        \
+    }
+
+#define GR_ERRORIF(name, cond, msg)                                           \
+    {                                                                         \
+        if ((cond)) {                                                         \
+            gr::logger_ptr logger = gr::logger_get_logger(name);              \
+            if (logger->isPriorityEnabled(log4cpp::Priority::ERROR))          \
+                *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
+        }                                                                     \
+    }
+
+#define GR_ASSERT(name, cond, msg)                                            \
+    {                                                                         \
+        if (!(cond)) {                                                        \
+            gr::logger_ptr logger = gr::logger_get_logger(name);              \
+            if (logger->isPriorityEnabled(log4cpp::Priority::EMERG))          \
+                *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
+        }                                                                     \
+        assert(0);                                                            \
     }
 
 /* LoggerPtr Referenced Macros */
-#define GR_LOG_DEBUG(logger, msg)                                     \
-    {                                                                 \
-        *logger << log4cpp::Priority::DEBUG << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_INFO(logger, msg)                                     \
-    {                                                                \
-        *logger << log4cpp::Priority::INFO << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_NOTICE(logger, msg)                                     \
-    {                                                                  \
-        *logger << log4cpp::Priority::NOTICE << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_WARN(logger, msg)                                     \
-    {                                                                \
-        *logger << log4cpp::Priority::WARN << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_ERROR(logger, msg)                                     \
-    {                                                                 \
-        *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_CRIT(logger, msg)                                     \
-    {                                                                \
-        *logger << log4cpp::Priority::CRIT << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_ALERT(logger, msg)                                     \
-    {                                                                 \
-        *logger << log4cpp::Priority::ALERT << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_FATAL(logger, msg)                                     \
-    {                                                                 \
-        *logger << log4cpp::Priority::FATAL << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_EMERG(logger, msg)                                     \
-    {                                                                 \
-        *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
-    }
-
-#define GR_LOG_ERRORIF(logger, cond, msg)                                 \
+#define GR_LOG_DEBUG(logger, msg)                                         \
     {                                                                     \
-        if ((cond)) {                                                     \
+        if (logger->isPriorityEnabled(log4cpp::Priority::DEBUG))          \
+            *logger << log4cpp::Priority::DEBUG << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_INFO(logger, msg)                                         \
+    {                                                                    \
+        if (logger->isPriorityEnabled(log4cpp::Priority::INFO))          \
+            *logger << log4cpp::Priority::INFO << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_NOTICE(logger, msg)                                         \
+    {                                                                      \
+        if (logger->isPriorityEnabled(log4cpp::Priority::NOTICE))          \
+            *logger << log4cpp::Priority::NOTICE << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_WARN(logger, msg)                                         \
+    {                                                                    \
+        if (logger->isPriorityEnabled(log4cpp::Priority::WARN))          \
+            *logger << log4cpp::Priority::WARN << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_ERROR(logger, msg)                                         \
+    {                                                                     \
+        if (logger->isPriorityEnabled(log4cpp::Priority::ERROR))          \
             *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
-        }                                                                 \
     }
 
-#define GR_LOG_ASSERT(logger, cond, msg)                                  \
+#define GR_LOG_CRIT(logger, msg)                                         \
+    {                                                                    \
+        if (logger->isPriorityEnabled(log4cpp::Priority::CRIT))          \
+            *logger << log4cpp::Priority::CRIT << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_ALERT(logger, msg)                                         \
     {                                                                     \
-        if (!(cond)) {                                                    \
+        if (logger->isPriorityEnabled(log4cpp::Priority::ALERT))          \
+            *logger << log4cpp::Priority::ALERT << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_FATAL(logger, msg)                                         \
+    {                                                                     \
+        if (logger->isPriorityEnabled(log4cpp::Priority::FATAL))          \
+            *logger << log4cpp::Priority::FATAL << (msg) << log4cpp::eol; \
+    }
+
+#define GR_LOG_EMERG(logger, msg)                                         \
+    {                                                                     \
+        if (logger->isPriorityEnabled(log4cpp::Priority::EMERG))          \
             *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
-            assert(0);                                                    \
-        }                                                                 \
+    }
+
+#define GR_LOG_ERRORIF(logger, cond, msg)                                     \
+    {                                                                         \
+        if ((cond)) {                                                         \
+            if (logger->isPriorityEnabled(log4cpp::Priority::ERROR))          \
+                *logger << log4cpp::Priority::ERROR << (msg) << log4cpp::eol; \
+        }                                                                     \
+    }
+
+#define GR_LOG_ASSERT(logger, cond, msg)                                      \
+    {                                                                         \
+        if (!(cond)) {                                                        \
+            if (logger->isPriorityEnabled(log4cpp::Priority::EMERG))          \
+                *logger << log4cpp::Priority::EMERG << (msg) << log4cpp::eol; \
+            assert(0);                                                        \
+        }                                                                     \
     }
 
 namespace gr {

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(92bf454f642caf2a1de6cdf3cbda722e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a972c786af4fc221d3c31300005c1ca8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Based on email discussion with Boris Marjanovic.

Logging is being overhauled on master branch, so this is being introduced directly to maint-3.9.

The logging macros always pass the "msg" param to the logger (currently
log4cpp). In the macros, "msg" can be an expression and it will be
evaluated, even if the log message would not be printed (based on log
level).

This commit adds checks to each macro to check whether the message will be
logged. Since this check is also done internally to log4cpp, some
duplication results, but it should be far less effort than evaluating
an arbitrary "msg".

Signed-off-by: Jeff Long <willcode4@gmail.com>