### PR TITLE
runtime: pybind version in gnuradio-config-info

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -41,7 +41,8 @@ int main(int argc, char** argv)
         "enabled-components", "print GNU Radio build time enabled components")(
         "cc", "print GNU Radio C compiler version")(
         "cxx", "print GNU Radio C++ compiler version")(
-        "cflags", "print GNU Radio CFLAGS")("version,v", "print GNU Radio version");
+        "cflags", "print GNU Radio CFLAGS")("version,v", "print GNU Radio version")(
+        "pybind", "print pybind11 version used in this build");
     // clang-format on
 
     try {
@@ -94,6 +95,9 @@ int main(int argc, char** argv)
 
     if (vm.count("cflags") || print_all)
         std::cout << gr::compiler_flags() << std::endl;
+
+    if (vm.count("pybind") || print_all)
+        std::cout << gr::pybind_version() << std::endl;
 
     return 0;
 }

--- a/gnuradio-runtime/include/gnuradio/constants.h
+++ b/gnuradio-runtime/include/gnuradio/constants.h
@@ -76,6 +76,12 @@ GR_RUNTIME_API const std::string compiler_flags();
  */
 GR_RUNTIME_API const std::string build_time_enabled_components();
 
+/*!
+ * \brief return the pybind11 version used to build this version of GNU Radio
+ */
+GR_RUNTIME_API const std::string pybind_version();
+
+
 } /* namespace gr */
 
 #endif /* INCLUDED_GR_CONSTANTS_H */

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -71,4 +71,7 @@ const std::string cxx_compiler() { return "@cmake_cxx_compiler_version@"; }
 const std::string compiler_flags() { return "@COMPILER_INFO@"; }
 
 const std::string build_time_enabled_components() { return "@_gr_enabled_components@"; }
+
+const std::string pybind_version() { return "@pybind11_VERSION@"; }
+
 } /* namespace gr */

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/constants_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/constants_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constants.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d98c7e72cb74921e5e07f332dbf5475a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(23118d18abd7aebdb0d674771473ed8b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Add the version of pybind that GNU Radio was compiled against.  Pybind has created some trouble for out of tree modules when gr is not installed from source but through some packaging (e.g. the ubuntu ppa) and then a different version of pybind is installed on the system that is compiling the OOT

Also could add a check in the gr_modtool template against this string

## Related Issue
https://github.com/bastibl/gr-rds/issues/48

## Which blocks/areas does this affect?
OOT modules

## Testing Done
This just prints an informational string about pybind11 version with `gnuradio-config-info --pybind`

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
