### PR TITLE
dtv: Fix use of uninitialized memory

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -1016,7 +1016,7 @@ void dvbt2_framemapper_cc_impl::bch_poly_build_tables(void)
     const int polys12[] = { 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1 };
 
     int len;
-    int polyout[2][200];
+    int polyout[2][200] = { 0 };
 
     len = poly_mult(polys01, 15, polys02, 15, polyout[0]);
     len = poly_mult(polys03, 15, polyout[0], len, polyout[1]);


### PR DESCRIPTION
## Description

Valgrind reports that `poly_pack` reads uninitialized memory, leading to undefined behaviour. This happens because it rounds the length up to the next multiple of 32 before reading the polynomial coefficients. Initializing the coefficients to zero solves the problem.

```
==1539339== Conditional jump or move depends on uninitialised value(s)
==1539339==    at 0x4C3174CE: poly_pack (dvbt2_framemapper_cc_impl.cc:994)
==1539339==    by 0x4C3174CE: gr::dtv::dvbt2_framemapper_cc_impl::bch_poly_build_tables() (dvbt2_framemapper_cc_impl.cc:1032)
==1539339==    by 0x4C31AC60: gr::dtv::dvbt2_framemapper_cc_impl::dvbt2_framemapper_cc_impl(gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t) (dvbt2_framemapper_cc_impl.cc:266)
==1539339==    by 0x4C31BF42: make_block_sptr<gr::dtv::dvbt2_framemapper_cc_impl, gr::dtv::dvb_framesize_t&, gr::dtv::dvb_code_rate_t&, gr::dtv::dvb_constellation_t&, gr::dtv::dvbt2_rotation_t&, int&, int&, gr::dtv::dvbt2_extended_carrier_t&, gr::dtv::dvbt2_fftsize_t&, gr::dtv::dvb_guardinterval_t&, gr::dtv::dvbt2_l1constellation_t&, gr::dtv::dvbt2_pilotpattern_t&, int&, int&, gr::dtv::dvbt2_papr_t&, gr::dtv::dvbt2_version_t&, gr::dtv::dvbt2_preamble_t&, gr::dtv::dvbt2_inputmode_t&, gr::dtv::dvbt2_reservedbiasbits_t&, gr::dtv::dvbt2_l1scrambled_t&, gr::dtv::dvbt2_inband_t&> (sptr_magic.h:57)
==1539339==    by 0x4C31BF42: gr::dtv::dvbt2_framemapper_cc::make(gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t) (dvbt2_framemapper_cc_impl.cc:42)
==1539339==    by 0x4C219696: operator() (init.h:242)
==1539339==    by 0x4C219696: call_impl<void, pybind11::detail::initimpl::factory<std::shared_ptr<gr::dtv::dvbt2_framemapper_cc> (*)(gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t), pybind11::detail::void_type (*)(), std::shared_ptr<gr::dtv::dvbt2_framemapper_cc>(gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t), pybind11::detail::void_type()>::execute<pybind11::class_<gr::dtv::dvbt2_framemapper_cc, gr::block, gr::basic_block, std::shared_ptr<gr::dtv::dvbt2_framemapper_cc> >, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, char const*>(pybind11::class_<gr::dtv::dvbt2_framemapper_cc, gr::block, gr::basic_block, std::shared_ptr<gr::dtv::dvbt2_framemapper_cc> >&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, char const* const&) &&::<lambda(pybind11::detail::value_and_holder&, gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t)>&, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, pybind11::detail::void_type> (cast.h:1207)
==1539339==    by 0x4C219696: call<void, pybind11::detail::void_type, pybind11::detail::initimpl::factory<std::shared_ptr<gr::dtv::dvbt2_framemapper_cc> (*)(gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t), pybind11::detail::void_type (*)(), std::shared_ptr<gr::dtv::dvbt2_framemapper_cc>(gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t), pybind11::detail::void_type()>::execute<pybind11::class_<gr::dtv::dvbt2_framemapper_cc, gr::block, gr::basic_block, std::shared_ptr<gr::dtv::dvbt2_framemapper_cc> >, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, pybind11::arg, char const*>(pybind11::class_<gr::dtv::dvbt2_framemapper_cc, gr::block, gr::basic_block, std::shared_ptr<gr::dtv::dvbt2_framemapper_cc> >&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, const pybind11::arg&, char const* const&) &&::<lambda(pybind11::detail::value_and_holder&, gr::dtv::dvb_framesize_t, gr::dtv::dvb_code_rate_t, gr::dtv::dvb_constellation_t, gr::dtv::dvbt2_rotation_t, int, int, gr::dtv::dvbt2_extended_carrier_t, gr::dtv::dvbt2_fftsize_t, gr::dtv::dvb_guardinterval_t, gr::dtv::dvbt2_l1constellation_t, gr::dtv::dvbt2_pilotpattern_t, int, int, gr::dtv::dvbt2_papr_t, gr::dtv::dvbt2_version_t, gr::dtv::dvbt2_preamble_t, gr::dtv::dvbt2_inputmode_t, gr::dtv::dvbt2_reservedbiasbits_t, gr::dtv::dvbt2_l1scrambled_t, gr::dtv::dvbt2_inband_t)>&> (cast.h:1184)
==1539339==    by 0x4C219696: _ZZN8pybind1112cpp_function10initializeIZNOS_6detail8initimpl7factoryIPFSt10shared_ptrIN2gr3dtv20dvbt2_framemapper_ccEENS7_15dvb_framesize_tENS7_15dvb_code_rate_tENS7_19dvb_constellation_tENS7_16dvbt2_rotation_tEiiNS7_24dvbt2_extended_carrier_tENS7_15dvbt2_fftsize_tENS7_19dvb_guardinterval_tENS7_23dvbt2_l1constellation_tENS7_20dvbt2_pilotpattern_tEiiNS7_12dvbt2_papr_tENS7_15dvbt2_version_tENS7_16dvbt2_preamble_tENS7_17dvbt2_inputmode_tENS7_24dvbt2_reservedbiasbits_tENS7_19dvbt2_l1scrambled_tENS7_14dvbt2_inband_tEEPFNS2_9void_typeEvESQ_ST_E7executeINS_6class_IS8_JNS6_5blockENS6_11basic_blockES9_EEEJNS_3argES11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_PKcEEEvRT_DpRKT0_EUlRNS2_16value_and_holderESA_SB_SC_SD_iiSE_SF_SG_SH_SI_iiSJ_SK_SL_SM_SN_SO_SP_E_vJS1B_SA_SB_SC_SD_iiSE_SF_SG_SH_SI_iiSJ_SK_SL_SM_SN_SO_SP_EJNS_4nameENS_9is_methodENS_7siblingENS2_24is_new_style_constructorES11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S11_S13_EEEvOS14_PFT0_DpT1_EDpRKT2_ENKUlRNS2_13function_callEE1_clES1S_.isra.0 (pybind11.h:233)
==1539339==    by 0x4C1AA7E1: pybind11::cpp_function::dispatcher(_object*, _object*, _object*) (pybind11.h:835)
==1539339==    by 0x26310D: ??? (in /usr/bin/python3.10)
==1539339==    by 0x259BBA: _PyObject_MakeTpCall (in /usr/bin/python3.10)
==1539339==    by 0x27141F: ??? (in /usr/bin/python3.10)
==1539339==    by 0x26DB4A: ??? (in /usr/bin/python3.10)
==1539339==    by 0x259F6A: ??? (in /usr/bin/python3.10)
==1539339==    by 0x610002A: pybind11_meta_call (class.h:174)
==1539339==    by 0x259BBA: _PyObject_MakeTpCall (in /usr/bin/python3.10)
```
It appears the uninitialized bits are not used after being packed into `m_poly_s_12` so this bug is unlikely to cause trouble in practice.

## Which blocks/areas does this affect?
* DVB-T2 Frame Mapper

## Testing Done
I verified that the `qa_dtv` test still passes after this change, but that the valgrind warning is no longer present.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
