### PR TITLE
dtv: Fix use of uninitialized memory (backport to maint-3.10)

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -1016,7 +1016,7 @@ void dvbt2_framemapper_cc_impl::bch_poly_build_tables(void)
     const int polys12[] = { 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1 };
 
     int len;
-    int polyout[2][200];
+    int polyout[2][200] = { 0 };
 
     len = poly_mult(polys01, 15, polys02, 15, polyout[0]);
     len = poly_mult(polys03, 15, polyout[0], len, polyout[1]);


### PR DESCRIPTION
Valgrind reports that poly_pack reads uninitialized memory, leading to
undefined behaviour. This happens because it rounds the length up to
the next multiple of 32 before reading the polynomial coefficients.
Initializing the coefficients to zero solves the problem.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit f41f254a31b18295852efff2a92e4fae94d6dd0a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5804