### PR TITLE
grc: Fix create hier / missing top_block error (backport to maint-3.9)

### DIFF
--- a/grc/gui/Application.py
+++ b/grc/gui/Application.py
@@ -311,7 +311,7 @@ class Application(Gtk.Application):
             flow_graph.move_selected(coords)
 
             # Set flow graph to heir block type
-            top_block = flow_graph.get_block("top_block")
+            top_block = flow_graph.get_block(Constants.DEFAULT_FLOW_GRAPH_ID)
             top_block.params['generate_options'].set_value('hb')
 
             # this needs to be a unique name


### PR DESCRIPTION
Signed-off-by: Bjoern Kerler <info@revskills.de>
(cherry picked from commit b89baa29b0fe63cb8691575f9784628bea4a4aec)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5702