### PR TITLE
qtgui: revert "qt-gui: enables use of Qwt 6.2" (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -29,10 +29,7 @@
 #include <vector>
 
 #if QWT_VERSION >= 0x060000
-typedef QPointF QwtDoublePoint;
-typedef QRectF QwtDoubleRect;
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
 #endif
 
 typedef QList<QColor> QColorList;

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -23,9 +23,7 @@
 #if QWT_VERSION < 0x060000
 #include <gnuradio/qtgui/plot_waterfall.h>
 #else
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
 #endif
 
 /*!

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -22,9 +22,7 @@
 #if QWT_VERSION < 0x060000
 #include <gnuradio/qtgui/plot_waterfall.h>
 #else
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
 #endif
 
 /*!

--- a/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
@@ -16,10 +16,8 @@
 #include <qwt_plot_rasteritem.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qsize.h>
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class QwtColorMap;

--- a/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
@@ -16,10 +16,8 @@
 #include <qwt_plot_rasteritem.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qsize.h>
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class QwtColorMap;

--- a/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
+++ b/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
@@ -14,7 +14,6 @@
 #include <gnuradio/high_res_timer.h>
 #include <qwt_color_map.h>
 #include <qwt_scale_draw.h>
-#include <qwt_text.h>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -15,9 +15,8 @@
 #include <cinttypes>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class TimeRasterData : public QwtRasterData
@@ -36,9 +35,6 @@ public:
 #if QWT_VERSION < 0x060000
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
-#else
-    virtual QwtInterval interval(Qt::Axis) const;
-    void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 
     double value(double x, double y) const override;
@@ -60,7 +56,6 @@ protected:
     QwtDoubleInterval d_intensityRange;
 #else
     QwtInterval d_intensityRange;
-    QwtInterval d_intervals[3];
 #endif
 
 private:

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -15,9 +15,8 @@
 #include <cinttypes>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class WaterfallData : public QwtRasterData
@@ -37,9 +36,6 @@ public:
 #if QWT_VERSION < 0x060000
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
-#else
-    virtual QwtInterval interval(Qt::Axis) const;
-    void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 
     double value(double x, double y) const override;
@@ -64,7 +60,6 @@ protected:
     QwtDoubleInterval _intensityRange;
 #else
     QwtInterval _intensityRange;
-    QwtInterval d_intervals[3];
 #endif
 
 private:

--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
+++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
@@ -16,7 +16,6 @@
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
-#include <cmath>
 
 class ConstellationDisplayZoomer : public QwtPlotZoomer
 {

--- a/gr-qtgui/lib/plot_raster.cc
+++ b/gr-qtgui/lib/plot_raster.cc
@@ -244,11 +244,7 @@ QImage PlotTimeRaster::renderImage(const QwtScaleMap& xMap,
         }
         d_data->data->incrementResidual();
     } else if (d_data->colorMap->format() == QwtColorMap::Indexed) {
-#if QWT_VERSION >= 0x060200
-        image.setColorTable(d_data->colorMap->colorTable(256));
-#else
         image.setColorTable(d_data->colorMap->colorTable(intensityRange));
-#endif
 
         for (int y = rect.top(); y <= rect.bottom(); y++) {
             const double ty = yyMap.invTransform(y);
@@ -257,13 +253,8 @@ QImage PlotTimeRaster::renderImage(const QwtScaleMap& xMap,
             for (int x = rect.left(); x <= rect.right(); x++) {
                 const double tx = xxMap.invTransform(x);
 
-#if QWT_VERSION >= 0x060200
-                *line++ = d_data->colorMap->colorIndex(
-                    256, intensityRange, d_data->data->value(tx, ty));
-#else
                 *line++ = d_data->colorMap->colorIndex(intensityRange,
                                                        d_data->data->value(tx, ty));
-#endif
             }
         }
     }

--- a/gr-qtgui/lib/plot_waterfall.cc
+++ b/gr-qtgui/lib/plot_waterfall.cc
@@ -240,11 +240,7 @@ QImage PlotWaterfall::renderImage(const QwtScaleMap& xMap,
             }
         }
     } else if (d_data->colorMap->format() == QwtColorMap::Indexed) {
-#if QWT_VERSION >= 0x060200
-        image.setColorTable(d_data->colorMap->colorTable(256));
-#else
         image.setColorTable(d_data->colorMap->colorTable(intensityRange));
-#endif
 
         for (int y = rect.top(); y <= rect.bottom(); y++) {
             const double ty = yyMap.invTransform(y);
@@ -253,13 +249,8 @@ QImage PlotWaterfall::renderImage(const QwtScaleMap& xMap,
             for (int x = rect.left(); x <= rect.right(); x++) {
                 const double tx = xxMap.invTransform(x);
 
-#if QWT_VERSION >= 0x060200
-                *line++ = d_data->colorMap->colorIndex(
-                    256, intensityRange, d_data->data->value(tx, ty));
-#else
                 *line++ = d_data->colorMap->colorIndex(intensityRange,
                                                        d_data->data->value(tx, ty));
-#endif
             }
         }
     }

--- a/gr-qtgui/lib/timeRasterGlobalData.cc
+++ b/gr-qtgui/lib/timeRasterGlobalData.cc
@@ -142,13 +142,6 @@ void TimeRasterData::setRange(const QwtDoubleInterval& newRange)
 {
     d_intensityRange = newRange;
 }
-#else
-void TimeRasterData::setInterval(Qt::Axis axis, const QwtInterval& interval)
-{
-    d_intervals[axis] = interval;
-}
-
-QwtInterval TimeRasterData::interval(Qt::Axis a) const { return d_intervals[a]; }
 
 #endif
 

--- a/gr-qtgui/lib/waterfallGlobalData.cc
+++ b/gr-qtgui/lib/waterfallGlobalData.cc
@@ -146,13 +146,7 @@ void WaterfallData::setRange(const QwtDoubleInterval& newRange)
 {
     _intensityRange = newRange;
 }
-#else
-void WaterfallData::setInterval(Qt::Axis axis, const QwtInterval& interval)
-{
-    d_intervals[axis] = interval;
-}
 
-QwtInterval WaterfallData::interval(Qt::Axis a) const { return d_intervals[a]; }
 #endif
 
 


### PR DESCRIPTION
This reverts commit cf04ca2132d6eff7f807a10141596389afcfbcd5.

Signed-off-by: Josh Morman <jmorman@peratonlabs.com>
(cherry picked from commit d08452d671d0f73ac94114b9627b2d340e68c012)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5202