### PR TITLE
Trickle throttle

### DIFF
--- a/gr-blocks/grc/blocks.tree.yml
+++ b/gr-blocks/grc/blocks.tree.yml
@@ -90,6 +90,7 @@
   - blocks_msg_meta_to_pair
 - Misc:
   - blocks_throttle
+  - blocks_trickling_throttle
   - blocks_vector_source_x
   - blocks_head
   - blocks_skiphead

--- a/gr-blocks/grc/blocks_throttle.block.yml
+++ b/gr-blocks/grc/blocks_throttle.block.yml
@@ -1,6 +1,6 @@
 id: blocks_throttle
-label: Throttle
-flags: [ throttle, python, cpp ]
+label: Throttle (unlimited blocking)
+flags: [ throttle, python, cpp, deprecated ]
 
 parameters:
 -   id: type

--- a/gr-blocks/grc/blocks_trickling_throttle.block.yml
+++ b/gr-blocks/grc/blocks_trickling_throttle.block.yml
@@ -1,0 +1,93 @@
+id: blocks_trickling_throttle
+label: Throttle (limited blocking)
+flags: [ throttle, python, cpp ]
+
+parameters:
+-   id: type
+    label: Type
+    dtype: enum
+    options: [complex, float, int, short, byte]
+    option_attributes:
+        size: [gr.sizeof_gr_complex, gr.sizeof_float, gr.sizeof_int, gr.sizeof_short,
+            gr.sizeof_char]
+    hide: part
+-   id: samples_per_second
+    label: Sample Rate
+    dtype: real
+    default: samp_rate
+-   id: vlen
+    label: Vector Length
+    dtype: int
+    default: '1'
+    hide: ${ 'part' if vlen == 1 else 'none' }
+-   id: ignoretag
+    label: Ignore rx_rate tag
+    dtype: bool
+    default: 'True'
+    hide: ${ ('part' if str(ignoretag) == 'True' else 'none') }
+-   id: duration_or_samples
+    label: Limited Quantity
+    dtype: enum
+    options: ['time', 'items', 'neither']
+    option_labels: ["Max. Time", "Max. Items", "No Limit"]
+-   id: maximum
+    label: 'Max. wait[s] or items'
+    dtype: real
+    hide: ${ ('part' if duration_or_samples == 'neither' else 'none') }
+    default: 0.1
+
+inputs:
+-   domain: stream
+    dtype: ${ type }
+    vlen: ${ vlen }
+
+outputs:
+-   domain: stream
+    dtype: ${ type }
+    vlen: ${ vlen }
+    optional: true
+
+asserts:
+- ${ vlen > 0 }
+- ${ samples_per_second > 0 }
+- ${ duration_or_samples == 'neither' or float(maximum) > 0 }
+
+templates:
+    imports: from gnuradio import blocks
+    make: 'blocks.throttle(
+               ${type.size}*${vlen},
+               ${samples_per_second},
+               ${ignoretag},
+               0 if "${duration_or_samples}" == "neither" 
+                   else max(
+                       int(float(${maximum}) * ${samples_per_second})
+                       if "${duration_or_samples}" == "time"
+                       else int(${maximum}),
+                       1)
+                )'
+    callbacks:
+    - set_sample_rate(${samples_per_second})
+
+cpp_templates:
+    includes: ['#include <gnuradio/blocks/throttle.h>', '#include <string_view>', '#include <algorithm>']
+    declarations: |-
+      constexpr unsigned int ${id}_limit(float value) {
+        const std::string_view limited("${duration_or_samples}");
+        if(limited == "time") {
+          return std::max(static_cast<unsigned int>(value * ${samples_per_second}), 1U);
+        } else if (limited == "items") {
+          return std::max(static_cast<unsigned int>(value), 1U);
+        }
+        return 0;
+      }
+      blocks::throttle::sptr ${id};
+
+    make: 'this->${id} = blocks::throttle::make(${type.size} * ${vlen}, ${samples_per_second}, ${ignoretag}, ${id}_limit(${maximum}));'
+    callbacks:
+    - 'set_sample_rate(${samples_per_second})'
+    - 'set_maximum_items_per_chunk(${id}_limit(${maximum}))'
+    translations:
+        'True': 'true'
+        'False': 'false'
+
+file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/throttle.h
+++ b/gr-blocks/include/gnuradio/blocks/throttle.h
@@ -1,7 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2005-2011,2013 Free Software Foundation, Inc.
- * Copyright 2021 Marcus Müller
+ * Copyright 2021,2022 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -44,13 +44,38 @@ class BLOCKS_API throttle : virtual public sync_block
 public:
     typedef std::shared_ptr<throttle> sptr;
 
