### PR TITLE
grc: fails to evaluate a block parameter that references another parameter of the block

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -235,6 +235,7 @@ class FlowGraph(Element):
         # to get rid of entries of blocks that
         # are no longer valid ( deleted, disabled, ...)
         self.namespace.clear()
+        self._eval_cache.clear()
         # Load imports
         for expr in self.imports():
             try:
@@ -292,8 +293,6 @@ class FlowGraph(Element):
                 log.exception('Failed to evaluate variable block {0}'.format(
                     variable_block.name), exc_info=True)
                 pass
-
-        self._eval_cache.clear()
 
     def evaluate(self, expr, namespace=None, local_namespace=None):
         """

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -216,7 +216,8 @@ class Param(Element):
                         if scale_factor in self.scale:
                             expr = str(float(expr[:-1]) *
                                        self.scale[scale_factor])
-                    value = self.parent_flowgraph.evaluate(expr)
+                    value = self.parent_flowgraph.evaluate(expr, self.parent.namespace, self.parent_flowgraph.namespace)
+                    self.parent.namespace[self.key] = value
                 except Exception as e:
                     raise Exception(
                         'Value "{}" cannot be evaluated:\n{}'.format(expr, e))


### PR DESCRIPTION



# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
If you have a block with

param1: 3
param2: 3 * param1

the evaluation of param2 fails, as only variables of the flowgraph are used during evaluation.
This pr stores previous evaluated paramters of the block and uses them during evaluation,
so param2 will be correctly evaluated.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5627

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Run
[ber_curve_gen](https://github.com/gnuradio/gnuradio/blob/main/gr-fec/examples/ber_curve_gen.grc)
in grc.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
