### PR TITLE
gr-runtime: Change hier_block2.py __getattr__ to avoid recursive loop in exception (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/hier_block2.py
+++ b/gnuradio-runtime/python/gnuradio/gr/hier_block2.py
@@ -75,11 +75,16 @@ class hier_block2(object):
         """
         Pass-through member requests to the C++ object.
         """
-        if not hasattr(self, "_impl"):
+        
+        try:
+            object.__getattribute__(self, "_impl")
+        except AttributeError as exception:
             raise RuntimeError(
                 "{0}: invalid state -- did you forget to call {0}.__init__ in "
-                "a derived class?".format(self.__class__.__name__))
+                "a derived class?".format(object.__getattribute__(self.__class__, "__name__"))) from exception
+
         return getattr(self._impl, name)
+        
 
     # FIXME: these should really be implemented
     # in the original C++ class (gr_hier_block2), then they would all be inherited here


### PR DESCRIPTION
gnuradio-runtime: hier_block2.py __getattr__ recursive loop bug fix #5072
Signed-off-by: Matt Mills <mmills@2bn.net>
(cherry picked from commit 4457eb145b8078614da1d4b64add6282e4ab8d5d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5153