### PR TITLE
dtv: Fix compiler warning (backport to maint-3.10)

### DIFF
--- a/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
+++ b/gr-dtv/lib/dvbt2/dvbt2_framemapper_cc_impl.cc
@@ -1016,7 +1016,7 @@ void dvbt2_framemapper_cc_impl::bch_poly_build_tables(void)
     const int polys12[] = { 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1 };
 
     int len;
-    int polyout[2][200] = { 0 };
+    int polyout[2][200] = {};
 
     len = poly_mult(polys01, 15, polys02, 15, polyout[0]);
     len = poly_mult(polys03, 15, polyout[0], len, polyout[1]);


### PR DESCRIPTION
In #5804 I accidentally caused a compiler warning:

warning: suggest braces around initialization of subobject [-Wmissing-braces]

This change fixes the warning while still initializing the polyout
array to zero.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 28c4b2b09abea94bca1ffedb6a4d9ecf254b7193)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5816