### PR TITLE
filter: use compatible names for bus parameters

### DIFF
--- a/gr-filter/grc/filter_pfb_channelizer.block.yml
+++ b/gr-filter/grc/filter_pfb_channelizer.block.yml
@@ -28,7 +28,7 @@ parameters:
     label: Channel Map
     dtype: int_vector
     default: '[]'
--   id: bus_conns
+-   id: bus_structure_source
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'

--- a/gr-filter/grc/filter_pfb_synthesizer.block.yml
+++ b/gr-filter/grc/filter_pfb_synthesizer.block.yml
@@ -28,7 +28,7 @@ parameters:
     label: Channel Map
     dtype: int_vector
     default: '[]'
--   id: bus_conns
+-   id: bus_structure_sink
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'


### PR DESCRIPTION
# Pull Request Details
## Description
GRC does nothing with the bus specification on the polyphase blocks because they are misnamed - there are some magical values in GRC that the parameters need be named in order to be consider the bus specification

## Related Issue
Fixes #5490

## Which blocks/areas does this affect?
Polyphase channelizer and Polyphase synthesizer

## Testing Done
Enabled bus ports on a polyphase channelizer

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
