### PR TITLE
runtime: remove unused d_mutex from custom_lock to remove warnings

### DIFF
--- a/gnuradio-runtime/include/gnuradio/custom_lock.h
+++ b/gnuradio-runtime/include/gnuradio/custom_lock.h
@@ -48,7 +48,7 @@ class custom_lock
 {
 public:
     explicit custom_lock(gr::thread::mutex& mutex, std::shared_ptr<custom_lock_if> locker)
-        : d_mutex(mutex), d_lock(mutex), d_locker(locker)
+        : d_lock(mutex), d_locker(locker)
     {
         d_locker->on_lock(d_lock);
     }
@@ -60,7 +60,6 @@ public:
     custom_lock& operator=(custom_lock const&) = delete;
 
 private:
-    gr::thread::mutex& d_mutex;
     gr::thread::scoped_lock d_lock;
     std::shared_ptr<custom_lock_if> d_locker;
 };


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

# Pull Request Details

My compiler annoys me with things like

```
[36/38] Building CXX object gr-analog/python/analog/bindings/CMakeFiles/analog_python.dir/squelch_base_ff_python.cc.o
In file included from ../gr-analog/python/analog/bindings/squelch_base_ff_python.cc:26:
In file included from ../gr-analog/python/analog/bindings/../../../include/gnuradio/analog/squelch_base_ff.h:15:
In file included from ../gnuradio-runtime/lib/../include/gnuradio/block.h:17:
In file included from ../gnuradio-runtime/lib/../include/gnuradio/basic_block.h:15:
In file included from ../gnuradio-runtime/lib/../include/gnuradio/io_signature.h:17:
In file included from ../gnuradio-runtime/lib/../include/gnuradio/buffer_double_mapped.h:15:
In file included from ../gnuradio-runtime/lib/../include/gnuradio/buffer.h:15:
../gnuradio-runtime/lib/../include/gnuradio/custom_lock.h:63:24: warning: private field 'd_mutex' is not used [-Wunused-private-field]
    gr::thread::mutex& d_mutex;
                       ^
```

I wish it wasn't right – that's a private field that nobody accesses. Now, the mutex is used internally in another member - so a reference is held, either way.


## Description

Removed an unused private field

## Related Issue
 --

## Which blocks/areas does this affect?

Less compile warnings

## Testing Done
Still compiles.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
