### PR TITLE
blocktool: fix binding generation for uhd rfnoc blocks

### DIFF
--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -328,7 +328,8 @@ class GenericHeaderParser(BlockTool):
                 define_symbols=self.define_symbols,
                 cflags='-std=c++17 -fPIC')
             decls = parser.parse(
-                [self.target_file], xml_generator_config)
+                [self.target_file], xml_generator_config,
+                compilation_mode=parser.COMPILATION_MODE.ALL_AT_ONCE)
 
             global_namespace = declarations.get_global_namespace(decls)
 


### PR DESCRIPTION
Signed-off-by: André Apitzsch <andre.apitzsch@etit.tu-chemnitz.de>

---
name: Pull Request Template
about: A template to help contributors submit clear pull-requests.
title: 'blocktool: fix binding generation for uhd rfnoc blocks'
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This fixes
```
Traceback (most recent call last):
  File "/home/USER/gnuradio/gr-uhd/python/uhd/../../../gr-utils/bindtool/scripts/bind_intree_file.py", line 60, in <module>
    bg.gen_file_binding(args.filename)
  File "/usr/lib/python3.10/site-packages/gnuradio/bindtool/core/generator.py", line 197, in gen_file_binding
    raise(e)
  File "/usr/lib/python3.10/site-packages/gnuradio/bindtool/core/generator.py", line 184, in gen_file_binding
    header_info = parser.get_header_info(self.namespace)
  File "/usr/lib/python3.10/site-packages/gnuradio/blocktool/core/parseheader_generic.py", line 330, in get_header_info
    decls = parser.parse(
  File "/usr/lib/python3.10/site-packages/pygccxml/parser/__init__.py", line 51, in parse
    declarations = parser.read_files(files, compilation_mode)
  File "/usr/lib/python3.10/site-packages/pygccxml/parser/project_reader.py", line 264, in read_files
    return self.__parse_file_by_file(files)
  File "/usr/lib/python3.10/site-packages/pygccxml/parser/project_reader.py", line 332, in __parse_file_by_file
    leaved_classes = self._join_class_hierarchy(answer)
  File "/usr/lib/python3.10/site-packages/pygccxml/parser/project_reader.py", line 479, in _join_class_hierarchy
    leaved_derived = leaved_classes[
KeyError: (('/usr/include/c++/11.1.0/type_traits', 530), ('::', 'std', 'type'))
```
when running
```
python ../../../gr-utils/bindtool/scripts/bind_intree_file.py --output_dir . --module uhd --filename ../../include/gnuradio/uhd/rfnoc_ddc.h
```
from working directory `gr-uhd/python/uhd`.

It seems only `rfnoc_*.h` header trigger this error.

pygccxml version 2.2.1.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
