### PR TITLE
network: tuntap knows what it's doing when it uses strncpy, suppress warning (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/tuntap_pdu_impl.cc
+++ b/gr-blocks/lib/tuntap_pdu_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2013 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -53,11 +54,21 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
     dev_cstr[IFNAMSIZ - 1] = '\0';
 
     bool istun = d_istunflag;
+
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+
     if (istun) {
         d_fd = tun_alloc(dev_cstr, (IFF_TUN | IFF_NO_PI));
     } else {
         d_fd = tun_alloc(dev_cstr, (IFF_TAP | IFF_NO_PI));
     }
+
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     if (d_fd <= 0)
         throw std::runtime_error(
@@ -116,9 +127,10 @@ int tuntap_pdu_impl::tun_alloc(char* dev, int flags)
      * the kernel will try to allocate the "next" device of the
      * specified type
      */
-    if (*dev)
+    if (*dev) {
+        // copy at most IFNAMSIZ - 1: If everything went well, the last byte is 0 anyway
         strncpy(ifr.ifr_name, dev, IFNAMSIZ - 1);
-
+    }
     /* try to create the device */
     if ((err = ioctl(fd, TUNSETIFF, (void*)&ifr)) < 0) {
         close(fd);


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 4c6ae3a386ec19698a8c01144c4e8a52fc113404)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5011