### PR TITLE
gr-digital: Make unpack optional for gmsk mod hier block (backport to maint-3.9)

### DIFF
--- a/gr-digital/grc/digital_gmsk_mod.block.yml
+++ b/gr-digital/grc/digital_gmsk_mod.block.yml
@@ -25,6 +25,13 @@ parameters:
     options: ['True', 'False']
     option_labels: ['On', 'Off']
     hide: ${ ('part' if str(log) == 'False' else 'none') }
+-   id: do_unpack
+    label: Unpack
+    dtype: bool
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['On', 'Off']
+    hide: ${ ('part' if do_unpack else 'none') }
 
 inputs:
 -   domain: stream
@@ -41,6 +48,7 @@ templates:
             samples_per_symbol=${samples_per_symbol},
             bt=${bt},
             verbose=${verbose},
-            log=${log})
+            log=${log},
+            do_unpack=${do_unpack})
 
 file_format: 1

--- a/gr-digital/python/digital/gmsk.py
+++ b/gr-digital/python/digital/gmsk.py
@@ -28,6 +28,7 @@ _def_samples_per_symbol = 2
 _def_bt = 0.35
 _def_verbose = False
 _def_log = False
+_def_do_unpack = True
 
 _def_gain_mu = None
 _def_mu = 0.5
@@ -62,7 +63,8 @@ class gmsk_mod(gr.hier_block2):
                  samples_per_symbol=_def_samples_per_symbol,
                  bt=_def_bt,
                  verbose=_def_verbose,
-                 log=_def_log):
+                 log=_def_log,
+                 do_unpack=_def_do_unpack):
 
         gr.hier_block2.__init__(self, "gmsk_mod",
                                 gr.io_signature(1, 1, gr.sizeof_char),       # Input signature
@@ -81,7 +83,6 @@ class gmsk_mod(gr.hier_block2):
 
         # Turn it into NRZ data.
         #self.nrz = digital.bytes_to_syms()
-        self.unpack = blocks.packed_to_unpacked_bb(1, gr.GR_MSB_FIRST)
         self.nrz = digital.chunks_to_symbols_bf([-1, 1], 1)
 
         # Form Gaussian filter
@@ -107,7 +108,11 @@ class gmsk_mod(gr.hier_block2):
             self._setup_logging()
 
         # Connect & Initialize base class
-        self.connect(self, self.unpack, self.nrz, self.gaussian_filter, self.fmmod, self)
+        if do_unpack:
+            self.unpack = blocks.packed_to_unpacked_bb(1, gr.GR_MSB_FIRST)
+            self.connect(self, self.unpack, self.nrz, self.gaussian_filter, self.fmmod, self)
+        else:
+            self.connect(self, self.nrz, self.gaussian_filter, self.fmmod, self)
 
     def samples_per_symbol(self):
         return self._samples_per_symbol


### PR DESCRIPTION
Allow the unpack option to be disabled for custom, non-byte-aligned bit
streams in gmsk mod, just like how it was done for gfsk in #4940.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit 0e7e21076f56aad0fed4816b6892f159c8f37190)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4970