### PR TITLE
qa: remove formatting in assertSequenceEqualGR (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr_unittest.py
+++ b/gnuradio-runtime/python/gnuradio/gr_unittest.py
@@ -121,7 +121,7 @@ class TestCase(unittest.TestCase):
             if item[0] != item[1]:
                 total_miscompares += 1
                 print(
-                    'Miscompare at: {:d} ({:d} -- {:d})'.format(idx, item[0], item[1]))
+                    'Miscompare at: {:d} ({} -- {})'.format(idx, item[0], item[1]))
         if total_miscompares > 0:
             print('Total miscompares: {:d}'.format(total_miscompares))
         self.assertTrue(total_miscompares == 0)


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 0ec72b4eaba56f1a1a72fa8262c8fae1ea412308)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5803