### PR TITLE
soapy: Convert to modern logging

### DIFF
--- a/gr-soapy/CMakeLists.txt
+++ b/gr-soapy/CMakeLists.txt
@@ -8,7 +8,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 
 ########################################################################
 # External dependencies
@@ -20,7 +19,6 @@ find_package(SoapySDR 0.7.2)
 ########################################################################
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-soapy" ENABLE_GR_SOAPY
-    Boost_FOUND
     SoapySDR_FOUND
     ENABLE_GNURADIO_RUNTIME
 )

--- a/gr-soapy/lib/sink_impl.cc
+++ b/gr-soapy/lib/sink_impl.cc
@@ -12,7 +12,6 @@
 
 #include "sink_impl.h"
 #include <SoapySDR/Errors.hpp>
-#include <boost/format.hpp>
 #include <iostream>
 
 namespace gr {
@@ -126,8 +125,7 @@ int sink_impl::general_work(__GR_ATTR_UNUSED int noutput_items,
     } else if (result == SOAPY_SDR_UNDERFLOW) {
         std::cerr << "sU" << std::flush;
     } else {
-        GR_LOG_WARN(d_logger,
-                    boost::format("Soapy sink error: %s") % SoapySDR::errToStr(result));
+        d_logger->warn("Soapy sink error: {:s}", SoapySDR::errToStr(result));
     }
 
     consume_each(nconsumed);

--- a/gr-soapy/lib/source_impl.cc
+++ b/gr-soapy/lib/source_impl.cc
@@ -12,7 +12,6 @@
 
 #include "source_impl.h"
 #include <SoapySDR/Errors.hpp>
-#include <boost/format.hpp>
 #include <iostream>
 
 namespace gr {
@@ -87,9 +86,7 @@ int source_impl::general_work(int noutput_items,
 
         // Report and yield back to scheduler on other errors.
         default:
-            GR_LOG_WARN(d_logger,
-                        boost::format("Soapy source error: %s") %
-                            SoapySDR::errToStr(result));
+            d_logger->warn("Soapy source error: {:s}", SoapySDR::errToStr(result));
             break;
         }
 


### PR DESCRIPTION
## Description

This continues the work started in #5270. Here I've updated gr-soapy to use modern logging, which has also removed the module's last dependence on Boost.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Soapy Sink
* Soapy Source

## Testing Done
So far I haven't done any testing. I'd appreciate help from folks familiar with gr-soapy.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
