### PR TITLE
runtime: downstream buffer size calculation back to 3.9 value (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -119,8 +119,8 @@ void flat_flowgraph::allocate_block_detail(basic_block_sptr block)
             double decimation = (1.0 / dgrblock->relative_rate());
             int multiple = dgrblock->output_multiple();
             int history = dgrblock->history();
-            nitems = std::max(
-                nitems, static_cast<int>(2 * (decimation * multiple + (history - 1))));
+            nitems =
+                std::max(nitems, static_cast<int>(2 * (decimation * multiple + history)));
 
             // Calculate the LCM of downstream reader nitems
 #ifdef BUFFER_DEBUG


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 120268de56dbf1a1ab01e27c601cd7d1342afaf7)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5543