### PR TITLE
runtime: Fix flaky qa_uncaught_exception test

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
@@ -62,7 +62,7 @@ class test_uncaught_exception(gr_unittest.TestCase):
         p = Process(target=process_func, args=(False,))
         p.daemon = True
         p.start()
-        p.join(2.5)
+        p.join(10.0)
         exit_code = p.exitcode
         self.assertIsNotNone(
             exit_code, "exception did not cause flowgraph exit")


### PR DESCRIPTION
## Description
The `qa_uncaught_exception` test sometimes fails in CI, for instance: https://github.com/gnuradio/gnuradio/runs/5827362248?check_suite_focus=true

This happens because the flow graph may take more than 2.5 seconds to execute. (The timeout was previously increased from 0.5 seconds to 2.5 seconds in https://github.com/gnuradio/gnuradio/pull/3029, but it's still not enough.)

Here I've increased the timeout to 10 seconds. This doesn't slow down the test in the success case, since the `join` returns as soon as the flow graph finishes.

## Related Issue
* https://github.com/gnuradio/gnuradio/pull/3029

## Which blocks/areas does this affect?
None. This change only affects tests.

## Testing Done
Played with the test locally and verified that it fails when the timeout is too low, and that increasing the timeout doesn't slow down the test.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
