### PR TITLE
iio: Fix sink scalar value to match format le:S16/16.

### DIFF
--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -357,9 +357,9 @@ int fmcomms2_sink_impl<gr_complex>::work(int noutput_items,
             d_float_r.data(), d_float_i.data(), in, noutput_items);
         // float to short
         volk_32f_s32f_convert_16i(
-            d_device_bufs[2 * i].data(), d_float_r.data(), 2048.0, noutput_items);
+            d_device_bufs[2 * i].data(), d_float_r.data(), 32768.0, noutput_items);
         volk_32f_s32f_convert_16i(
-            d_device_bufs[2 * i + 1].data(), d_float_i.data(), 2048.0, noutput_items);
+            d_device_bufs[2 * i + 1].data(), d_float_i.data(), 32768.0, noutput_items);
     }
 
 


### PR DESCRIPTION
# Pull Request Details
Fix scalar value in fmcomms2 sink to match the IIO format le:S16/16>>0

## Description
TX output power is aprox 25 dB lower (for the given example) when using ADALM Pluto with gnuradio 3.10 (compared to 3.8 results).
There is an error when converting data from float to int.
The data is scaled to 12 bits instead of 12 bits left shifted by 4 (16 bits where the 4 LSBs don't matter).
This caused the shifting of 4 most significant bits to the right, essentially losing 4 MSBs where most of the power is (about 90% power).

## Related Issue
Reported and tested here: https://ez.analog.com/adieducation/university-program/f/q-a/560641/pluto-grc-3-10-sink-block-has-low-output-power .

## Which blocks/areas does this affect?
The fmcomms2 sink, part of the gr-iio module.

## Testing Done
Testing reported in the issue mentioned above.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
