### PR TITLE
blocks: Remove usage of Boost

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/file_sink_base.h
+++ b/gr-blocks/include/gnuradio/blocks/file_sink_base.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/logger.h>
-#include <boost/thread.hpp>
+#include <gnuradio/thread/thread.h>
 #include <cstdio>
 
 namespace gr {
@@ -29,7 +29,7 @@ protected:
     FILE* d_new_fp; // new FILE pointer
     bool d_updated; // is there a new FILE pointer?
     bool d_is_binary;
-    boost::mutex d_mutex;
+    gr::thread::mutex d_mutex;
     bool d_unbuffered;
     bool d_append;
     gr::logger_ptr d_base_logger;

--- a/gr-blocks/lib/ctrlport_probe_c_impl.h
+++ b/gr-blocks/lib/ctrlport_probe_c_impl.h
@@ -13,7 +13,7 @@
 
 #include <gnuradio/blocks/ctrlport_probe_c.h>
 #include <gnuradio/rpcregisterhelpers.h>
-#include <boost/thread/shared_mutex.hpp>
+#include <gnuradio/thread/thread.h>
 
 namespace gr {
 namespace blocks {
@@ -21,7 +21,7 @@ namespace blocks {
 class ctrlport_probe_c_impl : public ctrlport_probe_c
 {
 private:
-    boost::shared_mutex ptrlock;
+    gr::thread::mutex ptrlock;
 
     const std::string d_id;
     const std::string d_desc;

--- a/gr-blocks/lib/file_source_impl.h
+++ b/gr-blocks/lib/file_source_impl.h
@@ -12,7 +12,7 @@
 #define INCLUDED_BLOCKS_FILE_SOURCE_IMPL_H
 
 #include <gnuradio/blocks/file_source.h>
-#include <boost/thread/mutex.hpp>
+#include <gnuradio/thread/thread.h>
 
 namespace gr {
 namespace blocks {
@@ -33,7 +33,7 @@ private:
     long d_repeat_cnt;
     pmt::pmt_t d_add_begin_tag;
 
-    boost::mutex fp_mutex;
+    gr::thread::mutex fp_mutex;
     pmt::pmt_t _id;
 
     void do_update();

--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -14,6 +14,8 @@
 
 #include "message_strobe_impl.h"
 #include <gnuradio/io_signature.h>
+#include <chrono>
+#include <thread>
 
 namespace gr {
 namespace blocks {
@@ -59,8 +61,8 @@ bool message_strobe_impl::stop()
 void message_strobe_impl::run()
 {
     while (!d_finished) {
-        boost::this_thread::sleep(
-            boost::posix_time::milliseconds(static_cast<long>(d_period_ms)));
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(static_cast<long>(d_period_ms)));
         if (d_finished) {
             return;
         }

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -14,6 +14,8 @@
 
 #include "message_strobe_random_impl.h"
 #include <gnuradio/io_signature.h>
+#include <chrono>
+#include <thread>
 
 namespace gr {
 namespace blocks {
@@ -100,8 +102,8 @@ message_strobe_random_impl::~message_strobe_random_impl()
 void message_strobe_random_impl::run()
 {
     while (!d_finished) {
-        boost::this_thread::sleep(
-            boost::posix_time::milliseconds(std::max(0L, next_delay())));
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(std::max(0L, next_delay())));
         if (d_finished) {
             return;
         }

--- a/gr-blocks/lib/probe_rate_impl.cc
+++ b/gr-blocks/lib/probe_rate_impl.cc
@@ -46,9 +46,9 @@ int probe_rate_impl::work(int noutput_items,
                           gr_vector_void_star& output_items)
 {
     d_lastthru += noutput_items;
-    boost::posix_time::ptime now(boost::posix_time::microsec_clock::local_time());
-    boost::posix_time::time_duration diff = now - d_last_update;
-    double diff_ms = diff.total_milliseconds();
+    auto now = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> diff = now - d_last_update;
+    double diff_ms = diff.count();
     if (diff_ms >= d_min_update_time) {
         double rate_this_update = d_lastthru * 1e3 / diff_ms;
         d_lastthru = 0;
@@ -100,16 +100,16 @@ double probe_rate_impl::rate() { return d_avg; }
 
 double probe_rate_impl::timesincelast()
 {
-    boost::posix_time::ptime now(boost::posix_time::microsec_clock::local_time());
-    boost::posix_time::time_duration diff = now - d_last_update;
-    return diff.total_milliseconds();
+    auto now = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> diff = now - d_last_update;
+    return diff.count();
 }
 
 bool probe_rate_impl::start()
 {
     d_avg = 0;
     d_lastthru = 0;
-    d_last_update = boost::posix_time::microsec_clock::local_time();
+    d_last_update = std::chrono::steady_clock::now();
     return true;
 }
 

--- a/gr-blocks/lib/probe_rate_impl.h
+++ b/gr-blocks/lib/probe_rate_impl.h
@@ -12,6 +12,7 @@
 #define INCLUDED_GR_PROBE_RATE_IMPL_H
 
 #include <gnuradio/blocks/probe_rate.h>
+#include <chrono>
 
 namespace gr {
 namespace blocks {
@@ -21,7 +22,7 @@ class probe_rate_impl : public probe_rate
 private:
     double d_alpha, d_beta, d_avg;
     const double d_min_update_time;
-    boost::posix_time::ptime d_last_update;
+    std::chrono::time_point<std::chrono::steady_clock> d_last_update;
     uint64_t d_lastthru;
     void setup_rpc() override;
 

--- a/gr-blocks/lib/qa_set_msg_handler.cc
+++ b/gr-blocks/lib/qa_set_msg_handler.cc
@@ -19,7 +19,8 @@
 #include <gnuradio/messages/msg_passing.h>
 #include <gnuradio/top_block.h>
 #include <boost/test/unit_test.hpp>
-#include <boost/thread/thread.hpp>
+#include <chrono>
+#include <thread>
 
 /*
  * The gr::block::nop block has been instrumented so that it counts
@@ -48,7 +49,7 @@ BOOST_AUTO_TEST_CASE(t0)
     }
 
     // Give the messages a chance to be processed
-    boost::this_thread::sleep(boost::posix_time::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     tb->stop();
     tb->wait();

--- a/gr-blocks/lib/wavfile_sink_impl.h
+++ b/gr-blocks/lib/wavfile_sink_impl.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/blocks/wavfile.h>
 #include <gnuradio/blocks/wavfile_sink.h>
+#include <gnuradio/thread/thread.h>
 #include <sndfile.h> // for SNDFILE
 
 namespace gr {
@@ -30,7 +31,7 @@ private:
     SNDFILE* d_fp;
     SNDFILE* d_new_fp;
     bool d_updated;
-    boost::mutex d_mutex;
+    gr::thread::mutex d_mutex;
 
     static constexpr int s_items_size = 8192;
     static constexpr int s_max_channels = 24;

--- a/gr-blocks/python/blocks/bindings/file_sink_base_python.cc
+++ b/gr-blocks/python/blocks/bindings/file_sink_base_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(file_sink_base.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c567888586a246a945067bdad44c874c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ce5dcca3a52128c3c675442eb76dc69f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
This pull request removes all usage of Boost from gr-blocks except for Boost.Test in test cases.

In a few cases, `boost::mutex` was used in headers but the implementation used it in `gr::thread::scoped_lock`, so I changed those to `gr::thread::mutex` (which can eventually be implemented as `std::mutex`).

In one case `boost::shared_mutex` was used, but shared locking was not actually used, so I replaced it with `gr::thread::mutex`.

## Which blocks/areas does this affect?
* Ctrlport Probe
* File Sink
* File Source
* Message Strobe
* Message Strobe Random-Delay
* Probe Rate
* Wav File Sink

## Testing Done
I tested the Message Strobe, Message Strobe Random-Delay, and Probe Rate blocks with the following flow graph:
![Screenshot from 2022-03-20 15-14-11](https://user-images.githubusercontent.com/583749/159178896-f9b602db-495d-453a-9104-f6bc71ac20fd.png)
All work as before.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.