### PR TITLE
Add python bindings and qa test for trellis sccc_encoder functions 

### DIFF
--- a/gr-trellis/python/trellis/bindings/sccc_encoder_python.cc
+++ b/gr-trellis/python/trellis/bindings/sccc_encoder_python.cc
@@ -27,4 +27,39 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <sccc_encoder_pydoc.h>
 
-void bind_sccc_encoder(py::module& m) {}
+template <class IN_T, class OUT_T>
+void bind_sccc_encoder_template(py::module& m, const char* classname)
+{
+    using sccc_encoder = gr::trellis::sccc_encoder<IN_T, OUT_T>;
+
+    py::class_<sccc_encoder,
+               gr::sync_block,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<sccc_encoder>>(m, classname)
+        .def(py::init(&gr::trellis::sccc_encoder<IN_T, OUT_T>::make),
+             py::arg("FSMo"),
+             py::arg("STo"),
+             py::arg("FSMi"),
+             py::arg("STi"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength") = 0)
+        .def("FSMo", &sccc_encoder::FSMo)
+        .def("STo", &sccc_encoder::STo)
+        .def("FSMi", &sccc_encoder::FSMi)
+        .def("STi", &sccc_encoder::STi)
+        .def("INTERLEAVER", &sccc_encoder::INTERLEAVER)
+        .def("blocklength", &sccc_encoder::blocklength);
+}
+
+void bind_sccc_encoder(py::module& m)
+{
+    bind_sccc_encoder_template<std::uint8_t, std::uint8_t>(m, "sccc_encoder_bb");
+    bind_sccc_encoder_template<std::uint8_t, std::int16_t>(m, "sccc_encoder_bs");
+    bind_sccc_encoder_template<std::uint8_t, std::int32_t>(m, "sccc_encoder_bi");
+    bind_sccc_encoder_template<std::int16_t, std::int16_t>(m, "sccc_encoder_ss");
+    bind_sccc_encoder_template<std::int16_t, std::int32_t>(m, "sccc_encoder_si");
+    bind_sccc_encoder_template<std::int32_t, std::int32_t>(m, "sccc_encoder_ii");
+}
+
+

--- a/gr-trellis/python/trellis/bindings/sccc_encoder_python.cc
+++ b/gr-trellis/python/trellis/bindings/sccc_encoder_python.cc
@@ -61,5 +61,3 @@ void bind_sccc_encoder(py::module& m)
     bind_sccc_encoder_template<std::int16_t, std::int32_t>(m, "sccc_encoder_si");
     bind_sccc_encoder_template<std::int32_t, std::int32_t>(m, "sccc_encoder_ii");
 }
-
-

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -73,6 +73,36 @@ class test_trellis (gr_unittest.TestCase):
             # Make sure all packets successfully transmitted.
             self.assertEqual(tb.dst.ntotal(), tb.dst.nright())
 
+    def test_001_sccc_encoder(self):
+        ftypes = ["bb", "bs", "bi", "ss", "si", "ii"]
+        for ftype in ftypes:
+            tb = trellis_sccc_encoder_tb(ftype)
+            tb.run()
+
+
+class trellis_sccc_encoder_tb(gr.top_block):
+    """
+    A simple top block for use testing gr-trellis.
+    """
+
+    def __init__(self, ftype):
+        super(trellis_sccc_encoder_tb, self).__init__()
+        func = eval("trellis.sccc_encoder_" + ftype)
+        dsttype = gr.sizeof_int
+        if ftype[1] == "b":
+            dsttype = gr.sizeof_char
+        elif ftype[1] == "i":
+            dsttype = gr.sizeof_int
+        elif ftype[1] == "s":
+            dsttype = gr.sizeof_short
+        src_func = eval("blocks.vector_source_" + ftype[0])
+        data = [1 * 200]
+        src = src_func(data)
+        self.dst = blocks.null_sink(dsttype * 1)
+        vbc = func(trellis.fsm(), 0, trellis.fsm(), 0, trellis.interleaver(), 2)
+        self.connect((src, 0), (vbc, 0))
+        self.connect((vbc, 0), (self.dst, 0))
+
 
 class trellis_tb(gr.top_block):
     """


### PR DESCRIPTION
Signed-off-by: Bjoern Kerler <info@revskills.de>

# Pull Request Details
Add missing python bindings for trellis sccc_encoder

## Description
This adds missing python bindings for trellis code, especially sccc_encoder_xx, which seem not to have been introduced after the project conversion from 3.8 (swig) to 3.9 (pybind11)

## Related Issue
Related to #5666

## Which blocks/areas does this affect?
gr-trellis, in particular all trellis.sccc_encoder_xx python bindings that weren't implemented since porting gnuradio from 3.8 (swig) to 3.9 (pybind11), including non-connected grc in the gnuradio application.

## Testing Done
Recompiled gnuradio, made a demo block and tested for the python binding to work

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass. 
