### PR TITLE
grc: use block deprecated flag for visual indication

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -570,8 +570,8 @@ class Block(Element):
             return False
 
         try:
-            return any("deprecated".casefold() in cat.casefold()
-                       for cat in self.category)
+            return self.flags.deprecated or any("deprecated".casefold() in cat.casefold()
+                                                for cat in self.category)
         except Exception as exception:
             print(exception.message)
         return False


### PR DESCRIPTION
## Description
The orange coloring of a deprecated block currently is only based on a block being in the "Deprecated" category - but some blocks such as the new SigMF placeholder blocks are not.  This expands the orange coloring to blocks that have the deprecated flag in their yaml

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
Tried it in GRC

![image](https://user-images.githubusercontent.com/34754695/150813073-02694630-eff2-4463-b2b4-418cee31f58b.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
