### PR TITLE
meson: do not require cmake when finding dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,8 +20,8 @@ SCRIPTS_DIR=join_paths(meson.project_source_root(),'utils','blockbuilder','scrip
 
 volk_dep = dependency('volk', version : '>=2.2')
 yaml_dep = dependency('yaml-cpp', version : '>=0.6')
-fmt_dep = dependency('fmt', method: 'cmake', modules: ['fmt::fmt'])
-spdlog_dep = dependency('spdlog', method: 'cmake', modules : ['spdlog::spdlog'])
+fmt_dep = dependency('fmt')
+spdlog_dep = dependency('spdlog')
 python3_dep = dependency('python3', required : get_option('enable_python'))
 python3_embed_dep = dependency('python3-embed', required : get_option('enable_python'))
 


### PR DESCRIPTION
fmt and spdlog provide pkg-config files, and these work and compile perfectly fine. Meson can try finding with both pkg-config and cmake, if it is allowed to, which means that dependency lookup now works on systems where cmake is not installed.

Note this is not immediately useful, since later on a cmake subproject is explicitly used, but that can be fixed in the future to make cmake no longer required for a successful full configure.

Even when using cmake for dependency lookup, the modules kwarg is not needed. Both dependencies export a single cmake target, so Meson can figure out the correct one to use without trouble.