### PR TITLE
Modtool bind with spdlog complication

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -17,6 +17,17 @@
  * \brief GNU Radio logging wrapper
  *
  */
+#ifdef DISABLE_LOGGER_H
+// pygccxml as of v2.2.1 has a difficult time parsing headers that
+// include spdlog or format
+// Since it only needs the top level header info, this is a hack to not
+// transitively include anything logger related when parsing the
+// headers
+#include <memory>
+namespace gr {
+using logger_ptr = std::shared_ptr<void>;
+}
+#else
 
 // Since this file is included in *all* gr::blocks, please make sure this list of includes
 // keeps as short as possible; if anything is needed only by the implementation in
@@ -276,5 +287,7 @@ struct fmt::formatter<boost::format> : formatter<string_view> {
         return formatter<string_view>::format(bfmt.str(), ctx);
     }
 };
+
+#endif
 
 #endif /* INCLUDED_GR_LOGGER_H */

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(7f3cbb9463e52829b27c58d9dd41b422)                     */
+/* BINDTOOL_HEADER_FILE_HASH(1b018cc2df46366b8b83a4fe08db2806)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -53,7 +53,7 @@ class GenericHeaderParser(BlockTool):
         BlockTool.__init__(self, **kwargs)
         self.parsed_data = {}
         self.addcomments = blocktool_comments
-        self.define_symbols = ('BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC',)
+        self.define_symbols = ('BOOST_ATOMIC_DETAIL_EXTRA_BACKEND_GENERIC', 'DISABLE_LOGGER_H')
         if(define_symbols):
             self.define_symbols += define_symbols
         self.include_paths = None


### PR DESCRIPTION

## Description
after the changes introduced in logger.h, pygccxml does not play well with the spdlog
headers which are implicitly included in every block.  This caused `gr_modtool bind`
to crash 

## Related Issue
Fixes #5364 

## Which blocks/areas does this affect?
Any OOT using gr_modtool bind

## Testing Done
Created a new OOT with a few blocks and then ran `gr_modtool bind`

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- N/A I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
