### PR TITLE
grc: Generate c++ vector from list compre in var

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -56,6 +56,12 @@ GR_PYTHON_CHECK_MODULE_RAW(
     NUMPY_FOUND
 )
 
+GR_PYTHON_CHECK_MODULE_RAW(
+    "asteval"
+    "import asteval"
+    ASTEVAL_FOUND
+)
+
 ########################################################################
 # Register component
 ########################################################################
@@ -69,6 +75,7 @@ if(NOT CMAKE_CROSSCOMPILING)
         CAIRO_GI_FOUND
         PANGOCAIRO_GI_FOUND
         NUMPY_FOUND
+        ASTEVAL_FOUND
     )
 endif(NOT CMAKE_CROSSCOMPILING)
 


### PR DESCRIPTION
Fixes #4955 .
Issue 4955 states that when a list comprehension is used in a variable
block, c++ code cannot be generated from the flowgraph. The cause of the
problem is `ast.literal_eval` which only considers a small number of
Python syntaxes to be valid. `eval` correctly evaluates a list
comprehension as valid python syntax.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>