### PR TITLE
grc: Raise error for unfilled parameters

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -214,7 +214,7 @@ class Param(Element):
                 except Exception as e:
                     raise Exception('Value "{}" cannot be evaluated:\n{}'.format(expr, e))
             else:
-                value = 0
+                value = None   # No parameter value provided
             if dtype == 'hex':
                 value = hex(value)
             elif dtype == 'bool':


### PR DESCRIPTION
Fixes #5032 .
Issue 5032 results from an unfilled parameter erroneously indicated as
filled with a default value of 0. This PR makes grc indicate an error
when there is an unfilled parameter by returning None.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>