### PR TITLE
Add missing python bindings for viterbi_combined

### DIFF
--- a/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
+++ b/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
@@ -27,4 +27,47 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <viterbi_combined_pydoc.h>
 
-void bind_viterbi_combined(py::module& m) {}
+template <typename IN_T, typename OUT_T>
+void bind_viterbi_combined_template(py::module& m, const char* classname)
+{
+    using viterbi_combined = gr::trellis::viterbi_combined<IN_T,OUT_T>;
+
+    py::class_<viterbi_combined, gr::block, gr::basic_block, std::shared_ptr<viterbi_combined>>(m,
+                                                                              classname)
+        .def(py::init(&gr::trellis::viterbi_combined<IN_T,OUT_T>::make),
+             py::arg("FSM"),
+             py::arg("K"),
+             py::arg("S0"),
+             py::arg("SK"),
+             py::arg("D"),
+             py::arg("TABLE"),
+             py::arg("TYPE"))
+        .def("FSM", &viterbi_combined::FSM)
+        .def("K", &viterbi_combined::K)
+        .def("S0", &viterbi_combined::S0)
+        .def("SK", &viterbi_combined::SK)
+        .def("D", &viterbi_combined::D)
+        .def("set_FSM", &viterbi_combined::set_FSM)
+        .def("set_K", &viterbi_combined::set_K)
+        .def("set_S0", &viterbi_combined::set_S0)
+        .def("set_SK", &viterbi_combined::set_SK)
+        .def("set_D", &viterbi_combined::set_D)
+        .def("set_TABLE", &viterbi_combined::set_TABLE)
+        .def("set_TYPE", &viterbi_combined::set_TYPE);
+}
+
+void bind_viterbi_combined(py::module& m)
+{
+    bind_viterbi_combined_template<std::int16_t,std::uint8_t>(m, "viterbi_combined_sb");
+    bind_viterbi_combined_template<std::int16_t,std::int16_t>(m, "viterbi_combined_ss");
+    bind_viterbi_combined_template<std::int16_t,std::int32_t>(m, "viterbi_combined_si");
+    bind_viterbi_combined_template<std::int32_t,std::uint8_t>(m, "viterbi_combined_ib");
+    bind_viterbi_combined_template<std::int32_t,std::int16_t>(m, "viterbi_combined_is");
+    bind_viterbi_combined_template<std::int32_t,std::int32_t>(m, "viterbi_combined_ii");
+    bind_viterbi_combined_template<float,std::uint8_t>(m, "viterbi_combined_fb");
+    bind_viterbi_combined_template<float,std::int16_t>(m, "viterbi_combined_fs");
+    bind_viterbi_combined_template<float,std::int32_t>(m, "viterbi_combined_fi");
+    bind_viterbi_combined_template<gr_complex,std::uint8_t>(m, "viterbi_combined_cb");
+    bind_viterbi_combined_template<gr_complex,std::int16_t>(m, "viterbi_combined_cs");
+    bind_viterbi_combined_template<gr_complex,std::int32_t>(m, "viterbi_combined_ci");
+}


### PR DESCRIPTION
# Pull Request Details
Add missing python bindings for trellis viterbi_combined

## Description
This adds missing python bindings for trellis code, especially viterbi_combinedxx, which seem not to have been introduced after the project conversion from 3.8 (swig) to 3.9 (pybind11)

## Related Issue
Fixes #5666

## Which blocks/areas does this affect?
gr-trellis, in particular all trellis.viterbi_combinedxx python bindings that weren't implemented since porting gnuradio from 3.8 (swig) to 3.9 (pybind11)

## Testing Done
Recompiled gnuradio, made a demo block and tested for the python binding to work

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass. => Tests were already implemented for this one.
