### PR TITLE
wavelet: Remove --no-as-needed linker option

### DIFF
--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -44,11 +44,6 @@ target_include_directories(gnuradio-wavelet
   )
 
 
-# we need -no-as-needed or else -lgslcblas gets stripped out on newer version of gcc
-if(CMAKE_COMPILER_IS_GNUCC AND NOT APPLE)
-    SET_TARGET_PROPERTIES(gnuradio-wavelet PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
-endif()
-
 if(BUILD_SHARED_LIBS)
   GR_LIBRARY_FOO(gnuradio-wavelet)
 endif()


### PR DESCRIPTION
This option causes a lot of extraneous libraries to be linked. It may no longer be needed.

It was added as a workaround in https://github.com/gnuradio/gnuradio/commit/c0b3ce38db0eaaca05fe2f45827fcf6c9184b72b.

I'm opening this draft pull request to see whether CI passes without it.