### PR TITLE
qtgui: Remove boost::format, modernize logging, and fix bugs

### DIFF
--- a/gr-qtgui/lib/ber_sink_b_impl.cc
+++ b/gr-qtgui/lib/ber_sink_b_impl.cc
@@ -14,7 +14,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cmath>
 
 #ifdef HAVE_CONFIG_H
@@ -304,12 +303,13 @@ int ber_sink_b_impl::general_work(int noutput_items,
             consume(i + 1, items);
 
             if (d_total_errors[i >> 1] >= d_ber_min_errors) {
-                GR_LOG_INFO(d_logger,
-                            boost::format("    %1% over %2%  -->  %3%") %
-                                d_total_errors[i >> 1] % (d_total[i >> 1] * 8) % ber);
+                d_logger->info("    {:d} over {:d}  -->  {:g}",
+                               d_total_errors[i >> 1],
+                               d_total[i >> 1] * 8,
+                               ber);
             } else if (std::log10(((double)d_ber_min_errors) / (d_total[i >> 1] * 8.0)) <
                        d_ber_limit) {
-                GR_LOG_INFO(d_logger, "BER Limit Reached");
+                d_logger->info("BER Limit Reached");
                 d_ber_buffers[i / (d_nconnections * 2)][(i % (d_nconnections * 2)) >> 1] =
                     d_ber_limit;
                 d_total_errors[i >> 1] = d_ber_min_errors + 1;

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/qtgui/utils.h>
-#include <boost/format.hpp>
 #include <sstream>
 
 namespace gr {
@@ -234,16 +233,14 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             if (d_is_static) {
                 std::string cur_key = d_key->text().toStdString();
                 if (skey != cur_key) {
-                    GR_LOG_WARN(d_logger,
-                                boost::format("Got key '%1%' but expected '%2%'") % skey %
-                                    cur_key);
+                    d_logger->warn("Got key '{:s}' but expected '{:s}'", skey, cur_key);
                     return;
                 }
             }
             val = pmt::cdr(val);
             d_key->setText(QString(skey.c_str()));
         } else {
-            GR_LOG_WARN(d_logger, "Did not find PMT pair");
+            d_logger->warn("Did not find PMT pair");
             return;
         }
     }
@@ -254,7 +251,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             xi = pmt::to_long(val);
             d_val->setText(QString::number(xi));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from integer failed");
+            d_logger->warn("Conversion from integer failed");
             return;
         }
         break;
@@ -267,7 +264,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             }
             d_val->setText(text_list.join(", "));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from integer vector failed");
+            d_logger->warn("Conversion from integer vector failed");
             return;
         }
         break;
@@ -276,7 +273,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             xf = pmt::to_float(val);
             d_val->setText(QString::number(xf));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from float failed");
+            d_logger->warn("Conversion from float failed");
             return;
         }
         break;
@@ -289,7 +286,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             }
             d_val->setText(text_list.join(", "));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from float vector failed");
+            d_logger->warn("Conversion from float vector failed");
             return;
         }
         break;
@@ -298,7 +295,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             xd = pmt::to_double(val);
             d_val->setText(QString::number(xd));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from double failed");
+            d_logger->warn("Conversion from double failed");
             return;
         }
         break;
@@ -311,7 +308,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             }
             d_val->setText(text_list.join(", "));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from double vector failed");
+            d_logger->warn("Conversion from double vector failed");
             return;
         }
         break;
@@ -320,7 +317,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             xc = pmt::to_complex(val);
             d_val->setText(QString("(%1,%2)").arg(xc.real()).arg(xc.imag()));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from complex failed");
+            d_logger->warn("Conversion from complex failed");
             return;
         }
         break;
@@ -333,7 +330,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             }
             d_val->setText(text_list.join(", "));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from complex vector failed");
+            d_logger->warn("Conversion from complex vector failed");
             return;
         }
         break;
