### PR TITLE
network: Replace some Boost with standard C++

### DIFF
--- a/gr-network/lib/socket_pdu_impl.cc
+++ b/gr-network/lib/socket_pdu_impl.cc
@@ -104,20 +104,18 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
 
         d_tcp_socket->async_read_some(
             boost::asio::buffer(d_rxbuf),
-            boost::bind(&socket_pdu_impl::handle_tcp_read,
-                        this,
-                        boost::asio::placeholders::error,
-                        boost::asio::placeholders::bytes_transferred));
+            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+                handle_tcp_read(error, bytes_transferred);
+            });
     } else if (type == "UDP_SERVER") {
         d_udp_socket =
             std::make_shared<boost::asio::ip::udp::socket>(d_io_service, d_udp_endpoint);
         d_udp_socket->async_receive_from(
             boost::asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
-            boost::bind(&socket_pdu_impl::handle_udp_read,
-                        this,
-                        boost::asio::placeholders::error,
-                        boost::asio::placeholders::bytes_transferred));
+            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+                handle_udp_read(error, bytes_transferred);
+            });
 
         set_msg_handler(msgport_names::pdus(),
                         [this](pmt::pmt_t msg) { this->udp_send(msg); });
@@ -127,10 +125,9 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
         d_udp_socket->async_receive_from(
             boost::asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
-            boost::bind(&socket_pdu_impl::handle_udp_read,
-                        this,
-                        boost::asio::placeholders::error,
-                        boost::asio::placeholders::bytes_transferred));
+            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+                handle_udp_read(error, bytes_transferred);
+            });
 
         set_msg_handler(msgport_names::pdus(),
                         [this](pmt::pmt_t msg) { this->udp_send(msg); });
@@ -165,10 +162,9 @@ void socket_pdu_impl::handle_tcp_read(const boost::system::error_code& error,
 
         d_tcp_socket->async_read_some(
             boost::asio::buffer(d_rxbuf),
-            boost::bind(&socket_pdu_impl::handle_tcp_read,
-                        this,
-                        boost::asio::placeholders::error,
-                        boost::asio::placeholders::bytes_transferred));
+            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+                handle_tcp_read(error, bytes_transferred);
+            });
     } else
         throw boost::system::system_error(error);
 }
@@ -183,11 +179,11 @@ void socket_pdu_impl::start_tcp_accept()
         d_acceptor_tcp->get_io_service(), d_rxbuf.size(), d_tcp_no_delay);
 #endif
 
-    d_acceptor_tcp->async_accept(new_connection->socket(),
-                                 boost::bind(&socket_pdu_impl::handle_tcp_accept,
-                                             this,
-                                             new_connection,
-                                             boost::asio::placeholders::error));
+    d_acceptor_tcp->async_accept(
+        new_connection->socket(),
+        [this, new_connection](const boost::system::error_code& error) {
+            handle_tcp_accept(new_connection, error);
+        });
 }
 
 void socket_pdu_impl::tcp_server_send(pmt::pmt_t msg)
@@ -262,10 +258,9 @@ void socket_pdu_impl::handle_udp_read(const boost::system::error_code& error,
         d_udp_socket->async_receive_from(
             boost::asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
-            boost::bind(&socket_pdu_impl::handle_udp_read,
-                        this,
-                        boost::asio::placeholders::error,
-                        boost::asio::placeholders::bytes_transferred));
+            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+                handle_udp_read(error, bytes_transferred);
+            });
     }
 }
 

