### PR TITLE
gr-qtgui: gui_hint avoid useless error messages

### DIFF
--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -115,6 +115,9 @@ def validate_vector(param, black_listed_ids):
 @validates('gui_hint')
 def validate_gui_hint(param, black_listed_ids):
     try:
+        # Only parse the param if there are no errors
+        if len(param.get_error_messages()) > 0:
+            return
         param.parse_gui_hint(param.value)
     except Exception as e:
         raise ValidateError(str(e))

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -347,7 +347,7 @@ class Param(Element):
             e = self.parent_flowgraph.evaluate(pos)
 
             if not isinstance(e, (list, tuple)) or len(e) not in (2, 4) or not all(isinstance(ei, int) for ei in e):
-                raise Exception(
+                self.add_error_message(
                     'Invalid GUI Hint entered: {e!r} (Must be a list of {{2,4}} non-negative integers).'.format(e=e))
 
             if len(e) == 2:
@@ -357,11 +357,11 @@ class Param(Element):
                 row, col, row_span, col_span = e
 
             if (row < 0) or (col < 0):
-                raise Exception(
-                    'Invalid GUI Hint entered: {e!r} (non-negative integers only).'.format(e=e))
+                self.add_error_message(
+                    'Invalid GUI Hint entered: {e!r} (non-negative rows/cols only).'.format(e=e))
 
             if (row_span < 1) or (col_span < 1):
-                raise Exception(
+                self.add_error_message(
                     'Invalid GUI Hint entered: {e!r} (positive row/column span required).'.format(e=e))
 
             return row, col, row_span, col_span
@@ -371,13 +371,14 @@ class Param(Element):
                     if block.key == 'qtgui_tab_widget' and block.name == tab)
             tab_block = next(iter(tabs), None)
             if not tab_block:
-                raise Exception(
+                self.add_error_message(
                     'Invalid tab name entered: {tab} (Tab name not found).'.format(tab=tab))
+                return
 
             tab_index_size = int(tab_block.params['num_tabs'].value)
             if index >= tab_index_size:
-                raise Exception('Invalid tab index entered: {tab}@{index} (Index out of range).'.format(
-                    tab=tab, index=index))
+                self.add_error_message(
+                    'Invalid tab index entered: {tab}@{index} (Index out of range).'.format(tab=tab, index=index))
 
         # Collision Detection
         def collision_detection(row, col, row_span, col_span):
@@ -394,7 +395,7 @@ class Param(Element):
                 collision = next(
                     iter(self.hostage_cells & other.hostage_cells), None)
                 if collision:
-                    raise Exception('Block {block!r} is also using parent {parent!r}, cell {cell!r}.'.format(
+                    self.add_error_message('Block {block!r} is also using parent {parent!r}, cell {cell!r}.'.format(
                         block=other.parent_block.name, parent=collision[0], cell=collision[1]
                     ))
 


### PR DESCRIPTION

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
Wrong values in the GUI HINT field are correctly handled in the gui
but lead to useless error messages in the terminal window
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
For instance take a QT GUI SINK and enter 
0,0,0,1 
in the GUI HINT field. Then you get an error message like
Param - GUI Hint(gui_hint):
	Invalid GUI Hint entered: (0, 0, 0, 1) (positive row/column span required).

and in the terminal window 
Traceback (most recent call last):
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/blocks/_templates.py", line 77, in render
    return template.render(**namespace)
  File "/usr/lib/python3.10/site-packages/mako/template.py", line 473, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 878, in _render
    _render_context(
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 920, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/lib/python3.10/site-packages/mako/runtime.py", line 947, in _exec_template
    callable_(context, *args, **kwargs)
  File "memory:0x7ff9fec84340", line 603, in render_body
TypeError: unsupported operand type(s) for %: 'NoneType' and 'str' 

This message is useless and will be avoided by this patch.
## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
All blocks providing a GUI HINT entry.
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested with a simple flowgraph containing a constant source and a QT GUI SINK and entering incorrect gui hint values.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
