### PR TITLE
4.0: Standardized Parameter types

### DIFF
--- a/blocklib/analog/agc/agc.yml
+++ b/blocklib/analog/agc/agc.yml
@@ -15,15 +15,15 @@ typekeys:
 parameters:
 -   id: rate
     label: Rate
-    dtype: float
+    dtype: rf32
     default: 1e-4
 -   id: reference
     label: Reference
-    dtype: float
+    dtype: rf32
     default: 1.0
 -   id: gain
     label: Gain
-    dtype: float
+    dtype: rf32
     default: 1.0
 
 ports:

--- a/blocklib/analog/fm_deemph/fm_deemph.yml
+++ b/blocklib/analog/fm_deemph/fm_deemph.yml
@@ -13,7 +13,7 @@ parameters:
         default: 400000
 -   id: tau
     label: Tau
-    dtype: double
+    dtype: rf64
     default: 75e-6
 
 

--- a/blocklib/analog/noise_source/noise_source.yml
+++ b/blocklib/analog/noise_source/noise_source.yml
@@ -18,16 +18,16 @@ typekeys:
 parameters:
 -   id: type
     label: Type
-    dtype: gr::analog::noise_t
+    dtype: enums/noise_t
     settable: true
     is_enum: true # this should be handled better
 -   id: amplitude
     label: Amplitude
-    dtype: float
+    dtype: rf32
     settable: true
 -   id: seed
     label: Seed
-    dtype: long
+    dtype: ru64
     settable: false
     default: 0
 

--- a/blocklib/analog/quadrature_demod/quadrature_demod.yml
+++ b/blocklib/analog/quadrature_demod/quadrature_demod.yml
@@ -32,7 +32,7 @@ doc:
 parameters:
 -   id: gain
     label: Gain
-    dtype: float
+    dtype: rf32
     settable: true
     grc:
         hide: part

--- a/blocklib/analog/sig_source/sig_source.yml
+++ b/blocklib/analog/sig_source/sig_source.yml
@@ -19,7 +19,7 @@ typekeys:
 parameters:
 -   id: sampling_freq
     label: Sampling Freq
-    dtype: double
+    dtype: rf64
     settable: true
     grc:
         default: samp_rate
@@ -32,13 +32,13 @@ parameters:
         default: analog.waveform.sin
 -   id: frequency
     label: Wave Freq
-    dtype: double
+    dtype: rf64
     settable: true
     grc:
         default: 1000
 -   id: ampl
     label: Amplitude
-    dtype: double
+    dtype: rf64
     settable: true
     grc:
         default: 1.0
@@ -49,7 +49,7 @@ parameters:
     default: 0
 -   id: phase
     label: Phase
-    dtype: double
+    dtype: rf64
     settable: true
     default: 0    
 

--- a/blocklib/audio/alsa_sink/alsa_sink.yml
+++ b/blocklib/audio/alsa_sink/alsa_sink.yml
@@ -8,20 +8,20 @@ category: '[Core]/Audio'
 parameters:
 -   id: sampling_rate
     label: Sampling Rate
-    dtype: unsigned int
+    dtype: ru32
     settable: false
     default: 0
     grc:
         hide: part
 -   id: device_name
     label: Device Name
-    dtype: std::string
+    dtype: string
     settable: false
     grc:
         hide: part
 -   id: num_inputs
     label: Num Inputs
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
     grc:

--- a/blocklib/blocks/message_debug/message_debug.yml
+++ b/blocklib/blocks/message_debug/message_debug.yml
@@ -14,14 +14,14 @@ parameters:
 callbacks:
     # virtual size_t num_messages() = 0;
 -   id: num_messages
-    return: size_t
+    return: size
     
     # virtual pmt::pmt_t get_message(size_t i) = 0;
 -   id: get_message
     return: pmtf::pmt
     args:
     - id: i
-      dtype: size_t
+      dtype: size
 
 
 

--- a/blocklib/blocks/msg_forward/msg_forward.yml
+++ b/blocklib/blocks/msg_forward/msg_forward.yml
@@ -9,12 +9,12 @@ includes:
 parameters:
 -   id: max_messages
     label: Max Messages
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
 -   id: message_count
     label: Message Count
-    dtype: size_t
+    dtype: size
     cotr: false
     gettable: true
     grc:

--- a/blocklib/blocks/nop_source/nop_source.yml
+++ b/blocklib/blocks/nop_source/nop_source.yml
@@ -7,12 +7,12 @@ category: '[Core]/Debug Tools'
 parameters:
 -   id: nports
     label: Num. Ports
-    dtype: size_t
+    dtype: size
     default: 1
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/blocks/null_sink/null_sink.yml
+++ b/blocklib/blocks/null_sink/null_sink.yml
@@ -7,12 +7,12 @@ category: '[Core]/Misc'
 parameters:
 -   id: nports
     label: Num. Ports
-    dtype: size_t
+    dtype: size
     default: 1
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/blocks/null_source/null_source.yml
+++ b/blocklib/blocks/null_source/null_source.yml
@@ -7,12 +7,12 @@ category: '[Core]/Misc'
 parameters:
 -   id: nports
     label: Num. Ports
-    dtype: size_t
+    dtype: size
     default: 1
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/blocks/tags_strobe/tags_strobe.yml
+++ b/blocklib/blocks/tags_strobe/tags_strobe.yml
@@ -10,13 +10,13 @@ parameters:
     dtype: pmtf::pmt
 -   id: nsamps
     label: "Num Samps"
-    dtype: size_t
+    dtype: size
 -   id: key
     label: "Key"
-    dtype: std::string
+    dtype: string
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/blocks/vector_sink/vector_sink.yml
+++ b/blocklib/blocks/vector_sink/vector_sink.yml
@@ -17,13 +17,13 @@ typekeys:
 parameters:
   - id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
     gettable: true
     default: 1
   - id: reserve_items
     label: Reserve Items
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1024
   - id: data

--- a/blocklib/blocks/vector_source/vector_source.yml
+++ b/blocklib/blocks/vector_source/vector_source.yml
@@ -29,7 +29,7 @@ parameters:
     default: 'false'
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 -   id: tags

--- a/blocklib/fft/fft/fft.yml
+++ b/blocklib/fft/fft/fft.yml
@@ -21,11 +21,11 @@ typekeys:
 parameters:
 -   id: fft_size
     label: FFT Size
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: window
     label: Window
-    dtype: float
+    dtype: rf32
     container: vector
     settable: false
 -   id: shift

--- a/blocklib/fileio/file_sink/file_sink.yml
+++ b/blocklib/fileio/file_sink/file_sink.yml
@@ -7,11 +7,11 @@ category: '[Core]/File Operators'
 parameters:
 -   id: filename
     label: Filename
-    dtype: std::string
+    dtype: string
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
 -   id: append

--- a/blocklib/fileio/file_source/file_source.yml
+++ b/blocklib/fileio/file_source/file_source.yml
@@ -7,7 +7,7 @@ category: '[Core]/File Operators'
 parameters:
 -   id: filename
     label: File Name
-    dtype: std::string
+    dtype: string
     settable: false
 -   id: repeat
     label: Repeat
@@ -16,17 +16,17 @@ parameters:
     default: 'false'
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
 -   id: offset
     label: Offset
-    dtype: uint64_t
+    dtype: ru64
     settable: false
     default: 0
 -   id: len
     label: Length
-    dtype: uint64_t
+    dtype: ru64
     settable: false
     default: 0
 
@@ -42,7 +42,7 @@ callbacks:
     return: bool
     args:
     - id: seek_point
-      dtype: int64_t
+      dtype: ri64
     - id: whence
       dtype: int
 

--- a/blocklib/filter/fir_filter/fir_filter.yml
+++ b/blocklib/filter/fir_filter/fir_filter.yml
@@ -42,7 +42,7 @@ type_inst:
 parameters:
 -   id: decimation
     label: Decimation
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: taps
     label: Taps

--- a/blocklib/filter/moving_average/moving_average.yml
+++ b/blocklib/filter/moving_average/moving_average.yml
@@ -14,7 +14,7 @@ typekeys:
 parameters:
 -   id: length
     label: Length
-    dtype: size_t
+    dtype: size
     settable: true
 -   id: scale
     label: Scale
@@ -22,12 +22,12 @@ parameters:
     settable: true
 -   id: max_iter
     label: Max Iter
-    dtype: size_t
+    dtype: size
     settable: false
     default: 4096
 -   id: vlen
     label: Vector Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/blocklib/filter/pfb_arb_resampler/pfb_arb_resampler.yml
+++ b/blocklib/filter/pfb_arb_resampler/pfb_arb_resampler.yml
@@ -32,7 +32,7 @@ type_inst:
 parameters:
 -   id: rate
     label: Rate
-    dtype: float
+    dtype: rf32
     settable: true
 -   id: taps
     label: Taps
