### PR TITLE
runtime: Replace BOOST_ASSERT with standard C++

### DIFF
--- a/gnuradio-runtime/lib/thread/thread_group.cc
+++ b/gnuradio-runtime/lib/thread/thread_group.cc
@@ -13,6 +13,7 @@
  */
 
 #include <gnuradio/thread/thread_group.h>
+#include <cassert>
 #include <memory>
 
 namespace gr {
@@ -40,7 +41,7 @@ void thread_group::add_thread(std::unique_ptr<boost::thread> thrd)
     // multiple times. Should we consider this an error and either
     // throw or return an error value?
     auto it = std::find(m_threads.begin(), m_threads.end(), thrd);
-    BOOST_ASSERT(it == m_threads.end());
+    assert(it == m_threads.end());
     if (it == m_threads.end())
         m_threads.push_back(std::move(thrd));
 }
@@ -56,7 +57,7 @@ void thread_group::remove_thread(boost::thread* thrd)
         m_threads.begin(),
         m_threads.end(),
         [&thrd](std::unique_ptr<boost::thread>& it) -> bool { return thrd == it.get(); });
-    BOOST_ASSERT(it != m_threads.end());
+    assert(it != m_threads.end());
     if (it != m_threads.end())
         m_threads.erase(it);
 }


### PR DESCRIPTION
## Description
`BOOST_ASSERT` is only used in one place in GNU Radio; elsewhere `assert` is used. By default, `BOOST_ASSERT(expr)` expands to `assert(expr)`, so nothing should change with this replacement.

## Which blocks/areas does this affect?
* Thread-per-block scheduler

## Testing Done
I verified that Gqrx still runs correctly with this change in place.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
