### PR TITLE
pkg: Add gir1.2-gtk-3.0 to the Debian list of runtime dependencies

### DIFF
--- a/.packaging/debian/control
+++ b/.packaging/debian/control
@@ -70,7 +70,8 @@ Vcs-Git: https://github.com/gnuradio/pkg-gnuradio.git
 
 Package: gnuradio
 Architecture: any
-Depends: libcanberra-gtk-module,
+Depends: gir1.2-gtk-3.0,
+         libcanberra-gtk-module,
          libcanberra-gtk3-module,
          libvolk2-bin,
          python3-click,


### PR DESCRIPTION
## The problem
I've just tried to run `gnuradio-companion` from GR 3.9.2 installed via binary package from `ppa:gnuradio/gnuradio-releases`. I tried it on a Docker environment and ran into the following error:

```
> gnuradio-companion
Traceback (most recent call last):
  File "/usr/bin/gnuradio-companion", line 49, in check_gtk
    gi.require_version('Gtk', '3.0')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/gnuradio-companion", line 90, in <module>
    check_gtk()
  File "/usr/bin/gnuradio-companion", line 57, in check_gtk
    die(err, "Failed to initialize GTK. If you are running over ssh, "
  File "/usr/bin/gnuradio-companion", line 31, in die
    gi.require_version('Gtk', '3.0')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Gtk not available
```

As far as I can tell from the PyGObject [installation instructions](https://pygobject.readthedocs.io/en/latest/getting_started.html#ubuntu-logo-ubuntu-debian-logo-debian), PyGObject requires the `python3-gi`, `python3-gi-cairo`, and `gir1.2-gtk-3.0` packages. Now, I can see that the first two packages are included as runtime dependencies on the `debian/control` file (see [L78](https://github.com/gnuradio/gnuradio/blob/master/.packaging/debian/control#L78)). On the other hand, `gir1.2-gtk-3.0,` is not. Instead, it is only listed as a build dependency (see [L9](https://github.com/gnuradio/gnuradio/blob/master/.packaging/debian/control#L9)).

So I ran `apt install -y gir1.2-gtk-3.0` and that solved the problem. GRC launched normally.

This problem seems to be affecting the Ubuntu/Debian package only. On Fedora, the PyGObject instructions indicate packages `python3-gobject` and `gtk3` are required, and both are listed as runtime dependencies on the Fedora spec file (see [L95](https://github.com/gnuradio/gnuradio/blob/master/.packaging/fedora/gnuradio.spec#L95)).

## Steps to Reproduce

Luckily, this is easy to reproduce as I found the problem using a [Docker image](https://hub.docker.com/r/igorfreire/gnuradio-oot-dev) I'm using for OOT module development. The instructions below work to reproduce the problem on OSX. In other operating systems, the steps may require some tweaking specifically regarding the X redirection part.

First, let a container talk to the host's X server so that we can run gnuradio-companion inside the container (I have some notes about this on the the [gnuradio-docker-env project](https://github.com/igorauad/gnuradio-docker-env#gui-configuration)):
```
xhost + localhost
```

Then
```
docker run --rm -it -e DISPLAY=host.docker.internal:0 igorfreire/gnuradio-oot-dev:3.9.2-ubuntu-focal
```

Finally, launch `gnuradio-companion` inside the container. It should display the above GTK error. Then, `apt install -y gir1.2-gtk-3.0` should solve it.

## Solution

I believe the solution is as simples as adding `gir1.2-gtk-3.0` to the `Depends` list on the `debian/control` file, which is what I'm pushing in this PR. Please, let me know if there are other preferable solutions to the problem.