### PR TITLE
gr-utils: make the pydoc_h.mako more clang compliant

### DIFF
--- a/gr-utils/bindtool/core/generator.py
+++ b/gr-utils/bindtool/core/generator.py
@@ -12,6 +12,7 @@ from gnuradio.blocktool import BlockHeaderParser, GenericHeaderParser
 
 import os
 import pathlib
+import subprocess
 import json
 from mako.template import Template
 from datetime import datetime
@@ -92,6 +93,19 @@ class BindingGenerator:
 
         )
 
+    def clang_format(self, s):
+        try:
+            p = subprocess.Popen(
+                ["clang-format"], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            out, err = p.communicate(s.encode('utf-8'))
+            if p.returncode != 0:
+                print("Failed to run clang-format: %s", err)
+                return s
+            return out.decode('utf-8')
+        except (RuntimeError, FileNotFoundError) as e:
+            print("Failed to run clang-format: %s", e)
+            return s
+
     def write_pydoc_h(self, header_info, base_name, output_dir):
 
         doc_pathname = os.path.join(
@@ -102,7 +116,7 @@ class BindingGenerator:
                 header_info, base_name)
             with open(doc_pathname, 'w+') as outfile:
                 print("Writing binding code to {}".format(doc_pathname))
-                outfile.write(pybind_code)
+                outfile.write(self.clang_format(pybind_code))
             return doc_pathname
         except Exception as e:
             print(e)
@@ -118,7 +132,7 @@ class BindingGenerator:
                 header_info, base_name)
             with open(binding_pathname_cc, 'w+') as outfile:
                 print("Writing binding code to {}".format(binding_pathname_cc))
-                outfile.write(pybind_code)
+                outfile.write(self.clang_format(pybind_code))
             return binding_pathname_cc
         except Exception as e:
             print(e)

--- a/gr-utils/bindtool/templates/generic_python_cc.mako
+++ b/gr-utils/bindtool/templates/generic_python_cc.mako
@@ -65,11 +65,16 @@ func = '\n\
                return PyLong_AsLongLong(p->'+fcn_name+'());\n\
         }'
 %>
+%       elif fcn['return_type'] == 'QWidget *':
+<%
+func = '\n\
+            []('+cls_name+'& self) { return reinterpret_cast<uintptr_t>(self.'+fcn_name+'()); }'
+%>
 %       else: ## No PyObject pointer 
 <%
 func = overloaded_str+'&'+cls_name+'::'+fcn_name
 %>        
-%       endif                    
+%       endif
         ${modvar if isfree else ""}${".def_static" if has_static and not isfree else ".def"}("${fcn['name']}",${func},       
 % for arg in fcn_args:
             py::arg("${arg['name']}")${" = " + arg['default'] if arg['default'] else ''},

--- a/gr-utils/bindtool/templates/pydoc_h.mako
+++ b/gr-utils/bindtool/templates/pydoc_h.mako
@@ -13,7 +13,7 @@ ${license}
 %>\
 \
 #include "pydoc_macros.h"
-#define D(...) DOC(gr,${modname}, __VA_ARGS__ )
+#define D(...) DOC(gr, ${modname}, __VA_ARGS__)
 \
 /*
   This file contains placeholders for docstrings for the Python bindings.
@@ -51,7 +51,7 @@ static const char *__doc_${'_'.join(names)}${suffix} = R"doc(${docstring})doc";
         constructors = cls['constructors'] if 'constructors' in cls else []
         class_enums = cls['enums'] if 'enums' in cls else []
         class_variables = cls['variables'] if 'variables' in cls else []
-%> \
+%>\
 \
 ${render_docstring_const(modname,namespace['name'].split('::')+[cls['name']],cls,cls['docstring'] if 'docstring' in cls else "")}
 \


### PR DESCRIPTION

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
Generating the *_pydoc_template.h file with bind_intree_file.py builds a non clang compliant file.
This pr is a proposal to fix some  errors.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested with modules of gr-display and gr-qtgui/include/gnuradio/qtgui/sink_c.h
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [ x I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
