### PR TITLE
gr-qtgui: Frequency sink freezes the running flowgraph

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -20,8 +20,9 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: int
+    dtype: enum
     default: '1024'
+    options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if (type == 'msg_complex' or type == 'msg_float') else 'none') }
 -   id: freqhalf
     label: Spectrum Width

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -397,6 +397,9 @@ outputs:
     optional: true
     hide: ${ not showports }
 
+asserts:
+- ${fftsize >= 32 and fftsize <= 32768}
+
 templates:
     imports: |-
         from PyQt5 import Qt

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -20,7 +20,7 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: enum
+    dtype: int
     default: '1024'
     options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if (type == 'msg_complex' or type == 'msg_float') else 'none') }

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '""'
 -   id: fftsize
     label: FFT Size
-    dtype: enum
+    dtype: int
     default: '1024'
     options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
 -   id: wintype

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -17,8 +17,9 @@ parameters:
     default: '""'
 -   id: fftsize
     label: FFT Size
-    dtype: int
+    dtype: enum
     default: '1024'
+    options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
 -   id: wintype
     label: Window Type
     dtype: enum

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -20,7 +20,7 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: enum
+    dtype: int
     default: '1024'
     options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if type.startswith('msg') else 'none') }

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -20,8 +20,9 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: int
+    dtype: enum
     default: '1024'
+    options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if type.startswith('msg') else 'none') }
 -   id: freqhalf
     label: Spectrum Width

--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -52,6 +52,10 @@ public:
     // checks if there was a double-click event; reset if there was
     bool checkClicked();
 
+    const int MIN_FFT_SIZE = 32;
+    const int MAX_FFT_SIZE = 32768;
+    const int FFT_DEFAULT_SIZE = 1024;
+
 public slots:
     void customEvent(QEvent* e) override;
 

--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -124,7 +124,6 @@ private:
     bool d_clicked;
     double d_clicked_freq;
 
-    FFTSizeMenu* d_sizemenu;
     FFTAverageMenu* d_avgmenu;
     FFTWindowMenu* d_winmenu;
     QAction *d_minhold_act, *d_maxhold_act;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
@@ -97,7 +97,6 @@ private:
     double d_min_val, d_cur_min_val;
     double d_max_val, d_cur_max_val;
 
-    FFTSizeMenu* d_sizemenu;
     FFTAverageMenu* d_avgmenu;
     FFTWindowMenu* d_winmenu;
 };

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -144,12 +144,11 @@ void freq_sink_c_impl::set_fft_size(const int fftsize)
     if ((fftsize >= d_main_gui->MIN_FFT_SIZE) && (fftsize <= d_main_gui->MAX_FFT_SIZE))
         d_main_gui->setFFTSize(fftsize);
     else {
-        GR_LOG_INFO(
-            d_logger,
-            fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
-                        d_main_gui->MIN_FFT_SIZE,
-                        d_main_gui->MAX_FFT_SIZE,
-                        d_main_gui->FFT_DEFAULT_SIZE));
+        GR_LOG_INFO(d_logger,
+                    fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
+                                d_main_gui->MIN_FFT_SIZE,
+                                d_main_gui->MAX_FFT_SIZE,
+                                d_main_gui->FFT_DEFAULT_SIZE));
         d_main_gui->setFFTSize(d_main_gui->FFT_DEFAULT_SIZE);
     }
 }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_c_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(32768);
+    set_output_multiple(d_main_gui->MAX_FFT_SIZE);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,17 @@ QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize <= 32768))
+    if ((fftsize >= d_main_gui->MIN_FFT_SIZE) && (fftsize <= d_main_gui->MAX_FFT_SIZE))
         d_main_gui->setFFTSize(fftsize);
