### PR TITLE
CI: Add Fedora 36, remove Fedora 34, second try

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -64,13 +64,13 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|metainfo_test"'
             ldpath:
-          - distro: 'Fedora 34'
-            containerid: 'gnuradio/ci:fedora-34-3.9'
+          - distro: 'Fedora 35'
+            containerid: 'gnuradio/ci:fedora-35-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
-          - distro: 'Fedora 35'
-            containerid: 'gnuradio/ci:fedora-35-3.9'
+          - distro: 'Fedora 36'
+            containerid: 'gnuradio/ci:fedora-36-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -165,7 +165,7 @@ if not install_dir:
     else:
         scheme = 'posix_prefix'
     install_dir = sysconfig.get_path('platlib', scheme)
-    prefix = sysconfig.get_config_var('prefix')
+    prefix = sysconfig.get_path('data')
 
 #strip the prefix to return a relative path
 print(os.path.relpath(install_dir, prefix))"


### PR DESCRIPTION
# Pull Request Details
## Description
CI: Add Fedora 36, remove Fedora 34.

In addition, Fedora 36 and Ubuntu 22.04 have changed the Python install
scheme to put modules under <prefix>/local. Our default install location
of /usr/local results in files being install under /usr/local/local. The
change to GrPython.cmake puts default installs back in /usr/local.
(Suggested by dl1ksv).

## Which blocks/areas does this affect?
CI.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
