### PR TITLE
filter: fix polyphase channelizer hier block and example

### DIFF
--- a/gr-filter/python/filter/pfb.py
+++ b/gr-filter/python/filter/pfb.py
@@ -452,8 +452,7 @@ class channelizer_hier_ccf(gr.hier_block2):
             gr.io_signature(1, 1, gr.sizeof_gr_complex),
             gr.io_signature(len(outchans), len(outchans), gr.sizeof_gr_complex))
         if taps is None:
-            taps = self.create_taps(
-                n_chans, atten=100, bw=1.0, tb=0.2, ripple=0.1)
+            taps = self.create_taps(n_chans, atten, bw, tb, ripple)
         taps = list(taps)
         extra_taps = int(math.ceil(1.0 * len(taps) / n_chans) *
                          n_chans - len(taps))


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/4015, the function call shouldn't have those default args included.  The example broke because the bw is set to 0.6 in the flowgraph but it was getting reset to 1.0 which messed up the channelizer.

Signed-off-by: Marc Lichtman [marcll@vt.edu](mailto:marcll@vt.edu)

Before fix - 
![Screenshot from 2022-02-12 17-20-56](https://user-images.githubusercontent.com/5722532/153731374-d0c3e7c8-a65e-425d-9707-ca31e1949cb2.png)

After fix -

![Screenshot from 2022-02-12 17-54-46](https://user-images.githubusercontent.com/5722532/153731382-b57e110d-fadc-456d-8e29-12d312959474.png)


