### PR TITLE
filter: Optimize filter setup a bit using the power of move

### DIFF
--- a/gr-filter/lib/mmse_fir_interpolator_cc.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_cc.cc
@@ -26,7 +26,7 @@ std::vector<kernel::fir_filter_ccf> build_filters()
     filters.reserve(NSTEPS + 1);
     for (int i = 0; i < NSTEPS + 1; i++) {
         std::vector<float> t(&taps[i][0], &taps[i][NTAPS]);
-        filters.emplace_back(t);
+        filters.emplace_back(std::move(t));
     }
     return filters;
 }

--- a/gr-filter/lib/mmse_fir_interpolator_ff.cc
+++ b/gr-filter/lib/mmse_fir_interpolator_ff.cc
@@ -26,7 +26,7 @@ std::vector<kernel::fir_filter_fff> build_filters()
     filters.reserve(NSTEPS + 1);
     for (int i = 0; i < NSTEPS + 1; i++) {
         std::vector<float> t(&taps[i][0], &taps[i][NTAPS]);
-        filters.emplace_back(t);
+        filters.emplace_back(std::move(t));
     }
     return filters;
 }

--- a/gr-filter/lib/mmse_interp_differentiator_cc.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_cc.cc
@@ -26,7 +26,7 @@ std::vector<kernel::fir_filter_ccf> build_filters()
     filters.reserve(DNSTEPS + 1);
     for (int i = 0; i < DNSTEPS + 1; i++) {
         std::vector<float> t(&Dtaps[i][0], &Dtaps[i][DNTAPS]);
-        filters.emplace_back(t);
+        filters.emplace_back(std::move(t));
     }
     return filters;
 }

--- a/gr-filter/lib/mmse_interp_differentiator_ff.cc
+++ b/gr-filter/lib/mmse_interp_differentiator_ff.cc
@@ -26,7 +26,7 @@ std::vector<kernel::fir_filter_fff> build_filters()
     filters.reserve(DNSTEPS + 1);
     for (int i = 0; i < DNSTEPS + 1; i++) {
         std::vector<float> t(&Dtaps[i][0], &Dtaps[i][DNTAPS]);
-        filters.emplace_back(t);
+        filters.emplace_back(std::move(t));
     }
     return filters;
 }

--- a/gr-filter/lib/pfb_arb_resampler.cc
+++ b/gr-filter/lib/pfb_arb_resampler.cc
@@ -44,7 +44,7 @@ pfb_arb_resampler_ccf::pfb_arb_resampler_ccf(float rate,
     d_last_filter = (taps.size() / 2) % filter_size;
 
     // Create an FIR filter for each channel and zero out the taps
-    std::vector<float> vtaps(0, d_int_rate);
+    const std::vector<float> vtaps(0, d_int_rate);
     d_filters.reserve(d_int_rate);
     d_diff_filters.reserve(d_int_rate);
     for (unsigned int i = 0; i < d_int_rate; i++) {
@@ -236,7 +236,7 @@ pfb_arb_resampler_ccc::pfb_arb_resampler_ccc(float rate,
     d_diff_filters.reserve(d_int_rate);
 
     // Create an FIR filter for each channel and zero out the taps
-    std::vector<gr_complex> vtaps(0, d_int_rate);
+    const std::vector<gr_complex> vtaps(0, d_int_rate);
     for (unsigned int i = 0; i < d_int_rate; i++) {
         d_filters.emplace_back(vtaps);
         d_diff_filters.emplace_back(vtaps);
@@ -429,7 +429,7 @@ pfb_arb_resampler_fff::pfb_arb_resampler_fff(float rate,
     d_diff_filters.reserve(d_int_rate);
 
     // Create an FIR filter for each channel and zero out the taps
-    std::vector<float> vtaps(0, d_int_rate);
+    const std::vector<float> vtaps(0, d_int_rate);
     for (unsigned int i = 0; i < d_int_rate; i++) {
         d_filters.emplace_back(vtaps);
         d_diff_filters.emplace_back(vtaps);

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -50,7 +50,7 @@ pfb_synthesizer_ccf_impl::pfb_synthesizer_ccf_impl(unsigned int numchans,
 
     // Create an FIR filter for each channel and zero out the taps
     // and set the default channel map
-    std::vector<float> vtaps(0, d_twox * d_numchans);
+    const std::vector<float> vtaps(0, d_twox * d_numchans);
     for (unsigned int i = 0; i < d_twox * d_numchans; i++) {
         d_filters.emplace_back(vtaps);
         d_channel_map[i] = i;

--- a/gr-filter/lib/polyphase_filterbank.cc
+++ b/gr-filter/lib/polyphase_filterbank.cc
@@ -26,7 +26,7 @@ polyphase_filterbank::polyphase_filterbank(unsigned int nfilts,
     d_fft_filters.reserve(d_nfilts);
 
     // Create an FIR filter for each channel and zero out the taps
-    std::vector<float> vtaps(1, 0.0f);
+    const std::vector<float> vtaps(1, 0.0f);
     for (unsigned int i = 0; i < d_nfilts; i++) {
         d_fir_filters.emplace_back(vtaps);
         d_fft_filters.emplace_back(1, vtaps);


### PR DESCRIPTION
---
name: Optimize filter setup a bit using the power of move
about: Minor speed increase and cleanup
title: ''
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Optimize filter setup a bit using the power of move.

Note that this PR will clash a bit with PR #5422. Probably should merge that first, and I'll sort out any conflict.

## Which blocks/areas does this affect?
`gr-filter`. Minor speedup by avoiding copies.

## Testing Done
WIP: Running tests now locally, and expecting this PR to trigger more testing.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
