### PR TITLE
gr-digital: Fix constellation normalization by average power (backport to maint-3.9)

### DIFF
--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -45,25 +45,26 @@ constellation::constellation(std::vector<gr_complex> constell,
       d_lut_scale(0)
 {
     unsigned int constsize = d_constellation.size();
-    float summed_mag = 0;
     switch (normalization) {
-    case NO_NORMALIZATION:
+    case NO_NORMALIZATION: {
         break;
-
-    case POWER_NORMALIZATION:
+    }
+    case POWER_NORMALIZATION: {
         // Scale constellation points so that average power is 1.
+        float summed_power = 0;
         for (unsigned int i = 0; i < constsize; i++) {
             gr_complex c = d_constellation[i];
-            summed_mag += std::norm(c);
+            summed_power += std::norm(c);
         }
-        d_scalefactor = constsize / sqrt(summed_mag);
+        d_scalefactor = sqrt(constsize / summed_power);
         for (unsigned int i = 0; i < constsize; i++) {
             d_constellation[i] = d_constellation[i] * d_scalefactor;
         }
         break;
-
-    case AMPLITUDE_NORMALIZATION:
+    }
+    case AMPLITUDE_NORMALIZATION: {
         // Scale constellation points so that average magnitude is 1.
+        float summed_mag = 0;
         for (unsigned int i = 0; i < constsize; i++) {
             gr_complex c = d_constellation[i];
             summed_mag += std::abs(c);
@@ -73,7 +74,7 @@ constellation::constellation(std::vector<gr_complex> constell,
             d_constellation[i] = d_constellation[i] * d_scalefactor;
         }
         break;
-
+    }
     default:
         throw std::runtime_error("Invalid constellation normalization type.");
     }
@@ -131,14 +132,10 @@ float constellation::get_distance(unsigned int index, const gr_complex* sample)
 
 unsigned int constellation::get_closest_point(const gr_complex* sample)
 {
+    float min_euclid_dist = get_distance(0, sample);
     unsigned int min_index = 0;
-    float min_euclid_dist;
-    float euclid_dist;
-
-    min_euclid_dist = get_distance(0, sample);
-    min_index = 0;
     for (unsigned int j = 1; j < d_arity; j++) {
-        euclid_dist = get_distance(j, sample);
+        float euclid_dist = get_distance(j, sample);
         if (euclid_dist < min_euclid_dist) {
             min_euclid_dist = euclid_dist;
             min_index = j;

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -15,7 +15,8 @@ from cmath import exp, pi, log, sqrt
 
 from gnuradio import gr, gr_unittest, digital, blocks
 from gnuradio.digital.utils import mod_codes
-from gnuradio.digital import psk, qam, qamlike
+from gnuradio.digital import constellation, psk, qam, qamlike
+import numpy as np
 
 tested_mod_codes = (mod_codes.NO_CODE, mod_codes.GRAY_CODE)
 
@@ -176,6 +177,26 @@ class test_constellation(gr_unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_normalization(self):
+        rot_sym = 1
+        side = 2
+        width = 2
+        # Test a couple of basic constellations
+        for constel_points, code in (digital.psk_4_0(), digital.qam_16_0()):
+            constel = digital.constellation_rect(constel_points, code, rot_sym,
+                                                 side, side, width, width,
+                                                 constellation.POWER_NORMALIZATION)
+
+            points = np.array(constel.points())
+            avg_power = np.sum(abs(points)**2) / len(points)
+            self.assertAlmostEqual(avg_power, 1.0, 6)
+            constel = digital.constellation_rect(constel_points, code, rot_sym,
+                                                 side, side, width, width,
+                                                 constellation.AMPLITUDE_NORMALIZATION)
+            points = np.array(constel.points())
+            avg_amp = np.sum(abs(points)) / len(points)
+            self.assertAlmostEqual(avg_amp, 1.0, 6)
 
     def test_hard_decision(self):
         for constellation, differential in tested_constellations():


### PR DESCRIPTION
Correct power normalization calculation.
Add a qa test for amplitude and power normalization.

Signed-off-by: David Pi <david.pinho@gmail.com>
(cherry picked from commit 0a4225dc9dd9e4d3c5ad58d40570d40d59f5670f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4909