### PR TITLE
grc: Remove extra logger in grc/core/platform (backport to maint-3.9)

### DIFF
--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -26,7 +26,6 @@ from .FlowGraph import FlowGraph
 from .Connection import Connection
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
 class Platform(Element):

--- a/grc/main.py
+++ b/grc/main.py
@@ -40,7 +40,15 @@ def main():
     # Enable logging
     # Note: All other modules need to use the 'grc.<module>' convention
     log = logging.getLogger('grc')
-    log.setLevel(logging.INFO)
+    # NOTE: This sets the log level to what was requested for the logger on the
+    # command line, but this may not be the correct approach if multiple handlers
+    # are intended to be used. The logger level shown here indicates all the log
+    # messages that are captured and the handler levels indicate messages each
+    # handler will output. A better approach may be resetting this to logging.DEBUG
+    # to catch everything and making sure the handlers have the correct levels set.
+    # This would be useful for a future GUI logging window that can filter messages
+    # independently of the console output. In this case, this should be DEBUG.
+    log.setLevel(LOG_LEVELS[args.log])
 
     # Console formatting
     console = logging.StreamHandler()


### PR DESCRIPTION
This is an update for PR #2424. The extra debug output from GRC was
being generated by another logger instance in grc/core/platform that
did not respect the command line arguments.

This removes the extra logger and sets the logger level in main to
whatever is requested from the command line. See grc/main.py:43 for more
detail.

(cherry picked from commit 43eac48b42c781c66b56279ff76e1b3d401f2753)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/3767