### PR TITLE
Additional Cleanup of Freq Sink

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -20,8 +20,9 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: int
+    dtype: enum
     default: '1024'
+    options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if (type == 'msg_complex' or type == 'msg_float') else 'none') }
 -   id: freqhalf
     label: Spectrum Width

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -20,7 +20,7 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: enum
+    dtype: int
     default: '1024'
     options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if (type == 'msg_complex' or type == 'msg_float') else 'none') }

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -17,7 +17,7 @@ parameters:
     default: '""'
 -   id: fftsize
     label: FFT Size
-    dtype: enum
+    dtype: int
     default: '1024'
     options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
 -   id: wintype

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -17,8 +17,9 @@ parameters:
     default: '""'
 -   id: fftsize
     label: FFT Size
-    dtype: int
+    dtype: enum
     default: '1024'
+    options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
 -   id: wintype
     label: Window Type
     dtype: enum

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -20,8 +20,9 @@ parameters:
     hide: ${ ('none' if len(name) > 0 else 'part') }
 -   id: fftsize
     label: FFT Size
-    dtype: int
+    dtype: enum
     default: '1024'
+    options: ['32','64','128','256','512','1024','2048','4096','8192','16384','32768']
     hide: ${ ('all' if type.startswith('msg') else 'none') }
 -   id: freqhalf
     label: Spectrum Width

--- a/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/freqdisplayform.h
@@ -124,7 +124,6 @@ private:
     bool d_clicked;
     double d_clicked_freq;
 
-    FFTSizeMenu* d_sizemenu;
     FFTAverageMenu* d_avgmenu;
     FFTWindowMenu* d_winmenu;
     QAction *d_minhold_act, *d_maxhold_act;

--- a/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfalldisplayform.h
@@ -97,7 +97,6 @@ private:
     double d_min_val, d_cur_min_val;
     double d_max_val, d_cur_max_val;
 
-    FFTSizeMenu* d_sizemenu;
     FFTAverageMenu* d_avgmenu;
     FFTWindowMenu* d_winmenu;
 };

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_c_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(d_fftsize);
+    set_output_multiple(32768);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,10 @@ QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize < 16384))
+    if ((fftsize > 16) && (fftsize <= 32768))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
 }
 
 int freq_sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_c_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(32768);
+    set_output_multiple(s_max_fft_size);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,13 @@ QWidget* freq_sink_c_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_c_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize <= 32768))
+    if ((fftsize >= s_min_fft_size) && (fftsize <= s_max_fft_size))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
+        throw std::runtime_error(
+            fmt::format("freq_sink: FFT size must be >= {} and <= {}.",
+                        s_min_fft_size,
+                        s_max_fft_size));
 }
 
 int freq_sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -27,6 +27,8 @@ class QTGUI_API freq_sink_c_impl : public freq_sink_c
 private:
     void initialize();
 
+    static const int s_min_fft_size = 32;
+    static const int s_max_fft_size = 32768;
     int d_fftsize;
     fft::fft_shift<float> d_fft_shift;
     float d_fftavg;

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_f_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(32768);
+    set_output_multiple(s_max_fft_size);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,13 @@ QWidget* freq_sink_f_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_f_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize <= 32768))
+    if ((fftsize >= s_min_fft_size) && (fftsize <= s_max_fft_size))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
+        throw std::runtime_error(
+            fmt::format("freq_sink: FFT size must be >= {} and <= {}.",
+                        s_min_fft_size,
+                        s_max_fft_size));
 }
 
 int freq_sink_f_impl::fft_size() const { return d_fftsize; }
@@ -647,5 +650,5 @@ void freq_sink_f_impl::handle_pdus(pmt::pmt_t msg)
     }
 }
 
-} /* namespace qtgui */
+} // namespace qtgui
 } /* namespace gr */

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -129,7 +129,7 @@ void freq_sink_f_impl::initialize()
     if (!d_name.empty())
         set_title(d_name);
 
-    set_output_multiple(d_fftsize);
+    set_output_multiple(32768);
 
     // initialize update time to 10 times a second
     set_update_time(0.1);
@@ -141,10 +141,10 @@ QWidget* freq_sink_f_impl::qwidget() { return d_main_gui; }
 
 void freq_sink_f_impl::set_fft_size(const int fftsize)
 {
-    if ((fftsize > 16) && (fftsize < 16384))
+    if ((fftsize > 16) && (fftsize <= 32768))
         d_main_gui->setFFTSize(fftsize);
     else
-        throw std::runtime_error("freq_sink: FFT size must be > 16 and < 16384.");
+        throw std::runtime_error("freq_sink: FFT size must be > 16 and <= 32768.");
 }
 
 int freq_sink_f_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -27,6 +27,8 @@ class QTGUI_API freq_sink_f_impl : public freq_sink_f
 private:
     void initialize();
 
+    static const int s_min_fft_size = 32;
+    static const int s_max_fft_size = 32768;
     int d_fftsize;
     fft::fft_shift<float> d_fft_shift;
     float d_fftavg;

--- a/gr-qtgui/lib/freqcontrolpanel.cc
+++ b/gr-qtgui/lib/freqcontrolpanel.cc
@@ -78,6 +78,8 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
     d_fft_size_combo->addItem("2048");
     d_fft_size_combo->addItem("4096");
     d_fft_size_combo->addItem("8192");
