### PR TITLE
wavelet: Remove unused dependency

### DIFF
--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -30,7 +30,6 @@ endif(MSVC)
 
 target_link_libraries(gnuradio-wavelet PUBLIC
     gnuradio-runtime
-    gnuradio-blocks
     GSL::gsl
 )
 


### PR DESCRIPTION
## Description
The gr-wavelet module has gnuradio-blocks in its `target_link_libraries` even though it doesn't use this module. Removing it will prevent extraneous libraries from being linked.

## Which blocks/areas does this affect?
CMake build for the gr-wavelet module.

## Testing Done
Using ldd, I verified that libgnuradio-pdu.so is no longer linked to extraneous libraries such as libFLAC and libvorbis. I also verified that the test suite still passes, and that Gqrx runs normally.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
