### PR TITLE
digital: use u with dots in yml (backport to maint-3.9)

### DIFF
--- a/gr-digital/grc/digital_symbol_sync_xx.block.yml
+++ b/gr-digital/grc/digital_symbol_sync_xx.block.yml
@@ -19,7 +19,7 @@ parameters:
     options: [digital.TED_MUELLER_AND_MULLER, digital.TED_MOD_MUELLER_AND_MULLER,
         digital.TED_ZERO_CROSSING, digital.TED_GARDNER, digital.TED_EARLY_LATE, digital.TED_DANDREA_AND_MENGALI_GEN_MSK,
         digital.TED_MENGALI_AND_DANDREA_GMSK, digital.TED_SIGNAL_TIMES_SLOPE_ML, digital.TED_SIGNUM_TIMES_SLOPE_ML]
-    option_labels: ["Mueller and Mueller", "Modified Mueller and Mueller", Zero
+    option_labels: ["Mueller and Müller", "Modified Mueller and Müller", Zero
             Crossing, Gardner, Early-Late, D'Andrea and Mengali Gen MSK, Mengali and
             D'Andrea GMSK, 'y[n]y''[n] Maximum likelihood', 'sgn(y[n])y''[n] Maximum
             likelihood']


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 177e60e2726989718a138c84dbb4734ad7a3ff4e)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5275