### PR TITLE
SigMF Minimal Blocks

### DIFF
--- a/gr-blocks/grc/blocks.tree.yml
+++ b/gr-blocks/grc/blocks.tree.yml
@@ -38,6 +38,7 @@
   - blocks_file_meta_source
   - blocks_file_meta_sink
   - blocks_tagged_file_sink
+  - blocks_sigmf_sink_minimal
 - IQ Correction:
   - blocks_correctiq_auto
   - blocks_correctiq_man

--- a/gr-blocks/grc/blocks.tree.yml
+++ b/gr-blocks/grc/blocks.tree.yml
@@ -38,6 +38,7 @@
   - blocks_file_meta_source
   - blocks_file_meta_sink
   - blocks_tagged_file_sink
+  - blocks_sigmf_source_minimal
   - blocks_sigmf_sink_minimal
 - IQ Correction:
   - blocks_correctiq_auto

--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -5,7 +5,7 @@ flags: [ python, deprecated ]
 parameters:
 -   id: filename
     label: File Name
-    dtype: string
+    dtype: file_save
 -   id: sample_rate
     label: Sample Rate
     dtype: float

--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -12,6 +12,7 @@ parameters:
 -   id: center_freq
     label: Center Frequency
     dtype: float
+    default: 0
 -   id: author
     label: Author
     dtype: string
@@ -27,10 +28,17 @@ parameters:
 -   id: type
     label: Stream Type
     dtype: enum
-    options: [complex, float]
+    options: [complex, float, short]
     option_attributes:
-        size: [gr.sizeof_gr_complex, gr.sizeof_float]
+        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_short]
     hide: part
+-   id: ishort
+    label: Type of Shorts
+    dtype: bool
+    default: 'True'
+    options: ['False', 'True']
+    option_labels: ['Real Only', 'Interleaved IQ']
+    hide: ${ 'all' if type != 'short' else 'none' }
 
 inputs:
 -   domain: stream
@@ -49,6 +57,7 @@ templates:
             center_freq=${center_freq},
             author=${author},
             description=${description},
-            hw_info=${hw_info})
+            hw_info=${hw_info},
+            ishort=${ishort})
 
 file_format: 1

--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -21,7 +21,8 @@ parameters:
 -   id: center_freq
     label: Center Frequency
     dtype: float
-    default: 0
+    options: [np.nan]
+    option_labels: ['None']
 -   id: author
     label: Author
     dtype: string
@@ -43,7 +44,9 @@ asserts:
 - ${ len(filename) > 0 }
 
 templates:
-    imports: from gnuradio import blocks
+    imports: |-
+        from gnuradio import blocks
+        import numpy as np
     make: |-
         blocks.sigmf_sink_minimal(
             item_size=${type.size},

--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -1,0 +1,54 @@
+id: blocks_sigmf_sink_minimal
+label: SigMF Sink (Minimal)
+flags: [ python, deprecated ]
+
+parameters:
+-   id: filename
+    label: File Name
+    dtype: string
+-   id: sample_rate
+    label: Sample Rate
+    dtype: float
+-   id: center_freq
+    label: Center Frequency
+    dtype: float
+-   id: author
+    label: Author
+    dtype: string
+    default: ''
+-   id: description
+    label: Description
+    dtype: string
+    default: ''
+-   id: hw_info
+    label: Hardware Info
+    dtype: string
+    default: ''
+-   id: type
+    label: Stream Type
+    dtype: enum
+    options: [complex, float]
+    option_attributes:
+        size: [gr.sizeof_gr_complex, gr.sizeof_float]
+    hide: part
+
+inputs:
+-   domain: stream
+    dtype: ${ type }
+
+asserts:
+- ${ len(filename) > 0 }
+
+templates:
+    imports: from gnuradio import blocks
+    make: |-
+        blocks.sigmf_sink_minimal(
+            item_size=${type.size},
+            filename=${filename},
+            sample_rate=${sample_rate},
+            center_freq=${center_freq},
+            author=${author},
+            description=${description},
+            hw_info=${hw_info})
+
+file_format: 1

--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -18,6 +18,7 @@ parameters:
 -   id: sample_rate
     label: Sample Rate
     dtype: float
+    default: samp_rate
 -   id: center_freq
     label: Center Frequency
     dtype: float

--- a/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_sink_minimal.block.yml
@@ -6,6 +6,15 @@ parameters:
 -   id: filename
     label: File Name
     dtype: file_save
+-   id: type
+    label: Stream Type
+    dtype: enum
+    options: [complex float (fc32_le), real float (rc32_le), complex short (sc16_le), real short (rc16_le)]
+    option_attributes:
+        type: [complex, float, short, short]
+        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_short, gr.sizeof_short]
+        complex: [True, False, True, False]
+    hide: part
 -   id: sample_rate
     label: Sample Rate
     dtype: float
