### PR TITLE
modtool,cmake: fix python-only QA, bindings copy handled in bindings cmake file (backport to maint-3.9)

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/CMakeLists.txt
@@ -32,13 +32,10 @@ include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-howto)
 
-# Create a module directory that tests can import. It includes everything
-# from `python/` and the built bindings shared lib.
+# Create a package directory that tests can import. It includes everything
+# from `python/`.
 add_custom_target(
   copy_module_for_tests ALL
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}
           ${CMAKE_BINARY_DIR}/test_modules/howto/
-  COMMAND
-    ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/bindings/
-    ${CMAKE_BINARY_DIR}/test_modules/howto/
-  DEPENDS howto_python)
+)

--- a/gr-utils/modtool/templates/gr-newmod/python/bindings/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/bindings/CMakeLists.txt
@@ -36,4 +36,12 @@ GR_PYBIND_MAKE_OOT(howto
    gr::howto
    "${howto_python_files}")
 
+# copy in bindings .so file for use in QA test module
+add_custom_target(
+  copy_bindings_for_tests ALL
+  COMMAND
+    ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
+    ${CMAKE_BINARY_DIR}/test_modules/howto/
+  DEPENDS howto_python)
+
 install(TARGETS howto_python DESTINATION ${GR_PYTHON_DIR}/howto COMPONENT pythonapi)


### PR DESCRIPTION
Signed-off-by: shwhiti <shwhiti@sandia.gov>
(cherry picked from commit d4df6a14db8864eb123de8d9b18865210540e904)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5335