### PR TITLE
gr-uhd: Fix NotImplemented Error (backport to maint-3.9)

### DIFF
--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -371,7 +371,7 @@ uint32_t usrp_block_impl::get_gpio_attr(const std::string& bank,
                                         const std::string& attr,
                                         const size_t mboard)
 {
-    throw std::runtime_error("not implemented in this version");
+    return _dev->get_gpio_attr(bank, attr, mboard);
 }
 
 void usrp_block_impl::set_time_now(const ::uhd::time_spec_t& time_spec, size_t mboard)


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/5681
Bug was introduced in https://github.com/gnuradio/gnuradio/commit/9cdfe5141a7aad1cf9c4c81167761cc291913fb0

Signed-off-by: Philipp Niedermayer <eltos@outlook.de>
(cherry picked from commit c6586f9af80e79c33ec9f4affdf239415151aeae)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5682