### PR TITLE
filter: use compatible names for bus parameters (backport to maint-3.10)

### DIFF
--- a/gr-filter/grc/filter_pfb_channelizer.block.yml
+++ b/gr-filter/grc/filter_pfb_channelizer.block.yml
@@ -28,7 +28,7 @@ parameters:
     label: Channel Map
     dtype: int_vector
     default: '[]'
--   id: bus_conns
+-   id: bus_structure_source
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'

--- a/gr-filter/grc/filter_pfb_synthesizer.block.yml
+++ b/gr-filter/grc/filter_pfb_synthesizer.block.yml
@@ -28,7 +28,7 @@ parameters:
     label: Channel Map
     dtype: int_vector
     default: '[]'
--   id: bus_conns
+-   id: bus_structure_sink
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit f626980888e8346b915d10c689ff3280df43dbd4)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5502