### PR TITLE
Remove co-author's name from documentation

### DIFF
--- a/gr-blocks/grc/blocks_matrix_interleaver.block.yml
+++ b/gr-blocks/grc/blocks_matrix_interleaver.block.yml
@@ -54,8 +54,7 @@ outputs:
 asserts:
 - ${ vlen > 0 }
 
-documentation: 'Jared Dulmage
-
+documentation: '|-
     Block interleaver reads inputs into rows and writes outputs by cols
 
     python/matrix_interleaver.py'


### PR DESCRIPTION
Removed co-author's name from yml doc

---
name: Jared Dulmage
about: Removes name from documentation
title: 'Remove name from GRC documentation'
labels: 'GRC Documentation'
assignees: ''

---

# Pull Request Details
Remove co-author's name from matrix_interleaver GRC documentation

## Description
Removed co-author name from documentation in GRC yml file for matrix_interleaver.
## Related Issue
None
## Which blocks/areas does this affect?
blocks:matrix_interleaver
## Testing Done
N/A no changes to code
## Checklist
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
