### PR TITLE
qtgui: Fix inconsistent override warnings

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/timeRasterGlobalData.h
@@ -37,7 +37,7 @@ public:
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
 #elif QWT_VERSION >= 0x060200
-    virtual QwtInterval interval(Qt::Axis) const;
+    virtual QwtInterval interval(Qt::Axis) const override;
     void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 

--- a/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
+++ b/gr-qtgui/include/gnuradio/qtgui/waterfallGlobalData.h
@@ -38,7 +38,7 @@ public:
     virtual QwtDoubleInterval range() const;
     virtual void setRange(const QwtDoubleInterval&);
 #elif QWT_VERSION >= 0x060200
-    virtual QwtInterval interval(Qt::Axis) const;
+    virtual QwtInterval interval(Qt::Axis) const override;
     void setInterval(Qt::Axis, const QwtInterval&);
 #endif
 


### PR DESCRIPTION
## Description
CI build logs show 23 warnings due to missing `override` specifiers in gr-qtgui. I've fixed those here.

## Which blocks/areas does this affect?
Various QTGUI blocks.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
