### PR TITLE
runtime: make IN_BLKD kick timer configurable

### DIFF
--- a/gnuradio-runtime/gnuradio-runtime.conf.in
+++ b/gnuradio-runtime/gnuradio-runtime.conf.in
@@ -12,6 +12,10 @@ max_messages = 8192
 # Block output buffer size in bytes.
 #buffer_size = 32768
 
+# The time to wait before continuing the block thread when input
+# is blocked
+input_blocked_retry_time_ms = 250
+
 [LOG]
 # Levels can be (case insensitive):
 #       DEBUG, INFO, WARN, TRACE, ERROR, ALERT, CRIT, FATAL, EMERG

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -48,6 +48,8 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
 
     prefs* p = prefs::singleton();
     size_t max_nmsgs = static_cast<size_t>(p->get_long("DEFAULT", "max_messages", 100));
+    unsigned int input_blocked_retry_time_ms =
+        static_cast<int>(p->get_long("DEFAULT", "input_blocked_retry_time_ms", 250));
 
     // Set up logging
     auto logger = gr::logger("tpb_thread_body");
@@ -132,7 +134,8 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
 
             if (!d->d_tpb.input_changed) {
                 boost::system_time const timeout =
-                    boost::get_system_time() + boost::posix_time::milliseconds(250);
+                    boost::get_system_time() +
+                    boost::posix_time::milliseconds(input_blocked_retry_time_ms);
                 d->d_tpb.input_cond.timed_wait(guard, timeout);
             }
         } break;


### PR DESCRIPTION
# Pull Request Details
## Description
The fixed setting in the scheduler of 250ms when the input is blocked to retry running the thread is arbitrary and in some blocks with blocking implementations, this timeout can be troublesome and give some weird interaction with the scheduler and the block getting samples from hardware.  For these scenarios, make the value configurable so the user can set what this timeout should be.

## Which blocks/areas does this affect?
Mainly blocks that poll for samples to be ready from some other source.  If the block returns immediately hoping the scheduler will call the work function again, that 250ms timeout could cause problems.

## Testing Done
Ran flowgraphs with UHD blocks

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
