### PR TITLE
grc: store grc version info in metadata (backport to maint-3.9)

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -395,7 +395,10 @@ class FlowGraph(Element):
         data['blocks'] = [b.export_data() for b in sorted(self.blocks, key=block_order)
                           if b is not self.options_block]
         data['connections'] = sorted(c.export_data() for c in self.connections)
-        data['metadata'] = {'file_format': FLOW_GRAPH_FILE_FORMAT_VERSION}
+        data['metadata'] = {
+            'file_format': FLOW_GRAPH_FILE_FORMAT_VERSION,
+            'grc_version': self.parent_platform.config.version
+        }
         return data
 
     def _build_depending_hier_block(self, block_id):

--- a/grc/core/schema_checker/flow_graph.py
+++ b/grc/core/schema_checker/flow_graph.py
@@ -18,6 +18,7 @@ FLOW_GRAPH_SCHEME = expand(
 
     metadata=Spec(types=dict, required=True, item_scheme=expand(
         file_format=Spec(types=int, required=True, item_scheme=None),
+        grc_version=Spec(types=str, required=False, item_scheme=None),
     ))
 
 )


### PR DESCRIPTION
Saving a flowgraph does not save the grc version
as it this info is not part of the schema.

This pr adds grc_version to the schema definition and
saves the grc version string when the fg is saved.

Possibly
fixes #5521

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit b0d3304e1b82821b60027858eb220bc513e2cf6f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5553