### PR TITLE
runtime: make a canary that lets compilation fail w/o HAVE_CONFIG_H

### DIFF
--- a/gnuradio-runtime/lib/vmcircbuf.cc
+++ b/gnuradio-runtime/lib/vmcircbuf.cc
@@ -10,6 +10,8 @@
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
+#else
+#error "There should really be a config.h; HAVE_CONFIG_H undefined"
 #endif
 
 #include "local_sighandler.h"


### PR DESCRIPTION
Don't merge, this is just a canary for #5993 to see whether this applies to all tested platforms.

Tests should fail early.
