### PR TITLE
Vocoder: SWIG needs a workaround for dealing with C99 keyword _Complex

### DIFF
--- a/gr-vocoder/swig/vocoder_swig.i
+++ b/gr-vocoder/swig/vocoder_swig.i
@@ -86,6 +86,49 @@ GR_SWIG_BLOCK_MAGIC2(vocoder, codec2_encode_sp);
 #endif
 
 #ifdef LIBCODEC2_HAS_FREEDV_API
+// == SWIG does not like standards ==
+// SWIG (as of SWIG 4.0.2) emulates C99 complex number support: C99 has a keyword
+// `_Complex`, and a header <complex.h>, which `#define`s a macro `complex` to be
+// replaced by `_Complex`. So, `_Complex` is the C99 keyword, `complex` the macro.
+//
+// Which means that of course SWIG treats `complex` as keyword and `_Complex` as
+// completely unknown token never to be used where a type specifier keyword was to
+// be expected.
+//
+// So we need to be the ones to jump through hoops. This potentially means we're
+// breaking future builds, when `_Complex` actually becomes supported and
+// `complex` actually a macro, just as standardized. Do we get a choice? Nope.
+//
+// To top this off, codec2 uses _Complex float, which is not strictly C99
+// (http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf); correct would be
+// float _Complex, but every serious compiler accepts either.
+//
+// The solution is to "define away" the whole _Complex.
+// This of course breaks the one symbol (as of codec2 1.0.1) that uses _Complex
+// in codec2/freedv_api.h, but that symbol ended up there by accident anyway, and
+// on codec2 master (git commit 7a554bad) it's moved out of the API.
+//
+// However, codec2, although it uses three-digit versioning, exports only a
+// two-digit API number, so we can't even check for "Codec 2 below 1.0.2"
+// (https://github.com/drowe67/codec2/issues/269). I don't have a great solution
+// yet; there's no visible #defines after v1.0.1 on master yet that we could abuse
+// as feature test macro.
+
+#ifdef CODEC2_HAVE_VERSION
+  #ifndef CODEC2_VERSION_PATCH
+    #define CODEC2_VERSION_PATCH 0
+  #endif
+  #define _CODEC2_VERSION_NUMERICAL  (100000 * CODEC2_VERSION_MAJOR + \
+                                      1000 * CODEC2_VERSION_MINOR + \
+                                      CODEC2_VERSION_PATCH )
+#else
+  #define _CODEC2_VERSION_NUMERICAL 0
+#endif
+#if _CODEC2_VERSION_NUMERICAL < 1001002
+  #define _Complex
+  #define SWIG_COMPLEX_HELL_VOCODER_SWIG
+#endif
+
 %{
 #include <codec2/freedv_api.h>
 #include "gnuradio/vocoder/freedv_api.h"
@@ -106,6 +149,11 @@ GR_SWIG_BLOCK_MAGIC2(vocoder, codec2_encode_sp);
 
 GR_SWIG_BLOCK_MAGIC2(vocoder, freedv_rx_ss);
 GR_SWIG_BLOCK_MAGIC2(vocoder, freedv_tx_ss);
+
+#ifdef SWIG_COMPLEX_HELL_VOCODER_SWIG
+  #undef freedv_callback_rx_sym
+  #undef _Complex
+#endif
 #endif
 
 #ifdef LIBGSM_FOUND


### PR DESCRIPTION
`_Complex` (actual C99 keyword) is not supported by SWIG, `complex` is.

It is not unlikely this will break later on when SWIG starts behaving
standards-compliant.

This became an error when codec2 1.0.1 started exposing API with
_Complex.

Signed-off-by: Marcus Müller <marcus@hostalia.de-

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Related Issue

#5411  

## Which blocks/areas does this affect?

Vocoder SWIG  build only on maint-3.8, sadly might lead to incompatibilities in the future

## Testing Done

None, since no build machine at hand

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
