### PR TITLE
modtool: working python general block template

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -389,10 +389,12 @@ class ${blockname}(${parenttype}):
 
 % if blocktype == 'general':
     def forecast(self, noutput_items, ninputs):
+        # ninputs is the number of input connections
         # setup size of input_items[i] for work call
-        ninput_items_required = [0] * ninputs
-        for i in range(ninputs):
-            ninput_items_required[i] = noutput_items
+        # the required number of input items is returned
+        #   in a list where each element represents the 
+        #   number of required items for each input
+        ninput_items_required = [noutput_items] * ninputs
         return ninput_items_required
 
     def general_work(self, input_items, output_items):


### PR DESCRIPTION
## Description
The automatically generated code from modtool when selecting python block with general type was invalid

## Related Issue
Fixes #5143

## Which blocks/areas does this affect?
Any OOT created from modtool with blocks that are python and general

## Testing Done
Created an OOT and ran a flowgraph that used the python general block

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
