### PR TITLE
gr-qtgui: freq_sink and others produce wrong error messages, when GUI Hint is used (backport to maint-3.9)

### DIFF
--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -109,14 +109,16 @@ parameters:
     dtype: real
     default: '0.10'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 -   id: tr_mode
     label: Trigger Mode

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -78,14 +78,16 @@ parameters:
     options: ['True', 'False']
     option_labels: ['On', 'Off']
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 
 inputs:

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -88,14 +88,16 @@ parameters:
     dtype: real
     default: '0.10'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 -   id: legend
     label: Legend

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -78,14 +78,16 @@ parameters:
     dtype: real
     default: '0.10'
     hide: part
--   id: gui_hint
-    label: GUI Hint
-    dtype: gui_hint
-    hide: part
 -   id: showports
     label: Show Msg Ports
     dtype: bool
     default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    hide: part
+-   id: gui_hint
+    label: GUI Hint
+    dtype: gui_hint
     hide: part
 -   id: legend
     label: Legend


### PR DESCRIPTION
freq_sink_x, sink_x, vector_sink_f .... produce error messages like
Traceback (most recent call last):
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/blocks/_templates.py", line 77, in render
    return template.render(**namespace)
  File "/usr/lib/python3.10/site-packages/mako/template.py", line 473, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 878, in _render
    _render_context(
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "memory:0x7f00a04d3a00", line 115, in render_body
TypeError: unsupported operand type(s) for %: 'NoneType' and 'str'

if the showport entry is changed, but widget will be properly placed.
To avoid this error message the order of Show Msg Port and GUI Hint must be changed.

And I changed the entry for Show Msg Port from a text entry to a pull down menu.

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit fca77e4cf0b84757a7702556f48d84ba3c32a168)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5665