### PR TITLE
filter: Fix flaky freq xlating filter test (backport to maint-3.10)

### DIFF
--- a/gr-filter/python/filter/qa_freq_xlating_fft_filter.py
+++ b/gr-filter/python/filter/qa_freq_xlating_fft_filter.py
@@ -72,8 +72,8 @@ class test_freq_xlating_filter(gr_unittest.TestCase):
 
     def assert_fft_ok(self, expected_result, result_data):
         expected_result = expected_result[:len(result_data)]
-        self.assertComplexTuplesAlmostEqual2(expected_result, result_data,
-                                             abs_eps=1e-9, rel_eps=1.5e-3)
+        self.assertComplexTuplesAlmostEqual(expected_result, result_data,
+                                            places=5)
 
     def test_fft_filter_ccf_001(self):
         self.generate_ccf_source()


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 2046bce50bb0f45c008718e2c8f8ec493a6e0b6b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5745