### PR TITLE
qtgui: Fixes #5623 - QEngValidator in range.py.cmakein incorrectly overwrites default background color

### DIFF
--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -53,7 +53,6 @@ class Range(object):
             val = 0
         return (val * self.step + self.min)
 
-
 class QEngValidator(Qt.QValidator):
     def __init__(self, minimum, maximum, parent):
         Qt.QValidator.__init__(self, parent)
@@ -67,17 +66,20 @@ class QEngValidator(Qt.QValidator):
             val = eng_notation.str_to_num(s)
         except (IndexError, ValueError) as e:
             if re.match(self.re, s):
-                self.parent.setStyleSheet("background-color: yellow;")
+                self.parent.setStyleSheet("background-color: yellow;"
+                                          "color: black")
                 return (Qt.QValidator.Intermediate, s, pos)
             else:
                 return (Qt.QValidator.Invalid, s, pos)
 
         if self.max is not None and val > self.max:
-            self.parent.setStyleSheet("background-color: yellow;")
+            self.parent.setStyleSheet("background-color: yellow;"
+                                      "color: black")
         elif self.min is not None and val < self.min:
-            self.parent.setStyleSheet("background-color: yellow;")
+            self.parent.setStyleSheet("background-color: yellow;"
+                                      "color: black")
         else:
-            self.parent.setStyleSheet("background-color: white;")
+            self.parent.setStyleSheet("")
 
         return (Qt.QValidator.Acceptable, s, pos)
 


### PR DESCRIPTION
## Description
QEngValidator in range.py.cmakein incorrectly overwrites default background color to white on successful validation. White may not be the correct color given the default qss of the user. Fix changes it to default coloring instead of white.

## Related Issue
Fixes #5623

## Which blocks/areas does this affect?
QT GUI Range

## Testing Done
Tested on osmocom_fft on kali linux OS.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