@@ -25,24 +34,10 @@ parameters:
     label: Hardware Info
     dtype: string
     default: ''
--   id: type
-    label: Stream Type
-    dtype: enum
-    options: [complex, float, short]
-    option_attributes:
-        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_short]
-    hide: part
--   id: ishort
-    label: Type of Shorts
-    dtype: bool
-    default: 'True'
-    options: ['False', 'True']
-    option_labels: ['Real Only', 'Interleaved IQ']
-    hide: ${ 'all' if type != 'short' else 'none' }
 
 inputs:
 -   domain: stream
-    dtype: ${ type }
+    dtype: ${ type.type }
 
 asserts:
 - ${ len(filename) > 0 }
@@ -58,6 +53,6 @@ templates:
             author=${author},
             description=${description},
             hw_info=${hw_info},
-            ishort=${ishort})
+            is_complex=${type.complex})
 
 file_format: 1

--- a/gr-blocks/grc/blocks_sigmf_source_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_source_minimal.block.yml
@@ -9,10 +9,10 @@ parameters:
 -   id: type
     label: Output Type
     dtype: enum
-    options: [complex, float, int, short, byte]
+    options: [complex float (fc32_le), real float (rc32_le), complex short (sc16_le), real short (rc16_le)]
     option_attributes:
-        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_int, gr.sizeof_short,
-            gr.sizeof_char]
+        type: [complex, float, short, short]
+        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_short, gr.sizeof_short]
     hide: part
 -   id: repeat
     label: Repeat
@@ -20,19 +20,10 @@ parameters:
     default: 'True'
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
--   id: vlen
-    label: Vector Length
-    dtype: int
-    default: '1'
-    hide: ${ 'part' if vlen == 1 else 'none' }
 -   id: begin_tag
     label: Add begin tag
     dtype: raw
     default: pmt.PMT_NIL
--   id: offset
-    label: Offset
-    dtype: int
-    default: '0'
 -   id: length
     label: Length
     dtype: int
@@ -40,18 +31,14 @@ parameters:
 
 outputs:
 -   domain: stream
-    dtype: ${ type }
-    vlen: ${ vlen }
-
-asserts:
-- ${ vlen > 0 }
+    dtype: ${ type.type }
 
 templates:
     imports: |-
         from gnuradio import blocks
         import pmt
     make: |-
-        blocks.file_source(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length})
+        blocks.file_source(${type.size}, ${file}, ${repeat}, 0, ${length})
         self.${id}.set_begin_tag(${begin_tag})
     callbacks:
     - open(${file}, ${repeat})
@@ -60,7 +47,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/file_source.h>']
     declarations: 'blocks::file_source::sptr ${id};'
-    make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length});'
+    make: 'this->${id} =blocks::file_source::make(${type.size}, ${file}, ${repeat}, 0, ${length});'
     callbacks:
     - open(${file}, ${repeat})
     translations:

