### PR TITLE
modtool: complete renaming of update-hash-only

### DIFF
--- a/gr-utils/bindtool/core/generator.py
+++ b/gr-utils/bindtool/core/generator.py
@@ -22,7 +22,7 @@ class BindingGenerator:
 
     def __init__(self, prefix, namespace, prefix_include_root, output_dir="", define_symbols=None, addl_includes= None, 
                     match_include_structure=False, catch_exceptions=True, write_json_output=False, status_output=None,
-                    flag_automatic=False, flag_pygccxml=False, fix_hash=False):
+                    flag_automatic=False, flag_pygccxml=False, update_hash_only=False):
         """Initialize BindingGenerator
         prefix -- path to installed gnuradio prefix (use gr.prefix() if unsure)
         namespace -- desired namespace to parse e.g. ['gr','module_name']
@@ -36,7 +36,7 @@ class BindingGenerator:
         match_include_structure -- 
             If set to False, a bindings/ dir will be placed directly under the specified output_dir
             If set to True, the directory structure under include/ will be mirrored
-        fix_hash -- If set to true, only update the hash in the pybind 
+        update_hash_only -- If set to true, only update the hash in the pybind 
         """
 
         self.header_extensions = ['.h', '.hh', '.hpp']
@@ -53,7 +53,7 @@ class BindingGenerator:
         self.status_output = status_output
         self.flag_automatic = flag_automatic
         self.flag_pygccxml = flag_pygccxml
-        self.fix_hash = fix_hash
+        self.update_hash_only = update_hash_only
 
         pass
 

--- a/gr-utils/modtool/core/bind.py
+++ b/gr-utils/modtool/core/bind.py
@@ -39,7 +39,7 @@ class ModToolGenBindings(ModTool):
         self.info['pattern'] = blockname
         self.info['addl_includes'] = kwargs['addl_includes']
         self.info['define_symbols'] = kwargs['define_symbols']
-        self.info['fix_hash'] = kwargs['fix_hash']
+        self.info['update_hash_only'] = kwargs['update_hash_only']
 
     def validate(self):
         """ Validates the arguments """
@@ -72,9 +72,9 @@ class ModToolGenBindings(ModTool):
             files_to_process = [os.path.join(self.dir, self.info['includedir'], f'{blockname}.h') for blockname in blocknames_to_process]
             bg = BindingGenerator(prefix=gr.prefix(), namespace=[
                                 'gr', self.info['modname']], prefix_include_root=self.info['modname'], output_dir=os.path.join(self.dir, 'python'),
-                                define_symbols=self.info['define_symbols'], addl_includes=self.info['addl_includes'], fix_hash=self.info['fix_hash'])
+                                define_symbols=self.info['define_symbols'], addl_includes=self.info['addl_includes'], update_hash_only=self.info['update_hash_only'])
             for file_to_process in files_to_process:
-                if self.info['fix_hash']:
+                if self.info['update_hash_only']:
                     bg.fix_file_hash(file_to_process)
                 else:
                     bg.gen_file_binding(file_to_process)


### PR DESCRIPTION
## Description
the naming of fix-hash to update-hash-only was not completed in the previous PR
