### PR TITLE
cmake: Always prefix git hash used as version with "g" (backport to maint-3.10)

### DIFF
--- a/cmake/Modules/GrVersion.cmake
+++ b/cmake/Modules/GrVersion.cmake
@@ -38,11 +38,22 @@ ENDMACRO()
 
 if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
     message(STATUS "Extracting version information from git describe...")
+    # try to get long description with tag followed by hash
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=8 --long
+        COMMAND ${GIT_EXECUTABLE} describe --abbrev=8 --long
         OUTPUT_VARIABLE GIT_DESCRIBE OUTPUT_STRIP_TRAILING_WHITESPACE
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
+    # long description failed, so try to just get commit hash
+    # (prefixed by "g" so that a hash that is just a number is not misinterpreted)
+    if(GIT_DESCRIBE STREQUAL "")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} log --format=g%h -n 1
+            OUTPUT_VARIABLE GIT_DESCRIBE OUTPUT_STRIP_TRAILING_WHITESPACE
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+    endif()
+    # git is failing, fallback
     if(GIT_DESCRIBE STREQUAL "")
         create_manual_git_describe()
     endif()


### PR DESCRIPTION
This prevents the hash from being misinterpreted as a number, which MSVC
does which will caused failed builds. This is never an issue with GR
itself because the plain hash is only used for the version when the
repository is untagged, but it can happen with OOTs which also use
GrVersion.cmake.

This works by removing the `--always` flag from `git describe` and
handling the no-tag case as a separate special case.

I have been unlucky enough to twice now encounter all-numeric short
hashes when building untagged OOTs with MSVC, so I can't ignore it.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit fa8953de2ae67990ccb052af08affac073e106ae)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5770