### PR TITLE
digital: Remove boost::format and modernize logging

### DIFF
--- a/gr-digital/lib/burst_shaper_impl.cc
+++ b/gr-digital/lib/burst_shaper_impl.cc
@@ -15,7 +15,6 @@
 #include "burst_shaper_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <algorithm>
 
 namespace gr {
@@ -147,8 +146,7 @@ int burst_shaper_impl<T>::general_work(int noutput_items,
                 nskip = ninput_items[0] - nread;
             }
             if (nskip > 0) {
-                GR_LOG_WARN(this->d_logger,
-                            boost::format("Dropping %1% samples") % nskip);
+                this->d_logger->warn("Dropping {:d} samples", nskip);
                 nread += nskip;
                 in += nskip;
             }

--- a/gr-digital/lib/clock_recovery_mm_cc_impl.cc
+++ b/gr-digital/lib/clock_recovery_mm_cc_impl.cc
@@ -164,10 +164,7 @@ int clock_recovery_mm_cc_impl::general_work(int noutput_items,
             d_mu -= floor(d_mu);
 
             if (d_verbose) {
-                std::stringstream tmp;
-                tmp << std::setprecision(8) << std::fixed << d_omega << "\t" << d_mu
-                    << std::endl;
-                GR_LOG_INFO(d_logger, tmp.str());
+                d_logger->info("{:.8f}\t{:.8f}", d_omega, d_mu);
             }
 
             if (ii < 0) // clamp it.  This should only happen with bogus input

--- a/gr-digital/lib/constellation_receiver_cb_impl.cc
+++ b/gr-digital/lib/constellation_receiver_cb_impl.cc
@@ -19,8 +19,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 
-#include <boost/format.hpp>
-
 #include <stdexcept>
 
 namespace gr {
@@ -71,12 +69,16 @@ void constellation_receiver_cb_impl::phase_error_tracking(float phase_error)
     frequency_limit();
 
 #if VERBOSE_COSTAS
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("cl: phase_error: %f  phase: %f  freq: %f  sample: %f+j%f "
-                               " constellation: %f+j%f") %
-                     phase_error % d_phase % d_freq % sample.real() % sample.imag() %
-                     d_constellation->points()[d_current_const_point].real() %
-                     d_constellation->points()[d_current_const_point].imag());
+    d_debug_logger->debug(
+        "cl: phase_error: {:f}  phase: {:f}  freq: {:f}  sample: {:f}+j{:f} "
+        " constellation: {:f}+j{:f}",
+        phase_error,
+        d_phase,
+        d_freq,
+        sample.real(),
+        sample.imag(),
+        d_constellation->points()[d_current_const_point].real(),
+        d_constellation->points()[d_current_const_point].imag());
 #endif
 }
 
@@ -95,7 +97,7 @@ void constellation_receiver_cb_impl::handle_set_constellation(
             boost::any_cast<constellation_sptr>(constellation_any);
         set_constellation(constellation);
     } else {
-        GR_LOG_ERROR(d_logger, "Received constellation that is not a PMT any; skipping.");
+        d_logger->error("Received constellation that is not a PMT any; skipping.");
     }
 }
 
@@ -105,7 +107,7 @@ void constellation_receiver_cb_impl::handle_rotate_phase(pmt::pmt_t rotation)
         const double phase = pmt::to_double(rotation);
         d_phase += phase;
     } else {
-        GR_LOG_ERROR(d_logger, "Received rotation value that is not real; skipping.");
+        d_logger->error("Received rotation value that is not real; skipping.");
     }
 }
 

