### PR TITLE
gr_newmod: Fix copying python bindings to test dir on Windows

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/CMakeLists.txt
@@ -36,12 +36,10 @@ GR_PYBIND_MAKE_OOT(howto
    gr::howto
    "${howto_python_files}")
 
-# copy in bindings .so file for use in QA test module
-add_custom_target(
-  copy_bindings_for_tests ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
+# copy bindings extension for use in QA test module
+add_custom_command(TARGET howto_python POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:howto_python>
     ${CMAKE_BINARY_DIR}/test_modules/gnuradio/howto/
-  DEPENDS howto_python)
+)
 
 install(TARGETS howto_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/howto COMPONENT pythonapi)


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
After building Python bindings for an OOT module generated from the gr_newmod template, the `cmake -E copy` command fails on Windows because the `*.so` wildcard doesn't match anything. This fixes that by using the a generator expression to get the path to the built Python bindings directly, and also changes the CMake instruction to a post-build target step rather than its own target.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #5767.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gr_newmod OOT template

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I modified gr-inspector with this same fix, and now the build completes and QA passes.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
