### PR TITLE
blocks: Add support for Ogg Opus if libsndfile is >= 1.0.29 (backport to maint-3.10)

### DIFF
--- a/gr-blocks/grc/blocks_wavfile_sink.block.yml
+++ b/gr-blocks/grc/blocks_wavfile_sink.block.yml
@@ -19,7 +19,7 @@ parameters:
     label: Output Format
     dtype: enum
     options: [FORMAT_WAV, FORMAT_FLAC, FORMAT_OGG, FORMAT_RF64]
-    option_labels: [WAV, FLAC, Ogg Vorbis, 64-bit WAV]
+    option_labels: [WAV, FLAC, Ogg, 64-bit WAV]
     default: FORMAT_WAV
     option_attributes:
         hide_wav: [none, all, all, all]
@@ -47,13 +47,13 @@ parameters:
         val: [blocks.FORMAT_PCM_S8, blocks.FORMAT_PCM_16, blocks.FORMAT_PCM_24]
     hide: ${ format.hide_flac }
 -   id: bits_per_sample3
-    label: Bits per Sample
+    label: Codec
     dtype: enum
-    options: [FORMAT_VORBIS]
-    option_labels: [Vorbis]
+    options: [FORMAT_VORBIS, FORMAT_OPUS]
+    option_labels: [Vorbis, Opus]
     default: FORMAT_VORBIS
     option_attributes:
-        val: [blocks.FORMAT_VORBIS]
+        val: [blocks.FORMAT_VORBIS, blocks.FORMAT_OPUS]
     hide: ${ format.hide_ogg }
 -   id: bits_per_sample4
     label: Bits per Sample

--- a/gr-blocks/include/gnuradio/blocks/wavfile.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile.h
@@ -57,6 +57,7 @@ enum wavfile_subformat_t {
     FORMAT_FLOAT,
     FORMAT_DOUBLE,
     FORMAT_VORBIS = 0x0060,
+    FORMAT_OPUS = 0x0064,
 };
 
 } /* namespace blocks */

--- a/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
@@ -36,7 +36,7 @@ public:
      * \param filename The .wav file to be opened
      * \param n_channels Number of channels (2 = stereo or I/Q output)
      * \param sample_rate Sample rate [S/s]
-     * \param format Output format (WAV, FLAC, Ogg Vorbis, RF64)
+     * \param format Output format (WAV, FLAC, Ogg, RF64)
      * \param subformat Bits per sample
      * \param append Append to existing file
      */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -11,6 +11,12 @@
 include(GrMiscUtils)
 GR_CHECK_HDR_N_DEF(io.h HAVE_IO_H)
 
+if(SNDFILE_FOUND)
+    if(NOT PC_SNDFILE_VERSION VERSION_LESS 1.0.29)
+        add_definitions(-DHAVE_SF_FORMAT_OPUS)
+    endif()
+endif()
+
 ########################################################################
 # Setup library
 ########################################################################

--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -83,6 +83,9 @@ wavfile_sink_impl::wavfile_sink_impl(const char* filename,
     case FORMAT_VORBIS:
         bits_per_sample = 32;
         break;
+    case FORMAT_OPUS:
+        bits_per_sample = 32;
+        break;
     }
     set_bits_per_sample_unlocked(bits_per_sample);
     d_h.bytes_per_sample = d_bytes_per_sample_new;
@@ -168,6 +171,13 @@ bool wavfile_sink_impl::open(const char* filename)
             switch (d_h.subformat) {
             case FORMAT_VORBIS:
                 sfinfo.format = (SF_FORMAT_OGG | SF_FORMAT_VORBIS);
+                break;
+            case FORMAT_OPUS:
+#ifdef HAVE_SF_FORMAT_OPUS
+                sfinfo.format = (SF_FORMAT_OGG | SF_FORMAT_OPUS);
+#else
+                throw std::runtime_error("libsndfile < 1.0.29 does not support Opus.");
+#endif
                 break;
             }
             break;

--- a/gr-blocks/python/blocks/bindings/wavfile_python.cc
+++ b/gr-blocks/python/blocks/bindings/wavfile_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(wavfile.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(69b513925578f5e61e5c98a083388fae)                     */
+/* BINDTOOL_HEADER_FILE_HASH(60587b1cdfc073a9bbe35dd38aba64ea)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -55,6 +55,7 @@ void bind_wavfile(py::module& m)
         .value("FORMAT_FLOAT", ::gr::blocks::FORMAT_FLOAT)   // 6
         .value("FORMAT_DOUBLE", ::gr::blocks::FORMAT_DOUBLE) // 7
         .value("FORMAT_VORBIS", ::gr::blocks::FORMAT_VORBIS) // 96
+        .value("FORMAT_OPUS", ::gr::blocks::FORMAT_OPUS)     // 100
         .export_values();
 
     py::implicitly_convertible<int, ::gr::blocks::wavfile_format_t>();

--- a/gr-blocks/python/blocks/bindings/wavfile_sink_python.cc
+++ b/gr-blocks/python/blocks/bindings/wavfile_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(wavfile_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(aef0fe37adeb3a7bb763e4ed9e807a17)                     */
+/* BINDTOOL_HEADER_FILE_HASH(22c6a3912c7f989ac2a701baa6581e9c)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit eaeb3789401137fa3d7f3a30fdf782f07b331cb1)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5829