### PR TITLE
dtv: Use unsigned integer for CRC calculation (backport to maint-3.10)

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -938,7 +938,7 @@ void dvbt2_framemapper_cc_impl::forecast(int noutput_items,
 
 int dvbt2_framemapper_cc_impl::add_crc32_bits(unsigned char* in, int length)
 {
-    int crc = 0xffffffff;
+    unsigned int crc = 0xffffffff;
     int b;
     int i = 0;
 


### PR DESCRIPTION
This fixes undefined behaviour (left shift of a negative number)
reported by gcc's Undefined Behaviour Sanitizer.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 3326c5614c73016d815f4c82a8176bad3468178f)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5805