### PR TITLE
grc: add .desktop suffix to the desktop launchable, other metainfo fixes (backport to maint-3.9)

### DIFF
--- a/grc/scripts/freedesktop/org.gnuradio.grc.metainfo.xml
+++ b/grc/scripts/freedesktop/org.gnuradio.grc.metainfo.xml
@@ -9,6 +9,7 @@
 -->
 <component type="desktop-application">
 <id>org.gnuradio.grc</id>
+<launchable type="desktop-id">gnuradio-grc.desktop</launchable>
 <metadata_license>CC0-1.0</metadata_license>
 <project_license>GPL-3.0+</project_license>
 <name>GNU Radio Companion</name>
@@ -39,7 +40,6 @@
   <category>HamRadio</category>
   <category>DataVisualization</category>
 </categories>
-<launchable type="desktop-id">gnuradio-grc</launchable>
 <screenshots>
   <screenshot type="default">
     <caption>GNU Radio Companion</caption>

--- a/grc/scripts/freedesktop/org.gnuradio.grc.metainfo.xml
+++ b/grc/scripts/freedesktop/org.gnuradio.grc.metainfo.xml
@@ -50,7 +50,6 @@
 <url type="homepage">https://www.gnuradio.org</url>
 <url type="help">https://wiki.gnuradio.org/</url>
 <url type="bugtracker">https://github.com/gnuradio/gnuradio/issues</url>
-<url type="contact">mailto:discuss-gnuradio@gnu.org</url>
 <url type="contact">https://lists.gnu.org/mailman/listinfo/discuss-gnuradio</url>
 <url type="contact">https://chat.gnuradio.org</url>
 <provides>


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/5615/commits