### PR TITLE
Backport 5464 5502 to maint-3.8

### DIFF
--- a/gr-filter/grc/filter_pfb_channelizer.block.yml
+++ b/gr-filter/grc/filter_pfb_channelizer.block.yml
@@ -28,7 +28,7 @@ parameters:
     label: Channel Map
     dtype: int_vector
     default: '[]'
--   id: bus_conns
+-   id: bus_structure_source
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'

--- a/gr-filter/grc/filter_pfb_synthesizer.block.yml
+++ b/gr-filter/grc/filter_pfb_synthesizer.block.yml
@@ -28,7 +28,7 @@ parameters:
     label: Channel Map
     dtype: int_vector
     default: '[]'
--   id: bus_conns
+-   id: bus_structure_sink
     label: Bus Connections
     dtype: raw
     default: '[[0,],]'

--- a/grc/blocks/snippet.block.yml
+++ b/grc/blocks/snippet.block.yml
@@ -11,6 +11,7 @@ parameters:
 -   id: priority
     label: Priority
     dtype: int
+    default: "0"
     hide: ${'part' if priority <= 0 else 'none'}
 -   id: code
     label: Code Snippet


### PR DESCRIPTION
Backport simple YAML fixes.

Backport #5464 
Default value for Priority parameter in Python Snippet block

Backport #5502 
filter: use compatible names for bus parameters