### PR TITLE
modify header_payload_demux

### DIFF
--- a/gr-digital/lib/header_payload_demux_impl.h
+++ b/gr-digital/lib/header_payload_demux_impl.h
@@ -18,6 +18,7 @@ namespace digital {
 class header_payload_demux_impl : public header_payload_demux
 {
 private:
+    int d_next_trigger_offset;              //!< The interval between two adjacent trigger signals
     int d_header_len;                       //!< Number of bytes per header
     const int d_header_padding_symbols;     //!< Symbols header padding
     const int d_header_padding_items;       //!< Items header padding


### PR DESCRIPTION
---
name: Pull Request Template
about: A template to help contributors submit clear pull-requests.
title: ''
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
i modify two files: gr-digital/lib/header_payload_demux_impl.cc and gr-digital/lib/header_payload_demux_impl.h in order to solve the problem of dropped frames. 
i use the example in gr-digital/examples/ofdm/rx_ofdm.grc to test my usrp equipment, i found a problem that even in an ideal channel simulation environment, frame dropping will occur randomly when i tried to modify it to transmit a picture , i can‘t uunderstood this phenomenon for a long time ， so i find a bug may lead to this issue in gr-digital/lib/header_payload_demux_impl.cc/h . 
When the original code consumes in general_work(), it ignores that if the data of the length of the current frame is consumed, the trigger signal from the Schmidl & Cox OFDM synch. block of the next frame of data may be overwritten, resulting in the failure of extracting the next frame of data ( Drop frame). So I modified the code so that when the code consumes, it also considers the position of the trigger signal of the next frame of data to prevent it from being eaten by the current frame. 

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
this will have a influence on block named Header/Payload Demux.
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
I modified the original routine. An ofdm symbol uses 128 carriers, so there are 1920 constellation points in a burst of data. At first I found the phenomenon of frame dropping. I printed the position of the trigger signal of the previous few frames of data as following :
```
143
2061
3981
......
```
i found When the two trigger signals differ by 1918 data(such as 2061-143=1918), the frame drop will occur next. obviously the normal interval is 1920. so i guess there may be a situation in the source code that the current frame ate the trigger signal of the next frame.so i mainly modified the code in `find_trigger_signal` in `gr-digital/lib/header_payload_demux_impl.cc` as following:

```
......
    int trigger_nums = 0;
    if (max_rel_offset < skip_items) {
        return rel_offset;
    }
    if (in_trigger) {
        for (int i = skip_items; i < max_rel_offset; i++) {
        for (int i = skip_items; i < max_rel_offset; i++) {
            if (in_trigger[i]) {
                trigger_nums++;
                // record location of the first trigger
                if(trigger_nums == 1) {
                    rel_offset = i;
                }
                // If there is a second trigger signal,record offset of between the first and second trigger
                else if (trigger_nums == 2) {
                    d_next_trigger_offset = i - rel_offset;
                    break;
                }
            }
        }
    }
......
```
and modified the consume method in `general_work()` as following:

```
            // Calculate whether the current frame consumes the trigger signal of the next frame data
            // If yes, then make corrections
            int consume_compensation = 0;
            int consume_nums = 0;
            // Calculate total consumption
            consume_nums = (d_curr_payload_len + d_header_len) * (d_items_per_symbol + d_gi) + 
                            d_header_padding_total_items + 
                            d_curr_payload_offset - 
                            items_padding ;
            // make a decision
            if(d_next_trigger_offset <= consume_nums) {
                consume_compensation = consume_nums - d_next_trigger_offset + 1;
            }
            else {
                consume_compensation = 0;
            }
            // add the corrections
            const int items_to_consume =
                d_curr_payload_len * (d_items_per_symbol + d_gi) - items_padding - consume_compensation;
```
i add a parameter named consume_compensation to ensure that the trigger of the next frame of data will not be eaten.
Then I recompiled and installed the modified code, and successfully solved the problem of dropped frames

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
