### PR TITLE
slight change to block documentation

### DIFF
--- a/gr-blocks/grc/xmlrpc_server.block.yml
+++ b/gr-blocks/grc/xmlrpc_server.block.yml
@@ -29,7 +29,7 @@ documentation: |-
     Example client in python:
 
     from xmlrpc.client import ServerProxy
-    ServerProxy('http://localhost:8080')
+    s = ServerProxy('http://localhost:8080')
     s.set_freq(5000)
 
 file_format: 1


### PR DESCRIPTION
the ServerProxy was not assigned to a variable in the client code example

---
name: Pull Request Template
about: A template to help contributors submit clear pull-requests.
title: 'slight change to block documentation'
labels: 'XMLRPC Server Block YAML'
assignees: ''

---

# Pull Request Details
XMLRPC Server block documentation: in example section, assign ServerProxy to variable

## Description

## Related Issue
mentioned on IRC 'Docs' channel

## Which blocks/areas does this affect?
XMLRPC Server 

## Testing Done
no testing, doc section only

## Checklist
- [x ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x ] I have squashed my commits to have one significant change per commit. 
- [x ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ x] I have added tests to cover my changes, and all previous tests pass.
