### PR TITLE
runtime: Replace boost::noncopyable with standard C++ (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcpmtconverters_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcpmtconverters_thrift.h
@@ -12,7 +12,6 @@
 
 #include "thrift/gnuradio_types.h"
 #include <pmt/pmt.h>
-#include <boost/noncopyable.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
 
 
@@ -71,9 +70,12 @@ struct to_pmt_c32vect_f : public to_pmt_f {
     pmt::pmt_t operator()(const GNURadio::Knob& knob);
 };
 
-class To_PMT : private boost::noncopyable
+class To_PMT
 {
 public:
+    To_PMT(const To_PMT&) = delete;
+    To_PMT& operator=(const To_PMT&) = delete;
+
     static To_PMT instance;
     template <typename TO_PMT_F>
     friend struct to_pmt_reg;

--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -18,7 +18,6 @@
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
 #include <boost/any.hpp>
-#include <boost/core/noncopyable.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <memory>
@@ -26,11 +25,13 @@
 namespace gr {
 namespace thread {
 
-class GR_RUNTIME_API thread_group : public boost::noncopyable
+class GR_RUNTIME_API thread_group
 {
 public:
     thread_group();
     ~thread_group();
+    thread_group(const thread_group&) = delete;
+    thread_group& operator=(const thread_group&) = delete;
 
     boost::thread* create_thread(const boost::function0<void>& threadfunc);
     void add_thread(std::unique_ptr<boost::thread> thrd);

--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -13,7 +13,6 @@
 
 #include <pmt/api.h>
 #include <boost/any.hpp>
-#include <boost/noncopyable.hpp>
 #include <complex>
 #include <cstdint>
 #include <iosfwd>

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -15,18 +15,19 @@
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/logger.h>
 #include <flat_flowgraph.h>
-#include <boost/core/noncopyable.hpp>
 
 namespace gr {
 
 /*!
  * \ingroup internal
  */
-class GR_RUNTIME_API hier_block2_detail : boost::noncopyable
+class GR_RUNTIME_API hier_block2_detail
 {
 public:
     hier_block2_detail(hier_block2* owner);
     ~hier_block2_detail();
+    hier_block2_detail(const hier_block2_detail&) = delete;
+    hier_block2_detail& operator=(const hier_block2_detail&) = delete;
 
     void connect(basic_block_sptr block);
     void connect(basic_block_sptr src, int src_port, basic_block_sptr dst, int dst_port);

--- a/gnuradio-runtime/lib/scheduler.h
+++ b/gnuradio-runtime/lib/scheduler.h
@@ -14,7 +14,6 @@
 #include "flat_flowgraph.h"
 #include <gnuradio/api.h>
 #include <gnuradio/block.h>
-#include <boost/core/noncopyable.hpp>
 
 namespace gr {
 
@@ -28,7 +27,7 @@ typedef std::shared_ptr<scheduler> scheduler_sptr;
  * Preconditions: details, buffers and buffer readers have been
  * assigned.
  */
-class GR_RUNTIME_API scheduler : boost::noncopyable
+class GR_RUNTIME_API scheduler
 {
 public:
     /*!
@@ -40,6 +39,9 @@ public:
     scheduler(flat_flowgraph_sptr ffg, int max_noutput_items, bool catch_exceptions);
 
     virtual ~scheduler();
+
+    scheduler(const scheduler&) = delete;
+    scheduler& operator=(const scheduler&) = delete;
 
     /*!
      * \brief Tell the scheduler to stop executing.

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/thread/thread_group_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/thread/thread_group_python.cc
@@ -22,9 +22,7 @@ void bind_thread_group(py::module& m)
     using thread_group = gr::thread_group;
 
 
-    py::class_<thread_group,
-               boost::noncopyable_::noncopyable,
-               std::shared_ptr<thread_group>>(m, "thread_group")
+    py::class_<thread_group, std::shared_ptr<thread_group>>(m, "thread_group")
 
         .def(py::init<>())
 


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit e16ae5c04aa4e967f3d367a26856ff47d53919b5)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5714