### PR TITLE
grc: Add aliases for "sc16==short" and "sc8==byte"

### DIFF
--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -121,14 +121,18 @@ ALIAS_OF = {
     'float': 'f32',
     'int': 's32',
     'short': 's16',
+    'short': 'sc16',
     'byte': 's8',
+    'byte': 'sc8',
     'bits': 'bit',
 
     'fc32': 'complex',
     'f32': 'float',
     's32': 'int',
     's16': 'short',
+    'sc16': 'short',
     's8': 'byte',
+    'sc8': 'byte',
     'bit': 'bits',
 }
 


### PR DESCRIPTION
When type checking was added for GRC connections, the valid connections between a block with the "sc16" type (e.g. UHD blocks) and a block with the "short" type and a vector length of 2 (e.g. ishort->complex) now fail. Adding these aliases fixes that as a stop-gap until a better solution can be found.

Fixes #4998. See further discussion on this subject in #5001.