### PR TITLE
cpp templates in yaml files: Fix some template errors

### DIFF
--- a/gr-blocks/grc/blocks_file_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_sink.block.yml
@@ -52,7 +52,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/file_sink.h>']
     declarations: 'blocks::file_sink::sptr ${id};'
-    make: 'this->${id} = blocks::file_sink::make(${type.size}*${vlen}, ${file}, ${append});'
+    make: 'this->${id} = blocks::file_sink::make(${type.size}*${vlen}, "${no_quotes(file)}", ${append});'
     callbacks:
     - open(${file})
     translations:

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -485,7 +485,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
-            ${name}, // name
+            "${no_quotes(name)}", // name
             ${ 0 if (type == 'msg_complex' or type == 'msg_float') else nconnections } // nconnections
         );
 

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -328,7 +328,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
-            ${name}, // name
+            "${no_quotes(name)}", // name
             ${ (0 if type.startswith('msg') else nconnections) } // number of inputs
         );
 


### PR DESCRIPTION

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
In some yaml files the cpp templates build wrong strings. They use 'value' instead of "value"
This is fixed here for three files.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
