### PR TITLE
audio: Remove boost::format and modernize logging

### DIFF
--- a/gr-audio/lib/alsa/alsa_impl.cc
+++ b/gr-audio/lib/alsa/alsa_impl.cc
@@ -17,7 +17,6 @@
 
 #include "alsa_impl.h"
 
-#include <boost/format.hpp>
 #include <algorithm>
 
 static snd_pcm_access_t access_types[] = { SND_PCM_ACCESS_MMAP_INTERLEAVED,
@@ -152,22 +151,22 @@ bool gri_alsa_pick_acceptable_format(snd_pcm_t* pcm,
         if (snd_pcm_hw_params_test_format(pcm, hwparams, acceptable_formats[i]) == 0) {
             err = snd_pcm_hw_params_set_format(pcm, hwparams, acceptable_formats[i]);
             if (err < 0) {
-                GR_LOG_ERROR(logger,
-                             boost::format("%s[%s]: failed to set format: %s") %
-                                 error_msg_tag % snd_pcm_name(pcm) % snd_strerror(err));
+                logger->error("{:s}[{:s}]: failed to set format: {:s}",
+                              error_msg_tag,
+                              snd_pcm_name(pcm),
+                              snd_strerror(err));
                 return false;
             }
-            GR_LOG_INFO(debug_logger,
-                        boost::format("%s[%s]: using %s") % error_msg_tag %
-                            snd_pcm_name(pcm) %
-                            snd_pcm_format_name(acceptable_formats[i]));
+            debug_logger->info("{:s}[{:s}]: using {:s}",
+                               error_msg_tag,
+                               snd_pcm_name(pcm),
+                               snd_pcm_format_name(acceptable_formats[i]));
             *selected_format = acceptable_formats[i];
             return true;
         }
     }
 
-    GR_LOG_ERROR(logger,
-                 boost::format("%s[%s]: failed to find acceptable format") %
-                     error_msg_tag % snd_pcm_name(pcm));
+    logger->error(
+        "{:s}[{:s}]: failed to find acceptable format", error_msg_tag, snd_pcm_name(pcm));
     return false;
 }

--- a/gr-audio/lib/audio_registry.cc
+++ b/gr-audio/lib/audio_registry.cc
@@ -10,7 +10,6 @@
 #include "audio_registry.h"
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 #include <vector>
 
@@ -135,10 +134,9 @@ static void do_arch_warning(const std::string& arch)
 
     gr::logger_ptr logger, debug_logger;
     gr::configure_default_loggers(logger, debug_logger, "audio_registry");
-    std::ostringstream msg;
-    msg << "Could not find audio architecture \"" << arch << "\" in registry.";
-    msg << " Defaulting to the first available architecture.";
-    GR_LOG_ERROR(logger, msg.str());
+    logger->error("Could not find audio architecture \"{:s}\" in registry."
+                  " Defaulting to the first available architecture.",
+                  arch);
 }
 
 source::sptr
@@ -162,7 +160,7 @@ source::make(int sampling_rate, const std::string device_name, bool ok_to_block)
         return e.source(sampling_rate, device_name, ok_to_block);
     }
 
-    GR_LOG_INFO(debug_logger, boost::format("Audio source arch: %1%") % (entry.arch));
+    debug_logger->info("Audio source arch: {:s}", entry.arch);
     return entry.source(sampling_rate, device_name, ok_to_block);
 }
 
@@ -187,7 +185,7 @@ sink::sptr sink::make(int sampling_rate, const std::string device_name, bool ok_
     }
 
     do_arch_warning(arch);
-    GR_LOG_INFO(debug_logger, boost::format("Audio sink arch: %1%") % (entry.arch));
+    debug_logger->info("Audio sink arch: {:s}", entry.arch);
     return entry.sink(sampling_rate, device_name, ok_to_block);
 }
 

--- a/gr-audio/lib/jack/jack_sink.cc
+++ b/gr-audio/lib/jack/jack_sink.cc
@@ -17,7 +17,6 @@
 #include "jack_sink.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -105,8 +104,7 @@ jack_sink::jack_sink(int sampling_rate, const std::string device_name, bool ok_t
     const char* server_name = NULL;
     if ((d_jack_client = jack_client_open(
              d_device_name.c_str(), options, &status, server_name)) == NULL) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("[%1%]: jack server not running?") % d_device_name);
+        d_logger->error("[{:s}]: jack server not running?", d_device_name);
         throw std::runtime_error("audio_jack_sink");
     }
 
@@ -133,10 +131,11 @@ jack_sink::jack_sink(int sampling_rate, const std::string device_name, bool ok_t
     jack_nframes_t sample_rate = jack_get_sample_rate(d_jack_client);
 
     if ((jack_nframes_t)sampling_rate != sample_rate) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("[%1%]: unable to support sampling rate %2%\n\tCard "
-                                  "requested %3% instead.") %
-                        d_device_name % sampling_rate % d_sampling_rate);
+        d_logger->info("[{:s}]: unable to support sampling rate {:d}\n\tCard "
+                       "requested {:d} instead.",
+                       d_device_name,
+                       sampling_rate,
+                       d_sampling_rate);
     }
 }
 
@@ -232,7 +231,7 @@ int jack_sink::work(int noutput_items,
 
 void jack_sink::output_error_msg(const char* msg, int err)
 {
-    GR_LOG_ERROR(d_logger, boost::format("[%1%]: %2%: %3%") % d_device_name % msg % err);
+    d_logger->error("[{:s}]: {:s}: {:d}", d_device_name, msg, err);
 }
 
 void jack_sink::bail(const char* msg, int err)

--- a/gr-audio/lib/jack/jack_source.cc
+++ b/gr-audio/lib/jack/jack_source.cc
@@ -18,7 +18,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <type_traits>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <stdexcept>
 
@@ -108,8 +107,7 @@ jack_source::jack_source(int sampling_rate,
     const char* server_name = NULL;
     if ((d_jack_client = jack_client_open(
              d_device_name.c_str(), options, &status, server_name)) == NULL) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("[%1%]: jack server not running?") % d_device_name);
+        d_logger->error("[{:s}]: jack server not running?", d_device_name);
         throw std::runtime_error("audio_jack_source");
     }
 
