### PR TITLE
gr-iio: fix grc block pluto sink attenuation callback

### DIFF
--- a/gr-iio/grc/iio_pluto_sink.block.yml
+++ b/gr-iio/grc/iio_pluto_sink.block.yml
@@ -113,7 +113,7 @@ templates:
         - set_bandwidth(${bandwidth})
         - set_frequency(${frequency})
         - set_samplerate(${samplerate})
-        - set_attenuation(${attenuation1})
+        - set_attenuation(0,${attenuation1})
         - set_filter_params(${filter_source}, ${filter}, ${fpass}, ${fstop})
 
 file_format: 1


### PR DESCRIPTION
As reported here: https://ez.analog.com/adieducation/university-program/f/q-a/557699/pluto-run-time-error-with-grc-3-10 the gr-iio pluto sink block attenuation callback causes a runtime error in gnuradio-companion when changing it. This is due to incorrect parameters being passed to the callback. Pluto Sink is a specialized fmcomms2 sink which requires a channel id when setting the attenuation.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>


