### PR TITLE
analog: Change noise_source seed type to uint64_t

### DIFF
--- a/gr-analog/include/gnuradio/analog/noise_source.h
+++ b/gr-analog/include/gnuradio/analog/noise_source.h
@@ -44,7 +44,7 @@ public:
      * \param seed seed for random generators. seed = 0 initializes
      *        the random number generator with the system time.
      */
-    static sptr make(noise_type_t type, float ampl, long seed = 0);
+    static sptr make(noise_type_t type, float ampl, uint64_t seed = 0);
 
     /*!
      * Set the noise type. Nominally from the

--- a/gr-analog/lib/fastnoise_source_impl.cc
+++ b/gr-analog/lib/fastnoise_source_impl.cc
@@ -16,6 +16,7 @@
 #include "fastnoise_source_impl.h"
 #include <gnuradio/io_signature.h>
 #include <gnuradio/xoroshiro128p.h>
+#include <type_traits>
 #include <stdexcept>
 #include <vector>
 
@@ -82,6 +83,10 @@ fastnoise_source_impl<T>::fastnoise_source_impl(noise_type_t type,
     }
     d_samples.resize(samples);
     xoroshiro128p_seed(d_state, seed);
+    this->d_logger->debug("Initializing {:s} pool of size {:d} with seed {:x}",
+                          std::is_arithmetic_v<T> ? "arithmetic" : "unknown",
+                          samples,
+                          seed);
     generate();
 }
 
@@ -106,7 +111,9 @@ fastnoise_source_impl<gr_complex>::fastnoise_source_impl(noise_type_t type,
             samples);
     }
     d_samples.resize(samples);
-    xoroshiro128p_seed(d_state, (uint64_t)seed);
+    xoroshiro128p_seed(d_state, seed);
+    this->d_logger->debug(
+        "Initializing {:s} pool of size {:d} with seed {:x}", "complex", samples, seed);
     generate();
 }
 

--- a/gr-analog/lib/noise_source_impl.cc
+++ b/gr-analog/lib/noise_source_impl.cc
@@ -22,13 +22,13 @@ namespace analog {
 
 template <class T>
 typename noise_source<T>::sptr
-noise_source<T>::make(noise_type_t type, float ampl, long seed)
+noise_source<T>::make(noise_type_t type, float ampl, uint64_t seed)
 {
     return gnuradio::make_block_sptr<noise_source_impl<T>>(type, ampl, seed);
 }
 
 template <class T>
-noise_source_impl<T>::noise_source_impl(noise_type_t type, float ampl, long seed)
+noise_source_impl<T>::noise_source_impl(noise_type_t type, float ampl, uint64_t seed)
     : sync_block("noise_source",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(T))),
@@ -39,7 +39,9 @@ noise_source_impl<T>::noise_source_impl(noise_type_t type, float ampl, long seed
 }
 
 template <>
-noise_source_impl<gr_complex>::noise_source_impl(noise_type_t type, float ampl, long seed)
+noise_source_impl<gr_complex>::noise_source_impl(noise_type_t type,
+                                                 float ampl,
+                                                 uint64_t seed)
     : sync_block("noise_source",
                  io_signature::make(0, 0, 0),
                  io_signature::make(1, 1, sizeof(gr_complex))),

--- a/gr-analog/lib/noise_source_impl.h
+++ b/gr-analog/lib/noise_source_impl.h
@@ -26,7 +26,7 @@ class noise_source_impl : public noise_source<T>
     gr::random d_rng;
 
 public:
-    noise_source_impl(noise_type_t type, float ampl, long seed = 0);
+    noise_source_impl(noise_type_t type, float ampl, uint64_t seed = 0);
 
     void set_type(noise_type_t type) override;
     void set_amplitude(float ampl) override;

--- a/gr-analog/python/analog/bindings/noise_source_python.cc
+++ b/gr-analog/python/analog/bindings/noise_source_python.cc
@@ -14,7 +14,11 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(noise_source.h)                                        */
+<<<<<<< HEAD
 /* BINDTOOL_HEADER_FILE_HASH(0071cb1f3a9d94514520262c90a968e9)                     */
