### PR TITLE
blocks: Add exponential distribution to Message Strobe Random-Delay (backport to maint-3.10)

### DIFF
--- a/gr-blocks/grc/blocks_message_strobe_random.block.yml
+++ b/gr-blocks/grc/blocks_message_strobe_random.block.yml
@@ -10,16 +10,17 @@ parameters:
 -   id: dist
     label: Distribution
     dtype: enum
-    options: [blocks.STROBE_POISSON, blocks.STROBE_UNIFORM, blocks.STROBE_GAUSSIAN]
-    option_labels: [Poisson, Uniform, Gaussian]
+    options: [blocks.STROBE_EXPONENTIAL, blocks.STROBE_UNIFORM, blocks.STROBE_GAUSSIAN, blocks.STROBE_POISSON]
+    option_labels: [Exponential, Uniform, Gaussian, Poisson]
 -   id: mean
     label: Mean (ms)
     dtype: real
     default: '1000'
 -   id: std
-    label: Std (ms)
+    label: ${ 'Max. Deviation (ms)' if dist == 'blocks.STROBE_UNIFORM' else 'Std. Deviation (ms)' }
     dtype: real
     default: '100'
+    hide: ${ 'none' if dist in ('blocks.STROBE_UNIFORM', 'blocks.STROBE_GAUSSIAN') else 'all' }
 
 inputs:
 -   domain: message
@@ -41,11 +42,5 @@ templates:
     - set_dist(${dist})
     - set_mean(${mean})
     - set_std(${std})
-
-documentation: |-
-    Please note some peculiarities below:
-                - poisson does not care about your std
-                - gaussian operates as expected
-                - uniform is actually of the range (mean-std, mean+std) - thus we are lying and it is not actually an std here
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/message_strobe_random.h
+++ b/gr-blocks/include/gnuradio/blocks/message_strobe_random.h
@@ -23,7 +23,8 @@ namespace blocks {
 typedef enum {
     STROBE_POISSON = 1,
     STROBE_GAUSSIAN = 2,
-    STROBE_UNIFORM = 3
+    STROBE_UNIFORM = 3,
+    STROBE_EXPONENTIAL = 4
 } message_strobe_random_distribution_t;
 
 /*!
@@ -32,8 +33,8 @@ typedef enum {
  *
  * \details
 
- * Takes a PMT message and sends it out every at random
- * intervals. The interval is basedon a random distribution, \p
+ * Takes a PMT message and sends it out at random
+ * intervals. The interval is based on a random distribution, \p
  * dist, with specified mean (\p mean_ms) and variance (\p
  * std_ms). Useful for testing/debugging the message system.
  */
@@ -49,9 +50,13 @@ public:
      * mean_ms and standard deviation \p std_ms.
      *
      * \param msg The message to send as a PMT.
-     * \param dist The random distribution from which to draw events.
-     * \param mean_ms The mean of the distribution.
-     * \param std_ms The standard deviation of the distribution.
+     * \param dist The random distribution from which to draw the time between
+     *             events.
+     * \param mean_ms The mean of the distribution, in milliseconds.
+     * \param std_ms The standard deviation of the Gaussian distribution,
+     *               or the maximum absolute deviation of the Uniform
+     *               distribution, in milliseconds. This argument is ignored
+     *               for other distributions.
      */
     static sptr make(pmt::pmt_t msg,
                      message_strobe_random_distribution_t dist,

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -44,6 +44,7 @@ message_strobe_random_impl::message_strobe_random_impl(
       pd(d_mean_ms),
       nd(d_mean_ms, d_std_ms),
       ud(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms),
+      ed(1.0f / d_mean_ms),
       d_finished(false),
       d_msg(msg),
       d_port(pmt::mp("strobe"))
@@ -62,6 +63,7 @@ void message_strobe_random_impl::set_mean(float mean_ms)
     pd = std::poisson_distribution<>(d_mean_ms);
     nd = std::normal_distribution<>(d_mean_ms, d_std_ms);
     ud = std::uniform_real_distribution<>(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms);
+    ed = std::exponential_distribution<>(1.0f / d_mean_ms);
 }
 
 float message_strobe_random_impl::mean() const { return d_mean_ms; }
@@ -77,12 +79,13 @@ long message_strobe_random_impl::next_delay()
 {
     switch (d_dist) {
     case STROBE_POISSON:
-        // return d_variate_poisson->operator()();
         return static_cast<long>(pd(d_rng));
     case STROBE_GAUSSIAN:
         return static_cast<long>(nd(d_rng));
     case STROBE_UNIFORM:
         return static_cast<long>(ud(d_rng));
+    case STROBE_EXPONENTIAL:
+        return static_cast<long>(ed(d_rng));
     default:
         throw std::runtime_error(
             "message_strobe_random_impl::d_distribution is very unhappy with you");

--- a/gr-blocks/lib/message_strobe_random_impl.h
+++ b/gr-blocks/lib/message_strobe_random_impl.h
@@ -29,6 +29,7 @@ private:
     std::poisson_distribution<> pd;      //(d_mean_ms);
     std::normal_distribution<> nd;       //(d_mean_ms, d_std_ms);
     std::uniform_real_distribution<> ud; //(d_mean_ms - d_std_ms, d_mean_ms + d_std_ms);
+    std::exponential_distribution<> ed;  //(1.0f / d_mean_ms);
     gr::thread::thread d_thread;
     std::atomic<bool> d_finished;
     pmt::pmt_t d_msg;

--- a/gr-blocks/python/blocks/bindings/message_strobe_random_python.cc
+++ b/gr-blocks/python/blocks/bindings/message_strobe_random_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(message_strobe_random.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a759e6e0483f67da0e1a9bdf8344f16e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(baaacfe399a27ddc18d1012195ac4d34)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -86,9 +86,10 @@ void bind_message_strobe_random(py::module& m)
 
     py::enum_<::gr::blocks::message_strobe_random_distribution_t>(
         m, "message_strobe_random_distribution_t")
-        .value("STROBE_POISSON", ::gr::blocks::STROBE_POISSON)   // 1
-        .value("STROBE_GAUSSIAN", ::gr::blocks::STROBE_GAUSSIAN) // 2
-        .value("STROBE_UNIFORM", ::gr::blocks::STROBE_UNIFORM)   // 3
+        .value("STROBE_POISSON", ::gr::blocks::STROBE_POISSON)         // 1
+        .value("STROBE_GAUSSIAN", ::gr::blocks::STROBE_GAUSSIAN)       // 2
+        .value("STROBE_UNIFORM", ::gr::blocks::STROBE_UNIFORM)         // 3
+        .value("STROBE_EXPONENTIAL", ::gr::blocks::STROBE_EXPONENTIAL) // 4
         .export_values();
 
     py::implicitly_convertible<int, ::gr::blocks::message_strobe_random_distribution_t>();

--- a/gr-zeromq/examples/zmq_msg.grc
+++ b/gr-zeromq/examples/zmq_msg.grc
@@ -45,7 +45,7 @@ blocks:
     affinity: ''
     alias: ''
     comment: ''
-    dist: blocks.STROBE_POISSON
+    dist: blocks.STROBE_EXPONENTIAL
     maxoutbuf: '0'
     mean: '100'
     minoutbuf: '0'


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit bb554fae5f69616b7e7bc047154a57e3b9f39d9f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5669