### PR TITLE
runtime: Replace Boost mutexes with standard C++

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -18,7 +18,6 @@
 #include <gnuradio/runtime_types.h>
 #include <gnuradio/sptr_magic.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/thread/condition_variable.hpp>
 #include <deque>
 #include <functional>
 #include <map>

--- a/gnuradio-runtime/include/gnuradio/rpcbufferedget.h
+++ b/gnuradio-runtime/include/gnuradio/rpcbufferedget.h
@@ -11,8 +11,8 @@
 #ifndef RPCBUFFEREDGET_H
 #define RPCBUFFEREDGET_H
 
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/mutex.hpp>
+#include <condition_variable>
+#include <mutex>
 
 template <typename TdataType>
 class rpcbufferedget
@@ -34,7 +34,7 @@ public:
         if (!d_data_needed)
             return;
         {
-            boost::mutex::scoped_lock lock(d_buffer_lock);
+            std::scoped_lock lock(d_buffer_lock);
             d_buffer = data;
             d_data_needed = false;
         }
@@ -43,7 +43,7 @@ public:
 
     TdataType get()
     {
-        boost::mutex::scoped_lock lock(d_buffer_lock);
+        std::unique_lock lock(d_buffer_lock);
         d_data_needed = true;
         d_data_ready.wait(lock);
         return d_buffer;
@@ -51,8 +51,8 @@ public:
 
 private:
     bool d_data_needed;
-    boost::condition_variable d_data_ready;
-    boost::mutex d_buffer_lock;
+    std::condition_variable d_data_ready;
+    std::mutex d_buffer_lock;
     TdataType d_buffer;
 };
 

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -16,8 +16,8 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
-#include <boost/thread/mutex.hpp>
 #include <map>
+#include <mutex>
 #include <string>
 
 #define S(x) #x
@@ -79,7 +79,7 @@ private:
     static gr::logger_ptr d_logger;
     static gr::logger_ptr d_debug_logger;
 
-    boost::mutex d_callback_map_lock;
+    std::mutex d_callback_map_lock;
 
     typedef std::map<std::string, configureCallback_t> ConfigureCallbackMap_t;
     ConfigureCallbackMap_t d_setcallbackmap;

--- a/gnuradio-runtime/include/gnuradio/thread/thread.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread.h
@@ -12,12 +12,11 @@
 #define INCLUDED_THREAD_H
 
 #include <gnuradio/api.h>
