### PR TITLE
dtv: Fix initialization of L1Post struct

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -252,7 +252,7 @@ dvbt2_framemapper_cc_impl::dvbt2_framemapper_cc_impl(
     } else {
         l1postinit->reserved_3 = 0;
     }
-    l1postinit->plp_id = 0;
+    l1postinit->plp_id_dynamic = 0;
     l1postinit->plp_start = 0;
     l1postinit->plp_num_blocks = fecblocks;
     if (reservedbiasbits == RESERVED_ON && version == VERSION_131) {


### PR DESCRIPTION
## Description
The `qa_dtv` test sometimes fails in CI, for instance:

* https://github.com/gnuradio/gnuradio/runs/5536495515?check_suite_focus=true
* https://github.com/gnuradio/gnuradio/runs/5435832708?check_suite_focus=true

Valgrind shows that `dvbt2_framemapper_cc_impl::add_l1post` accesses uninitialized memory, and I tracked this down to the fact that the `plp_id_dynamic` member of the `L1Post` struct is not initialized. It appears there is a typo in the constructor, where `plp_id` is initialized twice. I've corrected the second instance to `plp_id_dynamic`, which resolves the valgrind warning.

I also confirmed that this is the source of CI failures: If `plp_id_dynamic` is initialized to 1 instead of 0, then `qa_dtv` fails every time.

## Which blocks/areas does this affect?
QA for DVB-T2 Frame Mapper block.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
