### PR TITLE
Fix create hier / missing top_block error

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -311,7 +311,7 @@ class Application(Gtk.Application):
             flow_graph.move_selected(coords)
 
             # Set flow graph to heir block type
-            top_block = flow_graph.get_block("top_block")
+            top_block = flow_graph.get_block(Constants.DEFAULT_FLOW_GRAPH_ID)
             top_block.params['generate_options'].set_value('hb')
 
             # this needs to be a unique name


### PR DESCRIPTION
# Pull Request Details
Fixes an error on creating hier, which states that "top_block" is missing, thus making the option "Create hier" unusable. Affects gnuradio >= 3.8.

## Description
On selecting several blocks, right click "More -> Create Hier", the expected behaviour should be to create a new hier consisting of the selected blocks and to add pads to the hier block. Instead there is an error stating that "top_block" cannot be found.

## Related Issue
No issue found.

## Which blocks/areas does this affect?
Affects gnuradio-companion on using the menu "Create hier" as suggested in the wiki https://wiki.gnuradio.org/index.php?title=Hier_Blocks_and_Parameters

## Testing Done
The function was tested and seemed to work fine.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
