### PR TITLE
grc: added shortcuts zoom in/out/reset

### DIFF
--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -432,8 +432,22 @@ BLOCK_BYPASS = actions.register(
     icon_name='media-seek-forward',
     keypresses=["b"],
 )
-TOGGLE_SNAP_TO_GRID = actions.register(
-    "win.snap_to_grid",
+ZOOM_IN = actions.register("win.zoom_in",
+    label='Zoom In',
+    tooltip='Increase the canvas zoom level',
+    keypresses=["<Ctrl>plus","<Ctrl>equal","<Ctrl>KP_Add"],
+)
+ZOOM_OUT = actions.register("win.zoom_out",
+    label='Zoom Out',
+    tooltip='Decrease the canvas zoom level',
+    keypresses=["<Ctrl>minus","<Ctrl>KP_Subtract"],
+)
+ZOOM_RESET = actions.register("win.zoom_reset",
+    label='Reset Zoom',
+    tooltip='Reset the canvas zoom level',
+    keypresses=["<Ctrl>0","<Ctrl>KP_0"],
+)
+TOGGLE_SNAP_TO_GRID = actions.register("win.snap_to_grid",
     label='_Snap to grid',
     tooltip='Snap blocks to a grid for an easier connection alignment',
     preference_name='snap_to_grid',

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -543,6 +543,12 @@ class Application(Gtk.Application):
                     markup="Moving the variable editor requires a restart of GRC."
                 ).run_and_destroy()
                 action.save_to_preferences()
+        elif action == Actions.ZOOM_IN:
+            page.drawing_area.zoom_in()
+        elif action == Actions.ZOOM_OUT:
+            page.drawing_area.zoom_out()
+        elif action == Actions.ZOOM_RESET:
+            page.drawing_area.reset_zoom()
         ##################################################
         # Param Modifications
         ##################################################

--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -74,6 +74,9 @@ MENU_BAR_LIST = [
             Actions.TOGGLE_SHOW_PARAMETER_EXPRESSION, Actions.TOGGLE_SHOW_PARAMETER_EVALUATION],
         [Actions.TOGGLE_HIDE_DISABLED_BLOCKS, Actions.TOGGLE_AUTO_HIDE_PORT_LABELS, Actions.TOGGLE_SNAP_TO_GRID, Actions.TOGGLE_SHOW_BLOCK_COMMENTS, Actions.TOGGLE_SHOW_BLOCK_IDS,],
         [Actions.TOGGLE_SHOW_CODE_PREVIEW_TAB],
+        [Actions.ZOOM_IN],
+        [Actions.ZOOM_OUT],
+        [Actions.ZOOM_RESET],
         [Actions.ERRORS_WINDOW_DISPLAY, Actions.FIND_BLOCKS],
     ]),
     ('_Run', [

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -342,6 +342,8 @@ def show_keyboard_shortcuts(parent):
     <u>Shift+T/M/B/L/C/R</u>: Vertical Align Top/Middle/Bottom and
             Horizontal Align Left/Center/Right respectively of the
             selected block.
+    <u>Ctrl+0</u>: Reset the zoom level
+    <u>Ctrl++/-</u>: Zoom in and out
     \
     """)
     markup = markup.replace("Ctrl", Utils.get_modifier_key())

--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -90,17 +90,32 @@ class DrawingArea(Gtk.DrawingArea):
         coords = x / self.zoom_factor, y / self.zoom_factor
         self._flow_graph.add_new_block(selection_data.get_text(), coords)
 
+    def zoom_in(self):
+        change = 1.2
+        zoom_factor = min(self.zoom_factor * change, 5.0)
+        self._set_zoom_factor(zoom_factor)
+
+    def zoom_out(self):
+        change = 1/1.2 
+        zoom_factor = max(self.zoom_factor * change, 0.1)
+        self._set_zoom_factor(zoom_factor)
+
+    def reset_zoom(self):
+        self._set_zoom_factor(1.0)
+
+    def _set_zoom_factor(self, zoom_factor):
+        if zoom_factor != self.zoom_factor:
+            self.zoom_factor = zoom_factor
+            self._update_after_zoom = True
+            self.queue_draw()
+
     def _handle_mouse_scroll(self, widget, event):
         if event.get_state() & Gdk.ModifierType.CONTROL_MASK:
-            change = 1.2 if event.direction == Gdk.ScrollDirection.UP else 1/1.2
-            zoom_factor = min(max(self.zoom_factor * change, 0.1), 5.0)
-
-            if zoom_factor != self.zoom_factor:
-                self.zoom_factor = zoom_factor
-                self._update_after_zoom = True
-                self.queue_draw()
+            if event.direction == Gdk.ScrollDirection.UP:
+                self.zoom_in()
+            else:
+                self.zoom_out()
             return True
-
         return False
 
     def _handle_mouse_button_press(self, widget, event):


### PR DESCRIPTION
Co-authored-by: Jeff Dumps <jeffdumps@gmail.com>
Co-authored-by: Derek Kozel <derek@bitstovolts.com>
Signed-off-by: Derek Kozel <derek@bitstovolts.com>

## Description
Adds keyboard shortcuts for zooming in GRC.
Based on PR https://github.com/gnuradio/gnuradio/pull/3285 but rebased and resubmitted with DCO by me.

## Related Issue
Fixes **https://github.com/gnuradio/gnuradio/issues/3145**

## Which blocks/areas does this affect?
Zooming in GRC.

## Testing Done
Tested each basic function on Ubuntu 21.04.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
