### PR TITLE
Convert to modern logging

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -16,10 +16,8 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
-#include <boost/format.hpp>
 #include <boost/thread/mutex.hpp>
 #include <map>
-#include <sstream>
 #include <string>
 
 #define S(x) #x

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -20,7 +20,6 @@
 #include <gnuradio/buffer_type.h>
 #include <gnuradio/integer_math.h>
 #include <gnuradio/math.h>
-#include <boost/format.hpp>
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>

--- a/gnuradio-runtime/lib/pmt/qa_pmt_unv.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_unv.cc
@@ -11,11 +11,7 @@
 #include <gnuradio/messages/msg_passing.h>
 #include <pmt/api.h> //reason: suppress warnings
 #include <pmt/pmt.h>
-#include <boost/format.hpp>
 #include <boost/test/unit_test.hpp>
-#include <cstring>
-#include <sstream>
-
 
 using namespace pmt;
 BOOST_AUTO_TEST_CASE(test_u8vector)

--- a/gr-analog/CMakeLists.txt
+++ b/gr-analog/CMakeLists.txt
@@ -8,14 +8,13 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
+# Nobody here but us chickens
 
 ########################################################################
 # Register component
 ########################################################################
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-analog" ENABLE_GR_ANALOG
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_BLOCKS
     ENABLE_GR_FFT

--- a/gr-analog/grc/analog_wfm_tx.block.yml
+++ b/gr-analog/grc/analog_wfm_tx.block.yml
@@ -39,9 +39,9 @@ templates:
         \ttau=${tau},\n\tmax_dev=${max_dev},\n\tfh=${fh},\n)"
 
 cpp_templates:
-    includes: [ '#include <gnuradio/analog/frequency_modulator_fc.h>', '#include <boost/math/constants/constants.hpp>' ]
+    includes: [ '#include <gnuradio/analog/frequency_modulator_fc.h>', '#include <gnuradio/math.h>' ]
     declarations: gr::analog::frequency_modulator_fc::sptr ${id};
-    make: this->${id} = gr::analog::frequency_modulator_fc::make(2 * boost::math::constants::pi<double>() * ${max_dev} / ${quad_rate});
+    make: this->${id} = gr::analog::frequency_modulator_fc::make(2 * (GR_M_PI) * ${max_dev} / ${quad_rate});
     link: ['gnuradio::gnuradio-analog']          
       
 file_format: 1

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -13,8 +13,6 @@
 #include <config.h>
 #endif
 
-#include <boost/format.hpp>
-
 #include "fastnoise_source_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
@@ -43,10 +41,8 @@ void fastnoise_source_impl<gr_complex>::generate()
 {
     size_t noutput_items = d_samples.size();
     if (noutput_items >= 1 << 23) {
-        GR_LOG_INFO(
-            d_logger,
-            boost::format("Generating %d complex values. This might take a while.") %
-                noutput_items);
+        this->d_logger->info("Generating {:d} complex values. This might take a while.",
+                             noutput_items);
     }
 
     switch (d_type) {
@@ -79,10 +75,10 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
       d_bitmask(is_pwr_of_two(samples) ? samples - 1 : 0)
 {
     if (!d_bitmask) {
-        GR_LOG_INFO(this->d_logger,
-                    boost::format("Using non-power-of-2 sample pool size %d. This has "
-                                  "negative effect on performance.") %
-                        samples);
+        this->d_logger->info(
+            "Using non-power-of-2 sample pool size {:d}. This has negative "
+            "effect on performance.",
+            samples);
     }
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, seed);
@@ -104,10 +100,10 @@ fastnoise_source_impl<gr_complex>::fastnoise_source_impl(noise_type_t type,
       d_bitmask(is_pwr_of_two(samples) ? samples - 1 : 0)
 {
     if (!d_bitmask) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("Using non-power-of-2 sample pool size %d. This has "
-                                  "negative effect on performance.") %
-                        samples);
+        this->d_logger->info(
+            "Using non-power-of-2 sample pool size {:d}. This has negative "
+            "effect on performance.",
+            samples);
     }
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, (uint64_t)seed);
@@ -149,9 +145,8 @@ void fastnoise_source_impl<T>::generate()
 {
     size_t noutput_items = d_samples.size();
     if (noutput_items >= 1 << 23) {
-        GR_LOG_INFO(this->d_logger,
-                    boost::format("Generating %d values. This might take a while.") %
-                        noutput_items);
+        this->d_logger->info("Generating {:d} values. This might take a while.",
+                             noutput_items);
     }
     switch (d_type) {
     case GR_UNIFORM:

--- a/gr-blocks/include/gnuradio/blocks/file_sink_base.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink_base.h
@@ -32,13 +32,13 @@ protected:
     boost::mutex d_mutex;
     bool d_unbuffered;
     bool d_append;
-    gr::logger_ptr d_logger, d_debug_logger;
+    gr::logger d_base_logger;
 
 protected:
     file_sink_base(const char* filename, bool is_binary, bool append);
 
 public:
-    file_sink_base() {}
+    file_sink_base() : d_base_logger("unitialized file_sink_base") {}
     ~file_sink_base();
 
     /*!

--- a/gr-blocks/lib/check_lfsr_32k_s_impl.cc
+++ b/gr-blocks/lib/check_lfsr_32k_s_impl.cc
@@ -14,8 +14,6 @@
 
 #include "check_lfsr_32k_s_impl.h"
 #include <gnuradio/io_signature.h>
-#include <cstdio>
-#include <cstdlib>
 
 static constexpr bool CHECK_LFSR_DEBUG = false;
 
@@ -115,10 +113,9 @@ void check_lfsr_32k_s_impl::enter_SEARCHING()
     d_index = 0; // reset LFSR to beginning
 
     if (CHECK_LFSR_DEBUG)
-        GR_LOG_DEBUG(
-            d_debug_logger,
-            boost::format("check_lfsr_32k: enter_SEARCHING at offset %8ld (0x%08lx)") %
-                d_ntotal % d_ntotal);
+        d_debug_logger->debug("check_lfsr_32k: enter_SEARCHING at offset {:8d} ({:#08x})",
+                              d_ntotal,
+                              d_ntotal);
 
     enter_MATCH0();
 }
@@ -139,20 +136,21 @@ void check_lfsr_32k_s_impl::enter_LOCKED()
     d_index = 3; // already matched first 3 items
 
     if (CHECK_LFSR_DEBUG)
-        GR_LOG_DEBUG(
-            d_debug_logger,
-            boost::format("check_lfsr_32k: enter_LOCKED at offset %8ld (0x%08lx)") %
-                d_ntotal % d_ntotal);
+        d_debug_logger->debug(
+            "check_lfsr_32k: enter_LOCKED at offset {:8d} ({:#08x})", d_ntotal, d_ntotal);
 }
 
 void check_lfsr_32k_s_impl::log_error(unsigned short expected, unsigned short actual)
 {
     if (CHECK_LFSR_DEBUG)
-        GR_LOG_DEBUG(
-            d_debug_logger,
-            boost::format("check_lfsr_32k: expected %5d (0x%04x) got %5d (0x%04x) "
-                          "offset %8ld (0x%08lx)") %
-                expected % expected % actual % actual % d_ntotal % d_ntotal);
+        d_debug_logger->debug("check_lfsr_32k: expected {:5d} ({:#04x}) got {:5d} "
+                              "({:#04x}) offset {:8d} ({:#08x})",
+                              expected,
+                              expected,
+                              actual,
+                              actual,
+                              d_ntotal,
+                              d_ntotal);
 }
 
 } /* namespace blocks */

--- a/gr-blocks/lib/correctiq_auto_impl.cc
+++ b/gr-blocks/lib/correctiq_auto_impl.cc
@@ -15,7 +15,6 @@
 #include "correctiq_auto_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -57,16 +56,15 @@ correctiq_auto_impl::correctiq_auto_impl(double samp_rate,
     message_port_register_out(pmt::mp("sync_start"));
     message_port_register_out(pmt::mp("offsets"));
 
-    GR_LOG_INFO(d_logger, "Block start.  Auto Synchronizing...");
+    d_logger->info("Block start.  Auto Synchronizing...");
 }
 
 void correctiq_auto_impl::trigger_resync(std::string reason)
 {
     gr::thread::scoped_lock guard(d_setlock);
 
-    std::string d_resync_msg = reason + ".  Auto Synchronizing...";
+    d_logger->info("{:s}.  Auto Synchronizing...", reason);
 
-    GR_LOG_INFO(d_logger, d_resync_msg);
     d_synchronized = false;
     d_sync_counter = 0;
 
@@ -171,12 +169,11 @@ int correctiq_auto_impl::work(int noutput_items,
         d_k = gr_complex(d_avg_real, d_avg_img);
         fill_const_buffer();
 
-        GR_LOG_INFO(d_logger, "Auto offset now synchronized.");
-        GR_LOG_INFO(
-            d_logger,
-            boost::format{ "Applying these offsets (real-real_offset, "
-                           "imag-imag_offset)... real_offset: %.6f, imag_offset: %.6f" } %
-                d_avg_real % d_avg_img);
+        d_logger->info("Auto offset now synchronized.");
+        d_logger->info("Applying these offsets (real-real_offset, imag-imag_offset)... "
+                       "real_offset: {:.6f}, imag_offset: {:6f}",
+                       d_avg_real,
+                       d_avg_img);
 
         send_sync_values();
     }

--- a/gr-blocks/lib/correctiq_man_impl.cc
+++ b/gr-blocks/lib/correctiq_man_impl.cc
@@ -92,7 +92,7 @@ void correctiq_man_impl::handle_real(pmt::pmt_t msg)
 
             set_real(new_value);
         } else {
-            GR_LOG_WARN(d_logger, "Non-float real value received.  Ignoring.");
+            d_logger->warn("Non-float real value received.  Ignoring. (In PMT pair.)");
         }
     } else {
         if (pmt::is_real(msg)) {
@@ -100,7 +100,7 @@ void correctiq_man_impl::handle_real(pmt::pmt_t msg)
 
             set_real(new_value);
         } else {
-            GR_LOG_WARN(d_logger, "Non-float real value received.  Ignoring.");
+            d_logger->warn("Non-float real value received.  Ignoring.");
         }
     }
 }
