### PR TITLE
runtime: remove C++17 std::filesystem from logger.cc

### DIFF
--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -30,7 +30,6 @@
 #include <boost/thread.hpp>
 
 #include <algorithm>
-#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <stdexcept>


### PR DESCRIPTION
## Description
This happens to work on modern compilers, but we only require C++14
for v3.9.

## Related Issue
Fixes #5134 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
