### PR TITLE
blocktool: fix binding generation for uhd rfnoc blocks (backport to maint-3.10)

### DIFF
--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -322,7 +322,8 @@ class GenericHeaderParser(BlockTool):
                 define_symbols=self.define_symbols,
                 cflags='-std=c++17 -fPIC')
             decls = parser.parse(
-                [self.target_file], xml_generator_config)
+                [self.target_file], xml_generator_config,
+                compilation_mode=parser.COMPILATION_MODE.ALL_AT_ONCE)
 
             global_namespace = declarations.get_global_namespace(decls)
 


### PR DESCRIPTION
Signed-off-by: André Apitzsch <andre.apitzsch@etit.tu-chemnitz.de>
(cherry picked from commit 883ed283fbada33580e81d956c2f42ebbaf4415e)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5474