### PR TITLE
runtime: Fix broken log format string in set_min_output_buffer

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -365,7 +365,7 @@ long block::min_output_buffer(size_t i)
 void block::set_min_output_buffer(long min_output_buffer)
 {
     d_logger->info(
-        "set_min_output_buffer on block {:s} to {:d}", unique_id(), min_output_buffer);
+        "set_min_output_buffer on block {:d} to {:d}", unique_id(), min_output_buffer);
     for (int i = 0; i < output_signature()->max_streams(); i++) {
         set_min_output_buffer(i, min_output_buffer);
     }


### PR DESCRIPTION
## Description
If Minoutbuf is set to a value other than 0 in the "Advanced" tab of a block, then the following logging error occurs:
```
[*** LOG ERROR #0001 ***] [2022-05-18 16:38:00] [source] {invalid type specifier}
```
This happens because `unique_id()` is an integer, but `{:s}` was incorrectly specified in the format string.

This bug was introduced in #5599.

## Which blocks/areas does this affect?
Any block that uses a non-default minimum output buffer size.

## Testing Done
After changing the format specifier to `{:d}`, all is well:
```
source :info: set_min_output_buffer on block source(1) to 1024
```

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.