### PR TITLE
qa: update tests to work with OpenEmbedded (backport to maint-3.9)

### DIFF
--- a/gr-blocks/python/blocks/__init__.py
+++ b/gr-blocks/python/blocks/__init__.py
@@ -26,6 +26,7 @@ from .msg_meta_to_pair import meta_to_pair
 from .msg_pair_to_var import msg_pair_to_var
 from .var_to_msg import var_to_msg_pair
 from .matrix_interleaver import *
+from .parse_file_metadata import parse_header, parse_extra_dict
 
 #alias old add_vXX and multiply_vXX
 add_vcc = add_cc

--- a/gr-blocks/python/blocks/qa_file_metadata.py
+++ b/gr-blocks/python/blocks/qa_file_metadata.py
@@ -15,8 +15,6 @@ import math
 from gnuradio import gr, gr_unittest, blocks
 import pmt
 
-import parse_file_metadata
-
 
 def sig_source_c(samp_rate, freq, amp, N):
     t = [float(x) / samp_rate for x in range(N)]
@@ -58,7 +56,7 @@ class test_file_metadata(gr_unittest.TestCase):
         fsnk.close()
 
         handle = open(outfile, "rb")
-        header_str = handle.read(parse_file_metadata.HEADER_LENGTH)
+        header_str = handle.read(blocks.parse_file_metadata.HEADER_LENGTH)
         if(len(header_str) == 0):
             self.assertFalse()
 
@@ -67,7 +65,7 @@ class test_file_metadata(gr_unittest.TestCase):
         except RuntimeError:
             self.assertFalse()
 
-        info = parse_file_metadata.parse_header(header, False)
+        info = blocks.parse_header(header, False)
 
         extra_str = handle.read(info["extra_len"])
         self.assertEqual(len(extra_str) > 0, True)
@@ -79,7 +77,7 @@ class test_file_metadata(gr_unittest.TestCase):
         except RuntimeError:
             self.assertFalse()
 
-        extra_info = parse_file_metadata.parse_extra_dict(extra, info, False)
+        extra_info = blocks.parse_extra_dict(extra, info, False)
 
         self.assertEqual(info['rx_rate'], samp_rate)
         self.assertEqual(pmt.to_double(extra_info['samp_rate']), samp_rate)
@@ -137,7 +135,7 @@ class test_file_metadata(gr_unittest.TestCase):
 
         # Open detached header for reading
         handle = open(outfile_hdr, "rb")
-        header_str = handle.read(parse_file_metadata.HEADER_LENGTH)
+        header_str = handle.read(blocks.parse_file_metadata.HEADER_LENGTH)
         if(len(header_str) == 0):
             self.assertFalse()
 
@@ -146,7 +144,7 @@ class test_file_metadata(gr_unittest.TestCase):
         except RuntimeError:
             self.assertFalse()
 
-        info = parse_file_metadata.parse_header(header, False)
+        info = blocks.parse_header(header, False)
 
         extra_str = handle.read(info["extra_len"])
 
@@ -159,7 +157,7 @@ class test_file_metadata(gr_unittest.TestCase):
         except RuntimeError:
             self.assertFalse()
 
-        extra_info = parse_file_metadata.parse_extra_dict(extra, info, False)
+        extra_info = blocks.parse_extra_dict(extra, info, False)
 
         self.assertEqual(info['rx_rate'], samp_rate)
         self.assertEqual(pmt.to_double(extra_info['samp_rate']), samp_rate)

--- a/gr-blocks/python/blocks/qa_matrix_interleaver.py
+++ b/gr-blocks/python/blocks/qa_matrix_interleaver.py
@@ -10,7 +10,6 @@
 
 from gnuradio import gr, gr_unittest
 from gnuradio import blocks
-from matrix_interleaver import matrix_interleaver
 
 class qa_matrix_interleaver(gr_unittest.TestCase):
 
@@ -29,7 +28,7 @@ class qa_matrix_interleaver(gr_unittest.TestCase):
         expected = cols * list(range(rows))
 
         src = blocks.vector_source_f(vec, False)
-        itlv = matrix_interleaver(gr.sizeof_float, rows=rows, cols=cols)
+        itlv = blocks.matrix_interleaver(gr.sizeof_float, rows=rows, cols=cols)
         snk = blocks.vector_sink_f()
 
         tb.connect(src, itlv, snk)
@@ -48,7 +47,8 @@ class qa_matrix_interleaver(gr_unittest.TestCase):
         expected = rows * list(range(cols))
 
         src = blocks.vector_source_f(vec, False)
-        itlv = matrix_interleaver(gr.sizeof_float, rows=rows, cols=cols, deint=True)
+        itlv = blocks.matrix_interleaver(
+            gr.sizeof_float, rows=rows, cols=cols, deint=True)
         snk = blocks.vector_sink_f()
 
         tb.connect(src, itlv, snk)

--- a/gr-blocks/python/blocks/qa_nlog10.py
+++ b/gr-blocks/python/blocks/qa_nlog10.py
@@ -29,7 +29,7 @@ class test_nlog10(gr_unittest.TestCase):
         self.tb.connect(src, op, dst)
         self.tb.run()
         result_data = dst.data()
-        self.assertFloatTuplesAlmostEqual(expected_result, result_data, 5)
+        self.assertFloatTuplesAlmostEqual(expected_result, result_data, 4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* qa_nlog10.py: Update test to check for equal with one less decimal place.

On the qemu machines built with OpenEmbedded, this test failed if
the check was 5 decimal places. Relaxing to 4 lets the test pass.
The volk routines used in the implementation pass QA already.

Signed-off-by: Philip Balister <philip@balister.org>

* Update QA tests to import helper routines from blocks.

The file metadata QA installs a file in blocks, but imported it
directly. Updated init.py to import via blocks. matrix interleaver
imported some routines from a py file that was available via blocks.

These cretaed issues when you install the qa tests in images to run
them outside the build area.

Signed-off-by: Philip Balister <philip@balister.org>

* python formatting

Signed-off-by: Josh Morman <jmorman@gnuradio.org>

Co-authored-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 76cdd1ce10c20d9b67801b23874257aff9616535)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/4974