### PR TITLE
iio: Replace Boost with standard C++

### DIFF
--- a/gr-iio/CMakeLists.txt
+++ b/gr-iio/CMakeLists.txt
@@ -8,13 +8,10 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
-
 find_package(libiio)
 find_package(libad9361)
 
 set(GR_IIO_DEPENDENCIES
-  Boost_FOUND
   ENABLE_GNURADIO_RUNTIME
   ENABLE_GR_BLOCKS
   libiio_FOUND)

--- a/gr-iio/include/gnuradio/iio/iio_types.h
+++ b/gr-iio/include/gnuradio/iio/iio_types.h
@@ -10,7 +10,6 @@
 #define _INCLUDED_IIO_TYPES_H
 
 #include <gnuradio/iio/api.h>
-#include <boost/tokenizer.hpp>
 #include <charconv>
 #include <string>
 #include <variant>
@@ -31,9 +30,6 @@ enum class attr_type_t {
 
 typedef std::variant<long long unsigned int, long unsigned int, int, double, std::string>
     iio_param_value_t;
-
-#define tokenizer(inp, sep) \
-    boost::tokenizer<boost::char_separator<char>>(inp, boost::char_separator<char>(sep))
 
 class IIO_API iio_param_t : public std::pair<std::string, std::string>
 {

--- a/gr-iio/lib/attr_source_impl.cc
+++ b/gr-iio/lib/attr_source_impl.cc
@@ -13,8 +13,6 @@
 
 #include "attr_source_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <chrono>
 #include <string>
@@ -129,7 +127,7 @@ attr_source_impl::~attr_source_impl() {}
 void attr_source_impl::check(int ret)
 {
     if (ret < 0)
-        GR_LOG_WARN(d_logger, boost::format("Reading parameter failed: %d") % ret);
+        d_logger->warn("Reading parameter failed: {:d}", ret);
 }
 
 void attr_source_impl::get_register_data(uint32_t address, int* value)
@@ -137,7 +135,7 @@ void attr_source_impl::get_register_data(uint32_t address, int* value)
     uint32_t u32value;
     ret = iio_device_reg_read(dev, address, &u32value);
     attr_source_impl::check(ret);
-    *value = boost::lexical_cast<int>(u32value);
+    *value = static_cast<int>(u32value);
 }
 
 void attr_source_impl::get_attribute_data(const std::string& attribute, double* value)
@@ -171,7 +169,7 @@ void attr_source_impl::get_attribute_data(const std::string& attribute, float* v
         break;
     }
     attr_source_impl::check(ret);
-    *value = boost::lexical_cast<float>(dvalue);
+    *value = static_cast<float>(dvalue);
 }
 
 void attr_source_impl::get_attribute_data(const std::string& attribute, long long* value)
@@ -205,7 +203,7 @@ void attr_source_impl::get_attribute_data(const std::string& attribute, int* val
         break;
     }
     attr_source_impl::check(ret);
-    *value = boost::lexical_cast<int>(llvalue);
+    *value = static_cast<int>(llvalue);
 }
 
 void attr_source_impl::get_attribute_data(const std::string& attribute, uint8_t* value)
@@ -223,7 +221,7 @@ void attr_source_impl::get_attribute_data(const std::string& attribute, uint8_t*
         break;
     }
     attr_source_impl::check(ret);
-    *value = boost::lexical_cast<uint8_t>(bvalue);
+    *value = static_cast<uint8_t>(bvalue);
 }
 
 int attr_source_impl::work(int noutput_items,

--- a/gr-iio/lib/attr_updater_impl.cc
+++ b/gr-iio/lib/attr_updater_impl.cc
@@ -87,7 +87,7 @@ bool attr_updater_impl::start()
         d_finished = false;
         d_mtx.unlock();
         d_thread = std::shared_ptr<gr::thread::thread>(
-            new gr::thread::thread(boost::bind(&attr_updater_impl::run, this)));
+            new gr::thread::thread([this] { run(); }));
     }
     return block::start();
 }

--- a/gr-iio/lib/dds_control_impl.cc
+++ b/gr-iio/lib/dds_control_impl.cc
@@ -14,8 +14,6 @@
 #include "dds_control_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <boost/format.hpp>
-
 #include <string>
 #include <vector>
 
