### PR TITLE
Add parantheses

### DIFF
--- a/gr-blocks/grc/blocks_freqshift_cc.block.yml
+++ b/gr-blocks/grc/blocks_freqshift_cc.block.yml
@@ -24,9 +24,9 @@ templates:
     imports: |-
         from gnuradio import blocks
         import math
-    make: blocks.rotator_cc(2.0*math.pi*${freq}/${sample_rate})
+    make: blocks.rotator_cc(2.0*math.pi*(${freq})/(${sample_rate}))
     callbacks:
-    - set_phase_inc(2.0*math.pi*${freq}/${sample_rate})
+    - set_phase_inc(2.0*math.pi*(${freq})/(${sample_rate}))
 
 documentation: |-
     This block is a convenience wrapper around using a rotator block for frequency shifting.  This block obfuscates the 2*Pi*freq/samp_rate phase_inc field and calculation, and only requires the designer to provide the frequency and sample rate.


### PR DESCRIPTION
Add parantheses to the templates, such that entering expressions like `f1+f2` into the parameter fields will produce the expected result.

Phase increment before: `2.0*math.pi*f1 + f2/sample_rate`  
Phase increment now: `2.0*math.pi * (f1+f2) / (sample_rate)`  

Related: https://github.com/gnuradio/gnuradio/pull/3046
