### PR TITLE
runtime: Use <spdlog/fmt/fmt.h> header handling SPDLOG_FMT_EXTERNAL

### DIFF
--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -1,37 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.15'
-MACOSX_SDK_VERSION:
-- '10.15'
+alsa_lib:
+- 1.2.3
 boost_cpp:
 - 1.74.0
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - gnuradio main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fftw:
 - '3'
-fmt:
-- '8'
 gmp:
 - '6'
 gsl:
-- '2.6'
+- '2.7'
+libcblas:
+- 3.8 *netlib
 libiio:
-- '0.21'
+- '0'
 libthrift:
 - 0.15.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.18'
+- '1.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -44,22 +44,20 @@ pin_run_as_build:
     max_pin: x.x
   qt:
     max_pin: x.x
-  spdlog:
-    max_pin: x.x
   zeromq:
     max_pin: x.x
 pybind11_abi:
 - '4'
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 qt:
 - '5.12'
 soapysdr:
 - '0.8'
 spdlog:
-- '1.8'
+- '1.9'
 target_platform:
-- osx-64
+- linux-64
 uhd:
 - 4.1.0
 volk:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -1,49 +1,61 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.15'
+MACOSX_SDK_VERSION:
+- '10.15'
 boost_cpp:
 - 1.74.0
 c_compiler:
-- vs2017
+- clang
+c_compiler_version:
+- '11'
 channel_sources:
 - conda-forge
 channel_targets:
 - gnuradio main
 cxx_compiler:
-- vs2017
+- clangxx
+cxx_compiler_version:
+- '11'
 fftw:
 - '3'
-fmt:
-- '8'
+gmp:
+- '6'
 gsl:
-- '2.6'
+- '2.7'
 libiio:
-- '0.21'
+- '0'
+libthrift:
+- 0.15.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.18'
+- '1.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
   fftw:
+    max_pin: x
+  gmp:
     max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x
   qt:
     max_pin: x.x
-  spdlog:
-    max_pin: x.x
   zeromq:
-    max_pin: x.x.x
+    max_pin: x.x
 pybind11_abi:
 - '4'
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 qt:
 - '5.12'
 soapysdr:
 - '0.8'
 spdlog:
-- '1.8'
+- '1.9'
 target_platform:
-- win-64
+- osx-64
 uhd:
 - 4.1.0
 volk:
@@ -51,5 +63,7 @@ volk:
 zeromq:
 - 4.3.4
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - python
   - numpy

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -1,67 +1,45 @@
-alsa_lib:
-- 1.2.3
 boost_cpp:
 - 1.74.0
 c_compiler:
-- gcc
-c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- vs2017
 channel_sources:
 - conda-forge
 channel_targets:
 - gnuradio main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- vs2017
 fftw:
 - '3'
-fmt:
-- '8'
-gmp:
-- '6'
 gsl:
-- '2.6'
-libcblas:
-- 3.8 *netlib
+- '2.7'
 libiio:
-- '0.21'
-libthrift:
-- 0.15.0
+- '0'
 numpy:
-- '1.18'
+- '1.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
   fftw:
-    max_pin: x
-  gmp:
     max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x
   qt:
     max_pin: x.x
-  spdlog:
-    max_pin: x.x
   zeromq:
-    max_pin: x.x
+    max_pin: x.x.x
 pybind11_abi:
 - '4'
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 qt:
 - '5.12'
 soapysdr:
 - '0.8'
 spdlog:
-- '1.8'
+- '1.9'
 target_platform:
-- linux-64
+- win-64
 uhd:
 - 4.1.0
 volk:
@@ -69,9 +47,5 @@ volk:
 zeromq:
 - 4.3.4
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.conda-forge.yml
+++ b/.conda-forge.yml
@@ -30,6 +30,8 @@
 clone_depth: 0
 github_actions:
   store_build_artifacts: true
+os_version:
+  linux_64: cos7
 provider:
   linux: github_actions
   osx: github_actions

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -13,17 +13,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - CONFIG: linux_64_numpy1.18python3.8.____cpython
-            SHORT_CONFIG: linux_64_numpy1.18python3.8.____cpython
+          - CONFIG: linux_64_numpy1.19python3.9.____cpython
+            SHORT_CONFIG: linux_64_numpy1.19python3.9.____cpython
             UPLOAD_PACKAGES: True
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
             os: ubuntu
-          - CONFIG: win_64_numpy1.18python3.8.____cpython
-            SHORT_CONFIG: win_64_numpy1.18python3.8.____cpython
+          - CONFIG: win_64_numpy1.19python3.9.____cpython
+            SHORT_CONFIG: win_64_numpy1.19python3.9.____cpython
             UPLOAD_PACKAGES: True
             os: windows
-          - CONFIG: osx_64_numpy1.18python3.8.____cpython
-            SHORT_CONFIG: osx_64_numpy1.18python3.8.____cpython
+          - CONFIG: osx_64_numpy1.19python3.9.____cpython
+            SHORT_CONFIG: osx_64_numpy1.19python3.9.____cpython
             UPLOAD_PACKAGES: True
             os: macos
     steps:
@@ -37,7 +37,7 @@ jobs:
       env:
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        DOCKERIMAGE: ${{ matrix.DOCKERIMAGE }}
+        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
         UPLOAD_ON_BRANCH: master
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
@@ -77,14 +77,15 @@ jobs:
     - name: Install Miniconda for windows
       uses: conda-incubator/setup-miniconda@v2
       with:
-        miniconda-version: latest
+        miniforge-version: latest
+        miniforge-variant: Mambaforge
       if: matrix.os == 'windows'
 
     - name: Build on windows
       shell: cmd
       run: |
         call activate base
