### PR TITLE
Squelch_eob typo in comments propagates to online documentation.

### DIFF
--- a/gr-analog/include/gnuradio/analog/pwr_squelch_cc.h
+++ b/gr-analog/include/gnuradio/analog/pwr_squelch_cc.h
@@ -44,7 +44,7 @@ public:
      *
      * The block will emit a tag with the key pmt::intern("squelch_sob")
      * with the value of pmt::PMT_NIL on the first item it passes, and with
-     * the key pmt::intern("squelch:eob") on the last item it passes.
+     * the key pmt::intern("squelch_eob") on the last item it passes.
      */
     static sptr make(double db, double alpha = 0.0001, int ramp = 0, bool gate = false);
 

--- a/gr-analog/include/gnuradio/analog/pwr_squelch_ff.h
+++ b/gr-analog/include/gnuradio/analog/pwr_squelch_ff.h
@@ -44,7 +44,7 @@ public:
      *
      * The block will emit a tag with the key pmt::intern("squelch_sob")
      * with the value of pmt::PMT_NIL on the first item it passes, and with
-     * the key pmt::intern("squelch:eob") on the last item it passes.
+     * the key pmt::intern("squelch_eob") on the last item it passes.
      */
     static sptr make(double db, double alpha = 0.0001, int ramp = 0, bool gate = false);
 

--- a/gr-analog/python/analog/bindings/pwr_squelch_cc_python.cc
+++ b/gr-analog/python/analog/bindings/pwr_squelch_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pwr_squelch_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4a3eecaaf775434834d615f1a58d5f9e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(953ce0d8b4db6dee968c0a7281abd4e1)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/python/analog/bindings/pwr_squelch_ff_python.cc
+++ b/gr-analog/python/analog/bindings/pwr_squelch_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pwr_squelch_ff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e1ff64fcbc54b37e480c87c78a898df0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a6b84b6a82a74f2b9c047af54212b802)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
gnuradio documentation automatically generated for [pwr_squelch_ff](https://www.gnuradio.org/doc/doxygen/classgr_1_1analog_1_1pwr__squelch__ff.html) and [pwr_squelch_cc](https://www.gnuradio.org/doc/doxygen/classgr_1_1analog_1_1pwr__squelch__cc.html) states:

> The block will emit a tag with the key pmt::intern("squelch_sob") with the value of pmt::PMT_NIL on the first item it passes, and with the key pmt::intern("squelch:eob") on the last item it passes.

Based on squelch_base_ff and squelch_base_cc, it should be `pmt::intern("squelch_eob")`, not `pmt::intern("squelch:eob")`.

https://github.com/gnuradio/gnuradio/blob/1a0be2e6b54496a8136a64d86e372ab219c6559b/gr-analog/lib/squelch_base_ff_impl.cc#L28
https://github.com/gnuradio/gnuradio/blob/1a0be2e6b54496a8136a64d86e372ab219c6559b/gr-analog/lib/squelch_base_cc_impl.cc#L27