### PR TITLE
pdu: Remove --no-as-needed linker option

### DIFF
--- a/gr-pdu/lib/CMakeLists.txt
+++ b/gr-pdu/lib/CMakeLists.txt
@@ -53,11 +53,6 @@ target_include_directories(gnuradio-pdu
   )
 
 
-# we need -no-as-needed or else -lgslcblas gets stripped out on newer version of gcc
-if(CMAKE_COMPILER_IS_GNUCC AND NOT APPLE)
-    SET_TARGET_PROPERTIES(gnuradio-pdu PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
-endif()
-
 if(BUILD_SHARED_LIBS)
   GR_LIBRARY_FOO(gnuradio-pdu)
 endif()


### PR DESCRIPTION
## Description
It appears this workaround was copied from the gr-wavelet module, but it's not needed here because gr-pdu doesn't depend on GSL. Removing it reduces the number of libraries that gr-pdu links to.

## Which blocks/areas does this affect?
* gr-pdu cmake build

## Testing Done
None. If CI is happy, this should be good.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
