### PR TITLE
qtgui: Initialize _updateTime variable

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
+++ b/gr-qtgui/include/gnuradio/qtgui/SpectrumGUIClass.h
@@ -126,7 +126,7 @@ private:
     gr::high_res_timer_type _lastGUIUpdateTime = 0;
     unsigned int _pendingGUIUpdateEventsCount = 0;
     int _droppedEntriesCount = 0;
-    double _updateTime;
+    double _updateTime = 0.5;
 
     SpectrumDisplayForm* _spectrumDisplayForm = nullptr; // Deleted by QT.
 


### PR DESCRIPTION
# Pull Request Details

## Description

Valgrind shows that the `_updateTime` member variable is read before it is initialized when a GT GUI Sink is constructed:
```
==221466== Conditional jump or move depends on uninitialised value(s)
==221466==    at 0x491F722: SpectrumGUIClass::updateWindow(bool, float const*, unsigned long, float const*, unsigned long, float const*, unsigned long, long long, bool) (SpectrumGUIClass.cc:241)
==221466==    by 0x491F9E9: SpectrumGUIClass::openSpectrumWindow(QWidget*, bool, bool, bool, bool) (SpectrumGUIClass.cc:90)
==221466==    by 0x49287F5: gr::qtgui::sink_c_impl::initialize() (sink_c_impl.cc:129)
==221466==    by 0x4928E3F: gr::qtgui::sink_c_impl::sink_c_impl(int, int, double, double, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool, bool, QWidget*) (sink_c_impl.cc:91)
==221466==    by 0x4929074: make_block_sptr<gr::qtgui::sink_c_impl, int&, int&, double&, double&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool&, bool&, bool&, bool&, QWidget*&> (sptr_magic.h:57)
==221466==    by 0x4929074: gr::qtgui::sink_c::make(int, int, double, double, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool, bool, QWidget*) (sink_c_impl.cc:42)
==221466==    by 0x10E42B: freq_sink::freq_sink() (in /home/argilo/freq_sink/build/freq_sink)
==221466==    by 0x10D9AE: main (in /home/argilo/freq_sink/build/freq_sink)
```

The `SpectrumGUIClass::openSpectrumWindow` method reads `_updateTime`, but it is not written until `SpectrumGUIClass::setUpdateTime` is later called:

https://github.com/gnuradio/gnuradio/blob/b42996b1569722d34dad2057406e4a6c3de99366/gr-qtgui/lib/sink_c_impl.cc#L129-L133

https://github.com/gnuradio/gnuradio/blob/b42996b1569722d34dad2057406e4a6c3de99366/gr-qtgui/lib/SpectrumGUIClass.cc#L239-L244

https://github.com/gnuradio/gnuradio/blob/b42996b1569722d34dad2057406e4a6c3de99366/gr-qtgui/lib/SpectrumGUIClass.cc#L416-L421

To solve this problem, I've added a default value to the member variable. 0.5 matches the value that will later be assigned by `sink_c_impl::initialize`.

This seems to be an old bug. I've confirmed it's present in 3.8.

## Which blocks/areas does this affect?
* QT GUI Sink

## Testing Done
To test, I compiled the following flowgraph to C++ and executed it inside valgrind:
![Screenshot from 2022-01-22 21-55-28](https://user-images.githubusercontent.com/583749/150662976-e09fa99d-bb66-49e7-8a18-e7d140a54099.png)

After applying the patch, the valgrind error goes away.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