--- a/gr-blocks/grc/blocks_sigmf_source_minimal.block.yml
+++ b/gr-blocks/grc/blocks_sigmf_source_minimal.block.yml
@@ -1,6 +1,6 @@
 id: blocks_sigmf_source_minimal
 label: SigMF Source (Minimal)
-flags: [ python, cpp, deprecated ]
+flags: [ python, deprecated ]
 
 parameters:
 -   id: file
@@ -43,16 +43,6 @@ templates:
     callbacks:
     - open(${file}, ${repeat})
     - self.${id}.set_begin_tag(${begin_tag})
-
-cpp_templates:
-    includes: ['#include <gnuradio/blocks/file_source.h>']
-    declarations: 'blocks::file_source::sptr ${id};'
-    make: 'this->${id} =blocks::file_source::make(${type.size}, ${file}, ${repeat}, 0, ${length});'
-    callbacks:
-    - open(${file}, ${repeat})
-    translations:
-        'True': 'true'
-        'False': 'false'
 
 documentation: |-
 

--- a/gr-blocks/grc/sigmf_source_minimal.block.yml
+++ b/gr-blocks/grc/sigmf_source_minimal.block.yml
@@ -1,0 +1,91 @@
+id: blocks_sigmf_source_minimal
+label: SigMF Source (Minimal)
+flags: [ python, cpp, deprecated ]
+
+parameters:
+-   id: file
+    label: File
+    dtype: file_open
+-   id: type
+    label: Output Type
+    dtype: enum
+    options: [complex, float, int, short, byte]
+    option_attributes:
+        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_int, gr.sizeof_short,
+            gr.sizeof_char]
+    hide: part
+-   id: repeat
+    label: Repeat
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+-   id: vlen
+    label: Vector Length
+    dtype: int
+    default: '1'
+    hide: ${ 'part' if vlen == 1 else 'none' }
+-   id: begin_tag
+    label: Add begin tag
+    dtype: raw
+    default: pmt.PMT_NIL
+-   id: offset
+    label: Offset
+    dtype: int
+    default: '0'
+-   id: length
+    label: Length
+    dtype: int
+    default: '0'
+
+outputs:
+-   domain: stream
+    dtype: ${ type }
+    vlen: ${ vlen }
+
+asserts:
+- ${ vlen > 0 }
+
+templates:
+    imports: |-
+        from gnuradio import blocks
+        import pmt
+    make: |-
+        blocks.file_source(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length})
+        self.${id}.set_begin_tag(${begin_tag})
+    callbacks:
+    - open(${file}, ${repeat})
+    - self.${id}.set_begin_tag(${begin_tag})
+
+cpp_templates:
+    includes: ['#include <gnuradio/blocks/file_source.h>']
+    declarations: 'blocks::file_source::sptr ${id};'
+    make: 'this->${id} =blocks::file_source::make(${type.size}*${vlen}, ${file}, ${repeat}, ${offset}, ${length});'
+    callbacks:
+    - open(${file}, ${repeat})
+    translations:
+        'True': 'true'
+        'False': 'false'
+
+documentation: |-
+
+    This block is essentially just a File Source with some SigMF specific documentation.
+    In order to read in a SigMF file using this block, you must open the .sigmf-meta file
+    associated with the recording in a text editor, and note the value next to core:datatype.  
+    Based on this value, set the "Output Type" parameter to the following-
+    
+    cf32_le  ->  complex
+    rf32_le  ->  float
+    ri16_le  ->  short
+    ci16_le  ->  short, and add an iShort to Complex block right after this block
+    
+    For the "File" parameter, enter in the .sigmf-data file name (and optionally path).
+    You can leave the rest of the block parameters default.
+    
+    For more information on SigMF see https://github.com/gnuradio/SigMF
+    
+    The rest of this documentation comes from File Source
+    -----------------------------------------------------
+
+
+file_format: 1

