### PR TITLE
gr_newmod: Make untagged conda package version less specific (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/.conda/recipe/meta.yaml
+++ b/gr-utils/modtool/templates/gr-newmod/.conda/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set oot_name = "howto" %}
 {% set name = "gnuradio-" + oot_name %}
-{% set version = (environ.get("GIT_DESCRIBE_TAG_PEP440", "0.0.0." + datetime.datetime.now().strftime("%Y%m%d%H%M") + ".dev+" + environ.get("GIT_DESCRIBE_HASH", "local"))|string) %}
+{% set version = (environ.get("GIT_DESCRIBE_TAG_PEP440", "0.0.0." + datetime.datetime.now().strftime("%Y%m%d") + ".dev+" + environ.get("GIT_DESCRIBE_HASH", "local"))|string) %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
The version for an untagged OOT is based on the date, and previously
this included hour and minute. That's too specific and leads to CI-built
packages from the same run often having different versions. This can
still happen, but stopping at the year, month, and day is much saner. I
don't know what I was thinking previously.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit c6d094d79e420c34f7726b893691fdb43eab7360)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5769