### PR TITLE
runtime: Replace Boost with standard C++ in Apache Thrift code

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcpmtconverters_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcpmtconverters_thrift.h
@@ -12,7 +12,7 @@
 
 #include "thrift/gnuradio_types.h"
 #include <pmt/pmt.h>
-#include <boost/ptr_container/ptr_map.hpp>
+#include <map>
 
 
 namespace rpcpmtconverter {
@@ -82,7 +82,7 @@ public:
     pmt::pmt_t operator()(const GNURadio::Knob& knob);
 
 protected:
-    boost::ptr_map<GNURadio::BaseTypes::type, to_pmt_f> to_pmt_map;
+    std::map<GNURadio::BaseTypes::type, to_pmt_f> to_pmt_map;
 
 private:
     To_PMT() { ; }

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -16,8 +16,8 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
-#include <boost/thread/mutex.hpp>
 #include <map>
+#include <mutex>
 #include <string>
 
 #define S(x) #x
@@ -79,7 +79,7 @@ private:
     static gr::logger_ptr d_logger;
     static gr::logger_ptr d_debug_logger;
 
-    boost::mutex d_callback_map_lock;
+    std::mutex d_callback_map_lock;
 
     typedef std::map<std::string, configureCallback_t> ConfigureCallbackMap_t;
     ConfigureCallbackMap_t d_setcallbackmap;

--- a/gnuradio-runtime/include/gnuradio/thrift_application_base.h
+++ b/gnuradio-runtime/include/gnuradio/thrift_application_base.h
@@ -15,8 +15,9 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 #include <memory>
+#include <thread>
 
 namespace {
 // Time, in milliseconds, to wait between checks to the Thrift runtime to see if
@@ -208,8 +209,8 @@ void thrift_application_base<TserverBase, TserverClass>::start_application()
         bool app_started(false);
         for (unsigned int attempts(0); (!app_started && attempts < max_init_attempts);
              ++attempts) {
-            boost::this_thread::sleep(
-                boost::posix_time::milliseconds(THRIFTAPPLICATION_ACTIVATION_TIMEOUT_MS));
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(THRIFTAPPLICATION_ACTIVATION_TIMEOUT_MS));
             app_started = d_application->application_started();
         }
 

--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -11,7 +11,6 @@
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
-#include <boost/assign/ptr_map_inserter.hpp>
 
 GNURadio::Knob rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
 {
@@ -247,7 +246,7 @@ template <typename TO_PMT_F>
 rpcpmtconverter::to_pmt_reg<TO_PMT_F>::to_pmt_reg(To_PMT& instance,
                                                   const GNURadio::BaseTypes::type type)
 {
-    boost::assign::ptr_map_insert<TO_PMT_F>(instance.to_pmt_map)(type);
+    instance.to_pmt_map.emplace(type, TO_PMT_F());
 }
 
 pmt::pmt_t rpcpmtconverter::to_pmt_f::operator()(const GNURadio::Knob& knob)

--- a/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc
@@ -41,7 +41,7 @@ rpcserver_thrift::~rpcserver_thrift()
 void rpcserver_thrift::registerConfigureCallback(const std::string& id,
                                                  const configureCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     {
         ConfigureCallbackMap_t::const_iterator iter(d_setcallbackmap.find(id));
         if (iter != d_setcallbackmap.end()) {
@@ -63,7 +63,7 @@ void rpcserver_thrift::registerConfigureCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     ConfigureCallbackMap_t::iterator iter(d_setcallbackmap.find(id));
     if (iter == d_setcallbackmap.end()) {
         std::stringstream s;
@@ -85,7 +85,7 @@ void rpcserver_thrift::unregisterConfigureCallback(const std::string& id)
 void rpcserver_thrift::registerQueryCallback(const std::string& id,
                                              const queryCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     {
         QueryCallbackMap_t::const_iterator iter(d_getcallbackmap.find(id));
         if (iter != d_getcallbackmap.end()) {
@@ -107,7 +107,7 @@ void rpcserver_thrift::registerQueryCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     QueryCallbackMap_t::iterator iter(d_getcallbackmap.find(id));
     if (iter == d_getcallbackmap.end()) {
         std::stringstream s;
@@ -129,7 +129,7 @@ void rpcserver_thrift::unregisterQueryCallback(const std::string& id)
 void rpcserver_thrift::registerHandlerCallback(const std::string& id,
                                                const handlerCallback_t callback)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     {
         HandlerCallbackMap_t::const_iterator iter(d_handlercallbackmap.find(id));
         if (iter != d_handlercallbackmap.end()) {
@@ -151,7 +151,7 @@ void rpcserver_thrift::registerHandlerCallback(const std::string& id,
 
 void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     HandlerCallbackMap_t::iterator iter(d_handlercallbackmap.find(id));
     if (iter == d_handlercallbackmap.end()) {
         std::stringstream s;
@@ -173,7 +173,7 @@ void rpcserver_thrift::unregisterHandlerCallback(const std::string& id)
 
 void rpcserver_thrift::setKnobs(const GNURadio::KnobMap& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     std::for_each(knobs.begin(),
                   knobs.end(),
                   set_f<GNURadio::KnobMap::value_type, ConfigureCallbackMap_t>(
@@ -183,7 +183,7 @@ void rpcserver_thrift::setKnobs(const GNURadio::KnobMap& knobs)
 void rpcserver_thrift::getKnobs(GNURadio::KnobMap& _return,
                                 const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     if (knobs.empty()) {
         std::for_each(d_getcallbackmap.begin(),
                       d_getcallbackmap.end(),
@@ -201,7 +201,7 @@ void rpcserver_thrift::getKnobs(GNURadio::KnobMap& _return,
 void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
                              const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     if (knobs.empty()) {
         std::for_each(d_getcallbackmap.begin(),
                       d_getcallbackmap.end(),
@@ -226,7 +226,7 @@ void rpcserver_thrift::getRe(GNURadio::KnobMap& _return,
 void rpcserver_thrift::properties(GNURadio::KnobPropMap& _return,
                                   const GNURadio::KnobIDList& knobs)
 {
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
     if (knobs.empty()) {
         std::for_each(
             d_getcallbackmap.begin(),
@@ -255,7 +255,7 @@ void rpcserver_thrift::postMessage(const std::string& alias,
     // just need to get the PMT itself out of this to pass to the set_h
     // function for handling the message post.
 
-    boost::mutex::scoped_lock lock(d_callback_map_lock);
+    std::scoped_lock lock(d_callback_map_lock);
 
     pmt::pmt_t alias_pmt = pmt::deserialize_str(alias);
     pmt::pmt_t port_pmt = pmt::deserialize_str(port);


### PR DESCRIPTION
## Description
Here I've replaced almost all of the Boost used by ControlPort's Thrift middleware and replaced it with standard C++. The only thing I didn't touch was one instance of `boost::asio::ip::host_name()`; I don't know how to do that in a cross-platform way, so I left it for now.

## Which blocks/areas does this affect?
ControlPort

## Testing Done
I built GNU Radio with ControlPort and Performance Counters enabled, edited `gnuradio-runtime.conf` to enable both, ran a flow graph, and ran `gr-perf-monitorx` to make sure it's still possible to monitor performance using ControlPort.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
