### PR TITLE
soapy: Fix typos in HackRF VGA Gain labels (backport to maint-3.9)

### DIFF
--- a/gr-soapy/grc/soapy_hackrf_sink.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_sink.block.yml
@@ -43,7 +43,7 @@ parameters:
     hide: part
 
   - id: vga
-    label: VGA Gain (0dB - 47dB)'
+    label: 'VGA Gain (0dB - 47dB)'
     category: RF Options
     dtype: real
     default: '16'

--- a/gr-soapy/grc/soapy_hackrf_source.block.yml
+++ b/gr-soapy/grc/soapy_hackrf_source.block.yml
@@ -50,7 +50,7 @@ parameters:
     hide: part
 
   - id: vga
-    label: VGA Gain (0dB - 62dB)'
+    label: 'VGA Gain (0dB - 62dB)'
     category: RF Options
     dtype: real
     default: '16'


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 424df10acc063a7647bc5c67a3273c456154363d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5918