### PR TITLE
runtime: downstream buffer size calculation back to 3.9 value

### DIFF
--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -119,8 +119,8 @@ void flat_flowgraph::allocate_block_detail(basic_block_sptr block)
             double decimation = (1.0 / dgrblock->relative_rate());
             int multiple = dgrblock->output_multiple();
             int history = dgrblock->history();
-            nitems = std::max(
-                nitems, static_cast<int>(2 * (decimation * multiple + (history - 1))));
+            nitems =
+                std::max(nitems, static_cast<int>(2 * (decimation * multiple + history)));
 
             // Calculate the LCM of downstream reader nitems
 #ifdef BUFFER_DEBUG


### PR DESCRIPTION
## Description
The calculation of buffer sizes for downstream blocks was changed in the custom buffer implementation - the reason for the change related to history is still unclear.

## Related Issue
Fixes #5542 

## Which blocks/areas does this affect?
All blocks 

## Testing Done
Ran the example flowgraph that was broken as described in #5542.  Needs testing of 
- [ ] Custom Buffers
- [ ] Other flowgraph

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
