### PR TITLE
ci: Remove CentOS 8 from list of containers

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -74,11 +74,11 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
-          - distro: 'CentOS 8.4'
-            containerid: 'gnuradio/ci:centos-8.4-3.10'
-            cxxflags: ''
-            ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
-            ldpath: /usr/local/lib64/
+          # - distro: 'CentOS 8.4'
+          #   containerid: 'gnuradio/ci:centos-8.4-3.10'
+          #   cxxflags: ''
+          #   ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+          #   ldpath: /usr/local/lib64/
           - distro: 'Debian 11'
             containerid: 'gnuradio/ci:debian-11-3.10'
             cxxflags: -Werror -Wno-error=invalid-pch


### PR DESCRIPTION
~Boost 1.69, though available in CentOS 8 EPEL installs differently and is a bit unwieldy to use.  Instead, let's just keep with the same boost version that is in 3.9~

Removing CentOS 8 from the list of containers
It is too problematic to track and not worth changing our min versions over