### PR TITLE
pkg: Add gir1.2-gtk-3.0 as deb runtime dependency (backport to maint-3.9)

### DIFF
--- a/.packaging/debian/control
+++ b/.packaging/debian/control
@@ -70,7 +70,8 @@ Vcs-Git: https://github.com/gnuradio/pkg-gnuradio.git
 
 Package: gnuradio
 Architecture: any
-Depends: libcanberra-gtk-module,
+Depends: gir1.2-gtk-3.0,
+         libcanberra-gtk-module,
          libcanberra-gtk3-module,
          libvolk2-bin,
          python3-click,


### PR DESCRIPTION
It seems that package gir1.2-gtk-3.0 is a required runtime dependency
for running gnuradio-companion. Add it to the Debian package's list of
runtime dependencies.

Signed-off-by: Igor Freire <igor@blockstream.com>
(cherry picked from commit fd504fa26f71662ce4ddd4c8608722748e9beb86)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5015