### PR TITLE
grc: Fix category and module tooltips

### DIFF
--- a/grc/gui/BlockTreeWindow.py
+++ b/grc/gui/BlockTreeWindow.py
@@ -153,7 +153,7 @@ class BlockTreeWindow(Gtk.VBox):
                 iter_ = treestore.insert_before(categories[parent_category[:-1]], None)
                 treestore.set_value(iter_, NAME_INDEX, parent_cat_name)
                 treestore.set_value(iter_, KEY_INDEX, '')
-                treestore.set_value(iter_, DOC_INDEX, _format_cat_tooltip(parent_cat_name))
+                treestore.set_value(iter_, DOC_INDEX, _format_cat_tooltip(parent_category))
                 categories[parent_category] = iter_
         # add block
         iter_ = treestore.insert_before(categories[category], None)


### PR DESCRIPTION
Category and module tooltips have been broken since GNU Radio 3.8. The `_format_cat_tooltip` function expects a tuple representing the module & category hierarchy, but a single string is passed in. As a result, everyhing is treated as a category, and only the last letter of the category or module name is displayed. I've fixed the problem by passing in the full tuple instead.

Before:
![tooltips-before-1](https://user-images.githubusercontent.com/583749/135477477-d15f1cbb-643f-4910-83d4-fdd0f70f6c2c.png) ![tooltips-before-2](https://user-images.githubusercontent.com/583749/135477488-cbe8d762-55da-46b6-9bfe-676b86ba04a9.png)

After:
![tooltips-after-1](https://user-images.githubusercontent.com/583749/135477578-ed41502c-5cb1-4757-a921-b30da604ee33.png) ![tooltips-after-2](https://user-images.githubusercontent.com/583749/135477598-7a3ccdbe-91d1-43a4-bcc9-33dd47b09433.png)

Signed-off-by: Clayton Smith <argilo@gmail.com>

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
