### PR TITLE
zeromq: Replace boost::thread with std::thread

### DIFF
--- a/gr-zeromq/CMakeLists.txt
+++ b/gr-zeromq/CMakeLists.txt
@@ -9,7 +9,6 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 find_package(ZeroMQ)
 
 ########################################################################
@@ -18,7 +17,6 @@ find_package(ZeroMQ)
 include(GrComponent)
 
 GR_REGISTER_COMPONENT("gr-zeromq" ENABLE_GR_ZEROMQ
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ZEROMQ_FOUND
 )

--- a/gr-zeromq/lib/CMakeLists.txt
+++ b/gr-zeromq/lib/CMakeLists.txt
@@ -27,8 +27,6 @@ add_library(gnuradio-zeromq
 
 target_link_libraries(gnuradio-zeromq PUBLIC
   gnuradio-runtime
-  Boost::boost
-  Boost::thread
   ZeroMQ::ZeroMQ
 )
 

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -15,7 +15,6 @@
 #include "pull_msg_source_impl.h"
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
-#include <boost/thread/thread.hpp>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -61,7 +60,7 @@ pull_msg_source_impl::~pull_msg_source_impl() {}
 bool pull_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
+    d_thread = std::make_unique<std::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -13,6 +13,7 @@
 
 #include "zmq_common_impl.h"
 #include <gnuradio/zeromq/pull_msg_source.h>
+#include <thread>
 
 namespace gr {
 namespace zeromq {
@@ -23,7 +24,7 @@ private:
     int d_timeout; // microseconds, -1 is blocking
     zmq::context_t d_context;
     zmq::socket_t d_socket;
-    std::unique_ptr<boost::thread> d_thread;
+    std::unique_ptr<std::thread> d_thread;
     const pmt::pmt_t d_port;
 
     void readloop();

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -16,6 +16,7 @@
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
 #include <memory>
+#include <thread>
 
 namespace gr {
 namespace zeromq {
@@ -58,7 +59,7 @@ rep_msg_sink_impl::~rep_msg_sink_impl() {}
 bool rep_msg_sink_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
+    d_thread = std::make_unique<std::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -13,6 +13,7 @@
 
 #include "zmq_common_impl.h"
 #include <gnuradio/zeromq/rep_msg_sink.h>
+#include <thread>
 
 namespace gr {
 namespace zeromq {
@@ -23,7 +24,7 @@ private:
     int d_timeout;
     zmq::context_t d_context;
     zmq::socket_t d_socket;
-    std::unique_ptr<boost::thread> d_thread;
+    std::unique_ptr<std::thread> d_thread;
     bool d_finished;
 
     const pmt::pmt_t d_port;

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -15,7 +15,6 @@
 #include "req_msg_source_impl.h"
 #include "tag_headers.h"
 #include <gnuradio/io_signature.h>
-#include <boost/thread/thread.hpp>
 #include <chrono>
 #include <memory>
 #include <thread>
@@ -61,7 +60,7 @@ req_msg_source_impl::~req_msg_source_impl() {}
 bool req_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
+    d_thread = std::make_unique<std::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -13,6 +13,7 @@
 
 #include "zmq_common_impl.h"
 #include <gnuradio/zeromq/req_msg_source.h>
+#include <thread>
 
 namespace gr {
 namespace zeromq {
@@ -23,7 +24,7 @@ private:
     int d_timeout;
     zmq::context_t d_context;
     zmq::socket_t d_socket;
-    std::unique_ptr<boost::thread> d_thread;
+    std::unique_ptr<std::thread> d_thread;
     const pmt::pmt_t d_port;
 
     void readloop();

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -59,7 +59,7 @@ sub_msg_source_impl::~sub_msg_source_impl() {}
 bool sub_msg_source_impl::start()
 {
     d_finished = false;
-    d_thread = std::make_unique<boost::thread>([this] { readloop(); });
+    d_thread = std::make_unique<std::thread>([this] { readloop(); });
     return true;
 }
 

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -13,6 +13,7 @@
 
 #include "zmq_common_impl.h"
 #include <gnuradio/zeromq/sub_msg_source.h>
+#include <thread>
 
 namespace gr {
 namespace zeromq {
@@ -23,7 +24,7 @@ private:
     int d_timeout; // microseconds, -1 is blocking
     zmq::context_t d_context;
     zmq::socket_t d_socket;
-    std::unique_ptr<boost::thread> d_thread;
+    std::unique_ptr<std::thread> d_thread;
     const pmt::pmt_t d_port;
 
     void readloop();


### PR DESCRIPTION
## Description
gr-zeromq's only remaining usage of Boost is `boost::thread`. It should be possible to switch this to `std::thread`, thereby removing the module's dependence on Boost.

## Which blocks/areas does this affect?
* ZMQ PULL Message Source
* ZMQ REP Message Sink
* ZMQ REQ Message Source
* ZMQ SUB Message Source

## Testing Done
None yet. I'd appreciate help from someone familiar with ZeroMQ.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~`
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
