### PR TITLE
gr-qtgui: add missing fftsize entry in freqcontrolpanel

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -113,7 +113,6 @@ private slots:
     void onPlotPointSelected(const QPointF p) override;
 
 private:
-    uint64_t d_num_real_data_points;
     QIntValidator* d_int_validator;
 
     double d_samp_rate, d_center_freq;

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -77,6 +77,7 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     d_fft_size_combo->addItem("1024");
     d_fft_size_combo->addItem("2048");
     d_fft_size_combo->addItem("4096");
+    d_fft_size_combo->addItem("8192");
 
     d_fft_win_combo = new QComboBox();
     d_fft_win_combo->addItem("None");

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -31,7 +31,6 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
 
     d_controlpanel = NULL;
 
-    d_num_real_data_points = 1024;
     d_fftsize = 1024;
     d_fftavg = 1.0;
     d_clicked = false;


### PR DESCRIPTION
Add fftsize 8192 in freqcontrolpanel
remove unused variable d_num_real_data_points in freqdisplayform.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>

---



## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5399 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
frequency sink
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run example in #5399
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
