### PR TITLE
modtool: add basic ZSH completion support

### DIFF
--- a/gr-utils/modtool/CMakeLists.txt
+++ b/gr-utils/modtool/CMakeLists.txt
@@ -28,6 +28,10 @@ install(
     DESTINATION ${GR_PREFSDIR}
 )
 
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/support/_gr_modtool
+  DESTINATION ${GR_DATA_DIR}/zsh/site-functions
+)
+
 GR_PYTHON_INSTALL(
     PROGRAMS    gr_modtool
     DESTINATION ${GR_RUNTIME_DIR}

--- a/gr-utils/modtool/support/_gr_modtool
+++ b/gr-utils/modtool/support/_gr_modtool
@@ -1,0 +1,25 @@
+#compdef gr_modtool
+#autoload
+
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2021 Marcus Müller
+# This module offers tab-completion for ZSH
+# It's rudimentary.
+
+local -a subcmds
+subcmds=(
+    'add:Adds a block to the out-of-tree module.'
+    'bind:Generate Python bindings for GR block'
+    'disable:Disable selected block in module.'
+    'info:Return information about a given module'
+    'makeyaml:Generate YAML files for GRC block bindings.'
+    'newmod:Create new empty module, use add to add blocks.'
+    'rename:Rename a block inside a module.'
+    'rm:Remove a block from a module.'
+    'update:Update the grc bindings for a block'
+)
+_describe 'command' subcmds
+if (( CURRENT == 2 )); then
+    _describe -t commands 'subcommands' subcmds
+fi
+return 0


### PR DESCRIPTION
# Pull Request Details

This adds but rudimentary support for zsh completion to for `gr_modtool`, so that you can go `gr_modtool`<kbd>tab</kbd> and are shown a list of the commands, through which you can tab-cycle, or if you started to type one, can tab-complete it.

![completion](https://user-images.githubusercontent.com/958972/139604757-827c072a-403e-4485-b643-2904684b3475.png)

This should / could of course do much more, but my guess is that we'll never get something that knows the arguments of the subcommands if we don't start somewhere.

If someone wants to pick up, the [oh-my-zsh vagrant plugin](https://github.com/ohmyzsh/ohmyzsh/blob/00ccb449907d322c6bfa53f17e96cbf48651fee3/plugins/vagrant/_vagrant) could possibly be used as example.

## Description

Just write a compsys script, drop it in fpath, start shell, and tab away.

## Related Issue

Is a stab at #5206 ; certainly doesn't close it, as it neither addresses bash (which is probably much, much more common) nor does it do sensible things like know arguments to subcommands. 

## Which blocks/areas does this affect?

'modtool

## Testing Done

Wrote, installed, tabbed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
  - not quite sure if necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
  - hard to test interactive shell completion automatically. 
