### PR TITLE
digital: fix typos CRC Append and Check blocks (backport to maint-3.10)

### DIFF
--- a/gr-digital/grc/digital_crc_append.block.yml
+++ b/gr-digital/grc/digital_crc_append.block.yml
@@ -13,7 +13,7 @@ parameters:
     dtype: hex
     default: '0x4C11DB7'
 -   id: initial_value
-    label: Initial regsiter value
+    label: Initial register value
     dtype: hex
     default: '0xFFFFFFFF'
     hide: part

--- a/gr-digital/grc/digital_crc_check.block.yml
+++ b/gr-digital/grc/digital_crc_check.block.yml
@@ -13,7 +13,7 @@ parameters:
     dtype: hex
     default: '0x4C11DB7'
 -   id: initial_value
-    label: Initial regsiter value
+    label: Initial register value
     dtype: hex
     default: '0xFFFFFFFF'
     hide: part

--- a/gr-digital/include/gnuradio/digital/crc_check.h
+++ b/gr-digital/include/gnuradio/digital/crc_check.h
@@ -24,7 +24,7 @@ namespace digital {
  * \ingroup packet_operators_blk
  *
  * \details
- * The CRC append block receives a PDU containing a CRC at its end,
+ * The CRC check block receives a PDU containing a CRC at its end,
  * and checks whether the CRC is correct. The PDU is sent over the ok
  * or fail output ports according to the result of this check.
  * It can support any CRC whose size is a multiple of 8 bits between
@@ -36,7 +36,7 @@ public:
     typedef std::shared_ptr<crc_check> sptr;
 
     /*!
-     * \brief Build the CRC append block.
+     * \brief Build the CRC check block.
      *
      * \param num_bits CRC size in bits (must be a multiple of 8)
      * \param poly CRC polynomial, in MSB-first notation

--- a/gr-digital/python/digital/bindings/crc_check_python.cc
+++ b/gr-digital/python/digital/bindings/crc_check_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc_check.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0131cc8c9414fc3d807ca7cb843e16c4)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4170f8e1b07d628ce6b354c65f2f0502)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Fix typos in GRC blocks and in header files comments.

Signed-off-by: Daniel Estévez <daniel@destevez.net>
(cherry picked from commit c1876785dfd711e2725d685eafd59813e223be81)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5771