--- a/gr-blocks/python/blocks/CMakeLists.txt
+++ b/gr-blocks/python/blocks/CMakeLists.txt
@@ -13,6 +13,7 @@ GR_PYTHON_INSTALL(
     __init__.py
     matrix_interleaver.py
     parse_file_metadata.py
+    sigmf_sink_minimal.py
     stream_to_vector_decimator.py
     msg_pair_to_var.py
     msg_meta_to_pair.py

--- a/gr-blocks/python/blocks/__init__.py
+++ b/gr-blocks/python/blocks/__init__.py
@@ -21,6 +21,7 @@ except ImportError:
     __path__.append(os.path.join(dirname, "bindings"))
     from .blocks_python import *
 
+from .sigmf_sink_minimal import sigmf_sink_minimal
 from .stream_to_vector_decimator import *
 from .msg_meta_to_pair import meta_to_pair
 from .msg_pair_to_var import msg_pair_to_var

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -63,9 +63,6 @@ class sigmf_sink_minimal(gr.hier_block2):
             "global": {
                 "core:datatype": datatype_str,
                 "core:sample_rate": float(sample_rate),
-                "core:hw": str(hw_info),
-                "core:author": str(author),
-                "core:description": str(description),
                 "core:version": sigmf_version
             },
             "captures": [
@@ -75,8 +72,15 @@ class sigmf_sink_minimal(gr.hier_block2):
             ],
             "annotations": []
         }
-        if center_freq:
+        if center_freq is not np.nan:
             meta_dict["captures"][0]["core:frequency"] = float(center_freq)
+        if hw_info:
+            meta_dict["global"]["core:hw"] = str(hw_info)
+        if author:
+            meta_dict["global"]["core:author"] = str(author)
+        if description:
+            meta_dict["global"]["core:description"] = str(description)
+
         with open(filename + '.sigmf-meta', 'w') as f_meta:
             json.dump(meta_dict, f_meta, indent=2)
 

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -30,17 +30,17 @@ class sigmf_sink_minimal(gr.hier_block2):
         hw_info: optional string used to record hardware used in making of recording, e.g. SDR type and antenna, or whether it's simulated data
     """
 
-    def __init__(self, item_size, filename, sample_rate, center_freq, author, description, hw_info, ishort):
+    def __init__(self, item_size, filename, sample_rate, center_freq, author, description, hw_info, is_complex):
     
         # Input type, which is included in .sigmf-meta file
         if item_size == 8:
             datatype_str = 'cf32_le'
         elif item_size == 4:
             datatype_str = 'rf32_le'
-        elif item_size == 2 and ishort:
-            datatype_str = 'ci16'
-        elif item_size == 2 and not ishort:
-            datatype_str = 'ri16'
+        elif item_size == 2 and is_complex:
+            datatype_str = 'ci16_le'
+        elif item_size == 2 and not is_complex:
+            datatype_str = 'ri16_le'
         else:
             raise ValueError
         

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -47,8 +47,7 @@ class sigmf_sink_minimal(gr.hier_block2):
 
         if '.sigmf' in filename:
             filename = filename.rsplit('.', 1)[0]
-        gr.log.info('Generating '+filename +
-                    '.sigmf-meta, writing SigMF data to '+filename+'.sigmf-data')
+        gr.log.info(f'Generating {filename}.sigmf-meta, writing SigMF data to {filename}.sigmf-data')
 
         gr.hier_block2.__init__(self, "sigmf_sink_minimal",
                                 gr.io_signature(1, 1, item_size),

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -13,13 +13,14 @@ from . import blocks_python as blocks
 import numpy as np
 import json
 
+
 class sigmf_sink_minimal(gr.hier_block2):
     """
     A partial implementation of the SigMF standard to allow saving SigMF files from GNU Radio.
     It is expected that this block will be replaced with gr-sigmf in the near future, and thus
     it is immediately being depreciated.
     For more information on SigMF see https://github.com/gnuradio/SigMF
