### PR TITLE
GRC: add jsonschema check for JSON/YAML blocks module

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -56,6 +56,12 @@ GR_PYTHON_CHECK_MODULE_RAW(
     NUMPY_FOUND
 )
 
+GR_PYTHON_CHECK_MODULE_RAW(
+  "jsonschema"
+  "import jsonschema"
+  JSONSCHEMA_FOUND
+)
+
 ########################################################################
 # Register component
 ########################################################################
@@ -79,6 +85,11 @@ GR_REGISTER_COMPONENT("gnuradio-companion" ENABLE_GRC
 )
 
 if(ENABLE_GRC)
+
+  GR_REGISTER_COMPONENT("JSON/YAML config blocks" ENABLE_JSONYAML_BLOCKS
+    ENABLE_GRC
+    JSONSCHEMA_FOUND
+    )
 
 ########################################################################
 # Create and install the grc and grc-docs conf file

--- a/grc/blocks/CMakeLists.txt
+++ b/grc/blocks/CMakeLists.txt
@@ -37,6 +37,11 @@ GEN_BLOCK_YML(variable_struct.block.yml.py variable_struct.block.yml)
 
 add_custom_target(grc_generated_yml ALL DEPENDS ${generated_yml_files})
 
+if(NOT ENABLE_JSONYAML_BLOCKS)
+  list(REMOVE_ITEM yml_files "json_config.block.yml")
+  list(REMOVE_ITEM yml_files "yaml_config.block.yml")
+endif()
+
 install(
     FILES ${yml_files} ${generated_yml_files}
     DESTINATION ${GRC_BLOCKS_DIR}


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit b03529038f172e00c9f1835487d7954702461c85)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5698

#5698 also contains 5e062831f5, having to do with Conda builds. This commit was not included in the backport.