### PR TITLE
Fix: UHD get_gpio_attr throws RuntimeError "Not implemented"

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -376,7 +376,7 @@ uint32_t usrp_block_impl::get_gpio_attr(const std::string& bank,
                                         const std::string& attr,
                                         const size_t mboard)
 {
-    throw std::runtime_error("not implemented in this version");
+    return _dev->get_gpio_attr(bank, attr, mboard);
 }
 
 void usrp_block_impl::set_time_now(const ::uhd::time_spec_t& time_spec, size_t mboard)


### PR DESCRIPTION
## Description
See https://github.com/gnuradio/gnuradio/issues/5681  
Bug was introduced in https://github.com/gnuradio/gnuradio/commit/9cdfe5141a7aad1cf9c4c81167761cc291913fb0

## Related Issue
Fixes https://github.com/gnuradio/gnuradio/issues/5681

## Which blocks/areas does this affect?
UHD

## Testing Done
Yes. Compiled UHD and GNUradio with the proposed change cherry picked on top of v3.10.1.1 from source. Function call works as expected.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- ~~I have added tests to cover my changes, and all previous tests pass.~~
