### PR TITLE
network: tuntap knows what it's doing when it uses strncpy, suppress warning

### DIFF
--- a/gr-network/lib/tuntap_pdu_impl.cc
+++ b/gr-network/lib/tuntap_pdu_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2013 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -52,13 +53,22 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
     strncpy(dev_cstr, dev.c_str(), IFNAMSIZ);
     dev_cstr[IFNAMSIZ - 1] = '\0';
 
-
     bool istun = d_istunflag;
+
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+
     if (istun) {
         d_fd = tun_alloc(dev_cstr, (IFF_TUN | IFF_NO_PI));
     } else {
         d_fd = tun_alloc(dev_cstr, (IFF_TAP | IFF_NO_PI));
     }
+
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     if (d_fd <= 0)
         throw std::runtime_error(
@@ -117,9 +127,10 @@ int tuntap_pdu_impl::tun_alloc(char* dev, int flags)
      * the kernel will try to allocate the "next" device of the
      * specified type
      */
-    if (*dev)
+    if (*dev) {
+        // copy at most IFNAMSIZ - 1: If everything went well, the last byte is 0 anyway
         strncpy(ifr.ifr_name, dev, IFNAMSIZ - 1);
-
+    }
     /* try to create the device */
     if ((err = ioctl(fd, TUNSETIFF, (void*)&ifr)) < 0) {
         close(fd);


### PR DESCRIPTION
with -Werror, this became a problem (stopped builds under Debian 11).

Since we're setting the last byte to zero in the caller of this function, the truncation happens, if at all, there, not here.