### PR TITLE
Additional error messages for assertions (without the error messages)

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -398,8 +398,8 @@ outputs:
     hide: ${ not showports }
 
 asserts:
-- ${fftsize >= 32 and fftsize <= 32768}
-- ${not (fftsize & (fftsize -1))}
+- ${fftsize >= 32 and fftsize <= 32768#'The FFT Size is out of range 32 - 32768'}
+- ${not (fftsize & (fftsize -1))#The FFT Size should be a power of 2}
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -104,8 +104,8 @@ outputs:
     hide: ${ not showports }
 
 asserts:
-- ${fftsize >= 32 and fftsize <= 32768}
-- ${not (fftsize & (fftsize -1))}
+- ${fftsize >= 32 and fftsize <= 32768#The FFT Size is out of range 32 - 32768}
+- ${not (fftsize & (fftsize -1))#The FFT Size should be a power of 2}
 
 templates:
     imports: |-

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -251,8 +251,8 @@ outputs:
     hide: ${ not showports }
 
 asserts:
-- ${fftsize >= 32 and fftsize <= 32768}
-- ${not (fftsize & (fftsize -1))}
+- ${fftsize >= 32 and fftsize <= 32768#The FFT Size is out of range 32 - 32768}
+- ${not (fftsize & (fftsize -1))#The FFT Size should be a power of 2}
 
 templates:
     imports: |-

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -250,12 +250,8 @@ class Block(Element):
         for expr in self.asserts:
             try:
                 if not self.evaluate(expr):
-                    msg = expr.split('#')
-                    if len(msg) < 2:
-                        self.add_error_message(
-                            'Assertion "{}" failed.'.format(expr))
-                    else:
-                        self.add_error_message(msg[1])
+                    self.add_error_message(
+                        'Assertion "{}" failed.'.format(expr))
             except Exception:
                 self.add_error_message(
                     'Assertion "{}" did not evaluate.'.format(expr))

--- a/grc/core/blocks/block.py
+++ b/grc/core/blocks/block.py
@@ -250,8 +250,12 @@ class Block(Element):
         for expr in self.asserts:
             try:
                 if not self.evaluate(expr):
-                    self.add_error_message(
-                        'Assertion "{}" failed.'.format(expr))
+                    msg = expr.split('#')
+                    if len(msg) < 2:
+                        self.add_error_message(
+                            'Assertion "{}" failed.'.format(expr))
+                    else:
+                        self.add_error_message(msg[1])
             except Exception:
                 self.add_error_message(
                     'Assertion "{}" did not evaluate.'.format(expr))


### PR DESCRIPTION
This is a continuation of https://github.com/gnuradio/gnuradio/pull/5469

Keeps the comments in the yml files describing what the assertion values mean, but does not modify grc to parse based on the `#` character