### PR TITLE
Better Probe Rate

### DIFF
--- a/gr-blocks/grc/blocks_probe_rate.block.yml
+++ b/gr-blocks/grc/blocks_probe_rate.block.yml
@@ -24,6 +24,9 @@ parameters:
     label: Update Alpha
     dtype: real
     default: '0.15'
+-   id: name
+    label: Name
+    dtype: string
 
 inputs:
 -   domain: stream
@@ -40,11 +43,15 @@ asserts:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.probe_rate(${type.size}*${vlen}, ${mintime}, ${alpha})
+    make: blocks.probe_rate(${type.size}*${vlen}, ${mintime}, ${alpha}, ${name})
+    callbacks:
+    - set_alpha(${alpha})
+    - set_name(${name})
+
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/probe_rate.h>']
     declarations: 'blocks::probe_rate::sptr ${id};'
-    make: 'this->${id} = blocks::probe_rate::make(${type.size}*${vlen}, ${mintime}, ${alpha});'
+    make: 'this->${id} = blocks::probe_rate::make(${type.size}*${vlen}, ${mintime}, ${alpha}, ${name});'
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/probe_rate.h
+++ b/gr-blocks/include/gnuradio/blocks/probe_rate.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/sync_block.h>
+#include <string_view>
 
 namespace gr {
 namespace blocks {
@@ -32,11 +33,26 @@ public:
      * \param itemsize size of each stream item
      * \param update_rate_ms minimum update time in milliseconds
      * \param alpha gain for running average filter
+     * \param name name for this probe (used in generated dictionaries)
+     *
+     * If the name is empty, the "name" field in the emitted dictionaries is
+     * omitted.
      */
-    static sptr
-    make(size_t itemsize, double update_rate_ms = 500.0, double alpha = 0.0001);
+    static sptr make(size_t itemsize,
+                     double update_rate_ms = 500.0,
+                     double alpha = 0.0001,
+                     std::string_view name = "");
 
+    /*!
+     * \brief Set the decay of the exponential rate average
+     */
     virtual void set_alpha(double alpha) = 0;
+
+    /*!
+     * \brief Set the name of this probe
+     * Used in the emitted dictionaries if not empty
+     */
+    virtual void set_name(std::string_view name) = 0;
 
     virtual double rate() = 0;
 

--- a/gr-blocks/lib/probe_rate_impl.cc
+++ b/gr-blocks/lib/probe_rate_impl.cc
@@ -8,6 +8,7 @@
  *
  */
 
+#include "pmt/pmt.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -18,12 +19,19 @@
 namespace gr {
 namespace blocks {
 
-probe_rate::sptr probe_rate::make(size_t itemsize, double update_rate_ms, double alpha)
+probe_rate::sptr probe_rate::make(size_t itemsize,
+                                  double update_rate_ms,
+                                  double alpha,
+                                  std::string_view name)
 {
-    return gnuradio::make_block_sptr<probe_rate_impl>(itemsize, update_rate_ms, alpha);
+    return gnuradio::make_block_sptr<probe_rate_impl>(
+        itemsize, update_rate_ms, alpha, name);
 }
 
-probe_rate_impl::probe_rate_impl(size_t itemsize, double update_rate_ms, double alpha)
+probe_rate_impl::probe_rate_impl(size_t itemsize,
+                                 double update_rate_ms,
+                                 double alpha,
+                                 std::string_view name)
     : sync_block("probe_rate",
                  io_signature::make(1, 1, itemsize),
                  io_signature::make(0, 0, itemsize)),
@@ -37,6 +45,16 @@ probe_rate_impl::probe_rate_impl(size_t itemsize, double update_rate_ms, double 
       d_dict_now(pmt::mp("rate_now"))
 {
     message_port_register_out(d_port);
+    set_name(name);
+}
+
+void probe_rate_impl::set_name(std::string_view name)
+{
+    if (name.empty()) {
+        d_data_dict.erase(pmt::mp("name"));
+    } else {
+        d_data_dict[pmt::mp("name")] = pmt::mp(name);
+    }
 }
 
 probe_rate_impl::~probe_rate_impl() {}
@@ -58,10 +76,9 @@ int probe_rate_impl::work(int noutput_items,
         } else {
             d_avg = rate_this_update * d_alpha + d_avg * d_beta;
         }
-        pmt::pmt_t d = pmt::make_dict();
-        d = pmt::dict_add(d, d_dict_avg, pmt::mp(d_avg));
-        d = pmt::dict_add(d, d_dict_now, pmt::mp(rate_this_update));
-        message_port_pub(d_port, pmt::cons(d, pmt::PMT_NIL));
+        d_data_dict[d_dict_avg] = pmt::mp(d_avg);
+        d_data_dict[d_dict_now] = pmt::mp(rate_this_update);
+        message_port_pub(d_port, pmt::dict_from_mapping(d_data_dict));
     }
     return noutput_items;
 }

--- a/gr-blocks/lib/probe_rate_impl.h
+++ b/gr-blocks/lib/probe_rate_impl.h
@@ -11,8 +11,11 @@
 #ifndef INCLUDED_GR_PROBE_RATE_IMPL_H
 #define INCLUDED_GR_PROBE_RATE_IMPL_H
 
+#include "pmt/pmt.h"
 #include <gnuradio/blocks/probe_rate.h>
+#include <string_view>
 #include <chrono>
+#include <map>
 
 namespace gr {
 namespace blocks {
@@ -28,11 +31,16 @@ private:
 
     const pmt::pmt_t d_port;
     const pmt::pmt_t d_dict_avg, d_dict_now;
+    std::map<pmt::pmt_t, pmt::pmt_t> d_data_dict;
 
 public:
-    probe_rate_impl(size_t itemsize, double update_rate_ms, double alpha = 0.0001);
+    probe_rate_impl(size_t itemsize,
+                    double update_rate_ms,
+                    double alpha = 0.0001,
+                    std::string_view name = "");
     ~probe_rate_impl() override;
     void set_alpha(double alpha) override;
+    void set_name(std::string_view name) override;
     double rate() override;
     double timesincelast();
     bool start() override;

--- a/gr-blocks/python/blocks/bindings/docstrings/probe_rate_pydoc_template.h
+++ b/gr-blocks/python/blocks/bindings/docstrings/probe_rate_pydoc_template.h
@@ -30,6 +30,9 @@ static const char* __doc_gr_blocks_probe_rate_make = R"doc()doc";
 static const char* __doc_gr_blocks_probe_rate_set_alpha = R"doc()doc";
 
 
+static const char* __doc_gr_blocks_probe_rate_set_name = R"doc()doc";
+
+
 static const char* __doc_gr_blocks_probe_rate_rate = R"doc()doc";
 
 

--- a/gr-blocks/python/blocks/bindings/probe_rate_python.cc
+++ b/gr-blocks/python/blocks/bindings/probe_rate_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(probe_rate.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(6217f03a5dbd6c39f9dcdea629362e39)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5af71a4dfd73a4001d02a2253e28bd64)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,6 +43,7 @@ void bind_probe_rate(py::module& m)
              py::arg("itemsize"),
              py::arg("update_rate_ms") = 500.,
              py::arg("alpha") = 1.0E-4,
+             py::arg("name") = "",
              D(probe_rate, make))
 
 
@@ -50,6 +51,8 @@ void bind_probe_rate(py::module& m)
              &probe_rate::set_alpha,
              py::arg("alpha"),
              D(probe_rate, set_alpha))
+
+        .def("set_name", &probe_rate::set_name, py::arg("name"), D(probe_rate, set_name))
 
 
         .def("rate", &probe_rate::rate, D(probe_rate, rate))


### PR DESCRIPTION

# Pull Request Details

I needed a better probe_rate block to distinguish between multiple probe rates in one flow graph. So: added a name parameter which is added to the emitted dictionary

![probe_rate_message_debug](https://user-images.githubusercontent.com/958972/177782371-cd40c7d8-bd1d-410b-a9a4-7c0e8765fb28.png)


## Related Issue

Depends on  #5994 

## Which blocks/areas does this affect?

The old format was kept around if name is set to an empty string; this is thus a self-contained change.

## Testing Done

Would love to have done more testing, alas, needs work on message_debug first.

## Documentation Written

- yes. (block docs)
- Adding an example flowgraph to the extended message_debug PR (which hence will depend on this)
- wiki documentation: Will add example flowgraph picture; explain parameter


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
