### PR TITLE
fix typo in band reject taps variable block set_taps() (maint-3.8)

### DIFF
--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -40,7 +40,7 @@ templates:
         self.${id} = ${id} = firdes.band_reject(${gain}, ${samp_rate}, ${low_cutoff_freq},\
         ${high_cutoff_freq}, ${width}, ${win}, ${beta})
     callbacks:
-    - self.set_${id}(firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq}, ${width}, ${win}, ${beta}))
+    - self.set_${id}(firdes.band_reject(${gain}, ${samp_rate}, ${low_cutoff_freq}, ${high_cutoff_freq}, ${width}, ${win}, ${beta}))
 
 cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
GRC YML filter for band reject filter variable contained a typo in the set_taps() callback. Resulting generated code cause did not run.

Callback was added in b405ca8, but using the logic for the band pass taps block which has multiple types. Band reject only supports float.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5368

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Band-reject Filter Taps

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
