### PR TITLE
PMT: add string and map/vector<pair<>> interface

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -12,6 +12,8 @@
 #define INCLUDED_PMT_H
 
 #include <pmt/api.h>
+
+#include <string_view>
 #include <any>
 #include <complex>
 #include <cstdint>
@@ -159,10 +161,10 @@ PMT_API bool to_bool(pmt_t val);
 PMT_API bool is_symbol(const pmt_t& obj);
 
 //! Return the symbol whose name is \p s.
-PMT_API pmt_t string_to_symbol(const std::string& s);
+PMT_API pmt_t string_to_symbol(std::string_view s);
 
 //! Alias for pmt_string_to_symbol
-PMT_API pmt_t intern(const std::string& s);
+PMT_API pmt_t intern(std::string_view s);
 
 
 /*!
@@ -636,6 +638,25 @@ PMT_API pmt_t dcons(const pmt_t& x, const pmt_t& y);
 
 //! Make an empty dictionary
 PMT_API pmt_t make_dict();
+
+/*!
+ * \brief Make a dictionary from an existing mapping type.
+ * The constraint for this to work is the ability for the map_t to iterate over [key,
+ * value] pairs, that is, to be able to be used in a
+ *
+ * <pre>for(const auto& [key, val] : prototype)<pre>
+ *
+ * loop.
+ */
+template <typename map_t>
+pmt_t dict_from_mapping(const map_t& prototype)
+{
+    pmt_t protodict = make_dict();
+    for (const auto& [key, value] : prototype) {
+        protodict = dict_add(protodict, key, value);
+    }
+    return protodict;
+}
 
 //! Return a new dictionary with \p key associated with \p value.
 PMT_API pmt_t dict_add(const pmt_t& dict, const pmt_t& key, const pmt_t& value);

--- a/gnuradio-runtime/include/pmt/pmt_sugar.h
+++ b/gnuradio-runtime/include/pmt/pmt_sugar.h
@@ -17,11 +17,12 @@
  */
 
 #include <gnuradio/messages/msg_accepter.h>
+#include <string_view>
 
 namespace pmt {
 
 //! Make pmt symbol
-static inline pmt_t mp(const std::string& s) { return string_to_symbol(s); }
+static inline pmt_t mp(std::string_view s) { return string_to_symbol(s); }
 
 //! Make pmt symbol
 static inline pmt_t mp(const char* s) { return string_to_symbol(s); }

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -1,16 +1,13 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2006,2009,2010 Free Software Foundation, Inc.
+ * Copyright 2022 Marcus Müller
  *
  * This file is part of GNU Radio
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
  */
-
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
 
 #include "pmt_int.h"
 #include <gnuradio/messages/msg_accepter.h>

--- a/gnuradio-runtime/lib/pmt/pmt.cc
+++ b/gnuradio-runtime/lib/pmt/pmt.cc
@@ -13,6 +13,7 @@
 #include <gnuradio/messages/msg_accepter.h>
 #include <pmt/pmt.h>
 #include <pmt/pmt_pool.h>
+#include <string_view>
 #include <cstdio>
 #include <cstring>
 #include <mutex>
@@ -145,14 +146,14 @@ static std::vector<pmt_t>* get_symbol_hash_table()
     return &s_symbol_hash_table;
 }
 
-pmt_symbol::pmt_symbol(const std::string& name) : d_name(name) {}
+pmt_symbol::pmt_symbol(std::string_view name) : d_name(name) {}
 
 
 bool is_symbol(const pmt_t& obj) { return obj->is_symbol(); }
 
-pmt_t string_to_symbol(const std::string& name)
+pmt_t string_to_symbol(std::string_view name)
 {
-    unsigned hash = std::hash<std::string>()(name) % get_symbol_hash_table_size();
+    unsigned hash = std::hash<std::string_view>{}(name) % get_symbol_hash_table_size();
 
     // Does a symbol with this name already exist?
     for (pmt_t sym = (*get_symbol_hash_table())[hash]; sym; sym = _symbol(sym)->next()) {
@@ -178,7 +179,7 @@ pmt_t string_to_symbol(const std::string& name)
 }
 
 // alias...
-pmt_t intern(const std::string& name) { return string_to_symbol(name); }
+pmt_t intern(std::string_view name) { return string_to_symbol(name); }
 
 const std::string symbol_to_string(const pmt_t& sym)
 {

--- a/gnuradio-runtime/lib/pmt/pmt_int.h
+++ b/gnuradio-runtime/lib/pmt/pmt_int.h
@@ -11,6 +11,7 @@
 #define INCLUDED_PMT_INT_H
 
 #include <pmt/pmt.h>
+#include <string_view>
 #include <any>
 
 /*
@@ -38,7 +39,7 @@ class pmt_symbol : public pmt_base
     pmt_t d_next;
 
 public:
-    pmt_symbol(const std::string& name);
+    pmt_symbol(std::string_view name);
     //~pmt_symbol(){}
 
     bool is_symbol() const override { return true; }

--- a/gnuradio-runtime/python/pmt/bindings/pmt_sugar_python.cc
+++ b/gnuradio-runtime/python/pmt/bindings/pmt_sugar_python.cc
@@ -21,7 +21,7 @@ namespace py = pybind11;
 
 void bind_pmt_sugar(py::module& m)
 {
-    m.def("mp", (pmt::pmt_t(*)(std::string const&)) & ::pmt::mp, py::arg("s"), D(mp, 0));
+    m.def("mp", (pmt::pmt_t(*)(std::string_view)) & ::pmt::mp, py::arg("s"), D(mp, 0));
 
 
     m.def("mp", (pmt::pmt_t(*)(char const*)) & ::pmt::mp, py::arg("s"), D(mp, 1));


### PR DESCRIPTION
# Pull Request Details


## Description

PMT dicts are notoriously annoying to generate; with this it gets easier:

```c++
using pmt::mp;
using pmt::pmt_t;
auto dict = dict_from_mapping(std::map<pmt_t, pmt_t>{{mp(foo), mp(12)}, {mp(bar), mp(baz)}});
```

To make the whole generation of symbols less of a copyfest, make symbol
interfaces use `string_view` instead of `const string&`; this allows usage
of PMT symbols without having an owning string.  Goal is to remove
unnecessary copies and allocations for temporary strings.

(while we're at it, remove an unused config.h inclusion)


## Which blocks/areas does this affect?

PMT, and thus all block authors that want to emit dictionaries


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.

### Usage example

https://github.com/gnuradio/gnuradio/blob/66d98ba2adf1c3edc777399b19c07b0bc8b2df64/gr-blocks/lib/probe_rate_impl.cc#L79-L81