### PR TITLE
ci: make conda build integrated with main workflow

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -3,7 +3,8 @@
 # -*- mode: yaml -*-
 
 name: Build conda package
-on: [push, pull_request]
+on: 
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -136,4 +136,4 @@ jobs:
       run: 'cd /build && ctest --output-on-failure'
   call-conda-build:
     needs: [check-formatting, check-python-formatting]
-    uses: gnuradio/gnuradio/.github/workflows/conda-build.yml@main
+    uses: gnuradio/gnuradio/.github/workflows/conda-build.yml@78f1070ed

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -136,4 +136,4 @@ jobs:
       run: 'cd /build && ctest --output-on-failure'
   call-conda-build:
     needs: [check-formatting, check-python-formatting]
-    uses: ./.github/workflows/conda-build.yml@
+    uses: ./.github/workflows/conda-build.yml@${{ github.head_ref }}

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -134,3 +134,6 @@ jobs:
       run: 'cd /build && make -j2 -k'
     - name: Make Test
       run: 'cd /build && ctest --output-on-failure'
+  call-conda-build:
+    needs: [check-formatting, check-python-formatting]
+    uses: gnuradio/gnuradio/.github/workflows/conda-build.yml@main

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -136,4 +136,4 @@ jobs:
       run: 'cd /build && ctest --output-on-failure'
   call-conda-build:
     needs: [check-formatting, check-python-formatting]
-    uses: ./.github/workflows/conda-build.yml
+    uses: ./.github/workflows/conda-build.yml@

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -136,4 +136,4 @@ jobs:
       run: 'cd /build && ctest --output-on-failure'
   call-conda-build:
     needs: [check-formatting, check-python-formatting]
-    uses: ./.github/workflows/conda-build.yml@${{ github.base_ref }}
+    uses: ./.github/workflows/conda-build.yml

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -136,4 +136,4 @@ jobs:
       run: 'cd /build && ctest --output-on-failure'
   call-conda-build:
     needs: [check-formatting, check-python-formatting]
-    uses: gnuradio/gnuradio/.github/workflows/conda-build.yml@78f1070ed
+    uses: ./.github/workflows/conda-build.yml@${ GITHUB_REF }

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -136,4 +136,4 @@ jobs:
       run: 'cd /build && ctest --output-on-failure'
   call-conda-build:
     needs: [check-formatting, check-python-formatting]
-    uses: ./.github/workflows/conda-build.yml@${ GITHUB_REF }
+    uses: ./.github/workflows/conda-build.yml@${{ github.base_ref }}


### PR DESCRIPTION
## Description
Following a suggestion from @willcode on chat - don't do conda builds unless it passes the formatting checks

## Which blocks/areas does this affect?
none, just github ci

## Testing Done
- [x] check in with commit that doesn't pass clang-format, verify that conda doesn't build
- [ ] remove the commit and push, verify that conda does build