### PR TITLE
fft: Replace Boost with standard C++

### DIFF
--- a/gr-fft/include/gnuradio/fft/fft.h
+++ b/gr-fft/include/gnuradio/fft/fft.h
@@ -19,7 +19,7 @@
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/logger.h>
 #include <volk/volk_alloc.hh>
-#include <boost/thread.hpp>
+#include <mutex>
 
 namespace gr {
 namespace fft {
@@ -31,11 +31,10 @@ namespace fft {
 class FFT_API planner
 {
 public:
-    typedef boost::mutex::scoped_lock scoped_lock;
     /*!
      * Return reference to planner mutex
      */
-    static boost::mutex& mutex();
+    static std::mutex& mutex();
 };
 
 

--- a/gr-fft/lib/ctrlport_probe_psd_impl.cc
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.cc
@@ -49,9 +49,6 @@ void ctrlport_probe_psd_impl::forecast(int noutput_items,
         ninput_items_required[i] = d_len;
 }
 
-//    boost::shared_mutex mutex_buffer;
-//    mutable boost::mutex mutex_notify;
-//    boost::condition_variable condition_buffer_ready;
 std::vector<gr_complex> ctrlport_probe_psd_impl::get()
 {
     mutex_buffer.lock();
@@ -59,7 +56,7 @@ std::vector<gr_complex> ctrlport_probe_psd_impl::get()
     mutex_buffer.unlock();
 
     // wait for condition
-    boost::mutex::scoped_lock lock(mutex_notify);
+    std::unique_lock<std::mutex> lock(mutex_notify);
     condition_buffer_ready.wait(lock);
 
     mutex_buffer.lock();

--- a/gr-fft/lib/ctrlport_probe_psd_impl.h
+++ b/gr-fft/lib/ctrlport_probe_psd_impl.h
@@ -14,7 +14,8 @@
 #include <gnuradio/fft/ctrlport_probe_psd.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/rpcregisterhelpers.h>
-#include <boost/thread/shared_mutex.hpp>
+#include <condition_variable>
+#include <mutex>
 
 namespace gr {
 namespace fft {
@@ -25,9 +26,9 @@ private:
     std::string d_id;
     std::string d_desc;
     size_t d_len;
-    boost::shared_mutex mutex_buffer;
-    mutable boost::mutex mutex_notify;
-    boost::condition_variable condition_buffer_ready;
+    std::mutex mutex_buffer;
+    mutable std::mutex mutex_notify;
+    std::condition_variable condition_buffer_ready;
 
     std::vector<gr_complex> d_buffer;
     gr::fft::fft_complex_fwd d_fft;

--- a/gr-fft/lib/fft.cc
+++ b/gr-fft/lib/fft.cc
@@ -40,13 +40,13 @@ namespace fs = std::filesystem;
 
 namespace gr {
 namespace fft {
-static boost::mutex wisdom_thread_mutex;
+static std::mutex wisdom_thread_mutex;
 boost::interprocess::file_lock wisdom_lock;
 static bool wisdom_lock_init_done = false; // Modify while holding 'wisdom_thread_mutex'
 
-boost::mutex& planner::mutex()
+std::mutex& planner::mutex()
 {
-    static boost::mutex s_planning_mutex;
+    static std::mutex s_planning_mutex;
 
     return s_planning_mutex;
 }
@@ -139,7 +139,7 @@ fft<T, forward>::fft(int fft_size, int nthreads)
     : d_nthreads(nthreads), d_inbuf(fft_size), d_outbuf(fft_size), d_logger("fft_complex")
 {
     // Hold global mutex during plan construction and destruction.
-    planner::scoped_lock lock(planner::mutex());
+    std::scoped_lock lock(planner::mutex());
 
     static_assert(sizeof(fftwf_complex) == sizeof(gr_complex),
                   "The size of fftwf_complex is not equal to gr_complex");
@@ -205,7 +205,7 @@ template <class T, bool forward>
 fft<T, forward>::~fft()
 {
     // Hold global mutex during plan construction and destruction.
-    planner::scoped_lock lock(planner::mutex());
+    std::scoped_lock lock(planner::mutex());
 
     fftwf_destroy_plan((fftwf_plan)d_plan);
 }


### PR DESCRIPTION
## Description
This pull request removes most of gr-fft's usage of Boost, by replacing it with standard C++.

(All that remains are `boost::interprocess::file_lock` for FFT wisdom locking, and two C++ tests that could be converted to Python if the Python binding for `fft_shift` was completed.)

## Which blocks/areas does this affect?
* FFT planner
* Ctrlport Probe PSD block

## Testing Done
To test the FFT planner, I ran Gqrx and switched between various FFT sizes.

I have not tested the Ctrlport Probe PSD block. I'd appreciate help from someone familiar with Ctrlport.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
