### PR TITLE
GRC/Screenshots: create ImageSurface with int dimensions

### DIFF
--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -108,7 +108,13 @@ def make_screenshot(flow_graph, file_path, transparent_bg=False):
     height = y_max - y_min + 2 * padding
 
     if file_path.endswith('.png'):
-        psurf = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
+        # ImageSurface is pixel-based, so dimensions need to be integers
+        # We don't round up here, because our padding should allow for up
+        # to half a pixel size in loss of image area without optically bad
+        # effects
+        psurf = cairo.ImageSurface(cairo.FORMAT_ARGB32,
+                                   round(width),
+                                   round(height))
     elif file_path.endswith('.pdf'):
         psurf = cairo.PDFSurface(file_path, width, height)
     elif file_path.endswith('.svg'):


### PR DESCRIPTION
Since cairo.ImageSurface is pixel-based, it only accepts integer dimensions.

No need to round up – proper rounding and padding make this quite safe.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description

Sometimes, taking a PNG screenshot fails. This fixes it.

## Related Issue

Closes #5995

## Which blocks/areas does this affect?

GRC

## Testing Done

Tested doing some screenshots that triggered the behaviour in #5995.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [-] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