@@ -114,7 +114,7 @@ void correctiq_man_impl::handle_imag(pmt::pmt_t msg)
 
             set_imag(new_value);
         } else {
-            GR_LOG_WARN(d_logger, "Non-float imag value received.  Ignoring.");
+            d_logger->warn("Non-float imag value received.  Ignoring. (In PMT pair.)");
         }
     } else {
         if (pmt::is_real(msg)) {
@@ -122,7 +122,7 @@ void correctiq_man_impl::handle_imag(pmt::pmt_t msg)
 
             set_imag(new_value);
         } else {
-            GR_LOG_WARN(d_logger, "Non-float imag value received.  Ignoring.");
+            d_logger->warn("Non-float imag value received.  Ignoring.");
         }
     }
 }

--- a/gr-blocks/lib/correctiq_swapiq_impl.cc
+++ b/gr-blocks/lib/correctiq_swapiq_impl.cc
@@ -83,7 +83,7 @@ int swap_iq_impl::work(int noutput_items,
         }
     } break;
     default: {
-        GR_LOG_ERROR(d_logger, "Unknown data type.  Bytes not swapped.");
+        d_logger->error("Unknown data type.  Bytes not swapped.");
         return WORK_DONE;
     }
     }

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.cc
@@ -14,7 +14,6 @@
 
 #include "ctrlport_probe2_b_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -60,10 +59,7 @@ void ctrlport_probe2_b_impl::set_length(int len)
     gr::thread::scoped_lock guard(d_setlock);
 
     if (len > 8191) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("probe2_b: length %1% exceeds maximum"
-                                  " buffer size of 8191") %
-                        len);
+        d_logger->warn("length {:d} exceeds maximum buffer size of 8191", len);
         len = 8191;
     }
 

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.cc
@@ -14,7 +14,6 @@
 
 #include "ctrlport_probe2_c_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -60,10 +59,7 @@ void ctrlport_probe2_c_impl::set_length(int len)
     gr::thread::scoped_lock guard(d_setlock);
 
     if (len > 8191) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("probe2_c: length %1% exceeds maximum"
-                                  " buffer size of 8191") %
-                        len);
+        d_logger->warn("probe2_c: length {:d} exceeds maximum buffer size of 8191", len);
         len = 8191;
     }
 

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.h
@@ -14,7 +14,6 @@
 #include <gnuradio/blocks/ctrlport_probe2_c.h>
 #include <gnuradio/rpcbufferedget.h>
 #include <gnuradio/rpcregisterhelpers.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.cc
@@ -14,7 +14,6 @@
 
 #include "ctrlport_probe2_f_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -60,10 +59,7 @@ void ctrlport_probe2_f_impl::set_length(int len)
     gr::thread::scoped_lock guard(d_setlock);
 
     if (len > 8191) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("probe2_f: length %1% exceeds maximum"
-                                  " buffer size of 8191") %
-                        len);
+        d_logger->warn("length {:d} exceeds maximum buffer size of 8191", len);
         len = 8191;
     }
 

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.cc
@@ -14,7 +14,6 @@
 
 #include "ctrlport_probe2_i_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -59,10 +58,7 @@ void ctrlport_probe2_i_impl::set_length(int len)
     gr::thread::scoped_lock guard(d_setlock);
 
     if (len > 8191) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("probe2_i: length %1% exceeds maximum"
-                                  " buffer size of 8191") %
-                        len);
+        d_logger->warn("length {:d} exceeds maximum buffer size of 8191", len);
         len = 8191;
     }
 

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.cc
@@ -14,7 +14,6 @@
 
 #include "ctrlport_probe2_s_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -60,10 +59,7 @@ void ctrlport_probe2_s_impl::set_length(int len)
     gr::thread::scoped_lock guard(d_setlock);
 
     if (len > 8191) {
-        GR_LOG_WARN(d_logger,
-                    boost::format("probe2_s: length %1% exceeds maximum"
-                                  " buffer size of 8191") %
-                        len);
+        d_logger->warn("length {:d} exceeds maximum buffer size of 8191", len);
         len = 8191;
     }
 

--- a/gr-blocks/lib/delay_impl.cc
+++ b/gr-blocks/lib/delay_impl.cc
@@ -76,8 +76,7 @@ void delay_impl::handle_msg(pmt::pmt_t msg)
                 int value = pmt::to_long(data);
                 set_dly(value);
             } else
-                GR_LOG_WARN(
-                    d_logger,
+                d_logger->warn(
                     "Delay message must be a number or a number pair.  Ignoring value.");
         }
     }

