### PR TITLE
gr-qtgui: edit_box_msg, send message, only if return was pressed

### DIFF
--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -135,7 +135,7 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
     d_vlayout->addItem(d_hlayout);
     d_group->setLayout(d_vlayout);
 
-    QObject::connect(d_val, SIGNAL(editingFinished()), this, SLOT(edit_finished()));
+    QObject::connect(d_val, SIGNAL(returnPressed()), this, SLOT(edit_finished()));
 
     d_msg = pmt::PMT_NIL;
 
@@ -147,14 +147,8 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
 
 edit_box_msg_impl::~edit_box_msg_impl()
 {
-    delete d_group;
-    delete d_hlayout;
-    delete d_vlayout;
-    delete d_val;
     if (d_is_pair)
         delete d_key;
-    if (d_label)
-        delete d_label;
 }
 
 bool edit_box_msg_impl::start()

--- a/gr-qtgui/python/qtgui/digitalnumbercontrol.py
+++ b/gr-qtgui/python/qtgui/digitalnumbercontrol.py
@@ -369,7 +369,7 @@ class MsgDigitalNumberControl(gr.sync_block, LabeledDigitalNumberControl):
         self.setFrequency(new_val)
 
         self.message_port_pub(pmt.intern("valueout"), pmt.cons(pmt.intern(
-            self.outputmsgname), pmt.from_double(float(self.getFrequency()))))
+            self.outputmsgname), pmt.from_double(float(new_val))))
 
     def getValue(self):
         self.getFrequency()


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
At the moment, edit_box_msg sends the message if the widget looses it's focus
or if return was pressed.

This patch restricts sending to the return key press.

In addition some unneeded delete calls were removed, that caused segfaults
when the flowgraph was closed.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Replace signal editingFinished by signal returnPressed
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #3423
Fixes #5412
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested with
https://github.com/gnuradio/gnuradio/blob/master/gr-qtgui/examples/test_digitalnumcontrol.grc
https://github.com/gnuradio/gnuradio/blob/master/gr-qtgui/examples/test_qtgui_msg.grc
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
