### PR TITLE
qtgui: initial value of autoscalex defined

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
+++ b/gr-qtgui/include/gnuradio/qtgui/HistogramDisplayPlot.h
@@ -72,7 +72,7 @@ private:
 
     bool d_semilogx = false;
     bool d_semilogy = false;
-    bool d_autoscalex_state = true;
+    bool d_autoscalex_state = false;
 };
 
 #endif /* HISTOGRAM_DISPLAY_PLOT_H */


### PR DESCRIPTION

## Description
A regression was reported in QT GUI histogram block, where x autoscale was not happening.  This brings the behavior back to match how it was in 3.9

NOTE: autoscale X doesn't seem to work in 3.9 or here, but prior to this PR - NOT autoscaling doesn't work (lots of double negatives).  This just matches the 3.9 behavior.

## Related Issue

## Which blocks/areas does this affect?
QT GUI Histogram 

## Testing Done
Ran flowgraph with histogram block, verified behavior was same in 3.9/

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- N/A [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- N/A [ ] I have added tests to cover my changes, and all previous tests pass.
