### PR TITLE
blocks: Skip alignment check when the input file is not seekable

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -176,7 +176,7 @@ void file_source_impl::open(const char* filename,
     // If length is not specified, use the remainder of the file. Check alignment at end.
     if (length_items == 0) {
         length_items = items_available;
-        if (file_size % d_itemsize) {
+        if (d_seekable && (file_size % d_itemsize)) {
             d_logger->warn("file size is not a multiple of item size ({:d} ≠ N·{:d})",
                            file_size,
                            d_itemsize);


### PR DESCRIPTION
## Description

If a non-seekable file like /dev/zero is opened in the File Source block, the following warning appears:

`file_source :warning: file size is not a multiple of item size
(9223372036854775807 ≠ N·8)`

This happens because non-seekable files are treated as if their size is INT64_MAX, which is almost never a multiple of the item size.

https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gr-blocks/lib/file_source_impl.cc#L151-L180

To solve the problem, I propose to simply skip the alignment check for non-seekable files.

## Which blocks/areas does this affect?
* File Source

## Testing Done
* Open `/dev/zero` in a File Source block (Output Type = complex) and verify that no warning is printed.
* Open a 1024-byte file in a File Source block and verify that no warning is printed.
* Open a 1023-byte file in a File Source block and verify that a warning is printed.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
