### PR TITLE
gr-blocks: Fix cpp support for unpacked to packed (backport to maint-3.9)

### DIFF
--- a/gr-blocks/grc/blocks_unpacked_to_packed_xx.block.yml
+++ b/gr-blocks/grc/blocks_unpacked_to_packed_xx.block.yml
@@ -1,6 +1,6 @@
 id: blocks_unpacked_to_packed_xx
 label: Unpacked to Packed
-flags: [ python ]
+flags: [ python, cpp ]
 
 parameters:
 -   id: type
@@ -46,5 +46,7 @@ cpp_templates:
     includes: ['#include <gnuradio/blocks/unpacked_to_packed.h>']
     declarations: 'blocks::unpacked_to_packed_${type.fcn}::sptr ${id};'
     make: 'this->${id} = blocks::unpacked_to_packed_${type.fcn}::make(${bits_per_chunk}, ${endianness});'
+    translations:
+        gr\.: ''
 
 file_format: 1


### PR DESCRIPTION
In commit 612c650, cpp support was added to the unpacked_to_packed
block. However, the cpp flag was not added. Neither was the endianness
option set correctly. This commit fixes it using packed_to_unpacked as
reference.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit 6360992c4b3fcac3cc3226a709fb0bac57b432b1)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5093