### PR TITLE
examples: Repair all examples affected by commit 91e9ddf (backport to maint-3.9)

### DIFF
--- a/gr-audio/examples/grc/cvsd_sweep.grc
+++ b/gr-audio/examples/grc/cvsd_sweep.grc
@@ -221,8 +221,8 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: Original Spectrum
     nconnections: '1'
     showports: 'True'
@@ -298,8 +298,8 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: Encoded Spectrum
     nconnections: '1'
     showports: 'True'
@@ -375,8 +375,8 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: Decoded Spectrum
     nconnections: '1'
     showports: 'True'

--- a/gr-blocks/examples/ctrlport/comparing_resamplers.grc
+++ b/gr-blocks/examples/ctrlport/comparing_resamplers.grc
@@ -55,8 +55,8 @@ blocks:
     amp: '1'
     comment: ''
     freq: samp_rate/10
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     offset: '0'
     samp_rate: samp_rate
     type: complex
@@ -72,8 +72,8 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
     vlen: '1'
@@ -90,8 +90,8 @@ blocks:
     comment: ''
     epsilon: '1.0'
     freq_offset: '0.0'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     noise_voltage: '0.1'
     seed: '0'
     taps: '[1,]'
@@ -105,8 +105,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     phase_shift: '0'
     resamp_ratio: resamp_rate
     type: complex
@@ -121,8 +121,8 @@ blocks:
     alias: ''
     atten: '60'
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nfilts: '32'
     rrate: resamp_rate
     samp_delay: '0'

--- a/gr-blocks/examples/ctrlport/pfb_sync_test.grc
+++ b/gr-blocks/examples/ctrlport/pfb_sync_test.grc
@@ -128,8 +128,8 @@ blocks:
     bits_per_chunk: '8'
     comment: ''
     endianness: gr.GR_MSB_FIRST
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_ports: '1'
     type: byte
   states:
@@ -143,8 +143,8 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     samples_per_second: samp_rate
     type: byte
     vlen: '1'
@@ -158,8 +158,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     repeat: 'True'
     tags: '[]'
     type: byte
@@ -178,8 +178,8 @@ blocks:
     comment: ''
     epsilon: '1.0'
     freq_offset: '0.0'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     noise_voltage: noise
     seed: '0'
     taps: cmath.exp(1j*phase)
@@ -193,8 +193,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     order: '4'
     use_snr: 'False'
     w: 6.28/100.0
@@ -212,8 +212,8 @@ blocks:
     init_phase: nfilts/2
     loop_bw: 2*3.14/100.0
     max_dev: '1.5'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     osps: '1'
     sps: sps
     taps: firdes.root_raised_cosine(nfilts, nfilts,1.0/sps, 0.35, int(22*sps*nfilts))
@@ -232,8 +232,8 @@ blocks:
     differential: 'True'
     excess_bw: '0.35'
     log: 'False'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     mod_code: '"gray"'
     samples_per_symbol: sps
     verbose: 'False'

--- a/gr-blocks/examples/metadata/file_metadata_sink.grc
+++ b/gr-blocks/examples/metadata/file_metadata_sink.grc
@@ -64,8 +64,8 @@ blocks:
     amp: '1'
     comment: ''
     freq: '1000'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     offset: '0'
     samp_rate: samp_rate
     type: complex
@@ -99,8 +99,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_items: '20000000'
     type: complex
     vlen: '1'
@@ -391,8 +391,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     norm_gain0: 'False'
     norm_gain1: 'False'

--- a/gr-blocks/examples/metadata/file_metadata_source.grc
+++ b/gr-blocks/examples/metadata/file_metadata_source.grc
@@ -48,8 +48,8 @@ blocks:
     decay_rate: 1e-2
     gain: '1.0'
     max_gain: '0.0'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     reference: '1.0'
     type: complex
   states:
@@ -65,8 +65,8 @@ blocks:
     detached: 'True'
     file: /tmp/metadat_file.out
     hdr_file: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     repeat: 'False'
     type: complex
     vlen: '1'
@@ -112,8 +112,8 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
     vlen: '1'

--- a/gr-blocks/examples/metadata/file_metadata_vector_sink.grc
+++ b/gr-blocks/examples/metadata/file_metadata_vector_sink.grc
@@ -63,8 +63,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_items: '10010000'
     type: complex
     vlen: '10'
@@ -78,8 +78,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     repeat: 'True'
     tags: '[]'
     type: complex

--- a/gr-blocks/examples/metadata/file_metadata_vector_source.grc
+++ b/gr-blocks/examples/metadata/file_metadata_vector_source.grc
@@ -47,8 +47,8 @@ blocks:
     detached: 'True'
     file: /tmp/metadat_vector.out
     hdr_file: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     repeat: 'False'
     type: complex
     vlen: '10'
