### PR TITLE
gr-zeromq linger backport from master

### DIFF
--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -28,6 +28,10 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 
+namespace {
+constexpr int LINGER_DEFAULT = 1000; // 1 second.
+}
+
 namespace gr {
 namespace zeromq {
 
@@ -73,6 +77,9 @@ base_sink_impl::base_sink_impl(int type,
         d_socket->setsockopt(ZMQ_HWM, &tmp, sizeof(tmp));
 #endif
     }
+
+    /* Set ZMQ_LINGER so socket won't infinitely block during teardown */
+    d_socket.setsockopt(ZMQ_LINGER, &LINGER_DEFAULT, sizeof(LINGER_DEFAULT));
 
     /* Bind */
     d_socket->bind(address);
@@ -129,6 +136,9 @@ base_source_impl::base_source_impl(int type,
         d_socket->setsockopt(ZMQ_HWM, &tmp, sizeof(tmp));
 #endif
     }
+
+    /* Set ZMQ_LINGER so socket won't infinitely block during teardown */
+    d_socket.setsockopt(ZMQ_LINGER, &LINGER_DEFAULT, sizeof(LINGER_DEFAULT));
 
     /* Connect */
     d_socket->connect(address);


### PR DESCRIPTION
## backport linger from master; do not hang indefinitely on flowgraph exit
    
The following squashed commit was approved for public release by The Aerospace
Corporation on 2021-11-01. It is covered software release request #SW19-0024.
Commits made by the Communication Software Implementation Department.

## Description
This alllows ZMQ blocks to exit gracefully upon flowgraph close. We had a slightly different implementation in use for quite a while, but I saw that the `master` branch [already has this fix in place for GR3.9+](https://github.com/gnuradio/gnuradio/blob/e1ce5154560b9e850df4a3c9ba256c601661de31/gr-zeromq/lib/base_impl.cc#L79), so I just backported that implementation.

We have this change used in production, but I wasn't able to quickly add tests for this commit since it's not so easy to build GR3.7 on ubuntu20.04 even with pybombs 😕.

## Which blocks/areas does this affect?
`gr-zeromq`

## Testing Done
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have added tests to cover my changes, and all previous tests pass.
