### PR TITLE
blocks: Fix flaky qa_rotator test (backport to maint-3.9)

### DIFF
--- a/gr-blocks/python/blocks/qa_rotator_cc.py
+++ b/gr-blocks/python/blocks/qa_rotator_cc.py
@@ -39,12 +39,13 @@ class qa_rotator_cc(gr_unittest.TestCase):
         #
         self.tb = gr.top_block()
         self.source = blocks.vector_source_c(in_samples)
+        self.throttle = blocks.throttle(gr.sizeof_gr_complex, 2**16)
         self.rotator_cc = blocks.rotator_cc(phase_inc, tag_inc_updates)
         self.sink = blocks.vector_sink_c()
         self.tag_sink = blocks.tag_debug(gr.sizeof_gr_complex, "rot_phase_inc",
                                          "rot_phase_inc")
         self.tag_sink.set_save_all(True)
-        self.tb.connect(self.source, self.rotator_cc, self.sink)
+        self.tb.connect(self.source, self.throttle, self.rotator_cc, self.sink)
         self.tb.connect(self.rotator_cc, self.tag_sink)
 
     def setUp(self):


### PR DESCRIPTION
The test_phase_inc_update_out_of_range test in qa_rotator sometimes fails. For
instance: https://github.com/gnuradio/gnuradio/runs/5772119971?check_suite_focus=true

This is due to a race condition. The test schedules a phase increment for 32,768
samples in the future, waits for some samples to be processed, and then verifies
that the phase increment has not yet occurred. But it can happen (and often does
happen with the system is under load) that more than 32,768 samples will be
processed between these two steps.

To solve the problem, I've added a throttle block to the flow graph, so that it will
take 500 ms for 32,768 samples to be processed. This should be more than enough time
for the test to progress from the while (self.rotator_cc.nitems_written(0) == 0)
step to the self._assert_tags([], []) step.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit fc250b6dcf718c6a84ad00ed6a576900dc2001c4)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5755