### PR TITLE
4.0: meson: use supported wrap files cli11/nlohmann_json

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,11 +41,8 @@ cuda_dep = dependency('cuda', version : '>=10.1', required : USE_CUDA, modules :
 libpmtf = subproject('pmt')
 pmtf_dep = libpmtf.get_variable('pmtf_dep')
 
-libCLI11 = subproject('CLI11')
-CLI11_dep = libCLI11.get_variable('CLI11_dep')
-
-libjson = subproject('json')
-json_dep = libjson.get_variable('nlohmann_json_dep')
+CLI11_dep = dependency('cli11')
+json_dep = dependency('nlohmann_json')
 
 libcpphttp = subproject('cpp-httplib')
 cpphttp_dep = libcpphttp.get_variable('cpp_httplib_dep')

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,7 +1,8 @@
-CLI11/
+CLI11-*
 pmt/
-json/
+nlohmann_json-*
 cpp-httplib/
 cppzmq/
 moodycamel/
 cusp/
+packagecache/

--- a/subprojects/CLI11.wrap
+++ b/subprojects/CLI11.wrap
@@ -1,3 +1,0 @@
-[wrap-git]
-url = https://github.com/CLIUtils/CLI11
-revision = tags/v2.1.2

--- a/subprojects/cli11.wrap
+++ b/subprojects/cli11.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = CLI11-2.2.0
+source_url = https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.2.0.tar.gz
+source_filename = CLI11-2.2.0.tar.gz
+source_hash = d60440dc4d43255f872d174e416705f56ba40589f6eb07727f76376fb8378fd6
+
+[provide]
+cli11 = CLI11_dep
+

--- a/subprojects/json.wrap
+++ b/subprojects/json.wrap
@@ -1,4 +1,0 @@
-[wrap-git]
-url = https://github.com/nlohmann/json
-depth = 1
-revision = release/3.10.5

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = nlohmann_json-3.10.5
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip
+source_filename = nlohmann_json-3.10.5.zip
+source_hash = b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e
+
+[provide]
+nlohmann_json = nlohmann_json_dep
+


### PR DESCRIPTION

# Pull Request Details
Updates suggested by @eli-schwartz in #6012 to use the already supported wrap files for cli11 and nlohmann_json as found with `meson wrap install ...`

## Which blocks/areas does this affect?
meson build files

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
