### PR TITLE
Initialize _overflow_count to zero

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -41,6 +41,7 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
       _tag_now(false),
       _issue_stream_cmd_on_start(issue_stream_cmd_on_start),
       _last_log(std::chrono::steady_clock::now()),
+      _overflow_count(0),
       _overflow_log_interval(
           gr::prefs::singleton()->get_long("uhd", "logging_interval_ms", 750))
 {


### PR DESCRIPTION
The first overflow count that the USRP source prints is bogus, because `_overflow_count` is uninitialized.

> usrp_source :error: In the last 13041 ms, 6881380 overflows occurred.

Valgrind also complains that uninitialized memory was read:

```
==130286== Thread 16 usrp_source56:
==130286== Use of uninitialised value of size 8
==130286==    at 0x6A9A10B: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==130286==    by 0x6A9A7AD: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<unsigned long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, unsigned long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==130286==    by 0x6AA900E: std::ostream& std::ostream::_M_insert<unsigned long>(unsigned long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==130286==    by 0x6F58810: put_last<char, std::char_traits<char> > (feed_args.hpp:149)
==130286==    by 0x6F58810: void boost::io::detail::put<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::io::detail::put_holder<char, std::char_traits<char> > const&, boost::io::detail::format_item<char, std::char_traits<char>, std::allocator<char> > const&, boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::string_type&, boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::internal_streambuf_t&, std::locale*) (feed_args.hpp:197)
==130286==    by 0x6F5944F: distribute<char, std::char_traits<char>, std::allocator<char>, const boost::io::detail::put_holder<char, std::char_traits<char> >&> (feed_args.hpp:291)
==130286==    by 0x6F5944F: void boost::io::detail::distribute<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) (feed_args.hpp:282)
==130286==    by 0x6F5950E: boost::basic_format<char, std::char_traits<char>, std::allocator<char> >& boost::io::detail::feed_impl<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) (feed_args.hpp:301)
==130286==    by 0x6F88DFE: feed<char, std::char_traits<char>, std::allocator<char>, unsigned int&> (feed_args.hpp:313)
==130286==    by 0x6F88DFE: operator%<unsigned int> (format_class.hpp:68)
==130286==    by 0x6F88DFE: gr::uhd::usrp_source_impl::work(int, std::vector<void const*, std::allocator<void const*> >&, std::vector<void*, std::allocator<void*> >&) (usrp_source_impl.cc:655)
==130286==    by 0x655567A: gr::sync_block::general_work(int, std::vector<int, std::allocator<int> >&, std::vector<void const*, std::allocator<void const*> >&, std::vector<void*, std::allocator<void*> >&) (sync_block.cc:49)
==130286==    by 0x6501E02: gr::block_executor::run_one_iteration() (block_executor.cc:623)
==130286==    by 0x65677C6: gr::tpb_thread_body::tpb_thread_body(std::shared_ptr<gr::block>, std::shared_ptr<boost::barrier>, int) (tpb_thread_body.cc:97)
==130286==    by 0x6554514: operator() (scheduler_tpb.cc:38)
==130286==    by 0x6554514: gr::thread::thread_body_wrapper<gr::tpb_container>::operator()() (thread_body_wrapper.h:49)
==130286==    by 0x658FF37: operator() (function_template.hpp:763)
==130286==    by 0x658FF37: boost::detail::thread_data<boost::function0<void> >::run() (thread.hpp:120)
==130286== 
==130286== Conditional jump or move depends on uninitialised value(s)
==130286==    at 0x6A9A11D: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==130286==    by 0x6A9A7AD: std::ostreambuf_iterator<char, std::char_traits<char> > std::num_put<char, std::ostreambuf_iterator<char, std::char_traits<char> > >::_M_insert_int<unsigned long>(std::ostreambuf_iterator<char, std::char_traits<char> >, std::ios_base&, char, unsigned long) const (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==130286==    by 0x6AA900E: std::ostream& std::ostream::_M_insert<unsigned long>(unsigned long) (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==130286==    by 0x6F58810: put_last<char, std::char_traits<char> > (feed_args.hpp:149)
==130286==    by 0x6F58810: void boost::io::detail::put<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::io::detail::put_holder<char, std::char_traits<char> > const&, boost::io::detail::format_item<char, std::char_traits<char>, std::allocator<char> > const&, boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::string_type&, boost::basic_format<char, std::char_traits<char>, std::allocator<char> >::internal_streambuf_t&, std::locale*) (feed_args.hpp:197)
==130286==    by 0x6F5944F: distribute<char, std::char_traits<char>, std::allocator<char>, const boost::io::detail::put_holder<char, std::char_traits<char> >&> (feed_args.hpp:291)
==130286==    by 0x6F5944F: void boost::io::detail::distribute<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) (feed_args.hpp:282)
==130286==    by 0x6F5950E: boost::basic_format<char, std::char_traits<char>, std::allocator<char> >& boost::io::detail::feed_impl<char, std::char_traits<char>, std::allocator<char>, boost::io::detail::put_holder<char, std::char_traits<char> > const&>(boost::basic_format<char, std::char_traits<char>, std::allocator<char> >&, boost::io::detail::put_holder<char, std::char_traits<char> > const&) (feed_args.hpp:301)
==130286==    by 0x6F88DFE: feed<char, std::char_traits<char>, std::allocator<char>, unsigned int&> (feed_args.hpp:313)
==130286==    by 0x6F88DFE: operator%<unsigned int> (format_class.hpp:68)
==130286==    by 0x6F88DFE: gr::uhd::usrp_source_impl::work(int, std::vector<void const*, std::allocator<void const*> >&, std::vector<void*, std::allocator<void*> >&) (usrp_source_impl.cc:655)
==130286==    by 0x655567A: gr::sync_block::general_work(int, std::vector<int, std::allocator<int> >&, std::vector<void const*, std::allocator<void const*> >&, std::vector<void*, std::allocator<void*> >&) (sync_block.cc:49)
==130286==    by 0x6501E02: gr::block_executor::run_one_iteration() (block_executor.cc:623)
==130286==    by 0x65677C6: gr::tpb_thread_body::tpb_thread_body(std::shared_ptr<gr::block>, std::shared_ptr<boost::barrier>, int) (tpb_thread_body.cc:97)
==130286==    by 0x6554514: operator() (scheduler_tpb.cc:38)
==130286==    by 0x6554514: gr::thread::thread_body_wrapper<gr::tpb_container>::operator()() (thread_body_wrapper.h:49)
==130286==    by 0x658FF37: operator() (function_template.hpp:763)
==130286==    by 0x658FF37: boost::detail::thread_data<boost::function0<void> >::run() (thread.hpp:120)
```
I've fixed that by initializing it to zero.