@@ -41,7 +41,7 @@ parameters:
     settable: true
 -   id: filter_size
     label: Filter Size
-    dtype: float
+    dtype: rf32
     settable: false
     default: 32
 
@@ -66,9 +66,9 @@ callbacks:
     return: size_t
     args:
     - id: freq
-      dtype: float
+      dtype: rf32
     - id: fs
-      dtype: float
+      dtype: rf32
     const: true
 
 

--- a/blocklib/filter/pfb_channelizer/pfb_channelizer.yml
+++ b/blocklib/filter/pfb_channelizer/pfb_channelizer.yml
@@ -15,16 +15,16 @@ typekeys:
 parameters:
 -   id: numchans
     label: Number of Channels
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: taps
     label: Filter Taps
-    dtype: float
+    dtype: rf32
     container: vector
     settable: false
 -   id: oversample_rate
     label: Oversample Rate
-    dtype: float
+    dtype: rf32
     settable: false
 
 ports:

--- a/blocklib/math/add/add.yml
+++ b/blocklib/math/add/add.yml
@@ -16,14 +16,14 @@ typekeys:
 parameters:
 -   id: nports
     label: Num Ports
-    dtype: size_t
+    dtype: size
     default: 2
     grc:
       default: 2
       hide: part
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     default: 1
 
 ports:

--- a/blocklib/math/complex_to_mag/complex_to_mag.yml
+++ b/blocklib/math/complex_to_mag/complex_to_mag.yml
@@ -7,7 +7,7 @@ category: '[Core]/Math Operators'
 parameters:
 -   id: vlen
     label: Vector Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/blocklib/math/complex_to_mag_squared/complex_to_mag_squared.yml
+++ b/blocklib/math/complex_to_mag_squared/complex_to_mag_squared.yml
@@ -7,7 +7,7 @@ category: '[Core]/Math Operators'
 parameters:
 -   id: vlen
     label: Vector Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/blocklib/math/divide/divide.yml
+++ b/blocklib/math/divide/divide.yml
@@ -16,12 +16,12 @@ typekeys:
 parameters:
 -   id: num_inputs
     label: Number of Inputs
-    dtype: size_t
+    dtype: size
     settable: false
     default: 2 
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/blocklib/math/multiply/multiply.yml
+++ b/blocklib/math/multiply/multiply.yml
@@ -16,12 +16,12 @@ typekeys:
 parameters:
 -   id: num_inputs
     label: Number of Inputs
-    dtype: size_t
+    dtype: size
     settable: false
     default: 2
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/blocklib/math/multiply_const/multiply_const.yml
+++ b/blocklib/math/multiply_const/multiply_const.yml
@@ -20,7 +20,7 @@ parameters:
     settable: true
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/blocklib/streamops/annotator/annotator.yml
+++ b/blocklib/streamops/annotator/annotator.yml
@@ -11,15 +11,15 @@ category: '[Core]/Debug Tools'
 parameters:
 -   id: when
     label: When
-    dtype: uint64_t
+    dtype: ru64
     settable: false
 -   id: num_inputs
     label: Num Inputs
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: num_outputs
     label: Num Outputs
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: tpp
     label: Tag Propagation Policy
@@ -28,7 +28,7 @@ parameters:
     serializable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/copy/copy.yml
+++ b/blocklib/streamops/copy/copy.yml
@@ -13,7 +13,7 @@ doc:
 parameters:
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
       grc:

--- a/blocklib/streamops/deinterleave/deinterleave.yml
+++ b/blocklib/streamops/deinterleave/deinterleave.yml
@@ -32,18 +32,18 @@ doc:
 parameters:
 -   id: nstreams
     label: Num Streams
-    dtype: size_t
+    dtype: size
     settable: false
     grc:
         default: 2
 -   id: blocksize
     label: Block Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/delay/delay.yml
+++ b/blocklib/streamops/delay/delay.yml
@@ -7,11 +7,11 @@ category: '[Core]/Misc'
 parameters:
 -   id: dly
     label: Delay
-    dtype: size_t
+    dtype: size
     settable: true
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/head/head.yml
+++ b/blocklib/streamops/head/head.yml
@@ -7,11 +7,11 @@ category: '[Core]/Misc'
 parameters:
 -   id: nitems
     label: Num. Items
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/interleave/interleave.yml
+++ b/blocklib/streamops/interleave/interleave.yml
@@ -33,18 +33,18 @@ doc:
 parameters:
 -   id: nstreams
     label: Num Streams
-    dtype: size_t
+    dtype: size
     settable: false
     grc:
         default: 2
 -   id: blocksize
     label: Block Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex.yml
+++ b/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex.yml
@@ -12,7 +12,7 @@ parameters:
     default: 'false'
 -   id: scale_factor
     label: Scale Factor
-    dtype: float
+    dtype: rf32
     settable: true
     default: 1.0
 

--- a/blocklib/streamops/keep_m_in_n/keep_m_in_n.yml
+++ b/blocklib/streamops/keep_m_in_n/keep_m_in_n.yml
@@ -8,25 +8,25 @@ category: '[Core]/Stream Operators'
 parameters:
 -   id: m
     label: M
-    dtype: size_t
+    dtype: size
     settable: true
     grc:
       default: 1
 -   id: n
     label: N
-    dtype: size_t
+    dtype: size
     settable: true
     grc:
       default: 2
 -   id: offset
     label: offset
-    dtype: size_t
+    dtype: size
     settable: true
     grc:
       default: 0
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/load/load.yml
+++ b/blocklib/streamops/load/load.yml
@@ -7,14 +7,14 @@ category: '[Core]/Debug Tools'
 parameters:
 -   id: iterations
     label: Iterations (Load)
-    dtype: size_t
+    dtype: size
 -   id: use_cb
     label: Use Custom Buffers
     dtype: bool
     default: 'true'
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/nop/nop.yml
+++ b/blocklib/streamops/nop/nop.yml
@@ -7,7 +7,7 @@ category: '[Core]/Debug Tools'
 parameters:
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/nop_head/nop_head.yml
+++ b/blocklib/streamops/nop_head/nop_head.yml
@@ -7,11 +7,11 @@ category: '[Core]/Debug Tools'
 parameters:
 -   id: nitems
     label: Num. Items
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/probe_signal_v/probe_signal_v.yml
+++ b/blocklib/streamops/probe_signal_v/probe_signal_v.yml
@@ -20,7 +20,7 @@ typekeys:
 parameters:
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: level
     label: Constant

--- a/blocklib/streamops/selector/selector.yml
+++ b/blocklib/streamops/selector/selector.yml
@@ -7,33 +7,33 @@ category: '[Core]/Misc'
 parameters:
 -   id: num_inputs
     label: Num Inputs
-    dtype: size_t
+    dtype: size
     settable: false
     grc:
         hide: part
         default: 2
 -   id: num_outputs
     label: Num Outputs
-    dtype: size_t
+    dtype: size
     settable: false
     grc:
         hide: part
         default: 2
 -   id: input_index
     label: Input Index
-    dtype: size_t
+    dtype: size
     settable: true
     grc:
         default: 0
 -   id: output_index
     label: Output Index
-    dtype: size_t
+    dtype: size
     settable: true
     grc:
         default: 0
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/stream_to_streams/stream_to_streams.yml
+++ b/blocklib/streamops/stream_to_streams/stream_to_streams.yml
@@ -7,11 +7,11 @@ category: '[Core]/Stream Operators'
 parameters:
 -   id: nstreams
     label: Number of Streams
-    dtype: size_t
+    dtype: size
     settable: false
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/streamops/throttle/throttle.yml
+++ b/blocklib/streamops/throttle/throttle.yml
@@ -7,7 +7,7 @@ category: '[Core]/Misc'
 parameters:
 -   id: samples_per_sec
     label: Samples Per Second
-    dtype: double
+    dtype: rf64
     settable: false
     grc:
         default: samp_rate
@@ -18,7 +18,7 @@ parameters:
     default: 'true'
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/blocklib/zeromq/pub_sink/pub_sink.yml
+++ b/blocklib/zeromq/pub_sink/pub_sink.yml
@@ -8,7 +8,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout
@@ -27,12 +27,12 @@ parameters:
       default: -1
     - id: key
       label: Key
-      dtype: std::string
+      dtype: string
       settable: false
       default: "\"\""
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
 

--- a/blocklib/zeromq/pull_msg_source/pull_msg_source.yml
+++ b/blocklib/zeromq/pull_msg_source/pull_msg_source.yml
@@ -7,7 +7,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout

--- a/blocklib/zeromq/pull_source/pull_source.yml
+++ b/blocklib/zeromq/pull_source/pull_source.yml
@@ -8,7 +8,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout
@@ -27,7 +27,7 @@ parameters:
       default: -1
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
 ports:

