### PR TITLE
runtime: Remove boost::format and modernize logging

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_body_wrapper.h
@@ -49,13 +49,10 @@ public:
                 d_f();
             } catch (boost::thread_interrupted const&) {
             } catch (std::exception const& e) {
-                std::ostringstream msg;
-                msg << "ERROR thread[" << d_name << "]: " << e.what();
-                GR_LOG_ERROR(d_logger, msg.str());
+                d_logger->error("ERROR thread[{:s}]: {:s}", d_name, e.what());
             } catch (...) {
-                std::ostringstream msg;
-                msg << "ERROR thread[" << d_name << "]: caught unrecognized exception";
-                GR_LOG_ERROR(d_logger, msg.str());
+                d_logger->error("ERROR thread[{:s}]: caught unrecognized exception",
+                                d_name);
             }
 
         } else {

--- a/gnuradio-runtime/lib/basic_block.cc
+++ b/gnuradio-runtime/lib/basic_block.cc
@@ -179,9 +179,8 @@ void basic_block::insert_tail(pmt::pmt_t which_port, pmt::pmt_t msg)
     gr::thread::scoped_lock guard(mutex);
     const auto& queue = msg_queue.find(which_port);
     if (queue == msg_queue.end()) {
-        GR_LOG_ERROR(d_logger,
-                     std::string("attempted insertion on invalid queue ") +
-                         pmt::symbol_to_string(which_port));
+        d_logger->error("attempted insertion on invalid queue {:s}",
+                        pmt::symbol_to_string(which_port));
         throw std::runtime_error("attempted to insert_tail on invalid queue!");
     }
 

--- a/gnuradio-runtime/lib/block_detail.cc
+++ b/gnuradio-runtime/lib/block_detail.cc
@@ -224,7 +224,7 @@ void block_detail::set_processor_affinity(const std::vector<int>& mask)
         try {
             gr::thread::thread_bind_to_processor(thread, mask);
         } catch (std::runtime_error& e) {
-            GR_LOG_ERROR(d_logger, "set_processor_affinity: invalid mask.");
+            d_logger->error("set_processor_affinity: invalid mask.");
         }
     }
 }

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -273,7 +273,7 @@ block_executor::state block_executor::run_one_iteration()
     max_noutput_items = round_down(d_max_noutput_items, m->output_multiple());
 
     if (d->done()) {
-        GR_LOG_ERROR(d_logger, "unexpected done() in run_one_iteration");
+        d_logger->error("unexpected done() in run_one_iteration");
         return DONE;
     }
 
@@ -710,7 +710,7 @@ block_executor::state block_executor::run_one_iteration()
         // Have the caller try again...
         return READY_NO_OUTPUT;
     }
-    GR_LOG_ERROR(d_logger, "invalid state while going through iteration state machine");
+    d_logger->error("invalid state while going through iteration state machine");
 
 were_done:
     LOG(std::ostringstream msg; msg << m << " -- we're done";

--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -112,9 +112,7 @@ GNURadio::Knob rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
         // FIXME: Don't get loggers every time we need to log something.
         gr::logger_ptr logger, debug_logger;
         gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
-        std::ostringstream msg;
-        msg << "ERROR Don't know how to handle Knob Type (from): " << knob;
-        GR_LOG_ERROR(logger, msg.str());
+        logger->error("ERROR Don't know how to handle Knob Type (from): {}", knob);
         assert(0);
     }
     return GNURadio::Knob();
@@ -257,9 +255,7 @@ pmt::pmt_t rpcpmtconverter::to_pmt_f::operator()(const GNURadio::Knob& knob)
     // FIXME: Don't get loggers every time we need to log something.
     gr::logger_ptr logger, debug_logger;
     gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
-    std::ostringstream msg;
-    msg << "ERROR Don't know how to handle Knob Type (from): " << knob.type;
-    GR_LOG_ERROR(debug_logger, msg.str());
+    debug_logger->error("ERROR Don't know how to handle Knob Type (from): {}", knob.type);
     assert(0);
     return pmt::pmt_t();
 }

