### PR TITLE
c++ generation: Fix some template errors (backport to maint-3.10)

### DIFF
--- a/gr-analog/grc/analog_fastnoise_source_x.block.yml
+++ b/gr-analog/grc/analog_fastnoise_source_x.block.yml
@@ -42,6 +42,7 @@ templates:
 
 cpp_templates:
     includes: ['#include <gnuradio/analog/fastnoise_source.h>']
+    declarations: 'analog::fastnoise_source_${type.fcn}::sptr ${id};'
     make: 'this->${id} = analog::fastnoise_source_${type.fcn}::make(${noise_type}, ${amp}, ${seed}, ${samples});'
     callbacks:
     - set_type(${noise_type})

--- a/gr-filter/grc/filter_fir_filter_xxx.block.yml
+++ b/gr-filter/grc/filter_fir_filter_xxx.block.yml
@@ -48,18 +48,13 @@ templates:
     - set_taps(${taps})
 
 cpp_templates:
-    includes: ['#include <gnuradio/filter/fir_filter_${type}.h>']
+    includes: ['#include <gnuradio/filter/fir_filter_blk.h>']
     declarations: 'filter::fir_filter_${type}::sptr ${id};'
     make: |-
-        % if str(type.taps) == "complex_vector":
-        std::vector<gr_complex> taps = {${str(taps)[1:-1]}};
-        % else:
-        std::vector<float> taps = {${str(taps)[1:-1]}};
-        % endif
         this->${id} = filter::fir_filter_${type}::make(
             ${decim}, 
-            taps);
-        this->${id}.declare_sample_delay(${samp_delay});
+            ${taps});
+        this->${id}->declare_sample_delay(${samp_delay});
     link: ['gnuradio::gnuradio-filter']
     callbacks:
     - set_taps(taps)

--- a/gr-filter/grc/variable_band_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_pass_filter_taps.block.yml
@@ -36,6 +36,9 @@ parameters:
     label: Beta
     dtype: float
     default: '6.76'
+-   id: value
+    dtype: float_vector
+    hide: all
 value: ${ getattr(firdes, str(type))(gain, samp_rate, low_cutoff_freq, high_cutoff_freq,
     width, win, beta) }
 
@@ -51,8 +54,8 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']
     declarations: 'filter::firdes::sptr ${id};'
     var_make: |-
-        this->${id} = ${id} = firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, \
-        ${high_cutoff_freq}, ${width}, ${win}, ${beta});
+        ${id} = filter::firdes::${type}(${gain}, ${samp_rate}, ${low_cutoff_freq}, \
+        ${high_cutoff_freq}, ${width}, ${win.replace('window.','fft::window::')}, ${beta});
     link: ['gnuradio::gnuradio-filter']
 
 documentation: |-

--- a/gr-filter/grc/variable_band_reject_filter_taps.block.yml
+++ b/gr-filter/grc/variable_band_reject_filter_taps.block.yml
@@ -36,6 +36,9 @@ parameters:
     label: Beta
     dtype: float
     default: '6.76'
+-   id: value
+    dtype: float_vector
+    hide: all
 value: ${ getattr(firdes, str(type))(gain, samp_rate, low_cutoff_freq, high_cutoff_freq, width,
     win, beta) }
 
@@ -51,8 +54,8 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']
     declarations: 'filter::firdes::sptr ${id};'
     var_make: |-
-        this->${id} = ${id} = firdes.${type}(${gain}, ${samp_rate}, ${low_cutoff_freq},\
-        ${high_cutoff_freq}, ${width}, ${win}, ${beta});
+        ${id} = filter::firdes::${type}(${gain}, ${samp_rate}, ${low_cutoff_freq},\
+        ${high_cutoff_freq}, ${width}, ${win.replace('window.','fft::window::')}, ${beta});
     link: ['gnuradio::gnuradio-filter']
 
 documentation: |-

--- a/gr-filter/grc/variable_high_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_high_pass_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_high_pass_filter_taps
 label: High-pass Filter Taps
-flags: [ show_id, python ]
+flags: [ show_id, python, cpp]
 
 parameters:
 -   id: gain
