### PR TITLE
gr-qtgui: freq_sink and others produce wrong error messages, when GUI Hint is used

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -109,14 +109,16 @@ parameters:
     dtype: real
     default: '0.10'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 -   id: tr_mode
     label: Trigger Mode

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -78,14 +78,16 @@ parameters:
     options: ['True', 'False']
     option_labels: ['On', 'Off']
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 
 inputs:

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -88,14 +88,16 @@ parameters:
     dtype: real
     default: '0.10'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 -   id: legend
     label: Legend

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -78,14 +78,16 @@ parameters:
     dtype: real
     default: '0.10'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 -   id: legend
     label: Legend


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

freq_sink_x, sink_x, vector_sink_f .... produce error messages like

```
Traceback (most recent call last):
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/blocks/_templates.py", line 77, in render
    return template.render(**namespace)
  File "/usr/lib/python3.10/site-packages/mako/template.py", line 473, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 878, in _render
    _render_context(
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "memory:0x7f00a04d3a00", line 115, in render_body
TypeError: unsupported operand type(s) for %: 'NoneType' and 'str'
```

if the showport entry is changed, but widget will be properly placed.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
To avoid this error message the order of Show Msg Port and GUI Hint must be changed.
And I changed the entry for Show Msg Port from a text entry to a pull down menu.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
qtgui_sink_x, qtgui_freq_sink_x, qtgui_vector_sink_f, qtgui_waterfall_sink_x
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Start grc, add and open a gui_sink widget and add 0,0,1,1 to the GUI Hint.
Close the property editor. Reopen the widget and change the Show MSG Port entry from False to true and you get the above error message in your terminal window.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
