### PR TITLE
modtool: replace reinterpret_cast with static_cast

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -186,10 +186,10 @@ namespace gr {
                        gr_vector_void_star &output_items)
     {
     % if blocktype != 'source':
-      const input_type *in = reinterpret_cast<const input_type*>(input_items[0]);
+      auto in = static_cast<const input_type*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-      output_type *out = reinterpret_cast<output_type*>(output_items[0]);
+      auto out = static_cast<output_type*>(output_items[0]);
     % endif
 
       #pragma message("Implement the signal processing in your block and remove this warning")
@@ -217,10 +217,10 @@ namespace gr {
                        gr_vector_void_star &output_items)
     {
     % if blocktype != 'source':
-      const input_type *in = reinterpret_cast<const input_type*>(input_items[0]);
+      auto in = static_cast<const input_type*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-      output_type *out = reinterpret_cast<output_type*>(output_items[0]);
+      auto out = static_cast<output_type*>(output_items[0]);
     % endif
 
       #pragma message("Implement the signal processing in your block and remove this warning")
@@ -237,10 +237,10 @@ namespace gr {
         gr_vector_void_star &output_items)
     {
     % if blocktype != 'source':
-      const input_type *in = reinterpret_cast<const input_type*>(input_items[0]);
+      auto in = static_cast<const input_type*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-      output_type *out = reinterpret_cast<output_type*>(output_items[0]);
+      auto out = static_cast<output_type*>(output_items[0]);
     % endif
 
       #pragma message("Implement the signal processing in your block and remove this warning")


### PR DESCRIPTION
static_cast is preferable to reinterpret_cast, and can easily be used
when casting from void *

Casts should be cleaned up throughout the codebase, but at least when new blocks are created in modtool, should follow this practice.


- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
