### PR TITLE
grc: change default flowgraph id

### DIFF
--- a/grc/core/Constants.py
+++ b/grc/core/Constants.py
@@ -20,6 +20,7 @@ DATA_DIR = os.path.dirname(__file__)
 BLOCK_DTD = os.path.join(DATA_DIR, 'block.dtd')
 DEFAULT_FLOW_GRAPH = os.path.join(DATA_DIR, 'default_flow_graph.grc')
 DEFAULT_HIER_BLOCK_LIB_DIR = os.path.expanduser('~/.grc_gnuradio')
+DEFAULT_FLOW_GRAPH_ID = 'default'
 
 CACHE_FILE = os.path.expanduser('~/.cache/grc_gnuradio/cache_v2.json')
 

--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -13,7 +13,7 @@ from .. import Constants
 
 
 # Blacklist certain ids, its not complete, but should help
-ID_BLACKLIST = ['self', 'default'] + dir(builtins)
+ID_BLACKLIST = ['self'] + dir(builtins)
 try:
     from gnuradio import gr
     ID_BLACKLIST.extend(attr for attr in dir(

--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -660,7 +660,7 @@ class Application(Gtk.Application):
             file_path = FileDialogs.SaveFlowGraph(main, page.file_path).run()
 
             if file_path is not None:
-                if flow_graph.options_block.params['id'].get_value() == 'default':
+                if flow_graph.options_block.params['id'].get_value() == Constants.DEFAULT_FLOW_GRAPH_ID:
                     file_name = os.path.basename(file_path).replace(".grc", "")
                     flow_graph.options_block.params['id'].set_value(file_name)
                     flow_graph_update(flow_graph)


### PR DESCRIPTION
# Pull Request Details
This is a stopgap fix to help with the UX by reverting to the old behavior where the flowgraph is titled "top_block" (but doesn't really matter) - but it is not immediately in a state of error.  

There is likely a better UX solution for naming and saving flowgraphs, but hopefully this removes some of the frustration to a newly created flowgraph. 

Definitely open to ideas for doing something different here, but want to get *something* into 3.10.

## Related Issue
#5415

## Which blocks/areas does this affect?
grc

## Testing Done
Opened new flowgraph and ran without having to change the name or the block being red.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