@@ -94,8 +94,8 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
     vlen: '10'
@@ -109,8 +109,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_items: '10'
     type: complex
     vlen: '1'

--- a/gr-blocks/examples/msg_passing/hier/test_msg_hier.grc
+++ b/gr-blocks/examples/msg_passing/hier/test_msg_hier.grc
@@ -38,8 +38,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     msg: pmt.cons(pmt.PMT_NIL, pmt.make_u8vector(16,0x77))
     period: '200'
   states:
@@ -55,8 +55,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     msg: pmt.intern("OUTPUT2")
     period: '100'
   states:
@@ -109,8 +109,8 @@ blocks:
     alias: ''
     comment: ''
     label: TEST_PORT2
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_streams: '1'
     optional: 'False'
     type: message
@@ -129,8 +129,8 @@ blocks:
     alias: ''
     comment: ''
     label: TEST_PORT1
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_streams: '1'
     optional: 'False'
     type: message

--- a/gr-blocks/examples/msg_passing/hier/test_msg_hier_topblock.grc
+++ b/gr-blocks/examples/msg_passing/hier/test_msg_hier_topblock.grc
@@ -45,8 +45,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     msg: pmt.intern("UPDATED")
     period: '2000'
   states:
@@ -59,8 +59,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     msg: pmt.intern("UPDATED2")
     period: '3000'
   states:
@@ -73,8 +73,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
   states:
     coordinate: [400, 200.0]
     rotation: 0

--- a/gr-channels/examples/demo_gmsk.grc
+++ b/gr-channels/examples/demo_gmsk.grc
@@ -180,7 +180,7 @@ blocks:
     alias: ''
     comment: ''
     gain: '1.0'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
   states:
     coordinate: [864, 228.0]
@@ -193,7 +193,7 @@ blocks:
     alias: ''
     comment: ''
     max: '256'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     min: '0'
     minoutbuf: '0'
     num_samps: '100000'
@@ -210,7 +210,7 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
@@ -230,7 +230,7 @@ blocks:
     gamma: '0'
     i_ofs: i_ofs
     magbal: magbal
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     phase_noise_mag: phase_noise_mag
     phasebal: phasebal
@@ -247,7 +247,7 @@ blocks:
     bt: '0.3'
     comment: ''
     log: 'False'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samples_per_symbol: '10'
     verbose: 'False'

--- a/gr-channels/examples/demo_ofdm.grc
+++ b/gr-channels/examples/demo_ofdm.grc
@@ -198,7 +198,7 @@ blocks:
     alias: ''
     comment: ''
     max: int(k)
-    maxoutbuf: ''
+    maxoutbuf: '0'
     min: '0'
     minoutbuf: '0'
     num_samps: '10000'
@@ -215,7 +215,7 @@ blocks:
     alias: ''
     comment: ''
     max: int(k)
-    maxoutbuf: ''
+    maxoutbuf: '0'
     min: '0'
     minoutbuf: '0'
     num_samps: '10000'
@@ -232,7 +232,7 @@ blocks:
     alias: ''
     comment: ''
     const: (-1-1j)/2
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     type: complex
     vlen: '1'
@@ -246,7 +246,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     vlen: '1'
   states:
@@ -259,7 +259,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     scale: k-1
     vlen: '1'
@@ -273,7 +273,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     scale: k-1
     vlen: '1'
@@ -287,7 +287,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_items: fft_size
     type: complex
@@ -302,7 +302,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_items: fft_size
     type: complex
@@ -318,7 +318,7 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
@@ -333,7 +333,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_items: fft_size
     type: complex
@@ -348,7 +348,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_items: fft_size
     type: complex
@@ -368,7 +368,7 @@ blocks:
     gamma: '0'
     i_ofs: i_ofs
     magbal: magbal
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     phase_noise_mag: phase_noise_mag
     phasebal: phasebal
@@ -385,7 +385,7 @@ blocks:
     comment: ''
     fft_size: fft_size
     forward: 'False'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     nthreads: '1'
     shift: 'False'
@@ -403,7 +403,7 @@ blocks:
     comment: ''
     fft_size: fft_size
     forward: 'True'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     nthreads: '1'
     shift: 'False'

--- a/gr-channels/examples/demo_qam.grc
+++ b/gr-channels/examples/demo_qam.grc
@@ -189,7 +189,7 @@ blocks:
     alias: ''
     comment: ''
     max: int(k)
-    maxoutbuf: ''
+    maxoutbuf: '0'
     min: '0'
     minoutbuf: '0'
     num_samps: '10000'
@@ -206,7 +206,7 @@ blocks:
     alias: ''
     comment: ''
     max: int(k)
-    maxoutbuf: ''
+    maxoutbuf: '0'
     min: '0'
     minoutbuf: '0'
     num_samps: '10000'
