### PR TITLE
modtool: Fix gr_modtool bind (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -132,7 +132,7 @@ def get_block_names(pattern, modname):
     blocknames = []
     reg = re.compile(pattern)
     fname_re = re.compile(r'[a-zA-Z]\w+\.\w{1,5}$')
-    with open(f'include/{modname}/CMakeLists.txt', 'r') as f:
+    with open(f'include/gnuradio/{modname}/CMakeLists.txt', 'r') as f:
         for line in f.read().splitlines():
             if len(line.strip()) == 0 or line.strip()[0] == '#':
                 continue


### PR DESCRIPTION
When running gr_modtool bind, a crash occurs because get_block_names
tries to open the wrong include directory. It does not take into account
the new structure introduced in #5265. I've fixed that here.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit d4f943191dc7780ad102e19f39efb5136e8726e1)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5787