### PR TITLE
filter: Fix crash in Rational Resampler logging

### DIFF
--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -120,7 +120,7 @@ rational_resampler_impl<IN_T, OUT_T, TAP_T>::rational_resampler_impl(
     auto d = GR_GCD(interpolation, decimation);
 
     if (!taps.empty() && (d > 1)) {
-        d_logger->info(
+        this->d_logger->info(
             "Rational resampler has user-provided taps but interpolation ({:d}) and "
             "decimation ({:d}) have a GCD of {:d}, which increases the complexity of "
             "the filterbank. Consider reducing these values by the GCD.",

--- a/gr-filter/lib/rational_resampler_impl.h
+++ b/gr-filter/lib/rational_resampler_impl.h
@@ -30,8 +30,6 @@ private:
 
     void install_taps(const std::vector<TAP_T>& taps);
 
-    gr::logger_ptr d_logger;
-
 public:
     rational_resampler_impl(unsigned interpolation,
                             unsigned decimation,

--- a/gr-filter/python/filter/qa_rational_resampler.py
+++ b/gr-filter/python/filter/qa_rational_resampler.py
@@ -250,6 +250,29 @@ class test_rational_resampler (gr_unittest.TestCase):
         self.assertFloatTuplesAlmostEqual(
             expected_result[offset:offset + N], result_data[0:N], 5)
 
+    def test_007_interp_decim_common_factor(self):
+        taps = random_floats(31)
+        src_data = random_floats(10000)
+        interp = 6
+        decimation = 2
+
+        expected_result = reference_interp_dec_filter(
+            src_data, interp, decimation, taps)
+
+        tb = gr.top_block()
+        src = blocks.vector_source_f(src_data)
+        op = filter.rational_resampler_fff(interp, decimation, taps)
+        dst = blocks.vector_sink_f()
+        tb.connect(src, op)
+        tb.connect(op, dst)
+        tb.run()
+        result_data = dst.data()
+
+        N = 1000
+        offset = len(taps) // 2
+        self.assertFloatTuplesAlmostEqual(
+            expected_result[offset:offset + N], result_data[0:N], 5)
+
 
 if __name__ == '__main__':
     # FIXME: Disabled, see ticket:210


### PR DESCRIPTION
## Description

If the Interpolation and Decimation factors of a Rational Resampler block have common factor, and taps are manually specified, then the block segfaults when it is launched.

This happens because the block declares its own `d_logger` pointer but does not initialize it before use:

https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gr-filter/lib/rational_resampler_impl.h#L33

https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gr-filter/lib/rational_resampler_impl.cc#L124-L130

The `basic_block` class already provides a logger, so there is no need to override it. I've switched to using the provided logger here.

It looks like this bug was introduced in #3952. I've confirmed that it's present in 3.9 and 3.10.

## Which blocks/areas does this affect?
* Rational Resampler

## Testing Done
I used the following flow graph for testing:
![Screenshot from 2022-02-14 18-54-38](https://user-images.githubusercontent.com/583749/153966633-afb2cb57-f8d2-48bd-9ead-1fee564c5c34.png)

I also added a QA test (nearly an exact copy of `test_006_interp_decim`, but with an interpolation factor of 6 instead of 3. The test generates a segfault without the code changes, and passes with them in place.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
