### PR TITLE
digital: Replace boost::crc with built-in CRC implementation

### DIFF
--- a/gr-digital/include/gnuradio/digital/crc16_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc16_async_bb.h
@@ -40,8 +40,7 @@ namespace digital {
  * calculated on the PDU and appended to it. The output is then 2
  * bytes longer than the input.
  *
- * This block implements the CRC16 using the Boost crc_optimal
- * class for 16-bit CRCs with the standard generator 0x1021.
+ * This block implements the CRC16 using the standard generator 0x1021.
  */
 class DIGITAL_API crc16_async_bb : virtual public block
 {

--- a/gr-digital/include/gnuradio/digital/crc32_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_async_bb.h
@@ -38,8 +38,7 @@ namespace digital {
  * calculated on the PDU and appended to it. The output is then 4
  * bytes longer than the input.
  *
- * This block implements the CRC32 using the Boost crc_optimal
- * class for 32-bit CRCs with the standard generator 0x04C11DB7.
+ * This block implements the CRC32 using the standard generator 0x04C11DB7.
  */
 class DIGITAL_API crc32_async_bb : virtual public block
 {

--- a/gr-digital/include/gnuradio/digital/header_format_crc.h
+++ b/gr-digital/include/gnuradio/digital/header_format_crc.h
@@ -11,9 +11,9 @@
 #define INCLUDED_DIGITAL_HEADER_FORMAT_CRC_H
 
 #include <gnuradio/digital/api.h>
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/header_format_default.h>
 #include <pmt/pmt.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -90,7 +90,7 @@ protected:
     uint16_t d_header_number;
     pmt::pmt_t d_len_key_name;
     pmt::pmt_t d_num_key_name;
-    boost::crc_optimal<8, 0x07, 0xFF, 0x00, false, false> d_crc_impl;
+    crc d_crc_impl;
 
     //! Verify that the header is valid
     bool header_ok() override;

--- a/gr-digital/include/gnuradio/digital/packet_header_default.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_default.h
@@ -11,8 +11,8 @@
 #define INCLUDED_DIGITAL_PACKET_HEADER_DEFAULT_H
 
 #include <gnuradio/digital/api.h>
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/tags.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -91,7 +91,7 @@ protected:
     int d_bits_per_byte;
     unsigned d_header_number;
     unsigned d_mask;
-    boost::crc_optimal<8, 0x07, 0xFF, 0x00, false, false> d_crc_impl;
+    crc d_crc_impl;
 };
 
 } // namespace digital

--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -26,6 +26,7 @@ crc16_async_bb::sptr crc16_async_bb::make(bool check)
 
 crc16_async_bb_impl::crc16_async_bb_impl(bool check)
     : block("crc16_async_bb", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
+      d_crc_ccitt_impl(16, 0x1021, 0xFFFF, 0, false, false),
       d_npass(0),
       d_nfail(0)
 {
@@ -72,9 +73,7 @@ unsigned int crc16_async_bb_impl::process_crc(const uint8_t* bytes_in,
 
     unsigned int result;
 
-    d_crc_ccitt_impl.reset();
-    d_crc_ccitt_impl.process_bytes(bytes_in, n_bytes_prcss);
-    result = d_crc_ccitt_impl();
+    result = d_crc_ccitt_impl.compute(bytes_in, n_bytes_prcss);
     return result;
 }
 

--- a/gr-digital/lib/crc16_async_bb_impl.h
+++ b/gr-digital/lib/crc16_async_bb_impl.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_DIGITAL_CRC16_ASYNC_BB_IMPL_H
 #define INCLUDED_DIGITAL_CRC16_ASYNC_BB_IMPL_H
 
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/crc16_async_bb.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -20,7 +20,7 @@ namespace digital {
 class crc16_async_bb_impl : public crc16_async_bb
 {
 private:
-    boost::crc_ccitt_type d_crc_ccitt_impl;
+    crc d_crc_ccitt_impl;
 
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;

--- a/gr-digital/lib/crc32_async_bb_impl.h
+++ b/gr-digital/lib/crc32_async_bb_impl.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_DIGITAL_CRC32_ASYNC_BB_IMPL_H
 #define INCLUDED_DIGITAL_CRC32_ASYNC_BB_IMPL_H
 
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/crc32_async_bb.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -20,7 +20,7 @@ namespace digital {
 class crc32_async_bb_impl : public crc32_async_bb
 {
 private:
-    boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true> d_crc_impl;
+    crc d_crc_impl;
 
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;

--- a/gr-digital/lib/crc32_bb_impl.h
+++ b/gr-digital/lib/crc32_bb_impl.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_DIGITAL_CRC32_BB_IMPL_H
 #define INCLUDED_DIGITAL_CRC32_BB_IMPL_H
 
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/crc32_bb.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -22,9 +22,9 @@ class crc32_bb_impl : public crc32_bb
 private:
     bool d_check;
     bool d_packed;
-    boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true> d_crc_impl;
+    crc d_crc_impl;
     unsigned int d_crc_length;
-    std::vector<char> d_buffer;
+    std::vector<unsigned char> d_buffer;
     unsigned int calculate_crc32(const unsigned char* in, size_t packet_length);
 
 public:

--- a/gr-digital/python/digital/bindings/crc16_async_bb_python.cc
+++ b/gr-digital/python/digital/bindings/crc16_async_bb_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc16_async_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0266da27c09c311e854b9350c3761696)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c751e985e9d0790c891979f57c198f6f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/crc32_async_bb_python.cc
+++ b/gr-digital/python/digital/bindings/crc32_async_bb_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc32_async_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c084ed79dad8f1c325cf5c9c28fa1bce)                     */
+/* BINDTOOL_HEADER_FILE_HASH(21a4e7d0804db99d0f75ddbe2fe9ef51)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/header_format_crc_python.cc
+++ b/gr-digital/python/digital/bindings/header_format_crc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_format_crc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0a5a9ad1c6bc88eb23f7f65faac4b146)                     */
+/* BINDTOOL_HEADER_FILE_HASH(8c45adf0e2f688e58b014b05e6a8c204)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/packet_header_default_python.cc
+++ b/gr-digital/python/digital/bindings/packet_header_default_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(packet_header_default.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(986c8fe960c6f0510304dc660e276e34)                     */
+/* BINDTOOL_HEADER_FILE_HASH(07dc3324dfa4a18438259d00a6a894a9)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/qa_crc16_async_bb.py
+++ b/gr-digital/python/digital/qa_crc16_async_bb.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright 2022 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest, blocks, digital
+import pmt
+
+
+class qa_crc16_async_bb(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+        self.tsb_key = "length"
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_crc16(self):
+        crc_append_block = digital.crc16_async_bb(check=False)
+        crc_check_block = digital.crc16_async_bb(check=True)
+
+        dbg_append = blocks.message_debug()
+        dbg_check = blocks.message_debug()
+
+        self.tb.msg_connect((crc_append_block, 'out'), (crc_check_block, 'in'))
+        self.tb.msg_connect((crc_append_block, 'out'), (dbg_append, 'store'))
+        self.tb.msg_connect((crc_check_block, 'out'), (dbg_check, 'store'))
+
+        data = list(range(16))
+        pdu = pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(len(data), data))
+
+        crc_append_block._post(pmt.intern('in'), pdu)
+        crc_append_block._post(
+            pmt.intern('system'),
+            pmt.cons(pmt.intern('done'), pmt.from_long(1)))
+
+        self.tb.run()
+
+        self.assertEqual(dbg_append.num_messages(), 1)
+        out_append = pmt.u8vector_elements(pmt.cdr(dbg_append.get_message(0)))
+        self.assertEqual(out_append, data + [0x37, 0x3b])
+
+        self.assertEqual(dbg_check.num_messages(), 1)
+        out_check = pmt.u8vector_elements(pmt.cdr(dbg_check.get_message(0)))
+        self.assertEqual(out_check, data)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_crc16_async_bb)

--- a/gr-digital/python/digital/qa_crc32_async_bb.py
+++ b/gr-digital/python/digital/qa_crc32_async_bb.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright 2022 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest, blocks, digital
+import pmt
+
+
+class qa_crc32_async_bb(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+        self.tsb_key = "length"
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_crc32(self):
+        crc_append_block = digital.crc32_async_bb(check=False)
+        crc_check_block = digital.crc32_async_bb(check=True)
+
+        dbg_append = blocks.message_debug()
+        dbg_check = blocks.message_debug()
+
+        self.tb.msg_connect((crc_append_block, 'out'), (crc_check_block, 'in'))
+        self.tb.msg_connect((crc_append_block, 'out'), (dbg_append, 'store'))
+        self.tb.msg_connect((crc_check_block, 'out'), (dbg_check, 'store'))
+
+        data = list(range(16))
+        pdu = pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(len(data), data))
+
+        crc_append_block._post(pmt.intern('in'), pdu)
+        crc_append_block._post(
+            pmt.intern('system'),
+            pmt.cons(pmt.intern('done'), pmt.from_long(1)))
+
+        self.tb.run()
+
+        self.assertEqual(dbg_append.num_messages(), 1)
+        out_append = pmt.u8vector_elements(pmt.cdr(dbg_append.get_message(0)))
+        self.assertEqual(out_append, data + [0x88, 0xe2, 0xce, 0xce])
+
+        self.assertEqual(dbg_check.num_messages(), 1)
+        out_check = pmt.u8vector_elements(pmt.cdr(dbg_check.get_message(0)))
+        self.assertEqual(out_check, data)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_crc32_async_bb)


### PR DESCRIPTION
## Description
In #5619 a generic CRC class was added. Existing blocks that use Boost.CRC can switch over to this implementation, thereby eliminating a Boost dependency.

## Related Issue
* #5619

## Which blocks/areas does this affect?
* Async CRC16
* Async CRC32
* Stream CRC32
* Packet Header Generator
* Packet Header Parser

## Testing Done
There are five places where the CRC implementation was replaced:
1. `crc32_bb`: Here I verified that `qa_crc32_bb.py` fails if I corrupt the CRC parameters.
2. `crc16_async_bb`: This block had no tests. I added a basic test, and verified that it passes before & after my changes.
3. `crc32_async_bb`: This block had no tests. I added a basic test, and verified that it passes before & after my changes.
4. `packet_header_default`: Here I verified that `qa_packet_headerparser_b.py` and `qa_pacrket_headergenerater_bb.py` fail if I corrupt the CRC paremeters.
5. `header_format_crc`: This block does not appear to have tests. Unfortunately its Python binding appears broken, so I didn't attemp to create one. However, this class uses the same CRC parameters as `packet_header_default`, so it is unlikely to be broken.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.