--- a/gr-blocks/lib/file_descriptor_sink_impl.cc
+++ b/gr-blocks/lib/file_descriptor_sink_impl.cc
@@ -58,7 +58,7 @@ int file_descriptor_sink_impl::work(int noutput_items,
             if (errno == EINTR)
                 continue;
             else {
-                GR_LOG_ERROR(d_logger, strerror(errno));
+                d_logger->error(strerror(errno));
                 return -1; // indicate we're done
             }
         } else {

--- a/gr-blocks/lib/file_descriptor_source_impl.cc
+++ b/gr-blocks/lib/file_descriptor_source_impl.cc
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <boost/format.hpp>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
@@ -106,9 +105,7 @@ int file_descriptor_source_impl::work(int noutput_items,
             if (errno == EINTR)
                 continue;
             else {
-                GR_LOG_ERROR(d_logger,
-                             boost::format("file_descriptor_source[read]: %s") %
-                                 strerror(errno));
+                d_logger->error("[read]: {:s}", strerror(errno));
                 return -1;
             }
         } else if (r == 0) { // end of file
@@ -117,9 +114,7 @@ int file_descriptor_source_impl::work(int noutput_items,
             else {
                 flush_residue();
                 if (lseek(d_fd, 0, SEEK_SET) == -1) {
-                    GR_LOG_ERROR(d_logger,
-                                 boost::format("file_descriptor_source[lseek]: %s") %
-                                     strerror(errno));
+                    d_logger->error("[lseek]: {:s}", strerror(errno));
                     return -1;
                 }
             }

--- a/gr-blocks/lib/file_meta_sink_impl.cc
+++ b/gr-blocks/lib/file_meta_sink_impl.cc
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -155,7 +154,7 @@ bool file_meta_sink_impl::_open(FILE** fp, const char* filename)
     if ((fd = ::open(filename,
                      O_WRONLY | O_CREAT | O_TRUNC | OUR_O_LARGEFILE | OUR_O_BINARY,
                      0664)) < 0) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        d_logger->error("[::open] {:s}: {:s}", filename, strerror(errno));
         return false;
     }
 
@@ -165,7 +164,7 @@ bool file_meta_sink_impl::_open(FILE** fp, const char* filename)
     }
 
     if ((*fp = fdopen(fd, "wb")) == NULL) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        d_logger->error("[fdopen] {:s}: {:s}", filename, strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
     }
 

--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -17,7 +17,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -263,7 +262,7 @@ bool file_meta_source_impl::_open(FILE** fp, const char* filename)
     int fd;
 
     if ((fd = ::open(filename, O_RDONLY | OUR_O_LARGEFILE | OUR_O_BINARY)) < 0) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        d_logger->error("[::open] {:s}: {:s}", filename, strerror(errno));
         return false;
     }
 
@@ -273,7 +272,7 @@ bool file_meta_source_impl::_open(FILE** fp, const char* filename)
     }
 
     if ((*fp = fdopen(fd, "rb")) == NULL) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        d_logger->error("[fdopen] {:s}: {:s}", filename, strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
     }
 

