### PR TITLE
cmake: Always prefix git hash used as version with "g"

### DIFF
--- a/cmake/Modules/GrVersion.cmake
+++ b/cmake/Modules/GrVersion.cmake
@@ -38,11 +38,22 @@ ENDMACRO()
 
 if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
     message(STATUS "Extracting version information from git describe...")
+    # try to get long description with tag followed by hash
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=8 --long
+        COMMAND ${GIT_EXECUTABLE} describe --abbrev=8 --long
         OUTPUT_VARIABLE GIT_DESCRIBE OUTPUT_STRIP_TRAILING_WHITESPACE
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
+    # long description failed, so try to just get commit hash
+    # (prefixed by "g" so that a hash that is just a number is not misinterpreted)
+    if(GIT_DESCRIBE STREQUAL "")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} log --format=g%h -n 1
+            OUTPUT_VARIABLE GIT_DESCRIBE OUTPUT_STRIP_TRAILING_WHITESPACE
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+    endif()
+    # git is failing, fallback
     if(GIT_DESCRIBE STREQUAL "")
         create_manual_git_describe()
     endif()


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This prevents the hash from being misinterpreted as a number, which MSVC does which will caused failed builds. This is never an issue with GR itself because the plain hash is only used for the version when the repository is untagged, but it can happen with OOTs which also use GrVersion.cmake.

This works by removing the `--always` flag from `git describe` and handling the no-tag case as a separate special case.

I have been unlucky enough to twice now encounter all-numeric short hashes when building untagged OOTs with MSVC, so I can't ignore it.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
CMake, untagged OOTs.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I created a freshly-initialized repository with my local gnuradio so that no git tags were present, ran `cmake`, and verified that the version it identified was the letter "g" followed by the short commit hash. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
