### PR TITLE
runtime: Remove boost::format support from the logger

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -42,8 +42,6 @@ using logger_ptr = std::shared_ptr<void>;
 
 #include <spdlog/sinks/dist_sink.h>
 
-#include <boost/format.hpp>
-
 namespace gr {
 using log_level = spdlog::level::level_enum;
 
@@ -272,18 +270,6 @@ configure_default_loggers(gr::logger_ptr& l, gr::logger_ptr& d, const std::strin
     {                                 \
         log->d_logger->critical(msg); \
     }
-
-// Helper class to allow passing of boost::format to fmt
-template <>
-struct fmt::formatter<boost::format> : formatter<string_view> {
-    // parse is inherited from formatter<string_view>.
-    template <typename FormatContext>
-    auto format(const boost::format& bfmt, FormatContext& ctx)
-        -> decltype(formatter<string_view>::format(bfmt.str(), ctx))
-    {
-        return formatter<string_view>::format(bfmt.str(), ctx);
-    }
-};
 
 #endif
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a76c325b045da079c83e294cc4abb8c6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(23f6dee3b41e18f9148f0853ea31a91a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
Now that `boost::format` has been removed from all GNU Radio modules (in #5626 and others), it should no longer be necessary to support `boost::format` in the logger.

## Which blocks/areas does this affect?
* logging

## Testing Done
I build GNU Radio and tested a few flow graphs with the log levels set to `trace`. Everything still worked as before.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
