### PR TITLE
dtv: Fix compiler warning

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -1016,7 +1016,7 @@ void dvbt2_framemapper_cc_impl::bch_poly_build_tables(void)
     const int polys12[] = { 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1 };
 
     int len;
-    int polyout[2][200] = { 0 };
+    int polyout[2][200] = {};
 
     len = poly_mult(polys01, 15, polys02, 15, polyout[0]);
     len = poly_mult(polys03, 15, polyout[0], len, polyout[1]);


### PR DESCRIPTION
## Description

In #5804 I accidentally caused a compiler warning:

```
warning: suggest braces around initialization of subobject [-Wmissing-braces]
```

This change fixes the warning while still initializing the polyout array to zero.

## Related Issue
* #5804

## Which blocks/areas does this affect?
* DVB-T2 Frame Mapper

## Testing Done
I verified that `qa_dtv` still passes and does not produce any valgrind warnings.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
