### PR TITLE
uhd: Remove boost::format and modernize logging

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -35,6 +35,7 @@ using logger_ptr = std::shared_ptr<void>;
 #include <gnuradio/api.h>
 #include <spdlog/common.h>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ostr.h>
 #include <memory>
 
 #include <spdlog/spdlog.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3e2c7677a98ddd539794627cd5a43d93)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a76c325b045da079c83e294cc4abb8c6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-uhd/examples/c++/tag_sink_demo.h
+++ b/gr-uhd/examples/c++/tag_sink_demo.h
@@ -10,7 +10,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/sync_block.h>
-#include <boost/format.hpp>
 #include <complex>
 
 class tag_sink_demo : public gr::sync_block
@@ -41,15 +40,14 @@ public:
                           pmt::string_to_symbol("rx_time"));
 
         // print all tags
-        auto format_string =
-            boost::format("Full seconds %u, Frac seconds %f, abs sample offset %u");
         for (const auto& rx_time_tag : rx_time_tags) {
             const uint64_t offset = rx_time_tag.offset;
             const pmt::pmt_t& value = rx_time_tag.value;
 
-            GR_LOG_INFO(d_logger,
-                        format_string % pmt::to_uint64(pmt::tuple_ref(value, 0)) %
-                            pmt::to_double(pmt::tuple_ref(value, 1)) % offset);
+            d_logger->info("Full seconds {:d}, Frac seconds {:g}, abs sample offset {:d}",
+                           pmt::to_uint64(pmt::tuple_ref(value, 0)),
+                           pmt::to_double(pmt::tuple_ref(value, 1)),
+                           offset);
         }
 
         return ninput_items;

--- a/gr-uhd/examples/c++/tags_demo.cc
+++ b/gr-uhd/examples/c++/tags_demo.cc
@@ -13,7 +13,6 @@
 #include <gnuradio/uhd/usrp_sink.h>
 #include <gnuradio/uhd/usrp_source.h>
 #include <uhd/utils/safe_main.hpp>
-#include <boost/format.hpp>
 #include <boost/program_options.hpp>
 #include <chrono>
 #include <csignal>
@@ -64,7 +63,7 @@ int UHD_SAFE_MAIN(int argc, char* argv[])
 
     // print the help message
     if (vm.count("help")) {
-        std::cout << boost::format("UHD Tags Demo %s") % desc << std::endl
+        std::cout << "UHD Tags Demo " << desc << std::endl
                   << "The tags sink demo block will print USRP source time stamps."
                   << std::endl
                   << "The tags source demo block will send bursts to the USRP sink."

--- a/gr-uhd/lib/gr_uhd_common.h
+++ b/gr-uhd/lib/gr_uhd_common.h
@@ -13,7 +13,6 @@
 
 #include <uhd/stream.hpp>
 #include <uhd/version.hpp>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -25,13 +24,13 @@ static inline void check_abi(void)
     if (std::string(UHD_VERSION_ABI_STRING) == ::uhd::get_abi_string())
         return;
 
-    throw std::runtime_error(str(
-        boost::format("\nGR-UHD detected ABI compatibility mismatch with UHD library.\n"
-                      "GR-UHD was build against ABI: %s,\n"
-                      "but UHD library reports ABI: %s\n"
-                      "Suggestion: install an ABI compatible version of UHD,\n"
-                      "or rebuild GR-UHD component against this ABI version.\n") %
-        UHD_VERSION_ABI_STRING % ::uhd::get_abi_string()));
+    throw std::runtime_error(
+        "\nGR-UHD detected ABI compatibility mismatch with UHD library.\n"
+        "GR-UHD was built against ABI: " +
+        std::string(UHD_VERSION_ABI_STRING) +
+        ",\nbut UHD library reports ABI: " + ::uhd::get_abi_string() +
+        "\nSuggestion: install an ABI compatible version of UHD,\n"
+        "or rebuild GR-UHD component against this ABI version.\n");
 #endif
 }
 

--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
@@ -15,7 +15,6 @@
 #include <gnuradio/io_signature.h>
 #include <uhd/convert.hpp>
 #include <uhd/rfnoc/node.hpp>
