### PR TITLE
runtime: Replace Boost with standard C++ in high resolution timer

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/bindings/high_res_timer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/high_res_timer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(high_res_timer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(65bfb20df6b18709a817ce85f90e9e06)                     */
+/* BINDTOOL_HEADER_FILE_HASH(be41d50e91b3303dbc805bb9fc2204c9)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
GNU Radio's high resolution timer uses `boost::posix_time` in a few places. I've replaced those with `std::chrono`.

## Which blocks/areas does this affect?
* Performance counters
* QT GUI sinks

## Testing Done
To force the generic timer implementation to be used, I commented out the lines that check for the various platforms (`#if defined(linux)` etc.) to force `GNURADIO_HRT_USE_GENERIC_CLOCK` to be defined.

I checked the behaviour of the high resolution timer using the following Python code:
```
from gnuradio import gr
gr.high_res_timer_now()
gr.high_res_timer_now_perfmon()
gr.high_res_timer_tps()
gr.high_res_timer_epoch()
```
Also, I built GNU Radio with ControlPort and performance counters enabled (`-DENABLE_CTRLPORT_THRIFT=ON -DENABLE_PERFORMANCE_COUNTERS=ON`) and verified that I could still monitor the performance of a running flow graph with `gr-perf-monitorx`.

Finally, I verified that the QT GUI sinks work as before.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
