### PR TITLE
runtime: Make vmcircbuf logging quieter

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
@@ -54,7 +54,7 @@ vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(size_t size)
     gr::configure_default_loggers(
         d_logger, d_debug_logger, "vmcircbuf_createfilemapping");
 #if !defined(HAVE_CREATEFILEMAPPING)
-    d_logger->error("{:s}: createfilemapping is not available", __FUNCTION__);
+    d_debug_logger->info("{:s}: CreateFileMapping is not available", __FUNCTION__);
     throw std::runtime_error("gr::vmcircbuf_createfilemapping");
 #else
     gr::thread::scoped_lock guard(s_vm_mutex);

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -59,7 +59,7 @@ int vmcircbuf_prefs::get(const char* key, char* value, int value_size)
     gr::configure_default_loggers(logger, debug_logger, "vmcircbuf_prefs::get");
 
     if (fp == 0) {
-        logger->error("{:s}: {:s}", pathname(key), strerror(errno));
+        debug_logger->info("{:s}: {:s}", pathname(key), strerror(errno));
         return 0;
     }
 


### PR DESCRIPTION
## Description

When a flow graph is executed for the first time, and `~/.gnuradio` does not exist, the following error messages are printed:

```
vmcircbuf_prefs::get :erro: /home/argilo/.gnuradio/prefs/vmcircbuf_default_factory: No such file or directory
gr::vmcircbuf :error: vmcircbuf_createfilemapping: createfilemapping is not available
```

These are expected situations, so they should not be logged at the error level. Other similar vmcircbuf messages are logged to the debug logger at the info level, so I've done that here as well.

In addition, I changed `createfilemapping` to `CreateFileMapping` to reflect the actual name of the function.

After these changes, no log messages are printed the first time GNU Radio is used, since the debug logger is set to the emerg level by default.

## Testing Done
To test, I simply deleted the `~/.gnuradio` directory and executed a flow graph.

I also changed the debug log level to `info` in `/etc/gnuradio/conf.d/gnuradio-runtime.conf` to verify that the messages are printed in that case.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
