### PR TITLE
digital: replace likelyhood with likelihood (backport to maint-3.8)

### DIFF
--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -21,8 +21,8 @@ parameters:
         digital.TED_MENGALI_AND_DANDREA_GMSK, digital.TED_SIGNAL_TIMES_SLOPE_ML, digital.TED_SIGNUM_TIMES_SLOPE_ML]
     option_labels: ["Mueller and Mueller", "Modified Mueller and Mueller", Zero
             Crossing, Gardner, Early-Late, D'Andrea and Mengali Gen MSK, Mengali and
-            D'Andrea GMSK, 'y[n]y''[n] Maximum Likelyhood', 'sgn(y[n])y''[n] Maximum
-            Likelyhood']
+            D'Andrea GMSK, 'y[n]y''[n] Maximum likelihood', 'sgn(y[n])y''[n] Maximum
+            likelihood']
     option_attributes:
         hide_constellation: [part, part, part, all, all, all, all, all, all]
 -   id: constellation


### PR DESCRIPTION
Signed-off-by: Rohan Sharma <rhnsharma5113@gmail.com>
(cherry picked from commit 18689424bcb3581f29c5b18f85cd45107c6827b7)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5014