### PR TITLE
filter: remove pyqwt and qt4 from various places

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -84,9 +84,9 @@ except AttributeError:
     def _fromUtf8(s): return s
 
 # Gnuradio Filter design tool main window
-class gr_plot_filter(QtGui.QMainWindow):
+class gr_plot_filter(QtWidgets.QMainWindow):
     def __init__(self, options, callback=None, restype=""):
-        QtGui.QWidget.__init__(self, None)
+        QtWidgets.QWidget.__init__(self, None)
         self.gui = Ui_MainWindow()
         self.callback = callback
 
@@ -189,7 +189,8 @@ class gr_plot_filter(QtGui.QMainWindow):
 
         self.gui.mtimpPush.clicked.connect(self.set_mtimpulse)
 
-        self.gui.checkKeepcur.stateChanged['int'].connect(self.set_bufferplots)
+        # Not working as of 3.8
+        # self.gui.checkKeepcur.stateChanged['int'].connect(self.set_bufferplots)
 
         self.gui.checkGrid.stateChanged['int'].connect(self.set_grid)
 
@@ -396,7 +397,7 @@ class gr_plot_filter(QtGui.QMainWindow):
         self.bnfitems[0].attenChanged.connect(self.set_fatten)
 
         # Populate the Band-diagram scene.
-        self.scene = QtGui.QGraphicsScene()
+        self.scene = QtWidgets.QGraphicsScene()
         self.scene.setSceneRect(0,0,250,250)
         lightback = QtGui.qRgb(0xf8, 0xf8, 0xff)
         backbrush = Qt.QBrush(Qt.QColor(lightback))
