### PR TITLE
qtgui: Replace pyqwidget() with qwidget()

### DIFF
--- a/docs/usage-manual/(exported from wiki) QT GUI.txt
+++ b/docs/usage-manual/(exported from wiki) QT GUI.txt
@@ -154,7 +154,7 @@ import sys, sip
                              samp_rate,      #bw
                              "QT GUI Plot")  #name
  
-     self.snk_win = sip.wrapinstance(self.snk.pyqwidget(), Qt.QWidget)
+     self.snk_win = sip.wrapinstance(self.snk.qwidget(), Qt.QWidget)
      self.snk_win.show()
  
  def main():

--- a/gnuradio-runtime/python/gnuradio/ctrlport/GrDataPlotter.py
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/GrDataPlotter.py
@@ -75,7 +75,7 @@ class GrDataPlotParent(gr.top_block, Qt.QWidget):
             else:
                 self.connect(self.src[n], (self.snk,n))
 
-        self.py_window = sip.wrapinstance(self.snk.pyqwidget(), Qt.QWidget)
+        self.py_window = sip.wrapinstance(self.snk.qwidget(), Qt.QWidget)
 
         self.layout.addWidget(self.py_window)
 

--- a/gr-filter/examples/gr_filtdes_live_upd.py
+++ b/gr-filter/examples/gr_filtdes_live_upd.py
@@ -70,7 +70,7 @@ class my_top_block(gr.top_block):
         self.connect(src,  channel, thr, self.filt, (self.snk1, 0))
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtGui.QWidget

--- a/gr-qtgui/apps/uhd_display.py
+++ b/gr-qtgui/apps/uhd_display.py
@@ -207,7 +207,7 @@ class my_top_block(gr.top_block):
         # Get the reference pointer to the SpectrumDisplayForm QWidget
         # Wrap the pointer as a PyQt SIP object
         #     This can now be manipulated as a PyQt5.QtGui.QWidget
-        self.pysink = sip.wrapinstance(self.snk.pyqwidget(), QtGui.QWidget)
+        self.pysink = sip.wrapinstance(self.snk.qwidget(), QtGui.QWidget)
 
         self.main_win = main_window(self.pysink, self)
 

--- a/gr-qtgui/docs/qtgui.dox
+++ b/gr-qtgui/docs/qtgui.dox
@@ -161,7 +161,7 @@ class grclass(gr.top_block):
     	       		    samp_rate,      #bw
 			    "QT GUI Plot")  #name
 
-    self.snk_win = sip.wrapinstance(self.snk.pyqwidget(), Qt.QWidget)
+    self.snk_win = sip.wrapinstance(self.snk.qwidget(), Qt.QWidget)
     self.snk_win.show()
 
 def main():

--- a/gr-qtgui/examples/pyqt_const_c.py
+++ b/gr-qtgui/examples/pyqt_const_c.py
@@ -151,7 +151,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_example_c.py
+++ b/gr-qtgui/examples/pyqt_example_c.py
@@ -159,7 +159,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_example_f.py
+++ b/gr-qtgui/examples/pyqt_example_f.py
@@ -152,7 +152,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_freq_c.py
+++ b/gr-qtgui/examples/pyqt_freq_c.py
@@ -160,7 +160,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_freq_f.py
+++ b/gr-qtgui/examples/pyqt_freq_f.py
@@ -150,7 +150,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_histogram_f.py
+++ b/gr-qtgui/examples/pyqt_histogram_f.py
@@ -164,7 +164,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_time_c.py
+++ b/gr-qtgui/examples/pyqt_time_c.py
@@ -158,7 +158,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_time_f.py
+++ b/gr-qtgui/examples/pyqt_time_f.py
@@ -151,7 +151,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_time_raster_b.py
+++ b/gr-qtgui/examples/pyqt_time_raster_b.py
@@ -58,7 +58,7 @@ class my_top_block(gr.top_block):
         self.connect(src1, (self.snk1, 1))
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt = self.snk1.pyqwidget()
+        pyQt = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_time_raster_f.py
+++ b/gr-qtgui/examples/pyqt_time_raster_f.py
@@ -57,7 +57,7 @@ class my_top_block(gr.top_block):
         self.connect(src1, (self.snk1, 1))
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt = self.snk1.pyqwidget()
+        pyQt = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_waterfall_c.py
+++ b/gr-qtgui/examples/pyqt_waterfall_c.py
@@ -164,7 +164,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/examples/pyqt_waterfall_f.py
+++ b/gr-qtgui/examples/pyqt_waterfall_f.py
@@ -150,7 +150,7 @@ class my_top_block(gr.top_block):
         self.ctrl_win.attach_signal2(src2)
 
         # Get the reference pointer to the SpectrumDisplayForm QWidget
-        pyQt  = self.snk1.pyqwidget()
+        pyQt  = self.snk1.qwidget()
 
         # Wrap the pointer as a PyQt SIP object
         # This can now be manipulated as a PyQt5.QtWidgets.QWidget

--- a/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
+++ b/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
@@ -367,7 +367,7 @@ templates:
             self.${id}.set_line_marker(i, markers[i])
             self.${id}.set_line_alpha(i, alphas[i])
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -448,7 +448,7 @@ templates:
             self.${id}.set_line_marker(i, markers[i])
             self.${id}.set_line_alpha(i, alphas[i])
 