--- a/gr-blocks/lib/file_sink_base.cc
+++ b/gr-blocks/lib/file_sink_base.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2006,2007,2009,2013 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -18,7 +19,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -43,15 +43,20 @@ namespace gr {
 namespace blocks {
 
 file_sink_base::file_sink_base(const char* filename, bool is_binary, bool append)
-    : d_fp(0), d_new_fp(0), d_updated(false), d_is_binary(is_binary), d_append(append)
+    : d_fp(0),
+      d_new_fp(0),
+      d_updated(false),
+      d_is_binary(is_binary),
+      d_append(append),
+      d_base_logger("file_sink_base")
 {
     if (!open(filename))
         throw std::runtime_error("can't open file");
-    gr::configure_default_loggers(d_logger, d_debug_logger, "file_sink_base");
 }
 
 file_sink_base::~file_sink_base()
 {
+    d_base_logger.info("[destructor] Closing file");
     close();
     if (d_fp) {
         fclose(d_fp);
@@ -62,6 +67,7 @@ file_sink_base::~file_sink_base()
 bool file_sink_base::open(const char* filename)
 {
     gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this function
+    d_base_logger.info("opening file {:s}", filename);
 
     // we use the open system call to get access to the O_LARGEFILE flag.
     int fd;
@@ -73,7 +79,7 @@ bool file_sink_base::open(const char* filename)
         flags = O_WRONLY | O_CREAT | O_TRUNC | OUR_O_LARGEFILE | OUR_O_BINARY;
     }
     if ((fd = ::open(filename, flags, 0664)) < 0) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        d_base_logger.error("[::open] {:s}: {:s}", filename, strerror(errno));
         return false;
     }
     if (d_new_fp) { // if we've already got a new one open, close it
@@ -82,7 +88,7 @@ bool file_sink_base::open(const char* filename)
     }
 
     if ((d_new_fp = fdopen(fd, d_is_binary ? "wb" : "w")) == NULL) {
-        GR_LOG_ERROR(d_logger, boost::format("%s: %s") % filename % strerror(errno));
+        d_base_logger.error("[fdopen] {:s}: {:s}", filename, strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
     }
 
@@ -94,6 +100,7 @@ void file_sink_base::close()
 {
     gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this function
 
+    d_base_logger.info("Closing file");
     if (d_new_fp) {
         fclose(d_new_fp);
         d_new_fp = 0;
@@ -105,6 +112,7 @@ void file_sink_base::do_update()
 {
     if (d_updated) {
         gr::thread::scoped_lock guard(d_mutex); // hold mutex for duration of this block
+        d_base_logger.info("updating");
         if (d_fp)
             fclose(d_fp);
         d_fp = d_new_fp; // install new file pointer
@@ -113,7 +121,11 @@ void file_sink_base::do_update()
     }
 }
 
-void file_sink_base::set_unbuffered(bool unbuffered) { d_unbuffered = unbuffered; }
+void file_sink_base::set_unbuffered(bool unbuffered)
+{
+    d_base_logger.info("Setting to {:s}buffered state", unbuffered ? "un" : "");
+    d_unbuffered = unbuffered;
+}
 
 } /* namespace blocks */
 } /* namespace gr */

--- a/gr-blocks/lib/keep_m_in_n_impl.cc
+++ b/gr-blocks/lib/keep_m_in_n_impl.cc
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2012,2018 Free Software Foundation, Inc.
+ * Copyright 2012,2018,2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -8,13 +8,9 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include "keep_m_in_n_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
+#include <spdlog/fmt/fmt.h>
 
 namespace gr {
 namespace blocks {
@@ -35,29 +31,19 @@ keep_m_in_n_impl::keep_m_in_n_impl(size_t itemsize, int m, int n, int offset)
 {
     // sanity checking
     if (d_m <= 0) {
-        std::string s =
-            boost::str(boost::format("keep_m_in_n: m=%1% but must be > 0") % d_m);
-        throw std::runtime_error(s);
+        throw std::runtime_error(fmt::format("m={:d} but must be > 0", d_m));
     }
     if (d_n <= 0) {
-        std::string s =
-            boost::str(boost::format("keep_m_in_n: n=%1% but must be > 0") % d_n);
-        throw std::runtime_error(s);
+        throw std::runtime_error(fmt::format("n={:d} but must be > 0", d_n));
     }
     if (d_m > d_n) {
-        std::string s =
-            boost::str(boost::format("keep_m_in_n: m (%1%) <= n %2%") % d_m % d_n);
-        throw std::runtime_error(s);
+        throw std::runtime_error(fmt::format("m = {:d} ≤ {:d} = n", d_m, d_n));
     }
     if (d_offset < 0) {
-        std::string s = boost::str(
-            boost::format("keep_m_in_n: offset (%1%) must be >= 0") % d_offset);
-        throw std::runtime_error(s);
+        throw std::runtime_error(fmt::format("offset {:d} but must be >= 0", d_offset));
     }
     if (d_offset >= d_n) {
-        std::string s = boost::str(boost::format("keep_m_in_n: offset (%1%) < n (%2%)") %
-                                   d_offset % d_n);
-        throw std::runtime_error(s);
+        throw std::runtime_error(fmt::format("offset = {:d} < {:d} = n", d_offset, d_n));
     }
 
     set_output_multiple(m);

--- a/gr-blocks/lib/multiply_by_tag_value_cc_impl.cc
+++ b/gr-blocks/lib/multiply_by_tag_value_cc_impl.cc
@@ -15,7 +15,6 @@
 #include "multiply_by_tag_value_cc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace blocks {
@@ -70,9 +69,9 @@ int multiply_by_tag_value_cc_impl::work(int noutput_items,
         } else if (pmt::is_number(k)) {
             d_k = gr_complex(pmt::to_double(k), 0);
         } else {
-            GR_LOG_WARN(d_logger,
-                        boost::format("Got key '%1%' with incompatible value of '%2%'") %
-                            pmt::write_string(d_tag_key) % pmt::write_string(k));
+            d_logger->warn("Got key '{:s}' with incompatible value of '{:s}'",
+                           pmt::write_string(d_tag_key),
+                           pmt::write_string(k));
         }
     }
 

--- a/gr-blocks/lib/multiply_matrix_impl.cc
+++ b/gr-blocks/lib/multiply_matrix_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2014,2017,2018 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -46,12 +47,15 @@ bool multiply_matrix_impl<gr_complex>::set_A(
     const std::vector<std::vector<gr_complex>>& new_A)
 {
     if (d_A.size() != new_A.size()) {
-        GR_LOG_ALERT(d_logger, "Attempted to set matrix with invalid dimensions.");
+        d_logger->error("Attempted to set matrix with invalid dimensions. (Old and new "
+                        "number of rows different)");
         return false;
     }
     for (size_t i = 0; i < d_A.size(); i++) {
         if (d_A[i].size() != new_A[i].size()) {
-            GR_LOG_ALERT(d_logger, "Attempted to set matrix with invalid dimensions.");
+            d_logger->error("Attempted to set matrix with invalid dimensions. (Old and "
+                            "new number of columns different in row {:d})",
+                            i);
             return false;
         }
     }
@@ -63,11 +67,11 @@ template <>
 void multiply_matrix_impl<gr_complex>::msg_handler_A(pmt::pmt_t A)
 {
     if (!pmt::is_vector(A) && !pmt::is_tuple(A)) {
-        GR_LOG_ALERT(d_logger, "Invalid message to set A (wrong type).");
+        d_logger->error("Invalid message to set A (wrong type).");
         return;
     }
     if (pmt::length(A) != d_A.size()) {
-        GR_LOG_ALERT(d_logger, "Invalid message to set A (wrong size).");
+        d_logger->error("Invalid message to set A (wrong size).");
         return;
     }
 
@@ -81,8 +85,7 @@ void multiply_matrix_impl<gr_complex>::msg_handler_A(pmt::pmt_t A)
         }
         if (pmt::is_vector(row) || pmt::is_tuple(row)) {
             if (pmt::length(row) != d_A[0].size()) {
-                GR_LOG_ALERT(d_logger,
-                             "Invalid message to set A (wrong number of columns).");
+                d_logger->error("Invalid message to set A (wrong number of columns).");
                 return;
             }
             for (size_t k = 0; k < pmt::length(row); k++) {
@@ -94,8 +97,7 @@ void multiply_matrix_impl<gr_complex>::msg_handler_A(pmt::pmt_t A)
             size_t row_len = 0;
             const gr_complex* elements = pmt::c32vector_elements(row, row_len);
             if (row_len != d_A[0].size()) {
-                GR_LOG_ALERT(d_logger,
-                             "Invalid message to set A (wrong number of columns).");
+                d_logger->error("Invalid message to set A (wrong number of columns).");
                 return;
             }
             new_A[i].assign(elements, elements + row_len);
@@ -103,7 +105,7 @@ void multiply_matrix_impl<gr_complex>::msg_handler_A(pmt::pmt_t A)
     }
 
     if (!set_A(new_A)) {
-        GR_LOG_ALERT(d_logger, "Invalid message to set A.");
+        d_logger->error("Invalid message to set A.");
     }
 }
 
@@ -133,12 +135,15 @@ template <>
 bool multiply_matrix_impl<float>::set_A(const std::vector<std::vector<float>>& new_A)
 {
     if (d_A.size() != new_A.size()) {
-        GR_LOG_ALERT(d_logger, "Attempted to set matrix with invalid dimensions.");
+        d_logger->error("Attempted to set matrix with invalid dimensions. (Old and new "
+                        "number of rows different)");
         return false;
     }
     for (size_t i = 0; i < d_A.size(); i++) {
         if (d_A[i].size() != new_A[i].size()) {
-            GR_LOG_ALERT(d_logger, "Attempted to set matrix with invalid dimensions.");
+            d_logger->error("Attempted to set matrix with invalid dimensions. (Old and "
+                            "new number of columns different in row {:d})",
+                            i);
             return false;
         }
     }
@@ -150,11 +155,11 @@ template <>
 void multiply_matrix_impl<float>::msg_handler_A(pmt::pmt_t A)
 {
     if (!pmt::is_vector(A) && !pmt::is_tuple(A)) {
-        GR_LOG_ALERT(d_logger, "Invalid message to set A (wrong type).");
+        d_logger->error("Invalid message to set A (wrong type).");
         return;
     }
     if (pmt::length(A) != d_A.size()) {
-        GR_LOG_ALERT(d_logger, "Invalid message to set A (wrong size).");
+        d_logger->error("Invalid message to set A (wrong size).");
         return;
     }
 
@@ -168,8 +173,7 @@ void multiply_matrix_impl<float>::msg_handler_A(pmt::pmt_t A)
         }
         if (pmt::is_vector(row) || pmt::is_tuple(row)) {
             if (pmt::length(row) != d_A[0].size()) {
-                GR_LOG_ALERT(d_logger,
-                             "Invalid message to set A (wrong number of columns).");
+                d_logger->error("Invalid message to set A (wrong number of columns).");
                 return;
             }
             for (size_t k = 0; k < pmt::length(row); k++) {
@@ -181,8 +185,7 @@ void multiply_matrix_impl<float>::msg_handler_A(pmt::pmt_t A)
             size_t row_len = 0;
             const float* elements = pmt::f32vector_elements(row, row_len);
             if (row_len != d_A[0].size()) {
-                GR_LOG_ALERT(d_logger,
-                             "Invalid message to set A (wrong number of columns).");
+                d_logger->error("Invalid message to set A (wrong number of columns).");
                 return;
             }
             new_A[i].assign(elements, elements + row_len);
@@ -190,7 +193,7 @@ void multiply_matrix_impl<float>::msg_handler_A(pmt::pmt_t A)
     }
 
     if (!set_A(new_A)) {
-        GR_LOG_ALERT(d_logger, "Invalid message to set A.");
+        d_logger->error("Invalid message to set A.");
     }
 }
 

--- a/gr-blocks/lib/pack_k_bits_bb_impl.cc
+++ b/gr-blocks/lib/pack_k_bits_bb_impl.cc
@@ -44,13 +44,11 @@ int pack_k_bits_bb_impl::work(int noutput_items,
 
     std::vector<tag_t> wintags; // Temp variable to store tags for prop
 
-    // GR_LOG_DEBUG(d_logger, boost::format("Packing Outputs"));
     d_pack.pack(out, in, noutput_items);
 
     // Propagate tags
     get_tags_in_range(wintags, 0, nitems_read(0), nitems_read(0) + (noutput_items * d_k));
 
-    // GR_LOG_DEBUG(d_logger, boost::format("Propagating tags"));
     std::vector<tag_t>::iterator t;
     for (t = wintags.begin(); t != wintags.end(); t++) {
         tag_t new_tag = *t;

--- a/gr-blocks/lib/packed_to_unpacked_impl.cc
+++ b/gr-blocks/lib/packed_to_unpacked_impl.cc
@@ -15,7 +15,6 @@
 
 #include "packed_to_unpacked_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -40,9 +39,9 @@ packed_to_unpacked_impl<T>::packed_to_unpacked_impl(unsigned int bits_per_chunk,
       d_index(0)
 {
     if (bits_per_chunk > d_bits_per_type) {
-        GR_LOG_ERROR(this->d_logger,
-                     boost::format("Requested to get %d out of a %d bit chunk") %
-                         bits_per_chunk % d_bits_per_type);
+        this->d_logger->error("Requested to get {:d} out of a {:d} bit chunk",
+                              bits_per_chunk,
+                              d_bits_per_type);
         throw std::domain_error("can't have more bits in chunk than in output type");
     }
 
@@ -138,7 +137,7 @@ int packed_to_unpacked_impl<T>::general_work(int noutput_items,
             break;
 
         default:
-            GR_LOG_ERROR(this->d_logger, "unknown endianness");
+            this->d_logger->error("unknown endianness");
             throw std::runtime_error("unknown endianness");
         }
     }

--- a/gr-blocks/lib/phase_shift_impl.cc
+++ b/gr-blocks/lib/phase_shift_impl.cc
@@ -57,8 +57,7 @@ void phase_shift_impl::handle_msg_in(pmt::pmt_t msg)
             if (pmt::is_number(data)) {
                 set_shift(pmt::to_float(data));
             } else
-                GR_LOG_WARN(
-                    d_logger,
+                d_logger->warn(
                     "Phase message must be a number or a number pair.  Ignoring value.");
         }
     }

--- a/gr-blocks/lib/qa_block_tags.cc
+++ b/gr-blocks/lib/qa_block_tags.cc
@@ -22,7 +22,6 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/top_block.h>
 
-#include <boost/format.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
@@ -145,18 +144,13 @@ BOOST_AUTO_TEST_CASE(t1)
 
     // For annotator 3, we know it gets tags from ann0 and ann1, test this
     for (size_t i = 0; i < tags3.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags3[%d] = %s\t\t%s") % i % tags3[i] %
-                        expected_tags3[i]);
+        logger->info("tags3[{:d}] = {:16s}{:16s}", i, tags3[i], expected_tags3[i]);
         BOOST_REQUIRE_EQUAL(tags3[i], expected_tags3[i]);
     }
 
     // For annotator 4, we know it gets tags from ann0 and ann2, test this
-    GR_LOG_INFO(logger, "");
     for (size_t i = 0; i < tags4.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags4[%d] = %s\t\t%s") % i % tags4[i] %
-                        expected_tags4);
+        logger->info("tags4[{:d}] = {:16s}{:16s}", i, tags4[i], expected_tags4[i]);
         BOOST_REQUIRE_EQUAL(tags4[i], expected_tags4[i]);
     }
 #endif
@@ -254,17 +248,12 @@ BOOST_AUTO_TEST_CASE(t2)
     // Just testing ann2 and ann4; if they are correct it would be
     // inconceivable for ann3 to have it wrong.
     for (size_t i = 0; i < tags2.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags2[%d] = %s\t\t%s") % i % tags2[i] %
-                        expected_tags2[i]);
+        logger->info("tags2[{:d}] = {:16s}{:16s}", i, tags2[i], expected_tags2[i]);
         BOOST_REQUIRE_EQUAL(tags2[i], expected_tags2[i]);
     }
 
-    GR_LOG_INFO(logger, "");
     for (size_t i = 0; i < tags4.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags4[%d] = %s\t\t%s") % i % tags4[i] %
-                        expected_tags4[i]);
+        logger->info("tags4[{:d}] = {:16s}{:16s}", i, tags4[i], expected_tags4[i]);
         BOOST_REQUIRE_EQUAL(tags4[i], expected_tags4[i]);
     }
 #endif
@@ -345,18 +334,13 @@ BOOST_AUTO_TEST_CASE(t3)
 
     // For annotator 3, we know it gets tags from ann0 and ann1, test this
     for (size_t i = 0; i < tags3.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags3[%d] = %s\t\t%s") % i % tags3[i] %
-                        expected_tags3[i]);
+        logger->info("tags4[{:d}] = {:16s}{:16s}", i, tags4[i], expected_tags4[i]);
         BOOST_REQUIRE_EQUAL(tags3[i], expected_tags3[i]);
     }
 
     // For annotator 4, we know it gets tags from ann0 and ann2, test this
-    GR_LOG_INFO(logger, "");
     for (size_t i = 0; i < tags4.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags4[%d] = %s\t\t%s") % i % tags4[i] %
-                        expected_tags4[i]);
+        logger->info("tags4[{:d}] = {:16s}{:16s}", i, tags4[i], expected_tags4[i]);
         BOOST_REQUIRE_EQUAL(tags4[i], expected_tags4[i]);
     }
 #endif
@@ -389,8 +373,7 @@ BOOST_AUTO_TEST_CASE(t4)
     tb->connect(ann1, 0, snk0, 0);
     tb->connect(ann2, 0, snk1, 0);
 
-    GR_LOG_INFO(logger,
-                "NOTE: This is supposed to produce an error from block_executor!");
+    logger->info("NOTE: This is supposed to produce an error from block_executor!");
     tb->run();
 }
 
@@ -459,23 +442,18 @@ BOOST_AUTO_TEST_CASE(t5)
     expected_tags2[8] = make_tag(4000, pmt::mp(str1.str()), pmt::mp("seq"), pmt::mp(4));
     expected_tags2[9] = make_tag(4000, pmt::mp(str0.str()), pmt::mp("seq"), pmt::mp(4));
 
-    GR_LOG_INFO(logger, boost::format("tags1.size(): %d") % tags1.size());
+    logger->info("tags1.size(): {:d}", tags1.size);
 
     // annotator 1 gets tags from annotator 0
     for (size_t i = 0; i < tags1.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags1[%d] = %s\t\t%s") % i % tags1[i] %
-                        expected_tags1[i]);
+        logger->info("tags1[{:d}] = {:16s}{:16s}", i, tags1[i], expected_tags1[i]);
         BOOST_REQUIRE_EQUAL(tags1[i], expected_tags1[i]);
     }
 
     // annotator 2 gets tags from annotators 0 and 1
-    GR_LOG_INFO(logger, "");
-    GR_LOG_INFO(logger, boost::format("tags2.size(): %d") % tags2.size());
+    logger->info("tags2.size(): {:d}", tags2.size);
     for (size_t i = 0; i < tags2.size(); i++) {
-        GR_LOG_INFO(logger,
-                    boost::format("tags2[%d] = %s\t\t%s") % i % tags2[i] %
-                        expected_tags2[i]);
+        logger->info("tags2[{:d}] = {:16s}{:16s}", i, tags2[i], expected_tags2[i]);
         BOOST_REQUIRE_EQUAL(tags2[i], expected_tags2[i]);
     }
 #endif

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -57,19 +57,21 @@ selector_impl::~selector_impl() {}
 void selector_impl::set_input_index(unsigned int input_index)
 {
     gr::thread::scoped_lock l(d_mutex);
-    if (input_index < d_num_inputs)
+    if (input_index < d_num_inputs) {
         d_input_index = input_index;
-    else
+    } else {
         throw std::out_of_range("input_index must be < ninputs");
+    }
 }
 
 void selector_impl::set_output_index(unsigned int output_index)
 {
     gr::thread::scoped_lock l(d_mutex);
-    if (output_index < d_num_outputs)
+    if (output_index < d_num_outputs) {
         d_output_index = output_index;
-    else
+    } else {
         throw std::out_of_range("output_index must be < noutputs");
+    }
 }
 
 void selector_impl::handle_msg_input_index(pmt::pmt_t msg)
@@ -79,16 +81,18 @@ void selector_impl::handle_msg_input_index(pmt::pmt_t msg)
     if (pmt::is_integer(data)) {
         const unsigned int new_port = pmt::to_long(data);
 
-        if (new_port < d_num_inputs)
+        if (new_port < d_num_inputs) {
             set_input_index(new_port);
-        else
-            GR_LOG_WARN(
-                d_logger,
-                "handle_msg_input_index: port index greater than available ports.");
-    } else
-        GR_LOG_WARN(
-            d_logger,
+        } else {
+            d_logger->warn("handle_msg_input_index: port index {:d} greater than "
+                           "available ports {:d}.",
+                           new_port,
+                           d_num_inputs);
+        }
+    } else {
+        d_logger->warn(
             "handle_msg_input_index: Non-PMT type received, expecting integer PMT");
+    }
 }
 
 void selector_impl::handle_msg_output_index(pmt::pmt_t msg)
