### PR TITLE
digital: fix typo in CRC Append and Check GRC blocks

### DIFF
--- a/gr-digital/grc/digital_crc_append.block.yml
+++ b/gr-digital/grc/digital_crc_append.block.yml
@@ -13,7 +13,7 @@ parameters:
     dtype: hex
     default: '0x4C11DB7'
 -   id: initial_value
-    label: Initial regsiter value
+    label: Initial register value
     dtype: hex
     default: '0xFFFFFFFF'
     hide: part

--- a/gr-digital/grc/digital_crc_check.block.yml
+++ b/gr-digital/grc/digital_crc_check.block.yml
@@ -13,7 +13,7 @@ parameters:
     dtype: hex
     default: '0x4C11DB7'
 -   id: initial_value
-    label: Initial regsiter value
+    label: Initial register value
     dtype: hex
     default: '0xFFFFFFFF'
     hide: part

--- a/gr-digital/include/gnuradio/digital/crc_check.h
+++ b/gr-digital/include/gnuradio/digital/crc_check.h
@@ -24,7 +24,7 @@ namespace digital {
  * \ingroup packet_operators_blk
  *
  * \details
- * The CRC append block receives a PDU containing a CRC at its end,
+ * The CRC check block receives a PDU containing a CRC at its end,
  * and checks whether the CRC is correct. The PDU is sent over the ok
  * or fail output ports according to the result of this check.
  * It can support any CRC whose size is a multiple of 8 bits between
@@ -36,7 +36,7 @@ public:
     typedef std::shared_ptr<crc_check> sptr;
 
     /*!
-     * \brief Build the CRC append block.
+     * \brief Build the CRC check block.
      *
      * \param num_bits CRC size in bits (must be a multiple of 8)
      * \param poly CRC polynomial, in MSB-first notation

--- a/gr-digital/python/digital/bindings/crc_check_python.cc
+++ b/gr-digital/python/digital/bindings/crc_check_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc_check.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0131cc8c9414fc3d807ca7cb843e16c4)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4170f8e1b07d628ce6b354c65f2f0502)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
I've just noticed a typo in the GRC files for the CRC blocks. I didn't see this typo when I sent #5619. The blocks are already backported to 3.10, so the typo correction should also be backported. The backport to 3.9 is still not merged (it's in #5694) and perhaps this correction can be incorporated into that PR.

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
CRC Append and CRC Check.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. --> No update necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass. --> No tests necessary.