-        self._${id}_win = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        self._${id}_win = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
+++ b/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
@@ -61,7 +61,7 @@ templates:
             win = 'self._%s_win'%id
         %>\
         qtgui.edit_box_msg(${type.t}, ${value}, ${label}, ${is_pair}, ${is_static}, ${key}, None)
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -1008,7 +1008,7 @@ templates:
             self.${id}.set_line_alpha(i, alphas[i])
         % endif
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -457,7 +457,7 @@ templates:
             self.${id}.set_line_color(i, colors[i])
             self.${id}.set_line_alpha(i, alphas[i])
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${ gui_hint() % win}
 
 cpp_templates:

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -414,7 +414,7 @@ templates:
             self.${id}.set_line_marker(i, markers[i])
             self.${id}.set_line_alpha(i, alphas[i])
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -279,7 +279,7 @@ templates:
             self.${id}.set_factor(i, factor[i])
 
         self.${id}.enable_autoscale(${autoscale})
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 cpp_templates:

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -127,7 +127,7 @@ templates:
             None # parent
         )
         self.${id}.set_update_time(1.0/${rate})
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
 
         self.${id}.enable_rf_freq(${showrf})
 

--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -293,7 +293,7 @@ templates:
             self.${id}.set_color_map(i, colors[i])
             self.${id}.set_line_alpha(i, alphas[i])
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -1077,7 +1077,7 @@ templates:
             self.${id}.set_line_alpha(i, alphas[i])
         % endif
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -336,7 +336,7 @@ templates:
             self.${id}.set_line_alpha(i, alphas[i])
         % endif
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -341,7 +341,7 @@ templates:
             self.${id}.set_line_color(i, colors[i])
             self.${id}.set_line_alpha(i, alphas[i])
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -301,7 +301,7 @@ templates:
 
         self.${id}.set_intensity_range(${int_min}, ${int_max})
 
-        ${win} = sip.wrapinstance(self.${id}.pyqwidget(), Qt.QWidget)
+        ${win} = sip.wrapinstance(self.${id}.qwidget(), Qt.QWidget)
 
         ${gui_hint() % win}
 

--- a/gr-qtgui/include/gnuradio/qtgui/ber_sink_b.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ber_sink_b.h
@@ -38,12 +38,6 @@ public:
 
     virtual void exec_() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_x_axis(double min, double max) = 0;
 

--- a/gr-qtgui/include/gnuradio/qtgui/const_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/const_sink_c.h
@@ -64,12 +64,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_x_axis(double min, double max) = 0;
 

--- a/gr-qtgui/include/gnuradio/qtgui/edit_box_msg.h
+++ b/gr-qtgui/include/gnuradio/qtgui/edit_box_msg.h
@@ -124,12 +124,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     QApplication* d_qApplication;
 };
 

--- a/gr-qtgui/include/gnuradio/qtgui/eye_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/eye_sink_c.h
@@ -72,12 +72,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_y_label(const std::string& label, const std::string& unit = "") = 0;
     virtual void set_update_time(double t) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/eye_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/eye_sink_f.h
@@ -72,12 +72,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_y_label(const std::string& label, const std::string& unit = "") = 0;
     virtual void set_update_time(double t) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_c.h
@@ -111,12 +111,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_fft_size(const int fftsize) = 0;
     virtual int fft_size() const = 0;
     virtual void set_fft_average(const float fftavg) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freq_sink_f.h
@@ -111,12 +111,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_fft_size(const int fftsize) = 0;
     virtual int fft_size() const = 0;
     virtual void set_fft_average(const float fftavg) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/histogram_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/histogram_sink_f.h
@@ -88,12 +88,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
 public:
     virtual std::string title() = 0;
     virtual std::string line_label(unsigned int which) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/number_sink.h
+++ b/gr-qtgui/include/gnuradio/qtgui/number_sink.h
@@ -77,12 +77,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_update_time(double t) = 0;
     virtual void set_average(const float avg) = 0;
     virtual void set_graph_type(const graph_t type) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/sink_c.h
@@ -92,12 +92,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_fft_size(const int fftsize) = 0;
     virtual int fft_size() const = 0;
 

--- a/gr-qtgui/include/gnuradio/qtgui/sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/sink_f.h
@@ -92,12 +92,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_fft_size(const int fftsize) = 0;
     virtual int fft_size() const = 0;
 

--- a/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_b.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_b.h
@@ -78,12 +78,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_x_label(const std::string& label) = 0;
     virtual void set_x_range(double start, double end) = 0;
     virtual void set_y_label(const std::string& label) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_raster_sink_f.h
@@ -74,12 +74,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_x_label(const std::string& label) = 0;
     virtual void set_x_range(double start, double end) = 0;
     virtual void set_y_label(const std::string& label) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/time_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_sink_c.h
@@ -71,12 +71,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_y_label(const std::string& label, const std::string& unit = "") = 0;
     virtual void set_update_time(double t) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/time_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/time_sink_f.h
@@ -69,12 +69,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_y_label(const std::string& label, const std::string& unit = "") = 0;
     virtual void set_update_time(double t) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/vector_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/vector_sink_f.h
@@ -68,12 +68,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual unsigned int vlen() const = 0;
     virtual void set_vec_average(const float avg) = 0;
     virtual float vec_average() const = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_c.h
