### PR TITLE
modtool: Fix gr_modtool bind & rm

### DIFF
--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -132,7 +132,7 @@ def get_block_names(pattern, modname):
     blocknames = []
     reg = re.compile(pattern)
     fname_re = re.compile(r'[a-zA-Z]\w+\.\w{1,5}$')
-    with open(f'include/{modname}/CMakeLists.txt', 'r') as f:
+    with open(f'include/gnuradio/{modname}/CMakeLists.txt', 'r') as f:
         for line in f.read().splitlines():
             if len(line.strip()) == 0 or line.strip()[0] == '#':
                 continue


### PR DESCRIPTION
## Description
When running `gr_modtool bind` or `gr_modtool rm`, a crash occurs because `get_block_names` tries to open the wrong include directory. It does not take into account the new structure introduced in #5265. I've fixed that here.

```
Traceback (most recent call last):
  File "/home/argilo/prefix_310/bin/gr_modtool", line 18, in <module>
    cli()
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/argilo/prefix_310/local/lib/python3.10/dist-packages/gnuradio/modtool/cli/base.py", line 135, in wrapper
    return func(*args, **kwargs)
  File "/home/argilo/prefix_310/local/lib/python3.10/dist-packages/gnuradio/modtool/cli/rm.py", line 29, in cli
    run(self)
  File "/home/argilo/prefix_310/local/lib/python3.10/dist-packages/gnuradio/modtool/cli/base.py", line 155, in run
    module.run()
  File "/home/argilo/prefix_310/local/lib/python3.10/dist-packages/gnuradio/modtool/core/rm.py", line 114, in run
    blocknames_to_delete = get_block_names(
  File "/home/argilo/prefix_310/local/lib/python3.10/dist-packages/gnuradio/modtool/tools/util_functions.py", line 135, in get_block_names
    with open(f'include/{modname}/CMakeLists.txt', 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'include/dsdcc/CMakeLists.txt'
```

## Related Issue
* #5265

## Which blocks/areas does this affect?
* `gr_modtool bind`
* `gr_modtool rm`

## Testing Done
I tested the `gr_modtool bind` and `gr_modtool rm` commands to verify that they work as expected.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
