### PR TITLE
gr_newmod: Fix copying python bindings to test dir on Windows (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/CMakeLists.txt
+++ b/gr-utils/modtool/templates/gr-newmod/python/howto/bindings/CMakeLists.txt
@@ -36,12 +36,10 @@ GR_PYBIND_MAKE_OOT(howto
    gr::howto
    "${howto_python_files}")
 
-# copy in bindings .so file for use in QA test module
-add_custom_target(
-  copy_bindings_for_tests ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.so"
+# copy bindings extension for use in QA test module
+add_custom_command(TARGET howto_python POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:howto_python>
     ${CMAKE_BINARY_DIR}/test_modules/gnuradio/howto/
-  DEPENDS howto_python)
+)
 
 install(TARGETS howto_python DESTINATION ${GR_PYTHON_DIR}/gnuradio/howto COMPONENT pythonapi)


### PR DESCRIPTION
Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit bebe83801569225a710f10285664e5a3a1bf41ea)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5768