--- a/blocklib/zeromq/push_msg_sink/push_msg_sink.yml
+++ b/blocklib/zeromq/push_msg_sink/push_msg_sink.yml
@@ -8,7 +8,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout

--- a/blocklib/zeromq/push_sink/push_sink.yml
+++ b/blocklib/zeromq/push_sink/push_sink.yml
@@ -10,7 +10,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout
@@ -29,7 +29,7 @@ parameters:
       default: -1
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
 callbacks:

--- a/blocklib/zeromq/rep_sink/rep_sink.yml
+++ b/blocklib/zeromq/rep_sink/rep_sink.yml
@@ -10,7 +10,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout
@@ -29,7 +29,7 @@ parameters:
       default: -1
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
 callbacks:

--- a/blocklib/zeromq/req_source/req_source.yml
+++ b/blocklib/zeromq/req_source/req_source.yml
@@ -8,7 +8,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout
@@ -27,7 +27,7 @@ parameters:
       default: -1
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
 ports:

--- a/blocklib/zeromq/sub_source/sub_source.yml
+++ b/blocklib/zeromq/sub_source/sub_source.yml
@@ -8,7 +8,7 @@ category: '[Core]/ZeroMQ Interfaces'
 parameters:
     - id: address
       label: IP Address
-      dtype: std::string
+      dtype: string
       settable: false
     - id: timeout
       label: Timeout
@@ -27,12 +27,12 @@ parameters:
       default: -1
     - id: key
       label: Key
-      dtype: std::string
+      dtype: string
       settable: false
       default: "\"\""
     - id: itemsize
       label: Item Size
-      dtype: size_t
+      dtype: size
       settable: false
       default: 0
       

--- a/utils/blockbuilder/scripts/filters.py
+++ b/utils/blockbuilder/scripts/filters.py
@@ -33,13 +33,17 @@ def get_linked_value(value):
             newvalue = 'args.' + newvalue
     return newvalue
 
-def cpp_type(input):
+def cpp_type(input, vec=False):
     if is_list(input):
         input = input[0]
     if input in type_lookup:
-        return type_lookup[input][0]
+        x = type_lookup[input][0]
     else:
-        return get_linked_value(input)
+        x = get_linked_value(input)
+    
+    if (vec):
+        return f'std::vector<{x}>'
+    return x
 
 def py_type(input):
     if input in type_lookup:

--- a/utils/blockbuilder/scripts/filters.py
+++ b/utils/blockbuilder/scripts/filters.py
@@ -1,0 +1,56 @@
+# Custom filters for Jinja2 templates
+
+# cpp, python, grc 
+type_lookup = {
+    'cf64': ['std::complex<double>', 'complex', 'complex'],
+    'cf32': ['std::complex<float>', 'complex', 'complex'],
+    'rf64': ['double', 'float', 'real'],
+    'rf32': ['float', 'float', 'real'],
+    'ri64': ['int64_t', 'int', 'int'],
+    'ri32': ['int32_t', 'int', 'int'],
+    'ri16': ['int16_t', 'int', 'short'],
+    'ri8': ['int8_t', 'int', 'byte'],
+    'ru64': ['uint64_t', 'int', 'int'],
+    'ru32': ['uint32_t', 'int', 'int'],
+    'ru16': ['uint16_t', 'int', 'short'],
+    'ru8': ['uint8_t', 'int', 'byte'],
+    'size': ['size_t', 'int', 'int'],
+    'string': ['std::string', 'str', 'string'],
+    'bool': ['bool', 'bool', 'bool'],
+}
+
+def is_list(value):
+    return isinstance(value, list)
+
+# Parses on '/' and returns the second part
+def get_linked_value(value):
+    newvalue = value
+    if '/' in value:
+        list1 = value.split('/')
+        category = list1[0]
+        newvalue = list1[1]
+        if category == 'parameters':
+            newvalue = 'args.' + newvalue
+    return newvalue
+
+def cpp_type(input):
+    if is_list(input):
+        input = input[0]
+    if input in type_lookup:
+        return type_lookup[input][0]
+    else:
+        return get_linked_value(input)
+
+def py_type(input):
+    if input in type_lookup:
+        return type_lookup[input][1]
+    else:
+        return input
+
+def custom_filters():
+    return {
+        'is_list': is_list,
+        'cpp_type': cpp_type,
+        'py_type': py_type,
+        'get_linked_value': get_linked_value,
+    }

--- a/utils/blockbuilder/scripts/filters.py
+++ b/utils/blockbuilder/scripts/filters.py
@@ -4,8 +4,8 @@
 type_lookup = {
     'cf64': ['std::complex<double>', 'complex', 'complex'],
     'cf32': ['std::complex<float>', 'complex', 'complex'],
-    'rf64': ['double', 'float', 'real'],
-    'rf32': ['float', 'float', 'real'],
+    'rf64': ['double', 'float', 'float'],
+    'rf32': ['float', 'float', 'float'],
     'ri64': ['int64_t', 'int', 'int'],
     'ri32': ['int32_t', 'int', 'int'],
     'ri16': ['int16_t', 'int', 'short'],
@@ -22,8 +22,18 @@ type_lookup = {
 def is_list(value):
     return isinstance(value, list)
 
+def is_numeric(value):
+    return type(value) is int or type(value) is float or type(value) is complex
+
 # Parses on '/' and returns the second part
 def get_linked_value(value):
+    newvalue = value
+    if '/' in value:
+        list1 = value.split('/')
+        newvalue = list1[1]
+    return newvalue
+
+def get_linked_value_with_args(value):
     newvalue = value
     if '/' in value:
         list1 = value.split('/')
@@ -40,9 +50,35 @@ def cpp_type(input, vec=False):
         x = type_lookup[input][0]
     else:
         x = get_linked_value(input)
-    
+        if input.startswith('parameters/'):
+            x = 'args.' + x
+
     if (vec):
         return f'std::vector<{x}>'
+    return x
+
+def grc_type(input, vec=False, ref=False):
+    if is_list(input):
+        input = input[0]
+    try:
+        if is_numeric(eval(input)):
+            return input
+    except:
+        pass
+    
+    if input.startswith('enums/'):
+        return 'enum'
+    
+    if input in type_lookup:
+        x = type_lookup[input][2]
+    else:
+        x = get_linked_value(input)
+        if (ref):
+            x = f'${{{x}}}'
+        
+    if (vec):
+        return f'{x}_vector'
+
     return x
 
 def py_type(input):
@@ -55,6 +91,8 @@ def custom_filters():
     return {
         'is_list': is_list,
         'cpp_type': cpp_type,
+        'grc_type': grc_type,
         'py_type': py_type,
         'get_linked_value': get_linked_value,
+        'get_linked_value_with_args': get_linked_value_with_args,
     }

--- a/utils/blockbuilder/scripts/gen_pyshell.py
+++ b/utils/blockbuilder/scripts/gen_pyshell.py
@@ -3,9 +3,7 @@ import os
 import yaml
 import argparse
 import shutil
-
-def is_list(value):
-    return isinstance(value, list)
+import filters
 
 def argParse():
     """Parses commandline args."""
@@ -33,7 +31,7 @@ def main():
     paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','templates'))
     paths.append(os.path.dirname(os.path.realpath(args.yaml_file)))
     env = Environment(loader = FileSystemLoader(paths))
-    env.filters['is_list'] = is_list
+    env.filters.update(filters.custom_filters())
     
     blockname = os.path.basename(os.path.dirname(os.path.realpath(args.yaml_file)))
     

--- a/utils/blockbuilder/scripts/process_folder.py
+++ b/utils/blockbuilder/scripts/process_folder.py
@@ -7,6 +7,7 @@ import json
 import jsonschema
 from jsonschema import validate
 import jsonschema_default
+import filters
 
 def argParse():
     """Parses commandline args."""
@@ -22,10 +23,6 @@ def argParse():
     parser.add_argument("--build_dir")
 
     return parser.parse_args()
-
-def is_list(value):
-    return isinstance(value, list)
-
 
 def validate_json(d, schema):
     try:
@@ -53,7 +50,7 @@ def main():
     paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','templates'))
     paths.append(os.path.dirname(os.path.realpath(args.yaml_file)))
     env = Environment(loader = FileSystemLoader(paths))
-    env.filters['is_list'] = is_list
+    env.filters.update(filters.custom_filters())
 
     
     blockname = os.path.basename(os.path.dirname(os.path.realpath(args.yaml_file)))

--- a/utils/blockbuilder/scripts/process_gen_impl.py
+++ b/utils/blockbuilder/scripts/process_gen_impl.py
@@ -2,10 +2,7 @@ from jinja2 import Template, FileSystemLoader, DictLoader, Environment
 import os
 import yaml
 import argparse
-import shutil
-
-def is_list(value):
-    return isinstance(value, list)
+import filters
     
 def argParse():
     """Parses commandline args."""
@@ -32,7 +29,7 @@ def main():
     paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','templates'))
     paths.append(os.path.dirname(os.path.realpath(args.yaml_file)))
     env = Environment(loader = FileSystemLoader(paths))
-    env.filters['is_list'] = is_list
+    env.filters.update(filters.custom_filters())
     
     blockname = os.path.basename(os.path.dirname(os.path.realpath(args.yaml_file)))
     

--- a/utils/blockbuilder/scripts/process_module_enums.py
+++ b/utils/blockbuilder/scripts/process_module_enums.py
@@ -3,6 +3,7 @@ import os
 import argparse
 import yaml
 import shutil
+import filters
 
 def argParse():
     """Parses commandline args."""
@@ -24,6 +25,7 @@ def main():
     paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','templates'))
     paths.append(os.path.dirname(os.path.realpath(args.yaml_file)))
     env = Environment(loader = FileSystemLoader(paths))
+    env.filters.update(filters.custom_filters())
 
     with open(args.yaml_file) as file:
         d = yaml.load(file, Loader=yaml.FullLoader)

--- a/utils/blockbuilder/templates/blockname.cc.j2
+++ b/utils/blockbuilder/templates/blockname.cc.j2
@@ -42,7 +42,7 @@ namespace {{module}} {
 
     {% for p in parameters -%}
     {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
-    args.{{p['id']}} = pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}}>(pmtf::pmt::from_base64(json_obj["{{p['id']}}"].get<std::string>()));
+    args.{{p['id']}} = pmtf::get_as<{{ p['dtype']|cpp_type(vec=p['container']=='vector')}}>(pmtf::pmt::from_base64(json_obj["{{p['id']}}"].get<std::string>()));
     {% endif %}
     {% endfor -%}
 
@@ -67,7 +67,7 @@ void {{block}}::set_{{p['id']}}({{p['dtype']|cpp_type}} {{p['id']}})
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
 {{p['dtype']|cpp_type}} {{block}}::{{p['id']}}()
 {
-    return pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}}>(request_parameter_query(params::id_{{p['id']}}));
+    return pmtf::get_as<{{ p['dtype']|cpp_type(vec=p['container']=='vector')}}>(request_parameter_query(params::id_{{p['id']}}));
 }
 {% endif %}
 {% endfor -%}

