### PR TITLE
runtime: Remove invalid keyword argument from draw_networkx_nodes

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -877,8 +877,7 @@ class MForm(Qt.QWidget):
                                node_color='#A0CBE2',
                                node_shape="s",
                                node_size=self.node_weights,
-                               ax=self.sp,
-                               arrows=False)
+                               ax=self.sp)
 
         nx.draw_networkx_edges(self.G, self.pos,
                                edge_color=self.edge_weights,


### PR DESCRIPTION
## Description
The gr-perf-monitorx tool currently fails with the following error:

```
gr-perf-monitorx: lost connection (draw_networkx_nodes() got an unexpected keyword argument 'arrows').
```

[`draw_networkx_nodes`](https://networkx.org/documentation/stable/reference/generated/networkx.drawing.nx_pylab.draw_networkx_nodes.html) does not have an `arrows` argument.

The tool runs correctly once the incorrect keyword argument is removed.

## Which blocks/areas does this affect?
* gr-perf-monitorx

## Testing Done
I tested as follows:

1. Build GNU Radio with ControlPort support: `-DENABLE_CTRLPORT_THRIFT=True`.
2. Enable the following in gnuradio-runtime.conf:
```
[PerfCounters]
on = True
export = True

[ControlPort]
on = True
edges_list = True
```
3. Run a flow graph
4. Run `gr-perf-monitorx <port>`

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
