### PR TITLE
grc: Move menu init debug log to MainWindow.py

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -72,17 +72,6 @@ class Application(Gtk.Application):
         Gtk.Application.do_startup(self)
         log.debug("Application.do_startup()")
 
-        # Setup the menu
-        log.debug("Creating menu")
-        '''
-        self.menu = Bars.Menu()
-        self.set_menu()
-        if self.prefers_app_menu():
-            self.set_app_menu(self.menu)
-        else:
-            self.set_menubar(self.menu)
-        '''
-
     def do_activate(self):
         Gtk.Application.do_activate(self)
         log.debug("Application.do_activate()")

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -69,6 +69,7 @@ class MainWindow(Gtk.ApplicationWindow):
             self.set_icon(icon.load_icon())
 
         # Create the menu bar and toolbar
+        log.debug("Creating menu")
         generate_modes = platform.get_generate_options()
 
         # This needs to be replaced


### PR DESCRIPTION
This code belongs in MainWindow and not Application since the menu is
created in there. Additionally the commented-out code block below it
can also come out.

Signed-off-by: Mark Pentler <xxxx>

## Related Issue
None

## Which blocks/areas does this affect?
Logging system

## Testing Done
Ran grc with --log debug and verified statement was appearing on the console

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
