### PR TITLE
cmake: Fix cmake failure with unset VERSION_PATCH (backport to maint-3.9)

### DIFF
--- a/cmake/Modules/GrVersion.cmake
+++ b/cmake/Modules/GrVersion.cmake
@@ -10,11 +10,16 @@ if(DEFINED __INCLUDED_GR_VERSION_CMAKE)
 endif()
 set(__INCLUDED_GR_VERSION_CMAKE TRUE)
 
+# always have a value for VERSION_PATCH, even if unset (e.g. some OOTs)
+if(NOT DEFINED VERSION_PATCH)
+    set(VERSION_PATCH "0")
+endif()
+
 #eventually, replace version.sh and fill in the variables below
-set(MAJOR_VERSION ${VERSION_MAJOR})
-set(API_COMPAT    ${VERSION_API})
-set(MINOR_VERSION ${VERSION_ABI})
-set(MAINT_VERSION ${VERSION_PATCH})
+set(MAJOR_VERSION "${VERSION_MAJOR}")
+set(API_COMPAT    "${VERSION_API}")
+set(MINOR_VERSION "${VERSION_ABI}")
+set(MAINT_VERSION "${VERSION_PATCH}")
 
 ########################################################################
 # Extract the version string from git describe.
@@ -75,6 +80,6 @@ else()
     set(DOCVER "${VERSION}")
     set(LIBVER "${MAJOR_VERSION}.${API_COMPAT}.${MINOR_VERSION}")
     # ensure only numeric values are set for RC_ version parts
-    string(REGEX REPLACE "^([0-9]+).*$" "\\1" RC_MINOR_VERSION ${MINOR_VERSION})
-    string(REGEX REPLACE "^([0-9]+).*$" "\\1" RC_MAINT_VERSION ${MAINT_VERSION})
+    string(REGEX REPLACE "^([0-9]+).*$" "\\1" RC_MINOR_VERSION "${MINOR_VERSION}")
+    string(REGEX REPLACE "^([0-9]+).*$" "\\1" RC_MAINT_VERSION "${MAINT_VERSION}")
 endif()


### PR DESCRIPTION
After the recent change to use `string(REGEX REPLACE ...)` to ensure
that only numeric values are used for RC_*_VERSION, an unset
VERSION_PATCH now results in a cmake failure when it didn't previously.
While we should expect all 4 version fields to be set (except when one
of the values is "git"), we should also avoid failing here when it
worked before. At least one OOT (gr-satellites) doesn't set the
VERSION_PATCH field for releases, so this fixes the build in that case
without requiring OOT changes. Now an unset VERSION_PATCH defaults to
"0".

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit e79cc19b87a9976d1cb44a4c315b59cc90ebdbf8)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5146