### PR TITLE
runtime: remove unused includes from buffer headers

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -19,7 +19,6 @@
 #include <gnuradio/thread/thread.h>
 #include <gnuradio/transfer_type.h>
 
-#include <boost/weak_ptr.hpp>
 #include <functional>
 #include <iostream>
 #include <map>

--- a/gnuradio-runtime/include/gnuradio/buffer_reader.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader.h
@@ -17,8 +17,6 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/tags.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/weak_ptr.hpp>
-#include <map>
 #include <memory>
 
 namespace gr {

--- a/gnuradio-runtime/include/gnuradio/buffer_reader_sm.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader_sm.h
@@ -14,13 +14,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/buffer.h>
 #include <gnuradio/buffer_reader.h>
-#include <gnuradio/logger.h>
 #include <gnuradio/runtime_types.h>
-#include <gnuradio/tags.h>
-#include <gnuradio/thread/thread.h>
-#include <boost/weak_ptr.hpp>
-#include <map>
-#include <memory>
 
 namespace gr {
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(a21619a22acff81798a133305900125a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8e570cc3747473c3774ae5ffef6653aa)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer_reader.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(5a48682a66afd451d2f145b352c95a7e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f88a20e94ad6a628f5c8c13338474220)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
# Pull Request Details

Found some unused includes

## Description
... so I removed them

## Which blocks/areas does this affect?
None

## Testing Done
trying builds.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
