### PR TITLE
Add python bindings and qa test for viterbi combined functions

### DIFF
--- a/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
+++ b/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
@@ -31,31 +31,34 @@ template<typename IN_T, typename OUT_T>
 void bind_viterbi_combined_template(py::module &m, const char *classname) {
     using viterbi_combined = gr::trellis::viterbi_combined<IN_T, OUT_T>;
 
-    py::class_ < viterbi_combined, gr::block, gr::basic_block, std::shared_ptr < viterbi_combined >> (m,
-            classname)
-            .def(py::init(&gr::trellis::viterbi_combined<IN_T, OUT_T>::make),
-                 py::arg("FSM"),
-                 py::arg("K"),
-                 py::arg("S0"),
-                 py::arg("SK"),
-                 py::arg("D"),
-                 py::arg("TABLE"),
-                 py::arg("TYPE"))
-            .def("FSM", &viterbi_combined::FSM)
-            .def("K", &viterbi_combined::K)
-            .def("S0", &viterbi_combined::S0)
-            .def("SK", &viterbi_combined::SK)
-            .def("D", &viterbi_combined::D)
-            .def("set_FSM", &viterbi_combined::set_FSM)
-            .def("set_K", &viterbi_combined::set_K)
-            .def("set_S0", &viterbi_combined::set_S0)
-            .def("set_SK", &viterbi_combined::set_SK)
-            .def("set_D", &viterbi_combined::set_D)
-            .def("set_TABLE", &viterbi_combined::set_TABLE)
-            .def("set_TYPE", &viterbi_combined::set_TYPE);
+    py::class_<viterbi_combined,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr <viterbi_combined>> (m, classname)
+        .def(py::init(&gr::trellis::viterbi_combined<IN_T, OUT_T>::make),
+             py::arg("FSM"),
+             py::arg("K"),
+             py::arg("S0"),
+             py::arg("SK"),
+             py::arg("D"),
+             py::arg("TABLE"),
+             py::arg("TYPE"))
+        .def("FSM", &viterbi_combined::FSM)
+        .def("K", &viterbi_combined::K)
+        .def("S0", &viterbi_combined::S0)
+        .def("SK", &viterbi_combined::SK)
+        .def("D", &viterbi_combined::D)
+        .def("set_FSM", &viterbi_combined::set_FSM)
+        .def("set_K", &viterbi_combined::set_K)
+        .def("set_S0", &viterbi_combined::set_S0)
+        .def("set_SK", &viterbi_combined::set_SK)
+        .def("set_D", &viterbi_combined::set_D)
+        .def("set_TABLE", &viterbi_combined::set_TABLE)
+        .def("set_TYPE", &viterbi_combined::set_TYPE);
 }
 