@@ -342,7 +339,7 @@ void edit_box_msg_impl::set_value(pmt::pmt_t val)
             xs = pmt::symbol_to_string(val);
             d_val->setText(QString(xs.c_str()));
         } else {
-            GR_LOG_WARN(d_logger, "Conversion from string failed");
+            d_logger->warn("Conversion from string failed");
             return;
         }
         break;
@@ -369,7 +366,7 @@ void edit_box_msg_impl::edit_finished()
         if (conv_ok) {
             d_msg = pmt::from_long(xi);
         } else {
-            GR_LOG_WARN(d_logger, "Conversion to integer failed");
+            d_logger->warn("Conversion to integer failed");
             return;
         }
         break;
@@ -383,7 +380,7 @@ void edit_box_msg_impl::edit_finished()
             if (conv_ok) {
                 xv.push_back(t);
             } else {
-                GR_LOG_WARN(d_logger, "Conversion to integer vector failed");
+                d_logger->warn("Conversion to integer vector failed");
                 return;
             }
         }
@@ -394,7 +391,7 @@ void edit_box_msg_impl::edit_finished()
         if (conv_ok) {
             d_msg = pmt::from_float(xf);
         } else {
-            GR_LOG_WARN(d_logger, "Conversion to float failed");
+            d_logger->warn("Conversion to float failed");
             return;
         }
         break;
@@ -408,7 +405,7 @@ void edit_box_msg_impl::edit_finished()
             if (conv_ok) {
                 xv.push_back(t);
             } else {
-                GR_LOG_WARN(d_logger, "Conversion to float vector failed");
+                d_logger->warn("Conversion to float vector failed");
                 return;
             }
         }
@@ -419,7 +416,7 @@ void edit_box_msg_impl::edit_finished()
         if (conv_ok) {
             d_msg = pmt::from_double(xd);
         } else {
-            GR_LOG_WARN(d_logger, "Conversion to double failed");
+            d_logger->warn("Conversion to double failed");
             return;
         }
         break;
@@ -433,7 +430,7 @@ void edit_box_msg_impl::edit_finished()
             if (conv_ok) {
                 xv.push_back(t);
             } else {
-                GR_LOG_WARN(d_logger, "Conversion to double vector failed");
+                d_logger->warn("Conversion to double vector failed");
                 return;
             }
         }
@@ -443,9 +440,7 @@ void edit_box_msg_impl::edit_finished()
         std::stringstream ss(text.toStdString());
         ss >> xc;
         if (static_cast<size_t>(ss.tellg()) != ss.str().size()) {
-            GR_LOG_WARN(d_logger,
-                        boost::format("Conversion of %s to complex failed") %
-                            text.toStdString());
+            d_logger->warn("Conversion of {:s} to complex failed", text.toStdString());
             return;
         }
         d_msg = pmt::from_complex(xc.real(), xc.imag());
@@ -471,7 +466,7 @@ void edit_box_msg_impl::edit_finished()
                     even = true;
                 }
             } else {
-                GR_LOG_WARN(d_logger, "Conversion to complex vector failed");
+                d_logger->warn("Conversion to complex vector failed");
                 return;
             }
         }

--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -21,7 +21,6 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <boost/format.hpp>
 #include <algorithm>
 #include <cstring>
 
@@ -197,10 +196,9 @@ void eye_sink_c_impl::set_trigger_mode(gr::qtgui::trigger_mode mode,
     int d_sps = d_main_gui->getSamplesPerSymbol();
 
     if ((d_trigger_delay < 0) || (d_trigger_delay > 2 * d_sps)) {
-        GR_LOG_WARN(
-            d_logger,
-            boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                (d_trigger_delay / d_samp_rate) % ((2 * d_sps) / d_samp_rate));
+        d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                       d_trigger_delay / d_samp_rate,
+                       (2 * d_sps) / d_samp_rate);
         d_trigger_delay = std::max(0, std::min(2 * d_sps, d_trigger_delay));
         delay = d_trigger_delay / d_samp_rate;
     }
