### PR TITLE
zeromq: fix deprecation warnings

### DIFF
--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -32,7 +32,7 @@ base_impl::base_impl(int type,
     : d_context(1),
       d_socket(d_context, type),
       d_vsize(itemsize * vlen),
-      d_timeout(timeout),
+      d_timeout(std::chrono::milliseconds{timeout}),
       d_pass_tags(pass_tags),
       d_key(key)
 {
@@ -189,7 +189,7 @@ bool base_source_impl::load_message(bool wait)
 {
     /* Poll for input */
     zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
-    zmq::poll(&items[0], 1, wait ? d_timeout : 0);
+    zmq::poll(&items[0], 1, wait ? d_timeout : std::chrono::milliseconds{0});
 
     if (!(items[0].revents & ZMQ_POLLIN))
         return false;

--- a/gr-zeromq/lib/base_impl.cc
+++ b/gr-zeromq/lib/base_impl.cc
@@ -32,7 +32,7 @@ base_impl::base_impl(int type,
     : d_context(1),
       d_socket(d_context, type),
       d_vsize(itemsize * vlen),
-      d_timeout(std::chrono::milliseconds{timeout}),
+      d_timeout(std::chrono::milliseconds{ timeout }),
       d_pass_tags(pass_tags),
       d_key(key)
 {
@@ -189,7 +189,7 @@ bool base_source_impl::load_message(bool wait)
 {
     /* Poll for input */
     zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
-    zmq::poll(&items[0], 1, wait ? d_timeout : std::chrono::milliseconds{0});
+    zmq::poll(&items[0], 1, wait ? d_timeout : std::chrono::milliseconds{ 0 });
 
     if (!(items[0].revents & ZMQ_POLLIN))
         return false;

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -33,7 +33,7 @@ protected:
     zmq::context_t d_context;
     zmq::socket_t d_socket;
     size_t d_vsize;
-    int d_timeout;
+    std::chrono::milliseconds d_timeout;
     bool d_pass_tags;
     const std::string d_key;
 };

--- a/gr-zeromq/lib/pub_msg_sink_impl.cc
+++ b/gr-zeromq/lib/pub_msg_sink_impl.cc
@@ -39,8 +39,7 @@ pub_msg_sink_impl::pub_msg_sink_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    int time = 0;
-    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.set(zmq::sockopt::linger, 0);
 
     if (bind) {
         d_socket.bind(address);

--- a/gr-zeromq/lib/pub_msg_sink_impl.h
+++ b/gr-zeromq/lib/pub_msg_sink_impl.h
@@ -31,10 +31,7 @@ public:
     void handler(pmt::pmt_t msg);
     std::string last_endpoint() override
     {
-        char addr[256];
-        size_t addr_len = sizeof(addr);
-        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
-        return std::string(addr, addr_len - 1);
+        return d_socket.get(zmq::sockopt::last_endpoint);
     }
 };
 

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -31,7 +31,7 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
     : gr::block("pull_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(timeout),
+      d_timeout(std::chrono::milliseconds{timeout}),
       d_context(1),
       d_socket(d_context, ZMQ_PULL),
       d_port(pmt::mp("out"))
@@ -40,7 +40,7 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = timeout * 1000;
+        d_timeout = std::chrono::milliseconds{timeout * 1000};
     }
 
     d_socket.set(zmq::sockopt::linger, 0);

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -43,8 +43,7 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
         d_timeout = timeout * 1000;
     }
 
-    int time = 0;
-    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.set(zmq::sockopt::linger, 0);
 
     if (bind) {
         d_socket.bind(address);

--- a/gr-zeromq/lib/pull_msg_source_impl.cc
+++ b/gr-zeromq/lib/pull_msg_source_impl.cc
@@ -31,7 +31,7 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
     : gr::block("pull_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(std::chrono::milliseconds{timeout}),
+      d_timeout(std::chrono::milliseconds{ timeout }),
       d_context(1),
       d_socket(d_context, ZMQ_PULL),
       d_port(pmt::mp("out"))
@@ -40,7 +40,7 @@ pull_msg_source_impl::pull_msg_source_impl(char* address, int timeout, bool bind
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = std::chrono::milliseconds{timeout * 1000};
+        d_timeout = std::chrono::milliseconds{ timeout * 1000 };
     }
 
     d_socket.set(zmq::sockopt::linger, 0);

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -40,10 +40,7 @@ public:
 
     std::string last_endpoint() override
     {
-        char addr[256];
-        size_t addr_len = sizeof(addr);
-        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
-        return std::string(addr, addr_len - 1);
+        return d_socket.get(zmq::sockopt::last_endpoint);
     }
 };
 

--- a/gr-zeromq/lib/pull_msg_source_impl.h
+++ b/gr-zeromq/lib/pull_msg_source_impl.h
@@ -21,7 +21,7 @@ namespace zeromq {
 class pull_msg_source_impl : public pull_msg_source
 {
 private:
-    int d_timeout; // microseconds, -1 is blocking
+    std::chrono::milliseconds d_timeout; // microseconds, -1 is blocking
     zmq::context_t d_context;
     zmq::socket_t d_socket;
     std::unique_ptr<std::thread> d_thread;

--- a/gr-zeromq/lib/push_msg_sink_impl.cc
+++ b/gr-zeromq/lib/push_msg_sink_impl.cc
@@ -39,8 +39,7 @@ push_msg_sink_impl::push_msg_sink_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    int time = 0;
-    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.set(zmq::sockopt::linger, 0);
 
     if (bind) {
         d_socket.bind(address);

--- a/gr-zeromq/lib/push_msg_sink_impl.h
+++ b/gr-zeromq/lib/push_msg_sink_impl.h
@@ -31,10 +31,7 @@ public:
     void handler(pmt::pmt_t msg);
     std::string last_endpoint() override
     {
-        char addr[256];
-        size_t addr_len = sizeof(addr);
-        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
-        return std::string(addr, addr_len - 1);
+        return d_socket.get(zmq::sockopt::last_endpoint);
     }
 };
 

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -30,7 +30,7 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
     : gr::block("rep_msg_sink",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(std::chrono::milliseconds{timeout}),
+      d_timeout(std::chrono::milliseconds{ timeout }),
       d_context(1),
       d_socket(d_context, ZMQ_REP),
       d_port(pmt::mp("in"))
@@ -39,7 +39,7 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = std::chrono::milliseconds{timeout * 1000};
+        d_timeout = std::chrono::milliseconds{ timeout * 1000 };
     }
 
     d_socket.set(zmq::sockopt::linger, 0);

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -42,8 +42,7 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    int time = 0;
-    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.set(zmq::sockopt::linger, 0);
 
     if (bind) {
         d_socket.bind(address);

--- a/gr-zeromq/lib/rep_msg_sink_impl.cc
+++ b/gr-zeromq/lib/rep_msg_sink_impl.cc
@@ -30,7 +30,7 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
     : gr::block("rep_msg_sink",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(timeout),
+      d_timeout(std::chrono::milliseconds{timeout}),
       d_context(1),
       d_socket(d_context, ZMQ_REP),
       d_port(pmt::mp("in"))
@@ -39,7 +39,7 @@ rep_msg_sink_impl::rep_msg_sink_impl(char* address, int timeout, bool bind)
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = timeout * 1000;
+        d_timeout = std::chrono::milliseconds{timeout * 1000};
     }
 
     d_socket.set(zmq::sockopt::linger, 0);

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -40,10 +40,7 @@ public:
 
     std::string last_endpoint() override
     {
-        char addr[256];
-        size_t addr_len = sizeof(addr);
-        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
-        return std::string(addr, addr_len - 1);
+        return d_socket.get(zmq::sockopt::last_endpoint);
     }
 };
 

--- a/gr-zeromq/lib/rep_msg_sink_impl.h
+++ b/gr-zeromq/lib/rep_msg_sink_impl.h
@@ -21,7 +21,7 @@ namespace zeromq {
 class rep_msg_sink_impl : public rep_msg_sink
 {
 private:
-    int d_timeout;
+    std::chrono::milliseconds d_timeout;
     zmq::context_t d_context;
     zmq::socket_t d_socket;
     std::unique_ptr<std::thread> d_thread;

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -50,7 +50,7 @@ int rep_sink_impl::work(int noutput_items,
         /* We only wait if its the first iteration, for the others we'll
          * let the scheduler retry */
         zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
-        zmq::poll(&items[0], 1, first ? d_timeout : 0);
+        zmq::poll(&items[0], 1, first ? d_timeout : std::chrono::milliseconds{0});
 
         /* If we don't have anything, we're done */
         if (!(items[0].revents & ZMQ_POLLIN))

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -50,7 +50,7 @@ int rep_sink_impl::work(int noutput_items,
         /* We only wait if its the first iteration, for the others we'll
          * let the scheduler retry */
         zmq::pollitem_t items[] = { { static_cast<void*>(d_socket), 0, ZMQ_POLLIN, 0 } };
-        zmq::poll(&items[0], 1, first ? d_timeout : std::chrono::milliseconds{0});
+        zmq::poll(&items[0], 1, first ? d_timeout : std::chrono::milliseconds{ 0 });
 
         /* If we don't have anything, we're done */
         if (!(items[0].revents & ZMQ_POLLIN))

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -31,7 +31,7 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("req_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(timeout),
+      d_timeout(std::chrono::milliseconds{timeout}),
       d_context(1),
       d_socket(d_context, ZMQ_REQ),
       d_port(pmt::mp("out"))
@@ -40,7 +40,7 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = timeout * 1000;
+        d_timeout = std::chrono::milliseconds{timeout * 1000};
     }
 
     d_socket.set(zmq::sockopt::linger, 0);

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -43,8 +43,7 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    int time = 0;
-    d_socket.setsockopt(ZMQ_LINGER, &time, sizeof(time));
+    d_socket.set(zmq::sockopt::linger, 0);
 
     if (bind) {
         d_socket.bind(address);

--- a/gr-zeromq/lib/req_msg_source_impl.cc
+++ b/gr-zeromq/lib/req_msg_source_impl.cc
@@ -31,7 +31,7 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("req_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(std::chrono::milliseconds{timeout}),
+      d_timeout(std::chrono::milliseconds{ timeout }),
       d_context(1),
       d_socket(d_context, ZMQ_REQ),
       d_port(pmt::mp("out"))
@@ -40,7 +40,7 @@ req_msg_source_impl::req_msg_source_impl(char* address, int timeout, bool bind)
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = std::chrono::milliseconds{timeout * 1000};
+        d_timeout = std::chrono::milliseconds{ timeout * 1000 };
     }
 
     d_socket.set(zmq::sockopt::linger, 0);

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -21,7 +21,7 @@ namespace zeromq {
 class req_msg_source_impl : public req_msg_source
 {
 private:
-    int d_timeout;
+    std::chrono::milliseconds d_timeout;
     zmq::context_t d_context;
     zmq::socket_t d_socket;
     std::unique_ptr<std::thread> d_thread;

--- a/gr-zeromq/lib/req_msg_source_impl.h
+++ b/gr-zeromq/lib/req_msg_source_impl.h
@@ -40,10 +40,7 @@ public:
 
     std::string last_endpoint() override
     {
-        char addr[256];
-        size_t addr_len = sizeof(addr);
-        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
-        return std::string(addr, addr_len - 1);
+        return d_socket.get(zmq::sockopt::last_endpoint);
     }
 };
 

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -31,7 +31,7 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("sub_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(std::chrono::milliseconds{timeout}),
+      d_timeout(std::chrono::milliseconds{ timeout }),
       d_context(1),
       d_socket(d_context, ZMQ_SUB),
       d_port(pmt::mp("out"))
@@ -40,7 +40,7 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = std::chrono::milliseconds{timeout * 1000};
+        d_timeout = std::chrono::milliseconds{ timeout * 1000 };
     }
 
     d_socket.set(zmq::sockopt::subscribe, "");

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -43,7 +43,7 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
         d_timeout = timeout * 1000;
     }
 
-    d_socket.setsockopt(ZMQ_SUBSCRIBE, "", 0);
+    d_socket.set(zmq::sockopt::subscribe, "");
 
     if (bind) {
         d_socket.bind(address);

--- a/gr-zeromq/lib/sub_msg_source_impl.cc
+++ b/gr-zeromq/lib/sub_msg_source_impl.cc
@@ -31,7 +31,7 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
     : gr::block("sub_msg_source",
                 gr::io_signature::make(0, 0, 0),
                 gr::io_signature::make(0, 0, 0)),
-      d_timeout(timeout),
+      d_timeout(std::chrono::milliseconds{timeout}),
       d_context(1),
       d_socket(d_context, ZMQ_SUB),
       d_port(pmt::mp("out"))
@@ -40,7 +40,7 @@ sub_msg_source_impl::sub_msg_source_impl(char* address, int timeout, bool bind)
     zmq::version(&major, &minor, &patch);
 
     if (major < 3) {
-        d_timeout = timeout * 1000;
+        d_timeout = std::chrono::milliseconds{timeout * 1000};
     }
 
     d_socket.set(zmq::sockopt::subscribe, "");

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -40,10 +40,7 @@ public:
 
     std::string last_endpoint() override
     {
-        char addr[256];
-        size_t addr_len = sizeof(addr);
-        d_socket.getsockopt(ZMQ_LAST_ENDPOINT, addr, &addr_len);
-        return std::string(addr, addr_len - 1);
+        return d_socket.get(zmq::sockopt::last_endpoint);
     }
 };
 

--- a/gr-zeromq/lib/sub_msg_source_impl.h
+++ b/gr-zeromq/lib/sub_msg_source_impl.h
@@ -21,7 +21,7 @@ namespace zeromq {
 class sub_msg_source_impl : public sub_msg_source
 {
 private:
-    int d_timeout; // microseconds, -1 is blocking
+    std::chrono::milliseconds d_timeout; // microseconds, -1 is blocking
     zmq::context_t d_context;
     zmq::socket_t d_socket;
     std::unique_ptr<std::thread> d_thread;

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -44,7 +44,7 @@ sub_source_impl::sub_source_impl(size_t itemsize,
       base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm, key)
 {
     /* Subscribe */
-    d_socket.setsockopt(ZMQ_SUBSCRIBE, key.c_str(), key.size());
+    d_socket.set(zmq::sockopt::subscribe, key.c_str());
 }
 
 int sub_source_impl::work(int noutput_items,


### PR DESCRIPTION
# Pull Request Details

## Description
Eliminates compiler warnings when compiling gr-zeromq. These were due to deprecations in cppzmq that changed
1. The syntax for getting and setting socket options
2. The argument type for polling changed from long to std::chrono::miliseconds

My two commits address each of these, respectively. Please let me know if i should squash them, or if any of my changes could have been done better.

## Related Issue
Should close #5982.

## Which blocks/areas does this affect?
zeromq

## Testing Done
Existing tests pass.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] All previous tests pass.
