### PR TITLE
dtv: Convert to modern logging

### DIFF
--- a/gr-dtv/CMakeLists.txt
+++ b/gr-dtv/CMakeLists.txt
@@ -8,7 +8,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 
 ########################################################################
 # Register component
@@ -16,7 +15,6 @@ include(GrBoost)
 include(GrComponent)
 
 GR_REGISTER_COMPONENT("gr-dtv" ENABLE_GR_DTV
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_ANALOG
     ENABLE_GR_FILTER

--- a/gr-dtv/lib/atsc/atsc_fs_checker_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_fs_checker_impl.cc
@@ -73,8 +73,7 @@ int atsc_fs_checker_impl::general_work(int noutput_items,
             errors +=
                 (in[i * ATSC_DATA_SEGMENT_LENGTH + j + OFFSET_511] >= 0) ^ atsc_pn511[j];
 
-        GR_LOG_DEBUG(d_debug_logger,
-                     std::string("second PN63 error count = ") + std::to_string(errors));
+        this->d_debug_logger->debug("second PN63 error count = {:d}", errors);
 
         if (errors < PN511_ERROR_LIMIT) { // 511 pattern is good.
             // determine if this is field 1 or field 2
@@ -85,17 +84,16 @@ int atsc_fs_checker_impl::general_work(int noutput_items,
 
             // we should have either field 1 (== PN63) or field 2 (== ~PN63)
             if (errors <= PN63_ERROR_LIMIT) {
-                GR_LOG_DEBUG(d_debug_logger, "Found FIELD_SYNC_1")
+                this->d_debug_logger->debug("Found FIELD_SYNC_1");
                 d_field_num = 1;    // We are in field number 1 now
                 d_segment_num = -1; // This is the first segment
             } else if (errors >= (LENGTH_2ND_63 - PN63_ERROR_LIMIT)) {
-                GR_LOG_DEBUG(d_debug_logger, "Found FIELD_SYNC_2")
+                this->d_debug_logger->debug("Found FIELD_SYNC_2");
                 d_field_num = 2;    // We are in field number 2 now
                 d_segment_num = -1; // This is the first segment
             } else {
                 // should be extremely rare.
-                GR_LOG_WARN(d_logger,
-                            std::string("PN63 error count = ") + std::to_string(errors));
+                this->d_logger->warn("PN63 error count = {:d}", errors);
             }
         }
 

--- a/gr-dtv/lib/atsc/atsc_interleaver_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_interleaver_impl.cc
@@ -30,14 +30,14 @@ atsc_interleaver_impl::atsc_interleaver_impl()
     J = 4;
     registers = (unsigned char*)malloc(sizeof(unsigned char) * I * ((I - 1) * J));
     if (registers == NULL) {
-        GR_LOG_FATAL(d_logger, "ATSC Interleaver, cannot allocate memory for registers.");
+        this->d_logger->fatal("ATSC Interleaver, cannot allocate memory for registers.");
         throw std::bad_alloc();
     }
 
     pointers = (int*)malloc(sizeof(int) * I);
     if (pointers == NULL) {
         free(registers);
-        GR_LOG_FATAL(d_logger, "ATSC Interleaver, cannot allocate memory for pointers");
+        this->d_logger->fatal("ATSC Interleaver, cannot allocate memory for pointers");
         throw std::bad_alloc();
     }
 

--- a/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
+++ b/gr-dtv/lib/atsc/atsc_rs_decoder_impl.cc
@@ -16,8 +16,6 @@
 #include "gnuradio/dtv/atsc_consts.h"
 #include <gnuradio/io_signature.h>
 
-#include <boost/format.hpp>
-
 namespace gr {
 namespace dtv {
 
@@ -116,9 +114,10 @@ int atsc_rs_decoder_impl::work(int noutput_items,
         d_total_packets++;
 #if 0
         if (d_total_packets > 1000) {
-          GR_LOG_INFO(d_logger, boost::format("Error rate: %1%\tPacket error rate: %2%") \
-                       % ((float)d_nerrors_corrected_count/(ATSC_MPEG_PKT_LENGTH*d_total_packets))
-                       % ((float)d_bad_packet_count/d_total_packets));
+            this->d_logger->info("Error rate: {:g}\tPacket error rate: {:g}",
+                                 (float)d_nerrors_corrected_count /
+                                     (ATSC_MPEG_PKT_LENGTH * d_total_packets),
+                                 (float)d_bad_packet_count / d_total_packets);
         }
 #endif
     }

--- a/gr-dtv/lib/dvb/dvb_bbheader_bb_impl.cc
+++ b/gr-dtv/lib/dvb/dvb_bbheader_bb_impl.cc
@@ -487,7 +487,7 @@ int dvb_bbheader_bb_impl::general_work(int noutput_items,
                 for (int j = 0; j < (int)((kbch - 80 - padding) / 8); j++) {
                     if (count == 0) {
                         if (*in != 0x47) {
-                            GR_LOG_WARN(d_logger, "Transport Stream sync error!");
+                            this->d_logger->warn("Transport Stream sync error!");
                         }
                         j--;
                         in++;
@@ -508,7 +508,7 @@ int dvb_bbheader_bb_impl::general_work(int noutput_items,
                 for (int j = 0; j < (int)((kbch - 80 - padding) / 8); j++) {
                     if (count == 0) {
                         if (*in != 0x47) {
-                            GR_LOG_WARN(d_logger, "Transport Stream sync error!");
+                            this->d_logger->warn("Transport Stream sync error!");
                         }
                         in++;
                         b = crc;
@@ -539,7 +539,7 @@ int dvb_bbheader_bb_impl::general_work(int noutput_items,
                 if (nibble == TRUE) {
                     if (count == 0) {
                         if (*in != 0x47) {
-                            GR_LOG_WARN(d_logger, "Transport Stream sync error!");
+                            this->d_logger->warn("Transport Stream sync error!");
                         }
                         in++;
                         b = crc;

--- a/gr-dtv/lib/dvbs2/dvbs2_physical_cc_impl.cc
+++ b/gr-dtv/lib/dvbs2/dvbs2_physical_cc_impl.cc
@@ -78,8 +78,8 @@ dvbs2_physical_cc_impl::dvbs2_physical_cc_impl(dvb_framesize_t framesize,
         type |= 1;
     }
     if (goldcode < 0 || goldcode > 262141) {
-        GR_LOG_WARN(d_logger, "Gold Code must be between 0 and 262141 inclusive.");
-        GR_LOG_WARN(d_logger, "Gold Code set to 0.");
+        this->d_logger->warn("Gold Code must be between 0 and 262141 inclusive.");
+        this->d_logger->warn("Gold Code set to 0.");
         goldcode = 0;
     }
     gold_code = goldcode;

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_deinterleaver_impl.cc
@@ -13,8 +13,6 @@
 #include "dvbt_bit_inner_deinterleaver_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <boost/format.hpp>
-
 #define MAX_MODULATION_ORDER 6
 #define INTERLEAVER_BLOCK_SIZE 126
 
@@ -65,11 +63,10 @@ dvbt_bit_inner_deinterleaver_impl::dvbt_bit_inner_deinterleaver_impl(
     }
 
     if (d_nsize % d_bsize) {
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format(
-                "Input size must be multiple of block size: nsize: %1% bsize: %2%") %
-                d_nsize % d_bsize);
+        this->d_logger->error(
+            "Input size must be multiple of block size: nsize: {:d} bsize: {:d}",
+            d_nsize,
+            d_bsize);
     }
 }
 

--- a/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_bit_inner_interleaver_impl.cc
@@ -13,8 +13,6 @@
 #include "dvbt_bit_inner_interleaver_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <boost/format.hpp>
-
 #define MAX_MODULATION_ORDER 6
 #define INTERLEAVER_BLOCK_SIZE 126
 
@@ -66,11 +64,10 @@ dvbt_bit_inner_interleaver_impl::dvbt_bit_inner_interleaver_impl(
     }
 
     if (d_nsize % d_bsize) {
-        GR_LOG_ERROR(
-            d_logger,
-            boost::format(
-                "Input size must be multiple of block size: nsize: %1% bsize: %2%") %
-                d_nsize % d_bsize);
+        this->d_logger->error(
+            "Input size must be multiple of block size: nsize: {:d} bsize: {:d}",
+            d_nsize,
+            d_bsize);
     }
 }
 

--- a/gr-dtv/lib/dvbt/dvbt_energy_dispersal_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_energy_dispersal_impl.cc
@@ -98,7 +98,7 @@ int dvbt_energy_dispersal_impl::general_work(int noutput_items,
 
             for (int j = 0; j < d_npacks; j++) {
                 if (in[index + count] != d_SYNC) {
-                    GR_LOG_WARN(d_logger, "Malformed MPEG-TS!");
+                    this->d_logger->warn("Malformed MPEG-TS!");
                 }
 
                 out[count++] = sync;

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon_dec_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon_dec_impl.cc
@@ -43,7 +43,7 @@ dvbt_reed_solomon_dec_impl::dvbt_reed_solomon_dec_impl(
 {
     d_rs = init_rs_char(rs_init_symsize, gfpoly, rs_init_fcr, rs_init_prim, (n - k));
     if (d_rs == NULL) {
-        GR_LOG_FATAL(d_logger, "Reed-Solomon Decoder, cannot allocate memory for d_rs.");
+        this->d_logger->fatal("Reed-Solomon Decoder, cannot allocate memory for d_rs.");
         throw std::bad_alloc();
     }
     d_nerrors_corrected_count = 0;

--- a/gr-dtv/lib/dvbt/dvbt_reed_solomon_enc_impl.cc
+++ b/gr-dtv/lib/dvbt/dvbt_reed_solomon_enc_impl.cc
@@ -42,15 +42,14 @@ dvbt_reed_solomon_enc_impl::dvbt_reed_solomon_enc_impl(
 {
     d_rs = init_rs_char(rs_init_symsize, gfpoly, rs_init_fcr, rs_init_prim, (n - k));
     if (d_rs == NULL) {
-        GR_LOG_FATAL(d_logger, "Reed-Solomon Encoder, cannot allocate memory for d_rs.");
+        this->d_logger->fatal("Reed-Solomon Encoder, cannot allocate memory for d_rs.");
         throw std::bad_alloc();
     }
     // The full input frame size (d_k) (no need to add in d_s, as the block input is the
     // pre-shortedned K)
     d_data = (unsigned char*)malloc(sizeof(unsigned char) * (d_k));
     if (d_data == NULL) {
-        GR_LOG_FATAL(d_logger,
-                     "Reed-Solomon Encoder, cannot allocate memory for d_data.");
+        this->d_logger->fatal("Reed-Solomon Encoder, cannot allocate memory for d_data.");
         free_rs_char(d_rs);
         throw std::bad_alloc();
     }

--- a/gr-dtv/lib/dvbt2/dvbt2_cellinterleaver_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_cellinterleaver_cc_impl.cc
@@ -165,15 +165,14 @@ dvbt2_cellinterleaver_cc_impl::dvbt2_cellinterleaver_cc_impl(
     }
     time_interleave = (gr_complex*)malloc(sizeof(gr_complex) * cell_size * fecblocks);
     if (time_interleave == NULL) {
-        GR_LOG_FATAL(
-            d_logger,
+        this->d_logger->fatal(
             "Cell/Time Interleaver, cannot allocate memory for time_interleave.");
         throw std::bad_alloc();
     }
     cols = (gr_complex**)malloc(sizeof(gr_complex*) * FECBlocksPerBigTIBlock * 5);
     if (cols == NULL) {
         free(time_interleave);
-        GR_LOG_FATAL(d_logger, "Cell/Time Interleaver, cannot allocate memory for cols.");
+        this->d_logger->fatal("Cell/Time Interleaver, cannot allocate memory for cols.");
         throw std::bad_alloc();
     }
     ti_blocks = tiblocks;

--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -881,28 +881,28 @@ dvbt2_framemapper_cc_impl::dvbt2_framemapper_cc_impl(
         set_output_multiple((N_P2 * C_P2) + (numdatasyms * C_DATA));
         mapped_items = (N_P2 * C_P2) + (numdatasyms * C_DATA);
         if (mapped_items < (stream_items + 1840 + (N_post / eta_mod) + (N_FC - C_FC))) {
-            GR_LOG_WARN(d_logger, "Frame Mapper, too many FEC blocks in T2 frame.");
+            this->d_logger->warn("Frame Mapper, too many FEC blocks in T2 frame.");
             mapped_items = stream_items + 1840 + (N_post / eta_mod) +
                            (N_FC - C_FC); /* avoid segfault */
         }
         zigzag_interleave = (gr_complex*)malloc(sizeof(gr_complex) * mapped_items);
         if (zigzag_interleave == NULL) {
-            GR_LOG_FATAL(d_logger,
-                         "Frame Mapper, cannot allocate memory for zigzag_interleave.");
+            this->d_logger->fatal(
+                "Frame Mapper, cannot allocate memory for zigzag_interleave.");
             throw std::bad_alloc();
         }
     } else {
         set_output_multiple((N_P2 * C_P2) + ((numdatasyms - 1) * C_DATA) + N_FC);
         mapped_items = (N_P2 * C_P2) + ((numdatasyms - 1) * C_DATA) + N_FC;
         if (mapped_items < (stream_items + 1840 + (N_post / eta_mod) + (N_FC - C_FC))) {
-            GR_LOG_WARN(d_logger, "Frame Mapper, too many FEC blocks in T2 frame.");
+            this->d_logger->warn("Frame Mapper, too many FEC blocks in T2 frame.");
             mapped_items = stream_items + 1840 + (N_post / eta_mod) +
                            (N_FC - C_FC); /* avoid segfault */
         }
         zigzag_interleave = (gr_complex*)malloc(sizeof(gr_complex) * mapped_items);
         if (zigzag_interleave == NULL) {
-            GR_LOG_FATAL(d_logger,
-                         "Frame Mapper, cannot allocate memory for zigzag_interleave.");
+            this->d_logger->fatal(
+                "Frame Mapper, cannot allocate memory for zigzag_interleave.");
             throw std::bad_alloc();
         }
     }
@@ -911,8 +911,8 @@ dvbt2_framemapper_cc_impl::dvbt2_framemapper_cc_impl(
                             (N_post / eta_mod) - (N_FC - C_FC));
     if (dummy_randomize == NULL) {
         free(zigzag_interleave);
-        GR_LOG_FATAL(d_logger,
-                     "Frame Mapper, cannot allocate memory for dummy_randomize.");
+        this->d_logger->fatal(
+            "Frame Mapper, cannot allocate memory for dummy_randomize.");
         throw std::bad_alloc();
     }
     init_dummy_randomizer();


### PR DESCRIPTION
## Description

This continues the work started in #5270. Here I've updated gr-dtv to use modern logging, which has also removed the module's last dependence on Boost.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* ATSC Field Sync Checker
* ATSC Interleaver
* ATSC Reed-Solomon Decoder
* DVB BBheader
* DVB-S2 Physical Layer Framer
* DVB-T Bit Inner Deinterleaver
* DVB-T Bit Inner Interleaver
* DVB-T Energy Dispersal
* DVB-T Reed-Solomon Decoder
* DVB-T Reed-Solomon Encoder
* DVB-T2 Cell/Time Interleaver
* DVB-T2 Frame Mapper

## Testing Done
So far I haven't done any testing. I'd appreciate help from folks familiar with gr-dtv.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
