### PR TITLE
network: fix segfaults when TCP & UDP blocks are restarted

### DIFF
--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -50,19 +50,22 @@ tcp_sink_impl::tcp_sink_impl(
       d_initial_connection(true)
 {
     d_block_size = d_itemsize * d_veclen;
+}
 
+bool tcp_sink_impl::start()
+{
     if (d_sinkmode == TCPSINKMODE_CLIENT) {
         // In this mode, we're connecting to a remote TCP service listener
         // as a client.
         std::stringstream msg;
 
-        msg << "[TCP Sink] connecting to " << host << " on port " << port;
+        msg << "[TCP Sink] connecting to " << d_host << " on port " << d_port;
         GR_LOG_INFO(d_logger, msg.str());
 
         boost::system::error_code err;
         d_tcpsocket = new boost::asio::ip::tcp::socket(d_io_service);
 
-        std::string s_port = (boost::format("%d") % port).str();
+        std::string s_port = (boost::format("%d") % d_port).str();
         boost::asio::ip::tcp::resolver resolver(d_io_service);
         boost::asio::ip::tcp::resolver::query query(
             d_host, s_port, boost::asio::ip::resolver_query_base::passive);
@@ -101,6 +104,8 @@ tcp_sink_impl::tcp_sink_impl(
         d_start_new_listener = true;
         d_listener_thread = new boost::thread([this] { run_listener(); });
     }
+
+    return true;
 }
 
 void tcp_sink_impl::run_listener()

--- a/gr-network/lib/tcp_sink_impl.h
+++ b/gr-network/lib/tcp_sink_impl.h
@@ -57,6 +57,7 @@ public:
                   int sinkmode = TCPSINKMODE_CLIENT);
     ~tcp_sink_impl() override;
 
+    bool start() override;
     bool stop() override;
 
     void accept_handler(boost::asio::ip::tcp::socket* new_connection,

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -24,6 +24,7 @@ namespace network {
 class NETWORK_API udp_sink_impl : public udp_sink
 {
 protected:
+    std::string d_host;
     int d_port;
     size_t d_itemsize;
     size_t d_veclen;
@@ -67,6 +68,7 @@ public:
                   bool send_eof = true);
     ~udp_sink_impl() override;
 
+    bool start() override;
     bool stop() override;
 
     int work(int noutput_items,

--- a/gr-network/lib/udp_source_impl.h
+++ b/gr-network/lib/udp_source_impl.h
@@ -69,6 +69,7 @@ public:
                     bool ipv6);
     ~udp_source_impl() override;
 
+    bool start() override;
     bool stop() override;
 
     size_t data_available();

--- a/gr-network/python/network/qa_tcp_sink.py
+++ b/gr-network/python/network/qa_tcp_sink.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# Copyright 2021 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gnuradio import gr, gr_unittest, blocks, network
+import socket
+import threading
+import time
+
+
+class qa_tcp_sink (gr_unittest.TestCase):
+    def tcp_receive(self, serversocket):
+        for _ in range(2):
+            clientsocket, address = serversocket.accept()
+            while True:
+                data = clientsocket.recv(4096)
+                if not data:
+                    break
+            clientsocket.close()
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_restart(self):
+        serversocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        serversocket.bind(('localhost', 2000))
+        serversocket.listen()
+
+        thread = threading.Thread(target=self.tcp_receive, args=(serversocket,))
+        thread.start()
+
+        null_source = blocks.null_source(gr.sizeof_gr_complex)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, 320000, True)
+        tcp_sink = network.tcp_sink(gr.sizeof_gr_complex, 1, '127.0.0.1', 2000, 1)
+        self.tb.connect(null_source, throttle, tcp_sink)
+        self.tb.start()
+        time.sleep(0.1)
+        self.tb.stop()
+        time.sleep(0.1)
+        self.tb.start()
+        time.sleep(0.1)
+        self.tb.stop()
+
+        thread.join()
+        serversocket.close()
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_tcp_sink)

--- a/gr-network/python/network/qa_udp_sink.py
+++ b/gr-network/python/network/qa_udp_sink.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+#
+# Copyright 2021 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gnuradio import gr, gr_unittest, blocks, network
+import time
+
+
+class qa_udp_sink (gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_restart(self):
+        null_source = blocks.null_source(gr.sizeof_gr_complex)
+        throttle = blocks.throttle(gr.sizeof_gr_complex, 320000, True)
+        udp_sink = network.udp_sink(gr.sizeof_gr_complex, 1, '127.0.0.1', 2000,
+                                    0, 1472, False)
+        self.tb.connect(null_source, throttle, udp_sink)
+        self.tb.start()
+        time.sleep(0.1)
+        self.tb.stop()
+        time.sleep(0.1)
+        self.tb.start()
+        time.sleep(0.1)
+        self.tb.stop()
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_udp_sink)

--- a/gr-network/python/network/qa_udp_source.py
+++ b/gr-network/python/network/qa_udp_source.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#
+# Copyright 2021 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gnuradio import gr, gr_unittest, blocks, network
+import time
+
+
+class qa_udp_source (gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_restart(self):
+        udp_source = network.udp_source(gr.sizeof_gr_complex, 1, 1234, 0, 1472,
+                                        False, False, False)
+        null_sink = blocks.null_sink(gr.sizeof_gr_complex)
+        self.tb.connect(udp_source, null_sink)
+        self.tb.start()
+        time.sleep(0.1)
+        self.tb.stop()
+        time.sleep(0.1)
+        self.tb.start()
+        time.sleep(0.1)
+        self.tb.stop()
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_udp_source)


### PR DESCRIPTION
# Pull Request Details

## Description
The TCP and UDP blocks segfault if `start()` is called after `stop()`, because `stop()` frees resources that are not re-allocated by `start()`. To fix this, I've moved resource allocation for these blocks from the constructor to `start()`.

## Related Issue
Fixes #5112.
Also fixes the Gqrx crash noted in https://github.com/gqrx-sdr/gqrx/pull/982.

## Which blocks/areas does this affect?
* TCP Sink
* UDP Sink
* UDP Source

## Testing Done
I've added regression tests. All of them fail with segfaults before the changes, and pass afterwards.

In addition, I've verified that UDP output in Gqrx works with this change applied.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
