### PR TITLE
gr-video-sdl: Fix reversal of U and V channels on sink blocks (backport to maint-3.9)

### DIFF
--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -103,7 +103,7 @@ sink_s_impl::sink_s_impl(double framerate,
 
     /* Initialize and create the YUV Overlay used for video out */
     if (!(d_image =
-              SDL_CreateYUVOverlay(d_width, d_height, SDL_YV12_OVERLAY, d_screen))) {
+              SDL_CreateYUVOverlay(d_width, d_height, SDL_IYUV_OVERLAY, d_screen))) {
         std::ostringstream msg;
         msg << "Couldn't create a YUV overlay: " << SDL_GetError();
         GR_LOG_ERROR(d_logger, msg.str());

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -105,7 +105,7 @@ sink_uc_impl::sink_uc_impl(double framerate,
 
     /* Initialize and create the YUV Overlay used for video out */
     if (!(d_image =
-              SDL_CreateYUVOverlay(d_width, d_height, SDL_YV12_OVERLAY, d_screen))) {
+              SDL_CreateYUVOverlay(d_width, d_height, SDL_IYUV_OVERLAY, d_screen))) {
         std::ostringstream msg;
         msg << "SDL: Couldn't create a YUV overlay: " << SDL_GetError();
         GR_LOG_ERROR(d_logger, msg.str());


### PR DESCRIPTION
Signed-off-by: Ron Economos <w6rz@comcast.net>
(cherry picked from commit 314a87008559a04b911d9ed8fc77cb0c35d6f383)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4992