@@ -97,16 +101,18 @@ void selector_impl::handle_msg_output_index(pmt::pmt_t msg)
 
     if (pmt::is_integer(data)) {
         const unsigned int new_port = pmt::to_long(data);
-        if (new_port < d_num_outputs)
+        if (new_port < d_num_outputs) {
             set_output_index(new_port);
-        else
-            GR_LOG_WARN(
-                d_logger,
-                "handle_msg_output_index: port index greater than available ports.");
-    } else
-        GR_LOG_WARN(
-            d_logger,
+        } else {
+            d_logger->warn("handle_msg_input_index: port index {:d} greater than "
+                           "available ports {:d}.",
+                           new_port,
+                           d_num_inputs);
+        }
+    } else {
+        d_logger->warn(
             "handle_msg_output_index: Non-PMT type received, expecting integer PMT");
+    }
 }
 
 
@@ -117,8 +123,7 @@ void selector_impl::handle_enable(pmt::pmt_t msg)
         gr::thread::scoped_lock l(d_mutex);
         d_enabled = en;
     } else {
-        GR_LOG_WARN(d_logger,
-                    "handle_enable: Non-PMT type received, expecting Boolean PMT");
+        d_logger->warn("handle_enable: Non-PMT type received, expecting Boolean PMT");
     }
 }
 
