### PR TITLE
runtime: make forecast const

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -151,7 +151,7 @@ public:
      * number of data items required on each input stream.  The
      * estimate doesn't have to be exact, but should be close.
      */
-    virtual void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+    virtual void forecast(int noutput_items, gr_vector_int& ninput_items_required) const;
 
     /*!
      * \brief compute output items from input items
@@ -340,14 +340,14 @@ public:
      * N.B. this is only defined if fixed_rate returns true.
      * Generally speaking, you don't need to override this.
      */
-    virtual int fixed_rate_ninput_to_noutput(int ninput);
+    virtual int fixed_rate_ninput_to_noutput(int ninput) const;
 
     /*!
      * \brief Given noutput samples, return number of input samples required to produce
      * noutput. N.B. this is only defined if fixed_rate returns true. Generally speaking,
      * you don't need to override this.
      */
-    virtual int fixed_rate_noutput_to_ninput(int noutput);
+    virtual int fixed_rate_noutput_to_ninput(int noutput) const;
 
     /*!
      * \brief Return the number of items read on input stream which_input

--- a/gnuradio-runtime/include/gnuradio/sync_block.h
+++ b/gnuradio-runtime/include/gnuradio/sync_block.h
@@ -42,14 +42,14 @@ public:
                      gr_vector_void_star& output_items) = 0;
 
     // gr::sync_block overrides these to assist work
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
 
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/sync_decimator.h
+++ b/gnuradio-runtime/include/gnuradio/sync_decimator.h
@@ -43,7 +43,7 @@ public:
     }
 
     // gr::sync_decimator overrides these to assist work
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
@@ -51,8 +51,8 @@ public:
 
     // derived classes should override work
 
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/sync_interpolator.h
+++ b/gnuradio-runtime/include/gnuradio/sync_interpolator.h
@@ -44,7 +44,7 @@ public:
     }
 
     // gr::sync_interpolator overrides these to assist work
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
@@ -52,8 +52,8 @@ public:
 
     // derived classes should override work
 
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/include/gnuradio/tagged_stream_block.h
+++ b/gnuradio-runtime/include/gnuradio/tagged_stream_block.h
@@ -86,8 +86,8 @@ protected:
 public:
     /*! \brief Don't override this.
      */
-    void /* final */ forecast(int noutput_items,
-                              gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items,
+                              gr_vector_int& ninput_items_required) const final override;
 
     bool check_topology(int ninputs, int /* noutputs */) override;
 

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -89,7 +89,7 @@ unsigned block::sample_delay(int which) const { return d_attr_delay; }
 
 // stub implementation:  1:1
 
-void block::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void block::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
@@ -182,12 +182,12 @@ void block::produce(int which_output, int how_many_items)
     d_detail->produce(which_output, how_many_items);
 }
 
-int block::fixed_rate_ninput_to_noutput(int ninput)
+int block::fixed_rate_ninput_to_noutput(int ninput) const
 {
     throw std::runtime_error("Unimplemented");
 }
 
-int block::fixed_rate_noutput_to_ninput(int noutput)
+int block::fixed_rate_noutput_to_ninput(int noutput) const
 {
     throw std::runtime_error("Unimplemented");
 }

--- a/gnuradio-runtime/lib/block_gateway_impl.cc
+++ b/gnuradio-runtime/lib/block_gateway_impl.cc
@@ -31,7 +31,7 @@ block_gateway_impl::block_gateway_impl(const py::handle& p,
     _py_handle = p;
 }
 
-void block_gateway_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void block_gateway_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     py::gil_scoped_acquire acquire;
 

--- a/gnuradio-runtime/lib/block_gateway_impl.h
+++ b/gnuradio-runtime/lib/block_gateway_impl.h
@@ -29,7 +29,7 @@ public:
     /*******************************************************************
      * Overloads for various scheduler-called functions
      ******************************************************************/
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gnuradio-runtime/lib/sync_block.cc
+++ b/gnuradio-runtime/lib/sync_block.cc
@@ -24,19 +24,19 @@ sync_block::sync_block(const std::string& name,
     set_fixed_rate(true);
 }
 
-void sync_block::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void sync_block::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] = fixed_rate_noutput_to_ninput(noutput_items);
 }
 
-int sync_block::fixed_rate_noutput_to_ninput(int noutput_items)
+int sync_block::fixed_rate_noutput_to_ninput(int noutput_items) const
 {
     return noutput_items + history() - 1;
 }
 
-int sync_block::fixed_rate_ninput_to_noutput(int ninput_items)
+int sync_block::fixed_rate_ninput_to_noutput(int ninput_items) const
 {
     return std::max(0, ninput_items - (int)history() + 1);
 }

--- a/gnuradio-runtime/lib/sync_decimator.cc
+++ b/gnuradio-runtime/lib/sync_decimator.cc
@@ -25,19 +25,19 @@ sync_decimator::sync_decimator(const std::string& name,
     set_decimation(decimation);
 }
 
-void sync_decimator::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void sync_decimator::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] = fixed_rate_noutput_to_ninput(noutput_items);
 }
 
-int sync_decimator::fixed_rate_noutput_to_ninput(int noutput_items)
+int sync_decimator::fixed_rate_noutput_to_ninput(int noutput_items) const
 {
     return noutput_items * decimation() + history() - 1;
 }
 
-int sync_decimator::fixed_rate_ninput_to_noutput(int ninput_items)
+int sync_decimator::fixed_rate_ninput_to_noutput(int ninput_items) const
 {
     return std::max(0, ninput_items - (int)history() + 1) / decimation();
 }

--- a/gnuradio-runtime/lib/sync_interpolator.cc
+++ b/gnuradio-runtime/lib/sync_interpolator.cc
@@ -25,19 +25,19 @@ sync_interpolator::sync_interpolator(const std::string& name,
     set_interpolation(interpolation);
 }
 
-void sync_interpolator::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void sync_interpolator::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)
         ninput_items_required[i] = fixed_rate_noutput_to_ninput(noutput_items);
 }
 
-int sync_interpolator::fixed_rate_noutput_to_ninput(int noutput_items)
+int sync_interpolator::fixed_rate_noutput_to_ninput(int noutput_items) const
 {
     return noutput_items / interpolation() + history() - 1;
 }
 
-int sync_interpolator::fixed_rate_ninput_to_noutput(int ninput_items)
+int sync_interpolator::fixed_rate_ninput_to_noutput(int ninput_items) const
 {
     return std::max(0, ninput_items - (int)history() + 1) * interpolation();
 }

--- a/gnuradio-runtime/lib/tagged_stream_block.cc
+++ b/gnuradio-runtime/lib/tagged_stream_block.cc
@@ -31,7 +31,7 @@ tagged_stream_block::tagged_stream_block(const std::string& name,
 // This is evil hackery: We trick the scheduler into creating the right number of input
 // items
 void tagged_stream_block::forecast(int noutput_items,
-                                   gr_vector_int& ninput_items_required)
+                                   gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gnuradio-runtime/lib/test.h
+++ b/gnuradio-runtime/lib/test.h
@@ -74,7 +74,7 @@ public:
      * number of data items required on each input stream. The
      * estimate doesn't have to be exact, but should be close.
      */
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override
     {
         unsigned ninputs = ninput_items_required.size();
         for (unsigned i = 0; i < ninputs; i++)
@@ -119,7 +119,7 @@ public:
      * returns true.  Generally speaking, you don't need to override
      * this.
      */
-    int fixed_rate_ninput_to_noutput(int ninput) override
+    int fixed_rate_ninput_to_noutput(int ninput) const override
     {
         return (int)((double)ninput / relative_rate());
     }
@@ -129,7 +129,7 @@ public:
      * required to produce noutput. N.B. this is only defined if
      * fixed_rate returns true.
      */
-    int fixed_rate_noutput_to_ninput(int noutput) override
+    int fixed_rate_noutput_to_ninput(int noutput) const override
     {
         return (int)((double)noutput * relative_rate());
     }

--- a/gr-blocks/lib/copy_impl.cc
+++ b/gr-blocks/lib/copy_impl.cc
@@ -45,7 +45,7 @@ void copy_impl::handle_enable(pmt::pmt_t msg)
     }
 }
 