@@ -223,7 +223,7 @@ blocks:
     alias: ''
     comment: ''
     const: (-1-1j)/2
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     type: complex
     vlen: '1'
@@ -237,7 +237,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     vlen: '1'
   states:
@@ -250,7 +250,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     scale: k-1
     vlen: '1'
@@ -264,7 +264,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     scale: k-1
     vlen: '1'
@@ -279,7 +279,7 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
@@ -299,7 +299,7 @@ blocks:
     gamma: '0'
     i_ofs: i_ofs
     magbal: magbal
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     phase_noise_mag: phase_noise_mag
     phasebal: phasebal

--- a/gr-channels/examples/demo_quantization.grc
+++ b/gr-channels/examples/demo_quantization.grc
@@ -161,7 +161,7 @@ blocks:
     alias: ''
     amp: pow(10.0,noise_amp/20.0)
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     noise_type: analog.GR_GAUSSIAN
     seed: '42'
@@ -178,7 +178,7 @@ blocks:
     amp: pow(10.0,signal_amp/20.0)
     comment: ''
     freq: sigfreq
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
     samp_rate: samp_rate
@@ -200,7 +200,7 @@ blocks:
     high_cutoff_freq: min(samp_rate/2.0-bw/15.0,center+bw/2.0)
     interp: '1'
     low_cutoff_freq: max(bw/15.0,center-bw/2.0)
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samp_rate: samp_rate
     type: fir_filter_fff
@@ -216,7 +216,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_inputs: '2'
     type: float
@@ -232,7 +232,7 @@ blocks:
     alias: ''
     comment: ''
     const: pow(2,bits-1)
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     type: float
     vlen: '1'
@@ -247,7 +247,7 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samples_per_second: samp_rate
     type: float
@@ -263,7 +263,7 @@ blocks:
     alias: ''
     bits: bits
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
   states:
     coordinate: [664, 268.0]
@@ -327,8 +327,8 @@ blocks:
     label8: ''''''
     label9: ''''''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: ''
     nconnections: '1'
     showports: 'True'

--- a/gr-channels/examples/demo_spec_an.grc
+++ b/gr-channels/examples/demo_spec_an.grc
@@ -264,8 +264,8 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: FFT Plot
     nconnections: '1'
     showports: 'True'

--- a/gr-channels/examples/demo_two_tone.grc
+++ b/gr-channels/examples/demo_two_tone.grc
@@ -248,7 +248,7 @@ blocks:
     alias: ''
     amp: '.00001'
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     noise_type: analog.GR_GAUSSIAN
     seed: '42'
@@ -265,7 +265,7 @@ blocks:
     amp: pow(10,sig_amp/20.0)*twotones
     comment: ''
     freq: f2
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
     samp_rate: samp_rate
@@ -283,7 +283,7 @@ blocks:
     amp: pow(10,sig_amp/20.0)
     comment: ''
     freq: f1
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     offset: '0'
     samp_rate: samp_rate
@@ -299,7 +299,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     num_inputs: '3'
     type: complex
@@ -315,7 +315,7 @@ blocks:
     alias: ''
     comment: ''
     ignoretag: 'True'
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     samples_per_second: samp_rate
     type: complex
@@ -331,7 +331,7 @@ blocks:
     alias: ''
     alpha: '0.0001'
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
   states:
     coordinate: [848, 396.0]
@@ -348,7 +348,7 @@ blocks:
     gamma: gamma
     i_ofs: i_ofs
     magbal: magbal
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
     phase_noise_mag: phase_noise_mag
     phasebal: '0'
@@ -364,7 +364,7 @@ blocks:
     alias: ''
     alpha: '0.00001'
     comment: ''
-    maxoutbuf: ''
+    maxoutbuf: '0'
     minoutbuf: '0'
   states:
     coordinate: [856, 340.0]
@@ -428,8 +428,8 @@ blocks:
     label8: ''''''
     label9: ''''''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: QT GUI Plot
     nconnections: '1'
     showports: 'True'

--- a/gr-digital/examples/demod/pam_sync.grc
+++ b/gr-digital/examples/demod/pam_sync.grc
@@ -432,8 +432,8 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: Post-sync Spectrum
     nconnections: '1'
     showports: 'True'
@@ -509,8 +509,8 @@ blocks:
     label8: ''
     label9: ''
     legend: 'True'
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     name: Received Spectrum
     nconnections: '1'
     showports: 'True'

