### PR TITLE
ber_sink_b: Make qwidget() part of the API

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/ber_sink_b.h
+++ b/gr-qtgui/include/gnuradio/qtgui/ber_sink_b.h
@@ -37,6 +37,7 @@ public:
                      QWidget* parent = NULL);
 
     virtual void exec_() = 0;
+    virtual QWidget* qwidget() = 0;
 
     virtual void set_y_axis(double min, double max) = 0;
     virtual void set_x_axis(double min, double max) = 0;

--- a/gr-qtgui/lib/ber_sink_b_impl.h
+++ b/gr-qtgui/lib/ber_sink_b_impl.h
@@ -60,7 +60,7 @@ public:
     bool check_topology(int ninputs, int noutputs) override;
 
     void exec_() override;
-    QWidget* qwidget();
+    QWidget* qwidget() override;
 
     void set_y_axis(double min, double max) override;
     void set_x_axis(double min, double max) override;

--- a/gr-qtgui/python/qtgui/bindings/ber_sink_b_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/ber_sink_b_python.cc
@@ -55,6 +55,12 @@ void bind_ber_sink_b(py::module& m)
         .def("exec_", &ber_sink_b::exec_, D(ber_sink_b, exec_))
 
 
+        .def(
+            "qwidget",
+            [](ber_sink_b& self) { return reinterpret_cast<uintptr_t>(self.qwidget()); },
+            D(ber_sink_b, qwidget))
+
+
         .def("set_y_axis",
              &ber_sink_b::set_y_axis,
              py::arg("min"),

--- a/gr-qtgui/python/qtgui/bindings/docstrings/ber_sink_b_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/ber_sink_b_pydoc_template.h
@@ -18,6 +18,9 @@
 static const char* __doc_gr_qtgui_ber_sink_b = R"doc()doc";
 
 
+static const char* __doc_gr_qtgui_ber_sink_b_qwidget = R"doc()doc";
+
+
 static const char* __doc_gr_qtgui_ber_sink_b_ber_sink_b_0 = R"doc()doc";
 
 


### PR DESCRIPTION
The qwidget() method of ber_sink_b had previously not been declared part
of the public API, thus preventing its use from python.