### PR TITLE
gr-digital: replace clk recovery MM in hier blks (backport to maint-3.9)

### DIFF
--- a/gr-digital/grc/digital_gfsk_demod.block.yml
+++ b/gr-digital/grc/digital_gfsk_demod.block.yml
@@ -16,7 +16,7 @@ parameters:
     dtype: real
     default: '0.175'
 -   id: mu
-    label: Mu
+    label: Mu (Unused)
     dtype: real
     default: '0.5'
 -   id: omega_relative_limit

--- a/gr-digital/grc/digital_gmsk_demod.block.yml
+++ b/gr-digital/grc/digital_gmsk_demod.block.yml
@@ -12,7 +12,7 @@ parameters:
     dtype: real
     default: '0.175'
 -   id: mu
-    label: Mu
+    label: Mu (Unused)
     dtype: real
     default: '0.5'
 -   id: omega_relative_limit

--- a/gr-digital/python/digital/gfsk.py
+++ b/gr-digital/python/digital/gfsk.py
@@ -46,6 +46,20 @@ _def_omega_relative_limit = 0.005
 # /////////////////////////////////////////////////////////////////////////////
 
 class gfsk_mod(gr.hier_block2):
+    """
+    Hierarchical block for Gaussian Frequency Shift Key (GFSK)
+    modulation.
+
+    The input is a byte stream (unsigned char) and the
+    output is the complex modulated signal at baseband.
+
+    Args:
+        samples_per_symbol: samples per baud >= 2 (integer)
+        bt: Gaussian filter bandwidth * symbol time (float)
+        verbose: Print information about modulator? (bool)
+        debug: Print modualtion data to files? (bool)
+        unpack: Unpack input byte stream? (bool)
+    """
 
     def __init__(self,
                  samples_per_symbol=_def_samples_per_symbol,
@@ -54,20 +68,6 @@ class gfsk_mod(gr.hier_block2):
                  verbose=_def_verbose,
                  log=_def_log,
                  do_unpack=_def_do_unpack):