@@ -112,12 +112,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void clear_data() = 0;
 
     virtual void set_fft_size(const int fftsize) = 0;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfall_sink_f.h
@@ -113,12 +113,6 @@ public:
     virtual void exec_() = 0;
     virtual QWidget* qwidget() = 0;
 
-#ifdef ENABLE_PYTHON
-    virtual PyObject* pyqwidget() = 0;
-#else
-    virtual void* pyqwidget() = 0;
-#endif
-
     virtual void clear_data() = 0;
 
     virtual void set_fft_size(const int fftsize) = 0;

--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -140,17 +140,6 @@ void ber_sink_b_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* ber_sink_b_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* ber_sink_b_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* ber_sink_b_impl::pyqwidget() { return NULL; }
-#endif
-
 void ber_sink_b_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/ber_sink_b_impl.h
+++ b/gr-qtgui/lib/ber_sink_b_impl.h
@@ -62,12 +62,6 @@ public:
     void exec_() override;
     QWidget* qwidget();
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_x_axis(double min, double max) override;
 

--- a/gr-qtgui/lib/const_sink_c_impl.cc
+++ b/gr-qtgui/lib/const_sink_c_impl.cc
@@ -104,17 +104,6 @@ void const_sink_c_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* const_sink_c_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* const_sink_c_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* const_sink_c_impl::pyqwidget() { return NULL; }
-#endif
-
 void const_sink_c_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/const_sink_c_impl.h
+++ b/gr-qtgui/lib/const_sink_c_impl.h
@@ -84,12 +84,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_x_axis(double min, double max) override;
 

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -170,17 +170,6 @@ void edit_box_msg_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* edit_box_msg_impl::qwidget() { return (QWidget*)d_group; }
 
-#ifdef ENABLE_PYTHON
-PyObject* edit_box_msg_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_group);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* edit_box_msg_impl::pyqwidget() { return NULL; }
-#endif
-
 void edit_box_msg_impl::set_type(int type) { set_type(static_cast<data_type_t>(type)); }
 
 void edit_box_msg_impl::set_type(gr::qtgui::data_type_t type)

--- a/gr-qtgui/lib/edit_box_msg_impl.h
+++ b/gr-qtgui/lib/edit_box_msg_impl.h
@@ -68,12 +68,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_value(pmt::pmt_t val);
 
 public slots:

--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -122,17 +122,6 @@ void eye_sink_c_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* eye_sink_c_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* eye_sink_c_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* eye_sink_c_impl::pyqwidget() { return NULL; }
-#endif
-
 void eye_sink_c_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/eye_sink_c_impl.h
