### PR TITLE
filter: Minisule change to fix reconstruction.py example

### DIFF
--- a/gr-filter/examples/reconstruction.py
+++ b/gr-filter/examples/reconstruction.py
@@ -54,7 +54,7 @@ def main():
     rrc_taps = filter.firdes.root_raised_cosine(1, 2, 1, 0.35, 41)
 
     src = blocks.vector_source_b(data.astype(numpy.uint8).tolist(), False)
-    mod = digital.bpsk_mod(samples_per_symbol=2)
+    mod = digital.psk_mod(samples_per_symbol=2)
     chan = channels.channel_model(npwr)
     rrc = filter.fft_filter_ccc(1, rrc_taps)
 


### PR DESCRIPTION
# Pull Request Details

## Description
The reconstruction.py example in the filters module pointed at an old digital.bpsk_mod block which no longer exists. I just changed it to point at the current digital.psk_mod block.

## Related Issue
None

## Which blocks/areas does this affect?
Example in gr-filters

## Testing Done
I tested the corrected script and it now works.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
