### PR TITLE
runtime: Remove Boost::system and Boost::regex dependencies

### DIFF
--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -132,8 +132,6 @@ target_link_libraries(gnuradio-runtime PUBLIC
   gnuradio-pmt
   Volk::volk
   Boost::program_options
-  Boost::system
-  Boost::regex
   Boost::thread
   spdlog::spdlog
   MPLib::mplib


### PR DESCRIPTION
## Description
gnuradio-runtime no longer depends on Boost::system or Boost::regex, so it should be safe to remove these from target_link_libraries.

## Which blocks/areas does this affect?
* gnuradio-runtime cmake build

## Testing Done
I verified that GNU Radio still builds correctly on Ubuntu 22.04, the test suite passes, and Gqrx runs normally.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.