### PR TITLE
runtime: Remove boost::format and modernize logging

### DIFF
--- a/gnuradio-runtime/apps/gnuradio-config-info.cc
+++ b/gnuradio-runtime/apps/gnuradio-config-info.cc
@@ -13,10 +13,8 @@
 #endif
 
 #include <gnuradio/constants.h>
-#include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/sys_paths.h>
-#include <boost/format.hpp>
 #include <boost/program_options.hpp>
 #include <iostream>
 
@@ -24,8 +22,8 @@ namespace po = boost::program_options;
 
 int main(int argc, char** argv)
 {
-    po::options_description desc(
-        (boost::format("Program options: %1% [options]") % argv[0]).str());
+    po::options_description desc("Program options: " + std::string(argv[0]) +
+                                 " [options]");
     po::variables_map vm;
 
     // clang-format off
@@ -48,9 +46,8 @@ int main(int argc, char** argv)
         po::store(po::parse_command_line(argc, argv, desc), vm);
         po::notify(vm);
     } catch (po::error& error) {
-        gr::logger_ptr logger, debug_logger;
-        gr::configure_default_loggers(logger, debug_logger, "gnuradio-config-info.cc");
-        GR_LOG_ERROR(logger, boost::format("ERROR %s %s") % error.what() % desc);
+        std::cerr << "Error: " << error.what() << std::endl << std::endl;
+        std::cerr << desc << std::endl;
         return 1;
     }
 

--- a/gnuradio-runtime/include/gnuradio/pycallback_object.h
+++ b/gnuradio-runtime/include/gnuradio/pycallback_object.h
@@ -10,7 +10,6 @@
 
 #include <gnuradio/rpcregisterhelpers.h>
 #include <pythread.h>
-#include <boost/format.hpp>
 
 #include <iostream>
 
