### PR TITLE
filter: Fix various bugs in Generic Filterbank

### DIFF
--- a/gr-filter/lib/filterbank_vcvcf_impl.cc
+++ b/gr-filter/lib/filterbank_vcvcf_impl.cc
@@ -28,16 +28,17 @@ filterbank_vcvcf_impl::filterbank_vcvcf_impl(const std::vector<std::vector<float
     : block("filterbank_vcvcf",
             io_signature::make(1, 1, sizeof(gr_complex) * taps.size()),
             io_signature::make(1, 1, sizeof(gr_complex) * taps.size())),
-      filterbank(taps)
+      filterbank(taps),
+      d_updated(false)
 {
-    set_history(d_ntaps + 1);
+    set_history(d_ntaps);
 }
 
 void filterbank_vcvcf_impl::set_taps(const std::vector<std::vector<float>>& taps)
 {
     gr::thread::scoped_lock guard(d_mutex);
     filterbank::set_taps(taps);
-    set_history(d_ntaps + 1);
+    set_history(d_ntaps);
     d_updated = true;
 }
 
@@ -63,7 +64,7 @@ int filterbank_vcvcf_impl::general_work(int noutput_items,
         return 0; // history requirements may have changed.
     }
 
-    std::vector<gr_complex> working(noutput_items + d_ntaps);
+    volk::vector<gr_complex> working(noutput_items + d_ntaps - 1);
 
     for (unsigned int i = 0; i < d_nfilts; i++) {
         // Only call the filter method on active filters.

--- a/gr-filter/python/filter/qa_filterbank.py
+++ b/gr-filter/python/filter/qa_filterbank.py
@@ -81,8 +81,8 @@ class test_filterbank_vcvcf(gr_unittest.TestCase):
         results = []
         results2 = []
         for ds, ts, ts2 in zip(data_sets, taps1, taps2):
-            results.append(convolution(ds[-len(ts):] + ds[:-1], ts))
-            results2.append(convolution(ds[-len(ts):] + ds[:-1], ts2))
+            results.append(convolution(ds[-(len(ts) - 1):] + ds, ts))
+            results2.append(convolution(ds[-(len(ts) - 1):] + ds, ts2))
         # Convert results from 2D arrays to 1D arrays for ease of comparison.
         comb_results = []
         for rs in zip(*results):


### PR DESCRIPTION
## Description
The `qa_pfb_channelizer` sometimes fails in CI. For example: https://github.com/gnuradio/gnuradio/runs/5535718772?check_suite_focus=true

Running the test in valgrind reveals two bugs:

* `filterbank_vcvcf_impl::general_work` reads `d_updated` before it is initialized.
* `filterbank_vcvcf_impl::general_work` passes an unaligned buffer (`working`) into `fir_filter::filter`, which requires its input buffer to be aligned.

The second bug can result in `volk_32fc_32f_dot_prod_32fc_a` reading data from outside the `working` buffer, corrupting the filter calculation. (Out-of-bounds values are multiplied by zero, but this can still result in `NaN`, as seen in the CI failure.)

To fix these problems, I did the following:

* Initialize `d_updated` to false in the constructor.
* Allocate `working` using ~~`volk_malloc`~~ `volk::vector`.

I also fixed two other minor issues I noticed along the way:

* The history is set one sample too long, which causes the output to be delayed by one sample.
* The `working` buffer is one sample too long, which wastes a small amount of memory.

## Which blocks/areas does this affect?
* Generic Filterbank
* Hierarchical Polyphase Channelizer (which uses Generic Filterbank under the covers)

## Testing Done
* Verified that `qa_pfb_channelizer` still works correctly and does not produce any valgrind errors.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