+#include <condition_variable>
 #include <boost/thread/barrier.hpp>
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
@@ -34,9 +33,9 @@ namespace gr {
 namespace thread {
 
 typedef boost::thread thread;
-typedef boost::mutex mutex;
-typedef boost::unique_lock<boost::mutex> scoped_lock;
-typedef boost::condition_variable condition_variable;
+typedef std::mutex mutex;
+typedef std::unique_lock<std::mutex> scoped_lock;
+typedef std::condition_variable condition_variable;
 typedef boost::barrier barrier;
 typedef std::shared_ptr<barrier> barrier_sptr;
 

--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -17,10 +17,10 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
+#include <shared_mutex>
 #include <boost/any.hpp>
 #include <boost/core/noncopyable.hpp>
 #include <boost/function.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <memory>
 
 namespace gr {
@@ -41,7 +41,7 @@ public:
 
 private:
     std::list<std::unique_ptr<boost::thread>> m_threads;
-    mutable boost::shared_mutex m_mutex;
+    mutable std::shared_mutex m_mutex;
 };
 
 } /* namespace thread */

--- a/gnuradio-runtime/include/pmt/pmt_pool.h
+++ b/gnuradio-runtime/include/pmt/pmt_pool.h
@@ -10,9 +10,10 @@
 #ifndef INCLUDED_PMT_POOL_H
 #define INCLUDED_PMT_POOL_H
 
+#include <condition_variable>
 #include <pmt/api.h>
-#include <boost/thread.hpp>
 #include <cstddef>
+#include <mutex>
 #include <vector>
 
 namespace pmt {
@@ -30,9 +31,9 @@ class PMT_API pmt_pool
         struct item* d_next;
     };
 
-    typedef boost::unique_lock<boost::mutex> scoped_lock;
-    mutable boost::mutex d_mutex;
-    boost::condition_variable d_cond;
+    typedef std::unique_lock<std::mutex> scoped_lock;
+    mutable std::mutex d_mutex;
+    std::condition_variable d_cond;
 
     size_t d_itemsize;
     size_t d_alignment;

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
@@ -41,7 +41,7 @@ rpcserver_thrift::~rpcserver_thrift()
 void rpcserver_thrift::registerConfigureCallback(const std::string& id,
                                                  const configureCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     {
         ConfigureCallbackMap_t::const_iterator iter(d_setcallbackmap.find(id));
         if (iter != d_setcallbackmap.end()) {
@@ -63,7 +63,7 @@ void rpcserver_thrift::registerConfigureCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     ConfigureCallbackMap_t::iterator iter(d_setcallbackmap.find(id));
     if (iter == d_setcallbackmap.end()) {
         std::stringstream s;
@@ -85,7 +85,7 @@ void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
 void rpcserver_thrift::registerQueryCallback(const std::string& id,
                                              const queryCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     {
         QueryCallbackMap_t::const_iterator iter(d_getcallbackmap.find(id));
         if (iter != d_getcallbackmap.end()) {
@@ -107,7 +107,7 @@ void rpcserver_thrift::registerQueryCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     QueryCallbackMap_t::iterator iter(d_getcallbackmap.find(id));
     if (iter == d_getcallbackmap.end()) {
         std::stringstream s;
@@ -129,7 +129,7 @@ void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
 void rpcserver_thrift::registerHandlerCallback(const std::string& id,
                                                const handlerCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     {
         HandlerCallbackMap_t::const_iterator iter(d_handlercallbackmap.find(id));
         if (iter != d_handlercallbackmap.end()) {
@@ -151,7 +151,7 @@ void rpcserver_thrift::registerHandlerCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     HandlerCallbackMap_t::iterator iter(d_handlercallbackmap.find(id));
     if (iter == d_handlercallbackmap.end()) {
         std::stringstream s;
@@ -173,7 +173,7 @@ void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
 
 void rpcserver_thrift::setKnobs(const GNURadio::KnobMap& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     std::for_each(knobs.begin(),
                   knobs.end(),
                   set_f<GNURadio::KnobMap::value_type, ConfigureCallbackMap_t>(
@@ -183,7 +183,7 @@ void rpcserver_thrift::setKnobs(const GNURadio::KnobMap& knobs)
 void rpcserver_thrift::getKnobs(GNURadio::KnobMap& _return,
                                 const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     if (knobs.empty()) {
         std::for_each(d_getcallbackmap.begin(),
                       d_getcallbackmap.end(),
@@ -201,7 +201,7 @@ void rpcserver_thrift::getKnobs(GNURadio::KnobMap& _return,
 void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
                              const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     if (knobs.empty()) {
         std::for_each(d_getcallbackmap.begin(),
                       d_getcallbackmap.end(),
@@ -227,7 +227,7 @@ void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
 void rpcserver_thrift::properties(GNURadio::KnobPropMap& _return,
                                   const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     if (knobs.empty()) {
         std::for_each(
             d_getcallbackmap.begin(),
@@ -256,7 +256,7 @@ void rpcserver_thrift::postMessage(const std::string& alias,
     // just need to get the PMT itself out of this to pass to the set_h
     // function for handling the message post.
 
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
 
     pmt::pmt_t alias_pmt = pmt::deserialize_str(alias);
     pmt::pmt_t port_pmt = pmt::deserialize_str(port);

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -18,6 +18,7 @@
 #include <pmt/pmt_pool.h>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <vector>
 
 namespace pmt {
@@ -163,8 +164,8 @@ pmt_t string_to_symbol(const std::string& name)
     }
 
     // Lock the table on insert for thread safety:
-    static boost::mutex thread_safety;
-    boost::mutex::scoped_lock lock(thread_safety);
+    static std::mutex thread_safety;
+    std::scoped_lock lock(thread_safety);
     // Re-do the search in case another thread inserted this symbol into the table
     // before we got the lock
     for (pmt_t sym = (*get_symbol_hash_table())[hash]; sym; sym = _symbol(sym)->next()) {

--- a/gnuradio-runtime/lib/thread/thread_group.cc
+++ b/gnuradio-runtime/lib/thread/thread_group.cc
@@ -34,7 +34,7 @@ boost::thread* thread_group::create_thread(const boost::function0<void>& threadf
 
 void thread_group::add_thread(std::unique_ptr<boost::thread> thrd)
 {
-    boost::lock_guard<boost::shared_mutex> guard(m_mutex);
+    std::lock_guard<std::shared_mutex> guard(m_mutex);
 
     // For now we'll simply ignore requests to add a thread object
     // multiple times. Should we consider this an error and either
@@ -47,7 +47,7 @@ void thread_group::add_thread(std::unique_ptr<boost::thread> thrd)
 
 void thread_group::remove_thread(boost::thread* thrd)
 {
-    boost::lock_guard<boost::shared_mutex> guard(m_mutex);
+    std::lock_guard<std::shared_mutex> guard(m_mutex);
 
     // For now we'll simply ignore requests to remove a thread
     // object that's not in the group. Should we consider this an
@@ -63,7 +63,7 @@ void thread_group::remove_thread(boost::thread* thrd)
 
 void thread_group::join_all()
 {
-    boost::shared_lock<boost::shared_mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_mutex);
     for (auto& thrd : m_threads) {
         thrd->join();
     }
@@ -71,7 +71,7 @@ void thread_group::join_all()
 
 void thread_group::interrupt_all()
 {
-    boost::shared_lock<boost::shared_mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_mutex);
     for (auto& thrd : m_threads) {
         thrd->interrupt();
     }
@@ -79,7 +79,7 @@ void thread_group::interrupt_all()
 
 size_t thread_group::size() const
 {
-    boost::shared_lock<boost::shared_mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_mutex);
     return m_threads.size();
 }
 

--- a/gnuradio-runtime/lib/top_block_impl.h
+++ b/gnuradio-runtime/lib/top_block_impl.h
@@ -71,7 +71,7 @@ protected:
     tb_state d_state;
     int d_lock_count;
     bool d_retry_wait;
-    boost::condition_variable d_lock_cond;
+    gr::thread::condition_variable d_lock_cond;
     int d_max_noutput_items;
     bool d_catch_exceptions;
 

--- a/gnuradio-runtime/lib/tpb_thread_body.cc
+++ b/gnuradio-runtime/lib/tpb_thread_body.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/prefs.h>
 #include <pmt/pmt.h>
 #include <boost/thread.hpp>
+#include <chrono>
 #include <iostream>
 
 namespace gr {
@@ -128,10 +129,9 @@ tpb_thread_body::tpb_thread_body(block_sptr block,
             gr::thread::scoped_lock guard(d->d_tpb.mutex);
 
             if (!d->d_tpb.input_changed) {
-                boost::system_time const timeout =
-                    boost::get_system_time() +
-                    boost::posix_time::milliseconds(block->blkd_input_timer_value());
-                d->d_tpb.input_cond.timed_wait(guard, timeout);
+                std::chrono::duration const timeout =
+                    std::chrono::milliseconds(block->blkd_input_timer_value());
+                d->d_tpb.input_cond.wait_for(guard, timeout);
             }
         } break;
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(basic_block.h)                                             */
-/* BINDTOOL_HEADER_FILE_HASH(53f812404aa54083e64261ba5b5cf26c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f22a09637961bf600437f0df9f895e49)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
Here I've replaced all instances of `boost::mutex`, `boost::shared_mutex`, `boost::mutex::scoped_lock`, `boost::lock_guard`, `boost::unique_lock`, `boost::shared_lock`, and `boost::condition_variable` with standard C++.

## Which blocks/areas does this affect?
* `rpcbufferedget`
* `rpcserver_thrift`
* `gr::thread::condition_variable`
* `gr::thread::mutex`
* `gr::thread::scoped_lock`
* `gr::thread::thread_group`
* PMT
* `top_block_impl`
* `tpb_thread_body`

## Testing Done
Not much yet. I've verified that Gqrx still runs correctly. Help with testing would be appreciated.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [ ] ~~I have added tests to cover my changes~~, and all previous tests pass.