### PR TITLE
soapy: Fix typos in HackRF VGA Gain labels

### DIFF
--- a/gr-soapy/grc/soapy_hackrf_sink.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_sink.block.yml
@@ -43,7 +43,7 @@ parameters:
     hide: part
 
   - id: vga
-    label: VGA Gain (0dB - 47dB)'
+    label: 'VGA Gain (0dB - 47dB)'
     category: RF Options
     dtype: real
     default: '16'

--- a/gr-soapy/grc/soapy_hackrf_source.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_source.block.yml
@@ -50,7 +50,7 @@ parameters:
     hide: part
 
   - id: vga
-    label: VGA Gain (0dB - 62dB)'
+    label: 'VGA Gain (0dB - 62dB)'
     category: RF Options
     dtype: real
     default: '16'


### PR DESCRIPTION
## Description
Before:
![Screenshot from 2022-06-02 13-40-32](https://user-images.githubusercontent.com/583749/171692764-27dcdbce-1408-4fae-b1e3-474bca418723.png)

After:
![Screenshot from 2022-06-02 13-41-21](https://user-images.githubusercontent.com/583749/171692805-96aaf012-1c1c-4d10-a8b5-3826f4d3d528.png)

## Which blocks/areas does this affect?
* Soapy HackRF Source
* Soapy HackRF Sink

## Testing Done
I verified that the labels appear correctly, and the blocks still work as before.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
