### PR TITLE
fec/trellis/video-sdl: shared library throw not exit (backport to maint-3.9)

### DIFF
--- a/gr-fec/lib/alist.cc
+++ b/gr-fec/lib/alist.cc
@@ -119,8 +119,8 @@ void alist::read(const char* fname)
 void alist::write(const char* fname) const
 {
     if (!data_ok) {
-        std::cout << "Data not ok, exiting" << std::endl;
-        exit(1);
+        std::cout << "Data not ok, alist::write returning" << std::endl;
+        return;
     }
     // Else
     std::ofstream file(fname, std::ofstream::out);

--- a/gr-fec/lib/conv_bit_corr_bb_impl.cc
+++ b/gr-fec/lib/conv_bit_corr_bb_impl.cc
@@ -244,7 +244,7 @@ float conv_bit_corr_bb_impl::data_garble_rate(int taps, float target)
 
     if ((errno == EDOM) || (errno == ERANGE)) {
         GR_LOG_ERROR(d_logger, "Out of range errors while computing garble rate.");
-        exit(-1);
+        throw std::runtime_error("conv_bit_corr_bb_impl::data_garble_rate");
     }
     return answer;
 }

--- a/gr-fec/lib/fec_mtrx_impl.cc
+++ b/gr-fec/lib/fec_mtrx_impl.cc
@@ -302,12 +302,12 @@ void fec_mtrx_impl::add_matrices_mod2(gsl_matrix* result,
     if (matrix1_rows != matrix2_rows) {
         std::cout << "Error in add_matrices_mod2. Matrices do"
                   << " not have the same number of rows.\n";
-        exit(1);
+        throw std::runtime_error("fec_mtrx::add_matrices_mod2");
     }
     if (matrix1_cols != matrix2_cols) {
         std::cout << "Error in add_matrices_mod2. Matrices do"
                   << " not have the same number of columns.\n";
-        exit(1);
+        throw std::runtime_error("fec_mtrx::add_matrices_mod2");
     }
 
     // Copy matrix1 into result
@@ -342,7 +342,7 @@ void fec_mtrx_impl::mult_matrices_mod2(gsl_matrix* result,
                   << " Matrix dimensions do not allow for matrix "
                   << "multiplication operation:\nmatrix1 is " << a << " x " << b
                   << ", and matrix2 is " << c << " x " << d << ".\n";
-        exit(1);
+        throw std::runtime_error("fec_mtrx::mult_matrices_mod2");
     }
 
     // Perform matrix multiplication. This is not mod 2.

--- a/gr-trellis/lib/interleaver.cc
+++ b/gr-trellis/lib/interleaver.cc
@@ -136,8 +136,8 @@ void interleaver::write_interleaver_txt(std::string filename)
 {
     std::ofstream interleaver_fname(filename.c_str());
     if (!interleaver_fname) {
-        std::cout << "file not found " << std::endl;
-        exit(-1);
+        throw std::runtime_error(
+            "interleaver::write_interleaver(std::string filename): file not found error");
     }
     interleaver_fname << d_K << std::endl;
     interleaver_fname << std::endl;

--- a/gr-video-sdl/lib/sink_s_impl.cc
+++ b/gr-video-sdl/lib/sink_s_impl.cc
@@ -95,7 +95,7 @@ sink_s_impl::sink_s_impl(double framerate,
         msg << "Unable to set SDL video mode: " << SDL_GetError()
             << "; SDL_SetVideoMode() Failed";
         GR_LOG_ERROR(d_logger, msg.str());
-        exit(1);
+        throw std::runtime_error("video_sdl::sink_s");
     }
     if (d_image) {
         SDL_FreeYUVOverlay(d_image);

--- a/gr-video-sdl/lib/sink_uc_impl.cc
+++ b/gr-video-sdl/lib/sink_uc_impl.cc
@@ -96,7 +96,7 @@ sink_uc_impl::sink_uc_impl(double framerate,
         msg << "Unable to set SDL video mode: " << SDL_GetError()
             << "; SDL_SetVideoMode() Failed";
         GR_LOG_ERROR(d_logger, msg.str());
-        exit(1);
+        throw std::runtime_error("video_sdl::sink_uc");
     }
 
     if (d_image) {


### PR DESCRIPTION
In the case of an error, the library should instead return an
appropriate error code to the calling program which can then determine
how to handle the error, including performing any required
clean-up. In C++ the error can be thrown.

Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>
(cherry picked from commit 15a38a474ed2e1f9b0f59fadd93e253fec5cd5f9)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5731