### PR TITLE
pdu: Replace Boost with standard C++ (backport to maint-3.10)

### DIFF
--- a/gr-pdu/CMakeLists.txt
+++ b/gr-pdu/CMakeLists.txt
@@ -8,14 +8,12 @@
 ########################################################################
 # Setup dependencies
 ########################################################################
-include(GrBoost)
 
 ########################################################################
 # Register component
 ########################################################################
 include(GrComponent)
 GR_REGISTER_COMPONENT("gr-pdu" ENABLE_GR_PDU
-    Boost_FOUND
     ENABLE_GNURADIO_RUNTIME
     ENABLE_GR_BLOCKS
     ENABLE_GR_FILTER

--- a/gr-pdu/include/gnuradio/pdu/add_system_time.h
+++ b/gr-pdu/include/gnuradio/pdu/add_system_time.h
@@ -21,7 +21,7 @@ namespace pdu {
  * \ingroup debug_tools_blk
  * \ingroup pdu_blk
  *
- * Adds a user specified key to PDU dict containing the boost system time in seconds
+ * Adds a user specified key to PDU dict containing the system time in seconds
  * since unix epoch.
  */
 class PDU_API add_system_time : virtual public gr::block

--- a/gr-pdu/lib/add_system_time_impl.h
+++ b/gr-pdu/lib/add_system_time_impl.h
@@ -19,7 +19,6 @@ class add_system_time_impl : public add_system_time
 {
 private:
     std::string d_name;
-    const boost::posix_time::ptime d_epoch;
     pmt::pmt_t d_key;
 
     void handle_pdu(const pmt::pmt_t& pdu);

--- a/gr-pdu/lib/pdu_to_stream_impl.cc
+++ b/gr-pdu/lib/pdu_to_stream_impl.cc
@@ -16,8 +16,8 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/pdu.h>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/thread/thread.hpp>
+#include <chrono>
+#include <thread>
 
 namespace gr {
 namespace pdu {
@@ -243,14 +243,14 @@ int pdu_to_stream_impl<T>::work(int noutput_items,
         if (d_pdu_queue.empty()) {
             // if we have nothing to do, sleep for a short duration to prevent rapid
             // successive calls and then return zero items
-            boost::this_thread::sleep(boost::posix_time::microseconds(25));
+            std::this_thread::sleep_for(std::chrono::microseconds(25));
             return 0;
         }
 
         // fetch another PDU of data and update the size of the data
         data_remaining = queue_data();
         if (data_remaining == 0) {
-            boost::this_thread::sleep(boost::posix_time::microseconds(25));
+            std::this_thread::sleep_for(std::chrono::microseconds(25));
             return 0;
         }
     } /* end if data_remaining == 0 */

--- a/gr-pdu/lib/tags_to_pdu_impl.cc
+++ b/gr-pdu/lib/tags_to_pdu_impl.cc
@@ -15,6 +15,7 @@
 #include "tags_to_pdu_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/pdu.h>
+#include <chrono>
 
 namespace gr {
 namespace pdu {
@@ -156,8 +157,9 @@ void tags_to_pdu_impl<T>::publish_message()
     d_meta_dict = pmt::dict_add(
         d_meta_dict, metadata_keys::pdu_num(), pmt::from_uint64(d_burst_counter));
     if (d_wall_clock_time) {
-        double t_now((boost::get_system_time() - d_epoch).total_microseconds() /
-                     1000000.0);
+        double t_now(std::chrono::duration<double>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count());
         d_meta_dict = pmt::dict_add(
             d_meta_dict, metadata_keys::sys_time(), pmt::from_double(t_now));
     }
@@ -395,8 +397,6 @@ template <class T>
 void tags_to_pdu_impl<T>::enable_time_debug(bool enable)
 {
     if (enable) {
-        boost::posix_time::ptime epoch(boost::gregorian::date(1970, 1, 1));
-        d_epoch = epoch;
         d_wall_clock_time = true;
     } else {
         d_wall_clock_time = false;

--- a/gr-pdu/lib/tags_to_pdu_impl.h
+++ b/gr-pdu/lib/tags_to_pdu_impl.h
@@ -37,7 +37,6 @@ private:
     std::vector<T> d_vector;
     std::vector<tag_t> d_tags;
     tag_t d_tag;
-    boost::posix_time::ptime d_epoch;
     uint64_t d_known_time_int_sec; // known integer seconds of a particular item
     double d_known_time_frac_sec;  // known fractional seconds of a particular item
     uint64_t d_known_time_offset;  // known item offset of a particular item

--- a/gr-pdu/lib/time_delta_impl.h
+++ b/gr-pdu/lib/time_delta_impl.h
@@ -21,7 +21,6 @@ private:
     std::string d_name;
     const pmt::pmt_t d_delta_key;
     const pmt::pmt_t d_time_key;
-    const boost::posix_time::ptime d_epoch;
 
     gr::thread::mutex d_mutex;
 

--- a/gr-pdu/python/pdu/bindings/add_system_time_python.cc
+++ b/gr-pdu/python/pdu/bindings/add_system_time_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(add_system_time.h)                                         */
-/* BINDTOOL_HEADER_FILE_HASH(3abd057660e6652a1bb162bc47c0db73)                     */
+/* BINDTOOL_HEADER_FILE_HASH(577bac06b6db295b3384056d5dd8916d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 977de6599bdf14be3a620f9859f5d692b2f17559)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5651