### PR TITLE
Use `to_code()` in advanced block params fields

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -213,13 +213,13 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         self.${blk.name}.set_block_alias("${blk.params['alias'].get_evaluated()}")
         % endif
         % if 'affinity' in blk.params and blk.params['affinity'].get_evaluated():
-        self.${blk.name}.set_processor_affinity(${blk.params['affinity'].get_evaluated()})
+        self.${blk.name}.set_processor_affinity(${blk.params['affinity'].to_code()})
         % endif
         % if len(blk.sources) > 0 and 'minoutbuf' in blk.params and int(blk.params['minoutbuf'].get_evaluated()) > 0:
-        self.${blk.name}.set_min_output_buffer(${blk.params['minoutbuf'].get_evaluated()})
+        self.${blk.name}.set_min_output_buffer(${blk.params['minoutbuf'].to_code()})
         % endif
         % if len(blk.sources) > 0 and 'maxoutbuf' in blk.params and int(blk.params['maxoutbuf'].get_evaluated()) > 0:
-        self.${blk.name}.set_max_output_buffer(${blk.params['maxoutbuf'].get_evaluated()})
+        self.${blk.name}.set_max_output_buffer(${blk.params['maxoutbuf'].to_code()})
         % endif
         % endfor
 


### PR DESCRIPTION
---
name: "Code" for advanced block params in generated file
about: Allows script parameters so set advanced block parameters upon python script initialization in auto-generated code
title: Code instead of constants for advanced block parameters in generated python files
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

This will allow script parameters/arguments to define buffer sizes and process affinity.  I can't think of any unintended negative impacts as changes to any variables used to define affinity and buffer sizes would not be propagated through to affinity or buffer changes after initialization.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This allows script parameters of the generated python file to set processor affinity, minimum output buffer size, and maximum output buffer size.

An example from a [test flowgraph](https://gist.github.com/mcdiarmid/f9267a3c23dec8bc86b11fd513ff2ca2) I have put together for this PR.  *Setting* the `core` parameter via the script argument `--core` does not actually do anything.  This is because `.get_evaluated()` is called within the mako file, using the default value of 0 rather than the `core` parameter to set processor affinity when compiling the flowgraph to a python file.

```bash
[campbell@craptop PRs]$ cat pr_5468_example.py | grep affinity
        self.blocks_transcendental_0.set_processor_affinity([0])
        self.blocks_throttle_0.set_processor_affinity([0])
        self.blocks_null_sink_0.set_processor_affinity([0])
        self.blocks_multiply_xx_0.set_processor_affinity([0])
        self.analog_sig_source_x_0.set_processor_affinity([0])
```

By changing `.get_evaluated()` to `.to_code()` in the mako file, the result aligns with the intention of the `core` parameter, and I now have the ability to set the processor affinity without editing a flowgraph variable, or editing the auto-generated python file. 

```bash
[campbell@craptop PRs]$ cat pr_5468_example.py | grep affinity
        self.blocks_transcendental_0.set_processor_affinity([core])
        self.blocks_throttle_0.set_processor_affinity([core])
        self.blocks_null_sink_0.set_processor_affinity([core])
        self.blocks_multiply_xx_0.set_processor_affinity([core])
        self.analog_sig_source_x_0.set_processor_affinity([core])
```
Simply, I can set this using the `--core` argument to the untouched generated python script.  This can be useful for running multiple instances of a CPU intensive script, or quick experimentation when it comes to modifying buffer sizes or manual core allocations of complex flowgraphs, without the need to recompile.

## Related Issue
No related issues to my knowledge

## Which blocks/areas does this affect?
Flowgraph compilation/generation of python files via GNURadio Companion

## Testing Done
Minimal direct testing, passes automatic pipeline though.  I've only verified that this does indeed allow me to set these advanced block parameters via python script parameters

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary (N/A).
- [ ] I have added tests to cover my changes, and all previous tests pass.
