### PR TITLE
qtgui: remove vestigal parameter in fft cotr (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -90,7 +90,7 @@ freq_sink_f_impl::freq_sink_f_impl(int fftsize,
     // this is usually desired when plotting
     d_shift = true;
 
-    d_fft = new fft::fft_complex_fwd(d_fftsize, true);
+    d_fft = new fft::fft_complex_fwd(d_fftsize);
     d_fbuf = (float*)volk_malloc(d_fftsize * sizeof(float), volk_get_alignment());
     memset(d_fbuf, 0, d_fftsize * sizeof(float));
 


### PR DESCRIPTION
Backport 6ac6d36be9 (manual)

Signed-off-by: Josh Morman <jmorman@peratonlabs.com>
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5123