### PR TITLE
digital: Fix CRC checking in Async CRC16 and Async CRC32 blocks (backport to maint-3.9)

### DIFF
--- a/gr-digital/lib/crc16_async_bb_impl.cc
+++ b/gr-digital/lib/crc16_async_bb_impl.cc
@@ -90,7 +90,7 @@ void crc16_async_bb_impl::check(pmt::pmt_t msg)
 
     crc = process_crc(bytes_in, pkt_len - 2);
 
-    if (crc != *(unsigned int*)(bytes_in + pkt_len - 2)) { // Drop package
+    if (memcmp(&crc, bytes_in + pkt_len - 2, 2)) { // Drop package
         d_nfail++;
         return;
     }

--- a/gr-digital/lib/crc32_async_bb_impl.cc
+++ b/gr-digital/lib/crc32_async_bb_impl.cc
@@ -82,7 +82,7 @@ void crc32_async_bb_impl::check(pmt::pmt_t msg)
     d_crc_impl.reset();
     d_crc_impl.process_bytes(bytes_in, pkt_len - 4);
     crc = d_crc_impl();
-    if (crc != *(unsigned int*)(bytes_in + pkt_len - 4)) { // Drop package
+    if (memcmp(&crc, bytes_in + pkt_len - 4, 4)) { // Drop package
         d_nfail++;
         return;
     }


### PR DESCRIPTION
Original-author: Clayton Smith <argilo@gmail.com>
Signed-off-by: Jeff Long <willcode4@gmail.com>

Partial backport of #5830