### PR TITLE
blocks: Synchronize access to d_level to prevent race conditions (backport to maint-3.9)

### DIFF
--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -233,6 +233,10 @@ IF(MSVC)
     )
 ENDIF(MSVC)
 
+if(MSVC)
+    target_compile_definitions(gnuradio-blocks PUBLIC _ENABLE_ATOMIC_ALIGNMENT_FIX)
+endif()
+
 if(BUILD_SHARED_LIBS)
     if (SNDFILE_FOUND)
         GR_LIBRARY_FOO(gnuradio-blocks SNDFILE)

--- a/gr-blocks/lib/probe_signal_impl.h
+++ b/gr-blocks/lib/probe_signal_impl.h
@@ -13,6 +13,7 @@
 #define PROBE_SIGNAL_IMPL_H
 
 #include <gnuradio/blocks/probe_signal.h>
+#include <atomic>
 
 namespace gr {
 namespace blocks {
@@ -21,7 +22,7 @@ template <class T>
 class probe_signal_impl : public probe_signal<T>
 {
 private:
-    T d_level;
+    std::atomic<T> d_level;
 
 public:
     probe_signal_impl();

--- a/gr-blocks/lib/probe_signal_v_impl.cc
+++ b/gr-blocks/lib/probe_signal_v_impl.cc
@@ -47,6 +47,7 @@ int probe_signal_v_impl<T>::work(int noutput_items,
 {
     const T* in = (const T*)input_items[0];
 
+    gr::thread::scoped_lock guard(d_mutex);
     for (size_t i = 0; i < d_size; i++)
         d_level[i] = in[(noutput_items - 1) * d_size + i];
 
@@ -57,6 +58,13 @@ template class probe_signal_v<std::int16_t>;
 template class probe_signal_v<std::int32_t>;
 template class probe_signal_v<float>;
 template class probe_signal_v<gr_complex>;
+
+template <class T>
+std::vector<T> probe_signal_v_impl<T>::level() const
+{
+    gr::thread::scoped_lock guard(d_mutex);
+    return d_level;
+}
 
 } /* namespace blocks */
 } /* namespace gr */

--- a/gr-blocks/lib/probe_signal_v_impl.h
+++ b/gr-blocks/lib/probe_signal_v_impl.h
@@ -23,12 +23,13 @@ class probe_signal_v_impl : public probe_signal_v<T>
 private:
     std::vector<T> d_level;
     const size_t d_size;
+    mutable gr::thread::mutex d_mutex;
 
 public:
     probe_signal_v_impl(size_t size);
     ~probe_signal_v_impl() override;
 
-    std::vector<T> level() const override { return d_level; }
+    std::vector<T> level() const override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-blocks/python/blocks/qa_probe_signal.py
+++ b/gr-blocks/python/blocks/qa_probe_signal.py
@@ -49,6 +49,45 @@ class test_probe_signal(gr_unittest.TestCase):
         self.assertEqual(len(output), vector_length)
         self.assertAlmostEqual(value[3], output[3], places=6)
 
+    def test_003_race_condition_regression_test(self):
+        src = blocks.vector_source_c([1 + 2j, 3 + 4j], True)
+        dst = blocks.probe_signal_c()
+
+        self.tb.connect(src, dst)
+        self.tb.start()
+
+        while dst.level() == 0.0:
+            continue
+
+        for _ in range(100000):
+            output = dst.level()
+            self.assertIn(output, [1 + 2j, 3 + 4j])
+
+        self.tb.stop()
+        self.tb.wait()
+
+    def test_004_race_condition_regression_test_vector(self):
+        vector_length = 10
+        src_data = [1.0] * vector_length + [2.0] * vector_length
+
+        src = blocks.vector_source_f(src_data, True, vector_length)
+        dst = blocks.probe_signal_vf(vector_length)
+
+        self.tb.connect(src, dst)
+        self.tb.start()
+
+        while dst.level()[0] == 0.0:
+            continue
+
+        for _ in range(10000):
+            output = dst.level()
+            self.assertIn(output[0], [1.0, 2.0])
+            for i in range(1, vector_length):
+                self.assertEqual(output[0], output[i])
+
+        self.tb.stop()
+        self.tb.wait()
+
 
 if __name__ == '__main__':
     gr_unittest.run(test_probe_signal)


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 775efb182ef3d273c2490e6d208119e3fdef33f8)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5744