-void copy_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void copy_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-blocks/lib/copy_impl.h
+++ b/gr-blocks/lib/copy_impl.h
@@ -26,7 +26,7 @@ public:
     copy_impl(size_t itemsize);
     ~copy_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     bool check_topology(int ninputs, int noutputs) override;
 
     void handle_enable(pmt::pmt_t msg);

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.cc
@@ -45,7 +45,7 @@ ctrlport_probe2_b_impl::ctrlport_probe2_b_impl(const std::string& id,
 ctrlport_probe2_b_impl::~ctrlport_probe2_b_impl() {}
 
 void ctrlport_probe2_b_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-blocks/lib/ctrlport_probe2_b_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_b_impl.h
@@ -39,7 +39,7 @@ public:
 
     void setup_rpc() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<signed char> get() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.cc
@@ -45,7 +45,7 @@ ctrlport_probe2_c_impl::ctrlport_probe2_c_impl(const std::string& id,
 ctrlport_probe2_c_impl::~ctrlport_probe2_c_impl() {}
 
 void ctrlport_probe2_c_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-blocks/lib/ctrlport_probe2_c_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_c_impl.h
@@ -40,7 +40,7 @@ public:
 
     void setup_rpc() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<gr_complex> get() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.cc
@@ -45,7 +45,7 @@ ctrlport_probe2_f_impl::ctrlport_probe2_f_impl(const std::string& id,
 ctrlport_probe2_f_impl::~ctrlport_probe2_f_impl() {}
 
 void ctrlport_probe2_f_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-blocks/lib/ctrlport_probe2_f_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_f_impl.h
@@ -39,7 +39,7 @@ public:
 
     void setup_rpc() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<float> get() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.cc
@@ -44,7 +44,7 @@ ctrlport_probe2_i_impl::ctrlport_probe2_i_impl(const std::string& id,
 ctrlport_probe2_i_impl::~ctrlport_probe2_i_impl() {}
 
 void ctrlport_probe2_i_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-blocks/lib/ctrlport_probe2_i_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_i_impl.h
@@ -39,7 +39,7 @@ public:
 
     void setup_rpc() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<int> get() override;
 

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.cc
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.cc
@@ -45,7 +45,7 @@ ctrlport_probe2_s_impl::ctrlport_probe2_s_impl(const std::string& id,
 ctrlport_probe2_s_impl::~ctrlport_probe2_s_impl() {}
 
 void ctrlport_probe2_s_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-blocks/lib/ctrlport_probe2_s_impl.h
+++ b/gr-blocks/lib/ctrlport_probe2_s_impl.h
@@ -39,7 +39,7 @@ public:
 
     void setup_rpc() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<short> get() override;
 

--- a/gr-blocks/lib/deinterleave_impl.cc
+++ b/gr-blocks/lib/deinterleave_impl.cc
@@ -35,7 +35,7 @@ deinterleave_impl::deinterleave_impl(size_t itemsize, unsigned int blocksize)
     set_output_multiple(blocksize);
 }
 
-void deinterleave_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void deinterleave_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items * d_noutputs;
 }

--- a/gr-blocks/lib/deinterleave_impl.h
+++ b/gr-blocks/lib/deinterleave_impl.h
@@ -28,7 +28,7 @@ class BLOCKS_API deinterleave_impl : public deinterleave
 public:
     deinterleave_impl(size_t itemsize, unsigned int blocksize);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     bool check_topology(int ninputs, int noutputs) override;
 
     int general_work(int noutput_items,

--- a/gr-blocks/lib/delay_impl.cc
+++ b/gr-blocks/lib/delay_impl.cc
@@ -42,7 +42,7 @@ delay_impl::delay_impl(size_t itemsize, int delay)
 
 delay_impl::~delay_impl() {}
 
-void delay_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void delay_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-blocks/lib/delay_impl.h
+++ b/gr-blocks/lib/delay_impl.h
@@ -20,7 +20,7 @@ namespace blocks {
 class delay_impl : public delay
 {
 private:
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     const size_t d_itemsize;
     int d_delta;

--- a/gr-blocks/lib/interleave_impl.cc
+++ b/gr-blocks/lib/interleave_impl.cc
@@ -43,17 +43,17 @@ bool interleave_impl::check_topology(int ninputs, int noutputs)
 }
 
 
-int interleave_impl::fixed_rate_ninput_to_noutput(int ninput)
+int interleave_impl::fixed_rate_ninput_to_noutput(int ninput) const
 {
     return ninput * d_ninputs;
 }
 
-int interleave_impl::fixed_rate_noutput_to_ninput(int noutput)
+int interleave_impl::fixed_rate_noutput_to_ninput(int noutput) const
 {
     return (noutput / d_ninputs);
 }
 
-void interleave_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void interleave_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     for (unsigned int i = 0; i < ninput_items_required.size(); ++i) {
         ninput_items_required[i] = noutput_items / ninput_items_required.size();

--- a/gr-blocks/lib/interleave_impl.h
+++ b/gr-blocks/lib/interleave_impl.h
@@ -27,11 +27,11 @@ public:
 
     bool check_topology(int ninputs, int noutputs) override;
 
-    int fixed_rate_ninput_to_noutput(int ninput) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
 
-    int fixed_rate_noutput_to_ninput(int noutput) override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-blocks/lib/keep_m_in_n_impl.cc
+++ b/gr-blocks/lib/keep_m_in_n_impl.cc
@@ -64,7 +64,7 @@ keep_m_in_n_impl::keep_m_in_n_impl(size_t itemsize, int m, int n, int offset)
     set_relative_rate(static_cast<uint64_t>(d_m), static_cast<uint64_t>(d_n));
 }
 
-void keep_m_in_n_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void keep_m_in_n_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = d_n * (noutput_items / d_m);
 }

--- a/gr-blocks/lib/keep_m_in_n_impl.h
+++ b/gr-blocks/lib/keep_m_in_n_impl.h
@@ -23,7 +23,7 @@ class BLOCKS_API keep_m_in_n_impl : public keep_m_in_n
     int d_offset;
     const int d_itemsize;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
 public:
     keep_m_in_n_impl(size_t itemsize, int m, int n, int offset);

--- a/gr-blocks/lib/packed_to_unpacked_impl.cc
+++ b/gr-blocks/lib/packed_to_unpacked_impl.cc
@@ -56,7 +56,7 @@ packed_to_unpacked_impl<T>::~packed_to_unpacked_impl()
 
 template <class T>
 void packed_to_unpacked_impl<T>::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     const int input_required = (int)ceil((d_index + noutput_items * d_bits_per_chunk) /
                                          (1.0 * this->d_bits_per_type));

--- a/gr-blocks/lib/packed_to_unpacked_impl.h
+++ b/gr-blocks/lib/packed_to_unpacked_impl.h
@@ -33,7 +33,7 @@ public:
     packed_to_unpacked_impl(unsigned int bits_per_chunk, endianness_t endianness);
     ~packed_to_unpacked_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-blocks/lib/patterned_interleaver_impl.cc
+++ b/gr-blocks/lib/patterned_interleaver_impl.cc
@@ -69,7 +69,7 @@ int patterned_interleaver_impl::general_work(int noutput_items,
 }
 
 void patterned_interleaver_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     int nblks = noutput_items / d_pattern.size();
     for (size_t i = 0; i < ninput_items_required.size(); i++) {

--- a/gr-blocks/lib/patterned_interleaver_impl.h
+++ b/gr-blocks/lib/patterned_interleaver_impl.h
@@ -35,7 +35,7 @@ public:
         return *std::max_element(pattern.begin(), pattern.end());
     }
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<int> d_pattern;
     std::vector<int> d_counts;

--- a/gr-blocks/lib/plateau_detector_fb_impl.cc
+++ b/gr-blocks/lib/plateau_detector_fb_impl.cc
@@ -34,7 +34,7 @@ plateau_detector_fb_impl::plateau_detector_fb_impl(int max_len, float threshold)
 
 plateau_detector_fb_impl::~plateau_detector_fb_impl() {}
 
-void plateau_detector_fb_impl::forecast(int, gr_vector_int& ninput_items_required)
+void plateau_detector_fb_impl::forecast(int, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = 2 * d_max_len;
 }

--- a/gr-blocks/lib/plateau_detector_fb_impl.h
+++ b/gr-blocks/lib/plateau_detector_fb_impl.h
@@ -26,7 +26,7 @@ public:
     plateau_detector_fb_impl(int max_len, float threshold);
     ~plateau_detector_fb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-blocks/lib/selector_impl.cc
+++ b/gr-blocks/lib/selector_impl.cc
@@ -122,7 +122,7 @@ void selector_impl::handle_enable(pmt::pmt_t msg)
     }
 }
 
-void selector_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void selector_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gr-blocks/lib/selector_impl.h
+++ b/gr-blocks/lib/selector_impl.h
@@ -32,7 +32,7 @@ public:
     selector_impl(size_t itemsize, unsigned int input_index, unsigned int output_index);
     ~selector_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     bool check_topology(int ninputs, int noutputs) override;
     void setup_rpc() override;
     void handle_msg_input_index(pmt::pmt_t msg);

--- a/gr-blocks/lib/stream_demux_impl.cc
+++ b/gr-blocks/lib/stream_demux_impl.cc
@@ -53,7 +53,7 @@ stream_demux_impl::stream_demux_impl(size_t itemsize, const std::vector<int>& le
     set_tag_propagation_policy(TPP_DONT);
 }
 
-void stream_demux_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void stream_demux_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     std::fill(ninput_items_required.begin(), ninput_items_required.end(), 1);
 }

--- a/gr-blocks/lib/stream_demux_impl.h
+++ b/gr-blocks/lib/stream_demux_impl.h
@@ -39,7 +39,7 @@ private:
 public:
     stream_demux_impl(size_t itemsize, const std::vector<int>& lengths);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-blocks/lib/stream_mux_impl.cc
+++ b/gr-blocks/lib/stream_mux_impl.cc
@@ -41,7 +41,7 @@ stream_mux_impl::stream_mux_impl(size_t itemsize, const std::vector<int>& length
     set_tag_propagation_policy(TPP_DONT);
 }
 
-void stream_mux_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void stream_mux_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gr-blocks/lib/stream_mux_impl.h
+++ b/gr-blocks/lib/stream_mux_impl.h
@@ -24,7 +24,7 @@ private:
     int d_residual{ 0 };           // number of items left to put into current stream
     const gr_vector_int d_lengths; // number of items to pack per stream
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
 public:
     stream_mux_impl(size_t itemsize, const std::vector<int>& lengths);

--- a/gr-blocks/lib/unpacked_to_packed_impl.cc
+++ b/gr-blocks/lib/unpacked_to_packed_impl.cc
@@ -57,7 +57,7 @@ unpacked_to_packed_impl<T>::~unpacked_to_packed_impl()
 
 template <class T>
 void unpacked_to_packed_impl<T>::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     const int input_required =
         (int)ceil((d_index + noutput_items * 1.0 * d_bits_per_type) / d_bits_per_chunk);

--- a/gr-blocks/lib/unpacked_to_packed_impl.h
+++ b/gr-blocks/lib/unpacked_to_packed_impl.h
@@ -32,7 +32,7 @@ public:
     unpacked_to_packed_impl(unsigned int bits_per_chunk, endianness_t endianness);
     ~unpacked_to_packed_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-channels/lib/sro_model_impl.cc
+++ b/gr-channels/lib/sro_model_impl.cc
@@ -51,7 +51,7 @@ sro_model_impl::sro_model_impl(double sample_rate_hz,
 
 sro_model_impl::~sro_model_impl() {}
 
-void sro_model_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void sro_model_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gr-channels/lib/sro_model_impl.h
+++ b/gr-channels/lib/sro_model_impl.h
@@ -38,7 +38,7 @@ public:
                    double noise_seed = 0);
     ~sro_model_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/burst_shaper_impl.cc
+++ b/gr-digital/lib/burst_shaper_impl.cc
@@ -77,7 +77,7 @@ burst_shaper_impl<T>::~burst_shaper_impl()
 
 template <class T>
 void burst_shaper_impl<T>::forecast(int noutput_items,
-                                    gr_vector_int& ninput_items_required)
+                                    gr_vector_int& ninput_items_required) const
 {
     switch (d_state) {
     case (STATE_RAMPDOWN):

--- a/gr-digital/lib/burst_shaper_impl.h
+++ b/gr-digital/lib/burst_shaper_impl.h
@@ -65,7 +65,7 @@ public:
                       const std::string& length_tag_name);
     ~burst_shaper_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -65,7 +65,7 @@ clock_recovery_mm_cc_impl::clock_recovery_mm_cc_impl(
 clock_recovery_mm_cc_impl::~clock_recovery_mm_cc_impl() {}
 
 void clock_recovery_mm_cc_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.h
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.h
@@ -27,7 +27,7 @@ public:
                               float omega_relative_limi);
     ~clock_recovery_mm_cc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/clock_recovery_mm_ff_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_ff_impl.cc
@@ -51,7 +51,7 @@ clock_recovery_mm_ff_impl::clock_recovery_mm_ff_impl(
 clock_recovery_mm_ff_impl::~clock_recovery_mm_ff_impl() {}
 
 void clock_recovery_mm_ff_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-digital/lib/clock_recovery_mm_ff_impl.h
+++ b/gr-digital/lib/clock_recovery_mm_ff_impl.h
@@ -27,7 +27,7 @@ public:
                               float omega_relative_limi);
     ~clock_recovery_mm_ff_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/constellation_decoder_cb_impl.cc
+++ b/gr-digital/lib/constellation_decoder_cb_impl.cc
@@ -38,7 +38,7 @@ constellation_decoder_cb_impl::constellation_decoder_cb_impl(
 constellation_decoder_cb_impl::~constellation_decoder_cb_impl() {}
 
 void constellation_decoder_cb_impl::forecast(int noutput_items,
-                                             gr_vector_int& ninput_items_required)
+                                             gr_vector_int& ninput_items_required) const
 {
     const unsigned int input_required = noutput_items * d_dim;
 

--- a/gr-digital/lib/constellation_decoder_cb_impl.h
+++ b/gr-digital/lib/constellation_decoder_cb_impl.h
@@ -26,7 +26,7 @@ public:
     constellation_decoder_cb_impl(constellation_sptr constellation);
     ~constellation_decoder_cb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-digital/lib/header_payload_demux_impl.cc
+++ b/gr-digital/lib/header_payload_demux_impl.cc
@@ -154,7 +154,7 @@ header_payload_demux_impl::~header_payload_demux_impl() {}
 // - Otherwise, pretend this is a sync block with a decimation/interpolation
 //   depending on symbol size and if we output symbols or items
 void header_payload_demux_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     int n_items_reqd = 0;
     if (d_state == STATE_HEADER) {

--- a/gr-digital/lib/header_payload_demux_impl.h
+++ b/gr-digital/lib/header_payload_demux_impl.h
@@ -100,7 +100,7 @@ public:
                               const size_t header_padding);
     ~header_payload_demux_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -80,7 +80,7 @@ void msk_timing_recovery_cc_impl::set_limit(float limit) { d_limit = limit; }
 float msk_timing_recovery_cc_impl::get_limit(void) { return d_limit; }
 
 void msk_timing_recovery_cc_impl::forecast(int noutput_items,
-                                           gr_vector_int& ninput_items_required)
+                                           gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.h
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.h
@@ -35,7 +35,7 @@ public:
     ~msk_timing_recovery_cc_impl() override;
 
     // Where all the action really happens
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-digital/lib/ofdm_chanest_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_chanest_vcvc_impl.cc
@@ -127,7 +127,7 @@ ofdm_chanest_vcvc_impl::ofdm_chanest_vcvc_impl(
 ofdm_chanest_vcvc_impl::~ofdm_chanest_vcvc_impl() {}
 
 void ofdm_chanest_vcvc_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] =
         (noutput_items / d_n_data_syms) * (d_n_data_syms + d_n_sync_syms);

--- a/gr-digital/lib/ofdm_chanest_vcvc_impl.h
+++ b/gr-digital/lib/ofdm_chanest_vcvc_impl.h
@@ -66,7 +66,7 @@ public:
                            bool force_one_sync_symbol);
     ~ofdm_chanest_vcvc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.cc
@@ -107,7 +107,7 @@ bool pfb_clock_sync_ccf_impl::check_topology(int ninputs, int noutputs)
 }
 
 void pfb_clock_sync_ccf_impl::forecast(int noutput_items,
-                                       gr_vector_int& ninput_items_required)
+                                       gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-digital/lib/pfb_clock_sync_ccf_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_ccf_impl.h
@@ -68,7 +68,7 @@ public:
 
     void update_gains() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void update_taps(const std::vector<float>& taps) override;
 

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.cc
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.cc
@@ -103,7 +103,7 @@ bool pfb_clock_sync_fff_impl::check_topology(int ninputs, int noutputs)
 }
 
 void pfb_clock_sync_fff_impl::forecast(int noutput_items,
-                                       gr_vector_int& ninput_items_required)
+                                       gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-digital/lib/pfb_clock_sync_fff_impl.h
+++ b/gr-digital/lib/pfb_clock_sync_fff_impl.h
@@ -65,7 +65,7 @@ public:
 
     void update_gains() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void update_taps(const std::vector<float>& taps) override;
 

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -363,7 +363,7 @@ void symbol_sync_cc_impl::emit_optional_output(int oidx,
 }
 
 void symbol_sync_cc_impl::forecast(int noutput_items,
-                                   gr_vector_int& ninput_items_required)
+                                   gr_vector_int& ninput_items_required) const
 {
     const unsigned ninputs = ninput_items_required.size();
 

--- a/gr-digital/lib/symbol_sync_cc_impl.h
+++ b/gr-digital/lib/symbol_sync_cc_impl.h
@@ -34,7 +34,7 @@ public:
                         int n_filters,
                         const std::vector<float>& taps);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -366,7 +366,7 @@ void symbol_sync_ff_impl::emit_optional_output(int oidx,
 }
 
 void symbol_sync_ff_impl::forecast(int noutput_items,
-                                   gr_vector_int& ninput_items_required)
+                                   gr_vector_int& ninput_items_required) const
 {
     const unsigned ninputs = ninput_items_required.size();
 

--- a/gr-digital/lib/symbol_sync_ff_impl.h
+++ b/gr-digital/lib/symbol_sync_ff_impl.h
@@ -35,7 +35,7 @@ public:
                         const std::vector<float>& taps);
     ~symbol_sync_ff_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-dtv/lib/atsc/atsc_field_sync_mux_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_field_sync_mux_impl.cc
