### PR TITLE
grc: Include scale factor when computing drawing area size (backport to maint-3.8)

### DIFF
--- a/grc/gui/DrawingArea.py
+++ b/grc/gui/DrawingArea.py
@@ -166,7 +166,11 @@ class DrawingArea(Gtk.DrawingArea):
 
     def _update_size(self):
         w, h = self._flow_graph.get_extents()[2:]
-        self.set_size_request(w * self.zoom_factor + 100, h * self.zoom_factor + 100)
+        scale_factor = self.get_scale_factor()
+        self.set_size_request(
+            w * scale_factor * self.zoom_factor + 100,
+            h * scale_factor * self.zoom_factor + 100,
+        )
 
     def _auto_scroll(self, event):
         x, y = event.x, event.y


### PR DESCRIPTION
Fixes #4174.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit 59d04f4a19e54550b192d5d03f78a8307597c5cf)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5111