### PR TITLE
Remove co-author's name from documentation (backport to maint-3.9)

### DIFF
--- a/gr-blocks/grc/blocks_matrix_interleaver.block.yml
+++ b/gr-blocks/grc/blocks_matrix_interleaver.block.yml
@@ -54,8 +54,7 @@ outputs:
 asserts:
 - ${ vlen > 0 }
 
-documentation: 'Jared Dulmage
-
+documentation: '|-
     Block interleaver reads inputs into rows and writes outputs by cols
 
     python/matrix_interleaver.py'


### PR DESCRIPTION
Removed co-author's name from yml doc

(cherry picked from commit 141c0da0349703a483d0c5931d01ed207dcdd3b6)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5550