-void bind_viterbi_combined(py::module &m) {
+void bind_viterbi_combined(py::module &m)
+{
     bind_viterbi_combined_template<std::int16_t, std::uint8_t>(m, "viterbi_combined_sb");
     bind_viterbi_combined_template<std::int16_t, std::int16_t>(m, "viterbi_combined_ss");
     bind_viterbi_combined_template<std::int16_t, std::int32_t>(m, "viterbi_combined_si");

--- a/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
+++ b/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
@@ -28,7 +28,7 @@ namespace py = pybind11;
 #include <viterbi_combined_pydoc.h>
 
 template <typename IN_T, typename OUT_T>
-void bind_viterbi_combined_template(py::module &m, const char *classname)
+void bind_viterbi_combined_template(py::module& m, const char* classname)
 {
     using viterbi_combined = gr::trellis::viterbi_combined<IN_T, OUT_T>;
 

--- a/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
+++ b/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
@@ -27,14 +27,15 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <viterbi_combined_pydoc.h>
 
-template<typename IN_T, typename OUT_T>
-void bind_viterbi_combined_template(py::module &m, const char *classname) {
+template <typename IN_T, typename OUT_T>
+void bind_viterbi_combined_template(py::module &m, const char *classname)
+{
     using viterbi_combined = gr::trellis::viterbi_combined<IN_T, OUT_T>;
 
     py::class_<viterbi_combined,
                gr::block,
                gr::basic_block,
-               std::shared_ptr <viterbi_combined>> (m, classname)
+               std::shared_ptr<viterbi_combined>>(m, classname)
         .def(py::init(&gr::trellis::viterbi_combined<IN_T, OUT_T>::make),
              py::arg("FSM"),
              py::arg("K"),
@@ -57,7 +58,7 @@ void bind_viterbi_combined_template(py::module &m, const char *classname) {
         .def("set_TYPE", &viterbi_combined::set_TYPE);
 }
 
-void bind_viterbi_combined(py::module &m)
+void bind_viterbi_combined(py::module& m)
 {
     bind_viterbi_combined_template<std::int16_t, std::uint8_t>(m, "viterbi_combined_sb");
     bind_viterbi_combined_template<std::int16_t, std::int16_t>(m, "viterbi_combined_ss");

--- a/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
+++ b/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
@@ -27,4 +27,45 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <viterbi_combined_pydoc.h>
 
-void bind_viterbi_combined(py::module& m) {}
+template<typename IN_T, typename OUT_T>
+void bind_viterbi_combined_template(py::module &m, const char *classname) {
+    using viterbi_combined = gr::trellis::viterbi_combined<IN_T, OUT_T>;
+
+    py::class_ < viterbi_combined, gr::block, gr::basic_block, std::shared_ptr < viterbi_combined >> (m,
+            classname)
+            .def(py::init(&gr::trellis::viterbi_combined<IN_T, OUT_T>::make),
+                 py::arg("FSM"),
+                 py::arg("K"),
+                 py::arg("S0"),
+                 py::arg("SK"),
+                 py::arg("D"),
+                 py::arg("TABLE"),
+                 py::arg("TYPE"))
+            .def("FSM", &viterbi_combined::FSM)
+            .def("K", &viterbi_combined::K)
+            .def("S0", &viterbi_combined::S0)
+            .def("SK", &viterbi_combined::SK)
+            .def("D", &viterbi_combined::D)
+            .def("set_FSM", &viterbi_combined::set_FSM)
+            .def("set_K", &viterbi_combined::set_K)
+            .def("set_S0", &viterbi_combined::set_S0)
+            .def("set_SK", &viterbi_combined::set_SK)
+            .def("set_D", &viterbi_combined::set_D)
+            .def("set_TABLE", &viterbi_combined::set_TABLE)
+            .def("set_TYPE", &viterbi_combined::set_TYPE);
+}
+
+void bind_viterbi_combined(py::module &m) {
+    bind_viterbi_combined_template<std::int16_t, std::uint8_t>(m, "viterbi_combined_sb");
+    bind_viterbi_combined_template<std::int16_t, std::int16_t>(m, "viterbi_combined_ss");
+    bind_viterbi_combined_template<std::int16_t, std::int32_t>(m, "viterbi_combined_si");
+    bind_viterbi_combined_template<std::int32_t, std::uint8_t>(m, "viterbi_combined_ib");
+    bind_viterbi_combined_template<std::int32_t, std::int16_t>(m, "viterbi_combined_is");
+    bind_viterbi_combined_template<std::int32_t, std::int32_t>(m, "viterbi_combined_ii");
+    bind_viterbi_combined_template<float, std::uint8_t>(m, "viterbi_combined_fb");
+    bind_viterbi_combined_template<float, std::int16_t>(m, "viterbi_combined_fs");
+    bind_viterbi_combined_template<float, std::int32_t>(m, "viterbi_combined_fi");
+    bind_viterbi_combined_template<gr_complex, std::uint8_t>(m, "viterbi_combined_cb");
+    bind_viterbi_combined_template<gr_complex, std::int16_t>(m, "viterbi_combined_cs");
+    bind_viterbi_combined_template<gr_complex, std::int32_t>(m, "viterbi_combined_ci");
+}

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -74,7 +74,6 @@ class test_trellis (gr_unittest.TestCase):
             self.assertEqual(tb.dst.ntotal(), tb.dst.nright())
 
     def test_001_viterbi_combined(self):
-        fsm = trellis.fsm()
         ftypes = ["ss", "si", "ib", "is", "ii", "fb", "fs", "fi", "cb", "cs", "ci"]
         for ftype in ftypes:
             tb = trellis_comb_tb(ftype)

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -73,6 +73,46 @@ class test_trellis (gr_unittest.TestCase):
             # Make sure all packets successfully transmitted.
             self.assertEqual(tb.dst.ntotal(), tb.dst.nright())
 
+    def test_001_viterbi_combined(self):
+        fsm = trellis.fsm()
+        ftypes = ["ss", "si", "ib", "is", "ii", "fb", "fs", "fi", "cb", "cs", "ci"]
+        for ftype in ftypes:
+            tb = trellis_comb_tb(ftype, fsm)
+            tb.run()
+
+
+class trellis_comb_tb(gr.top_block):
+    """
+    A simple top block for use testing gr-trellis.
+    """
+
+    def __init__(self, ftype, fsm):
+        super(trellis_comb_tb, self).__init__()
+        func = eval("trellis.viterbi_combined_" + ftype)
+        dsttype = gr.sizeof_int
+        if ftype[1] == "b":
+            dsttype = gr.sizeof_char
+        elif ftype[1] == "i":
+            dsttype = gr.sizeof_int
+        elif ftype[1] == "s":
+            dsttype = gr.sizeof_short
+        elif ftype[1] == "f":
+            dsttype = gr.sizeof_float
+        elif ftype[1] == "c":
+            dsttype = gr.sizeof_gr_complex
+        src_func = eval("blocks.vector_source_" + ftype[0])
+        data = [1 * 200]
+        src = src_func(data)
+        self.dst = blocks.null_sink(dsttype * 1)
+        constellation = [1, 1, 1, 1, 1, -1, 1, -1, 1, 1, -1, -1, -1, 1, 1, -1, 1, -1, -1, -1, 1, -1, -1, -1]
+        vbc = func(trellis.fsm(1, 3, [91, 121, 117]), 1, 0, -1, 3, constellation, digital.TRELLIS_EUCLIDEAN)
+
+        ##################################################
+        # Connections
+        ##################################################
+
+        self.connect((src, 0), (vbc, 0))
+        self.connect((vbc, 0), (self.dst, 0))
 
 class trellis_tb(gr.top_block):
     """

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -77,7 +77,7 @@ class test_trellis (gr_unittest.TestCase):
         fsm = trellis.fsm()
         ftypes = ["ss", "si", "ib", "is", "ii", "fb", "fs", "fi", "cb", "cs", "ci"]
         for ftype in ftypes:
-            tb = trellis_comb_tb(ftype, fsm)
+            tb = trellis_comb_tb(ftype)
             tb.run()
 
 
@@ -86,7 +86,7 @@ class trellis_comb_tb(gr.top_block):
     A simple top block for use testing gr-trellis.
     """
 
-    def __init__(self, ftype, fsm):
+    def __init__(self, ftype):
         super(trellis_comb_tb, self).__init__()
         func = eval("trellis.viterbi_combined_" + ftype)
         dsttype = gr.sizeof_int
@@ -113,6 +113,7 @@ class trellis_comb_tb(gr.top_block):
 
         self.connect((src, 0), (vbc, 0))
         self.connect((vbc, 0), (self.dst, 0))
+
 
 class trellis_tb(gr.top_block):
     """


### PR DESCRIPTION
# Pull Request Details
Add missing python bindings for trellis viterbi_combined

## Description
This adds missing python bindings for trellis code, especially viterbi_combinedxx, which seem not to have been introduced after the project conversion from 3.8 (swig) to 3.9 (pybind11)

## Related Issue
Fixes #5666

## Which blocks/areas does this affect?
gr-trellis, in particular all trellis.viterbi_combinedxx python bindings that weren't implemented since porting gnuradio from 3.8 (swig) to 3.9 (pybind11)

## Testing Done
Recompiled gnuradio, made a demo block and tested for the python binding to work

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass. 