@@ -133,7 +133,7 @@ inline bool atsc_field_sync_mux_impl::last_regular_seg_p(const plinfo& pli)
 }
 
 void atsc_field_sync_mux_impl::forecast(int noutput_items,
-                                        gr_vector_int& ninput_items_required)
+                                        gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/atsc/atsc_field_sync_mux_impl.h
+++ b/gr-dtv/lib/atsc/atsc_field_sync_mux_impl.h
@@ -38,7 +38,7 @@ public:
     atsc_field_sync_mux_impl();
     ~atsc_field_sync_mux_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/atsc/atsc_sync_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_sync_impl.cc
@@ -67,7 +67,7 @@ void atsc_sync_impl::reset()
 
 atsc_sync_impl::~atsc_sync_impl() {}
 
-void atsc_sync_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void atsc_sync_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-dtv/lib/atsc/atsc_sync_impl.h
+++ b/gr-dtv/lib/atsc/atsc_sync_impl.h
@@ -48,7 +48,7 @@ public:
 
     void reset();
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/catv/catv_frame_sync_enc_bb_impl.cc
+++ b/gr-dtv/lib/catv/catv_frame_sync_enc_bb_impl.cc
@@ -47,7 +47,7 @@ catv_frame_sync_enc_bb_impl::catv_frame_sync_enc_bb_impl(
 catv_frame_sync_enc_bb_impl::~catv_frame_sync_enc_bb_impl() {}
 
 void catv_frame_sync_enc_bb_impl::forecast(int noutput_items,
-                                           gr_vector_int& ninput_items_required)
+                                           gr_vector_int& ninput_items_required) const
 {
     if (signal_constellation == CATV_MOD_64QAM) {
         ninput_items_required[0] = noutput_items / ((60 * 128 * 7) + 42) * (60 * 128);

--- a/gr-dtv/lib/catv/catv_frame_sync_enc_bb_impl.h
+++ b/gr-dtv/lib/catv/catv_frame_sync_enc_bb_impl.h
@@ -24,7 +24,7 @@ public:
     catv_frame_sync_enc_bb_impl(catv_constellation_t constellation, int ctrlword);
     ~catv_frame_sync_enc_bb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/catv/catv_reed_solomon_enc_bb_impl.cc
+++ b/gr-dtv/lib/catv/catv_reed_solomon_enc_bb_impl.cc
@@ -105,7 +105,7 @@ void catv_reed_solomon_enc_bb_impl::reed_solomon_enc(const unsigned char* messag
 }
 
 void catv_reed_solomon_enc_bb_impl::forecast(int noutput_items,
-                                             gr_vector_int& ninput_items_required)
+                                             gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = (noutput_items / 128) * 122;
 }

--- a/gr-dtv/lib/catv/catv_reed_solomon_enc_bb_impl.h
+++ b/gr-dtv/lib/catv/catv_reed_solomon_enc_bb_impl.h
@@ -29,7 +29,7 @@ public:
     catv_reed_solomon_enc_bb_impl();
     ~catv_reed_solomon_enc_bb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/catv/catv_trellis_enc_bb_impl.cc
+++ b/gr-dtv/lib/catv/catv_trellis_enc_bb_impl.cc
@@ -50,7 +50,7 @@ catv_trellis_enc_bb_impl::catv_trellis_enc_bb_impl(catv_constellation_t constell
 catv_trellis_enc_bb_impl::~catv_trellis_enc_bb_impl() {}
 
 void catv_trellis_enc_bb_impl::forecast(int noutput_items,
-                                        gr_vector_int& ninput_items_required)
+                                        gr_vector_int& ninput_items_required) const
 {
     if (signal_constellation == CATV_MOD_64QAM) {
         ninput_items_required[0] = noutput_items / 5 * 28;

--- a/gr-dtv/lib/catv/catv_trellis_enc_bb_impl.h
+++ b/gr-dtv/lib/catv/catv_trellis_enc_bb_impl.h
@@ -37,7 +37,7 @@ public:
     ~catv_trellis_enc_bb_impl() override;
 
     // Where all the action really happens
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvb/dvb_bbheader_bb_impl.cc
+++ b/gr-dtv/lib/dvb/dvb_bbheader_bb_impl.cc
@@ -298,7 +298,7 @@ dvb_bbheader_bb_impl::dvb_bbheader_bb_impl(dvb_standard_t standard,
 dvb_bbheader_bb_impl::~dvb_bbheader_bb_impl() {}
 
 void dvb_bbheader_bb_impl::forecast(int noutput_items,
-                                    gr_vector_int& ninput_items_required)
+                                    gr_vector_int& ninput_items_required) const
 {
     if (input_mode == INPUTMODE_NORMAL) {
         if (frame_size != FECFRAME_MEDIUM) {

--- a/gr-dtv/lib/dvb/dvb_bbheader_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_bbheader_bb_impl.h
@@ -68,7 +68,7 @@ public:
                          int tsrate);
     ~dvb_bbheader_bb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvb/dvb_bch_bb_impl.cc
+++ b/gr-dtv/lib/dvb/dvb_bch_bb_impl.cc
@@ -386,7 +386,7 @@ dvb_bch_bb_impl::dvb_bch_bb_impl(dvb_standard_t standard,
  */
 dvb_bch_bb_impl::~dvb_bch_bb_impl() {}
 
-void dvb_bch_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void dvb_bch_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = (noutput_items / nbch) * kbch;
 }

--- a/gr-dtv/lib/dvb/dvb_bch_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_bch_bb_impl.h
@@ -42,7 +42,7 @@ public:
                     dvb_code_rate_t rate);
     ~dvb_bch_bb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvb/dvb_ldpc_bb_impl.cc
+++ b/gr-dtv/lib/dvb/dvb_ldpc_bb_impl.cc
@@ -355,7 +355,7 @@ dvb_ldpc_bb_impl::dvb_ldpc_bb_impl(dvb_standard_t standard,
  */
 dvb_ldpc_bb_impl::~dvb_ldpc_bb_impl() {}
 
-void dvb_ldpc_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void dvb_ldpc_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = (noutput_items / frame_size) * nbch;
 }

--- a/gr-dtv/lib/dvb/dvb_ldpc_bb_impl.h
+++ b/gr-dtv/lib/dvb/dvb_ldpc_bb_impl.h
@@ -172,7 +172,7 @@ public:
     dvb_ldpc_bb_impl& operator=(const dvb_ldpc_bb_impl&) = delete;
     dvb_ldpc_bb_impl& operator=(dvb_ldpc_bb_impl&&) = delete;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbs2/dvbs2_interleaver_bb_impl.cc
+++ b/gr-dtv/lib/dvbs2/dvbs2_interleaver_bb_impl.cc
@@ -453,7 +453,7 @@ dvbs2_interleaver_bb_impl::dvbs2_interleaver_bb_impl(dvb_framesize_t framesize,
 dvbs2_interleaver_bb_impl::~dvbs2_interleaver_bb_impl() {}
 
 void dvbs2_interleaver_bb_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     if (signal_constellation == MOD_128APSK) {
         ninput_items_required[0] = ((noutput_items / 9270) * 9258) * mod;

--- a/gr-dtv/lib/dvbs2/dvbs2_interleaver_bb_impl.h
+++ b/gr-dtv/lib/dvbs2/dvbs2_interleaver_bb_impl.h
@@ -39,7 +39,7 @@ public:
                               dvb_constellation_t constellation);
     ~dvbs2_interleaver_bb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbs2/dvbs2_modulator_bc_impl.cc
+++ b/gr-dtv/lib/dvbs2/dvbs2_modulator_bc_impl.cc
@@ -2680,7 +2680,7 @@ dvbs2_modulator_bc_impl::dvbs2_modulator_bc_impl(dvb_framesize_t framesize,
 dvbs2_modulator_bc_impl::~dvbs2_modulator_bc_impl() {}
 
 void dvbs2_modulator_bc_impl::forecast(int noutput_items,
-                                       gr_vector_int& ninput_items_required)
+                                       gr_vector_int& ninput_items_required) const
 {
     if (signal_interpolation == INTERPOLATION_OFF) {
         ninput_items_required[0] = noutput_items;

--- a/gr-dtv/lib/dvbs2/dvbs2_modulator_bc_impl.h
+++ b/gr-dtv/lib/dvbs2/dvbs2_modulator_bc_impl.h
@@ -37,7 +37,7 @@ public:
                             dvbs2_interpolation_t interpolation);
     ~dvbs2_modulator_bc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbs2/dvbs2_physical_cc_impl.cc
+++ b/gr-dtv/lib/dvbs2/dvbs2_physical_cc_impl.cc
@@ -662,7 +662,7 @@ dvbs2_physical_cc_impl::dvbs2_physical_cc_impl(dvb_framesize_t framesize,
 dvbs2_physical_cc_impl::~dvbs2_physical_cc_impl() {}
 
 void dvbs2_physical_cc_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     if (vlsnr_set == VLSNR_OFF) {
         ninput_items_required[0] =

--- a/gr-dtv/lib/dvbs2/dvbs2_physical_cc_impl.h
+++ b/gr-dtv/lib/dvbs2/dvbs2_physical_cc_impl.h
@@ -53,7 +53,7 @@ public:
                            int goldcode);
     ~dvbs2_physical_cc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
@@ -79,7 +79,7 @@ dvbt_bit_inner_deinterleaver_impl::dvbt_bit_inner_deinterleaver_impl(
 dvbt_bit_inner_deinterleaver_impl::~dvbt_bit_inner_deinterleaver_impl() {}
 
 void dvbt_bit_inner_deinterleaver_impl::forecast(int noutput_items,
-                                                 gr_vector_int& ninput_items_required)
+                                                 gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.h
@@ -40,7 +40,7 @@ public:
                                       dvbt_transmission_mode_t transmission);
     ~dvbt_bit_inner_deinterleaver_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
@@ -80,7 +80,7 @@ dvbt_bit_inner_interleaver_impl::dvbt_bit_inner_interleaver_impl(
 dvbt_bit_inner_interleaver_impl::~dvbt_bit_inner_interleaver_impl() {}
 
 void dvbt_bit_inner_interleaver_impl::forecast(int noutput_items,
-                                               gr_vector_int& ninput_items_required)
+                                               gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.h
@@ -40,7 +40,7 @@ public:
                                     dvbt_transmission_mode_t transmission);
     ~dvbt_bit_inner_interleaver_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_convolutional_deinterleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_convolutional_deinterleaver_impl.cc
@@ -58,7 +58,7 @@ dvbt_convolutional_deinterleaver_impl::dvbt_convolutional_deinterleaver_impl(int
 dvbt_convolutional_deinterleaver_impl::~dvbt_convolutional_deinterleaver_impl() {}
 
 void dvbt_convolutional_deinterleaver_impl::forecast(int noutput_items,
-                                                     gr_vector_int& ninput_items_required)
+                                                     gr_vector_int& ninput_items_required) const
 {
     int ninputs = ninput_items_required.size();
 

--- a/gr-dtv/lib/dvbt/dvbt_convolutional_deinterleaver_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_convolutional_deinterleaver_impl.h
@@ -30,7 +30,7 @@ public:
     dvbt_convolutional_deinterleaver_impl(int nsize, int I, int M);
     ~dvbt_convolutional_deinterleaver_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_demap_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_demap_impl.cc
@@ -125,7 +125,7 @@ int dvbt_demap_impl::find_constellation_value(gr_complex val)
 
 int dvbt_demap_impl::bin_to_gray(int val) { return (val >> 1) ^ val; }
 
-void dvbt_demap_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void dvbt_demap_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_demap_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_demap_impl.h
@@ -47,7 +47,7 @@ public:
                     float gain);
     ~dvbt_demap_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_demod_reference_signals_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_demod_reference_signals_impl.cc
@@ -88,7 +88,7 @@ dvbt_demod_reference_signals_impl::dvbt_demod_reference_signals_impl(
 dvbt_demod_reference_signals_impl::~dvbt_demod_reference_signals_impl() {}
 
 void dvbt_demod_reference_signals_impl::forecast(int noutput_items,
-                                                 gr_vector_int& ninput_items_required)
+                                                 gr_vector_int& ninput_items_required) const
 {
     int ninputs = ninput_items_required.size();
 

--- a/gr-dtv/lib/dvbt/dvbt_demod_reference_signals_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_demod_reference_signals_impl.h
@@ -48,7 +48,7 @@ public:
         int cell_id = 0);
     ~dvbt_demod_reference_signals_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_energy_descramble_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_energy_descramble_impl.cc
@@ -70,7 +70,7 @@ dvbt_energy_descramble_impl::dvbt_energy_descramble_impl(int nblocks)
 dvbt_energy_descramble_impl::~dvbt_energy_descramble_impl() {}
 
 void dvbt_energy_descramble_impl::forecast(int noutput_items,
-                                           gr_vector_int& ninput_items_required)
+                                           gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = 4 * (noutput_items / (d_nblocks * d_bsize));
 }

--- a/gr-dtv/lib/dvbt/dvbt_energy_descramble_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_energy_descramble_impl.h
@@ -38,7 +38,7 @@ public:
     dvbt_energy_descramble_impl(int nblocks);
     ~dvbt_energy_descramble_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_energy_dispersal_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_energy_dispersal_impl.cc
@@ -61,7 +61,7 @@ dvbt_energy_dispersal_impl::dvbt_energy_dispersal_impl(int nblocks)
 dvbt_energy_dispersal_impl::~dvbt_energy_dispersal_impl() {}
 
 void dvbt_energy_dispersal_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     // Add one block size for SYNC search
     ninput_items_required[0] = d_npacks * (d_psize + 1) * d_nblocks * noutput_items;

--- a/gr-dtv/lib/dvbt/dvbt_energy_dispersal_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_energy_dispersal_impl.h
@@ -38,7 +38,7 @@ public:
     dvbt_energy_dispersal_impl(int nsize);
     ~dvbt_energy_dispersal_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.cc
@@ -164,7 +164,7 @@ dvbt_inner_coder_impl::dvbt_inner_coder_impl(int ninput,
 dvbt_inner_coder_impl::~dvbt_inner_coder_impl() {}
 
 void dvbt_inner_coder_impl::forecast(int noutput_items,
-                                     gr_vector_int& ninput_items_required)
+                                     gr_vector_int& ninput_items_required) const
 {
     int input_required = noutput_items * d_noutput * d_k * d_m / (d_ninput * 8 * d_n);
 

--- a/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_inner_coder_impl.h
@@ -56,7 +56,7 @@ public:
                           dvbt_hierarchy_t hierarchy,
                           dvb_code_rate_t coderate);
     ~dvbt_inner_coder_impl() override;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_map_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_map_impl.cc
@@ -111,7 +111,7 @@ gr_complex dvbt_map_impl::find_constellation_point(int val)
     return d_constellation_points[val];
 }
 
-void dvbt_map_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void dvbt_map_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_map_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_map_impl.h
@@ -47,7 +47,7 @@ public:
                   float gain);
     ~dvbt_map_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.cc
@@ -256,7 +256,7 @@ dvbt_ofdm_sym_acquisition_impl::dvbt_ofdm_sym_acquisition_impl(
 dvbt_ofdm_sym_acquisition_impl::~dvbt_ofdm_sym_acquisition_impl() {}
 
 void dvbt_ofdm_sym_acquisition_impl::forecast(int noutput_items,
-                                              gr_vector_int& ninput_items_required)
+                                              gr_vector_int& ninput_items_required) const
 {
     int ninputs = ninput_items_required.size();
 

--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.h
@@ -73,7 +73,7 @@ public:
         int blocks, int fft_length, int occupied_tones, int cp_length, float snr);
     ~dvbt_ofdm_sym_acquisition_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon_dec_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon_dec_impl.cc
@@ -57,7 +57,7 @@ dvbt_reed_solomon_dec_impl::dvbt_reed_solomon_dec_impl(
 dvbt_reed_solomon_dec_impl::~dvbt_reed_solomon_dec_impl() { free_rs_char(d_rs); }
 
 void dvbt_reed_solomon_dec_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon_dec_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon_dec_impl.h
@@ -38,7 +38,7 @@ public:
         int p, int m, int gfpoly, int n, int k, int t, int s, int blocks);
     ~dvbt_reed_solomon_dec_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon_enc_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon_enc_impl.cc
@@ -66,7 +66,7 @@ dvbt_reed_solomon_enc_impl::~dvbt_reed_solomon_enc_impl()
 }
 
 void dvbt_reed_solomon_enc_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon_enc_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon_enc_impl.h
@@ -36,7 +36,7 @@ public:
         int p, int m, int gfpoly, int n, int k, int t, int s, int blocks);
     ~dvbt_reed_solomon_enc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.cc
@@ -1053,7 +1053,7 @@ dvbt_reference_signals_impl::dvbt_reference_signals_impl(
 dvbt_reference_signals_impl::~dvbt_reference_signals_impl() {}
 
 void dvbt_reference_signals_impl::forecast(int noutput_items,
-                                           gr_vector_int& ninput_items_required)
+                                           gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_reference_signals_impl.h
@@ -249,7 +249,7 @@ public:
                                 int cell_id = 0);
     ~dvbt_reference_signals_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_symbol_inner_interleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_symbol_inner_interleaver_impl.cc
@@ -126,7 +126,7 @@ dvbt_symbol_inner_interleaver_impl::dvbt_symbol_inner_interleaver_impl(
 dvbt_symbol_inner_interleaver_impl::~dvbt_symbol_inner_interleaver_impl() {}
 
 void dvbt_symbol_inner_interleaver_impl::forecast(int noutput_items,
-                                                  gr_vector_int& ninput_items_required)
+                                                  gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt/dvbt_symbol_inner_interleaver_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_symbol_inner_interleaver_impl.h
@@ -45,7 +45,7 @@ public:
                                        int direction);
     ~dvbt_symbol_inner_interleaver_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.cc
@@ -574,7 +574,7 @@ dvbt_viterbi_decoder_impl::dvbt_viterbi_decoder_impl(dvb_constellation_t constel
 dvbt_viterbi_decoder_impl::~dvbt_viterbi_decoder_impl() {}
 
 void dvbt_viterbi_decoder_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     int input_required = noutput_items * 8 * d_n / (d_k * d_m);
 

--- a/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_viterbi_decoder_impl.h
@@ -137,7 +137,7 @@ public:
                               int bsize);
     ~dvbt_viterbi_decoder_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -929,7 +929,7 @@ dvbt2_framemapper_cc_impl::~dvbt2_framemapper_cc_impl()
 }
 
 void dvbt2_framemapper_cc_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = stream_items * (noutput_items / mapped_items);
 }

