### PR TITLE
gr-uhd: fix input filename in freq hopping examples (backport to maint-3.9)

### DIFF
--- a/gr-uhd/examples/python/freq_hopping.py
+++ b/gr-uhd/examples/python/freq_hopping.py
@@ -157,7 +157,7 @@ class FlowGraph(gr.top_block):
     def __init__(self, args):
         gr.top_block.__init__(self)
         if args.input_file is not None:
-            src = blocks.file_source(gr.sizeof_gr_complex, args.filename, repeat=True)
+            src = blocks.file_source(gr.sizeof_gr_complex, args.input_file, repeat=True)
         else:
             src = blocks.vector_source_c((.5,) * int(1e6) * 2, repeat=True)
         # Setup USRP


### PR DESCRIPTION
Signed-off-by: Adrien Michel <adriengit@users.noreply.github.com>
(cherry picked from commit b538984ef32c20825a88a10e388039984abeaaa2)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4980