### PR TITLE
filter: Fix crash in Rational Resampler logging (backport to maint-3.9)

### DIFF
--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -122,7 +122,7 @@ rational_resampler_impl<IN_T, OUT_T, TAP_T>::rational_resampler_impl(
 
     if (taps.size() && (d > 1)) {
         GR_LOG_INFO(
-            d_logger,
+            this->d_logger,
             boost::format(
                 "Rational resampler has user-provided taps but interpolation (%1%) and "
                 "decimation (%2%) have a GCD of %3%, which increases the complexity of "

--- a/gr-filter/lib/rational_resampler_impl.h
+++ b/gr-filter/lib/rational_resampler_impl.h
@@ -30,8 +30,6 @@ private:
 
     void install_taps(const std::vector<TAP_T>& taps);
 
-    gr::logger_ptr d_logger;
-
 public:
     rational_resampler_impl(unsigned interpolation,
                             unsigned decimation,

--- a/gr-filter/python/filter/qa_rational_resampler.py
+++ b/gr-filter/python/filter/qa_rational_resampler.py
@@ -250,6 +250,29 @@ class test_rational_resampler (gr_unittest.TestCase):
         self.assertFloatTuplesAlmostEqual(
             expected_result[offset:offset + N], result_data[0:N], 5)
 
+    def test_007_interp_decim_common_factor(self):
+        taps = random_floats(31)
+        src_data = random_floats(10000)
+        interp = 6
+        decimation = 2
+
+        expected_result = reference_interp_dec_filter(
+            src_data, interp, decimation, taps)
+
+        tb = gr.top_block()
+        src = blocks.vector_source_f(src_data)
+        op = filter.rational_resampler_fff(interp, decimation, taps)
+        dst = blocks.vector_sink_f()
+        tb.connect(src, op)
+        tb.connect(op, dst)
+        tb.run()
+        result_data = dst.data()
+
+        N = 1000
+        offset = len(taps) // 2
+        self.assertFloatTuplesAlmostEqual(
+            expected_result[offset:offset + N], result_data[0:N], 5)
+
 
 if __name__ == '__main__':
     # FIXME: Disabled, see ticket:210


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 95ee7221f8d72d5021c92595e1779719eb9c8fbb)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5569