### PR TITLE
runtime: correct single_mapped_buffer's output blocked callback handling

### DIFF
--- a/gnuradio-runtime/lib/buffer_reader.cc
+++ b/gnuradio-runtime/lib/buffer_reader.cc
@@ -58,7 +58,7 @@ buffer_add_reader(buffer_sptr buf, int nzero_preload, block_sptr link, int delay
     msg << " [" << buf.get() << ";" << r.get() << "] buffer_add_reader() nzero_preload "
         << nzero_preload << " -- delay: " << delay << " -- history: " << link->history()
         << " -- RD_idx: " << r->d_read_index;
-    GR_LOG_DEBUG(debug_logger, msg.str());
+    GR_LOG_DEBUG(logger, msg.str());
 #endif
 
     return r;


### PR DESCRIPTION
of block history

Signed-off-by: David Sorber <david.sorber@blacklynx.tech>

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Correct `single_mapped_buffer` handling of block history to prevent stalling due to being unable to execute the output blocked callback.  This change ensures that a gap of history - 1 is left between the write and read pointers to allow room for the callback to execute. 

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5634.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
`single_mapped_buffer` specifically, and therefore all custom buffers using it

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

- Ran through case described in #5634 to verify that the flowgraph no longer gets stuck.  Also added memcpy to test block to ensure that output is correctly aligned.
- Ran through test suite with buffer type set to `host_buffer`. Noticed an issue with `qa_hier_block2::test_035_lock_after_disconnect`

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
