### PR TITLE
fec: Remove the last references to Boost

### DIFF
--- a/gr-fec/CMakeLists.txt
+++ b/gr-fec/CMakeLists.txt
@@ -8,7 +8,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 
 ########################################################################
 # Register component
@@ -18,7 +17,6 @@ include(GrComponent)
 find_package(GSL)
 
 GR_REGISTER_COMPONENT("gr-fec" ENABLE_GR_FEC
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_BLOCKS
 )

--- a/gr-fec/include/gnuradio/fec/decoder.h
+++ b/gr-fec/include/gnuradio/fec/decoder.h
@@ -14,7 +14,6 @@
 #include <gnuradio/block.h>
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_decoder.h>
-#include <boost/shared_array.hpp>
 #include <memory>
 
 namespace gr {
@@ -54,7 +53,6 @@ class FEC_API decoder : virtual public block
 {
 public:
     typedef std::shared_ptr<decoder> sptr;
-    typedef boost::shared_array<unsigned char> buf_sptr;
 
     /*!
      * Create the FEC decoder block by taking in the FECAPI decoder

--- a/gr-fec/include/gnuradio/fec/tagged_decoder.h
+++ b/gr-fec/include/gnuradio/fec/tagged_decoder.h
@@ -14,7 +14,6 @@
 #include <gnuradio/fec/api.h>
 #include <gnuradio/fec/generic_decoder.h>
 #include <gnuradio/tagged_stream_block.h>
-#include <boost/shared_array.hpp>
 #include <memory>
 
 namespace gr {
@@ -54,7 +53,6 @@ class FEC_API tagged_decoder : virtual public tagged_stream_block
 {
 public:
     typedef std::shared_ptr<tagged_decoder> sptr;
-    typedef boost::shared_array<unsigned char> buf_sptr;
 
     /*!
      * Create the FEC decoder block by taking in the FECAPI decoder

--- a/gr-fec/python/fec/bindings/decoder_python.cc
+++ b/gr-fec/python/fec/bindings/decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(cbb67b408431fa0272f9cd6095801212)                     */
+/* BINDTOOL_HEADER_FILE_HASH(662191634b23e5216992ab2bb954c5a8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-fec/python/fec/bindings/tagged_decoder_python.cc
+++ b/gr-fec/python/fec/bindings/tagged_decoder_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(tagged_decoder.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a29fe9713a9a6206088424b8cf11a12d)                     */
+/* BINDTOOL_HEADER_FILE_HASH(35eaf013275db539b393773b6fbb8ed2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
gr-fec references `boost::shared_array` in two places, but never uses it. (The last usage was removed in https://github.com/gnuradio/gnuradio/commit/2e26269d32a357688f6fea652137d9a1900c3a29). We can therefore remove these references, and thereby rid gr-fec of Boost completely.

## Which blocks/areas does this affect?
* FEC Decoder
* FEC Tagged Decoder

## Testing Done
None yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