+++ b/gr-qtgui/lib/eye_sink_c_impl.h
@@ -88,12 +88,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_y_label(const std::string& label, const std::string& unit = "") override;
     void set_update_time(double t) override;

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -117,17 +117,6 @@ void eye_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* eye_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* eye_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* eye_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void eye_sink_f_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/eye_sink_f_impl.h
+++ b/gr-qtgui/lib/eye_sink_f_impl.h
@@ -85,12 +85,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_y_label(const std::string& label, const std::string& unit = "") override;
     void set_update_time(double t) override;

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -139,17 +139,6 @@ void freq_sink_c_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* freq_sink_c_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* freq_sink_c_impl::pyqwidget() { return NULL; }
-#endif
-
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
     if ((fftsize > 16) && (fftsize < 16384))

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -115,12 +115,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_fft_size(const int fftsize) override;
     int fft_size() const override;
     void set_fft_average(const float fftavg) override;

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -139,17 +139,6 @@ void freq_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* freq_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* freq_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* freq_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void freq_sink_f_impl::set_fft_size(const int fftsize)
 {
     if ((fftsize > 16) && (fftsize < 16384))

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -115,12 +115,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_fft_size(const int fftsize) override;
     int fft_size() const override;
     void set_fft_average(const float fftavg) override;

--- a/gr-qtgui/lib/histogram_sink_f_impl.cc
+++ b/gr-qtgui/lib/histogram_sink_f_impl.cc
@@ -114,17 +114,6 @@ void histogram_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* histogram_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* histogram_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* histogram_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void histogram_sink_f_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/histogram_sink_f_impl.h
+++ b/gr-qtgui/lib/histogram_sink_f_impl.h
@@ -72,12 +72,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_x_axis(double min, double max) override;
     void set_update_time(double t) override;

--- a/gr-qtgui/lib/number_sink_impl.cc
+++ b/gr-qtgui/lib/number_sink_impl.cc
@@ -93,17 +93,6 @@ void number_sink_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* number_sink_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* number_sink_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* number_sink_impl::pyqwidget() { return NULL; }
-#endif
-
 void number_sink_impl::set_update_time(double t)
 {
     // convert update time to ticks

--- a/gr-qtgui/lib/number_sink_impl.h
+++ b/gr-qtgui/lib/number_sink_impl.h
@@ -69,12 +69,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_update_time(double t) override;
     void set_average(const float avg) override;
     void set_graph_type(const graph_t type) override;

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -140,17 +140,6 @@ void sink_c_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* sink_c_impl::qwidget() { return d_main_gui.qwidget(); }
 
-#ifdef ENABLE_PYTHON
-PyObject* sink_c_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui.qwidget());
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* sink_c_impl::pyqwidget() { return NULL; }
-#endif
-
 void sink_c_impl::set_fft_size(const int fftsize)
 {
     d_fftsize = fftsize;

--- a/gr-qtgui/lib/sink_c_impl.h
+++ b/gr-qtgui/lib/sink_c_impl.h
@@ -92,12 +92,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_fft_size(const int fftsize) override;
     int fft_size() const override;
 

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -133,17 +133,6 @@ void sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* sink_f_impl::qwidget() { return d_main_gui.qwidget(); }
 
-#ifdef ENABLE_PYTHON
-PyObject* sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui.qwidget());
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void sink_f_impl::set_fft_size(const int fftsize)
 {
     d_fftsize = fftsize;

--- a/gr-qtgui/lib/sink_f_impl.h
+++ b/gr-qtgui/lib/sink_f_impl.h
@@ -93,12 +93,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_fft_size(const int fftsize) override;
     int fft_size() const override;
 

--- a/gr-qtgui/lib/time_raster_sink_b_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.cc
@@ -122,17 +122,6 @@ void time_raster_sink_b_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* time_raster_sink_b_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* time_raster_sink_b_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* time_raster_sink_b_impl::pyqwidget() { return NULL; }
-#endif
-
 void time_raster_sink_b_impl::set_x_label(const std::string& label)
 {
     d_main_gui->setXLabel(label);

--- a/gr-qtgui/lib/time_raster_sink_b_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_b_impl.h
@@ -75,12 +75,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_x_label(const std::string& label) override;
     void set_x_range(double start, double end) override;
     void set_y_label(const std::string& label) override;

--- a/gr-qtgui/lib/time_raster_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.cc
@@ -119,17 +119,6 @@ void time_raster_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* time_raster_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* time_raster_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* time_raster_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void time_raster_sink_f_impl::set_x_label(const std::string& label)
 {
     d_main_gui->setXLabel(label);

--- a/gr-qtgui/lib/time_raster_sink_f_impl.h
+++ b/gr-qtgui/lib/time_raster_sink_f_impl.h
@@ -74,12 +74,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_x_label(const std::string& label) override;
     void set_x_range(double start, double end) override;
     void set_y_label(const std::string& label) override;

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -127,17 +127,6 @@ void time_sink_c_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* time_sink_c_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* time_sink_c_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* time_sink_c_impl::pyqwidget() { return NULL; }
-#endif
-
 void time_sink_c_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/time_sink_c_impl.h
+++ b/gr-qtgui/lib/time_sink_c_impl.h
@@ -83,12 +83,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_y_label(const std::string& label, const std::string& unit = "") override;
     void set_update_time(double t) override;

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -125,17 +125,6 @@ void time_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* time_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* time_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* time_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void time_sink_f_impl::set_y_axis(double min, double max)
 {
     d_main_gui->setYaxis(min, max);

--- a/gr-qtgui/lib/time_sink_f_impl.h
+++ b/gr-qtgui/lib/time_sink_f_impl.h
@@ -82,12 +82,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void set_y_axis(double min, double max) override;
     void set_y_label(const std::string& label, const std::string& unit = "") override;
     void set_update_time(double t) override;

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -117,17 +117,6 @@ void vector_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* vector_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* vector_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* vector_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 unsigned int vector_sink_f_impl::vlen() const { return d_vlen; }
 
 void vector_sink_f_impl::set_vec_average(const float avg)

--- a/gr-qtgui/lib/vector_sink_f_impl.h
+++ b/gr-qtgui/lib/vector_sink_f_impl.h
@@ -82,12 +82,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     unsigned int vlen() const override;
     void set_vec_average(const float avg) override;
     float vec_average() const override;

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -138,17 +138,6 @@ void waterfall_sink_c_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* waterfall_sink_c_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* waterfall_sink_c_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* waterfall_sink_c_impl::pyqwidget() { return NULL; }
-#endif
-
 void waterfall_sink_c_impl::clear_data() { d_main_gui->clearData(); }
 
 void waterfall_sink_c_impl::set_fft_size(const int fftsize)

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -99,12 +99,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void clear_data() override;
 
     void set_fft_size(const int fftsize) override;

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -135,17 +135,6 @@ void waterfall_sink_f_impl::exec_() { d_qApplication->exec(); }
 
 QWidget* waterfall_sink_f_impl::qwidget() { return d_main_gui; }
 
-#ifdef ENABLE_PYTHON
-PyObject* waterfall_sink_f_impl::pyqwidget()
-{
-    PyObject* w = PyLong_FromVoidPtr((void*)d_main_gui);
-    PyObject* retarg = Py_BuildValue("N", w);
-    return retarg;
-}
-#else
-void* waterfall_sink_f_impl::pyqwidget() { return NULL; }
-#endif
-
 void waterfall_sink_f_impl::clear_data() { d_main_gui->clearData(); }
 
 void waterfall_sink_f_impl::set_fft_size(const int fftsize)

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -99,12 +99,6 @@ public:
     void exec_() override;
     QWidget* qwidget() override;
 
-#ifdef ENABLE_PYTHON
-    PyObject* pyqwidget() override;
-#else
-    void* pyqwidget();
-#endif
-
     void clear_data() override;
 
     void set_fft_size(const int fftsize) override;

--- a/gr-qtgui/python/qtgui/auto_correlator_sink.py
+++ b/gr-qtgui/python/qtgui/auto_correlator_sink.py
@@ -129,4 +129,4 @@ class AutoCorrelatorSink(gr.hier_block2):
 
 
     def getWidget(self):
-        return sip.wrapinstance(self.timeSink.pyqwidget(), QWidget)
+        return sip.wrapinstance(self.timeSink.qwidget(), QWidget)

--- a/gr-qtgui/python/qtgui/bindings/ber_sink_b_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/ber_sink_b_python.cc
@@ -55,19 +55,6 @@ void bind_ber_sink_b(py::module& m)
         .def("exec_", &ber_sink_b::exec_, D(ber_sink_b, exec_))
 
 
-        // .def("pyqwidget",&ber_sink_b::pyqwidget,
-        //     D(ber_sink_b,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
-        .def(
-            "pyqwidget",
-            [](std::shared_ptr<ber_sink_b> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(ber_sink_b, pyqwidget))
-
-
         .def("set_y_axis",
              &ber_sink_b::set_y_axis,
              py::arg("min"),

--- a/gr-qtgui/python/qtgui/bindings/const_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/const_sink_c_python.cc
@@ -56,20 +56,12 @@ void bind_const_sink_c(py::module& m)
         .def("exec_", &const_sink_c::exec_, D(const_sink_c, exec_))
 
 
-        .def("qwidget", &const_sink_c::qwidget, D(const_sink_c, qwidget))
-
-
-        // .def("pyqwidget",&const_sink_c::pyqwidget,
-        //     D(const_sink_c,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<const_sink_c> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](const_sink_c& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(const_sink_c, pyqwidget))
+            D(const_sink_c, qwidget))
 
 
         .def("set_y_axis",

--- a/gr-qtgui/python/qtgui/bindings/docstrings/ber_sink_b_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/ber_sink_b_pydoc_template.h
@@ -30,9 +30,6 @@ static const char* __doc_gr_qtgui_ber_sink_b_make = R"doc()doc";
 static const char* __doc_gr_qtgui_ber_sink_b_exec_ = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_ber_sink_b_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_ber_sink_b_set_y_axis = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/const_sink_c_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/const_sink_c_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_const_sink_c_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_const_sink_c_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_const_sink_c_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_const_sink_c_set_y_axis = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/edit_box_msg_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/edit_box_msg_pydoc_template.h
@@ -31,6 +31,3 @@ static const char* __doc_gr_qtgui_edit_box_msg_exec_ = R"doc()doc";
 
 
 static const char* __doc_gr_qtgui_edit_box_msg_qwidget = R"doc()doc";
-
-
-static const char* __doc_gr_qtgui_edit_box_msg_pyqwidget = R"doc()doc";

--- a/gr-qtgui/python/qtgui/bindings/docstrings/eye_sink_c_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/eye_sink_c_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_eye_sink_c_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_eye_sink_c_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_eye_sink_c_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_eye_sink_c_set_y_axis = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/eye_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/eye_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_eye_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_eye_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_eye_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_eye_sink_f_set_y_axis = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/freq_sink_c_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/freq_sink_c_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_freq_sink_c_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_freq_sink_c_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_freq_sink_c_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_freq_sink_c_set_fft_size = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/freq_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/freq_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_freq_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_freq_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_freq_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_freq_sink_f_set_fft_size = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/histogram_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/histogram_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_histogram_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_histogram_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_histogram_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_histogram_sink_f_title = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/number_sink_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/number_sink_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_number_sink_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_number_sink_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_number_sink_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_number_sink_set_update_time = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/sink_c_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/sink_c_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_sink_c_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_sink_c_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_sink_c_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_sink_c_set_fft_size = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_sink_f_set_fft_size = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_b_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_b_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_time_raster_sink_b_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_time_raster_sink_b_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_time_raster_sink_b_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_time_raster_sink_b_set_x_label = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/time_raster_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_time_raster_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_time_raster_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_time_raster_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_time_raster_sink_f_set_x_label = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/time_sink_c_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/time_sink_c_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_time_sink_c_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_time_sink_c_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_time_sink_c_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_time_sink_c_set_y_axis = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/time_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/time_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_time_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_time_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_time_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_time_sink_f_set_y_axis = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/vector_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/vector_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_vector_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_vector_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_vector_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_vector_sink_f_vlen = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/waterfall_sink_c_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/waterfall_sink_c_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_waterfall_sink_c_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_waterfall_sink_c_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_waterfall_sink_c_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_waterfall_sink_c_clear_data = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/docstrings/waterfall_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/waterfall_sink_f_pydoc_template.h
@@ -33,9 +33,6 @@ static const char* __doc_gr_qtgui_waterfall_sink_f_exec_ = R"doc()doc";
 static const char* __doc_gr_qtgui_waterfall_sink_f_qwidget = R"doc()doc";
 
 
-static const char* __doc_gr_qtgui_waterfall_sink_f_pyqwidget = R"doc()doc";
-
-
 static const char* __doc_gr_qtgui_waterfall_sink_f_clear_data = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/edit_box_msg_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/edit_box_msg_python.cc
@@ -55,23 +55,11 @@ void bind_edit_box_msg(py::module& m)
 
         .def("exec_", &edit_box_msg::exec_, D(edit_box_msg, exec_))
 
-        // .def("pyqwidget",&edit_box_msg::pyqwidget,
-        //     D(edit_box_msg,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
+
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<edit_box_msg> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](edit_box_msg& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(edit_box_msg, pyqwidget))
-
-
-        .def("qwidget", &edit_box_msg::qwidget, D(edit_box_msg, qwidget))
-
-
-        .def("pyqwidget", &edit_box_msg::pyqwidget, D(edit_box_msg, pyqwidget))
-
-        ;
+            D(edit_box_msg, qwidget));
 }

--- a/gr-qtgui/python/qtgui/bindings/eye_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/eye_sink_c_python.cc
@@ -59,20 +59,11 @@ void bind_eye_sink_c(py::module& m)
         .def("exec_", &eye_sink_c::exec_, D(eye_sink_c, exec_))
 
 
-        .def("qwidget", &eye_sink_c::qwidget, D(eye_sink_c, qwidget))
-
-
-        // .def("pyqwidget",&eye_sink_c::pyqwidget,
-        //     D(eye_sink_c,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<eye_sink_c> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(eye_sink_c, pyqwidget))
+            "qwidget",
+            [](eye_sink_c& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(eye_sink_c, qwidget))
+
 
         .def("set_y_axis",
              &eye_sink_c::set_y_axis,

--- a/gr-qtgui/python/qtgui/bindings/eye_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/eye_sink_f_python.cc
@@ -56,20 +56,11 @@ void bind_eye_sink_f(py::module& m)
         .def("exec_", &eye_sink_f::exec_, D(eye_sink_f, exec_))
 
 
-        .def("qwidget", &eye_sink_f::qwidget, D(eye_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&eye_sink_f::pyqwidget,
-        //     D(eye_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<eye_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(eye_sink_f, pyqwidget))
+            "qwidget",
+            [](eye_sink_f& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(eye_sink_f, qwidget))
+
 
         .def("set_y_axis",
              &eye_sink_f::set_y_axis,

--- a/gr-qtgui/python/qtgui/bindings/freq_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/freq_sink_c_python.cc
@@ -59,20 +59,10 @@ void bind_freq_sink_c(py::module& m)
         .def("exec_", &freq_sink_c::exec_, D(freq_sink_c, exec_))
 
 
-        .def("qwidget", &freq_sink_c::qwidget, D(freq_sink_c, qwidget))
-
-
-        // .def("pyqwidget",&freq_sink_c::pyqwidget,
-        //     D(freq_sink_c,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<freq_sink_c> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(freq_sink_c, pyqwidget))
+            "qwidget",
+            [](freq_sink_c& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(freq_sink_c, qwidget))
 
 
         .def("set_fft_size",

--- a/gr-qtgui/python/qtgui/bindings/freq_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/freq_sink_f_python.cc
@@ -59,20 +59,10 @@ void bind_freq_sink_f(py::module& m)
         .def("exec_", &freq_sink_f::exec_, D(freq_sink_f, exec_))
 
 
-        .def("qwidget", &freq_sink_f::qwidget, D(freq_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&freq_sink_f::pyqwidget,
-        //     D(freq_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<freq_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(freq_sink_f, pyqwidget))
+            "qwidget",
+            [](freq_sink_f& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(freq_sink_f, qwidget))
 
 
         .def("set_fft_size",

--- a/gr-qtgui/python/qtgui/bindings/histogram_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/histogram_sink_f_python.cc
@@ -60,20 +60,12 @@ void bind_histogram_sink_f(py::module& m)
         .def("exec_", &histogram_sink_f::exec_, D(histogram_sink_f, exec_))
 
 
-        .def("qwidget", &histogram_sink_f::qwidget, D(histogram_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&histogram_sink_f::pyqwidget,
-        //     D(histogram_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<histogram_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](histogram_sink_f& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(histogram_sink_f, pyqwidget))
+            D(histogram_sink_f, qwidget))
 
 
         .def("title", &histogram_sink_f::title, D(histogram_sink_f, title))

--- a/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
@@ -57,20 +57,10 @@ void bind_number_sink(py::module& m)
         .def("exec_", &number_sink::exec_, D(number_sink, exec_))
 
 
-        .def("qwidget", &number_sink::qwidget, D(number_sink, qwidget))
-
-
-        // .def("pyqwidget",&number_sink::pyqwidget,
-        //     D(number_sink,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<number_sink> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(number_sink, pyqwidget))
+            "qwidget",
+            [](number_sink& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(number_sink, qwidget))
 
 
         .def("set_update_time",

--- a/gr-qtgui/python/qtgui/bindings/sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/sink_c_python.cc
@@ -59,18 +59,10 @@ void bind_sink_c(py::module& m)
         .def("exec_", &sink_c::exec_, D(sink_c, exec_))
 
 
-        .def("qwidget", &sink_c::qwidget, D(sink_c, qwidget))
-
-
-        // .def("pyqwidget",&sink_c::pyqwidget,
-        //     D(sink_c,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<sink_c> p) { return PyLong_AsLongLong(p->pyqwidget()); },
-            D(sink_c, pyqwidget))
+            "qwidget",
+            [](sink_c& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(sink_c, qwidget))
 
 
         .def("set_fft_size",

--- a/gr-qtgui/python/qtgui/bindings/sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/sink_f_python.cc
@@ -59,18 +59,10 @@ void bind_sink_f(py::module& m)
         .def("exec_", &sink_f::exec_, D(sink_f, exec_))
 
 
-        .def("qwidget", &sink_f::qwidget, D(sink_f, qwidget))
-
-
-        // .def("pyqwidget",&sink_f::pyqwidget,
-        //     D(sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<sink_f> p) { return PyLong_AsLongLong(p->pyqwidget()); },
-            D(sink_f, pyqwidget))
+            "qwidget",
+            [](sink_f& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(sink_f, qwidget))
 
 
         .def("set_fft_size",

--- a/gr-qtgui/python/qtgui/bindings/time_raster_sink_b_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_raster_sink_b_python.cc
@@ -61,20 +61,13 @@ void bind_time_raster_sink_b(py::module& m)
         .def("exec_", &time_raster_sink_b::exec_, D(time_raster_sink_b, exec_))
 
 
-        .def("qwidget", &time_raster_sink_b::qwidget, D(time_raster_sink_b, qwidget))
-
-
-        // .def("pyqwidget",&time_raster_sink_b::pyqwidget,
-        //     D(time_raster_sink_b,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<time_raster_sink_b> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](time_raster_sink_b& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(time_raster_sink_b, pyqwidget))
+            D(time_raster_sink_b, qwidget))
+
 
         .def("set_x_range",
              &time_raster_sink_b::set_x_range,

--- a/gr-qtgui/python/qtgui/bindings/time_raster_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_raster_sink_f_python.cc
@@ -61,20 +61,13 @@ void bind_time_raster_sink_f(py::module& m)
         .def("exec_", &time_raster_sink_f::exec_, D(time_raster_sink_f, exec_))
 
 
-        .def("qwidget", &time_raster_sink_f::qwidget, D(time_raster_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&time_raster_sink_f::pyqwidget,
-        //     D(time_raster_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<time_raster_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](time_raster_sink_f& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(time_raster_sink_f, pyqwidget))
+            D(time_raster_sink_f, qwidget))
+
 
         .def("set_x_range",
              &time_raster_sink_f::set_x_range,

--- a/gr-qtgui/python/qtgui/bindings/time_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_sink_c_python.cc
@@ -60,20 +60,11 @@ void bind_time_sink_c(py::module& m)
         .def("exec_", &time_sink_c::exec_, D(time_sink_c, exec_))
 
 
-        .def("qwidget", &time_sink_c::qwidget, D(time_sink_c, qwidget))
-
-
-        // .def("pyqwidget",&time_sink_c::pyqwidget,
-        //     D(time_sink_c,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<time_sink_c> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(time_sink_c, pyqwidget))
+            "qwidget",
+            [](time_sink_c& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(time_sink_c, qwidget))
+
 
         .def("set_y_axis",
              &time_sink_c::set_y_axis,

--- a/gr-qtgui/python/qtgui/bindings/time_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_sink_f_python.cc
@@ -57,20 +57,11 @@ void bind_time_sink_f(py::module& m)
         .def("exec_", &time_sink_f::exec_, D(time_sink_f, exec_))
 
 
-        .def("qwidget", &time_sink_f::qwidget, D(time_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&time_sink_f::pyqwidget,
-        //     D(time_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<time_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
-            },
-            D(time_sink_f, pyqwidget))
+            "qwidget",
+            [](time_sink_f& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(time_sink_f, qwidget))
+
 
         .def("set_y_axis",
              &time_sink_f::set_y_axis,

--- a/gr-qtgui/python/qtgui/bindings/vector_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/vector_sink_f_python.cc
@@ -60,20 +60,12 @@ void bind_vector_sink_f(py::module& m)
         .def("exec_", &vector_sink_f::exec_, D(vector_sink_f, exec_))
 
 
-        .def("qwidget", &vector_sink_f::qwidget, D(vector_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&time_sink_c::pyqwidget,
-        //     D(vector_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<vector_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](vector_sink_f& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(vector_sink_f, pyqwidget))
+            D(vector_sink_f, qwidget))
 
 
         .def("vlen", &vector_sink_f::vlen, D(vector_sink_f, vlen))

--- a/gr-qtgui/python/qtgui/bindings/waterfall_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/waterfall_sink_c_python.cc
@@ -60,20 +60,12 @@ void bind_waterfall_sink_c(py::module& m)
         .def("exec_", &waterfall_sink_c::exec_, D(waterfall_sink_c, exec_))
 
 
-        .def("qwidget", &waterfall_sink_c::qwidget, D(waterfall_sink_c, qwidget))
-
-
-        // .def("pyqwidget",&waterfall_sink_c::pyqwidget,
-        //     D(waterfall_sink_c,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<waterfall_sink_c> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](waterfall_sink_c& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(waterfall_sink_c, pyqwidget))
+            D(waterfall_sink_c, qwidget))
 
 
         .def("clear_data", &waterfall_sink_c::clear_data, D(waterfall_sink_c, clear_data))

--- a/gr-qtgui/python/qtgui/bindings/waterfall_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/waterfall_sink_f_python.cc
@@ -60,20 +60,13 @@ void bind_waterfall_sink_f(py::module& m)
         .def("exec_", &waterfall_sink_f::exec_, D(waterfall_sink_f, exec_))
 
 
-        .def("qwidget", &waterfall_sink_f::qwidget, D(waterfall_sink_f, qwidget))
-
-
-        // .def("pyqwidget",&waterfall_sink_f::pyqwidget,
-        //     D(waterfall_sink_f,pyqwidget)
-        // )
-        // For the sip conversion to python to work, the widget object
-        // needs to be explicitly converted to long long.
         .def(
-            "pyqwidget",
-            [](std::shared_ptr<waterfall_sink_f> p) {
-                return PyLong_AsLongLong(p->pyqwidget());
+            "qwidget",
+            [](waterfall_sink_f& self) {
+                return reinterpret_cast<uintptr_t>(self.qwidget());
             },
-            D(waterfall_sink_f, pyqwidget))
+            D(waterfall_sink_f, qwidget))
+
 
         .def("clear_data", &waterfall_sink_f::clear_data, D(waterfall_sink_f, clear_data))
 

--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -255,7 +255,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
             self.qtgui_waterfall_sink_x_0.set_line_alpha(i, alpha)
         self.qtgui_waterfall_sink_x_0.set_intensity_range(-90, 10)
         self._qtgui_waterfall_sink_x_0_win = sip.wrapinstance(
-            self.qtgui_waterfall_sink_x_0.pyqwidget(), Qt.QWidget)
+            self.qtgui_waterfall_sink_x_0.qwidget(), Qt.QWidget)
         self.display_grid_layout_1.addWidget(self._qtgui_waterfall_sink_x_0_win, 0, 0, 1, 4)
         self.qtgui_time_sink_x_0 = qtgui.time_sink_c(
             1024, #size
@@ -285,7 +285,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
             self.qtgui_time_sink_x_0.set_line_marker(i, markers[i])
             self.qtgui_time_sink_x_0.set_line_alpha(i, alphas[i])
         self._qtgui_time_sink_x_0_win = sip.wrapinstance(
-            self.qtgui_time_sink_x_0.pyqwidget(), Qt.QWidget)
+            self.qtgui_time_sink_x_0.qwidget(), Qt.QWidget)
         self.display_grid_layout_2.addWidget(self._qtgui_time_sink_x_0_win, 0, 0, 1, 4)
         self.qtgui_freq_sink_x_0 = qtgui.freq_sink_c(
             self.fft_size, #size
@@ -317,7 +317,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
             self.qtgui_freq_sink_x_0.set_line_color(i, colors[i])
             self.qtgui_freq_sink_x_0.set_line_alpha(i, alphas[i])
         self._qtgui_freq_sink_x_0_win = sip.wrapinstance(
-            self.qtgui_freq_sink_x_0.pyqwidget(), Qt.QWidget)
+            self.qtgui_freq_sink_x_0.qwidget(), Qt.QWidget)
         self.display_grid_layout_0.addWidget(self._qtgui_freq_sink_x_0_win, 0, 0, 1, 4)
         def _freeze_scaling(widget, sleep_time):
             time.sleep(sleep_time)
@@ -363,7 +363,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
                 self.qtgui_phase_plot.set_line_marker(i, markers[i])
                 self.qtgui_phase_plot.set_line_alpha(i, alphas[i])
             self._qtgui_phase_plot_win = sip.wrapinstance(
-                self.qtgui_phase_plot.pyqwidget(), Qt.QWidget)
+                self.qtgui_phase_plot.qwidget(), Qt.QWidget)
             self.display_grid_layout_phase.addWidget(self._qtgui_phase_plot_win, 0, 0, 1, 4)
         ### Other widgets ###################################################
         self._lo_locked_probe_tool_bar = Qt.QToolBar(self)

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -327,7 +327,7 @@ class uhd_siggen_gui(Qt.QWidget):
             self.qtgui_freq_sink_x_0.set_line_width(0, 1)
             self.qtgui_freq_sink_x_0.set_line_color(0, "blue")
             self.qtgui_freq_sink_x_0.set_line_alpha(0, 1.0)
-            self._qtgui_freq_sink_x_0_win = sip.wrapinstance(self.qtgui_freq_sink_x_0.pyqwidget(), Qt.QWidget)
+            self._qtgui_freq_sink_x_0_win = sip.wrapinstance(self.qtgui_freq_sink_x_0.qwidget(), Qt.QWidget)
             self.top_grid_layout.addWidget(self._qtgui_freq_sink_x_0_win, 9, 0, 2, 5)
             # Reconnect:
             self._sg.extra_sink = self.qtgui_freq_sink_x_0


### PR DESCRIPTION
Previously, two versions of the `qtwidget` functions existed,
`qwidget()` and `pyqwidget()`, with the only difference being that
`qwidget()` returned a pointer to the `QWidget` object managed by the
corresponding block, while `pyqwidget()` returned that same pointer, but as
an integer (Or `PyLong` in this case).

While `qwidget()` is used by C++ code accessing the widgets,
`pyqwidget()` is only used for the python interface. This makes these
two methods redundant, thus this commit entirely removes `pyqwidget()`,
and modifies the `qwidget()` python wrapper to behave like
`pyqwidget()`. Note that we can be fairly confident that this change
will not effect potential users of `qwidget()`, because any invocation
on the objects previously returned by `qwidget()` would cause a
segmentation fault.

This commit also fixes a memory leak:

Internally, the `pyqwidget()` functions were returning a PyLong `PyObject *`,
which was then upwrapped in a pybind trampoline without decrementing
the reference count of that python object.

This PR partially addresses issue #4857.