-#include <boost/format.hpp>
 
 const pmt::pmt_t EOB_KEY = pmt::string_to_symbol("rx_eob");
 const pmt::pmt_t CMD_TIME_KEY = pmt::mp("time");
@@ -71,7 +70,7 @@ rfnoc_rx_streamer_impl::~rfnoc_rx_streamer_impl() {}
  *****************************************************************************/
 bool rfnoc_rx_streamer_impl::check_topology(int, int)
 {
-    GR_LOG_DEBUG(d_logger, "Committing graph...");
+    d_logger->debug("Committing graph...");
     d_graph->commit();
     return true;
 }
@@ -89,10 +88,10 @@ bool rfnoc_rx_streamer_impl::start()
             stream_cmd.stream_now = true;
         }
 
-        GR_LOG_DEBUG(d_logger, "Sending start stream command...");
+        d_logger->debug("Sending start stream command...");
         d_streamer->issue_stream_cmd(stream_cmd);
     } else {
-        GR_LOG_DEBUG(d_logger, "Starting RX streamer without stream command...");
+        d_logger->debug("Starting RX streamer without stream command...");
     }
     return true;
 }
@@ -122,7 +121,7 @@ int rfnoc_rx_streamer_impl::work(int noutput_items,
         // vector will be received, but it won't be available in the output_items.
         // We need to store the partial vector, and prepend it to the next
         // run.
-        GR_LOG_WARN(d_logger, "Received fractional vector! Expect signal fragmentation.");
+        d_logger->warn("Received fractional vector! Expect signal fragmentation.");
     }
 
     using ::uhd::rx_metadata_t;
@@ -132,7 +131,7 @@ int rfnoc_rx_streamer_impl::work(int noutput_items,
 
     case rx_metadata_t::ERROR_CODE_TIMEOUT:
         // its ok to timeout, perhaps the user is doing finite streaming
-        GR_LOG_DEBUG(d_logger, "UHD recv() call timed out.");
+        d_logger->debug("UHD recv() call timed out.");
         break;
 
     case rx_metadata_t::ERROR_CODE_OVERFLOW:
@@ -141,10 +140,9 @@ int rfnoc_rx_streamer_impl::work(int noutput_items,
         break;
 
     default:
-        GR_LOG_WARN(
-            d_logger,
-            str(boost::format("RFNoC Streamer block received error %s (Code: 0x%x)") %
-                d_metadata.strerror() % d_metadata.error_code));
+        d_logger->warn("RFNoC Streamer block received error {:s} (Code: {:#x})",
+                       d_metadata.strerror(),
+                       d_metadata.error_code);
     }
 
     if (d_metadata.end_of_burst) {

--- a/gr-uhd/lib/rfnoc_tx_streamer_impl.cc
+++ b/gr-uhd/lib/rfnoc_tx_streamer_impl.cc
@@ -60,7 +60,7 @@ rfnoc_tx_streamer_impl::~rfnoc_tx_streamer_impl() {}
  *****************************************************************************/
 bool rfnoc_tx_streamer_impl::check_topology(int, int)
 {
-    GR_LOG_DEBUG(d_logger, "Committing graph...");
+    d_logger->debug("Committing graph...");
     d_graph->commit();
     return true;
 }
@@ -82,7 +82,7 @@ int rfnoc_tx_streamer_impl::work(int noutput_items,
         // vector will be sent, but it won't be consumed from the input_items.
         // We need to store the offset (what fraction of the vector was sent)
         // and tx that first.
-        GR_LOG_WARN(d_logger, "Sent fractional vector! Expect signal fragmentation.");
+        d_logger->warn("Sent fractional vector! Expect signal fragmentation.");
     }
 
     return num_vecs_sent;


### PR DESCRIPTION
## Description
This continues the work started in #5270. Here I've updated gr-uhd to use modern logging, and removed all usage of Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Tags demo
* RFNoC Rx Streamer
* RFNoC Tx Streamer
* USRP Sink
* USRP Source

## Testing Done
So far:
* Tested Gqrx with a UHD source. (Overflow logs appeared as before.)
* Tested gr-nrsc5 with a UHD sink.
* Ran `tags_demo --help`. (Help message displayed correctly.)

Additional testing help would be appreciated.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
