### PR TITLE
WIP: 4.0 - Registry and reflection capability

### DIFF
--- a/blocklib/blocks/vector_sink/vector_sink_cpu.h
+++ b/blocklib/blocks/vector_sink/vector_sink_cpu.h
@@ -29,7 +29,7 @@ public:
     // private member variable, and pass it out as pmt when queried
     void on_parameter_query(param_action_sptr action) override
     {
-        this->d_debug_logger->debug(
+        this->d_debug_logger->trace(
             "block {}: on_parameter_query param_id: {}", this->id(), action->id());
         pmtf::pmt param = d_data;
         // auto data = pmtf::get_as<std::vector<float>>(*param);

--- a/gr/include/gnuradio/constants.h
+++ b/gr/include/gnuradio/constants.h
@@ -31,6 +31,11 @@ GR_RUNTIME_API const std::string sysconfdir();
 GR_RUNTIME_API const std::string prefsdir();
 
 /*!
+ * \brief return lib directory.
+ */
+GR_RUNTIME_API const std::string libdir();
+
+/*!
  * \brief return date/time of build, as set when 'cmake' is run
  */
 GR_RUNTIME_API const std::string build_date();

--- a/gr/include/gnuradio/registry.h
+++ b/gr/include/gnuradio/registry.h
@@ -1,0 +1,119 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <gnuradio/block.h>
+
+
+namespace gr {
+
+using generic_block_factory =
+    std::function<std::shared_ptr<block>(std::map<std::string, pmtf::pmt>&)>;
+
+/**
+ * @brief Singleton object to register instantiated classes and methods
+ *
+ */
+class registry
+{
+public:
+    static registry& get_instance();
+
+    /**
+     * @brief Initializes the registry by finding and loading dynamic modules
+     *
+     */
+    static void init();
+
+    /**
+     * @brief Return a list of modules available
+     *
+     * @return std::vector<std::string>
+     */
+    static std::vector<std::string> modules();
+
+    /**
+     * @brief Return a list of blocks available in the specified module
+     *
+     * @param module
+     * @return std::vector<std::string>
+     */
+    static std::vector<std::string> blocks(const std::string& module);
+    /**
+     * @brief Return a list of implementations available for specified block
+     *
+     * @param module
+     * @param block
+     * @return std::vector<std::string>
+     */
+    static std::vector<std::string> impls(const std::string& module,
+                                          const std::string& block);
+
+    /**
+     * @brief Return the generic block factory for a specified block
+     *
+     * @param module
+     * @param block
+     * @param impl
+     * @return generic_block_factory
+     */
+    static generic_block_factory factory(const std::string& module,
+                                         const std::string& block,
+                                         const std::string& impl = "cpu");
+    /**
+     * @brief Register a block class at initialization time
+     *
+     * @param module
+     * @param block
+     * @param impl
+     * @param factory
+     * @return registry&
+     */
+    static registry& register_class(const std::string& module,
+                                    const std::string& block,
+                                    const std::string& impl,
+                                    generic_block_factory factory);
+
+
+private:
+    registry();
+    // [module][block][impl] --> generic_block_factory
+    std::map<std::string,
+             std::map<std::string, std::map<std::string, generic_block_factory>>>
+        _constructor_map;
+
+    bool _initialized = false;
+
+    void _init();
+
+    std::vector<std::string> _modules();
+
+    std::vector<std::string> _blocks(const std::string& module);
+    std::vector<std::string> _impls(const std::string& module, const std::string& block);
+
+    generic_block_factory _factory(const std::string& module,
+                                   const std::string& block,
+                                   const std::string& impl);
+
+    registry& _register_class(const std::string& module,
+                              const std::string& block,
+                              const std::string& impl,
+                              generic_block_factory factory);
+
+    // public:
+    //     registry(registry const&) = delete;
+    //     void operator=(registry const&) = delete;
+};
+
+} // namespace gr

--- a/gr/lib/block.cc
+++ b/gr/lib/block.cc
@@ -75,7 +75,7 @@ void block::set_tag_propagation_policy(tag_propagation_policy_t policy)
 
 void block::on_parameter_change(param_action_sptr action)
 {
-    d_debug_logger->debug(
+    d_debug_logger->trace(
         "block {}: on_parameter_change param_id: {}", id(), action->id());
     auto param = d_parameters.get(action->id());
     *param = action->pmt_value();
@@ -83,7 +83,7 @@ void block::on_parameter_change(param_action_sptr action)
 
 void block::on_parameter_query(param_action_sptr action)
 {
-    d_debug_logger->debug(
+    d_debug_logger->trace(
         "block {}: on_parameter_query param_id: {}", id(), action->id());
     auto param = d_parameters.get(action->id());
     action->set_pmt_value(*param);

--- a/gr/lib/constants.cc.in
+++ b/gr/lib/constants.cc.in
@@ -53,6 +53,13 @@ const std::string prefsdir()
     return prefsdir_path.lexically_normal().string();
 }
 
+const std::string libdir()
+{
+    path prefix_path = prefix();
+    path libdir_path = prefix_path / "@LIBDIR@";
+    return libdir_path.lexically_normal().string();
+}
+
 const std::string build_date() { return "@BUILD_DATE@"; }
 
 const std::string version() { return "@VERSION@"; }

--- a/gr/lib/meson.build
+++ b/gr/lib/meson.build
@@ -18,6 +18,8 @@ cdata = configuration_data()
 cdata.set('VERSION', meson.project_version())
 cdata.set('prefix_relative_to_lib', prefix_relative_to_lib)
 cdata.set('GR_PREFSDIR_relative_to_prefix', 'etc/gnuradio/conf.d')
+cdata.set('LIBDIR', libdir)
+cdata.set('PREFIX', prefix)
 constants_file = configure_file(input: 'constants.cc.in',
                           output: 'constants.cc',
                           configuration: cdata,
@@ -59,7 +61,8 @@ runtime_sources = [
   'sptr_magic.cc',
   'hier_block.cc',
   'prefs.cc',
-  'tag.cc'
+  'tag.cc',
+  'registry.cc'
 ]
 
 if USE_CUDA

--- a/gr/lib/registry.cc
+++ b/gr/lib/registry.cc
@@ -67,11 +67,32 @@ void registry::_init()
 {
     std::string prefix("libgnuradio-blocklib");
     // Get the list of shared object files in libdir
-    for (const auto& file : directory_iterator(libdir())) {
-        auto fn = file.path().string();
-        auto pos = fn.find(prefix);
-        if (pos != std::string::npos) {
-            [[maybe_unused]] void* handle = dlopen(fn.c_str(), RTLD_LAZY);
+    std::string default_lib_dir = libdir();
+    std::vector<std::string> dirlist;
+
+    if (const char* env_p = std::getenv("LD_LIBRARY_PATH")) {
+        std::string str(env_p);
+
+        char* token = strtok(const_cast<char*>(str.c_str()), ":");
+        while (token != nullptr) {
+            dirlist.push_back(std::string(token));
+            token = strtok(nullptr, ":");
+        }
+    }
+    else {
+        dirlist.push_back(default_lib_dir);
+    }
+
+    for (auto& d : dirlist) {
+        try {
+            for (const auto& file : directory_iterator(d)) {
+                auto fn = file.path().string();
+                auto pos = fn.find(prefix);
+                if (pos != std::string::npos) {
+                    [[maybe_unused]] void* handle = dlopen(fn.c_str(), RTLD_LAZY);
+                }
+            }
+        } catch (...) {
         }
     }
 

--- a/gr/lib/registry.cc
+++ b/gr/lib/registry.cc
@@ -1,0 +1,154 @@
+#include <gnuradio/registry.h>
+
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+
+#include <functional>
+
+#include <gnuradio/block.h>
+#include <gnuradio/constants.h>
+
+#include <dlfcn.h>
+#include <filesystem>
+
+using std::filesystem::directory_iterator;
+
+namespace gr {
+
+
+registry& registry::get_instance()
+{
+    static registry instance;
+    return instance;
+}
+
+void registry::init() { get_instance()._init(); }
+
+std::vector<std::string> registry::modules() { return get_instance()._modules(); }
+
+std::vector<std::string> registry::blocks(const std::string& module)
+{
+    return get_instance()._blocks(module);
+}
+
+std::vector<std::string> registry::impls(const std::string& module,
+                                         const std::string& block)
+{
+    return get_instance().impls(module, block);
+}
+
+generic_block_factory registry::factory(const std::string& module,
+                                        const std::string& block,
+                                        const std::string& impl)
+{
+    return get_instance()._factory(module, block, impl);
+}
+
+registry& registry::register_class(const std::string& module,
+                                   const std::string& block,
+                                   const std::string& impl,
+                                   generic_block_factory factory)
+{
+    return get_instance()._register_class(module, block, impl, factory);
+}
+
+
+registry::registry() {}
+
+void registry::_init()
+{
+    std::string prefix("libgnuradio-blocklib");
+    // Get the list of shared object files in libdir
+    for (const auto& file : directory_iterator(libdir())) {
+        auto fn = file.path().string();
+        auto pos = fn.find(prefix);
+        if (pos != std::string::npos) {
+            [[maybe_unused]] void* handle = dlopen(fn.c_str(), RTLD_LAZY);
+        }
+    }
+
+    _initialized = true;
+}
+
+std::vector<std::string> registry::_modules()
+{
+    if (!_initialized) {
+        _init();
+    }
+    std::vector<std::string> ret;
+    for (const auto& [key, value] : _constructor_map) {
+        ret.push_back(key);
+    }
+    return ret;
+}
+
+std::vector<std::string> registry::_blocks(const std::string& module)
+{
+    if (!_initialized) {
+        _init();
+    }
+    std::vector<std::string> ret;
+    for (const auto& [key, value] : _constructor_map[module]) {
+        ret.push_back(key);
+    }
+    return ret;
+}
+std::vector<std::string> registry::_impls(const std::string& module,
+                                          const std::string& block)
+{
+    if (!_initialized) {
+        _init();
+    }
+    std::vector<std::string> ret;
+    for (const auto& [key, value] : _constructor_map[module][block]) {
+        ret.push_back(key);
+    }
+    return ret;
+}
+
+generic_block_factory registry::_factory(const std::string& module,
+                                         const std::string& block,
+                                         const std::string& impl)
+{
+    if (!_initialized) {
+        _init();
+    }
+    return _constructor_map[module][block][impl];
+}
+
+registry& registry::_register_class(const std::string& module,
+                                    const std::string& block,
+                                    const std::string& impl,
+                                    generic_block_factory factory)
+{
+    if (_constructor_map.count(module)) {
+        if (_constructor_map[module].count(block)) {
+            _constructor_map[module][block][impl] = factory;
+        }
+        else {
+            _constructor_map[module][block] = {
+                { impl, factory },
+            };
+        }
+    }
+    else {
+        _constructor_map[module] = {
+            { block,
+              {
+                  { impl, factory },
+              } },
+        };
+    }
+    return *this;
+}
+
+
+} // namespace gr

--- a/test/meson.build
+++ b/test/meson.build
@@ -7,7 +7,8 @@ qa_srcs = ['qa_default_runtime',
            'qa_message_ports',
            'qa_tags',
            'qa_zmq_buffers',
-           'qa_hier_block'
+           'qa_hier_block',
+           'qa_reflection',
           ]
 deps = [gnuradio_gr_dep,
                 gnuradio_blocklib_blocks_dep,

--- a/test/qa_reflection.cc
+++ b/test/qa_reflection.cc
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <thread>
+
+#include <gnuradio/registry.h>
+
+#include <gnuradio/blocks/vector_sink.h>
+#include <gnuradio/blocks/vector_source.h>
+#include <gnuradio/buffer_cpu_vmcirc.h>
+#include <gnuradio/flowgraph.h>
+#include <gnuradio/math/multiply_const.h>
+#include <gnuradio/schedulers/nbt/scheduler_nbt.h>
+#include <gnuradio/streamops/copy.h>
+
+using namespace gr;
+
+static bool is_in_list(const std::vector<std::string>& list, const std::string_view name)
+{
+    auto it = std::find(std::begin(list), std::end(list), name);
+    return (it != std::end(list));
+}
+
+TEST(Reflection, Basic)
+{
+    gr::registry::init();
+    auto list = gr::registry::modules();
+    EXPECT_TRUE(is_in_list(list, "math"));
+    EXPECT_TRUE(is_in_list(list, "blocks"));
+
+    list = gr::registry::blocks("math");
+    EXPECT_TRUE(is_in_list(list, "multiply_const_ff"));
+    EXPECT_TRUE(is_in_list(list, "multiply_const_cc"));
+
+    list = gr::registry::blocks("blocks");
+    EXPECT_TRUE(is_in_list(list, "vector_source_c"));
+    EXPECT_TRUE(is_in_list(list, "vector_sink_f"));
+
+    float orig_value = 12.0;
+    std::map<std::string, pmtf::pmt> param_map{ { "k", orig_value }, { "vlen", 1 } };
+    auto blk = gr::registry::factory("math", "multiply_const_ff")(param_map);
+    EXPECT_EQ(blk->request_parameter_query("k"), orig_value);
+    // list = gr::registry::parameters("blocks","multiply_const_ff");
+    // Verify that "k" is on the list
+    // Verify that "vlen" is on the list
+
+    float newval = 17.3;
+    blk->request_parameter_change("k", newval);
+    EXPECT_EQ(blk->request_parameter_query("k"), newval);
+}

--- a/utils/blockbuilder/templates/blockname.cc.j2
+++ b/utils/blockbuilder/templates/blockname.cc.j2
@@ -2,6 +2,7 @@
 {{ macros.header() }}
 
 #include <gnuradio/{{module}}/{{block}}.h>
+#include <gnuradio/registry.h>
 #include <nlohmann/json.hpp>
 
 namespace gr {
@@ -49,6 +50,22 @@ namespace {{module}} {
     return make(args, impl);
 }
 
+{% for impl in implementations %}
+{% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
+{{block}}::sptr {{block}}::make_from_params_{{impl['id']}}(std::map<std::string, pmtf::pmt>& param_map)
+{
+    block_args args;
+
+    {% for p in parameters -%}
+    {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
+    args.{{p['id']}} = {{'('+macros.get_linked_value(p['dtype'])+')' if p['is_enum']}}pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else 'int' if p['is_enum'] else p['dtype']}}>(param_map["{{p['id']}}"]);
+    {% endif %}
+    {% endfor -%}
+
+    return make(args, available_impl::{{impl['id'] | upper }});
+}
+{% endif %}
+{% endfor %}
 
 {{block}}::{{block}}(const block_args& args) : {{blocktype}}("{{ block }}", "{{ module }}") {
  {{ macros.ports(ports, parameters) }}
@@ -73,6 +90,11 @@ void {{block}}::set_{{p['id']}}({{p['dtype']}} {{p['id']}})
 {% endfor -%}
 {% endif %}
 
+{% for impl in implementations -%}
+{% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
+[[maybe_unused]] static auto reg_{{module}}_{{block}}_{{impl['id']}} = gr::registry::register_class("{{module}}","{{block}}","{{impl['id']}}",{{block}}::make_from_params_{{impl['id']}});
+{% endif -%}
+{% endfor -%}
 
 } // namespace {{ module }}
 } // namespace gr

--- a/utils/blockbuilder/templates/blockname_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_templated.cc.j2
@@ -1,6 +1,7 @@
 {% import 'macros.j2' as macros -%}
 {{ macros.header() }}
 #include <gnuradio/{{module}}/{{block}}.h>
+#include <gnuradio/registry.h>
 #include <nlohmann/json.hpp>
 
 namespace gr {
@@ -50,6 +51,25 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
     return make(args, impl);
 }
 
+{% for impl in implementations %}
+{% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
+template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
+typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::sptr {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::make_from_params_{{impl['id']}}(std::map<std::string, pmtf::pmt>& param_map)
+{
+    block_args args;
+
+    {% for p in parameters -%}
+    {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
+    args.{{p['id']}} = {{'('+macros.get_linked_value(p['dtype'])+')' if p['is_enum']}}pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else 'int' if p['is_enum'] else p['dtype']}}>(param_map["{{p['id']}}"]);
+    {% endif %}
+    {% endfor -%}
+
+    return make(args, available_impl::{{impl['id'] | upper }});
+}
+{% endif %}
+{% endfor %}
+
+
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
 {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::{{block}}(const block_args& args) : {{blocktype}}("{{ block }}", "{{ module }}") {
  {{ macros.ports(ports, parameters, typekeys) }}
@@ -90,6 +110,11 @@ template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not 
 template <>
 std::string {{block}}<{{ macros.cpp_type_lookup(opt) }}>::suffix(){ return "_{{macros.typekey_suffix(opt, key1['id'],ports)}}"; }
 template class {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
+{% for impl in implementations -%}
+{% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
+[[maybe_unused]] static auto reg_{{module}}_{{block}}_{{ macros.typekey_suffix(opt, key1['id'],ports) }}_{{impl['id']}} = gr::registry::register_class("{{module}}","{{block}}_{{ macros.typekey_suffix(opt, key1['id'],ports) }}","{{impl['id']}}",{{block}}<{{ macros.cpp_type_lookup(opt) }}>::make_from_params_{{impl['id']}});
+{% endif -%}
+{% endfor -%}
 {% endfor -%}
 {% elif typekeys | length == 2 -%}
 {%set key1 = typekeys|first %}
@@ -102,12 +127,18 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
 template <>
 std::string {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}"; }
 template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>;
+{% for impl in implementations -%}{% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
+[[maybe_unused]] static auto reg_{{module}}_{{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}_{{impl['id']}} = gr::registry::register_class("{{module}}","{{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}","{{impl['id']}}",{{block}}<{{ macros.cpp_type_lookup(opt1) }}, {{ macros.cpp_type_lookup(opt2) }}>::make_from_params_{{impl['id']}});
+{% endif -%}{% endfor -%}
 {% endif %}
 {% endfor %}
 {% else %}
 template <>
 std::string {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}"; }
 template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>;
+{% for impl in implementations -%}{% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
+[[maybe_unused]] static auto reg_{{module}}_{{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}_{{impl['id']}} = gr::registry::register_class("{{module}}","{{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}","{{impl['id']}}",{{block}}<{{ macros.cpp_type_lookup(opt1) }}, {{ macros.cpp_type_lookup(opt2) }}>::make_from_params_{{impl['id']}});
+{% endif -%}{% endfor -%}
 {% endif %}
 {% endfor -%}
 {% endfor -%}
@@ -135,5 +166,8 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_l
 {% endfor -%}
 {% endfor -%}
 {% endif -%}
+
+
+
 } // namespace {{ module }}
 } // namespace gr

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -112,6 +112,7 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
      * @return std::shared_ptr<{{ block }}> 
      */
     static sptr make_{{impl['id']}}(const block_args& args);
+    static sptr make_from_params_{{impl['id']}}(std::map<std::string, pmtf::pmt>&);
     {% elif 'lang' in impl and impl['lang'] == 'python' and not vars.pyshell -%}
     static sptr make_pyshell(const block_args& args);
     {% if vars.update({'pyshell': True}) %} {% endif %}


### PR DESCRIPTION
Create a GR registry that maintains knowledge about what modules,
blocks, etc. are available, and has the ability to return generic block
constructors.

Basic usage would be
```
auto list = gr::registry::modules()
// "math" should be in list
list = gr::registry::blocks("math");
// "vector_source_f" should be in list
auto f = gr::registry::factory("math","vector_source_f")
auto blk = f(.... map of string/pmt)
```

Right now, this is all done through auto code generation, with the need being 
`.yml` --> headers, then headers should include reflection capability

This adds a generic factory to each block that can be invoked with `std::map<std::string, pmtf::pmt>' - which is a list of all the parameters in the block.  Since some parameters are not part of the constructor, these will need to be handled through the setters.

There is probably a more elegant solution using `refl-cpp` which can then be wrapped for nicer python bindable API, but this first pass is pretty brute force just generate the code.  I still question whether some of these things can be done with a general purpose tool like refl-cpp, such as some parameters being part of the constructor and some being setters

Still needing to be addressed:

- [ ] python bindings of `registry.h`
- [ ] block parameters and callbacks
- [ ] rest of the things in `block.yml`
- [ ] parameters that are not part of constructor
- [ ] schedulers, buffers, other modular components 
