### PR TITLE
iio: GRC bindings: remove global variable from hidden defaults

### DIFF
--- a/gr-iio/grc/iio_fmcomms2_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_sink.block.yml
@@ -96,14 +96,14 @@ parameters:
     category: Filter
     label: Fpass (Hz)
     dtype: float
-    default: samp_rate/4
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: fstop
     category: Filter
     label: Fstop (Hz)
     dtype: float
-    default: samp_rate/3
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: bandwidth

--- a/gr-iio/grc/iio_fmcomms2_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_source.block.yml
@@ -121,14 +121,14 @@ parameters:
     category: Filter
     label: Fpass (Hz)
     dtype: float
-    default: samp_rate/4
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: fstop
     category: Filter
     label: Fstop (Hz)
     dtype: float
-    default: samp_rate/3
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: bandwidth

--- a/gr-iio/grc/iio_fmcomms5_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms5_sink.block.yml
@@ -118,14 +118,14 @@ parameters:
     category: Filter
     label: Fpass (Hz)
     dtype: float
-    default: samp_rate/4
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: fstop
     category: Filter
     label: Fstop (Hz)
     dtype: float
-    default: samp_rate/3
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: bandwidth

--- a/gr-iio/grc/iio_fmcomms5_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms5_source.block.yml
@@ -164,14 +164,14 @@ parameters:
     category: Filter
     label: Fpass (Hz)
     dtype: float
-    default: samp_rate/4
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: fstop
     category: Filter
     label: Fstop (Hz)
     dtype: float
-    default: samp_rate/3
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: bandwidth

--- a/gr-iio/grc/iio_pluto_sink.block.yml
+++ b/gr-iio/grc/iio_pluto_sink.block.yml
@@ -68,14 +68,14 @@ parameters:
     category: Filter
     label: Fpass (Hz)
     dtype: float
-    default: samp_rate/4
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: fstop
     category: Filter
     label: Fstop (Hz)
     dtype: float
-    default: samp_rate/3
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: bandwidth

--- a/gr-iio/grc/iio_pluto_source.block.yml
+++ b/gr-iio/grc/iio_pluto_source.block.yml
@@ -91,14 +91,14 @@ parameters:
     category: Filter
     label: Fpass (Hz)
     dtype: float
-    default: samp_rate/4
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: fstop
     category: Filter
     label: Fstop (Hz)
     dtype: float
-    default: samp_rate/3
+    default: 0
     hide: ${ ('none' if filter_source == "'Design'" else 'all') }
 
 -   id: bandwidth


### PR DESCRIPTION
# Pull Request Details

When the fields are hidden, and the expected global variable is
undefined, the flow graph becomes unsynthesizable.

I've only found this pattern with IIO blocks.

Sadly, we *have* to put defaults here, in order to have valid arguments
to the (useless) `set_filter_params` call in the non-Design filter mode.

Since the fpass and fstop fields, however, aren't used, the actual value
used there doesn't matter – so, 0 it is.



## Description

Simply replaces all occurences of `samp_rate/x` in hidden defaults by 0

## Related Issue

#5414

## Which blocks/areas does this affect?

IIO's GRC bindings

## Testing Done

Prior, deleting the `samp_rate` variable from a flow graph made it impossible to generate the python. Now, it's possible. 

Have *not* tested whether this works at runtime – no hardware right now.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.