--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -77,7 +77,7 @@ void flowgraph::validate()
         std::vector<int> used_ports;
         int ninputs, noutputs;
 
-        GR_LOG_DEBUG(d_debug_logger, boost::format("Validating block: %s") % *p);
+        d_debug_logger->debug("Validating block: {}", *p);
 
         used_ports = calc_used_ports(*p, true); // inputs
         ninputs = used_ports.size();
@@ -125,16 +125,15 @@ void flowgraph::check_valid_port(gr::io_signature::sptr sig, int port)
 
 void flowgraph::check_valid_port(const msg_endpoint& e)
 {
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("check_valid_port(%s, %s)") % e.block() % e.port());
+    d_debug_logger->debug("check_valid_port({}, {})", e.block(), e.port());
 
     if (!e.block()->has_msg_port(e.port())) {
         const gr::basic_block::msg_queue_map_t& msg_map = e.block()->get_msg_map();
-        GR_LOG_WARN(d_logger, boost::format("Could not find port %s in:") % e.port());
+        d_logger->warn("Could not find port {} in:", e.port());
         for (gr::basic_block::msg_queue_map_t::const_iterator it = msg_map.begin();
              it != msg_map.end();
              ++it)
-            GR_LOG_WARN(d_logger, boost::format("  %s") % it->first);
+            d_logger->warn("  {}", it->first);
         throw std::invalid_argument("invalid msg port in connect() or disconnect()");
     }
 }

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -16,7 +16,6 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
-#include <boost/format.hpp>
 #include <sstream>
 #include <stdexcept>
 
@@ -76,9 +75,8 @@ void hier_block2_detail::connect(basic_block_sptr block)
     hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
 
     if (hblock && hblock.get() != d_owner) {
-        GR_LOG_DEBUG(
-            d_debug_logger,
-            boost::format("connect: block is hierarchical, setting parent to %s") % this);
+        d_debug_logger->debug("connect: block is hierarchical, setting parent to {:p}",
+                              (void*)this);
         hblock->d_detail->set_parent(this->d_owner);
     }
 
@@ -92,9 +90,8 @@ void hier_block2_detail::connect(basic_block_sptr src,
 {
     std::stringstream msg;
 
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("connecting: %s -> %s") % endpoint(src, src_port) %
-                     endpoint(dst, dst_port));
+    d_debug_logger->debug(
+        "connecting: {} -> {}", endpoint(src, src_port), endpoint(dst, dst_port));
 
     if (src.get() == dst.get())
         throw std::invalid_argument(
@@ -104,16 +101,14 @@ void hier_block2_detail::connect(basic_block_sptr src,
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if (src_block && src.get() != d_owner) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("connect: src is hierarchical, setting parent to %s") %
-                         this);
+        d_debug_logger->debug("connect: src is hierarchical, setting parent to {:p}",
+                              (void*)this);
         src_block->d_detail->set_parent(this->d_owner);
     }
 
     if (dst_block && dst.get() != d_owner) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("connect: dst is hierarchical, setting parent to %s") %
-                         this);
+        d_debug_logger->debug("connect: dst is hierarchical, setting parent to {:p}",
+                              (void*)this);
         dst_block->d_detail->set_parent(this->d_owner);
     }
 
