### PR TITLE
gr-soapy: deactivate stream before closing

### DIFF
--- a/gr-soapy/lib/block_impl.cc
+++ b/gr-soapy/lib/block_impl.cc
@@ -383,6 +383,7 @@ bool block_impl::stop()
 {
     if (d_stream) {
         std::lock_guard<std::mutex> l(d_device_mutex);
+        d_device->deactivateStream(d_stream);
         d_device->closeStream(d_stream);
         d_stream = nullptr;
     }


### PR DESCRIPTION
# Pull Request Details

It was reported that, with the HackRF module, a flowgraph terminated
with a segfault. Most Soapy modules implement deactivateStream(), but
that function is not called from gr-soapy.

Problem reported by Gavin Jacobs on the mailing list.

## Which blocks/areas does this affect?

gr-soapy

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