--- a/utils/blockbuilder/templates/blockname.cc.j2
+++ b/utils/blockbuilder/templates/blockname.cc.j2
@@ -42,7 +42,7 @@ namespace {{module}} {
 
     {% for p in parameters -%}
     {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
-    args.{{p['id']}} = pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}}>(pmtf::pmt::from_base64(json_obj["{{p['id']}}"].get<std::string>()));
+    args.{{p['id']}} = pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}}>(pmtf::pmt::from_base64(json_obj["{{p['id']}}"].get<std::string>()));
     {% endif %}
     {% endfor -%}
 
@@ -59,15 +59,15 @@ namespace {{module}} {
 {% if parameters %}
 {% for p in parameters -%}
 {% if p['settable']%}
-void {{block}}::set_{{p['id']}}({{p['dtype']}} {{p['id']}})
+void {{block}}::set_{{p['id']}}({{p['dtype']|cpp_type}} {{p['id']}})
 {
     return request_parameter_change(params::id_{{p['id']}},{{p['id']}});
 }
 {% endif -%}
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
-{{p['dtype']}} {{block}}::{{p['id']}}()
+{{p['dtype']|cpp_type}} {{block}}::{{p['id']}}()
 {
-    return pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}}>(request_parameter_query(params::id_{{p['id']}}));
+    return pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}}>(request_parameter_query(params::id_{{p['id']}}));
 }
 {% endif %}
 {% endfor -%}

--- a/utils/blockbuilder/templates/blockname.grc.j2
+++ b/utils/blockbuilder/templates/blockname.grc.j2
@@ -1,26 +1,4 @@
 {% import 'macros.j2' as macros -%}
-{%- macro type_lookup(type, default) -%}
-{%- if type | is_list() -%}{% set type = type[0] -%}{%- endif -%}{%- if default | is_list() -%}{% set default = default[0] -%}{%- endif -%}
-{%- if type in ['ri32','ru32', 'uint32_t', 'int32_t', 'size_t',  'unsigned', 'unsigned int', 'long', 'unsigned long', 'long long', 'unsigned long long']  -%}int
-{%- elif type in ['ri16','ru16','short', 'unsigned short', 'uint16_t', 'int16_t'] -%}short
-{%- elif type in ['ri8','ru8','uint8_t', 'int8_t', 'byte', 'char', 'unsigned char'] -%}byte
-{%- elif type in ['cf64','cf32','std::complex<float>', 'gr_complex'] -%}complex
-{%- elif type in ['rf64','rf32','float'] -%}float
-{%- elif type in ['const char *', 'const std::string&'] -%}string
-{%- elif type in ['bool'] -%}bool
-{%- elif type in ['gui_hint'] -%}gui_hint
-{%- elif type.startswith('enums/') %}enum
-{%- else -%}{{default}}{%-endif-%}
-{%- endmacro -%}
-{%- macro vec_type_lookup(type, default) -%}
-{%- if type | is_list() -%}{% set type = type[0] -%}{%- endif -%}{%- if default | is_list() -%}{% set default = default[0] -%}{%- endif -%}
-{%- if type in ['ri32','ru32','int', 'uint32_t', 'int32_t', 'size_t',  'unsigned', 'unsigned int', 'long', 'unsigned long', 'long long', 'unsigned long long']  -%}int_vector
-{%- elif type in ['ri16','ru16','short', 'unsigned short', 'uint16_t', 'int16_t'] -%}int_vector
-{%- elif type in ['ri8','ru8','uint8_t', 'int8_t', 'byte', 'char', 'unsigned char'] -%}int_vector
-{%- elif type in ['cf64','cf32','std::complex<float>', 'gr_complex'] -%}complex_vector
-{%- elif type in ['rf64','rf32','float'] -%}float_vector
-{%- else -%}{{default}}{%-endif-%}
-{%- endmacro -%}
 {% macro get_linked_value(value, ports, parameters, typekeys) -%}
     {% set newvalue = value -%}
     {% if '/' in value | string() -%}
@@ -54,14 +32,14 @@ parameters:
     option_labels: [{% for opt in type_inst %}{{opt['label']}}{{"," if not loop.last}} {% endfor %}]
     option_attributes:
     {%-for key in typekeys%} {% set outer_loop = loop %}
-        {{key['id']}}: [{% for typev in type_inst %}{{type_lookup(typev['value'][outer_loop.index0])}},{%endfor%}]
+        {{key['id']}}: [{% for typev in type_inst %}{{typev['value'][outer_loop.index0]|grc_type}},{%endfor%}]
     {%-endfor-%}
 {% else %}
 {% for key in typekeys -%}
 -   id: {{key['id']}}
     label: {% if 'label' in key %}{{key['label']}}{% else %}IO Type{% endif %}
     dtype: enum
-    options: [{% for opt in key['options'] %}{{type_lookup(opt,opt)}}{{"," if not loop.last}} {% endfor %}]
+    options: [{% for opt in key['options'] %}{{opt|grc_type}}{{"," if not loop.last}} {% endfor %}]
     option_attributes:
         fcn: [{% for opt in key['options'] %}{{macros.typekey_suffix(opt,key['id'],ports)}}{{"," if not loop.last}} {% endfor %}]
     hide: part
@@ -72,7 +50,7 @@ parameters:
 {% if 'grc' not in param or 'hide' not in param['grc'] or ('hide' in param['grc'] and param['grc']['hide'] != 'all') -%}
 -   id: {{param['id']}}
     label: {{param['label']}}
-    dtype: {{type_lookup(param['dtype'],'raw') if 'container' not in param or param['container'] == 'scalar' else vec_type_lookup(param['dtype'],'raw')}}
+    dtype: {{param['dtype']|grc_type(ref=True,vec=param['container']=='vector')}}
     {%if 'is_enum' in param and param['is_enum'] %}
     options: [{%for k1,enum_type in module_enums.items() %}{% if param['dtype'].endswith(k1) %}{% for val in enum_type['enumerators']%} {{module}}.{{k1}}.{{val['id']}}{{',' if not loop.last}}{%endfor%}{%endif%}{%endfor%}]
     option_labels: [{%for k1,enum_type in module_enums.items() %}{% if param['dtype'].endswith(k1) %}{% for val in enum_type['enumerators']%}{{val['label'] if 'label' in val else val['id'] | upper}}{{',' if not loop.last}}{%endfor%}{%endif%}{%endfor%}]