@@ -133,10 +131,11 @@ jack_source::jack_source(int sampling_rate,
     jack_nframes_t sample_rate = jack_get_sample_rate(d_jack_client);
 
     if ((jack_nframes_t)sampling_rate != sample_rate) {
-        GR_LOG_INFO(d_logger,
-                    boost::format("[%1%]: unable to support sampling rate %2%\n\tCard "
-                                  "requested %3% instead.") %
-                        d_device_name % sampling_rate % d_sampling_rate);
+        d_logger->info("[{:s}]: unable to support sampling rate {:d}\n\tCard "
+                       "requested {:d} instead.",
+                       d_device_name,
+                       sampling_rate,
+                       d_sampling_rate);
     }
 }
 
@@ -234,7 +233,7 @@ int jack_source::work(int noutput_items,
 
 void jack_source::output_error_msg(const char* msg, int err)
 {
-    GR_LOG_ERROR(d_logger, boost::format("[%1%]: %2%: %3%") % d_device_name % msg % err);
+    d_logger->error("[{:s}]: {:s}: {:d}", d_device_name, msg, err);
 }
 
 void jack_source::bail(const char* msg, int err)

--- a/gr-audio/lib/osx/osx_common.h
+++ b/gr-audio/lib/osx/osx_common.h
@@ -12,7 +12,6 @@
 #define INCLUDED_AUDIO_OSX_COMMON_H
 
 #include <gnuradio/audio/osx_impl.h>
-#include <boost/format.hpp>
 
 namespace gr {
 namespace audio {
@@ -26,27 +25,27 @@ namespace osx {
 #define _OSX_AU_DEBUG_RENDER_ 0
 #endif
 
-#define check_error_and_throw(err, what, throw_str)                                    \
-    if (err) {                                                                         \
-        OSStatus error = static_cast<OSStatus>(err);                                   \
-        char err_str[sizeof(OSStatus) + 1];                                            \
-        memcpy((void*)(&err_str), (void*)(&error), sizeof(OSStatus));                  \
-        err_str[sizeof(OSStatus)] = 0;                                                 \
-        GR_LOG_FATAL(d_logger, boost::format(what));                                   \
-        GR_LOG_FATAL(d_logger, boost::format("  Error# %u ('%s')") % error % err_str); \
-        GR_LOG_FATAL(d_logger, boost::format("  %s:%d") % __FILE__ % __LINE__);        \
-        throw std::runtime_error(throw_str);                                           \
+#define check_error_and_throw(err, what, throw_str)                   \
+    if (err) {                                                        \
+        OSStatus error = static_cast<OSStatus>(err);                  \
+        char err_str[sizeof(OSStatus) + 1];                           \
+        memcpy((void*)(&err_str), (void*)(&error), sizeof(OSStatus)); \
+        err_str[sizeof(OSStatus)] = 0;                                \
+        d_logger->fatal(what);                                        \
+        d_logger->fatal("  Error# {} ('{:s}')", error, err_str);      \
+        d_logger->fatal("  {:s}:{:d}", __FILE__, __LINE__);           \
+        throw std::runtime_error(throw_str);                          \
     }
 
-#define check_error(err, what)                                                        \
-    if (err) {                                                                        \
-        OSStatus error = static_cast<OSStatus>(err);                                  \
-        char err_str[sizeof(OSStatus) + 1];                                           \
-        memcpy((void*)(&err_str), (void*)(&error), sizeof(OSStatus));                 \
-        err_str[sizeof(OSStatus)] = 0;                                                \
-        GR_LOG_WARN(d_logger, boost::format(what));                                   \
-        GR_LOG_WARN(d_logger, boost::format("  Error# %u ('%s')") % error % err_str); \
-        GR_LOG_WARN(d_logger, boost::format("  %s:%d") % __FILE__ % __LINE__);        \
+#define check_error(err, what)                                        \
+    if (err) {                                                        \
+        OSStatus error = static_cast<OSStatus>(err);                  \
+        char err_str[sizeof(OSStatus) + 1];                           \
+        memcpy((void*)(&err_str), (void*)(&error), sizeof(OSStatus)); \
+        err_str[sizeof(OSStatus)] = 0;                                \
+        d_logger->warn(what);                                         \
+        d_logger->warn("  Error# {} ('{:s}')", error, err_str);       \
+        d_logger->warn("  {:s}:{:d}", __FILE__, __LINE__);            \
     }
 
 #ifdef GR_IS_BIG_ENDIAN

--- a/gr-audio/lib/osx/osx_impl.cc
+++ b/gr-audio/lib/osx/osx_impl.cc
@@ -155,9 +155,7 @@ void find_audio_devices(const std::string& device_name,
         gr::logger_ptr logger, debug_logger;
         gr::configure_default_loggers(
             logger, debug_logger, "osx_impl::find_audio_devices");
-        std::ostringstream msg;
-        msg << "Unable to retrieve number of audio objects: " << err;
-        GR_LOG_ERROR(logger, msg.str());
+        logger->error("Unable to retrieve number of audio objects: {}", err);
 #endif
         return;
     }
@@ -177,9 +175,7 @@ void find_audio_devices(const std::string& device_name,
                                           &prop_size,
                                           all_dev_ids.get())) != noErr) {
 #if _OSX_AU_DEBUG_
-        std::ostringstream msg;
-        msg << "Unable to retrieve audio object ids: " << err;
-        GR_LOG_ERROR(logger, msg.str());
+        logger->error("Unable to retrieve audio object ids: {}", err);
 #endif
         return;
     }
@@ -233,9 +229,7 @@ void find_audio_devices(const std::string& device_name,
         if ((err = AudioObjectGetPropertyData(
                  t_id, &ao_address, 0, NULL, &prop_size, (void*)c_name_buf)) != noErr) {
 #if _OSX_AU_DEBUG_
-            std::ostringstream msg;
-            msg << "Unable to retrieve audio device name #" << (nn + 1) << ": " << err;
-            GR_LOG_ERROR(logger, msg.str());
+            logger->error("Unable to retrieve audio device name #{:d}: {}", nn + 1, err);
 #endif
             continue;
         }

--- a/gr-audio/lib/osx/osx_source.cc
+++ b/gr-audio/lib/osx/osx_source.cc
@@ -17,7 +17,6 @@
 
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
-#include <boost/format.hpp>
 #include <stdexcept>
 
 namespace gr {
@@ -74,7 +73,7 @@ osx_source::osx_source(int sample_rate, const std::string& device_name, bool ok_
     // set the desired output sample rate
 
     if (sample_rate <= 0) {
-        GR_LOG_ERROR(d_logger, boost::format("Invalid Sample Rate: %d") % sample_rate);
+        d_logger->error("Invalid Sample Rate: {:d}", sample_rate);
         throw std::invalid_argument("audio_osx_source");
     } else {
         d_output_sample_rate = (Float64)sample_rate;
@@ -110,9 +109,7 @@ void osx_source::setup()
             if (all_names[0].compare(d_desired_name) != 0) {
 
                 // yes: log the full device name
-                GR_LOG_INFO(d_logger,
-                            boost::format("Using input audio device '%s'.") %
-                                all_names[0]);
+                d_logger->info("Using input audio device '{:s}'.", all_names[0]);
             }
 
             // store info on this device
@@ -137,7 +134,7 @@ void osx_source::setup()
             for (UInt32 nn = 0; nn < all_names.size(); ++nn) {
                 err_str += "    " + all_names[nn] + "\n";
             }
-            GR_LOG_ERROR(d_logger, boost::format(err_str));
+            d_logger->error(err_str);
             throw std::runtime_error("audio_osx_source::setup");
         }
     }
@@ -184,14 +181,13 @@ void osx_source::setup()
 
             } else {
 
-                GR_LOG_INFO(d_logger,
-                            boost::format("\n\nUsing input audio device '%s'.\n  ... "
-                                          "which is the current default input audio"
-                                          " device.\n  Changing the default input"
-                                          " audio device in the System Preferences"
-                                          " will \n  result in changing it here, too "
-                                          "(with an internal reconfiguration).\n") %
-                                std::string(c_name_buf));
+                d_logger->info("\n\nUsing input audio device '{:s}'.\n  ... "
+                               "which is the current default input audio"
+                               " device.\n  Changing the default input"
+                               " audio device in the System Preferences"
+                               " will \n  result in changing it here, too "
+                               "(with an internal reconfiguration).\n",
+                               std::string(c_name_buf));
             }
 
             d_selected_name = c_name_buf;
@@ -221,8 +217,7 @@ void osx_source::setup()
         (d_output_sample_rate < 50000.0 ? 50000 : (UInt32)d_output_sample_rate);
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("source(): max # samples = %d") % d_buffer_sample_count);
+    d_debug_logger->debug("source(): max # samples = {:d}", d_buffer_sample_count);
 #endif
 
     // create the default AudioUnit for input
@@ -245,7 +240,7 @@ void osx_source::setup()
 
     AudioComponent comp = AudioComponentFindNext(NULL, &desc);
     if (!comp) {
-        GR_LOG_FATAL(d_logger, boost::format("AudioComponentFindNext Failed"));
+        d_logger->fatal("AudioComponentFindNext Failed");
         throw std::runtime_error("audio_osx_source::setup");
     }
     err = AudioComponentInstanceNew(comp, &d_input_au);
@@ -256,7 +251,7 @@ void osx_source::setup()
 
     Component comp = FindNextComponent(NULL, &desc);
     if (!comp) {
-        GR_LOG_FATAL(d_logger, boost::format("FindNextComponent Failed"));
+        d_logger->fatal("FindNextComponent Failed");
         throw std::runtime_error("audio_osx_source::setup");
     }
     err = OpenAComponent(comp, &d_input_au);
@@ -332,9 +327,8 @@ void osx_source::setup()
         err, "Get Device Input Stream Format (before) failed", "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("\n---- Device Stream Format (before) ----\n%s\n") %
-                     d_asbd_device);
+    d_debug_logger->debug("\n---- Device Stream Format (before) ----\n{:s}\n",
+                          d_asbd_device);
 #endif
 
     // try to set the device (input) side of the audio device to the
@@ -365,9 +359,8 @@ void osx_source::setup()
         err, "Get Device Input Stream Format (after) failed", "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("\n---- Device Stream Format (after) ----\n%s\n") %
-                     d_asbd_device);
+    d_debug_logger->debug("\n---- Device Stream Format (after) ----\n{:s}\n",
+                          d_asbd_device);
 #endif
 
     d_device_sample_rate = d_asbd_device.mSampleRate;
@@ -387,9 +380,8 @@ void osx_source::setup()
                           "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("---- Client Stream Format (Before) ----\n%s\n") %
-                     d_asbd_client);
+    d_debug_logger->debug("---- Client Stream Format (Before) ----\n{:s}\n",
+                          d_asbd_client);
 #endif
 
     // Set the format of all the AUs to the
@@ -436,9 +428,8 @@ void osx_source::setup()
         err, "Get Device Output Stream Format (after) failed", "audio_osx_source::setup");
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("---- Client Stream Format (After) ----\n%s\n") %
-                     d_asbd_client);
+    d_debug_logger->debug("---- Client Stream Format (After) ----\n{:s}\n",
+                          d_asbd_client);
 #endif
 
     d_pass_through = (d_asbd_client.mSampleRate == d_output_sample_rate);
