### PR TITLE
qtgui range: setRange() requires int

### DIFF
--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -131,7 +131,7 @@ class RangeWidget(QtWidgets.QWidget):
             self.rangeType = rangeType
 
             # Setup the dial
-            self.setRange(0, ranges.nsteps-1)
+            self.setRange(0, int(ranges.nsteps-1))
             self.setSingleStep(1)
             self.setNotchesVisible(True)
             self.range = ranges
@@ -158,7 +158,7 @@ class RangeWidget(QtWidgets.QWidget):
 
             # Setup the slider
             #self.setFocusPolicy(QtCore.Qt.NoFocus)
-            self.setRange(0, ranges.nsteps - 1)
+            self.setRange(0, int(ranges.nsteps - 1))
             self.setTickPosition(2)
             self.setSingleStep(1)
             self.range = ranges
@@ -191,7 +191,7 @@ class RangeWidget(QtWidgets.QWidget):
                     new = self.minimum() + ((self.maximum()-self.minimum()) * event.x()) / self.width()
                 else:
                     new = self.minimum() + ((self.maximum()-self.minimum()) * event.y()) / self.height()
-                self.setValue(new)
+                self.setValue(int(new))
                 event.accept()
             # Use repaint rather than calling the super mousePressEvent.
             # Calling super causes issue where slider jumps to wrong value.
@@ -202,7 +202,7 @@ class RangeWidget(QtWidgets.QWidget):
                 new = self.minimum() + ((self.maximum()-self.minimum()) * event.x()) / self.width()
             else:
                 new = self.minimum() + ((self.maximum()-self.minimum()) * event.y()) / self.height()
-            self.setValue(new)
+            self.setValue(int(new))
             event.accept()
             QtWidgets.QSlider.repaint(self)
 


### PR DESCRIPTION
Author: Chris Vine <vine35792468@gmail.com>

Signed-off-by: Jeff Long <willcode4@gmail.com>

# Pull Request Details

## Description
Python 3.10 sees setRange( non-int-value ) as an error. Reported by Chris Vine.

## Related Issue
Fixes #5341 

## Which blocks/areas does this affect?
qtgui/range

## Testing Done

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
 