### PR TITLE
cmake: handle optional components in `find_package`

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -97,7 +97,11 @@ set(GR_COMPONENTS
   )
 
 foreach(target ${GR_COMPONENTS})
-  if (${target} IN_LIST Gnuradio_FIND_COMPONENTS)
-    include("${CMAKE_CURRENT_LIST_DIR}/gnuradio-${target}Config.cmake")
+  set(GR_COMPONENT_INCLUDE_FILE
+      "${CMAKE_CURRENT_LIST_DIR}/gnuradio-${target}Config.cmake")
+  if(${target} IN_LIST Gnuradio_FIND_COMPONENTS
+     AND (EXISTS ${GR_COMPONENT_INCLUDE_FILE}
+          OR "${Gnuradio_FIND_REQUIRED_${target}}"))
+    include(${GR_COMPONENT_INCLUDE_FILE})
   endif()
 endforeach(target)


### PR DESCRIPTION

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

See related issue. This change allows OPTIONAL_COMPONENTS in a `find_package` call: It'll include the component if the CMake config exists (i.e. it's been enabled during compilation), otherwise it won't.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #5309 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
CMake config

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Tested OPTIONAL_COMPONENTS with this change and they are correctly included when available, otherwise they are silently passed over.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
