### PR TITLE
ci: execute make install and test Python package

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -55,26 +55,38 @@ jobs:
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath:
+            pythonpath: /usr/local/lib/python3/dist-packages
           - distro: 'Fedora 33'
             containerid: 'gnuradio/ci:fedora-33-3.9'
             cxxflags: ''
             ctest_args: '-E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath: /usr/local/lib64/
+            pythonpath:
           - distro: 'Fedora 34'
             containerid: 'gnuradio/ci:fedora-34-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath: /usr/local/lib64/
+            pythonpath:
           - distro: 'CentOS 8.3'
             containerid: 'gnuradio/ci:centos-8.3-3.9'
             cxxflags: ''
             ctest_args: '-E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath: /usr/local/lib64/
+            pythonpath:
           - distro: 'Debian 10'
             containerid: 'gnuradio/ci:debian-10-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath:
+            pythonpath: /usr/local/lib/python3/dist-packages
           - distro: 'Debian 11'
             containerid: 'gnuradio/ci:debian-11-3.10'
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|qa_polar_..coder_(sc_)?systematic"'
+            ldpath:
+            pythonpath: /usr/local/lib/python3/dist-packages
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}
@@ -92,3 +104,13 @@ jobs:
       run: 'cd /build && make -j2 -k'
     - name: Make Test
       run: 'cd /build && ctest --output-on-failure ${{ matrix.ctest_args }}'
+    - name: Make Install
+      run: |
+       cd /build
+       su -c "make install"
+       su -c "echo ${{matrix.ldpath}} >> /etc/ld.so.conf"
+       su -c ldconfig
+    - name: Test Python3
+      env:
+        PYTHONPATH: ${{ matrix.pythonpath }}
+      run: python3 -c "import gnuradio.blocks; print(gnuradio.blocks.complex_to_float())"


### PR DESCRIPTION
Installs GNURadio into the container and checks if Python can find,
import and use the gnuradio package.

Signed-off-by: schneider <schneider@blinkenlichts.net>

This relates to https://github.com/gnuradio/gnuradio/issues/5121

Currently Ubuntu/Debian need a special PYTHONPATH to be set for this to work. The goal of the issue above is to change that.