+=======
+/* BINDTOOL_HEADER_FILE_HASH(65566b2708852e8118e54a18aed0a292)                     */
+>>>>>>> analog: Change noise_source seed type to uint64_t
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-analog/python/analog/bindings/noise_source_python.cc
+++ b/gr-analog/python/analog/bindings/noise_source_python.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2022 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -14,11 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(noise_source.h)                                        */
-<<<<<<< HEAD
-/* BINDTOOL_HEADER_FILE_HASH(0071cb1f3a9d94514520262c90a968e9)                     */
-=======
-/* BINDTOOL_HEADER_FILE_HASH(65566b2708852e8118e54a18aed0a292)                     */
->>>>>>> analog: Change noise_source seed type to uint64_t
+/* BINDTOOL_HEADER_FILE_HASH(1225d21c7d3f1525c34938764ac179bf)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -39,10 +36,18 @@ void bind_noise_source_template(py::module& m, const char* classname)
                gr::block,
                gr::basic_block,
                std::shared_ptr<noise_source>>(m, classname)
-        .def(py::init(&gr::analog::noise_source<T>::make),
+        .def(py::init([](gr::analog::noise_type_t type, float ampl, int64_t seed) {
+                 return gr::analog::noise_source<T>::make(type, ampl, seed);
+             }),
              py::arg("type"),
              py::arg("ampl"),
-             py::arg("seed") = 0)
+             py::arg("seed").noconvert(true) = 0)
+        .def(py::init([](gr::analog::noise_type_t type, float ampl, uint64_t seed) {
+                 return gr::analog::noise_source<T>::make(type, ampl, seed);
+             }),
+             py::arg("type"),
+             py::arg("ampl"),
+             py::arg("seed").noconvert(true) = 0)
 
         .def("set_type", &noise_source::set_type, py::arg("type"))
         .def("set_amplitude", &noise_source::set_amplitude, py::arg("ampl"))

--- a/gr-analog/python/analog/qa_fastnoise.py
+++ b/gr-analog/python/analog/qa_fastnoise.py
@@ -49,6 +49,30 @@ class test_fastnoise_source(gr_unittest.TestCase):
         tb.run()
         return numpy.array(sink.data())
 
+    def test_000_real_negative_seed_instantiation(self):
+        _ = analog.fastnoise_source_f(analog.noise_type_t.GR_GAUSSIAN,
+                                      2.0,
+                                      -666,
+                                      128)
+
+    def test_000_complex_negative_seed_instantiation(self):
+        _ = analog.fastnoise_source_c(analog.noise_type_t.GR_GAUSSIAN,
+                                      2.0,
+                                      -666,
+                                      128)
+
+    def test_000_real_64bit_seed_instantiation(self):
+        _ = analog.fastnoise_source_f(analog.noise_type_t.GR_GAUSSIAN,
+                                      2.0,
+                                      0xFFFFFFFFFFFFFFFF,
+                                      128)
+
+    def test_000_complex_64bit_seed_instantiation(self):
+        _ = analog.fastnoise_source_f(analog.noise_type_t.GR_GAUSSIAN,
+                                      2.0,
+                                      0xFFFFFFFFFFFFFFFF,
+                                      128)
+
     def test_001_real_uniform_moments(self):
 
         data = self.run_test_real(analog.GR_UNIFORM)

--- a/gr-analog/python/analog/qa_noise.py
+++ b/gr-analog/python/analog/qa_noise.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright 2007,2010,2012 Free Software Foundation, Inc.
+# Copyright 2022 Marcus Müller
 #
 # This file is part of GNU Radio
 #
@@ -8,23 +9,25 @@
 #
 #
 
-
 from gnuradio import gr, gr_unittest, analog
 
 
 class test_noise_source(gr_unittest.TestCase):
-
     def setUp(self):
         self.tb = gr.top_block()
 
     def tearDown(self):
         self.tb = None
 
-    def test_001(self):
+    def test_001_instantiate(self):
         # Just confirm that we can instantiate a noise source
-        op = analog.noise_source_f(analog.GR_GAUSSIAN, 10, 10)
+        analog.noise_source_f(analog.GR_GAUSSIAN, 10, 10)
+        analog.noise_source_f(analog.GR_GAUSSIAN, 10, -10)
+        # test large seeds
+        analog.noise_source_f(analog.GR_GAUSSIAN, 10, -2**63)
+        analog.noise_source_f(analog.GR_GAUSSIAN, 10, 2**64 - 1)
 
-    def test_002(self):
+    def test_002_getters(self):
         # Test get methods
         set_type = analog.GR_GAUSSIAN
         set_ampl = 10

--- a/gr-trellis/python/trellis/qa_trellis.py
+++ b/gr-trellis/python/trellis/qa_trellis.py
@@ -211,7 +211,7 @@ class trellis_tb(gr.top_block):
         # CHANNEL
         add = blocks.add_cc()
         noise = analog.noise_source_c(
-            analog.GR_GAUSSIAN, math.sqrt(
+            analog.noise_type_t.GR_GAUSSIAN, math.sqrt(
                 N0 / 2), seed)
 
         # RX


### PR DESCRIPTION
Type of `seed` in noise_source was inconsistent with fastnoise_source
and with the random number generator classes. This makes everything
consistent.

Signed-off-by: Brett Gottula <bgottula@gmail.com>

---
name: Pull Request Template
about: A template to help contributors submit clear pull-requests.
title: ''
labels: ''
assignees: ''

---

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Type of `seed` in noise_source was inconsistent with fastnoise_source
and with the random number generator classes. This makes everything
consistent.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Addresses part of #5959

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
analog/noise_source

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
None, but willing to if the automated test coverage is not sufficient.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
