### PR TITLE
cmake: GrPython: make set_target_properties suitable for older cmake

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -97,8 +97,8 @@ set(Python_NumPy_INCLUDE_DIRS ${Python_NumPy_INCLUDE_DIR})
 add_library(Python::NumPy INTERFACE IMPORTED)
 set_target_properties(Python::NumPy PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${Python_NumPy_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES Python::Module
 )
-target_link_libraries(Python::NumPy INTERFACE Python::Module)
 
 
 ########################################################################


### PR DESCRIPTION
## Description
Older version of cmake, acceptable for v3.9, do not support changes made to GrPython.cmake. This PR uses a method compatible with both older and newer versions of cmake.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