@@ -414,17 +415,17 @@ class gr_plot_filter(QtGui.QMainWindow):
         self.cpicker2.mouseposChanged.connect(self.set_mstatusbar)
         # Edit boxes for band-diagrams (Not required todate so may be remove?).
         """
-        self.lpfpassEdit = QtGui.QLineEdit()
+        self.lpfpassEdit = QtWidgets.QLineEdit()
         self.lpfpassEdit.setMaximumSize(QtCore.QSize(75,20))
         self.lpfpassEdit.setText('Not set')
-        self.lpfstartproxy = QtGui.QGraphicsProxyWidget()
+        self.lpfstartproxy = QtWidgets.QGraphicsProxyWidget()
         self.lpfstartproxy.setWidget(self.lpfpassEdit)
         self.lpfstartproxy.setPos(400,30)
 
-        self.lpfstopEdit = QtGui.QLineEdit()
+        self.lpfstopEdit = QtWidgets.QLineEdit()
         self.lpfstopEdit.setMaximumSize(QtCore.QSize(75,20))
         self.lpfstopEdit.setText('Not set')
-        self.lpfstopproxy = QtGui.QGraphicsProxyWidget()
+        self.lpfstopproxy = QtWidgets.QGraphicsProxyWidget()
         self.lpfstopproxy.setWidget(self.lpfstopEdit)
         self.lpfstopproxy.setPos(400,50)
         self.lpfitems.append(self.lpfstartproxy)
@@ -781,9 +782,9 @@ class gr_plot_filter(QtGui.QMainWindow):
                 warnings.simplefilter("always")
                 self.design_iir()
                 if len(w):
-                    reply = QtGui.QMessageBox.information(self, "BadCoefficients",
+                    reply = QtWidgets.QMessageBox.information(self, "BadCoefficients",
                                                           str(w[-1].message),
-                                                          QtGui.QMessageBox.Ok)
+                                                          QtWidgets.QMessageBox.Ok)
 
     # Do FIR design.
     def design_fir(self, ftype, fs, gain, winstr):
@@ -909,8 +910,8 @@ class gr_plot_filter(QtGui.QMainWindow):
                 (self.b, self.a) = signal.iirfilter(order, besselparams, btype=iirbtype.replace(' ', '').lower(),
                                                     analog=sanalog[atype], ftype=iirft[iirftype], output='ba')
             except Exception as e:
-                reply = QtGui.QMessageBox.information(self, "IIR design error", e.args[0],
-                                                      QtGui.QMessageBox.Ok)
+                reply = QtWidgets.QMessageBox.information(self, "IIR design error", e.args[0],
+                                                      QtWidgets.QMessageBox.Ok)
 
             (self.z, self.p, self.k) = signal.tf2zpk(self.b, self.a)
 
@@ -921,8 +922,8 @@ class gr_plot_filter(QtGui.QMainWindow):
                 (self.b, self.a) = signal.iirdesign(params[0], params[1], params[2], params[3],
                                                     analog=sanalog[atype], ftype=iirft[iirftype], output='ba')
             except Exception as e:
-                reply = QtGui.QMessageBox.information(self, "IIR design error", e.args[0],
-                                                      QtGui.QMessageBox.Ok)
+                reply = QtWidgets.QMessageBox.information(self, "IIR design error", e.args[0],
+                                                      QtWidgets.QMessageBox.Ok)
 
             (self.z, self.p, self.k) = signal.tf2zpk(self.b, self.a)
             # Create parameters.
@@ -1427,39 +1428,40 @@ class gr_plot_filter(QtGui.QMainWindow):
         else:
             self.gui.filterFrame.hide()
 
-    # Saves and attach the plots for comparison.
-    def set_bufferplots(self):
-        if (self.gui.checkKeepcur.checkState() == 0 ):
-            # Detach and delete all plots if unchecked.
-            for c in self.bufferplots:
-                c.detach()
-                self.replot_all()
-                self.bufferplots = []
-        else:
-            self.bufferplots = []
-            # Iterate through tabgroup children and copy curves.
-            for i in range(self.gui.tabGroup.count()):
-                page = self.gui.tabGroup.widget(i)
-                for item in page.children():
-                    if isinstance(item, Qwt.QwtPlot):
-                        # Change colours as both plots overlay.
-                        colours = [QtCore.Qt.darkYellow,QtCore.Qt.black]
-                        for c in item.itemList():
-                            if isinstance(c, Qwt.QwtPlotCurve):
-                                dup = Qwt.QwtPlotCurve()
-                                dpen = c.pen()
-                                dsym = c.symbol()
-                                dsym.setPen(Qt.QPen(colours[0]))
-                                dsym.setSize(Qt.QSize(6, 6))
-                                dpen.setColor(colours[0])
-                                del colours[0]
-                                dup.setPen(dpen)
-                                dup.setSymbol(dsym)
-                                dup.setRenderHint(Qwt.QwtPlotItem.RenderAntialiased)
-                                dup.setData([c.x(i) for i in range(c.dataSize())],
-                                            [c.y(i) for i in range(c.dataSize())])
-                                self.bufferplots.append(dup)
-                                self.bufferplots[-1].attach(item)
+    # TODO: method still uses QWT - migrate to pyqtgraph
+    # # Saves and attach the plots for comparison.
+    # def set_bufferplots(self):
+    #     if (self.gui.checkKeepcur.checkState() == 0 ):
+    #         # Detach and delete all plots if unchecked.
+    #         for c in self.bufferplots:
+    #             c.detach()
+    #             self.replot_all()
+    #             self.bufferplots = []
+    #     else:
+    #         self.bufferplots = []
+    #         # Iterate through tabgroup children and copy curves.
+    #         for i in range(self.gui.tabGroup.count()):
+    #             page = self.gui.tabGroup.widget(i)
+    #             for item in page.children():
+    #                 if isinstance(item, Qwt.QwtPlot):
+    #                     # Change colours as both plots overlay.
+    #                     colours = [QtCore.Qt.darkYellow,QtCore.Qt.black]
+    #                     for c in item.itemList():
+    #                         if isinstance(c, Qwt.QwtPlotCurve):
+    #                             dup = Qwt.QwtPlotCurve()
+    #                             dpen = c.pen()
+    #                             dsym = c.symbol()
+    #                             dsym.setPen(Qt.QPen(colours[0]))
+    #                             dsym.setSize(Qt.QSize(6, 6))
+    #                             dpen.setColor(colours[0])
+    #                             del colours[0]
+    #                             dup.setPen(dpen)
+    #                             dup.setSymbol(dsym)
+    #                             dup.setRenderHint(Qwt.QwtPlotItem.RenderAntialiased)
+    #                             dup.setData([c.x(i) for i in range(c.dataSize())],
+    #                                         [c.y(i) for i in range(c.dataSize())])
+    #                             self.bufferplots.append(dup)
+    #                             self.bufferplots[-1].attach(item)
 
     def set_grid(self):
         if (self.gui.checkGrid.checkState() == 0):
@@ -1620,20 +1622,20 @@ class gr_plot_filter(QtGui.QMainWindow):
         else:
             return False
 
-    def detach_firstattached(self, plot):
-        items = plot.itemList()
-        plot.enableAxis(Qwt.QwtPlot.yRight)
-        if len(items) > 2:
-            yaxis=items[0].yAxis()
-            items[2].setPen(items[0].pen())
-            items[2].setYAxis(yaxis)
-            items[0].detach()
-        else:
-            items[1].setYAxis(Qwt.QwtPlot.yRight)
-            if plot is self.mplots['mFREQ']:
-                items[1].setPen(QtGui.QPen(QtCore.Qt.red, 1, QtCore.Qt.SolidLine))
-                self.set_actgrid()
-
+    # TODO: method still uses QWT - migrate to pyqtgraph
+    # def detach_firstattached(self, plot):
+    #     items = plot.itemList()
+    #     plot.enableAxis(Qwt.QwtPlot.yRight)
+    #     if len(items) > 2:
+    #         yaxis=items[0].yAxis()
+    #         items[2].setPen(items[0].pen())
+    #         items[2].setYAxis(yaxis)
+    #         items[0].detach()
+    #     else:
+    #         items[1].setYAxis(Qwt.QwtPlot.yRight)
+    #         if plot is self.mplots['mFREQ']:
+    #             items[1].setPen(QtGui.QPen(QtCore.Qt.red, 1, QtCore.Qt.SolidLine))
+    #             self.set_actgrid()
 
     def update_fft(self, taps, params):
         self.params = params
@@ -1968,14 +1970,14 @@ class gr_plot_filter(QtGui.QMainWindow):
         self.gui.mfilterCoeff.setText(fcoeff)
 
     def action_save_dialog(self):
-        file_dialog_output = QtGui.QFileDialog.getSaveFileName(self, "Save CSV Filter File", ".", "")
+        file_dialog_output = QtWidgets.QFileDialog.getSaveFileName(self, "Save CSV Filter File", ".", "")
         filename = file_dialog_output[0]
         try:
             handle = open(filename, "w")
         except IOError:
-            reply = QtGui.QMessageBox.information(self, 'File Name',
+            reply = QtWidgets.QMessageBox.information(self, 'File Name',
                                                   ("Could not save to file: %s" % filename),
-                                                  QtGui.QMessageBox.Ok)
+                                                  QtWidgets.QMessageBox.Ok)
             return
 
         csvhandle = csv.writer(handle, delimiter=",")
@@ -2005,7 +2007,7 @@ class gr_plot_filter(QtGui.QMainWindow):
         self.replot_all()
 
     def action_open_dialog(self):
-        file_dialog_output = QtGui.QFileDialog.getOpenFileName(self, "Open CSV Filter File", ".", "")
+        file_dialog_output = QtWidgets.QFileDialog.getOpenFileName(self, "Open CSV Filter File", ".", "")
         if(len(file_dialog_output) == 0):
             return
         # file_dialog_output returns tuple of (filename, file filter)
@@ -2013,9 +2015,9 @@ class gr_plot_filter(QtGui.QMainWindow):
         try:
             handle = open(filename, "r")
         except IOError:
-            reply = QtGui.QMessageBox.information(self, 'File Name',
+            reply = QtWidgets.QMessageBox.information(self, 'File Name',
                                                   ("Could not open file: %s" % filename),
-                                                  QtGui.QMessageBox.Ok)
+                                                  QtWidgets.QMessageBox.Ok)
             return
 
         csvhandle = csv.reader(handle, delimiter=",")

--- a/gr-filter/python/filter/gui/banditems.py
+++ b/gr-filter/python/filter/gui/banditems.py
@@ -8,18 +8,18 @@
 
 
 try:
-    from PyQt5 import Qt, QtCore, QtGui
+    from PyQt5 import Qt, QtCore, QtGui, QtWidgets
 except ImportError:
     raise SystemExit('Please install PyQt5 to run this script (http://www.riverbankcomputing.co.uk/software/pyqt/download)')
 
 
 # Movable solid line for filter ideal-band diagram.
 # Enable split to cut the line into two (for bpf).
-class filtermovlineItem(QtGui.QGraphicsObject):
+class filtermovlineItem(QtWidgets.QGraphicsObject):
     attenChanged = QtCore.pyqtSignal(float)
 
     def __init__(self, x1, y1, x2, y2, lower, upper, split=False, sx1=0, sy1=0, sx2=0, sy2=0):
-        QtGui.QGraphicsObject.__init__(self)
+        QtWidgets.QGraphicsObject.__init__(self)
         self.lower = lower
         self.upper = upper
         self.x1, self.y1 = x1, y1
@@ -43,7 +43,7 @@ class filtermovlineItem(QtGui.QGraphicsObject):
 
     # Allow only vertical movement and emit signals.
     def itemChange(self, change, value):
-        if (change == QtGui.QGraphicsItem.ItemPositionChange):
+        if (change == QtWidgets.QGraphicsItem.ItemPositionChange):
             newpos = value.toPointF()
             div = 0
             if newpos.y() < self.pos().y():
@@ -61,13 +61,13 @@ class filtermovlineItem(QtGui.QGraphicsObject):
             if not(hit):
                 self.attenChanged.emit(div)
             return QtCore.QPointF(self.pos().x(), newpos.y())
-        return QtGui.QGraphicsItem.itemChange(self, change, value)
+        return QtWidgets.QGraphicsItem.itemChange(self, change, value)
 
 
 # Static lines in lpf band diagram.
-class lpfsLines(QtGui.QGraphicsObject):
+class lpfsLines(QtWidgets.QGraphicsObject):
     def __init__(self):
-        QtGui.QGraphicsObject.__init__(self)
+        QtWidgets.QGraphicsObject.__init__(self)
 
     def paint(self, painter, option, widget):
         painter.setPen(QtGui.QPen(QtCore.Qt.darkGray, 2, QtCore.Qt.SolidLine))
@@ -92,9 +92,9 @@ class lpfsLines(QtGui.QGraphicsObject):
 
 
 # Static lines in hpf band diagram.
-class hpfsLines(QtGui.QGraphicsObject):
+class hpfsLines(QtWidgets.QGraphicsObject):
     def __init__(self):
-        QtGui.QGraphicsObject.__init__(self)
+        QtWidgets.QGraphicsObject.__init__(self)
 
     def paint(self, painter, option, widget):
         painter.setPen(QtGui.QPen(QtCore.Qt.darkGray, 2, QtCore.Qt.SolidLine))
@@ -115,9 +115,9 @@ class hpfsLines(QtGui.QGraphicsObject):
 
 
 # Static lines in bpf band diagram.
-class bpfsLines(QtGui.QGraphicsObject):
+class bpfsLines(QtWidgets.QGraphicsObject):
     def __init__(self):
-        QtGui.QGraphicsObject.__init__(self)
+        QtWidgets.QGraphicsObject.__init__(self)
 
     def paint(self, painter, option, widget):
         painter.setPen(QtGui.QPen(QtCore.Qt.darkGray, 2, QtCore.Qt.SolidLine))
@@ -143,9 +143,9 @@ class bpfsLines(QtGui.QGraphicsObject):
 
 
 # Static lines in bnf band diagram.
-class bnfsLines(QtGui.QGraphicsObject):
+class bnfsLines(QtWidgets.QGraphicsObject):
     def __init__(self):
-        QtGui.QGraphicsObject.__init__(self)
+        QtWidgets.QGraphicsObject.__init__(self)
 
     def paint(self, painter, option, widget):
         painter.setPen(QtGui.QPen(QtCore.Qt.darkGray, 2, QtCore.Qt.SolidLine))
@@ -178,24 +178,24 @@ bnfItems = []
 # lpfitems list.
 lpfItems.append(filtermovlineItem(200, 175, 400, 175, 0, -60))
 # lpfItems.append(filtermovlineItem(200, 145, 400, 145, 30, -30))
-lpfItems[0].setFlags(QtGui.QGraphicsItem.ItemIsSelectable | QtGui.QGraphicsItem.ItemIsMovable |
-                     QtGui.QGraphicsItem.ItemSendsGeometryChanges)
+lpfItems[0].setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable | QtWidgets.QGraphicsItem.ItemIsMovable |
+                     QtWidgets.QGraphicsItem.ItemSendsGeometryChanges)
 lpfItems.append(lpfsLines())
 
 # hpfitems list.
 hpfItems.append(filtermovlineItem(6, 175, 150, 175, 0, -60))
-hpfItems[0].setFlags(QtGui.QGraphicsItem.ItemIsSelectable | QtGui.QGraphicsItem.ItemIsMovable |
-                     QtGui.QGraphicsItem.ItemSendsGeometryChanges)
+hpfItems[0].setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable | QtWidgets.QGraphicsItem.ItemIsMovable |
+                     QtWidgets.QGraphicsItem.ItemSendsGeometryChanges)
 hpfItems.append(hpfsLines())
 
 # bpfitems list.
 bpfItems.append(filtermovlineItem(6, 175, 110, 175, 0, -60, True, 300, 175, 400, 175))
-bpfItems[0].setFlags(QtGui.QGraphicsItem.ItemIsSelectable | QtGui.QGraphicsItem.ItemIsMovable |
-                     QtGui.QGraphicsItem.ItemSendsGeometryChanges)
+bpfItems[0].setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable | QtWidgets.QGraphicsItem.ItemIsMovable |
+                     QtWidgets.QGraphicsItem.ItemSendsGeometryChanges)
 bpfItems.append(bpfsLines())
 
 # bnfitems list.
 bnfItems.append(filtermovlineItem(155, 175, 255, 175, 0, -60))
-bnfItems[0].setFlags(QtGui.QGraphicsItem.ItemIsSelectable | QtGui.QGraphicsItem.ItemIsMovable |
-                     QtGui.QGraphicsItem.ItemSendsGeometryChanges)
+bnfItems[0].setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable | QtWidgets.QGraphicsItem.ItemIsMovable |
+                     QtWidgets.QGraphicsItem.ItemSendsGeometryChanges)
 bnfItems.append(bnfsLines())


### PR DESCRIPTION
# Pull Request Details
---
## Description
Filter designer wasn't working at all on Ubuntu 20.04 because it used Qt4 syntax.  
Need to also remove PyQwt from various places
Need to verify minimum specified QT version

## Related Issue
#1634

## Which blocks/areas does this affect?
gr_filter_design

## Testing Done
limited to this point.  Just enough to launch filter_design

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
