### PR TITLE
CI: Add Fedora 36, remove Fedora 34 (backport to maint-3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -64,13 +64,13 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui|metainfo_test"'
             ldpath:
-          - distro: 'Fedora 34'
-            containerid: 'gnuradio/ci:fedora-34-3.9'
+          - distro: 'Fedora 35'
+            containerid: 'gnuradio/ci:fedora-35-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/
-          - distro: 'Fedora 35'
-            containerid: 'gnuradio/ci:fedora-35-3.9'
+          - distro: 'Fedora 36'
+            containerid: 'gnuradio/ci:fedora-36-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
             ctest_args: '-E "qa_cpp_py_binding|qa_cpp_py_binding_set|qa_ctrlport_probes|qa_qtgui"'
             ldpath: /usr/local/lib64/

--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -165,7 +165,7 @@ if not install_dir:
     else:
         scheme = 'posix_prefix'
     install_dir = sysconfig.get_path('platlib', scheme)
-    prefix = sysconfig.get_config_var('prefix')
+    prefix = sysconfig.get_path('data')
 
 #strip the prefix to return a relative path
 print(os.path.relpath(install_dir, prefix))"


### PR DESCRIPTION
In addition, Fedora 36 and Ubuntu 22.04 have changed the Python install
scheme to put modules under <prefix>/local. Our default install location
of /usr/local results in files being install under /usr/local/local. The
change to GrPython.cmake puts default installs back in /usr/local.
(Suggested by dl1ksv).

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 6ff02a5289770ae1da7c5f7b243d0708331b8695)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5905