### PR TITLE
Bump Major Dependency Versions for 3.10

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -66,13 +66,13 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
-          - distro: 'CentOS 8.3'
-            containerid: 'gnuradio/ci:centos-8.3-3.9'
+          - distro: 'CentOS 8.4'
+            containerid: 'gnuradio/ci:centos-8.4-3.10'
             cxxflags: ''
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
           - distro: 'Debian 10'
-            containerid: 'gnuradio/ci:debian-10-3.9'
+            containerid: 'gnuradio/ci:debian-10-3.10'
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath:

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -56,13 +56,13 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|metainfo_test"'
             ldpath:
-          - distro: 'Fedora 33'
-            containerid: 'gnuradio/ci:fedora-33-3.9'
-            cxxflags: ''
-            ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
-            ldpath: /usr/local/lib64/
           - distro: 'Fedora 34'
             containerid: 'gnuradio/ci:fedora-34-3.9'
+            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
+            ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath: /usr/local/lib64/
+          - distro: 'Fedora 35'
+            containerid: 'gnuradio/ci:fedora-35-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
@@ -71,11 +71,6 @@ jobs:
             cxxflags: ''
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
-          - distro: 'Debian 10'
-            containerid: 'gnuradio/ci:debian-10-3.10'
-            cxxflags: -Werror -Wno-error=invalid-pch
-            ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
-            ldpath:
           - distro: 'Debian 11'
             containerid: 'gnuradio/ci:debian-11-3.10'
             cxxflags: -Werror -Wno-error=invalid-pch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,14 +49,14 @@ SET(VERSION_PATCH git)
 include(GrVersion) #setup version info
 
 # Minimum dependency versions for central dependencies:
-set(GR_BOOST_MIN_VERSION "1.65")      ## Version in Ubuntu 18.04LTS
-set(GR_CMAKE_MIN_VERSION "3.10.2")    ## Version in Ubuntu 18.04LTS
-set(GR_MAKO_MIN_VERSION "1.0.7")      ## debian buster, 18.04LTS
+set(GR_BOOST_MIN_VERSION "1.69")      ## Version in CentOS 8 (EPEL)
+set(GR_CMAKE_MIN_VERSION "3.16.3")    ## Version in Ubuntu 20.04LTS
+set(GR_MAKO_MIN_VERSION "1.1.0")      ## Version in Ubuntu 20.04LTS
 set(GR_PYTHON_MIN_VERSION "3.6.5")    ## Version in Ubuntu 18.04LTS
-set(GR_NUMPY_MIN_VERSION "1.13.3")    ## Version in Ubuntu 18.04LTS
 set(GR_PYGCCXML_MIN_VERSION "2.0.0")  ## Version to support c++17 (in pip)
-set(GCC_MIN_VERSION "8.3.0")          ## debian buster
-set(CLANG_MIN_VERSION "11.0.0")       ## debian bullseye, Fedora 33
+set(GR_NUMPY_MIN_VERSION "1.17.4")    ## Version in Ubuntu 20.04LTS
+set(GCC_MIN_VERSION "9.3.0")          ## Version in Ubuntu 20.04LTS
+set(CLANG_MIN_VERSION "11.0.0")       ## Version in Ubuntu 20.04LTS
 set(APPLECLANG_MIN_VERSION "1100")    ## same as clang 11.0.0, in Xcode11
 set(MSVC_MIN_VERSION "1914")          ## VS2017 15.7, for full-ish C++17 support
 set(VOLK_MIN_VERSION "2.4.1")         ## first version with CPU features


### PR DESCRIPTION
# Pull Request Details
---
## Description
For the 3.10 release we will support the latest LTS releases from major distributions.  The major bottleneck here in terms of dependencies is Ubuntu 3.10.

## Related Issue
Fixes #2719

## Which blocks/areas does this affect?
top level CMake

## Testing Done
None

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
--> Needs to be updated before merging
- [ ] I have added tests to cover my changes, and all previous tests pass.
