### PR TITLE
Trellis PyBind11 Rollup (backport to maint-3.9)

### DIFF
--- a/gr-trellis/python/trellis/bindings/pccc_decoder_blk_python.cc
+++ b/gr-trellis/python/trellis/bindings/pccc_decoder_blk_python.cc
@@ -27,4 +27,41 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <pccc_decoder_blk_pydoc.h>
 
-void bind_pccc_decoder_blk(py::module& m) {}
+template <class T>
+void bind_pccc_decoder_blk_template(py::module& m, const char* classname)
+{
+    using pccc_decoder_blk = gr::trellis::pccc_decoder_blk<T>;
+
+    py::class_<pccc_decoder_blk,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<pccc_decoder_blk>>(m, classname)
+        .def(py::init(&gr::trellis::pccc_decoder_blk<T>::make),
+             py::arg("FSM1"),
+             py::arg("FSM2"),
+             py::arg("ST10"),
+             py::arg("ST1K"),
+             py::arg("ST20"),
+             py::arg("ST2K"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength"),
+             py::arg("repetitions"),
+             py::arg("SISO_TYPE"))
+        .def("FSM1", &pccc_decoder_blk::FSM1)
+        .def("FSM2", &pccc_decoder_blk::FSM2)
+        .def("ST10", &pccc_decoder_blk::ST10)
+        .def("ST1K", &pccc_decoder_blk::ST1K)
+        .def("ST20", &pccc_decoder_blk::ST20)
+        .def("ST2K", &pccc_decoder_blk::ST2K)
+        .def("INTERLEAVER", &pccc_decoder_blk::INTERLEAVER)
+        .def("blocklength", &pccc_decoder_blk::blocklength)
+        .def("repetitions", &pccc_decoder_blk::repetitions)
+        .def("SISO_TYPE", &pccc_decoder_blk::SISO_TYPE);
+}
+
+void bind_pccc_decoder_blk(py::module& m)
+{
+    bind_pccc_decoder_blk_template<std::uint8_t>(m, "pccc_decoder_b");
+    bind_pccc_decoder_blk_template<std::int16_t>(m, "pccc_decoder_s");
+    bind_pccc_decoder_blk_template<std::int32_t>(m, "pccc_decoder_i");
+}

--- a/gr-trellis/python/trellis/bindings/pccc_decoder_combined_blk_python.cc
+++ b/gr-trellis/python/trellis/bindings/pccc_decoder_combined_blk_python.cc
@@ -27,4 +27,58 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <pccc_decoder_combined_blk_pydoc.h>
 
-void bind_pccc_decoder_combined_blk(py::module& m) {}
+template <class IN_T, class OUT_T>
+void bind_pccc_decoder_combined_blk_template(py::module& m, const char* classname)
+{
+    using pccc_decoder_combined_blk = gr::trellis::pccc_decoder_combined_blk<IN_T, OUT_T>;
+
+    py::class_<pccc_decoder_combined_blk,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<pccc_decoder_combined_blk>>(m, classname)
+        .def(py::init(&gr::trellis::pccc_decoder_combined_blk<IN_T, OUT_T>::make),
+             py::arg("FSMo"),
+             py::arg("STo0"),
+             py::arg("SToK"),
+             py::arg("FSMi"),
+             py::arg("STi0"),
+             py::arg("STiK"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength"),
+             py::arg("repetitions"),
+             py::arg("SISO_TYPE"),
+             py::arg("D"),
+             py::arg("TABLE"),
+             py::arg("METRIC_TYPE"),
+             py::arg("scaling"))
+        .def("FSM1", &pccc_decoder_combined_blk::FSM1)
+        .def("ST10", &pccc_decoder_combined_blk::ST10)
+        .def("ST1K", &pccc_decoder_combined_blk::ST1K)
+        .def("FSM2", &pccc_decoder_combined_blk::FSM2)
+        .def("ST20", &pccc_decoder_combined_blk::ST20)
+        .def("ST2K", &pccc_decoder_combined_blk::ST2K)
+        .def("INTERLEAVER", &pccc_decoder_combined_blk::INTERLEAVER)
+        .def("blocklength", &pccc_decoder_combined_blk::blocklength)
+        .def("repetitions", &pccc_decoder_combined_blk::repetitions)
+        .def("SISO_TYPE", &pccc_decoder_combined_blk::SISO_TYPE)
+        .def("D", &pccc_decoder_combined_blk::D)
+        .def("TABLE", &pccc_decoder_combined_blk::TABLE)
+        .def("METRIC_TYPE", &pccc_decoder_combined_blk::METRIC_TYPE)
+        .def("scaling", &pccc_decoder_combined_blk::scaling);
+}
+
+void bind_pccc_decoder_combined_blk(py::module& m)
+{
+    bind_pccc_decoder_combined_blk_template<float, std::uint8_t>(
+        m, "pccc_decoder_combined_fb");
+    bind_pccc_decoder_combined_blk_template<float, std::int16_t>(
+        m, "pccc_decoder_combined_fs");
+    bind_pccc_decoder_combined_blk_template<float, std::int32_t>(
+        m, "pccc_decoder_combined_fi");
+    bind_pccc_decoder_combined_blk_template<gr_complex, std::uint8_t>(
+        m, "pccc_decoder_combined_cb");
+    bind_pccc_decoder_combined_blk_template<gr_complex, std::int16_t>(
+        m, "pccc_decoder_combined_cs");
+    bind_pccc_decoder_combined_blk_template<gr_complex, std::int32_t>(
+        m, "pccc_decoder_combined_ci");
+}

--- a/gr-trellis/python/trellis/bindings/pccc_encoder_python.cc
+++ b/gr-trellis/python/trellis/bindings/pccc_encoder_python.cc
@@ -27,4 +27,34 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <pccc_encoder_pydoc.h>
 
-void bind_pccc_encoder(py::module& m) {}
+template <class IN_T, class OUT_T>
+void bind_pccc_encoder_template(py::module& m, const char* classname)
+{
+    using pccc_encoder = gr::trellis::pccc_encoder<IN_T, OUT_T>;
+
+    py::class_<pccc_encoder, gr::block, gr::basic_block, std::shared_ptr<pccc_encoder>>(
+        m, classname)
+        .def(py::init(&gr::trellis::pccc_encoder<IN_T, OUT_T>::make),
+             py::arg("FSM1"),
+             py::arg("ST1"),
+             py::arg("FSM2"),
+             py::arg("ST2"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength"))
+        .def("FSM1", &pccc_encoder::FSM1)
+        .def("ST1", &pccc_encoder::ST1)
+        .def("FSM2", &pccc_encoder::FSM2)
+        .def("ST2", &pccc_encoder::ST2)
+        .def("INTERLEAVER", &pccc_encoder::INTERLEAVER)
+        .def("blocklength", &pccc_encoder::blocklength);
+}
+
+void bind_pccc_encoder(py::module& m)
+{
+    bind_pccc_encoder_template<std::uint8_t, std::uint8_t>(m, "pccc_encoder_bb");
+    bind_pccc_encoder_template<std::uint8_t, std::int16_t>(m, "pccc_encoder_bs");
+    bind_pccc_encoder_template<std::uint8_t, std::int32_t>(m, "pccc_encoder_bi");
+    bind_pccc_encoder_template<std::int16_t, std::int16_t>(m, "pccc_encoder_ss");
+    bind_pccc_encoder_template<std::int16_t, std::int32_t>(m, "pccc_encoder_si");
+    bind_pccc_encoder_template<std::int32_t, std::int32_t>(m, "pccc_encoder_ii");
+}

--- a/gr-trellis/python/trellis/bindings/sccc_decoder_blk_python.cc
+++ b/gr-trellis/python/trellis/bindings/sccc_decoder_blk_python.cc
@@ -27,4 +27,41 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <sccc_decoder_blk_pydoc.h>
 
-void bind_sccc_decoder_blk(py::module& m) {}
+template <class T>
+void bind_sccc_decoder_blk_template(py::module& m, const char* classname)
+{
+    using sccc_decoder_blk = gr::trellis::sccc_decoder_blk<T>;
+
+    py::class_<sccc_decoder_blk,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<sccc_decoder_blk>>(m, classname)
+        .def(py::init(&gr::trellis::sccc_decoder_blk<T>::make),
+             py::arg("FSMo"),
+             py::arg("FSMi"),
+             py::arg("STo0"),
+             py::arg("SToK"),
+             py::arg("STi0"),
+             py::arg("STiK"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength"),
+             py::arg("repetitions"),
+             py::arg("SISO_TYPE"))
+        .def("FSMo", &sccc_decoder_blk::FSMo)
+        .def("FSMi", &sccc_decoder_blk::FSMi)
+        .def("STo0", &sccc_decoder_blk::STo0)
+        .def("SToK", &sccc_decoder_blk::SToK)
+        .def("STi0", &sccc_decoder_blk::STi0)
+        .def("STiK", &sccc_decoder_blk::STiK)
+        .def("INTERLEAVER", &sccc_decoder_blk::INTERLEAVER)
+        .def("blocklength", &sccc_decoder_blk::blocklength)
+        .def("repetitions", &sccc_decoder_blk::repetitions)
+        .def("SISO_TYPE", &sccc_decoder_blk::SISO_TYPE);
+}
+
+void bind_sccc_decoder_blk(py::module& m)
+{
+    bind_sccc_decoder_blk_template<std::uint8_t>(m, "sccc_decoder_b");
+    bind_sccc_decoder_blk_template<std::int16_t>(m, "sccc_decoder_s");
+    bind_sccc_decoder_blk_template<std::int32_t>(m, "sccc_decoder_i");
+}

--- a/gr-trellis/python/trellis/bindings/sccc_decoder_combined_blk_python.cc
+++ b/gr-trellis/python/trellis/bindings/sccc_decoder_combined_blk_python.cc
@@ -27,4 +27,58 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <sccc_decoder_combined_blk_pydoc.h>
 
-void bind_sccc_decoder_combined_blk(py::module& m) {}
+template <class IN_T, class OUT_T>
+void bind_sccc_decoder_combined_blk_template(py::module& m, const char* classname)
+{
+    using sccc_decoder_combined_blk = gr::trellis::sccc_decoder_combined_blk<IN_T, OUT_T>;
+
+    py::class_<sccc_decoder_combined_blk,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<sccc_decoder_combined_blk>>(m, classname)
+        .def(py::init(&gr::trellis::sccc_decoder_combined_blk<IN_T, OUT_T>::make),
+             py::arg("FSMo"),
+             py::arg("STo0"),
+             py::arg("SToK"),
+             py::arg("FSMi"),
+             py::arg("STi0"),
+             py::arg("STiK"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength"),
+             py::arg("repetitions"),
+             py::arg("SISO_TYPE"),
+             py::arg("D"),
+             py::arg("TABLE"),
+             py::arg("METRIC_TYPE"),
+             py::arg("scaling"))
+        .def("FSMo", &sccc_decoder_combined_blk::FSMo)
+        .def("STo0", &sccc_decoder_combined_blk::STo0)
+        .def("SToK", &sccc_decoder_combined_blk::SToK)
+        .def("FSMi", &sccc_decoder_combined_blk::FSMi)
+        .def("STi0", &sccc_decoder_combined_blk::STi0)
+        .def("STiK", &sccc_decoder_combined_blk::STiK)
+        .def("INTERLEAVER", &sccc_decoder_combined_blk::INTERLEAVER)
+        .def("blocklength", &sccc_decoder_combined_blk::blocklength)
+        .def("repetitions", &sccc_decoder_combined_blk::repetitions)
+        .def("SISO_TYPE", &sccc_decoder_combined_blk::SISO_TYPE)
+        .def("D", &sccc_decoder_combined_blk::D)
+        .def("TABLE", &sccc_decoder_combined_blk::TABLE)
+        .def("METRIC_TYPE", &sccc_decoder_combined_blk::METRIC_TYPE)
+        .def("scaling", &sccc_decoder_combined_blk::scaling);
+}
+
+void bind_sccc_decoder_combined_blk(py::module& m)
+{
+    bind_sccc_decoder_combined_blk_template<float, std::uint8_t>(
+        m, "sccc_decoder_combined_fb");
+    bind_sccc_decoder_combined_blk_template<float, std::int16_t>(
+        m, "sccc_decoder_combined_fs");
+    bind_sccc_decoder_combined_blk_template<float, std::int32_t>(
+        m, "sccc_decoder_combined_fi");
+    bind_sccc_decoder_combined_blk_template<gr_complex, std::uint8_t>(
+        m, "sccc_decoder_combined_cb");
+    bind_sccc_decoder_combined_blk_template<gr_complex, std::int16_t>(
+        m, "sccc_decoder_combined_cs");
+    bind_sccc_decoder_combined_blk_template<gr_complex, std::int32_t>(
+        m, "sccc_decoder_combined_ci");
+}

--- a/gr-trellis/python/trellis/bindings/sccc_encoder_python.cc
+++ b/gr-trellis/python/trellis/bindings/sccc_encoder_python.cc
@@ -27,4 +27,37 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <sccc_encoder_pydoc.h>
 
-void bind_sccc_encoder(py::module& m) {}
+template <class IN_T, class OUT_T>
+void bind_sccc_encoder_template(py::module& m, const char* classname)
+{
+    using sccc_encoder = gr::trellis::sccc_encoder<IN_T, OUT_T>;
+
+    py::class_<sccc_encoder,
+               gr::sync_block,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<sccc_encoder>>(m, classname)
+        .def(py::init(&gr::trellis::sccc_encoder<IN_T, OUT_T>::make),
+             py::arg("FSMo"),
+             py::arg("STo"),
+             py::arg("FSMi"),
+             py::arg("STi"),
+             py::arg("INTERLEAVER"),
+             py::arg("blocklength") = 0)
+        .def("FSMo", &sccc_encoder::FSMo)
+        .def("STo", &sccc_encoder::STo)
+        .def("FSMi", &sccc_encoder::FSMi)
+        .def("STi", &sccc_encoder::STi)
+        .def("INTERLEAVER", &sccc_encoder::INTERLEAVER)
+        .def("blocklength", &sccc_encoder::blocklength);
+}
+
+void bind_sccc_encoder(py::module& m)
+{
+    bind_sccc_encoder_template<std::uint8_t, std::uint8_t>(m, "sccc_encoder_bb");
+    bind_sccc_encoder_template<std::uint8_t, std::int16_t>(m, "sccc_encoder_bs");
+    bind_sccc_encoder_template<std::uint8_t, std::int32_t>(m, "sccc_encoder_bi");
+    bind_sccc_encoder_template<std::int16_t, std::int16_t>(m, "sccc_encoder_ss");
+    bind_sccc_encoder_template<std::int16_t, std::int32_t>(m, "sccc_encoder_si");
+    bind_sccc_encoder_template<std::int32_t, std::int32_t>(m, "sccc_encoder_ii");
+}

--- a/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
+++ b/gr-trellis/python/trellis/bindings/viterbi_combined_python.cc
@@ -27,4 +27,49 @@ namespace py = pybind11;
 // pydoc.h is automatically generated in the build directory
 #include <viterbi_combined_pydoc.h>
 
-void bind_viterbi_combined(py::module& m) {}
+template <typename IN_T, typename OUT_T>
+void bind_viterbi_combined_template(py::module& m, const char* classname)
+{
+    using viterbi_combined = gr::trellis::viterbi_combined<IN_T, OUT_T>;
+
+    py::class_<viterbi_combined,
+               gr::block,
+               gr::basic_block,
+               std::shared_ptr<viterbi_combined>>(m, classname)
+        .def(py::init(&gr::trellis::viterbi_combined<IN_T, OUT_T>::make),
+             py::arg("FSM"),
+             py::arg("K"),
+             py::arg("S0"),
+             py::arg("SK"),
+             py::arg("D"),
+             py::arg("TABLE"),
+             py::arg("TYPE"))
+        .def("FSM", &viterbi_combined::FSM)
+        .def("K", &viterbi_combined::K)
+        .def("S0", &viterbi_combined::S0)
+        .def("SK", &viterbi_combined::SK)
+        .def("D", &viterbi_combined::D)
+        .def("set_FSM", &viterbi_combined::set_FSM)
+        .def("set_K", &viterbi_combined::set_K)
+        .def("set_S0", &viterbi_combined::set_S0)
+        .def("set_SK", &viterbi_combined::set_SK)
+        .def("set_D", &viterbi_combined::set_D)
+        .def("set_TABLE", &viterbi_combined::set_TABLE)
+        .def("set_TYPE", &viterbi_combined::set_TYPE);
+}
+
+void bind_viterbi_combined(py::module& m)
+{
+    bind_viterbi_combined_template<std::int16_t, std::uint8_t>(m, "viterbi_combined_sb");
+    bind_viterbi_combined_template<std::int16_t, std::int16_t>(m, "viterbi_combined_ss");
+    bind_viterbi_combined_template<std::int16_t, std::int32_t>(m, "viterbi_combined_si");
+    bind_viterbi_combined_template<std::int32_t, std::uint8_t>(m, "viterbi_combined_ib");
+    bind_viterbi_combined_template<std::int32_t, std::int16_t>(m, "viterbi_combined_is");
+    bind_viterbi_combined_template<std::int32_t, std::int32_t>(m, "viterbi_combined_ii");
+    bind_viterbi_combined_template<float, std::uint8_t>(m, "viterbi_combined_fb");
+    bind_viterbi_combined_template<float, std::int16_t>(m, "viterbi_combined_fs");
+    bind_viterbi_combined_template<float, std::int32_t>(m, "viterbi_combined_fi");
+    bind_viterbi_combined_template<gr_complex, std::uint8_t>(m, "viterbi_combined_cb");
+    bind_viterbi_combined_template<gr_complex, std::int16_t>(m, "viterbi_combined_cs");
+    bind_viterbi_combined_template<gr_complex, std::int32_t>(m, "viterbi_combined_ci");
+}

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -83,34 +83,58 @@ class test_trellis (gr_unittest.TestCase):
         ftypes = ["bb", "bs", "bi", "ss", "si", "ii"]
         for ftype in ftypes:
             tb = trellis_pccc_encoder_tb(ftype)
+
+    def test_001_pccc_decoder(self):
+        ftypes = ["b", "s", "i"]
+        for ftype in ftypes:
+            tb = trellis_pccc_decoder_tb(ftype)
+            tb.run()
+
+    def test_001_pccc_decoder_combined(self):
+        ftypes = ["fb", "fs", "fi", "cb", "cs", "ci"]
+        for ftype in ftypes:
+            tb = trellis_pccc_decoder_combined_tb(ftype)
             tb.run()
 
 
 class trellis_comb_tb(gr.top_block):
+    def test_001_sccc_encoder(self):
+        ftypes = ["bb", "bs", "bi", "ss", "si", "ii"]
+        for ftype in ftypes:
+            tb = trellis_sccc_encoder_tb(ftype)
+            tb.run()
+
+
+class trellis_sccc_encoder_tb(gr.top_block):
+    def test_001_sccc_decoder_combined(self):
+        ftypes = ["fb", "fs", "fi", "cb", "cs", "ci"]
+        for ftype in ftypes:
+            tb = trellis_sccc_decoder_combined_tb(ftype)
+            tb.run()
+
+
+class trellis_sccc_decoder_combined_tb(gr.top_block):
     """
     A simple top block for use testing gr-trellis.
     """
 
     def __init__(self, ftype):
-        super(trellis_comb_tb, self).__init__()
-        func = eval("trellis.viterbi_combined_" + ftype)
+        super(trellis_sccc_decoder_combined_tb, self).__init__()
+        func = eval("trellis.sccc_decoder_combined_" + ftype)
         dsttype = gr.sizeof_int
         if ftype[1] == "b":
             dsttype = gr.sizeof_char
-        elif ftype[1] == "i":
-            dsttype = gr.sizeof_int
         elif ftype[1] == "s":
             dsttype = gr.sizeof_short
-        elif ftype[1] == "f":
-            dsttype = gr.sizeof_float
-        elif ftype[1] == "c":
-            dsttype = gr.sizeof_gr_complex
+        elif ftype[1] == "i":
+            dsttype = gr.sizeof_int
         src_func = eval("blocks.vector_source_" + ftype[0])
         data = [1 * 200]
         src = src_func(data)
         self.dst = blocks.null_sink(dsttype * 1)
         constellation = [1, 1, 1, 1, 1, -1, 1, -1, 1, 1, -1, -1, -1, 1, 1, -1, 1, -1, -1, -1, 1, -1, -1, -1]
-        vbc = func(trellis.fsm(1, 3, [91, 121, 117]), 1, 0, -1, 3, constellation, digital.TRELLIS_EUCLIDEAN)
+        vbc = func(trellis.fsm(), 0, -1, trellis.fsm(1, 3, [91, 121, 117]), 0, -1, trellis.interleaver(), 10, 10,
+                   trellis.TRELLIS_MIN_SUM, 2, constellation, digital.TRELLIS_EUCLIDEAN, 1.0)
 
         ##################################################
         # Connections
@@ -121,30 +145,33 @@ class trellis_comb_tb(gr.top_block):
 
 
 class trellis_pccc_encoder_tb(gr.top_block):
+    def test_001_sccc_decoder(self):
+        ftypes = ["b", "s", "i"]
+        for ftype in ftypes:
+            tb = trellis_sccc_decoder_tb(ftype)
+            tb.run()
+
+
+class trellis_sccc_decoder_tb(gr.top_block):
     """
     A simple top block for use testing gr-trellis.
     """
 
     def __init__(self, ftype):
-        super(trellis_pccc_encoder_tb, self).__init__()
-        func = eval("trellis.pccc_encoder_" + ftype)
+        super(trellis_sccc_decoder_tb, self).__init__()
+        func = eval("trellis.sccc_decoder_" + ftype)
         dsttype = gr.sizeof_int
-        if ftype[1] == "b":
+        if ftype == "b":
             dsttype = gr.sizeof_char
-        elif ftype[1] == "s":
+        elif ftype == "s":
             dsttype = gr.sizeof_short
-        elif ftype[1] == "i":
+        elif ftype == "i":
             dsttype = gr.sizeof_int
-        src_func = eval("blocks.vector_source_" + ftype[0])
         data = [1 * 200]
-        src = src_func(data)
+        src = blocks.vector_source_f(data)
         self.dst = blocks.null_sink(dsttype * 1)
-        vbc = func(trellis.fsm(), 0, trellis.fsm(), 0, trellis.interleaver(), 10)
-
-        ##################################################
-        # Connections
-        ##################################################
-
+        vbc = func(trellis.fsm(), 0, -1, trellis.fsm(1, 3, [91, 121, 117]),
+                   0, -1, trellis.interleaver(), 10, 10, trellis.TRELLIS_MIN_SUM)
         self.connect((src, 0), (vbc, 0))
         self.connect((vbc, 0), (self.dst, 0))
 
@@ -202,6 +229,61 @@ class trellis_tb(gr.top_block):
         self.connect(mod, (add, 0))
         self.connect(noise, (add, 1))
         self.connect(add, metrics, va, fsmi2s, self.dst)
+
+
+class trellis_pccc_decoder_tb(gr.top_block):
+    """
+    A simple top block for use testing gr-trellis.
+    """
+
+    def __init__(self, ftype):
+        super(trellis_pccc_decoder_tb, self).__init__()
+        func = eval("trellis.pccc_decoder_" + ftype)
+        dsttype = gr.sizeof_int
+        if ftype == "b":
+            dsttype = gr.sizeof_char
+        elif ftype == "s":
+            dsttype = gr.sizeof_short
+        elif ftype == "i":
+            dsttype = gr.sizeof_int
+        data = [1 * 200]
+        src = blocks.vector_source_f(data)
+        self.dst = blocks.null_sink(dsttype * 1)
+        vbc = func(trellis.fsm(1, 3, [91, 121, 117]), 0, -1, trellis.fsm(1, 3, [91, 121, 117]),
+                   0, -1, trellis.interleaver(), 10, 10, trellis.TRELLIS_MIN_SUM)
+        self.connect((src, 0), (vbc, 0))
+        self.connect((vbc, 0), (self.dst, 0))
+
+
+class trellis_pccc_decoder_combined_tb(gr.top_block):
+    """
+    A simple top block for use testing gr-trellis.
+    """
+
+    def __init__(self, ftype):
+        super(trellis_pccc_decoder_combined_tb, self).__init__()
+        func = eval("trellis.pccc_decoder_combined_" + ftype)
+        dsttype = gr.sizeof_int
+        if ftype[1] == "b":
+            dsttype = gr.sizeof_char
+        elif ftype[1] == "s":
+            dsttype = gr.sizeof_short
+        elif ftype[1] == "i":
+            dsttype = gr.sizeof_int
+        src_func = eval("blocks.vector_source_" + ftype[0])
+        data = [1 * 200]
+        src = src_func(data)
+        self.dst = blocks.null_sink(dsttype * 1)
+        constellation = [1, 1, 1, 1, 1, -1, 1, -1, 1, 1, -1, -1, -1, 1, 1, -1, 1, -1, -1, -1, 1, -1, -1, -1]
+        vbc = func(trellis.fsm(), 0, -1, trellis.fsm(), 0, -1, trellis.interleaver(), 10, 10,
+                   trellis.TRELLIS_MIN_SUM, 2, constellation, digital.TRELLIS_EUCLIDEAN, 1.0)
+
+        ##################################################
+        # Connections
+        ##################################################
+
+        self.connect((src, 0), (vbc, 0))
+        self.connect((vbc, 0), (self.dst, 0))
 
 
 if __name__ == '__main__':

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -79,6 +79,12 @@ class test_trellis (gr_unittest.TestCase):
             tb = trellis_comb_tb(ftype)
             tb.run()
 
+    def test_001_pccc_encoder(self):
+        ftypes = ["bb", "bs", "bi", "ss", "si", "ii"]
+        for ftype in ftypes:
+            tb = trellis_pccc_encoder_tb(ftype)
+            tb.run()
+
 
 class trellis_comb_tb(gr.top_block):
     """
@@ -105,6 +111,35 @@ class trellis_comb_tb(gr.top_block):
         self.dst = blocks.null_sink(dsttype * 1)
         constellation = [1, 1, 1, 1, 1, -1, 1, -1, 1, 1, -1, -1, -1, 1, 1, -1, 1, -1, -1, -1, 1, -1, -1, -1]
         vbc = func(trellis.fsm(1, 3, [91, 121, 117]), 1, 0, -1, 3, constellation, digital.TRELLIS_EUCLIDEAN)
+
+        ##################################################
+        # Connections
+        ##################################################
+
+        self.connect((src, 0), (vbc, 0))
+        self.connect((vbc, 0), (self.dst, 0))
+
+
+class trellis_pccc_encoder_tb(gr.top_block):
+    """
+    A simple top block for use testing gr-trellis.
+    """
+
+    def __init__(self, ftype):
+        super(trellis_pccc_encoder_tb, self).__init__()
+        func = eval("trellis.pccc_encoder_" + ftype)
+        dsttype = gr.sizeof_int
+        if ftype[1] == "b":
+            dsttype = gr.sizeof_char
+        elif ftype[1] == "s":
+            dsttype = gr.sizeof_short
+        elif ftype[1] == "i":
+            dsttype = gr.sizeof_int
+        src_func = eval("blocks.vector_source_" + ftype[0])
+        data = [1 * 200]
+        src = src_func(data)
+        self.dst = blocks.null_sink(dsttype * 1)
+        vbc = func(trellis.fsm(), 0, trellis.fsm(), 0, trellis.interleaver(), 10)
 
         ##################################################
         # Connections


### PR DESCRIPTION
Backport #5671
Backport #5683
Backport #5707

Note that 5707 is a rollup of
#5674
#5679
#5680
#5684
#5685