### PR TITLE
gr-filter: Corrects reconstruction filter bank example to point at existing psk block (backport to maint-3.9)

### DIFF
--- a/gr-filter/examples/reconstruction.py
+++ b/gr-filter/examples/reconstruction.py
@@ -54,7 +54,7 @@ def main():
     rrc_taps = filter.firdes.root_raised_cosine(1, 2, 1, 0.35, 41)
 
     src = blocks.vector_source_b(data.astype(numpy.uint8).tolist(), False)
-    mod = digital.bpsk_mod(samples_per_symbol=2)
+    mod = digital.psk_mod(samples_per_symbol=2)
     chan = channels.channel_model(npwr)
     rrc = filter.fft_filter_ccc(1, rrc_taps)
 


### PR DESCRIPTION
Signed-off-by: Nicholas Bruce <saltair93+github@gmail.com>
(cherry picked from commit ed7f128355770a1b82673b42919617ca260693e2)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5321