### PR TITLE
grc: introduce sc16 format to interleaved_short blocks

### DIFF
--- a/gr-blocks/grc/blocks_complex_to_interleaved_short.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_interleaved_short.block.yml
@@ -15,6 +15,11 @@ parameters:
     option_labels: ['No', 'Yes']
     option_attributes:
         vlen: [1, 2]
+-   id: output_type
+    label: Output type
+    dtype: enum
+    default: 'short'
+    options: [short, sc16]
 
 inputs:
 -   domain: stream
@@ -22,7 +27,7 @@ inputs:
 
 outputs:
 -   domain: stream
-    dtype: short
+    dtype: ${output_type}
     vlen: ${ vector_output.vlen }
 
 templates:

--- a/gr-blocks/grc/blocks_interleaved_short_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_interleaved_short_to_complex.block.yml
@@ -15,6 +15,11 @@ parameters:
     option_labels: ['No', 'Yes']
     option_attributes:
         vlen: [1, 2]
+-   id: input_type
+    label: Input type
+    dtype: enum
+    default: 'short'
+    options: [short, sc16]
 -   id: swap
     label: Swap
     dtype: enum
@@ -25,7 +30,7 @@ parameters:
 
 inputs:
 -   domain: stream
-    dtype: short
+    dtype: ${input_type}
     vlen: ${ vector_input.vlen }
 
 outputs:


### PR DESCRIPTION
At the moment there exist no block to convert comlex to sc16 and vice versa,
but only from complex to ishort.
But you can interpret an ishort as sc16. So adding sc16 as possible input/output type
should solve this issue.

Fixes: #4998

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>