### PR TITLE
runtime: Replace boost::shared_mutex with standard C++

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -17,8 +17,7 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
-#include <boost/any.hpp>
-#include <boost/thread/shared_mutex.hpp>
+#include <shared_mutex>
 #include <functional>
 #include <memory>
 
@@ -42,7 +41,7 @@ public:
 
 private:
     std::list<std::unique_ptr<boost::thread>> m_threads;
-    mutable boost::shared_mutex m_mutex;
+    mutable std::shared_mutex m_mutex;
 };
 
 } /* namespace thread */

--- a/gnuradio-runtime/lib/thread/thread_group.cc
+++ b/gnuradio-runtime/lib/thread/thread_group.cc
@@ -34,7 +34,7 @@ boost::thread* thread_group::create_thread(const std::function<void()>& threadfu
 
 void thread_group::add_thread(std::unique_ptr<boost::thread> thrd)
 {
-    boost::lock_guard<boost::shared_mutex> guard(m_mutex);
+    std::scoped_lock guard(m_mutex);
 
     // For now we'll simply ignore requests to add a thread object
     // multiple times. Should we consider this an error and either
@@ -47,7 +47,7 @@ void thread_group::add_thread(std::unique_ptr<boost::thread> thrd)
 
 void thread_group::remove_thread(boost::thread* thrd)
 {
-    boost::lock_guard<boost::shared_mutex> guard(m_mutex);
+    std::scoped_lock guard(m_mutex);
 
     // For now we'll simply ignore requests to remove a thread
     // object that's not in the group. Should we consider this an
@@ -63,7 +63,7 @@ void thread_group::remove_thread(boost::thread* thrd)
 
 void thread_group::join_all()
 {
-    boost::shared_lock<boost::shared_mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_mutex);
     for (auto& thrd : m_threads) {
         thrd->join();
     }
@@ -71,7 +71,7 @@ void thread_group::join_all()
 
 void thread_group::interrupt_all()
 {
-    boost::shared_lock<boost::shared_mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_mutex);
     for (auto& thrd : m_threads) {
         thrd->interrupt();
     }
@@ -79,7 +79,7 @@ void thread_group::interrupt_all()
 
 size_t thread_group::size() const
 {
-    boost::shared_lock<boost::shared_mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_mutex);
     return m_threads.size();
 }
 


### PR DESCRIPTION
## Description
This is a continuation of the Boost removal work. `boost::shared_mutex` can be replaced with the `std` equivalent, which is available starting in C++17.

## Which blocks/areas does this affect?
* Thread-per-block scheduler

## Testing Done
I verified that Gqrx still works correctly with these changes in place.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
