### PR TITLE
gr-iio: FMComms234 Source/Sink fixes (backport to maint-3.10)

### DIFF
--- a/gr-iio/grc/iio_fmcomms2_sink.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_sink.block.yml
@@ -77,6 +77,11 @@ parameters:
     default: 10.0
     hide: ${ ('part' if tx2_en else 'all') }
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    hide: part
+
 -   id: filter_source
     category: Filter
     label: Filter Configuration
@@ -132,17 +137,21 @@ asserts:
 templates:
     imports: from gnuradio import iio
     make: |
-        iio.fmcomms2_sink_${type.type}(${uri}, [tx1_en, tx2_en], ${buffer_size}, ${cyclic})
+        iio.fmcomms2_sink_${type.type}(${uri}, [${tx1_en}, ${tx1_en}, ${tx2_en}, ${tx2_en}], ${buffer_size}, ${cyclic})
         self.${id}.set_len_tag_key(${len_tag_key})
         self.${id}.set_bandwidth(${bandwidth})
         self.${id}.set_frequency(${frequency})
         self.${id}.set_samplerate(${samplerate})
-        self.${id}.set_attenuation(0, ${attenuation1})
+        if ${tx1_en}:
+            self.${id}.set_attenuation(0, ${attenuation1})
+        if ${tx2_en}:
+            self.${id}.set_attenuation(1, ${attenuation2})
         self.${id}.set_filter_params(${filter_source}, ${filter}, ${fpass}, ${fstop})
     callbacks:
         - set_bandwidth(${bandwidth})
         - set_frequency(${frequency})
         - set_samplerate(${samplerate})
-        - set_attenuation(${attenuation1})
+        - set_attenuation(0, ${attenuation1})
+        - set_attenuation(1, ${attenuation2})
         - set_filter_params(${filter_source}, ${filter}, ${fpass}, ${fstop})
 file_format: 1

--- a/gr-iio/grc/iio_fmcomms2_source.block.yml
+++ b/gr-iio/grc/iio_fmcomms2_source.block.yml
@@ -102,6 +102,12 @@ parameters:
     options: ["'A_BALANCED'", "'B_BALANCED'", "'C_BALANCED'", "'A_N'", "'A_P'", "'B_N'", "'B_P'", "'C_N'", "'C_P'", "'TX_MONITOR1'", "'TX_MONITOR2'", "'TX_MONITOR1_2'"]
     option_labels: ['A_BALANCED', 'B_BALANCED', 'C_BALANCED', 'A_N', 'A_P', 'B_N', 'B_P', 'C_N', 'C_P', 'TX_MONITOR1', 'TX_MONITOR2', 'TX_MONITOR1_2']
 
+-   id: len_tag_key
+    label: Packet Length Tag
+    dtype: string
+    default: packet_len
+    hide: part
+
 -   id: filter_source
     category: Filter
     label: Filter Configuration
@@ -157,14 +163,16 @@ asserts:
 templates:
     imports: from gnuradio import iio
     make: |
-        iio.fmcomms2_source_${type.type}(${uri}, [rx1_en, rx2_en], ${buffer_size})
+        iio.fmcomms2_source_${type.type}(${uri}, [${rx1_en}, ${rx1_en}, ${rx2_en}, ${rx2_en}], ${buffer_size})
         self.${id}.set_len_tag_key(${len_tag_key})
         self.${id}.set_frequency(${frequency})
         self.${id}.set_samplerate(${samplerate})
