### PR TITLE
hier_block2: prevent crash/freeze after disconnection

### DIFF
--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -59,7 +59,8 @@ public:
 private:
     // Private implementation data
     hier_block2* d_owner;
-    hier_block2_detail* d_parent_detail;
+    std::weak_ptr<hier_block2> d_parent;
+    int d_parent_refcnt;
     flowgraph_sptr d_fg;
     std::vector<endpoint_vector_t>
         d_inputs;                // Multiple internal endpoints per external input
@@ -77,6 +78,9 @@ private:
 
     endpoint_vector_t resolve_port(int port, bool is_input);
     endpoint_vector_t resolve_endpoint(const endpoint& endp, bool is_input) const;
+    void set_parent(hier_block2* parent);
+    void reset_parent(bool force = false);
+    void reset_hier_blocks_parent();
 };
 
 } /* namespace gr */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -253,6 +253,9 @@ if(ENABLE_TESTING)
     GR_ADD_CPP_TEST("blocks_${qa_file}"
       ${CMAKE_CURRENT_SOURCE_DIR}/${qa_file}
     )
+    set_tests_properties("blocks_${qa_file}"
+        PROPERTIES TIMEOUT 30
+    )
   endforeach(qa_file)
 
 endif(ENABLE_TESTING)

--- a/gr-blocks/python/blocks/qa_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_hier_block2.py
@@ -476,6 +476,46 @@ class test_hier_block2(gr_unittest.TestCase):
         hblock.wait()
         self.assertEqual(40, self.test_34b_val)
 
+    def test_035_lock_after_disconnect(self):
+        tb = gr.top_block()
+        src = blocks.vector_source_f([1.0, ])
+        hb = gr.hier_block2("hb",
+                            gr.io_signature(1, 1, gr.sizeof_float),
+                            gr.io_signature(1, 1, gr.sizeof_float))
+        m1 = multiply_const_ff(1.0)
+        hb.connect(hb, m1)
+        hb.connect(m1, hb)
+        dst1 = blocks.vector_sink_f()
+        dst2 = blocks.vector_sink_f()
+        tb.connect(src, hb, dst1)
+        tb.connect(hb, dst2)
+        tb.run()
+        tb.disconnect(hb, dst2)
+        hb.lock()
+        hb.unlock()
+        tb.run()
+
+    def test_036_unconnected_lock(self):
+        hb = gr.hier_block2("hb",
+                            gr.io_signature(1, 1, gr.sizeof_float),
+                            gr.io_signature(1, 1, gr.sizeof_float))
+        hb.lock()
+        hb.unlock()
+
+    def test_037_crossparent(self):
+        hb = gr.hier_block2("hb",
+                            gr.io_signature(1, 1, gr.sizeof_float),
+                            gr.io_signature(1, 1, gr.sizeof_float))
+        parent0 = gr.hier_block2("parent0",
+                                 gr.io_signature(1, 1, gr.sizeof_float),
+                                 gr.io_signature(1, 1, gr.sizeof_float))
+        parent1 = gr.hier_block2("parent1",
+                                 gr.io_signature(1, 1, gr.sizeof_float),
+                                 gr.io_signature(1, 1, gr.sizeof_float))
+        parent0.connect(parent0, hb)
+        self.assertRaises(RuntimeError,
+                          lambda: parent1.connect(hb, parent1))
+
 
 if __name__ == "__main__":
     gr_unittest.run(test_hier_block2)


### PR DESCRIPTION
Signed-off-by: Vladisslav P <vladisslav@inbox.ru>


# Pull Request Details
Fix freeze on hier_block2::lock() when hier_block2 is just created.
Fix freeze on hier_block2::lock() when was disconnected from another block
and disconnect(hier_block...) is the last operation before  hier_block2::lock()

## Description
1. Check for top_block correctly with dynamic_cast
2. Use weak_ptr to track parent block
3. Maintain reference counter and clear d_parent when all ports get disconnected
4. Clear d_parent on disconnect_all
5. Add tests
6. Limit test run time to 30 seconds to make it fail in predictable time (blocks only)

## Related Issue
Close https://github.com/gnuradio/gnuradio/issues/5436

## Which blocks/areas does this affect?
hier_block2

## Testing Done
C++ test `main.cpp`:
```
#include <iostream>

#include <gnuradio/blocks/null_sink.h>
#include <gnuradio/blocks/null_source.h>
#include <gnuradio/hier_block2.h>
#include <gnuradio/blocks/copy.h>
#include <gnuradio/top_block.h>


class test_block : public gr::hier_block2
{

public:
typedef std::shared_ptr<test_block> sptr;
    static test_block::sptr make()
    {
        return gnuradio::get_initial_sptr(new test_block());
    }
    test_block();
    virtual ~test_block();
    void trigger();

private:
    gr::blocks::copy::sptr d_copy;
};

test_block::test_block(): gr::hier_block2 ("test_block",
                          gr::io_signature::make (1, 1, sizeof(gr_complex)),
                          gr::io_signature::make (1, 1, sizeof(gr_complex)))

{
    d_copy = gr::blocks::copy::make(sizeof(gr_complex));
    connect(self() , 0 , d_copy , 0);
    connect(d_copy , 0, self() , 0);
}

test_block::~test_block()
{
}

void test_block::trigger()
{
    std::cerr<<"test_block->trigger"<<std::endl;
    lock();
    std::cerr<<"test_block->lock"<<std::endl;
    unlock();
    std::cerr<<"test_block->unlock"<<std::endl;
}

int main()
{
    auto tb = gr::make_top_block("buggy");
    auto test0 = test_block::make();
    auto src0 = gr::blocks::null_source::make(sizeof(gr_complex));
    auto snk0 = gr::blocks::null_sink::make(sizeof(gr_complex));
    auto snk1 = gr::blocks::null_sink::make(sizeof(gr_complex));
    test0->lock();
    test0->unlock();
    std::cerr<<"Unconnected lock test successful."<<std::endl;
    tb->lock();
    std::cerr<<"tb->lock"<<std::endl;
    tb->connect(src0, 0, test0, 0);
    tb->connect(test0, 0, snk0, 0);
    tb->connect(test0, 0, snk1, 0);
    tb->unlock();
    std::cerr<<"tb->unlock"<<std::endl;
    tb->start();
    std::cerr<<"tb->start"<<std::endl;
    tb->lock();
    std::cerr<<"tb->lock"<<std::endl;
    tb->disconnect(test0, 0, snk1, 0);
    tb->unlock();
    std::cerr<<"tb->unlock"<<std::endl;
    test0->trigger();
    std::cerr<<"TEST PASSED!!!"<<std::endl;
    tb->lock();
    tb->disconnect_all();
    std::cerr<<"tb->disconnect_all"<<std::endl;
    tb->connect(src0, 0, snk0, 0);
    tb->unlock();
    std::cerr<<"tb->unlock"<<std::endl;
    test0->trigger();
    std::cerr<<"TEST 2PASSED!!!"<<std::endl;
    return 0;
}

```
Compile: `g++ main.cpp -o main -lboost_system -lfmt -lgnuradio-runtime -lgnuradio-pmt -lvolk -lgnuradio-blocks`
Run: `./main`
Expected output:
```
Unconnected lock test successful.
tb->lock
tb->unlock
tb->start
tb->lock
tb->unlock
test_block->trigger
test_block->lock
test_block->unlock
TEST PASSED!!!
tb->disconnect_all
tb->unlock
test_block->trigger
test_block->lock
test_block->unlock
TEST 2PASSED!!!
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
