### PR TITLE
grc: Move menu init debug log to MainWindow.py (backport to maint-3.9)

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -72,17 +72,6 @@ class Application(Gtk.Application):
         Gtk.Application.do_startup(self)
         log.debug("Application.do_startup()")
 
-        # Setup the menu
-        log.debug("Creating menu")
-        '''
-        self.menu = Bars.Menu()
-        self.set_menu()
-        if self.prefers_app_menu():
-            self.set_app_menu(self.menu)
-        else:
-            self.set_menubar(self.menu)
-        '''
-
     def do_activate(self):
         Gtk.Application.do_activate(self)
         log.debug("Application.do_activate()")

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -69,6 +69,7 @@ class MainWindow(Gtk.ApplicationWindow):
             self.set_icon(icon.load_icon())
 
         # Create the menu bar and toolbar
+        log.debug("Creating menu")
         generate_modes = platform.get_generate_options()
 
         # This needs to be replaced


### PR DESCRIPTION
This code belongs in MainWindow and not Application since the menu is
created in there. Additionally the commented-out code block below it
can also come out.

Signed-off-by: Mark Pentler <tehhustler@hotmail.com>
(cherry picked from commit 1d61a3cefd82434ff12ae30a350f6496eadc065d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5221