### PR TITLE
runtime: Replace boost::function0 with std::function

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -18,8 +18,8 @@
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
 #include <boost/any.hpp>
-#include <boost/function.hpp>
 #include <boost/thread/shared_mutex.hpp>
+#include <functional>
 #include <memory>
 
 namespace gr {
@@ -33,7 +33,7 @@ public:
     thread_group(const thread_group&) = delete;
     thread_group& operator=(const thread_group&) = delete;
 
-    boost::thread* create_thread(const boost::function0<void>& threadfunc);
+    boost::thread* create_thread(const std::function<void()>& threadfunc);
     void add_thread(std::unique_ptr<boost::thread> thrd);
     void remove_thread(boost::thread* thrd);
     void join_all();

--- a/gnuradio-runtime/lib/thread/thread_group.cc
+++ b/gnuradio-runtime/lib/thread/thread_group.cc
@@ -22,7 +22,7 @@ thread_group::thread_group() {}
 
 thread_group::~thread_group() {}
 
-boost::thread* thread_group::create_thread(const boost::function0<void>& threadfunc)
+boost::thread* thread_group::create_thread(const std::function<void()>& threadfunc)
 {
     // No scoped_lock required here since the only "shared data" that's
     // modified here occurs inside add_thread which does scoped_lock.


### PR DESCRIPTION
## Description
`boost::function0` is used in one place in gnuradio-runtime; I've replaced it with `std::function` here.

## Which blocks/areas does this affect?
Thread groups, which are used by the thread-per-block scheduler.

## Testing Done
I verified that flow graphs still execute after this change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