@@ -107,7 +106,7 @@ public:
 #ifdef GR_CTRLPORT
         add_rpc_variable(
             rpcbasic_sptr(new rpcbasic_register_get<pycallback_object, myType>(
-                (boost::format("%s%d") % d_name % d_id).str(),
+                d_name + std::to_string(d_id),
                 d_functionbase.c_str(),
                 this,
                 &pycallback_object::get,

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/buffer.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
-#include <boost/format.hpp>
 #include <iostream>
 #include <stdexcept>
 
@@ -365,9 +364,8 @@ long block::min_output_buffer(size_t i)
 
 void block::set_min_output_buffer(long min_output_buffer)
 {
-    GR_LOG_INFO(d_logger,
-                boost::format("set_min_output_buffer on block %s to %d") % unique_id() %
-                    min_output_buffer);
+    d_logger->info(
+        "set_min_output_buffer on block {:s} to {:d}", unique_id(), min_output_buffer);
     for (int i = 0; i < output_signature()->max_streams(); i++) {
         set_min_output_buffer(i, min_output_buffer);
     }
@@ -396,7 +394,7 @@ void block::allocate_detail(int ninputs,
 {
     block_detail_sptr detail = make_block_detail(ninputs, noutputs);
 
-    GR_LOG_DEBUG(d_debug_logger, "Creating block detail for " + identifier());
+    d_debug_logger->debug("Creating block detail for {:s}", identifier());
 
     for (int i = 0; i < noutputs; i++) {
         expand_minmax_buffer(i);
@@ -405,17 +403,16 @@ void block::allocate_detail(int ninputs,
                                              downstream_max_nitems_vec[i],
                                              downstream_lcm_nitems_vec[i],
                                              downstream_max_out_mult_vec[i]);
-        GR_LOG_DEBUG(d_debug_logger,
-                     "Allocated buffer for output " + identifier() + " " +
-                         std::to_string(i));
+        d_debug_logger->debug("Allocated buffer for output {:s} {:d}", identifier(), i);
         detail->set_output(i, buffer);
 
         // Update the block's max_output_buffer based on what was actually allocated.
         if ((max_output_buffer(i) != buffer->bufsize()) && (max_output_buffer(i) != -1))
-            GR_LOG_WARN(d_logger,
-                        boost::format("Block (%1%) max output buffer set to %2%"
-                                      " instead of requested %3%") %
-                            alias() % buffer->bufsize() % max_output_buffer(i));
+            d_logger->warn("Block ({:s}) max output buffer set to {:d}"
+                           " instead of requested {:d}",
+                           alias(),
+                           buffer->bufsize(),
+                           max_output_buffer(i));
         set_max_output_buffer(i, buffer->bufsize());
     }
 
@@ -489,8 +486,7 @@ buffer_sptr block::allocate_buffer(size_t port,
     buffer_sptr buf;
 
 #ifdef BUFFER_DEBUG
-    GR_LOG_DEBUG(d_logger,
-                 "Block: " + name() + " allocated buffer for output " + identifier());
+    d_logger->debug("Block: {:s} allocated buffer for output {:s}", name(), identifier());
 #endif
 
     // Grab the buffer type associated with the output port and use it to
@@ -514,7 +510,7 @@ buffer_sptr block::allocate_buffer(size_t port,
             msg << " (" << num_inputs << " -> "
                 << fixed_rate_ninput_to_noutput(num_inputs + (history() - 1)) << ")";
         }
-        GR_LOG_DEBUG(d_logger, msg.str());
+        d_logger->debug(msg.str());
 #endif
         buf = buftype.make_buffer(nitems,
                                   item_size,
@@ -758,13 +754,13 @@ void block::reset_perf_counters()
 
 void block::system_handler(pmt::pmt_t msg)
 {
-    // GR_LOG_INFO(d_logger, boost::format("system handler %s") % msg);
+    // d_logger->info("system handler {:s}", msg);
     pmt::pmt_t op = pmt::car(msg);
     if (pmt::eqv(op, d_pmt_done)) {
         d_finished = pmt::to_long(pmt::cdr(msg));
         global_block_registry.notify_blk(d_symbol_name);
     } else {
-        GR_LOG_WARN(d_logger, "bad message op on system port!");
+        d_logger->warn("bad message op on system port!");
         pmt::print(msg);
     }
 }

--- a/gnuradio-runtime/lib/buffer_double_mapped.cc
+++ b/gnuradio-runtime/lib/buffer_double_mapped.cc
@@ -60,7 +60,7 @@ buffer_double_mapped::buffer_double_mapped(int nitems,
         std::ostringstream msg;
         msg << "[" << this << "] "
             << "buffer_double_mapped constructor -- history: " << link->history();
-        GR_LOG_DEBUG(d_logger, msg.str());
+        d_logger->debug(msg.str());
     }
 #endif
 }
@@ -100,24 +100,23 @@ bool buffer_double_mapped::allocate_buffer(int nitems)
     // If we rounded-up a whole bunch, give the user a heads up.
     // This only happens if sizeof_item is not a power of two.
     if (nitems > 2 * orig_nitems && nitems * (int)d_sizeof_item > granularity) {
-        auto msg =
-            str(boost::format(
-                    "allocate_buffer: tried to allocate"
-                    "   %d items of size %d. Due to alignment requirements"
-                    "   %d were allocated.  If this isn't OK, consider padding"
-                    "   your structure to a power-of-two bytes."
-                    "   On this platform, our allocation granularity is %d bytes.") %
-                orig_nitems % d_sizeof_item % nitems % granularity);
-        GR_LOG_WARN(d_logger, msg.c_str());
+        d_logger->warn("allocate_buffer: tried to allocate"
+                       "   {:d} items of size {:d}. Due to alignment requirements"
+                       "   {:d} were allocated.  If this isn't OK, consider padding"
+                       "   your structure to a power-of-two bytes."
+                       "   On this platform, our allocation granularity is {:d} bytes.",
+                       orig_nitems,
+                       d_sizeof_item,
+                       nitems,
+                       granularity);
     }
 
     d_bufsize = nitems;
     d_vmcircbuf.reset(gr::vmcircbuf_sysconfig::make(d_bufsize * d_sizeof_item));
     if (d_vmcircbuf == 0) {
-        std::ostringstream msg;
-        msg << "gr::buffer::allocate_buffer: failed to allocate buffer of size "
-            << d_bufsize * d_sizeof_item / 1024 << " KB";
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error(
+            "gr::buffer::allocate_buffer: failed to allocate buffer of size {:d} KB",
+            d_bufsize * d_sizeof_item / 1024);
         return false;
     }
 
@@ -150,7 +149,7 @@ int buffer_double_mapped::space_available()
         msg << "[" << this << "] "
             << "space_available() called  d_write_index: " << d_write_index
             << " -- space_available: " << (d_bufsize - most_data - 1);
-        GR_LOG_DEBUG(d_logger, msg.str());
+        d_logger->debug(msg.str());
 #endif
 
         // The -1 ensures that the case d_write_index == d_read_index is

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc
@@ -10,7 +10,6 @@
 
 #include <gnuradio/rpcserver_booter_thrift.h>
 #include <gnuradio/rpcserver_thrift.h>
-#include <boost/format.hpp>
 
 #include <boost/asio/ip/host_name.hpp>
 
@@ -121,11 +120,11 @@ bool thrift_application_base<rpcserver_base,
         const std::string boost_hostname(boost::asio::ip::host_name());
 
         std::string endpoint =
-            boost::str(boost::format("-h %1% -p %2%") % boost_hostname % used_port);
+            "-h " + boost_hostname + " -p " + std::to_string(used_port);
 
         set_endpoint(endpoint);
 
-        GR_LOG_INFO(d_logger, "Apache Thrift: " + endpoint);
+        d_logger->info("Apache Thrift: {:s}", endpoint);
         d_thirft_is_running = true;
         result = true;
     }

--- a/gnuradio-runtime/lib/local_sighandler.cc
+++ b/gnuradio-runtime/lib/local_sighandler.cc
@@ -13,7 +13,6 @@
 #endif
 
 #include "local_sighandler.h"
-#include <boost/format.hpp>
 #include <cstring>
 #include <stdexcept>
 
@@ -32,8 +31,7 @@ local_sighandler::local_sighandler(int signum, void (*new_handler)(int))
 
     gr::configure_default_loggers(d_logger, d_debug_logger, "local_sighandler");
     if (sigaction(d_signum, &new_action, &d_old_action) < 0) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("sigaction (install new): %s") % strerror(errno))
+        d_logger->error("sigaction (install new): {:s}", strerror(errno));
         throw std::runtime_error("sigaction");
     }
 #endif
@@ -43,8 +41,7 @@ local_sighandler::~local_sighandler() noexcept(false)
 {
 #ifdef HAVE_SIGACTION
     if (sigaction(d_signum, &d_old_action, 0) < 0) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("sigaction (restore old): %s") % strerror(errno))
+        d_logger->error("sigaction (restore old): {:s}", strerror(errno));
         throw std::runtime_error("sigaction");
     }
 #endif
@@ -61,8 +58,6 @@ void local_sighandler::throw_signal(int signum) { throw signal(signum); }
 
 std::string signal::name() const
 {
-    std::string tmp;
-
     switch (signum()) {
 #ifdef SIGHUP
         SIGNAME(SIGHUP);
@@ -160,12 +155,10 @@ std::string signal::name() const
     default:
 #if defined(SIGRTMIN) && defined(SIGRTMAX)
         if (signum() >= SIGRTMIN && signum() <= SIGRTMAX) {
-            tmp = str(boost::format("SIGRTMIN + %d") % signum());
-            return tmp;
+            return "SIGRTMIN + " + std::to_string(signum());
         }
 #endif
-        tmp = str(boost::format("SIGNAL %d") % signum());
-        return tmp;
+        return "SIGNAL " + std::to_string(signum());
     }
 }
 

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
-#include <boost/format.hpp>
 
 #include "pagesize.h"
 #include <unistd.h>
@@ -37,11 +36,11 @@ int pagesize()
 #elif defined(HAVE_SYSCONF)
         s_pagesize = sysconf(_SC_PAGESIZE);
         if (s_pagesize == -1) {
-            GR_LOG_ERROR(logger, boost::format("_SC_PAGESIZE: %s") % strerror(errno));
+            logger->error("_SC_PAGESIZE: {:s}", strerror(errno));
             s_pagesize = 4096;
         }
 #else
-        GR_LOG_ERROR(logger, "no info; setting pagesize = 4096");
+        logger->error("no info; setting pagesize = 4096");
         s_pagesize = 4096;
 #endif
     }

--- a/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
+++ b/gnuradio-runtime/lib/pmt/qa_pmt_prims.cc
@@ -10,7 +10,6 @@
 
 #include <gnuradio/messages/msg_passing.h>
 #include <pmt/api.h> //reason: suppress warnings
-#include <boost/format.hpp>
 #include <boost/test/unit_test.hpp>
 #include <cstring>
 #include <sstream>
@@ -39,7 +38,7 @@ BOOST_AUTO_TEST_CASE(test_symbols)
 
     // generate a bunch of symbols
     for (int i = 0; i < N; i++) {
-        std::string buf = str(boost::format("test-%d") % i);
+        std::string buf = "test-" + std::to_string(i);
         v1[i] = pmt::mp(buf.c_str());
     }
 
@@ -50,7 +49,7 @@ BOOST_AUTO_TEST_CASE(test_symbols)
 
     // generate the same symbols again
     for (int i = 0; i < N; i++) {
-        std::string buf = str(boost::format("test-%d") % i);
+        std::string buf = "test-" + std::to_string(i);
         v2[i] = pmt::mp(buf.c_str());
     }
 

--- a/gnuradio-runtime/lib/realtime_impl.cc
+++ b/gnuradio-runtime/lib/realtime_impl.cc
@@ -20,7 +20,6 @@
 #include <sched.h>
 #endif
 
-#include <boost/format.hpp>
 #include <algorithm>
 #include <cerrno>
 #include <cmath>
@@ -111,11 +110,8 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
         else {
             gr::logger_ptr logger, debug_logger;
             gr::configure_default_loggers(logger, debug_logger, "realtime_impl");
-            GR_LOG_ERROR(
-                logger,
-                boost::format(
-                    "pthread_setschedparam: failed to set real time priority: %s") %
-                    strerror(result));
+            logger->error("pthread_setschedparam: failed to set real time priority: {:s}",
+                          strerror(result));
             return RT_OTHER_ERROR;
         }
     }
@@ -152,9 +148,7 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
         else {
             gr::logger_ptr logger, debug_logger;
             gr::configure_default_loggers(logger, debug_logger, "realtime_impl");
-            GR_LOG_ERROR(
-                logger,
-                boost::format("sched_setscheduler: failed to set real time priority."));
+            logger->error("sched_setscheduler: failed to set real time priority.");
             return RT_OTHER_ERROR;
         }
     }