@@ -122,28 +120,23 @@ void dds_control_impl::set_dds_confg(std::vector<long> frequencies,
             ret = iio_channel_attr_write_longlong(
                 chan, "frequency", d_frequencies[dds_indx]);
             if (ret < 0)
-                GR_LOG_WARN(d_logger,
-                            boost::format("Unable to set DDS frequency: %ld") %
-                                d_frequencies[dds_indx]);
+                d_logger->warn("Unable to set DDS frequency: {:d}",
+                               d_frequencies[dds_indx]);
 
             ret = iio_channel_attr_write_longlong(chan, "phase", d_phases[dds_indx]);
             if (ret < 0)
-                GR_LOG_WARN(d_logger,
-                            boost::format("Unable to set DDS phase: %f") %
-                                d_phases[dds_indx]);
+                d_logger->warn("Unable to set DDS phase: {:g}", d_phases[dds_indx]);
 
             if (d_enabled[enable_indx])
                 ret = iio_channel_attr_write_double(chan, "scale", d_scales[dds_indx]);
             else
                 ret = iio_channel_attr_write_double(chan, "scale", 0);
             if (ret < 0)
-                GR_LOG_WARN(d_logger,
-                            boost::format("Unable to set DDS scale: %f") %
-                                d_scales[dds_indx]);
+                d_logger->warn("Unable to set DDS scale: {:g}", d_scales[dds_indx]);
 
             ret = iio_channel_attr_write_longlong(chan, "raw", enable);
             if (ret < 0)
-                GR_LOG_WARN(d_logger, boost::format("Unable to set DDS: %d") % ret);
+                d_logger->warn("Unable to set DDS: {:d}", ret);
 
             dds_indx++;
             if ((dds_indx % 4) == 0)

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -15,8 +15,6 @@
 #include "device_source_impl.h"
 #include <gnuradio/io_signature.h>
 
-#include <boost/format.hpp>
-
 #include <string>
 #include <vector>
 
@@ -225,7 +223,7 @@ int device_sink_impl::work(int noutput_items,
         iio_strerror(-ret, buf, sizeof(buf));
         std::string error(buf);
 
-        GR_LOG_WARN(d_logger, boost::format("Unable to push buffer: %d") % error);
+        d_logger->warn("Unable to push buffer: {:s}", error);
         return WORK_DONE; /* EOF */
     }
 

--- a/gr-iio/lib/iio_types.cc
+++ b/gr-iio/lib/iio_types.cc
@@ -7,6 +7,8 @@
  */
 
 #include <gnuradio/iio/iio_types.h>
+#include <sstream>
+#include <string>
 
 namespace gr {
 namespace iio {
@@ -19,8 +21,10 @@ iio_param_t::iio_param_t(const std::string& key, iio_param_value_t value)
 }
 iio_param_t::iio_param_t(const std::string& kvpair)
 {
+    std::istringstream ss(kvpair);
+    std::string tok;
     std::vector<std::string> toks;
-    for (const std::string& tok : tokenizer(kvpair, "=")) {
+    while (getline(ss, tok, '=')) {
         toks.push_back(tok);
     }
     if (toks.size() == 2 && !toks[0].empty()) { // only valid combination

--- a/gr-iio/lib/pluto_utils.cc
+++ b/gr-iio/lib/pluto_utils.cc
@@ -41,10 +41,10 @@ std::string get_pluto_uri()
         logger.info("More than one Pluto found:");
 
         for (unsigned int i = 0; i < (size_t)ret; i++) {
-            logger.info((boost::format("\t%d: %s [%s]") % i %
-                         iio_context_info_get_description(info[i]) %
-                         iio_context_info_get_uri(info[i]))
-                            .str());
+            logger.info("\t{:d}: {:s} [{:s}]",
+                        i,
+                        iio_context_info_get_description(info[i]),
+                        iio_context_info_get_uri(info[i]));
         }
 
         logger.info("We will use the first one.");

--- a/gr-iio/python/iio/bindings/iio_types_python.cc
+++ b/gr-iio/python/iio/bindings/iio_types_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(iio_types.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2e0a29b6c915504e7bac45fa7fa47949)                     */
+/* BINDTOOL_HEADER_FILE_HASH(77b1d523bd8cf53e30fcb42f41c6ed8d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
gr-iio only uses Boost in a few places. I've replaced each with standard C++, thereby removing the dependence on Boost.

## Which blocks/areas does this affect?
* DDS Control
* IIO Attribute Sink
* IIO Attribute Source
* IIO Attribute Updater
* IIO Device Sink
* PlutoSDR Sink
* PlutoSDR Source

## Testing Done
With some simple flow graphs, I verified that PlutoSDR Sink & Source are still working.

I also verified that parameter parsing still works:
```
>>> gnuradio.iio.iio_param_t("a")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid parameter string: a

>>> gnuradio.iio.iio_param_t("a=b")
<gnuradio.iio.iio_python.iio_param_t object at 0x7fd8864f6af0>

>>> gnuradio.iio.iio_param_t("a=b=c")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid parameter string: a=b=c

>>> gnuradio.iio.iio_param_t("a", 1)
<gnuradio.iio.iio_python.iio_param_t object at 0x7fd8b1c02630>
```

I would appreciate help with testing from others who are more familiar with the gr-iio module.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
