### PR TITLE
ci: Add Fedora 36, remove Fedora 34

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -64,16 +64,19 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|metainfo_test"'
             ldpath:
-          - distro: 'Fedora 34'
-            containerid: 'gnuradio/ci:fedora-34-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
-            ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
-            ldpath: /usr/local/lib64/
+            pypath:
           - distro: 'Fedora 35'
             containerid: 'gnuradio/ci:fedora-35-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
+            pypath:
+          - distro: 'Fedora 36'
+            containerid: 'gnuradio/ci:fedora-36-3.9'
+            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
+            ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
+            ldpath: /usr/local/lib64/
+            pypath: local/
           # - distro: 'CentOS 8.4'
           #   containerid: 'gnuradio/ci:centos-8.4-3.10'
           #   cxxflags: ''
@@ -84,6 +87,7 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|qa_polar_..coder_(sc_)?systematic"'
             ldpath:
+            pypath:
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}
@@ -108,7 +112,9 @@ jobs:
        su -c "echo ${{matrix.ldpath}} >> /etc/ld.so.conf"
        su -c ldconfig
     - name: Test Python3
-      run: python3 -c "import gnuradio.blocks; print(gnuradio.blocks.complex_to_float())"
+      run: |
+       export PYTHONPATH=$PYTHONPATH:$(python3 -c "import sys; print(f'/usr/${{matrix.pypath}}local/lib64/python{sys.version_info.major}.{sys.version_info.minor}/site-packages')")
+       python3 -c "import gnuradio.blocks; print(gnuradio.blocks.complex_to_float())"
   no-python:
   # All of these shall depend on the formatting check (needs: check-formatting)
     needs: [check-formatting, check-python-formatting]


### PR DESCRIPTION
## Description
Fedora 36 is current. Change CI to test Fedora 35/36 instead of 34/35.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
