### PR TITLE
runtime: Fix two alloc dealloc mismatch errors

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
@@ -120,7 +120,7 @@ protected:
 
     block_sptr d_buf_owner; // block that "owns" this buffer
 
-    std::unique_ptr<char> d_buffer;
+    std::unique_ptr<char[]> d_buffer;
 
     /*!
      * \brief constructor is private.  Use gr_make_buffer to create instances.

--- a/gnuradio-runtime/include/gnuradio/host_buffer.h
+++ b/gnuradio-runtime/include/gnuradio/host_buffer.h
@@ -95,7 +95,7 @@ public:
 
 private:
     // This is the simulated device buffer
-    std::unique_ptr<char> d_device_buf;
+    std::unique_ptr<char[]> d_device_buf;
     char* d_device_base;
 
     /*!


### PR DESCRIPTION
# Pull Request Details
Fix two alloc dealoc mismatch errors

## Description
In `host_buffer::do_allocate_buffer(...) the memory for `d_buffer` and `d_device_buf` is allocated using `new char[]` but it is de-allocated using  `delete` as both members are defined as `std::unique_ptr<char>`. Mixing `new[]` with `delete` is considered UB.

To reproduce the error compile with `-fsanitize=address -fsanitize=undefined` and execute `ctest -R runtime_qa_host_buffer.cc --output-on-failure`

```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x631000014800
    #0 0x7ffbdc10f9d7 in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xad9d7)
    #1 0x7ffbd8a6646f in std::default_delete<char>::operator()(char*) const /usr/include/c++/10/bits/unique_ptr.h:85
    #2 0x7ffbd8a6646f in std::unique_ptr<char, std::default_delete<char> >::~unique_ptr() /usr/include/c++/10/bits/unique_ptr.h:361
    #3 0x7ffbd8a6646f in gr::buffer_single_mapped::~buffer_single_mapped() /home/user/src/gnuradio/gnuradio-runtime/lib/buffer_single_mapped.cc:46
    #4 0x7ffbd8c805c4 in gr::host_buffer::~host_buffer() /home/user/src/gnuradio/gnuradio-runtime/lib/host_buffer.cc:65

0x631000014800 is located 0 bytes inside of 65536-byte region [0x631000014800,0x631000024800)
allocated by thread T0 here:
    #0 0x7ffbdc10ecb7 in operator new[](unsigned long) (/lib64/libasan.so.6+0xaccb7)
    #1 0x7ffbd8c73a60 in gr::host_buffer::do_allocate_buffer(unsigned long, unsigned long) /home/user/src/gnuradio/gnuradio-runtime/lib/host_buffer.cc:119
    #2 0x7ffbd8fdaebf  (/home/user/src/gnuradio/build/gnuradio-runtime/lib/libgnuradio-runtime.so.3.10.0git+0x3475ebf)
```
```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x631000028800
    #0 0x7f87c88129d7 in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xad9d7)
    #1 0x7f87c5378c57 in std::default_delete<char>::operator()(char*) const /usr/include/c++/10/bits/unique_ptr.h:85
    #2 0x7f87c5378c57 in std::unique_ptr<char, std::default_delete<char> >::~unique_ptr() /usr/include/c++/10/bits/unique_ptr.h:361
    #3 0x7f87c5378c57 in gr::host_buffer::~host_buffer() /home/user/src/gnuradio/gnuradio-runtime/lib/host_buffer.cc:65
    #4 0x7f87c5384654 in gr::host_buffer::~host_buffer() /home/user/src/gnuradio/gnuradio-runtime/lib/host_buffer.cc:65

0x631000028800 is located 0 bytes inside of 65536-byte region [0x631000028800,0x631000038800)
allocated by thread T0 here:
    #0 0x7f87c8811cb7 in operator new[](unsigned long) (/lib64/libasan.so.6+0xaccb7)
    #1 0x7f87c5377a7a in gr::host_buffer::do_allocate_buffer(unsigned long, unsigned long) /home/user/src/gnuradio/gnuradio-runtime/lib/host_buffer.cc:123
    #2 0x7f87c56deebf  (/home/user/src/gnuradio/build/gnuradio-runtime/lib/libgnuradio-runtime.so.3.10.0git+0x3475ebf)
```


## Related Issue
None

## Which blocks/areas does this affect?

## Testing Done
`make test`

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
