### PR TITLE
grc: Raise error for unfilled parameters (backport to maint-3.9)

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -214,7 +214,7 @@ class Param(Element):
                 except Exception as e:
                     raise Exception('Value "{}" cannot be evaluated:\n{}'.format(expr, e))
             else:
-                value = 0
+                value = None   # No parameter value provided
             if dtype == 'hex':
                 value = hex(value)
             elif dtype == 'bool':


### PR DESCRIPTION
Issue 5032 results from an unfilled parameter erroneously indicated as
filled with a default value of 0. This PR makes grc indicate an error
when there is an unfilled parameter by returning None.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>
(cherry picked from commit 91e9ddf8e1c37adff0c982c80bd1792df58cbe23)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5035