### PR TITLE
modtool: ability to fix the hash using modtool (backport to maint-3.9)

### DIFF
--- a/docs/PYBIND11.md
+++ b/docs/PYBIND11.md
@@ -52,7 +52,7 @@ Each block binding file contains an automatically generated and maintained comme
 
 `BINDTOOL_HEADER_FILE`: The header file that bindings are based on, filename only
 
-`BINDTOOL_HEADER_FILE_HASH`: The MD5 hash of the header file that the bindings are based on.  If minor changes are made to the header file that don't require regeneration of the bindings, this hash can just be updated as the value returned from `md5hash [header_filename].h`
+`BINDTOOL_HEADER_FILE_HASH`: The MD5 hash of the header file that the bindings are based on.  If minor changes are made to the header file that don't require regeneration of the bindings, this hash can just be updated as the value returned from `md5sum [header_filename].h`
 
 ## Workflow
 

--- a/gr-utils/modtool/cli/bind.py
+++ b/gr-utils/modtool/cli/bind.py
@@ -32,6 +32,9 @@ from .base import common_params, block_name, run, cli_input
               help = 'Comma separated list of additional include directories (default None)')
 @click.option('-D', '--define_symbols', multiple=True, default=None,
               help = 'Set precompiler defines')
+@click.option('-u', '--update-hash-only', is_flag = True,
+              help = 'If given, only the hash in the binding will be updated')
+              
 @common_params
 @block_name
 def cli(**kwargs):

--- a/gr-utils/modtool/core/bind.py
+++ b/gr-utils/modtool/core/bind.py
@@ -39,6 +39,7 @@ class ModToolGenBindings(ModTool):
         self.info['pattern'] = blockname
         self.info['addl_includes'] = kwargs['addl_includes']
         self.info['define_symbols'] = kwargs['define_symbols']
+        self.info['fix_hash'] = kwargs['fix_hash']
 
     def validate(self):
         """ Validates the arguments """
@@ -67,9 +68,13 @@ class ModToolGenBindings(ModTool):
                 blocknames_to_process = get_block_names(self.info['pattern'], self.info['modname'])
             else:
                 raise ModToolException("No block name or regex was specified!")
-            bg = BindingGenerator(prefix=gr.prefix(), namespace=[
-                                  'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'),
-                                   define_symbols=self.info['define_symbols'], addl_includes=self.info['addl_includes'])
+
             files_to_process = [os.path.join(self.dir, self.info['includedir'], f'{blockname}.h') for blockname in blocknames_to_process]
+            bg = BindingGenerator(prefix=gr.prefix(), namespace=[
+                                'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'),
+                                define_symbols=self.info['define_symbols'], addl_includes=self.info['addl_includes'], fix_hash=self.info['fix_hash'])
             for file_to_process in files_to_process:
-                bg.gen_file_binding(file_to_process)
+                if self.info['fix_hash']:
+                    bg.fix_file_hash(file_to_process)
+                else:
+                    bg.gen_file_binding(file_to_process)


### PR DESCRIPTION
* modtool: bind --update-hash-only command

Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit c4f99a8842490d37010ec20cddc63f7cfdc69b6c)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5224