### PR TITLE
filter: Remove unused dependency

### DIFF
--- a/gr-filter/lib/CMakeLists.txt
+++ b/gr-filter/lib/CMakeLists.txt
@@ -57,7 +57,6 @@ add_library(gnuradio-filter
 target_link_libraries(gnuradio-filter PUBLIC
     gnuradio-runtime
     gnuradio-fft
-    gnuradio-blocks
     Volk::volk
 )
 


### PR DESCRIPTION
## Description
The gr-filter module has gnuradio-blocks in its `target_link_libraries` even though it doesn't use this module. Removing it will prevent extraneous libraries from being linked.

## Which blocks/areas does this affect?
CMake build for the gr-filter module.

## Testing Done
I verified that GNU Radio still builds correctly, the test suite passes, and Gqrx runs without issue.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.