### PR TITLE
qt-gui: enables use of Qwt 6.2 (backport to maint-3.8)

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/DisplayPlot.h
@@ -41,7 +41,10 @@
 #include <vector>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_compat.h>
+typedef QPointF QwtDoublePoint;
+typedef QRectF QwtDoubleRect;
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 typedef QList<QColor> QColorList;

--- a/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/TimeRasterDisplayPlot.h
@@ -35,7 +35,9 @@
 #if QWT_VERSION < 0x060000
 #include <gnuradio/qtgui/plot_waterfall.h>
 #else
-#include <qwt_compat.h>
+#include <qwt_interval.h>
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 /*!

--- a/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/WaterfallDisplayPlot.h
@@ -34,7 +34,9 @@
 #if QWT_VERSION < 0x060000
 #include <gnuradio/qtgui/plot_waterfall.h>
 #else
-#include <qwt_compat.h>
+#include <qwt_interval.h>
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 /*!

--- a/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_raster.h
@@ -28,8 +28,10 @@
 #include <qwt_plot_rasteritem.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_compat.h>
-#include <qwt_point_3d.h> // doesn't seem necessary, but is...
+#include <qsize.h>
+#include <qwt_interval.h>
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 class QwtColorMap;

--- a/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
+++ b/gr-qtgui/include/gnuradio/qtgui/plot_waterfall.h
@@ -28,8 +28,10 @@
 #include <qwt_plot_rasteritem.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_compat.h>
-#include <qwt_point_3d.h> // doesn't seem necessary, but is...
+#include <qsize.h>
+#include <qwt_interval.h>
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 class QwtColorMap;

--- a/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
+++ b/gr-qtgui/include/gnuradio/qtgui/qtgui_types.h
@@ -26,6 +26,7 @@
 #include <gnuradio/high_res_timer.h>
 #include <qwt_color_map.h>
 #include <qwt_scale_draw.h>
+#include <qwt_text.h>
 
 namespace gr {
 namespace qtgui {

--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -27,8 +27,9 @@
 #include <qwt_raster_data.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_compat.h>
-#include <qwt_point_3d.h> // doesn't seem necessary, but is...
+#include <qwt_interval.h>
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 class TimeRasterData : public QwtRasterData
@@ -47,6 +48,9 @@ public:
 #if QWT_VERSION < 0x060000
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
+#elif QWT_VERSION >= 0x060200
+    virtual QwtInterval interval(Qt::Axis) const;
+    void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 
     virtual double value(double x, double y) const;
@@ -68,6 +72,10 @@ protected:
     QwtDoubleInterval d_intensityRange;
 #else
     QwtInterval d_intensityRange;
+#endif
+
+#if QWT_VERSION >= 0x060200
+    QwtInterval d_intervals[3];
 #endif
 
 private:

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -27,8 +27,9 @@
 #include <qwt_raster_data.h>
 
 #if QWT_VERSION >= 0x060000
-#include <qwt_compat.h>
-#include <qwt_point_3d.h> // doesn't seem necessary, but is...
+#include <qwt_interval.h>
+
+typedef QwtInterval QwtDoubleInterval;
 #endif
 
 class WaterfallData : public QwtRasterData
@@ -48,6 +49,9 @@ public:
 #if QWT_VERSION < 0x060000
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
+#elif QWT_VERSION >= 0x060200
+    virtual QwtInterval interval(Qt::Axis) const;
+    void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 
     virtual double value(double x, double y) const;
@@ -72,6 +76,10 @@ protected:
     QwtDoubleInterval _intensityRange;
 #else
     QwtInterval _intensityRange;
+#endif
+
+#if QWT_VERSION >= 0x060200
+    QwtInterval d_intervals[3];
 #endif
 
 private:

--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
+++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
@@ -28,6 +28,7 @@
 #include <qwt_legend.h>
 #include <qwt_scale_draw.h>
 #include <QColor>
+#include <cmath>
 #include <iostream>
 
 class ConstellationDisplayZoomer : public QwtPlotZoomer

--- a/gr-qtgui/lib/plot_raster.cc
+++ b/gr-qtgui/lib/plot_raster.cc
@@ -257,7 +257,11 @@ QImage PlotTimeRaster::renderImage(const QwtScaleMap& xMap,
         }
         d_data->data->incrementResidual();
     } else if (d_data->colorMap->format() == QwtColorMap::Indexed) {
+#if QWT_VERSION >= 0x060200
+        image.setColorTable(d_data->colorMap->colorTable(256));
+#else
         image.setColorTable(d_data->colorMap->colorTable(intensityRange));
+#endif
 
         for (int y = rect.top(); y <= rect.bottom(); y++) {
             const double ty = yyMap.invTransform(y);
@@ -266,8 +270,13 @@ QImage PlotTimeRaster::renderImage(const QwtScaleMap& xMap,
             for (int x = rect.left(); x <= rect.right(); x++) {
                 const double tx = xxMap.invTransform(x);
 
+#if QWT_VERSION >= 0x060200
+                *line++ = d_data->colorMap->colorIndex(
+                    256, intensityRange, d_data->data->value(tx, ty));
+#else
                 *line++ = d_data->colorMap->colorIndex(intensityRange,
                                                        d_data->data->value(tx, ty));
+#endif
             }
         }
     }

--- a/gr-qtgui/lib/plot_waterfall.cc
+++ b/gr-qtgui/lib/plot_waterfall.cc
@@ -252,7 +252,11 @@ QImage PlotWaterfall::renderImage(const QwtScaleMap& xMap,
             }
         }
     } else if (d_data->colorMap->format() == QwtColorMap::Indexed) {
+#if QWT_VERSION >= 0x060200
+        image.setColorTable(d_data->colorMap->colorTable(256));
+#else
         image.setColorTable(d_data->colorMap->colorTable(intensityRange));
+#endif
 
         for (int y = rect.top(); y <= rect.bottom(); y++) {
             const double ty = yyMap.invTransform(y);
@@ -261,8 +265,13 @@ QImage PlotWaterfall::renderImage(const QwtScaleMap& xMap,
             for (int x = rect.left(); x <= rect.right(); x++) {
                 const double tx = xxMap.invTransform(x);
 
+#if QWT_VERSION >= 0x060200
+                *line++ = d_data->colorMap->colorIndex(
+                    256, intensityRange, d_data->data->value(tx, ty));
+#else
                 *line++ = d_data->colorMap->colorIndex(intensityRange,
                                                        d_data->data->value(tx, ty));
+#endif
             }
         }
     }

--- a/gr-qtgui/lib/timeRasterGlobalData.cc
+++ b/gr-qtgui/lib/timeRasterGlobalData.cc
@@ -155,6 +155,13 @@ void TimeRasterData::setRange(const QwtDoubleInterval& newRange)
 {
     d_intensityRange = newRange;
 }
+#elif QWT_VERSION >= 0x060200
+void TimeRasterData::setInterval(Qt::Axis axis, const QwtInterval& interval)
+{
+    d_intervals[axis] = interval;
+}
+
+QwtInterval TimeRasterData::interval(Qt::Axis a) const { return d_intervals[a]; }
 
 #endif
 

--- a/gr-qtgui/lib/waterfallGlobalData.cc
+++ b/gr-qtgui/lib/waterfallGlobalData.cc
@@ -158,7 +158,13 @@ void WaterfallData::setRange(const QwtDoubleInterval& newRange)
 {
     _intensityRange = newRange;
 }
+#elif QWT_VERSION >= 0x060200
+void WaterfallData::setInterval(Qt::Axis axis, const QwtInterval& interval)
+{
+    d_intervals[axis] = interval;
+}
 
+QwtInterval WaterfallData::interval(Qt::Axis a) const { return d_intervals[a]; }
 #endif
 
 


### PR DESCRIPTION
Adds the typedefs and includes needed to build with Qwt 6.2.

Signed-off-by: Bill Muzika <bill.muzika@outlook.com>
(cherry picked from commit 14d30f134cd402a35f46911342eb4d519e2ad7aa)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5302