### PR TITLE
runtime: change name of level_enum in py binding

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -30,7 +30,7 @@ namespace py = pybind11;
 
 void bind_logger(py::module& m)
 {
-    py::enum_<spdlog::level::level_enum>(m, "level_enum")
+    py::enum_<spdlog::level::level_enum>(m, "log_levels")
         // Values directly from spdlog/common.h
         .value("trace", spdlog::level::trace)
         .value("debug", spdlog::level::debug)


### PR DESCRIPTION
# Pull Request Details
changes the python binding of the logging levels (warn, trace, debug, etc.) from `gr.level_enum` to `gr.log_levels`


- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
