### PR TITLE
CI: Update the Fedora Container to F34

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -57,6 +57,9 @@ jobs:
           - distro: 'Fedora 33'
             containerid: 'ghcr.io/gnuradio/ci:fedora-33-3.9'
             cxxflags: ''
+          - distro: 'Fedora 34'
+            containerid: 'ghcr.io/gnuradio/ci:fedora-34-3.9'
+            cxxflags: ''
           - distro: 'CentOS 8.3'
             # FIXME -- We're pulling this from Docker Hub, because somehow that works
             # Should be from ghcr.io like the rest

--- a/.github/workflows/pkg-fedora.yml
+++ b/.github/workflows/pkg-fedora.yml
@@ -26,8 +26,8 @@ jobs:
         # descriptive name, and one key 'containerid' with the name of the
         # container (i.e., what you want to docker-pull)
         include:
-          - distro: 'Fedora 33'
-            containerid: 'gnuradio/ci:fedora-33-3.9'
+          - distro: 'Fedora 34'
+            containerid: 'ghcr.io/gnuradio/ci:fedora-34-3.9'
             cxxflags: -Werror
     name: ${{ matrix.distro }}
     container:


### PR DESCRIPTION
this has the main advantage of bringing UHD4, so we can test more of gr-uhd.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
Signed-off-by: Martin Braun <martin@gnuradio.org>

Replaces https://github.com/gnuradio/gnuradio/pull/4935, which I accidentally auto-closed.
