### PR TITLE
pdu: add samp_rate key

### DIFF
--- a/gnuradio-runtime/include/gnuradio/pdu.h
+++ b/gnuradio-runtime/include/gnuradio/pdu.h
@@ -19,6 +19,7 @@ namespace gr {
 namespace metadata_keys {
 GR_RUNTIME_API const pmt::pmt_t pdu_num();
 GR_RUNTIME_API const pmt::pmt_t rx_time();
+GR_RUNTIME_API const pmt::pmt_t sample_rate();
 GR_RUNTIME_API const pmt::pmt_t sys_time();
 GR_RUNTIME_API const pmt::pmt_t tx_eob();
 GR_RUNTIME_API const pmt::pmt_t tx_time();

--- a/gnuradio-runtime/lib/pdu.cc
+++ b/gnuradio-runtime/lib/pdu.cc
@@ -27,6 +27,11 @@ const pmt::pmt_t rx_time()
     static const pmt::pmt_t val = pmt::mp("rx_time");
     return val;
 }
+const pmt::pmt_t sample_rate()
+{
+    static const pmt::pmt_t val = pmt::mp("sample_rate");
+    return val;
+}
 const pmt::pmt_t sys_time()
 {
     static const pmt::pmt_t val = pmt::mp("sys_time");

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/pdu_pydoc_template.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/pdu_pydoc_template.h
@@ -21,6 +21,9 @@ static const char* __doc_gr_metadata_keys_pdu_num = R"doc()doc";
 static const char* __doc_gr_metadata_keys_rx_time = R"doc()doc";
 
 
+static const char* __doc_gr_metadata_keys_sample_rate = R"doc()doc";
+
+
 static const char* __doc_gr_metadata_keys_sys_time = R"doc()doc";
 
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/pdu_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/pdu_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pdu.h)                                                     */
-/* BINDTOOL_HEADER_FILE_HASH(6772caeddffe60c0c16148f68d21654f)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a347d61f9dff47c4bfcc26d89ad69a0c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -50,6 +50,9 @@ void bind_pdu(py::module& m)
 
     m_metadata_keys.def(
         "rx_time", &::gr::metadata_keys::rx_time, D(metadata_keys, rx_time));
+
+    m_metadata_keys.def(
+        "sample_rate", &::gr::metadata_keys::sample_rate, D(metadata_keys, sample_rate));
 
     m_metadata_keys.def(
         "sys_time", &::gr::metadata_keys::sys_time, D(metadata_keys, sys_time));

--- a/gr-pdu/lib/tags_to_pdu_impl.cc
+++ b/gr-pdu/lib/tags_to_pdu_impl.cc
@@ -157,6 +157,8 @@ void tags_to_pdu_impl<T>::publish_message()
         pmt::make_tuple(pmt::from_uint64(int_seconds), pmt::from_double(frac_seconds));
     d_meta_dict = pmt::dict_add(d_meta_dict, metadata_keys::rx_time(), time_tuple);
     d_meta_dict = pmt::dict_add(
+        d_meta_dict, metadata_keys::sample_rate(), pmt::from_double(d_samp_rate));
+    d_meta_dict = pmt::dict_add(
         d_meta_dict, metadata_keys::pdu_num(), pmt::from_uint64(d_burst_counter));
     if (d_wall_clock_time) {
         double t_now((boost::get_system_time() - d_epoch).total_microseconds() /


### PR DESCRIPTION
This was omitted accidentally, but is necessary in general for correct processing of PDU data