-    else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
+    else {
+        GR_LOG_INFO(
+            d_logger,
+            fmt::format("FFT size must be>= {} and <= {}. \n So falling back to {}.",
+                        d_main_gui->MIN_FFT_SIZE,
+                        d_main_gui->MAX_FFT_SIZE,
+                        d_main_gui->FFT_DEFAULT_SIZE));
+        d_main_gui->setFFTSize(d_main_gui->FFT_DEFAULT_SIZE);
+    }
 }
 
 int freq_sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -146,7 +146,7 @@ void freq_sink_c_impl::set_fft_size(const int fftsize)
     else {
         GR_LOG_INFO(
             d_logger,
-            fmt::format("FFT size must be>= {} and <= {}. \n So falling back to {}.",
+            fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
                         d_main_gui->MIN_FFT_SIZE,
                         d_main_gui->MAX_FFT_SIZE,
                         d_main_gui->FFT_DEFAULT_SIZE));

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_c_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(d_fftsize);
+    set_output_multiple(32768);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,10 @@ QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize < 16384))
+    if ((fftsize > 16) && (fftsize <= 32768))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
 }
 
 int freq_sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -144,12 +144,11 @@ void freq_sink_f_impl::set_fft_size(const int fftsize)
     if ((fftsize >= d_main_gui->MIN_FFT_SIZE) && (fftsize <= d_main_gui->MAX_FFT_SIZE))
         d_main_gui->setFFTSize(fftsize);
     else {
-        GR_LOG_INFO(
-            d_logger,
-            fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
-                        d_main_gui->MIN_FFT_SIZE,
-                        d_main_gui->MAX_FFT_SIZE,
-                        d_main_gui->FFT_DEFAULT_SIZE));
+        GR_LOG_INFO(d_logger,
+                    fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
+                                d_main_gui->MIN_FFT_SIZE,
+                                d_main_gui->MAX_FFT_SIZE,
+                                d_main_gui->FFT_DEFAULT_SIZE));
         d_main_gui->setFFTSize(d_main_gui->FFT_DEFAULT_SIZE);
     }
 }

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -146,7 +146,7 @@ void freq_sink_f_impl::set_fft_size(const int fftsize)
     else {
         GR_LOG_INFO(
             d_logger,
-            fmt::format("FFT size must be>= {} and <= {}. \n So falling back to {}.",
+            fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
                         d_main_gui->MIN_FFT_SIZE,
                         d_main_gui->MAX_FFT_SIZE,
                         d_main_gui->FFT_DEFAULT_SIZE));

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_f_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(32768);
+    set_output_multiple(d_main_gui->MAX_FFT_SIZE);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,17 @@ QWidget* freq_sink_f_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_f_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize <= 32768))
+    if ((fftsize >= d_main_gui->MIN_FFT_SIZE) && (fftsize <= d_main_gui->MAX_FFT_SIZE))
         d_main_gui->setFFTSize(fftsize);
-    else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
+    else {
+        GR_LOG_INFO(
+            d_logger,
+            fmt::format("FFT size must be>= {} and <= {}. \n So falling back to {}.",
+                        d_main_gui->MIN_FFT_SIZE,
+                        d_main_gui->MAX_FFT_SIZE,
+                        d_main_gui->FFT_DEFAULT_SIZE));
+        d_main_gui->setFFTSize(d_main_gui->FFT_DEFAULT_SIZE);
+    }
 }
 
 int freq_sink_f_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_f_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(d_fftsize);
+    set_output_multiple(32768);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,10 @@ QWidget* freq_sink_f_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_f_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize < 16384))
+    if ((fftsize > 16) && (fftsize <= 32768))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
 }
 
 int freq_sink_f_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -78,6 +78,8 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     d_fft_size_combo->addItem("2048");
     d_fft_size_combo->addItem("4096");
     d_fft_size_combo->addItem("8192");
+    d_fft_size_combo->addItem("16384");
+    d_fft_size_combo->addItem("32768");
 
     d_fft_win_combo = new QComboBox();
     d_fft_win_combo->addItem("None");
@@ -169,7 +171,7 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
         d_autoscale_button, SIGNAL(pressed(void)), d_parent, SLOT(autoScaleShot(void)));
 
     connect(d_fft_size_combo,
-            SIGNAL(currentIndexChanged(const QString&)),
+            SIGNAL(currentTextChanged(const QString&)),
             d_parent,
             SLOT(notifyFFTSize(const QString&)));
     connect(d_fft_win_combo,
@@ -243,10 +245,7 @@ void FreqControlPanel::setFFTAverage(float val)
 
 void FreqControlPanel::toggleFFTSize(int val)
 {
-    int index = static_cast<int>(round(logf(static_cast<float>(val)) / logf(2.0f))) - 5;
-    index = std::max(index, 0);
-    index = std::min(index, d_fft_size_combo->count() - 1);
-    d_fft_size_combo->setCurrentIndex(index);
+    d_fft_size_combo->setCurrentText(QString::number(val));
 }
 
 void FreqControlPanel::toggleFFTWindow(const gr::fft::window::win_type win)

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -238,7 +238,19 @@ void FreqControlPanel::setFFTAverage(float val)
 
 void FreqControlPanel::toggleFFTSize(int val)
 {
-    d_fft_size_combo->setCurrentText(QString::number(val));
+    // Check if val is contained in combobox
+    if (d_fft_size_combo->findText(QString::number(val)) > 0)
+        d_fft_size_combo->setCurrentText(QString::number(val));
+    else {
+        // Find greatest entry in combobox < val
+        int count = 1;
+        int test = val >> 1;
+        while (test > 0) {
+            count *= 2;
+            test = test >> 1;
+        }
+        d_fft_size_combo->setCurrentText(QString::number(count));
+    }
 }
 
 void FreqControlPanel::toggleFFTWindow(const gr::fft::window::win_type win)

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -69,17 +69,10 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     d_fft_box = new QGroupBox("FFT");
     d_fft_layout = new QVBoxLayout;
     d_fft_size_combo = new QComboBox();
-    d_fft_size_combo->addItem("32");
-    d_fft_size_combo->addItem("64");
-    d_fft_size_combo->addItem("128");
-    d_fft_size_combo->addItem("256");
-    d_fft_size_combo->addItem("512");
-    d_fft_size_combo->addItem("1024");
-    d_fft_size_combo->addItem("2048");
-    d_fft_size_combo->addItem("4096");
-    d_fft_size_combo->addItem("8192");
-    d_fft_size_combo->addItem("16384");
-    d_fft_size_combo->addItem("32768");
+    for (int fftsize = d_parent->MIN_FFT_SIZE; fftsize <= d_parent->MAX_FFT_SIZE;
+         fftsize *= 2) {
+        d_fft_size_combo->addItem(QString("%1").arg(fftsize));
+    }
 
     d_fft_win_combo = new QComboBox();
     d_fft_win_combo->addItem("None");

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -41,13 +41,10 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
     d_trig_channel = 0;
     d_trig_tag_key = "";
 
-    d_sizemenu = new FFTSizeMenu(this);
     d_avgmenu = new FFTAverageMenu(this);
     d_winmenu = new FFTWindowMenu(this);
-    d_menu->addMenu(d_sizemenu);
     d_menu->addMenu(d_avgmenu);
     d_menu->addMenu(d_winmenu);
-    connect(d_sizemenu, SIGNAL(whichTrigger(int)), this, SLOT(setFFTSize(const int)));
     connect(
         d_avgmenu, SIGNAL(whichTrigger(float)), this, SLOT(setFFTAverage(const float)));
     connect(d_winmenu,
@@ -136,7 +133,7 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
             this,
             SLOT(onPlotPointSelected(const QPointF)));
 
-    connect(this, SIGNAL(signalReplot()), getPlot(), SLOT(replot()));
+    connect(this, SIGNAL(signalReplot()), d_display_plot, SLOT(replot()));
 }
 
 FreqDisplayForm::~FreqDisplayForm()
