### PR TITLE
network: Convert to modern logging

### DIFF
--- a/gr-network/lib/socket_pdu_impl.cc
+++ b/gr-network/lib/socket_pdu_impl.cc
@@ -214,12 +214,7 @@ void socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection,
         d_tcp_connections.push_back(new_connection);
         start_tcp_accept();
     } else {
-        // need to convert error to printable string;
-        // can't do (std::stringstream() << error).str() since
-        // under some compilers, << yields an ostream and that has no .str()
-        std::stringstream ss;
-        ss << error;
-        GR_LOG_ERROR(d_logger, ss.str());
+        d_logger->error(error.message());
     }
 }
 

--- a/gr-network/lib/stream_pdu_base.cc
+++ b/gr-network/lib/stream_pdu_base.cc
@@ -24,7 +24,6 @@
 #include <gnuradio/basic_block.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/pdu.h>
-#include <boost/format.hpp>
 
 static const long timeout_us = 100 * 1000; // 100ms
 
@@ -100,9 +99,11 @@ void stream_pdu_base::send(pmt::pmt_t msg)
 
     const int rv = write(d_fd, pmt::uniform_vector_elements(vector, offset), len);
     if (rv != len) {
-        static auto msg = boost::format(
-            "stream_pdu_base::send(pdu) write failed! (d_fd=%d, len=%d, rv=%d)");
-        GR_LOG_WARN(d_pdu_logger, msg % d_fd % len % rv);
+        d_pdu_logger->warn(
+            "stream_pdu_base::send(pdu) write failed! (d_fd={:d}, len={:d}, rv={:d})",
+            d_fd,
+            len,
+            rv);
     }
 }
 

--- a/gr-network/lib/tuntap_pdu_impl.cc
+++ b/gr-network/lib/tuntap_pdu_impl.cc
@@ -16,7 +16,6 @@
 #include "tuntap_pdu_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/pdu.h>
-#include <boost/format.hpp>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -67,21 +66,21 @@ tuntap_pdu_impl::tuntap_pdu_impl(std::string dev, int MTU, bool istunflag)
 
     int err = set_mtu(dev_cstr, MTU);
     if (err < 0) {
-        std::ostringstream msg;
-        msg << boost::format("failed to set MTU to %d. You should use ifconfig to set "
-                             "the MTU. E.g., `$ sudo ifconfig %s mtu %d`") %
-                   MTU % dev % MTU;
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("failed to set MTU to {:d}. You should use ifconfig to set "
+                        "the MTU. E.g., `$ sudo ifconfig {:s} mtu {:d}`",
+                        MTU,
+                        dev,
+                        MTU);
     }
 
 
-    GR_LOG_WARN(d_logger,
-                (boost::format("Allocated virtual ethernet interface: %s\n"
-                               "You must now use ifconfig to set its IP address. E.g.,\n"
-                               "  $ sudo ifconfig %s 192.168.200.1\n"
-                               "Be sure to use a different address in the same subnet "
-                               "for each machine.\n") %
-                 dev % dev));
+    d_logger->warn("Allocated virtual ethernet interface: {:s}\n"
+                   "You must now use ifconfig to set its IP address. E.g.,\n"
+                   "  $ sudo ifconfig {:s} 192.168.200.1\n"
+                   "Be sure to use a different address in the same subnet "
+                   "for each machine.\n",
+                   dev,
+                   dev);
 
     // set up output message port
     message_port_register_out(msgport_names::pdus());

--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -15,7 +15,6 @@
 #include "udp_sink_impl.h"
 #include <gnuradio/io_signature.h>
 #include <boost/array.hpp>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace network {
@@ -78,15 +77,14 @@ udp_sink_impl::udp_sink_impl(size_t itemsize,
         break;
 
     default:
-        GR_LOG_ERROR(d_logger, "Unknown header type.");
+        d_logger->error("Unknown header type.");
         throw std::invalid_argument("Unknown UDP header type.");
         break;
     }
 
     if (d_payloadsize < 8) {
-        GR_LOG_ERROR(d_logger,
-                     "Payload size is too small.  Must be at "
-                     "least 8 bytes once header/trailer adjustments are made.");
+        d_logger->error("Payload size is too small.  Must be at "
+                        "least 8 bytes once header/trailer adjustments are made.");
         throw std::invalid_argument(
             "Payload size is too small.  Must be at "
             "least 8 bytes once header/trailer adjustments are made.");
@@ -125,7 +123,7 @@ bool udp_sink_impl::start()
 
     d_udpsocket = new boost::asio::ip::udp::socket(d_io_service);
 
-    std::string str_port = (boost::format("%d") % d_port).str();
+    std::string str_port = std::to_string(d_port);
     std::string str_host = d_host.empty() ? std::string("localhost") : d_host;
     boost::asio::ip::udp::resolver resolver(d_io_service);
     boost::asio::ip::udp::resolver::query query(

--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -85,15 +85,14 @@ udp_source_impl::udp_source_impl(size_t itemsize,
         break;
 
     default:
-        GR_LOG_ERROR(d_logger, "Unknown UDP header type.");
+        d_logger->error("Unknown UDP header type.");
         throw std::invalid_argument("Unknown UDP header type.");
         break;
     }
 
     if (d_payloadsize < 8) {
-        GR_LOG_ERROR(d_logger,
-                     "Payload size is too small.  Must be at "
-                     "least 8 bytes once header/trailer adjustments are made.");
+        d_logger->error("Payload size is too small.  Must be at "
+                        "least 8 bytes once header/trailer adjustments are made.");
 
         throw std::invalid_argument(
             "Payload size is too small.  Must be at "
@@ -140,10 +139,7 @@ bool udp_source_impl::start()
                                  ex.what());
     }
 
-
-    std::stringstream msg_stream;
-    msg_stream << "Listening for data on UDP port " << d_port << ".";
-    GR_LOG_INFO(d_logger, msg_stream.str());
+    d_logger->info("Listening for data on UDP port {:d}.", d_port);
 
     return true;
 }
@@ -286,11 +282,9 @@ int udp_source_impl::work(int noutput_items,
         d_partial_frame_counter++;
 
         if (d_partial_frame_counter >= 100) {
-            std::stringstream msg_stream;
-            msg_stream << "Insufficient block data.  Check your sending "
-                          "app is using "
-                       << d_payloadsize << " send blocks.";
-            GR_LOG_WARN(d_logger, msg_stream.str());
+            d_logger->warn("Insufficient block data.  Check your sending "
+                           "app is using {:d} send blocks.",
+                           d_payloadsize);
 
             // This is just a safety to clear in the case there's a hanging partial
             // packet. If we've lingered through a number of calls and we still don't
@@ -369,10 +363,8 @@ int udp_source_impl::work(int noutput_items,
     }
 
     if (skipped_packets > 0 && d_notify_missed) {
-        std::stringstream msg_stream;
-        msg_stream << "[UDP source:" << d_port
-                   << "] missed  packets: " << skipped_packets;
-        GR_LOG_WARN(d_logger, msg_stream.str());
+        d_logger->warn(
+            "[UDP source:{:d}] missed  packets: {:d}", d_port, skipped_packets);
     }
 
     // If we had less data than requested, it'll be reflected in the return value.


### PR DESCRIPTION
## Description
This continues the work started in #5270. Here I've updated gr-network to use modern logging, which has also removed the module's dependence on Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Socket PDU
* TCP Sink
* TUNTAP PDU
* UDP Sink
* UDP Source

## Testing Done
I haven't done much testing yet. I'd appreciate help from someone more familiar with gr-network.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
