### PR TITLE
runtime: Remove invalid keyword argument from draw_networkx_nodes (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -877,8 +877,7 @@ class MForm(Qt.QWidget):
                                node_color='#A0CBE2',
                                node_shape="s",
                                node_size=self.node_weights,
-                               ax=self.sp,
-                               arrows=False)
+                               ax=self.sp)
 
         nx.draw_networkx_edges(self.G, self.pos,
                                edge_color=self.edge_weights,


### PR DESCRIPTION
The gr-perf-monitorx tool currently fails with the following error:

gr-perf-monitorx: lost connection (draw_networkx_nodes() got an
unexpected keyword argument 'arrows').

The tool runs correctly once the incorrect keyword argument is removed.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 16e2221503f7fa2d20cf93e32283be6fb00d7a9d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5737