### PR TITLE
runtime: configurable blkd_input timer

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -518,6 +518,30 @@ public:
     void set_min_output_buffer(int port, long min_output_buffer);
 
     /*!
+     * \brief DEPRECATED Configure the timer set when input is blocked \p port.
+     *
+     * \details
+     * This is an advanced/experimental feature and might be removed in a future
+     * version. Calling this can affect some fundamental assumptions about the
+     * system behavior and
+     * performance.
+     *
+     * In the TPB scheduler, when a block has no work to do because there
+     * is no data at it inputs, it sets a timer and tries again after a
+     * period of time.  The default is 250 ms, but this can be configured
+     * differently per block when necessary
+     *
+     * \param timer_value_ms the timer value in milliseconds
+     */
+    void set_blkd_input_timer_value(unsigned int timer_value_ms);
+
+    /*!
+     * \brief DEPRECATED Returns timer value set when input is blocked
+     */
+    unsigned int blkd_input_timer_value();
+
+
+    /*!
      * \brief Allocate the block_detail and necessary output buffers for this
      * block.
      */
@@ -949,6 +973,8 @@ protected:
 
     std::vector<long> d_max_output_buffer;
     std::vector<long> d_min_output_buffer;
+
+    unsigned int d_blkd_input_timer_value = 250;
 
     /*! Used by block's setters and work functions to make
      * setting/resetting of parameters thread-safe.

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -381,6 +381,13 @@ void block::set_min_output_buffer(int port, long min_output_buffer)
         d_min_output_buffer[port] = min_output_buffer;
 }
 
+void block::set_blkd_input_timer_value(unsigned int value)
+{
+    d_blkd_input_timer_value = value;
+}
+
+unsigned int block::blkd_input_timer_value() { return d_blkd_input_timer_value; }
+
 void block::allocate_detail(int ninputs,
                             int noutputs,
                             const std::vector<int>& downstream_max_nitems_vec,

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -132,7 +132,8 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
 
             if (!d->d_tpb.input_changed) {
                 boost::system_time const timeout =
-                    boost::get_system_time() + boost::posix_time::milliseconds(250);
+                    boost::get_system_time() +
+                    boost::posix_time::milliseconds(block->blkd_input_timer_value());
                 d->d_tpb.input_cond.timed_wait(guard, timeout);
             }
         } break;

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(ee5f3ad6384686a28dce290f2da34ceb)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c8416d414680c7aa6fab4fdd471daa3e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -279,6 +279,15 @@ void bind_block(py::module& m)
              py::arg("min_output_buffer"),
              D(block, set_min_output_buffer, 1))
 
+
+        .def("set_blkd_input_timer_value",
+             &block::set_blkd_input_timer_value,
+             py::arg("value"),
+             D(block, set_blkd_input_timer_value))
+
+        .def("blkd_input_timer_value",
+             &block::set_blkd_input_timer_value,
+             D(block, blkd_input_timer_value))
 
         .def("pc_noutput_items", &block::pc_noutput_items, D(block, pc_noutput_items))
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/block_pydoc_template.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/block_pydoc_template.h
@@ -162,6 +162,12 @@ static const char* __doc_gr_block_set_min_output_buffer_0 = R"doc()doc";
 static const char* __doc_gr_block_set_min_output_buffer_1 = R"doc()doc";
 
 
+static const char* __doc_gr_block_set_blkd_input_timer_value = R"doc()doc";
+
+
+static const char* __doc_gr_block_blkd_input_timer_value = R"doc()doc";
+
+
 static const char* __doc_gr_block_pc_noutput_items = R"doc()doc";
 
 


### PR DESCRIPTION
# Pull Request Details
## Description
The fixed setting in the scheduler of 250ms when the input is blocked to retry running the thread is arbitrary and in some blocks with blocking implementations, this timeout can be troublesome and give some weird interaction with the scheduler and the block getting samples from hardware.  For these scenarios, make the value configurable so the user can set what this timeout should be.

## Which blocks/areas does this affect?
Mainly blocks that poll for samples to be ready from some other source.  If the block returns immediately hoping the scheduler will call the work function again, that 250ms timeout could cause problems.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