@@ -150,7 +145,7 @@ void hier_block2_detail::msg_connect(basic_block_sptr src,
                                      basic_block_sptr dst,
                                      pmt::pmt_t dstport)
 {
-    GR_LOG_DEBUG(d_debug_logger, "connecting message port...");
+    d_debug_logger->debug("connecting message port...");
 
     // add block uniquely to list to internal blocks
     if (std::find(d_blocks.begin(), d_blocks.end(), dst) == d_blocks.end()) {
@@ -174,25 +169,25 @@ void hier_block2_detail::msg_connect(basic_block_sptr src,
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if (src_block && src.get() != d_owner) {
-        GR_LOG_DEBUG(
-            d_debug_logger,
-            boost::format("msg_connect: src is hierarchical, setting parent to %s") %
-                this);
+        d_debug_logger->debug("msg_connect: src is hierarchical, setting parent to {:p}",
+                              (void*)this);
         src_block->d_detail->set_parent(this->d_owner);
     }
 
     if (dst_block && dst.get() != d_owner) {
-        GR_LOG_DEBUG(
-            d_debug_logger,
-            boost::format("msg_connect: dst is hierarchical, setting parent to %s") %
-                this);
+        d_debug_logger->debug("msg_connect: dst is hierarchical, setting parent to {:p}",
+                              (void*)this);
         dst_block->d_detail->set_parent(this->d_owner);
     }
 
     // add edge for this message connection
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("msg_connect( (%s, %s, %d), (%s, %s, %d) )") % src %
-                     srcport % hier_out % dst % dstport % hier_in);
+    d_debug_logger->debug("msg_connect( ({}, {}, {:d}), ({}, {}, {:d}) )",
+                          src,
+                          srcport,
+                          hier_out,
+                          dst,
+                          dstport,
+                          hier_in);
     d_fg->connect(msg_endpoint(src, srcport, hier_out),
                   msg_endpoint(dst, dstport, hier_in));
 }
@@ -202,7 +197,7 @@ void hier_block2_detail::msg_disconnect(basic_block_sptr src,
                                         basic_block_sptr dst,
                                         pmt::pmt_t dstport)
 {
-    GR_LOG_DEBUG(d_debug_logger, "disconnecting message port...");
+    d_debug_logger->debug("disconnecting message port...");
 
     // remove edge for this message connection
     bool hier_in = false, hier_out = false;
@@ -260,8 +255,8 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
 
             hier_block2_sptr hblock(cast_to_hier_block2_sptr(block));
             if (hblock && hblock.get() != d_owner) {
-                GR_LOG_DEBUG(d_debug_logger,
-                             "disconnect: block is hierarchical, clearing parent");
+                d_debug_logger->debug(
+                    "disconnect: block is hierarchical, clearing parent");
                 hblock->d_detail->reset_parent();
             }
 
@@ -276,8 +271,7 @@ void hier_block2_detail::disconnect(basic_block_sptr block)
         if ((*p).src().block() == block || (*p).dst().block() == block) {
             edges.push_back(*p);
 
-            GR_LOG_DEBUG(d_debug_logger,
-                         boost::format("disconnect: block found in edge %s") % *p);
+            d_debug_logger->debug("disconnect: block found in edge {}", *p);
         }
     }
 
@@ -298,9 +292,8 @@ void hier_block2_detail::disconnect(basic_block_sptr src,
                                     basic_block_sptr dst,
                                     int dst_port)
 {
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("disconnecting: %s -> %s") % endpoint(src, src_port) %
-                     endpoint(dst, dst_port));
+    d_debug_logger->debug(
+        "disconnecting: {} -> {}", endpoint(src, src_port), endpoint(dst, dst_port));
 
     if (src.get() == dst.get())
         throw std::invalid_argument(
@@ -310,12 +303,12 @@ void hier_block2_detail::disconnect(basic_block_sptr src,
     hier_block2_sptr dst_block(cast_to_hier_block2_sptr(dst));
 
     if (src_block && src.get() != d_owner) {
-        GR_LOG_DEBUG(d_debug_logger, "disconnect: src is hierarchical, clearing parent");
+        d_debug_logger->debug("disconnect: src is hierarchical, clearing parent");
         src_block->d_detail->reset_parent();
     }
 
     if (dst_block && dst.get() != d_owner) {
-        GR_LOG_DEBUG(d_debug_logger, "disconnect: dst is hierarchical, clearing parent");
+        d_debug_logger->debug("disconnect: dst is hierarchical, clearing parent");
         dst_block->d_detail->reset_parent();
     }
 
@@ -448,9 +441,10 @@ endpoint_vector_t hier_block2_detail::resolve_port(int port, bool is_input)
 {
     std::stringstream msg;
 
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format("Resolving port %s as an %s of %s") % port %
-                     (is_input ? "input" : "output") % d_owner->name());
+    d_debug_logger->debug("Resolving port {:d} as an {:s} of {:s}",
+                          port,
+                          is_input ? "input" : "output",
+                          d_owner->name());
 
     endpoint_vector_t result;
 
@@ -501,7 +495,7 @@ endpoint_vector_t hier_block2_detail::resolve_port(int port, bool is_input)
 
 void hier_block2_detail::disconnect_all()
 {
-    GR_LOG_DEBUG(d_debug_logger, "Disconnect all...");
+    d_debug_logger->debug("Disconnect all...");
     reset_hier_blocks_parent();
     d_fg->clear();
     d_blocks.clear();
@@ -520,8 +514,7 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
 
     // Check if endpoint is a leaf node
     if (cast_to_block_sptr(endp.block())) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("Block %s is a leaf node, returning.") % endp.block());
+        d_debug_logger->debug("Block {} is a leaf node, returning.", endp.block());
         result.push_back(endp);
         return result;
     }
@@ -529,9 +522,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
     // Check if endpoint is a hierarchical block
     hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(endp.block()));
     if (hier_block2) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("Resolving endpoint %s as an %s, recursing") % endp %
-                         (is_input ? "input" : "output"));
+        d_debug_logger->debug("Resolving endpoint {} as an {:s}, recursing",
+                              endp,
+                              is_input ? "input" : "output");
         return hier_block2->d_detail->resolve_port(endp.port(), is_input);
     }
 
