### PR TITLE
runtime: Replace PMT's Boost mutexes with standard C++

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt_pool.h
+++ b/gnuradio-runtime/include/pmt/pmt_pool.h
@@ -10,9 +10,10 @@
 #ifndef INCLUDED_PMT_POOL_H
 #define INCLUDED_PMT_POOL_H
 
+#include <condition_variable>
 #include <pmt/api.h>
-#include <boost/thread.hpp>
 #include <cstddef>
+#include <mutex>
 #include <vector>
 
 namespace pmt {
@@ -30,9 +31,9 @@ class PMT_API pmt_pool
         struct item* d_next;
     };
 
-    typedef boost::unique_lock<boost::mutex> scoped_lock;
-    mutable boost::mutex d_mutex;
-    boost::condition_variable d_cond;
+    using scoped_lock = std::unique_lock<std::mutex>;
+    mutable std::mutex d_mutex;
+    std::condition_variable d_cond;
 
     size_t d_itemsize;
     size_t d_alignment;

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -18,6 +18,7 @@
 #include <pmt/pmt_pool.h>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
 #include <vector>
 
 namespace pmt {
@@ -163,8 +164,8 @@ pmt_t string_to_symbol(const std::string& name)
     }
 
     // Lock the table on insert for thread safety:
-    static boost::mutex thread_safety;
-    boost::mutex::scoped_lock lock(thread_safety);
+    static std::mutex thread_safety;
+    std::scoped_lock lock(thread_safety);
     // Re-do the search in case another thread inserted this symbol into the table
     // before we got the lock
     for (pmt_t sym = (*get_symbol_hash_table())[hash]; sym; sym = _symbol(sym)->next()) {


### PR DESCRIPTION
## Description
PMT uses Boost mutexes & condition variables in a few places. Those can easily be replaced with their standard C++ equivalents.

## Which blocks/areas does this affect?
Polymorphic Types

## Testing Done
None yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
