### PR TITLE
grpython use posix prefix scheme

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -159,7 +159,7 @@ except AttributeError: pass
 
 if not install_dir:
     #find where to install the python module
-    install_dir = sysconfig.get_path('platlib')
+    install_dir = sysconfig.get_path('platlib','posix_prefix')
     prefix = sysconfig.get_config_var('prefix')
 
 #strip the prefix to return a relative path


### PR DESCRIPTION
Recently in Debian's pthon3.10 the default scheme for sysconfig
changed from 'posix_prefix' to 'posix_local'. GrPython.cmake
expects the 'posix_prefix' behavior. So explicity use it.

Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>

---
name: grpython use posix prefix scheme
about: GrPython.cmake
title: ''
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Install path changed to /usr/local with python3.10 - even though the desire
is to set the install directories using gnuradio's cmake paths.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Debian bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008854

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Not only gnuradio itself - but every OOT project that inherits GrPython.cmake.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Debian builds as part of the python3.10-default transition.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
