### PR TITLE
Revert "Replace boost::any with std::any"

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -17,6 +17,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
+#include <boost/any.hpp>
 #include <boost/core/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/shared_mutex.hpp>

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -12,8 +12,8 @@
 #define INCLUDED_PMT_H
 
 #include <pmt/api.h>
+#include <boost/any.hpp>
 #include <boost/noncopyable.hpp>
-#include <any>
 #include <complex>
 #include <cstdint>
 #include <iosfwd>
@@ -664,9 +664,10 @@ PMT_API pmt_t dict_values(pmt_t dict);
 
 /*
  * ------------------------------------------------------------------------
- *   Any (wraps std::any -- can be used to wrap pretty much anything)
+ *   Any (wraps boost::any -- can be used to wrap pretty much anything)
  *
  * Cannot be serialized or used across process boundaries.
+ * See http://www.boost.org/doc/html/any.html
  * ------------------------------------------------------------------------
  */
 
@@ -674,13 +675,13 @@ PMT_API pmt_t dict_values(pmt_t dict);
 PMT_API bool is_any(pmt_t obj);
 
 //! make an any
-PMT_API pmt_t make_any(const std::any& any);
+PMT_API pmt_t make_any(const boost::any& any);
 
-//! Return underlying std::any
-PMT_API std::any any_ref(pmt_t obj);
+//! Return underlying boost::any
+PMT_API boost::any any_ref(pmt_t obj);
 
 //! Store \p any in \p obj