--- a/gr-digital/lib/corr_est_cc_impl.cc
+++ b/gr-digital/lib/corr_est_cc_impl.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace digital {
@@ -136,11 +135,11 @@ void corr_est_cc_impl::_set_mark_delay(unsigned int mark_delay)
 
     if (mark_delay >= d_symbols.size()) {
         d_mark_delay = d_symbols.size() - 1;
-        GR_LOG_WARN(d_logger,
-                    boost::format("set_mark_delay: asked for %1% but due "
-                                  "to the symbol size constraints, "
-                                  "mark delay set to %2%.") %
-                        mark_delay % d_mark_delay);
+        d_logger->warn("set_mark_delay: asked for {:d} but due "
+                       "to the symbol size constraints, "
+                       "mark delay set to {:d}.",
+                       mark_delay,
+                       d_mark_delay);
     } else {
         d_mark_delay = mark_delay;
     }

--- a/gr-digital/lib/correlate_access_code_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_impl.cc
@@ -40,7 +40,7 @@ correlate_access_code_bb_impl::correlate_access_code_bb_impl(
       d_threshold(threshold)
 {
     if (!set_access_code(access_code)) {
-        GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
+        d_logger->error("access_code is > 64 bits");
         throw std::out_of_range("access_code is > 64 bits");
     }
 }

--- a/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_bb_ts_impl.cc
@@ -15,7 +15,6 @@
 #include "correlate_access_code_bb_ts_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -43,7 +42,7 @@ correlate_access_code_bb_ts_impl::correlate_access_code_bb_ts_impl(
     set_tag_propagation_policy(TPP_DONT);
 
     if (!set_access_code(access_code)) {
-        GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
+        d_logger->error("access_code is > 64 bits");
         throw std::out_of_range("access_code is > 64 bits");
     }
 
@@ -75,8 +74,8 @@ bool correlate_access_code_bb_ts_impl::set_access_code(const std::string& access
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
     }
 
-    GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
-    GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
+    d_logger->debug("Access code: {:x}", d_access_code);
+    d_logger->debug("Mask: {:x}", d_mask);
 
     return true;
 }

--- a/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
+++ b/gr-digital/lib/correlate_access_code_ff_ts_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -43,7 +42,7 @@ correlate_access_code_ff_ts_impl::correlate_access_code_ff_ts_impl(
     set_tag_propagation_policy(TPP_DONT);
 
     if (!set_access_code(access_code)) {
-        GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
+        d_logger->error("access_code is > 64 bits");
         throw std::out_of_range("access_code is > 64 bits");
     }
 
@@ -75,8 +74,8 @@ bool correlate_access_code_ff_ts_impl::set_access_code(const std::string& access
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
     }
 
-    GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
-    GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
+    d_logger->debug("Access code: {:x}", d_access_code);
+    d_logger->debug("Mask: {:x}", d_mask);
 
     return true;
 }

--- a/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_bb_impl.cc
@@ -15,7 +15,6 @@
 #include "correlate_access_code_tag_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -41,7 +40,7 @@ correlate_access_code_tag_bb_impl::correlate_access_code_tag_bb_impl(
       d_len(0)
 {
     if (!set_access_code(access_code)) {
-        GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
+        d_logger->error("access_code is > 64 bits");
         throw std::out_of_range("access_code is > 64 bits");
     }
 
@@ -69,8 +68,8 @@ bool correlate_access_code_tag_bb_impl::set_access_code(const std::string& acces
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
     }
 
-    GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
-    GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
+    d_logger->debug("Access code: {:x}", d_access_code);
+    d_logger->debug("Mask: {:x}", d_mask);
 
     return true;
 }
@@ -103,9 +102,7 @@ int correlate_access_code_tag_bb_impl::work(int noutput_items,
         // shift in new data
         d_data_reg = (d_data_reg << 1) | (in[i] & 0x1);
         if (nwrong <= d_threshold) {
-            GR_LOG_DEBUG(d_logger,
-                         boost::format("writing tag at sample %llu") %
-                             (abs_out_sample_cnt + i));
+            d_logger->debug("writing tag at sample {:d}", abs_out_sample_cnt + i);
             add_item_tag(0,                      // stream ID
                          abs_out_sample_cnt + i, // sample
                          d_key,                  // frame info

--- a/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
+++ b/gr-digital/lib/correlate_access_code_tag_ff_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -42,7 +41,7 @@ correlate_access_code_tag_ff_impl::correlate_access_code_tag_ff_impl(
       d_len(0)
 {
     if (!set_access_code(access_code)) {
-        GR_LOG_ERROR(d_logger, "access_code is > 64 bits");
+        d_logger->error("access_code is > 64 bits");
         throw std::out_of_range("access_code is > 64 bits");
     }
 
@@ -70,8 +69,8 @@ bool correlate_access_code_tag_ff_impl::set_access_code(const std::string& acces
         d_access_code = (d_access_code << 1) | (access_code[i] & 1);
     }
 
-    GR_LOG_DEBUG(d_logger, boost::format("Access code: %llx") % d_access_code);
-    GR_LOG_DEBUG(d_logger, boost::format("Mask: %llx") % d_mask);
+    d_logger->debug("Access code: {:x}", d_access_code);
+    d_logger->debug("Mask: {:x}", d_mask);
 
     return true;
 }
@@ -104,9 +103,7 @@ int correlate_access_code_tag_ff_impl::work(int noutput_items,
         // shift in new data
         d_data_reg = (d_data_reg << 1) | (gr::branchless_binary_slicer(in[i]) & 0x1);
         if (nwrong <= d_threshold) {
-            GR_LOG_DEBUG(d_logger,
-                         boost::format("writing tag at sample %llu") %
-                             (abs_out_sample_cnt + i));
+            d_logger->debug("writing tag at sample {:d}", abs_out_sample_cnt + i);
             add_item_tag(0,                      // stream ID
                          abs_out_sample_cnt + i, // sample
                          d_key,                  // frame info

--- a/gr-digital/lib/fll_band_edge_cc_impl.cc
+++ b/gr-digital/lib/fll_band_edge_cc_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/expj.h>
 #include <gnuradio/io_signature.h>
 #include <cstdio>
+#include <iomanip>
 #include <memory>
 #include <sstream>
 
@@ -173,17 +174,18 @@ void fll_band_edge_cc_impl::design_filter(float samps_per_sym,
 void fll_band_edge_cc_impl::print_taps()
 {
     std::stringstream ss;
+    ss << std::setprecision(4) << std::scientific;
     ss << "Upper Band-edge: [";
     for (const auto& tap : d_taps_upper)
-        ss << boost::format(" %.4e + %.4ej,") % tap.real() % tap.imag();
+        ss << " " << tap.real() << " + " << tap.imag() << "j,";
     ss << "]\n\n";
 
     ss << "Lower Band-edge: [";
     for (const auto& tap : d_taps_lower)
-        ss << boost::format(" %.4e + %.4ej,") % tap.real() % tap.imag();
+        ss << " " << tap.real() << " + " << tap.imag() << "j,";
     ss << "]\n";
 
-    GR_LOG_INFO(d_logger, ss.str());
+    d_logger->info(ss.str());
 }
 
 int fll_band_edge_cc_impl::work(int noutput_items,

--- a/gr-digital/lib/framer_sink_1_impl.cc
+++ b/gr-digital/lib/framer_sink_1_impl.cc
@@ -14,7 +14,6 @@
 
 #include "framer_sink_1_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <string>
 
@@ -23,14 +22,14 @@ namespace digital {
 
 inline void framer_sink_1_impl::enter_search()
 {
-    GR_LOG_INFO(d_debug_logger, "enter_search");
+    d_debug_logger->info("enter_search");
 
     d_state = STATE_SYNC_SEARCH;
 }
 
 inline void framer_sink_1_impl::enter_have_sync()
 {
-    GR_LOG_INFO(d_debug_logger, "enter_have_sync");
+    d_debug_logger->info("enter_have_sync");
 
     d_state = STATE_HAVE_SYNC;
     d_header = 0;
@@ -39,9 +38,9 @@ inline void framer_sink_1_impl::enter_have_sync()
 
 inline void framer_sink_1_impl::enter_have_header(int payload_len, int whitener_offset)
 {
-    GR_LOG_INFO(d_debug_logger,
-                boost::format("enter_have_header (payload_len = %d) (offset = %d)") %
-                    payload_len % whitener_offset);
+    d_debug_logger->info("enter_have_header (payload_len = {:d}) (offset = {:d})",
+                         payload_len,
+                         whitener_offset);
 
     d_state = STATE_HAVE_HEADER;
     d_packetlen = payload_len;
@@ -74,14 +73,13 @@ int framer_sink_1_impl::work(int noutput_items,
     const unsigned char* in = (const unsigned char*)input_items[0];
     int count = 0;
 
-    GR_LOG_INFO(d_debug_logger, "enter state machine");
+    d_debug_logger->info("enter state machine");
 
     while (count < noutput_items) {
         switch (d_state) {
 
         case STATE_SYNC_SEARCH: // Look for flag indicating beginning of pkt
-            GR_LOG_INFO(d_debug_logger,
-                        boost::format("SYNC Search, noutput=%d") % noutput_items);
+            d_debug_logger->info("SYNC Search, noutput={:d}", noutput_items);
 
             while (count < noutput_items) {
                 if (in[count] & 0x2) { // Found it, set up for header decode
@@ -93,16 +91,15 @@ int framer_sink_1_impl::work(int noutput_items,
             break;
 
         case STATE_HAVE_SYNC:
-            GR_LOG_INFO(d_debug_logger,
-                        boost::format("Header Search bitcnt=%d, header=0x%08x") %
-                            d_headerbitlen_cnt % d_header);
+            d_debug_logger->info("Header Search bitcnt={:d}, header={:#08x}",
+                                 d_headerbitlen_cnt,
+                                 d_header);
 
             while (count < noutput_items) { // Shift bits one at a time into header
                 d_header = (d_header << 1) | (in[count++] & 0x1);
                 if (++d_headerbitlen_cnt == HEADERBITLEN) {
 
-                    GR_LOG_INFO(d_debug_logger,
-                                boost::format("got header: 0x%08x") % d_header);
+                    d_debug_logger->info("got header: {:#08x}", d_header);
 
                     // we have a full header, check to see if it has been received
                     // properly
@@ -131,7 +128,7 @@ int framer_sink_1_impl::work(int noutput_items,
             break;
 
         case STATE_HAVE_HEADER:
-            GR_LOG_INFO(d_debug_logger, "Packet Build");
+            d_debug_logger->info("Packet Build");
 
             while (count <
                    noutput_items) { // shift bits into bytes of packet one at a time

--- a/gr-digital/lib/msk_timing_recovery_cc_impl.cc
+++ b/gr-digital/lib/msk_timing_recovery_cc_impl.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace digital {
@@ -129,10 +128,9 @@ int msk_timing_recovery_cc_impl::general_work(int noutput_items,
                     goto out;
                 }
                 if (std::abs(center) >= 1.0f) {
-                    GR_LOG_WARN(d_logger,
-                                boost::format("work: ignoring time_est tag "
-                                              "(%.2f) outside of (-1, 1)") %
-                                    center);
+                    d_logger->warn("work: ignoring time_est tag "
+                                   "({:.2f}) outside of (-1, 1)",
+                                   center);
                     tags.erase(tags.begin());
                     goto out;
                 }

--- a/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
+++ b/gr-digital/lib/ofdm_cyclic_prefixer_impl.cc
@@ -88,8 +88,7 @@ ofdm_cyclic_prefixer_impl::ofdm_cyclic_prefixer_impl(int fft_len,
     // Flank of length 1 would just be rectangular.
     if (d_rolloff_len == 1) {
         d_rolloff_len = 0;
-        GR_LOG_WARN(d_logger,
-                    "Set rolloff to 0, because 1 would result in a boxcar function.");
+        d_logger->warn("Set rolloff to 0, because 1 would result in a boxcar function.");
     }
     if (d_rolloff_len) {
         d_delay_line.resize(d_rolloff_len - 1, 0);

--- a/gr-digital/lib/packet_headergenerator_bb_impl.cc
+++ b/gr-digital/lib/packet_headergenerator_bb_impl.cc
@@ -13,7 +13,6 @@
 
 #include "packet_headergenerator_bb_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace digital {
@@ -71,10 +70,9 @@ int packet_headergenerator_bb_impl::work(int noutput_items,
     std::vector<tag_t> tags;
     get_tags_in_range(tags, 0, nitems_read(0), nitems_read(0) + ninput_items[0]);
     if (!d_formatter->header_formatter(ninput_items[0], out, tags)) {
-        GR_LOG_FATAL(d_logger,
-                     boost::format("header_formatter() returned false (this shouldn't "
-                                   "happen). Offending header started at %1%") %
-                         nitems_read(0));
+        d_logger->fatal("header_formatter() returned false (this shouldn't "
+                        "happen). Offending header started at {:d}",
+                        nitems_read(0));
         throw std::runtime_error("header formatter returned false.");
     }
 

--- a/gr-digital/lib/packet_headerparser_b_impl.cc
+++ b/gr-digital/lib/packet_headerparser_b_impl.cc
@@ -13,7 +13,6 @@
 
 #include "packet_headerparser_b_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace digital {
@@ -61,9 +60,7 @@ int packet_headerparser_b_impl::work(int noutput_items,
         tags, 0, nitems_read(0), nitems_read(0) + d_header_formatter->header_len());
 
     if (!d_header_formatter->header_parser(in, tags)) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("Detected an invalid packet at item %1%") %
-                        nitems_read(0));
+        d_logger->info("Detected an invalid packet at item {:d}", nitems_read(0));
         message_port_pub(d_port, pmt::PMT_F);
     } else {
         pmt::pmt_t dict(pmt::make_dict());

--- a/gr-digital/lib/packet_sink_impl.cc
+++ b/gr-digital/lib/packet_sink_impl.cc
@@ -15,7 +15,6 @@
 #include "packet_sink_impl.h"
 #include <gnuradio/blocks/count_bits.h>
 #include <gnuradio/io_signature.h>
-#include <boost/format.hpp>
 #include <cstring>
 
 namespace gr {
@@ -29,7 +28,7 @@ static const int DEFAULT_THRESHOLD = 12;
 inline void packet_sink_impl::enter_search()
 {
     if (VERBOSE) {
-        GR_LOG_INFO(d_debug_logger, "enter_search");
+        d_debug_logger->info("enter_search");
     }
 
     d_state = STATE_SYNC_SEARCH;
@@ -39,7 +38,7 @@ inline void packet_sink_impl::enter_search()
 inline void packet_sink_impl::enter_have_sync()
 {
     if (VERBOSE) {
-        GR_LOG_INFO(d_debug_logger, "enter_have_sync");
+        d_debug_logger->info("enter_have_sync");
     }
     d_state = STATE_HAVE_SYNC;
     d_header = 0;
@@ -49,8 +48,7 @@ inline void packet_sink_impl::enter_have_sync()
 inline void packet_sink_impl::enter_have_header(int payload_len)
 {
     if (VERBOSE) {
-        GR_LOG_INFO(d_debug_logger,
-                    boost::format("enter_have_header (payload_len = %d)") % payload_len);
+        d_debug_logger->info("enter_have_header (payload_len = {:d})", payload_len);
     }
     d_state = STATE_HAVE_HEADER;
     d_packetlen = payload_len;
@@ -95,7 +93,7 @@ int packet_sink_impl::work(int noutput_items,
     int count = 0;
 
     if (VERBOSE) {
-        GR_LOG_INFO(d_debug_logger, "enter state machine");
+        d_debug_logger->info("enter state machine");
     }
 
     while (count < noutput_items) {
@@ -103,7 +101,7 @@ int packet_sink_impl::work(int noutput_items,
 
         case STATE_SYNC_SEARCH: // Look for sync vector
             if (VERBOSE)
-                GR_LOG_INFO(d_debug_logger, "SYNC Search, noutput=%d");
+                d_debug_logger->info("SYNC Search, noutput={:d}", noutput_items);
 
             while (count < noutput_items) {
                 if (slice(inbuf[count++]))
@@ -123,9 +121,9 @@ int packet_sink_impl::work(int noutput_items,
 
         case STATE_HAVE_SYNC:
             if (VERBOSE)
-                GR_LOG_INFO(d_debug_logger,
-                            boost::format("Header Search bitcnt=%d, header=0x%08x") %
-                                d_headerbitlen_cnt % d_header);
+                d_debug_logger->info("Header Search bitcnt={:d}, header={:#08x}",
+                                     d_headerbitlen_cnt,
+                                     d_header);
 
             while (count < noutput_items) { // Shift bits one at a time into header
                 if (slice(inbuf[count++]))
@@ -135,8 +133,7 @@ int packet_sink_impl::work(int noutput_items,
 
                 if (++d_headerbitlen_cnt == HEADERBITLEN) {
                     if (VERBOSE)
-                        GR_LOG_INFO(d_debug_logger,
-                                    boost::format("got header: 0x%08x") % d_header);
+                        d_debug_logger->info("got header: {:#08x}", d_header);
 
                     // we have a full header, check to see if it has been received
                     // properly
@@ -155,7 +152,7 @@ int packet_sink_impl::work(int noutput_items,
 
         case STATE_HAVE_HEADER:
             if (VERBOSE) {
-                GR_LOG_INFO(d_debug_logger, "Packet Build");
+                d_debug_logger->info("Packet Build");
             }
 
             while (count <

--- a/gr-digital/lib/protocol_formatter_bb_impl.cc
+++ b/gr-digital/lib/protocol_formatter_bb_impl.cc
@@ -15,7 +15,6 @@
 #include "protocol_formatter_bb_impl.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>
-#include <boost/format.hpp>
 #include <cstdio>
 
 namespace gr {
@@ -68,11 +67,10 @@ int protocol_formatter_bb_impl::work(int noutput_items,
     pmt::pmt_t pmt_out;
     pmt::pmt_t info = pmt::PMT_NIL;
     if (!d_format->format(ninput_items[0], in, pmt_out, info)) {
-        GR_LOG_FATAL(d_logger,
-                     boost::format("header format returned false "
-                                   "(this shouldn't happen). Offending "
-                                   "header started at %1%") %
-                         nitems_read(0));
+        d_logger->fatal("header format returned false "
+                        "(this shouldn't happen). Offending "
+                        "header started at {:d}",
+                        nitems_read(0));
         throw std::runtime_error("header format returned false.");
     }
 

--- a/gr-digital/lib/symbol_sync_cc_impl.cc
+++ b/gr-digital/lib/symbol_sync_cc_impl.cc
@@ -15,7 +15,6 @@
 #include "symbol_sync_cc_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <boost/format.hpp>
 #include <numeric>
 #include <stdexcept>
 
@@ -112,12 +111,12 @@ symbol_sync_cc_impl::symbol_sync_cc_impl(enum ted_type detector_type,
     d_inst_interp_period = d_inst_clock_period / d_interps_per_symbol;
 
     if (d_interps_per_symbol > sps)
-        GR_LOG_WARN(d_logger,
-                    boost::format("block performing more interpolations per "
-                                  "symbol (%3f) than input samples per symbol "
-                                  "(%3f). Consider reducing osps or "
-                                  "increasing sps") %
-                        d_interps_per_symbol % sps);
+        d_logger->warn("block performing more interpolations per "
+                       "symbol ({:g}) than input samples per symbol "
+                       "({:g}). Consider reducing osps or "
+                       "increasing sps",
+                       d_interps_per_symbol,
+                       sps);
 
     // Timing Error Detector
     d_ted->sync_reset();
@@ -243,11 +242,10 @@ bool symbol_sync_cc_impl::find_sync_tag(uint64_t nitems_rd,
 
         if (!(timing_offset >= -1.0f && timing_offset <= 1.0f)) {
             // the time_est/clock_est tag's payload is invalid
-            GR_LOG_WARN(d_logger,
-                        boost::format("ignoring time_est/clock_est tag with"
-                                      " value %.2f, outside of allowed "
-                                      "range [-1.0, 1.0]") %
-                            timing_offset);
+            d_logger->warn("ignoring time_est/clock_est tag with"
+                           " value {:.2f}, outside of allowed "
+                           "range [-1.0, 1.0]",
+                           timing_offset);
             found = false;
             continue;
         }

--- a/gr-digital/lib/symbol_sync_ff_impl.cc
+++ b/gr-digital/lib/symbol_sync_ff_impl.cc
@@ -15,7 +15,6 @@
 #include "symbol_sync_ff_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/math.h>
-#include <boost/format.hpp>
 #include <numeric>
 #include <stdexcept>
 
@@ -113,12 +112,12 @@ symbol_sync_ff_impl::symbol_sync_ff_impl(enum ted_type detector_type,
     d_inst_interp_period = d_inst_clock_period / d_interps_per_symbol;
 
     if (d_interps_per_symbol > sps)
-        GR_LOG_WARN(d_logger,
-                    boost::format("block performing more interpolations per "
-                                  "symbol (%3f) than input samples per symbol "
-                                  "(%3f). Consider reducing osps or "
-                                  "increasing sps") %
-                        d_interps_per_symbol % sps);
+        d_logger->warn("block performing more interpolations per "
+                       "symbol ({:g}) than input samples per symbol "
+                       "({:g}). Consider reducing osps or "
+                       "increasing sps",
+                       d_interps_per_symbol,
+                       sps);
 
     // Timing Error Detector
     d_ted->sync_reset();
@@ -246,11 +245,10 @@ bool symbol_sync_ff_impl::find_sync_tag(uint64_t nitems_rd,
 
         if (!(timing_offset >= -1.0f && timing_offset <= 1.0f)) {
             // the time_est/clock_est tag's payload is invalid
-            GR_LOG_WARN(d_logger,
-                        boost::format("ignoring time_est/clock_est tag with"
-                                      " value %.2f, outside of allowed "
-                                      "range [-1.0, 1.0]") %
-                            timing_offset);
+            d_logger->warn("ignoring time_est/clock_est tag with"
+                           " value {:.2f}, outside of allowed "
+                           "range [-1.0, 1.0]",
+                           timing_offset);
             found = false;
             continue;
         }


### PR DESCRIPTION
## Description
This continues the work started in https://github.com/gnuradio/gnuradio/pull/5270. Here I've updated gr-digital to use modern logging, and removed all usage of Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Burst Shaper
* Clock Recovery MM
* Correlation Estimator
* Correlate Access Code - Tag
* Correlate Access Code - Tag Stream
* FLL Band-Edge
* Framer Sink 1
* Header/Payload Demux
* MSK Timing Recovery
* OFDM Cyclic Prefixer
* Packet Header Generator
* Packet Header Parser
* Packet Sink
* Protocol Formatter
* Symbol Sync

## Testing Done
So far I've only tested the Symbol Sync blocks. I'd appreciate help from people familiar with gr-digital.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