-        conda.exe install -c conda-forge 'python=3.6' conda-build conda "conda-forge-ci-setup=3" pip boa
+        mamba.exe install -c conda-forge 'python=3.9' conda-build conda "conda-forge-ci-setup=3" pip boa
         if errorlevel 1 exit 1
         setup_conda_rc .\ ".\.packaging/conda_recipe" .\.ci_support\%CONFIG%.yaml
         if errorlevel 1 exit 1

--- a/.packaging/conda_recipe/meta.yaml
+++ b/.packaging/conda_recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py!=38]
+  skip: true  # [py!=39]
   entry_points:
     - gnuradio-companion = gnuradio.grc.main:main  # [win]
     - gr_filter_design = gnuradio.filter.filter_design:main  # [win]
@@ -27,15 +27,12 @@ requirements:
     - cmake >=3.8
     - ninja
     - pkg-config  # [not win]
+    - sysroot_linux-64 2.17  # [linux64]
     # cross-compilation requirements
     - python                              # [build_platform != target_platform]
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - pybind11                            # [build_platform != target_platform]
     - numpy                               # [build_platform != target_platform]
-    # libudev needed to link against libusb through uhd on linux
-    # libudev is on its own in CentOS 6, packaged with systemd in CentOS 7
-    - {{ cdt('libudev-devel') }}  # [linux and cdt_name=='cos6']
-    - {{ cdt('systemd-devel') }}  # [linux and cdt_name=='cos7']
    # below are needed to link with Qt for qtgui
     - {{ cdt('libice') }}  # [linux]
     - {{ cdt('libselinux') }}  # [linux]
@@ -58,7 +55,6 @@ requirements:
     # use codec2 1.0.0 because 1.0.1 has header which fails on Windows (complex.h)
     - codec2 1.0.0*
     - fftw
-    - fmt
     - gmp  # [not win]
     - gsl
     # blas needed to link with gsl

--- a/.packaging/conda_recipe/yum_requirements.txt
+++ b/.packaging/conda_recipe/yum_requirements.txt
@@ -1,7 +1,6 @@
 mesa-libGL
 mesa-dri-drivers
 libselinux
-libudev
 libX11
 libXcomposite
 libXcursor

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -40,7 +42,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libudev libX11 libXcomposite libXcursor libXdamage libXext libXfixes libXi libXinerama libXrandr libXxf86vm
+/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libX11 libXcomposite libXcursor libXdamage libXext libXfixes libXi libXinerama libXrandr libXxf86vm
 
 
 # make the build number clobber
@@ -61,7 +63,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# -*- mode: jinja-shell -*-
+
 source .scripts/logging_utils.sh
 
 set -xe
@@ -9,7 +11,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
+MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
@@ -18,14 +20,12 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-GET_BOA=boa
-BUILD_CMD=mambabuild
-
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
+mamba install -n base --update-specs --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
+mamba update -n base --update-specs --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
 
 
 
@@ -55,7 +55,7 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./.packaging/conda_recipe ./.ci_support/${CONFIG}.yaml
 
-conda $BUILD_CMD ./.packaging/conda_recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda mambabuild ./.packaging/conda_recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 
 ( startgroup "Uploading packages" ) 2> /dev/null
 

--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -33,14 +33,10 @@ using logger_ptr = std::shared_ptr<void>;
 // keeps as short as possible; if anything is needed only by the implementation in
 // buffer.cc, then only include it there
 #include <gnuradio/api.h>
-#include <fmt/core.h>
-#include <fmt/format.h>
 #include <spdlog/common.h>
+#include <spdlog/fmt/fmt.h>
 #include <memory>
 
-#ifndef SPDLOG_FMT_EXTERNAL
-#define SPDLOG_FMT_EXTERNAL
-#endif
 #include <spdlog/spdlog.h>
 
 #include <spdlog/sinks/dist_sink.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1b018cc2df46366b8b83a4fe08db2806)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3e2c7677a98ddd539794627cd5a43d93)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-audio/lib/osx/osx_impl.cc
+++ b/gr-audio/lib/osx/osx_impl.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <locale>
+#include <memory>
 #include <stdexcept>
 
 std::ostream& operator<<(std::ostream& s, const AudioStreamBasicDescription& asbd)
@@ -68,7 +69,7 @@ static UInt32 _get_num_channels(AudioDeviceID ad_id, AudioObjectPropertyScope sc
     OSStatus err = noErr;
     if ((err = AudioObjectGetPropertyDataSize(ad_id, &ao_address, 0, NULL, &prop_size)) ==
         noErr) {
-        boost::scoped_array<AudioBufferList> buf_list(
+        std::unique_ptr<AudioBufferList[]> buf_list(
             reinterpret_cast<AudioBufferList*>(new char[prop_size]));
         if ((err = AudioObjectGetPropertyData(
                  ad_id, &ao_address, 0, NULL, &prop_size, buf_list.get())) == noErr) {
@@ -167,7 +168,7 @@ void find_audio_devices(const std::string& device_name,
 
     // retrieve all audio device ids
 
-    boost::scoped_array<AudioDeviceID> all_dev_ids(new AudioDeviceID[num_devices]);
+    std::unique_ptr<AudioDeviceID[]> all_dev_ids(new AudioDeviceID[num_devices]);
 
     if ((err = AudioObjectGetPropertyData(kAudioObjectSystemObject,
                                           &ao_address,


### PR DESCRIPTION
Regardless of how spdlog was built (with/without `SPDLOG_FMT_EXTERNAL`), this ensures that the proper fmt headers are included. This makes it so that fmt is not a required dependency when spdlog is built with `SPDLOG_FMT_EXTERNAL=OFF`.

Fixes #5349. Gets the conda CI running against spdlog.