### PR TITLE
digital: Fix CRC checking in Async CRC16 and Async CRC32 blocks

### DIFF
--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -77,7 +77,7 @@ void crc16_async_bb_impl::check(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
 
     crc = d_crc_ccitt_impl.compute(bytes_in, pkt_len - 2);
-    if (crc != *(unsigned int*)(bytes_in + pkt_len - 2)) { // Drop package
+    if (memcmp(&crc, bytes_in + pkt_len - 2, 2)) { // Drop package
         d_nfail++;
         return;
     }

--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -55,8 +55,7 @@ void crc16_async_bb_impl::calc(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
     std::vector<uint8_t> bytes_out(2 + pkt_len);
 
-    crc = process_crc(bytes_in, pkt_len);
-
+    crc = d_crc_ccitt_impl.compute(bytes_in, pkt_len);
     memcpy((void*)bytes_out.data(), (const void*)bytes_in, pkt_len);
     memcpy((void*)(bytes_out.data() + pkt_len), &crc, 2);
 
@@ -65,16 +64,6 @@ void crc16_async_bb_impl::calc(pmt::pmt_t msg)
         bytes_out.data()); // this copies the values from bytes_out into the u8vector
     pmt::pmt_t msg_pair = pmt::cons(meta, output);
     message_port_pub(d_out_port, msg_pair);
-}
-
-unsigned int crc16_async_bb_impl::process_crc(const uint8_t* bytes_in,
-                                              size_t n_bytes_prcss)
-{
-
-    unsigned int result;
-
-    result = d_crc_ccitt_impl.compute(bytes_in, n_bytes_prcss);
-    return result;
 }
 
 void crc16_async_bb_impl::check(pmt::pmt_t msg)
@@ -87,8 +76,7 @@ void crc16_async_bb_impl::check(pmt::pmt_t msg)
     size_t pkt_len(0);
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
 
-    crc = process_crc(bytes_in, pkt_len - 2);
-
+    crc = d_crc_ccitt_impl.compute(bytes_in, pkt_len - 2);
     if (crc != *(unsigned int*)(bytes_in + pkt_len - 2)) { // Drop package
         d_nfail++;
         return;

--- a/gr-digital/lib/crc16_async_bb_impl.h
+++ b/gr-digital/lib/crc16_async_bb_impl.h
@@ -25,7 +25,6 @@ private:
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;
 
-    unsigned int process_crc(const uint8_t* bytes_in, size_t n_bytes_prcss);
     void calc(pmt::pmt_t msg);
     void check(pmt::pmt_t msg);
 

--- a/gr-digital/lib/crc32_async_bb_impl.cc
+++ b/gr-digital/lib/crc32_async_bb_impl.cc
@@ -79,7 +79,7 @@ void crc32_async_bb_impl::check(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
 
     crc = d_crc_impl.compute(bytes_in, pkt_len - 4);
-    if (crc != *(unsigned int*)(bytes_in + pkt_len - 4)) { // Drop package
+    if (memcmp(&crc, bytes_in + pkt_len - 4, 4)) { // Drop package
         d_nfail++;
         return;
     }


### PR DESCRIPTION
## Description
The Async CRC16 and Async CRC32 blocks can perform misaligned loads, as was the case in #5807.

In addition, the Async CRC16 check fails randomly because it reads four bytes from memory instead of two, causing #5818.

I've fixed both problems by using `memcmp` (with the correct number of bytes) to perform the CRC comparison.

I also removed the unnecessary `crc16_async_bb_impl::process_crc` method to make the implementations of Async CRC16 and CRC32 nearly identical.

## Related Issue
* Fixes #5818.

## Which blocks/areas does this affect?
* Async CRC16
* Async CRC32

## Testing Done
I verified that the `qa_crc16_async_bb` and `qa_crc32_async_bb` tests still pass with these changes in place.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~`
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
