### PR TITLE
utils: use tempfile instead of /tmp in bindtool and modtool (backport to maint-3.9)

### DIFF
--- a/gr-utils/bindtool/scripts/bind_gr_module.py
+++ b/gr-utils/bindtool/scripts/bind_gr_module.py
@@ -2,12 +2,13 @@ import argparse
 import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR In-Tree Module')
 parser.add_argument('names', type=str, nargs='+',
                     help='Names of gr modules to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',

--- a/gr-utils/bindtool/scripts/bind_intree_file.py
+++ b/gr-utils/bindtool/scripts/bind_intree_file.py
@@ -4,12 +4,13 @@ import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
 import sys
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR In-Tree Module')
 parser.add_argument('--module', type=str,
                     help='Name of gr module containing file to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/bind_oot_file.py
@@ -4,12 +4,13 @@ import os
 from gnuradio.bindtool import BindingGenerator
 import pathlib
 import sys
+import tempfile
 
 parser = argparse.ArgumentParser(description='Bind a GR Out of Tree Block')
 parser.add_argument('--module', type=str,
                     help='Name of gr module containing file to bind (e.g. fft digital analog)')
 
-parser.add_argument('--output_dir', default='/tmp',
+parser.add_argument('--output_dir', default=tempfile.gettempdir(),
                     help='Output directory of generated bindings')
 parser.add_argument('--prefix', help='Prefix of Installed GNU Radio')
 parser.add_argument('--src', help='Directory of gnuradio source tree',


### PR DESCRIPTION
Author: Gisle Vanem (gvanem) in Github issue #5157

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit fa01c8759dbfbff208690dbf39ef0ccc06a05a0f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5160