### PR TITLE
modtool,cmake: fix python-only QA, clean up build directory

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
@@ -32,13 +32,10 @@ include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-howto)
 
-# Create a module directory that tests can import. It includes everything
-# from `python/` and the built bindings shared lib.
+# Create a package directory that tests can import. It includes everything
+# from `python/`.
 add_custom_target(
   copy_module_for_tests ALL
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}
           ${CMAKE_BINARY_DIR}/test_modules/howto/
-  COMMAND
-    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/bindings/
-    ${CMAKE_BINARY_DIR}/test_modules/howto/
-  DEPENDS howto_python)
+)

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/CMakeLists.txt
@@ -36,4 +36,12 @@ GR_PYBIND_MAKE_OOT(howto
    gr::howto
    "${howto_python_files}")
 
+# copy in bindings .so file for use in QA test module
+add_custom_target(
+  copy_bindings_for_tests ALL
+  COMMAND
+    ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
+    ${CMAKE_BINARY_DIR}/test_modules/howto/
+  DEPENDS howto_python)
+
 install(TARGETS howto_python DESTINATION ${GR_PYTHON_DIR}/howto COMPONENT pythonapi)


### PR DESCRIPTION
Signed-off-by: shwhiti <shwhiti@sandia.gov>

# Pull Request Details
This pull request allows a python-only module to build without error. All new OOT modules built with gr_modtool currently
will fail in the `make` step.

The `python/CmakeLists.txt` file is now only in charge of copying python source files into `build/test-module/module-name/` where previously it copied in anything in the `python` source directory as well as the pybind `.so` file from the `/build/python/bindings/` directory.

The `bindings/CmakeLists.txt` file is now in charge of copying the `build/python/bindings/` `.so` file into the test module directory. This is only done when there is `c++` code to be added to the module.

These changes make the python package in `build` match more closely to what is actually installed by not copying over things like header files.

## Related Issue
Fixes #5334
related to #3999 and #4825

## Which blocks/areas does this affect?
CMake generated by gr_modtool

## Testing Done
Made a new OOT module with gr_modtool, added a single python block, it built and passed test. Added a c++ block, and the module still builds and passes test.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.

Will request access to update wiki page for porting modules to 3.9...