### PR TITLE
blocks: Skip alignment check when the input file is not seekable (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -173,7 +173,7 @@ void file_source_impl::open(const char* filename,
     // If length is not specified, use the remainder of the file. Check alignment at end.
     if (length_items == 0) {
         length_items = items_available;
-        if (file_size % d_itemsize) {
+        if (d_seekable && (file_size % d_itemsize)) {
             GR_LOG_WARN(d_logger, "file size is not a multiple of item size");
         }
     }


### PR DESCRIPTION
If a non-seekable file like /dev/zero is opened in the File Source block,
the following warning appears:

file_source :warning: file size is not a multiple of item size
(9223372036854775807 ≠ N·8)

This happens because non-seekable files are treated as if their size is
INT64_MAX, which is almost never a multiple of the item size. To solve
the problem, I propose to simply skip the alignment check for non-
seekable files.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 72311c0763ca9f8953a5e0a303140a54da322c3e)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5583