### PR TITLE
qtgui: Add output message ports to range widgets

### DIFF
--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -58,16 +58,16 @@ parameters:
     dtype: string
     default: 'value'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: enum
     options: ['True', 'False']
     option_labels: ['Yes', 'No']
     default: 'False'
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 value: ${ value }
 

--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -53,11 +53,29 @@ parameters:
     dtype: int
     default: '200'
     hide: part
+-   id: outputmsgname
+    label: Message Property Name
+    dtype: string
+    default: 'value'
+    hide: part
 -   id: gui_hint
     label: GUI Hint
     dtype: gui_hint
     hide: part
+-   id: showports
+    label: Show Msg Ports
+    dtype: enum
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    default: 'False'
+    hide: part
 value: ${ value }
+
+outputs:
+-   domain: message
+    id: out
+    optional: true
+    hide: ${ showports != 'True' }
 
 asserts:
 - ${start <= value <= stop}
@@ -65,7 +83,7 @@ asserts:
 
 templates:
     imports: |- 
-        from gnuradio.qtgui import Range, RangeWidget
+        from gnuradio.qtgui import Range, GrRangeWidget
         from PyQt5 import QtCore
     var_make: self.${id} = ${id} = ${value}
     callbacks:
@@ -76,7 +94,9 @@ templates:
             range = 'self._%s_range'%id
         %>\
         ${range} = Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
-        ${win} = RangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient})
+        ${win} = GrRangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient}, "${no_quotes(outputmsgname)}")
+        self.${id} = ${win}
+
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/python/qtgui/__init__.py
+++ b/gr-qtgui/python/qtgui/__init__.py
@@ -31,7 +31,7 @@ except ImportError:
     gr.log.warn("Matplotlib is a required dependency to use DistanceRadar and AzElPlot."
                 "  Please install matplotlib to use these blocks (https://matplotlib.org/)")
 
-from .range import Range, RangeWidget
+from .range import Range, RangeWidget, GrRangeWidget
 from . import util
 
 from .compass import GrCompass

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -12,7 +12,9 @@
 @PY_QT_IMPORT@
 from .util import check_set_qss
 import gnuradio.eng_notation as eng_notation
+from gnuradio import gr
 import re
+import pmt
 
 class Range(object):
     def __init__(self, minv, maxv, step, default, min_length):
@@ -99,7 +101,7 @@ class RangeWidget(QtWidgets.QWidget):
         # Top-block function to call when any value changes
         # Some widgets call this directly when their value changes.
         # Others have intermediate functions to map the value into the right range.
-        self.notifyChanged = slot
+        self.__slot = slot
 
         layout = Qt.QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -130,6 +132,10 @@ class RangeWidget(QtWidgets.QWidget):
 
         layout.addWidget(self.d_widget)
         self.setLayout(layout)
+
+    def notifyChanged(self, value):
+        self.message_port_pub(self.outputportname_pmt, pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
+        self.__slot(value)
 
     class Dial(QtWidgets.QDial):
         """ Creates the range using a dial """
@@ -388,6 +394,23 @@ class RangeWidget(QtWidgets.QWidget):
                 self.slider.setValue(new)
                 self.first = False
 
+class GrRangeWidget(gr.sync_block, RangeWidget):
+    def __init__(self, ranges, varCallback, label, style, rangeType=float,
+            orientation=QtCore.Qt.Horizontal, outputmsgname='value'):
+        RangeWidget.__init__(self, ranges, varCallback, label, style, rangeType, orientation)
+        gr.sync_block.__init__(self, name='GrRangeWidget', in_sig=None, out_sig=None)
+        self.outputportname_pmt = pmt.intern('out')
+        self.outputmsgname_pmt = pmt.intern(outputmsgname)
+        self.message_port_register_out(self.outputportname_pmt)
+        self.value_to_pmt = (pmt.from_float if self.rangeType is float else pmt.from_long)
+        self.varCallback = varCallback
+
+    def valueChanged(self, new_value):
+        if self.varCallback is not None:
+            self.varCallback(new_value)
+        self.message_port_pub(self.outputportname_pmt,
+                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
+
 
 if __name__ == "__main__":
     from PyQt5 import Qt
@@ -397,7 +420,7 @@ if __name__ == "__main__":
         print("Value updated - " + str(frequency))
 
     app = Qt.QApplication(sys.argv)
-    widget = RangeWidget(Range(0, 100, 10, 1, 100),
+    widget = GrRangeWidget(Range(0, 100, 10, 1, 100),
                          valueChanged, "Test", "counter_slider", int)
 
     widget.show()


### PR DESCRIPTION
# Pull Request Details

## Description

Previously, the Qt range widget did not support output ports -- contrary to several other Qt widgets (such as the dial control), which does.

This PR brings the widget types into conformance and lets messages be used to convey data entered by the user.

## Related Issue

None filed.

## Which blocks/areas does this affect?

The Qt range block is modified. In theory, performance impact should be minimal.

## Testing Done

Instantiated a flowgraph with a range block, with another GUI widget following its output via variable updates, and a message sink block following outputs over the message port. Validated that both consumers retrieve updates, thus that the traditional callback mechanism was not impacted. Modified the message name, and checked that the value passed to the message debug sink was updated accordingly.

Also directly invoked `python -m gnuradio.qtgui.range` to invoke the block's self-test capabilities.

## Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
