### PR TITLE
modtool: parse io signatures without gr:: prefix

### DIFF
--- a/gr-utils/modtool/tools/parser_cc_block.py
+++ b/gr-utils/modtool/tools/parser_cc_block.py
@@ -72,9 +72,9 @@ class ParserCCBlock(object):
             elif len(vlen_parts) > 1:
                 return '*'.join(vlen_parts).strip()
         iosig = {}
-        iosig_regex = r'(?P<incall>gr::io_signature::make[23v]?)\s*\(\s*(?P<inmin>[^,]+),\s*(?P<inmax>[^,]+),' + \
+        iosig_regex = r'(?P<incall>(gr::)?io_signature::make[23v]?)\s*\(\s*(?P<inmin>[^,]+),\s*(?P<inmax>[^,]+),' + \
                       r'\s*(?P<intype>(\([^\)]*\)|[^)])+)\),\s*' + \
-                      r'(?P<outcall>gr::io_signature::make[23v]?)\s*\(\s*(?P<outmin>[^,]+),\s*(?P<outmax>[^,]+),' + \
+                      r'(?P<outcall>(gr::)?io_signature::make[23v]?)\s*\(\s*(?P<outmin>[^,]+),\s*(?P<outmax>[^,]+),' + \
                       r'\s*(?P<outtype>(\([^\)]*\)|[^)])+)\)'
         iosig_match = re.compile(
             iosig_regex, re.MULTILINE).search(self.code_cc)


### PR DESCRIPTION
# Pull Request Details

## Description
Previously, parsing signatures would fail if the io_signature call was
not prefixed with gr::, which is not necessary if currently in the gr
namespace anyway. This error may be encountered when copying gnuradio
source files into a new module, which don't use the gr:: prefix.

(Or at least, that's how I encountered this issue)

## Related Issue
Fixes #5800.

## Which blocks/areas does this affect?
Affects gr-utils/modtool

## Testing Done
Fails to parse:
```c++
    : gr::sync_block("test",
                     io_signature::make(1, 1, sizeof(input_type) * 64),
                     io_signature::make(0, 0, 0))
```
After modifying the program, it parses correctly, and groups are parsed as expected.

## Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes
- [X] All previous tests pass 