@@ -276,10 +274,10 @@ void eye_sink_c_impl::set_nsamps(const int newsize)
 
         // If delay was set beyond the new boundary, pull it back.
         if (d_trigger_delay > 2 * d_sps) {
-            GR_LOG_WARN(d_logger,
-                        boost::format("Trigger delay (%1%) outside of display range "
-                                      "(0:%2%). Moving to 50%% point.") %
-                            (2 * d_sps / d_samp_rate) % ((d_sps) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range "
+                           "(0:{:g}). Moving to 50% point.",
+                           2 * d_sps / d_samp_rate,
+                           (d_sps) / d_samp_rate);
             d_trigger_delay = d_sps;
             d_main_gui->setTriggerDelay(d_trigger_delay / d_samp_rate);
         }
@@ -428,10 +426,9 @@ void eye_sink_c_impl::_gui_update_trigger()
         // We restrict the delay to be within the window of time being
         // plotted.
         if ((delay < 0) || (delay > 2 * d_sps)) {
-            GR_LOG_WARN(
-                d_logger,
-                boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                    (delay / d_samp_rate) % ((2 * d_sps) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                           delay / d_samp_rate,
+                           (2 * d_sps) / d_samp_rate);
             delay = std::max(0, std::min(2 * d_sps, delay));
             delayf = delay / d_samp_rate;
         }

--- a/gr-qtgui/lib/eye_sink_c_impl.cc
+++ b/gr-qtgui/lib/eye_sink_c_impl.cc
@@ -276,8 +276,8 @@ void eye_sink_c_impl::set_nsamps(const int newsize)
         if (d_trigger_delay > 2 * d_sps) {
             d_logger->warn("Trigger delay ({:g}) outside of display range "
                            "(0:{:g}). Moving to 50% point.",
-                           2 * d_sps / d_samp_rate,
-                           (d_sps) / d_samp_rate);
+                           d_trigger_delay / d_samp_rate,
+                           (2 * d_sps) / d_samp_rate);
             d_trigger_delay = d_sps;
             d_main_gui->setTriggerDelay(d_trigger_delay / d_samp_rate);
         }

--- a/gr-qtgui/lib/eye_sink_f_impl.cc
+++ b/gr-qtgui/lib/eye_sink_f_impl.cc
@@ -22,7 +22,6 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <boost/format.hpp>
 #include <cstring>
 
 namespace gr {
@@ -192,10 +191,9 @@ void eye_sink_f_impl::set_trigger_mode(gr::qtgui::trigger_mode mode,
     int d_sps = d_main_gui->getSamplesPerSymbol();
 
     if ((d_trigger_delay < 0) || (d_trigger_delay > 2 * d_sps)) {
-        GR_LOG_WARN(
-            d_logger,
-            boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                (d_trigger_delay / d_samp_rate) % ((2 * d_sps) / d_samp_rate));
+        d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                       d_trigger_delay / d_samp_rate,
+                       (2 * d_sps) / d_samp_rate);
         d_trigger_delay = std::max(0, std::min(2 * d_sps, d_trigger_delay));
         delay = d_trigger_delay / d_samp_rate;
     }
@@ -259,11 +257,10 @@ void eye_sink_f_impl::set_nsamps(const int newsize)
 
         // If delay was set beyond the new boundary, pull it back.
         if (d_trigger_delay > 2 * d_sps) {
-            GR_LOG_WARN(d_logger,
-                        boost::format("Trigger delay (%1%) outside of display range "
-                                      "(0:%2%). Moving to 50%% point.") %
-                            (d_trigger_delay / d_samp_rate) %
-                            ((2 * d_sps) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range "
+                           "(0:{:g}). Moving to 50% point.",
+                           d_trigger_delay / d_samp_rate,
+                           (2 * d_sps) / d_samp_rate);
             d_trigger_delay = d_sps;
             d_main_gui->setTriggerDelay(d_trigger_delay / d_samp_rate);
         }
@@ -412,10 +409,9 @@ void eye_sink_f_impl::_gui_update_trigger()
         // We restrict the delay to be within the window of time being
         // plotted.
         if ((delay < 0) || (delay > 2 * d_sps)) {
-            GR_LOG_WARN(
-                d_logger,
-                boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                    (delay / d_samp_rate) % ((2 * d_sps) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                           delay / d_samp_rate,
+                           (2 * d_sps) / d_samp_rate);
             delay = std::max(0, std::min(2 * d_sps, delay));
             delayf = delay / d_samp_rate;
         }

--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -144,11 +144,10 @@ void freq_sink_c_impl::set_fft_size(const int fftsize)
     if ((fftsize >= d_main_gui->MIN_FFT_SIZE) && (fftsize <= d_main_gui->MAX_FFT_SIZE))
         d_main_gui->setFFTSize(fftsize);
     else {
-        GR_LOG_INFO(d_logger,
-                    fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
-                                d_main_gui->MIN_FFT_SIZE,
-                                d_main_gui->MAX_FFT_SIZE,
-                                d_main_gui->FFT_DEFAULT_SIZE));
+        d_logger->info("FFT size must be >= {} and <= {}. \nFalling back to {}.",
+                       d_main_gui->MIN_FFT_SIZE,
+                       d_main_gui->MAX_FFT_SIZE,
+                       d_main_gui->FFT_DEFAULT_SIZE);
         d_main_gui->setFFTSize(d_main_gui->FFT_DEFAULT_SIZE);
     }
 }

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -144,11 +144,10 @@ void freq_sink_f_impl::set_fft_size(const int fftsize)
     if ((fftsize >= d_main_gui->MIN_FFT_SIZE) && (fftsize <= d_main_gui->MAX_FFT_SIZE))
         d_main_gui->setFFTSize(fftsize);
     else {
-        GR_LOG_INFO(d_logger,
-                    fmt::format("FFT size must be >= {} and <= {}. \nFalling back to {}.",
-                                d_main_gui->MIN_FFT_SIZE,
-                                d_main_gui->MAX_FFT_SIZE,
-                                d_main_gui->FFT_DEFAULT_SIZE));
+        d_logger->info("FFT size must be >= {} and <= {}. \nFalling back to {}.",
+                       d_main_gui->MIN_FFT_SIZE,
+                       d_main_gui->MAX_FFT_SIZE,
+                       d_main_gui->FFT_DEFAULT_SIZE);
         d_main_gui->setFFTSize(d_main_gui->FFT_DEFAULT_SIZE);
     }
 }

--- a/gr-qtgui/lib/sink_c_impl.cc
+++ b/gr-qtgui/lib/sink_c_impl.cc
@@ -146,12 +146,10 @@ void sink_c_impl::set_fft_size(const int fftsize)
         d_fftsize = fftsize;
         d_main_gui.setFFTSize(fftsize);
     } else {
-        GR_LOG_INFO(
-            d_logger,
-            fmt::format("FFT size must be >= {} and <= {}.\nSo falling back to {}.",
-                        d_main_gui.MIN_FFT_SIZE,
-                        d_main_gui.MAX_FFT_SIZE,
-                        d_main_gui.DEFAULT_FFT_SIZE));
+        d_logger->info("FFT size must be >= {} and <= {}.\nSo falling back to {}.",
+                       d_main_gui.MIN_FFT_SIZE,
+                       d_main_gui.MAX_FFT_SIZE,
+                       d_main_gui.DEFAULT_FFT_SIZE);
         d_main_gui.setFFTSize(d_main_gui.DEFAULT_FFT_SIZE);
     }
 }

