### PR TITLE
utils: use tempfile instead of /tmp in bindtool and modtool

### DIFF
--- a/gr-utils/bindtool/scripts/bind_gr_module.py
+++ b/gr-utils/bindtool/scripts/bind_gr_module.py
@@ -2,12 +2,13 @@ import argparse
 import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR In-Tree Module')
 parser.add_argument('names', type=str, nargs='+',
                     help='Names of gr modules to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',

--- a/gr-utils/bindtool/scripts/bind_intree_file.py
+++ b/gr-utils/bindtool/scripts/bind_intree_file.py
@@ -4,12 +4,13 @@ import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
 import sys
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR In-Tree Module')
 parser.add_argument('--module', type=str,
                     help='Name of gr module containing file to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
@@ -4,12 +4,13 @@ import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
 import sys
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR Out of Tree Block')
 parser.add_argument('--module', type=str,
                     help='Name of gr module containing file to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',


### PR DESCRIPTION
Author: Gisle Vanem (gvanem) in Github issue #5157

Signed-off-by: Jeff Long <willcode4@gmail.com>

# Pull Request Details

## Description
Use tempfile instead of /tmp in bindtool and modtool. This works for Windows, and is a better idea in general.

## Related Issue
Fixes #5157 

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