+    d_fft_size_combo->addItem("16384");
+    d_fft_size_combo->addItem("32768");
 
     d_fft_win_combo = new QComboBox();
     d_fft_win_combo->addItem("None");
@@ -169,7 +171,7 @@ FreqControlPanel::FreqControlPanel(FreqDisplayForm* form) : QVBoxLayout(), d_par
         d_autoscale_button, SIGNAL(pressed(void)), d_parent, SLOT(autoScaleShot(void)));
 
     connect(d_fft_size_combo,
-            SIGNAL(currentIndexChanged(const QString&)),
+            SIGNAL(currentTextChanged(const QString&)),
             d_parent,
             SLOT(notifyFFTSize(const QString&)));
     connect(d_fft_win_combo,
@@ -243,10 +245,7 @@ void FreqControlPanel::setFFTAverage(float val)
 
 void FreqControlPanel::toggleFFTSize(int val)
 {
-    int index = static_cast<int>(round(logf(static_cast<float>(val)) / logf(2.0f))) - 5;
-    index = std::max(index, 0);
-    index = std::min(index, d_fft_size_combo->count() - 1);
-    d_fft_size_combo->setCurrentIndex(index);
+    d_fft_size_combo->setCurrentText(QString::number(val));
 }
 
 void FreqControlPanel::toggleFFTWindow(const gr::fft::window::win_type win)

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -41,13 +41,10 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
     d_trig_channel = 0;
     d_trig_tag_key = "";
 
-    d_sizemenu = new FFTSizeMenu(this);
     d_avgmenu = new FFTAverageMenu(this);
     d_winmenu = new FFTWindowMenu(this);
-    d_menu->addMenu(d_sizemenu);
     d_menu->addMenu(d_avgmenu);
     d_menu->addMenu(d_winmenu);
-    connect(d_sizemenu, SIGNAL(whichTrigger(int)), this, SLOT(setFFTSize(const int)));
     connect(
         d_avgmenu, SIGNAL(whichTrigger(float)), this, SLOT(setFFTAverage(const float)));
     connect(d_winmenu,
@@ -136,7 +133,7 @@ FreqDisplayForm::FreqDisplayForm(int nplots, QWidget* parent)
             this,
             SLOT(onPlotPointSelected(const QPointF)));
 
-    connect(this, SIGNAL(signalReplot()), getPlot(), SLOT(replot()));
+    connect(this, SIGNAL(signalReplot()), d_display_plot, SLOT(replot()));
 }
 
 FreqDisplayForm::~FreqDisplayForm()
@@ -173,8 +170,6 @@ void FreqDisplayForm::setupControlPanel()
             SIGNAL(triggered(bool)),
             d_controlpanel,
             SLOT(toggleAxisLabels(bool)));
-    connect(
-        d_sizemenu, SIGNAL(whichTrigger(int)), d_controlpanel, SLOT(toggleFFTSize(int)));
     connect(d_winmenu,
             SIGNAL(whichTrigger(gr::fft::window::win_type)),
             d_controlpanel,
@@ -271,10 +266,9 @@ void FreqDisplayForm::setSampleRate(const QString& samprate)
 void FreqDisplayForm::setFFTSize(const int newsize)
 {
     d_fftsize = newsize;
-    d_sizemenu->getActionFromSize(newsize)->setChecked(true);
 
-    emit signalReplot();
     emit signalFFTSize(newsize);
+    emit signalReplot();
 }
 
 void FreqDisplayForm::setFFTAverage(const float newavg)

--- a/gr-qtgui/lib/waterfalldisplayform.cc
+++ b/gr-qtgui/lib/waterfalldisplayform.cc
@@ -73,13 +73,10 @@ WaterfallDisplayForm::WaterfallDisplayForm(int nplots, QWidget* parent)
     d_autoscale_act->setText(tr("Auto Scale"));
     d_autoscale_act->setCheckable(false);
 
-    d_sizemenu = new FFTSizeMenu(this);
     d_avgmenu = new FFTAverageMenu(this);
     d_winmenu = new FFTWindowMenu(this);
-    d_menu->addMenu(d_sizemenu);
     d_menu->addMenu(d_avgmenu);
     d_menu->addMenu(d_winmenu);
-    connect(d_sizemenu, SIGNAL(whichTrigger(int)), this, SLOT(setFFTSize(const int)));
     connect(
         d_avgmenu, SIGNAL(whichTrigger(float)), this, SLOT(setFFTAverage(const float)));
     connect(d_winmenu,
@@ -187,7 +184,6 @@ void WaterfallDisplayForm::setSampleRate(const QString& samprate)
 void WaterfallDisplayForm::setFFTSize(const int newsize)
 {
     d_fftsize = newsize;
-    d_sizemenu->getActionFromSize(newsize)->setChecked(true);
     getPlot()->replot();
 }
 


### PR DESCRIPTION
## Description
Continuation of #5442 - merge after that one
Change enums in grc to int so they can be made as variables
Add static variables to control the range

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
freq_sink_{c,f}

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Ran flowgraphs with freq sink of varying fft size

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
