### PR TITLE
runtime: Fix signed integer overflows

### DIFF
--- a/gnuradio-runtime/include/gnuradio/fxpt.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt.h
@@ -64,7 +64,7 @@ public:
      */
     static float cos(int32_t x)
     {
-        uint32_t ux = x + 0x40000000;
+        uint32_t ux = (uint32_t)x + 0x40000000;
         int index = ux >> (WORDBITS - NBITS);
         return s_sine_table[index][0] * (ux & ACCUM_MASK) + s_sine_table[index][1];
     }
@@ -78,7 +78,7 @@ public:
         int sin_index = ux >> (WORDBITS - NBITS);
         *s = s_sine_table[sin_index][0] * (ux & ACCUM_MASK) + s_sine_table[sin_index][1];
 
-        ux = x + 0x40000000;
+        ux = (uint32_t)x + 0x40000000;
         int cos_index = ux >> (WORDBITS - NBITS);
         *c = s_sine_table[cos_index][0] * (ux & ACCUM_MASK) + s_sine_table[cos_index][1];
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fxpt.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(f6f6a6028a7944b8a1032337bba08124)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3ef217d934584260ccbfc030dc904fe8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description

When running QA tests, gcc's Undefined Behaviour Sanitizer reports signed integer overflows in fxpt.h. I've fixed them by explicitly casting the input to an unsigned integer prior to the addition step.

```
/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/lib/../include/gnuradio/fxpt.h:67:25: runtime error: signed integer overflow: 1074904320 + 1073741824 cannot be represented in type 'int'
/home/argilo/prefix_311/src/gnuradio/gnuradio-runtime/lib/../include/gnuradio/fxpt.h:81:16: runtime error: signed integer overflow: 1074904320 + 1073741824 cannot be represented in type 'int'
```

## Which blocks/areas does this affect?
* Runtime: fixed point `cos` and `sincos` calculations.

## Testing Done
Verified that the `math_qa_fxpt`, `math_qa_fxpt_nco`, and `math_qa_fxpt_vco` still pass, but no longer produce undefined behaviour warnings.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
