### PR TITLE
Fix issue 4595 qa_agc Assertion Error (backport to maint-3.9)

### DIFF
--- a/gr-analog/python/analog/qa_agc.py
+++ b/gr-analog/python/analog/qa_agc.py
@@ -454,7 +454,9 @@ class test_agc(gr_unittest.TestCase):
         tb = self.tb
 
         sampling_freq = 100
-        N = int(5 * sampling_freq)
+        # N must by a multiple of the volk_alignment of the system for this test to work.
+        # For a machine with 512-bit registers, that would be 8 complex-floats.
+        N = int(8 * sampling_freq)
         src1 = analog.sig_source_c(sampling_freq, analog.GR_SIN_WAVE,
                                    sampling_freq * 0.10, 100)
         dst1 = blocks.vector_sink_c()


### PR DESCRIPTION
The number of input elements needs to be disivible by volk_alignment, which it wasn't
for machines with 512-bit registers.

Signed-off-by: John Sallay <jasallay@gmail.com>
(cherry picked from commit 39e88e44607fe750fc6cba456554213adf9b862a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5244