### PR TITLE
global: cleanup name change master to main

### DIFF
--- a/.conda-forge.yml
+++ b/.conda-forge.yml
@@ -47,4 +47,4 @@ skip_render:
   - LICENSE
 # enable uploads to Anaconda Cloud from specified branches only
 # ***** UPDATE THIS FOR MAINTENANCE BRANCHES ********************************
-upload_on_branch: master
+upload_on_branch: main

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,10 +38,11 @@ body:
       label: GNU Radio Version
       description: What version of GNU Radio are you running?
       options:
-        - 3.10-git (master)
-        - 3.9 (maint-3.9)
-        - 3.8 (maint-3.8)
-        - 3.7 (maint-3.7)
+        - 3.11-git (main)
+        - 3.10 (maint-3.10)
+        - 3.9  (maint-3.9)
+        - 3.8  (maint-3.8)
+        - 3.7  (maint-3.7)
     validations:
       required: true
   - type: input

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ assignees: ''
 <!--- (leave blank) -->
 <!--- `details of what/why/how an issue was addressed` -->
 <!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
-<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
+<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
 
 ## Description
 <!--- Provide a general summary of your changes in the title above -->
@@ -41,9 +41,9 @@ assignees: ''
 <!--- boxes that apply. Note that some of these may not be valid -->
 <!--- for all PRs. -->
 
-- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md).
+- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
 - [ ] I have squashed my commits to have one significant change per commit. 
-- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md#dco-signed)
-- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md).
+- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
+- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
 - [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
 - [ ] I have added tests to cover my changes, and all previous tests pass.

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -39,7 +39,7 @@ jobs:
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        UPLOAD_ON_BRANCH: master
+        UPLOAD_ON_BRANCH: main
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
       shell: bash
       run: |
@@ -61,7 +61,7 @@ jobs:
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
-        UPLOAD_ON_BRANCH: master
+        UPLOAD_ON_BRANCH: main
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
       shell: bash
       run: |
@@ -109,7 +109,7 @@ jobs:
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
-        UPLOAD_ON_BRANCH: master
+        UPLOAD_ON_BRANCH: main
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
       if: matrix.os == 'windows'
     - name: Prepare conda build artifacts

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -2,10 +2,10 @@ name: 'Make Test'
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   # We start with checking C++ formatting. No one gets free CPU cycles if they
   # can't use clang-format.

--- a/.github/workflows/pkg-debian.yml
+++ b/.github/workflows/pkg-debian.yml
@@ -5,7 +5,7 @@ on:
       build_branch:
         description: 'Branch to build from'
         required: true
-        default: 'master'
+        default: 'main'
       rev:
         description: 'Package revision'
         required: true
@@ -68,7 +68,7 @@ jobs:
         export DEBEMAIL="${{secrets.EMAIL}}" 
         export UBUEMAIL="${{secrets.EMAIL}}" 
         export DISTRIBUTION="${{ github.event.inputs.distribution }}"
-        export GITBRANCH="master"
+        export GITBRANCH="main"
         export REV="${{ github.event.inputs.rev }}"
         cd /build && sh $GITHUB_WORKSPACE/.packaging/scripts/pkg-debian.sh
     - name: Push to Launchpad

--- a/.github/workflows/pkg-fedora.yml
+++ b/.github/workflows/pkg-fedora.yml
@@ -5,7 +5,7 @@ on:
       build_branch:
         description: 'Branch to build from'
         required: true
-        default: 'master'
+        default: 'main'
       rev:
         description: 'Package revision'
         required: true
@@ -59,7 +59,7 @@ jobs:
     - name: Run Packaging Script
       run: |
         export DISTRIBUTION="fedora"
-        export GITBRANCH="master"
+        export GITBRANCH="main"
         export REV="${{ github.event.inputs.rev }}"
         cd /build && sh $GITHUB_WORKSPACE/.packaging/scripts/pkg-fedora.sh
     - name: Archive SRPM

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-<img src="https://github.com/gnuradio/gnuradio/blob/master/docs/gnuradio.png" width="75%" />
+<img src="https://github.com/gnuradio/gnuradio/blob/main/docs/gnuradio.png" width="75%" />
 </p>
 
-[![Make Test](https://github.com/gnuradio/gnuradio/actions/workflows/make-test.yml/badge.svg?branch=master)](https://github.com/gnuradio/gnuradio/actions/workflows/make-test.yml)
+[![Make Test](https://github.com/gnuradio/gnuradio/actions/workflows/make-test.yml/badge.svg?branch=main)](https://github.com/gnuradio/gnuradio/actions/workflows/make-test.yml)
 ![Version](https://img.shields.io/github/tag/gnuradio/gnuradio.svg)
-[![AUR](https://img.shields.io/github/license/gnuradio/gnuradio)](https://github.com/gnuradio/gnuradio/blob/master/COPYING)
+[![AUR](https://img.shields.io/github/license/gnuradio/gnuradio)](https://github.com/gnuradio/gnuradio/blob/main/COPYING)
 [![Docs](https://img.shields.io/badge/docs-doxygen-orange.svg)](https://www.gnuradio.org/doc/doxygen/)
 [![Packaging status](https://repology.org/badge/tiny-repos/gnuradio.svg)](https://repology.org/project/gnuradio/badges)
 

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -443,7 +443,7 @@ class Repo(object):
 
     def get_branch_name(self):
         """Get the current branch name, short form
-           This returns "master", not "refs/head/master"
+           This returns "main", not "refs/head/main"
            Will not work if the current branch is detached
         """
         branch = self.rev_parse(["--abbrev-ref", "HEAD"])
@@ -658,8 +658,8 @@ def _reformat_branch(clang_format, commit_prior_to_reformat,
             "Please rebase to '%s' and resolve all conflicts before running this script"
             % (commit_prior_to_reformat))
 
-    # We assume the target branch is master, it could be a different branch if needed for testing
-    merge_base = repo.get_merge_base("master")
+    # We assume the target branch is main, it could be a different branch if needed for testing
+    merge_base = repo.get_merge_base("main")
 
     if not merge_base == commit_prior_to_reformat:
         raise ValueError(
@@ -762,7 +762,7 @@ def _reformat_branch(clang_format, commit_prior_to_reformat,
         "A copy of your branch has been made named '%s', and formatted with clang-format.\n"
         % new_branch)
     print("The original branch has been left unchanged.")
-    print("The next step is to rebase the new branch on 'master'.")
+    print("The next step is to rebase the new branch on 'main'.")
 
 
 def format_func(args):


### PR DESCRIPTION
## Description
In the change of default branch naming, some things in the code that explicitly refers to `master` that needs to be changed to `main`

## Related Issue
Fixes #4963 

## Which blocks/areas does this affect?
Mostly just docs and CI configurations

