### PR TITLE
GrPython.cmake: update method for determining installation directory

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -158,16 +158,14 @@ try:
 except AttributeError: pass
 
 if not install_dir:
-    #find where to install the python module
-    #for Python 3.11+, we could use the 'venv' scheme for all platforms
-    if os.name == 'nt':
+    # Newer Python versions have 'venv' scheme, use for all OSs.
+    if 'venv' in sysconfig.get_scheme_names():
+        scheme = 'venv'
+    elif os.name == 'nt':
         scheme = 'nt'
     else:
         scheme = 'posix_prefix'
-    install_dir = sysconfig.get_path('platlib', scheme)
-    prefix = sysconfig.get_path('data')
-
-#strip the prefix to return a relative path
+    install_dir = sysconfig.get_path('platlib', scheme=scheme, vars={'base': prefix, 'platbase': prefix})
 print(os.path.relpath(install_dir, prefix))"
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE GR_PYTHON_DIR


### PR DESCRIPTION
# Pull Request Details
## Description
In 6ff02a5289, we changed the method of determining the installation
directory to work with Fedora 36 and Ubuntu 22.04. For custom prefixes,
this did not end up working on Ubuntu 22.04.

## Related Issue
#5905 (previous PR, which was not sufficient)

## Which blocks/areas does this affect?
cmake

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
