### PR TITLE
digital: remove deprecation of pfb_clock_sync

### DIFF
--- a/gr-digital/grc/digital.tree.yml
+++ b/gr-digital/grc/digital.tree.yml
@@ -67,5 +67,6 @@
   - digital_pn_correlator_cc
   - digital_symbol_sync_xx
   - digital_corr_est_cc
+  - digital_pfb_clock_sync_xxx
 - Waveform Generators:
   - digital_glfsr_source_x

--- a/gr-digital/grc/digital_pfb_clock_sync.block.yml
+++ b/gr-digital/grc/digital_pfb_clock_sync.block.yml
@@ -1,6 +1,5 @@
 id: digital_pfb_clock_sync_xxx
 label: Polyphase Clock Sync
-category: '[Core]/Deprecated'
 flags: [ python, cpp ]
 
 parameters:

--- a/gr-digital/include/gnuradio/digital/pfb_clock_sync_ccf.h
+++ b/gr-digital/include/gnuradio/digital/pfb_clock_sync_ccf.h
@@ -22,7 +22,6 @@ namespace digital {
 /*!
  * \brief Timing synchronizer using polyphase filterbanks
  * \ingroup synchronizers_blk
- * \ingroup deprecated_blk
  *
  * \details
  * This block performs timing synchronization for PAM signals by

--- a/gr-digital/include/gnuradio/digital/pfb_clock_sync_fff.h
+++ b/gr-digital/include/gnuradio/digital/pfb_clock_sync_fff.h
@@ -21,7 +21,6 @@ namespace digital {
 /*!
  * \brief Timing synchronizer using polyphase filterbanks
  * \ingroup synchronizers_blk
- * \ingroup deprecated_blk
  *
  * \details
  * This block performs timing synchronization for PAM signals by

--- a/gr-digital/python/digital/bindings/pfb_clock_sync_ccf_python.cc
+++ b/gr-digital/python/digital/bindings/pfb_clock_sync_ccf_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_clock_sync_ccf.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(beadeabb3442683fa98ecbdff1319291)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ff1ec489c6af5b0c2d7ab649fecc8757)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/pfb_clock_sync_fff_python.cc
+++ b/gr-digital/python/digital/bindings/pfb_clock_sync_fff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pfb_clock_sync_fff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0ff21f303c65027ebf6517658e2f2f6d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a3246c72d3a0a56ddfa3be6489dd2ff3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
# Pull Request Details

The PFB Clock Sync block (which was deprecated in 3.9) is not straightforward to drop in replace with the symbol_sync block - there are some non-trivial calculations that have to take place.  Let's just leave the PFB clock sync block where it is as it is not fussy and very useful.

