### PR TITLE
filter: Fix flaky qa_filterbank test (backport to maint-3.10)

### DIFF
--- a/gr-filter/python/filter/qa_filterbank.py
+++ b/gr-filter/python/filter/qa_filterbank.py
@@ -111,7 +111,7 @@ class test_filterbank_vcvcf(gr_unittest.TestCase):
         fb.set_taps(taps2)
         outdata2 = None
         # Wait until we have new data.
-        while (not outdata2) or outdata[0] == outdata2[0]:
+        while (not outdata2) or abs(outdata2[0] - outdata[0]) < 1e-6:
             time.sleep(waittime)
             outdata2 = snk.level()
         self.tb.stop()


### PR DESCRIPTION
The qa_filterbank test occasionally fails, and from the error message
it's apparent that on these occasions outdata2 contains the same values
as outdata. This suggests that the while loop that waits for the new
filter taps to kick in is exiting too soon. I suspect this occurs
because it compares floating point values for exact equality. I've
changed this to check for approximate equality instead.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 390fe9fb82891d1c3a7976a570440b0c3970a9a7)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5833