### PR TITLE
digital: Fix load of misaligned address (backport to maint-3.9)

### DIFF
--- a/gr-digital/lib/crc32_bb_impl.cc
+++ b/gr-digital/lib/crc32_bb_impl.cc
@@ -92,8 +92,9 @@ int crc32_bb_impl::work(int noutput_items,
         d_crc_impl.process_bytes(in, packet_length - d_crc_length);
         crc = calculate_crc32(in, packet_length - d_crc_length);
         if (d_packed) {
-            if (crc !=
-                *(unsigned int*)(in + packet_length - d_crc_length)) { // Drop package
+            if (memcmp(&crc,
+                       in + packet_length - d_crc_length,
+                       d_crc_length)) { // Drop package
                 return 0;
             }
         } else {


### PR DESCRIPTION
gcc's Undefined Behaviour Sanitizer reports load of a misaligned
address. Replacing the offending code with a memcmp fixes the issue.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit a20f0dd4b5587aeafbf907087d5d0afd04513d9b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5807