### PR TITLE
gr-blocks: use correct namespace for nco and vco in benchmarks

### DIFF
--- a/gr-blocks/tests/benchmark_nco.cc
+++ b/gr-blocks/tests/benchmark_nco.cc
@@ -17,12 +17,13 @@
 #include <gnuradio/nco.h>
 
 #ifdef HAVE_SYS_RESOURCE_H
-/* from man gtrusage
+/* from man getrusage
    "including <sys/time.h> is not required these days"
    So, we don't */
 #include <sys/resource.h>
 #endif
 
+#include <sys/time.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -101,7 +102,7 @@ static void benchmark(void test(float* x, float* y), const char* implementation_
 
 void basic_sincos_vec(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -115,7 +116,7 @@ void basic_sincos_vec(float* x, float* y)
 
 void native_sincos_vec(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -126,7 +127,7 @@ void native_sincos_vec(float* x, float* y)
 
 void fxpt_sincos_vec(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -139,7 +140,7 @@ void fxpt_sincos_vec(float* x, float* y)
 
 void native_sincos(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -151,7 +152,7 @@ void native_sincos(float* x, float* y)
 
 void fxpt_sincos(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -165,7 +166,7 @@ void fxpt_sincos(float* x, float* y)
 
 void native_sin(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -177,7 +178,7 @@ void native_sin(float* x, float* y)
 
 void fxpt_sin(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 

--- a/gr-blocks/tests/benchmark_vco.cc
+++ b/gr-blocks/tests/benchmark_vco.cc
@@ -24,6 +24,7 @@
 #include <sys/resource.h>
 #endif
 
+#include <sys/time.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -124,7 +125,7 @@ void basic_vco(float* output, const float* input)
 
 void native_vco(float* output, const float* input)
 {
-    gr::blocks::vco<float, float> vco;
+    gr::vco<float, float> vco;
 
     for (int j = 0; j < ITERATIONS / BLOCK_SIZE; j++) {
         vco.cos(output, input, BLOCK_SIZE, K, AMPLITUDE);
@@ -133,7 +134,7 @@ void native_vco(float* output, const float* input)
 
 void fxpt_vco(float* output, const float* input)
 {
-    gr::blocks::fxpt_vco vco;
+    gr::fxpt_vco vco;
 
     for (int j = 0; j < ITERATIONS / BLOCK_SIZE; j++) {
         vco.cos(output, input, BLOCK_SIZE, K, AMPLITUDE);


### PR DESCRIPTION
Fix provided by Gisle Vanem (@gvanem)

Signed-off-by: Jeff Long <willcode4@gmail.com>

Fixes https://github.com/gnuradio/gnuradio/issues/4995