### PR TITLE
grc: Follow up to #5442

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -399,6 +399,7 @@ outputs:
 
 asserts:
 - ${fftsize >= 32 and fftsize <= 32768}
+- ${not (fftsize & (fftsize -1))}
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -105,6 +105,7 @@ outputs:
 
 asserts:
 - ${fftsize >= 32 and fftsize <= 32768}
+- ${not (fftsize & (fftsize -1))}
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -103,6 +103,9 @@ outputs:
     optional: true
     hide: ${ not showports }
 
+asserts:
+- ${fftsize >= 32 and fftsize <= 32768}
+
 templates:
     imports: |-
         from PyQt5 import Qt

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -250,6 +250,9 @@ outputs:
     optional: true
     hide: ${ not showports }
 
+asserts:
+- ${fftsize >= 32 and fftsize <= 32768}
+
 templates:
     imports: |-
         from PyQt5 import Qt

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -252,6 +252,7 @@ outputs:
 
 asserts:
 - ${fftsize >= 32 and fftsize <= 32768}
+- ${not (fftsize & (fftsize -1))}
 
 templates:
     imports: |-

--- a/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
+++ b/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
@@ -94,6 +94,7 @@ public:
 
     static const long MAX_FFT_SIZE;
     static const long MIN_FFT_SIZE;
+    static const long DEFAULT_FFT_SIZE;
 
     QWidget* qwidget();
 

--- a/gr-qtgui/lib/SpectrumGUIClass.cc
+++ b/gr-qtgui/lib/SpectrumGUIClass.cc
@@ -18,7 +18,8 @@
 #include <QEvent>
 
 const long SpectrumGUIClass::MAX_FFT_SIZE = 32768;
-const long SpectrumGUIClass::MIN_FFT_SIZE = 256;
+const long SpectrumGUIClass::MIN_FFT_SIZE = 32;
+const long SpectrumGUIClass::DEFAULT_FFT_SIZE = 1024;
 
 SpectrumGUIClass::SpectrumGUIClass(const uint64_t maxDataSize,
                                    const uint64_t fftSize,

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -142,8 +142,18 @@ QWidget* sink_c_impl::qwidget() { return d_main_gui.qwidget(); }
 
 void sink_c_impl::set_fft_size(const int fftsize)
 {
-    d_fftsize = fftsize;
-    d_main_gui.setFFTSize(fftsize);
+    if ((fftsize >= d_main_gui.MIN_FFT_SIZE) && (fftsize <= d_main_gui.MAX_FFT_SIZE)) {
+        d_fftsize = fftsize;
+        d_main_gui.setFFTSize(fftsize);
+    } else {
+        GR_LOG_INFO(
+            d_logger,
+            fmt::format("FFT size must be >= {} and <= {}.\nSo falling back to {}.",
+                        d_main_gui.MIN_FFT_SIZE,
+                        d_main_gui.MAX_FFT_SIZE,
+                        d_main_gui.DEFAULT_FFT_SIZE));
+        d_main_gui.setFFTSize(d_main_gui.DEFAULT_FFT_SIZE);
+    }
 }
 
 int sink_c_impl::fft_size() const { return d_fftsize; }

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -135,8 +135,18 @@ QWidget* sink_f_impl::qwidget() { return d_main_gui.qwidget(); }
 
 void sink_f_impl::set_fft_size(const int fftsize)
 {
-    d_fftsize = fftsize;
-    d_main_gui.setFFTSize(fftsize);
+    if ((fftsize >= d_main_gui.MIN_FFT_SIZE) && (fftsize <= d_main_gui.MAX_FFT_SIZE)) {
+        d_fftsize = fftsize;
+        d_main_gui.setFFTSize(fftsize);
+    } else {
+        GR_LOG_INFO(
+            d_logger,
+            fmt::format("FFT size must be >= {} and <= {}.\nSo falling back to {}.",
+                        d_main_gui.MIN_FFT_SIZE,
+                        d_main_gui.MAX_FFT_SIZE,
+                        d_main_gui.DEFAULT_FFT_SIZE));
+        d_main_gui.setFFTSize(d_main_gui.DEFAULT_FFT_SIZE);
+    }
 }
 
 int sink_f_impl::fft_size() const { return d_fftsize; }


### PR DESCRIPTION
fftsize starts in the runtime gui of the f/c sink with 512.
Adjust it to 32 , as in freq_sink_f/c

Introduce fft range check to the sink_x and the waterfall_sink_x block.
Check inside the sink_(f/c) blcok, if the fftsize is valid, to avoid core dump.

---

# Pull Request Details
fftsize starts in the runtime gui of the f/c sink with 512.
Adjust it to 32 , as in it's yml file and in freq_sink_f/c

Introduce fft range check to the sink_x and the waterfall_sink_x block.
Check inside the sink_(f/c) blcok, if the fftsize is valid, to avoid core dump.

## Description
Adds range checks for sink_x and waterfall_sink_x
Completes #5442 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
