### PR TITLE
grc: Add no_quotes() convenience function (callable from templates)

### DIFF
--- a/grc/core/blocks/_templates.py
+++ b/grc/core/blocks/_templates.py
@@ -14,6 +14,16 @@ from mako.exceptions import SyntaxException
 
 from ..errors import TemplateError
 
+# The utils dict contains convenience functions
+# that can be called from any template
+def no_quotes(string, fallback=None):
+    if len(string) > 2:
+        if str(string)[0] + str(string)[-1] in ("''", '""'):
+            return str(string)[1:-1]
+    return str(fallback if fallback else string)
+
+utils = {'no_quotes': no_quotes}
+
 
 class MakoTemplates(dict):
 
@@ -53,6 +63,7 @@ class MakoTemplates(dict):
         if not text:
             return ''
         namespace = self.instance.namespace_templates
+        namespace = {**namespace, **utils}
 
         try:
             if isinstance(text, list):


### PR DESCRIPTION
Lots of C++-enabled blocks (especially in gr-digital and gr-filter) do a substring operation in order to get rid of quotes, like the FIR Filter block:
https://github.com/gnuradio/gnuradio/blob/1f1733eb4489b48fb73509e7806df19e1c738092/gr-filter/grc/filter_fir_filter_xxx.block.yml#L55

It's neither pretty nor robust, and they would benefit from having the quotes-stripping operation available as a function. It would be easier to just do `std::vector<gr_complex> taps = {${no_quotes(taps)}}; `

This PR adds such a function to the Mako template namespace, so that it can be used from all templates. This will also be useful for the XMLRPC block: https://github.com/gnuradio/gnuradio/pull/5008

