### PR TITLE
qtgui: remove int type from number_sink block yaml

### DIFF
--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -12,9 +12,9 @@ parameters:
     label: Input Type
     category: General
     dtype: enum
-    options: [float, int, short, byte]
+    options: [float, short, byte]
     option_attributes:
-        size: [gr.sizeof_float, gr.sizeof_int, gr.sizeof_short, gr.sizeof_char]
+        size: [gr.sizeof_float, gr.sizeof_short, gr.sizeof_char]
     hide: part
 -   id: autoscale
     label: Autoscale


### PR DESCRIPTION
Number Sink takes a size, rather than a type, and does not support int32.
It assumes items of size 4 are floats.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Stopgap fix for https://github.com/gnuradio/gnuradio/issues/5056