@@ -645,27 +636,31 @@ void osx_source::setup()
     check_error_and_throw(err, "AudioUnitInitialize", "audio_osx_source::check_channels");
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format(R"EOF(
+    d_debug_logger->debug(R"EOF(
 audio_osx_source Parameters:
-  Device Sample Rate is %d
-  Client Sample Rate is %d
-  User Sample Rate is %d
-  Do Passthrough is %s
-  Max Sample Count is %d
-  # Device Channels is %d
-  Device Buffer Size in Frames = %d
-  Lead Size in Frames = %d
-  Trail Size in Frames = %d
-  Input Buffer Size in Frames = %d
-  Output Buffer Size in Frames = %d
-)EOF") % d_device_sample_rate %
-                     (d_pass_through ? d_output_sample_rate : d_device_sample_rate) %
-                     d_output_sample_rate % (d_pass_through ? "true" : "false") %
-                     d_buffer_sample_count % d_n_dev_channels %
-                     d_device_buffer_size_frames % d_lead_size_frames %
-                     d_trail_size_frames % d_input_buffer_size_frames %
-                     d_output_buffer_size_frames);
+  Device Sample Rate is {:d}
+  Client Sample Rate is {:d}
+  User Sample Rate is {:d}
+  Do Passthrough is {:s}
+  Max Sample Count is {:d}
+  # Device Channels is {:d}
+  Device Buffer Size in Frames = {:d}
+  Lead Size in Frames = {:d}
+  Trail Size in Frames = {:d}
+  Input Buffer Size in Frames = {:d}
+  Output Buffer Size in Frames = {:d}
+)EOF",
+                          d_device_sample_rate,
+                          d_pass_through ? d_output_sample_rate : d_device_sample_rate,
+                          d_output_sample_rate,
+                          d_pass_through ? "true" : "false",
+                          d_buffer_sample_count,
+                          d_n_dev_channels,
+                          d_device_buffer_size_frames,
+                          d_lead_size_frames,
+                          d_trail_size_frames,
+                          d_input_buffer_size_frames,
+                          d_output_buffer_size_frames);
 #endif
 }
 
