### PR TITLE
grc: fix typo in Connection.py

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -94,7 +94,7 @@ class Connection(Element):
         source_dtype = self.source_port.dtype
         sink_dtype = self.sink_port.dtype
         if source_dtype != sink_dtype and source_dtype not in ALIASES_OF.get(
-            sink_dtype, default=set()
+            sink_dtype, set()
         ):
             self.add_error_message('Source IO type "{}" does not match sink IO type "{}".'.format(source_dtype, sink_dtype))
 


### PR DESCRIPTION
`dict.get()` does not take a `default=` keyword, just a second arg.

Signed-off-by: Jeff Long <willcode4@gmail.com>