@@ -543,9 +536,9 @@ endpoint_vector_t hier_block2_detail::resolve_endpoint(const endpoint& endp,
 void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 {
     hier_block2_sptr parent = d_parent.lock();
-    GR_LOG_DEBUG(d_debug_logger,
-                 boost::format(" ** Flattening %s parent: %s") % d_owner->name() %
-                     (parent ? parent->name() : "NULL"));
+    d_debug_logger->debug(" ** Flattening {:s} parent: {:s}",
+                          d_owner->name(),
+                          parent ? parent->name() : "NULL");
     bool is_top_block = (dynamic_cast<top_block*>(d_owner) != NULL);
 
     // Add my edges to the flow graph, resolving references to actual endpoints
@@ -564,13 +557,11 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     bool set_all_max_buff = d_owner->all_max_output_buffer_p();
     // Get the min and max buffer length
     if (set_all_min_buff) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("Getting (%s) min buffer") % d_owner->alias());
+        d_debug_logger->debug("Getting ({:s}) min buffer", d_owner->alias());
         min_buff = d_owner->min_output_buffer();
     }
     if (set_all_max_buff) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("Getting (%s) max buffer") % d_owner->alias());
+        d_debug_logger->debug("Getting ({:s}) max buffer", d_owner->alias());
         max_buff = d_owner->max_output_buffer();
     }
 
@@ -586,18 +577,16 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
-                        GR_LOG_DEBUG(d_debug_logger,
-                                     boost::format("Block (%s) min_buff (%d)") %
-                                         bb->alias() % min_buff);
+                        d_debug_logger->debug(
+                            "Block ({:s}) min_buff ({:d})", bb->alias(), min_buff);
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
-                            GR_LOG_DEBUG(d_debug_logger,
-                                         boost::format("HBlock (%s) min_buff (%d)") %
-                                             hh->alias() % min_buff);
+                            d_debug_logger->debug(
+                                "HBlock ({:s}) min_buff ({:s})", hh->alias(), min_buff);
                             hh->set_min_output_buffer(min_buff);
                         }
                     }
@@ -610,18 +599,16 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
-                        GR_LOG_DEBUG(d_debug_logger,
-                                     boost::format("Block (%s) max_buff (%d)") %
-                                         bb->alias() % max_buff);
+                        d_debug_logger->debug(
+                            "Block ({:s}) max_buff ({:d})", bb->alias(), max_buff);
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
-                            GR_LOG_DEBUG(d_debug_logger,
-                                         boost::format("HBlock (%s) max_buff (%d)") %
-                                             hh->alias() % max_buff);
+                            d_debug_logger->debug(
+                                "HBlock ({:s}) max_buff ({:d})", hh->alias(), max_buff);
                             hh->set_max_output_buffer(max_buff);
                         }
                     }