@@ -682,9 +677,9 @@ void osx_source::alloc_audio_buffer_list(AudioBufferList** t_abl,
     int counter = n_channels;
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("alloc_audio_buffer_list: (#chan, #bytes) == (%d, %d)") %
-                     n_channels % input_buffer_size_bytes);
+    d_debug_logger->debug("alloc_audio_buffer_list: (#chan, #bytes) == ({:d}, {:d})",
+                          n_channels,
+                          input_buffer_size_bytes);
 #endif
 
     while (--counter >= 0) {
@@ -732,17 +727,15 @@ bool osx_source::is_running()
 bool osx_source::start()
 {
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::start: Starting.") %
-                     ((void*)(pthread_self())));
+    d_debug_logger->debug("{:p} : audio_osx_source::start: Starting.",
+                          (void*)pthread_self());
 #endif
 
     if ((!is_running()) && d_input_au) {
 
 #if _OSX_AU_DEBUG_
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("%s : audio_osx_source::start: Starting Audio Unit.") %
-                         ((void*)(pthread_self())));
+        d_debug_logger->debug("{:p} : audio_osx_source::start: Starting Audio Unit.",
+                              (void*)pthread_self());
 #endif
 
         // reset buffers before starting
@@ -763,9 +756,8 @@ bool osx_source::start()
     }
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::start: Returning.") %
-                     (void*)(pthread_self()));
+    d_debug_logger->debug("{:p} : audio_osx_source::start: Returning.",
+                          (void*)pthread_self());
 
 #endif
 
@@ -775,16 +767,14 @@ bool osx_source::start()
 bool osx_source::stop()
 {
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::stop: Starting.") %
-                     ((void*)(pthread_self())));
+    d_debug_logger->debug("{:p} : audio_osx_source::stop: Starting.",
+                          (void*)pthread_self());
 #endif
     if (is_running()) {
 
 #if _OSX_AU_DEBUG_
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("%s : audio_osx_source::stop: stopping audio unit.") %
-                         ((void*)(pthread_self())));
+        d_debug_logger->debug("{:p} : audio_osx_source::stop: stopping audio unit.",
+                              (void*)pthread_self());
 #endif
 
         // stop the audio unit
@@ -800,9 +790,8 @@ bool osx_source::stop()
     }
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::stop: Returning.") %
-                     ((void*)(pthread_self())));
+    d_debug_logger->debug("{:p} : audio_osx_source::stop: Returning.",
+                          (void*)pthread_self());
 #endif
 
     return (true);
@@ -811,9 +800,8 @@ bool osx_source::stop()
 void osx_source::teardown()
 {
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::teardown: Starting.") %
-                     ((void*)(pthread_self())));
+    d_debug_logger->debug("{:p} : audio_osx_source::teardown: Starting.",
+                          (void*)pthread_self());
 #endif
 
     OSStatus err = noErr;
@@ -937,9 +925,8 @@ void osx_source::teardown()
     d_using_default_device = false;
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::teardown: Returning.") %
-                     ((void*)(pthread_self())));
+    d_debug_logger->debug("{:p} : audio_osx_source::teardown: Returning.",
+                          (void*)pthread_self());
 #endif
 }
 
@@ -948,21 +935,20 @@ bool osx_source::check_topology(int ninputs, int noutputs)
     // check # inputs to make sure it's valid
     if (ninputs != 0) {
 
-        GR_LOG_FATAL(d_logger,
-                     boost::format("check_topology(): number of input "
-                                   "streams provided (%d) should be 0.") %
-                         ninputs);
+        d_logger->fatal("check_topology(): number of input "
+                        "streams provided ({:d}) should be 0.",
+                        ninputs);
         throw std::runtime_error("audio_osx_source::check_topology");
     }
 
     // check # outputs to make sure it's valid
     if ((noutputs < 1) | (noutputs > (int)d_n_dev_channels)) {
 
-        GR_LOG_FATAL(d_logger,
-                     boost::format("check_topology(): number of output "
-                                   "streams provided (%d) should be in [1,%d] "
-                                   "for the selected input audio device.") %
-                         noutputs % d_n_dev_channels);
+        d_logger->fatal("check_topology(): number of output "
+                        "streams provided ({:d}) should be in [1,{:d}] "
+                        "for the selected input audio device.",
+                        noutputs,
+                        d_n_dev_channels);
         throw std::runtime_error("audio_osx_source::check_topology");
     }
 
