### PR TITLE
Soapy: Make sure target uses expected C++ standard [master]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 
+set(GR_CXX_VERSION_FEATURE cxx_std_${CMAKE_CXX_STANDARD})
+
 ########################################################################
 # Environment setup
 ########################################################################

--- a/gr-soapy/lib/CMakeLists.txt
+++ b/gr-soapy/lib/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(gnuradio-soapy
   sink_impl.cc
 )
 
+target_compile_features(gnuradio-soapy PRIVATE ${GR_CXX_VERSION_FEATURE})
+
 target_link_libraries(gnuradio-soapy PUBLIC
     gnuradio-runtime
     ${SoapySDR_LIBRARIES}

--- a/gr-soapy/python/soapy/bindings/CMakeLists.txt
+++ b/gr-soapy/python/soapy/bindings/CMakeLists.txt
@@ -27,4 +27,6 @@ GR_PYBIND_MAKE_CHECK_HASH(soapy
    gr::soapy
    "${soapy_python_files}")
 
+target_compile_features(soapy_python PRIVATE ${GR_CXX_VERSION_FEATURE})
+
 install(TARGETS soapy_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/soapy COMPONENT pythonapi)


### PR DESCRIPTION

# Pull Request Details

This was the unusual case of me testing something against maint-3.9, to make sure it doesn't become a maintenance liability, before applying it to master.

## Description

SoapySDR exports its own C++ standard version into cmake consumers. This breaks C++17-using GNU Radio. This tells CMake that, yes, we want the CMAKE_CXX_STANDARD that we set in the main CMakeLists. (grml.)

## Related Issue

Same thing, merged in maint-3.9: #5234 

## Which blocks/areas does this affect?
Soapy

## Testing Done

No extra testing – compilability of C++17 code is restored within the context of #5218, which can hence shed the equivalent commit.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass. (See **compilability** above)