--- a/gr-dtv/examples/catv_tx_256qam.grc
+++ b/gr-dtv/examples/catv_tx_256qam.grc
@@ -682,8 +682,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/catv_tx_64qam.grc
+++ b/gr-dtv/examples/catv_tx_64qam.grc
@@ -682,8 +682,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/dvbs2_tx.grc
+++ b/gr-dtv/examples/dvbs2_tx.grc
@@ -695,8 +695,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/dvbs_tx.grc
+++ b/gr-dtv/examples/dvbs_tx.grc
@@ -637,8 +637,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/dvbt_tx_2k.grc
+++ b/gr-dtv/examples/dvbt_tx_2k.grc
@@ -552,8 +552,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/dvbt_tx_8k.grc
+++ b/gr-dtv/examples/dvbt_tx_8k.grc
@@ -552,8 +552,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/file_atsc_tx.grc
+++ b/gr-dtv/examples/file_atsc_tx.grc
@@ -361,8 +361,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     stream_id: mod-rot
   states:
     coordinate: [336, 276.0]

--- a/gr-dtv/examples/germany-g1.grc
+++ b/gr-dtv/examples/germany-g1.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g10.grc
+++ b/gr-dtv/examples/germany-g10.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g2.grc
+++ b/gr-dtv/examples/germany-g2.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g3.grc
+++ b/gr-dtv/examples/germany-g3.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g4.grc
+++ b/gr-dtv/examples/germany-g4.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g5.grc
+++ b/gr-dtv/examples/germany-g5.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g6.grc
+++ b/gr-dtv/examples/germany-g6.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g7.grc
+++ b/gr-dtv/examples/germany-g7.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g8.grc
+++ b/gr-dtv/examples/germany-g8.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/germany-g9.grc
+++ b/gr-dtv/examples/germany-g9.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/uhd_atsc_tx.grc
+++ b/gr-dtv/examples/uhd_atsc_tx.grc
@@ -684,8 +684,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv001-cr35.grc
+++ b/gr-dtv/examples/vv001-cr35.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv003-cr23.grc
+++ b/gr-dtv/examples/vv003-cr23.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv004-8kfft.grc
+++ b/gr-dtv/examples/vv004-8kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv005-8kfft.grc
+++ b/gr-dtv/examples/vv005-8kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv007-16kfft.grc
+++ b/gr-dtv/examples/vv007-16kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv008-16kfft.grc
+++ b/gr-dtv/examples/vv008-16kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv009-4kfft.grc
+++ b/gr-dtv/examples/vv009-4kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv010-2kfft.grc
+++ b/gr-dtv/examples/vv010-2kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv011-1kfft.grc
+++ b/gr-dtv/examples/vv011-1kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv012-64qam45.grc
+++ b/gr-dtv/examples/vv012-64qam45.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv013-64qam56.grc
+++ b/gr-dtv/examples/vv013-64qam56.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv014-64qam34.grc
+++ b/gr-dtv/examples/vv014-64qam34.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv015-8kfft.grc
+++ b/gr-dtv/examples/vv015-8kfft.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv016-256qam34.grc
+++ b/gr-dtv/examples/vv016-256qam34.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv017-paprtr.grc
+++ b/gr-dtv/examples/vv017-paprtr.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv018-miso.grc
+++ b/gr-dtv/examples/vv018-miso.grc
@@ -833,8 +833,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '2'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv019-norot.grc
+++ b/gr-dtv/examples/vv019-norot.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv034-dtg016.grc
+++ b/gr-dtv/examples/vv034-dtg016.grc
@@ -702,8 +702,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv035-dtg052.grc
+++ b/gr-dtv/examples/vv035-dtg052.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-dtv/examples/vv036-dtg091.grc
+++ b/gr-dtv/examples/vv036-dtg091.grc
@@ -727,8 +727,8 @@ blocks:
     lo_source7: internal
     lo_source8: internal
     lo_source9: internal
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     nchan: '1'
     num_mboards: '1'
     otw: ''

--- a/gr-vocoder/examples/loopback-codec2.grc
+++ b/gr-vocoder/examples/loopback-codec2.grc
@@ -97,8 +97,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     num_inputs: '2'
     type: float
     vlen: '1'
@@ -127,8 +127,8 @@ blocks:
     alias: ''
     comment: ''
     const: 0.0 if play_encoded  else 1.0
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     type: float
     vlen: '1'
   states:
@@ -142,8 +142,8 @@ blocks:
     alias: ''
     comment: ''
     const: 1.0 if play_encoded  else 0.0
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     type: float
     vlen: '1'
   states:
@@ -502,8 +502,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     stream_id: Encoded Speech
   states:
     coordinate: [0, 292.0]
@@ -515,8 +515,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     stream_id: Raw Audio
   states:
     coordinate: [-1, 389]
@@ -528,8 +528,8 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    maxoutbuf: ''
-    minoutbuf: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
     stream_id: Decoded Speech
   states:
     coordinate: [3, 449]


### PR DESCRIPTION
Replace all occurrences of empty minoutbuf and maxoutbuf with 0.

Signed-off-by: Ron Economos <w6rz@comcast.net>
(cherry picked from commit 89e45e3f9422a8b6f069d770de23f5ca841426d6)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5129