### PR TITLE
GRC: Ignore Gtk.init_check failures, which seem to be unrelated to actual Gtk functionality

### DIFF
--- a/grc/scripts/gnuradio-companion
+++ b/grc/scripts/gnuradio-companion
@@ -7,7 +7,6 @@
 
 import os
 import sys
-import warnings
 
 
 GR_IMPORT_ERROR_MESSAGE = """\
@@ -50,15 +49,20 @@ def die(error, message):
 
 def check_gtk():
     try:
-        warnings.filterwarnings("error")
         import gi
         gi.require_version('Gtk', '3.0')
         gi.require_version('PangoCairo', '1.0')
         gi.require_foreign('cairo', 'Context')
 
         from gi.repository import Gtk
-        Gtk.init_check()
-        warnings.filterwarnings("always")
+        success = Gtk.init_check()[0]
+        if not success:
+            # Don't display a warning dialogue. This seems to be a Gtk bug. If it
+            # still can display warning dialogues, it does probably work!
+            print(
+                "Gtk init_check failed. GRC might not be able to start a GUI.",
+                file=sys.stderr)
+
     except Exception as err:
         die(err, "Failed to initialize GTK. If you are running over ssh, "
                  "did you enable X forwarding and start ssh with -X?")


### PR DESCRIPTION
This emerged in #5216, and in #4891 before.

We really shouldn't be promoting warnings to errors as a broad measure to detect non-working GUI (e.g. X11 not being there, or actual Gtk failure). In absence of a good solution for checking whether GUI works, let's just try to get as far as we can instead of failing where we don't have to.


## Description

We convert all warnings during setup of Gtk to errors. That turns out to be too strict and breaks some systems.

## Related Issue

This is supposed to address [Fedora bugzilla 2014797](https://bugzilla.redhat.com/show_bug.cgi?id=2014797).

If verified working:

Closes #5216

## Which blocks/areas does this affect?

GRC should start again.

Also, fixed a bug where gnuradio-companion would try to display an error dialog when getting GTK to work fails. Which is bound to fail.

## Testing Done

Run under a Fedora 35 container, which triggered the "exit due to init_check failure prematurely" behaviour. Didn't try whether GRC still actually works on that system.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.