--- a/gr-qtgui/lib/sink_f_impl.cc
+++ b/gr-qtgui/lib/sink_f_impl.cc
@@ -139,12 +139,10 @@ void sink_f_impl::set_fft_size(const int fftsize)
         d_fftsize = fftsize;
         d_main_gui.setFFTSize(fftsize);
     } else {
-        GR_LOG_INFO(
-            d_logger,
-            fmt::format("FFT size must be >= {} and <= {}.\nSo falling back to {}.",
-                        d_main_gui.MIN_FFT_SIZE,
-                        d_main_gui.MAX_FFT_SIZE,
-                        d_main_gui.DEFAULT_FFT_SIZE));
+        d_logger->info("FFT size must be >= {} and <= {}.\nSo falling back to {}.",
+                       d_main_gui.MIN_FFT_SIZE,
+                       d_main_gui.MAX_FFT_SIZE,
+                       d_main_gui.DEFAULT_FFT_SIZE);
         d_main_gui.setFFTSize(d_main_gui.DEFAULT_FFT_SIZE);
     }
 }

--- a/gr-qtgui/lib/time_sink_c_impl.cc
+++ b/gr-qtgui/lib/time_sink_c_impl.cc
@@ -21,7 +21,6 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <boost/format.hpp>
 #include <algorithm>
 #include <cstring>
 
