### PR TITLE
runtime: mark buffer methods as override

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -70,7 +70,7 @@ public:
     gr::logger_ptr d_logger;
     gr::logger_ptr d_debug_logger;
 
-    virtual ~buffer();
+    ~buffer() override;
 
     /*!
      * \brief return the buffer's mapping type
@@ -262,12 +262,12 @@ public:
     /*!
      * \brief "on_lock" function from the custom_lock_if.
      */
-    void on_lock(gr::thread::scoped_lock& lock);
+    void on_lock(gr::thread::scoped_lock& lock) override;
 
     /*!
      * \brief "on_unlock" function from the custom_lock_if.
      */
-    void on_unlock();
+    void on_unlock() override;
 
     friend std::ostream& operator<<(std::ostream& os, const buffer& buf);
 

--- a/gnuradio-runtime/include/gnuradio/buffer_double_mapped.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_double_mapped.h
@@ -40,27 +40,27 @@ public:
     gr::logger_ptr d_logger;
     gr::logger_ptr d_debug_logger;
 
-    virtual ~buffer_double_mapped();
+    ~buffer_double_mapped() override;
 
     /*!
      * \brief return number of items worth of space available for writing
      */
-    virtual int space_available();
+    int space_available() override;
 
     /*!
      * Inherited from buffer class.
      * @param nitems is the number of items produced by the general_work() function.
      */
-    virtual void post_work([[maybe_unused]] int nitems) {}
+    void post_work([[maybe_unused]] int nitems) override {}
 
 protected:
     /*!
      * sets d_vmcircbuf, d_base, d_bufsize.
      * returns true iff successful.
      */
-    bool allocate_buffer(int nitems);
+    bool allocate_buffer(int nitems) override;
 
-    virtual unsigned index_add(unsigned a, unsigned b)
+    unsigned index_add(unsigned a, unsigned b) override
     {
         unsigned s = a + b;
 
@@ -71,7 +71,7 @@ protected:
         return s;
     }
 
-    virtual unsigned index_sub(unsigned a, unsigned b)
+    unsigned index_sub(unsigned a, unsigned b) override
     {
         int s = a - b;
 

--- a/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
@@ -33,7 +33,7 @@ public:
     gr::logger_ptr d_logger;
     gr::logger_ptr d_debug_logger;
 
-    virtual ~buffer_single_mapped();
+    ~buffer_single_mapped() override;
 
     /*!
      * \brief Return the block that owns this buffer.
@@ -43,33 +43,34 @@ public:
     /*!
      * \brief return number of items worth of space available for writing
      */
-    virtual int space_available();
+    int space_available() override;
 
-    virtual void update_reader_block_history(unsigned history, int delay);
+    void update_reader_block_history(unsigned history, int delay) override;
 
     /*!
      * \brief Return true if thread is ready to call input_blocked_callback,
      * false otherwise
      */
-    virtual bool input_blkd_cb_ready(int items_required, unsigned read_index);
+    bool input_blkd_cb_ready(int items_required, unsigned read_index) override;
 
     /*!
      * \brief Callback function that the scheduler will call when it determines
      * that the input is blocked. Override this function if needed.
      */
-    virtual bool
-    input_blocked_callback(int items_required, int items_avail, unsigned read_index) = 0;
+    bool input_blocked_callback(int items_required,
+                                int items_avail,
+                                unsigned read_index) override = 0;
 
     /*!
      * \brief Return true if thread is ready to call the callback, false otherwise
      */
-    virtual bool output_blkd_cb_ready(int output_multiple);
+    bool output_blkd_cb_ready(int output_multiple) override;
 
     /*!
      * \brief Callback function that the scheduler will call when it determines
      * that the output is blocked
      */
-    virtual bool output_blocked_callback(int output_multiple, bool force) = 0;
+    bool output_blocked_callback(int output_multiple, bool force) override = 0;
 
 protected:
     /*!
@@ -77,7 +78,7 @@ protected:
      * granularity then delegate actual allocation to do_allocate_buffer().
      * @return true iff successful.
      */
-    virtual bool allocate_buffer(int nitems);
+    bool allocate_buffer(int nitems) override;
 
     /*!
      * \brief Do actual buffer allocation. This is intended (required) to be
@@ -85,7 +86,7 @@ protected:
      */
     virtual bool do_allocate_buffer(size_t final_nitems, size_t sizeof_item) = 0;
 
-    virtual unsigned index_add(unsigned a, unsigned b)
+    unsigned index_add(unsigned a, unsigned b) override
     {
         unsigned s = a + b;
 
@@ -96,7 +97,7 @@ protected:
         return s;
     }
 
-    virtual unsigned index_sub(unsigned a, unsigned b)
+    unsigned index_sub(unsigned a, unsigned b) override
     {
         // NOTE: a is writer ptr and b is read ptr
         int s = a - b;

--- a/gnuradio-runtime/include/gnuradio/host_buffer.h
+++ b/gnuradio-runtime/include/gnuradio/host_buffer.h
@@ -30,7 +30,7 @@ public:
                                    block_sptr link = block_sptr(),
                                    block_sptr buf_owner = block_sptr());
 
-    virtual ~host_buffer();
+    ~host_buffer() override;
 
     /*!
      * \brief Handles post-general_work() cleanup and data transfer
@@ -41,37 +41,38 @@ public:
      *
      * \param nitems is the number of items produced by the general_work() function.
      */
-    void post_work(int nitems);
+    void post_work(int nitems) override;
 
     /*!
      * \brief Do actual buffer allocation. Inherited from buffer_single_mapped.
      */
-    bool do_allocate_buffer(size_t final_nitems, size_t sizeof_item);
+    bool do_allocate_buffer(size_t final_nitems, size_t sizeof_item) override;
 
     /*!
      * \brief Return a pointer to the write buffer depending on the context
      */
-    virtual void* write_pointer();
+    void* write_pointer() override;
 
     /*!
      * \brief return pointer to read buffer depending on the context
      *
      * The return value points to at least items_available() items.
      */
-    virtual const void* _read_pointer(unsigned int read_index);
+    const void* _read_pointer(unsigned int read_index) override;
 
     /*!
      * \brief Callback function that the scheduler will call when it determines
      * that the input is blocked. Override this function if needed.
      */
-    virtual bool
-    input_blocked_callback(int items_required, int items_avail, unsigned read_index);
+    bool input_blocked_callback(int items_required,
+                                int items_avail,
+                                unsigned read_index) override;
 
     /*!
      * \brief Callback function that the scheduler will call when it determines
      * that the output is blocked
      */
-    virtual bool output_blocked_callback(int output_multiple, bool force);
+    bool output_blocked_callback(int output_multiple, bool force) override;
 
     /*!
      * \brief Creates a new host_buffer object

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(a9735c1e3334b958ac0ae85cf03b7eaf)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a21619a22acff81798a133305900125a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION

# Pull Request Details
found with 
```
run-clang-tidy -header-filter='.*' -checks='-*,misc-throw-by-value-catch-by-reference,misc-static-assert,readability-container-size-empty,modernize-use-override,modernize-make-unique,modernize-deprecated-headers,misc-unused-using-decls,misc-redundant-expression' -fix
```
## Related Issue

## Which blocks/areas does this affect?
runtime, buffers - the whole codebase

## Testing Done
CI should be sufficient

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
