### PR TITLE
cmake: Set "nt" install scheme for Python on Windows

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -159,7 +159,12 @@ except AttributeError: pass
 
 if not install_dir:
     #find where to install the python module
-    install_dir = sysconfig.get_path('platlib','posix_prefix')
+    #for Python 3.11+, we could use the 'venv' scheme for all platforms
+    if os.name == 'nt':
+        scheme = 'nt'
+    else:
+        scheme = 'posix_prefix'
+    install_dir = sysconfig.get_path('platlib', scheme)
     prefix = sysconfig.get_config_var('prefix')
 
 #strip the prefix to return a relative path


### PR DESCRIPTION
This restores behavior on Windows to what it was prior to the recent fix to deal with Debian overriding the default scheme (#5739). Other platforms remain as they currently are.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
