### PR TITLE
gr-blocks: use correct namespace for nco and vco in benchmarks (backport to maint-3.9)

### DIFF
--- a/gr-blocks/tests/benchmark_nco.cc
+++ b/gr-blocks/tests/benchmark_nco.cc
@@ -22,6 +22,7 @@
 #include <sys/resource.h>
 #endif
 
+#include <sys/time.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -100,7 +101,7 @@ static void benchmark(void test(float* x, float* y), const char* implementation_
 
 void basic_sincos_vec(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -114,7 +115,7 @@ void basic_sincos_vec(float* x, float* y)
 
 void native_sincos_vec(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -125,7 +126,7 @@ void native_sincos_vec(float* x, float* y)
 
 void fxpt_sincos_vec(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -138,7 +139,7 @@ void fxpt_sincos_vec(float* x, float* y)
 
 void native_sincos(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -150,7 +151,7 @@ void native_sincos(float* x, float* y)
 
 void fxpt_sincos(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -164,7 +165,7 @@ void fxpt_sincos(float* x, float* y)
 
 void native_sin(float* x, float* y)
 {
-    gr::blocks::nco<float, float> nco;
+    gr::nco<float, float> nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 
@@ -176,7 +177,7 @@ void native_sin(float* x, float* y)
 
 void fxpt_sin(float* x, float* y)
 {
-    gr::blocks::fxpt_nco nco;
+    gr::fxpt_nco nco;
 
     nco.set_freq(2 * GR_M_PI / FREQ);
 

--- a/gr-blocks/tests/benchmark_vco.cc
+++ b/gr-blocks/tests/benchmark_vco.cc
@@ -22,6 +22,7 @@
 #include <sys/resource.h>
 #endif
 
+#include <sys/time.h>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -122,7 +123,7 @@ void basic_vco(float* output, const float* input)
 
 void native_vco(float* output, const float* input)
 {
-    gr::blocks::vco<float, float> vco;
+    gr::vco<float, float> vco;
 
     for (int j = 0; j < ITERATIONS / BLOCK_SIZE; j++) {
         vco.cos(output, input, BLOCK_SIZE, K, AMPLITUDE);
@@ -131,7 +132,7 @@ void native_vco(float* output, const float* input)
 
 void fxpt_vco(float* output, const float* input)
 {
-    gr::blocks::fxpt_vco vco;
+    gr::fxpt_vco vco;
 
     for (int j = 0; j < ITERATIONS / BLOCK_SIZE; j++) {
         vco.cos(output, input, BLOCK_SIZE, K, AMPLITUDE);


### PR DESCRIPTION
Fix provided by Gisle Vanem (@gvanem)

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit bfde34493e9e4216b6096cadda8236573cf36f0d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4997/files