### PR TITLE
network: remove unused d_setlock guards

### DIFF
--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -228,8 +228,6 @@ int tcp_sink_impl::work(int noutput_items,
                         gr_vector_const_void_star& input_items,
                         gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
-
     if (!d_connected)
         return noutput_items;
 

--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -167,8 +167,6 @@ udp_sink_impl::~udp_sink_impl() { stop(); }
 bool udp_sink_impl::stop()
 {
     if (d_udpsocket) {
-        gr::thread::scoped_lock guard(d_setlock);
-
         if (b_send_eof) {
             // Send a few zero-length packets to signal receiver we are done
             boost::array<char, 0> send_buf;
@@ -220,8 +218,6 @@ int udp_sink_impl::work(int noutput_items,
                         gr_vector_const_void_star& input_items,
                         gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
-
     long num_bytes_to_transmit = noutput_items * d_block_size;
     const char* in = (const char*)input_items[0];
 

--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -221,8 +221,6 @@ int udp_source_impl::work(int noutput_items,
                           gr_vector_const_void_star& input_items,
                           gr_vector_void_star& output_items)
 {
-    gr::thread::scoped_lock guard(d_setlock);
-
     static bool first_time = true;
     static int underrun_counter = 0;
 


### PR DESCRIPTION
There are no protected accessors in these blocks, and stop() can never be called while work() is running.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Found that `d_setlock` was guarded in work() – but never actually used anywhere else. Since acquiring a lock is relatively costly, removed that.
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

UDP sink & source, TCP sink.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
