### PR TITLE
FMComms234 Source/Sink fixes

### DIFF
--- a/gr-iio/grc/iio_fmcomms2_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_sink.block.yml
@@ -77,6 +77,11 @@ parameters:
     default: 10.0
     hide: ${ ('part' if tx2_en else 'all') }
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    hide: part
+
 -   id: filter_source
     category: Filter
     label: Filter Configuration
@@ -132,17 +137,21 @@ asserts:
 templates:
     imports: from gnuradio import iio
     make: |
-        iio.fmcomms2_sink_${type.type}(${uri}, [tx1_en, tx2_en], ${buffer_size}, ${cyclic})
+        iio.fmcomms2_sink_${type.type}(${uri}, [${tx1_en}, ${tx1_en}, ${tx2_en}, ${tx2_en}], ${buffer_size}, ${cyclic})
         self.${id}.set_len_tag_key(${len_tag_key})
         self.${id}.set_bandwidth(${bandwidth})
         self.${id}.set_frequency(${frequency})
         self.${id}.set_samplerate(${samplerate})
-        self.${id}.set_attenuation(0, ${attenuation1})
+        if ${tx1_en}:
+            self.${id}.set_attenuation(0, ${attenuation1})
+        if ${tx2_en}:
+            self.${id}.set_attenuation(1, ${attenuation2})
         self.${id}.set_filter_params(${filter_source}, ${filter}, ${fpass}, ${fstop})
     callbacks:
         - set_bandwidth(${bandwidth})
         - set_frequency(${frequency})
         - set_samplerate(${samplerate})
-        - set_attenuation(${attenuation1})
+        - set_attenuation(0, ${attenuation1})
+        - set_attenuation(1, ${attenuation2})
         - set_filter_params(${filter_source}, ${filter}, ${fpass}, ${fstop})
 file_format: 1

--- a/gr-iio/grc/iio_fmcomms2_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_source.block.yml
@@ -102,6 +102,12 @@ parameters:
     options: ["'A_BALANCED'", "'B_BALANCED'", "'C_BALANCED'", "'A_N'", "'A_P'", "'B_N'", "'B_P'", "'C_N'", "'C_P'", "'TX_MONITOR1'", "'TX_MONITOR2'", "'TX_MONITOR1_2'"]
     option_labels: ['A_BALANCED', 'B_BALANCED', 'C_BALANCED', 'A_N', 'A_P', 'B_N', 'B_P', 'C_N', 'C_P', 'TX_MONITOR1', 'TX_MONITOR2', 'TX_MONITOR1_2']
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    default: packet_len
+    hide: part
+
 -   id: filter_source
     category: Filter
     label: Filter Configuration
@@ -157,14 +163,16 @@ asserts:
 templates:
     imports: from gnuradio import iio
     make: |
-        iio.fmcomms2_source_${type.type}(${uri}, [rx1_en, rx2_en], ${buffer_size})
+        iio.fmcomms2_source_${type.type}(${uri}, [${rx1_en}, ${rx1_en}, ${rx2_en}, ${rx2_en}], ${buffer_size})
         self.${id}.set_len_tag_key(${len_tag_key})
         self.${id}.set_frequency(${frequency})
         self.${id}.set_samplerate(${samplerate})
