### PR TITLE
uhd: Initialize _overflow_count to zero (backport to maint-3.10)

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -41,6 +41,7 @@ usrp_source_impl::usrp_source_impl(const ::uhd::device_addr_t& device_addr,
       _tag_now(false),
       _issue_stream_cmd_on_start(issue_stream_cmd_on_start),
       _last_log(std::chrono::steady_clock::now()),
+      _overflow_count(0),
       _overflow_log_interval(
           gr::prefs::singleton()->get_long("uhd", "logging_interval_ms", 750))
 {


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 0975b99f70a31d57bc3a7af9b4a585c54ab9745f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5475