### PR TITLE
cmake: use same scheme for py rel path calculation

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -165,7 +165,7 @@ if not install_dir:
     else:
         scheme = 'posix_prefix'
     install_dir = sysconfig.get_path('platlib', scheme)
-    prefix = sysconfig.get_path('data')
+    prefix = sysconfig.get_path('data', scheme)
 
 #strip the prefix to return a relative path
 print(os.path.relpath(install_dir, prefix))"


### PR DESCRIPTION
Another attempt at making the python relative path calculation consistent between distros
