### PR TITLE
grc: Look up type aliases as a set instead of a single value

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 
 from .base import Element
-from .Constants import ALIAS_OF
+from .Constants import ALIASES_OF
 from .utils.descriptors import lazy_property
 
 
@@ -93,7 +93,7 @@ class Connection(Element):
 
         source_dtype = self.source_port.dtype
         sink_dtype = self.sink_port.dtype
-        if source_dtype != sink_dtype and source_dtype != ALIAS_OF.get(sink_dtype):
+        if source_dtype != sink_dtype and source_dtype not in ALIASES_OF.get(sink_dtype):
             self.add_error_message('Source IO type "{}" does not match sink IO type "{}".'.format(source_dtype, sink_dtype))
 
         source_size = self.source_port.item_size

--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -116,24 +116,22 @@ ALIAS_TYPES = {
     'bits':    (1, GRC_COLOR_PURPLE_A100),
 }
 
-ALIAS_OF = {
-    'complex': 'fc32',
-    'float': 'f32',
-    'int': 's32',
-    'short': 's16',
-    'short': 'sc16',
-    'byte': 's8',
-    'byte': 'sc8',
-    'bits': 'bit',
+ALIASES_OF = {
+    'complex': {'fc32'},
+    'float': {'f32'},
+    'int': {'s32'},
+    'short': {'s16', 'sc16'},
+    'byte': {'s8', 'sc8'},
+    'bits': {'bit'},
 
-    'fc32': 'complex',
-    'f32': 'float',
-    's32': 'int',
-    's16': 'short',
-    'sc16': 'short',
-    's8': 'byte',
-    'sc8': 'byte',
-    'bit': 'bits',
+    'fc32': {'complex'},
+    'f32': {'float'},
+    's32': {'int'},
+    's16': {'short'},
+    'sc16': {'short'},
+    's8': {'byte'},
+    'sc8': {'byte'},
+    'bit': {'bits'},
 }
 
 TYPE_TO_SIZEOF = {key: sizeof for name, key, sizeof, color in CORE_TYPES}


### PR DESCRIPTION
After #5127, we inadvertently had duplicate dictionary keys, meaning the last entry is the only one that actually existed and some desired aliases were missing. This changes the ALIAS_OF dictionary to ALIASES_OF where the values are now a set of aliases instead of a single string value. The one use of the ALIAS_OF dictionary was changed to operate on the returned set.