### PR TITLE
runtime: Silence unused parameter warnings

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
+++ b/gnuradio-runtime/include/gnuradio/rpcregisterhelpers.h
@@ -802,8 +802,8 @@ struct rpcbasic_register_set : public rpcbasic_base {
      * \param display_     The display mask
      */
     rpcbasic_register_set(const std::string& block_alias,
-                          const char* functionbase,
-                          void (T::*function)(Tto),
+                          [[maybe_unused]] const char* functionbase,
+                          [[maybe_unused]] void (T::*function)(Tto),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -862,10 +862,10 @@ struct rpcbasic_register_set : public rpcbasic_base {
      * \param minpriv_     The required minimum privilege level
      * \param display_     The display mask
      */
-    rpcbasic_register_set(const std::string& name,
-                          const char* functionbase,
+    rpcbasic_register_set([[maybe_unused]] const std::string& name,
+                          [[maybe_unused]] const char* functionbase,
                           T* obj,
-                          void (T::*function)(Tto),
+                          [[maybe_unused]] void (T::*function)(Tto),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -982,8 +982,8 @@ struct rpcbasic_register_trigger : public rpcbasic_base {
      * \param minpriv_     The required minimum privilege level
      */
     rpcbasic_register_trigger(const std::string& block_alias,
-                              const char* functionbase,
-                              void (T::*function)(),
+                              [[maybe_unused]] const char* functionbase,
+                              [[maybe_unused]] void (T::*function)(),
                               const char* desc_ = "",
                               priv_lvl_t minpriv_ = RPC_PRIVLVL_MIN)
     {
@@ -1022,10 +1022,10 @@ struct rpcbasic_register_trigger : public rpcbasic_base {
      * \param desc_        A string to describing the variable.
      * \param minpriv_     The required minimum privilege level
      */
-    rpcbasic_register_trigger(const std::string& name,
-                              const char* functionbase,
+    rpcbasic_register_trigger([[maybe_unused]] const std::string& name,
+                              [[maybe_unused]] const char* functionbase,
                               T* obj,
-                              void (T::*function)(),
+                              [[maybe_unused]] void (T::*function)(),
                               const char* desc_ = "",
                               priv_lvl_t minpriv_ = RPC_PRIVLVL_MIN)
     {
@@ -1133,8 +1133,8 @@ public:
      * \param display_     The display mask
      */
     rpcbasic_register_get(const std::string& block_alias,
-                          const char* functionbase,
-                          Tfrom (T::*function)(),
+                          [[maybe_unused]] const char* functionbase,
+                          [[maybe_unused]] Tfrom (T::*function)(),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1176,8 +1176,8 @@ public:
      * '[variable]() const' getter functions.
      */
     rpcbasic_register_get(const std::string& block_alias,
-                          const char* functionbase,
-                          Tfrom (T::*function)() const,
+                          [[maybe_unused]] const char* functionbase,
+                          [[maybe_unused]] Tfrom (T::*function)() const,
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1238,10 +1238,10 @@ public:
      * \param minpriv_     The required minimum privilege level
      * \param display_     The display mask
      */
-    rpcbasic_register_get(const std::string& name,
-                          const char* functionbase,
+    rpcbasic_register_get([[maybe_unused]] const std::string& name,
+                          [[maybe_unused]] const char* functionbase,
                           T* obj,
-                          Tfrom (T::*function)(),
+                          [[maybe_unused]] Tfrom (T::*function)(),
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1281,10 +1281,10 @@ public:
      * \brief Same as above that allows using '[variable]() const'
      * getter functions.
      */
-    rpcbasic_register_get(const std::string& name,
-                          const char* functionbase,
+    rpcbasic_register_get([[maybe_unused]] const std::string& name,
+                          [[maybe_unused]] const char* functionbase,
                           T* obj,
-                          Tfrom (T::*function)() const,
+                          [[maybe_unused]] Tfrom (T::*function)() const,
                           const pmt::pmt_t& min,
                           const pmt::pmt_t& max,
                           const pmt::pmt_t& def,
@@ -1612,7 +1612,7 @@ public:
      * \param display_     The display mask
      */
     rpcbasic_register_handler(const std::string& block_alias,
-                              const char* handler,
+                              [[maybe_unused]] const char* handler,
                               const char* units_ = "",
                               const char* desc_ = "",
                               priv_lvl_t minpriv_ = RPC_PRIVLVL_MIN,

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/rpcregisterhelpers_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/rpcregisterhelpers_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rpcregisterhelpers.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0e7fa8e10f2385eff09832a4476c1fff)                     */
+/* BINDTOOL_HEADER_FILE_HASH(655cba56c80e645375b1cc15510d87d3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/lib/qa_rotator.cc
+++ b/gr-blocks/lib/qa_rotator.cc
@@ -21,7 +21,7 @@
 #include <cmath>
 
 // error vector magnitude
-__GR_ATTR_UNUSED static float error_vector_mag(gr_complex a, gr_complex b)
+[[maybe_unused]] static float error_vector_mag(gr_complex a, gr_complex b)
 {
     return abs(a - b);
 }

--- a/gr-soapy/lib/sink_impl.cc
+++ b/gr-soapy/lib/sink_impl.cc
@@ -53,10 +53,10 @@ void sink_impl::set_length_tag_name(const std::string& length_tag_name)
     d_length_tag_key = pmt::mp(length_tag_name);
 }
 
-int sink_impl::general_work(__GR_ATTR_UNUSED int noutput_items,
+int sink_impl::general_work([[maybe_unused]] int noutput_items,
                             gr_vector_int& ninput_items,
                             gr_vector_const_void_star& input_items,
-                            __GR_ATTR_UNUSED gr_vector_void_star& output_items)
+                            [[maybe_unused]] gr_vector_void_star& output_items)
 {
     int nin = ninput_items[0];
     long long int time_ns = 0;

--- a/gr-soapy/lib/source_impl.cc
+++ b/gr-soapy/lib/source_impl.cc
@@ -49,8 +49,8 @@ source_impl::source_impl(const std::string& device,
 }
 
 int source_impl::general_work(int noutput_items,
-                              __GR_ATTR_UNUSED gr_vector_int& ninput_items,
-                              __GR_ATTR_UNUSED gr_vector_const_void_star& input_items,
+                              [[maybe_unused]] gr_vector_int& ninput_items,
+                              [[maybe_unused]] gr_vector_const_void_star& input_items,
                               gr_vector_void_star& output_items)
 {
     long long int time_ns = 0;


### PR DESCRIPTION
## Description
CI build logs show 63 warnings for unused parameters in `rpcregisterhelpers.h`. Adding `[[maybe_unused]]` should silence the warnings.

I also replaced `__GR_ATTR_UNUSED` with C++17's `[[maybe_unused]]` elsewhere in GNU Radio. I left the macro in place, since removing it would be an API change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