--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.h
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.h
@@ -201,7 +201,7 @@ public:
                               dvbt2_inband_t inband);
     ~dvbt2_framemapper_cc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt2/dvbt2_interleaver_bb_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_interleaver_bb_impl.cc
@@ -345,7 +345,7 @@ void dvbt2_interleaver_bb_impl::generate_lookup()
 dvbt2_interleaver_bb_impl::~dvbt2_interleaver_bb_impl() {}
 
 void dvbt2_interleaver_bb_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items * mod;
 }

--- a/gr-dtv/lib/dvbt2/dvbt2_interleaver_bb_impl.h
+++ b/gr-dtv/lib/dvbt2/dvbt2_interleaver_bb_impl.h
@@ -65,7 +65,7 @@ public:
                               dvb_constellation_t constellation);
     ~dvbt2_interleaver_bb_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt2/dvbt2_modulator_bc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_modulator_bc_impl.cc
@@ -176,7 +176,7 @@ dvbt2_modulator_bc_impl::dvbt2_modulator_bc_impl(dvb_framesize_t framesize,
 dvbt2_modulator_bc_impl::~dvbt2_modulator_bc_impl() {}
 
 void dvbt2_modulator_bc_impl::forecast(int noutput_items,
-                                       gr_vector_int& ninput_items_required)
+                                       gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = noutput_items;
 }

