### PR TITLE
digital: put back import of packet_utils

### DIFF
--- a/gr-digital/python/digital/__init__.py
+++ b/gr-digital/python/digital/__init__.py
@@ -37,6 +37,7 @@ from .soft_dec_lut_gen import *
 from .psk_constellations import *
 from .qam_constellations import *
 from .constellation_map_generator import *
+from . import packet_utils
 
 
 class gmskmod_bc(cpmmod_bc):


### PR DESCRIPTION
Had gotten lost in the autopep8 formatting
Thanks to @drmpeg for finding and bisecting as part of #5188

