### PR TITLE
digital: Replace boost::crc with built-in CRC implementation (backport to maint-3.9)

### DIFF
--- a/gr-digital/include/gnuradio/digital/crc16_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc16_async_bb.h
@@ -40,8 +40,7 @@ namespace digital {
  * calculated on the PDU and appended to it. The output is then 2
  * bytes longer than the input.
  *
- * This block implements the CRC16 using the Boost crc_optimal
- * class for 16-bit CRCs with the standard generator 0x1021.
+ * This block implements the CRC16 using the standard generator 0x1021.
  */
 class DIGITAL_API crc16_async_bb : virtual public block
 {

--- a/gr-digital/include/gnuradio/digital/crc32_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_async_bb.h
@@ -38,8 +38,7 @@ namespace digital {
  * calculated on the PDU and appended to it. The output is then 4
  * bytes longer than the input.
  *
- * This block implements the CRC32 using the Boost crc_optimal
- * class for 32-bit CRCs with the standard generator 0x04C11DB7.
+ * This block implements the CRC32 using the standard generator 0x04C11DB7.
  */
 class DIGITAL_API crc32_async_bb : virtual public block
 {

--- a/gr-digital/include/gnuradio/digital/header_format_crc.h
+++ b/gr-digital/include/gnuradio/digital/header_format_crc.h
@@ -11,6 +11,7 @@
 #define INCLUDED_DIGITAL_HEADER_FORMAT_CRC_H
 
 #include <gnuradio/digital/api.h>
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/header_format_default.h>
 #include <pmt/pmt.h>
 #include <boost/crc.hpp>
@@ -90,7 +91,7 @@ protected:
     uint16_t d_header_number;
     pmt::pmt_t d_len_key_name;
     pmt::pmt_t d_num_key_name;
-    boost::crc_optimal<8, 0x07, 0xFF, 0x00, false, false> d_crc_impl;
+    crc d_crc_impl;
 
     //! Verify that the header is valid
     bool header_ok() override;

--- a/gr-digital/include/gnuradio/digital/packet_header_default.h
+++ b/gr-digital/include/gnuradio/digital/packet_header_default.h
@@ -11,6 +11,7 @@
 #define INCLUDED_DIGITAL_PACKET_HEADER_DEFAULT_H
 
 #include <gnuradio/digital/api.h>
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/tags.h>
 #include <boost/crc.hpp>
 
@@ -91,7 +92,7 @@ protected:
     int d_bits_per_byte;
     unsigned d_header_number;
     unsigned d_mask;
-    boost::crc_optimal<8, 0x07, 0xFF, 0x00, false, false> d_crc_impl;
+    crc d_crc_impl;
 };
 
 } // namespace digital

--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -26,6 +26,7 @@ crc16_async_bb::sptr crc16_async_bb::make(bool check)
 
 crc16_async_bb_impl::crc16_async_bb_impl(bool check)
     : block("crc16_async_bb", io_signature::make(0, 0, 0), io_signature::make(0, 0, 0)),
+      d_crc_ccitt_impl(16, 0x1021, 0xFFFF, 0, false, false),
       d_npass(0),
       d_nfail(0)
 {
@@ -72,9 +73,7 @@ unsigned int crc16_async_bb_impl::process_crc(const uint8_t* bytes_in,
 
     unsigned int result;
 
-    d_crc_ccitt_impl.reset();
-    d_crc_ccitt_impl.process_bytes(bytes_in, n_bytes_prcss);
-    result = d_crc_ccitt_impl();
+    result = d_crc_ccitt_impl.compute(bytes_in, n_bytes_prcss);
     return result;
 }
 

--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -77,7 +77,7 @@ void crc16_async_bb_impl::check(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
 
     crc = d_crc_ccitt_impl.compute(bytes_in, pkt_len - 2);
-    if (crc != *(unsigned int*)(bytes_in + pkt_len - 2)) { // Drop package
+    if (memcmp(&crc, bytes_in + pkt_len - 2, 2)) { // Drop package
         d_nfail++;
         return;
     }

--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -55,8 +55,7 @@ void crc16_async_bb_impl::calc(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
     std::vector<uint8_t> bytes_out(2 + pkt_len);
 
-    crc = process_crc(bytes_in, pkt_len);
-
+    crc = d_crc_ccitt_impl.compute(bytes_in, pkt_len);
     memcpy((void*)bytes_out.data(), (const void*)bytes_in, pkt_len);
     memcpy((void*)(bytes_out.data() + pkt_len), &crc, 2);
 
@@ -65,16 +64,6 @@ void crc16_async_bb_impl::calc(pmt::pmt_t msg)
         bytes_out.data()); // this copies the values from bytes_out into the u8vector
     pmt::pmt_t msg_pair = pmt::cons(meta, output);
     message_port_pub(d_out_port, msg_pair);
-}
-
-unsigned int crc16_async_bb_impl::process_crc(const uint8_t* bytes_in,
-                                              size_t n_bytes_prcss)
-{
-
-    unsigned int result;
-
-    result = d_crc_ccitt_impl.compute(bytes_in, n_bytes_prcss);
-    return result;
 }
 
 void crc16_async_bb_impl::check(pmt::pmt_t msg)
@@ -87,8 +76,7 @@ void crc16_async_bb_impl::check(pmt::pmt_t msg)
     size_t pkt_len(0);
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
 
-    crc = process_crc(bytes_in, pkt_len - 2);
-
+    crc = d_crc_ccitt_impl.compute(bytes_in, pkt_len - 2);
     if (crc != *(unsigned int*)(bytes_in + pkt_len - 2)) { // Drop package
         d_nfail++;
         return;

--- a/gr-digital/lib/crc16_async_bb_impl.h
+++ b/gr-digital/lib/crc16_async_bb_impl.h
@@ -25,7 +25,6 @@ private:
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;
 
-    unsigned int process_crc(const uint8_t* bytes_in, size_t n_bytes_prcss);
     void calc(pmt::pmt_t msg);
     void check(pmt::pmt_t msg);
 

--- a/gr-digital/lib/crc16_async_bb_impl.h
+++ b/gr-digital/lib/crc16_async_bb_impl.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_DIGITAL_CRC16_ASYNC_BB_IMPL_H
 #define INCLUDED_DIGITAL_CRC16_ASYNC_BB_IMPL_H
 
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/crc16_async_bb.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -20,7 +20,7 @@ namespace digital {
 class crc16_async_bb_impl : public crc16_async_bb
 {
 private:
-    boost::crc_ccitt_type d_crc_ccitt_impl;
+    crc d_crc_ccitt_impl;
 
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;

--- a/gr-digital/lib/crc32_async_bb_impl.cc
+++ b/gr-digital/lib/crc32_async_bb_impl.cc
@@ -79,7 +79,7 @@ void crc32_async_bb_impl::check(pmt::pmt_t msg)
     const uint8_t* bytes_in = pmt::u8vector_elements(bytes, pkt_len);
 
     crc = d_crc_impl.compute(bytes_in, pkt_len - 4);
-    if (crc != *(unsigned int*)(bytes_in + pkt_len - 4)) { // Drop package
+    if (memcmp(&crc, bytes_in + pkt_len - 4, 4)) { // Drop package
         d_nfail++;
         return;
     }

--- a/gr-digital/lib/crc32_async_bb_impl.h
+++ b/gr-digital/lib/crc32_async_bb_impl.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_DIGITAL_CRC32_ASYNC_BB_IMPL_H
 #define INCLUDED_DIGITAL_CRC32_ASYNC_BB_IMPL_H
 
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/crc32_async_bb.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -20,7 +20,7 @@ namespace digital {
 class crc32_async_bb_impl : public crc32_async_bb
 {
 private:
-    boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true> d_crc_impl;
+    crc d_crc_impl;
 
     pmt::pmt_t d_in_port;
     pmt::pmt_t d_out_port;

--- a/gr-digital/lib/crc32_bb_impl.cc
+++ b/gr-digital/lib/crc32_bb_impl.cc
@@ -29,14 +29,15 @@ crc32_bb_impl::crc32_bb_impl(bool check, const std::string& lengthtagname, bool 
                           io_signature::make(1, 1, sizeof(char)),
                           lengthtagname),
       d_check(check),
-      d_packed(packed)
+      d_packed(packed),
+      d_crc_impl(32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true)
 {
     d_crc_length = 4;
     if (!d_packed) {
         d_crc_length = 32;
-        d_buffer = std::vector<char>(d_crc_length);
+        d_buffer = std::vector<unsigned char>(d_crc_length);
     } else {
-        d_buffer = std::vector<char>(4096);
+        d_buffer = std::vector<unsigned char>(4096);
     }
     set_tag_propagation_policy(TPP_DONT);
 }
@@ -55,7 +56,6 @@ int crc32_bb_impl::calculate_output_stream_length(const gr_vector_int& ninput_it
 unsigned int crc32_bb_impl::calculate_crc32(const unsigned char* in, size_t packet_length)
 {
     unsigned int crc = 0;
-    d_crc_impl.reset();
     if (!d_packed) {
         const size_t n_packed_length = 1 + ((packet_length - 1) / 8);
         if (n_packed_length > d_buffer.size()) {
@@ -65,11 +65,9 @@ unsigned int crc32_bb_impl::calculate_crc32(const unsigned char* in, size_t pack
         for (size_t bit = 0; bit < packet_length; bit++) {
             d_buffer[bit / 8] |= (in[bit] << (bit % 8));
         }
-        d_crc_impl.process_bytes(&d_buffer[0], n_packed_length);
-        crc = d_crc_impl();
+        crc = d_crc_impl.compute(&d_buffer[0], n_packed_length);
     } else {
-        d_crc_impl.process_bytes(in, packet_length);
-        crc = d_crc_impl();
+        crc = d_crc_impl.compute(in, packet_length);
     }
     return crc;
 }
@@ -89,7 +87,6 @@ int crc32_bb_impl::work(int noutput_items,
         if (packet_length <= d_crc_length) {
             return 0;
         }
-        d_crc_impl.process_bytes(in, packet_length - d_crc_length);
         crc = calculate_crc32(in, packet_length - d_crc_length);
         if (d_packed) {
             if (memcmp(&crc,

--- a/gr-digital/lib/crc32_bb_impl.h
+++ b/gr-digital/lib/crc32_bb_impl.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_DIGITAL_CRC32_BB_IMPL_H
 #define INCLUDED_DIGITAL_CRC32_BB_IMPL_H
 
+#include <gnuradio/digital/crc.h>
 #include <gnuradio/digital/crc32_bb.h>
-#include <boost/crc.hpp>
 
 namespace gr {
 namespace digital {
@@ -22,9 +22,9 @@ class crc32_bb_impl : public crc32_bb
 private:
     bool d_check;
     bool d_packed;
-    boost::crc_optimal<32, 0x04C11DB7, 0xFFFFFFFF, 0xFFFFFFFF, true, true> d_crc_impl;
+    crc d_crc_impl;
     unsigned int d_crc_length;
-    std::vector<char> d_buffer;
+    std::vector<unsigned char> d_buffer;
     unsigned int calculate_crc32(const unsigned char* in, size_t packet_length);
 
 public:

--- a/gr-digital/python/digital/bindings/crc16_async_bb_python.cc
+++ b/gr-digital/python/digital/bindings/crc16_async_bb_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc16_async_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0266da27c09c311e854b9350c3761696)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c751e985e9d0790c891979f57c198f6f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/crc32_async_bb_python.cc
+++ b/gr-digital/python/digital/bindings/crc32_async_bb_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc32_async_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c084ed79dad8f1c325cf5c9c28fa1bce)                     */
+/* BINDTOOL_HEADER_FILE_HASH(21a4e7d0804db99d0f75ddbe2fe9ef51)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/header_format_crc_python.cc
+++ b/gr-digital/python/digital/bindings/header_format_crc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_format_crc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(0a5a9ad1c6bc88eb23f7f65faac4b146)                     */
+/* BINDTOOL_HEADER_FILE_HASH(6f463d9032ecfd4cba3fec81e9b2fcad)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/packet_header_default_python.cc
+++ b/gr-digital/python/digital/bindings/packet_header_default_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(packet_header_default.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(986c8fe960c6f0510304dc660e276e34)                     */
+/* BINDTOOL_HEADER_FILE_HASH(905f301b011a0fc27c9b9844167afb64)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/qa_crc16_async_bb.py
+++ b/gr-digital/python/digital/qa_crc16_async_bb.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright 2022 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest, blocks, digital
+import pmt
+
+
+class qa_crc16_async_bb(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+        self.tsb_key = "length"
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_crc16(self):
+        crc_append_block = digital.crc16_async_bb(check=False)
+        crc_check_block = digital.crc16_async_bb(check=True)
+
+        dbg_append = blocks.message_debug()
+        dbg_check = blocks.message_debug()
+
+        self.tb.msg_connect((crc_append_block, 'out'), (crc_check_block, 'in'))
+        self.tb.msg_connect((crc_append_block, 'out'), (dbg_append, 'store'))
+        self.tb.msg_connect((crc_check_block, 'out'), (dbg_check, 'store'))
+
+        data = list(range(16))
+        pdu = pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(len(data), data))
+
+        crc_append_block._post(pmt.intern('in'), pdu)
+        crc_append_block._post(
+            pmt.intern('system'),
+            pmt.cons(pmt.intern('done'), pmt.from_long(1)))
+
+        self.tb.run()
+
+        self.assertEqual(dbg_append.num_messages(), 1)
+        out_append = pmt.u8vector_elements(pmt.cdr(dbg_append.get_message(0)))
+        self.assertEqual(out_append, data + [0x37, 0x3b])
+
+        self.assertEqual(dbg_check.num_messages(), 1)
+        out_check = pmt.u8vector_elements(pmt.cdr(dbg_check.get_message(0)))
+        self.assertEqual(out_check, data)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_crc16_async_bb)

--- a/gr-digital/python/digital/qa_crc32_async_bb.py
+++ b/gr-digital/python/digital/qa_crc32_async_bb.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright 2022 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest, blocks, digital
+import pmt
+
+
+class qa_crc32_async_bb(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+        self.tsb_key = "length"
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_crc32(self):
+        crc_append_block = digital.crc32_async_bb(check=False)
+        crc_check_block = digital.crc32_async_bb(check=True)
+
+        dbg_append = blocks.message_debug()
+        dbg_check = blocks.message_debug()
+
+        self.tb.msg_connect((crc_append_block, 'out'), (crc_check_block, 'in'))
+        self.tb.msg_connect((crc_append_block, 'out'), (dbg_append, 'store'))
+        self.tb.msg_connect((crc_check_block, 'out'), (dbg_check, 'store'))
+
+        data = list(range(16))
+        pdu = pmt.cons(pmt.PMT_NIL, pmt.init_u8vector(len(data), data))
+
+        crc_append_block._post(pmt.intern('in'), pdu)
+        crc_append_block._post(
+            pmt.intern('system'),
+            pmt.cons(pmt.intern('done'), pmt.from_long(1)))
+
+        self.tb.run()
+
+        self.assertEqual(dbg_append.num_messages(), 1)
+        out_append = pmt.u8vector_elements(pmt.cdr(dbg_append.get_message(0)))
+        self.assertEqual(out_append, data + [0x88, 0xe2, 0xce, 0xce])
+
+        self.assertEqual(dbg_check.num_messages(), 1)
+        out_check = pmt.u8vector_elements(pmt.cdr(dbg_check.get_message(0)))
+        self.assertEqual(out_check, data)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_crc32_async_bb)


### PR DESCRIPTION
Backport #5700 
Backport #5830

#5830 is a fix. In the process of applying the fix, it made sense to pull in #5700, which adds a built-in CRC implementation. #5700 was not originally backported because it changes transitive includes. Here, these includes are added back, so there should be no API change.