### PR TITLE
runtime: add virtual destructor to custom_lock_if class

### DIFF
--- a/gnuradio-runtime/include/gnuradio/custom_lock.h
+++ b/gnuradio-runtime/include/gnuradio/custom_lock.h
@@ -26,6 +26,8 @@ namespace gr {
 class custom_lock_if
 {
 public:
+    virtual ~custom_lock_if(){};
+
     /*!
      * This function will be executed on construction of the custom lock.
      */


### PR DESCRIPTION
Signed-off-by: David Sorber <david.sorber@blacklynx.tech>


# Pull Request Details

Add virtual destructor to custom_lock_if abstract class to fix #5269 

## Description

Add missing virtual destructor to abstract class

## Related Issue

--

## Which blocks/areas does this affect?

Fix compile warnings

## Testing Done

I don't have gcc 11.2.0 installed but this should fix the warnings mentioned in #5269

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
