### PR TITLE
digital: move EVM Measurement block into the Core tree

### DIFF
--- a/gr-digital/grc/digital.tree.yml
+++ b/gr-digital/grc/digital.tree.yml
@@ -7,6 +7,7 @@
   - variable_adaptive_algorithm
   - digital_linear_equalizer
   - digital_decision_feedback_equalizer
+  - digital_meas_evm_cc
 - Measurement Tools:
   - digital_mpsk_snr_est_cc
   - digital_probe_density_b


### PR DESCRIPTION
Currently the "EVM Measurement" block shows up in its own "Equalizers" module in GRC instead of the "Equalizers" category in the Core module. Adding it to the tree file fixes that.

Before:
![Screenshot from 2022-02-07 20-38-10](https://user-images.githubusercontent.com/583749/152901571-37ea3c2b-fd45-4b5a-94e8-5a7340b8ea4c.png)

After:
![Screenshot from 2022-02-07 20-36-48](https://user-images.githubusercontent.com/583749/152901564-fae23ea1-080b-4f4f-a013-7e683ed763b7.png)

## Which blocks/areas does this affect?
* EVM Measurement

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [ ] ~~I have added tests to cover my changes, and all previous tests pass.~~