### PR TITLE
c++ gen: fix template errors in blocks, qtgui (backport to maint-3.10)

### DIFF
--- a/gr-blocks/grc/blocks_file_sink.block.yml
+++ b/gr-blocks/grc/blocks_file_sink.block.yml
@@ -52,7 +52,7 @@ templates:
 cpp_templates:
     includes: ['#include <gnuradio/blocks/file_sink.h>']
     declarations: 'blocks::file_sink::sptr ${id};'
-    make: 'this->${id} = blocks::file_sink::make(${type.size}*${vlen}, ${file}, ${append});'
+    make: 'this->${id} = blocks::file_sink::make(${type.size}*${vlen}, "${no_quotes(file)}", ${append});'
     callbacks:
     - open(${file})
     translations:

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -485,7 +485,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
-            ${name}, // name
+            "${no_quotes(name)}", // name
             ${ 0 if (type == 'msg_complex' or type == 'msg_float') else nconnections } // nconnections
         );
 

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -328,7 +328,7 @@ cpp_templates:
             ${wintype.cpp_opts}, // wintype
             ${fc}, // fc
             ${bw}, // bw
-            ${name}, // name
+            "${no_quotes(name)}", // name
             ${ (0 if type.startswith('msg') else nconnections) } // number of inputs
         );
 


### PR DESCRIPTION
Build cpp strings correctly

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 77df6200b0217aa726b9109a92edc46eb56fcd64)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5857