### PR TITLE
runtime: correct single_mapped_buffer's output blocked callback handling (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/buffer_reader.cc
+++ b/gnuradio-runtime/lib/buffer_reader.cc
@@ -59,7 +59,7 @@ buffer_add_reader(buffer_sptr buf, int nzero_preload, block_sptr link, int delay
     msg << " [" << buf.get() << ";" << r.get() << "] buffer_add_reader() nzero_preload "
         << nzero_preload << " -- delay: " << delay << " -- history: " << link->history()
         << " -- RD_idx: " << r->d_read_index;
-    GR_LOG_DEBUG(debug_logger, msg.str());
+    GR_LOG_DEBUG(logger, msg.str());
 #endif
 
     return r;


### PR DESCRIPTION
of block history

Signed-off-by: David Sorber <david.sorber@blacklynx.tech>
(cherry picked from commit 931ae5ff228d91ec9367393c5366aaa8be7e8485)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5637