### PR TITLE
modtool: replace reinterpret_cast with static_cast (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -186,10 +186,10 @@ namespace gr {
                        gr_vector_void_star &output_items)
     {
     % if blocktype != 'source':
-      const input_type *in = reinterpret_cast<const input_type*>(input_items[0]);
+      auto in = static_cast<const input_type*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-      output_type *out = reinterpret_cast<output_type*>(output_items[0]);
+      auto out = static_cast<output_type*>(output_items[0]);
     % endif
 
       #pragma message("Implement the signal processing in your block and remove this warning")
@@ -217,10 +217,10 @@ namespace gr {
                        gr_vector_void_star &output_items)
     {
     % if blocktype != 'source':
-      const input_type *in = reinterpret_cast<const input_type*>(input_items[0]);
+      auto in = static_cast<const input_type*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-      output_type *out = reinterpret_cast<output_type*>(output_items[0]);
+      auto out = static_cast<output_type*>(output_items[0]);
     % endif
 
       #pragma message("Implement the signal processing in your block and remove this warning")
@@ -237,10 +237,10 @@ namespace gr {
         gr_vector_void_star &output_items)
     {
     % if blocktype != 'source':
-      const input_type *in = reinterpret_cast<const input_type*>(input_items[0]);
+      auto in = static_cast<const input_type*>(input_items[0]);
     % endif
     % if blocktype != 'sink':
-      output_type *out = reinterpret_cast<output_type*>(output_items[0]);
+      auto out = static_cast<output_type*>(output_items[0]);
     % endif
 
       #pragma message("Implement the signal processing in your block and remove this warning")


### PR DESCRIPTION
static_cast is preferable to reinterpret_cast, and can easily be used
when casting from void *

Signed-off-by: Josh Morman <jmorman@peratonlabs.com>
(cherry picked from commit dee640362cb565757f0f09dc2001127e0ffaa33e)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5215