### PR TITLE
runtime: Make vmcircbuf logging quieter (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_createfilemapping.cc
@@ -54,7 +54,7 @@ vmcircbuf_createfilemapping::vmcircbuf_createfilemapping(size_t size)
     gr::configure_default_loggers(
         d_logger, d_debug_logger, "vmcircbuf_createfilemapping");
 #if !defined(HAVE_CREATEFILEMAPPING)
-    d_logger->error("{:s}: createfilemapping is not available", __FUNCTION__);
+    d_debug_logger->info("{:s}: CreateFileMapping is not available", __FUNCTION__);
     throw std::runtime_error("gr::vmcircbuf_createfilemapping");
 #else
     gr::thread::scoped_lock guard(s_vm_mutex);

--- a/gnuradio-runtime/lib/vmcircbuf_prefs.cc
+++ b/gnuradio-runtime/lib/vmcircbuf_prefs.cc
@@ -59,7 +59,7 @@ int vmcircbuf_prefs::get(const char* key, char* value, int value_size)
     gr::configure_default_loggers(logger, debug_logger, "vmcircbuf_prefs::get");
 
     if (fp == 0) {
-        logger->error("{:s}: {:s}", pathname(key), strerror(errno));
+        debug_logger->info("{:s}: {:s}", pathname(key), strerror(errno));
         return 0;
     }
 


### PR DESCRIPTION
When a flow graph is executed for the first time, and ~/.gnuradio does
not exist, the following error messages are printed:

vmcircbuf_prefs::get :erro: /home/argilo/.gnuradio/prefs/vmcircbuf_default_factory: No such file or directory
gr::vmcircbuf :error: vmcircbuf_createfilemapping: createfilemapping is not available

These are expected situations, so they should not be logged at the error
level. Other similar vmcircbuf messages are logged to the debug logger
at the info level, so I've done that here as well.

In addition, I changed createfilemapping to CreateFileMapping to reflect
the actual name of the function.

After these changes, no log messages are printed the first time GNU Radio
is used, since the debug logger is set to the emerg level by default.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 6767475c9312520395cb888997d3348de32b1054)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5699