### PR TITLE
gr_newmod: Make untagged conda package version less specific

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/.conda/recipe/meta.yaml
+++ b/gr-utils/modtool/templates/gr-newmod/.conda/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set oot_name = "howto" %}
 {% set name = "gnuradio-" + oot_name %}
-{% set version = (environ.get("GIT_DESCRIBE_TAG_PEP440", "0.0.0." + datetime.datetime.now().strftime("%Y%m%d%H%M") + ".dev+" + environ.get("GIT_DESCRIBE_HASH", "local"))|string) %}
+{% set version = (environ.get("GIT_DESCRIBE_TAG_PEP440", "0.0.0." + datetime.datetime.now().strftime("%Y%m%d") + ".dev+" + environ.get("GIT_DESCRIBE_HASH", "local"))|string) %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
The version for an untagged OOT is based on the date, and previously this included hour and minute. That's too specific and leads to CI-built packages from the same run often having different versions. This can still happen, but stopping at the year, month, and day is much saner. I don't know what I was thinking previously.

Note for backporting: this can be merged with #5673, commit e3efb76617087e778026086287c6e545f6be2c0f.

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