@@ -636,18 +623,16 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->min_output_buffer(0) != min_buff) {
-                        GR_LOG_DEBUG(d_debug_logger,
-                                     boost::format("Block (%s) min_buff (%d)") %
-                                         bb->alias() % min_buff);
+                        d_debug_logger->debug(
+                            "Block ({:s}) min_buff ({:d})", bb->alias(), min_buff);
                         bb->set_min_output_buffer(min_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
-                            GR_LOG_DEBUG(d_debug_logger,
-                                         boost::format("HBlock (%s) min_buff (%d)") %
-                                             hh->alias() % min_buff);
+                            d_debug_logger->debug(
+                                "HBlock ({:s}) min_buff ({:d})", hh->alias(), min_buff);
                             hh->set_min_output_buffer(min_buff);
                         }
                     }
@@ -660,21 +645,16 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(b);
                 if (bb != 0) {
                     if (bb->max_output_buffer(0) != max_buff) {
-                        GR_LOG_DEBUG(d_debug_logger,
-                                     boost::format("Block (%s) max_buff (%d)") %
-                                         bb->alias() % max_buff);
+                        d_debug_logger->debug(
+                            "Block ({:s}) max_buff ({:d})", bb->alias(), max_buff);
                         bb->set_max_output_buffer(max_buff);
                     }
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(b);
                     if (hh != 0) {
                         if (hh->max_output_buffer(0) != max_buff) {
-                            GR_LOG_DEBUG(d_debug_logger,
-                                         boost::format("HBlock (%s) max_buff (%d)") %
-                                             hh->alias() % max_buff);
-                            GR_LOG_DEBUG(d_debug_logger,
-                                         boost::format("HBlock (%s) max_buff (%d)") %
-                                             hh->alias() % max_buff);
+                            d_debug_logger->debug(
+                                "HBlock ({:s}) max_buff ({:d})", hh->alias(), max_buff);
                             hh->set_max_output_buffer(max_buff);
                         }
                     }
@@ -683,10 +663,10 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         }
     }
 
-    GR_LOG_DEBUG(d_debug_logger, "Flattening stream connections: ");
+    d_debug_logger->debug("Flattening stream connections: ");
 
     for (p = edges.begin(); p != edges.end(); p++) {
-        GR_LOG_DEBUG(d_debug_logger, boost::format("Flattening edge %s") % *p);
+        d_debug_logger->debug("Flattening edge {}", *p);
 
         endpoint_vector_t src_endps = resolve_endpoint(p->src(), false);
         endpoint_vector_t dst_endps = resolve_endpoint(p->dst(), true);
@@ -694,40 +674,40 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
         endpoint_viter_t s, d;
         for (s = src_endps.begin(); s != src_endps.end(); s++) {
             for (d = dst_endps.begin(); d != dst_endps.end(); d++) {
-                GR_LOG_DEBUG(d_debug_logger, boost::format(" %s -> %s") % *s % *d);
+                d_debug_logger->debug(" {} -> {}", *s, *d);
                 sfg->connect(*s, *d);
             }
         }
     }
 
     // loop through flattening hierarchical connections
-    GR_LOG_DEBUG(d_debug_logger, "Flattening msg connections: ");
+    d_debug_logger->debug("Flattening msg connections: ");
 
     std::vector<std::pair<msg_endpoint, bool>> resolved_endpoints;
     for (q = msg_edges.begin(); q != msg_edges.end(); q++) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format(" flattening edge ( %s, %s, %d) -> ( %s, %s, %d)") %
