### PR TITLE
gnuradio: make test fix a lot of depreciation warnings (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/top_block.py
+++ b/gnuradio-runtime/python/gnuradio/gr/top_block.py
@@ -45,7 +45,7 @@ class _top_block_waiter(threading.Thread):
 
     def __init__(self, tb):
         threading.Thread.__init__(self)
-        self.setDaemon(1)
+        self.daemon = True
         self.tb = tb
         self.event = threading.Event()
         self.start()

--- a/gr-blocks/python/blocks/qa_message.py
+++ b/gr-blocks/python/blocks/qa_message.py
@@ -41,20 +41,20 @@ class test_message(gr_unittest.TestCase):
 
     def test_100(self):
         msg = gr.message(0, 1.5, 2.3)
-        self.assertEquals(0, msg.type())
+        self.assertEqual(0, msg.type())
         self.assertAlmostEqual(1.5, msg.arg1())
         self.assertAlmostEqual(2.3, msg.arg2())
-        self.assertEquals(0, msg.length())
+        self.assertEqual(0, msg.length())
 
     def test_101(self):
         s = b'This is a test'
         msg = gr.message_from_string(s.decode('utf8'))
-        self.assertEquals(s, msg.to_string())
+        self.assertEqual(s, msg.to_string())
 
     def test_102_unicodechars(self):
         s = u"(╯°□°)╯︵ ┻━┻"
         msg = gr.message_from_string(s)
-        self.assertEquals(s.encode('utf8'), msg.to_string())
+        self.assertEqual(s.encode('utf8'), msg.to_string())
 
     # msg_queue was removed from API in 3.8
     # def test_200(self):
@@ -62,23 +62,23 @@ class test_message(gr_unittest.TestCase):
 
     # def body_200(self):
     #     self.msgq.insert_tail(gr.message(0))
-    #     self.assertEquals(1, self.msgq.count())
+    #     self.assertEqual(1, self.msgq.count())
     #     self.msgq.insert_tail(gr.message(1))
-    #     self.assertEquals(2, self.msgq.count())
+    #     self.assertEqual(2, self.msgq.count())
     #     msg0 = self.msgq.delete_head()
-    #     self.assertEquals(0, msg0.type())
+    #     self.assertEqual(0, msg0.type())
     #     msg1 = self.msgq.delete_head()
-    #     self.assertEquals(1, msg1.type())
-    #     self.assertEquals(0, self.msgq.count())
+    #     self.assertEqual(1, msg1.type())
+    #     self.assertEqual(0, self.msgq.count())
 
     # def test_201(self):
     #     self.leak_check(self.body_201)
 
     # def body_201(self):
     #     self.msgq.insert_tail(gr.message(0))
-    #     self.assertEquals(1, self.msgq.count())
+    #     self.assertEqual(1, self.msgq.count())
     #     self.msgq.insert_tail(gr.message(1))
-    #     self.assertEquals(2, self.msgq.count())
+    #     self.assertEqual(2, self.msgq.count())
 
     # def test_202(self):
     #     self.leak_check(self.body_202)
@@ -94,7 +94,7 @@ class test_message(gr_unittest.TestCase):
         tb = gr.top_block()
         tb.connect(src, dst)
         tb.run()
-        self.assertEquals(input_data, dst.data())
+        self.assertEqual(input_data, dst.data())
 
     def test_debug_401(self):
         msg = pmt.intern("TESTING")

--- a/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
+++ b/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
@@ -293,7 +293,7 @@ class qa_ofdm_chanest_vcvc (gr_unittest.TestCase):
 
         def run_flow_graph(sync_sym1, sync_sym2, data_sym):
             top_block = gr.top_block()
-            carr_offset = random.randint(-max_offset / 2, max_offset / 2) * 2
+            carr_offset = random.randint(-max_offset // 2, max_offset // 2) * 2
             tx_data = shift_tuple(sync_sym1, carr_offset) + \
                 shift_tuple(sync_sym2, carr_offset) + \
                 shift_tuple(data_sym, carr_offset)

--- a/gr-fec/python/fec/polar/common.py
+++ b/gr-fec/python/fec/polar/common.py
@@ -20,14 +20,14 @@ class PolarCommon(object):
         if not is_power_of_two(n):
             raise ValueError("n={0} is not a power of 2!".format(n))
         if frozenbits is None:
-            frozenbits = np.zeros(n - k, dtype=np.int)
+            frozenbits = np.zeros(n - k, dtype=np.int_)
         if not len(frozenbits) == n - k:
             raise ValueError(
                 "len(frozenbits)={0} is not equal to n-k={1}!".format(
                     len(frozenbits), n - k
                 )
             )
-        if not frozenbits.dtype == np.int:
+        if not frozenbits.dtype == np.int_:
             frozenbits = frozenbits.astype(dtype=int)
         if not len(frozen_bit_position) == (n - k):
             raise ValueError(
@@ -35,7 +35,7 @@ class PolarCommon(object):
                     len(frozen_bit_position), n - k
                 )
             )
-        if not frozen_bit_position.dtype == np.int:
+        if not frozen_bit_position.dtype == np.int_:
             frozen_bit_position = frozen_bit_position.astype(dtype=int)
 
         self.bit_reverse_positions = self._vector_bit_reversed(

--- a/gr-fec/python/fec/polar/helper_functions.py
+++ b/gr-fec/python/fec/polar/helper_functions.py
@@ -43,10 +43,10 @@ def is_power_of_two(num):
 
 def bit_reverse(value, n):
     # is this really missing in NumPy???
-    seq = np.int(value)
-    rev = np.int(0)
-    rmask = np.int(1)
-    lmask = np.int(2 ** (n - 1))
+    seq = np.int_(value)
+    rev = np.int_(0)
+    rmask = np.int_(1)
+    lmask = np.int_(2 ** (n - 1))
     for i in range(n // 2):
         shiftval = n - 1 - (i * 2)
         rshift = np.left_shift(np.bitwise_and(seq, rmask), shiftval)
@@ -79,7 +79,7 @@ def get_Fn(n):
     if n == 1:
         return np.array([1, ])
     nump = power_of_2_int(n) - 1  # number of Kronecker products to calculate
-    F2 = np.array([[1, 0], [1, 1]], np.int)
+    F2 = np.array([[1, 0], [1, 1]], np.int_)
     Fn = F2
     for i in range(nump):
         Fn = np.kron(Fn, F2)


### PR DESCRIPTION
18/243 Testing: qa_hier_block2
gnuradio-runtime/python/gnuradio/gr/top_block.py:48: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead

58/243 Testing: qa_message
gr-blocks/python/blocks/qa_message.py:44: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(0, msg.type())

205/243 Testing: qa_ofdm_chanest_vcvc
...../usr/lib64/python3.10/random.py:370: DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
  return self.randrange(a, b+1)

114/243 Testing: qa_polar_decoder_sc
gnuradio/fec/polar/common.py:30: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`

Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit ad0563be00bff9a82639e5f668549da8d18dfc47)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5585