### PR TITLE
analog: Fix C++ code generation for random_uniform_source (backport to maint-3.10)

### DIFF
--- a/gr-analog/grc/analog_random_uniform_source_x.block.yml
+++ b/gr-analog/grc/analog_random_uniform_source_x.block.yml
@@ -32,7 +32,8 @@ templates:
 
 cpp_templates:
     includes: ['#include <gnuradio/analog/random_uniform_source.h>']
-    make: 'this->${id} = analog.random_uniform_source_${type.fcn}(${minimum}, ${maximum}, ${seed});'
+    declarations: 'analog::random_uniform_source_${type.fcn}::sptr ${id};'
+    make: 'this->${id} = analog::random_uniform_source_${type.fcn}::make(${minimum}, ${maximum}, ${seed});'
     link: ['gnuradio::gnuradio-analog']
 
 file_format: 1


### PR DESCRIPTION
Signed-off-by: Thomas Habets <habets@google.com>
(cherry picked from commit 79f95a3d8e9da27981377e08f7f66942b6999a84)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5491