### PR TITLE
runtime: Process system messages before others (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/basic_block.h
+++ b/gnuradio-runtime/include/gnuradio/basic_block.h
@@ -28,6 +28,25 @@
 
 namespace gr {
 
+class msg_queue_comparator
+{
+private:
+    const pmt::pmt_t d_system_port = pmt::intern("system");
+
+public:
+    bool operator()(pmt::pmt_t const& queue_key1, pmt::pmt_t const& queue_key2) const
+    {
+        if (pmt::eqv(queue_key2, d_system_port))
+            return false;
+        else if (pmt::eqv(queue_key1, d_system_port))
+            return true;
+        else {
+            pmt::comparator cmp;
+            return cmp(queue_key1, queue_key2);
+        }
+    }
+};
+
 /*!
  * \brief The abstract base class for all signal processing blocks.
  * \ingroup internal
@@ -49,8 +68,8 @@ private:
     d_msg_handlers_t d_msg_handlers;
 
     typedef std::deque<pmt::pmt_t> msg_queue_t;
-    typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator> msg_queue_map_t;
-    typedef std::map<pmt::pmt_t, msg_queue_t, pmt::comparator>::iterator
+    typedef std::map<pmt::pmt_t, msg_queue_t, msg_queue_comparator> msg_queue_map_t;
+    typedef std::map<pmt::pmt_t, msg_queue_t, msg_queue_comparator>::iterator
         msg_queue_map_itr;
 
     gr::thread::mutex mutex; //< protects all vars

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(basic_block.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9239cc3381582f5f44010485cd48fa72)                     */
+/* BINDTOOL_HEADER_FILE_HASH(1cb9f84afc9a70b10005bf996a571f19)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
This avoids a race condition which causes messages to be skipped while
the flow graph finishes execution.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit df75146e158c92fd2750af16bbec9848ca6d5b33)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5754