-    static sptr make(size_t itemsize, double samples_per_sec, bool ignore_tags = true);
+    /*!
+     * Make a sptr to a Throttle block
+     *
+     * \param itemsize Size of each item, e.g. 8 for gr_complex
+     *
+     * \param samples_per_sec Number of items to be passed per second. Waiting time is
+     * calculated based on this.
+     *
+     * \param ignore_tags Whether or not to react to "rx_rate" tags with a double value
+     * specifying a new rate.
+     *
+     * \param maximum_items_per_chunk Limit the amount of items that are produced/consumed
+     * between waiting. Set to 0 (or leave at default) to always wait for the full
+     * duration dictated by the current size of workload items, divided by the
+     * samples_per_sec.
+     */
+    static sptr make(size_t itemsize,
+                     double samples_per_sec,
+                     bool ignore_tags = true,
+                     unsigned int maximum_items_per_chunk = 0);
 
     //! Sets the sample rate in samples per second.
     virtual void set_sample_rate(double rate) = 0;
 
     //! Get the sample rate in samples per second.
     virtual double sample_rate() const = 0;
+
+    //! Set the maximum items that will be produced per waiting period
+    virtual void set_maximum_items_per_chunk(unsigned int maximum_items_per_chunk) = 0;
+
+    //! Get the maximum items that will be produced per waiting period
+    virtual unsigned int maximum_items_per_chunk() const = 0;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2005-2011 Free Software Foundation, Inc.
+ * Copyright 2022 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -8,12 +9,15 @@
  *
  */
 
+#include "gnuradio/thread/thread.h"
+#include <chrono>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
 #include "throttle_impl.h"
 #include <gnuradio/io_signature.h>
+#include <algorithm>
 #include <cstring>
 #include <limits>
 #include <thread>
