### PR TITLE
gnuradio-runtime: Remove Doxygen warnings from custom buffers

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer_double_mapped.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_double_mapped.h
@@ -109,6 +109,8 @@ private:
      * \param sizeof_item is the size of an item in bytes.
      * \param downstream_lcm_nitems is the least common multiple of the items to
      *                              read by downstream blocks
+     * \param downstream_max_out_mult is the maximum output multiple of all
+     *                                downstream blocks
      * \param link is the block that writes to this buffer.
      *
      * The total size of the buffer will be rounded up to a system

--- a/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
@@ -130,6 +130,8 @@ protected:
      * \param sizeof_item is the size of an item in bytes.
      * \param downstream_lcm_nitems is the least common multiple of the items to
      *                              read by downstream blocks
+     * \param downstream_max_out_mult is the maximum output multiple of all
+     *                                downstream blocks
      * \param link is the block that writes to this buffer.
      * \param buf_owner if the block that owns the buffer which may or may not
      *                  be the same as the block that writes to this buffer

--- a/gnuradio-runtime/include/gnuradio/host_buffer.h
+++ b/gnuradio-runtime/include/gnuradio/host_buffer.h
@@ -79,6 +79,7 @@ public:
      * \param nitems
      * \param sizeof_item
      * \param downstream_lcm_nitems
+     * \param downstream_max_out_mult
      * \param link
      * \param buf_owner
      *


### PR DESCRIPTION
Signed-off-by: Ron Economos <w6rz@comcast.net>
