### PR TITLE
cmake: handle optional components in `find_package` (backport to maint-3.9)

### DIFF
--- a/cmake/Modules/GnuradioConfig.cmake.in
+++ b/cmake/Modules/GnuradioConfig.cmake.in
@@ -96,7 +96,11 @@ set(GR_COMPONENTS
   )
 
 foreach(target ${GR_COMPONENTS})
-  if (${target} IN_LIST Gnuradio_FIND_COMPONENTS)
-    include("${CMAKE_CURRENT_LIST_DIR}/gnuradio-${target}Config.cmake")
+  set(GR_COMPONENT_INCLUDE_FILE
+      "${CMAKE_CURRENT_LIST_DIR}/gnuradio-${target}Config.cmake")
+  if(${target} IN_LIST Gnuradio_FIND_COMPONENTS
+     AND (EXISTS ${GR_COMPONENT_INCLUDE_FILE}
+          OR "${Gnuradio_FIND_REQUIRED_${target}}"))
+    include(${GR_COMPONENT_INCLUDE_FILE})
   endif()
 endforeach(target)


### PR DESCRIPTION
Signed-off-by: Christoph Koehler <christoph@zerodeviation.net>
(cherry picked from commit f9a693d7af02b6ce88fb0e4f3fad78390980c968)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5310