### PR TITLE
gr-utils/modtool: info.py fix modname variable

### DIFF
--- a/gr-utils/modtool/core/info.py
+++ b/gr-utils/modtool/core/info.py
@@ -47,7 +47,7 @@ class ModToolInfo(ModTool):
             self.info['version'] = '37'
         if not os.path.isfile(os.path.join('cmake', 'Modules', 'FindCppUnit.cmake')):
             self.info['version'] = '38'
-            if os.path.isdir(os.path.join('include', 'gnuradio', self.info['modname'])):
+            if os.path.isdir(os.path.join('include', 'gnuradio', mod_info['modname'])):
                 self.info['version'] = '310'
         mod_info['version'] = self.info['version']
         if 'is_component' in list(self.info.keys()) and self.info['is_component']:


### PR DESCRIPTION
# Pull Request Details
fix the variable used to get modname string

## Description
Without this fix the following error arise with `gr_modtool info` and a new OOT module (with `gr_modtool newmod`)

```
Traceback (most recent call last):
  File "/opt/local/bin/gr_modtool", line 18, in <module>
    cli()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/gnuradio/modtool/cli/base.py", line 135, in wrapper
    return func(*args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/gnuradio/modtool/cli/info.py", line 27, in cli
    run(self)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/gnuradio/modtool/cli/base.py", line 155, in run
    module.run()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/gnuradio/modtool/core/info.py", line 50, in run
    if os.path.isdir(os.path.join('include', 'gnuradio', self.info['modname'])):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/posixpath.py", line 90, in join
    genericpath._check_arg_types('join', a, *p)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/genericpath.py", line 152, in _check_arg_types
    raise TypeError(f'{funcname}() argument must be str, bytes, or '
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```

## Which blocks/areas does this affect?
`gr_modtool`

## Testing Done
```
gr_modtool newmod test
cd gr-test
gr_modtool info
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
