### PR TITLE
grc: Fix category and module tooltips (backport to maint-3.8)

### DIFF
--- a/grc/gui/BlockTreeWindow.py
+++ b/grc/gui/BlockTreeWindow.py
@@ -167,7 +167,7 @@ class BlockTreeWindow(Gtk.VBox):
                 iter_ = treestore.insert_before(categories[parent_category[:-1]], None)
                 treestore.set_value(iter_, NAME_INDEX, parent_cat_name)
                 treestore.set_value(iter_, KEY_INDEX, '')
-                treestore.set_value(iter_, DOC_INDEX, _format_cat_tooltip(parent_cat_name))
+                treestore.set_value(iter_, DOC_INDEX, _format_cat_tooltip(parent_category))
                 categories[parent_category] = iter_
         # add block
         iter_ = treestore.insert_before(categories[category], None)


### PR DESCRIPTION
Category and module tooltips have been broken since GNU Radio 3.8.
The _format_cat_tooltip function expects a tuple representing the
module & category hierarchy, but a single string is passed in. As
a result, everyhing is treated as a category, and only the last
letter of the category or module name is displayed. I've fixed
the problem by passing in the full tuple instead.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 64a6f07f20ca7921da021b2a943968d89489ffa6)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5120