--- a/gr-dtv/lib/dvbt2/dvbt2_modulator_bc_impl.h
+++ b/gr-dtv/lib/dvbt2/dvbt2_modulator_bc_impl.h
@@ -33,7 +33,7 @@ public:
                             dvbt2_rotation_t rotation);
     ~dvbt2_modulator_bc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt2/dvbt2_p1insertion_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_p1insertion_cc_impl.cc
@@ -202,7 +202,7 @@ void dvbt2_p1insertion_cc_impl::init_p1_randomizer(void)
 dvbt2_p1insertion_cc_impl::~dvbt2_p1insertion_cc_impl() {}
 
 void dvbt2_p1insertion_cc_impl::forecast(int noutput_items,
-                                         gr_vector_int& ninput_items_required)
+                                         gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = frame_items * (noutput_items / insertion_items);
 }

--- a/gr-dtv/lib/dvbt2/dvbt2_p1insertion_cc_impl.h
+++ b/gr-dtv/lib/dvbt2/dvbt2_p1insertion_cc_impl.h
@@ -61,7 +61,7 @@ public:
                               float vclip);
     ~dvbt2_p1insertion_cc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.cc
@@ -1150,7 +1150,7 @@ dvbt2_pilotgenerator_cc_impl::dvbt2_pilotgenerator_cc_impl(
 dvbt2_pilotgenerator_cc_impl::~dvbt2_pilotgenerator_cc_impl() {}
 
 void dvbt2_pilotgenerator_cc_impl::forecast(int noutput_items,
-                                            gr_vector_int& ninput_items_required)
+                                            gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = active_items * (noutput_items / num_symbols);
 }