@@ -137,11 +142,9 @@ bool selector_impl::check_topology(int ninputs, int noutputs)
         d_num_inputs = (unsigned int)ninputs;
         d_num_outputs = (unsigned int)noutputs;
         return true;
-    } else {
-        GR_LOG_WARN(d_logger,
-                    "check_topology: Input or Output index greater than number of ports");
-        return false;
     }
+    d_logger->warn("check_topology: Input or Output index greater than number of ports");
+    return false;
 }
 
 int selector_impl::general_work(int noutput_items,

--- a/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
+++ b/gr-blocks/lib/test_tag_variable_rate_ff_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2015 Free Software Foundation, Inc.
+ * Copyright 2021 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -15,7 +16,6 @@
 #include "test_tag_variable_rate_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
-#include <boost/format.hpp>
 #include <cstdint>
 
 using namespace pmt;
@@ -59,9 +59,10 @@ int test_tag_variable_rate_ff_impl::general_work(int noutput_items,
     const float* in = (const float*)input_items[0];
     float* out = (float*)output_items[0];
 
-    GR_LOG_DEBUG(d_logger, "\n");
-    GR_LOG_DEBUG(d_logger, boost::format("ninput_items:  %1%") % ninput_items[0]);
-    GR_LOG_DEBUG(d_logger, boost::format("noutput_items: %1%") % noutput_items);
+    d_logger->debug("ninput_items:  {:10d}\n"
+                    "noutput_items: {:10d}",
+                    ninput_items[0],
+                    noutput_items);
 
     if (d_update_once) {
         if (xoroshiro128p_next(d_rng_state) > (UINT64_MAX / 2)) {
@@ -110,9 +111,8 @@ int test_tag_variable_rate_ff_impl::general_work(int noutput_items,
         i++;
     }
 
-    GR_LOG_DEBUG(d_logger, boost::format("consuming: %1%") % i);
-    GR_LOG_DEBUG(d_logger, boost::format("producing: %1%") % j);
-    GR_LOG_DEBUG(d_logger, boost::format("block's rel rate:  %1%") % d_rrate);
+    d_logger->debug(
+        "consuming {:10d}, producing {:10d}, block's rel rate {:10f}", i, j, d_rrate);
 
     consume_each(i);
     return j;

--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -93,9 +93,8 @@ int throttle_impl::work(int noutput_items,
         auto limit_duration =
             std::chrono::duration<double>(std::numeric_limits<long>::max());
         if (expected_time - now > limit_duration) {
-            GR_LOG_ALERT(d_logger,
-                         "WARNING: Throttle sleep time overflow! You "
-                         "are probably using a very low sample rate.");
+            d_logger->error("WARNING: Throttle sleep time overflow! You are probably "
+                            "using a very low sample rate.");
         }
         std::this_thread::sleep_until(expected_time);
     }

--- a/gr-blocks/lib/unpacked_to_packed_impl.cc
+++ b/gr-blocks/lib/unpacked_to_packed_impl.cc
@@ -15,7 +15,6 @@
 
 #include "unpacked_to_packed_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -41,9 +40,8 @@ unpacked_to_packed_impl<T>::unpacked_to_packed_impl(unsigned int bits_per_chunk,
       d_index(0)
 {
     if (bits_per_chunk > d_bits_per_type) {
-        GR_LOG_ERROR(this->d_logger,
-                     boost::format("Requested to put %d in a %d bit chunk") %
-                         bits_per_chunk % d_bits_per_type);
+        this->d_logger->error(
+            "Requested to put {:d} in a {:d} bit chunk", bits_per_chunk, d_bits_per_type);
         throw std::domain_error("can't have more bits in chunk than in output type");
     }
 
@@ -126,7 +124,7 @@ int unpacked_to_packed_impl<T>::general_work(int noutput_items,
             break;
 
         default:
-            GR_LOG_ERROR(this->d_logger, "unknown endianness");
+            this->d_logger->error("unknown endianness");
             throw std::runtime_error("unknown endianness");
         }
     }

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -15,7 +15,6 @@
 #include "wavfile_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/format.hpp>
 #include <cstring>
 #include <stdexcept>
 
@@ -111,21 +110,18 @@ bool wavfile_sink_impl::open(const char* filename)
         // We are appending to an existing file, be extra careful here.
         sfinfo.format = 0;
         if (!(d_new_fp = sf_open(filename, SFM_RDWR, &sfinfo))) {
-            GR_LOG_ERROR(d_logger,
-                         boost::format("sf_open failed: %s: %s") % filename %
-                             strerror(errno));
+            d_logger->error("sf_open(1) failed: {:s}: {:s}", filename, strerror(errno));
             return false;
         }
         if (d_h.sample_rate != sfinfo.samplerate || d_h.nchans != sfinfo.channels ||
             d_h.format != (sfinfo.format & SF_FORMAT_TYPEMASK) ||
             d_h.subformat != (sfinfo.format & SF_FORMAT_SUBMASK)) {
-            GR_LOG_ERROR(d_logger,
-                         "Existing WAV file is incompatible with configured options.");
+            d_logger->error("Existing WAV file is incompatible with configured options.");
             sf_close(d_new_fp);
             return false;
         }
         if (sf_seek(d_new_fp, 0, SEEK_END) == -1) {
-            GR_LOG_ERROR(d_logger, "Seek error.");
+            d_logger->error("Seek error.");
             return false; // This can only happen if the file disappears under our feet.
         }
     } else {
@@ -199,9 +195,7 @@ bool wavfile_sink_impl::open(const char* filename)
             break;
         }
         if (!(d_new_fp = sf_open(filename, SFM_WRITE, &sfinfo))) {
-            GR_LOG_ERROR(d_logger,
-                         boost::format("sf_open failed: %s: %s") % filename %
-                             strerror(errno));
+            d_logger->error("sf_open(2) failed: {:s}: {:s}", filename, strerror(errno));
             return false;
         }
     }
@@ -272,7 +266,7 @@ int wavfile_sink_impl::work(int noutput_items,
 
     errnum = sf_error(d_fp);
     if (errnum) {
-        GR_LOG_ERROR(d_logger, boost::format("sf_error: %s") % sf_error_number(errnum));
+        d_logger->error("sf_error: {:s}", sf_error_number(errnum));
         close();
         throw std::runtime_error("File I/O error.");
     }

--- a/gr-blocks/lib/wavfile_source_impl.cc
+++ b/gr-blocks/lib/wavfile_source_impl.cc
@@ -8,6 +8,7 @@
  *
  */
 
+#include <cstring>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -15,7 +16,6 @@
 #include "wavfile_source_impl.h"
 #include <gnuradio/io_signature.h>
 #include <sys/types.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -39,9 +39,7 @@ wavfile_source_impl::wavfile_source_impl(const char* filename, bool repeat)
 
     sfinfo.format = 0;
     if (!(d_fp = sf_open(filename, SFM_READ, &sfinfo))) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("sf_open failed: %s: %s") % filename %
-                         strerror(errno));
+        d_logger->error("sf_open failed: {:s}: {:s}", filename, strerror(errno));
         throw std::runtime_error("Can't open WAV file.");
     }
 
@@ -109,8 +107,7 @@ int wavfile_source_impl::work(int noutput_items,
             }
 
             if (sf_seek(d_fp, 0, SEEK_SET) == -1) {
-                GR_LOG_ERROR(d_logger,
-                             boost::format("sf_seek failed: %s") % strerror(errno));
+                d_logger->error("sf_seek failed: {:s}", strerror(errno));
                 throw std::runtime_error("Seek error.");
             }
 
@@ -137,10 +134,8 @@ int wavfile_source_impl::work(int noutput_items,
         errnum = sf_error(d_fp);
         if (errnum) {
             if (items == 0) {
-                GR_LOG_ERROR(
-                    d_logger,
-                    boost::format("WAV file has corrupted header or I/O error, %s") %
-                        sf_error_number(errnum));
+                d_logger->error("WAV file has corrupted header or I/O error, {:s}",
+                                sf_error_number(errnum));
                 return -1;
             }
             return produced;

--- a/gr-blocks/python/blocks/bindings/file_sink_base_python.cc
+++ b/gr-blocks/python/blocks/bindings/file_sink_base_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(file_sink_base.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3ecad3bebf54f73e2fa57cb95d5154c8)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b832eef38e5444b08f329837184e86c8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/qa_keep_m_in_n.py
+++ b/gr-blocks/python/blocks/qa_keep_m_in_n.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2008,2010,2012,2013,2018 Free Software Foundation, Inc.
+# Copyright 2008,2010,2012,2013,2018,2022 Free Software Foundation, Inc.
 #
 # This file is part of GNU Radio
 #
@@ -70,24 +70,24 @@ class test_keep_m_in_n(gr_unittest.TestCase):
     def test_003(self):
         with self.assertRaises(RuntimeError) as cm:
             blocks.keep_m_in_n(8, 0, 5, 0)
-        self.assertEqual(str(cm.exception), 'keep_m_in_n: m=0 but must be > 0')
+        self.assertEqual(str(cm.exception), 'm=0 but must be > 0')
 
         with self.assertRaises(RuntimeError) as cm:
             blocks.keep_m_in_n(8, 5, 0, 0)
-        self.assertEqual(str(cm.exception), 'keep_m_in_n: n=0 but must be > 0')
+        self.assertEqual(str(cm.exception), 'n=0 but must be > 0')
 
         with self.assertRaises(RuntimeError) as cm:
             blocks.keep_m_in_n(8, 6, 5, 0)
-        self.assertEqual(str(cm.exception), 'keep_m_in_n: m (6) <= n 5')
+        self.assertEqual(str(cm.exception), 'm = 6 ≤ 5 = n')
 
         with self.assertRaises(RuntimeError) as cm:
             blocks.keep_m_in_n(8, 2, 5, -1)
         self.assertEqual(str(cm.exception),
-                         'keep_m_in_n: offset (-1) must be >= 0')
+                         'offset -1 but must be >= 0')
 
         with self.assertRaises(RuntimeError) as cm:
             blocks.keep_m_in_n(8, 2, 5, 5)
-        self.assertEqual(str(cm.exception), 'keep_m_in_n: offset (5) < n (5)')
+        self.assertEqual(str(cm.exception), 'offset = 5 < 5 = n')
 
 
 if __name__ == '__main__':

--- a/gr-fec/include/gnuradio/fec/decoder.h
+++ b/gr-fec/include/gnuradio/fec/decoder.h
@@ -14,7 +14,6 @@
 #include <gnuradio/block.h>
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_decoder.h>
-#include <boost/format.hpp>
 #include <boost/shared_array.hpp>
 #include <memory>
 

--- a/gr-fec/python/fec/bindings/decoder_python.cc
+++ b/gr-fec/python/fec/bindings/decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(5cf5ec49fcb93668344db1ab0c58c17b)                     */
+/* BINDTOOL_HEADER_FILE_HASH(cbb67b408431fa0272f9cd6095801212)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fft/include/gnuradio/fft/fft.h
+++ b/gr-fft/include/gnuradio/fft/fft.h
@@ -73,8 +73,7 @@ class FFT_API fft
     volk::vector<typename fft_inbuf<T, forward>::type> d_inbuf;
     volk::vector<typename fft_outbuf<T, forward>::type> d_outbuf;
     void* d_plan;
-    gr::logger_ptr d_logger;
-    gr::logger_ptr d_debug_logger;
+    gr::logger d_logger;
     void initialize_plan(int fft_size);
 
 public:

--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/integer_math.h>
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -121,13 +120,13 @@ rational_resampler_impl<IN_T, OUT_T, TAP_T>::rational_resampler_impl(
     auto d = GR_GCD(interpolation, decimation);
 
     if (!taps.empty() && (d > 1)) {
-        GR_LOG_INFO(
-            d_logger,
-            boost::format(
-                "Rational resampler has user-provided taps but interpolation (%1%) and "
-                "decimation (%2%) have a GCD of %3%, which increases the complexity of "
-                "the filterbank. Consider reducing these values by the GCD.") %
-                interpolation % decimation % d);
+        d_logger->info(
+            "Rational resampler has user-provided taps but interpolation ({:d}) and "
+            "decimation ({:d}) have a GCD of {:d}, which increases the complexity of "
+            "the filterbank. Consider reducing these values by the GCD.",
+            interpolation,
+            decimation,
+            d);
     }
 
     std::vector<TAP_T> staps;

--- a/gr-trellis/CMakeLists.txt
+++ b/gr-trellis/CMakeLists.txt
@@ -8,14 +8,13 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
+# ↺↺↺↺↺↺↺ (Tumbleweed)
 
 ########################################################################
 # Register component
 ########################################################################
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-trellis" ENABLE_GR_TRELLIS
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_ANALOG
     ENABLE_GR_BLOCKS

--- a/gr-trellis/lib/fsm.cc
+++ b/gr-trellis/lib/fsm.cc
@@ -11,7 +11,6 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/trellis/base.h>
 #include <gnuradio/trellis/fsm.h>
-#include <boost/format.hpp>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
@@ -419,8 +418,7 @@ void fsm::generate_PS_PI()
 //######################################################################
 void fsm::generate_TM()
 {
-    gr::logger_ptr logger, debug_logger;
-    gr::configure_default_loggers(logger, debug_logger, "gnuradio-config-info.cc");
+    gr::logger logger("gnuradio-config-info.cc");
     d_TMi.resize(d_S * d_S);
     d_TMl.resize(d_S * d_S);
 
@@ -442,11 +440,9 @@ void fsm::generate_TM()
             // throw std::runtime_error ("fsm::generate_TM(): FSM appears to be
             // disconnected");
 
-            GR_LOG_ERROR(
-                logger,
-                (boost::format("fsm::generate_TM(): FSM appears to be disconnected"
-                               "state %d cannot be reached from all other states") %
-                 s));
+            logger.error("fsm::generate_TM(): FSM appears to be disconnected; state "
+                         "{:d} cannot be reached from all other states",
+                         s);
         }
     }
 }

--- a/gr-video-sdl/CMakeLists.txt
+++ b/gr-video-sdl/CMakeLists.txt
@@ -8,8 +8,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
-
 find_package(SDL)
 
 ########################################################################
@@ -18,7 +16,6 @@ find_package(SDL)
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-video-sdl" ENABLE_GR_VIDEO_SDL
     SDL_FOUND
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
 )
 

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -18,7 +18,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
@@ -99,10 +98,9 @@ sink_s_impl::sink_s_impl(
         throw std::runtime_error("video_sdl::sink_s");
     }
 
-    GR_LOG_INFO(d_debug_logger,
-                boost::format("SDL screen_mode %d bits-per-pixel") %
-                    d_screen->format->BitsPerPixel);
-    GR_LOG_INFO(d_debug_logger, boost::format("SDL overlay_mode %i") % d_image->format);
+    d_debug_logger->info("SDL screen_mode {:d} bits-per-pixel",
+                         d_screen->format->BitsPerPixel);
+    d_debug_logger->info("SDL overlay_mode {:d}", d_image->format);
 
     d_chunk_size = std::min(1, 16384 / width); // width*16;
     d_chunk_size = d_chunk_size * width;

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -18,7 +18,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
@@ -100,10 +99,9 @@ sink_uc_impl::sink_uc_impl(
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
-    GR_LOG_INFO(d_debug_logger,
-                boost::format("SDL screen_mode %d bits-per-pixel") %
-                    d_screen->format->BitsPerPixel);
-    GR_LOG_INFO(d_debug_logger, boost::format("SDL overlay_mode %i ") % d_image->format);
+    d_debug_logger->info("SDL screen_mode {:d} bits-per-pixel",
+                         d_screen->format->BitsPerPixel);
+    d_debug_logger->info("SDL overlay_mode {:d} ", d_image->format);
 
     d_chunk_size = std::min(1, 16384 / width); // width*16;
     d_chunk_size = d_chunk_size * width;

--- a/gr-vocoder/CMakeLists.txt
+++ b/gr-vocoder/CMakeLists.txt
@@ -8,14 +8,13 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
+# ---- crickets
 
 ########################################################################
 # Register component
 ########################################################################
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-vocoder" ENABLE_GR_VOCODER
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_FFT
     ENABLE_GR_BLOCKS

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -15,7 +15,6 @@
 #include "freedv_rx_ss_impl.h"
 
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -68,9 +67,10 @@ freedv_rx_ss_impl::~freedv_rx_ss_impl()
     if (freedv_get_test_frames(d_freedv)) {
         total_bits = freedv_get_total_bits(d_freedv);
         total_bit_errors = freedv_get_total_bit_errors(d_freedv);
-        GR_LOG_ERROR(d_logger,
-                     boost::format("bits: %d errors: %d BER: %3.2f") % total_bits %
-                         total_bit_errors % ((1.0 * total_bit_errors) / total_bits));
+        d_logger->error("bits: {:8d} errors: {:8d} BER: {:3.2f}",
+                        total_bits,
+                        total_bit_errors,
+                        ((1.0 * total_bit_errors) / total_bits));
     }
     freedv_close(d_freedv);
 }


### PR DESCRIPTION
# Pull Request Details
## Description

Since #4981 has been implemented, we'll need to convert to more modern logging for two reasons:

1. to get rid of the high-cost boost::format that's still in tree
2. to get rid of logging macros (which make debugging harder and don't optimize away better than logging templated functions, unless you call anything expensive with side effects in the arguments to logging, which you basically never have to do – since formatting can be done on the fly only if enabled)
3. having references for "how to log" in-tree

## Related Issue

depends on #4981; merged / in 3.10.0.0

## Which blocks/areas does this affect?
Whole tree.

## Testing Done

Fixed all unit tests.

There's been a unit test change in `qa_keep_m_in_n`, since that checks the verbatim string from an exception, and the strings weren't very good in the original code. Not sure whether we consider exception `what()` string API, though.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary: https://wiki.gnuradio.org/index.php?title=GNU_Radio_3.10_OOT_Module_Porting_Guide#Logging
- [x] I have added tests to cover my changes, and all previous tests pass.
