### PR TITLE
pdu: install examples correctly

### DIFF
--- a/gr-pdu/CMakeLists.txt
+++ b/gr-pdu/CMakeLists.txt
@@ -21,6 +21,8 @@ GR_REGISTER_COMPONENT("gr-pdu" ENABLE_GR_PDU
     ENABLE_GR_FILTER
     )
 
+SET(GR_PKG_PDU_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/pdu)
+
 ########################################################################
 # Begin conditional configuration
 ########################################################################

--- a/gr-pdu/examples/CMakeLists.txt
+++ b/gr-pdu/examples/CMakeLists.txt
@@ -7,7 +7,11 @@
 
 install(
   FILES
+  pdu_lambda_chirp_demo.grc
+  pdu_lambda_example.grc
   pdu_tools_demo.grc
-  DESTINATION ${GR_PKG_DATA_DIR}/examples/pdu
+  simple_pdu_to_stream_example.grc
+  tags_to_pdu_example.grc
+  take_skip_to_pdu_example.grc
+  DESTINATION ${GR_PKG_PDU_EXAMPLES_DIR}
 )
-


### PR DESCRIPTION
Simple fix to be consistent with other in tree modules and to install the examples properly.