-        self.${id}.set_gain_mode(0, ${gain1})
-        self.${id}.set_gain(0, ${manual_gain1})
-        self.${id}.set_gain_mode(1, ${gain2})
-        self.${id}.set_gain(1, ${manual_gain2})
+        if ${rx1_en}:
+            self.${id}.set_gain_mode(0, ${gain1})
+            self.${id}.set_gain(0, ${manual_gain1})
+        if ${rx2_en}:
+            self.${id}.set_gain_mode(1, ${gain2})
+            self.${id}.set_gain(1, ${manual_gain2})
         self.${id}.set_quadrature(${quadrature})
         self.${id}.set_rfdc(${rfdc})
         self.${id}.set_bbdc(${bbdc})

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -182,7 +182,14 @@ int device_sink_impl::work(int noutput_items,
     int ret;
 
     if (d_len_tag_key != pmt::PMT_NIL) {
-        for (size_t i = 0; i < input_items.size(); i++) {
+
+        size_t ninputs;
+        if (override_tagged_input_channels > 0)
+            ninputs = override_tagged_input_channels;
+        else
+            ninputs = input_items.size();
+
+        for (size_t i = 0; i < ninputs; i++) {
             auto items_read = nitems_read(i);
             get_tags_in_range(d_tags, i, items_read, items_read + 1, d_len_tag_key);
 

--- a/gr-iio/lib/device_sink_impl.h
+++ b/gr-iio/lib/device_sink_impl.h
@@ -34,6 +34,7 @@ protected:
     unsigned int buffer_size;
     bool destroy_ctx;
     pmt::pmt_t d_len_tag_key;
+    uint16_t override_tagged_input_channels = 0;
 
 public:
     device_sink_impl(iio_context* ctx,

--- a/gr-iio/lib/device_source_impl.cc
+++ b/gr-iio/lib/device_source_impl.cc
@@ -291,7 +291,13 @@ int device_source_impl::work(int noutput_items,
 
         // Tag start of new packet
         if (d_len_tag_key != pmt::PMT_NIL) {
-            for (size_t i = 0; i < output_items.size(); i += 2) {
+            size_t toutputs;
+            if (override_tagged_output_channels > 0)
+                toutputs = override_tagged_output_channels;
+            else
+                toutputs = output_items.size();
+
+            for (size_t i = 0; i < toutputs; i += 1) {
                 this->add_item_tag(i,
                                    this->nitems_written(0),
                                    this->d_len_tag_key,

--- a/gr-iio/lib/device_source_impl.h
+++ b/gr-iio/lib/device_source_impl.h
@@ -62,6 +62,7 @@ protected:
     unsigned int decimation;
     bool destroy_ctx;
     volatile bool thread_stopped;
+    uint16_t override_tagged_output_channels = 0;
 
 
 public:

--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -229,7 +229,7 @@ template <typename T>
 void fmcomms2_sink_impl<T>::set_attenuation(size_t chan, double attenuation)
 {
     bool is_fmcomms4 = !iio_device_find_channel(phy, "voltage1", false);
-    if ((!is_fmcomms4 && chan > 0) || chan > 1) {
+    if ((is_fmcomms4 && chan > 0) || chan > 1) {
         throw std::runtime_error("Channel out of range for this device");
     }
     iio_param_vec_t params;

--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -126,6 +126,9 @@ fmcomms2_sink_impl<T>::fmcomms2_sink_impl(iio_context* ctx,
     }
     d_float_r.resize(s_initial_device_buf_size);
     d_float_i.resize(s_initial_device_buf_size);
+
+    // Tell tagger in device_sink_impl::work that we are using a less inputs
+    override_tagged_input_channels = d_device_bufs.size() / 2;
 }
 
 template <typename T>
@@ -338,7 +341,7 @@ int fmcomms2_sink_impl<gr_complex>::work(int noutput_items,
 
     for (size_t i = 0; i < input_items.size(); i++) {
         auto in = static_cast<const gr_complex*>(input_items[i]);
-        if (noutput_items > (int)d_device_bufs[i].size()) {
+        if (noutput_items > (int)d_device_bufs[2 * i].size()) {
             d_device_bufs[2 * i].resize(noutput_items);
             d_device_bufs[2 * i + 1].resize(noutput_items);
             d_float_r.resize(noutput_items);

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -334,7 +334,7 @@ template <typename T>
 void fmcomms2_source_impl<T>::set_gain_mode(size_t chan, const std::string& mode)
 {
     bool is_fmcomms4 = !iio_device_find_channel(phy, "voltage1", false);
-    if ((!is_fmcomms4 && chan > 0) || chan > 1) {
+    if ((is_fmcomms4 && chan > 0) || chan > 1) {
         throw std::runtime_error("Channel out of range for this device");
     }
     iio_param_vec_t params;
@@ -350,7 +350,7 @@ template <typename T>
 void fmcomms2_source_impl<T>::set_gain(size_t chan, double gain_value)
 {
     bool is_fmcomms4 = !iio_device_find_channel(phy, "voltage1", false);
-    if ((!is_fmcomms4 && chan > 0) || chan > 1) {
+    if ((is_fmcomms4 && chan > 0) || chan > 1) {
         throw std::runtime_error("Channel out of range for this device");
     }
     iio_param_vec_t params;

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -115,6 +115,9 @@ fmcomms2_source_impl<T>::fmcomms2_source_impl(iio_context* ctx,
     }
     d_float_ivec.resize(s_initial_device_buf_size);
     d_float_rvec.resize(s_initial_device_buf_size);
+
+    // Tell tagger in device_source_impl::work that we are using a less outputs
+    override_tagged_output_channels = d_device_bufs.size() / 2;
 }
 
 template <typename T>


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

PR fixes #5476 for both the FMComms234 source and sink blocks.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The fixes update the GRC files to use the correct APIs for 1RX/2RX 1TX/2TX configurations that interface with AD9361/AD9363/AD9364 based systems using the IIO drivers. The core iio_device_{source/sink} blocks have been updated to allow inherited blocks to better define tags to be generated/processed when using the packet_len APIs. Unrelated to #5476 was the incorrect behavior of the incorrect number of channels being processed for these tags. All of these have been addressed and tested.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
#5476 

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
- fmcomms2_source (PlutoSDR, FMComms 2/3/4)
- fmcomms2_sink (PlutoSDR, FMComms 2/3/4)
- iio_device_source
- iio_device_sink

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Flowgraphs have been generated and run without error for device combinations with source and sink blocks:
- ADRV9361-Z7035 (Equivalent to FMComms2 and FMComms3)
- PlutoSDR (Equivalent to FMComms4)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