-                         q->src().block() % q->src().port() % q->src().is_hier() %
-                         q->dst().block() % q->dst().port() % q->dst().is_hier());
+        d_debug_logger->debug(" flattening edge ( {}, {}, {:d}) -> ( {}, {}, {:d})",
+                              q->src().block(),
+                              q->src().port(),
+                              q->src().is_hier(),
+                              q->dst().block(),
+                              q->dst().port(),
+                              q->dst().is_hier());
 
 
         if (q->src().is_hier() && q->src().block().get() == d_owner) {
             // connection into this block ..
-            GR_LOG_DEBUG(d_debug_logger,
-                         boost::format("hier incoming port: %s") % q->src());
+            d_debug_logger->debug("hier incoming port: {}", q->src());
             sfg->replace_endpoint(q->src(), q->dst(), false);
             resolved_endpoints.push_back(std::pair<msg_endpoint, bool>(q->src(), false));
         } else if (q->dst().is_hier() && q->dst().block().get() == d_owner) {
             // connection out of this block
-            GR_LOG_DEBUG(d_debug_logger,
-                         boost::format("hier outgoing port: %s") % q->dst());
+            d_debug_logger->debug("hier outgoing port: {}", q->dst());
             sfg->replace_endpoint(q->dst(), q->src(), true);
             resolved_endpoints.push_back(std::pair<msg_endpoint, bool>(q->dst(), true));
         } else {
             // internal connection only
-            GR_LOG_DEBUG(d_debug_logger,
-                         boost::format("internal msg connection: %s --> %s") % q->src() %
-                             q->dst());
+            d_debug_logger->debug(
+                "internal msg connection: {} --> {}", q->src(), q->dst());
             sfg->connect(q->src(), q->dst());
         }
     }
@@ -736,9 +716,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
              resolved_endpoints.begin();
          it != resolved_endpoints.end();
          it++) {
-        GR_LOG_DEBUG(d_debug_logger,
-                     boost::format("sfg->clear_endpoint(%s, %s)") % it->first %
-                         it->second);
+        d_debug_logger->debug("sfg->clear_endpoint({}, {})", it->first, it->second);
         sfg->clear_endpoint((*it).first, (*it).second);
     }
 
@@ -792,18 +770,19 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(blk);
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
-                    GR_LOG_DEBUG(d_debug_logger,
-                                 boost::format("Block (%s) Port (%d) min_buff (d)") %
-                                     bb->alias() % bb_src_port % min_buff);
+                    d_debug_logger->debug("Block ({:s}) Port ({:d}) min_buff ({:d})",
+                                          bb->alias(),
+                                          bb_src_port,
+                                          min_buff);
                     bb->set_min_output_buffer(bb_src_port, min_buff);
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
-                        GR_LOG_DEBUG(
-                            d_debug_logger,
-                            boost::format("HBlock (%s) Port (%d) min_buff (%d)") %
-                                hh->alias() % hh_src_port % min_buff);
+                        d_debug_logger->debug("HBlock ({:s}) Port ({:d}) min_buff ({:d})",
+                                              hh->alias(),
+                                              hh_src_port,
+                                              min_buff);
                         hh->set_min_output_buffer(hh_src_port, min_buff);
                     }
                 }
@@ -815,18 +794,19 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                 block_sptr bb = std::dynamic_pointer_cast<block>(blk);
                 if (bb != 0) {
                     int bb_src_port = d_outputs[i].port();
-                    GR_LOG_DEBUG(d_debug_logger,
-                                 boost::format("Block (%s) Port (%d) max_buff (%d)") %
-                                     bb->alias() % bb_src_port % max_buff);
+                    d_debug_logger->debug("Block ({:s}) Port ({:d}) max_buff ({:d})",
+                                          bb->alias(),
+                                          bb_src_port,
+                                          max_buff);
                     bb->set_max_output_buffer(bb_src_port, max_buff);
                 } else {
                     hier_block2_sptr hh = std::dynamic_pointer_cast<hier_block2>(blk);
                     if (hh != 0) {
                         int hh_src_port = d_outputs[i].port();
-                        GR_LOG_DEBUG(
-                            d_debug_logger,
-                            boost::format("HBlock (%s) Port (%d) max_buff (%d)") %
-                                hh->alias() % hh_src_port % max_buff);
+                        d_debug_logger->debug("HBlock ({:s}) Port ({:d}) max_buff ({:d})",
+                                              hh->alias(),
+                                              hh_src_port,
+                                              max_buff);
                         hh->set_max_output_buffer(hh_src_port, max_buff);
                     }
                 }
