### PR TITLE
cmake: fix incorrect backporting of #5444

### DIFF
--- a/gnuradio-runtime/CMakeLists.txt
+++ b/gnuradio-runtime/CMakeLists.txt
@@ -36,7 +36,7 @@ GR_REGISTER_COMPONENT("gnuradio-runtime" ENABLE_GNURADIO_RUNTIME
     Boost_FOUND
     PYTHONINTERP_FOUND
     MPLIB_FOUND
-    spdlog_FOUND
+    LOG4CPP_FOUND
 )
 endif()
 


### PR DESCRIPTION
The backport of #5444 copied a reference to spdlog into GNU Radio 3.9. LOG4CPP should be referenced instead.