### PR TITLE
runtime: Fix signed integer overflows (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/fxpt.h
+++ b/gnuradio-runtime/include/gnuradio/fxpt.h
@@ -64,7 +64,7 @@ public:
      */
     static float cos(int32_t x)
     {
-        uint32_t ux = x + 0x40000000;
+        uint32_t ux = (uint32_t)x + 0x40000000;
         int index = ux >> (WORDBITS - NBITS);
         return s_sine_table[index][0] * (ux & ACCUM_MASK) + s_sine_table[index][1];
     }
@@ -78,7 +78,7 @@ public:
         int sin_index = ux >> (WORDBITS - NBITS);
         *s = s_sine_table[sin_index][0] * (ux & ACCUM_MASK) + s_sine_table[sin_index][1];
 
-        ux = x + 0x40000000;
+        ux = (uint32_t)x + 0x40000000;
         int cos_index = ux >> (WORDBITS - NBITS);
         *c = s_sine_table[cos_index][0] * (ux & ACCUM_MASK) + s_sine_table[cos_index][1];
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(fxpt.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(f6f6a6028a7944b8a1032337bba08124)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3ef217d934584260ccbfc030dc904fe8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
When running QA tests, gcc's Undefined Behaviour Sanitizer reports
signed integer overflows in fxpt.h. I've fixed them by explicitly
casting the input to an unsigned integer prior to the addition step.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit eebf0778cf6d1c4957f43a1548919c999fad6998)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5806