### PR TITLE
runtime: pybind version in gnuradio-config-info (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -41,7 +41,8 @@ int main(int argc, char** argv)
         "enabled-components", "print GNU Radio build time enabled components")(
         "cc", "print GNU Radio C compiler version")(
         "cxx", "print GNU Radio C++ compiler version")(
-        "cflags", "print GNU Radio CFLAGS")("version,v", "print GNU Radio version");
+        "cflags", "print GNU Radio CFLAGS")("version,v", "print GNU Radio version")(
+        "pybind", "print pybind11 version used in this build");
     // clang-format on
 
     try {
@@ -94,6 +95,9 @@ int main(int argc, char** argv)
 
     if (vm.count("cflags") || print_all)
         std::cout << gr::compiler_flags() << std::endl;
+
+    if (vm.count("pybind") || print_all)
+        std::cout << gr::pybind_version() << std::endl;
 
     return 0;
 }

--- a/gnuradio-runtime/include/gnuradio/constants.h
+++ b/gnuradio-runtime/include/gnuradio/constants.h
@@ -76,6 +76,12 @@ GR_RUNTIME_API const std::string compiler_flags();
  */
 GR_RUNTIME_API const std::string build_time_enabled_components();
 
+/*!
+ * \brief return the pybind11 version used to build this version of GNU Radio
+ */
+GR_RUNTIME_API const std::string pybind_version();
+
+
 } /* namespace gr */
 
 #endif /* INCLUDED_GR_CONSTANTS_H */

--- a/gnuradio-runtime/lib/constants.cc.in
+++ b/gnuradio-runtime/lib/constants.cc.in
@@ -77,4 +77,7 @@ const std::string cxx_compiler() { return "@cmake_cxx_compiler_version@"; }
 const std::string compiler_flags() { return "@COMPILER_INFO@"; }
 
 const std::string build_time_enabled_components() { return "@_gr_enabled_components@"; }
+
+const std::string pybind_version() { return "@pybind11_VERSION@"; }
+
 } /* namespace gr */

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/constants_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/constants_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constants.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(d98c7e72cb74921e5e07f332dbf5475a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(23118d18abd7aebdb0d674771473ed8b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 81b07c74ebd7cbd8e535ec0815356ed85dea9c32)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5252