### PR TITLE
pdu: Remove unused dependencies

### DIFF
--- a/gr-pdu/lib/CMakeLists.txt
+++ b/gr-pdu/lib/CMakeLists.txt
@@ -39,8 +39,6 @@ endif(MSVC)
 
 target_link_libraries(gnuradio-pdu PUBLIC
     gnuradio-runtime
-    gnuradio-blocks
-    gnuradio-filter
 )
 
 if(ENABLE_COMMON_PCH)


### PR DESCRIPTION
## Description
The gr-pdu module has gnuradio-blocks and gnuradio-filter in its `target_link_libraries` even though it doesn't use these modules. Removing them will prevent extraneous libraries from being linked.

## Which blocks/areas does this affect?
CMake build for the gr-pdu module.

## Testing Done
Using ldd, I verified that libgnuradio-pdu.so is no longer linked to extraneous libraries such as libFLAC and libvorbis. I also verified that the test suite still passes, and that Gqrx runs normally.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