@@ -84,7 +62,7 @@ parameters:
 {% for param in grc['parameters'] -%}
 -   id: {{param['id']}}
     label: {{param['label']}}
-    dtype: {{param['dtype']}}
+    dtype: {{param['dtype']|grc_type}}
     {% if 'default' in param %}default: {{param['default']}}{%endif%}
     {% if 'hide' in param %}hide: {{param['hide']}}{%endif%}
 {% endfor -%}
@@ -111,12 +89,12 @@ inputs:
 {% for port in ports -%}{%- if port['direction'] == 'input'%}
 -   domain: {{'${impl.domain}' if port['domain'] == 'stream' else port['domain']}}
 {% if type_inst %}
-    dtype: ${ type_inst.{{type_lookup(get_linked_value2(port['type']),get_linked_value2(port['type']))}} }
+    dtype: ${ type_inst.{{port['type']|grc_type}} }
 {% else %}
-    dtype: {{type_lookup(get_linked_value(port['type']),get_linked_value(port['type']))}}
+    dtype: {{port['type']|grc_type(ref=True)}}
 {% endif %}
-    {%if 'shape' in port %}vlen: {{get_linked_value(port['shape'])}}{% endif %}
-    {%if 'multiplicity' in port %}multiplicity: {{get_linked_value(port['multiplicity'])}}{% endif %}
+    {%if 'shape' in port %}vlen: {{port['shape']|get_linked_value}}{% endif %}
+    {%if 'multiplicity' in port %}multiplicity: {{port['multiplicity']|grc_type(ref=True)}}{% endif %}
     label: {{port['id']}}
     optional: {{ port['optional'] if 'optional' in port else 'false' }}
 {% endif %}{% endfor %}
@@ -131,12 +109,12 @@ outputs:
 {% if port['direction'] == 'output'-%}
 -   domain: {{'${impl.domain}' if port['domain'] == 'stream' else port['domain']}}
 {% if type_inst %}
-    dtype: ${ type_inst.{{type_lookup(get_linked_value2(port['type']),get_linked_value2(port['type']))}} }
+    dtype: ${ type_inst.{{port['type']|grc_type}} }
 {% else %}
-    dtype: {{type_lookup(get_linked_value(port['type']),get_linked_value(port['type']))}}
+    dtype: {{port['type']|grc_type(ref=True)}}
 {% endif %}
     {%if 'shape' in port %}vlen: {{get_linked_value(port['shape'])}}{% endif %}
-    {%if 'multiplicity' in port %}multiplicity: {{get_linked_value(port['multiplicity'])}}{% endif %}
+    {%if 'multiplicity' in port %}multiplicity: {{port['multiplicity']|grc_type(ref=True)}}{% endif %}
     label: {{port['id']}}
     optional: {{ port['optional'] if 'optional' in port else 'false' }}
 {% endif -%}

--- a/utils/blockbuilder/templates/blockname_impl_gen.h.j2
+++ b/utils/blockbuilder/templates/blockname_impl_gen.h.j2
@@ -23,7 +23,7 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
 {%if typekeys | length == 1 -%}
 {%set key1 = typekeys|first %}
 {% for opt in key1['options'] -%}
-template class {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
+template class {{block}}<{{ opt | cpp_type }}>;
 {% endfor -%}
 {% elif typekeys | length == 2 -%}
 {%set key1 = typekeys|first %}
@@ -33,11 +33,11 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
 {% if type_inst -%}
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] -%}
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>;
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}>;
 {% endif %}
 {% endfor %}
 {% else %}
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{  macros.cpp_type_lookup(opt2)}}>;
+template class {{block}}<{{ opt1 | cpp_type}}, {{  opt2 | cpp_type}}>;
 {% endif %}
 {% endfor -%}
 {% endfor -%}
@@ -51,11 +51,11 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{  macros.cpp_type_
 {% if type_inst -%}
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] and opt3 == typev['value'][2] -%}
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}},  {{macros.cpp_type_lookup(opt3)}}>;
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}},  {{opt3 | cpp_type}}>;
 {% endif %}
 {% endfor %}
 {% else %}
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}},  {{macros.cpp_type_lookup(opt3)}}>;
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}},  {{opt3 | cpp_type}}>;
 {% endif %}
 {% endfor -%}
 {% endfor -%}
@@ -77,7 +77,7 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_l
 // Figure out a way to do this elegantly without macros or string lookups
 {% if parameters %} {% for param in parameters -%}
 {% if 'container' not in param or param['container'] == scalar %}
-#define GET_PARAM_{{param['id']|upper()}} pmtf::get_as<{{param['dtype']}}>(*this->param_{{param['id']}})
+#define GET_PARAM_{{param['id']|upper()}} pmtf::get_as<{{param['dtype']|cpp_type}}>(*this->param_{{param['id']}})
 {% elif param['container'] == 'vector' %}
 {% endif %}
 {% endfor %}

--- a/utils/blockbuilder/templates/blockname_pybind.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind.cc.j2
@@ -29,7 +29,7 @@ void bind_{{block}}(py::module& m)
     {% endfor -%}
         .export_values();
 
-    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype'] if param['container'] != 'vector' else "std::vector<" + param['dtype'] + ">"}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}::available_impl impl) {
+    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype']|cpp_type if param['container'] != 'vector' else "std::vector<" + param['dtype']|cpp_type + ">"}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}::available_impl impl) {
                        return {{block}}::make({ {% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['id'] }}{{ ", " if not loop.last }}{% endif %}{%endfor%}{% endif %} }, impl);
                    }),
         {% if parameters %} {% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}

--- a/utils/blockbuilder/templates/blockname_pybind.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind.cc.j2
@@ -29,7 +29,7 @@ void bind_{{block}}(py::module& m)
     {% endfor -%}
         .export_values();
 
-    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype']|cpp_type if param['container'] != 'vector' else "std::vector<" + param['dtype']|cpp_type + ">"}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}::available_impl impl) {
+    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype']|cpp_type(vec=param['container']=='vector')}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}::available_impl impl) {
                        return {{block}}::make({ {% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['id'] }}{{ ", " if not loop.last }}{% endif %}{%endfor%}{% endif %} }, impl);
                    }),
         {% if parameters %} {% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}

--- a/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
@@ -32,7 +32,7 @@ void bind_{{ block }}_template(py::module& m, const char* classname)
         //.value("base", ::gr::{{module}}::{{block}}<{{typestr}}>::available_impl::BASE ) 
         .export_values();
 
-    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ macros.get_linked_value(param['dtype']) if param['container'] != 'vector' else "std::vector<" + param['dtype'] + ">"}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}<{{typestr}}>::available_impl impl) {
+    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype']|cpp_type if param['container'] != 'vector' else "std::vector<" + param['dtype']|cpp_type + ">"}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}<{{typestr}}>::available_impl impl) {
                        return ::gr::{{ module }}::{{block}}<{{typestr}}>::make({ {% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['id'] }}{{ ", " if not loop.last }}{% endif %}{%endfor%}{% endif %} }, impl);
                    }),
         {% if parameters %} {% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}
@@ -65,7 +65,7 @@ void bind_{{ block }}(py::module& m)
 {%if typekeys | length == 1 -%}
 {%set key1 = typekeys|first %}
 {% for opt in key1['options'] -%}
-    bind_{{ block }}_template<{{  macros.cpp_type_lookup(opt) }}>(m, "{{ block }}_{{macros.typekey_suffix(opt, key1['id'],ports)}}");
+    bind_{{ block }}_template<{{ opt | cpp_type }}>(m, "{{ block }}_{{macros.typekey_suffix(opt, key1['id'],ports)}}");
 {% endfor %}
 {% elif typekeys | length == 2 -%}
 {%set key1 = typekeys|first %}
@@ -75,11 +75,11 @@ void bind_{{ block }}(py::module& m)
 {% if type_inst -%}
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] -%}
-    bind_{{ block }}_template<{{  macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}");
+    bind_{{ block }}_template<{{ opt1 | cpp_type }}, {{ opt2 | cpp_type}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}");
 {% endif %}
 {% endfor %}
 {% else %}
-    bind_{{ block }}_template<{{  macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}");
+    bind_{{ block }}_template<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}");
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -93,11 +93,11 @@ void bind_{{ block }}(py::module& m)
 {% if type_inst -%}
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] and opt3 == typev['value'][2] -%}
-    bind_{{ block }}_template<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}, {{ macros.cpp_type_lookup(opt3)}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }}");
+    bind_{{ block }}_template<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}, {{ opt3 | cpp_type}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }}");
 {% endif %}
 {% endfor %}
 {% else %}
-    bind_{{ block }}_template<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}, {{ macros.cpp_type_lookup(opt3)}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }}");
+    bind_{{ block }}_template<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}, {{ opt3 | cpp_type}}>(m, "{{ block }}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }}");
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
@@ -32,7 +32,7 @@ void bind_{{ block }}_template(py::module& m, const char* classname)
         //.value("base", ::gr::{{module}}::{{block}}<{{typestr}}>::available_impl::BASE ) 
         .export_values();
 
