### PR TITLE
qtgui: additional fft sizes

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/form_menus.h
+++ b/gr-qtgui/include/gnuradio/qtgui/form_menus.h
@@ -16,6 +16,7 @@
 #include <QtGui/QtGui>
 #include <stdexcept>
 #include <vector>
+#include <math.h>
 
 #if QT_VERSION >= 0x050000
 #include <QtWidgets/QtWidgets>
@@ -606,7 +607,7 @@ public:
             d_act[t]->setActionGroup(d_grp);
         }
 
-        QIntValidator* valid = new QIntValidator(32, 4096, this);
+        QIntValidator* valid = new QIntValidator(32, 16384, this);
         ((OtherAction*)d_act[d_act.size() - 1])->setValidator(valid);
 
         connect(d_act[0], SIGNAL(triggered()), this, SLOT(get05()));
@@ -651,12 +652,10 @@ public:
         float ipt;
         float which = std::log(static_cast<float>(size)) / std::log(2.0f) - 5;
         // If we're a predefined value
-        if (std::modf(which, &ipt) == 0) {
-            if (which < static_cast<unsigned int>(d_act.size()) - 1)
-                return d_act[static_cast<int>(which)];
-            else
-                throw std::runtime_error(
-                    "FFTSizeMenu::getActionFromString: which out of range.");
+        auto f = std::modf(which, &ipt);
+        if ((f < 0.00001 || f > 0.99999) &&
+            which < static_cast<unsigned int>(d_act.size()) - 1) {
+            return d_act[static_cast<int>(round(which))];
         }
         // Or a non-predefined value, return Other
         else {

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -141,10 +141,10 @@ QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize <= 16384))
+    if ((fftsize > 16) && (fftsize <= 8192))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 8192.");
 }
 
 int freq_sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -141,10 +141,10 @@ QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize < 16384))
+    if ((fftsize > 16) && (fftsize <= 16384))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 16384.");
 }
 
 int freq_sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -141,10 +141,10 @@ QWidget* freq_sink_f_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_f_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize < 16384))
+    if ((fftsize > 16) && (fftsize <= 16384))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 16384.");
 }
 
 int freq_sink_f_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -77,7 +77,9 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     d_fft_size_combo->addItem("1024");
     d_fft_size_combo->addItem("2048");
     d_fft_size_combo->addItem("4096");
-    d_fft_size_combo->addItem("8192");
+    // d_fft_size_combo->addItem("8192");
+    // d_fft_size_combo->addItem("16384");
+    // d_fft_size_combo->addItem("32768");
 
     d_fft_win_combo = new QComboBox();
     d_fft_win_combo->addItem("None");

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -142,8 +142,12 @@ QWidget* sink_c_impl::qwidget() { return d_main_gui.qwidget(); }
 
 void sink_c_impl::set_fft_size(const int fftsize)
 {
-    d_fftsize = fftsize;
-    d_main_gui.setFFTSize(fftsize);
+    if (fftsize <= 32768) {
+        d_fftsize = fftsize;
+        d_main_gui.setFFTSize(fftsize);
+    } else {
+        throw std::runtime_error("qtgui_sink: FFT size must be <= 32768.");
+    }
 }
 
 int sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -135,8 +135,12 @@ QWidget* sink_f_impl::qwidget() { return d_main_gui.qwidget(); }
 
 void sink_f_impl::set_fft_size(const int fftsize)
 {
-    d_fftsize = fftsize;
-    d_main_gui.setFFTSize(fftsize);
+    if (fftsize <= 32768) {
+        d_fftsize = fftsize;
+        d_main_gui.setFFTSize(fftsize);
+    } else {
+        throw std::runtime_error("qtgui_sink: FFT size must be <= 32768.");
+    }
 }
 
 int sink_f_impl::fft_size() const { return d_fftsize; }


### PR DESCRIPTION
# Pull Request Details
Additional FFT sizes for the Frequency Sinks

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Rather than < 16384, make the range on the FFT frequency sink <=16384 but keep the size of the fft dropdown in the control panel the same

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
#5404

## Which blocks/areas does this affect?
QT GUI Frequency Blocks

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
