### PR TITLE
digital: Fix load of misaligned address

### DIFF
--- a/gr-digital/lib/crc32_bb_impl.cc
+++ b/gr-digital/lib/crc32_bb_impl.cc
@@ -92,8 +92,9 @@ int crc32_bb_impl::work(int noutput_items,
         d_crc_impl.process_bytes(in, packet_length - d_crc_length);
         crc = calculate_crc32(in, packet_length - d_crc_length);
         if (d_packed) {
-            if (crc !=
-                *(unsigned int*)(in + packet_length - d_crc_length)) { // Drop package
+            if (memcmp(&crc,
+                       in + packet_length - d_crc_length,
+                       d_crc_length)) { // Drop package
                 return 0;
             }
         } else {


### PR DESCRIPTION
## Description
gcc's Undefined Behaviour Sanitizer reports load of a misaligned address. Replacing the offending code with a memcmp fixes the issue.

## Which blocks/areas does this affect?
* Stream CRC32

## Testing Done
Verified that `qa_crc32_bb_test` still passes, but without the misaligned address warning.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
