### PR TITLE
grc: enable debug logging

### DIFF
--- a/grc/converter/main.py
+++ b/grc/converter/main.py
@@ -13,7 +13,7 @@ import os
 from . import block_tree, block
 
 path = os.path
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"grc.{__name__}")
 
 excludes = [
     'qtgui_',

--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -19,7 +19,7 @@ from .base import Element
 from .utils import expr_utils
 from .utils.backports import shlex
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 class FlowGraph(Element):

--- a/grc/core/cache.py
+++ b/grc/core/cache.py
@@ -11,7 +11,7 @@ import time
 
 from .io import yaml
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"grc.{__name__}")
 
 
 class Cache(object):

--- a/grc/core/platform.py
+++ b/grc/core/platform.py
@@ -25,7 +25,7 @@ from .generator import Generator
 from .FlowGraph import FlowGraph
 from .Connection import Connection
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"grc.{__name__}")
 
 
 class Platform(Element):

--- a/grc/gui/Actions.py
+++ b/grc/gui/Actions.py
@@ -13,7 +13,7 @@ from gi.repository import Gtk, Gdk, Gio, GLib, GObject
 
 from . import Utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 def filter_from_dict(vars):

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -24,7 +24,7 @@ from .PropsDialog import PropsDialog
 from ..core import Messages
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 class Application(Gtk.Application):

--- a/grc/gui/Bars.py
+++ b/grc/gui/Bars.py
@@ -14,7 +14,7 @@ from gi.repository import Gtk, GObject, Gio, GLib
 from . import Actions
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 '''

--- a/grc/gui/Console.py
+++ b/grc/gui/Console.py
@@ -20,7 +20,7 @@ from .Dialogs import TextDisplay, MessageDialogWrapper
 from ..core import Messages
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 class Console(Gtk.ScrolledWindow):

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -24,7 +24,7 @@ from .Notebook import Notebook, Page
 from ..core import Messages
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 ############################################################

--- a/grc/gui/Notebook.py
+++ b/grc/gui/Notebook.py
@@ -17,7 +17,7 @@ from .Constants import MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT
 from .DrawingArea import DrawingArea
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(f"grc.{__name__}")
 
 
 class Notebook(Gtk.Notebook):


### PR DESCRIPTION
Partially fixes #4628 in grc only. The call to getLogger was missing the
grc. prefix, so I have added this in using an f-string to each call to
evaluate the module name.

Signed-off-by: Mark Pentler <xxx>

## Description
As above. It worked in the grc main.py, but nowhere else.

## Related Issue
Partially fixes #4628 but for grc only - there are other similar calls in gr-utils which may need similar work?

## Which blocks/areas does this affect?
Just the logging output to console from grc (in the sense that it now works)

## Testing Done
Enabled logging and confirmed each individual source file was successfully outputting statements to the console. I really don't know much about unit testing etc and not sure how to do anything like that, so this was just manual testing.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
