### PR TITLE
digital: use umlauts in yml

### DIFF
--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -19,7 +19,7 @@ parameters:
     options: [digital.TED_MUELLER_AND_MULLER, digital.TED_MOD_MUELLER_AND_MULLER,
         digital.TED_ZERO_CROSSING, digital.TED_GARDNER, digital.TED_EARLY_LATE, digital.TED_DANDREA_AND_MENGALI_GEN_MSK,
         digital.TED_MENGALI_AND_DANDREA_GMSK, digital.TED_SIGNAL_TIMES_SLOPE_ML, digital.TED_SIGNUM_TIMES_SLOPE_ML]
-    option_labels: ["Mueller and Mueller", "Modified Mueller and Mueller", Zero
+    option_labels: ["Mueller and Müller", "Modified Mueller and Müller", Zero
             Crossing, Gardner, Early-Late, D'Andrea and Mengali Gen MSK, Mengali and
             D'Andrea GMSK, 'y[n]y''[n] Maximum likelihood', 'sgn(y[n])y''[n] Maximum
             likelihood']


### PR DESCRIPTION

# Pull Request Details
---
## Description
Simple change to `gr-digital/grc/digital_symbol_sync_xx.block.yml` to put umlaut where the ue was used.  Has been noted in #3209 that this seems to have been resolved with python3 (and it works fine on my machine)

## Related Issue
#3209

## Which blocks/areas does this affect?
Seems to just be the symbol sync block yml 

## Testing Done
Loaded it up in GRC

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
