### PR TITLE
gr-iio: cmake/Modules: Fix detection and linking for libiio and libad9361.

### DIFF
--- a/cmake/Modules/Findlibad9361.cmake
+++ b/cmake/Modules/Findlibad9361.cmake
@@ -85,6 +85,15 @@ if(libad9361_FOUND)
   set(libad9361_LIBRARIES ${libad9361_LIBRARY})
 endif()
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  include(CMakeFindFrameworks)
+  CMAKE_FIND_FRAMEWORKS(ad9361)
+  if(ad9361_FRAMEWORKS)
+    list(GET ad9361_FRAMEWORKS 0 libad9361_LIBRARY)
+    set(libad9361_LIBRARY ${libad9361_LIBRARY}/ad9361)
+  endif()
+endif()
+
 if(libad9361_FOUND AND NOT TARGET libad9361::ad9361)
   add_library(libad9361::ad9361 UNKNOWN IMPORTED)
   set_target_properties(libad9361::ad9361 PROPERTIES

--- a/cmake/Modules/Findlibiio.cmake
+++ b/cmake/Modules/Findlibiio.cmake
@@ -85,6 +85,15 @@ if(libiio_FOUND)
   set(libiio_LIBRARIES ${libiio_LIBRARY})
 endif()
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  include(CMakeFindFrameworks)
+  CMAKE_FIND_FRAMEWORKS(iio)
+  if(iio_FRAMEWORKS)
+    list(GET iio_FRAMEWORKS 0 libiio_LIBRARY)
+    set(libiio_LIBRARY ${libiio_LIBRARY}/iio)
+  endif()
+endif()
+
 if(libiio_FOUND AND NOT TARGET libiio::iio)
   add_library(libiio::iio UNKNOWN IMPORTED)
   set_target_properties(libiio::iio PROPERTIES


### PR DESCRIPTION
# Pull Request Details
On OSX the libraries are detected as frameworks. CMake will not properly
link the newly created target, since it points to the framework directory,
instead of the framework library symlink.

## Description
The `find_library` call will detect the iio.framework and ad9361.framework and will populate the 
variables accordingly (libiio_LIBRARY = /Library/Frameworks/iio.framework). 
Using this variable directly in `target_link_libraries` will detect that the target is a framework
and generate the link command using the flags: `-F/Library/Frameworks -f iio.framework`.
But, by creating an UNKNOWN IMPORTED target, the Framework property will be lost and
the `target_link_libraries` call will try to link to the location specified by **IMPORTED_LOCATION "${libiio_LIBRARY}**.
This will fail, as it tries to link to a directory (without knowing it is a framework), instead of linking
to the library symlink located inside the framework dir.


## Which blocks/areas does this affect?
This affects the way gr-iio is built manually on OSX.

## Testing Done
Tried the following build configuration on MacOS:
`cmake -DENABLE_DEFAULT=OFF -DENABLE_GNURADIO_RUNTIME=ON
		-DENABLE_GR_ANALOG=ON  -DENABLE_GR_BLOCKS=ON
		-DENABLE_GR_FFT=ON  -DENABLE_GR_FILTER=ON
		-DENABLE_GR_IIO=ON ..`
This fails at the linking step for gr-iio with the following error: 
`ld: can't map file, errno=22 file '/Library/Frameworks/iio.framework' for architecture x86_64
clang: error: linker command failed with exit code 1`
After applying the current changes, the entire project builds succesfully. 

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
