### PR TITLE
gr-qtgui: Vector sink add disable_legend (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -97,6 +97,14 @@ parameters:
     dtype: bool
     default: 'False'
     hide: part
+-   id: legend
+    label: Legend
+    category: Config
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
 -   id: label1
     label: Line 1 Label
     category: Config
@@ -322,6 +330,10 @@ templates:
         self.${id}.set_x_axis_units(${x_units})
         self.${id}.set_y_axis_units(${y_units})
         self.${id}.set_ref_level(${ref_level})
+
+        % if legend == "False":
+        self.${id}.disable_legend()
+        % endif
 
         labels = [${label1}, ${label2}, ${label3}, ${label4}, ${label5},
             ${label6}, ${label7}, ${label8}, ${label9}, ${label10}]

--- a/gr-qtgui/include/gnuradio/qtgui/vector_sink_f.h
+++ b/gr-qtgui/include/gnuradio/qtgui/vector_sink_f.h
@@ -110,6 +110,7 @@ public:
 
     virtual void enable_menu(bool en = true) = 0;
     virtual void enable_grid(bool en = true) = 0;
+    virtual void disable_legend() = 0;
     virtual void enable_autoscale(bool en = true) = 0;
     virtual void clear_max_hold() = 0;
     virtual void clear_min_hold() = 0;

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -253,6 +253,8 @@ void vector_sink_f_impl::enable_menu(bool en) { d_main_gui->enableMenu(en); }
 
 void vector_sink_f_impl::enable_grid(bool en) { d_main_gui->setGrid(en); }
 
+void vector_sink_f_impl::disable_legend() { d_main_gui->disableLegend(); }
+
 void vector_sink_f_impl::enable_autoscale(bool en) { d_main_gui->autoScale(en); }
 
 void vector_sink_f_impl::clear_max_hold() { d_main_gui->clearMaxHold(); }

--- a/gr-qtgui/lib/vector_sink_f_impl.h
+++ b/gr-qtgui/lib/vector_sink_f_impl.h
@@ -118,6 +118,7 @@ public:
 
     void enable_menu(bool en) override;
     void enable_grid(bool en) override;
+    void disable_legend() override;
     void enable_autoscale(bool en) override;
     void clear_max_hold() override;
     void clear_min_hold() override;

--- a/gr-qtgui/python/qtgui/bindings/docstrings/vector_sink_f_pydoc_template.h
+++ b/gr-qtgui/python/qtgui/bindings/docstrings/vector_sink_f_pydoc_template.h
@@ -114,6 +114,9 @@ static const char* __doc_gr_qtgui_vector_sink_f_set_size = R"doc()doc";
 static const char* __doc_gr_qtgui_vector_sink_f_enable_menu = R"doc()doc";
 
 
+static const char* __doc_gr_qtgui_vector_sink_f_disable_legend = R"doc()doc";
+
+
 static const char* __doc_gr_qtgui_vector_sink_f_enable_grid = R"doc()doc";
 
 

--- a/gr-qtgui/python/qtgui/bindings/vector_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/vector_sink_f_python.cc
@@ -236,6 +236,11 @@ void bind_vector_sink_f(py::module& m)
              D(vector_sink_f, enable_grid))
 
 
+        .def("disable_legend",
+             &vector_sink_f::disable_legend,
+             D(vector_sink_f, disable_legend))
+
+
         .def("enable_autoscale",
              &vector_sink_f::enable_autoscale,
              py::arg("en") = true,


### PR DESCRIPTION
Adds a disabled_legend option to the vector sink.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 2910458586ee3e5d34b23f36de510fe05fe9ec7b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5540