### PR TITLE
analog: Replace boost::format with standard C++

### DIFF
--- a/gr-analog/CMakeLists.txt
+++ b/gr-analog/CMakeLists.txt
@@ -8,14 +8,12 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 
 ########################################################################
 # Register component
 ########################################################################
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-analog" ENABLE_GR_ANALOG
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_BLOCKS
     ENABLE_GR_FFT

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -13,8 +13,6 @@
 #include <config.h>
 #endif
 
-#include <boost/format.hpp>
-
 #include "fastnoise_source_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
@@ -43,10 +41,9 @@ void fastnoise_source_impl<gr_complex>::generate()
 {
     size_t noutput_items = d_samples.size();
     if (noutput_items >= 1 << 23) {
-        GR_LOG_INFO(
-            d_logger,
-            boost::format("Generating %d complex values. This might take a while.") %
-                noutput_items);
+        GR_LOG_INFO(d_logger,
+                    "Generating " + std::to_string(noutput_items) +
+                        " complex values. This might take a while.");
     }
 
     switch (d_type) {
@@ -80,9 +77,8 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
 {
     if (!d_bitmask) {
         GR_LOG_INFO(this->d_logger,
-                    boost::format("Using non-power-of-2 sample pool size %d. This has "
-                                  "negative effect on performance.") %
-                        samples);
+                    "Using non-power-of-2 sample pool size " + std::to_string(samples) +
+                        ". This has negative effect on performance.");
     }
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, seed);
@@ -105,9 +101,8 @@ fastnoise_source_impl<gr_complex>::fastnoise_source_impl(noise_type_t type,
 {
     if (!d_bitmask) {
         GR_LOG_INFO(d_logger,
-                    boost::format("Using non-power-of-2 sample pool size %d. This has "
-                                  "negative effect on performance.") %
-                        samples);
+                    "Using non-power-of-2 sample pool size " + std::to_string(samples) +
+                        ". This has negative effect on performance.");
     }
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, (uint64_t)seed);
@@ -150,8 +145,8 @@ void fastnoise_source_impl<T>::generate()
     size_t noutput_items = d_samples.size();
     if (noutput_items >= 1 << 23) {
         GR_LOG_INFO(this->d_logger,
-                    boost::format("Generating %d values. This might take a while.") %
-                        noutput_items);
+                    "Generating " + std::to_string(noutput_items) +
+                        " values. This might take a while.");
     }
     switch (d_type) {
     case GR_UNIFORM:


### PR DESCRIPTION
## Description
This pull request removes gr-analog's last dependence on Boost.

## Which blocks/areas does this affect?
* Fast Noise Source

## Testing Done
To print out all the error messages, I created Fast Noise Source blocks (one with Output Type = complex, one with Output Type = float) and set Virtual Pool Size to 10000000. The output is as expected:

```
fastnoise_source :info: Using non-power-of-2 sample pool size 10000000. This has negative effect on performance.
fastnoise_source :info: Generating 10000000 complex values. This might take a while.

fastnoise_source :info: Using non-power-of-2 sample pool size 10000000. This has negative effect on performance.
fastnoise_source :info: Generating 10000000 values. This might take a while.
```

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
