### PR TITLE
ci: sync CI test structure with master/maint-3.9

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -7,21 +7,24 @@ on:
     branches:
       - maint-3.8
 jobs:
+  # We start with checking C++ formatting. No one gets free CPU cycles if they
+  # can't use clang-format.
   check-formatting:
     name: Check C++ Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: gnuradio/clang-format-lint-action@v0.5-4
       with:
         source: '.'
         exclude: './volk'
-        extensions: 'h,hpp,cpp,cc'
+        extensions: 'h,hpp,cpp,cc,cc.in'
+  # Doxygen gets built separately. It has a lot of output and its own weirdness.
   doxygen:
     name: Doxygen
-    runs-on: ubuntu-20.04 # This can run on whatever
+    runs-on: ubuntu-latest # This can run on whatever
     container:
-      image: 'gnuradio/ci-ubuntu-18.04-3.8:0.2'
+      image: 'gnuradio/ci:ubuntu-18.04-3.8'
       volumes:
         - build_data:/build
     steps:
@@ -33,65 +36,60 @@ jobs:
       run: 'cd /build && cmake ${GITHUB_WORKSPACE}'
     - name: Make Docs
       run: 'cd /build && make doxygen_target'
+  linux-docker:
   # All of these shall depend on the formatting check (needs: check-formatting)
-  ubuntu-18_04:
-    name: Ubuntu 18.04
     needs: check-formatting
-    runs-on: ubuntu-20.04 # This can run on whatever
+    runs-on: ubuntu-latest # This can run on whatever
+    # The GH default is 360 minutes (it's also the max as of Feb-2021). However
+    # we should fail sooner. The only reason to exceed this time is if a test
+    # hangs.
+    timeout-minutes: 120
+    strategy:
+      # Enabling fail-fast would kill all Dockers if one of them fails. We want
+      # maximum output.
+      fail-fast: false
+      matrix:
+        # For every distro we want to test here, add one key 'distro' with a
+        # descriptive name, and one key 'containerid' with the name of the
+        # container (i.e., what you want to docker-pull)
+        include:
+          - distro: 'Ubuntu 18.04'
+            containerid: 'gnuradio/ci:ubuntu-18.04-3.8'
+            cxxflags: ''
+            cmakeflags: ''
+            ctest_args: '-E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui|volk"'
+            use_internal_volk: true
+          - distro: 'Ubuntu 18.04 (Python 2)'
+            containerid: 'gnuradio/ci:ubuntu-18.04-3.8'
+            cxxflags: ''
+            cmakeflags: '-DPYTHON_EXECUTABLE=/usr/bin/python2'
+            ctest_args: '-E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui|volk"'
+            use_internal_volk: true
+          - distro: 'CentOS 7.6'
+            containerid: 'gnuradio/ci:centos-7.6-3.8'
+            cxxflags: ''
+            cmakeflags: '-DENABLE_INTERNAL_VOLK=OFF'
+            ctest_args: '-E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui|volk"'
+            use_internal_volk: false
     container:
-      image: 'gnuradio/ci-ubuntu-18.04-3.8:0.2'
+      image: ${{ matrix.containerid }}
       volumes:
         - build_data:/build
       options: --cpus 2
     steps:
-    - uses: actions/checkout@v2
+    - if: ${{ matrix.use_internal_volk }}
       name: Checkout Project
+      uses: actions/checkout@v2
       with:
         submodules: 'recursive'
-    - name: CMake
-      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
-    - name: Make
-      run: 'cd /build && make -j2'
-    - name: Make Test
-      run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui"'
-  ubuntu-18_04_py2:
-    name: Ubuntu 18.04 (Python 2)
-    needs: check-formatting
-    runs-on: ubuntu-20.04 # This can run on whatever
-    container:
-      image: 'gnuradio/ci-ubuntu-18.04-3.8:0.2'
-      volumes:
-        - build_data:/build
-      options: --cpus 2
-    steps:
-    - uses: actions/checkout@v2
+    - if: ${{ !matrix.use_internal_volk }}
       name: Checkout Project
-      with:
-        submodules: 'recursive'
+      uses: actions/checkout@v2
     - name: CMake
-      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF -DPYTHON_EXECUTABLE=/usr/bin/python2'
+      env:
+        CXXFLAGS: ${{ matrix.cxxflags }}
+      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF ${{ matrix.cmakeflags }}'
     - name: Make
-      run: 'cd /build && make -j2'
+      run: 'cd /build && make -j2 -k'
     - name: Make Test
-      run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui"'
-  centos7:
-    name: Centos 7.6
-    needs: check-formatting
-    runs-on: ubuntu-20.04 # This can run on whatever
-    container:
-      image: 'gnuradio/ci-centos-7.6-3.8:0.2'
-      volumes:
-        - build_data:/build
-      options: --cpus 2
-    steps:
-    # Note: We don't checkout the submodule here, because we already have VOLK
-    # in this container, the installed git version is too old for GitHub Actions
-    # to checkout a submodule.
-    - uses: actions/checkout@v2
-      name: Checkout Project
-    - name: CMake
-      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF -DENABLE_INTERNAL_VOLK=OFF'
-    - name: Make
-      run: 'cd /build && make -j2'
-    - name: Make Test
-      run: 'cd /build && ctest --output-on-failure -E "qa_uhd|qa_uncaught_exception|qa_header_payload_demux|qa_agc|qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_file_taps_loader|qa_qtgui|volk"'
+      run: 'cd /build && ctest --output-on-failure ${{ matrix.ctest_args }}'


### PR DESCRIPTION
- Use GH matrix builds
- Backport minor improvements