### PR TITLE
Import PyQt5 before matplotlib, and only catch Thrift transport exceptions (backport to maint-3.9)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -19,6 +19,7 @@ import math
 import operator
 
 from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
+from PyQt5 import QtCore, Qt
 
 try:
     import networkx as nx
@@ -40,7 +41,6 @@ except ImportError:
           "Please check that they are installed and try again.")
     sys.exit(1)
 
-from PyQt5 import QtCore, Qt
 import itertools
 
 from gnuradio import gr, ctrlport

--- a/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
+++ b/gnuradio-runtime/python/gnuradio/ctrlport/gr-perf-monitorx
@@ -17,6 +17,7 @@ import signal
 import random
 import math
 import operator
+import thrift
 
 from gnuradio.ctrlport.GNURadioControlPortClient import GNURadioControlPortClient
 from PyQt5 import QtCore, Qt
@@ -908,7 +909,7 @@ class MyApp(object):
         try:
             GNURadioControlPortClient(
                 args.host, args.port, 'thrift', self.run, Qt.QApplication(sys.argv).exec_)
-        except:
+        except thrift.transport.TTransport.TTransportException:
             print("ControlPort failed to connect. Check the config of your endpoint.")
             print("\t[ControlPort] on = True")
             print("\t[ControlPort] edges_list = True")


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/5849