### PR TITLE
gr-blocks: add sc16 type to ishort->complex and complex->ishort

### DIFF
--- a/gr-blocks/grc/blocks_complex_to_interleaved_char.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_interleaved_char.block.yml
@@ -7,6 +7,11 @@ parameters:
     label: Scale Factor
     dtype: float
     default: '1.0'
+-   id: output_type
+    label: Output type
+    dtype: enum
+    default: 'byte'
+    options: [byte, sc8]
 -   id: vector_output
     label: Vector Output
     dtype: enum
@@ -15,6 +20,7 @@ parameters:
     option_labels: ['No', 'Yes']
     option_attributes:
         vlen: [1, 2]
+    hide: ${ 'all' if output_type == 'sc8' else 'none' }
 
 inputs:
 -   domain: stream
@@ -22,17 +28,17 @@ inputs:
 
 outputs:
 -   domain: stream
-    dtype: byte
-    vlen: ${ vector_output.vlen }
+    dtype: ${output_type}
+    vlen: ${ 1 if output_type == 'sc8' else vector_output.vlen }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.complex_to_interleaved_char(${vector_output}, ${scale_factor})
+    make: blocks.complex_to_interleaved_char(${output_type == 'sc8' or vector_output}, ${scale_factor})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/complex_to_interleaved_char.h>']
     declarations: 'blocks::complex_to_interleaved_char::sptr ${id};'
-    make: 'this->${id} = blocks::complex_to_interleaved_char::make(${vector_output});'
+    make: 'this->${id} = blocks::complex_to_interleaved_char::make(${output_type == "sc8" or vector_output});'
     translations:
         'True': 'true'
         'False': 'false'

--- a/gr-blocks/grc/blocks_complex_to_interleaved_short.block.yml
+++ b/gr-blocks/grc/blocks_complex_to_interleaved_short.block.yml
@@ -7,6 +7,11 @@ parameters:
     label: Scale Factor
     dtype: float
     default: '1.0'
+-   id: output_type
+    label: Output type
+    dtype: enum
+    default: 'short'
+    options: [short, sc16]
 -   id: vector_output
     label: Vector Output
     dtype: enum
@@ -15,6 +20,7 @@ parameters:
     option_labels: ['No', 'Yes']
     option_attributes:
         vlen: [1, 2]
+    hide: ${ 'all' if output_type == 'sc16' else 'none' }
 
 inputs:
 -   domain: stream
@@ -22,19 +28,19 @@ inputs:
 
 outputs:
 -   domain: stream
-    dtype: short
-    vlen: ${ vector_output.vlen }
+    dtype: ${output_type}
+    vlen: ${ 1 if output_type == 'sc16' else vector_output.vlen }
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.complex_to_interleaved_short(${vector_output},${scale_factor})
+    make: blocks.complex_to_interleaved_short(${output_type == 'sc16' or vector_output},${scale_factor})
     callbacks:
     - set_scale_factor(${scale_factor})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/complex_to_interleaved_short.h>']
     declarations: 'blocks::complex_to_interleaved_short::sptr ${id};'
-    make: 'this->${id} = blocks::complex_to_interleaved_short::make(${vector_output});'
+    make: 'this->${id} = blocks::complex_to_interleaved_short::make(${output_type == "sc16" or vector_output});'
     callbacks:
     - set_scale_factor(${scale_factor})
     translations:

--- a/gr-blocks/grc/blocks_interleaved_char_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_interleaved_char_to_complex.block.yml
@@ -7,6 +7,11 @@ parameters:
     label: Scale Factor
     dtype: float
     default: '1.0'
+-   id: input_type
+    label: Input type
+    dtype: enum
+    default: 'byte'
+    options: [byte, sc8]
 -   id: vector_input
     label: Vector Input
     dtype: enum
@@ -15,11 +20,12 @@ parameters:
     option_labels: ['No', 'Yes']
     option_attributes:
         vlen: [1, 2]
+    hide: ${ 'all' if input_type == 'sc8' else 'none' }
 
 inputs:
 -   domain: stream
-    dtype: byte
-    vlen: ${ vector_input.vlen }
+    dtype: ${input_type}
+    vlen: ${ 1 if input_type == 'sc8' else vector_input.vlen }
 
 outputs:
 -   domain: stream
@@ -27,14 +33,14 @@ outputs:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.interleaved_char_to_complex(${vector_input},${scale_factor})
+    make: blocks.interleaved_char_to_complex(${input_type == 'sc8' or vector_input},${scale_factor})
     callbacks:
     - set_scale_factor(${scale_factor})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/interleaved_char_to_complex.h>']
     declarations: 'blocks::interleaved_char_to_complex::sptr ${id};'
-    make: 'this->${id} = blocks::interleaved_char_to_complex::make(${vector_input});'
+    make: 'this->${id} = blocks::interleaved_char_to_complex::make(${input_type == "sc8" or vector_input});'
     callbacks:
     - set_scale_factor(${scale_factor})
     translations:

--- a/gr-blocks/grc/blocks_interleaved_short_to_complex.block.yml
+++ b/gr-blocks/grc/blocks_interleaved_short_to_complex.block.yml
@@ -7,6 +7,11 @@ parameters:
     label: Scale Factor
     dtype: float
     default: '1.0'
+-   id: input_type
+    label: Input type
+    dtype: enum
+    default: 'short'
+    options: [short, sc16]
 -   id: vector_input
     label: Vector Input
     dtype: enum
@@ -15,6 +20,7 @@ parameters:
     option_labels: ['No', 'Yes']
     option_attributes:
         vlen: [1, 2]
+    hide: ${ 'all' if input_type == 'sc16' else 'none' }
 -   id: swap
     label: Swap
     dtype: enum
@@ -25,8 +31,8 @@ parameters:
 
 inputs:
 -   domain: stream
-    dtype: short
-    vlen: ${ vector_input.vlen }
+    dtype: ${input_type}
+    vlen: ${ 1 if input_type == 'sc16' else vector_input.vlen }
 
 outputs:
 -   domain: stream
@@ -34,7 +40,7 @@ outputs:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.interleaved_short_to_complex(${vector_input}, ${swap},${scale_factor})
+    make: blocks.interleaved_short_to_complex(${input_type == 'sc16' or vector_input},${swap},${scale_factor})
     callbacks:
     - set_swap(${swap})
     - set_scale_factor(${scale_factor})
@@ -42,7 +48,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/interleaved_short_to_complex.h>']
     declarations: 'blocks::interleaved_short_to_complex::sptr ${id};'
-    make: 'this->${id} = blocks::interleaved_short_to_complex::make(${vector_input}, ${swap});'
+    make: 'this->${id} = blocks::interleaved_short_to_complex::make(${input_type == "sc16" or vector_input}, ${swap});'
     callbacks:
     - set_swap(${swap})
     - set_scale_factor(${scale_factor})


### PR DESCRIPTION
Based on PR #4999 Volker Schroer

Signed-off-by: Jeff Long <willcode4@gmail.com>

Addresses #4998, which notes that a vector of short[2] previously match sc16. Since stricter typechecking was added, this is no longer the cases. This PR allows the I2C/C2I blocks can now be used as adapters.