-        """
-        Hierarchical block for Gaussian Frequency Shift Key (GFSK)
-        modulation.
-
-        The input is a byte stream (unsigned char) and the
-        output is the complex modulated signal at baseband.
-
-        Args:
-            samples_per_symbol: samples per baud >= 2 (integer)
-            bt: Gaussian filter bandwidth * symbol time (float)
-            verbose: Print information about modulator? (bool)
-            debug: Print modualtion data to files? (bool)
-            unpack: Unpack input byte stream? (bool)
-        """
 
         gr.hier_block2.__init__(self, "gfsk_mod",
                                 gr.io_signature(1, 1, gr.sizeof_char),       # Input signature
@@ -165,6 +165,26 @@ class gfsk_mod(gr.hier_block2):
 # /////////////////////////////////////////////////////////////////////////////
 
 class gfsk_demod(gr.hier_block2):
+    """
+    Hierarchical block for Gaussian Minimum Shift Key (GFSK)
+    demodulation.
+
+    The input is the complex modulated signal at baseband.
+    The output is a stream of bits packed 1 bit per byte (the LSB)
+
+    Args:
+        samples_per_symbol: samples per baud (integer)
+        verbose: Print information about modulator? (bool)
+        log: Print modualtion data to files? (bool)
+
+    Clock recovery parameters.  These all have reasonable defaults.
+
+    Args:
+        gain_mu: controls rate of mu adjustment (float)
+        mu: unused but unremoved for backward compatibility (unused)
+        omega_relative_limit: sets max variation in omega (float, typically 0.000200 (200 ppm))
+        freq_error: bit rate error as a fraction
+    """
 
     def __init__(self,
                  samples_per_symbol=_def_samples_per_symbol,
@@ -175,27 +195,6 @@ class gfsk_demod(gr.hier_block2):
                  freq_error=_def_freq_error,
                  verbose=_def_verbose,
                  log=_def_log):
-        """
-        Hierarchical block for Gaussian Minimum Shift Key (GFSK)
-        demodulation.
-
-        The input is the complex modulated signal at baseband.
-        The output is a stream of bits packed 1 bit per byte (the LSB)
-
-        Args:
-            samples_per_symbol: samples per baud (integer)
-            verbose: Print information about modulator? (bool)
-            log: Print modualtion data to files? (bool)
-
-        Clock recovery parameters.  These all have reasonable defaults.
-
-        Args:
-            gain_mu: controls rate of mu adjustment (float)
-            mu: unused but unremoved for backward compatibility (unused)
-            omega_relative_limit: sets max variation in omega (float, typically 0.000200 (200 ppm))
-            freq_error: bit rate error as a fraction
-            float:
-        """
 
         gr.hier_block2.__init__(self, "gfsk_demod",
                                 gr.io_signature(1, 1, gr.sizeof_gr_complex), # Input signature

--- a/gr-digital/python/digital/gmsk.py
+++ b/gr-digital/python/digital/gmsk.py
@@ -14,6 +14,7 @@
 # See gnuradio-examples/python/digital for examples
 
 from math import pi
+from math import log as ln
 from pprint import pprint
 import inspect
 
@@ -167,7 +168,7 @@ class gmsk_demod(gr.hier_block2):
     Args:
         samples_per_symbol: samples per baud (integer)
         gain_mu: controls rate of mu adjustment (float)
-        mu: fractional delay [0.0, 1.0] (float)
+        mu: unused but unremoved for backward compatibility (unused)
         omega_relative_limit: sets max variation in omega (float)
         freq_error: bit rate error as a fraction (float)
         verbose: Print information about modulator? (boolean)
@@ -189,7 +190,6 @@ class gmsk_demod(gr.hier_block2):
 
         self._samples_per_symbol = samples_per_symbol
         self._gain_mu = gain_mu
-        self._mu = mu
         self._omega_relative_limit = omega_relative_limit
         self._freq_error = freq_error
         self._differential = False
@@ -204,15 +204,27 @@ class gmsk_demod(gr.hier_block2):
 
         self._gain_omega = .25 * self._gain_mu * self._gain_mu        # critically damped
 
+        self._damping = 1.0
+        self._loop_bw = -ln((self._gain_mu + self._gain_omega)/(-2.0) + 1)        # critically damped
+        self._max_dev = self._omega_relative_limit * self._samples_per_symbol
+
         # Demodulate FM
         sensitivity = (pi / 2) / samples_per_symbol
         self.fmdemod = analog.quadrature_demod_cf(1.0 / sensitivity)
 
         # the clock recovery block tracks the symbol clock and resamples as needed.
         # the output of the block is a stream of soft symbols (float)
-        self.clock_recovery = digital.clock_recovery_mm_ff(self._omega, self._gain_omega,
-                                                           self._mu, self._gain_mu,
-                                                           self._omega_relative_limit)
+        self.clock_recovery = self.digital_symbol_sync_xx_0 = digital.symbol_sync_ff(digital.TED_MUELLER_AND_MULLER,
+                            self._omega,
+                            self._loop_bw,
+                            self._damping,
+                            1.0,  # Expected TED gain
+                            self._max_dev,
+                            1,  # Output sps
+                            digital.constellation_bpsk().base(),
+                            digital.IR_MMSE_8TAP,
+                            128,
+                            [])
 
         # slice the floats at 0, outputting 1 bit (the LSB of the output byte) per sample
         self.slicer = digital.binary_slicer_fb()
@@ -235,10 +247,10 @@ class gmsk_demod(gr.hier_block2):
 
     def _print_verbage(self):
         print("bits per symbol = %d" % self.bits_per_symbol())
-        print("M&M clock recovery omega = %f" % self._omega)
-        print("M&M clock recovery gain mu = %f" % self._gain_mu)
-        print("M&M clock recovery mu = %f" % self._mu)
-        print("M&M clock recovery omega rel. limit = %f" % self._omega_relative_limit)
+        print("Symbol Sync M&M omega = %f" % self._omega)
+        print("Symbol Sync M&M gain mu = %f" % self._gain_mu)
+        print("M&M clock recovery mu (Unused) = %f" % self._mu)
+        print("Symbol Sync M&M omega rel. limit = %f" % self._omega_relative_limit)
         print("frequency error = %f" % self._freq_error)
 
 
@@ -257,13 +269,13 @@ class gmsk_demod(gr.hier_block2):
         Adds GMSK demodulation-specific options to the standard parser
         """
         parser.add_option("", "--gain-mu", type="float", default=_def_gain_mu,
-                          help="M&M clock recovery gain mu [default=%default] (GMSK/PSK)")
+                          help="Symbol Sync M&M gain mu [default=%default] (GMSK/PSK)")
         parser.add_option("", "--mu", type="float", default=_def_mu,
-                          help="M&M clock recovery mu [default=%default] (GMSK/PSK)")
+                          help="M&M clock recovery mu [default=%default] (Unused)")
         parser.add_option("", "--omega-relative-limit", type="float", default=_def_omega_relative_limit,
-                          help="M&M clock recovery omega relative limit [default=%default] (GMSK/PSK)")
+                          help="Symbol Sync M&M omega relative limit [default=%default] (GMSK/PSK)")
         parser.add_option("", "--freq-error", type="float", default=_def_freq_error,
-                          help="M&M clock recovery frequency error [default=%default] (GMSK)")
+                          help="Symbol Sync M&M frequency error [default=%default] (GMSK)")
 
     @staticmethod
     def extract_kwargs_from_options(options):


### PR DESCRIPTION
As Clock Recovery MM is deprecated, this commit replaces them
in the hier blocks, gmfsk demod and gfsk demod, with Andy Wall's Symbol
Sync block. Backward compatibility is maintained by keeping the
parameters unchanged, and converting the two gain values to the
corresponding loop bandwidth value that Symbol Sync requires.

Note: This means the mu parameter is no longer needed.

Backport https://github.com/gnuradio/gnuradio/pull/4969/commits