### PR TITLE
qtgui: Remove unused variable from Waterfall Sink

### DIFF
--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -480,7 +480,7 @@ void waterfall_sink_c_impl::handle_pdus(pmt::pmt_t msg)
         int j = 0;
         size_t min = 0;
         size_t max = std::min(d_fftsize, static_cast<int>(len));
-        for (size_t i = 0; j < d_nrows; i += stride) {
+        while (j < d_nrows) {
             // Clear residbufs if len < d_fftsize
             std::fill_n(d_residbufs[d_nconnections].data(), d_fftsize, 0x00);
 

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -482,7 +482,7 @@ void waterfall_sink_f_impl::handle_pdus(pmt::pmt_t msg)
         int j = 0;
         size_t min = 0;
         size_t max = std::min(d_fftsize, static_cast<int>(len));
-        for (size_t i = 0; j < d_nrows; i += stride) {
+        while (j < d_nrows) {
             // Clear residbufs if len < d_fftsize
             memset(d_residbufs[d_nconnections].data(), 0x00, sizeof(float) * d_fftsize);
 


### PR DESCRIPTION
## Description
This fixes a couple unused variable warnings that @drmpeg noticed:
```
/home/ubuntu/xfer/gnuradio/gr-qtgui/lib/waterfall_sink_c_[impl.cc:483](http://impl.cc:483/):21: warning: variable 'i' set but not used [-Wunused-but-set-variable]
        for (size_t i = 0; j < d_nrows; i += stride) {

/home/ubuntu/xfer/gnuradio/gr-qtgui/lib/waterfall_sink_f_[impl.cc:485](http://impl.cc:485/):21: warning: variable 'i' set but not used [-Wunused-but-set-variable]
        for (size_t i = 0; j < d_nrows; i += stride) {
```

## Which blocks/areas does this affect?
* QT GUI Waterfall Sink

## Testing Done
I verified that the Waterfall Sink still works as expected.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