--- a/gr-network/lib/tcp_connection.cc
+++ b/gr-network/lib/tcp_connection.cc
@@ -67,11 +67,11 @@ void tcp_connection::start(gr::basic_block* block)
 {
     d_block = block;
     d_socket.set_option(boost::asio::ip::tcp::no_delay(d_no_delay));
-    d_socket.async_read_some(boost::asio::buffer(d_buf),
-                             boost::bind(&tcp_connection::handle_read,
-                                         this,
-                                         boost::asio::placeholders::error,
-                                         boost::asio::placeholders::bytes_transferred));
+    d_socket.async_read_some(
+        boost::asio::buffer(d_buf),
+        [this](const boost::system::error_code& error, size_t bytes_transferred) {
+            handle_read(error, bytes_transferred);
+        });
 }
 
 void tcp_connection::handle_read(const boost::system::error_code& error,
@@ -88,10 +88,9 @@ void tcp_connection::handle_read(const boost::system::error_code& error,
 
         d_socket.async_read_some(
             boost::asio::buffer(d_buf),
-            boost::bind(&tcp_connection::handle_read,
-                        this,
-                        boost::asio::placeholders::error,
-                        boost::asio::placeholders::bytes_transferred));
+            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+                handle_read(error, bytes_transferred);
+            });
     } else {
         d_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
         d_socket.close();

--- a/gr-network/lib/tcp_connection.h
+++ b/gr-network/lib/tcp_connection.h
@@ -12,7 +12,6 @@
 #define INCLUDED_TCP_CONNECTION_H
 
 #include <pmt/pmt.h>
-#include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <memory>
 

--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -98,7 +98,7 @@ bool tcp_sink_impl::start()
         // In this mode, we're starting a local port listener and waiting
         // for inbound connections.
         d_start_new_listener = true;
-        d_listener_thread = new boost::thread([this] { run_listener(); });
+        d_listener_thread = new std::thread([this] { run_listener(); });
     }
 
     return true;
@@ -172,10 +172,9 @@ void tcp_sink_impl::connect(bool initial_connection)
     boost::asio::ip::tcp::socket* tmpSocket =
         new boost::asio::ip::tcp::socket(d_io_service);
     d_acceptor->async_accept(*tmpSocket,
-                             boost::bind(&tcp_sink_impl::accept_handler,
-                                         this,
-                                         tmpSocket,
-                                         boost::asio::placeholders::error));
+                             [this, tmpSocket](const boost::system::error_code& error) {
+                                 accept_handler(tmpSocket, error);
+                             });
 
     d_io_service.run();
 }

--- a/gr-network/lib/tcp_sink_impl.h
+++ b/gr-network/lib/tcp_sink_impl.h
@@ -14,7 +14,7 @@
 #include <gnuradio/network/tcp_sink.h>
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/thread/thread.hpp>
+#include <thread>
 
 namespace gr {
 namespace network {
@@ -30,7 +30,7 @@ protected:
 
     bool d_thread_running;
     bool d_stop_thread;
-    boost::thread* d_listener_thread;
+    std::thread* d_listener_thread;
     bool d_start_new_listener;
     bool d_initial_connection;
 

--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -14,7 +14,7 @@
 
 #include "udp_sink_impl.h"
 #include <gnuradio/io_signature.h>
-#include <boost/array.hpp>
+#include <array>
 
 namespace gr {
 namespace network {
@@ -169,7 +169,7 @@ bool udp_sink_impl::stop()
 
         if (b_send_eof) {
             // Send a few zero-length packets to signal receiver we are done
-            boost::array<char, 0> send_buf;
+            std::array<char, 0> send_buf;
             for (int i = 0; i < 3; i++)
                 d_udpsocket->send_to(boost::asio::buffer(send_buf), d_endpoint);
         }

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -53,8 +53,6 @@ protected:
     boost::asio::ip::udp::endpoint d_endpoint;
     boost::asio::ip::udp::socket* d_udpsocket;
 
-    boost::mutex d_mutex;
-
     virtual void
     build_header(); // returns header size.  Header is stored in tmpHeaderBuff
 


### PR DESCRIPTION
## Description
Here I've removed some Boost from gr-network:

* Replaced `boost::bind` with lambda expressions
* Replaced `boost::array` with `std::array`
* Replaced `boost::thread` with `std::thread`
* Removed an unused instance of `boost::mutex`

## Which blocks/areas does this affect?
* Socket PDU
* TCP Sink
* UDP Sink

## Testing Done
I tested Gqrx's UDP output, which uses GNU Radio's UDP Sink block. I'd appreciate help testing the other blocks.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
