### PR TITLE
cmake: Initialize `CMAKE_BUILD_TYPE` to Release before project() call (backport to maint-3.9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "Prevented in-tree build. This is bad practice.")
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 
+# Select the release build type by default to get optimization flags.
+# This has to come before project() which otherwise initializes it.
+# Build type can still be overridden by setting -DCMAKE_BUILD_TYPE=
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
 ########################################################################
 # Project setup
 ########################################################################
@@ -23,15 +28,9 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
+# Add more build types and check that requested build type is valid
 include(GrBuildTypes)
-
-# Select the release build type by default to get optimization flags
-if(NOT CMAKE_BUILD_TYPE)
-   SET(CMAKE_BUILD_TYPE "Release")
-   message(STATUS "Build type not specified: defaulting to release.")
-endif(NOT CMAKE_BUILD_TYPE)
 GR_CHECK_BUILD_TYPE(${CMAKE_BUILD_TYPE})
-SET(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 message(STATUS "Build type set to ${CMAKE_BUILD_TYPE}.")
 
 # Set the build date

--- a/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/CMakeLists.txt
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+# Select the release build type by default to get optimization flags.
+# This has to come before project() which otherwise initializes it.
+# Build type can still be overridden by setting -DCMAKE_BUILD_TYPE=
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+
 ########################################################################
 # Project setup
 ########################################################################
@@ -18,13 +23,6 @@ if(DEFINED ENV{PYBOMBS_PREFIX})
     set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})
     message(STATUS "PyBOMBS installed GNU Radio. Setting CMAKE_INSTALL_PREFIX to $ENV{PYBOMBS_PREFIX}")
 endif()
-
-# Select the release build type by default to get optimization flags
-if(NOT CMAKE_BUILD_TYPE)
-   set(CMAKE_BUILD_TYPE "Release")
-   message(STATUS "Build type not specified: defaulting to release.")
-endif(NOT CMAKE_BUILD_TYPE)
-set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
 # Make sure our local CMake Modules path comes first
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)


### PR DESCRIPTION
Calling project() sets the default value for `CMAKE_BUILD_TYPE`. For
most generators this results in a null value so that any later check
acting on an unset `CMAKE_BUILD_TYPE` will proceed. However, on Windows
the default value is set to Debug, so the existing attempts to detect an
unset `CMAKE_BUILD_TYPE` and set it to Release fail to do the job on
Windows.

This commit sets `CMAKE_BUILD_TYPE` to Release before the project() call
so that the generator-dependent default is avoided. Because
`CMAKE_BUILD_TYPE` is set as a `CACHE` variable, this set command will
not overwrite any existing cached value for `CMAKE_BUILD_TYPE`, thus
still allowing users to override the setting from the CMake
command line.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit fa67b36027de1368d0e65760148f50b9786459d5)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5544