### PR TITLE
Revert "grc: Add no_quotes() convenience function (callable from templates) (backport to maint-3.8)"

### DIFF
--- a/grc/core/blocks/_templates.py
+++ b/grc/core/blocks/_templates.py
@@ -26,16 +26,6 @@ from mako.exceptions import SyntaxException
 
 from ..errors import TemplateError
 
-# The utils dict contains convenience functions
-# that can be called from any template
-def no_quotes(string, fallback=None):
-    if len(string) > 2:
-        if str(string)[0] + str(string)[-1] in ("''", '""'):
-            return str(string)[1:-1]
-    return str(fallback if fallback else string)
-
-utils = {'no_quotes': no_quotes}
-
 
 class MakoTemplates(dict):
 
@@ -75,7 +65,6 @@ class MakoTemplates(dict):
         if not text:
             return ''
         namespace = self.instance.namespace_templates
-        namespace = {**namespace, **utils}
 
         try:
             if isinstance(text, list):


### PR DESCRIPTION
Not compatible with Python2 - missed that one.

Reverts gnuradio/gnuradio#5046