### PR TITLE
blocks: Fix rotator_cc scheduled phase inc updates

### DIFF
--- a/gr-blocks/lib/rotator_cc_impl.cc
+++ b/gr-blocks/lib/rotator_cc_impl.cc
@@ -111,7 +111,8 @@ int rotator_cc_impl::work(int noutput_items,
 
             // Process all samples until the scheduled phase increment update
             int items_before_update = next_update.offset - n_written - nprocessed_items;
-            d_r.rotateN(out, in, items_before_update);
+            d_r.rotateN(
+                out + nprocessed_items, in + nprocessed_items, items_before_update);
             nprocessed_items += items_before_update;
 
             set_phase_inc(next_update.phase_inc);


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

This PR fixes a bug on the `rotator_cc` handling of phase increment updates via control message (message port). The rotator block has an optional message port for controlling its operating phase increment (or angular frequency), which I added back in #2984, and which I use in the [`gr-dvbs2rx` project](https://github.com/igorauad/gr-dvbs2rx), see, e.g.,  [dvbs2-rx#L797](https://github.com/igorauad/gr-dvbs2rx/blob/master/apps/dvbs2-rx#L797). However, the implementation has a bug when multiple updates are scheduled for close sample indexes processed in the same work call.

The main fix is on this line:
```diff
-            d_r.rotateN(out, in, items_before_update);
+            d_r.rotateN(
+                out + nprocessed_items, in + nprocessed_items, items_before_update);
```

The previous `rotateN` call was not taking into account any updates processed in the same work call, which are recorded in the `nprocessed_items` variable. For instance, if the work function processes 300 samples, and there are two phase increment updates, one for index 100, the other for index 150, the loop on L97 would be as follows:

- Iteration 1: `nprocessed_items = 0`, `items_before_update = 100`, call `d_r.rotateN(out, in, 100)`.
- Iteration 2: `nprocessed_items = 100`, `items_before_update = 50`, call `d_r.rotateN(out + 100, in + 100, 50)`.

After that, there is one last `rotateN` call (on L129) to complete the remaining work:
- `nprocessed_items = 150`, `noutput_items = 300`, call `d_r.rotateN(out + 150, in + 150, 150)`.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

- `rotator_cc` from `gr-blocks`.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

 The previous QA implementation was not covering this bug because the multi-update test cases were only checking the tags produced on each phase increment update (which were correct) and not whether the actual IQ output was as expected. The two relevant test cases on `qa_rotator_cc.py` are named `test_consecutive_phase_inc_updates ` and `test_out_of_order_phase_inc_updates`. This patch adds the missing verification on the rotator output samples, with a change like the following:
 
```diff
+        expected_samples = self._compute_expected_samples(
+            offsets, new_phase_incs)
+        self.assertComplexTuplesAlmostEqual(self.sink.data(),
+                                            expected_samples,
+                                            places=4)
```

The diff on `qa_rotator_cc.py` may be a little inconvenient to read because I've split a previous helper function into two helpers, one for posting random phase increment updates to the rotator (called `_post_random_phase_inc_updates`) and another for computing the expected IQ output (called `_compute_expected_samples`). Previously, both tasks were accomplished by a single helper called `_test_scheduled_phase_inc_update`. Also, I've extended the `_compute_expected_samples` to compute the expected samples under multiple phase increment updates.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
