### PR TITLE
Code for advanced block params (backport to maint-3.9)

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -213,13 +213,13 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         self.${blk.name}.set_block_alias("${blk.params['alias'].get_evaluated()}")
         % endif
         % if 'affinity' in blk.params and blk.params['affinity'].get_evaluated():
-        self.${blk.name}.set_processor_affinity(${blk.params['affinity'].get_evaluated()})
+        self.${blk.name}.set_processor_affinity(${blk.params['affinity'].to_code()})
         % endif
         % if len(blk.sources) > 0 and 'minoutbuf' in blk.params and int(blk.params['minoutbuf'].get_evaluated()) > 0:
-        self.${blk.name}.set_min_output_buffer(${blk.params['minoutbuf'].get_evaluated()})
+        self.${blk.name}.set_min_output_buffer(${blk.params['minoutbuf'].to_code()})
         % endif
         % if len(blk.sources) > 0 and 'maxoutbuf' in blk.params and int(blk.params['maxoutbuf'].get_evaluated()) > 0:
-        self.${blk.name}.set_max_output_buffer(${blk.params['maxoutbuf'].get_evaluated()})
+        self.${blk.name}.set_max_output_buffer(${blk.params['maxoutbuf'].to_code()})
         % endif
         % endfor
 


### PR DESCRIPTION
This will allow script parameters/arguments to define buffer sizes and process affinity.  I can't think of any unintended negative impacts as changes to any variables used to define affinity and buffer sizes would not be propagated through to affinity or buffer changes after initialization.

Signed-off-by: Campbell <campbell.mcdiarmid@icloud.com>
(cherry picked from commit 341e8c8e3f072675d39e53a807fee098aa1a75a6)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5468