### PR TITLE
github: Use GH container registry instead of Docker Hub

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -11,7 +11,7 @@ jobs:
   # can't use clang-format.
   check-formatting:
     name: Check C++ Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: gnuradio/clang-format-lint-action@v0.5-4
@@ -22,9 +22,9 @@ jobs:
   # Doxygen gets built separately. It has a lot of output and its own weirdness.
   doxygen:
     name: Doxygen
-    runs-on: ubuntu-20.04 # This can run on whatever
+    runs-on: ubuntu-latest # This can run on whatever
     container:
-      image: 'gnuradio/ci-ubuntu-20.04-3.9:0.3'
+      image: 'ghcr.io/gnuradio/ci:ubuntu-20.04-3.9'
       volumes:
         - build_data:/build
     steps:
@@ -37,7 +37,7 @@ jobs:
   linux-docker:
   # All of these shall depend on the formatting check (needs: check-formatting)
     needs: check-formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # The GH default is 360 minutes (it's also the max as of Feb-2021). However
     # we should fail sooner. The only reason to exceed this time is if a test
     # hangs.
@@ -52,16 +52,18 @@ jobs:
         # container (i.e., what you want to docker-pull)
         include:
           - distro: 'Ubuntu 20.04'
-            containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
+            containerid: 'ghcr.io/gnuradio/ci:ubuntu-20.04-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch
           - distro: 'Fedora 33'
-            containerid: 'gnuradio/ci:fedora-33-3.9'
+            containerid: 'ghcr.io/gnuradio/ci:fedora-33-3.9'
             cxxflags: ''
           - distro: 'CentOS 8.3'
+            # FIXME -- We're pulling this from Docker Hub, because somehow that works
+            # Should be from ghcr.io like the rest
             containerid: 'gnuradio/ci:centos-8.3-3.9'
-            cxxflags: -Werror
+            cxxflags: -Werror -Wno-error=invalid-pch
           - distro: 'Debian 10'
-            containerid: 'gnuradio/ci-debian-10-3.9:1.0'
+            containerid: 'ghcr.io/gnuradio/ci:debian-10-3.9'
             cxxflags: -Werror
     name: ${{ matrix.distro }}
     container:


### PR DESCRIPTION
Since autobuild was disabled for Docker Hub and free plans, this ties in
more easily with the GitHub integration.
