### PR TITLE
cmake updates #5544 #5545 (backport to maint-3.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "Prevented in-tree build. This is bad practice.")
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 
+# Select the release build type by default to get optimization flags.
+# This has to come before project() which otherwise initializes it.
+# Build type can still be overridden by setting -DCMAKE_BUILD_TYPE=
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
 ########################################################################
 # Project setup
 ########################################################################
@@ -23,15 +28,9 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
+# Add more build types and check that requested build type is valid
 include(GrBuildTypes)
-
-# Select the release build type by default to get optimization flags
-if(NOT CMAKE_BUILD_TYPE)
-   SET(CMAKE_BUILD_TYPE "Release")
-   message(STATUS "Build type not specified: defaulting to release.")
-endif(NOT CMAKE_BUILD_TYPE)
 GR_CHECK_BUILD_TYPE(${CMAKE_BUILD_TYPE})
-SET(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 message(STATUS "Build type set to ${CMAKE_BUILD_TYPE}.")
 
 # Set the build date

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -166,6 +166,8 @@ target_include_directories(gnuradio-runtime
     ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
+target_compile_features(gnuradio-runtime PUBLIC cxx_std_17)
+
 target_compile_definitions(gnuradio-runtime PUBLIC ${MPLIB_DEFINITIONS})
 
 # constants.cc includes boost::dll headers, force them to use std::filesystem

--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+# Select the release build type by default to get optimization flags.
+# This has to come before project() which otherwise initializes it.
+# Build type can still be overridden by setting -DCMAKE_BUILD_TYPE=
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
 ########################################################################
 # Project setup
 ########################################################################
@@ -18,13 +23,6 @@ if(DEFINED ENV{PYBOMBS_PREFIX})
     set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})
     message(STATUS "PyBOMBS installed GNU Radio. Setting CMAKE_INSTALL_PREFIX to $ENV{PYBOMBS_PREFIX}")
 endif()
-
-# Select the release build type by default to get optimization flags
-if(NOT CMAKE_BUILD_TYPE)
-   set(CMAKE_BUILD_TYPE "Release")
-   message(STATUS "Build type not specified: defaulting to release.")
-endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)


### PR DESCRIPTION
Backport #5545 - Set target_compile_features to cxx_std_17
Backport #5544 - Initialize CMAKE_BUILD_TYPE to Release before project() call