### PR TITLE
Fix variable_struct value initialization

### DIFF
--- a/grc/blocks/variable_struct.block.yml.py
+++ b/grc/blocks/variable_struct.block.yml.py
@@ -87,7 +87,8 @@ def make_yml(num_fields):
         HEADER.format(num_fields),
         FIELD0, ''.join(FIELDS.format(i) for i in range(1, num_fields)),
         ''.join(VALUES.format(i) for i in range(num_fields)),
-        'value: ${value}\n\nasserts:\n',
+        'value: ${'+','.join("value{0}".format(i) for i in range(num_fields))+'}\n\n',
+        'asserts:\n',
         ''.join(ASSERTS.format(i) for i in range(num_fields)),
         ''.join(TEMPLATES.format(num_fields)),
         FOOTER


### PR DESCRIPTION
# Pull Request Details
This fixes an issue with improper value field initialization on variable_struct, which
makes using the variable struct block unusable. This affects gnuradio 3.10/3.11 and may affect gnuradio 3.8/3.9 as well.

## Description
On creating a variable struct block, this will fail and create an error :
`
ERROR:gnuradio.grc.core.FlowGraph:Failed to evaluate variable block variable_struct_0
Traceback (most recent call last):
  File "/home/xxx/gnuradio/lib/python3/dist-packages/gnuradio/grc/core/FlowGraph.py", line 288, in renew_namespace
    value = eval(variable_block.value, namespace, variable_block.namespace)
  File "<string>", line 1, in <module>
NameError: name 'value' is not defined
`
The reason for the issue is that when var_make is being used on the yml structure, the field value is hardcoded within
the "make_yml" function in "variable_struct.block.yml.py". This should never happen as the value field does not exist and will never be initialized, unlike the value0-19 fields. Instead it should be initialized with the existing value fields.

## Related Issue
No reported issue

## Which blocks/areas does this affect?
This affects the variable struct block but indirectly also affects embedded python blocks.

## Testing Done
Two variable struct fields were created. One was filled with hardcoded integer values, the other was initialized pointing to the variable instead, which succeeded. Example:
variable_struct_1 => field0:0, field1:3, field2:2
variable_struct_2 => field0:1, field1:variable_struct_1[1], field2:3
Result: variable_struct_2 shows 1,3,3 as expected

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
