### PR TITLE
Addition of a throttle flag to the network blocks

### DIFF
--- a/gr-network/grc/network_tcp_sink.block.yml
+++ b/gr-network/grc/network_tcp_sink.block.yml
@@ -1,6 +1,7 @@
 id: network_tcp_sink
 label: TCP Sink
 category: '[Core]/Networking Tools'
+flags: [ throttle ]
 
 parameters:
 -   id: type

--- a/gr-network/grc/network_tcp_source.block.yml
+++ b/gr-network/grc/network_tcp_source.block.yml
@@ -1,6 +1,7 @@
 id: network_tcp_source
 label: TCP Source
 category: '[Core]/Networking Tools'
+flags: [ throttle ]
 
 parameters:
 -   id: type


### PR DESCRIPTION
Signed-off-by: Aditya Thomas <sepia_tone@protonmail.com>


# Pull Request Details

## Description
A throttle flag is added to the network blocks - TCP source and TCP sink. This prevents a warning about the lack of rate limiting.

## Related Issue
Fixes #5094 

## Which blocks/areas does this affect?
network

## Testing Done
Tested on Ubuntu 20.04

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