--- a/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.h
+++ b/gr-dtv/lib/dvbt2/dvbt2_pilotgenerator_cc_impl.h
@@ -159,7 +159,7 @@ public:
                                  unsigned int vlength);
     ~dvbt2_pilotgenerator_cc_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-fec/include/gnuradio/fec/decoder.h
+++ b/gr-fec/include/gnuradio/fec/decoder.h
@@ -74,9 +74,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override = 0;
-    int fixed_rate_ninput_to_noutput(int ninput) override = 0;
-    int fixed_rate_noutput_to_ninput(int noutput) override = 0;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override = 0;
+    int fixed_rate_ninput_to_noutput(int ninput) const override = 0;
+    int fixed_rate_noutput_to_ninput(int noutput) const override = 0;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override = 0;
 };
 
 } /* namespace fec */

--- a/gr-fec/include/gnuradio/fec/encoder.h
+++ b/gr-fec/include/gnuradio/fec/encoder.h
@@ -52,9 +52,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override = 0;
-    int fixed_rate_ninput_to_noutput(int ninput) override = 0;
-    int fixed_rate_noutput_to_ninput(int noutput) override = 0;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override = 0;
+    int fixed_rate_ninput_to_noutput(int ninput) const override = 0;
+    int fixed_rate_noutput_to_ninput(int noutput) const override = 0;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override = 0;
 };
 
 } /* namespace fec */

--- a/gr-fec/lib/decoder_impl.cc
+++ b/gr-fec/lib/decoder_impl.cc
@@ -49,17 +49,17 @@ decoder_impl::decoder_impl(generic_decoder::sptr my_decoder,
     d_decoder = my_decoder;
 }
 
-int decoder_impl::fixed_rate_ninput_to_noutput(int ninput)
+int decoder_impl::fixed_rate_ninput_to_noutput(int ninput) const
 {
     return std::lround(ninput * relative_rate());
 }
 
-int decoder_impl::fixed_rate_noutput_to_ninput(int noutput)
+int decoder_impl::fixed_rate_noutput_to_ninput(int noutput) const
 {
     return std::lround(noutput / relative_rate());
 }
 
-void decoder_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void decoder_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = std::lround(fixed_rate_noutput_to_ninput(noutput_items));
 }

--- a/gr-fec/lib/decoder_impl.h
+++ b/gr-fec/lib/decoder_impl.h
@@ -32,9 +32,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 };
 
 } /* namespace fec */

--- a/gr-fec/lib/depuncture_bb_impl.cc
+++ b/gr-fec/lib/depuncture_bb_impl.cc
@@ -71,17 +71,17 @@ depuncture_bb_impl::depuncture_bb_impl(int puncsize,
 
 depuncture_bb_impl::~depuncture_bb_impl() {}
 
-int depuncture_bb_impl::fixed_rate_ninput_to_noutput(int ninput)
+int depuncture_bb_impl::fixed_rate_ninput_to_noutput(int ninput) const
 {
     return std::lround((d_puncsize / (double)(d_puncsize - d_puncholes)) * ninput);
 }
 
-int depuncture_bb_impl::fixed_rate_noutput_to_ninput(int noutput)
+int depuncture_bb_impl::fixed_rate_noutput_to_ninput(int noutput) const
 {
     return std::lround(((d_puncsize - d_puncholes) / (double)(d_puncsize)) * noutput);
 }
 
-void depuncture_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void depuncture_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] =
         std::lround(((d_puncsize - d_puncholes) / (double)(d_puncsize)) * noutput_items);

--- a/gr-fec/lib/depuncture_bb_impl.h
+++ b/gr-fec/lib/depuncture_bb_impl.h
@@ -33,9 +33,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 };
 
 } /* namespace fec */

--- a/gr-fec/lib/encoder_impl.cc
+++ b/gr-fec/lib/encoder_impl.cc
@@ -48,17 +48,17 @@ encoder_impl::encoder_impl(generic_encoder::sptr my_encoder,
 
 encoder_impl::~encoder_impl() {}
 
-int encoder_impl::fixed_rate_ninput_to_noutput(int ninput)
+int encoder_impl::fixed_rate_ninput_to_noutput(int ninput) const
 {
     return std::lround(ninput * relative_rate());
 }
 
-int encoder_impl::fixed_rate_noutput_to_ninput(int noutput)
+int encoder_impl::fixed_rate_noutput_to_ninput(int noutput) const
 {
     return std::lround(noutput / relative_rate());
 }
 
-void encoder_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void encoder_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = fixed_rate_noutput_to_ninput(noutput_items);
 }

--- a/gr-fec/lib/encoder_impl.h
+++ b/gr-fec/lib/encoder_impl.h
@@ -35,9 +35,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 };
 
 } /* namespace fec */

--- a/gr-fec/lib/puncture_bb_impl.cc
+++ b/gr-fec/lib/puncture_bb_impl.cc
@@ -65,17 +65,17 @@ puncture_bb_impl::puncture_bb_impl(int puncsize, int puncpat, int delay)
 
 puncture_bb_impl::~puncture_bb_impl() {}
 
-int puncture_bb_impl::fixed_rate_ninput_to_noutput(int ninput)
+int puncture_bb_impl::fixed_rate_ninput_to_noutput(int ninput) const
 {
     return std::lround(((d_puncsize - d_puncholes) / (double)(d_puncsize)) * ninput);
 }
 
-int puncture_bb_impl::fixed_rate_noutput_to_ninput(int noutput)
+int puncture_bb_impl::fixed_rate_noutput_to_ninput(int noutput) const
 {
     return std::lround((d_puncsize / (double)(d_puncsize - d_puncholes)) * noutput);
 }
 
-void puncture_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void puncture_bb_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] =
         std::lround((d_puncsize / (double)(d_puncsize - d_puncholes)) * noutput_items);

--- a/gr-fec/lib/puncture_bb_impl.h
+++ b/gr-fec/lib/puncture_bb_impl.h
@@ -34,9 +34,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 };
 
 } /* namespace fec */

--- a/gr-fec/lib/puncture_ff_impl.cc
+++ b/gr-fec/lib/puncture_ff_impl.cc
@@ -65,17 +65,17 @@ puncture_ff_impl::puncture_ff_impl(int puncsize, int puncpat, int delay)
 
 puncture_ff_impl::~puncture_ff_impl() {}
 
-int puncture_ff_impl::fixed_rate_ninput_to_noutput(int ninput)
+int puncture_ff_impl::fixed_rate_ninput_to_noutput(int ninput) const
 {
     return std::lround(((d_puncsize - d_puncholes) / (double)(d_puncsize)) * ninput);
 }
 
-int puncture_ff_impl::fixed_rate_noutput_to_ninput(int noutput)
+int puncture_ff_impl::fixed_rate_noutput_to_ninput(int noutput) const
 {
     return std::lround((d_puncsize / (double)(d_puncsize - d_puncholes)) * noutput);
 }
 
