### PR TITLE
fec: Remove boost::format and modernize logging

### DIFF
--- a/gr-fec/include/gnuradio/fec/generic_decoder.h
+++ b/gr-fec/include/gnuradio/fec/generic_decoder.h
@@ -13,7 +13,6 @@
 
 #include <gnuradio/fec/api.h>
 #include <gnuradio/logger.h>
-#include <boost/format.hpp>
 #include <memory>
 
 namespace gr {
@@ -57,7 +56,7 @@ public:
     int my_id;
     int unique_id();
     std::string d_name;
-    std::string alias() { return (boost::format("%s%d") % d_name % unique_id()).str(); }
+    std::string alias() { return d_name + std::to_string(unique_id()); }
 
 public:
     typedef std::shared_ptr<generic_decoder> sptr;

--- a/gr-fec/lib/async_encoder_impl.cc
+++ b/gr-fec/lib/async_encoder_impl.cc
@@ -17,8 +17,6 @@
 #include <gnuradio/logger.h>
 #include <volk/volk.h>
 
-#include <boost/format.hpp>
-
 namespace gr {
 namespace fec {
 
@@ -96,10 +94,10 @@ void async_encoder_impl::encode_unpacked(pmt::pmt_t msg)
     } else {
         nblocks = nbits_in / d_encoder->get_input_size();
         if (nblocks * d_encoder->get_input_size() != nbits_in) {
-            GR_LOG_ERROR(
-                d_logger,
-                boost::format("nblocks: %u, in_block_size: %d, got_input_size: %d") %
-                    nblocks % d_encoder->get_input_size() % nbits_in);
+            d_logger->error("nblocks: {:d}, in_block_size: {:d}, got_input_size: {:d}",
+                            nblocks,
+                            d_encoder->get_input_size(),
+                            nbits_in);
             throw std::runtime_error("input does not divide into code block size!");
         }
         nbits_out = nblocks * d_encoder->get_output_size();

--- a/gr-fec/lib/ber_bf_impl.cc
+++ b/gr-fec/lib/ber_bf_impl.cc
@@ -15,7 +15,6 @@
 #include "ber_bf_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cmath>
 
 namespace gr {
@@ -79,14 +78,15 @@ int ber_bf_impl::general_work(int noutput_items,
 
             if (d_total_errors >= d_berminerrors) {
                 outbuffer[0] = calculate_log_ber();
-                GR_LOG_INFO(d_logger,
-                            boost::format("    %1% over %2% --> %3%") % d_total_errors %
-                                (d_total * 8) % outbuffer[0]);
+                d_logger->info("    {:d} over {:d} --> {:g}",
+                               d_total_errors,
+                               d_total * 8,
+                               outbuffer[0]);
                 return 1;
             }
             // check for total_errors to prevent early shutdown at high SNR simulations
             else if (calculate_log_ber() < d_ber_limit && d_total_errors > 0) {
-                GR_LOG_INFO(d_logger, "    Min. BER limit reached");
+                d_logger->info("    Min. BER limit reached");
                 outbuffer[0] = d_ber_limit;
                 d_total_errors = d_berminerrors + 1;
                 return 1;

--- a/gr-fec/lib/cc_decoder_impl.cc
+++ b/gr-fec/lib/cc_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "cc_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -346,10 +345,9 @@ bool cc_decoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(
-            d_logger,
-            boost::format("cc_decoder: tried to set frame to %1%; max possible is %2%") %
-                frame_size % d_max_frame_size);
+        d_logger->info("cc_decoder: tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/cc_encoder_impl.cc
+++ b/gr-fec/lib/cc_encoder_impl.cc
@@ -17,7 +17,6 @@
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
 #include <volk/volk_typedefs.h>
-#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -105,9 +104,9 @@ bool cc_encoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("tried to set frame to %1%; max possible is %2%") %
-                        frame_size % d_max_frame_size);
+        d_logger->info("tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/ccsds_encoder_impl.cc
+++ b/gr-fec/lib/ccsds_encoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "ccsds_encoder_impl.h"
 #include <gnuradio/fec/generic_encoder.h>
-#include <boost/format.hpp>
 #include <cstdio>
 
 #include <gnuradio/fec/viterbi.h>
@@ -56,9 +55,9 @@ bool ccsds_encoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("tried to set frame to %1%; max possible is %2%") %
-                        frame_size % d_max_frame_size);
+        d_logger->info("tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/conv_bit_corr_bb_impl.cc
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.cc
@@ -243,7 +243,7 @@ float conv_bit_corr_bb_impl::data_garble_rate(int taps, float target)
     answer = 0.5 * (1 - pow(base, expo));
 
     if ((errno == EDOM) || (errno == ERANGE)) {
-        GR_LOG_ERROR(d_logger, "Out of range errors while computing garble rate.");
+        d_logger->error("Out of range errors while computing garble rate.");
         exit(-1);
     }
     return answer;

--- a/gr-fec/lib/depuncture_bb_impl.cc
+++ b/gr-fec/lib/depuncture_bb_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 
@@ -113,21 +112,18 @@ int depuncture_bb_impl::general_work(int noutput_items,
     }
 
     /*
-    GR_LOG_DEBUG(d_debug_logger, ">>>>>> start");
-    for(int i = 0, k=0; i < noutput_items; ++i) {
-      if((d_puncpat >> (d_puncsize - 1 - (i % d_puncsize))) & 1) {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("%1%...%2%") \
-                     % out[i] % in[k++]);
-      }
-      else {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("snit %1%") % out[i]);
-      }
+    d_debug_logger->debug(">>>>>> start");
+    for (int i = 0, k = 0; i < noutput_items; ++i) {
+        if ((d_puncpat >> (d_puncsize - 1 - (i % d_puncsize))) & 1) {
+            d_debug_logger->debug("{:d}...{:d}", out[i], in[k++]);
+        } else {
+            d_debug_logger->debug("snit {:d}", out[i]);
+        }
     }
 
-    GR_LOG_DEBUG(d_debug_logger, boost::format("comp: %1%, %2%\n") \
-                 % noutput_items % ninput_items[0]);
-    GR_LOG_DEBUG(d_debug_logger, boost::format("consuming %1%") \
-                 % ((int)(((1.0/relative_rate()) * noutput_items) + .5)));
+    d_debug_logger->debug("comp: {:d}, {:d}\n", noutput_items, ninput_items[0]);
+    d_debug_logger->debug("consuming {:d}",
+                          std::lround((1.0 / relative_rate()) * noutput_items));
     */
 
     consume_each(std::lround((1.0 / relative_rate()) * noutput_items));

--- a/gr-fec/lib/dummy_decoder_impl.cc
+++ b/gr-fec/lib/dummy_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "dummy_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -55,9 +54,9 @@ bool dummy_decoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("tried to set frame to %1%; max possible is %2%") %
-                        frame_size % d_max_frame_size);
+        d_logger->info("tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/dummy_encoder_impl.cc
+++ b/gr-fec/lib/dummy_encoder_impl.cc
@@ -15,7 +15,6 @@
 #include "dummy_encoder_impl.h"
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <sstream>
 
 namespace gr {
@@ -56,9 +55,9 @@ bool dummy_encoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("tried to set frame to %1%; max possible is %2%") %
-                        frame_size % d_max_frame_size);
+        d_logger->info("tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/generic_encoder.cc
+++ b/gr-fec/lib/generic_encoder.cc
@@ -13,7 +13,6 @@
 #endif
 
 #include <gnuradio/fec/generic_encoder.h>
-#include <boost/format.hpp>
 #include <memory>
 
 namespace gr {
@@ -28,10 +27,7 @@ generic_encoder::generic_encoder(std::string name)
 
 generic_encoder::~generic_encoder() {}
 
-std::string generic_encoder::alias()
-{
-    return (boost::format("%s%d") % d_name % unique_id()).str();
-}
+std::string generic_encoder::alias() { return d_name + std::to_string(unique_id()); }
 const char* generic_encoder::get_input_conversion() { return "none"; }
 
 const char* generic_encoder::get_output_conversion() { return "none"; }

--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -71,11 +71,10 @@ ldpc_G_matrix_impl::ldpc_G_matrix_impl(const std::string filename) : fec_mtrx_im
 
     // if(!test_if_equal) {
     if (test_if_not_equal > 0) {
-        GR_LOG_ERROR(d_logger,
-                     "Error in ldpc_G_matrix_impl constructor. It appears "
-                     "that the given alist file did not contain either a "
-                     "valid parity check matrix of the form H = [P' I] or "
-                     "a generator matrix of the form G = [I P].\n");
+        d_logger->error("Error in ldpc_G_matrix_impl constructor. It appears "
+                        "that the given alist file did not contain either a "
+                        "valid parity check matrix of the form H = [P' I] or "
+                        "a generator matrix of the form G = [I P].\n");
         throw std::runtime_error("ldpc_G_matrix: Bad matrix definition");
     }
 

--- a/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
+++ b/gr-fec/lib/ldpc_bit_flip_decoder_impl.cc
@@ -12,7 +12,6 @@
 
 #include "ldpc_bit_flip_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -53,11 +52,11 @@ int ldpc_bit_flip_decoder_impl::get_input_size() { return d_input_size; }
 bool ldpc_bit_flip_decoder_impl::set_frame_size(unsigned int frame_size)
 {
     if (frame_size % d_mtrx->k() != 0) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("Frame size (%1% bits) must be a "
-                                   "multiple of the information word "
-                                   "size of the LDPC matrix, %2%") %
-                         frame_size % (d_mtrx->k()));
+        d_logger->error("Frame size ({:d} bits) must be a "
+                        "multiple of the information word "
+                        "size of the LDPC matrix, {:d}",
+                        frame_size,
+                        d_mtrx->k());
         throw std::runtime_error("ldpc_bit_flip_decoder: cannot use frame size.");
     }
 

--- a/gr-fec/lib/ldpc_decoder.cc
+++ b/gr-fec/lib/ldpc_decoder.cc
@@ -12,7 +12,6 @@
 #include <gnuradio/fec/ldpc_decoder.h>
 #include <gnuradio/fec/maxstar.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <algorithm> // for std::reverse
 #include <cmath>
 #include <cstdio>
@@ -58,11 +57,11 @@ double ldpc_decoder::rate() { return d_rate; }
 bool ldpc_decoder::set_frame_size(unsigned int frame_size)
 {
     if (frame_size % d_code.dimension() != 0) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("Frame size (%1% bits) must be a "
-                                   "multiple of the information word "
-                                   "size of the LDPC matrix, %2%") %
-                         frame_size % (d_code.dimension()));
+        d_logger->error("Frame size ({:d} bits) must be a "
+                        "multiple of the information word "
+                        "size of the LDPC matrix, {:d}",
+                        frame_size,
+                        d_code.dimension());
         throw std::runtime_error("ldpc_decoder: cannot use frame size.");
     }
 

--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
@@ -11,7 +11,6 @@
 #endif
 
 #include "ldpc_gen_mtrx_encoder_impl.h"
-#include <boost/format.hpp>
 
 namespace gr {
 namespace fec {
@@ -46,11 +45,11 @@ bool ldpc_gen_mtrx_encoder_impl::set_frame_size(unsigned int frame_size)
     bool ret = true;
 
     if (frame_size % d_G->k() != 0) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("Frame size (%1% bits) must be a "
-                                   "multiple of the information word "
-                                   "size of the LDPC matrix (%2%).") %
-                         frame_size % (d_G->k()));
+        d_logger->error("Frame size ({:d} bits) must be a "
+                        "multiple of the information word "
+                        "size of the LDPC matrix ({:d}).",
+                        frame_size,
+                        d_G->k());
         throw std::runtime_error("ldpc_gen_mtrx_encoder: cannot use frame size.");
     }
 

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -10,7 +10,6 @@
 
 #include "ldpc_par_mtrx_encoder_impl.h"
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <algorithm> // for std::reverse
 #include <cmath>
 #include <cstdio>
@@ -66,11 +65,11 @@ bool ldpc_par_mtrx_encoder_impl::set_frame_size(unsigned int frame_size)
     bool ret = true;
 
     if (frame_size % d_H->k() != 0) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("Frame size (%1% bits) must be a "
-                                   "multiple of the information word "
-                                   "size of the LDPC matrix (%2%).") %
-                         frame_size % (d_H->k()));
+        d_logger->error("Frame size ({:d} bits) must be a "
+                        "multiple of the information word "
+                        "size of the LDPC matrix ({:d}).",
+                        frame_size,
+                        d_H->k());
         throw std::runtime_error("ldpc_par_mtrx_encoder: cannot use frame size.");
     }
 

--- a/gr-fec/lib/puncture_bb_impl.cc
+++ b/gr-fec/lib/puncture_bb_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 
@@ -109,21 +108,18 @@ int puncture_bb_impl::general_work(int noutput_items,
     }
 
     /*
-    GR_LOG_DEBUG(d_debug_logger, ">>>>>> start");
-    for(int i = 0, k=0; i < noutput_items; ++i) {
-      if((d_puncpat >> (d_puncsize - 1 - (i % d_puncsize))) & 1) {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("%1%...%2%") \
-                     % out[k++] % in[i]);
-      }
-      else {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("snit %1%") % in[i]);
-      }
+    d_debug_logger->debug(">>>>>> start");
+    for (int i = 0, k = 0; i < noutput_items; ++i) {
+        if ((d_puncpat >> (d_puncsize - 1 - (i % d_puncsize))) & 1) {
+            d_debug_logger->debug("{:d}...{:d}", out[k++], in[i]);
+        } else {
+            d_debug_logger->debug("snit {:d}", in[i]);
+        }
     }
 
-    GR_LOG_DEBUG(d_debug_logger, boost::format("comp: %1%, %2%\n") \
-                 % noutput_items % ninput_items[0]);
-    GR_LOG_DEBUG(d_debug_logger, boost::format("consuming %1%") \
-                 % ((int)(((1.0/relative_rate()) * noutput_items) + .5)));
+    d_debug_logger->debug("comp: {:d}, {:d}\n", noutput_items, ninput_items[0]);
+    d_debug_logger->debug("consuming {:d}",
+                          std::lround((1.0 / relative_rate()) * noutput_items));
     */
 
     consume_each(std::lround((1.0 / relative_rate()) * noutput_items));

--- a/gr-fec/lib/puncture_ff_impl.cc
+++ b/gr-fec/lib/puncture_ff_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 
@@ -109,21 +108,18 @@ int puncture_ff_impl::general_work(int noutput_items,
     }
 
     /*
-    GR_LOG_DEBUG(d_debug_logger, ">>>>>> start");
-    for(int i = 0, k=0; i < noutput_items; ++i) {
-      if((d_puncpat >> (d_puncsize - 1 - (i % d_puncsize))) & 1) {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("%1%...%2%") \
-                     % out[k++] % in[i]);
-      }
-      else {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("snit %1%") % in[i]);
-      }
+    d_debug_logger->debug(">>>>>> start");
+    for (int i = 0, k = 0; i < noutput_items; ++i) {
+        if ((d_puncpat >> (d_puncsize - 1 - (i % d_puncsize))) & 1) {
+            d_debug_logger->debug("{:d}...{:d}", out[k++], in[i]);
+        } else {
+            d_debug_logger->debug("snit {:d}", in[i]);
+        }
     }
 
-    GR_LOG_DEBUG(d_debug_logger, boost::format("comp: %1%, %2%\n") \
-                 % noutput_items % ninput_items[0]);
-    GR_LOG_DEBUG(d_debug_logger, boost::format("consuming %1%") \
-                 % ((int)(((1.0/relative_rate()) * noutput_items) + .5)));
+    d_debug_logger->debug("comp: {:d}, {:d}\n", noutput_items, ninput_items[0]);
+    d_debug_logger->debug("consuming {:d}",
+                          std::lround((1.0 / relative_rate()) * noutput_items));
     */
 
     consume_each(std::lround((1.0 / relative_rate()) * noutput_items));

--- a/gr-fec/lib/repetition_decoder_impl.cc
+++ b/gr-fec/lib/repetition_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "repetition_decoder_impl.h"
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cmath>
 #include <cstdio>
 #include <sstream>
@@ -68,9 +67,9 @@ bool repetition_decoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("tried to set frame to %1%; max possible is %2%") %
-                        frame_size % d_max_frame_size);
+        d_logger->info("tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/repetition_encoder_impl.cc
+++ b/gr-fec/lib/repetition_encoder_impl.cc
@@ -15,7 +15,6 @@
 #include "repetition_encoder_impl.h"
 #include <gnuradio/fec/generic_encoder.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <sstream>
 
 namespace gr {
@@ -49,9 +48,9 @@ bool repetition_encoder_impl::set_frame_size(unsigned int frame_size)
 {
     bool ret = true;
     if (frame_size > d_max_frame_size) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("tried to set frame to %1%; max possible is %2%") %
-                        frame_size % d_max_frame_size);
+        d_logger->info("tried to set frame to {:d}; max possible is {:d}",
+                       frame_size,
+                       d_max_frame_size);
         frame_size = d_max_frame_size;
         ret = false;
     }

--- a/gr-fec/lib/tagged_decoder_impl.cc
+++ b/gr-fec/lib/tagged_decoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "tagged_decoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstdio>
 
 namespace gr {
@@ -66,9 +65,8 @@ int tagged_decoder_impl::work(int noutput_items,
     const unsigned char* in = (unsigned char*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
 
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%1%, %2%, %3%") % noutput_items % ninput_items[0] %
-                     d_decoder->get_output_size());
+    d_debug_logger->debug(
+        "{:d}, {:d}, {:d}", noutput_items, ninput_items[0], d_decoder->get_output_size());
 
     d_decoder->generic_work((void*)in, (void*)out);
 

--- a/gr-fec/lib/tagged_encoder_impl.cc
+++ b/gr-fec/lib/tagged_encoder_impl.cc
@@ -14,7 +14,6 @@
 
 #include "tagged_encoder_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstdio>
 
 namespace gr {
@@ -66,9 +65,10 @@ int tagged_encoder_impl::work(int noutput_items,
     char* inbuffer = (char*)input_items[0];
     char* outbuffer = (char*)output_items[0];
 
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("nout: %1%   nin: %2%   ret: %3%") % noutput_items %
-                     ninput_items[0] % d_encoder->get_output_size());
+    d_debug_logger->debug("nout: {:d}   nin: {:d}   ret: {:d}",
+                          noutput_items,
+                          ninput_items[0],
+                          d_encoder->get_output_size());
 
     d_encoder->generic_work((void*)(inbuffer), (void*)(outbuffer));
 

--- a/gr-fec/python/fec/bindings/generic_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/generic_decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(generic_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2ec1a34c9249874acbe730fd27adc535)                     */
+/* BINDTOOL_HEADER_FILE_HASH(afdc6a2b05a7afcfe27356539ef41b03)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
This continues the work started in https://github.com/gnuradio/gnuradio/pull/5270. Here I've updated gr-fec to use modern logging, and removed all usage of Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
Many FEC encoders and decoders.

## Testing Done
None yet. I'd appreciate help from people familiar with gr-fec.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
