### PR TITLE
modtool,cmake: make module dir for tests 

### DIFF
--- a/cmake/Modules/GrTest.cmake
+++ b/cmake/Modules/GrTest.cmake
@@ -61,6 +61,10 @@ function(GR_ADD_TEST test_name)
     # Keep the original path conversion for pypath - the above commented line breaks CI tests
     file(TO_NATIVE_PATH "${GR_TEST_PYTHON_DIRS}" pypath) #ok to use on dir list?
 
+    # add test module directory to PYTHONPATH to allow CTest to find QA test modules.
+    # We add it to the beginning of the list to use locally-built modules before installed ones.
+    list(INSERT pypath 0 "${CMAKE_BINARY_DIR}/test_modules")
+
     set(environs "VOLK_GENERIC=1" "GR_DONT_LOAD_PREFS=1" "srcdir=${srcdir}"
         "GR_CONF_CONTROLPORT_ON=False")
     list(APPEND environs ${GR_TEST_ENVIRONS})

--- a/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
@@ -31,3 +31,14 @@ GR_PYTHON_INSTALL(
 include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-howto)
+
+# Create a module directory that tests can import. It includes everything
+# from `python/` and the built bindings shared lib.
+add_custom_target(
+  copy_module_for_tests ALL
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}
+          ${CMAKE_BINARY_DIR}/test_modules/howto/
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/bindings/
+    ${CMAKE_BINARY_DIR}/test_modules/howto/
+  DEPENDS howto_python)


### PR DESCRIPTION
# Pull Request Details

## Description

Updated:

This change creates a module directory inside the build tree (`build/test_modules/modulename`). It consists of the build artifacts from `build/python/bindings` and `python/*`. `GrTest` then adds `build/test_modules` to the PYTHONPATH.

Old description:
This change makes CTest look for locally-built modules (i.e. during development, in the build directory) before installed ones.

Also adjust test module name in the template, though that's not ideal. I _think_ we could remove the `_python` suffix from the module in this line, but not quite sure about that: https://github.com/gnuradio/gnuradio/blob/master/cmake/Modules/GrPybind.cmake#L9

If we can, existing modules should just work with the GrTest.cmake (and GrPybind.cmake) changes (i.e. a new GR version).

## Related Issue
I think it takes care of these issues:

Fixes #3999 
Fixes #4825

## Which blocks/areas does this affect?

One line change in `GrTest.cmake` to prepend the bindings dir to PYTHONPATH for tests; `CMakeLists.txt` in `python/` changed to copy the module directory into a separate directory that can be imported.

## Testing Done

Successfully ran `make test` with these changes in place and saw passing tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
