### PR TITLE
issue 4595 qa_agc Assertion Error

### DIFF
--- a/gr-analog/python/analog/qa_agc.py
+++ b/gr-analog/python/analog/qa_agc.py
@@ -454,7 +454,9 @@ class test_agc(gr_unittest.TestCase):
         tb = self.tb
 
         sampling_freq = 100
-        N = int(5 * sampling_freq)
+        # N must by a multiple of the volk_alignment of the system for this test to work.
+        # For a machine with 512-bit registers, that would be 8 complex-floats.
+        N = int(8 * sampling_freq)
         src1 = analog.sig_source_c(sampling_freq, analog.GR_SIN_WAVE,
                                    sampling_freq * 0.10, 100)
         dst1 = blocks.vector_sink_c()


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
GNU Radio in general does not guarantee knowable behavior at the tail end of a data streams.  For example, when processing a data file, there is no guarantee that all of the elements in the file will be processed by all of the blocks.  In unit tests, it is common to want to input a set of amount of data and then see if the output matches the expected processing of that data.  In qa_agc::test_006, it takes that approach.  It fails for me on some machines consistently, while consistently passing on others.

The agc3_cc block has in the constructor
```
const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
set_alignment(std::max(1, alignment_multiple));
```
For a machine with 512-bit instructions, alignment_multiple = 8 (8 complex floats/ 512 bits). The alignment requirement forces the beginning of each work buffer to be aligned. As a side effect, it will never call work with fewer than alignement elements (otherwise the next call wouldn't be aligned).

In the qa code we have:
```
sampling_freq = 100
N = int(5 * sampling_freq)
...
head = blocks.head(gr.sizeof_gr_complex, N)
...
tb.connect(head, agc)
```
So the head block will output 500 elements and then stop. But 500/8 = 62.5 so the agc block will never receive the final 4 elements.

I updated the value of N to be `int(8*sampling_freq)`.  This will work until we have 4096 bit instructions.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #4595 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
qa_agc test_006.  It might take slightly longer to perform this test.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I did a lot of analysis of the scheduler to figure out was going on.  I tested this change on a machine with 512-bit instructions in a ubuntu20.04 docker container.  This change has no impact on anything other than this unit test.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
