### PR TITLE
uhd: Replace boost::dynamic_bitset with std::vector<bool>

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -286,19 +286,18 @@ bool usrp_block_impl::_check_mboard_sensors_locked()
 
 void usrp_block_impl::_set_center_freq_from_internals_allchans()
 {
-    unsigned int chan;
-    while (_rx_chans_to_tune.any()) {
-        // This resets() bits, so this loop should not run indefinitely
-        chan = _rx_chans_to_tune.find_first();
-        _set_center_freq_from_internals(chan, direction_rx());
-        _rx_chans_to_tune.reset(chan);
+    for (size_t chan = 0; chan < _rx_chans_to_tune.size(); chan++) {
+        if (_rx_chans_to_tune[chan]) {
+            _set_center_freq_from_internals(chan, direction_rx());
+            _rx_chans_to_tune[chan] = false;
+        }
     }
 
-    while (_tx_chans_to_tune.any()) {
-        // This resets() bits, so this loop should not run indefinitely
-        chan = _tx_chans_to_tune.find_first();
-        _set_center_freq_from_internals(chan, direction_tx());
-        _tx_chans_to_tune.reset(chan);
+    for (size_t chan = 0; chan < _tx_chans_to_tune.size(); chan++) {
+        if (_tx_chans_to_tune[chan]) {
+            _set_center_freq_from_internals(chan, direction_tx());
+            _tx_chans_to_tune[chan] = false;
+        }
     }
 }
 
@@ -582,7 +581,7 @@ void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req,
             tune_req.dsp_freq_policy != _curr_rx_tune_req[chan].dsp_freq_policy ||
             _force_tune) {
             _curr_rx_tune_req[chan] = tune_req;
-            _rx_chans_to_tune.set(chan);
+            _rx_chans_to_tune[chan] = true;
         }
     } else {
         if (tune_req.target_freq != _curr_tx_tune_req[chan].target_freq ||
@@ -592,7 +591,7 @@ void usrp_block_impl::_update_curr_tune_req(::uhd::tune_request_t& tune_req,
             tune_req.dsp_freq_policy != _curr_tx_tune_req[chan].dsp_freq_policy ||
             _force_tune) {
             _curr_tx_tune_req[chan] = tune_req;
-            _tx_chans_to_tune.set(chan);
+            _tx_chans_to_tune[chan] = true;
         }
     }
 }

--- a/gr-uhd/lib/usrp_block_impl.h
+++ b/gr-uhd/lib/usrp_block_impl.h
@@ -14,7 +14,6 @@
 #include <gnuradio/uhd/usrp_block.h>
 #include <pmt/pmt.h>
 #include <uhd/usrp/multi_usrp.hpp>
-#include <boost/dynamic_bitset.hpp>
 #include <functional>
 
 
@@ -165,16 +164,16 @@ protected:
     // - If chan is -1, it depends on minus_one_updates_all:
     //   - Either set vector_to_update[0] or
     //   - Set *all* entries in vector_to_update
-    // - Returns a dynamic_bitset, all indexes that where changed in
-    //   vector_to_update are set to 1
+    // - Returns a bool vector, all indexes that where changed in
+    //   vector_to_update are set to true
     template <typename T>
-    static boost::dynamic_bitset<>
+    static std::vector<bool>
     _update_vector_from_cmd_val(std::vector<T>& vector_to_update,
                                 int chan,
                                 const T cmd_val,
                                 bool minus_one_updates_all = false)
     {
-        boost::dynamic_bitset<> vals_updated(vector_to_update.size());
+        std::vector<bool> vals_updated(vector_to_update.size(), false);
         if (chan == -1) {
             if (minus_one_updates_all) {
                 for (size_t i = 0; i < vector_to_update.size(); i++) {
@@ -222,8 +221,8 @@ protected:
     // (this is not necessarily the true value the USRP is currently tuned to!).
     std::vector<::uhd::tune_request_t> _curr_tx_tune_req;
     std::vector<::uhd::tune_request_t> _curr_rx_tune_req;
-    boost::dynamic_bitset<> _tx_chans_to_tune;
-    boost::dynamic_bitset<> _rx_chans_to_tune;
+    std::vector<bool> _tx_chans_to_tune;
+    std::vector<bool> _rx_chans_to_tune;
 
     //! Stores the individual command handlers
     ::uhd::dict<pmt::pmt_t, cmd_handler_t> _msg_cmd_handlers;

--- a/gr-uhd/lib/usrp_sink_impl.cc
+++ b/gr-uhd/lib/usrp_sink_impl.cc
@@ -100,10 +100,10 @@ usrp_sink_impl::set_center_freq(const ::uhd::tune_request_t tune_request, size_t
 {
     if (pmt::eqv(direction, direction_rx())) {
         // TODO: what happens if the RX device is not instantiated? Catch error?
-        _rx_chans_to_tune.reset(chan);
+        _rx_chans_to_tune[chan] = false;
         return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        _tx_chans_to_tune.reset(chan);
+        _tx_chans_to_tune[chan] = false;
         return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     }
 }

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -112,10 +112,10 @@ usrp_source_impl::_set_center_freq_from_internals(size_t chan, pmt::pmt_t direct
 {
     if (pmt::eqv(direction, direction_tx())) {
         // TODO: what happens if the TX device is not instantiated? Catch error?
-        _tx_chans_to_tune.reset(chan);
+        _tx_chans_to_tune[chan] = false;
         return _dev->set_tx_freq(_curr_tx_tune_req[chan], _stream_args.channels[chan]);
     } else {
-        _rx_chans_to_tune.reset(chan);
+        _rx_chans_to_tune[chan] = false;
         return _dev->set_rx_freq(_curr_rx_tune_req[chan], _stream_args.channels[chan]);
     }
 }

--- a/gr-uhd/lib/usrp_source_impl.cc
+++ b/gr-uhd/lib/usrp_source_impl.cc
@@ -11,7 +11,6 @@
 #include "gr_uhd_common.h"
 #include "usrp_source_impl.h"
 #include <gnuradio/prefs.h>
-#include <boost/make_shared.hpp>
 #include <boost/thread/thread.hpp>
 #include <chrono>
 #include <mutex>


### PR DESCRIPTION
## Description
To reduce gr-uhd's dependence on Boost, I've replaced `boost::dynamic_bitset` with `std::vector<bool>`. (The module actually used `std::vector<bool>` for the same purpose prior to 350d285a27ee6ea0f448a778551cdd3a5ffcedba.)

## Which blocks/areas does this affect?
* UHD: USRP Sink
* UHD: USRP Source

## Testing Done
I haven't had a chance to test this yet, but I expect I'll have some time to do so tomorrow.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
