### PR TITLE
grc: Write "ID", not "Id"

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -34,7 +34,7 @@ class Param(Element):
         """Make a new param from nested data"""
         super(Param, self).__init__(parent)
         self.key = id
-        self.name = label.strip() or id.title()
+        self.name = 'ID' if id == 'id' else (label.strip() or id.title())
         self.category = category or Constants.DEFAULT_PARAM_TAB
 
         self.dtype = dtype

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -99,7 +99,7 @@ class VariableEditor(Gtk.VBox):
         # Block Name or Category
         self.id_cell = Gtk.CellRendererText()
         self.id_cell.connect('edited', self._handle_name_edited_cb)
-        id_column = Gtk.TreeViewColumn("Id", self.id_cell, text=ID_INDEX)
+        id_column = Gtk.TreeViewColumn("ID", self.id_cell, text=ID_INDEX)
         id_column.set_name("id")
         id_column.set_resizable(True)
         id_column.set_max_width(Utils.scale_scalar(300))


### PR DESCRIPTION
## Description
The word "ID" is written with a lowercase "d" in some places (blocks and variable editor), this PR changes that.

## Which blocks/areas does this affect?
GRC

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
