### PR TITLE
grc: Write "ID", not "Id" (backport to maint-3.9)

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -34,7 +34,7 @@ class Param(Element):
         """Make a new param from nested data"""
         super(Param, self).__init__(parent)
         self.key = id
-        self.name = label.strip() or id.title()
+        self.name = 'ID' if id == 'id' else (label.strip() or id.title())
         self.category = category or Constants.DEFAULT_PARAM_TAB
 
         self.dtype = dtype

--- a/grc/gui/VariableEditor.py
+++ b/grc/gui/VariableEditor.py
@@ -99,7 +99,7 @@ class VariableEditor(Gtk.VBox):
         # Block Name or Category
         self.id_cell = Gtk.CellRendererText()
         self.id_cell.connect('edited', self._handle_name_edited_cb)
-        id_column = Gtk.TreeViewColumn("Id", self.id_cell, text=ID_INDEX)
+        id_column = Gtk.TreeViewColumn("ID", self.id_cell, text=ID_INDEX)
         id_column.set_name("id")
         id_column.set_resizable(True)
         id_column.set_max_width(Utils.scale_scalar(300))


### PR DESCRIPTION
Signed-off-by: Håkon Vågsether <hauk142@gmail.com>
(cherry picked from commit 58d3849bce9b59cb5306757ab1d56a0dad536b49)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5156