-    
+
     Args:
         item_size: complex, float, or short is all that is supported at the moment
         filename: filename, NOT including the extension, SigMF uses .sigmf-meta and .sigmf-data which will be automatically added to your filename
@@ -31,7 +32,7 @@ class sigmf_sink_minimal(gr.hier_block2):
     """
 
     def __init__(self, item_size, filename, sample_rate, center_freq, author, description, hw_info, is_complex):
-    
+
         # Input type, which is included in .sigmf-meta file
         if item_size == 8:
             datatype_str = 'cf32_le'
@@ -43,21 +44,24 @@ class sigmf_sink_minimal(gr.hier_block2):
             datatype_str = 'ri16_le'
         else:
             raise ValueError
-        
+
         if '.sigmf' in filename:
             filename = filename.rsplit('.', 1)[0]
-        gr.log.info('Generating '+filename+'.sigmf-meta, writing SigMF data to '+filename+'.sigmf-data')
+        gr.log.info('Generating '+filename +
+                    '.sigmf-meta, writing SigMF data to '+filename+'.sigmf-data')
 
         gr.hier_block2.__init__(self, "sigmf_sink_minimal",
                                 gr.io_signature(1, 1, item_size),
                                 gr.io_signature(0, 0, 0))
 
-        file_sink = blocks.file_sink(item_size, filename + '.sigmf-data', False) # use regular File Sink, no append
+        # use regular File Sink, no append
+        file_sink = blocks.file_sink(
+            item_size, filename + '.sigmf-data', False)
         self.connect(self, file_sink)
-        
+
         # JSON/Meta Stuff
-        sigmf_version = "1.0.0" # update me if the time comes
-        
+        sigmf_version = "1.0.0"  # update me if the time comes
+
         # Create .sigmf-meta file
         meta_dict = {
             "global": {
@@ -83,5 +87,3 @@ class sigmf_sink_minimal(gr.hier_block2):
 
         with open(filename + '.sigmf-meta', 'w') as f_meta:
             json.dump(meta_dict, f_meta, indent=2)
-
-

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Copyright 2022 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+from gnuradio import gr
+import numpy as np
+import json
+
+class sigmf_sink_minimal(gr.sync_block):
+    """
+    A partial implementation of the SigMF standard to allow saving SigMF files from GNU Radio.
+    It is expected that this block will be replaced with gr-sigmf in the near future, and thus
+    it is immediately being depreciated.
+    
+    Args:
+        item_size: Complex or Float stream is all that is currently supported
+        filename: Filename, NOT including the extension, SigMF uses .sigmf-meta and .sigmf-data which will be automatically added to your filename
+        sample_rate: Sample Rate in Hz
+        center_freq: Center Frequency in Hz
+        author: optional string used to record author of recording
+        description: optional string used to store whatever other info you want about the recording
+        hw_info: optional string used to record hardware used in making of recording, e.g. SDR type and antenna, or whether it's simulated data
+    """
+
+    def __init__(self, item_size, filename, sample_rate, center_freq, author, description, hw_info):
+    
+        # Input type, which is included in .sigmf-meta file
+        if item_size == 8:
+            dtype = np.complex64
+            datatype_str = 'cf32_le'
+        elif item_size == 4:
+            dtype = np.float32
+            datatype_str = 'rf32_le'
+        else:
+            raise ValueError
+
+        gr.sync_block.__init__(self,
+                               name = "sigmf_sink_minimal",
+                               in_sig = [dtype], # input sig
+                               out_sig = None) # no outputs
+
+        sigmf_version = "1.0.0" # update me if the time comes
+        
+        # Create .sigmf-meta file
+        meta_dict = {
+            "global": {
+                "core:datatype": datatype_str,
+                "core:sample_rate": float(sample_rate),
+                "core:hw": str(hw_info),
+                "core:author": str(author),
+                "core:description": str(description),
+                "core:version": sigmf_version
+            },
+            "captures": [
+                {
+                    "core:sample_start": 0,
+                    "core:frequency": float(center_freq)
+                }
+            ],
+            "annotations": []
+        }
+        with open(filename + '.sigmf-meta', 'w') as f_meta:
+            json.dump(meta_dict, f_meta, indent=2)
+
+        # Open .sigmf-data file
+        self.f_data = open(filename + '.sigmf-data', "w") # overwrite file
+
+        
+    def work(self, input_items, output_items):
+        input_items[0].tofile(self.f_data)
+        return len(input_items[0])
+    
+    def stop(self):
+        self.f_data.close()
+

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -45,8 +45,8 @@ class sigmf_sink_minimal(gr.hier_block2):
             raise ValueError
         
         if '.sigmf' in filename:
-            gr.log.warn('SigMF file extension was found in provided filename, stripping it off')
-            filename = filename.split('.')[0]
+            filename = filename.rsplit('.', 1)[0]
+        gr.log.info('Generating '+filename+'.sigmf-meta, writing SigMF data to '+filename+'.sigmf-data')
 
         gr.hier_block2.__init__(self, "sigmf_sink_minimal",
                                 gr.io_signature(1, 1, item_size),

--- a/gr-blocks/python/blocks/sigmf_sink_minimal.py
+++ b/gr-blocks/python/blocks/sigmf_sink_minimal.py
@@ -18,12 +18,13 @@ class sigmf_sink_minimal(gr.hier_block2):
     A partial implementation of the SigMF standard to allow saving SigMF files from GNU Radio.
     It is expected that this block will be replaced with gr-sigmf in the near future, and thus
     it is immediately being depreciated.
+    For more information on SigMF see https://github.com/gnuradio/SigMF
     
     Args:
-        item_size: Complex or Float stream is all that is currently supported
-        filename: Filename, NOT including the extension, SigMF uses .sigmf-meta and .sigmf-data which will be automatically added to your filename
-        sample_rate: Sample Rate in Hz
-        center_freq: Center Frequency in Hz
+        item_size: complex, float, or short is all that is supported at the moment
+        filename: filename, NOT including the extension, SigMF uses .sigmf-meta and .sigmf-data which will be automatically added to your filename
+        sample_rate: sample rate in Hz
+        center_freq: optional center Frequency in Hz
         author: optional string used to record author of recording
         description: optional string used to store whatever other info you want about the recording
         hw_info: optional string used to record hardware used in making of recording, e.g. SDR type and antenna, or whether it's simulated data


### PR DESCRIPTION
## Description

A first cut of the two minimal SigMF blocks that have been discussed in #SigMF within Matrix.  The motivation here is to improve adoption of SigMF, by having at least basic ability to save and read SigMF files within GNU Radio, in Ubuntu 22 specifically, as the freeze is happening soon and gr-sigmf isn't ready.  These blocks are immediately being set to "deprecated" as you can see, they will be removed when gr-sigmf is ready to use.

The SigMF Sink is just a wrapper around File Sink that produces the .sigmf-meta file based on params fed into the block.  The idea was to keep it extremely simple.  

The SigMF Source is literally just a File Source with some extra documentation explaining how to use it to read in SigMF files, so this is targeted at newer folks, and the most important part of this block is that a SigMF Source will come up in the block tree, else we would be leaving people wondering why there is a Sink with no Source.

This is obviously extremely last minute, wrt Ubuntu 22 freeze, so if there is any chance that these changes might break something or lead to poor quality code locked into Ubuntu, we can just nix this PR and focus on the actual gr-sigmf.

If anyone wants to help, I can give you write access to my fork. 

## Testing Done

Only basic testing, done on 3.10 in Ubuntu 20.04.  I should have more time next week to test and throw it weird combos of params, but I didn't want to wait to get it up here due to the time crunch of Ubuntu 22 freeze.