### PR TITLE
grc: Add parentheses on arithmetic expressions (backport to maint-3.10)

### DIFF
--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -308,6 +308,8 @@ class Param(Element):
                 self.evaluate()
             return '[' + value + ']' if self._lisitify_flag else value
         else:
+            if self.dtype in ('int', 'real') and ('+' in value or '-' in value or '*' in value or '/' in value):
+                value = '(' + value + ')'
             return value
 
     def get_opt(self, item):


### PR DESCRIPTION
* grc: Add parentheses on arithmetic expressions

If a variable consists of an aritmetic expression an is used in another
expression the expression should be put in parentheses

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>

* Extend operator checking to * /

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 9a478c44cd66134b3a52e29be4fae7cd7828f917)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5856