### PR TITLE
Cross compiling is skipping c++ tests, don't try to set properties on them (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -264,9 +264,11 @@ if(ENABLE_TESTING)
     GR_ADD_CPP_TEST("blocks_${qa_file}"
       ${CMAKE_CURRENT_SOURCE_DIR}/${qa_file}
     )
-    set_tests_properties("blocks_${qa_file}"
-        PROPERTIES TIMEOUT 30
-    )
+    IF (NOT CMAKE_CROSSCOMPILING)
+        set_tests_properties("blocks_${qa_file}"
+            PROPERTIES TIMEOUT 30
+        )
+    ENDIF (NOT CMAKE_CROSSCOMPILING)
   endforeach(qa_file)
 
 endif(ENABLE_TESTING)


### PR DESCRIPTION
Signed-off-by: Philip Balister <philip@balister.org>
(cherry picked from commit afaddfe9d109204fa65485a7d59fe9a8c3399300)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport afaddfe9d109204fa65485a7d59fe9a8c3399300 only from https://github.com/gnuradio/gnuradio/pull/5559