### PR TITLE
filter: Fix flaky qa_filterbank test

### DIFF
--- a/gr-filter/python/filter/qa_filterbank.py
+++ b/gr-filter/python/filter/qa_filterbank.py
@@ -111,7 +111,7 @@ class test_filterbank_vcvcf(gr_unittest.TestCase):
         fb.set_taps(taps2)
         outdata2 = None
         # Wait until we have new data.
-        while (not outdata2) or outdata[0] == outdata2[0]:
+        while (not outdata2) or abs(outdata2[0] - outdata[0]) < 1e-6:
             time.sleep(waittime)
             outdata2 = snk.level()
         self.tb.stop()


### PR DESCRIPTION
## Description
The `qa_filterbank` test occasionally fails, and from the error message it's apparent that on these occasions `outdata2` contains the same values as `outdata`. This suggests that the while loop that waits for the new filter taps to kick in is exiting too soon. I suspect this occurs because it compares complex floating point values for exact equality. I've changed this to check for approximate equality instead.

## Related Issue
* Fixes #5831

## Which blocks/areas does this affect?
Tests for the Generic Filterbank block.

## Testing Done
I verified that the test still passes after this change.

Unfortunately I have not been able to reproduce the failure locally, so it's difficult to know for certain whether this will correct the flaky test. If no failures occur for a few months, we'll know this was successful.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