--- a/gnuradio-runtime/lib/tagged_stream_block.cc
+++ b/gnuradio-runtime/lib/tagged_stream_block.cc
@@ -13,7 +13,6 @@
 #endif
 
 #include <gnuradio/tagged_stream_block.h>
-#include <boost/format.hpp>
 
 namespace gr {
 
@@ -100,10 +99,9 @@ int tagged_stream_block::general_work(int noutput_items,
     }
     for (unsigned i = 0; i < input_items.size(); i++) {
         if (d_n_input_items_reqd[i] == -1) {
-            GR_LOG_FATAL(
-                d_logger,
-                boost::format("Missing a required length tag on port %1% at item #%2%") %
-                    i % nitems_read(i));
+            d_logger->fatal("Missing a required length tag on port {:d} at item #{:d}",
+                            i,
+                            nitems_read(i));
             throw std::runtime_error("Missing length tag.");
         }
         if (d_n_input_items_reqd[i] > ninput_items[i]) {

--- a/gnuradio-runtime/lib/thread/thread.cc
+++ b/gnuradio-runtime/lib/thread/thread.cc
@@ -13,7 +13,6 @@
 #endif
 
 #include <gnuradio/thread/thread.h>
-#include <boost/format.hpp>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
 
@@ -119,7 +118,7 @@ void set_thread_name(gr_thread_t thread, std::string name)
         return;
 
     if (name.empty())
-        name = boost::str(boost::format("thread %lu") % dwThreadId);
+        name = "thread " + std::to_string(dwThreadId);
 
     _set_thread_name(thread, name.c_str(), dwThreadId);
 }
@@ -300,7 +299,7 @@ void set_thread_name(gr_thread_t thread, std::string name)
         return;
 
     if (name.empty())
-        name = boost::str(boost::format("thread %llu") % ((unsigned long long)thread));
+        name = "thread " + std::to_string((unsigned long long)thread);
 
     const int max_len = 16; // Maximum accepted by PR_SET_NAME
 

--- a/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
+++ b/gnuradio-runtime/lib/thread/thread_body_wrapper.cc
@@ -14,7 +14,6 @@
 
 #include <gnuradio/logger.h>
 #include <gnuradio/thread/thread_body_wrapper.h>
-#include <boost/format.hpp>
 
 #ifdef HAVE_SIGNAL_H
 #include <csignal>
@@ -69,7 +68,7 @@ void mask_signals()
         gr::logger_ptr logger, debug_logger;
         gr::configure_default_loggers(
             logger, debug_logger, "thread_body_wrapper::mask_signals");
-        GR_LOG_ERROR(logger, boost::format("pthread_sigmask: %s") % strerror(errno));
+        logger->error("pthread_sigmask: {:s}", strerror(errno));
     }
 }
 

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -15,7 +15,6 @@
 #include "tpb_thread_body.h"
 #include <gnuradio/prefs.h>
 #include <pmt/pmt.h>
