### PR TITLE
filter: Fix flaky freq xlating filter test

### DIFF
--- a/gr-filter/python/filter/qa_freq_xlating_fft_filter.py
+++ b/gr-filter/python/filter/qa_freq_xlating_fft_filter.py
@@ -72,8 +72,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
     def assert_fft_ok(self, expected_result, result_data):
         expected_result = expected_result[:len(result_data)]
-        self.assertComplexTuplesAlmostEqual2(expected_result, result_data,
-                                             abs_eps=1e-9, rel_eps=1.5e-3)
+        self.assertComplexTuplesAlmostEqual(expected_result, result_data,
+                                            places=5)
 
     def test_fft_filter_ccf_001(self):
         self.generate_ccf_source()


### PR DESCRIPTION
## Description
The `qa_freq_xlating_fft_filter` test frequently fails. For example:
* https://github.com/gnuradio/gnuradio/runs/5821437722?check_suite_focus=true
* https://github.com/gnuradio/gnuradio/runs/5821466413?check_suite_focus=true

This test has been problematic in the past: 1c74a4bb5fb9e13323ed768d24a96169f7d0182c

The test uses `assertComplexTuplesAlmostEqual2` to check the output samples against the expected values:

https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gr-filter/python/filter/qa_freq_xlating_fft_filter.py#L75-L76

For each sample, `assertComplexTuplesAlmostEqual2` checks whether the absolute error is less than `1e-9`, and if not it checks whether the relative error is less than `1.5e-3`. But `1e-9` is smaller than the precision of the floating point calculations, so every sample is in fact checked using the relative error measurement. However, a relative error measurement doesn't make sense for a filter, because the size of the errors is proportional to the input samples, not the output samples. It can be seen from the test results that failures occur when an output sample happens to be very small.

In contrast, the test for the Freq Xlating FIR filter test always uses absolute error measurements. I think the test for Freq Xlating FFT filter test should do the same, so I've changed it here.

## Which blocks/areas does this affect?
None. I've only changed tests.

## Testing Done
* Verified that the modified test passes.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
