### PR TITLE
dtv: Fix initialization of L1Post struct (backport to maint-3.10)

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -252,7 +252,7 @@ dvbt2_framemapper_cc_impl::dvbt2_framemapper_cc_impl(
     } else {
         l1postinit->reserved_3 = 0;
     }
-    l1postinit->plp_id = 0;
+    l1postinit->plp_id_dynamic = 0;
     l1postinit->plp_start = 0;
     l1postinit->plp_num_blocks = fecblocks;
     if (reservedbiasbits == RESERVED_ON && version == VERSION_131) {


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit dcd794f80223ecfacff8a7229b5e205005f26858)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backporthttps://github.com/gnuradio/gnuradio/pull/5750