### PR TITLE
runtime: Fix broken log format string in set_min_output_buffer (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -365,7 +365,7 @@ long block::min_output_buffer(size_t i)
 void block::set_min_output_buffer(long min_output_buffer)
 {
     d_logger->info(
-        "set_min_output_buffer on block {:s} to {:d}", unique_id(), min_output_buffer);
+        "set_min_output_buffer on block {:d} to {:d}", unique_id(), min_output_buffer);
     for (int i = 0; i < output_signature()->max_streams(); i++) {
         set_min_output_buffer(i, min_output_buffer);
     }


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit ef3ea5cd0121e850d4f81e1b2d05e779928e5eb7)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5858