### PR TITLE
GRC: numbers: supersede often misled "engineering" representation

### DIFF
--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -84,6 +84,18 @@ def num_to_str(num) -> str:
             .replace("e+", "e")\
             .strip()
 
+    def thousands_sep(inputstr: str,
+                      replacement: str = "\N{SPACE}",
+                      original_sep: str = "_") -> str:
+        """
+        Python allows us to group thousands with _ , but not with arbitrary
+        characters.
+
+        This function is just a simple str.replace wrapper to keep the default
+        somewhere visible
+        """
+        return inputstr.replace(original_sep, replacement)
+
     if numpy.iscomplex(num):
         intreal = int(numpy.real(num))
         intimag = int(numpy.imag(num))
@@ -92,13 +104,13 @@ def num_to_str(num) -> str:
            abs(num) < 2**0.5 * 10**6:
             if intreal < 10**6 and intimag < 10**6:
                 return f"{intreal:d}{intimag:+d}j"
-            return f"{intreal:_d}{intimag:+_d}j"
+            return thousands_sep(f"{intreal:_d}{intimag:+_d}j")
         return clean_e(f"{numpy.real(num):5.4g}{numpy.imag(num):+5.4g}j")
 
     if int(num) == num and abs(num) < 10**9:
         if abs(num) < 10**6:
             return f"{int(num):d}"
-        return f"{int(num):_d}"
+        return thousands_sep(f"{int(num):_d}")
     return clean_e(f"{num:9g}")
 
 


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Problem being solved

GRC currently displays numbers, regardless of their "integerness", in a kind-of-engineering notation. On one hand, that's fine, for fields like "Carrier Frequency" with values like 2 400 000.2 (that would be displayed as "2.4G"); on the other hand, that's very confusing for values like 1024 (which often appears as count of elements), which under no sensible circumstances should be displayed as "1.024k" or 0.1, which gets displayed as "100m".

Another issue arises because "2.4G" is not actually valid Python, and hence can't be entered into a field. So, a user *sees* a number displayed in a specific format, and tries to use that format (which means they've *intuited* from the UI!), which then promptly fails. We want these fields to evaluate valid python, and I'd rather not invent a new language where we can mix Python and 2.4G-style numbers, so entering "2.4G" has to fail.

For most of us, reading 2.4G isn't nicer than 2.4e9; and unlike the former, the latter is valid python. Let's use that format for display!

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

* modest Ints: under no circumstances write 1024 as 1.024k or 1.024e3
* large ints: from (incl) 1 million to (excluding) 10⁹, 1_000_000 is the format of choice (and valid python) (later edit: we could alternatively use spaces to group thousands, and hope people won't try to enter spaces, but spaces look less like a "character I should also use" than "G" or ","; commas, by the way, would also make it hard to localize later on)
* supersized ints: 2³⁰ -> 1.07374e9
* modest floats: 0.12
* very small/large floats: -1.2e-18
* never does the 1.2e`+0`9 that sadly `f"{number:g}"` introduces
 
## Related Issue

Closes #5986 

## Which blocks/areas does this affect?

Display of parameters in GRC (and only there)

## Testing Done

Since visual: Here's a screenshot. In the comments below the blocks, the literal inputs

### Before

![before](https://user-images.githubusercontent.com/958972/178248746-8332a0fa-d71d-48f0-a84f-0aa4e9084814.png)


### After

![GRC](https://user-images.githubusercontent.com/958972/177828170-770410e5-28eb-4b10-8a1a-cac06d8ca73e.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
