### PR TITLE
runtime: Replace Boost with standard C++ in rpcbufferedget

### DIFF
--- a/gnuradio-runtime/include/gnuradio/rpcbufferedget.h
+++ b/gnuradio-runtime/include/gnuradio/rpcbufferedget.h
@@ -11,8 +11,8 @@
 #ifndef RPCBUFFEREDGET_H
 #define RPCBUFFEREDGET_H
 
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/mutex.hpp>
+#include <condition_variable>
+#include <mutex>
 
 template <typename TdataType>
 class rpcbufferedget
@@ -34,7 +34,7 @@ public:
         if (!d_data_needed)
             return;
         {
-            boost::mutex::scoped_lock lock(d_buffer_lock);
+            std::scoped_lock lock(d_buffer_lock);
             d_buffer = data;
             d_data_needed = false;
         }
@@ -43,7 +43,7 @@ public:
 
     TdataType get()
     {
-        boost::mutex::scoped_lock lock(d_buffer_lock);
+        std::unique_lock lock(d_buffer_lock);
         d_data_needed = true;
         d_data_ready.wait(lock);
         return d_buffer;
@@ -51,8 +51,8 @@ public:
 
 private:
     bool d_data_needed;
-    boost::condition_variable d_data_ready;
-    boost::mutex d_buffer_lock;
+    std::condition_variable d_data_ready;
+    std::mutex d_buffer_lock;
     TdataType d_buffer;
 };
 


### PR DESCRIPTION
## Description
rpcbufferedget uses Boost mutexes & condition variables in a few places. Those can easily be replaced with their standard C++ equivalents.

## Which blocks/areas does this affect?
rpcbufferedget, which is used by ControlPort probes.

## Testing Done
None yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
