### PR TITLE
blocks: Deprecate Fast Multiply Const (just an alias for multiply_const)

### DIFF
--- a/gr-blocks/grc/blocks_multiply_const_xx.block.yml
+++ b/gr-blocks/grc/blocks_multiply_const_xx.block.yml
@@ -1,5 +1,6 @@
 id: blocks_multiply_const_xx
 label: Fast Multiply Const
+category: '[Core]/Deprecated'
 flags: [ python, cpp ]
 
 parameters:

--- a/gr-dtv/examples/germany-g1.grc
+++ b/gr-dtv/examples/germany-g1.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g10.grc
+++ b/gr-dtv/examples/germany-g10.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g2.grc
+++ b/gr-dtv/examples/germany-g2.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g3.grc
+++ b/gr-dtv/examples/germany-g3.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g4.grc
+++ b/gr-dtv/examples/germany-g4.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g5.grc
+++ b/gr-dtv/examples/germany-g5.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g6.grc
+++ b/gr-dtv/examples/germany-g6.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g7.grc
+++ b/gr-dtv/examples/germany-g7.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g8.grc
+++ b/gr-dtv/examples/germany-g8.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/germany-g9.grc
+++ b/gr-dtv/examples/germany-g9.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv001-cr35.grc
+++ b/gr-dtv/examples/vv001-cr35.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 76.0]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv003-cr23.grc
+++ b/gr-dtv/examples/vv003-cr23.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_interleaver_bb_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']

--- a/gr-dtv/examples/vv004-8kfft.grc
+++ b/gr-dtv/examples/vv004-8kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv005-8kfft.grc
+++ b/gr-dtv/examples/vv005-8kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv007-16kfft.grc
+++ b/gr-dtv/examples/vv007-16kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv008-16kfft.grc
+++ b/gr-dtv/examples/vv008-16kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv009-4kfft.grc
+++ b/gr-dtv/examples/vv009-4kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv010-2kfft.grc
+++ b/gr-dtv/examples/vv010-2kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv011-1kfft.grc
+++ b/gr-dtv/examples/vv011-1kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv012-64qam45.grc
+++ b/gr-dtv/examples/vv012-64qam45.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']

--- a/gr-dtv/examples/vv013-64qam56.grc
+++ b/gr-dtv/examples/vv013-64qam56.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv014-64qam34.grc
+++ b/gr-dtv/examples/vv014-64qam34.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv015-8kfft.grc
+++ b/gr-dtv/examples/vv015-8kfft.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv016-256qam34.grc
+++ b/gr-dtv/examples/vv016-256qam34.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv017-paprtr.grc
+++ b/gr-dtv/examples/vv017-paprtr.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv018-miso.grc
+++ b/gr-dtv/examples/vv018-miso.grc
@@ -135,8 +135,8 @@ blocks:
     coordinate: [344, 108.0]
     rotation: 180
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -153,8 +153,8 @@ blocks:
     coordinate: [592, 508]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -871,10 +871,10 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '1']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '1']
-- [blocks_multiply_const_xx_0_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '1']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '1']
+- [blocks_multiply_const_vxx_0_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [digital_ofdm_cyclic_prefixer_0_0, '0', dtv_dvbt2_p1insertion_cc_0_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
@@ -889,9 +889,9 @@ connections:
 - [dtv_dvbt2_miso_cc_0, '1', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0_0, '0', blocks_multiply_const_xx_0_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0_0, '0', blocks_multiply_const_vxx_0_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_1, '0', digital_ofdm_cyclic_prefixer_0_0, '0']
 

--- a/gr-dtv/examples/vv019-norot.grc
+++ b/gr-dtv/examples/vv019-norot.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv034-dtg016.grc
+++ b/gr-dtv/examples/vv034-dtg016.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -792,8 +792,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -805,7 +805,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']
 - [virtual_source_1, '0', dtv_dvbt2_interleaver_bb_0, '0']

--- a/gr-dtv/examples/vv035-dtg052.grc
+++ b/gr-dtv/examples/vv035-dtg052.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_pilotgenerator_cc_0, '0']

--- a/gr-dtv/examples/vv036-dtg091.grc
+++ b/gr-dtv/examples/vv036-dtg091.grc
@@ -117,8 +117,8 @@ blocks:
     coordinate: [120, 75]
     rotation: 0
     state: enabled
-- name: blocks_multiply_const_xx_0
-  id: blocks_multiply_const_xx
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
   parameters:
     affinity: ''
     alias: ''
@@ -817,8 +817,8 @@ blocks:
 
 connections:
 - [blocks_file_source_0, '0', dtv_dvb_bbheader_bb_0, '0']
-- [blocks_multiply_const_xx_0, '0', soapy_custom_sink_0, '0']
-- [blocks_multiply_const_xx_0, '0', uhd_usrp_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', soapy_custom_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', uhd_usrp_sink_0, '0']
 - [digital_ofdm_cyclic_prefixer_0, '0', dtv_dvbt2_p1insertion_cc_0, '0']
 - [dtv_dvb_bbheader_bb_0, '0', dtv_dvb_bbscrambler_bb_0, '0']
 - [dtv_dvb_bbscrambler_bb_0, '0', dtv_dvb_bch_bb_0, '0']
@@ -830,7 +830,7 @@ connections:
 - [dtv_dvbt2_interleaver_bb_0, '0', dtv_dvbt2_modulator_bc_0, '0']
 - [dtv_dvbt2_modulator_bc_0, '0', dtv_dvbt2_cellinterleaver_cc_0, '0']
 - [dtv_dvbt2_p1insertion_cc_0, '0', blocks_file_sink_0, '0']
-- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_xx_0, '0']
+- [dtv_dvbt2_p1insertion_cc_0, '0', blocks_multiply_const_vxx_0, '0']
 - [dtv_dvbt2_paprtr_cc_0, '0', digital_ofdm_cyclic_prefixer_0, '0']
 - [dtv_dvbt2_pilotgenerator_cc_0, '0', dtv_dvbt2_paprtr_cc_0, '0']
 - [virtual_source_0, '0', dtv_dvbt2_interleaver_bb_0, '0']


### PR DESCRIPTION
block_multiply_const_vxx.block.yml contains the same functionality + vector abilities

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>


# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

"Fast" might be a remnant from the time before VOLK (?). Anyways, the `_vxx.block.yml` builds exactly the same, but can also work on vectors. No sense in maintaining both, I guess

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

gr-blocks

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.


----

Deprecations need to be marked in the wiki