-#include <boost/format.hpp>
 #include <boost/thread.hpp>
 #include <iostream>
 
@@ -30,13 +29,11 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <windows.h>
-    thread::set_thread_name(
-        GetCurrentThread(),
-        boost::str(boost::format("%s%d") % block->name() % block->unique_id()));
+    thread::set_thread_name(GetCurrentThread(),
+                            block->name() + std::to_string(block->unique_id()));
 #else
-    thread::set_thread_name(
-        pthread_self(),
-        boost::str(boost::format("%s%d") % block->name() % block->unique_id()));
+    thread::set_thread_name(pthread_self(),
+                            block->name() + std::to_string(block->unique_id()));
 #endif
 
     block_detail* d = block->detail().get();

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -18,7 +18,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -60,8 +59,7 @@ int vmcircbuf_prefs::get(const char* key, char* value, int value_size)
     gr::configure_default_loggers(logger, debug_logger, "vmcircbuf_prefs::get");
 
     if (fp == 0) {
-        GR_LOG_ERROR(logger,
-                     boost::format("%s: %s") % pathname(key).c_str() % strerror(errno));
+        logger->error("{:s}: {:s}", pathname(key), strerror(errno));
         return 0;
     }
 
@@ -69,9 +67,7 @@ int vmcircbuf_prefs::get(const char* key, char* value, int value_size)
     value[ret] = '\0';
     if (ret == 0 && !feof(fp)) {
         if (ferror(fp) != 0) {
-            GR_LOG_ERROR(logger,
-                         boost::format("%s: %s") % pathname(key).c_str() %
-                             strerror(errno));
+            logger->error("{:s}: {:s}", pathname(key), strerror(errno));
             fclose(fp);
             return -1;
         }
@@ -90,17 +86,14 @@ void vmcircbuf_prefs::set(const char* key, const char* value)
 
     FILE* fp = fopen(pathname(key).c_str(), "w");
     if (fp == 0) {
-        GR_LOG_ERROR(logger,
-                     boost::format("%s: %s") % pathname(key).c_str() % strerror(errno));
+        logger->error("{:s}: {:s}", pathname(key), strerror(errno));
         return;
     }
 
     size_t ret = fwrite(value, 1, strlen(value), fp);
     if (ret == 0) {
         if (ferror(fp) != 0) {
-            GR_LOG_ERROR(logger,
-                         boost::format("%s: %s") % pathname(key).c_str() %
-                             strerror(errno));
+            logger->error("{:s}: {:s}", pathname(key), strerror(errno));
             fclose(fp);
             return;
         }

--- a/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_sysv_shm.cc
@@ -15,7 +15,6 @@
 #include "vmcircbuf_sysv_shm.h"
 #include <fcntl.h>
 #include <unistd.h>
-#include <boost/format.hpp>
 #include <cstdlib>
 #include <stdexcept>
 #ifdef HAVE_SYS_IPC_H
@@ -34,7 +33,7 @@ namespace gr {
 vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
 {
 #if !defined(HAVE_SYS_SHM_H)
-    GR_LOG_ERROR(d_logger, "sysv shared memory is not available");
+    d_logger->error("sysv shared memory is not available");
     throw std::runtime_error("gr::vmcircbuf_sysv_shm");
 #else
 
@@ -43,7 +42,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
     int pagesize = gr::pagesize();
 
     if (size <= 0 || (size % pagesize) != 0) {
-        GR_LOG_ERROR(d_logger, boost::format("invalid size = %d") % size);
+        d_logger->error("invalid size = {:d}", size);
         throw std::runtime_error("gr::vmcircbuf_sysv_shm");
     }
 
@@ -59,19 +58,19 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
         // buffer. Ideally we'd map it no access, but I don't think that's possible with
         // SysV
         if ((shmid_guard = shmget(IPC_PRIVATE, pagesize, IPC_CREAT | 0400)) == -1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmget (0): %s") % strerror(errno));
+            d_logger->error("shmget (0): {:s}", strerror(errno));
             continue;
         }
 
         if ((shmid2 = shmget(IPC_PRIVATE, 2 * size + 2 * pagesize, IPC_CREAT | 0700)) ==
             -1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmget (1): %s") % strerror(errno));
+            d_logger->error("shmget (1): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             continue;
         }
 
         if ((shmid1 = shmget(IPC_PRIVATE, size, IPC_CREAT | 0700)) == -1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmget (2): %s") % strerror(errno));
+            d_logger->error("shmget (2): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid2, IPC_RMID, 0);
             continue;
@@ -79,7 +78,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
 
         void* first_copy = shmat(shmid2, 0, 0);
         if (first_copy == (void*)-1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmat (1): %s") % strerror(errno));
+            d_logger->error("shmat (1): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid2, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
@@ -99,7 +98,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
 
         // first read-only guard page
         if (shmat(shmid_guard, first_copy, SHM_RDONLY) == (void*)-1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmat (2): %s") % strerror(errno));
+            d_logger->error("shmat (2): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             continue;
@@ -107,7 +106,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
 
         // first copy
         if (shmat(shmid1, (char*)first_copy + pagesize, 0) == (void*)-1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmat (3): %s") % strerror(errno));
+            d_logger->error("shmat (3): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             shmdt(first_copy);
@@ -116,7 +115,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
 
         // second copy
         if (shmat(shmid1, (char*)first_copy + pagesize + size, 0) == (void*)-1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmat (4): %s") % strerror(errno));
+            d_logger->error("shmat (4): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             shmdt((char*)first_copy + pagesize);
@@ -126,7 +125,7 @@ vmcircbuf_sysv_shm::vmcircbuf_sysv_shm(size_t size) : gr::vmcircbuf(size)
         // second read-only guard page
         if (shmat(shmid_guard, (char*)first_copy + pagesize + 2 * size, SHM_RDONLY) ==
             (void*)-1) {
-            GR_LOG_ERROR(d_logger, boost::format("shmat (5): %s") % strerror(errno));
+            d_logger->error("shmat (5): {:s}", strerror(errno));
             shmctl(shmid_guard, IPC_RMID, 0);
             shmctl(shmid1, IPC_RMID, 0);
             shmdt(first_copy);
@@ -156,7 +155,7 @@ vmcircbuf_sysv_shm::~vmcircbuf_sysv_shm()
 
     if (shmdt(d_base - gr::pagesize()) == -1 || shmdt(d_base) == -1 ||
         shmdt(d_base + d_size) == -1 || shmdt(d_base + 2 * d_size) == -1) {
-        GR_LOG_ERROR(d_logger, boost::format("shmdt (2): %s") % strerror(errno));
+        d_logger->error("shmdt (2): {:s}", strerror(errno));
     }
 #endif
 }


### PR DESCRIPTION
## Description
This continues the work started in #5270. Here I've updated parts of gnuradio-runtime to use modern logging, and removed some usage of Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* gnuradio-config-info executable
* double-mapped buffers
* blocks
* threads
* tagged stream block

## Testing Done
I have verified that Gqrx and gr-nrsc5 still work correctly when using this branch.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.