### PR TITLE
runtime: Fix flaky qa_uncaught_exception test (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_uncaught_exception.py
@@ -62,7 +62,7 @@ class test_uncaught_exception(gr_unittest.TestCase):
         p = Process(target=process_func, args=(False,))
         p.daemon = True
         p.start()
-        p.join(2.5)
+        p.join(10.0)
         exit_code = p.exitcode
         self.assertIsNotNone(
             exit_code, "exception did not cause flowgraph exit")


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 7eced84a812fac4b4ed2aea421694f63e9f3c91b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5746