### PR TITLE
qtgui: add bounds checks to calculation of d_fft_size_combo index

### DIFF
--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -243,6 +243,8 @@ void FreqControlPanel::setFFTAverage(float val)
 void FreqControlPanel::toggleFFTSize(int val)
 {
     int index = static_cast<int>(round(logf(static_cast<float>(val)) / logf(2.0f))) - 5;
+    index = std::max(index, 0);
+    index = std::min(index, d_fft_size_combo->count() - 1);
     d_fft_size_combo->setCurrentIndex(index);
 }
 


### PR DESCRIPTION
## Description
The QT GUI Frequency Sink block segfaults if a large (e.g. 8192) or small (e.g. 17) FFT size is specified, and the Control Panel is subsequently opened. This happens because there are no bounds checks on the index computed here:
https://github.com/gnuradio/gnuradio/blob/19864fc6ede818b169259607bb85bd5931013e02/gr-qtgui/lib/freqcontrolpanel.cc#L243-L247

It looks like this bug has been around since the control panel was added in https://github.com/gnuradio/gnuradio/pull/459, so GNU Radio 3.7.7+ would be affected.

## Which blocks/areas does this affect?
* QT GUI Frequency Sink

## Testing Done
I used this flow graph to test:
![Screenshot from 2021-12-16 13-11-17](https://user-images.githubusercontent.com/583749/146426015-ce18d513-01d9-4db3-b135-631e2476e0cc.png)
After starting the flow graph, middle click on the Frequency Sink and click "Control Panel". Prior to this change, a segfault will occur. Same if the FFT size is changed to 17.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [ ] I have added tests to cover my changes, and all previous tests pass.
