### PR TITLE
Fix constructor & destructor template syntax (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer_type.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_type.h
@@ -111,7 +111,7 @@ public:
                                     buf_owner);
     }
 
-    buftype<classname, factory_class>() : buffer_type_base(typeid(classname).name()) {}
+    buftype() : buffer_type_base(typeid(classname).name()) {}
 };
 
 } // namespace gr

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_type_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_type_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer_type.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(879f41aa2a2009fd5fb31bc24ecef768)                     */
+/* BINDTOOL_HEADER_FILE_HASH(02a0b4a46ed0e72d2854190c469e86e2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/lib/noise_source_impl.cc
+++ b/gr-analog/lib/noise_source_impl.cc
@@ -49,12 +49,6 @@ noise_source_impl<gr_complex>::noise_source_impl(noise_type_t type, float ampl, 
 {
 }
 
-
-template <class T>
-noise_source_impl<T>::~noise_source_impl<T>()
-{
-}
-
 template <class T>
 void noise_source_impl<T>::set_type(noise_type_t type)
 {

--- a/gr-analog/lib/noise_source_impl.h
+++ b/gr-analog/lib/noise_source_impl.h
@@ -27,7 +27,6 @@ class noise_source_impl : public noise_source<T>
 
 public:
     noise_source_impl(noise_type_t type, float ampl, long seed = 0);
-    ~noise_source_impl() override;
 
     void set_type(noise_type_t type) override;
     void set_amplitude(float ampl) override;


### PR DESCRIPTION
C++20 is stricter about template syntax, and does not allow redundant
template parameter lists in constructors and destructors. I've fixed
the two instances that occur in GNU Radio, and verified that compiling
in C++20 mode succeeds.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 89a07f0085e0553d2d8f3439551b18e1f3fb10d0)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5862