@@ -23,18 +27,25 @@ pmt::pmt_t throttle_rx_rate_pmt(pmt::intern("rx_rate"));
 namespace gr {
 namespace blocks {
 
-throttle::sptr throttle::make(size_t itemsize, double samples_per_sec, bool ignore_tags)
+throttle::sptr throttle::make(size_t itemsize,
+                              double samples_per_sec,
+                              bool ignore_tags,
+                              unsigned int maximum_items_per_chunk)
 {
     return gnuradio::make_block_sptr<throttle_impl>(
-        itemsize, samples_per_sec, ignore_tags);
+        itemsize, samples_per_sec, ignore_tags, maximum_items_per_chunk);
 }
 
-throttle_impl::throttle_impl(size_t itemsize, double samples_per_second, bool ignore_tags)
+throttle_impl::throttle_impl(size_t itemsize,
+                             double samples_per_second,
+                             bool ignore_tags,
+                             unsigned int maximum_items_per_chunk)
     : sync_block("throttle",
                  io_signature::make(1, 1, itemsize),
                  io_signature::make(0, 1, itemsize)),
       d_itemsize(itemsize),
-      d_ignore_tags(ignore_tags)
+      d_ignore_tags(ignore_tags),
+      d_maximum_items_per_chunk(maximum_items_per_chunk)
 {
     set_sample_rate(samples_per_second);
 }
@@ -44,30 +55,44 @@ throttle_impl::~throttle_impl() {}
 bool throttle_impl::start()
 {
     d_start = std::chrono::steady_clock::now();
-    d_total_samples = 0;
     return block::start();
 }
 
 void throttle_impl::set_sample_rate(double rate)
 {
-    // changing the sample rate performs a reset of state params
+    gr::thread::scoped_lock lock(d_setlock);
+    // changing the sample rate performs a reset of state parameters
+    d_total_items = 0;
     d_start = std::chrono::steady_clock::now();
-    d_total_samples = 0;
+
     d_sample_rate = rate;
     d_sample_period = std::chrono::duration<double>(1 / rate);
 }
 
 double throttle_impl::sample_rate() const { return d_sample_rate; }
 
+void throttle_impl::set_maximum_items_per_chunk(unsigned int maximum_items_per_chunk)
+{
+    gr::thread::scoped_lock lock(d_setlock);
+    d_maximum_items_per_chunk = maximum_items_per_chunk;
+}
+unsigned int throttle_impl::maximum_items_per_chunk() const
+{
+    return d_maximum_items_per_chunk;
+}
+
 int throttle_impl::work(int noutput_items,
                         gr_vector_const_void_star& input_items,
                         gr_vector_void_star& output_items)
 {
+    // We need this as unsigned everywhere, but GNU Radio 3 API gives it to us as signed
+    unsigned int noutput = static_cast<unsigned int>(noutput_items);
+
     // check for updated rx_rate tag
     if (!d_ignore_tags) {
         uint64_t abs_N = nitems_read(0);
         std::vector<tag_t> all_tags;
-        get_tags_in_range(all_tags, 0, abs_N, abs_N + noutput_items);
+        get_tags_in_range(all_tags, 0, abs_N, abs_N + noutput);
         for (const auto& tag : all_tags) {
             if (pmt::eq(tag.key, throttle_rx_rate_pmt)) {
                 double new_rate = pmt::to_double(tag.value);
@@ -76,21 +101,38 @@ int throttle_impl::work(int noutput_items,
         }
     }
 
-    // copy all samples output[i] <= input[i]
-    const char* in = (const char*)input_items[0];
+
+    // If d_maximum_items_per_chunk is set, we should be emitting things in
+    // chunks of that. But we'll allow shorter emissions if noutput is lower, in
+    // order to not block flowgraphs that might never produce enough items for a
+    // single chunk.
+    unsigned int items_per_chunk;
+    if (d_maximum_items_per_chunk) {
+        items_per_chunk = std::min(noutput, d_maximum_items_per_chunk);
+    } else {
+        items_per_chunk = noutput;
+    }
 
     // iff we have a connected output, then copy
     if (!output_items.empty()) {
-        char* out = reinterpret_cast<char*>(output_items[0]);
-        std::memcpy(out, in, noutput_items * d_itemsize);
+        // copy all samples output[i] <= input[i]
+        std::memcpy(reinterpret_cast<char*>(output_items[0]),
+                    reinterpret_cast<const char*>(input_items[0]),
+                    items_per_chunk * d_itemsize);
     }
-    d_total_samples += noutput_items;
 
-    auto now = std::chrono::steady_clock::now();
-    auto expected_time = d_start + d_sample_period * d_total_samples;
+    const auto now = std::chrono::steady_clock::now();
+    decltype(d_start + d_sample_period * 1U) expected_time;
 
+    // calculate the point in time until which we should wait
+    // protect against corruption of complex timepoint object when set_sample_rate is
+    // called concurrently
+    {
+        gr::thread::scoped_lock lock(d_setlock);
+        expected_time = d_start + d_sample_period * (d_total_items + items_per_chunk);
+    }
     if (expected_time > now) {
-        auto limit_duration =
+        constexpr auto limit_duration =
             std::chrono::duration<double>(std::numeric_limits<long>::max());
         if (expected_time - now > limit_duration) {
             d_logger->error("WARNING: Throttle sleep time overflow! You are probably "
@@ -99,7 +141,13 @@ int throttle_impl::work(int noutput_items,
         std::this_thread::sleep_until(expected_time);
     }
 
-    return noutput_items;
+    // increase number of processes items
+    // protect against concurrent writing in set_sample_rate
+    {
+        gr::thread::scoped_lock lock(d_setlock);
+        d_total_items += items_per_chunk;
+    }
+    return items_per_chunk;
 }
 
 void throttle_impl::setup_rpc()

--- a/gr-blocks/lib/throttle_impl.h
+++ b/gr-blocks/lib/throttle_impl.h
@@ -22,13 +22,17 @@ class throttle_impl : public throttle
 private:
     std::chrono::time_point<std::chrono::steady_clock> d_start;
     const size_t d_itemsize;
-    uint64_t d_total_samples;
     double d_sample_rate;
     std::chrono::duration<double> d_sample_period;
     const bool d_ignore_tags;
+    unsigned int d_maximum_items_per_chunk;
+    uint64_t d_total_items = 0;
 
 public:
-    throttle_impl(size_t itemsize, double samples_per_sec, bool ignore_tags = true);
+    throttle_impl(size_t itemsize,
+                  double samples_per_sec,
+                  bool ignore_tags = true,
+                  unsigned int maximum_items_per_chunk = 0);
     ~throttle_impl() override;
 
     // Overloading gr::block::start to reset timer
@@ -38,6 +42,9 @@ public:
 
     void set_sample_rate(double rate) override;
     double sample_rate() const override;
+
+    void set_maximum_items_per_chunk(unsigned int maximum_items_per_chunk) override;
+    unsigned int maximum_items_per_chunk() const override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-blocks/python/blocks/bindings/throttle_python.cc
+++ b/gr-blocks/python/blocks/bindings/throttle_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(throttle.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c3a597508d581cabdc653faaa323232c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(9259d01362558f938bdbfec179b6e164)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,6 +43,7 @@ void bind_throttle(py::module& m)
              py::arg("itemsize"),
              py::arg("samples_per_sec"),
              py::arg("ignore_tags") = true,
+             py::arg("maximum_items_per_chunk") = 0,
              D(throttle, make))
 
 


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
This should reduce the amount of chunkiness of signal  processing if used.

Users can now use throttle and get regular, because smaller, item chunks even if (sample rate) << buffer size.

This works now, without the user waiting half an hour for the first message debug output:

![throttle_rate_test](https://user-images.githubusercontent.com/958972/159302011-6b7780e8-d9d1-4f4d-a577-08b72cc711c8.png)


To avoid surprise, this is an optional argument defaulting to previous behaviour (i.e., API and ABI compatible and backportable).


## Which blocks/areas does this affect?
gr::blocks::throttle

## Testing Done

Added a test with an infinite sample source, a throttle at a rate of 50, and a max chunk size of 10, stopping the flowgraph after 0.5 s; without the chunkification, this should lead to an output of buffer_size / 2 items after waiting for buffer_size/2/50 (s, so typically 4096 samples  after 40s or so), with, this should lead to 20 or 30 items.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
  - [x] Block API docs
  - [ ] Wiki
- [x] I have added tests to cover my changes, and all previous tests pass.
