### PR TITLE
qtgui: remove vestigal parameter in fft cotr

### DIFF
--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -76,7 +76,7 @@ freq_sink_f_impl::freq_sink_f_impl(int fftsize,
     message_port_register_in(pmt::mp("in"));
     set_msg_handler(pmt::mp("in"), [this](pmt::pmt_t msg) { this->handle_pdus(msg); });
 
-    d_fft = std::make_unique<fft::fft_complex_fwd>(d_fftsize, true);
+    d_fft = std::make_unique<fft::fft_complex_fwd>(d_fftsize);
     d_fbuf.resize(d_fftsize);
 
     // save the last "connection" for the PDU memory


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@peratonlabs.com>

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
When the fft object is instantiated in qt gui freq sink (float), there is a `true` parameter that is interpreted as nthreads, but is really left over when the object was instantiated with bool as the forward rather than templated

This shouldn't affect any functionality, but is just a minor cleanup of the instantiation of this one object to remove confusion.


## Testing done
Verified that qt gui freq sink still works