### PR TITLE
modtool,cmake: make module dir for tests (backport to maint-3.9)

### DIFF
--- a/cmake/Modules/GrTest.cmake
+++ b/cmake/Modules/GrTest.cmake
@@ -61,6 +61,10 @@ function(GR_ADD_TEST test_name)
     # Keep the original path conversion for pypath - the above commented line breaks CI tests
     file(TO_NATIVE_PATH "${GR_TEST_PYTHON_DIRS}" pypath) #ok to use on dir list?
 
+    # add test module directory to PYTHONPATH to allow CTest to find QA test modules.
+    # We add it to the beginning of the list to use locally-built modules before installed ones.
+    list(INSERT pypath 0 "${CMAKE_BINARY_DIR}/test_modules")
+
     set(environs "VOLK_GENERIC=1" "GR_DONT_LOAD_PREFS=1" "srcdir=${srcdir}"
         "GR_CONF_CONTROLPORT_ON=False")
     list(APPEND environs ${GR_TEST_ENVIRONS})

--- a/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
@@ -31,3 +31,14 @@ GR_PYTHON_INSTALL(
 include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-howto)
+
+# Create a module directory that tests can import. It includes everything
+# from `python/` and the built bindings shared lib.
+add_custom_target(
+  copy_module_for_tests ALL
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}
+          ${CMAKE_BINARY_DIR}/test_modules/howto/
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/bindings/
+    ${CMAKE_BINARY_DIR}/test_modules/howto/
+  DEPENDS howto_python)


### PR DESCRIPTION
Creates a python module in the build tree for tests to import.

Addresses #3999 and #4825

Signed-off-by: Christoph Koehler <christoph@zerodeviation.net>
(cherry picked from commit c7390f29c7047ed00df3831e83998ccf3a72a8bb)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5279