### PR TITLE
grc: Move menu init debug log to MainWindow.py

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -29,10 +29,7 @@
 #include <vector>
 
 #if QWT_VERSION >= 0x060000
-typedef QPointF QwtDoublePoint;
-typedef QRectF QwtDoubleRect;
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
 #endif
 
 typedef QList<QColor> QColorList;

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -23,9 +23,7 @@
 #if QWT_VERSION < 0x060000
 #include <gnuradio/qtgui/plot_waterfall.h>
 #else
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
 #endif
 
 /*!

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -22,9 +22,7 @@
 #if QWT_VERSION < 0x060000
 #include <gnuradio/qtgui/plot_waterfall.h>
 #else
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
 #endif
 
 /*!

--- a/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
@@ -16,10 +16,8 @@
 #include <qwt_plot_rasteritem.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qsize.h>
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class QwtColorMap;

--- a/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
@@ -16,10 +16,8 @@
 #include <qwt_plot_rasteritem.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qsize.h>
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class QwtColorMap;

--- a/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
+++ b/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
@@ -14,7 +14,6 @@
 #include <gnuradio/high_res_timer.h>
 #include <qwt_color_map.h>
 #include <qwt_scale_draw.h>
-#include <qwt_text.h>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -15,9 +15,8 @@
 #include <cinttypes>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class TimeRasterData : public QwtRasterData
@@ -36,9 +35,6 @@ public:
 #if QWT_VERSION < 0x060000
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
-#else
-    virtual QwtInterval interval(Qt::Axis) const;
-    void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 
     double value(double x, double y) const override;
@@ -60,7 +56,6 @@ protected:
     QwtDoubleInterval d_intensityRange;
 #else
     QwtInterval d_intensityRange;
-    QwtInterval d_intervals[3];
 #endif
 
 private:

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -15,9 +15,8 @@
 #include <cinttypes>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_interval.h>
-
-typedef QwtInterval QwtDoubleInterval;
+#include <qwt_compat.h>
+#include <qwt_point_3d.h> // doesn't seem necessary, but is...
 #endif
 
 class WaterfallData : public QwtRasterData
@@ -37,9 +36,6 @@ public:
 #if QWT_VERSION < 0x060000
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
-#else
-    virtual QwtInterval interval(Qt::Axis) const;
-    void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 
     double value(double x, double y) const override;
@@ -64,7 +60,6 @@ protected:
     QwtDoubleInterval _intensityRange;
 #else
     QwtInterval _intensityRange;
-    QwtInterval d_intervals[3];
 #endif
 
 private:

--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
+++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
@@ -16,7 +16,6 @@
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
-#include <cmath>
 
 class ConstellationDisplayZoomer : public QwtPlotZoomer
 {

--- a/gr-qtgui/lib/plot_raster.cc
+++ b/gr-qtgui/lib/plot_raster.cc
@@ -244,11 +244,7 @@ QImage PlotTimeRaster::renderImage(const QwtScaleMap& xMap,
         }
         d_data->data->incrementResidual();
     } else if (d_data->colorMap->format() == QwtColorMap::Indexed) {
-#if QWT_VERSION >= 0x060200
-        image.setColorTable(d_data->colorMap->colorTable(256));
-#else
         image.setColorTable(d_data->colorMap->colorTable(intensityRange));
-#endif
 
         for (int y = rect.top(); y <= rect.bottom(); y++) {
             const double ty = yyMap.invTransform(y);
@@ -257,13 +253,8 @@ QImage PlotTimeRaster::renderImage(const QwtScaleMap& xMap,
             for (int x = rect.left(); x <= rect.right(); x++) {
                 const double tx = xxMap.invTransform(x);
 
-#if QWT_VERSION >= 0x060200
-                *line++ = d_data->colorMap->colorIndex(
-                    256, intensityRange, d_data->data->value(tx, ty));
-#else
                 *line++ = d_data->colorMap->colorIndex(intensityRange,
                                                        d_data->data->value(tx, ty));
-#endif
             }
         }
     }

--- a/gr-qtgui/lib/plot_waterfall.cc
+++ b/gr-qtgui/lib/plot_waterfall.cc
@@ -240,11 +240,7 @@ QImage PlotWaterfall::renderImage(const QwtScaleMap& xMap,
             }
         }
     } else if (d_data->colorMap->format() == QwtColorMap::Indexed) {
-#if QWT_VERSION >= 0x060200
-        image.setColorTable(d_data->colorMap->colorTable(256));
-#else
         image.setColorTable(d_data->colorMap->colorTable(intensityRange));
-#endif
 
         for (int y = rect.top(); y <= rect.bottom(); y++) {
             const double ty = yyMap.invTransform(y);
@@ -253,13 +249,8 @@ QImage PlotWaterfall::renderImage(const QwtScaleMap& xMap,
             for (int x = rect.left(); x <= rect.right(); x++) {
                 const double tx = xxMap.invTransform(x);
 
-#if QWT_VERSION >= 0x060200
-                *line++ = d_data->colorMap->colorIndex(
-                    256, intensityRange, d_data->data->value(tx, ty));
-#else
                 *line++ = d_data->colorMap->colorIndex(intensityRange,
                                                        d_data->data->value(tx, ty));
-#endif
             }
         }
     }

--- a/gr-qtgui/lib/timeRasterGlobalData.cc
+++ b/gr-qtgui/lib/timeRasterGlobalData.cc
@@ -132,13 +132,6 @@ void TimeRasterData::setRange(const QwtDoubleInterval& newRange)
 {
     d_intensityRange = newRange;
 }
-#else
-void TimeRasterData::setInterval(Qt::Axis axis, const QwtInterval& interval)
-{
-    d_intervals[axis] = interval;
-}
-
-QwtInterval TimeRasterData::interval(Qt::Axis a) const { return d_intervals[a]; }
 
 #endif
 

--- a/gr-qtgui/lib/waterfallGlobalData.cc
+++ b/gr-qtgui/lib/waterfallGlobalData.cc
@@ -139,13 +139,7 @@ void WaterfallData::setRange(const QwtDoubleInterval& newRange)
 {
     _intensityRange = newRange;
 }
-#else
-void WaterfallData::setInterval(Qt::Axis axis, const QwtInterval& interval)
-{
-    d_intervals[axis] = interval;
-}
 
-QwtInterval WaterfallData::interval(Qt::Axis a) const { return d_intervals[a]; }
 #endif
 
 

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -126,13 +126,7 @@ class Platform(Element):
         self.connection_templates.clear()
         self.cpp_connection_templates.clear()
         self._block_categories.clear()
-
-        # # FIXME: remove this as soon as converter is stable
-        # from ..converter import Converter
-        # converter = Converter(self.config.block_paths, self.config.yml_block_cache)
-        # converter.run()
-        # logging.info('XML converter done.')
-
+        
         with Cache(Constants.CACHE_FILE, version = self.config.version) as cache:
             for file_path in self._iter_files_in_block_path(path):
 

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -72,17 +72,6 @@ class Application(Gtk.Application):
         Gtk.Application.do_startup(self)
         log.debug("Application.do_startup()")
 
-        # Setup the menu
-        log.debug("Creating menu")
-        '''
-        self.menu = Bars.Menu()
-        self.set_menu()
-        if self.prefers_app_menu():
-            self.set_app_menu(self.menu)
-        else:
-            self.set_menubar(self.menu)
-        '''
-
     def do_activate(self):
         Gtk.Application.do_activate(self)
         log.debug("Application.do_activate()")

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -69,6 +69,7 @@ class MainWindow(Gtk.ApplicationWindow):
             self.set_icon(icon.load_icon())
 
         # Create the menu bar and toolbar
+        log.debug("Creating menu")
         generate_modes = platform.get_generate_options()
 
         # This needs to be replaced


### PR DESCRIPTION
This code belongs in MainWindow and not Application since the menu is
created in there. Additionally the commented-out code block below it
can also come out.

Signed-off-by: Mark Pentler <xxxxxx>

# Pull Request Details
A small one to get something in for October and get used to sending in PRs.

## Description
The menu is created in MainWindow.py and not Application.py, so I have moved the logging statement across and removed the commented-out code below it.

## Related Issue
#4628 is still an issue here, so the statement isn't actually run. If you do change the logging initialisation statement to reference `'grc'` instead of `(__name__)` then the statement does run as intended. I am interested in looking further into this issue.

## Which blocks/areas does this affect?
grc output logging

## Testing Done
As noted above, tested by somewhat hamfistedly getting logging to work from that source file, and seeing the output as intended in my console window. I haven't really changed anything major, so not sure how much work is required here.

## Checklist
You'll note I haven't filled all of these in, and I am wondering how important it is given what I've changed. Happy to do the extra work needed. My change only had one commit - do I need to squash?

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
