### PR TITLE
grc/cmake: Improve pyyaml check (forward port from 3.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ SET(VERSION_PATCH git)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:
-
 set(GR_BOOST_MIN_VERSION "1.65")      ## Version in Ubuntu 18.04LTS
 set(GR_CMAKE_MIN_VERSION "3.10.2")    ## Version in Ubuntu 18.04LTS
 set(GR_MAKO_MIN_VERSION "1.0.7")      ## debian buster, 18.04LTS

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -13,7 +13,7 @@ include(GrPython)
 message(STATUS "")
 
 GR_PYTHON_CHECK_MODULE_RAW(
-    "PyYAML >= 3.10"
+    "PyYAML >= 3.11"
     "import yaml; assert yaml.__version__ >= '3.11'"
     PYYAML_FOUND
 )


### PR DESCRIPTION
The check checked for one version and reported another.

Signed-off-by: Martin Braun <martin@gnuradio.org>