### PR TITLE
gr-runtime: hier_block2.py __getattr__ avoid recursive loop in exception

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/hier_block2.py
+++ b/gnuradio-runtime/python/gnuradio/gr/hier_block2.py
@@ -75,11 +75,16 @@ class hier_block2(object):
         """
         Pass-through member requests to the C++ object.
         """
-        if not hasattr(self, "_impl"):
+        
+        try:
+            object.__getattribute__(self, "_impl")
+        except AttributeError as exception:
             raise RuntimeError(
                 "{0}: invalid state -- did you forget to call {0}.__init__ in "
-                "a derived class?".format(self.__class__.__name__))
+                "a derived class?".format(object.__getattribute__(self.__class__, "__name__"))) from exception
+
         return getattr(self._impl, name)
+        
 
     # FIXME: these should really be implemented
     # in the original C++ class (gr_hier_block2), then they would all be inherited here


### PR DESCRIPTION
gnuradio-runtime: hier_block2.py `__getattr__` recursive loop bug fixes #5072

Simple test code to reproduce issue:
```
from gnuradio import gr
  
class test_block(gr.top_block):
    def __init__(self):
        #gr.top_block.__init__(self, "test_block")
        print("%s" % self.name)

tb = test_block()
```


- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
