### PR TITLE
uhd: Fix ddc/duc block descriptor names

### DIFF
--- a/gr-uhd/grc/uhd_fpga_ddc.block.yml
+++ b/gr-uhd/grc/uhd_fpga_ddc.block.yml
@@ -11,7 +11,7 @@ parameters:
 -   id: desc
     label: Block Descriptor
     dtype: string
-    default: 'ddc_2x64.yml'
+    default: 'ddc.yml'
     hide: all
 -   id: nports
     label: Number of Ports

--- a/gr-uhd/grc/uhd_fpga_duc.block.yml
+++ b/gr-uhd/grc/uhd_fpga_duc.block.yml
@@ -11,7 +11,7 @@ parameters:
 -   id: desc
     label: Block Descriptor
     dtype: string
-    default: 'duc_2x64.yml'
+    default: 'duc.yml'
     hide: all
 -   id: nports
     label: Number of Ports


### PR DESCRIPTION
Upstream changed names in
https://github.com/EttusResearch/uhd/commit/72e833e7bb71b2b2891ef5b07ada5aaf856a266a.

Signed-off-by: André Apitzsch <andre.apitzsch@etit.tu-chemnitz.de>
(cherry picked from commit 2ea2750bcb98f21d0f6a065ceb5d69a61a505213)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5493