### PR TITLE
pdu: Remove boost::format and modernize logging

### DIFF
--- a/gr-pdu/lib/add_system_time_impl.cc
+++ b/gr-pdu/lib/add_system_time_impl.cc
@@ -52,7 +52,7 @@ void add_system_time_impl::handle_pdu(const pmt::pmt_t& pdu)
 {
     // make sure the message is a PDU
     if (!(pmt::is_pdu(pdu))) {
-        GR_LOG_WARN(d_logger, "Message received is not a PDU, dropping");
+        d_logger->warn("Message received is not a PDU, dropping");
         return;
     }
 

--- a/gr-pdu/lib/pdu_split_impl.cc
+++ b/gr-pdu/lib/pdu_split_impl.cc
@@ -41,7 +41,7 @@ void pdu_split_impl::handle_pdu(const pmt::pmt_t& pdu)
 {
     // make sure the message is a PDU
     if (!(pmt::is_pdu(pdu))) {
-        GR_LOG_WARN(d_logger, "Message received is not a PDU, dropping");
+        d_logger->warn("Message received is not a PDU, dropping");
         return;
     }
 

--- a/gr-pdu/lib/pdu_to_stream_impl.cc
+++ b/gr-pdu/lib/pdu_to_stream_impl.cc
@@ -103,15 +103,15 @@ void pdu_to_stream_impl<T>::store_pdu(pmt::pmt_t pdu)
     // check and see if there is already data in the vector, drop if not in an append mode
     if (d_drop_early_bursts & (d_data.size() | d_pdu_queue.size())) {
         if (d_early_burst_err) {
-            GR_LOG_ERROR(this->d_logger,
-                         "PDU received before previous burst finished writing - dropped");
+            this->d_logger->error(
+                "PDU received before previous burst finished writing - dropped");
         }
         return;
     }
 
     // make sure PDU data is formed properly
     if (!(pmt::is_pdu(pdu))) {
-        GR_LOG_ERROR(this->d_logger, "PMT is not a PDU, dropping");
+        this->d_logger->error("PMT is not a PDU, dropping");
         return;
     }
 
@@ -121,9 +121,9 @@ void pdu_to_stream_impl<T>::store_pdu(pmt::pmt_t pdu)
     if (pmt::length(v_data) != 0) {
         size_t v_itemsize = pmt::uniform_vector_itemsize(v_data);
         if (v_itemsize != d_itemsize) {
-            GR_LOG_ERROR(this->d_logger,
-                         boost::format("PDU received has incorrect itemsize (%d != %d)") %
-                             v_itemsize % d_itemsize);
+            this->d_logger->error("PDU received has incorrect itemsize ({:d} != {:d})",
+                                  v_itemsize,
+                                  d_itemsize);
             return;
         }
 
@@ -133,12 +133,11 @@ void pdu_to_stream_impl<T>::store_pdu(pmt::pmt_t pdu)
             d_drop_ctr = 0;
         } else {
             d_drop_ctr++;
-            GR_LOG_WARN(this->d_logger,
-                        boost::format("Queue full, PDU dropped (%d dropped so far)") %
-                            d_drop_ctr);
+            this->d_logger->warn("Queue full, PDU dropped ({:d} dropped so far)",
+                                 d_drop_ctr);
         }
     } else {
-        GR_LOG_WARN(this->d_logger, "zero size PDU ignored");
+        this->d_logger->warn("zero size PDU ignored");
     }
 
     return;

--- a/gr-pdu/lib/take_skip_to_pdu_impl.cc
+++ b/gr-pdu/lib/take_skip_to_pdu_impl.cc
@@ -41,7 +41,7 @@ take_skip_to_pdu_impl<T>::take_skip_to_pdu_impl(uint32_t take, uint32_t skip)
       d_prev_byte(0)
 {
     if (d_take == 0) {
-        GR_LOG_FATAL(this->d_logger, "TAKE value too small, must be > 0");
+        this->d_logger->fatal("TAKE value too small, must be > 0");
         throw std::invalid_argument("TAKE value out of bounds");
     }
 
@@ -49,7 +49,7 @@ take_skip_to_pdu_impl<T>::take_skip_to_pdu_impl(uint32_t take, uint32_t skip)
     d_meta_dict = pmt::make_dict();
     this->message_port_register_out(msgport_names::pdus());
 
-    GR_LOG_INFO(this->d_logger, "Starting Take Skip PDU Generator!");
+    this->d_logger->info("Starting Take Skip PDU Generator!");
 }
 
 
@@ -64,7 +64,7 @@ take_skip_to_pdu_impl<T>::~take_skip_to_pdu_impl()
 template <class T>
 bool take_skip_to_pdu_impl<T>::stop()
 {
-    GR_LOG_NOTICE(this->d_logger, boost::format("Generated %d PDUs") % d_burst_counter);
+    this->d_logger->notice("Generated {:d} PDUs", d_burst_counter);
     return true;
 }
 

--- a/gr-pdu/lib/time_delta_impl.cc
+++ b/gr-pdu/lib/time_delta_impl.cc
@@ -14,7 +14,6 @@
 #include "time_delta_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/pdu.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace pdu {
@@ -47,9 +46,10 @@ time_delta_impl::~time_delta_impl() {}
 
 bool time_delta_impl::stop()
 {
-    GR_LOG_NOTICE(d_logger,
-                  boost::format("Statistics for %s: Mean = %0.6f ms, Var = %0.6f ms") %
-                      d_name % d_mean % get_variance());
+    d_logger->notice("Statistics for {:s}: Mean = {:.6f} ms, Var = {:.6f} ms",
+                     d_name,
+                     d_mean,
+                     get_variance());
     return true;
 }
 
@@ -78,7 +78,7 @@ void time_delta_impl::handle_pdu(const pmt::pmt_t& pdu)
 {
     // make sure the message is a PDU
     if (!(pmt::is_pdu(pdu))) {
-        GR_LOG_WARN(d_logger, "Message received is not a PDU, dropping");
+        d_logger->warn("Message received is not a PDU, dropping");
         return;
     }
 
@@ -89,16 +89,16 @@ void time_delta_impl::handle_pdu(const pmt::pmt_t& pdu)
     pmt::pmt_t meta = pmt::car(pdu);
     pmt::pmt_t sys_time_pmt = pmt::dict_ref(meta, d_time_key, pmt::PMT_NIL);
     if (!pmt::is_real(sys_time_pmt)) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("PDU received with no system time at %f") % t_now);
+        d_logger->info("PDU received with no system time at {:f}", t_now);
         return;
     }
 
     double pdu_time = pmt::to_double(sys_time_pmt);
     double time_delta_ms = (t_now - pdu_time) * 1000.0;
-    GR_LOG_DEBUG(d_logger,
-                 boost::format("%s PDU received at %f with time delta %f milliseconds") %
-                     d_name % t_now % time_delta_ms);
+    d_logger->debug("{:s} PDU received at {:f} with time delta {:f} milliseconds",
+                    d_name,
+                    t_now,
+                    time_delta_ms);
     update_stats(time_delta_ms);
 
     meta = pmt::dict_add(meta, d_delta_key, pmt::from_double(time_delta_ms));


### PR DESCRIPTION
## Description
This continues the work started in https://github.com/gnuradio/gnuradio/pull/5270. Here I've updated gr-pdu to use modern logging, and removed all usage of Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Add System Time
* PDU Split
* PDU To Stream
* Tags To PDU
* Take/Skip To PDU
* Time Delta

## Testing Done
None yet. I'd appreciate help from people familiar with gr-pdu.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
