### PR TITLE
blocks: Fix rotator_cc scheduled phase inc updates (backport to maint-3.10)

### DIFF
--- a/gr-blocks/lib/rotator_cc_impl.cc
+++ b/gr-blocks/lib/rotator_cc_impl.cc
@@ -111,7 +111,8 @@ int rotator_cc_impl::work(int noutput_items,
 
             // Process all samples until the scheduled phase increment update
             int items_before_update = next_update.offset - n_written - nprocessed_items;
-            d_r.rotateN(out, in, items_before_update);
+            d_r.rotateN(
+                out + nprocessed_items, in + nprocessed_items, items_before_update);
             nprocessed_items += items_before_update;
 
             set_phase_inc(next_update.phase_inc);


### PR DESCRIPTION
The previous implementation was applying the rotation to the wrong
indexes when multiple scheduled phase increment updates were processed
in the same work call. This patch fixes the input/output buffer indexes
on the `rotateN()` call and covers the multi-update scenario on QA. The
previous QA implementation was not covering this bug because the
multi-update test case was only checking the tags produced on each phase
increment update and not whether the actual IQ output was correct.

Signed-off-by: Igor Freire <igor@blockstream.com>
(cherry picked from commit c1d882f49ab54666f5e232bbef670d729587a84b)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5887