### PR TITLE
grc: Don't fail when type lookup fails by defaulting to an empty set (backport to maint-3.9)

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -93,7 +93,9 @@ class Connection(Element):
 
         source_dtype = self.source_port.dtype
         sink_dtype = self.sink_port.dtype
-        if source_dtype != sink_dtype and source_dtype not in ALIASES_OF.get(sink_dtype):
+        if source_dtype != sink_dtype and source_dtype not in ALIASES_OF.get(
+            sink_dtype, default=set()
+        ):
             self.add_error_message('Source IO type "{}" does not match sink IO type "{}".'.format(source_dtype, sink_dtype))
 
         source_size = self.source_port.item_size


### PR DESCRIPTION
Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit 2c83f5ce267267119e90c1ab552845edb500030c)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5193