### PR TITLE
grc: fix the evaluation of interdependent variables (backport to maint-3.8)

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -239,7 +239,6 @@ class FlowGraph(Element):
 
     def renew_namespace(self):
         namespace = {}
-        self.namespace.clear()
         # Load imports
         for expr in self.imports():
             try:

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -130,6 +130,7 @@ class Application(Gtk.Application):
 
         def flow_graph_update(fg=flow_graph):
             main.vars.update_gui(fg.blocks)
+            fg.namespace.clear()
             fg.update()
 
         ##################################################


### PR DESCRIPTION
The gr-digital/examples/tx_ofdm.grc fails to evaluate the
header_formater variable.

This pr fixes #4937

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 1f1733eb4489b48fb73509e7806df19e1c738092)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4949