### PR TITLE
global: Replace stdio logging with logger (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/flowgraph.h
+++ b/gnuradio-runtime/include/gnuradio/flowgraph.h
@@ -252,6 +252,8 @@ protected:
     basic_block_vector_t d_blocks;
     edge_vector_t d_edges;
     msg_edge_vector_t d_msg_edges;
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
     flowgraph();
     std::vector<int> calc_used_ports(basic_block_sptr block, bool check_inputs);

--- a/gnuradio-runtime/include/gnuradio/pycallback_object.h
+++ b/gnuradio-runtime/include/gnuradio/pycallback_object.h
@@ -13,6 +13,8 @@
 #include <boost/format.hpp>
 #include <iostream>
 
+#include <iostream>
+
 enum pyport_t { PYPORT_STRING, PYPORT_FLOAT };
 
 int pycallback_object_count = 500;
@@ -71,7 +73,9 @@ public:
     {
         myType rVal = d_deflt;
         if (d_callback == NULL) {
-            printf("WARNING: pycallback_object get() called without py callback set!\n");
+            std::cerr
+                << "WARNING: pycallback_object get() called without py callback set!"
+                << std::endl;
             return rVal;
         } else {
             // obtain  PyGIL
@@ -131,7 +135,7 @@ private:
      * something. */
     myType pyCast(PyObject* obj)
     {
-        printf("TYPE NOT IMPLEMENTED!\n");
+        std::cerr << "TYPE NOT IMPLEMENTED!" << std::endl;
         assert(0);
         // the following is to make compilers happy only.
         myType dummy;

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -16,7 +16,9 @@
 #include <gnuradio/block_detail.h>
 #include <gnuradio/block_registry.h>
 #include <gnuradio/buffer.h>
+#include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
+#include <boost/format.hpp>
 #include <iostream>
 #include <stdexcept>
 
@@ -357,8 +359,9 @@ long block::min_output_buffer(size_t i)
 
 void block::set_min_output_buffer(long min_output_buffer)
 {
-    std::cout << "set_min_output_buffer on block " << unique_id() << " to "
-              << min_output_buffer << std::endl;
+    GR_LOG_INFO(d_logger,
+                boost::format("set_min_output_buffer on block %s to %d") % unique_id() %
+                    min_output_buffer);
     for (int i = 0; i < output_signature()->max_streams(); i++) {
         set_min_output_buffer(i, min_output_buffer);
     }
@@ -594,13 +597,13 @@ void block::reset_perf_counters()
 
 void block::system_handler(pmt::pmt_t msg)
 {
-    // std::cout << "system_handler " << msg << "\n";
+    // GR_LOG_INFO(d_logger, boost::format("system handler %s") % msg);
     pmt::pmt_t op = pmt::car(msg);
     if (pmt::eqv(op, d_pmt_done)) {
         d_finished = pmt::to_long(pmt::cdr(msg));
         global_block_registry.notify_blk(d_symbol_name);
     } else {
-        std::cout << "WARNING: bad message op on system port!\n";
+        GR_LOG_WARN(d_logger, "bad message op on system port!");
         pmt::print(msg);
     }
 }

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -35,10 +35,7 @@ flat_flowgraph_sptr make_flat_flowgraph()
     return flat_flowgraph_sptr(new flat_flowgraph());
 }
 
-flat_flowgraph::flat_flowgraph()
-{
-    configure_default_loggers(d_logger, d_debug_logger, "flat_flowgraph");
-}
+flat_flowgraph::flat_flowgraph() {}
 
 flat_flowgraph::~flat_flowgraph() {}
 
@@ -130,8 +127,8 @@ buffer_sptr flat_flowgraph::allocate_buffer(basic_block_sptr block, int port)
 
     // limit buffer size if indicated
     if (grblock->max_output_buffer(port) > 0) {
-        // std::cout << "constraining output items to " << block->max_output_buffer(port)
-        // << "\n";
+        // GR_LOG_INFO(d_debug_logger, boost::format("constraining output items to %d")
+        //         % block->max_output_buffer(port));
         nitems = std::min((long)nitems, (long)grblock->max_output_buffer(port));
         nitems -= nitems % grblock->output_multiple();
         if (nitems < 1)
@@ -371,24 +368,25 @@ std::string flat_flowgraph::msg_edge_list()
 void flat_flowgraph::dump()
 {
     for (edge_viter_t e = d_edges.begin(); e != d_edges.end(); e++)
-        std::cout << " edge: " << (*e) << std::endl;
+        GR_LOG_INFO(d_logger, boost::format(" edge: %s") % *e);
 
     for (basic_block_viter_t p = d_blocks.begin(); p != d_blocks.end(); p++) {
-        std::cout << " block: " << (*p) << std::endl;
+        GR_LOG_INFO(d_logger, boost::format(" block: %s") % *p);
         block_detail_sptr detail = cast_to_block_sptr(*p)->detail();
-        std::cout << "  detail @" << detail << ":" << std::endl;
+        GR_LOG_INFO(d_logger, boost::format(" detail @%s:") % detail);
 
         int ni = detail->ninputs();
         int no = detail->noutputs();
         for (int i = 0; i < no; i++) {
             buffer_sptr buffer = detail->output(i);
-            std::cout << "   output " << i << ": " << buffer << std::endl;
+            GR_LOG_INFO(d_logger, boost::format("   output %d: %s") % i % buffer);
         }
 
         for (int i = 0; i < ni; i++) {
             buffer_reader_sptr reader = detail->input(i);
-            std::cout << "   reader " << i << ": " << reader
-                      << " reading from buffer=" << reader->buffer() << std::endl;
+            GR_LOG_INFO(d_logger,
+                        boost::format("   reader %d: %s reading from buffer=%s") % i %
+                            reader % reader->buffer());
         }
     }
 }

--- a/gnuradio-runtime/lib/flat_flowgraph.h
+++ b/gnuradio-runtime/lib/flat_flowgraph.h
@@ -90,9 +90,6 @@ private:
      * start and restarts.
      */
     void setup_buffer_alignment(block_sptr block);
-
-    gr::logger_ptr d_logger;
-    gr::logger_ptr d_debug_logger;
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -22,13 +22,14 @@
 
 namespace gr {
 
-constexpr bool FLOWGRAPH_DEBUG = false;
-
 edge::~edge() {}
 
 flowgraph_sptr make_flowgraph() { return flowgraph_sptr(new flowgraph()); }
 
-flowgraph::flowgraph() {}
+flowgraph::flowgraph()
+{
+    configure_default_loggers(d_logger, d_debug_logger, "flowgraph");
+}
 
 flowgraph::~flowgraph() {}
 
@@ -76,8 +77,7 @@ void flowgraph::validate()
         std::vector<int> used_ports;
         int ninputs, noutputs;
 
-        if (FLOWGRAPH_DEBUG)
-            std::cout << "Validating block: " << (*p) << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, boost::format("Validating block: %s") % *p);
 
         used_ports = calc_used_ports(*p, true); // inputs
         ninputs = used_ports.size();
@@ -125,17 +125,16 @@ void flowgraph::check_valid_port(gr::io_signature::sptr sig, int port)
 
 void flowgraph::check_valid_port(const msg_endpoint& e)
 {
-    if (FLOWGRAPH_DEBUG)
-        std::cout << "check_valid_port( " << e.block() << ", " << e.port() << ")\n";
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("check_valid_port(%s, %s)") % e.block() % e.port());
 
     if (!e.block()->has_msg_port(e.port())) {
         const gr::basic_block::msg_queue_map_t& msg_map = e.block()->get_msg_map();
-        std::cout << "Could not find port: " << e.port() << " in:" << std::endl;
+        GR_LOG_WARN(d_logger, boost::format("Could not find port %s in:") % e.port());
         for (gr::basic_block::msg_queue_map_t::const_iterator it = msg_map.begin();
              it != msg_map.end();
              ++it)
-            std::cout << it->first << std::endl;
-        std::cout << std::endl;
+            GR_LOG_WARN(d_logger, boost::format("  %s") % it->first);
         throw std::invalid_argument("invalid msg port in connect() or disconnect()");
     }
 }

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/hier_block2.h>
+#include <gnuradio/logger.h>
 #include <flat_flowgraph.h>
 #include <boost/core/noncopyable.hpp>
 
@@ -64,6 +65,9 @@ private:
         d_inputs;                // Multiple internal endpoints per external input
     endpoint_vector_t d_outputs; // Single internal endpoint per external output
     basic_block_vector_t d_blocks;
+
+    gr::logger_ptr d_logger;
+    gr::logger_ptr d_debug_logger;
 
     void refresh_io_signature();
     void connect_input(int my_port, int port, basic_block_sptr block);

--- a/gnuradio-runtime/lib/logger.cc
+++ b/gnuradio-runtime/lib/logger.cc
@@ -82,7 +82,7 @@ void logger_config::watch_file(std::string filename, unsigned int watch_period)
             boost::this_thread::sleep(
                 boost::posix_time::time_duration(0, 0, watch_period, 0));
         } catch (const boost::thread_interrupted&) {
-            std::cout << "GNURadio leaving logger config file watch." << std::endl;
+            std::cerr << "GNURadio leaving logger config file watch." << std::endl;
             break;
         }
     }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/flowgraph_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/flowgraph_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(flowgraph.h)                                               */
-/* BINDTOOL_HEADER_FILE_HASH(3ab08834070348db57c720795b8de826)                     */
+/* BINDTOOL_HEADER_FILE_HASH(491fc0ad1bf7fb7ddeaf29bb662b5433)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-audio/lib/alsa/alsa_impl.cc
+++ b/gr-audio/lib/alsa/alsa_impl.cc
@@ -155,12 +155,10 @@ bool gri_alsa_pick_acceptable_format(snd_pcm_t* pcm,
                                  error_msg_tag % snd_pcm_name(pcm) % snd_strerror(err));
                 return false;
             }
-            if (verbose)
-                fprintf(stdout,
-                        "%s[%s]: using %s",
-                        error_msg_tag,
-                        snd_pcm_name(pcm),
-                        snd_pcm_format_name(acceptable_formats[i]));
+            GR_LOG_INFO(debug_logger,
+                        boost::format("%s[%s]: using %s") % error_msg_tag %
+                            snd_pcm_name(pcm) %
+                            snd_pcm_format_name(acceptable_formats[i]));
             *selected_format = acceptable_formats[i];
             return true;
         }

--- a/gr-audio/lib/osx/osx_source.cc
+++ b/gr-audio/lib/osx/osx_source.cc
@@ -220,7 +220,8 @@ void osx_source::setup()
         (d_output_sample_rate < 50000.0 ? 50000 : (UInt32)d_output_sample_rate);
 
 #if _OSX_AU_DEBUG_
-    std::cerr << "source(): max # samples = " << d_buffer_sample_count << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("source(): max # samples = %d") % d_buffer_sample_count);
 #endif
 
     // create the default AudioUnit for input
@@ -330,10 +331,9 @@ void osx_source::setup()
         err, "Get Device Input Stream Format (before) failed", "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    std::cerr << std::endl
-              << "---- Device Stream Format (before) ----" << std::endl
-              << d_asbd_device << std::endl
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("\n---- Device Stream Format (before) ----\n%s\n") %
+                     d_asbd_device);
 #endif
 
     // try to set the device (input) side of the audio device to the
@@ -364,10 +364,9 @@ void osx_source::setup()
         err, "Get Device Input Stream Format (after) failed", "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    std::cerr << std::endl
-              << "---- Device Stream Format (after) ----" << std::endl
-              << d_asbd_device << std::endl
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("\n---- Device Stream Format (after) ----\n%s\n") %
+                     d_asbd_device);
 #endif
 
     d_device_sample_rate = d_asbd_device.mSampleRate;
@@ -387,9 +386,9 @@ void osx_source::setup()
                           "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    std::cerr << "---- Client Stream Format (Before) ----" << std::endl
-              << d_asbd_client << std::endl
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("---- Client Stream Format (Before) ----\n%s\n") %
+                     d_asbd_client);
 #endif
 
     // Set the format of all the AUs to the
@@ -436,9 +435,9 @@ void osx_source::setup()
         err, "Get Device Output Stream Format (after) failed", "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    std::cerr << "---- Client Stream Format (After) ----" << std::endl
-              << d_asbd_client << std::endl
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("---- Client Stream Format (After) ----\n%s\n") %
+                     d_asbd_client);
 #endif
 
     d_pass_through = (d_asbd_client.mSampleRate == d_output_sample_rate);
@@ -645,26 +644,27 @@ void osx_source::setup()
     check_error_and_throw(err, "AudioUnitInitialize", "audio_osx_source::check_channels");
 
 #if _OSX_AU_DEBUG_
-    std::cerr << std::endl
-              << "audio_osx_source Parameters:" << std::endl
-              << "  Device Sample Rate is " << d_device_sample_rate << std::endl
-              << "  Client Sample Rate is "
-              << (d_pass_through ? d_output_sample_rate : d_device_sample_rate)
-              << std::endl
-              << "  User Sample Rate is " << d_output_sample_rate << std::endl
-              << "  Do Passthrough is " << (d_pass_through ? "true" : "false")
-              << std::endl
-              << "  Max Sample Count is " << d_buffer_sample_count << std::endl
-              << "  # Device Channels is " << d_n_dev_channels << std::endl
-              << "  Device Buffer Size in Frames = " << d_device_buffer_size_frames
-              << std::endl
-              << "  Lead Size in Frames = " << d_lead_size_frames << std::endl
-              << "  Trail Size in Frames = " << d_trail_size_frames << std::endl
-              << "  Input Buffer Size in Frames = " << d_input_buffer_size_frames
-              << std::endl
-              << "  Output Buffer Size in Frames = " << d_output_buffer_size_frames
-              << std::endl
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format(R"EOF(
+audio_osx_source Parameters:
+  Device Sample Rate is %d
+  Client Sample Rate is %d
+  User Sample Rate is %d
+  Do Passthrough is %s
+  Max Sample Count is %d
+  # Device Channels is %d
+  Device Buffer Size in Frames = %d
+  Lead Size in Frames = %d
+  Trail Size in Frames = %d
+  Input Buffer Size in Frames = %d
+  Output Buffer Size in Frames = %d
+)EOF") % d_device_sample_rate %
+                     (d_pass_through ? d_output_sample_rate : d_device_sample_rate) %
+                     d_output_sample_rate % (d_pass_through ? "true" : "false") %
+                     d_buffer_sample_count % d_n_dev_channels %
+                     d_device_buffer_size_frames % d_lead_size_frames %
+                     d_trail_size_frames % d_input_buffer_size_frames %
+                     d_output_buffer_size_frames);
 #endif
 }
 
@@ -681,8 +681,9 @@ void osx_source::alloc_audio_buffer_list(AudioBufferList** t_abl,
     int counter = n_channels;
 
 #if _OSX_AU_DEBUG_
-    std::cerr << "alloc_audio_buffer_list: (#chan, #bytes) == (" << n_channels << ", "
-              << input_buffer_size_bytes << ")" << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("alloc_audio_buffer_list: (#chan, #bytes) == (%d, %d)") %
+                     n_channels % input_buffer_size_bytes);
 #endif
 
     while (--counter >= 0) {
@@ -730,15 +731,17 @@ bool osx_source::is_running()
 bool osx_source::start()
 {
 #if _OSX_AU_DEBUG_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::start: Starting."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::start: Starting.") %
+                     ((void*)(pthread_self())));
 #endif
 
     if ((!is_running()) && d_input_au) {
 
 #if _OSX_AU_DEBUG_
-        std::cerr << ((void*)(pthread_self()))
-                  << " : audio_osx_source::start: Starting Audio Unit." << std::endl;
+        GR_LOG_DEBUG(d_debug_logger,
+                     boost::format("%s : audio_osx_source::start: Starting Audio Unit.") %
+                         ((void*)(pthread_self())));
 #endif
 
         // reset buffers before starting
@@ -759,8 +762,10 @@ bool osx_source::start()
     }
 
 #if _OSX_AU_DEBUG_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::start: Returning."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::start: Returning.") %
+                     (void*)(pthread_self()));
+
 #endif
 
     return (true);
@@ -769,14 +774,16 @@ bool osx_source::start()
 bool osx_source::stop()
 {
 #if _OSX_AU_DEBUG_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::stop: Starting."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::stop: Starting.") %
+                     ((void*)(pthread_self())));
 #endif
     if (is_running()) {
 
 #if _OSX_AU_DEBUG_
-        std::cerr << ((void*)(pthread_self()))
-                  << " : audio_osx_source::stop: stopping audio unit." << std::endl;
+        GR_LOG_DEBUG(d_debug_logger,
+                     boost::format("%s : audio_osx_source::stop: stopping audio unit.") %
+                         ((void*)(pthread_self())));
 #endif
 
         // stop the audio unit
@@ -792,8 +799,9 @@ bool osx_source::stop()
     }
 
 #if _OSX_AU_DEBUG_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::stop: Returning."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::stop: Returning.") %
+                     ((void*)(pthread_self())));
 #endif
 
     return (true);
@@ -802,8 +810,9 @@ bool osx_source::stop()
 void osx_source::teardown()
 {
 #if _OSX_AU_DEBUG_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::teardown: Starting."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::teardown: Starting.") %
+                     ((void*)(pthread_self())));
 #endif
 
     OSStatus err = noErr;
@@ -927,8 +936,9 @@ void osx_source::teardown()
     d_using_default_device = false;
 
 #if _OSX_AU_DEBUG_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::teardown: Returning."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::teardown: Returning.") %
+                     ((void*)(pthread_self())));
 #endif
 }
 
@@ -960,7 +970,9 @@ bool osx_source::check_topology(int ninputs, int noutputs)
     d_n_user_channels = noutputs;
 
 #if _OSX_AU_DEBUG_
-    std::cerr << "chk_topo: Actual # user output channels = " << noutputs << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("chk_topo: Actual # user output channels = %d") %
+                     noutputs);
 #endif
 
     return (true);
@@ -971,8 +983,9 @@ int osx_source::work(int noutput_items,
                      gr_vector_void_star& output_items)
 {
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << ((void*)(pthread_self())) << " : audio_osx_source::work: Starting."
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("%s : audio_osx_source::work: Starting.") %
+                     ((void*)(pthread_self())));
 #endif
     if (d_do_reset) {
         if (d_hardware_changed) {
@@ -999,13 +1012,13 @@ int osx_source::work(int noutput_items,
         } else {
 
 #if _OSX_AU_DEBUG_RENDER_
-            std::cerr << "audio_osx_source::work: doing reset." << std::endl;
+            GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: doing reset.");
 #endif
 
             GR_LOG_WARN(d_logger,
-                        boost::format("\n\nThe default input audio device has "
-                                      "changed; resetting audio.\nThere may "
-                                      "be a sound glitch while resetting.\n"));
+                        "\n\nThe default input audio device has "
+                        "changed; resetting audio.\nThere may "
+                        "be a sound glitch while resetting.\n");
 
             // for any changes, just tear down the current
             // configuration, then set it up again using the user's
@@ -1016,14 +1029,15 @@ int osx_source::work(int noutput_items,
             gr::thread::scoped_lock l(d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
-            std::cerr << "audio_osx_source::work: mutex locked." << std::endl;
+            GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: mutex locked.");
 #endif
 
             setup();
             start();
 
 #if _OSX_AU_DEBUG_RENDER_
-            std::cerr << "audio_osx_source::work: returning after reset." << std::endl;
+            GR_LOG_DEBUG(d_debug_logger,
+                         "audio_osx_source::work: returning after reset.");
 #endif
             return (0);
         }
@@ -1032,12 +1046,11 @@ int osx_source::work(int noutput_items,
     gr::thread::scoped_lock l(d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "audio_osx_source::work: mutex locked." << std::endl;
-#endif
+    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: mutex locked.");
 
-#if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "work1: SC = " << d_queue_sample_count << ", #OI = " << noutput_items
-              << ", #Chan = " << output_items.size() << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("work1: SC=%d, #OI=%d, #Chan=%d") % d_queue_sample_count %
+                     noutput_items % output_items.size());
 #endif
 
     // set the actual # of output items to the 'desired' amount then
@@ -1057,13 +1070,13 @@ int osx_source::work(int noutput_items,
                     // release control so-as to allow data to be retrieved;
                     // block until there is data to return
 #if _OSX_AU_DEBUG_RENDER_
-                    std::cerr << "audio_osx_source::work: waiting." << std::endl;
+                    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: waiting.");
 #endif
                     d_waiting_for_data = true;
                     d_cond_data.wait(l);
                     d_waiting_for_data = false;
 #if _OSX_AU_DEBUG_RENDER_
-                    std::cerr << "audio_osx_source::work: done waiting." << std::endl;
+                    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: done waiting.");
 #endif
                     // the condition's 'notify' was called; acquire control to
                     // keep thread safe
@@ -1072,9 +1085,8 @@ int osx_source::work(int noutput_items,
                     // up the next time this method is called.
                     if (d_do_reset) {
 #if _OSX_AU_DEBUG_RENDER_
-                        std::cerr << "audio_osx_source::work: "
-                                     "returning for reset."
-                                  << std::endl;
+                        GR_LOG_DEBUG(d_debug_logger,
+                                     "audio_osx_source::work: returning for reset.");
 #endif
                         return (0);
                     }
@@ -1082,9 +1094,9 @@ int osx_source::work(int noutput_items,
             } else {
                 // no data & not blocking; return nothing
 #if _OSX_AU_DEBUG_RENDER_
-                std::cerr << "audio_osx_source::work: no data "
-                             "& not blocking; returning 0."
-                          << std::endl;
+                GR_LOG_DEBUG(
+                    d_debug_logger,
+                    "audio_osx_source::work: no data & not blocking; returning 0.");
 #endif
                 return (0);
             }
@@ -1095,8 +1107,9 @@ int osx_source::work(int noutput_items,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "audio_osx_source::work: copying " << actual_noutput_items
-              << " items per channel" << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("audio_osx_source::work: copying %d items per channel") %
+                     actual_noutput_items);
 #endif
 
     // number of channels
@@ -1127,12 +1140,12 @@ int osx_source::work(int noutput_items,
     d_queue_sample_count -= actual_noutput_items;
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "work2: SC = " << d_queue_sample_count
-              << ", act#OI = " << actual_noutput_items << std::endl
-              << "Returning." << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("work2: SC = %d, act#OI = %d\nReturning.") %
+                     d_queue_sample_count % actual_noutput_items);
 #endif
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "audio_osx_source::work: returning." << std::endl;
+    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: returning.");
 #endif
 
     return (actual_noutput_items);
@@ -1157,9 +1170,9 @@ OSStatus osx_source::converter_callback(AudioConverterRef in_audio_converter,
     This->d_n_actual_input_frames = (*io_number_data_packets);
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "cc1: io#DP = " << (*io_number_data_packets)
-              << ", TIBSB = " << total_input_buffer_size_bytes << ", #C = " << counter
-              << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("cc1: io#DP = %d, TIBSB = %d, #C = %d") %
+                     (*io_number_data_packets) % total_input_buffer_size_bytes % counter);
 #endif
 
     while (--counter >= 0) {
@@ -1170,7 +1183,7 @@ OSStatus osx_source::converter_callback(AudioConverterRef in_audio_converter,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "cc2: Returning." << std::endl;
+    GR_LOG_DEBUG(d_debug_logger, "cc2: Returning.");
 #endif
 
     return (noErr);
@@ -1184,26 +1197,30 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
                                        AudioBufferList* io_data)
 {
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << ((void*)(pthread_self()))
-              << " : audio_osx_source::au_input_callback: Starting." << std::endl;
+    // GR_LOG_DEBUG(This->d_debug_logger, boost::format("%s :
+    // audio_osx_source::au_input_callback: Starting." )
+    //         % ((void*)(pthread_self())));
 #endif
 
     osx_source* This = reinterpret_cast<osx_source*>(in_ref_con);
     gr::thread::scoped_lock l(This->d_internal);
     gr::logger_ptr d_logger = This->d_logger;
+    gr::logger_ptr d_debug_logger = This->d_debug_logger;
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "audio_osx_source::au_input_callback: mutex locked." << std::endl;
+    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::au_input_callback: mutex locked.");
 #endif
 
     OSStatus err = noErr;
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "cb0: in#Fr = " << in_number_frames << ", inBus# = " << in_bus_number
-              << ", idD = " << ((void*)io_data)
-              << ", d_ib = " << ((void*)(This->d_input_buffer))
-              << ", d_ib#c = " << This->d_input_buffer->mNumberBuffers
-              << ", SC = " << This->d_queue_sample_count << std::endl;
+    GR_LOG_DEBUG(
+        d_debug_logger,
+        boost::format(
+            "cb0: in#Fr = %d, inBus# = %d, idD = %d, d_ib = %d, d_ib#c = %d, SC = %d") %
+            in_number_frames % in_bus_number % ((void*)io_data) %
+            ((void*)(This->d_input_buffer)) % This->d_input_buffer->mNumberBuffers %
+            This->d_queue_sample_count);
 #endif
 
     if (This->d_do_reset) {
@@ -1278,8 +1295,9 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
 #endif
 
 #if _OSX_AU_DEBUG_RENDER_
-        std::cerr << "cb1:  avail: #IF = " << available_input_frames
-                  << ", #OF = " << available_output_frames << std::endl;
+        GR_LOG_DEBUG(d_debug_logger,
+                     boost::format("cb1:  avail: #IF = %d, #OF = %d") %
+                         available_input_frames % available_output_frames);
 #endif
         actual_output_frames = available_output_frames;
 
@@ -1302,11 +1320,14 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
         // output frames
 
 #if _OSX_AU_DEBUG_RENDER_
-        std::cerr << "cb2: actual: #IF = " << This->d_n_actual_input_frames
-                  << ", #OF = " << actual_output_frames << std::endl;
+        GR_LOG_DEBUG(d_debug_logger,
+                     boost::format("cb2: actual: #IF = %d, #OF = %d") %
+                         This->d_n_actual_input_frames % actual_output_frames);
+
         if (This->d_n_actual_input_frames != available_input_frames)
-            std::cerr << "cb2.1: avail#IF = " << available_input_frames
-                      << ", actual#IF = " << This->d_n_actual_input_frames << std::endl;
+            GR_LOG_WARN(d_debug_logger,
+                        boost::format("cb2.1: (avail#IF = %d) != (actual#IF = %d)") %
+                            available_input_frames % This->d_n_actual_input_frames);
 #endif
     }
 
@@ -1319,7 +1340,7 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
         float* in_buffer = (float*)This->d_output_buffer->mBuffers[counter].mData;
 
 #if _OSX_AU_DEBUG_RENDER_
-        std::cerr << "cb3: enqueuing audio data." << std::endl;
+        GR_LOG_DEBUG(d_debug_logger, "cb3: enqueuing audio data.");
 #endif
 
         int l_res = This->d_buffers[counter]->enqueue(in_buffer, actual_output_frames);
@@ -1340,9 +1361,10 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "cb4: #OI = " << actual_output_frames
-              << ", #Cnt = " << This->d_queue_sample_count
-              << ", mSC = " << This->d_buffer_sample_count << std::endl;
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("cb4: #OI = %d, #Cnt = %d, mSC = %d") %
+                     actual_output_frames % This->d_queue_sample_count %
+                     This->d_buffer_sample_count);
 #endif
 
     // signal that data is available, if appropriate
@@ -1352,7 +1374,7 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    std::cerr << "cb5: returning." << std::endl;
+    GR_LOG_DEBUG(d_debug_logger, "cb5: returning.");
 #endif
 
     return (err);

--- a/gr-blocks/lib/check_lfsr_32k_s_impl.cc
+++ b/gr-blocks/lib/check_lfsr_32k_s_impl.cc
@@ -17,6 +17,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+static constexpr bool CHECK_LFSR_DEBUG = false;
+
 namespace gr {
 namespace blocks {
 
@@ -112,11 +114,11 @@ void check_lfsr_32k_s_impl::enter_SEARCHING()
     d_runlength = 0;
     d_index = 0; // reset LFSR to beginning
 
-    if (0)
-        fprintf(stdout,
-                "check_lfsr_32k: enter_SEARCHING at offset %8ld (0x%08lx)\n",
-                d_ntotal,
-                d_ntotal);
+    if (CHECK_LFSR_DEBUG)
+        GR_LOG_DEBUG(
+            d_debug_logger,
+            boost::format("check_lfsr_32k: enter_SEARCHING at offset %8ld (0x%08lx)") %
+                d_ntotal % d_ntotal);
 
     enter_MATCH0();
 }
@@ -136,25 +138,21 @@ void check_lfsr_32k_s_impl::enter_LOCKED()
 
     d_index = 3; // already matched first 3 items
 
-    if (0)
-        fprintf(stdout,
-                "check_lfsr_32k: enter_LOCKED at offset %8ld (0x%08lx)\n",
-                d_ntotal,
-                d_ntotal);
+    if (CHECK_LFSR_DEBUG)
+        GR_LOG_DEBUG(
+            d_debug_logger,
+            boost::format("check_lfsr_32k: enter_LOCKED at offset %8ld (0x%08lx)") %
+                d_ntotal % d_ntotal);
 }
 
 void check_lfsr_32k_s_impl::log_error(unsigned short expected, unsigned short actual)
 {
-    if (0)
-        fprintf(stdout,
-                "check_lfsr_32k: expected %5d (0x%04x) got %5d (0x%04x) offset %8ld "
-                "(0x%08lx)\n",
-                expected,
-                expected,
-                actual,
-                actual,
-                d_ntotal,
-                d_ntotal);
+    if (CHECK_LFSR_DEBUG)
+        GR_LOG_DEBUG(
+            d_debug_logger,
+            boost::format("check_lfsr_32k: expected %5d (0x%04x) got %5d (0x%04x) "
+                          "offset %8ld (0x%08lx)") %
+                expected % expected % actual % actual % d_ntotal % d_ntotal);
 }
 
 } /* namespace blocks */

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -18,6 +18,9 @@
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
+
+#include <boost/format.hpp>
+
 #include <stdexcept>
 
 namespace gr {
@@ -68,15 +71,12 @@ void constellation_receiver_cb_impl::phase_error_tracking(float phase_error)
     frequency_limit();
 
 #if VERBOSE_COSTAS
-    printf("cl: phase_error: %f  phase: %f  freq: %f  sample: %f+j%f  constellation: "
-           "%f+j%f\n",
-           phase_error,
-           d_phase,
-           d_freq,
-           sample.real(),
-           sample.imag(),
-           d_constellation->points()[d_current_const_point].real(),
-           d_constellation->points()[d_current_const_point].imag());
+    GR_LOG_DEBUG(d_debug_logger,
+                 boost::format("cl: phase_error: %f  phase: %f  freq: %f  sample: %f+j%f "
+                               " constellation: %f+j%f") %
+                     phase_error % d_phase % d_freq % sample.real() % sample.imag() %
+                     d_constellation->points()[d_current_const_point].real() %
+                     d_constellation->points()[d_current_const_point].imag());
 #endif
 }
 

--- a/gr-digital/lib/fll_band_edge_cc_impl.cc
+++ b/gr-digital/lib/fll_band_edge_cc_impl.cc
@@ -17,6 +17,7 @@
 #include <gnuradio/io_signature.h>
 #include <cstdio>
 #include <memory>
+#include <sstream>
 
 namespace gr {
 namespace digital {
@@ -171,17 +172,18 @@ void fll_band_edge_cc_impl::design_filter(float samps_per_sym,
 
 void fll_band_edge_cc_impl::print_taps()
 {
-    printf("Upper Band-edge: [");
-    for (const auto& tap : d_taps_upper) {
-        printf(" %.4e + %.4ej,", tap.real(), tap.imag());
-    }
-    printf("]\n\n");
+    std::stringstream ss;
+    ss << "Upper Band-edge: [";
+    for (const auto& tap : d_taps_upper)
+        ss << boost::format(" %.4e + %.4ej,") % tap.real() % tap.imag();
+    ss << "]\n\n";
 
-    printf("Lower Band-edge: [");
-    for (const auto& tap : d_taps_lower) {
-        printf(" %.4e + %.4ej,", tap.real(), tap.imag());
-    }
-    printf("]\n\n");
+    ss << "Lower Band-edge: [";
+    for (const auto& tap : d_taps_lower)
+        ss << boost::format(" %.4e + %.4ej,") % tap.real() % tap.imag();
+    ss << "]\n";
+
+    GR_LOG_INFO(d_logger, ss.str());
 }
 
 int fll_band_edge_cc_impl::work(int noutput_items,

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -14,8 +14,10 @@
 
 #include "async_encoder_impl.h"
 #include <gnuradio/io_signature.h>
+#include <gnuradio/logger.h>
 #include <volk/volk.h>
-#include <cstdio>
+
+#include <boost/format.hpp>
 
 namespace gr {
 namespace fec {
@@ -94,10 +96,10 @@ void async_encoder_impl::encode_unpacked(pmt::pmt_t msg)
     } else {
         nblocks = nbits_in / d_encoder->get_input_size();
         if (nblocks * d_encoder->get_input_size() != nbits_in) {
-            printf("nblocks: %u, in_block_size: %d, got_input_size: %d\n",
-                   nblocks,
-                   d_encoder->get_input_size(),
-                   nbits_in);
+            GR_LOG_ERROR(
+                d_logger,
+                boost::format("nblocks: %u, in_block_size: %d, got_input_size: %d") %
+                    nblocks % d_encoder->get_input_size() % nbits_in);
             throw std::runtime_error("input does not divide into code block size!");
         }
         nbits_out = nblocks * d_encoder->get_output_size();


### PR DESCRIPTION
This commit replaces many uses of std::c{out,err} and printf with the
appropriate GR_LOG_* directives.

Signed-off-by: David Winter <david.winter@analog.com>
(cherry picked from commit db01027fd99c882cf8b3a7dad854606499778e3b)

Removed mods to gr-blocks/lib/qa_block_tags.cc due to differences
in logging code.

Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport #5105 