### PR TITLE
digital: move EVM Measurement block into the Core tree (backport to maint-3.9)

### DIFF
--- a/gr-digital/grc/digital.tree.yml
+++ b/gr-digital/grc/digital.tree.yml
@@ -7,6 +7,7 @@
   - variable_adaptive_algorithm
   - digital_linear_equalizer
   - digital_decision_feedback_equalizer
+  - digital_meas_evm_cc
 - Measurement Tools:
   - digital_mpsk_snr_est_cc
   - digital_probe_density_b


### PR DESCRIPTION
Currently the "EVM Measurement" block shows up in its own "Equalizers"
module in GRC instead of the "Equalizers" category in the Core module.
Adding it to the tree file fixes that.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit cecde9b314b6440429e7519e81e562fdc911c039)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5560