### PR TITLE
grc: use block deprecated flag for visual indication (backport to maint-3.10)

### DIFF
--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -570,8 +570,8 @@ class Block(Element):
             return False
 
         try:
-            return any("deprecated".casefold() in cat.casefold()
-                       for cat in self.category)
+            return self.flags.deprecated or any("deprecated".casefold() in cat.casefold()
+                                                for cat in self.category)
         except Exception as exception:
             print(exception.message)
         return False


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 942aff023d2c8152623aacb433ba2ce9a99ad3df)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5515