@@ -173,8 +170,6 @@ void FreqDisplayForm::setupControlPanel()
             SIGNAL(triggered(bool)),
             d_controlpanel,
             SLOT(toggleAxisLabels(bool)));
-    connect(
-        d_sizemenu, SIGNAL(whichTrigger(int)), d_controlpanel, SLOT(toggleFFTSize(int)));
     connect(d_winmenu,
             SIGNAL(whichTrigger(gr::fft::window::win_type)),
             d_controlpanel,
@@ -271,10 +266,9 @@ void FreqDisplayForm::setSampleRate(const QString& samprate)
 void FreqDisplayForm::setFFTSize(const int newsize)
 {
     d_fftsize = newsize;
-    d_sizemenu->getActionFromSize(newsize)->setChecked(true);
 
-    emit signalReplot();
     emit signalFFTSize(newsize);
+    emit signalReplot();
 }
 
 void FreqDisplayForm::setFFTAverage(const float newavg)

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -73,13 +73,10 @@ WaterfallDisplayForm::WaterfallDisplayForm(int nplots, QWidget* parent)
     d_autoscale_act->setText(tr("Auto Scale"));
     d_autoscale_act->setCheckable(false);
 
-    d_sizemenu = new FFTSizeMenu(this);
     d_avgmenu = new FFTAverageMenu(this);
     d_winmenu = new FFTWindowMenu(this);
-    d_menu->addMenu(d_sizemenu);
     d_menu->addMenu(d_avgmenu);
     d_menu->addMenu(d_winmenu);
-    connect(d_sizemenu, SIGNAL(whichTrigger(int)), this, SLOT(setFFTSize(const int)));
     connect(
         d_avgmenu, SIGNAL(whichTrigger(float)), this, SLOT(setFFTAverage(const float)));
     connect(d_winmenu,
@@ -187,7 +184,6 @@ void WaterfallDisplayForm::setSampleRate(const QString& samprate)
 void WaterfallDisplayForm::setFFTSize(const int newsize)
 {
     d_fftsize = newsize;
-    d_sizemenu->getActionFromSize(newsize)->setChecked(true);
     getPlot()->replot();
 }
 


### PR DESCRIPTION



---

# Pull Request Details
With #5405 the segfault of freq_sink_c was fixed, but
if you enable the control panel and change the FFT size to 8192
while the flow graph is running, the whole flowgraph freezes.
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
This patch:

- fixes the freeze
- extends the fftsize to 32768 for freq_sink_c and freq_sink_f
- changes the entry for fftsize in the corresponding yml files from integer to enum
  and provides a drop down menu with those values that are provided by the gui
  in the running flowgraph.

The code provides code for setting the fftsize in form_menus.h and in freqcontrolpanel.cc
If you change some signal and slots you can do without the code from form_menus.h.
So this part is removed.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
freq_sink_c, freq_sink_f
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Flowgraph:
signal source -> freq_sink 
                      ->gui_sink
While running, change fftsize to each availabe size. No freeze at all.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>

- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
