### PR TITLE
runtime: Replace boost::xpressive with std::regex

### DIFF
--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
@@ -14,8 +14,8 @@
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TSocket.h>
 #include <thrift/transport/TTransportUtils.h>
-#include <boost/xpressive/xpressive.hpp>
 #include <iostream>
+#include <regex>
 #include <sstream>
 #include <stdexcept>
 
@@ -212,9 +212,8 @@ void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
         QueryCallbackMap_t::iterator it;
         for (it = d_getcallbackmap.begin(); it != d_getcallbackmap.end(); it++) {
             for (size_t j = 0; j < knobs.size(); j++) {
-                const boost::xpressive::sregex re(
-                    boost::xpressive::sregex::compile(knobs[j]));
-                if (boost::xpressive::regex_match(it->first, re)) {
+                const std::regex re(knobs[j]);
+                if (std::regex_match(it->first, re)) {
                     get_f<GNURadio::KnobIDList::value_type, QueryCallbackMap_t>(
                         d_getcallbackmap, cur_priv, _return)(it->first);
                     break;


### PR DESCRIPTION
## Description
This change removes a bit more Boost from gnuradio-runtime, replacing `boost::xpressive` with `std::regex`.

## Which blocks/areas does this affect?
* ControlPort

## Testing Done
I tested this functionality using the gr-perf-monitorx utility, which uses ControlPort's regular expression functionality: https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx#L484

gr-perf-monitorx was broken, so I fixed that in #5737. Testing instructions can also be found there.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