@@ -843,10 +823,8 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
     for (basic_block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
         hier_block2_sptr hier_block2(cast_to_hier_block2_sptr(*p));
         if (hier_block2 && (hier_block2.get() != d_owner)) {
-            GR_LOG_DEBUG(
-                d_debug_logger,
-                boost::format("flatten_aux: recursing into hierarchical block %s") %
-                    hier_block2->alias());
+            d_debug_logger->debug("flatten_aux: recursing into hierarchical block {:s}",
+                                  hier_block2->alias());
             hier_block2->d_detail->flatten_aux(sfg);
         }
     }
@@ -860,7 +838,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 
     // print all primitive connections at exit
     if (is_top_block) {
-        GR_LOG_DEBUG(d_debug_logger, "flatten_aux finished in top_block");
+        d_debug_logger->debug("flatten_aux finished in top_block");
         // sfg->dump();
     }
 
@@ -877,7 +855,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
 
 void hier_block2_detail::lock()
 {
-    GR_LOG_DEBUG(d_debug_logger, boost::format("lock: entered in %s") % this);
+    d_debug_logger->debug("lock: entered in {:p}", (void*)this);
 
     auto parent = d_parent.lock();
     if (parent)
@@ -891,7 +869,7 @@ void hier_block2_detail::lock()
 
 void hier_block2_detail::unlock()
 {
-    GR_LOG_DEBUG(d_debug_logger, boost::format("unlock: entered in %s") % this);
+    d_debug_logger->debug("unlock: entered in {:p}", (void*)this);
 
     auto parent = d_parent.lock();
     if (parent)

--- a/gnuradio-runtime/lib/top_block_impl.cc
+++ b/gnuradio-runtime/lib/top_block_impl.cc
@@ -60,10 +60,10 @@ make_scheduler(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_except
             if (factory == 0) {
                 gr::logger_ptr logger, debug_logger;
                 gr::configure_default_loggers(logger, debug_logger, "top_block_impl");
-                std::ostringstream msg;
-                msg << "Invalid GR_SCHEDULER environment variable value \"" << v
-                    << "\".  Using \"" << scheduler_table[0].name << "\"";
-                GR_LOG_WARN(logger, msg.str());
+                logger->warn("Invalid GR_SCHEDULER environment variable value \"{:s}\".  "
+                             "Using \"{:s}\"",
+                             v,
+                             scheduler_table[0].name);
                 factory = scheduler_table[0].f;
             }
         }
@@ -86,7 +86,7 @@ top_block_impl::top_block_impl(top_block* owner, bool catch_exceptions = true)
 top_block_impl::~top_block_impl()
 {
     if (d_lock_count) {
-        GR_LOG_ERROR(d_logger, "destroying locked block.");
+        d_logger->error("destroying locked block.");
     }
     // NOTE: Investigate the sensibility of setting a raw pointer to zero at the end of
     // destructor


### PR DESCRIPTION
## Description
This continues the work started in https://github.com/gnuradio/gnuradio/pull/5270. Here I've removed all remaining usage of `boost::format` from gnuradio-runtime, and modernized some more of the logging.

Together with my other pull requests, this removes all usage of `boost::format` from GNU Radio, with the exception of the following helper class in the logger:

https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gnuradio-runtime/include/gnuradio/logger.h#L276-L286

That can be removed as soon as the other pull requests are merged.

## Related Issue
* #5270

## Which blocks/areas does this affect?
* `thread_body_wrapper`
* `basic_block`
* `block_detail`
* `block_executor`
* `rpcpmtconverter`
* `flat_flowgraph`
* `flowgraph`
* `hier_block2_detail`
* `top_block`

## Testing Done
1. Set `debug_level = trace` and `log_level = trace`, ran a sample flowgraph (including a hierarchical block) before & after, and verified that the debug output matched (apart from differing process IDs).
2. Ran Gqrx and verified that trace-level debug output looks sane.

I'd appreciate help with additional testing.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
