### PR TITLE
modtool: update pygccxml to c++17 std, add pygccxml version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(GR_CMAKE_MIN_VERSION "3.10.2")    ## Version in Ubuntu 18.04LTS
 set(GR_MAKO_MIN_VERSION "1.0.7")      ## debian buster, 18.04LTS
 set(GR_PYTHON_MIN_VERSION "3.6.5")    ## Version in Ubuntu 18.04LTS
 set(GR_NUMPY_MIN_VERSION "1.13.3")    ## Version in Ubuntu 18.04LTS
+set(GR_PYGCCXML_MIN_VERSION "2.0.0")  ## Version to support c++17 (in pip)
 set(GCC_MIN_VERSION "8.3.0")          ## debian buster
 set(CLANG_MIN_VERSION "11.0.0")       ## debian bullseye, Fedora 33
 set(APPLECLANG_MIN_VERSION "1100")    ## same as clang 11.0.0, in Xcode11
@@ -324,12 +325,20 @@ GR_PYTHON_CHECK_MODULE(
     "LooseVersion(numpy.__version__) >= LooseVersion('${GR_NUMPY_MIN_VERSION}')"
     NUMPY_FOUND)
 # Needed for automatic regeneration of some bindings
-GR_PYTHON_CHECK_MODULE_RAW(
+GR_PYTHON_CHECK_MODULE(
     "pygccxml"
-    "import pygccxml"
+    pygccxml
+    "LooseVersion(pygccxml.__version__) >= LooseVersion('${GR_PYGCCXML_MIN_VERSION}')"
     PYGCCXML_FOUND
     )
-
+if(NOT PYGCCXML_FOUND)
+    message(STATUS "")
+    message(STATUS "***************************** WARNING!!! *************************")
+    message(STATUS "pygccxml is highly recommended for using gr_modtool")
+    message(STATUS "and is either not present or below the minimum version " ${GR_PYGCCXML_MIN_VERSION})
+    message(STATUS "Only trivial bindings will be generated using gr_modtool bind ")
+    message(STATUS "******************************************************************")
+endif()
 
 find_package(pybind11 REQUIRED)
 IF(${pybind11_VERSION} VERSION_LESS ${PYBIND11_MIN_VERSION})

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -326,7 +326,7 @@ class GenericHeaderParser(BlockTool):
                 compiler='gcc',
                 undefine_symbols=['__PIE__'],
                 define_symbols=self.define_symbols,
-                cflags='-std=c++11 -fPIC')
+                cflags='-std=c++17 -fPIC')
             decls = parser.parse(
                 [self.target_file], xml_generator_config)
 


### PR DESCRIPTION
# Pull Request Details
Updates the call to pygccxml that is invoked when `gr_modtool bind` is called to use -std c++17
Has minimum version check on pygccxml since the tool is now useless anything below 2.0.0 because we use c++17

## Related Issue
Fixes #5281
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
gr_modtool

## Testing Done
rebuilt the gnuradio codebase with and without pygccxml installed
created an oot module with a block and ran gr_modtool bind

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