@@ -971,9 +957,7 @@ bool osx_source::check_topology(int ninputs, int noutputs)
     d_n_user_channels = noutputs;
 
 #if _OSX_AU_DEBUG_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("chk_topo: Actual # user output channels = %d") %
-                     noutputs);
+    d_debug_logger->debug("chk_topo: Actual # user output channels = {:d}", noutputs);
 #endif
 
     return (true);
@@ -984,9 +968,8 @@ int osx_source::work(int noutput_items,
                      gr_vector_void_star& output_items)
 {
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("%s : audio_osx_source::work: Starting.") %
-                     ((void*)(pthread_self())));
+    d_debug_logger->debug("{:p} : audio_osx_source::work: Starting.",
+                          (void*)pthread_self());
 #endif
     if (d_do_reset) {
         if (d_hardware_changed) {
@@ -1001,10 +984,9 @@ int osx_source::work(int noutput_items,
             }
             if (!found) {
 
-                GR_LOG_FATAL(d_logger,
-                             boost::format("The selected input audio device ('%s') "
-                                           "is no longer available.\n") %
-                                 d_selected_name);
+                d_logger->fatal("The selected input audio device ('{:s}') "
+                                "is no longer available.\n",
+                                d_selected_name);
                 return (gr::block::WORK_DONE);
             }
 
@@ -1013,13 +995,12 @@ int osx_source::work(int noutput_items,
         } else {
 
 #if _OSX_AU_DEBUG_RENDER_
-            GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: doing reset.");
+            d_debug_logger->debug("audio_osx_source::work: doing reset.");
 #endif
 
-            GR_LOG_WARN(d_logger,
-                        "\n\nThe default input audio device has "
-                        "changed; resetting audio.\nThere may "
-                        "be a sound glitch while resetting.\n");
+            d_logger->warn("\n\nThe default input audio device has "
+                           "changed; resetting audio.\nThere may "
+                           "be a sound glitch while resetting.\n");
 
             // for any changes, just tear down the current
             // configuration, then set it up again using the user's
@@ -1030,15 +1011,14 @@ int osx_source::work(int noutput_items,
             gr::thread::scoped_lock l(d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
-            GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: mutex locked.");
+            d_debug_logger->debug("audio_osx_source::work: mutex locked.");
 #endif
 
             setup();
             start();
 
 #if _OSX_AU_DEBUG_RENDER_
-            GR_LOG_DEBUG(d_debug_logger,
-                         "audio_osx_source::work: returning after reset.");
+            d_debug_logger->debug("audio_osx_source::work: returning after reset.");
 #endif
             return (0);
         }
@@ -1047,11 +1027,12 @@ int osx_source::work(int noutput_items,
     gr::thread::scoped_lock l(d_internal);
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: mutex locked.");
+    d_debug_logger->debug("audio_osx_source::work: mutex locked.");
 
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("work1: SC=%d, #OI=%d, #Chan=%d") % d_queue_sample_count %
-                     noutput_items % output_items.size());
+    d_debug_logger->debug("work1: SC={:d}, #OI={:d}, #Chan={:d}",
+                          d_queue_sample_count,
+                          noutput_items,
+                          output_items.size());
 #endif
 
     // set the actual # of output items to the 'desired' amount then
@@ -1071,13 +1052,13 @@ int osx_source::work(int noutput_items,
                     // release control so-as to allow data to be retrieved;
                     // block until there is data to return
 #if _OSX_AU_DEBUG_RENDER_
-                    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: waiting.");
+                    d_debug_logger->debug("audio_osx_source::work: waiting.");
 #endif
                     d_waiting_for_data = true;
                     d_cond_data.wait(l);
                     d_waiting_for_data = false;
 #if _OSX_AU_DEBUG_RENDER_
-                    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: done waiting.");
+                    d_debug_logger->debug("audio_osx_source::work: done waiting.");
 #endif
                     // the condition's 'notify' was called; acquire control to
                     // keep thread safe
@@ -1086,8 +1067,8 @@ int osx_source::work(int noutput_items,
                     // up the next time this method is called.
                     if (d_do_reset) {
 #if _OSX_AU_DEBUG_RENDER_
-                        GR_LOG_DEBUG(d_debug_logger,
-                                     "audio_osx_source::work: returning for reset.");
+                        d_debug_logger->debug(
+                            "audio_osx_source::work: returning for reset.");
 #endif
                         return (0);
                     }
@@ -1095,8 +1076,7 @@ int osx_source::work(int noutput_items,
             } else {
                 // no data & not blocking; return nothing
 #if _OSX_AU_DEBUG_RENDER_
-                GR_LOG_DEBUG(
-                    d_debug_logger,
+                d_debug_logger->debug(
                     "audio_osx_source::work: no data & not blocking; returning 0.");
 #endif
                 return (0);
@@ -1108,9 +1088,8 @@ int osx_source::work(int noutput_items,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("audio_osx_source::work: copying %d items per channel") %
-                     actual_noutput_items);
+    d_debug_logger->debug("audio_osx_source::work: copying {:d} items per channel",
+                          actual_noutput_items);
 #endif
 
     // number of channels
@@ -1126,11 +1105,10 @@ int osx_source::work(int noutput_items,
 
         if (t_n_output_items != actual_noutput_items) {
 
-            GR_LOG_FATAL(d_logger,
-                         boost::format("work(): ERROR: number of available "
-                                       "items changing unexpectedly; expecting %d"
-                                       ", got %d.") %
-                             actual_noutput_items % t_n_output_items);
+            d_logger->fatal("work(): ERROR: number of available "
+                            "items changing unexpectedly; expecting {:d}, got {:d}.",
+                            actual_noutput_items,
+                            t_n_output_items);
             throw std::runtime_error("audio_osx_source::work()");
         }
     }
@@ -1141,12 +1119,12 @@ int osx_source::work(int noutput_items,
     d_queue_sample_count -= actual_noutput_items;
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("work2: SC = %d, act#OI = %d\nReturning.") %
-                     d_queue_sample_count % actual_noutput_items);
+    d_debug_logger->debug("work2: SC = {:d}, act#OI = {:d}\nReturning.",
+                          d_queue_sample_count,
+                          actual_noutput_items);
 #endif
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::work: returning.");
+    d_debug_logger->debug("audio_osx_source::work: returning.");
 #endif
 
     return (actual_noutput_items);
@@ -1171,9 +1149,10 @@ OSStatus osx_source::converter_callback(AudioConverterRef in_audio_converter,
     This->d_n_actual_input_frames = (*io_number_data_packets);
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("cc1: io#DP = %d, TIBSB = %d, #C = %d") %
-                     (*io_number_data_packets) % total_input_buffer_size_bytes % counter);
+    d_debug_logger->debug("cc1: io#DP = {:d}, TIBSB = {:d}, #C = {:d}",
+                          *io_number_data_packets,
+                          total_input_buffer_size_bytes,
+                          counter);
 #endif
 
     while (--counter >= 0) {
@@ -1184,7 +1163,7 @@ OSStatus osx_source::converter_callback(AudioConverterRef in_audio_converter,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger, "cc2: Returning.");
+    d_debug_logger->debug("cc2: Returning.");
 #endif
 
     return (noErr);
@@ -1198,9 +1177,9 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
                                        AudioBufferList* io_data)
 {
 #if _OSX_AU_DEBUG_RENDER_
-    // GR_LOG_DEBUG(This->d_debug_logger, boost::format("%s :
-    // audio_osx_source::au_input_callback: Starting." )
-    //         % ((void*)(pthread_self())));
+    // This->d_debug_logger->debug("{:p} : audio_osx_source::au_input_callback:
+    //                             Starting.",
+    //                             (void*)pthread_self());
 #endif
 
     osx_source* This = reinterpret_cast<osx_source*>(in_ref_con);
@@ -1209,19 +1188,20 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
     gr::logger_ptr d_debug_logger = This->d_debug_logger;
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger, "audio_osx_source::au_input_callback: mutex locked.");
+    d_debug_logger->debug("audio_osx_source::au_input_callback: mutex locked.");
 #endif
 
     OSStatus err = noErr;
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(
-        d_debug_logger,
-        boost::format(
-            "cb0: in#Fr = %d, inBus# = %d, idD = %d, d_ib = %d, d_ib#c = %d, SC = %d") %
-            in_number_frames % in_bus_number % ((void*)io_data) %
-            ((void*)(This->d_input_buffer)) % This->d_input_buffer->mNumberBuffers %
-            This->d_queue_sample_count);
+    d_debug_logger->debug("cb0: in#Fr = {:d}, inBus# = {:d}, idD = {:p}, d_ib = {:p}, "
+                          "d_ib#c = {:d}, SC = {:d}",
+                          in_number_frames,
+                          in_bus_number,
+                          (void*)io_data,
+                          (void*)(This->d_input_buffer),
+                          This->d_input_buffer->mNumberBuffers,
+                          This->d_queue_sample_count);
 #endif
 
     if (This->d_do_reset) {
@@ -1296,9 +1276,9 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
 #endif
 
 #if _OSX_AU_DEBUG_RENDER_
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("cb1:  avail: #IF = %d, #OF = %d") %
-                         available_input_frames % available_output_frames);
+        d_debug_logger->debug("cb1:  avail: #IF = {:d}, #OF = {:d}",
+                              available_input_frames,
+                              available_output_frames);
 #endif
         actual_output_frames = available_output_frames;
 
@@ -1321,14 +1301,14 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
         // output frames
 
 #if _OSX_AU_DEBUG_RENDER_
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("cb2: actual: #IF = %d, #OF = %d") %
-                         This->d_n_actual_input_frames % actual_output_frames);
+        d_debug_logger->debug("cb2: actual: #IF = {:d}, #OF = {:d}",
+                              This->d_n_actual_input_frames,
+                              actual_output_frames);
 
         if (This->d_n_actual_input_frames != available_input_frames)
-            GR_LOG_WARN(d_debug_logger,
-                        boost::format("cb2.1: (avail#IF = %d) != (actual#IF = %d)") %
-                            available_input_frames % This->d_n_actual_input_frames);
+            d_debug_logger->warn("cb2.1: (avail#IF = {:d}) != (actual#IF = {:d})",
+                                 available_input_frames,
+                                 This->d_n_actual_input_frames);
 #endif
     }
 
@@ -1341,7 +1321,7 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
         float* in_buffer = (float*)This->d_output_buffer->mBuffers[counter].mData;
 
 #if _OSX_AU_DEBUG_RENDER_
-        GR_LOG_DEBUG(d_debug_logger, "cb3: enqueuing audio data.");
+        d_debug_logger->debug("cb3: enqueuing audio data.");
 #endif
 
         int l_res = This->d_buffers[counter]->enqueue(in_buffer, actual_output_frames);
@@ -1362,10 +1342,10 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("cb4: #OI = %d, #Cnt = %d, mSC = %d") %
-                     actual_output_frames % This->d_queue_sample_count %
-                     This->d_buffer_sample_count);
+    d_debug_logger->debug("cb4: #OI = {:d}, #Cnt = {:d}, mSC = {:d}",
+                          actual_output_frames,
+                          This->d_queue_sample_count,
+                          This->d_buffer_sample_count);
 #endif
 
     // signal that data is available, if appropriate
@@ -1375,7 +1355,7 @@ OSStatus osx_source::au_input_callback(void* in_ref_con,
     }
 
 #if _OSX_AU_DEBUG_RENDER_
-    GR_LOG_DEBUG(d_debug_logger, "cb5: returning.");
+    d_debug_logger->debug("cb5: returning.");
 #endif
 
     return (err);

--- a/gr-audio/lib/portaudio/portaudio_source.cc
+++ b/gr-audio/lib/portaudio/portaudio_source.cc
@@ -22,7 +22,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <unistd.h>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
@@ -59,9 +58,9 @@ void portaudio_source::create_ringbuffer(void)
         d_portaudio_buffer_size_frames * d_input_parameters.channelCount;
 
     if (d_verbose)
-        GR_LOG_INFO(d_debug_logger,
-                    boost::format("ring buffer size  = %d frames") %
-                        (N_BUFFERS * bufsize_samples / d_input_parameters.channelCount));
+        d_debug_logger->info("ring buffer size  = {:d} frames",
+                             N_BUFFERS * bufsize_samples /
+                                 d_input_parameters.channelCount);
 
     // FYI, the buffer indices are in units of samples.
     d_writer = gr::make_buffer(
@@ -116,7 +115,7 @@ int portaudio_source_callback(const void* inputBuffer,
             gr::logger_ptr logger, debug_logger;
             gr::configure_default_loggers(
                 logger, debug_logger, "portaudio_source_callback");
-            GR_LOG_ERROR(logger, boost::format("write error: %s") % strerror(errno));
+            logger->error("write error: {:s}", strerror(errno));
         }
 
         self->d_ringbuffer_ready = false;
@@ -169,26 +168,24 @@ portaudio_source::portaudio_source(int sampling_rate,
         // FIXME Get smarter about picking something
         device = Pa_GetDefaultInputDevice();
         deviceInfo = Pa_GetDeviceInfo(device);
-        GR_LOG_ERROR(d_logger,
-                     boost::format("%s is the chosen device using %s as the host") %
-                         deviceInfo->name % Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
+        d_logger->error("{:s} is the chosen device using {:s} as the host",
+                        deviceInfo->name,
+                        Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
     } else {
         bool found = false;
-        GR_LOG_INFO(d_debug_logger, "Test Devices");
+        d_debug_logger->info("Test Devices");
         for (i = 0; i < numDevices; i++) {
             deviceInfo = Pa_GetDeviceInfo(i);
-            GR_LOG_INFO(d_debug_logger,
-                        boost::format("Testing device name: %s...") % deviceInfo->name);
+            d_debug_logger->info("Testing device name: {:s}...", deviceInfo->name);
             if (deviceInfo->maxInputChannels <= 0) {
                 continue;
             }
             if (strstr(deviceInfo->name, d_device_name.c_str())) {
-                GR_LOG_INFO(d_debug_logger, "  Chosen!");
+                d_debug_logger->info("  Chosen!");
                 device = i;
-                GR_LOG_INFO(d_debug_logger,
-                            boost::format("%s using %s as the host") %
-                                d_device_name.c_str() %
-                                Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
+                d_debug_logger->info("{:s} using {:s} as the host",
+                                     d_device_name,
+                                     Pa_GetHostApiInfo(deviceInfo->hostApi)->name);
                 found = true;
                 deviceInfo = Pa_GetDeviceInfo(device);
                 i = numDevices; // force loop exit
@@ -233,9 +230,9 @@ bool portaudio_source::check_topology(int ninputs, int noutputs)
 #if 1
     d_portaudio_buffer_size_frames =
         (int)(0.0213333333 * d_sampling_rate + 0.5); // Force 512 frame buffers at 48000
-    GR_LOG_ERROR(d_logger,
-                 boost::format("Latency = %8.5f, requested sampling_rate = %g") %
-                     0.0213333333 % (double)d_sampling_rate);
+    d_logger->error("Latency = {:8.5f}, requested sampling_rate = {:g}",
+                    0.0213333333,
+                    (double)d_sampling_rate);
 #endif
     err = Pa_OpenStream(&d_stream,
                         &d_input_parameters,
@@ -252,16 +249,16 @@ bool portaudio_source::check_topology(int ninputs, int noutputs)
     }
 
 #if 0
-        const PaStreamInfo *psi = Pa_GetStreamInfo(d_stream);
+    const PaStreamInfo* psi = Pa_GetStreamInfo(d_stream);
 
-        d_portaudio_buffer_size_frames = (int)(d_input_parameters.suggestedLatency  * psi->sampleRate);
-        GR_LOG_ERROR(d_logger,
-                     boost::format("Latency = %7.4f, psi->sampleRate = %g") %
-                     d_input_parameters.suggestedLatency % psi->sampleRate);
+    d_portaudio_buffer_size_frames =
+        (int)(d_input_parameters.suggestedLatency * psi->sampleRate);
+    d_logger->error("Latency = {:7.4f}, psi->sampleRate = {:g}",
+                    d_input_parameters.suggestedLatency,
+                    psi->sampleRate);
 #endif
-    GR_LOG_ERROR(d_logger,
-                 boost::format("d_portaudio_buffer_size_frames = %d") %
-                     d_portaudio_buffer_size_frames);
+    d_logger->error("d_portaudio_buffer_size_frames = {:d}",
+                    d_portaudio_buffer_size_frames);
 
     assert(d_portaudio_buffer_size_frames != 0);
 
@@ -356,9 +353,7 @@ int portaudio_source::work(int noutput_items,
 
 void portaudio_source::output_error_msg(const char* msg, int err)
 {
-    GR_LOG_ERROR(d_logger,
-                 boost::format("%s: %s %s") % d_device_name.c_str() % msg %
-                     Pa_GetErrorText(err));
+    d_logger->error("{:s}: {:s} {:s}", d_device_name, msg, Pa_GetErrorText(err));
 }
 
 void portaudio_source::bail(const char* msg, int err)

--- a/gr-audio/lib/windows/windows_source.cc
+++ b/gr-audio/lib/windows/windows_source.cc
@@ -22,7 +22,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <boost/format.hpp>
 #include <cctype>
 #include <sstream>
 #include <stdexcept>
@@ -92,11 +91,10 @@ windows_source::windows_source(int sampling_freq, const std::string device_name)
 
     gr::logger_ptr logger, debug_logger;
     if (open_wavein_device() < 0) {
-        GR_LOG_ERROR(logger,
-                     boost::format("open_wavein_device() failed %s") % strerror(errno));
+        logger->error("open_wavein_device() failed {:s}", strerror(errno));
         throw std::runtime_error("audio_windows_source:open_wavein_device() failed");
     } else {
-        GR_LOG_INFO(d_debug_logger, "Opened windows wavein device");
+        d_debug_logger->info("Opened windows wavein device");
     }
     lp_buffers = new LPWAVEHDR[nPeriods];
     for (int i = 0; i < nPeriods; i++) {
@@ -108,20 +106,18 @@ windows_source::windows_source(int sampling_freq, const std::string device_name)
         lp_buffer->lpData = new CHAR[d_buffer_size];
         MMRESULT w_result = waveInPrepareHeader(d_h_wavein, lp_buffer, sizeof(WAVEHDR));
         if (w_result != 0) {
-            GR_LOG_ERROR(logger,
-                         boost::format("Failed to waveInPrepareHeader %s") %
-                             strerror(errno));
+            logger->error("Failed to waveInPrepareHeader {:s}", strerror(errno));
             throw std::runtime_error("open_wavein_device() failed");
         }
         waveInAddBuffer(d_h_wavein, lp_buffer, sizeof(WAVEHDR));
     }
     waveInStart(d_h_wavein);
     if (verbose) {
-        GR_LOG_INFO(
-            d_debug_logger,
-            boost::format(
-                "Initialized %1% %2% ms audio buffers, total memory used: %3$0.2f kiB") %
-                (nPeriods) % (CHUNK_TIME * 1000) % ((d_buffer_size * nPeriods) / 1024.0));
+        d_debug_logger->info(
+            "Initialized {:d} {:g} ms audio buffers, total memory used: {:0.2f} kiB",
+            nPeriods,
+            CHUNK_TIME * 1000,
+            (d_buffer_size * nPeriods) / 1024.0);
     }
 }
 
@@ -234,10 +230,9 @@ UINT windows_source::find_device(std::string szDeviceName)
             if (num < num_devices) {
                 result = num;
             } else {
-                GR_LOG_WARN(logger,
-                            boost::format("waveIn deviceID %d was not found, "
-                                          "defaulting to WAVE_MAPPER") %
-                                num);
+                logger->warn("waveIn deviceID {:d} was not found, "
+                             "defaulting to WAVE_MAPPER",
+                             num);
                 result = WAVE_MAPPER;
             }
 
@@ -246,31 +241,26 @@ UINT windows_source::find_device(std::string szDeviceName)
             for (UINT i = 0; i < num_devices; i++) {
                 WAVEINCAPS woc;
                 if (waveInGetDevCaps(i, &woc, sizeof(woc)) != MMSYSERR_NOERROR) {
-                    GR_LOG_ERROR(logger,
-                                 boost::format("Could not retrieve wave out device "
-                                               "capabilities for device %s") %
-                                     strerror(errno));
+                    logger->error("Could not retrieve wave out device "
+                                  "capabilities for device {:s}",
+                                  strerror(errno));
                     return -1;
                 }
                 if (woc.szPname == szDeviceName) {
                     result = i;
                 }
                 if (verbose)
-                    GR_LOG_INFO(d_debug_logger,
-                                boost::format("WaveIn Device %d: %s") % i % woc.szPname);
+                    d_debug_logger->info("WaveIn Device {:d}: {:s}", i, woc.szPname);
             }
             if (result == -1) {
-                GR_LOG_INFO(d_debug_logger,
-                            boost::format("Warning: waveIn device '%s' was not found, "
-                                          "defaulting to WAVE_MAPPER") %
-                                szDeviceName);
+                d_debug_logger->info("Warning: waveIn device '{:s}' was not found, "
+                                     "defaulting to WAVE_MAPPER",
+                                     szDeviceName);
                 result = WAVE_MAPPER;
             }
         }
     } else {
-        GR_LOG_ERROR(logger,
-                     boost::format("No WaveIn devices present or accessible: %s") %
-                         strerror(errno));
+        logger->error("No WaveIn devices present or accessible: {:s}", strerror(errno));
     }
     return result;
 }
@@ -298,19 +288,16 @@ int windows_source::open_wavein_device(void)
         // and stick with WAVE_MAPPER
         u_device_id = find_device(d_device_name);
     if (verbose)
-        GR_LOG_INFO(d_debug_logger,
-                    boost::format("waveIn Device ID: %1%") % (u_device_id));
+        d_debug_logger->info("waveIn Device ID: {:d}", u_device_id);
 
     // Check if the sampling rate/bits/channels are good to go with the device.
     MMRESULT supported = is_format_supported(&wave_format, u_device_id);
     if (supported != MMSYSERR_NOERROR) {
         char err_msg[50];
         waveInGetErrorText(supported, err_msg, 50);
-        GR_LOG_INFO(d_debug_logger, boost::format("format error: %s") % err_msg);
-        GR_LOG_ERROR(logger,
-                     boost::format(
-                         "Requested audio format is not supported by device driver: %s") %
-                         strerror(errno));
+        d_debug_logger->info("format error: {:s}", err_msg);
+        logger->error("Requested audio format is not supported by device driver: {:s}",
+                      strerror(errno));
         return -1;
     }
 
@@ -323,9 +310,7 @@ int windows_source::open_wavein_device(void)
                         CALLBACK_FUNCTION | WAVE_ALLOWSYNC);
 
     if (result) {
-        GR_LOG_ERROR(logger,
-                     boost::format("Failed to open waveform output device: %s") %
-                         strerror(errno));
+        logger->error("Failed to open waveform output device: {:s}", strerror(errno));
         return -1;
     }
     return 0;
@@ -338,9 +323,8 @@ static void CALLBACK read_wavein(
     if (uMsg == WIM_DATA) {
         if (!dwInstance) {
             gr::logger_ptr logger;
-            GR_LOG_ERROR(logger,
-                         boost::format("callback function missing buffer queue: %s") %
-                             strerror(errno));
+            logger->error("callback function missing buffer queue: {:s}",
+                          strerror(errno));
         }
         LPWAVEHDR lp_wave_hdr = (LPWAVEHDR)dwParam1; // The new audio data
         boost::lockfree::spsc_queue<LPWAVEHDR>* q =


### PR DESCRIPTION
## Description
This continues the work started in https://github.com/gnuradio/gnuradio/pull/5270. Here I've updated gr-audio to use modern logging, and removed all usage of Boost.Format.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* Audio Sink
* Audio Source

## Testing Done
None yet. I'd appreciate help from people familiar with gr-audio.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