-        self.${id}.set_gain_mode(0, ${gain1})
-        self.${id}.set_gain(0, ${manual_gain1})
-        self.${id}.set_gain_mode(1, ${gain2})
-        self.${id}.set_gain(1, ${manual_gain2})
+        if ${rx1_en}:
+            self.${id}.set_gain_mode(0, ${gain1})
+            self.${id}.set_gain(0, ${manual_gain1})
+        if ${rx2_en}:
+            self.${id}.set_gain_mode(1, ${gain2})
+            self.${id}.set_gain(1, ${manual_gain2})
         self.${id}.set_quadrature(${quadrature})
         self.${id}.set_rfdc(${rfdc})
         self.${id}.set_bbdc(${bbdc})

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -182,7 +182,14 @@ int device_sink_impl::work(int noutput_items,
     int ret;
 
     if (d_len_tag_key != pmt::PMT_NIL) {
-        for (size_t i = 0; i < input_items.size(); i++) {
+
+        size_t ninputs;
+        if (override_tagged_input_channels > 0)
+            ninputs = override_tagged_input_channels;
+        else
+            ninputs = input_items.size();
+
+        for (size_t i = 0; i < ninputs; i++) {
             auto items_read = nitems_read(i);
             get_tags_in_range(d_tags, i, items_read, items_read + 1, d_len_tag_key);
 

--- a/gr-iio/lib/device_sink_impl.h
+++ b/gr-iio/lib/device_sink_impl.h
@@ -34,6 +34,7 @@ protected:
     unsigned int buffer_size;
     bool destroy_ctx;
     pmt::pmt_t d_len_tag_key;
+    uint16_t override_tagged_input_channels = 0;
 
 public:
     device_sink_impl(iio_context* ctx,

--- a/gr-iio/lib/device_source_impl.cc
+++ b/gr-iio/lib/device_source_impl.cc
@@ -291,7 +291,13 @@ int device_source_impl::work(int noutput_items,
 
         // Tag start of new packet
         if (d_len_tag_key != pmt::PMT_NIL) {
-            for (size_t i = 0; i < output_items.size(); i += 2) {
+            size_t toutputs;
+            if (override_tagged_output_channels > 0)
+                toutputs = override_tagged_output_channels;
+            else
+                toutputs = output_items.size();
+
+            for (size_t i = 0; i < toutputs; i += 1) {
                 this->add_item_tag(i,
                                    this->nitems_written(0),
                                    this->d_len_tag_key,

--- a/gr-iio/lib/device_source_impl.h
+++ b/gr-iio/lib/device_source_impl.h
@@ -62,6 +62,7 @@ protected:
     unsigned int decimation;
     bool destroy_ctx;
     volatile bool thread_stopped;
+    uint16_t override_tagged_output_channels = 0;
 
 
 public:

--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -126,6 +126,9 @@ fmcomms2_sink_impl<T>::fmcomms2_sink_impl(iio_context* ctx,
     }
     d_float_r.resize(s_initial_device_buf_size);
     d_float_i.resize(s_initial_device_buf_size);
+
+    // Tell tagger in device_sink_impl::work that we are using a less inputs
+    override_tagged_input_channels = d_device_bufs.size() / 2;
 }
 
 template <typename T>
@@ -229,7 +232,7 @@ template <typename T>
 void fmcomms2_sink_impl<T>::set_attenuation(size_t chan, double attenuation)
 {
     bool is_fmcomms4 = !iio_device_find_channel(phy, "voltage1", false);
-    if ((!is_fmcomms4 && chan > 0) || chan > 1) {
+    if ((is_fmcomms4 && chan > 0) || chan > 1) {
         throw std::runtime_error("Channel out of range for this device");
     }
     iio_param_vec_t params;
@@ -338,7 +341,7 @@ int fmcomms2_sink_impl<gr_complex>::work(int noutput_items,
 
     for (size_t i = 0; i < input_items.size(); i++) {
         auto in = static_cast<const gr_complex*>(input_items[i]);
-        if (noutput_items > (int)d_device_bufs[i].size()) {
+        if (noutput_items > (int)d_device_bufs[2 * i].size()) {
             d_device_bufs[2 * i].resize(noutput_items);
             d_device_bufs[2 * i + 1].resize(noutput_items);
             d_float_r.resize(noutput_items);

--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -115,6 +115,9 @@ fmcomms2_source_impl<T>::fmcomms2_source_impl(iio_context* ctx,
     }
     d_float_ivec.resize(s_initial_device_buf_size);
     d_float_rvec.resize(s_initial_device_buf_size);
+
+    // Tell tagger in device_source_impl::work that we are using a less outputs
+    override_tagged_output_channels = d_device_bufs.size() / 2;
 }
 
 template <typename T>
@@ -334,7 +337,7 @@ template <typename T>
 void fmcomms2_source_impl<T>::set_gain_mode(size_t chan, const std::string& mode)
 {
     bool is_fmcomms4 = !iio_device_find_channel(phy, "voltage1", false);
-    if ((!is_fmcomms4 && chan > 0) || chan > 1) {
+    if ((is_fmcomms4 && chan > 0) || chan > 1) {
         throw std::runtime_error("Channel out of range for this device");
     }
     iio_param_vec_t params;
@@ -350,7 +353,7 @@ template <typename T>
 void fmcomms2_source_impl<T>::set_gain(size_t chan, double gain_value)
 {
     bool is_fmcomms4 = !iio_device_find_channel(phy, "voltage1", false);
-    if ((!is_fmcomms4 && chan > 0) || chan > 1) {
+    if ((is_fmcomms4 && chan > 0) || chan > 1) {
         throw std::runtime_error("Channel out of range for this device");
     }
     iio_param_vec_t params;


### PR DESCRIPTION
* Fix FMComms234 Source GRC file

Add len_tag_key parameter, fix enables, and selectively use gain sets
based on channels.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

* Fix FMComms4 checks for fmcomms2_source

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

* Fix iio source blocks packet_len marker

Packet length (start of buffer) tags were broken on FMComms234 but
functioning on Pluto. It was also not generating tagged streams for all
output channels, only odd channels. The main issue came from the nested
work calls where the channels known by the iio_device_source class was
different than what the parent block (fmcomm2_source) was actually
outputting. This fix adds an override mechanism to tell the
iio_device_source the true number of output channels. This fixes both
issues.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

* Fix FMComms234 Source GRC file

Add len_tag_key parameter, fix enables, and selectively use attenuation
sets based on channels.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

* Fix FMComms4 checks for fmcomms2_sink

Signed-off-by: Travis F. Collins <travis.collins@analog.com>

* Fix iio sink blocks packet_len processor

Packet length tagged processing would break for FMComms234 sinks due to
how the work function gets called and channels are interpreted.
Borrowing from the fix for the source blocks an additional property is
used to tell the parent device_sink block what the true channel inputs
are to be processed.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>
(cherry picked from commit b44e28a8e5041dcb22812a8c514bcc0d88857150)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5501