### PR TITLE
qtgui: Remove unused variable from Waterfall Sink (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/lib/waterfall_sink_c_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_c_impl.cc
@@ -480,7 +480,7 @@ void waterfall_sink_c_impl::handle_pdus(pmt::pmt_t msg)
         int j = 0;
         size_t min = 0;
         size_t max = std::min(d_fftsize, static_cast<int>(len));
-        for (size_t i = 0; j < d_nrows; i += stride) {
+        while (j < d_nrows) {
             // Clear residbufs if len < d_fftsize
             std::fill_n(d_residbufs[d_nconnections].data(), d_fftsize, 0x00);
 

--- a/gr-qtgui/lib/waterfall_sink_f_impl.cc
+++ b/gr-qtgui/lib/waterfall_sink_f_impl.cc
@@ -482,7 +482,7 @@ void waterfall_sink_f_impl::handle_pdus(pmt::pmt_t msg)
         int j = 0;
         size_t min = 0;
         size_t max = std::min(d_fftsize, static_cast<int>(len));
-        for (size_t i = 0; j < d_nrows; i += stride) {
+        while (j < d_nrows) {
             // Clear residbufs if len < d_fftsize
             memset(d_residbufs[d_nconnections].data(), 0x00, sizeof(float) * d_fftsize);
 


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 1eeff3df12006a7c90f18cd2542ab9c8fa60088d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5828