### PR TITLE
Message Debug: Add log output

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -219,6 +219,14 @@ public:
     {
         d_logger->critical(msg, args...);
     }
+    /*! \brief inline function, wrapper for logging with ad-hoc adjustable level*/
+    template <typename... Args>
+    inline void log(spdlog::level::level_enum level,
+                    const spdlog::string_view_t& msg,
+                    const Args&... args)
+    {
+        d_logger->log(level, msg, args...);
+    }
 };
 using logger_ptr = std::shared_ptr<logger>;
 

--- a/gnuradio-runtime/lib/qa_logger.cc
+++ b/gnuradio-runtime/lib/qa_logger.cc
@@ -12,12 +12,6 @@
  * directory into a single test suite.  As you create new test cases,
  * add them here.
  */
-
-#include <boost/test/tools/old/interface.hpp>
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include <gnuradio/logger.h>
 #include <boost/test/unit_test.hpp>
 #include <memory>
@@ -26,7 +20,7 @@ BOOST_AUTO_TEST_CASE(t1)
 {
     // This doesn't really test anything, more just
     // making sure nothing's gone horribly wrong.
-    auto log = std::make_shared<gr::logger>("main");
+    auto log = std::make_shared<gr::logger>("t1");
     GR_LOG_NOTICE(log, "test from c++ NOTICE");
     GR_LOG_DEBUG(log, "test from c++ DEBUG");
     GR_LOG_INFO(log, "test from c++ INFO");
@@ -38,9 +32,18 @@ BOOST_AUTO_TEST_CASE(t1)
 
 BOOST_AUTO_TEST_CASE(t2)
 {
-    auto& logsys = gr::logging::singleton();
-    logsys.set_default_level(gr::log_level::critical);
-    BOOST_CHECK_EQUAL(logsys.default_level(), gr::log_level::critical);
-    logsys.set_default_level(gr::log_level::info);
-    BOOST_CHECK_EQUAL(logsys.default_level(), gr::log_level::info);
+    gr::logger log("t2");
+    unsigned int counter = 0;
+    log.trace("{} test", ++counter);
+    log.debug("{} test", ++counter);
+    log.info("{} test", ++counter);
+    log.warn("{} test", ++counter);
+    log.error("{} test", ++counter);
+    log.crit("{} test", ++counter);
+    {
+        using namespace spdlog::level;
+        for (const auto& level : { trace, debug, info, warn, err, critical }) {
+            log.log(level, "{} test", ++counter);
+        }
+    }
 }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/logger_pydoc_template.h
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/docstrings/logger_pydoc_template.h
@@ -31,6 +31,8 @@ static const char* __doc_gr_logger_alert = R"doc()doc";
 static const char* __doc_gr_logger_fatal = R"doc()doc";
 static const char* __doc_gr_logger_emerg = R"doc()doc";
 
+static const char* __doc_gr_logger_log = R"doc()doc";
+
 static const char* __doc_gr_logging_singleton = R"doc()doc";
 static const char* __doc_gr_logging_default_level = R"doc()doc";
 static const char* __doc_gr_logging_set_default_level = R"doc()doc";

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(132b88712cdbc1c5b5acee7ee9b546f5)                     */
+/* BINDTOOL_HEADER_FILE_HASH(b62b327197c0c1d4d5c662725810d1b6)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -110,7 +110,15 @@ void bind_logger(py::module& m)
             "emerg",
             [](logger& log, const std::string& msg) { log.emerg("{:s}", msg); },
             py::arg("msg"),
-            D(logger, emerg));
+            D(logger, emerg))
+        .def(
+            "log",
+            [](logger& log, spdlog::level::level_enum level, const std::string& msg) {
+                log.log(level, "{:s}", msg);
+            },
+            py::arg("level"),
+            py::arg("msg"),
+            D(logger, log));
 
     using logging = gr::logging;
 

--- a/gr-blocks/examples/message_debug.grc
+++ b/gr-blocks/examples/message_debug.grc
@@ -1,0 +1,150 @@
+options:
+  parameters:
+    author: "Marcus M\xFCller"
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: '2022'
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: no_gui
+    hier_block_src_path: '.:'
+    id: message_debug_demo
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: 'Message Debug: Different log levels'
+    window_size: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [24, 300.0]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: blocks_message_debug_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    en_uvec: 'True'
+    log_level: info
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [440, 40.0]
+    rotation: 0
+    state: true
+- name: blocks_message_debug_0_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    en_uvec: 'True'
+    log_level: critical
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [440, 216.0]
+    rotation: 0
+    state: true
+- name: blocks_message_strobe_1
+  id: blocks_message_strobe
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    msg: pmt.mp("TEST")
+    period: '2500'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [104, 116.0]
+    rotation: 0
+    state: true
+- name: blocks_message_strobe_random_0
+  id: blocks_message_strobe_random
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    dist: blocks.STROBE_POISSON
+    maxoutbuf: '0'
+    mean: '10000'
+    minoutbuf: '0'
+    msg: pmt.mp("rare event")
+    std: '100'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [80, 196.0]
+    rotation: 0
+    state: true
+- name: blocks_null_source_0
+  id: blocks_null_source
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_source: '[[0,],]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_outputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 40.0]
+    rotation: 0
+    state: enabled
+- name: blocks_probe_rate_0
+  id: blocks_probe_rate
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha: '0.15'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mintime: '500.0'
+    name: Throughput
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [168, 20.0]
+    rotation: 0
+    state: enabled
+
+connections:
+- [blocks_message_strobe_1, strobe, blocks_message_debug_0, log]
+- [blocks_message_strobe_random_0, strobe, blocks_message_debug_0_0, log]
+- [blocks_null_source_0, '0', blocks_probe_rate_0, '0']
+- [blocks_probe_rate_0, rate, blocks_message_debug_0, log]
+
+metadata:
+  file_format: 1
+  grc_version: v3.11.0.0git-191-gf7b9efd3

--- a/gr-blocks/examples/probe_rate_message_debug.grc
+++ b/gr-blocks/examples/probe_rate_message_debug.grc
@@ -1,0 +1,97 @@
+options:
+  parameters:
+    author: "Marcus M\xFCller"
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: '2022'
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: no_gui
+    hier_block_src_path: '.:'
+    id: probe_rate_message_debug
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: Probe the rate of the Null Source
+    window_size: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 116.0]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: blocks_message_debug_0
+  id: blocks_message_debug
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    en_uvec: 'True'
+    log_level: info
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [440, 40.0]
+    rotation: 0
+    state: true
+- name: blocks_null_source_0
+  id: blocks_null_source
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_source: '[[0,],]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_outputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 40.0]
+    rotation: 0
+    state: enabled
+- name: blocks_probe_rate_0
+  id: blocks_probe_rate
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha: '0.15'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mintime: '500.0'
+    name: Throughput
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [168, 20.0]
+    rotation: 0
+    state: enabled
+
+connections:
+- [blocks_null_source_0, '0', blocks_probe_rate_0, '0']
+- [blocks_probe_rate_0, rate, blocks_message_debug_0, log]
+
+metadata:
+  file_format: 1
+  grc_version: v3.11.0.0git-191-gf7b9efd3

--- a/gr-blocks/grc/blocks_message_debug.block.yml
+++ b/gr-blocks/grc/blocks_message_debug.block.yml
@@ -4,13 +4,22 @@ flags: [ python, cpp ]
 
 parameters:
 -   id: en_uvec
-    label: PDU Vectors
+    label: Print PDU contents
     dtype: enum
     default: 'True'
     options: ['True', 'False']
     option_labels: ['On', 'Off']
+-   id: log_level
+    label: Log level
+    dtype: enum
+    default: 'info'
+    options: ['trace', 'debug', 'info', 'warn', 'err', 'critical']
+    option_labels: ['🔬 Trace', '🔎 Debug', '🛈 Info (default)', '⚠ Warning', '💥 Error', '☠ Critical']
 
 inputs:
+-   domain: message
+    id: 'log'
+    optional: true
 -   domain: message
     id: print
     optional: true
@@ -22,14 +31,15 @@ inputs:
     optional: true
 
 templates:
-    imports: from gnuradio import blocks
-    make: blocks.message_debug(${en_uvec})
+    imports: from gnuradio import blocks, gr
+    make: blocks.message_debug(${en_uvec}, gr.log_levels.${log_level})
     callbacks:
     - set_vector_print(${en_uvec})
+    - level(gr.log_levels.${log_level})
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/message_debug.h>']
     declarations: 'blocks::message_debug::sptr ${id};'
-    make: 'this->${id} = blocks::message_debug::make();'
+    make: 'this->${id} = blocks::message_debug::make(${en_uvec}, spdlog::level::${log_level});'
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/message_debug.h
+++ b/gr-blocks/include/gnuradio/blocks/message_debug.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2005,2012-2013 Free Software Foundation, Inc.
+ * Copyright 2022,2023 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -13,6 +14,7 @@
 
 #include <gnuradio/block.h>
 #include <gnuradio/blocks/api.h>
+#include <spdlog/common.h>
 
 namespace gr {
 namespace blocks {
@@ -46,8 +48,10 @@ public:
      * to disable PDU vector printing and has two message ports: print and store.
      *
      * \param en_uvec Enable PDU Vector Printing.
+     * \param log_level The log level of the `log` port. Defaults to "info".
      */
-    static sptr make(bool en_uvec = true);
+    static sptr make(bool en_uvec = true,
+                     spdlog::level::level_enum log_level = spdlog::level::info);
 
     /*!
      * \brief Reports the number of messages received by this block.
@@ -73,6 +77,15 @@ public:
      * \brief Enables or disables printing of PDU uniform vector data.
      */
     virtual void set_vector_print(bool en) = 0;
+
+    /*!
+     * \brief get the log level
+     */
+    virtual spdlog::level::level_enum level() const = 0;
+    /*!
+     * \brief set the log level
+     */
+    virtual void set_level(spdlog::level::level_enum log_level) = 0;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/lib/message_debug_impl.h
+++ b/gr-blocks/lib/message_debug_impl.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2005,2012-2013 Free Software Foundation, Inc.
+ * Copyright 2022 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -15,6 +16,7 @@
 #include <gnuradio/blocks/message_debug.h>
 #include <gnuradio/thread/thread.h>
 #include <pmt/pmt.h>
+#include <spdlog/common.h>
 
 namespace gr {
 namespace blocks {
@@ -23,6 +25,20 @@ class message_debug_impl : public message_debug
 {
 private:
     bool d_en_uvec;
+
+    /*!
+     * \brief Messages received in this port are properly logged.
+     *
+     * This port receives messages from the scheduler's message
+     * handling mechanism and logs them to the internal logging system.
+     * This message handler function is only meant to be used by the scheduler to
+     * handle messages posted to port 'log'. If the message is a
+     * PDU, special formatting will be applied.
+     *
+     * \param msg A pmt message passed from the scheduler's message handling.
+     * \param level the logging level, defaults to information only
+     */
+    void log(const pmt::pmt_t& msg);
 
     /*!
      * \brief Messages received in this port are printed to stdout.
@@ -66,14 +82,23 @@ private:
 
     gr::thread::mutex d_mutex;
     std::vector<pmt::pmt_t> d_messages;
+    spdlog::level::level_enum d_level;
 
 public:
-    message_debug_impl(bool en_uvec);
+    message_debug_impl(bool en_uvec, spdlog::level::level_enum level);
     ~message_debug_impl() override;
 
     size_t num_messages() override;
     pmt::pmt_t get_message(size_t i) override;
     void set_vector_print(bool en) override { d_en_uvec = en; };
+    /*!
+     * \brief get the log level
+     */
+    spdlog::level::level_enum level() const override;
+    /*!
+     * \brief set the log level
+     */
+    void set_level(spdlog::level::level_enum log_level) override;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/python/blocks/bindings/message_debug_python.cc
+++ b/gr-blocks/python/blocks/bindings/message_debug_python.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Free Software Foundation, Inc.
+ * Copyright 2022 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -14,12 +15,13 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(message_debug.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(23b39e92e05151acfe9f9c5ed93c3c43)                     */
+/* BINDTOOL_HEADER_FILE_HASH(6f4bb7d39b43ec95fce8da7dbc15bd7b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <spdlog/common.h>
 
 namespace py = pybind11;
 
@@ -38,6 +40,7 @@ void bind_message_debug(py::module& m)
 
         .def(py::init(&message_debug::make),
              py::arg("en_uvec") = true,
+             py::arg("level") = spdlog::level::info,
              D(message_debug, make))
 
 
@@ -54,6 +57,13 @@ void bind_message_debug(py::module& m)
              &message_debug::set_vector_print,
              py::arg("en"),
              D(message_debug, set_vector_print))
+
+        .def_property(
+            "level",
+            [](const message_debug& instance) { return instance.level(); },
+            [](message_debug& instance, spdlog::level::level_enum level) {
+                instance.set_level(level);
+            })
 
         ;
 }


### PR DESCRIPTION

# Pull Request Details
## Description


Wanted to work with the probe rate block, ended up having trouble using the output

Decided this thing should be able to log to our logging system instead of the very verbose printf that it does

Allowed people to set log levels.

![message_debug](https://user-images.githubusercontent.com/958972/177781823-7f0d9720-b75f-49e7-b643-3a6b7e1d42bb.png)

Updated wiki page staging: https://wiki.gnuradio.org/index.php?title=User:MarcusMueller/Message_Debug

## Related Issue
Depends on #5996 

## Which blocks/areas does this affect?

Since the original inputs remain unchanged, this is a self-contained change.

## Testing Done

Only connection testing

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