@@ -201,10 +200,9 @@ void time_sink_c_impl::set_trigger_mode(trigger_mode mode,
     d_trigger_count = 0;
 
     if ((d_trigger_delay < 0) || (d_trigger_delay >= d_size)) {
-        GR_LOG_WARN(
-            d_logger,
-            boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                (d_trigger_delay / d_samp_rate) % ((d_size - 1) / d_samp_rate));
+        d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                       d_trigger_delay / d_samp_rate,
+                       (d_size - 1) / d_samp_rate);
         d_trigger_delay = std::max(0, std::min(d_size - 1, d_trigger_delay));
         delay = d_trigger_delay / d_samp_rate;
     }
@@ -279,11 +277,10 @@ void time_sink_c_impl::set_nsamps(const int newsize)
 
         // If delay was set beyond the new boundary, pull it back.
         if (d_trigger_delay >= d_size) {
-            GR_LOG_WARN(d_logger,
-                        boost::format("Trigger delay (%1%) outside of display range "
-                                      "(0:%2%). Moving to 50%% point.") %
-                            (d_trigger_delay / d_samp_rate) %
-                            ((d_size - 1) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range "
+                           "(0:{:g}). Moving to 50% point.",
+                           d_trigger_delay / d_samp_rate,
+                           (d_size - 1) / d_samp_rate);
             d_trigger_delay = d_size / 2;
             d_main_gui->setTriggerDelay(d_trigger_delay / d_samp_rate);
         }
@@ -422,10 +419,9 @@ void time_sink_c_impl::_gui_update_trigger()
         // We restrict the delay to be within the window of time being
         // plotted.
         if ((delay < 0) || (delay >= d_size)) {
-            GR_LOG_WARN(
-                d_logger,
-                boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                    (delay / d_samp_rate) % ((d_size - 1) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                           delay / d_samp_rate,
+                           (d_size - 1) / d_samp_rate);
             delay = std::max(0, std::min(d_size - 1, delay));
             delayf = delay / d_samp_rate;
         }

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -23,7 +23,6 @@
 #include <qwt_symbol.h>
 #include <volk/volk.h>
 
-#include <boost/format.hpp>
 #include <cstring>
 
 namespace gr {
@@ -199,10 +198,9 @@ void time_sink_f_impl::set_trigger_mode(trigger_mode mode,
     d_trigger_count = 0;
 
     if ((d_trigger_delay < 0) || (d_trigger_delay >= d_size)) {
-        GR_LOG_WARN(
-            d_logger,
-            boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                (d_trigger_delay / d_samp_rate) % ((d_size - 1) / d_samp_rate));
+        d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                       d_trigger_delay / d_samp_rate,
+                       (d_size - 1) / d_samp_rate);
         d_trigger_delay = std::max(0, std::min(d_size - 1, d_trigger_delay));
         delay = d_trigger_delay / d_samp_rate;
     }
@@ -274,11 +272,10 @@ void time_sink_f_impl::set_nsamps(const int newsize)
 
         // If delay was set beyond the new boundary, pull it back.
         if (d_trigger_delay >= d_size) {
-            GR_LOG_WARN(d_logger,
-                        boost::format("Trigger delay (%1%) outside of display range "
-                                      "(0:%2%). Moving to 50%% point.") %
-                            (d_trigger_delay / d_samp_rate) %
-                            ((d_size - 1) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range "
+                           "(0:{:g}). Moving to 50% point.",
+                           d_trigger_delay / d_samp_rate,
+                           (d_size - 1) / d_samp_rate);
             d_trigger_delay = d_size - 1;
             d_main_gui->setTriggerDelay(d_trigger_delay / d_samp_rate);
         }
@@ -417,10 +414,9 @@ void time_sink_f_impl::_gui_update_trigger()
         // We restrict the delay to be within the window of time being
         // plotted.
         if ((delay < 0) || (delay >= d_size)) {
-            GR_LOG_WARN(
-                d_logger,
-                boost::format("Trigger delay (%1%) outside of display range (0:%2%).") %
-                    (delay / d_samp_rate) % ((d_size - 1) / d_samp_rate));
+            d_logger->warn("Trigger delay ({:g}) outside of display range (0:{:g}).",
+                           delay / d_samp_rate,
+                           (d_size - 1) / d_samp_rate);
             delay = std::max(0, std::min(d_size - 1, delay));
             delayf = delay / d_samp_rate;
         }

--- a/gr-qtgui/lib/time_sink_f_impl.cc
+++ b/gr-qtgui/lib/time_sink_f_impl.cc
@@ -276,7 +276,7 @@ void time_sink_f_impl::set_nsamps(const int newsize)
                            "(0:{:g}). Moving to 50% point.",
                            d_trigger_delay / d_samp_rate,
                            (d_size - 1) / d_samp_rate);
-            d_trigger_delay = d_size - 1;
+            d_trigger_delay = d_size / 2;
             d_main_gui->setTriggerDelay(d_trigger_delay / d_samp_rate);
         }
 

--- a/gr-qtgui/lib/timerasterdisplayform.cc
+++ b/gr-qtgui/lib/timerasterdisplayform.cc
@@ -24,8 +24,7 @@ TimeRasterDisplayForm::TimeRasterDisplayForm(
     gr::logger_ptr logger, debug_logger;
     gr::configure_default_loggers(logger, debug_logger, "timerasterdisplayform");
 
-    GR_LOG_WARN(
-        logger,
+    logger->warn(
         "Warning: QWT5 has been found which has serious performance issues with raster "
         "plots. Consider updating to QWT version 6 to use the time raster GUIs.");
 #endif

--- a/gr-qtgui/lib/vector_sink_f_impl.cc
+++ b/gr-qtgui/lib/vector_sink_f_impl.cc
@@ -122,9 +122,8 @@ unsigned int vector_sink_f_impl::vlen() const { return d_vlen; }
 void vector_sink_f_impl::set_vec_average(const float avg)
 {
     if (avg < 0 || avg > 1.0) {
-        GR_LOG_ALERT(d_logger,
-                     "Invalid average value received in set_vec_average(), must be "
-                     "within [0, 1].");
+        d_logger->alert("Invalid average value received in set_vec_average(), must be "
+                        "within [0, 1].");
         return;
     }
     d_main_gui->setVecAverage(avg);


### PR DESCRIPTION
## Description
This continues the work started in #5270. Here I've updated gr-qtgui to use modern logging, and removed all usage of Boost.Format.

In addition, I noticed a couple bugs along the way:

1. The complex Eye Sink prints incorrect values in its error message: https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gr-qtgui/lib/eye_sink_c_impl.cc#L279-L282
2. The floating point Time Sink incorrectly sets its trigger point to the end of the range rather than the midpoint when it is out of range: https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gr-qtgui/lib/time_sink_f_impl.cc#L277-L282

I fixed each of these bugs in its own commit.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* QT GUI Bercurve Sink
* QT GUI Message Edit Box
* QT GUI Eye Sink
* QT GUI Frequency Sink
* QT GUI Sink
* QT GUI Time Sink
* QT GUI Time Raster Sink
* QT GUI Vector Sink

## Testing Done
None yet.

Additional testing help would be appreciated.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.