### PR TITLE
Fix various broken fmt strings (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -586,7 +586,7 @@ void hier_block2_detail::flatten_aux(flat_flowgraph_sptr sfg) const
                     if (hh != 0) {
                         if (hh->min_output_buffer(0) != min_buff) {
                             d_debug_logger->debug(
-                                "HBlock ({:s}) min_buff ({:s})", hh->alias(), min_buff);
+                                "HBlock ({:s}) min_buff ({:d})", hh->alias(), min_buff);
                             hh->set_min_output_buffer(min_buff);
                         }
                     }

--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -116,7 +116,7 @@ static bool check_mapping(
 {
     bool ok = true;
 
-    debug_logger->info(msg);
+    debug_logger->info("{:s}", msg);
 
     unsigned int* p1 = (unsigned int*)c.pointer_to_first_copy();
     unsigned int* p2 = (unsigned int*)c.pointer_to_second_copy();

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -62,52 +62,52 @@ void bind_logger(py::module& m)
         .def("get_string_level", &logger::get_string_level, D(logger, get_string_level))
         .def(
             "trace",
-            [](logger& log, const std::string& msg) { log.trace(msg); },
+            [](logger& log, const std::string& msg) { log.trace("{:s}", msg); },
             py::arg("msg"),
             D(logger, trace))
         .def(
             "debug",
-            [](logger& log, const std::string& msg) { log.debug(msg); },
+            [](logger& log, const std::string& msg) { log.debug("{:s}", msg); },
             py::arg("msg"),
             D(logger, debug))
         .def(
             "info",
-            [](logger& log, const std::string& msg) { log.info(msg); },
+            [](logger& log, const std::string& msg) { log.info("{:s}", msg); },
             py::arg("msg"),
             D(logger, info))
         .def(
             "notice",
-            [](logger& log, const std::string& msg) { log.notice(msg); },
+            [](logger& log, const std::string& msg) { log.notice("{:s}", msg); },
             py::arg("msg"),
             D(logger, notice))
         .def(
             "warn",
-            [](logger& log, const std::string& msg) { log.warn(msg); },
+            [](logger& log, const std::string& msg) { log.warn("{:s}", msg); },
             py::arg("msg"),
             D(logger, warn))
         .def(
             "error",
-            [](logger& log, const std::string& msg) { log.error(msg); },
+            [](logger& log, const std::string& msg) { log.error("{:s}", msg); },
             py::arg("msg"),
             D(logger, error))
         .def(
             "crit",
-            [](logger& log, const std::string& msg) { log.crit(msg); },
+            [](logger& log, const std::string& msg) { log.crit("{:s}", msg); },
             py::arg("msg"),
             D(logger, crit))
         .def(
             "alert",
-            [](logger& log, const std::string& msg) { log.alert(msg); },
+            [](logger& log, const std::string& msg) { log.alert("{:s}", msg); },
             py::arg("msg"),
             D(logger, alert))
         .def(
             "fatal",
-            [](logger& log, const std::string& msg) { log.fatal(msg); },
+            [](logger& log, const std::string& msg) { log.fatal("{:s}", msg); },
             py::arg("msg"),
             D(logger, fatal))
         .def(
             "emerg",
-            [](logger& log, const std::string& msg) { log.emerg(msg); },
+            [](logger& log, const std::string& msg) { log.emerg("{:s}", msg); },
             py::arg("msg"),
             D(logger, emerg));
 

--- a/gr-blocks/lib/file_descriptor_sink_impl.cc
+++ b/gr-blocks/lib/file_descriptor_sink_impl.cc
@@ -58,7 +58,7 @@ int file_descriptor_sink_impl::work(int noutput_items,
             if (errno == EINTR)
                 continue;
             else {
-                d_logger->error(strerror(errno));
+                d_logger->error("{:s}", strerror(errno));
                 return -1; // indicate we're done
             }
         } else {

--- a/gr-blocks/lib/tagged_file_sink_impl.cc
+++ b/gr-blocks/lib/tagged_file_sink_impl.cc
@@ -155,7 +155,7 @@ int tagged_file_sink_impl::work(int noutput_items,
                     // FIXME:
                     // if((d_handle = fdopen (fd, d_is_binary ? "wb" : "w")) == NULL) {
                     if ((d_handle = fdopen(fd, "wb")) == NULL) {
-                        d_logger->error("fdopen {:s}:{:s", filename, strerror(errno));
+                        d_logger->error("fdopen {:s}:{:s}", filename, strerror(errno));
                         ::close(fd); // don't leak file descriptor if fdopen fails.
                     }
 

--- a/gr-digital/lib/fll_band_edge_cc_impl.cc
+++ b/gr-digital/lib/fll_band_edge_cc_impl.cc
@@ -185,7 +185,7 @@ void fll_band_edge_cc_impl::print_taps()
         ss << " " << tap.real() << " + " << tap.imag() << "j,";
     ss << "]\n";
 
-    d_logger->info(ss.str());
+    d_logger->info("{:s}", ss.str());
 }
 
 int fll_band_edge_cc_impl::work(int noutput_items,

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -765,7 +765,7 @@ static int remez(double h[],
 
 static void punt(gr::logger_ptr logger, const std::string msg)
 {
-    logger->error(msg);
+    logger->error("{:s}", msg);
     throw std::runtime_error(msg);
 }
 

--- a/gr-network/lib/socket_pdu_impl.cc
+++ b/gr-network/lib/socket_pdu_impl.cc
@@ -210,7 +210,7 @@ void socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection,
         d_tcp_connections.push_back(new_connection);
         start_tcp_accept();
     } else {
-        d_logger->error(error.message());
+        d_logger->error("{:s}", error.message());
     }
 }
 

--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
@@ -140,7 +140,7 @@ int rfnoc_rx_streamer_impl::work(int noutput_items,
         break;
 
     default:
-        d_logger->warn("RFNoC Streamer block received error {:s} (Code: {:#x})",
+        d_logger->warn("RFNoC Streamer block received error {:s} (Code: {})",
                        d_metadata.strerror(),
                        d_metadata.error_code);
     }


### PR DESCRIPTION
In a few instances, the format string does not match the types of the
arguments. In other cases, the format string is not constant. I fixed
both problems here, and verified that C++20 type checking is happy
with the updated format strings.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit bed4dba514bb9dbd48defbb744debb77c6710202)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5859