### PR TITLE
look for x-terminal-emulator

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -102,7 +102,7 @@ endif(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
 
 if(UNIX)
     find_program(GRC_XTERM_EXE
-        NAMES x-terminal-emulator gnome-terminal.wrapper konsole xterm foot
+        NAMES x-terminal-emulator gnome-terminal konsole xterm foot
         HINTS ENV PATH
         DOC "graphical terminal emulator used in GRC's no-gui-mode"
     )

--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -102,12 +102,12 @@ endif(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
 
 if(UNIX)
     find_program(GRC_XTERM_EXE
-        NAMES xterminal-emulator gnome-terminal konsole xterm
+        NAMES x-terminal-emulator gnome-terminal.wrapper konsole xterm foot
         HINTS ENV PATH
         DOC "graphical terminal emulator used in GRC's no-gui-mode"
     )
     if(NOT GRC_XTERM_EXE)
-        set(GRC_XTERM_EXE "")
+        set(GRC_XTERM_EXE "x-terminal-emulator")
     endif()
 else()  # APPLE CYGWIN
     set(GRC_XTERM_EXE "xterm")


### PR DESCRIPTION
Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>

---
name: Pull Request for gnuradio main
about: generating grc.conf
title: 'look for x-terminal-emulator'
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
When building gnuradio in a clean build environment, which is great for doing
repeatable builds, the CMake logic for generating the grc.conf file
left nothing for the xterm_executable.

This leads to a confusing error the first time a user runs gnuradio-companion.

This patch uses c-terminal-emulator by default. Which is a nice choice in Debian and Ubuntu.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gnuradio-companion

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
This patch has long been in debian/patches
Recently not included, the result was quickly noticed.

I added foot to the search list. It does the right thing when running
gnuradio-companion under Wayland and the sway window manager,
where foot is the default Wayland terminal. So - not X, but works.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
