### PR TITLE
Fix gr perf monitorx 2

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -19,6 +19,7 @@ import math
 import operator
 
 from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
+from PyQt5 import QtCore, Qt
 
 try:
     import networkx as nx
@@ -40,7 +41,6 @@ except ImportError:
           "Please check that they are installed and try again.")
     sys.exit(1)
 
-from PyQt5 import QtCore, Qt
 import itertools
 
 from gnuradio import gr, ctrlport

--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -17,6 +17,7 @@ import signal
 import random
 import math
 import operator
+import thrift
 
 from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
 from PyQt5 import QtCore, Qt
@@ -908,7 +909,7 @@ class MyApp(object):
         try:
             GNURadioControlPortClient(
                 args.host, args.port, 'thrift', self.run, Qt.QApplication(sys.argv).exec_)
-        except:
+        except thrift.transport.TTransport.TTransportException:
             print("ControlPort failed to connect. Check the config of your endpoint.")
             print("\t[ControlPort] on = True")
             print("\t[ControlPort] edges_list = True")


### PR DESCRIPTION
## Description
gr-perf-monitorx fails to start on Ubuntu 22.04 due to https://github.com/matplotlib/matplotlib/issues/21998. That bug was introduced in matplotlib 3.5 and fixed in 3.5.2, but Ubuntu 22.04 ships with 3.5.1. I worked around the problem by applying the suggested workaround of importing `PyQt5` before `matplotlib`.

I also adjusted gr-perf-monitorx's exception handling to only catch `thrift.transport.TTransport.TTransportException`. Otherwise it incorrectly reports every error (including the one above) as "ControlPort failed to connect."

## Related Issue
Fixes #5848.

## Which blocks/areas does this affect?
gr-perf-monitorx

## Testing Done
I followed the reproduction steps in #5848 and verified that gr-perf-monitorx is able to monitor a flow graph, and that it still reports a connection error when an incorrect host or port is specified.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
