### PR TITLE
qa: remove formatting in assertSequenceEqualGR

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr_unittest.py
+++ b/gnuradio-runtime/python/gnuradio/gr_unittest.py
@@ -121,7 +121,7 @@ class TestCase(unittest.TestCase):
             if item[0] != item[1]:
                 total_miscompares += 1
                 print(
-                    'Miscompare at: {:d} ({:d} -- {:d})'.format(idx, item[0], item[1]))
+                    'Miscompare at: {:d} ({} -- {})'.format(idx, item[0], item[1]))
         if total_miscompares > 0:
             print('Total miscompares: {:d}'.format(total_miscompares))
         self.assertTrue(total_miscompares == 0)


### PR DESCRIPTION

# Pull Request Details
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
the assertSequenceEqualGR method gets around a python unittest bug that hangs when the sequences aren't equal.  This method that was introduced in #5028 works around that.  In the printing of the results though it does assume integer values on the lists - which is removed here

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
some QA tests

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
CI should be sufficient

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
