### PR TITLE
grc: generate cpp hier code switch to std::shared_ptr (backport to maint-3.9)

### DIFF
--- a/grc/core/generator/cpp_templates/flow_graph.hpp.mako
+++ b/grc/core/generator/cpp_templates/flow_graph.hpp.mako
@@ -44,7 +44,7 @@ param_str = ", ".join((param.vtype + " " + param.name) for param in parameters)
 
 % if generate_options.startswith('hb'):
 class ${class_name};
-typedef boost::shared_ptr<${class_name}> ${class_name}_sptr;
+typedef std::shared_ptr<${class_name}> ${class_name}_sptr;
 ${class_name}_sptr make_${class_name}();
 % endif
 


### PR DESCRIPTION
gnuradio >= 3.9 uses std::shared_ptr instead of boost::shared_ptr
This is fixed here. See too: #4951

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit ed4cc57c043741d43dfa071770bdf3b78821ba54)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5036