### PR TITLE
grc: Dependent variables sometimes fail to evaluate

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -227,6 +227,10 @@ class FlowGraph(Element):
 
     def renew_namespace(self):
         namespace = {}
+        # Before renewing the namespace, clear it
+        # to get rid of entries of blocks that
+        # are no longer valid ( deleted, disabled, ...)
+        self.namespace.clear()
         # Load imports
         for expr in self.imports():
             try:
@@ -262,6 +266,9 @@ class FlowGraph(Element):
                 pass
         namespace.update(np)  # Merge param namespace
 
+        # We need the updated namespace to evaluate the variable blocks
+        # otherwise sometimes variable_block rewrite / eval fails
+        self.namespace.update(namespace)
         # Load variables
         for variable_block in self.get_variables():
             try:
@@ -275,9 +282,7 @@ class FlowGraph(Element):
                 log.exception('Failed to evaluate variable block {0}'.format(variable_block.name), exc_info=True)
                 pass
 
-        self.namespace.clear()
         self._eval_cache.clear()
-        self.namespace.update(namespace)
 
     def evaluate(self, expr, namespace=None, local_namespace=None):
         """

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -118,7 +118,6 @@ class Application(Gtk.Application):
 
         def flow_graph_update(fg=flow_graph):
             main.vars.update_gui(fg.blocks)
-            fg.namespace.clear()
             fg.update()
 
         ##################################################


### PR DESCRIPTION
Sometimes dependent variables fail to evaluate or are not updated if the parent variable is disabled or deleted.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
In renew_namespace of FlowGraph.py the namespace must be deleted first, otherwise the namespace may contain
entries of deleted blocks.
Loading the variable blocks calls 
variable_block.rewrite() which requires the actual namespace.
So before loading the variable blocks , the namespace must be updated

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #4788
Fixes #5100
Fixes #5108

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested with the examples in the mentioned issues 
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
