### PR TITLE
gr-utils/modtool: info.py fix modname variable (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/core/info.py
+++ b/gr-utils/modtool/core/info.py
@@ -47,7 +47,7 @@ class ModToolInfo(ModTool):
             self.info['version'] = '37'
         if not os.path.isfile(os.path.join('cmake', 'Modules', 'FindCppUnit.cmake')):
             self.info['version'] = '38'
-            if os.path.isdir(os.path.join('include', 'gnuradio', self.info['modname'])):
+            if os.path.isdir(os.path.join('include', 'gnuradio', mod_info['modname'])):
                 self.info['version'] = '310'
         mod_info['version'] = self.info['version']
         if 'is_component' in list(self.info.keys()) and self.info['is_component']:


### PR DESCRIPTION
Signed-off-by: Davide Gerhard <rainbow@irh.it>
(cherry picked from commit 1cf09ff12f02e699b058dee4a2c4bbf4fb74c3d5)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5565