### PR TITLE
gnuradio: replace deprecated distutils

### DIFF
--- a/.packaging/conda_recipe/meta.yaml
+++ b/.packaging/conda_recipe/meta.yaml
@@ -64,6 +64,7 @@ requirements:
     - mako
     - mpir  # [win]
     - numpy
+    - packaging
     - pip  # [win]
     - pybind11
     - pybind11-abi
@@ -107,6 +108,7 @@ requirements:
     - mako
     - menuinst  # [win]
     - numpy
+    - packaging
     - {{ pin_compatible('portaudio') }}
     - pygobject
     - pyqt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,20 @@ add_custom_target(uninstall
 # Enable python component
 ########################################################################
 include(GrPython)
+GR_PYTHON_CHECK_MODULE_RAW(
+    "packaging"
+    "import packaging"
+    PACKAGING_FOUND
+)
+if(NOT PACKAGING_FOUND)
+    message(STATUS "")
+    message(STATUS "***************************** WARNING!!! *******")
+    message(STATUS "The python package packaging is missing")
+    message(STATUS "So some checks will fail")
+    message(STATUS "Please install python3-packaging")
+    message(STATUS "or run pip3 install packaging")
+    message(STATUS "************************************************")
+endif()
 GR_PYTHON_CHECK_MODULE(
     "numpy"
     numpy
@@ -258,6 +272,7 @@ ENDIF()
 include(GrComponent)
 GR_REGISTER_COMPONENT("python-support" ENABLE_PYTHON
     PYTHONLIBS_FOUND
+    PACKAGING_FOUND
     pybind11_FOUND
     NUMPY_FOUND
 )

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -127,7 +127,7 @@ macro(GR_PYTHON_CHECK_MODULE desc mod cmd have)
     GR_PYTHON_CHECK_MODULE_RAW(
         "${desc}" "
 #########################################
-from distutils.version import LooseVersion
+from packaging.version import Version as LooseVersion
 try:
     import ${mod}
     assert ${cmd}
@@ -145,19 +145,22 @@ endmacro(GR_PYTHON_CHECK_MODULE)
 if(NOT DEFINED GR_PYTHON_DIR)
 execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c "import os
+import sysconfig
 import site
-from distutils.sysconfig import get_python_lib
 
+install_dir = None
 prefix = '${CMAKE_INSTALL_PREFIX}'
-
-#ask distutils where to install the python module
-install_dir = get_python_lib(plat_specific=True, prefix=prefix)
 
 #use sites when the prefix is already recognized
 try:
   paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
   if len(paths) == 1: install_dir = paths[0]
 except AttributeError: pass
+
+if not install_dir:
+    #find where to install the python module
+    install_dir = sysconfig.get_path('platlib')
+    prefix = sysconfig.get_config_var('prefix')
 
 #strip the prefix to return a relative path
 print(os.path.relpath(install_dir, prefix))"

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -22,7 +22,7 @@
 ##################################################
 
 % if generate_options == 'qt_gui':
-from distutils.version import StrictVersion
+from packaging.version import Version as StrictVersion
 
 if __name__ == '__main__':
     import ctypes

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -7,7 +7,7 @@
 
 import sys
 import textwrap
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 
 from gi.repository import Gtk, GLib, Gdk
 

--- a/grc/gui/Executor.py
+++ b/grc/gui/Executor.py
@@ -11,7 +11,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 
 from gi.repository import GLib
 

--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 import ast
 import functools
 import random
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 from itertools import count
 
 from gi.repository import GLib, Gtk

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -31,7 +31,7 @@ from subprocess import check_output, CalledProcessError
 import sys
 import threading
 import time
-from distutils import spawn
+import shutil
 from argparse import ArgumentParser
 from multiprocessing import cpu_count
 
@@ -100,7 +100,7 @@ class ClangFormat(object):
                     programs[i] += '.exe'
 
             for program in programs:
-                self.path = spawn.find_executable(program)
+                self.path = shutil.which(program)
 
                 if self.path:
                     if not self._validate_version():


### PR DESCRIPTION
Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
---

# Pull Request Details
With the upcoming python 3.10 ( for example in fedora 35 ) the package distutils is marked as depreciated and will be removed in 3.12.

## Description
Python provides replacements for the distutils functions.
Only distutils.sysconfig.get_python_lib() has no direct counterpart,.

## Which blocks/areas does this affect?
grc, grc generated flowgraphs

## Testing Done
Building gnuradio from scratch on fedora 33 and 35 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
