### PR TITLE
Modernize logging in analog, fft, filter, video-sdl and zeromq

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -35,6 +35,7 @@ using logger_ptr = std::shared_ptr<void>;
 #include <gnuradio/api.h>
 #include <spdlog/common.h>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ostr.h>
 #include <memory>
 
 #include <spdlog/spdlog.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(3e2c7677a98ddd539794627cd5a43d93)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a76c325b045da079c83e294cc4abb8c6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -78,7 +78,7 @@ void sig_source_impl<T>::set_cmd_msg(pmt::pmt_t msg)
     } else if (pmt::is_pair(msg)) {
         list_of_items = pmt::list1(msg);
     } else {
-        GR_LOG_WARN(this->d_logger, "malformed message: is not dict nor pair");
+        this->d_logger->warn("malformed message: is not dict nor pair");
         return;
     }
 
@@ -92,29 +92,28 @@ void sig_source_impl<T>::set_cmd_msg(pmt::pmt_t msg)
             if (pmt::is_number(val)) {
                 set_frequency(pmt::to_double(val));
             } else {
-                GR_LOG_WARN(this->d_logger, "frequency value needs to be a number")
+                this->d_logger->warn("frequency value needs to be a number");
             }
         } else if (key == ampl_key) {
             if (pmt::is_number(val)) {
                 set_amplitude(pmt::to_double(val));
             } else {
-                GR_LOG_WARN(this->d_logger, "amplitude value needs to be a number")
+                this->d_logger->warn("amplitude value needs to be a number");
             }
         } else if (key == phase_key) {
             if (pmt::is_number(val)) {
                 set_phase(pmt::to_double(val));
             } else {
-                GR_LOG_WARN(this->d_logger, "phase value needs to be a number")
+                this->d_logger->warn("phase value needs to be a number");
             }
         } else if (key == offset_key) {
             if (pmt::is_number(val)) {
                 set_offset(pmt::to_double(val));
             } else {
-                GR_LOG_WARN(this->d_logger, "offset value needs to be a number")
+                this->d_logger->warn("offset value needs to be a number");
             }
         } else {
-            GR_LOG_WARN(this->d_logger,
-                        "unsupported message key " + pmt::write_string(key));
+            this->d_logger->warn("unsupported message key {}", key);
         }
 
         // advance to next item, if any

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -83,9 +83,7 @@ std::vector<gr_complex> ctrlport_probe_psd_impl::get()
 void ctrlport_probe_psd_impl::set_length(int len)
 {
     if (len > 8191) {
-        std::ostringstream msg;
-        msg << "length " << len << " exceeds maximum buffer size of 8191";
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("length {:d} exceeds maximum buffer size of 8191", len);
         len = 8191;
     }
 

--- a/gr-filter/lib/fft_filter.cc
+++ b/gr-filter/lib/fft_filter.cc
@@ -77,10 +77,10 @@ void fft_filter_fff::compute_sizes(int ntaps)
     d_nsamples = d_fftsize - d_ntaps + 1;
 
     if (VERBOSE) {
-        std::ostringstream msg;
-        msg << "fft_filter_fff: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
-            << " nsamples = " << d_nsamples;
-        GR_LOG_ALERT(d_logger, msg.str());
+        d_logger->alert("fft_filter_fff: ntaps = {:d} fftsize = {:d} nsamples = {:d}",
+                        d_ntaps,
+                        d_fftsize,
+                        d_nsamples);
     }
 
     // compute new plans
@@ -208,10 +208,10 @@ void fft_filter_ccc::compute_sizes(int ntaps)
     d_nsamples = d_fftsize - d_ntaps + 1;
 
     if (VERBOSE) {
-        std::ostringstream msg;
-        msg << "fft_filter_ccc: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
-            << " nsamples = " << d_nsamples;
-        GR_LOG_ALERT(d_logger, msg.str());
+        d_logger->alert("fft_filter_ccc: ntaps = {:d} fftsize = {:d} nsamples = {:d}",
+                        d_ntaps,
+                        d_fftsize,
+                        d_nsamples);
     }
 
     // compute new plans
@@ -340,10 +340,10 @@ void fft_filter_ccf::compute_sizes(int ntaps)
     d_nsamples = d_fftsize - d_ntaps + 1;
 
     if (VERBOSE) {
-        std::ostringstream msg;
-        msg << "fft_filter_ccf: ntaps = " << d_ntaps << " fftsize = " << d_fftsize
-            << " nsamples = " << d_nsamples;
-        GR_LOG_ALERT(d_logger, msg.str());
+        d_logger->alert("fft_filter_ccf: ntaps = {:d} fftsize = {:d} nsamples = {:d}",
+                        d_ntaps,
+                        d_fftsize,
+                        d_nsamples);
     }
 
     // compute new plans

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -765,7 +765,7 @@ static int remez(double h[],
 
 static void punt(gr::logger_ptr logger, const std::string msg)
 {
-    GR_LOG_ERROR(logger, msg);
+    logger->error(msg);
     throw std::runtime_error(msg);
 }
 

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -63,10 +63,8 @@ sink_s_impl::sink_s_impl(
 
     atexit(SDL_Quit); // check if this is the way to do this
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        std::ostringstream msg;
-        msg << "Couldn't initialize SDL:" << SDL_GetError()
-            << "; SDL_Init(SDL_INIT_VIDEO) failed";
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Couldn't initialize SDL: {:s}; SDL_Init(SDL_INIT_VIDEO) failed",
+                        SDL_GetError());
         throw std::runtime_error("video_sdl::sink_s");
     };
 
@@ -79,10 +77,8 @@ sink_s_impl::sink_s_impl(
             SDL_ANYFORMAT); // SDL_DOUBLEBUF |SDL_SWSURFACE| SDL_HWSURFACE||SDL_FULLSCREEN
 
     if (d_screen == NULL) {
-        std::ostringstream msg;
-        msg << "Unable to set SDL video mode: " << SDL_GetError()
-            << "; SDL_SetVideoMode() Failed";
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Unable to set SDL video mode: {:s}; SDL_SetVideoMode() Failed",
+                        SDL_GetError());
         exit(1);
     }
     if (d_image) {
@@ -92,9 +88,7 @@ sink_s_impl::sink_s_impl(
     /* Initialize and create the YUV Overlay used for video out */
     if (!(d_image =
               SDL_CreateYUVOverlay(d_width, d_height, SDL_IYUV_OVERLAY, d_screen))) {
-        std::ostringstream msg;
-        msg << "Couldn't create a YUV overlay: " << SDL_GetError();
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Couldn't create a YUV overlay: {:s}", SDL_GetError());
         throw std::runtime_error("video_sdl::sink_s");
     }
 
@@ -115,9 +109,7 @@ sink_s_impl::sink_s_impl(
     // clear the surface to grey
 
     if (SDL_LockYUVOverlay(d_image)) {
-        std::ostringstream msg;
-        msg << "Couldn't lock a YUV overlay:" << SDL_GetError();
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Couldn't lock a YUV overlay: {:s}", SDL_GetError());
         throw std::runtime_error("video_sdl::sink_s");
     }
 
@@ -290,11 +282,10 @@ int sink_s_impl::work(int noutput_items,
         }
         break;
     default: // 0 or more then 3 channels
-        std::ostringstream msg;
-        msg << "Wrong number of channels: 1, 2 or 3 channels are supported. Requested "
-               "number of channels is "
-            << input_items.size();
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error(
+            "Wrong number of channels: 1, 2 or 3 channels are supported. Requested "
+            "number of channels is {:d}",
+            input_items.size());
         throw std::runtime_error("video_sdl::sink_s");
     }
 

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -63,10 +63,8 @@ sink_uc_impl::sink_uc_impl(
 
     atexit(SDL_Quit); // check if this is the way to do this
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        std::ostringstream msg;
-        msg << "Couldn't initialize SDL:" << SDL_GetError()
-            << "; SDL_Init(SDL_INIT_VIDEO) failed";
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Couldn't initialize SDL: {:s}; SDL_Init(SDL_INIT_VIDEO) failed",
+                        SDL_GetError());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
@@ -79,10 +77,8 @@ sink_uc_impl::sink_uc_impl(
             SDL_ANYFORMAT); // SDL_DOUBLEBUF |SDL_SWSURFACE| SDL_HWSURFACE||SDL_FULLSCREEN
 
     if (d_screen == NULL) {
-        std::ostringstream msg;
-        msg << "Unable to set SDL video mode: " << SDL_GetError()
-            << "; SDL_SetVideoMode() Failed";
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Unable to set SDL video mode: {:s}; SDL_SetVideoMode() Failed",
+                        SDL_GetError());
         exit(1);
     }
 
@@ -93,9 +89,7 @@ sink_uc_impl::sink_uc_impl(
     /* Initialize and create the YUV Overlay used for video out */
     if (!(d_image =
               SDL_CreateYUVOverlay(d_width, d_height, SDL_IYUV_OVERLAY, d_screen))) {
-        std::ostringstream msg;
-        msg << "SDL: Couldn't create a YUV overlay: " << SDL_GetError();
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Couldn't create a YUV overlay: {:s}", SDL_GetError());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
@@ -116,9 +110,7 @@ sink_uc_impl::sink_uc_impl(
     // clear the surface to grey
 
     if (SDL_LockYUVOverlay(d_image)) {
-        std::ostringstream msg;
-        msg << "SDL: Couldn't lock a YUV overlay: " << SDL_GetError();
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error("Couldn't lock a YUV overlay: {:s}", SDL_GetError());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 
@@ -285,11 +277,10 @@ int sink_uc_impl::work(int noutput_items,
         }
         break;
     default: // 0 or more then 3 channels
-        std::ostringstream msg;
-        msg << "Wrong number of channels: 1, 2 or 3 channels are supported. Requested "
-               "number of channels is "
-            << input_items.size();
-        GR_LOG_ERROR(d_logger, msg.str());
+        d_logger->error(
+            "Wrong number of channels: 1, 2 or 3 channels are supported. Requested "
+            "number of channels is {:d}",
+            input_items.size());
         throw std::runtime_error("video_sdl::sink_uc");
     }
 

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -217,7 +217,7 @@ bool base_source_impl::load_message(bool wait)
     if (!ok) {
         // This shouldn't happen since we polled POLLIN, but ZMQ wants us to check
         // the return value.
-        GR_LOG_WARN(d_logger, "Failed to recv() message.");
+        d_logger->warn("Failed to recv() message.");
         return false;
     }
 
@@ -235,7 +235,7 @@ bool base_source_impl::load_message(bool wait)
             const bool multi_ok = d_socket.recv(&d_msg);
 #endif
             if (!multi_ok) {
-                GR_LOG_ERROR(d_logger, "Failure to receive multi-part message.");
+                d_logger->error("Failure to receive multi-part message.");
             }
         } else {
             return false;

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -92,7 +92,7 @@ void pull_msg_source_impl::readloop()
 #endif
             if (!ok) {
                 // Should not happen, we've checked POLLIN.
-                GR_LOG_ERROR(d_logger, "Failed to receive message.");
+                d_logger->error("Failed to receive message.");
                 std::this_thread::sleep_for(100us);
                 continue;
             }
@@ -103,7 +103,7 @@ void pull_msg_source_impl::readloop()
                 pmt::pmt_t m = pmt::deserialize(sb);
                 message_port_pub(d_port, m);
             } catch (pmt::exception& e) {
-                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+                d_logger->error("Invalid PMT message: {:s}", e.what());
             }
 
         } else {

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -94,7 +94,7 @@ void rep_msg_sink_impl::readloop()
 #endif
                 if (!ok) {
                     // Should not happen, we've checked POLLIN.
-                    GR_LOG_ERROR(d_logger, "Failed to receive message.");
+                    d_logger->error("Failed to receive message.");
                     break; // Fall back to re-check d_finished
                 }
 

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -65,7 +65,7 @@ int rep_sink_impl::work(int noutput_items,
 #endif
         if (!ok) {
             // Should not happen, we've checked POLLIN.
-            GR_LOG_ERROR(d_logger, "Failed to receive message.");
+            d_logger->error("Failed to receive message.");
             break;
         }
 

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -110,7 +110,7 @@ void req_msg_source_impl::readloop()
 #endif
             if (!ok) {
                 // Should not happen, we've checked POLLIN.
-                GR_LOG_ERROR(d_logger, "Failed to receive message.");
+                d_logger->error("Failed to receive message.");
                 std::this_thread::sleep_for(100us);
                 continue;
             }
@@ -121,7 +121,7 @@ void req_msg_source_impl::readloop()
                 pmt::pmt_t m = pmt::deserialize(sb);
                 message_port_pub(d_port, m);
             } catch (pmt::exception& e) {
-                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+                d_logger->error("Invalid PMT message: {:s}", e.what());
             }
 
         } else {

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -90,7 +90,7 @@ void sub_msg_source_impl::readloop()
 #endif
             if (!ok) {
                 // Should not happen, we've checked POLLIN.
-                GR_LOG_ERROR(d_logger, "Failed to receive message.");
+                d_logger->error("Failed to receive message.");
                 std::this_thread::sleep_for(100us);
                 continue;
             }
@@ -101,7 +101,7 @@ void sub_msg_source_impl::readloop()
                 pmt::pmt_t m = pmt::deserialize(sb);
                 message_port_pub(d_port, m);
             } catch (pmt::exception& e) {
-                GR_LOG_ERROR(d_logger, std::string("Invalid PMT message: ") + e.what());
+                d_logger->error("Invalid PMT message: {:s}", e.what());
             }
         } else {
             std::this_thread::sleep_for(100us);


### PR DESCRIPTION
## Description
This continues the work started in #5270. Here I've updated several modules (gr-analog, gr-fft, gr-filter, gr-video-sdl, and gr-zeromq), each of which has only a small amount of logging code to be updated.

I pulled in the `#include <spdlog/fmt/ostr.h>` change from #5601 here, since it's needed to log a PMT in gr-analog/lib/sig_source_impl.cc.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Signal Source
* Ctrlport Probe PSD
* FFT Filter
* Video SDL Sink
* ZMQ PULL Message Source
* ZMQ REP Message Sink
* ZMQ REP Sink
* ZMQ REQ Message Source
* ZMQ SUB Message Source

## Testing Done
None yet.

I'd appreciate help from people familiar with these blocks.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
