### PR TITLE
grc: typo in Connection.py - default for dict is just an extra arg, no default= keyword

### DIFF
--- a/grc/core/Connection.py
+++ b/grc/core/Connection.py
@@ -94,7 +94,7 @@ class Connection(Element):
         source_dtype = self.source_port.dtype
         sink_dtype = self.sink_port.dtype
         if source_dtype != sink_dtype and source_dtype not in ALIASES_OF.get(
-            sink_dtype, default=set()
+            sink_dtype, set()
         ):
             self.add_error_message('Source IO type "{}" does not match sink IO type "{}".'.format(source_dtype, sink_dtype))
 


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 553248575079794236923ad3aa03cda03ed902d0)
Signed-off-by: Jeff Long <willcode4@gmail.com>
