### PR TITLE
modtool: makeyaml update import to from gnuradio

### DIFF
--- a/gr-utils/modtool/tools/grc_yaml_generator.py
+++ b/gr-utils/modtool/tools/grc_yaml_generator.py
@@ -51,7 +51,7 @@ class GRCYAMLGenerator(object):
                         ('label', blockname.replace('_', ' ')),
                         (f'category', f'[{modname.capitalize()}]')
                         )
-        self._templates = (('imports', f'import {modname}'),
+        self._templates = (('imports', f'from gnuradio import {modname}'),
                            ('make', f'{modname}.{blockname}({str_})')
                            )
         self.params = params


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>

---
name: Pull Request Template
about: A template to help contributors submit clear pull-requests.
title: ''
labels: ''
## Description
Using `gr_modtool makeyaml` in gr 3.10 creates the old style import for the module
This updates to `from gnuradio import mymodule` in the make template in the generated yaml
Ideally this would do the check of gr39/gr310, but it is not readily availble at this point, so since makeyaml is an experimental feature, sticking with the broadest use case

## Which blocks/areas does this affect?
gr_modtool maintained blocks using gr_modtool makeyaml

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