-    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype']|cpp_type if param['container'] != 'vector' else "std::vector<" + param['dtype']|cpp_type + ">"}} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}<{{typestr}}>::available_impl impl) {
+    {{block}}_class.def(py::init([]({% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['dtype']|cpp_type(vec=param['container']=='vector') }} {{ param['id'] }},{%endif%} {%endfor%}{% endif %} typename gr::{{module}}::{{block}}<{{typestr}}>::available_impl impl) {
                        return ::gr::{{ module }}::{{block}}<{{typestr}}>::make({ {% if parameters %}{% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}{{ param['id'] }}{{ ", " if not loop.last }}{% endif %}{%endfor%}{% endif %} }, impl);
                    }),
         {% if parameters %} {% for param in parameters -%}{% if 'cotr' not in param or param['cotr']%}

--- a/utils/blockbuilder/templates/blockname_pyshell.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell.cc.j2
@@ -23,7 +23,7 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
 {%if typekeys | length == 1 -%}
 {%set key1 = typekeys|first %}
 {% for opt in key1['options'] -%}
-template class {{block}}<{{ macros.cpp_type_lookup(opt)}}>;
+template class {{block}}<{{ opt | cpp_type}}>;
 {% endfor -%}
 {% elif typekeys | length == 2 -%}
 {%set key1 = typekeys|first %}

--- a/utils/blockbuilder/templates/blockname_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_templated.cc.j2
@@ -43,7 +43,7 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
 
     {% for p in parameters -%}
     {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
-    args.{{p['id']}} = {{'('+macros.get_linked_value(p['dtype'])+')' if p['is_enum']}}pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else 'int' if p['is_enum'] else p['dtype']}}>(deserialize_param_to_pmt(json_obj["{{p['id']}}"].get<std::string>()));
+    args.{{p['id']}} = {{'('+p['dtype']|cpp_type+')' if p['is_enum']}}pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else 'int' if p['is_enum'] else p['dtype']|cpp_type}}>(deserialize_param_to_pmt(json_obj["{{p['id']}}"].get<std::string>()));
     {% endif %}
     {% endfor -%}
 
@@ -61,23 +61,23 @@ template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not 
 {% for p in parameters -%}
 {% if p['settable']%}
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
-void {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::set_{{p['id']}}({{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else macros.get_linked_value(p['dtype'])}} {{p['id']}})
+void {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::set_{{p['id']}}({{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype'] | cpp_type}} {{p['id']}})
 {
     return request_parameter_change(params::id_{{p['id']}}, {{"(int)" if p['is_enum']}}{{p['id']}});
 }
 {% endif -%}
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
-{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else macros.get_linked_value(p['dtype'])}} {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::{{p['id']}}()
+{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}} {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::{{p['id']}}()
 {
 {% if p['is_enum'] %}
 {% if 'container' in p and p['container'] == 'vector' %}
     return pmtf::get_as<{{ 'std::vector<int>' }}>(request_parameter_query(params::id_{{p['id']}}));
 {% else %}
-    return ({{macros.get_linked_value(p['dtype'])}}) pmtf::get_as<int>(request_parameter_query(params::id_{{p['id']}}));
+    return ({{p['dtype']|cpp_type}}) pmtf::get_as<int>(request_parameter_query(params::id_{{p['id']}}));
 {% endif %}
 {% else %}
-    return pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}}>(request_parameter_query(params::id_{{p['id']}}));
+    return pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}}>(request_parameter_query(params::id_{{p['id']}}));
 {% endif %}
 }
 {% endif %}
@@ -88,8 +88,8 @@ template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not 
 {% for opt in key1['options'] -%}
 
 template <>
-std::string {{block}}<{{ macros.cpp_type_lookup(opt) }}>::suffix(){ return "_{{macros.typekey_suffix(opt, key1['id'],ports)}}"; }
-template class {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
+std::string {{block}}<{{ opt | cpp_type }}>::suffix(){ return "_{{macros.typekey_suffix(opt, key1['id'],ports)}}"; }
+template class {{block}}<{{ opt | cpp_type }}>;
 {% endfor -%}
 {% elif typekeys | length == 2 -%}
 {%set key1 = typekeys|first %}
@@ -100,14 +100,14 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] -%}
 template <>
-std::string {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}"; }
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>;
+std::string {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}"; }
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}>;
 {% endif %}
 {% endfor %}
 {% else %}
 template <>
-std::string {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}"; }
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}>;
+std::string {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}"; }
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}>;
 {% endif %}
 {% endfor -%}
 {% endfor -%}
@@ -122,14 +122,14 @@ template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_l
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] and opt3 == typev['value'][2] -%}
 template <>
-std::string {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}, {{ macros.cpp_type_lookup(opt3)}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}{{macros.typekey_suffix(opt3, key3['id'],ports)}}"; }
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}, {{ macros.cpp_type_lookup(opt3)}}>;
+std::string {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}, {{ opt3 | cpp_type}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}{{macros.typekey_suffix(opt3, key3['id'],ports)}}"; }
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}, {{ opt3 | cpp_type}}>;
 {% endif -%}
 {% endfor -%}
 {% else %}
 template <>
-std::string {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}, {{ macros.cpp_type_lookup(opt3)}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}{{macros.typekey_suffix(opt3, key3['id'],ports)}}"; }
-template class {{block}}<{{ macros.cpp_type_lookup(opt1)}}, {{ macros.cpp_type_lookup(opt2)}}, {{ macros.cpp_type_lookup(opt3)}}>;
+std::string {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}, {{ opt3 | cpp_type}}>::suffix(){ return "_{{macros.typekey_suffix(opt1, key1['id'],ports)}}{{macros.typekey_suffix(opt2, key2['id'],ports)}}{{macros.typekey_suffix(opt3, key3['id'],ports)}}"; }
+template class {{block}}<{{ opt1 | cpp_type}}, {{ opt2 | cpp_type}}, {{ opt3 | cpp_type}}>;
 {% endif %}
 {% endfor -%}
 {% endfor -%}

--- a/utils/blockbuilder/templates/blockname_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_templated.cc.j2
@@ -43,7 +43,7 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
 
     {% for p in parameters -%}
     {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
-    args.{{p['id']}} = {{'('+p['dtype']|cpp_type+')' if p['is_enum']}}pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else 'int' if p['is_enum'] else p['dtype']|cpp_type}}>(deserialize_param_to_pmt(json_obj["{{p['id']}}"].get<std::string>()));
+    args.{{p['id']}} = {{'('+p['dtype']|cpp_type+')' if p['is_enum']}}pmtf::get_as<{{ 'int' if p['is_enum'] else p['dtype']|cpp_type(vec=p['container']=='vector')}}>(deserialize_param_to_pmt(json_obj["{{p['id']}}"].get<std::string>()));
     {% endif %}
     {% endfor -%}
 
@@ -61,14 +61,14 @@ template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not 
 {% for p in parameters -%}
 {% if p['settable']%}
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
-void {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::set_{{p['id']}}({{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype'] | cpp_type}} {{p['id']}})
+void {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::set_{{p['id']}}({{p['dtype'] | cpp_type(vec=p['container']=='vector')}} {{p['id']}})
 {
     return request_parameter_change(params::id_{{p['id']}}, {{"(int)" if p['is_enum']}}{{p['id']}});
 }
 {% endif -%}
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
-{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}} {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::{{p['id']}}()
+{{ p['dtype']|cpp_type(vec=p['container']=='vector')}} {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::{{p['id']}}()
 {
 {% if p['is_enum'] %}
 {% if 'container' in p and p['container'] == 'vector' %}
@@ -77,7 +77,7 @@ template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not 
     return ({{p['dtype']|cpp_type}}) pmtf::get_as<int>(request_parameter_query(params::id_{{p['id']}}));
 {% endif %}
 {% else %}
-    return pmtf::get_as<{{ 'std::vector<'+p['dtype']|cpp_type+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']|cpp_type}}>(request_parameter_query(params::id_{{p['id']}}));
+    return pmtf::get_as<{{ p['dtype']|cpp_type(vec=p['container']=='vector')}}>(request_parameter_query(params::id_{{p['id']}}));
 {% endif %}
 }
 {% endif %}

--- a/utils/blockbuilder/templates/blockname_templated.h.j2
+++ b/utils/blockbuilder/templates/blockname_templated.h.j2
@@ -39,7 +39,7 @@ protected:
 {%if typekeys | length == 1 -%}
 {%set key1 = typekeys|first %}
 {% for opt in key1['options'] -%}
-using {{block}}_{{ macros.typekey_suffix(opt, key1['id'],ports) }} = {{block}}<{{ macros.cpp_type_lookup(opt) }}>;
+using {{block}}_{{ macros.typekey_suffix(opt, key1['id'],ports) }} = {{block}}<{{ opt | cpp_type }}>;
 {% endfor -%}
 {% elif typekeys | length == 2 -%}
 {%set key1 = typekeys|first %}
@@ -49,11 +49,11 @@ using {{block}}_{{ macros.typekey_suffix(opt, key1['id'],ports) }} = {{block}}<{
 {% if type_inst -%}
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] -%}
-using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }} = {{block}}<{{ macros.cpp_type_lookup(opt1)+ ", " + macros.cpp_type_lookup(opt2)}}>;
+using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }} = {{block}}<{{ opt1 | cpp_type+ ", " + opt2 | cpp_type}}>;
 {% endif -%}
 {% endfor -%}
 {% else -%}
-using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }} = {{block}}<{{ macros.cpp_type_lookup(opt1)+ ", " + macros.cpp_type_lookup(opt2)}}>;
+using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }} = {{block}}<{{ opt1 | cpp_type+ ", " + opt2 | cpp_type}}>;
 {% endif -%}
 {% endfor -%}
 {% endfor -%}
