### PR TITLE
gr-soapy: deactivate stream before closing (backport to maint-3.9)

### DIFF
--- a/gr-soapy/lib/block_impl.cc
+++ b/gr-soapy/lib/block_impl.cc
@@ -384,6 +384,7 @@ bool block_impl::stop()
 {
     if (d_stream) {
         std::lock_guard<std::mutex> l(d_device_mutex);
+        d_device->deactivateStream(d_stream);
         d_device->closeStream(d_stream);
         d_stream = nullptr;
     }


### PR DESCRIPTION
It was reported that, with the HackRF module, a flowgraph terminated
with a segfault. Most Soapy modules implement deactivateStream(), but
that function is not called from gr-soapy.

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 5fa60c7c10e63192968a7a5daacf6a9fdb9e6d47)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5772