-void puncture_ff_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void puncture_ff_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] =
         std::lround((d_puncsize / (double)(d_puncsize - d_puncholes)) * noutput_items);

--- a/gr-fec/lib/puncture_ff_impl.h
+++ b/gr-fec/lib/puncture_ff_impl.h
@@ -34,9 +34,9 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items) override;
-    int fixed_rate_ninput_to_noutput(int ninput) override;
-    int fixed_rate_noutput_to_ninput(int noutput) override;
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int fixed_rate_ninput_to_noutput(int ninput) const override;
+    int fixed_rate_noutput_to_ninput(int noutput) const override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 };
 
 } /* namespace fec */

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -41,7 +41,7 @@ ctrlport_probe_psd_impl::ctrlport_probe_psd_impl(const std::string& id,
 ctrlport_probe_psd_impl::~ctrlport_probe_psd_impl() {}
 
 void ctrlport_probe_psd_impl::forecast(int noutput_items,
-                                       gr_vector_int& ninput_items_required)
+                                       gr_vector_int& ninput_items_required) const
 {
     // make sure all inputs have noutput_items available
     unsigned ninputs = ninput_items_required.size();

--- a/gr-fft/lib/ctrlport_probe_psd_impl.h
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.h
@@ -38,7 +38,7 @@ public:
 
     void setup_rpc() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     std::vector<gr_complex> get() override;
 

--- a/gr-filter/lib/mmse_resampler_cc_impl.cc
+++ b/gr-filter/lib/mmse_resampler_cc_impl.cc
@@ -58,7 +58,7 @@ void mmse_resampler_cc_impl::handle_msg(pmt::pmt_t msg)
 }
 
 void mmse_resampler_cc_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gr-filter/lib/mmse_resampler_cc_impl.h
+++ b/gr-filter/lib/mmse_resampler_cc_impl.h
@@ -29,7 +29,7 @@ public:
 
     void handle_msg(pmt::pmt_t msg);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-filter/lib/mmse_resampler_ff_impl.cc
+++ b/gr-filter/lib/mmse_resampler_ff_impl.cc
@@ -59,7 +59,7 @@ void mmse_resampler_ff_impl::handle_msg(pmt::pmt_t msg)
 }
 
 void mmse_resampler_ff_impl::forecast(int noutput_items,
-                                      gr_vector_int& ninput_items_required)
+                                      gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++) {

--- a/gr-filter/lib/mmse_resampler_ff_impl.h
+++ b/gr-filter/lib/mmse_resampler_ff_impl.h
@@ -29,7 +29,7 @@ public:
 
     void handle_msg(pmt::pmt_t msg);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.cc
@@ -44,7 +44,7 @@ pfb_arb_resampler_ccc_impl::pfb_arb_resampler_ccc_impl(
 }
 
 void pfb_arb_resampler_ccc_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     if (noutput_items / relative_rate() < 1) {

--- a/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccc_impl.h
@@ -31,7 +31,7 @@ public:
                                const std::vector<gr_complex>& taps,
                                unsigned int filter_size);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void set_taps(const std::vector<gr_complex>& taps) override;
     std::vector<std::vector<gr_complex>> taps() const override;

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.cc
@@ -46,7 +46,7 @@ pfb_arb_resampler_ccf_impl::pfb_arb_resampler_ccf_impl(float rate,
 }
 
 void pfb_arb_resampler_ccf_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     if (noutput_items / relative_rate() < 1) {

--- a/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_ccf_impl.h
@@ -31,7 +31,7 @@ public:
                                const std::vector<float>& taps,
                                unsigned int filter_size);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void set_taps(const std::vector<float>& taps) override;
     std::vector<std::vector<float>> taps() const override;

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.cc
@@ -46,7 +46,7 @@ pfb_arb_resampler_fff_impl::pfb_arb_resampler_fff_impl(float rate,
 }
 
 void pfb_arb_resampler_fff_impl::forecast(int noutput_items,
-                                          gr_vector_int& ninput_items_required)
+                                          gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     if (noutput_items / relative_rate() < 1) {

--- a/gr-filter/lib/pfb_arb_resampler_fff_impl.h
+++ b/gr-filter/lib/pfb_arb_resampler_fff_impl.h
@@ -31,7 +31,7 @@ public:
                                const std::vector<float>& taps,
                                unsigned int filter_size);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void set_taps(const std::vector<float>& taps) override;
     std::vector<std::vector<float>> taps() const override;

--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -209,7 +209,7 @@ std::vector<TAP_T> rational_resampler_impl<IN_T, OUT_T, TAP_T>::taps() const
 
 template <class IN_T, class OUT_T, class TAP_T>
 void rational_resampler_impl<IN_T, OUT_T, TAP_T>::forecast(
-    int noutput_items, gr_vector_int& ninput_items_required)
+    int noutput_items, gr_vector_int& ninput_items_required) const
 {
     int nreqd = std::max(
         1U,

--- a/gr-filter/lib/rational_resampler_impl.h
+++ b/gr-filter/lib/rational_resampler_impl.h
@@ -47,7 +47,7 @@ public:
     void set_taps(const std::vector<TAP_T>& taps) override;
     std::vector<TAP_T> taps() const override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -226,7 +226,7 @@ int device_sink_impl::work(int noutput_items,
     return 0;
 }
 
-void device_sink_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void device_sink_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     for (unsigned int i = 0; i < ninput_items_required.size(); i++)
         ninput_items_required[i] = noutput_items;

--- a/gr-iio/lib/device_sink_impl.h
+++ b/gr-iio/lib/device_sink_impl.h
@@ -57,7 +57,7 @@ public:
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const;
 };
 
 } // namespace iio

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -95,7 +95,7 @@ sink_c_impl::~sink_c_impl() {}
 
 bool sink_c_impl::check_topology(int ninputs, int noutputs) { return ninputs == 1; }
 
