### PR TITLE
runtime: Process system messages before others

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -28,6 +28,25 @@
 
 namespace gr {
 
+class msg_queue_comparator
+{
+private:
+    const pmt::pmt_t d_system_port = pmt::intern("system");
+
+public:
+    bool operator()(pmt::pmt_t const& queue_key1, pmt::pmt_t const& queue_key2) const
+    {
+        if (pmt::eqv(queue_key2, d_system_port))
+            return false;
+        else if (pmt::eqv(queue_key1, d_system_port))
+            return true;
+        else {
+            pmt::comparator cmp;
+            return cmp(queue_key1, queue_key2);
+        }
+    }
+};
+
 /*!
  * \brief The abstract base class for all signal processing blocks.
  * \ingroup internal
@@ -49,8 +68,8 @@ private:
     d_msg_handlers_t d_msg_handlers;
 
     typedef std::deque<pmt::pmt_t> msg_queue_t;
-    typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator> msg_queue_map_t;
-    typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator>::iterator
+    typedef std::map<pmt::pmt_t, msg_queue_t, msg_queue_comparator> msg_queue_map_t;
+    typedef std::map<pmt::pmt_t, msg_queue_t, msg_queue_comparator>::iterator
         msg_queue_map_itr;
 
     gr::thread::mutex mutex; //< protects all vars

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(basic_block.h)                                             */
-/* BINDTOOL_HEADER_FILE_HASH(53f812404aa54083e64261ba5b5cf26c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(97ef3f809e58b459c57d41bab36bb97d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
Various tests involving message passing fail intermittently, for example `qa_packet_headerparser_b`. One or more messages fail to arrive at the `message_debug` block when the flow graph stops processing samples. This occurs due to a race condition in `tpb_thread_body`.

The [main loop of `tpb_thread_body`](https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gnuradio-runtime/lib/tpb_thread_body.cc#L70-L152) iterates over the message queues in an undefined order, reading pending messages from each. One of these queues is the special "system" queue; if a "done" message arrives on this queue, then the corresponding handler sets `d_finished` to true, which will later cause the main loop to exit:

https://github.com/gnuradio/gnuradio/blob/3349d483a1f7e5db0eea042815d237810373857b/gnuradio-runtime/lib/block.cc#L759-L770

The following race condition can occur:

1. The main loop reads from the "foo" message queue, and finds it empty.
2. A message arrives on the "foo" queue.
3. A "done" message arrives on the "system" queue.
4. The main loop reads from the "system" queue, finds the "done" message, and sets `d_finished` to true.
5. The main loop exits, because `d_finished` is true.

The message on the "foo" queue is never processed.

To solve this problem, I've used a custom comparator to order the message queues such that the "system" queue comes first. This guarantees that after a "done" message is processed, all other queues will be processed at least once before the main loop exits.

## Related Issue
Fixes #4348.

## Which blocks/areas does this affect?
Message passing in the thread-per-block scheduler.

## Testing Done
I ran `qa_packet_headerparser_b` in a loop (`while gr-digital/python/digital/qa_packet_headerparser_b_test.sh; do :; done`) to verify that it no longer fails intermittently.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