-PMT_API void any_set(pmt_t obj, const std::any& any);
+PMT_API void any_set(pmt_t obj, const boost::any& any);
 
 
 /*

--- a/gnuradio-runtime/lib/block_registry.cc
+++ b/gnuradio-runtime/lib/block_registry.cc
@@ -13,7 +13,6 @@
 #include <gnuradio/block_detail.h>
 #include <gnuradio/block_registry.h>
 #include <gnuradio/tpb_detail.h>
-#include <any>
 
 gr::block_registry global_block_registry;
 
@@ -97,7 +96,7 @@ basic_block_sptr block_registry::block_lookup(pmt::pmt_t symbol)
     if (pmt::eq(ref, pmt::PMT_NIL)) {
         throw std::runtime_error("block lookup failed! block not found!");
     }
-    basic_block* blk = std::any_cast<basic_block*>(pmt::any_ref(ref));
+    basic_block* blk = boost::any_cast<basic_block*>(pmt::any_ref(ref));
     return blk->shared_from_this();
 }
 

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/messages/msg_accepter.h>
 #include <pmt/pmt.h>
 #include <pmt/pmt_pool.h>
-#include <any>
 #include <cstdio>
 #include <cstring>
 #include <vector>
@@ -742,20 +741,20 @@ pmt_t dict_values(pmt_t dict)
 //                                 Any
 ////////////////////////////////////////////////////////////////////////////
 
-pmt_any::pmt_any(const std::any& any) : d_any(any) {}
+pmt_any::pmt_any(const boost::any& any) : d_any(any) {}
 
 bool is_any(pmt_t obj) { return obj->is_any(); }
 
-pmt_t make_any(const std::any& any) { return pmt_t(new pmt_any(any)); }
+pmt_t make_any(const boost::any& any) { return pmt_t(new pmt_any(any)); }
 
-std::any any_ref(pmt_t obj)
+boost::any any_ref(pmt_t obj)
 {
     if (!obj->is_any())
         throw wrong_type("pmt_any_ref", obj);
     return _any(obj)->ref();
 }
 
-void any_set(pmt_t obj, const std::any& any)
+void any_set(pmt_t obj, const boost::any& any)
 {
     if (!obj->is_any())
         throw wrong_type("pmt_any_set", obj);
@@ -771,8 +770,8 @@ bool is_msg_accepter(const pmt_t& obj)
     if (!is_any(obj))
         return false;
 
-    std::any r = any_ref(obj);
-    return std::any_cast<gr::messages::msg_accepter_sptr>(&r) != 0;
+    boost::any r = any_ref(obj);
+    return boost::any_cast<gr::messages::msg_accepter_sptr>(&r) != 0;
 }
 
 //! make a msg_accepter
@@ -782,8 +781,8 @@ pmt_t make_msg_accepter(gr::messages::msg_accepter_sptr ma) { return make_any(ma
 gr::messages::msg_accepter_sptr msg_accepter_ref(const pmt_t& obj)
 {
     try {
-        return std::any_cast<gr::messages::msg_accepter_sptr>(any_ref(obj));
-    } catch (std::bad_any_cast& e) {
+        return boost::any_cast<gr::messages::msg_accepter_sptr>(any_ref(obj));
+    } catch (boost::bad_any_cast& e) {
         throw wrong_type("pmt_msg_accepter_ref", obj);
     }
 }

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -11,7 +11,7 @@
 #define INCLUDED_PMT_INT_H
 
 #include <pmt/pmt.h>
-#include <any>
+#include <boost/any.hpp>
 
 /*
  * EVERYTHING IN THIS FILE IS PRIVATE TO THE IMPLEMENTATION!
@@ -170,15 +170,15 @@ public:
 
 class pmt_any : public pmt_base
 {
-    std::any d_any;
+    boost::any d_any;
 
 public:
-    pmt_any(const std::any& any);
+    pmt_any(const boost::any& any);
     //~pmt_any();
 
     bool is_any() const override { return true; }
-    const std::any& ref() const { return d_any; }
-    void set(const std::any& any) { d_any = any; }
+    const boost::any& ref() const { return d_any; }
+    void set(const boost::any& any) { d_any = any; }
 };
 
 

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -12,7 +12,6 @@
 #include <pmt/api.h> //reason: suppress warnings
 #include <boost/format.hpp>
 #include <boost/test/unit_test.hpp>
-#include <any>
 #include <cstring>
 #include <sstream>
 
@@ -456,9 +455,9 @@ std::ostream& operator<<(std::ostream& os, const foo obj)
 
 BOOST_AUTO_TEST_CASE(test_any)
 {
-    std::any a0;
-    std::any a1;
-    std::any a2;
+    boost::any a0;
+    boost::any a1;
+    boost::any a2;
 
     a0 = std::string("Hello!");
     a1 = 42;
@@ -469,11 +468,11 @@ BOOST_AUTO_TEST_CASE(test_any)
     pmt::pmt_t p2 = pmt::make_any(a2);
 
     BOOST_CHECK_EQUAL(std::string("Hello!"),
-                      std::any_cast<std::string>(pmt::any_ref(p0)));
+                      boost::any_cast<std::string>(pmt::any_ref(p0)));
 
-    BOOST_CHECK_EQUAL(42, std::any_cast<int>(pmt::any_ref(p1)));
+    BOOST_CHECK_EQUAL(42, boost::any_cast<int>(pmt::any_ref(p1)));
 
-    BOOST_CHECK_EQUAL(foo(3.250, 21), std::any_cast<foo>(pmt::any_ref(p2)));
+    BOOST_CHECK_EQUAL(foo(3.250, 21), boost::any_cast<foo>(pmt::any_ref(p2)));
 }
 
 // ------------------------------------------------------------------------
@@ -492,7 +491,7 @@ BOOST_AUTO_TEST_CASE(test_msg_accepter)
 {
     pmt::pmt_t sym = pmt::mp("my-symbol");
 
-    std::any a0;
+    boost::any a0;
     a0 = std::string("Hello!");
     pmt::pmt_t p0 = pmt::make_any(a0);
 

--- a/gnuradio-runtime/python/pmt/__init__.py
+++ b/gnuradio-runtime/python/pmt/__init__.py
@@ -24,7 +24,7 @@ more flexible.
 
 The PMT library supports the following major types:
 bool, symbol (string), integer, real, complex, null, pair, list,
-vector, dict, uniform_vector, any (std::any cast)
+vector, dict, uniform_vector, any (boost::any cast)
 '''
 
 

--- a/gr-digital/include/gnuradio/digital/constellation.h
+++ b/gr-digital/include/gnuradio/digital/constellation.h
@@ -15,7 +15,7 @@
 #include <gnuradio/digital/metric_type.h>
 #include <gnuradio/gr_complex.h>
 #include <pmt/pmt.h>
-#include <any>
+#include <boost/any.hpp>
 #include <vector>
 
 namespace gr {
@@ -113,7 +113,7 @@ public:
 
     constellation_sptr base() { return shared_from_this(); }
 
-    pmt::pmt_t as_pmt() { return pmt::make_any(std::any(base())); }
+    pmt::pmt_t as_pmt() { return pmt::make_any(boost::any(base())); }
 
     /*! \brief Generates the soft decision LUT based on
      *         constellation and symbol map.

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -18,7 +18,9 @@
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <any>
+
+#include <boost/format.hpp>
+
 #include <stdexcept>
 
 namespace gr {
@@ -88,9 +90,9 @@ void constellation_receiver_cb_impl::handle_set_constellation(
     pmt::pmt_t constellation_pmt)
 {
     if (pmt::is_any(constellation_pmt)) {
-        std::any constellation_any = pmt::any_ref(constellation_pmt);
+        boost::any constellation_any = pmt::any_ref(constellation_pmt);
         constellation_sptr constellation =
-            std::any_cast<constellation_sptr>(constellation_any);
+            boost::any_cast<constellation_sptr>(constellation_any);
         set_constellation(constellation);
     } else {
         GR_LOG_ERROR(d_logger, "Received constellation that is not a PMT any; skipping.");

--- a/gr-digital/python/digital/bindings/constellation_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constellation.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(0dd35633df785034ea38ce7065495486)                     */
+/* BINDTOOL_HEADER_FILE_HASH(096509fbce3ab57c42e63e4c4c15c6f6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
This reverts commit ccd28dfbb1504fdc29db267acd8aa3354fe10cd2.

# Pull Request Details
Decision made to not include std::any with the 3.10 release as it forces OOTs to compile with c++17 via the changes to the public headers.  

## Description
We will defer the change to std::any as it prevents OOTs between 3.9 and 3.10 from being compatible without changing to c++17 - and there is not necessarily a good reason to enforce this

## Related Issue

## Which blocks/areas does this affect?
all OOTs

## Testing Done
Created a new OOT, left it at C++14 and compiled.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