@@ -28,6 +28,9 @@ parameters:
     label: Beta
     dtype: float
     default: '6.76'
+-   id: value
+    dtype: float_vector
+    hide: all
 value: ${ firdes.high_pass(gain, samp_rate, cutoff_freq, width, win, beta) }
 
 templates:
@@ -42,8 +45,8 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']
     declarations: 'filter::firdes::sptr ${id};'
     var_make: |-
-        this->${id} = ${id} = firdes.high_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
-        ${width}, ${win}, ${beta});
+        ${id} = filter::firdes::high_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
+        ${width}, ${win.replace('window.','fft::window::')}, ${beta});
     link: ['gnuradio::gnuradio-filter']
 
 documentation: |-

--- a/gr-filter/grc/variable_low_pass_filter_taps.block.yml
+++ b/gr-filter/grc/variable_low_pass_filter_taps.block.yml
@@ -1,6 +1,6 @@
 id: variable_low_pass_filter_taps
 label: Low-pass Filter Taps
-flags: [ show_id, python ]
+flags: [ show_id, python, cpp]
 
 parameters:
 -   id: gain
@@ -28,6 +28,9 @@ parameters:
     label: Beta
     dtype: float
     default: '6.76'
+-   id: value
+    dtype: float_vector
+    hide: all
 value: ${ firdes.low_pass(gain, samp_rate, cutoff_freq, width, win, beta) }
 
 templates:
@@ -42,8 +45,8 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']
     declarations: 'filter::firdes::sptr ${id};'
     var_make: |-
-        this->${id} = ${id} = firdes.low_pass(${gain}, ${samp_rate}, ${cutoff_freq},\
-        ${width}, ${win}, ${beta});
+        ${id} = filter::firdes::low_pass(${gain}, ${samp_rate}, ${cutoff_freq},
+                ${width}, ${win.replace('window.','fft::window::')}, ${beta});
     link: ['gnuradio::gnuradio-filter']
 
 documentation: |-

--- a/gr-filter/grc/variable_rrc_filter_taps.block.yml
+++ b/gr-filter/grc/variable_rrc_filter_taps.block.yml
@@ -22,6 +22,9 @@ parameters:
     label: Num Taps
     dtype: int
     default: 11*sps
+-   id: value
+    dtype: float_vector
+    hide: all
 value: ${ firdes.root_raised_cosine(gain, samp_rate, sym_rate, alpha, ntaps) }
 
 templates:
@@ -36,7 +39,7 @@ cpp_templates:
     includes: ['#include <gnuradio/filter/firdes.h>']
     declarations: 'filter::firdes::sptr ${id};'
     var_make: |-
-        this->${id} = ${id} = firdes.root_raised_cosine(${gain}, ${samp_rate},\
+        ${id} = filter::firdes::root_raised_cosine(${gain}, ${samp_rate},\
         ${sym_rate}, ${alpha}, ${ntaps});
     link: ['gnuradio::gnuradio-filter']
 

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -501,14 +501,12 @@ cpp_templates:
         ${id}->enable_axis_labels(${axislabels});
         ${id}->enable_control_panel(${ctrlpanel});
 
-        if (!${legend}) {
-            ${id}->disable_legend(); // if (!legend)
-        }
-
-        /* C++ doesn't have this
-        if ("${type}" == "float" or "${type}" == "msg_float") {
-            this->${id}->set_plot_pos_half(not ${freqhalf});
-        }*/
+        % if legend == "False":
+        ${id}->disable_legend();
+        % endif
+        % if type.endswith('float'):
+        ${id}->set_plot_pos_half(not ${freqhalf});
+        % endif
 
         {
             std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",


### PR DESCRIPTION
Set cpp flag in low/high_pass_filter_taps block

Replase firdes. by filter::firdes:: in all *_filter_taps blocks

Switch to correct include file in filter_fir_filter_xxx block

Enabling enable_legend and setting spectrum width in qtgui_freq_sink_x block

Testing with gr-filter/examples/filter_taps.grc

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 740cc6b04f6e9d9618fd067820858f29e167a268)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5889