### PR TITLE
gr-utils: make the pydoc_h.mako more clang compliant (backport to maint-3.10)

### DIFF
--- a/gr-utils/bindtool/core/generator.py
+++ b/gr-utils/bindtool/core/generator.py
@@ -12,6 +12,7 @@ from gnuradio.blocktool import BlockHeaderParser, GenericHeaderParser
 
 import os
 import pathlib
+import subprocess
 import json
 from mako.template import Template
 from datetime import datetime
@@ -92,6 +93,19 @@ class BindingGenerator:
 
         )
 
+    def clang_format(self, s):
+        try:
+            p = subprocess.Popen(
+                ["clang-format"], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            out, err = p.communicate(s.encode('utf-8'))
+            if p.returncode != 0:
+                print("Failed to run clang-format: %s", err)
+                return s
+            return out.decode('utf-8')
+        except (RuntimeError, FileNotFoundError) as e:
+            print("Failed to run clang-format: %s", e)
+            return s
+
     def write_pydoc_h(self, header_info, base_name, output_dir):
 
         doc_pathname = os.path.join(
@@ -102,7 +116,7 @@ class BindingGenerator:
                 header_info, base_name)
             with open(doc_pathname, 'w+') as outfile:
                 print("Writing binding code to {}".format(doc_pathname))
-                outfile.write(pybind_code)
+                outfile.write(self.clang_format(pybind_code))
             return doc_pathname
         except Exception as e:
             print(e)
@@ -118,7 +132,7 @@ class BindingGenerator:
                 header_info, base_name)
             with open(binding_pathname_cc, 'w+') as outfile:
                 print("Writing binding code to {}".format(binding_pathname_cc))
-                outfile.write(pybind_code)
+                outfile.write(self.clang_format(pybind_code))
             return binding_pathname_cc
         except Exception as e:
             print(e)

--- a/gr-utils/bindtool/templates/generic_python_cc.mako
+++ b/gr-utils/bindtool/templates/generic_python_cc.mako
@@ -65,11 +65,16 @@ func = '\n\
                return PyLong_AsLongLong(p->'+fcn_name+'());\n\
         }'
 %>
+%       elif fcn['return_type'] == 'QWidget *':
+<%
+func = '\n\
+            []('+cls_name+'& self) { return reinterpret_cast<uintptr_t>(self.'+fcn_name+'()); }'
+%>
 %       else: ## No PyObject pointer 
 <%
 func = overloaded_str+'&'+cls_name+'::'+fcn_name
 %>        
-%       endif                    
+%       endif
         ${modvar if isfree else ""}${".def_static" if has_static and not isfree else ".def"}("${fcn['name']}",${func},       
 % for arg in fcn_args:
             py::arg("${arg['name']}")${" = " + arg['default'] if arg['default'] else ''},

--- a/gr-utils/bindtool/templates/pydoc_h.mako
+++ b/gr-utils/bindtool/templates/pydoc_h.mako
@@ -13,7 +13,7 @@ ${license}
 %>\
 \
 #include "pydoc_macros.h"
-#define D(...) DOC(gr,${modname}, __VA_ARGS__ )
+#define D(...) DOC(gr, ${modname}, __VA_ARGS__)
 \
 /*
   This file contains placeholders for docstrings for the Python bindings.
@@ -51,7 +51,7 @@ static const char *__doc_${'_'.join(names)}${suffix} = R"doc(${docstring})doc";
         constructors = cls['constructors'] if 'constructors' in cls else []
         class_enums = cls['enums'] if 'enums' in cls else []
         class_variables = cls['variables'] if 'variables' in cls else []
-%> \
+%>\
 \
 ${render_docstring_const(modname,namespace['name'].split('::')+[cls['name']],cls,cls['docstring'] if 'docstring' in cls else "")}
 \


### PR DESCRIPTION
Format *_c_pydoc_template.h and *_python.cc using clang-format
to make the generated files clang_format compliant.

It's better to use clang-format than to modify the mako templates.
Using clang-format directly you have nothing to do when changing the formatting
rules but only run the binding process again, but you must not change the mako templates.

As with https://github.com/gnuradio/gnuradio/commit/956f332e410331fde426e1485589d905cdf80fb1
pywidget() was replaced qwidget() generic_python_cc.mako had to be modified, to generate the correct
binding code.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 794a6114a11c28fb4529105fdcd62acd853b733c)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5775