### PR TITLE
extremely small output buffer sizes

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block_gateway.h
+++ b/gnuradio-runtime/include/gnuradio/block_gateway.h
@@ -150,6 +150,18 @@ public:
         return gr::block::set_min_output_buffer(size);
     }
 
+    long block__max_output_buffer(size_t i) {
+         return gr::block::max_output_buffer(i);
+    }
+
+    void block__set_max_output_buffer(long max_output_buffer) {
+        gr::block::set_max_output_buffer(max_output_buffer);
+    }
+
+    void block__set_max_output_buffer(int port, long max_output_buffer) {
+        gr::block::set_max_output_buffer(port, max_output_buffer);
+    }
+
     int block__output_multiple(void) const { return gr::block::output_multiple(); }
 
     void block__consume(int which_input, int how_many_items)

--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -162,6 +162,7 @@ private:
 protected:
     char* d_base;           // base address of buffer
     unsigned int d_bufsize; // in items
+    unsigned int d_orig_bufsize; // in items
 
     // Keep track of maximum sample delay of any reader; Only prune tags past this.
     unsigned d_max_reader_delay;

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -114,6 +114,7 @@ buffer::~buffer()
 bool buffer::allocate_buffer(int nitems, size_t sizeof_item)
 {
     int orig_nitems = nitems;
+    d_orig_bufsize = nitems;
 
     // Any buffersize we come up with must be a multiple of min_nitems.
     int granularity = gr::vmcircbuf_sysconfig::granularity();
@@ -171,7 +172,7 @@ int buffer::space_available()
 
         // The -1 ensures that the case d_write_index == d_read_index is
         // unambiguous.  It indicates that there is no data for the reader
-        return d_bufsize - most_data - 1;
+        return d_orig_bufsize - most_data - 1;
     }
 }
 

--- a/gnuradio-runtime/swig/block.i
+++ b/gnuradio-runtime/swig/block.i
@@ -64,6 +64,7 @@ class gr::block : public gr::basic_block
   bool is_set_max_noutput_items();
   void set_min_noutput_items(int m);
   int min_noutput_items() const;
+  void set_output_multiple(int multiple);
 
   // Methods to manage block's min/max buffer sizes.
   long max_output_buffer(int i);


### PR DESCRIPTION
## allow setting block output sizes from python; allow very small output buffers; fix resampler tag propagation

The following squashed commit was approved for public release by The Aerospace
Corporation on 2021-11-11. It is covered software release request #SW19-0024.
Commits made by the Digital Communications Implementation Department.

## Description
The patch fixes the following issues:
* set `max_output_block_size` and `output_multiple` from python
* allows set maximum output block size smaller than 4kB (for low latency applications)
* fixes tag propagation in the fractional resampler

Similar to #5318 we have this change used in production for quite a long time, but I wasn't able to quickly add tests for this commit since it's not so easy to build GR3.7 on ubuntu20.04 even with pybombs 😕. Ideally there should be some tests especially for the very small output buffer sizes.

I intend on submitting a separate PR to port these chanages forward to `master`.

## Which blocks/areas does this affect?
* `gnuradio-runtime`
* `gr-filter`

## Testing Done
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have added tests to cover my changes, and all previous tests pass.