### PR TITLE
digital: put back import of packet_utils (backport to maint-3.10)

### DIFF
--- a/gr-digital/python/digital/__init__.py
+++ b/gr-digital/python/digital/__init__.py
@@ -37,6 +37,7 @@ from .soft_dec_lut_gen import *
 from .psk_constellations import *
 from .qam_constellations import *
 from .constellation_map_generator import *
+from . import packet_utils
 
 
 class gmskmod_bc(cpmmod_bc):


### PR DESCRIPTION
Had gotten lost in the autopep8 formatting

Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit b42996b1569722d34dad2057406e4a6c3de99366)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5506