@@ -67,11 +67,11 @@ using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typ
 {% if type_inst -%}
 {% for typev in type_inst -%}
 {% if opt1 == typev['value'][0] and opt2 == typev['value'][1] and opt3 == typev['value'][2] -%}
-using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }} = {{block}}<{{ macros.cpp_type_lookup(opt1)+ ", " + macros.cpp_type_lookup(opt2)+ ", " + macros.cpp_type_lookup(opt3)}}>;
+using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }} = {{block}}<{{ opt1 | cpp_type+ ", " + opt2 | cpp_type+ ", " + opt3 | cpp_type}}>;
 {% endif %}
 {% endfor %}
 {%else %}
-using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }} = {{block}}<{{ macros.cpp_type_lookup(opt1)+ ", " + macros.cpp_type_lookup(opt2)+ ", " + macros.cpp_type_lookup(opt3)}}>;
+using {{block}}_{{ macros.typekey_suffix(opt1, key1['id'],ports) }}{{ macros.typekey_suffix(opt2, key2['id'],ports) }}{{ macros.typekey_suffix(opt3, key3['id'],ports) }} = {{block}}<{{ opt1 | cpp_type+ ", " + opt2 | cpp_type+ ", " + opt3 | cpp_type}}>;
 {% endif %}
 {% endfor -%}
 {% endfor -%}

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -34,11 +34,7 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
 {% macro block_args(parameters) -%}
     struct block_args {
         {% if parameters %} {% for param in parameters -%}{% if 'cotr' not in param or param['cotr'] == true %}
-        {% if param['container'] == 'vector' -%}
-        std::vector<{{ param['dtype']|cpp_type }}> {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
-        {% else %}
-        {{param['dtype']|cpp_type }} {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
-        {% endif %}
+        {{param['dtype']|cpp_type(vec=param['container']=='vector') }} {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
         {% endif %}{% endfor -%}{% endif %}};
 {% endmacro %}
 
@@ -130,20 +126,11 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
 {% if parameters -%}
 public:
     {% for p in parameters -%}
-        {% if p['container'] == 'vector' -%}
-            {% if p['settable']%}
-    virtual void set_{{p['id']}}(std::vector<{{p['dtype']|cpp_type}}> {{p['id']}}); 
-            {% endif -%}
-            {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
-    virtual std::vector<{{p['dtype']|cpp_type}}> {{p['id']}}();
-            {% endif -%}
-        {% else -%}
-            {% if p['settable']%}
-    virtual void set_{{p['id']}}({{p['dtype']|cpp_type}} {{p['id']}}); 
-            {% endif -%}
-            {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
-    virtual {{p['dtype']|cpp_type}} {{p['id']}}();
-            {% endif -%}
+        {% if p['settable']%}
+    virtual void set_{{p['id']}}({{p['dtype']|cpp_type(vec=p['container']=='vector')}} {{p['id']}}); 
+        {% endif -%}
+        {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
+    virtual {{p['dtype']|cpp_type(vec=p['container']=='vector')}} {{p['id']}}();
         {% endif -%}
     {% endfor -%}
 protected:

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -31,30 +31,13 @@
 class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ inherits }}#}
 {% endmacro %}
 
-{% macro get_linked_value(value, ports, parameters, typekeys, enums) -%}
-    {% set newvalue = value -%}
-    {% if '/' in value | string() -%}
-    {% set list1 = value.split('/') -%}
-    {% set category = list1[0] -%}
-        {% if category == 'ports' -%}
-            {% set newvalue = list1[1] -%}
-        {% elif category == 'parameters' -%}
-            {% set newvalue = 'args.' + list1[1] -%}
-        {% elif category == 'typekeys' -%}
-            {% set newvalue = list1[1] -%}
-        {% elif category == 'enums' -%}
-            {% set newvalue = list1[1] -%}
-        {% endif -%}
-    {% endif -%}
-{{newvalue}}{% endmacro -%}
-
 {% macro block_args(parameters) -%}
     struct block_args {
         {% if parameters %} {% for param in parameters -%}{% if 'cotr' not in param or param['cotr'] == true %}
         {% if param['container'] == 'vector' -%}
-        std::vector<{{ param['dtype'] }}> {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
+        std::vector<{{ param['dtype']|cpp_type }}> {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
         {% else %}
-        {{get_linked_value(param['dtype']) }} {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
+        {{param['dtype']|cpp_type }} {{ param['id'] }}{% if 'default' in param %} = {{param['default']}}{% endif %};
         {% endif %}
         {% endif %}{% endfor -%}{% endif %}};
 {% endmacro %}
@@ -67,20 +50,19 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
 
 {% macro ports(ports, parameters, typekeys) -%}
         {% for port in ports %}
-        {% set porttype = get_linked_value(port['type']) -%}
         {% if port['domain'] != 'message' -%}
         {% if port['type'] == 'untyped'%}   
-        for (size_t i = 0; i < {{ get_linked_value(port['multiplicity'])}}; i++) {
+        for (size_t i = 0; i < {{ port['multiplicity']|get_linked_value()}}; i++) {
         add_port(untyped_port::make(
-            "{{ port['id'] }}" {{ "+ std::to_string(i)" if get_linked_value(port['multiplicity'])|int() > 1}}, 
+            "{{ port['id'] }}" {{ "+ std::to_string(i)" if port['multiplicity']|get_linked_value()|int() > 1}}, 
             {{ 'port_direction_t::INPUT' if port['direction'] == "input" else 'port_direction_t::OUTPUT' }}, 
-            {{ get_linked_value(port['size'])}}, {{port['optional']|lower()}}));
+            {{ port['size']|get_linked_value() }}, {{port['optional']|lower()}}));
         }
         {% else %}
-        for (size_t i = 0; i < {{ get_linked_value(port['multiplicity'])}}; i++) {
-        add_port(port<{{porttype}}>::make("{{ port['id'] }}" {{ "+ std::to_string(i)" if get_linked_value(port['multiplicity'])|int() > 1}}, 
+        for (size_t i = 0; i < {{ port['multiplicity']|get_linked_value()}}; i++) {
+        add_port(port<{{port['type']|cpp_type}}>::make("{{ port['id'] }}" {{ "+ std::to_string(i)" if port['multiplicity']|get_linked_value()|int() > 1}}, 
                             {{ 'port_direction_t::INPUT' if port['direction'] == "input" else 'port_direction_t::OUTPUT' }},
-                            std::vector<size_t>{ {{ get_linked_value(port['shape'])}} }, {{port['optional']|lower()}}));
+                            std::vector<size_t>{ {{ port['shape']|get_linked_value()}} }, {{port['optional']|lower()}}));
         }
         {% endif %}
         {% else %}
@@ -124,10 +106,10 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
 {% macro callbacks(callbacks) -%}
     {% for cb in callbacks -%}
     {% if 'inherited' not in cb or not cb['inherited'] -%}
-    virtual  {{cb['return']}} {{cb['id']}} (
+    virtual  {{cb['return']|cpp_type}} {{cb['id']}} (
     {% if 'args' in cb -%}
     {% for arg in cb['args'] -%}
-    {{get_linked_value(arg['dtype'])}} {{arg['id']}}{{ ", " if not loop.last }}
+    {{arg['dtype']|cpp_type}} {{arg['id']}}{{ ", " if not loop.last }}
     {% endfor -%}
     {% endif -%}
     ) {% if cb['const'] %}const {%endif%} = 0;
@@ -150,17 +132,17 @@ public:
     {% for p in parameters -%}
         {% if p['container'] == 'vector' -%}
             {% if p['settable']%}
-    virtual void set_{{p['id']}}(std::vector<{{p['dtype']}}> {{p['id']}}); 
+    virtual void set_{{p['id']}}(std::vector<{{p['dtype']|cpp_type}}> {{p['id']}}); 
             {% endif -%}
             {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
-    virtual std::vector<{{p['dtype']}}> {{p['id']}}();
+    virtual std::vector<{{p['dtype']|cpp_type}}> {{p['id']}}();
             {% endif -%}
         {% else -%}
             {% if p['settable']%}
-    virtual void set_{{p['id']}}({{get_linked_value(p['dtype'])}} {{p['id']}}); 
+    virtual void set_{{p['id']}}({{p['dtype']|cpp_type}} {{p['id']}}); 
             {% endif -%}
             {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
-    virtual {{get_linked_value(p['dtype'])}} {{p['id']}}();
+    virtual {{p['dtype']|cpp_type}} {{p['id']}}();
             {% endif -%}
         {% endif -%}
     {% endfor -%}
@@ -168,11 +150,7 @@ protected:
     enum params : uint32_t { {% for p in parameters -%}{#% if p['settable'] or p['gettable'] %#}id_{{p['id']}},{#% endif %#}{% endfor %} num_params };
 {% for p in parameters -%}
 {#% if p['settable'] or p['gettable'] %#}{% if 'serializable' not in p or p['serializable'] %}
-    {% if 'string' in p['dtype'] %}
     pmt_sptr param_{{p['id']}};
-    {% else %}
-    pmt_sptr param_{{p['id']}};
-    {% endif %}
     
 {% endif %}
 {% endfor -%}
@@ -187,16 +165,12 @@ protected:
 {% for p in parameters -%}
 {#% if p['settable'] or p['gettable']%#}{% if 'serializable' not in p or p['serializable'] %}
     {% if 'string' in p['dtype'] %}
-    //param_{{p['id']}} = string_param::make(params::id_{{p['id']}}, 
-    //    "{{p['id']}}"{{", args."+p['id'] if 'cotr' not in p or p['cotr']}});
     param_{{p['id']}} = std::make_shared<pmtf::pmt>(pmtf::string({{"args."+p['id'] if 'cotr' not in p or p['cotr']}}));
     {% else %}
-    //param_{{p['id']}} = {{ 'scalar' if 'container' not in p else p['container']}}_param<{{p['dtype']}}>::make(params::id_{{p['id']}}, 
-    //    "{{p['id']}}"{{", args."+p['id'] if 'cotr' not in p or p['cotr']}});
     {%if 'cotr' not in p or p['cotr']%}
     param_{{p['id']}} = std::make_shared<pmtf::pmt>({{'(int)' if p['is_enum']}}{{"args."+p['id']}});
     {%else%}
-    param_{{p['id']}} = std::make_shared<pmtf::pmt>(pmtf::{{'scalar' if 'container' not in p else p['container']}}<{{p['dtype']}}>({%if 'default' in p %}{{p['default'] | string() | lower()}}{%endif%}));
+    param_{{p['id']}} = std::make_shared<pmtf::pmt>(pmtf::{{'scalar' if 'container' not in p else p['container']}}<{{p['dtype']|cpp_type}}>({%if 'default' in p %}{{p['default'] | string() | lower()}}{%endif%}));
     {%endif%}
     {% endif %}
     add_param("{{p['id']}}", d_param_str_map["{{p['id']}}"], param_{{p['id']}});
@@ -219,24 +193,6 @@ Ports:
 )"
 {% endif -%}
 {% endmacro%}
-
-{% macro cpp_type_lookup(sigmf_type) %}
-{%- set lu_type = sigmf_type -%}{%- if sigmf_type | is_list() -%}{%- set lu_type = sigmf_type[0] -%}{% endif %}
-{%- set cpp_type = lu_type -%}
-{%- if sigmf_type | trim() == 'cf32'-%}{%- set cpp_type = 'gr_complex' -%}
-{%- elif sigmf_type | trim() == 'cf64'-%}{%- set cpp_type = 'gr_complexd' -%}
-{%- elif sigmf_type | trim() == 'rf64'-%}{%- set cpp_type = 'double' -%}
-{%- elif sigmf_type | trim() == 'rf32'-%}{%- set cpp_type = 'float' -%}
-{%- elif sigmf_type | trim() == 'ri64'-%}{%- set cpp_type = 'std::int64_t' -%}
-{%- elif sigmf_type | trim() == 'ri32'-%}{%- set cpp_type = 'std::int32_t' -%}
-{%- elif sigmf_type | trim() == 'ri16'-%}{%- set cpp_type = 'std::int16_t' -%}
-{%- elif sigmf_type | trim() == 'ri8'-%}{%- set cpp_type = 'std::int8_t' -%}
-{%- elif sigmf_type | trim() == 'ru64'-%}{%- set cpp_type = 'std::uint64_t' -%}
-{%- elif sigmf_type | trim() == 'ru32'-%}{%- set cpp_type = 'std::uint32_t' -%}
-{%- elif sigmf_type | trim() == 'ru16'-%}{%- set cpp_type = 'std::uint16_t' -%}
-{%- elif sigmf_type | trim() == 'ru8'-%}{%- set cpp_type = 'std::uint8_t' -%}
-{%- endif -%}{{cpp_type}}
-{%- endmacro -%}
 
 {% macro suffix_lookup(type) %}
 {%- set suffix = type -%}

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -48,17 +48,17 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
         {% for port in ports %}
         {% if port['domain'] != 'message' -%}
         {% if port['type'] == 'untyped'%}   
-        for (size_t i = 0; i < {{ port['multiplicity']|get_linked_value()}}; i++) {
+        for (size_t i = 0; i < {{ port['multiplicity']|get_linked_value_with_args()}}; i++) {
         add_port(untyped_port::make(
-            "{{ port['id'] }}" {{ "+ std::to_string(i)" if port['multiplicity']|get_linked_value()|int() > 1}}, 
+            "{{ port['id'] }}" {{ "+ std::to_string(i)" if port['multiplicity']|get_linked_value_with_args()|int() > 1}}, 
             {{ 'port_direction_t::INPUT' if port['direction'] == "input" else 'port_direction_t::OUTPUT' }}, 
-            {{ port['size']|get_linked_value() }}, {{port['optional']|lower()}}));
+            {{ port['size']|get_linked_value_with_args() }}, {{port['optional']|lower()}}));
         }
         {% else %}
-        for (size_t i = 0; i < {{ port['multiplicity']|get_linked_value()}}; i++) {
-        add_port(port<{{port['type']|cpp_type}}>::make("{{ port['id'] }}" {{ "+ std::to_string(i)" if port['multiplicity']|get_linked_value()|int() > 1}}, 
+        for (size_t i = 0; i < {{ port['multiplicity']|get_linked_value_with_args()}}; i++) {
+        add_port(port<{{port['type']|cpp_type}}>::make("{{ port['id'] }}" {{ "+ std::to_string(i)" if port['multiplicity']|get_linked_value_with_args()|int() > 1}}, 
                             {{ 'port_direction_t::INPUT' if port['direction'] == "input" else 'port_direction_t::OUTPUT' }},
-                            std::vector<size_t>{ {{ port['shape']|get_linked_value()}} }, {{port['optional']|lower()}}));
+                            std::vector<size_t>{ {{ port['shape']|get_linked_value_with_args()}} }, {{port['optional']|lower()}}));
         }
         {% endif %}
         {% else %}


### PR DESCRIPTION
# Pull Request Details
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Makes the types described in the block yaml file for parameters consisistent with the typed ports - e.g. rf32, cf64, etc.
Also cleans up some of the code generation by adding custom filters

Here is the list of types, followed by how they translate into c++, python, and grc
```python
type_lookup = {
    'cf64': ['std::complex<double>', 'complex', 'complex'],
    'cf32': ['std::complex<float>', 'complex', 'complex'],
    'rf64': ['double', 'float', 'float'],
    'rf32': ['float', 'float', 'float'],
    'ri64': ['int64_t', 'int', 'int'],
    'ri32': ['int32_t', 'int', 'int'],
    'ri16': ['int16_t', 'int', 'short'],
    'ri8': ['int8_t', 'int', 'byte'],
    'ru64': ['uint64_t', 'int', 'int'],
    'ru32': ['uint32_t', 'int', 'int'],
    'ru16': ['uint16_t', 'int', 'short'],
    'ru8': ['uint8_t', 'int', 'byte'],
    'size': ['size_t', 'int', 'int'],
    'string': ['std::string', 'str', 'string'],
    'bool': ['bool', 'bool', 'bool'],
}
```
## Related Issue
Fixes #6040 

## Which blocks/areas does this affect?
All blocks in the blocktree

## Testing Done
Building and CI passing should be sufficient