-void sink_c_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void sink_c_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned int ninputs = ninput_items_required.size();
     for (unsigned int i = 0; i < ninputs; i++) {

--- a/gr-qtgui/lib/sink_c_impl.h
+++ b/gr-qtgui/lib/sink_c_impl.h
@@ -25,7 +25,7 @@ namespace qtgui {
 class QTGUI_API sink_c_impl : public sink_c
 {
 private:
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void initialize();
 

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -95,7 +95,7 @@ sink_f_impl::~sink_f_impl() {}
 
 bool sink_f_impl::check_topology(int ninputs, int noutputs) { return ninputs == 1; }
 
-void sink_f_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void sink_f_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned int ninputs = ninput_items_required.size();
     for (unsigned int i = 0; i < ninputs; i++) {

--- a/gr-qtgui/lib/sink_f_impl.h
+++ b/gr-qtgui/lib/sink_f_impl.h
@@ -25,7 +25,7 @@ namespace qtgui {
 class QTGUI_API sink_f_impl : public sink_f
 {
 private:
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void initialize();
 

--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -98,7 +98,7 @@ bool waterfall_sink_c_impl::check_topology(int ninputs, int noutputs)
 }
 
 void waterfall_sink_c_impl::forecast(int noutput_items,
-                                     gr_vector_int& ninput_items_required)
+                                     gr_vector_int& ninput_items_required) const
 {
     unsigned int ninputs = ninput_items_required.size();
     for (unsigned int i = 0; i < ninputs; i++) {

--- a/gr-qtgui/lib/waterfall_sink_c_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.h
@@ -25,7 +25,7 @@ namespace qtgui {
 class QTGUI_API waterfall_sink_c_impl : public waterfall_sink_c
 {
 private:
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void initialize();
 

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -95,7 +95,7 @@ bool waterfall_sink_f_impl::check_topology(int ninputs, int noutputs)
 }
 
 void waterfall_sink_f_impl::forecast(int noutput_items,
-                                     gr_vector_int& ninput_items_required)
+                                     gr_vector_int& ninput_items_required) const
 {
     unsigned int ninputs = ninput_items_required.size();
     for (unsigned int i = 0; i < ninputs; i++) {

--- a/gr-qtgui/lib/waterfall_sink_f_impl.h
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.h
@@ -25,7 +25,7 @@ namespace qtgui {
 class QTGUI_API waterfall_sink_f_impl : public waterfall_sink_f
 {
 private:
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     void initialize();
 

--- a/gr-trellis/lib/constellation_metrics_cf_impl.cc
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.cc
@@ -44,7 +44,7 @@ constellation_metrics_cf_impl::constellation_metrics_cf_impl(
 constellation_metrics_cf_impl::~constellation_metrics_cf_impl() {}
 
 void constellation_metrics_cf_impl::forecast(int noutput_items,
-                                             gr_vector_int& ninput_items_required)
+                                             gr_vector_int& ninput_items_required) const
 {
     assert(noutput_items % d_O == 0);
 

--- a/gr-trellis/lib/constellation_metrics_cf_impl.h
+++ b/gr-trellis/lib/constellation_metrics_cf_impl.h
@@ -30,7 +30,7 @@ public:
                                   digital::trellis_metric_type_t TYPE);
     ~constellation_metrics_cf_impl() override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/metrics_impl.cc
+++ b/gr-trellis/lib/metrics_impl.cc
@@ -84,7 +84,7 @@ metrics_impl<T>::~metrics_impl()
 
 
 template <class T>
-void metrics_impl<T>::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void metrics_impl<T>::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     int input_required = d_D * noutput_items / d_O;
     unsigned ninputs = ninput_items_required.size();

--- a/gr-trellis/lib/metrics_impl.h
+++ b/gr-trellis/lib/metrics_impl.h
@@ -43,7 +43,7 @@ public:
     void set_TYPE(digital::trellis_metric_type_t type) override;
     void set_TABLE(const std::vector<T>& table) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/pccc_decoder_blk_impl.cc
+++ b/gr-trellis/lib/pccc_decoder_blk_impl.cc
@@ -81,7 +81,7 @@ pccc_decoder_blk_impl<T>::~pccc_decoder_blk_impl()
 
 template <class T>
 void pccc_decoder_blk_impl<T>::forecast(int noutput_items,
-                                        gr_vector_int& ninput_items_required)
+                                        gr_vector_int& ninput_items_required) const
 {
     int input_required = d_FSM1.O() * d_FSM2.O() * noutput_items;
     ninput_items_required[0] = input_required;

--- a/gr-trellis/lib/pccc_decoder_blk_impl.h
+++ b/gr-trellis/lib/pccc_decoder_blk_impl.h
@@ -57,7 +57,7 @@ public:
     int repetitions() const override { return d_repetitions; }
     siso_type_t SISO_TYPE() const override { return d_SISO_TYPE; }
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/pccc_decoder_combined_blk_impl.cc
+++ b/gr-trellis/lib/pccc_decoder_combined_blk_impl.cc
@@ -106,7 +106,7 @@ void pccc_decoder_combined_blk_impl<IN_T, OUT_T>::set_scaling(float scaling)
 
 template <class IN_T, class OUT_T>
 void pccc_decoder_combined_blk_impl<IN_T, OUT_T>::forecast(
-    int noutput_items, gr_vector_int& ninput_items_required)
+    int noutput_items, gr_vector_int& ninput_items_required) const
 {
     int input_required = d_D * noutput_items;
     ninput_items_required[0] = input_required;

--- a/gr-trellis/lib/pccc_decoder_combined_blk_impl.h
+++ b/gr-trellis/lib/pccc_decoder_combined_blk_impl.h
@@ -69,7 +69,7 @@ public:
     float scaling() const override { return d_scaling; }
     void set_scaling(float scaling) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/sccc_decoder_blk_impl.cc
+++ b/gr-trellis/lib/sccc_decoder_blk_impl.cc
@@ -81,7 +81,7 @@ sccc_decoder_blk_impl<T>::~sccc_decoder_blk_impl()
 
 template <class T>
 void sccc_decoder_blk_impl<T>::forecast(int noutput_items,
-                                        gr_vector_int& ninput_items_required)
+                                        gr_vector_int& ninput_items_required) const
 {
     int input_required = d_FSMi.O() * noutput_items;
     ninput_items_required[0] = input_required;

--- a/gr-trellis/lib/sccc_decoder_blk_impl.h
+++ b/gr-trellis/lib/sccc_decoder_blk_impl.h
@@ -57,7 +57,7 @@ public:
     int repetitions() const override { return d_repetitions; }
     siso_type_t SISO_TYPE() const override { return d_SISO_TYPE; }
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/sccc_decoder_combined_blk_impl.cc
+++ b/gr-trellis/lib/sccc_decoder_combined_blk_impl.cc
@@ -105,7 +105,7 @@ void sccc_decoder_combined_blk_impl<IN_T, OUT_T>::set_scaling(float scaling)
 
 template <class IN_T, class OUT_T>
 void sccc_decoder_combined_blk_impl<IN_T, OUT_T>::forecast(
-    int noutput_items, gr_vector_int& ninput_items_required)
+    int noutput_items, gr_vector_int& ninput_items_required) const
 {
     int input_required = d_D * noutput_items;
     ninput_items_required[0] = input_required;

--- a/gr-trellis/lib/sccc_decoder_combined_blk_impl.h
+++ b/gr-trellis/lib/sccc_decoder_combined_blk_impl.h
@@ -69,7 +69,7 @@ public:
     float scaling() const override { return d_scaling; }
     void set_scaling(float scaling) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/siso_combined_f_impl.cc
+++ b/gr-trellis/lib/siso_combined_f_impl.cc
@@ -158,7 +158,7 @@ void siso_combined_f_impl::set_TYPE(digital::trellis_metric_type_t type)
 siso_combined_f_impl::~siso_combined_f_impl() {}
 
 void siso_combined_f_impl::forecast(int noutput_items,
-                                    gr_vector_int& ninput_items_required)
+                                    gr_vector_int& ninput_items_required) const
 {
     int multiple;
     if (d_POSTI && d_POSTO)

--- a/gr-trellis/lib/siso_combined_f_impl.h
+++ b/gr-trellis/lib/siso_combined_f_impl.h
@@ -68,7 +68,7 @@ public:
     void set_TABLE(const std::vector<float>& table) override;
     void set_TYPE(digital::trellis_metric_type_t type) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/siso_f_impl.cc
+++ b/gr-trellis/lib/siso_f_impl.cc
@@ -119,7 +119,7 @@ void siso_f_impl::set_SISO_TYPE(trellis::siso_type_t type)
 
 siso_f_impl::~siso_f_impl() {}
 
-void siso_f_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void siso_f_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     int multiple;
     if (d_POSTI && d_POSTO)

--- a/gr-trellis/lib/siso_f_impl.h
+++ b/gr-trellis/lib/siso_f_impl.h
@@ -60,7 +60,7 @@ public:
     void set_POSTO(bool POSTO) override;
     void set_SISO_TYPE(trellis::siso_type_t type) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/viterbi_combined_impl.cc
+++ b/gr-trellis/lib/viterbi_combined_impl.cc
@@ -115,7 +115,7 @@ viterbi_combined_impl<IN_T, OUT_T>::~viterbi_combined_impl()
 
 template <class IN_T, class OUT_T>
 void viterbi_combined_impl<IN_T, OUT_T>::forecast(int noutput_items,
-                                                  gr_vector_int& ninput_items_required)
+                                                  gr_vector_int& ninput_items_required) const
 {
     int input_required = d_D * noutput_items;
     unsigned ninputs = ninput_items_required.size();

--- a/gr-trellis/lib/viterbi_combined_impl.h
+++ b/gr-trellis/lib/viterbi_combined_impl.h
@@ -56,7 +56,7 @@ public:
     void set_TABLE(const std::vector<IN_T>& table) override;
     void set_TYPE(digital::trellis_metric_type_t type) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-trellis/lib/viterbi_impl.cc
+++ b/gr-trellis/lib/viterbi_impl.cc
@@ -76,7 +76,7 @@ viterbi_impl<T>::~viterbi_impl()
 }
 
 template <class T>
-void viterbi_impl<T>::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void viterbi_impl<T>::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     int input_required = d_FSM.O() * noutput_items;
     unsigned ninputs = ninput_items_required.size();

--- a/gr-trellis/lib/viterbi_impl.h
+++ b/gr-trellis/lib/viterbi_impl.h
@@ -42,7 +42,7 @@ public:
     void set_SK(int SK) override;
     // std::vector<int> trace () const { return d_trace; }
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,

--- a/gr-vocoder/lib/freedv_rx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.cc
@@ -75,7 +75,7 @@ freedv_rx_ss_impl::~freedv_rx_ss_impl()
     freedv_close(d_freedv);
 }
 
-void freedv_rx_ss_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void freedv_rx_ss_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     unsigned ninputs = ninput_items_required.size();
     for (unsigned i = 0; i < ninputs; i++)

--- a/gr-vocoder/lib/freedv_rx_ss_impl.h
+++ b/gr-vocoder/lib/freedv_rx_ss_impl.h
@@ -45,7 +45,7 @@ public:
     void set_squelch_en(bool squelch_enabled) override;
 
     // Where all the action really happens
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,

--- a/gr-vocoder/lib/freedv_tx_ss_impl.cc
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.cc
@@ -88,7 +88,7 @@ void freedv_tx_ss_impl::set_tx_bpf(bool val)
         freedv_tx_ss_impl::set_tx_bpf(0);
 }
 
-void freedv_tx_ss_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required)
+void freedv_tx_ss_impl::forecast(int noutput_items, gr_vector_int& ninput_items_required) const
 {
     ninput_items_required[0] = (noutput_items / d_nom_modem_samples) * d_speech_samples;
 }

--- a/gr-vocoder/lib/freedv_tx_ss_impl.h
+++ b/gr-vocoder/lib/freedv_tx_ss_impl.h
@@ -42,7 +42,7 @@ public:
     void set_tx_bpf(int val);
 
     // Where all the action really happens
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) const override;
 
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,


### PR DESCRIPTION
# Pull Request Details
---
## Description
This make forecast const so that it cannot be used to improperly to modify state
Does not address `check_topology` as this is used already in-tree to modify state, so will require more thought

## Related Issue
#2665

## Which blocks/areas does this affect?
All general blocks in-tree and in every OOT

This makes me think it shouldn't be considered until after 3.10 because it will cause breaking changes in OOTs with general blocks.  Certainly if this is introduced it should be along with other useful API breaking changes, otherwise it will just be an annoyance

## Testing Done
Just CI
- [ ] Need to test against some OOTs

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
