### PR TITLE
4.0: enum cleanup and consistency

### DIFF
--- a/bench/bm_copy.cc
+++ b/bench/bm_copy.cc
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
 
     CLI11_PARSE(app, argc, argv);
 
-    if (rt_prio && gr::enable_realtime_scheduling() != RT_OK) {
+    if (rt_prio && gr::enable_realtime_scheduling() != rt_status_t::OK) {
         std::cout << "Error: failed to enable real-time scheduling." << std::endl;
     }
 

--- a/bench/bm_fanout.cc
+++ b/bench/bm_fanout.cc
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
                    "Buffer Type (0:simple, 1:vmcirc, 2:cuda, 3:cuda_pinned");
     app.add_flag("--rt_prio", rt_prio, "Enable Real-time priority");
 
-    if (rt_prio && gr::enable_realtime_scheduling() != RT_OK) {
+    if (rt_prio && gr::enable_realtime_scheduling() != rt_status_t::OK) {
         std::cout << "Error: failed to enable real-time scheduling." << std::endl;
     }
 

--- a/bench/bm_msg_forward.cc
+++ b/bench/bm_msg_forward.cc
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
 
     CLI11_PARSE(app, argc, argv);
 
-    if (rt_prio && gr::enable_realtime_scheduling() != RT_OK) {
+    if (rt_prio && gr::enable_realtime_scheduling() != rt_status_t::OK) {
         std::cout << "Error: failed to enable real-time scheduling." << std::endl;
     }
 

--- a/bench/bm_nop.cc
+++ b/bench/bm_nop.cc
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
                    "Buffer Type (0:simple, 1:vmcirc, 2:cuda, 3:cuda_pinned");
     app.add_flag("--rt_prio", rt_prio, "Enable Real-time priority");
 
-    if (rt_prio && gr::enable_realtime_scheduling() != RT_OK) {
+    if (rt_prio && gr::enable_realtime_scheduling() != rt_status_t::OK) {
         std::cout << "Error: failed to enable real-time scheduling." << std::endl;
     }
 

--- a/blocklib/README.md
+++ b/blocklib/README.md
@@ -59,7 +59,7 @@ Each of the parameters that are defined in the `.yml` are available as a member 
 Work functions are conceptually the same as GR3, but syntactically slightly different to keep the block API separated from the scheduler API.
 
 ```c++
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 ```
 
 First, the work function takes in a vector of pointers to input objects, and a vector of pointers to output objects.
@@ -88,7 +88,7 @@ wio.outputs()[0].n_produced = noutput_items;
 ```
 and then 
 ```
-return work_return_code_t::WORK_OK;
+return work_return_t::OK;
 ```
 
 ### Message Handlers

--- a/blocklib/analog/agc/agc_cpu.cc
+++ b/blocklib/analog/agc/agc_cpu.cc
@@ -12,7 +12,7 @@ agc_cpu<T>::agc_cpu(const typename agc<T>::block_args& args)
 }
 
 template <class T>
-work_return_code_t agc_cpu<T>::work(work_io& wio)
+work_return_t agc_cpu<T>::work(work_io& wio)
 {
     auto in = wio.inputs()[0].items<T>();
     auto out = wio.outputs()[0].items<T>();
@@ -20,7 +20,7 @@ work_return_code_t agc_cpu<T>::work(work_io& wio)
     kernel::analog::agc<T>::scaleN(out, in, noutput_items);
 
     wio.outputs()[0].n_produced = noutput_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } // namespace analog

--- a/blocklib/analog/agc/agc_cpu.h
+++ b/blocklib/analog/agc/agc_cpu.h
@@ -11,7 +11,7 @@ class agc_cpu : public agc<T>, kernel::analog::agc<T>
 {
 public:
     agc_cpu(const typename agc<T>::block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
 };

--- a/blocklib/analog/noise_source/noise_source_cpu.cc
+++ b/blocklib/analog/noise_source/noise_source_cpu.cc
@@ -32,7 +32,7 @@ noise_source_cpu<gr_complex>::noise_source_cpu(
 }
 
 template <class T>
-work_return_code_t noise_source_cpu<T>::work(work_io& wio)
+work_return_t noise_source_cpu<T>::work(work_io& wio)
 
 {
     auto out = wio.outputs()[0].items<T>();
@@ -42,25 +42,25 @@ work_return_code_t noise_source_cpu<T>::work(work_io& wio)
     auto ampl = pmtf::get_as<float>(*this->param_amplitude);
 
     switch (static_cast<noise_t>(type)) {
-    case noise_t::uniform:
+    case noise_t::UNIFORM:
         for (size_t i = 0; i < noutput_items; i++) {
             out[i] = static_cast<T>(ampl * ((d_rng.ran1() * 2.0) - 1.0));
         }
         break;
 
-    case noise_t::gaussian:
+    case noise_t::GAUSSIAN:
         for (size_t i = 0; i < noutput_items; i++) {
             out[i] = static_cast<T>(ampl * d_rng.gasdev());
         }
         break;
 
-    case noise_t::laplacian:
+    case noise_t::LAPLACIAN:
         for (size_t i = 0; i < noutput_items; i++) {
             out[i] = static_cast<T>(ampl * d_rng.laplacian());
         }
         break;
 
-    case noise_t::impulse: // FIXME changeable impulse settings
+    case noise_t::IMPULSE: // FIXME changeable impulse settings
         for (size_t i = 0; i < noutput_items; i++) {
             out[i] = static_cast<T>(ampl * d_rng.impulse(9));
         }
@@ -70,7 +70,7 @@ work_return_code_t noise_source_cpu<T>::work(work_io& wio)
     }
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace analog */

--- a/blocklib/analog/noise_source/noise_source_cpu.h
+++ b/blocklib/analog/noise_source/noise_source_cpu.h
@@ -22,7 +22,7 @@ class noise_source_cpu : public noise_source<T>
 public:
     noise_source_cpu(const typename noise_source<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     kernel::math::random d_rng;

--- a/blocklib/analog/quadrature_demod/quadrature_demod_cpu.cc
+++ b/blocklib/analog/quadrature_demod/quadrature_demod_cpu.cc
@@ -23,7 +23,7 @@ quadrature_demod_cpu::quadrature_demod_cpu(block_args args) : INHERITED_CONSTRUC
     // FIXME: do volk alignment
 }
 
-work_return_code_t quadrature_demod_cpu::work(work_io& wio)
+work_return_t quadrature_demod_cpu::work(work_io& wio)
 {
     auto in = wio.inputs()[0].items<gr_complex>();
     auto out = wio.outputs()[0].items<float>();
@@ -42,7 +42,7 @@ work_return_code_t quadrature_demod_cpu::work(work_io& wio)
 
     wio.produce_each(to_produce);
     wio.consume_each(to_produce);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/analog/quadrature_demod/quadrature_demod_cpu.h
+++ b/blocklib/analog/quadrature_demod/quadrature_demod_cpu.h
@@ -20,7 +20,7 @@ class quadrature_demod_cpu : public virtual quadrature_demod
 {
 public:
     quadrature_demod_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_history = 2;

--- a/blocklib/analog/sig_source/sig_source_cpu.cc
+++ b/blocklib/analog/sig_source/sig_source_cpu.cc
@@ -26,7 +26,7 @@ sig_source_cpu<T>::sig_source_cpu(const typename sig_source<T>::block_args& args
 }
 
 template <typename T>
-work_return_code_t sig_source_cpu<T>::work(work_io& wio)
+work_return_t sig_source_cpu<T>::work(work_io& wio)
 {
     auto optr = wio.outputs()[0].items<T>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -39,12 +39,12 @@ work_return_code_t sig_source_cpu<T>::work(work_io& wio)
     auto waveform = static_cast<waveform_t>(pmtf::get_as<int>(*this->param_waveform));
 
     switch (waveform) {
-    case waveform_t::constant:
+    case waveform_t::CONSTANT:
         t = (T)ampl + offset;
         std::fill_n(optr, noutput_items, t);
         break;
 
-    case waveform_t::sin:
+    case waveform_t::SIN:
         d_nco.sin(optr, noutput_items, ampl);
         if (offset == 0)
             break;
@@ -53,7 +53,7 @@ work_return_code_t sig_source_cpu<T>::work(work_io& wio)
             optr[i] += offset;
         }
         break;
-    case waveform_t::cos:
+    case waveform_t::COS:
         d_nco.cos(optr, noutput_items, ampl);
         if (offset == 0)
             break;
@@ -64,7 +64,7 @@ work_return_code_t sig_source_cpu<T>::work(work_io& wio)
         break;
 
         /* The square wave is high from -PI to 0. */
-    case waveform_t::square:
+    case waveform_t::SQUARE:
         t = (T)ampl + offset;
         for (size_t i = 0; i < noutput_items; i++) {
             if (d_nco.get_phase() < 0)
@@ -76,7 +76,7 @@ work_return_code_t sig_source_cpu<T>::work(work_io& wio)
         break;
 
         /* The triangle wave rises from -PI to 0 and falls from 0 to PI. */
-    case waveform_t::triangle:
+    case waveform_t::TRIANGLE:
         for (size_t i = 0; i < noutput_items; i++) {
             double t = ampl * d_nco.get_phase() / GR_M_PI;
             if (d_nco.get_phase() < 0)
@@ -88,7 +88,7 @@ work_return_code_t sig_source_cpu<T>::work(work_io& wio)
         break;
 
         /* The saw tooth wave rises from -PI to PI. */
-    case waveform_t::sawtooth:
+    case waveform_t::SAWTOOTH:
         for (size_t i = 0; i < noutput_items; i++) {
             t = static_cast<T>(ampl * d_nco.get_phase() / (2 * GR_M_PI) + ampl / 2 +
                                offset);
@@ -101,11 +101,11 @@ work_return_code_t sig_source_cpu<T>::work(work_io& wio)
     }
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <>
-work_return_code_t sig_source_cpu<gr_complex>::work(work_io& wio)
+work_return_t sig_source_cpu<gr_complex>::work(work_io& wio)
 
 {
     auto optr = wio.outputs()[0].items<gr_complex>();
@@ -119,13 +119,13 @@ work_return_code_t sig_source_cpu<gr_complex>::work(work_io& wio)
     auto waveform = static_cast<waveform_t>(pmtf::get_as<int>(*this->param_waveform));
 
     switch (waveform) {
-    case waveform_t::constant:
+    case waveform_t::CONSTANT:
         t = (gr_complex)ampl + offset;
         std::fill_n(optr, noutput_items, t);
         break;
 
-    case waveform_t::sin:
-    case waveform_t::cos:
+    case waveform_t::SIN:
+    case waveform_t::COS:
         d_nco.sincos(optr, noutput_items, ampl);
         if (offset == gr_complex(0, 0))
             break;
@@ -138,7 +138,7 @@ work_return_code_t sig_source_cpu<gr_complex>::work(work_io& wio)
         /* Implements a real square wave high from -PI to 0.
          * The imaginary square wave leads by 90 deg.
          */
-    case waveform_t::square:
+    case waveform_t::SQUARE:
         for (size_t i = 0; i < noutput_items; i++) {
             if (d_nco.get_phase() < -1 * GR_M_PI / 2)
                 optr[i] = gr_complex(ampl, 0) + offset;
@@ -156,7 +156,7 @@ work_return_code_t sig_source_cpu<gr_complex>::work(work_io& wio)
          * falling from 0 to PI. The imaginary triangle wave leads by
          * 90 deg.
          */
-    case waveform_t::triangle:
+    case waveform_t::TRIANGLE:
         for (size_t i = 0; i < noutput_items; i++) {
             if (d_nco.get_phase() < -1 * GR_M_PI / 2) {
                 optr[i] = gr_complex(ampl * d_nco.get_phase() / GR_M_PI + ampl,
@@ -186,7 +186,7 @@ work_return_code_t sig_source_cpu<gr_complex>::work(work_io& wio)
         /* Implements a real saw tooth wave rising from -PI to PI.
          * The imaginary saw tooth wave leads by 90 deg.
          */
-    case waveform_t::sawtooth:
+    case waveform_t::SAWTOOTH:
         for (size_t i = 0; i < noutput_items; i++) {
             if (d_nco.get_phase() < -1 * GR_M_PI / 2) {
                 optr[i] =
@@ -208,7 +208,7 @@ work_return_code_t sig_source_cpu<gr_complex>::work(work_io& wio)
     }
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace analog */

--- a/blocklib/analog/sig_source/sig_source_cpu.h
+++ b/blocklib/analog/sig_source/sig_source_cpu.h
@@ -24,7 +24,7 @@ class sig_source_cpu : public sig_source<T>
 public:
     sig_source_cpu(const typename sig_source<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 
     void on_parameter_change(param_action_sptr action) override

--- a/blocklib/analog/test/qa_noise.py
+++ b/blocklib/analog/test/qa_noise.py
@@ -22,11 +22,11 @@ class test_noise_source(gr_unittest.TestCase):
 
     def test_001(self):
         # Just confirm that we can instantiate a noise source
-        op = analog.noise_source_f(analog.noise_t.gaussian, 10, 10)
+        op = analog.noise_source_f(analog.noise_t.GAUSSIAN, 10, 10)
 
     def test_002(self):
         # Test get methods
-        set_type = analog.noise_t.gaussian
+        set_type = analog.noise_t.GAUSSIAN
         set_ampl = 10
         op = analog.noise_source_f(set_type, set_ampl, 10)
         get_type = op.type()

--- a/blocklib/analog/test/qa_sig_source.py
+++ b/blocklib/analog/test/qa_sig_source.py
@@ -24,7 +24,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_const_f(self):
         tb = self.tb
         expected_result = [1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]
-        src1 = analog.sig_source_f(1e6, analog.waveform_t.constant, 0, 1.5)
+        src1 = analog.sig_source_f(1e6, analog.waveform_t.CONSTANT, 0, 1.5)
         op = streamops.head(10)
         dst1 = blocks.vector_sink_f()
         tb.connect(src1, op)
@@ -36,7 +36,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_const_i(self):
         tb = self.tb
         expected_result = [1, 1, 1, 1]
-        src1 = analog.sig_source_i(1e6, analog.waveform_t.constant, 0, 1)
+        src1 = analog.sig_source_i(1e6, analog.waveform_t.CONSTANT, 0, 1)
         op = streamops.head(4)
         dst1 = blocks.vector_sink_i()
         tb.connect(src1, op)
@@ -48,7 +48,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_const_b(self):
         tb = self.tb
         expected_result = [1, 1, 1, 1]
-        src1 = analog.sig_source_b(1e6, analog.waveform_t.constant, 0, 1)
+        src1 = analog.sig_source_b(1e6, analog.waveform_t.CONSTANT, 0, 1)
         op = streamops.head(4)
         dst1 = blocks.vector_sink_b()
         tb.connect(src1, op)
@@ -61,7 +61,7 @@ class test_sig_source(gr_unittest.TestCase):
         tb = self.tb
         sqrt2 = math.sqrt(2) / 2
         expected_result = [0, sqrt2, 1, sqrt2, 0, -sqrt2, -1, -sqrt2, 0]
-        src1 = analog.sig_source_f(8, analog.waveform_t.sin, 1.0, 1.0)
+        src1 = analog.sig_source_f(8, analog.waveform_t.SIN, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_f()
         tb.connect(src1, op)
@@ -76,7 +76,7 @@ class test_sig_source(gr_unittest.TestCase):
         temp_result = [0, sqrt2, 1, sqrt2, 0, -sqrt2, -1, -sqrt2, 0]
         amp = 8
         expected_result = tuple([int(z * amp) for z in temp_result])
-        src1 = analog.sig_source_b(8, analog.waveform_t.sin, 1.0, amp)
+        src1 = analog.sig_source_b(8, analog.waveform_t.SIN, 1.0, amp)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_b()
         tb.connect(src1, op)
@@ -91,7 +91,7 @@ class test_sig_source(gr_unittest.TestCase):
         tb = self.tb
         sqrt2 = math.sqrt(2) / 2
         expected_result = [1, sqrt2, 0, -sqrt2, -1, -sqrt2, 0, sqrt2, 1]
-        src1 = analog.sig_source_f(8, analog.waveform_t.cos, 1.0, 1.0)
+        src1 = analog.sig_source_f(8, analog.waveform_t.COS, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_f()
         tb.connect(src1, op)
@@ -108,7 +108,7 @@ class test_sig_source(gr_unittest.TestCase):
             1, sqrt2 + sqrt2j, 1j, -sqrt2 + sqrt2j, -1, -sqrt2 - sqrt2j, -1j,
             sqrt2 - sqrt2j, 1
         ]
-        src1 = analog.sig_source_c(8, analog.waveform_t.cos, 1.0, 1.0)
+        src1 = analog.sig_source_c(8, analog.waveform_t.COS, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_c()
         tb.connect(src1, op)
@@ -120,7 +120,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_sqr_c(self):
         tb = self.tb  # arg6 is a bit before -PI/2
         expected_result = [1j, 1j, 0, 0, 1, 1, 1 + 0j, 1 + 1j, 1j]
-        src1 = analog.sig_source_c(8, analog.waveform_t.square, 1.0, 1.0)
+        src1 = analog.sig_source_c(8, analog.waveform_t.SQUARE, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_c()
         tb.connect(src1, op)
@@ -135,7 +135,7 @@ class test_sig_source(gr_unittest.TestCase):
             1 + .5j, .75 + .75j, .5 + 1j, .25 + .75j, 0 + .5j, .25 + .25j,
             .5 + 0j, .75 + .25j, 1 + .5j
         ]
-        src1 = analog.sig_source_c(8, analog.waveform_t.triangle, 1.0, 1.0)
+        src1 = analog.sig_source_c(8, analog.waveform_t.TRIANGLE, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_c()
         tb.connect(src1, op)
@@ -150,7 +150,7 @@ class test_sig_source(gr_unittest.TestCase):
             .5 + .25j, .625 + .375j, .75 + .5j, .875 + .625j, 0 + .75j,
             .125 + .875j, .25 + 1j, .375 + .125j, .5 + .25j
         ]
-        src1 = analog.sig_source_c(8, analog.waveform_t.sawtooth, 1.0, 1.0)
+        src1 = analog.sig_source_c(8, analog.waveform_t.SAWTOOTH, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_c()
         tb.connect(src1, op)
@@ -162,7 +162,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_sqr_f(self):
         tb = self.tb
         expected_result = [0, 0, 0, 0, 1, 1, 1, 1, 0]
-        src1 = analog.sig_source_f(8, analog.waveform_t.square, 1.0, 1.0)
+        src1 = analog.sig_source_f(8, analog.waveform_t.SQUARE, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_f()
         tb.connect(src1, op)
@@ -174,7 +174,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_tri_f(self):
         tb = self.tb
         expected_result = [1, .75, .5, .25, 0, .25, .5, .75, 1]
-        src1 = analog.sig_source_f(8, analog.waveform_t.triangle, 1.0, 1.0)
+        src1 = analog.sig_source_f(8, analog.waveform_t.TRIANGLE, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_f()
         tb.connect(src1, op)
@@ -186,7 +186,7 @@ class test_sig_source(gr_unittest.TestCase):
     def test_saw_f(self):
         tb = self.tb
         expected_result = [.5, .625, .75, .875, 0, .125, .25, .375, .5]
-        src1 = analog.sig_source_f(8, analog.waveform_t.sawtooth, 1.0, 1.0)
+        src1 = analog.sig_source_f(8, analog.waveform_t.SAWTOOTH, 1.0, 1.0)
         op = streamops.head(9)
         dst1 = blocks.vector_sink_f()
         tb.connect(src1, op)

--- a/blocklib/audio/alsa_sink/alsa_sink_cpu.cc
+++ b/blocklib/audio/alsa_sink/alsa_sink_cpu.cc
@@ -269,7 +269,7 @@ bool alsa_sink_cpu::start()
     return true;
 }
 
-work_return_code_t alsa_sink_cpu::work(work_io& wio)
+work_return_t alsa_sink_cpu::work(work_io& wio)
 
 {
     // assert((noutput_items % d_period_size) == 0);
@@ -282,7 +282,7 @@ work_return_code_t alsa_sink_cpu::work(work_io& wio)
 /*
  * Work function that deals with float to S16 conversion
  */
-work_return_code_t alsa_sink_cpu::work_s16(work_io& wio)
+work_return_t alsa_sink_cpu::work_s16(work_io& wio)
 {
     typedef int16_t sample_t; // the type of samples we're creating
     static const float scale_factor = std::pow(2.0f, 16 - 1) - 1;
@@ -315,18 +315,18 @@ work_return_code_t alsa_sink_cpu::work_s16(work_io& wio)
             in[chan] += d_period_size;
 
         if (!write_buffer(buf, d_period_size, sizeof_frame))
-            return work_return_code_t::WORK_DONE; // No fixing this problem.  Say
-                                                  // we're done.
+            return work_return_t::DONE; // No fixing this problem.  Say
+                                        // we're done.
     }
 
     wio.consume_each(n);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 /*
  * Work function that deals with float to S32 conversion
  */
-work_return_code_t alsa_sink_cpu::work_s32(work_io& wio)
+work_return_t alsa_sink_cpu::work_s32(work_io& wio)
 {
     typedef int32_t sample_t; // the type of samples we're creating
     static const float scale_factor = std::pow(2.0f, 32 - 1) - 1;
@@ -359,19 +359,19 @@ work_return_code_t alsa_sink_cpu::work_s32(work_io& wio)
             in[chan] += d_period_size;
 
         if (!write_buffer(buf, d_period_size, sizeof_frame))
-            return work_return_code_t::WORK_DONE; // No fixing this problem.  Say
-                                                  // we're done.
+            return work_return_t::DONE; // No fixing this problem.  Say
+                                        // we're done.
     }
 
     wio.consume_each(n);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 /*
  * Work function that deals with float to S16 conversion and
  * mono to stereo kludge.
  */
-work_return_code_t alsa_sink_cpu::work_s16_1x2(work_io& wio)
+work_return_t alsa_sink_cpu::work_s16_1x2(work_io& wio)
 {
     typedef int16_t sample_t; // the type of samples we're creating
     static const float scale_factor = std::pow(2.0f, 16 - 1) - 1;
@@ -404,19 +404,19 @@ work_return_code_t alsa_sink_cpu::work_s16_1x2(work_io& wio)
         in[0] += d_period_size;
 
         if (!write_buffer(buf, d_period_size, sizeof_frame))
-            return work_return_code_t::WORK_DONE; // No fixing this problem.  Say
-                                                  // we're done.
+            return work_return_t::DONE; // No fixing this problem.  Say
+                                        // we're done.
     }
 
     wio.consume_each(n);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 /*
  * Work function that deals with float to S32 conversion and
  * mono to stereo kludge.
  */
-work_return_code_t alsa_sink_cpu::work_s32_1x2(work_io& wio)
+work_return_t alsa_sink_cpu::work_s32_1x2(work_io& wio)
 {
     typedef int32_t sample_t; // the type of samples we're creating
     static const float scale_factor = std::pow(2.0f, 32 - 1) - 1;
@@ -448,12 +448,12 @@ work_return_code_t alsa_sink_cpu::work_s32_1x2(work_io& wio)
         in[0] += d_period_size;
 
         if (!write_buffer(buf, d_period_size, sizeof_frame))
-            return work_return_code_t::WORK_DONE; // No fixing this problem.  Say
-                                                  // we're done.
+            return work_return_t::DONE; // No fixing this problem.  Say
+                                        // we're done.
     }
 
     wio.consume_each(n);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 bool alsa_sink_cpu::write_buffer(const void* vbuffer,

--- a/blocklib/audio/alsa_sink/alsa_sink_cpu.h
+++ b/blocklib/audio/alsa_sink/alsa_sink_cpu.h
@@ -22,7 +22,7 @@ class alsa_sink_cpu : public virtual alsa_sink
 {
 public:
     alsa_sink_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     // TODO: change to std::function
@@ -55,13 +55,13 @@ private:
 protected:
     bool write_buffer(const void* buffer, unsigned nframes, unsigned sizeof_frame);
 
-    work_return_code_t work_s16(work_io& wio);
+    work_return_t work_s16(work_io& wio);
 
-    work_return_code_t work_s16_1x2(work_io& wio);
+    work_return_t work_s16_1x2(work_io& wio);
 
-    work_return_code_t work_s32(work_io& wio);
+    work_return_t work_s32(work_io& wio);
 
-    work_return_code_t work_s32_1x2(work_io& wio);
+    work_return_t work_s32_1x2(work_io& wio);
 };
 
 } // namespace audio

--- a/blocklib/audio/examples/alsa_tones.grc
+++ b/blocklib/audio/examples/alsa_tones.grc
@@ -60,7 +60,7 @@ blocks:
     phase: '0'
     sampling_freq: samp_rate
     showports: 'False'
-    waveform: analog.waveform_t.cos
+    waveform: analog.waveform_t.COS
   states:
     bus_sink: false
     bus_source: false
@@ -84,7 +84,7 @@ blocks:
     phase: '0'
     sampling_freq: samp_rate
     showports: 'False'
-    waveform: analog.waveform_t.cos
+    waveform: analog.waveform_t.COS
   states:
     bus_sink: false
     bus_source: false

--- a/blocklib/blocks/nop_source/nop_source_cpu.cc
+++ b/blocklib/blocks/nop_source/nop_source_cpu.cc
@@ -14,14 +14,14 @@ namespace blocks {
 
 nop_source_cpu::nop_source_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
 
-work_return_code_t nop_source_cpu::work(work_io& wio)
+work_return_t nop_source_cpu::work(work_io& wio)
 {
     for (auto& out : wio.outputs()) {
         auto noutput_items = out.n_items;
         out.n_produced = noutput_items;
     }
 
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/blocks/nop_source/nop_source_cpu.h
+++ b/blocklib/blocks/nop_source/nop_source_cpu.h
@@ -17,7 +17,7 @@ class nop_source_cpu : public nop_source
 {
 public:
     nop_source_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_nports;

--- a/blocklib/blocks/null_sink/null_sink_cpu.cc
+++ b/blocklib/blocks/null_sink/null_sink_cpu.cc
@@ -14,10 +14,7 @@ namespace blocks {
 
 null_sink_cpu::null_sink_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
 
-work_return_code_t null_sink_cpu::work(work_io& wio)
-{
-    return work_return_code_t::WORK_OK;
-}
+work_return_t null_sink_cpu::work(work_io& wio) { return work_return_t::OK; }
 
 
 } // namespace blocks

--- a/blocklib/blocks/null_sink/null_sink_cpu.h
+++ b/blocklib/blocks/null_sink/null_sink_cpu.h
@@ -17,7 +17,7 @@ class null_sink_cpu : public null_sink
 {
 public:
     null_sink_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_nports;

--- a/blocklib/blocks/null_source/null_source_cpu.cc
+++ b/blocklib/blocks/null_source/null_source_cpu.cc
@@ -14,7 +14,7 @@ namespace blocks {
 
 null_source_cpu::null_source_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
 
-work_return_code_t null_source_cpu::work(work_io& wio)
+work_return_t null_source_cpu::work(work_io& wio)
 {
     auto itemsize = wio.outputs()[0].buf().item_size();
     for (auto& out : wio.outputs()) {
@@ -23,7 +23,7 @@ work_return_code_t null_source_cpu::work(work_io& wio)
         out.n_produced = noutput_items;
     }
 
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/blocks/null_source/null_source_cpu.h
+++ b/blocklib/blocks/null_source/null_source_cpu.h
@@ -17,7 +17,7 @@ class null_source_cpu : public null_source
 {
 public:
     null_source_cpu(block_args args);
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 
 protected:
     size_t d_nports;

--- a/blocklib/blocks/tags_strobe/tags_strobe_cpu.cc
+++ b/blocklib/blocks/tags_strobe/tags_strobe_cpu.cc
@@ -22,7 +22,7 @@ tags_strobe_cpu::tags_strobe_cpu(block_args args)
 {
 }
 
-work_return_code_t tags_strobe_cpu::work(work_io& wio)
+work_return_t tags_strobe_cpu::work(work_io& wio)
 {
     auto optr = wio.outputs()[0].raw_items();
     auto itemsize = wio.outputs()[0].buf().item_size();
@@ -38,7 +38,7 @@ work_return_code_t tags_strobe_cpu::work(work_io& wio)
     }
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/blocks/tags_strobe/tags_strobe_cpu.h
+++ b/blocklib/blocks/tags_strobe/tags_strobe_cpu.h
@@ -19,7 +19,7 @@ class tags_strobe_cpu : public virtual tags_strobe
 {
 public:
     tags_strobe_cpu(block_args args);
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 
 private:
     uint64_t d_nsamps;

--- a/blocklib/blocks/vector_sink/vector_sink_cpu.cc
+++ b/blocklib/blocks/vector_sink/vector_sink_cpu.cc
@@ -23,7 +23,7 @@ vector_sink_cpu<T>::vector_sink_cpu(const typename vector_sink<T>::block_args& a
 }
 
 template <class T>
-work_return_code_t vector_sink_cpu<T>::work(work_io& wio)
+work_return_t vector_sink_cpu<T>::work(work_io& wio)
 {
     auto iptr = wio.inputs()[0].items<T>();
     int noutput_items = wio.inputs()[0].n_items;
@@ -36,7 +36,7 @@ work_return_code_t vector_sink_cpu<T>::work(work_io& wio)
 
     wio.consume_each(noutput_items);
     this->d_debug_logger->debug("sizeof_data: {}", d_data.size());
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace blocks */

--- a/blocklib/blocks/vector_sink/vector_sink_cpu.h
+++ b/blocklib/blocks/vector_sink/vector_sink_cpu.h
@@ -21,7 +21,7 @@ class vector_sink_cpu : public vector_sink<T>
 public:
     vector_sink_cpu(const typename vector_sink<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     // on_parameter_query is overridden here because PMT currently does not
     // support element push_back of pmtf::vector.  So it is very inefficient

--- a/blocklib/blocks/vector_source/vector_source_cpu.cc
+++ b/blocklib/blocks/vector_source/vector_source_cpu.cc
@@ -41,7 +41,7 @@ vector_source_cpu<T>::vector_source_cpu(const typename vector_source<T>::block_a
 
 
 template <class T>
-work_return_code_t vector_source_cpu<T>::work(work_io& wio)
+work_return_t vector_source_cpu<T>::work(work_io& wio)
 {
 
     // size_t noutput_ports = wio.outputs().size(); // is 1 for this block
@@ -52,7 +52,7 @@ work_return_code_t vector_source_cpu<T>::work(work_io& wio)
         unsigned int size = d_data.size();
         unsigned int offset = d_offset;
         if (size == 0)
-            return work_return_code_t::WORK_DONE;
+            return work_return_t::DONE;
 
         if (d_settags) {
             int n_outputitems_per_vector = d_data.size() / d_vlen;
@@ -79,12 +79,12 @@ work_return_code_t vector_source_cpu<T>::work(work_io& wio)
         d_offset = offset;
 
         wio.outputs()[0].n_produced = noutput_items;
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
     else {
         if (d_offset >= d_data.size()) {
             wio.outputs()[0].n_produced = 0;
-            return work_return_code_t::WORK_DONE; // Done!
+            return work_return_t::DONE; // Done!
         }
 
         unsigned n = std::min(d_data.size() - d_offset, noutput_items * d_vlen);
@@ -99,7 +99,7 @@ work_return_code_t vector_source_cpu<T>::work(work_io& wio)
         d_offset += n;
 
         wio.outputs()[0].n_produced = n / d_vlen;
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 }
 

--- a/blocklib/blocks/vector_source/vector_source_cpu.h
+++ b/blocklib/blocks/vector_source/vector_source_cpu.h
@@ -21,7 +21,7 @@ class vector_source_cpu : public vector_source<T>
 public:
     vector_source_cpu(const typename vector_source<T>::block_args& args);
 
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 
     void set_data_and_tags(std::vector<T> data, std::vector<gr::tag_t> tags) override;
     void rewind() override { d_offset = 0; }

--- a/blocklib/fft/fft/fft_cpu.cc
+++ b/blocklib/fft/fft/fft_cpu.cc
@@ -172,7 +172,7 @@ void fft_cpu<float, false>::fft_and_shift(const float* in, gr_complex* out)
 }
 
 template <class T, bool forward>
-work_return_code_t fft_cpu<T, forward>::work(work_io& wio)
+work_return_t fft_cpu<T, forward>::work(work_io& wio)
 {
     auto in = wio.inputs()[0].items<T>();
     auto out = wio.outputs()[0].items<gr_complex>();
@@ -190,7 +190,7 @@ work_return_code_t fft_cpu<T, forward>::work(work_io& wio)
 
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/fft/fft/fft_cpu.h
+++ b/blocklib/fft/fft/fft_cpu.h
@@ -22,7 +22,7 @@ class fft_cpu : public fft<T, forward>
 {
 public:
     fft_cpu(const typename fft<T, forward>::block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     void set_nthreads(int n);
     int nthreads() const;

--- a/blocklib/fft/fft/fft_cuda.cc
+++ b/blocklib/fft/fft/fft_cuda.cc
@@ -85,7 +85,7 @@ void fft_cuda<float, false>::fft_and_shift(const float* in, gr_complex* out, int
 }
 
 template <class T, bool forward>
-work_return_code_t fft_cuda<T, forward>::work(work_io& wio)
+work_return_t fft_cuda<T, forward>::work(work_io& wio)
 {
 
     auto in = wio.inputs()[0].items<T>();
@@ -95,7 +95,7 @@ work_return_code_t fft_cuda<T, forward>::work(work_io& wio)
     fft_and_shift(in, out, noutput_items);
     cudaStreamSynchronize(d_stream);
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } // namespace fft

--- a/blocklib/fft/fft/fft_cuda.h
+++ b/blocklib/fft/fft/fft_cuda.h
@@ -21,7 +21,7 @@ class fft_cuda : public fft<T, forward>
 {
 public:
     fft_cuda(const typename fft<T, forward>::block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_fft_size;

--- a/blocklib/fft/python/fft/bindings/window_pybind.cc
+++ b/blocklib/fft/python/fft/bindings/window_pybind.cc
@@ -31,29 +31,29 @@ void bind_window(py::module& m)
 
     py::class_<window, std::shared_ptr<window>> window_class(m, "window");
 
-    py::enum_<gr::kernel::fft::window::win_type>(window_class, "win_type")
-        .value("WIN_HAMMING", gr::kernel::fft::window::WIN_HAMMING)                   // 0
-        .value("WIN_HANN", gr::kernel::fft::window::WIN_HANN)                         // 1
-        .value("WIN_HANNING", gr::kernel::fft::window::WIN_HANNING)                   // 1
-        .value("WIN_BLACKMAN", gr::kernel::fft::window::WIN_BLACKMAN)                 // 2
-        .value("WIN_RECTANGULAR", gr::kernel::fft::window::WIN_RECTANGULAR)           // 3
-        .value("WIN_KAISER", gr::kernel::fft::window::WIN_KAISER)                     // 4
-        .value("WIN_BLACKMAN_hARRIS", gr::kernel::fft::window::WIN_BLACKMAN_hARRIS)   // 5
-        .value("WIN_BLACKMAN_HARRIS", gr::kernel::fft::window::WIN_BLACKMAN_HARRIS)   // 5
-        .value("WIN_BARTLETT", gr::kernel::fft::window::WIN_BARTLETT)                 // 6
-        .value("WIN_FLATTOP", gr::kernel::fft::window::WIN_FLATTOP)                   // 7
-        .value("WIN_NUTTALL", gr::kernel::fft::window::WIN_NUTTALL)                   // 8
-        .value("WIN_BLACKMAN_NUTTALL", gr::kernel::fft::window::WIN_BLACKMAN_NUTTALL) // 8
-        .value("WIN_NUTTALL_CFD", gr::kernel::fft::window::WIN_NUTTALL_CFD)           // 9
-        .value("WIN_WELCH", gr::kernel::fft::window::WIN_WELCH)             // 10
-        .value("WIN_PARZEN", gr::kernel::fft::window::WIN_PARZEN)           // 11
-        .value("WIN_EXPONENTIAL", gr::kernel::fft::window::WIN_EXPONENTIAL) // 12
-        .value("WIN_RIEMANN", gr::kernel::fft::window::WIN_RIEMANN)         // 13
-        .value("WIN_GAUSSIAN", gr::kernel::fft::window::WIN_GAUSSIAN)       // 14
-        .value("WIN_TUKEY", gr::kernel::fft::window::WIN_TUKEY)             // 15
+    py::enum_<gr::kernel::fft::window::window_t>(window_class, "window_t")
+        .value("HAMMING", gr::kernel::fft::window::HAMMING)                   // 0
+        .value("HANN", gr::kernel::fft::window::HANN)                         // 1
+        .value("HANNING", gr::kernel::fft::window::HANNING)                   // 1
+        .value("BLACKMAN", gr::kernel::fft::window::BLACKMAN)                 // 2
+        .value("RECTANGULAR", gr::kernel::fft::window::RECTANGULAR)           // 3
+        .value("KAISER", gr::kernel::fft::window::KAISER)                     // 4
+        .value("BLACKMAN_hARRIS", gr::kernel::fft::window::BLACKMAN_hARRIS)   // 5
+        .value("BLACKMAN_HARRIS", gr::kernel::fft::window::BLACKMAN_HARRIS)   // 5
+        .value("BARTLETT", gr::kernel::fft::window::BARTLETT)                 // 6
+        .value("FLATTOP", gr::kernel::fft::window::FLATTOP)                   // 7
+        .value("NUTTALL", gr::kernel::fft::window::NUTTALL)                   // 8
+        .value("BLACKMAN_NUTTALL", gr::kernel::fft::window::BLACKMAN_NUTTALL) // 8
+        .value("NUTTALL_CFD", gr::kernel::fft::window::NUTTALL_CFD)           // 9
+        .value("WELCH", gr::kernel::fft::window::WELCH)                       // 10
+        .value("PARZEN", gr::kernel::fft::window::PARZEN)                     // 11
+        .value("EXPONENTIAL", gr::kernel::fft::window::EXPONENTIAL)           // 12
+        .value("RIEMANN", gr::kernel::fft::window::RIEMANN)                   // 13
+        .value("GAUSSIAN", gr::kernel::fft::window::GAUSSIAN)                 // 14
+        .value("TUKEY", gr::kernel::fft::window::TUKEY)                       // 15
         .export_values();
 
-    py::implicitly_convertible<int, gr::kernel::fft::window::win_type>();
+    py::implicitly_convertible<int, gr::kernel::fft::window::window_t>();
 
     window_class
         .def_static("max_attenuation",

--- a/blocklib/fileio/file_sink/file_sink_cpu.cc
+++ b/blocklib/fileio/file_sink/file_sink_cpu.cc
@@ -24,7 +24,7 @@ file_sink_cpu::file_sink_cpu(const block_args& args)
 
 file_sink_cpu::~file_sink_cpu() {}
 
-work_return_code_t file_sink_cpu::work(work_io& wio)
+work_return_t file_sink_cpu::work(work_io& wio)
 {
     auto inbuf = wio.inputs()[0].items<uint8_t>();
     auto noutput_items = wio.inputs()[0].n_items;
@@ -39,7 +39,7 @@ work_return_code_t file_sink_cpu::work(work_io& wio)
 
     if (!d_fp) {
         wio.inputs()[0].n_consumed = noutput_items; // drop output on the floor
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     while (nwritten < noutput_items) {
@@ -62,7 +62,7 @@ work_return_code_t file_sink_cpu::work(work_io& wio)
         fflush(d_fp);
 
     wio.consume_each(nwritten);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 bool file_sink_cpu::stop()

--- a/blocklib/fileio/file_sink/file_sink_cpu.h
+++ b/blocklib/fileio/file_sink/file_sink_cpu.h
@@ -24,7 +24,7 @@ public:
 
     bool stop() override;
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     void set_unbuffered(bool unbuffered) override
     {

--- a/blocklib/fileio/file_source/file_source_cpu.cc
+++ b/blocklib/fileio/file_source/file_source_cpu.cc
@@ -252,7 +252,7 @@ void file_source_cpu::do_update()
 
 void file_source_cpu::set_begin_tag(const std::string& val) { d_add_begin_tag = val; }
 
-work_return_code_t file_source_cpu::work(work_io& wio)
+work_return_t file_source_cpu::work(work_io& wio)
 {
     auto out = wio.outputs()[0].items<uint8_t>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -272,7 +272,7 @@ work_return_code_t file_source_cpu::work(work_io& wio)
     // No items remaining - all done
     if (d_items_remaining == 0) {
         wio.outputs()[0].n_produced = 0;
-        return work_return_code_t::WORK_DONE;
+        return work_return_t::DONE;
     }
 
     while (size) {
@@ -327,7 +327,7 @@ work_return_code_t file_source_cpu::work(work_io& wio)
     }
 
     wio.produce_each(noutput_items - size);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/fileio/file_source/file_source_cpu.h
+++ b/blocklib/fileio/file_source/file_source_cpu.h
@@ -20,7 +20,7 @@ class file_source_cpu : public file_source
 public:
     file_source_cpu(const block_args& args);
     ~file_source_cpu() override;
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     /*!
      * \brief seek file to \p seek_point relative to \p whence

--- a/blocklib/filter/bench/bm_pfb_channelizer.py
+++ b/blocklib/filter/bench/bm_pfb_channelizer.py
@@ -31,7 +31,7 @@ class benchmark_pfb_channelizer(gr.flowgraph):
         attn = args.attenuation
         bufsize = args.buffer_size
                 
-        taps = firdes.low_pass_2(1, nchans, 1 / 2, 1 / 10,  attenuation_dB=attn,window=window.WIN_BLACKMAN_hARRIS)
+        taps = firdes.low_pass_2(1, nchans, 1 / 2, 1 / 10,  attenuation_dB=attn,window=window.BLACKMAN_hARRIS)
 
         ##################################################
         # Blocks

--- a/blocklib/filter/dc_blocker/dc_blocker_cpu.cc
+++ b/blocklib/filter/dc_blocker/dc_blocker_cpu.cc
@@ -40,7 +40,7 @@ int dc_blocker_cpu<T>::group_delay()
 }
 
 template <class T>
-work_return_code_t dc_blocker_cpu<T>::work(work_io& wio)
+work_return_t dc_blocker_cpu<T>::work(work_io& wio)
 {
 
     auto in = wio.inputs()[0].items<T>();
@@ -72,7 +72,7 @@ work_return_code_t dc_blocker_cpu<T>::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = noutput_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace filter */

--- a/blocklib/filter/dc_blocker/dc_blocker_cpu.h
+++ b/blocklib/filter/dc_blocker/dc_blocker_cpu.h
@@ -22,7 +22,7 @@ class dc_blocker_cpu : public dc_blocker<T>
 public:
     dc_blocker_cpu(const typename dc_blocker<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     int group_delay();
 

--- a/blocklib/filter/examples/pfb_channelizer_example.grc
+++ b/blocklib/filter/examples/pfb_channelizer_example.grc
@@ -57,7 +57,7 @@ blocks:
     minoutbuf: '0'
     seed: '0'
     showports: 'False'
-    type: analog.noise_t.gaussian
+    type: analog.noise_t.GAUSSIAN
   states:
     bus_sink: false
     bus_source: false
@@ -81,7 +81,7 @@ blocks:
     phase: '0'
     sampling_freq: samp_rate
     showports: 'False'
-    waveform: analog.waveform_t.cos
+    waveform: analog.waveform_t.COS
   states:
     bus_sink: false
     bus_source: false
@@ -105,7 +105,7 @@ blocks:
     phase: '0'
     sampling_freq: samp_rate
     showports: 'False'
-    waveform: analog.waveform_t.cos
+    waveform: analog.waveform_t.COS
   states:
     bus_sink: false
     bus_source: false

--- a/blocklib/filter/fir_filter/fir_filter_cpu.cc
+++ b/blocklib/filter/fir_filter/fir_filter_cpu.cc
@@ -40,7 +40,7 @@ void fir_filter_cpu<IN_T, OUT_T, TAP_T>::on_parameter_change(param_action_sptr a
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-work_return_code_t fir_filter_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
+work_return_t fir_filter_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
 {
     // Do forecasting
     size_t ninput = wio.inputs()[0].n_items;
@@ -60,7 +60,7 @@ work_return_code_t fir_filter_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
     auto noutput_items = std::min(min_ninput / decim, noutput);
 
     if (noutput_items <= 0) {
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
 
 
@@ -82,7 +82,7 @@ work_return_code_t fir_filter_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
         d_hist_change = 0;
         d_hist_updated = false;
     }
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace filter */

--- a/blocklib/filter/fir_filter/fir_filter_cpu.h
+++ b/blocklib/filter/fir_filter/fir_filter_cpu.h
@@ -22,7 +22,7 @@ class fir_filter_cpu : public fir_filter<IN_T, OUT_T, TAP_T>
 public:
     fir_filter_cpu(const typename fir_filter<IN_T, OUT_T, TAP_T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     void on_parameter_change(param_action_sptr action) override;
 

--- a/blocklib/filter/iir_filter/iir_filter_cpu.cc
+++ b/blocklib/filter/iir_filter/iir_filter_cpu.cc
@@ -23,7 +23,7 @@ iir_filter_cpu<T_IN, T_OUT, TAP_T>::iir_filter_cpu(
 }
 
 template <class T_IN, class T_OUT, class TAP_T>
-work_return_code_t iir_filter_cpu<T_IN, T_OUT, TAP_T>::work(work_io& wio)
+work_return_t iir_filter_cpu<T_IN, T_OUT, TAP_T>::work(work_io& wio)
 {
     auto in = wio.inputs()[0].items<T_IN>();
     auto out = wio.outputs()[0].items<T_OUT>();
@@ -31,7 +31,7 @@ work_return_code_t iir_filter_cpu<T_IN, T_OUT, TAP_T>::work(work_io& wio)
 
     d_iir.filter_n(out, in, noutput_items);
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace filter */

--- a/blocklib/filter/iir_filter/iir_filter_cpu.h
+++ b/blocklib/filter/iir_filter/iir_filter_cpu.h
@@ -23,7 +23,7 @@ class iir_filter_cpu : public iir_filter<T_IN, T_OUT, TAP_T>
 public:
     iir_filter_cpu(const typename iir_filter<T_IN, T_OUT, TAP_T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     bool d_updated;

--- a/blocklib/filter/moving_average/moving_average_cpu.cc
+++ b/blocklib/filter/moving_average/moving_average_cpu.cc
@@ -31,12 +31,12 @@ moving_average_cpu<T>::moving_average_cpu(
 }
 
 template <class T>
-work_return_code_t moving_average_cpu<T>::work(work_io& wio)
+work_return_t moving_average_cpu<T>::work(work_io& wio)
 {
     if (wio.inputs()[0].n_items < d_length) {
         wio.outputs()[0].n_produced = 0;
         wio.inputs()[0].n_consumed = 0;
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
 
     if (d_updated) {
@@ -45,7 +45,7 @@ work_return_code_t moving_average_cpu<T>::work(work_io& wio)
         d_updated = false;
         wio.outputs()[0].n_produced = 0;
         wio.inputs()[0].n_consumed = 0;
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     auto in = wio.inputs()[0].items<T>();
@@ -82,7 +82,7 @@ work_return_code_t moving_average_cpu<T>::work(work_io& wio)
     // don't consume the last d_length-1 samples
     wio.outputs()[0].n_produced = num_iter;
     wio.inputs()[0].n_consumed = tr == 0 ? num_iter - (d_length - 1) : num_iter;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 } // namespace filter
 
 } // namespace filter

--- a/blocklib/filter/moving_average/moving_average_cpu.h
+++ b/blocklib/filter/moving_average/moving_average_cpu.h
@@ -23,7 +23,7 @@ class moving_average_cpu : public moving_average<T>
 public:
     moving_average_cpu(const typename moving_average<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     int group_delay();
 

--- a/blocklib/filter/moving_average/moving_average_cuda.cc
+++ b/blocklib/filter/moving_average/moving_average_cuda.cc
@@ -37,12 +37,12 @@ moving_average_cuda<T>::moving_average_cuda(
 }
 
 template <class T>
-work_return_code_t moving_average_cuda<T>::work(work_io& wio)
+work_return_t moving_average_cuda<T>::work(work_io& wio)
 {
     if (wio.inputs()[0].n_items < d_length) {
         wio.outputs()[0].n_produced = 0;
         wio.inputs()[0].n_consumed = 0;
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
 
     auto in = wio.inputs()[0].items<T>();
@@ -65,7 +65,7 @@ work_return_code_t moving_average_cuda<T>::work(work_io& wio)
     wio.outputs()[0].n_produced = tr == 0 ? num_iter : num_iter - (d_length - 1);
     wio.inputs()[0].n_consumed =
         tr == 0 ? num_iter - (d_length - 1) : num_iter - (d_length - 1);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 } // namespace filter
 
 } // namespace filter

--- a/blocklib/filter/moving_average/moving_average_cuda.h
+++ b/blocklib/filter/moving_average/moving_average_cuda.h
@@ -25,7 +25,7 @@ class moving_average_cuda : public moving_average<T>
 public:
     moving_average_cuda(const typename moving_average<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     int group_delay();
 

--- a/blocklib/filter/pfb_arb_resampler/pfb_arb_resampler_cpu.cc
+++ b/blocklib/filter/pfb_arb_resampler/pfb_arb_resampler_cpu.cc
@@ -29,7 +29,7 @@ pfb_arb_resampler_cpu<IN_T, OUT_T, TAP_T>::pfb_arb_resampler_cpu(
 }
 
 template <class IN_T, class OUT_T, class TAP_T>
-work_return_code_t pfb_arb_resampler_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
+work_return_t pfb_arb_resampler_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
 {
     auto noutput_items = wio.outputs()[0].n_items;
 
@@ -46,7 +46,7 @@ work_return_code_t pfb_arb_resampler_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
 
     auto ninput_items = wio.inputs()[0].n_items;
     if (ninput_items < min_ninput) {
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
 
     size_t nitems =
@@ -61,7 +61,7 @@ work_return_code_t pfb_arb_resampler_cpu<IN_T, OUT_T, TAP_T>::work(work_io& wio)
 
     wio.consume_each(nitems_read);
     wio.produce_each(processed);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace filter */

--- a/blocklib/filter/pfb_arb_resampler/pfb_arb_resampler_cpu.h
+++ b/blocklib/filter/pfb_arb_resampler/pfb_arb_resampler_cpu.h
@@ -23,7 +23,7 @@ public:
     pfb_arb_resampler_cpu(
         const typename pfb_arb_resampler<IN_T, OUT_T, TAP_T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
     virtual size_t group_delay() const override { return d_resamp.group_delay(); }
     virtual size_t phase_offset(float freq, float fs) const override
     {

--- a/blocklib/filter/pfb_channelizer/pfb_channelizer_cpu.cc
+++ b/blocklib/filter/pfb_channelizer/pfb_channelizer_cpu.cc
@@ -89,7 +89,7 @@ void pfb_channelizer_cpu<T>::set_taps(const std::vector<float>& taps)
 
 
 template <class T>
-work_return_code_t pfb_channelizer_cpu<T>::work(work_io& wio)
+work_return_t pfb_channelizer_cpu<T>::work(work_io& wio)
 {
     // std::scoped_lock guard(d_mutex);
 
@@ -99,12 +99,12 @@ work_return_code_t pfb_channelizer_cpu<T>::work(work_io& wio)
     auto ninput_items = wio.inputs()[0].n_items;
 
     if ((size_t)ninput_items < d_history * d_nchans) { // if we can produce 1 output item
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
 
     if (d_updated) {
         d_updated = false;
-        return work_return_code_t::WORK_OK; // history requirements may have changed.
+        return work_return_t::OK; // history requirements may have changed.
     }
 
     // includes history
@@ -173,7 +173,7 @@ work_return_code_t pfb_channelizer_cpu<T>::work(work_io& wio)
     wio.consume_each(toconsume * d_nchans);
     // this->produce_each(noutput_items - (d_history / d_nchans - 1), work_output);
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace filter */

--- a/blocklib/filter/pfb_channelizer/pfb_channelizer_cpu.h
+++ b/blocklib/filter/pfb_channelizer/pfb_channelizer_cpu.h
@@ -25,7 +25,7 @@ class pfb_channelizer_cpu : public pfb_channelizer<T>,
 public:
     pfb_channelizer_cpu(const typename pfb_channelizer<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     int group_delay();
     void set_taps(const std::vector<float>& taps) override;

--- a/blocklib/filter/pfb_channelizer/pfb_channelizer_cuda.cc
+++ b/blocklib/filter/pfb_channelizer/pfb_channelizer_cuda.cc
@@ -50,7 +50,7 @@ pfb_channelizer_cuda<T>::pfb_channelizer_cuda(
 }
 
 template <class T>
-work_return_code_t pfb_channelizer_cuda<T>::work(work_io& wio)
+work_return_t pfb_channelizer_cuda<T>::work(work_io& wio)
 {
     // std::scoped_lock guard(d_mutex);
 
@@ -58,7 +58,7 @@ work_return_code_t pfb_channelizer_cuda<T>::work(work_io& wio)
     auto ninput_items = wio.inputs()[0].n_items;
 
     if ((size_t)ninput_items < noutput_items * d_nchans + d_overlap) {
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
 
     d_in_items = wio.all_input_ptrs();
@@ -74,7 +74,7 @@ work_return_code_t pfb_channelizer_cuda<T>::work(work_io& wio)
 
     wio.consume_each(noutput_items * d_nchans);
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace filter */

--- a/blocklib/filter/pfb_channelizer/pfb_channelizer_cuda.h
+++ b/blocklib/filter/pfb_channelizer/pfb_channelizer_cuda.h
@@ -23,7 +23,7 @@ class pfb_channelizer_cuda : public pfb_channelizer<T>
 public:
     pfb_channelizer_cuda(const typename pfb_channelizer<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 
 private:

--- a/blocklib/filter/python/filter/bindings/firdes_pybind.cc
+++ b/blocklib/filter/python/filter/bindings/firdes_pybind.cc
@@ -47,7 +47,7 @@ void bind_firdes(py::module& m)
                     py::arg("sampling_freq"),
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -58,7 +58,7 @@ void bind_firdes(py::module& m)
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -68,7 +68,7 @@ void bind_firdes(py::module& m)
                     py::arg("sampling_freq"),
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -79,7 +79,7 @@ void bind_firdes(py::module& m)
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -90,7 +90,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -102,7 +102,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -113,7 +113,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -125,7 +125,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -136,7 +136,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -148,7 +148,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -159,7 +159,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -171,7 +171,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -179,7 +179,7 @@ void bind_firdes(py::module& m)
                     &firdes::hilbert,
                     py::arg("ntaps") = 19,
                     py::arg("windowtype") =
-                        ::gr::kernel::fft::window::win_type::WIN_RECTANGULAR,
+                        ::gr::kernel::fft::window::window_t::RECTANGULAR,
                     py::arg("param") = 6.7599999999999998)
 
 

--- a/blocklib/filter/test/qa_pfb_arb_resampler.py
+++ b/blocklib/filter/test/qa_pfb_arb_resampler.py
@@ -48,7 +48,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
             fs / 2,
             fs / 10,
             attenuation_dB=80,
-            window=window.WIN_BLACKMAN_hARRIS)
+            window=window.BLACKMAN_hARRIS)
 
         freq = 121.213
         data = sig_source_f(fs, freq, 1, N)
@@ -90,7 +90,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
     #         fs / 2,
     #         fs / 10,
     #         attenuation_dB=80,
-    #         window=window.WIN_BLACKMAN_hARRIS)
+    #         window=window.BLACKMAN_hARRIS)
 
     #     freq = 211.123
     #     data = sig_source_c(fs, freq, 1, N)
@@ -145,7 +145,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
     #         fs / 4,
     #         fs / 10,
     #         attenuation_dB=80,
-    #         window=window.WIN_BLACKMAN_hARRIS)
+    #         window=window.BLACKMAN_hARRIS)
 
     #     freq = 211.123
     #     data = sig_source_c(fs, freq, 1, N)
@@ -201,7 +201,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
     #         400,
     #         fs / 10,
     #         attenuation_dB=80,
-    #         window=window.WIN_BLACKMAN_hARRIS)
+    #         window=window.BLACKMAN_hARRIS)
 
     #     freq = 211.123
     #     data = sig_source_c(fs, freq, 1, N)
@@ -257,7 +257,7 @@ class test_pfb_arb_resampler(gr_unittest.TestCase):
     #         400,
     #         fs / 10,
     #         attenuation_dB=80,
-    #         window=window.WIN_BLACKMAN_hARRIS)
+    #         window=window.BLACKMAN_hARRIS)
 
     #     freq = 211.123
     #     data = sig_source_c(fs, freq, 1, N)

--- a/blocklib/filter/test/qa_pfb_channelizer.py
+++ b/blocklib/filter/test/qa_pfb_channelizer.py
@@ -40,7 +40,7 @@ class test_pfb_channelizer(gr_unittest.TestCase):
         self.taps = firdes.low_pass_2(
             1, self.ifs, self.fs / 2, self.fs / 10,
             attenuation_dB=80,
-            window=window.WIN_BLACKMAN_hARRIS)
+            window=window.BLACKMAN_hARRIS)
 
         self.Ntest = 50
 

--- a/blocklib/math/add/add_cpu.cc
+++ b/blocklib/math/add/add_cpu.cc
@@ -47,7 +47,7 @@ add_cpu<T>::add_cpu(const typename add<T>::block_args& args)
 
 
 template <class T>
-work_return_code_t add_cpu<T>::work(work_io& wio)
+work_return_t add_cpu<T>::work(work_io& wio)
 {
     auto out = wio.outputs()[0].items<T>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -60,7 +60,7 @@ work_return_code_t add_cpu<T>::work(work_io& wio)
 
     wio.produce_each(noutput_items);
     wio.consume_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace math */

--- a/blocklib/math/add/add_cpu.h
+++ b/blocklib/math/add/add_cpu.h
@@ -19,7 +19,7 @@ class add_cpu : public add<T>
 public:
     add_cpu(const typename add<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     const size_t d_vlen;

--- a/blocklib/math/add/add_cuda.cc
+++ b/blocklib/math/add/add_cuda.cc
@@ -22,7 +22,7 @@ add_cuda<T>::add_cuda(const typename add<T>::block_args& args)
 }
 
 template <class T>
-work_return_code_t add_cuda<T>::work(work_io& wio)
+work_return_t add_cuda<T>::work(work_io& wio)
 {
     auto out = wio.outputs()[0].items<T>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -37,7 +37,7 @@ work_return_code_t add_cuda<T>::work(work_io& wio)
 
     wio.produce_each(noutput_items);
     wio.consume_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace math */

--- a/blocklib/math/add/add_cuda.h
+++ b/blocklib/math/add/add_cuda.h
@@ -20,7 +20,7 @@ class add_cuda : public add<T>
 public:
     add_cuda(const typename add<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     const size_t d_vlen;

--- a/blocklib/math/add/numpy/add.py
+++ b/blocklib/math/add/numpy/add.py
@@ -17,4 +17,4 @@ class add_ff(math.add_ff):
 
         outbuf1[:] = inbuf1 + inbuf2
 
-        return gr.work_return_t.WORK_OK 
+        return gr.work_return_t.OK 

--- a/blocklib/math/complex_to_mag/complex_to_mag_cpu.cc
+++ b/blocklib/math/complex_to_mag/complex_to_mag_cpu.cc
@@ -22,7 +22,7 @@ complex_to_mag_cpu::complex_to_mag_cpu(const block_args& args)
     // set_output_multiple(std::max(1, alignment_multiple));
 }
 
-work_return_code_t complex_to_mag_cpu::work(work_io& wio)
+work_return_t complex_to_mag_cpu::work(work_io& wio)
 {
     auto noutput_items = wio.outputs()[0].n_items;
     int noi = noutput_items * d_vlen;
@@ -33,7 +33,7 @@ work_return_code_t complex_to_mag_cpu::work(work_io& wio)
     volk_32fc_magnitude_32f_u(optr, iptr, noi);
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/math/complex_to_mag/complex_to_mag_cpu.h
+++ b/blocklib/math/complex_to_mag/complex_to_mag_cpu.h
@@ -19,7 +19,7 @@ class complex_to_mag_cpu : public complex_to_mag
 {
 public:
     complex_to_mag_cpu(const block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_vlen;

--- a/blocklib/math/complex_to_mag_squared/complex_to_mag_squared_cpu.cc
+++ b/blocklib/math/complex_to_mag_squared/complex_to_mag_squared_cpu.cc
@@ -21,7 +21,7 @@ complex_to_mag_squared_cpu::complex_to_mag_squared_cpu(const block_args& args)
     // set_output_multiple(std::max(1, alignment_multiple));
 }
 
-work_return_code_t complex_to_mag_squared_cpu::work(work_io& wio)
+work_return_t complex_to_mag_squared_cpu::work(work_io& wio)
 {
     auto noutput_items = wio.outputs()[0].n_items;
     int noi = noutput_items * d_vlen;
@@ -32,7 +32,7 @@ work_return_code_t complex_to_mag_squared_cpu::work(work_io& wio)
     volk_32fc_magnitude_squared_32f(optr, iptr, noi);
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/math/complex_to_mag_squared/complex_to_mag_squared_cpu.h
+++ b/blocklib/math/complex_to_mag_squared/complex_to_mag_squared_cpu.h
@@ -21,7 +21,7 @@ class complex_to_mag_squared_cpu : public complex_to_mag_squared
 public:
     complex_to_mag_squared_cpu(const block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_vlen;

--- a/blocklib/math/conjugate/conjugate_cpu.cc
+++ b/blocklib/math/conjugate/conjugate_cpu.cc
@@ -21,7 +21,7 @@ conjugate_cpu::conjugate_cpu(const block_args& args) : INHERITED_CONSTRUCTORS
     // set_output_multiple(std::max(1, alignment_multiple));
 }
 
-work_return_code_t conjugate_cpu::work(work_io& wio)
+work_return_t conjugate_cpu::work(work_io& wio)
 {
     auto noutput_items = wio.outputs()[0].n_items;
 
@@ -31,7 +31,7 @@ work_return_code_t conjugate_cpu::work(work_io& wio)
     volk_32fc_conjugate_32fc(optr, iptr, noutput_items);
 
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/math/conjugate/conjugate_cpu.h
+++ b/blocklib/math/conjugate/conjugate_cpu.h
@@ -21,7 +21,7 @@ class conjugate_cpu : public conjugate
 public:
     conjugate_cpu(const block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 };
 
 } // namespace math

--- a/blocklib/math/divide/divide_cpu.cc
+++ b/blocklib/math/divide/divide_cpu.cc
@@ -39,7 +39,7 @@ divide_cpu<gr_complex>::divide_cpu(const typename divide<gr_complex>::block_args
 
 
 template <>
-work_return_code_t divide_cpu<float>::work(work_io& wio)
+work_return_t divide_cpu<float>::work(work_io& wio)
 {
     auto optr = wio.outputs()[0].items<float>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -52,11 +52,11 @@ work_return_code_t divide_cpu<float>::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <>
-work_return_code_t divide_cpu<gr_complex>::work(work_io& wio)
+work_return_t divide_cpu<gr_complex>::work(work_io& wio)
 
 {
     auto optr = wio.outputs()[0].items<gr_complex>();
@@ -72,11 +72,11 @@ work_return_code_t divide_cpu<gr_complex>::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <class T>
-work_return_code_t divide_cpu<T>::work(work_io& wio)
+work_return_t divide_cpu<T>::work(work_io& wio)
 
 {
     auto optr = wio.outputs()[0].items<T>();
@@ -92,7 +92,7 @@ work_return_code_t divide_cpu<T>::work(work_io& wio)
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
     wio.inputs()[0].n_consumed = wio.inputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/math/divide/divide_cpu.h
+++ b/blocklib/math/divide/divide_cpu.h
@@ -21,7 +21,7 @@ class divide_cpu : public divide<T>
 public:
     divide_cpu(const typename divide<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_num_inputs;

--- a/blocklib/math/multiply/multiply_cpu.cc
+++ b/blocklib/math/multiply/multiply_cpu.cc
@@ -39,7 +39,7 @@ multiply_cpu<gr_complex>::multiply_cpu(
 }
 
 template <>
-work_return_code_t multiply_cpu<float>::work(work_io& wio)
+work_return_t multiply_cpu<float>::work(work_io& wio)
 {
     auto out = wio.outputs()[0].items<float>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -51,11 +51,11 @@ work_return_code_t multiply_cpu<float>::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <>
-work_return_code_t multiply_cpu<gr_complex>::work(work_io& wio)
+work_return_t multiply_cpu<gr_complex>::work(work_io& wio)
 
 {
     auto out = wio.outputs()[0].items<gr_complex>();
@@ -68,11 +68,11 @@ work_return_code_t multiply_cpu<gr_complex>::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <class T>
-work_return_code_t multiply_cpu<T>::work(work_io& wio)
+work_return_t multiply_cpu<T>::work(work_io& wio)
 
 {
     auto optr = wio.outputs()[0].items<T>();
@@ -88,7 +88,7 @@ work_return_code_t multiply_cpu<T>::work(work_io& wio)
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
     wio.inputs()[0].n_consumed = wio.inputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace math */

--- a/blocklib/math/multiply/multiply_cpu.h
+++ b/blocklib/math/multiply/multiply_cpu.h
@@ -21,7 +21,7 @@ class multiply_cpu : public multiply<T>
 public:
     multiply_cpu(const typename multiply<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_num_inputs;

--- a/blocklib/math/multiply_const/multiply_const_cpu.cc
+++ b/blocklib/math/multiply_const/multiply_const_cpu.cc
@@ -23,7 +23,7 @@ multiply_const_cpu<T>::multiply_const_cpu(
 }
 
 template <>
-work_return_code_t multiply_const_cpu<float>::work(work_io& wio)
+work_return_t multiply_const_cpu<float>::work(work_io& wio)
 {
     auto k = pmtf::get_as<float>(*this->param_k);
 
@@ -34,11 +34,11 @@ work_return_code_t multiply_const_cpu<float>::work(work_io& wio)
     volk_32f_s32f_multiply_32f(out, in, k, noi);
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <>
-work_return_code_t multiply_const_cpu<gr_complex>::work(work_io& wio)
+work_return_t multiply_const_cpu<gr_complex>::work(work_io& wio)
 {
     auto k = pmtf::get_as<gr_complex>(*this->param_k);
 
@@ -49,11 +49,11 @@ work_return_code_t multiply_const_cpu<gr_complex>::work(work_io& wio)
     volk_32fc_s32fc_multiply_32fc(out, in, k, noi);
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <class T>
-work_return_code_t multiply_const_cpu<T>::work(work_io& wio)
+work_return_t multiply_const_cpu<T>::work(work_io& wio)
 {
     auto k = pmtf::get_as<T>(*this->param_k);
 
@@ -80,7 +80,7 @@ work_return_code_t multiply_const_cpu<T>::work(work_io& wio)
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
     wio.inputs()[0].n_consumed = wio.inputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace math */

--- a/blocklib/math/multiply_const/multiply_const_cpu.h
+++ b/blocklib/math/multiply_const/multiply_const_cpu.h
@@ -21,7 +21,7 @@ class multiply_const_cpu : public multiply_const<T>
 public:
     multiply_const_cpu(const typename multiply_const<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_vlen;

--- a/blocklib/math/multiply_const/multiply_const_cuda.cc
+++ b/blocklib/math/multiply_const/multiply_const_cuda.cc
@@ -40,7 +40,7 @@ multiply_const_cuda<gr_complex>::multiply_const_cuda(
 }
 
 template <class T>
-work_return_code_t multiply_const_cuda<T>::work(work_io& wio)
+work_return_t multiply_const_cuda<T>::work(work_io& wio)
 {
     auto out = wio.outputs()[0].items<T>();
     auto noutput_items = wio.outputs()[0].n_items;
@@ -51,7 +51,7 @@ work_return_code_t multiply_const_cuda<T>::work(work_io& wio)
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
     wio.inputs()[0].n_consumed = wio.inputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace math */

--- a/blocklib/math/multiply_const/multiply_const_cuda.h
+++ b/blocklib/math/multiply_const/multiply_const_cuda.h
@@ -23,7 +23,7 @@ class multiply_const_cuda : public multiply_const<T>
 public:
     multiply_const_cuda(const typename multiply_const<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     T d_k;

--- a/blocklib/math/multiply_const/numpy/multiply_const.py
+++ b/blocklib/math/multiply_const/numpy/multiply_const.py
@@ -25,4 +25,4 @@ class multiply_const_ff(math.multiply_const_ff):
 
         outbuf1[:] = inbuf1 * self.k
 
-        return gr.work_return_t.WORK_OK 
+        return gr.work_return_t.OK 

--- a/blocklib/streamops/annotator/annotator_cpu.cc
+++ b/blocklib/streamops/annotator/annotator_cpu.cc
@@ -34,7 +34,7 @@ annotator_cpu::annotator_cpu(const block_args& args)
     // set_relative_rate(1, 1);
 }
 
-work_return_code_t annotator_cpu::work(work_io& wio)
+work_return_t annotator_cpu::work(work_io& wio)
 
 {
     auto noutput_items = wio.outputs()[0].n_items;
@@ -75,7 +75,7 @@ work_return_code_t annotator_cpu::work(work_io& wio)
         wio.outputs()[i].n_produced = noutput_items;
     }
 
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace streamops */

--- a/blocklib/streamops/annotator/annotator_cpu.h
+++ b/blocklib/streamops/annotator/annotator_cpu.h
@@ -20,7 +20,7 @@ class annotator_cpu : public annotator
 {
 public:
     annotator_cpu(const block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     std::vector<tag_t> data() const override { return d_stored_tags; };
 

--- a/blocklib/streamops/copy/copy_cpu.cc
+++ b/blocklib/streamops/copy/copy_cpu.cc
@@ -13,7 +13,7 @@ namespace gr {
 namespace streamops {
 
 copy_cpu::copy_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
-work_return_code_t copy_cpu::work(work_io& wio)
+work_return_t copy_cpu::work(work_io& wio)
 {
     auto iptr = wio.inputs()[0].items<uint8_t>();
     int size = wio.outputs()[0].n_items * wio.outputs()[0].buf().item_size();
@@ -22,7 +22,7 @@ work_return_code_t copy_cpu::work(work_io& wio)
     memcpy(optr, iptr, size);
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/copy/copy_cpu.h
+++ b/blocklib/streamops/copy/copy_cpu.h
@@ -17,7 +17,7 @@ class copy_cpu : public copy
 {
 public:
     copy_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 };
 
 } // namespace streamops

--- a/blocklib/streamops/copy/copy_cuda.cc
+++ b/blocklib/streamops/copy/copy_cuda.cc
@@ -26,7 +26,7 @@ copy_cuda::copy_cuda(block_args args) : INHERITED_CONSTRUCTORS
     cudaStreamCreate(&d_stream);
 }
 
-work_return_code_t copy_cuda::work(work_io& wio)
+work_return_t copy_cuda::work(work_io& wio)
 
 {
     auto in = wio.inputs()[0].items<uint8_t>();
@@ -41,7 +41,7 @@ work_return_code_t copy_cuda::work(work_io& wio)
 
     // Tell runtime system how many output items we produced.
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 } // namespace streamops
 } // namespace gr

--- a/blocklib/streamops/copy/copy_cuda.h
+++ b/blocklib/streamops/copy/copy_cuda.h
@@ -23,7 +23,7 @@ class copy_cuda : public copy
 {
 public:
     copy_cuda(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     int d_block_size;

--- a/blocklib/streamops/deinterleave/deinterleave_cpu.cc
+++ b/blocklib/streamops/deinterleave/deinterleave_cpu.cc
@@ -25,7 +25,7 @@ deinterleave_cpu::deinterleave_cpu(block_args args) : INHERITED_CONSTRUCTORS
     set_relative_rate(1.0 / args.nstreams);
 }
 
-work_return_code_t deinterleave_cpu::work(work_io& wio)
+work_return_t deinterleave_cpu::work(work_io& wio)
 
 {
     auto blocksize = pmtf::get_as<size_t>(*this->param_blocksize);
@@ -35,7 +35,7 @@ work_return_code_t deinterleave_cpu::work(work_io& wio)
     if (d_size_bytes == 0) {
         d_size_bytes = itemsize * blocksize;
         set_output_multiple(blocksize);
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     // Forecasting
@@ -44,7 +44,7 @@ work_return_code_t deinterleave_cpu::work(work_io& wio)
     auto ninput_items = wio.inputs()[0].n_items;
     auto min_output = blocksize * (ninput_items / (blocksize * nstreams));
     if (min_output < 1) {
-        return work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
     }
     noutput_items = std::min(noutput_items, min_output);
     ninput_items = noutput_items * nstreams;
@@ -75,7 +75,7 @@ work_return_code_t deinterleave_cpu::work(work_io& wio)
         count += blocksize;
     }
     wio.consume_each(totalcount);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/deinterleave/deinterleave_cpu.h
+++ b/blocklib/streamops/deinterleave/deinterleave_cpu.h
@@ -19,7 +19,7 @@ class deinterleave_cpu : public virtual deinterleave
 {
 public:
     deinterleave_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_current_output = 0;

--- a/blocklib/streamops/delay/delay_cpu.cc
+++ b/blocklib/streamops/delay/delay_cpu.cc
@@ -33,7 +33,7 @@ void delay_cpu::set_dly(size_t d)
     }
 }
 
-work_return_code_t delay_cpu::work(work_io& wio)
+work_return_t delay_cpu::work(work_io& wio)
 {
     auto itemsize = wio.outputs()[0].buf().item_size();
 
@@ -104,7 +104,7 @@ work_return_code_t delay_cpu::work(work_io& wio)
     wio.consume_each(cons);
     wio.produce_each(ret);
 
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/delay/delay_cpu.h
+++ b/blocklib/streamops/delay/delay_cpu.h
@@ -20,7 +20,7 @@ class delay_cpu : public delay
 {
 public:
     delay_cpu(const block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
     size_t dly() override { return d_delay; }
     void set_dly(size_t d) override;
 

--- a/blocklib/streamops/head/head_cpu.cc
+++ b/blocklib/streamops/head/head_cpu.cc
@@ -19,21 +19,21 @@ head_cpu::head_cpu(const block_args& args) : INHERITED_CONSTRUCTORS, d_nitems(ar
 {
 }
 
-work_return_code_t head_cpu::work(work_io& wio)
+work_return_t head_cpu::work(work_io& wio)
 {
     auto iptr = wio.inputs()[0].items<uint8_t>();
     auto optr = wio.outputs()[0].items<uint8_t>();
 
     if (d_ncopied_items >= d_nitems) {
         wio.outputs()[0].n_produced = 0;
-        return work_return_code_t::WORK_DONE; // Done!
+        return work_return_t::DONE; // Done!
     }
 
     unsigned n = std::min(d_nitems - d_ncopied_items, (uint64_t)wio.outputs()[0].n_items);
 
     if (n == 0) {
         wio.outputs()[0].n_produced = 0;
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     memcpy(optr, iptr, n * wio.inputs()[0].buf().item_size());
@@ -42,9 +42,9 @@ work_return_code_t head_cpu::work(work_io& wio)
     wio.outputs()[0].n_produced = n;
 
     if (d_ncopied_items >= d_nitems) {
-        return work_return_code_t::WORK_DONE; // Done!
+        return work_return_t::DONE; // Done!
     }
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace streamops */

--- a/blocklib/streamops/head/head_cpu.h
+++ b/blocklib/streamops/head/head_cpu.h
@@ -19,7 +19,7 @@ class head_cpu : public head
 {
 public:
     head_cpu(const block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_nitems;

--- a/blocklib/streamops/interleave/interleave_cpu.cc
+++ b/blocklib/streamops/interleave/interleave_cpu.cc
@@ -25,14 +25,14 @@ interleave_cpu::interleave_cpu(block_args args)
     set_output_multiple(d_blocksize * d_ninputs);
 }
 
-work_return_code_t interleave_cpu::work(work_io& wio)
+work_return_t interleave_cpu::work(work_io& wio)
 
 {
 
     // Since itemsize can be set after construction
     if (d_itemsize == 0) {
         d_itemsize = wio.inputs()[0].buf().item_size();
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     // Forecasting
@@ -42,7 +42,7 @@ work_return_code_t interleave_cpu::work(work_io& wio)
         std::min(ninput_items / d_blocksize, noutput_items / (d_blocksize * d_ninputs));
 
     if (noutput_blocks < 1) {
-        return work_return_code_t::WORK_INSUFFICIENT_OUTPUT_ITEMS;
+        return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
     }
 
     auto out = wio.outputs()[0].items<uint8_t>();
@@ -57,7 +57,7 @@ work_return_code_t interleave_cpu::work(work_io& wio)
     }
     wio.consume_each(noutput_blocks * d_blocksize);
     wio.produce_each(noutput_blocks * d_blocksize * d_ninputs);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/interleave/interleave_cpu.h
+++ b/blocklib/streamops/interleave/interleave_cpu.h
@@ -19,7 +19,7 @@ class interleave_cpu : public virtual interleave
 {
 public:
     interleave_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     const unsigned int d_ninputs;

--- a/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex_cpu.cc
+++ b/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex_cpu.cc
@@ -26,7 +26,7 @@ void interleaved_short_to_complex_cpu::set_scale_factor(float new_value)
     d_scalar = new_value;
 }
 
-work_return_code_t interleaved_short_to_complex_cpu::work(work_io& wio)
+work_return_t interleaved_short_to_complex_cpu::work(work_io& wio)
 
 {
     auto in = wio.inputs()[0].items<short>();
@@ -46,7 +46,7 @@ work_return_code_t interleaved_short_to_complex_cpu::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = noutput_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex_cpu.h
+++ b/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex_cpu.h
@@ -20,7 +20,7 @@ class interleaved_short_to_complex_cpu : public interleaved_short_to_complex
 public:
     interleaved_short_to_complex_cpu(const block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 
     void set_swap(bool swap);

--- a/blocklib/streamops/keep_m_in_n/keep_m_in_n_cpu.cc
+++ b/blocklib/streamops/keep_m_in_n/keep_m_in_n_cpu.cc
@@ -43,7 +43,7 @@ keep_m_in_n_cpu::keep_m_in_n_cpu(block_args args) : INHERITED_CONSTRUCTORS
     set_relative_rate((double)args.m / args.n);
 }
 
-work_return_code_t keep_m_in_n_cpu::work(work_io& wio)
+work_return_t keep_m_in_n_cpu::work(work_io& wio)
 
 {
     auto out = wio.outputs()[0].items<uint8_t>();
@@ -77,7 +77,7 @@ work_return_code_t keep_m_in_n_cpu::work(work_io& wio)
 
     wio.consume_each(blks * n);
     wio.produce_each(blks * m);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 void keep_m_in_n_cpu::on_parameter_change(param_action_sptr action)

--- a/blocklib/streamops/keep_m_in_n/keep_m_in_n_cpu.h
+++ b/blocklib/streamops/keep_m_in_n/keep_m_in_n_cpu.h
@@ -19,7 +19,7 @@ class keep_m_in_n_cpu : public virtual keep_m_in_n
 {
 public:
     keep_m_in_n_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     void on_parameter_change(param_action_sptr action) override;

--- a/blocklib/streamops/keep_m_in_n/keep_m_in_n_cuda.cc
+++ b/blocklib/streamops/keep_m_in_n/keep_m_in_n_cuda.cc
@@ -51,7 +51,7 @@ keep_m_in_n_cuda::keep_m_in_n_cuda(block_args args) : INHERITED_CONSTRUCTORS
     set_relative_rate((double)args.m / args.n);
 }
 
-work_return_code_t keep_m_in_n_cuda::work(work_io& wio)
+work_return_t keep_m_in_n_cuda::work(work_io& wio)
 
 {
     auto out = wio.outputs()[0].items<uint8_t>();
@@ -69,7 +69,7 @@ work_return_code_t keep_m_in_n_cuda::work(work_io& wio)
     if (blks == 0) {
         wio.consume_each(0);
         wio.produce_each(0);
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     int gridSize = (blks * m * itemsize + d_min_block - 1) / d_min_block;
@@ -86,7 +86,7 @@ work_return_code_t keep_m_in_n_cuda::work(work_io& wio)
 
     wio.consume_each(blks * n);
     wio.produce_each(blks * m);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 void keep_m_in_n_cuda::on_parameter_change(param_action_sptr action)

--- a/blocklib/streamops/keep_m_in_n/keep_m_in_n_cuda.h
+++ b/blocklib/streamops/keep_m_in_n/keep_m_in_n_cuda.h
@@ -21,7 +21,7 @@ class keep_m_in_n_cuda : public keep_m_in_n
 {
 public:
     keep_m_in_n_cuda(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     int d_min_block;

--- a/blocklib/streamops/load/load_cpu.cc
+++ b/blocklib/streamops/load/load_cpu.cc
@@ -16,7 +16,7 @@ namespace streamops {
 
 load_cpu::load_cpu(block_args args) : INHERITED_CONSTRUCTORS, d_load(args.iterations) {}
 
-work_return_code_t load_cpu::work(work_io& wio)
+work_return_t load_cpu::work(work_io& wio)
 
 {
     auto iptr = wio.inputs()[0].items<uint8_t>();
@@ -28,7 +28,7 @@ work_return_code_t load_cpu::work(work_io& wio)
         memcpy(optr, iptr, size);
 
     wio.outputs()[0].n_produced = wio.outputs()[0].n_items;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/load/load_cpu.h
+++ b/blocklib/streamops/load/load_cpu.h
@@ -19,7 +19,7 @@ class load_cpu : public load
 {
 public:
     load_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_load;

--- a/blocklib/streamops/load/load_cuda.cc
+++ b/blocklib/streamops/load/load_cuda.cc
@@ -36,7 +36,7 @@ load_cuda::load_cuda(block_args args)
     }
 }
 
-work_return_code_t load_cuda::work(work_io& wio)
+work_return_t load_cuda::work(work_io& wio)
 
 {
     auto in = wio.inputs()[0].items<uint8_t>();
@@ -64,7 +64,7 @@ work_return_code_t load_cuda::work(work_io& wio)
 
     // Tell runtime system how many output items we produced.
     wio.produce_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 } // namespace streamops
 } // namespace gr

--- a/blocklib/streamops/load/load_cuda.h
+++ b/blocklib/streamops/load/load_cuda.h
@@ -23,7 +23,7 @@ class load_cuda : public load
 {
 public:
     load_cuda(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     size_t d_load;

--- a/blocklib/streamops/nop/nop_cpu.cc
+++ b/blocklib/streamops/nop/nop_cpu.cc
@@ -14,11 +14,11 @@ namespace streamops {
 
 nop_cpu::nop_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
 
-work_return_code_t nop_cpu::work(work_io& wio)
+work_return_t nop_cpu::work(work_io& wio)
 
 {
     wio.produce_each(wio.outputs()[0].n_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/nop/nop_cpu.h
+++ b/blocklib/streamops/nop/nop_cpu.h
@@ -17,7 +17,7 @@ class nop_cpu : public nop
 {
 public:
     nop_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 };
 
 } // namespace streamops

--- a/blocklib/streamops/nop_head/nop_head_cpu.cc
+++ b/blocklib/streamops/nop_head/nop_head_cpu.cc
@@ -17,20 +17,20 @@ nop_head_cpu::nop_head_cpu(const block_args& args)
 {
 }
 
-work_return_code_t nop_head_cpu::work(work_io& wio)
+work_return_t nop_head_cpu::work(work_io& wio)
 
 {
 
     if (d_ncopied_items >= d_nitems) {
         wio.outputs()[0].n_produced = 0;
-        return work_return_code_t::WORK_DONE; // Done!
+        return work_return_t::DONE; // Done!
     }
 
     unsigned n = std::min(d_nitems - d_ncopied_items, (uint64_t)wio.outputs()[0].n_items);
 
     if (n == 0) {
         wio.outputs()[0].n_produced = 0;
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     // Do Nothing
@@ -38,7 +38,7 @@ work_return_code_t nop_head_cpu::work(work_io& wio)
     d_ncopied_items += n;
     wio.outputs()[0].n_produced = n;
 
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace streamops */

--- a/blocklib/streamops/nop_head/nop_head_cpu.h
+++ b/blocklib/streamops/nop_head/nop_head_cpu.h
@@ -17,7 +17,7 @@ class nop_head_cpu : public nop_head
 {
 public:
     nop_head_cpu(const block_args& args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_nitems;

--- a/blocklib/streamops/probe_signal/probe_signal_cpu.cc
+++ b/blocklib/streamops/probe_signal/probe_signal_cpu.cc
@@ -21,7 +21,7 @@ probe_signal_cpu<T>::probe_signal_cpu(const typename probe_signal<T>::block_args
 }
 
 template <class T>
-work_return_code_t probe_signal_cpu<T>::work(work_io& wio)
+work_return_t probe_signal_cpu<T>::work(work_io& wio)
 
 {
     auto in = wio.inputs()[0].items<T>();
@@ -31,7 +31,7 @@ work_return_code_t probe_signal_cpu<T>::work(work_io& wio)
         *this->param_level = in[ninput_items - 1];
 
     wio.consume_each(ninput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace streamops */

--- a/blocklib/streamops/probe_signal/probe_signal_cpu.h
+++ b/blocklib/streamops/probe_signal/probe_signal_cpu.h
@@ -21,7 +21,7 @@ class probe_signal_cpu : public probe_signal<T>
 public:
     probe_signal_cpu(const typename probe_signal<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     // Declare private variables here

--- a/blocklib/streamops/probe_signal_v/probe_signal_v_cpu.cc
+++ b/blocklib/streamops/probe_signal_v/probe_signal_v_cpu.cc
@@ -23,7 +23,7 @@ probe_signal_v_cpu<T>::probe_signal_v_cpu(
 }
 
 template <class T>
-work_return_code_t probe_signal_v_cpu<T>::work(work_io& wio)
+work_return_t probe_signal_v_cpu<T>::work(work_io& wio)
 
 {
     auto in = wio.inputs()[0].items<T>();
@@ -32,7 +32,7 @@ work_return_code_t probe_signal_v_cpu<T>::work(work_io& wio)
     memcpy(d_level.data(), &in[(ninput_items - 1) * d_vlen], d_vlen * sizeof(T));
 
     wio.consume_each(ninput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace streamops */

--- a/blocklib/streamops/probe_signal_v/probe_signal_v_cpu.h
+++ b/blocklib/streamops/probe_signal_v/probe_signal_v_cpu.h
@@ -21,7 +21,7 @@ class probe_signal_v_cpu : public probe_signal_v<T>
 public:
     probe_signal_v_cpu(const typename probe_signal_v<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     // Just work with the private member variable, and pass it out as pmt when queried

--- a/blocklib/streamops/selector/selector_cpu.cc
+++ b/blocklib/streamops/selector/selector_cpu.cc
@@ -23,7 +23,7 @@ selector_cpu::selector_cpu(block_args args)
     set_tag_propagation_policy(gr::tag_propagation_policy_t::TPP_CUSTOM);
 }
 
-work_return_code_t selector_cpu::work(work_io& wio)
+work_return_t selector_cpu::work(work_io& wio)
 
 {
     auto input_index = pmtf::get_as<size_t>(*this->param_input_index);
@@ -55,7 +55,7 @@ work_return_code_t selector_cpu::work(work_io& wio)
     }
 
     wio.consume_each(noutput_items);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/selector/selector_cpu.h
+++ b/blocklib/streamops/selector/selector_cpu.h
@@ -19,7 +19,7 @@ class selector_cpu : public virtual selector
 {
 public:
     selector_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_itemsize = 0;

--- a/blocklib/streamops/stream_to_streams/stream_to_streams_cpu.cc
+++ b/blocklib/streamops/stream_to_streams/stream_to_streams_cpu.cc
@@ -20,7 +20,7 @@ stream_to_streams_cpu::stream_to_streams_cpu(const block_args& args)
 {
 }
 
-work_return_code_t stream_to_streams_cpu::work(work_io& wio)
+work_return_t stream_to_streams_cpu::work(work_io& wio)
 {
     auto in = wio.inputs()[0].items<uint8_t>();
 
@@ -41,7 +41,7 @@ work_return_code_t stream_to_streams_cpu::work(work_io& wio)
 
     wio.produce_each(total_items);
     wio.consume_each(total_items * nstreams);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/stream_to_streams/stream_to_streams_cpu.h
+++ b/blocklib/streamops/stream_to_streams/stream_to_streams_cpu.h
@@ -20,7 +20,7 @@ class stream_to_streams_cpu : public stream_to_streams
 public:
     stream_to_streams_cpu(const block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 };
 
 

--- a/blocklib/streamops/stream_to_streams/stream_to_streams_cuda.cc
+++ b/blocklib/streamops/stream_to_streams/stream_to_streams_cuda.cc
@@ -23,7 +23,7 @@ stream_to_streams_cuda::stream_to_streams_cuda(const block_args& args)
     cudaStreamCreate(&d_stream);
 }
 
-work_return_code_t stream_to_streams_cuda::work(work_io& wio)
+work_return_t stream_to_streams_cuda::work(work_io& wio)
 
 {
     auto noutput_items = wio.outputs()[0].n_items;
@@ -49,7 +49,7 @@ work_return_code_t stream_to_streams_cuda::work(work_io& wio)
 
     wio.produce_each(total_items);
     wio.consume_each(total_items * nstreams);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/stream_to_streams/stream_to_streams_cuda.h
+++ b/blocklib/streamops/stream_to_streams/stream_to_streams_cuda.h
@@ -21,7 +21,7 @@ class stream_to_streams_cuda : public stream_to_streams
 public:
     stream_to_streams_cuda(const block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     size_t d_nstreams;

--- a/blocklib/streamops/throttle/throttle_cpu.cc
+++ b/blocklib/streamops/throttle/throttle_cpu.cc
@@ -38,12 +38,12 @@ bool throttle_cpu::start()
     return block::start();
 }
 
-work_return_code_t throttle_cpu::work(work_io& wio)
+work_return_t throttle_cpu::work(work_io& wio)
 {
     if (d_sleeping) {
         wio.produce_each(0);
         wio.consume_each(0);
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     // copy all samples output[i] <= input[i]
@@ -69,7 +69,7 @@ work_return_code_t throttle_cpu::work(work_io& wio)
         d_total_samples -= noutput_items;
         wio.produce_each(0);
         wio.consume_each(0);
-        return work_return_code_t::WORK_OK;
+        return work_return_t::OK;
     }
 
     // TODO: blocks like throttle shouldn't need to do a memcpy, but this would have to be
@@ -80,7 +80,7 @@ work_return_code_t throttle_cpu::work(work_io& wio)
     wio.outputs()[0].n_produced = n;
 
     d_debug_logger->debug("Throttle produced {}", n);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/streamops/throttle/throttle_cpu.h
+++ b/blocklib/streamops/throttle/throttle_cpu.h
@@ -25,7 +25,7 @@ public:
     void set_sample_rate(double rate);
 
     bool start() override;
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 protected:
     double d_samps_per_sec;

--- a/blocklib/zeromq/pub_sink/pub_sink_cpu.cc
+++ b/blocklib/zeromq/pub_sink/pub_sink_cpu.cc
@@ -16,7 +16,7 @@ pub_sink_cpu::pub_sink_cpu(block_args args)
 {
 }
 
-work_return_code_t pub_sink_cpu::work(work_io& wio)
+work_return_t pub_sink_cpu::work(work_io& wio)
 {
     auto noutput_items = wio.inputs()[0].n_items;
     auto nread = wio.inputs()[0].nitems_read();
@@ -25,7 +25,7 @@ work_return_code_t pub_sink_cpu::work(work_io& wio)
                               nread,
                               wio.inputs()[0].tags_in_window(0, noutput_items));
     wio.consume_each(nsent);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/zeromq/pub_sink/pub_sink_cpu.h
+++ b/blocklib/zeromq/pub_sink/pub_sink_cpu.h
@@ -10,7 +10,7 @@ class pub_sink_cpu : public virtual pub_sink, public virtual base_sink
 {
 public:
     pub_sink_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
     std::string last_endpoint() const override { return base_sink::last_endpoint(); }
 
     // Since vsize can be set as 0, then inferred on flowgraph init, set it during start()

--- a/blocklib/zeromq/pull_source/pull_source_cpu.cc
+++ b/blocklib/zeromq/pull_source/pull_source_cpu.cc
@@ -14,7 +14,7 @@ pull_source_cpu::pull_source_cpu(block_args args)
 {
 }
 
-work_return_code_t pull_source_cpu::work(work_io& wio)
+work_return_t pull_source_cpu::work(work_io& wio)
 {
 
     auto noutput_items = wio.outputs()[0].n_items;
@@ -45,7 +45,7 @@ work_return_code_t pull_source_cpu::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = done;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/zeromq/pull_source/pull_source_cpu.h
+++ b/blocklib/zeromq/pull_source/pull_source_cpu.h
@@ -10,7 +10,7 @@ class pull_source_cpu : public virtual pull_source, public virtual base_source
 {
 public:
     pull_source_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     // Since vsize can be set as 0, then inferred on flowgraph init, set it during start()
     bool start() override

--- a/blocklib/zeromq/push_sink/push_sink_cpu.cc
+++ b/blocklib/zeromq/push_sink/push_sink_cpu.cc
@@ -10,7 +10,7 @@ push_sink_cpu::push_sink_cpu(block_args args)
           ZMQ_PUSH, args.itemsize, args.address, args.timeout, args.pass_tags, args.hwm)
 {
 }
-work_return_code_t push_sink_cpu::work(work_io& wio)
+work_return_t push_sink_cpu::work(work_io& wio)
 
 {
     // Poll with a timeout (FIXME: scheduler can't wait for us)
@@ -26,7 +26,7 @@ work_return_code_t push_sink_cpu::work(work_io& wio)
                          wio.inputs()[0].tags_in_window(0, wio.inputs()[0].n_items));
     }
 
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/zeromq/push_sink/push_sink_cpu.h
+++ b/blocklib/zeromq/push_sink/push_sink_cpu.h
@@ -10,7 +10,7 @@ class push_sink_cpu : public virtual push_sink, public virtual base_sink
 {
 public:
     push_sink_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
     std::string last_endpoint() const override { return base_sink::last_endpoint(); }
 
     // Since vsize can be set as 0, then inferred on flowgraph init, set it during start()

--- a/blocklib/zeromq/rep_sink/rep_sink_cpu.cc
+++ b/blocklib/zeromq/rep_sink/rep_sink_cpu.cc
@@ -20,7 +20,7 @@ rep_sink_cpu::rep_sink_cpu(block_args args)
           ZMQ_REP, args.itemsize, args.address, args.timeout, args.pass_tags, args.hwm)
 {
 }
-work_return_code_t rep_sink_cpu::work(work_io& wio)
+work_return_t rep_sink_cpu::work(work_io& wio)
 {
     auto in = wio.inputs()[0].items<uint8_t>();
     auto noutput_items = wio.inputs()[0].n_items;
@@ -66,7 +66,7 @@ work_return_code_t rep_sink_cpu::work(work_io& wio)
     }
 
     wio.inputs()[0].n_consumed = done;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/zeromq/rep_sink/rep_sink_cpu.h
+++ b/blocklib/zeromq/rep_sink/rep_sink_cpu.h
@@ -20,7 +20,7 @@ class rep_sink_cpu : public virtual rep_sink, public virtual base_sink
 {
 public:
     rep_sink_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
     std::string last_endpoint() const override { return base_sink::last_endpoint(); }
 
     // Since vsize can be set as 0, then inferred on flowgraph init, set it during start()

--- a/blocklib/zeromq/req_source/req_source_cpu.cc
+++ b/blocklib/zeromq/req_source/req_source_cpu.cc
@@ -24,7 +24,7 @@ req_source_cpu::req_source_cpu(block_args args)
 {
 }
 
-work_return_code_t req_source_cpu::work(work_io& wio)
+work_return_t req_source_cpu::work(work_io& wio)
 {
 
     auto noutput_items = wio.outputs()[0].n_items;
@@ -70,7 +70,7 @@ work_return_code_t req_source_cpu::work(work_io& wio)
     }
 
     wio.outputs()[0].n_produced = done;
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/zeromq/req_source/req_source_cpu.h
+++ b/blocklib/zeromq/req_source/req_source_cpu.h
@@ -20,7 +20,7 @@ class req_source_cpu : public virtual req_source, public virtual base_source
 {
 public:
     req_source_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     // Since vsize can be set as 0, then inferred on flowgraph init, set it during start()
     bool start() override

--- a/blocklib/zeromq/sub_source/sub_source_cpu.cc
+++ b/blocklib/zeromq/sub_source/sub_source_cpu.cc
@@ -22,7 +22,7 @@ sub_source_cpu::sub_source_cpu(block_args args)
     d_socket.set(zmq::sockopt::subscribe, args.key);
 }
 
-work_return_code_t sub_source_cpu::work(work_io& wio)
+work_return_t sub_source_cpu::work(work_io& wio)
 {
     auto noutput_items = wio.outputs()[0].n_items;
     bool first = true;
@@ -52,7 +52,7 @@ work_return_code_t sub_source_cpu::work(work_io& wio)
     }
 
     wio.produce_each(done);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/blocklib/zeromq/sub_source/sub_source_cpu.h
+++ b/blocklib/zeromq/sub_source/sub_source_cpu.h
@@ -10,7 +10,7 @@ class sub_source_cpu : public virtual sub_source, public virtual base_source
 {
 public:
     sub_source_cpu(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
     // Since vsize can be set as 0, then inferred on flowgraph init, set it during start()
     bool start() override

--- a/gr/include/gnuradio/block.h
+++ b/gr/include/gnuradio/block.h
@@ -86,22 +86,22 @@ public:
      *
      * @param work_input Vector of block_work_input structs
      * @param work_output Vector of block_work_output structs
-     * @return work_return_code_t
+     * @return work_return_t
      */
-    virtual work_return_code_t work(work_io& wio)
+    virtual work_return_t work(work_io& wio)
     {
         throw std::runtime_error("work function has been called but not implemented");
     }
-    using work_t = std::function<work_return_code_t(work_io&)>;
+    using work_t = std::function<work_return_t(work_io&)>;
     /**
      * @brief Wrapper for work to perform special checks and take care of special
      * cases for certain types of blocks, e.g. sync_block, decim_block
      *
      * @param work_input Vector of block_work_input structs
      * @param work_output Vector of block_work_output structs
-     * @return work_return_code_t
+     * @return work_return_t
      */
-    virtual work_return_code_t do_work(work_io& wio) { return work(wio); };
+    virtual work_return_t do_work(work_io& wio) { return work(wio); };
 
     void set_parent_intf(neighbor_interface_sptr sched) { p_scheduler = sched; }
     parameter_config d_parameters;

--- a/gr/include/gnuradio/block_work_io.h
+++ b/gr/include/gnuradio/block_work_io.h
@@ -99,16 +99,16 @@ public:
  * @brief Enum for return codes from calls to block::work
  *
  */
-enum class work_return_code_t {
-    WORK_ERROR = -100, /// error occurred in the work function
-    WORK_INSUFFICIENT_OUTPUT_ITEMS =
+enum class work_return_t {
+    ERROR = -100, /// error occurred in the work function
+    INSUFFICIENT_OUTPUT_ITEMS =
         -3, /// work requires a larger output buffer to produce output
-    WORK_INSUFFICIENT_INPUT_ITEMS =
+    INSUFFICIENT_INPUT_ITEMS =
         -2, /// work requires a larger input buffer to produce output
-    WORK_DONE =
+    DONE =
         -1, /// this block has completed its processing and the flowgraph should be done
-    WORK_OK = 0, /// work call was successful and return values in i/o structs are valid
-    WORK_CALLBACK_INITIATED =
+    OK = 0, /// work call was successful and return values in i/o structs are valid
+    CALLBACK_INITIATED =
         1, /// rather than blocking in the work function, the block will call back to the
            /// parent interface when it is ready to be called again
 };

--- a/gr/include/gnuradio/executor.h
+++ b/gr/include/gnuradio/executor.h
@@ -2,8 +2,8 @@
 
 namespace gr {
 
-enum class executor_state { WORKING, DONE, FLUSHED, EXIT };
-enum class executor_iteration_status {
+enum class executor_state_t { WORKING, DONE, FLUSHED, EXIT };
+enum class executor_iteration_status_t {
     READY,           // We made progress; everything's cool.
     READY_NO_OUTPUT, // We consumed some input, but produced no output.
     BLKD_IN,         // no progress; we're blocked waiting for input data.

--- a/gr/include/gnuradio/flat_graph.h
+++ b/gr/include/gnuradio/flat_graph.h
@@ -36,8 +36,8 @@ public:
 class flat_graph : public graph
 {
     static constexpr const char* BLOCK_COLOR_KEY = "color";
-    enum vcolor { WHITE, GREY, BLACK };
-    enum io { INPUT, OUTPUT };
+    enum class vcolor_t { WHITE, GREY, BLACK };
+    enum class io_t { INPUT, OUTPUT };
 
 public:
     void clear() override;
@@ -256,7 +256,7 @@ private:
     std::vector<block_vector_t> partition();
     block_vector_t topological_sort(block_vector_t& blocks);
 
-    std::map<block_sptr, int> block_color;
+    std::map<block_sptr, vcolor_t> block_color;
 }; // namespace gr
 
 using flat_graph_sptr = std::shared_ptr<flat_graph>;

--- a/gr/include/gnuradio/python_block.h
+++ b/gr/include/gnuradio/python_block.h
@@ -27,8 +27,6 @@ namespace gr {
  *
  * The gateway provides access to all the gr::block routines.
  */
-enum py_block_t { PY_BLOCK_GENERAL = 0, PY_BLOCK_SYNC, PY_BLOCK_DECIM, PY_BLOCK_INTERP };
-
 
 class GR_RUNTIME_API python_block : virtual public gr::block
 {
@@ -43,7 +41,7 @@ public:
     /*******************************************************************
      * Overloads for various scheduler-called functions
      ******************************************************************/
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 
     bool start(void) override;
     bool stop(void) override;
@@ -63,7 +61,7 @@ public:
     /*******************************************************************
      * Overloads for various scheduler-called functions
      ******************************************************************/
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 
     bool start(void) override;
     bool stop(void) override;

--- a/gr/include/gnuradio/realtime.h
+++ b/gr/include/gnuradio/realtime.h
@@ -12,11 +12,11 @@
 
 namespace gr {
 
-enum rt_status_t { RT_OK = 0, RT_NOT_IMPLEMENTED, RT_NO_PRIVS, RT_OTHER_ERROR };
+enum class rt_status_t { OK = 0, NOT_IMPLEMENTED, NO_PRIVS, OTHER_ERROR };
 
-enum rt_sched_policy {
-    RT_SCHED_RR = 0,   // round robin
-    RT_SCHED_FIFO = 1, // first in first out
+enum class rt_sched_policy_t {
+    RR = 0,   // round robin
+    FIFO = 1, // first in first out
 };
 
 /*!

--- a/gr/include/gnuradio/sync_block.h
+++ b/gr/include/gnuradio/sync_block.h
@@ -41,9 +41,9 @@ public:
      *
      * @param work_input
      * @param work_output
-     * @return work_return_code_t
+     * @return work_return_t
      */
-    work_return_code_t do_work(work_io& wio) override
+    work_return_t do_work(work_io& wio) override
     {
         // Check all inputs and outputs have the same number of items
         auto min_num_items = std::numeric_limits<size_t>::max();
@@ -68,11 +68,11 @@ public:
 
         for (auto& w : wio.outputs()) {
             if (w.n_items < output_multiple()) {
-                return work_return_code_t::WORK_INSUFFICIENT_OUTPUT_ITEMS;
+                return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
             }
         }
 
-        work_return_code_t ret = work(wio);
+        work_return_t ret = work(wio);
 
         // For a sync block the n_produced must be the same on every
         // output port

--- a/gr/lib/flat_graph.cc
+++ b/gr/lib/flat_graph.cc
@@ -119,14 +119,14 @@ block_vector_t flat_graph::calc_reachable_blocks(block_sptr block, block_vector_
 
     // Mark all blocks as unvisited
     for (auto& b : blocks)
-        block_color[b] = WHITE;
+        block_color[b] = vcolor_t::WHITE;
 
     // Recursively mark all reachable blocks
     reachable_dfs_visit(block, blocks);
 
     // Collect all the blocks that have been visited
     for (auto& b : blocks)
-        if (block_color[b] == BLACK)
+        if (block_color[b] == vcolor_t::BLACK)
             result.push_back(b);
 
     return result;
@@ -136,13 +136,13 @@ block_vector_t flat_graph::calc_reachable_blocks(block_sptr block, block_vector_
 void flat_graph::reachable_dfs_visit(block_sptr block, block_vector_t& blocks)
 {
     // Mark the current one as visited
-    block_color[block] = BLACK;
+    block_color[block] = vcolor_t::BLACK;
 
     // Recurse into adjacent vertices
     block_vector_t adjacent = calc_adjacent_blocks(block, blocks);
 
     for (auto& b : adjacent)
-        if (block_color[b] == WHITE)
+        if (block_color[b] == vcolor_t::WHITE)
             reachable_dfs_visit(b, blocks);
 }
 
@@ -170,10 +170,10 @@ block_vector_t flat_graph::topological_sort(block_vector_t& blocks)
 
     // Start 'em all white
     for (auto& b : tmp)
-        block_color[b] = WHITE;
+        block_color[b] = vcolor_t::WHITE;
 
     for (auto& b : tmp) {
-        if (block_color[b] == WHITE)
+        if (block_color[b] == vcolor_t::WHITE)
             topological_dfs_visit(b, result);
     }
 
@@ -205,19 +205,19 @@ bool flat_graph::source_p(block_sptr block) { return calc_upstream_edges(block).
 
 void flat_graph::topological_dfs_visit(block_sptr block, block_vector_t& output)
 {
-    block_color[block] = GREY;
+    block_color[block] = vcolor_t::GREY;
     block_vector_t blocks(calc_downstream_blocks(block));
 
     for (auto& b : blocks) {
         switch (block_color[b]) {
-        case WHITE:
+        case vcolor_t::WHITE:
             topological_dfs_visit(b, output);
             break;
 
-        case GREY:
+        case vcolor_t::GREY:
             throw std::runtime_error("flow graph has loops!");
 
-        case BLACK:
+        case vcolor_t::BLACK:
             continue;
 
         default:

--- a/gr/lib/python_block.cc
+++ b/gr/lib/python_block.cc
@@ -29,13 +29,13 @@ python_block::python_block(const py::handle& p, const std::string& name) : block
     d_py_handle = p;
 }
 
-work_return_code_t python_block::work(work_io& wio)
+work_return_t python_block::work(work_io& wio)
 {
     py::gil_scoped_acquire acquire;
 
     py::object ret = d_py_handle.attr("handle_work")(&wio);
 
-    return ret.cast<work_return_code_t>();
+    return ret.cast<work_return_t>();
 }
 
 bool python_block::start(void)
@@ -70,14 +70,14 @@ python_sync_block::python_sync_block(const py::handle& p, const std::string& nam
 }
 
 
-work_return_code_t python_sync_block::work(work_io& wio)
+work_return_t python_sync_block::work(work_io& wio)
 {
     py::gil_scoped_acquire acquire;
 
     auto ww = d_py_handle.attr("work");
     py::object ret = ww(&wio);
 
-    return ret.cast<work_return_code_t>();
+    return ret.cast<work_return_t>();
 }
 
 bool python_sync_block::start(void)

--- a/gr/lib/realtime.cc
+++ b/gr/lib/realtime.cc
@@ -61,7 +61,7 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
     // set the priority class on the process
     int pri_class = (true) ? REALTIME_PRIORITY_CLASS : NORMAL_PRIORITY_CLASS;
     if (SetPriorityClass(GetCurrentProcess(), pri_class) == 0)
-        return RT_OTHER_ERROR;
+        return rt_status_t::OTHER_ERROR;
 
     // scale the priority value to the constants
     int priorities[] = { THREAD_PRIORITY_IDLE,         THREAD_PRIORITY_LOWEST,
@@ -74,10 +74,10 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
 
     // set the thread priority on the thread
     if (SetThreadPriority(GetCurrentThread(), priorities[pri_index]) == 0)
-        return RT_OTHER_ERROR;
+        return rt_status_t::OTHER_ERROR;
 
     // printf("SetPriorityClass + SetThreadPriority\n");
-    return RT_OK;
+    return rt_status_t::OK;
 }
 } // namespace gr
 
@@ -87,7 +87,7 @@ namespace gr {
 
 rt_status_t enable_realtime_scheduling(rt_sched_param p)
 {
-    int policy = p.policy == RT_SCHED_FIFO ? SCHED_FIFO : SCHED_RR;
+    int policy = p.policy == rt_sched_policy_t::FIFO ? SCHED_FIFO : SCHED_RR;
     int min_real_pri = sched_get_priority_min(policy);
     int max_real_pri = sched_get_priority_max(policy);
     int pri = rescale_virtual_pri(p.priority, min_real_pri, max_real_pri);
@@ -101,18 +101,18 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
     int result = pthread_setschedparam(pthread_self(), policy, &param);
     if (result != 0) {
         if (result == EPERM) // N.B., return value, not errno
-            return RT_NO_PRIVS;
+            return rt_status_t::NO_PRIVS;
         else {
             gr::logger_ptr logger, debug_logger;
             gr::configure_default_loggers(logger, debug_logger, "realtime");
             logger->error("pthread_setschedparam: failed to set real time priority: {}",
                           strerror(result));
-            return RT_OTHER_ERROR;
+            return rt_status_t::OTHER_ERROR;
         }
     }
 
     // printf("SCHED_FIFO enabled with priority = %d\n", pri);
-    return RT_OK;
+    return rt_status_t::OK;
 }
 } // namespace gr
 
@@ -123,7 +123,7 @@ namespace gr {
 
 rt_status_t enable_realtime_scheduling(rt_sched_param p)
 {
-    int policy = p.policy == RT_SCHED_FIFO ? SCHED_FIFO : SCHED_RR;
+    int policy = p.policy == rt_sched_policy_t::FIFO ? SCHED_FIFO : SCHED_RR;
     int min_real_pri = sched_get_priority_min(policy);
     int max_real_pri = sched_get_priority_max(policy);
     int pri = rescale_virtual_pri(p.priority, min_real_pri, max_real_pri);
@@ -138,18 +138,18 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
     int result = sched_setscheduler(pid, policy, &param);
     if (result != 0) {
         if (errno == EPERM)
-            return RT_NO_PRIVS;
+            return rt_status_t::NO_PRIVS;
         else {
             gr::logger_ptr logger, debug_logger;
             gr::configure_default_loggers(logger, debug_logger, "realtime");
             logger->error("sched_setscheduler: failed to set real time priority: {}",
                           strerror(result));
-            return RT_OTHER_ERROR;
+            return rt_status_t::OTHER_ERROR;
         }
     }
 
     // printf("SCHED_FIFO enabled with priority = %d\n", pri);
-    return RT_OK;
+    return rt_status_t::OK;
 }
 
 } // namespace gr
@@ -157,7 +157,10 @@ rt_status_t enable_realtime_scheduling(rt_sched_param p)
 #else
 
 namespace gr {
-rt_status_t enable_realtime_scheduling(rt_sched_param p) { return RT_NOT_IMPLEMENTED; }
+rt_status_t enable_realtime_scheduling(rt_sched_param p)
+{
+    return rt_status_t::NOT_IMPLEMENTED;
+}
 } // namespace gr
 
 #endif

--- a/gr/lib/realtime_impl.h
+++ b/gr/lib/realtime_impl.h
@@ -33,11 +33,11 @@ static inline int rt_priority_default() { return 1; }
 
 struct rt_sched_param {
     int priority;
-    rt_sched_policy policy;
+    rt_sched_policy_t policy;
 
-    rt_sched_param() : priority(rt_priority_default()), policy(RT_SCHED_RR) {}
+    rt_sched_param() : priority(rt_priority_default()), policy(rt_sched_policy_t::RR) {}
 
-    rt_sched_param(int priority_, rt_sched_policy policy_ = RT_SCHED_RR)
+    rt_sched_param(int priority_, rt_sched_policy_t policy_ = rt_sched_policy_t::RR)
     {
         if (priority_ < rt_priority_min() || priority_ > rt_priority_max())
             throw std::invalid_argument("rt_sched_param: priority out of range");

--- a/gr/python/gr/bindings/block_work_io_pybind.cc
+++ b/gr/python/gr/bindings/block_work_io_pybind.cc
@@ -17,15 +17,15 @@ namespace py = pybind11;
 
 void bind_block_work_io(py::module& m)
 {
-    py::enum_<gr::work_return_code_t>(m, "work_return_t")
-        .value("WORK_ERROR", gr::work_return_code_t::WORK_ERROR) // -100
-        .value("WORK_INSUFFICIENT_OUTPUT_ITEMS",
-               gr::work_return_code_t::WORK_INSUFFICIENT_OUTPUT_ITEMS) // -3
-        .value("WORK_INSUFFICIENT_INPUT_ITEMS",
-               gr::work_return_code_t::WORK_INSUFFICIENT_INPUT_ITEMS) // -2
-        .value("WORK_DONE", gr::work_return_code_t::WORK_DONE)        // -1
-        .value("WORK_OK", gr::work_return_code_t::WORK_OK)            //  0
-        .export_values();
+    py::enum_<gr::work_return_t>(m, "work_return_t")
+        .value("ERROR", gr::work_return_t::ERROR) // -100
+        .value("INSUFFICIENT_OUTPUT_ITEMS",
+               gr::work_return_t::INSUFFICIENT_OUTPUT_ITEMS) // -3
+        .value("INSUFFICIENT_INPUT_ITEMS",
+               gr::work_return_t::INSUFFICIENT_INPUT_ITEMS) // -2
+        .value("DONE", gr::work_return_t::DONE)             // -1
+        .value("OK", gr::work_return_t::OK)                 //  0
+        ;
 
     py::class_<gr::block_work_output>(m, "block_work_output")
         .def_readwrite("n_items", &gr::block_work_output::n_items)

--- a/gr/python/gr/bindings/python_block_pybind.cc
+++ b/gr/python/gr/bindings/python_block_pybind.cc
@@ -33,11 +33,4 @@ void bind_python_block(py::module& m)
                std::shared_ptr<python_sync_block>>(m, "python_sync_block")
 
         .def(py::init(&python_sync_block::make), py::arg("p"), py::arg("name"));
-
-    py::enum_<gr::py_block_t>(m, "py_block_t")
-        .value("PY_BLOCK_GENERAL", gr::PY_BLOCK_GENERAL)
-        .value("PY_BLOCK_SYNC", gr::PY_BLOCK_SYNC)
-        .value("PY_BLOCK_DECIM", gr::PY_BLOCK_DECIM)
-        .value("PY_BLOCK_INTERP", gr::PY_BLOCK_INTERP)
-        .export_values();
 }

--- a/kernel/include/gnuradio/kernel/digital/constellation.h
+++ b/kernel/include/gnuradio/kernel/digital/constellation.h
@@ -48,17 +48,18 @@ using constellation_sptr = std::shared_ptr<constellation>;
 class constellation : public std::enable_shared_from_this<constellation>
 {
 public:
-    enum normalization_t {
+    enum class normalization_t {
         NO_NORMALIZATION,
         POWER_NORMALIZATION,
         AMPLITUDE_NORMALIZATION,
     };
 
-    constellation(std::vector<gr_complex> constell,
-                  std::vector<int> pre_diff_code,
-                  unsigned int rotational_symmetry,
-                  unsigned int dimensionality,
-                  normalization_t normalization = AMPLITUDE_NORMALIZATION);
+    constellation(
+        std::vector<gr_complex> constell,
+        std::vector<int> pre_diff_code,
+        unsigned int rotational_symmetry,
+        unsigned int dimensionality,
+        normalization_t normalization = normalization_t::AMPLITUDE_NORMALIZATION);
     constellation();
     virtual ~constellation();
 
@@ -243,11 +244,12 @@ public:
      * mean(abs(points))=1 (default), POWER_NORMALIZATION to normalize points
      * to mean(abs(points)^2)=1 or NO_NORMALIZATION to keep the original amplitude.
      */
-    static sptr make(std::vector<gr_complex> constell,
-                     std::vector<int> pre_diff_code,
-                     unsigned int rotational_symmetry,
-                     unsigned int dimensionality,
-                     normalization_t normalization = AMPLITUDE_NORMALIZATION);
+    static sptr
+    make(std::vector<gr_complex> constell,
+         std::vector<int> pre_diff_code,
+         unsigned int rotational_symmetry,
+         unsigned int dimensionality,
+         normalization_t normalization = normalization_t::AMPLITUDE_NORMALIZATION);
 
     unsigned int decision_maker(const gr_complex* sample) override;
     // void calc_metric(gr_complex *sample, float *metric, trellis_metric_type_t type);
@@ -255,11 +257,12 @@ public:
     // void calc_hard_symbol_metric(gr_complex *sample, float *metric);
 
 protected:
-    constellation_calcdist(std::vector<gr_complex> constell,
-                           std::vector<int> pre_diff_code,
-                           unsigned int rotational_symmetry,
-                           unsigned int dimensionality,
-                           normalization_t normalization = AMPLITUDE_NORMALIZATION);
+    constellation_calcdist(
+        std::vector<gr_complex> constell,
+        std::vector<int> pre_diff_code,
+        unsigned int rotational_symmetry,
+        unsigned int dimensionality,
+        normalization_t normalization = normalization_t::AMPLITUDE_NORMALIZATION);
 };
 
 
@@ -291,12 +294,13 @@ public:
      * mean(abs(points))=1 (default), POWER_NORMALIZATION to normalize points
      * to mean(abs(points)^2)=1 or NO_NORMALIZATION to keep the original amplitude.
      */
-    constellation_sector(std::vector<gr_complex> constell,
-                         std::vector<int> pre_diff_code,
-                         unsigned int rotational_symmetry,
-                         unsigned int dimensionality,
-                         unsigned int n_sectors,
-                         normalization_t normalization = AMPLITUDE_NORMALIZATION);
+    constellation_sector(
+        std::vector<gr_complex> constell,
+        std::vector<int> pre_diff_code,
+        unsigned int rotational_symmetry,
+        unsigned int dimensionality,
+        unsigned int n_sectors,
+        normalization_t normalization = normalization_t::AMPLITUDE_NORMALIZATION);
 
     ~constellation_sector() override;
 
@@ -359,18 +363,19 @@ public:
          unsigned int imag_sectors,
          float width_real_sectors,
          float width_imag_sectors,
-         normalization_t normalization = AMPLITUDE_NORMALIZATION);
+         normalization_t normalization = normalization_t::AMPLITUDE_NORMALIZATION);
     ~constellation_rect() override;
 
 protected:
-    constellation_rect(std::vector<gr_complex> constell,
-                       std::vector<int> pre_diff_code,
-                       unsigned int rotational_symmetry,
-                       unsigned int real_sectors,
-                       unsigned int imag_sectors,
-                       float width_real_sectors,
-                       float width_imag_sectors,
-                       normalization_t normalization = AMPLITUDE_NORMALIZATION);
+    constellation_rect(
+        std::vector<gr_complex> constell,
+        std::vector<int> pre_diff_code,
+        unsigned int rotational_symmetry,
+        unsigned int real_sectors,
+        unsigned int imag_sectors,
+        float width_real_sectors,
+        float width_imag_sectors,
+        normalization_t normalization = normalization_t::AMPLITUDE_NORMALIZATION);
 
     unsigned int get_sector(const gr_complex* sample) override;
     gr_complex calc_sector_center(unsigned int sector);

--- a/kernel/include/gnuradio/kernel/digital/metric_type.h
+++ b/kernel/include/gnuradio/kernel/digital/metric_type.h
@@ -14,11 +14,7 @@ namespace gr {
 namespace kernel {
 namespace digital {
 
-enum trellis_metric_type_t {
-    TRELLIS_EUCLIDEAN = 200,
-    TRELLIS_HARD_SYMBOL,
-    TRELLIS_HARD_BIT
-};
+enum class trellis_metric_type_t { EUCLIDEAN = 200, HARD_SYMBOL, HARD_BIT };
 
 } // namespace digital
 } // namespace kernel

--- a/kernel/include/gnuradio/kernel/fft/window.h
+++ b/kernel/include/gnuradio/kernel/fft/window.h
@@ -25,35 +25,33 @@ public:
     // illegal value for any window that requires a parameter
     static constexpr double INVALID_WIN_PARAM = -1;
 
-    enum win_type {
-        WIN_NONE = -1,       //!< don't use a window
-        WIN_HAMMING = 0,     //!< Hamming window; max attenuation 53 dB
-        WIN_HANN = 1,        //!< Hann window; max attenuation 44 dB
-        WIN_HANNING = 1,     //!< alias to WIN_HANN
-        WIN_BLACKMAN = 2,    //!< Blackman window; max attenuation 74 dB
-        WIN_RECTANGULAR = 3, //!< Basic rectangular window; max attenuation 21 dB
-        WIN_KAISER = 4, //!< Kaiser window; max attenuation see window::max_attenuation
-        WIN_BLACKMAN_hARRIS = 5, //!< Blackman-harris window; max attenuation 92 dB
-        WIN_BLACKMAN_HARRIS =
-            5,            //!< alias to WIN_BLACKMAN_hARRIS for capitalization consistency
-        WIN_BARTLETT = 6, //!< Barlett (triangular) window; max attenuation 26 dB
-        WIN_FLATTOP = 7,  //!< flat top window; useful in FFTs; max attenuation 93 dB
-        WIN_NUTTALL = 8,  //!< Nuttall window; max attenuation 114 dB
-        WIN_BLACKMAN_NUTTALL = 8, //!< Nuttall window; max attenuation 114 dB
-        WIN_NUTTALL_CFD =
+    enum class window_t {
+        NONE = -1,       //!< don't use a window
+        HAMMING = 0,     //!< Hamming window; max attenuation 53 dB
+        HANN = 1,        //!< Hann window; max attenuation 44 dB
+        HANNING = 1,     //!< alias to HANN
+        BLACKMAN = 2,    //!< Blackman window; max attenuation 74 dB
+        RECTANGULAR = 3, //!< Basic rectangular window; max attenuation 21 dB
+        KAISER = 4,      //!< Kaiser window; max attenuation see window::max_attenuation
+        BLACKMAN_hARRIS = 5,  //!< Blackman-harris window; max attenuation 92 dB
+        BLACKMAN_HARRIS = 5,  //!< alias to BLACKMAN_hARRIS for capitalization consistency
+        BARTLETT = 6,         //!< Barlett (triangular) window; max attenuation 26 dB
+        FLATTOP = 7,          //!< flat top window; useful in FFTs; max attenuation 93 dB
+        NUTTALL = 8,          //!< Nuttall window; max attenuation 114 dB
+        BLACKMAN_NUTTALL = 8, //!< Nuttall window; max attenuation 114 dB
+        NUTTALL_CFD =
             9, //!< Nuttall continuous-first-derivative window; max attenuation 112 dB
-        WIN_WELCH = 10,  //!< Welch window; max attenuation 31 dB
-        WIN_PARZEN = 11, //!< Parzen window; max attenuation 56 dB
-        WIN_EXPONENTIAL =
-            12, //!< Exponential window; max attenuation see window::max_attenuation
-        WIN_RIEMANN = 13, //!< Riemann window; max attenuation 39 dB
-        WIN_GAUSSIAN =
-            14,         //!< Gaussian window; max attenuation see window::max_attenuation
-        WIN_TUKEY = 15, //!< Tukey window; max attenuation see window::max_attenuation
+        WELCH = 10,  //!< Welch window; max attenuation 31 dB
+        PARZEN = 11, //!< Parzen window; max attenuation 56 dB
+        EXPONENTIAL =
+            12,       //!< Exponential window; max attenuation see window::max_attenuation
+        RIEMANN = 13, //!< Riemann window; max attenuation 39 dB
+        GAUSSIAN = 14, //!< Gaussian window; max attenuation see window::max_attenuation
+        TUKEY = 15,    //!< Tukey window; max attenuation see window::max_attenuation
     };
 
     /*!
-     * \brief Given a window::win_type, this tells you the maximum
+     * \brief Given a window::window_t, this tells you the maximum
      * attenuation (really the maximum approximation error) you can expect.
      *
      * \details
@@ -79,11 +77,11 @@ public:
      * Tukey windows provide attenuation that varies non-linearily between Rectangular (21
      * dB) and Hann (44 dB) windows.
      *
-     * \param type The window::win_type enumeration of the window type.
+     * \param type The window::window_t enumeration of the window type.
      * \param param Parameter value used for Kaiser (beta), Exponential (d), Gaussian
      * (sigma) and Tukey (alpha) window creation.
      */
-    static double max_attenuation(win_type type, double param = INVALID_WIN_PARAM);
+    static double max_attenuation(window_t type, double param = INVALID_WIN_PARAM);
 
     /*!
      * \brief Helper function to build cosine-based windows. 3-coefficient version.
@@ -352,16 +350,16 @@ public:
     static std::vector<float> gaussian(int ntaps, float sigma);
 
     /*!
-     * \brief Build a window using gr::fft::win_type to index the
+     * \brief Build a window using gr::fft::window_t to index the
      * type of window desired.
      *
-     * \param type a gr::fft::win_type index for the type of window.
+     * \param type a gr::fft::window_t index for the type of window.
      * \param ntaps Number of coefficients in the window.
      * \param param Parameter value used for Kaiser (beta), Exponential (d), Gaussian
      * (sigma) and Tukey (alpha) window creation. \param normalize If true, return a
      * window with unit power
      */
-    static std::vector<float> build(win_type type,
+    static std::vector<float> build(window_t type,
                                     int ntaps,
                                     double param = INVALID_WIN_PARAM,
                                     const bool normalize = false);

--- a/kernel/include/gnuradio/kernel/filter/firdes.h
+++ b/kernel/include/gnuradio/kernel/filter/firdes.h
@@ -28,7 +28,7 @@ namespace filter {
 class firdes
 {
 public:
-    static std::vector<float> window(fft::window::win_type type, int ntaps, double param);
+    static std::vector<float> window(fft::window::window_t type, int ntaps, double param);
 
     // ... class methods ...
 
@@ -42,7 +42,7 @@ public:
      * \param sampling_freq       sampling freq (Hz)
      * \param cutoff_freq         center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -50,7 +50,7 @@ public:
              double sampling_freq,
              double cutoff_freq,      // Hz center of transition band
              double transition_width, // Hz width of transition band
-             fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+             fft::window::window_t window = fft::window::window_t::HAMMING,
              double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -65,7 +65,7 @@ public:
      * \param cutoff_freq         beginning of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      required stopband attenuation
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -74,7 +74,7 @@ public:
                double cutoff_freq,      // Hz beginning transition band
                double transition_width, // Hz width of transition band
                double attenuation_dB,   // out of band attenuation dB
-               fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+               fft::window::window_t window = fft::window::window_t::HAMMING,
                double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -87,7 +87,7 @@ public:
      * \param sampling_freq       sampling freq (Hz)
      * \param cutoff_freq         center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -95,7 +95,7 @@ public:
               double sampling_freq,
               double cutoff_freq,      // Hz center of transition band
               double transition_width, // Hz width of transition band
-              fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+              fft::window::window_t window = fft::window::window_t::HAMMING,
               double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -110,7 +110,7 @@ public:
      * \param cutoff_freq         center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -119,7 +119,7 @@ public:
                 double cutoff_freq,      // Hz center of transition band
                 double transition_width, // Hz width of transition band
                 double attenuation_dB,   // out of band attenuation dB
-                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+                fft::window::window_t window = fft::window::window_t::HAMMING,
                 double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -133,7 +133,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -142,7 +142,7 @@ public:
               double low_cutoff_freq,  // Hz center of transition band
               double high_cutoff_freq, // Hz center of transition band
               double transition_width, // Hz width of transition band
-              fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+              fft::window::window_t window = fft::window::window_t::HAMMING,
               double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -158,7 +158,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -168,7 +168,7 @@ public:
                 double high_cutoff_freq, // Hz beginning transition band
                 double transition_width, // Hz width of transition band
                 double attenuation_dB,   // out of band attenuation dB
-                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+                fft::window::window_t window = fft::window::window_t::HAMMING,
                 double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
     /*!
      * \brief Use the "window method" to design a complex band-reject FIR
@@ -181,7 +181,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<gr_complex> complex_band_reject(
@@ -190,7 +190,7 @@ public:
         double low_cutoff_freq,
         double high_cutoff_freq,
         double transition_width, // Hz width of transition band
-        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        fft::window::window_t window = fft::window::window_t::HAMMING,
         double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -206,7 +206,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<gr_complex> complex_band_reject_2(
@@ -216,7 +216,7 @@ public:
         double high_cutoff_freq, // Hz beginning transition band
         double transition_width, // Hz width of transition band
         double attenuation_dB,   // out of band attenuation dB
-        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        fft::window::window_t window = fft::window::window_t::HAMMING,
         double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -230,7 +230,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<gr_complex> complex_band_pass(
@@ -239,7 +239,7 @@ public:
         double low_cutoff_freq,  // Hz center of transition band
         double high_cutoff_freq, // Hz center of transition band
         double transition_width, // Hz width of transition band
-        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        fft::window::window_t window = fft::window::window_t::HAMMING,
         double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -255,7 +255,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<gr_complex> complex_band_pass_2(
@@ -265,7 +265,7 @@ public:
         double high_cutoff_freq, // Hz beginning transition band
         double transition_width, // Hz width of transition band
         double attenuation_dB,   // out of band attenuation dB
-        fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+        fft::window::window_t window = fft::window::window_t::HAMMING,
         double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -279,7 +279,7 @@ public:
      * \param low_cutoff_freq     center of transition band (Hz)
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz)
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -288,7 +288,7 @@ public:
                 double low_cutoff_freq,  // Hz center of transition band
                 double high_cutoff_freq, // Hz center of transition band
                 double transition_width, // Hz width of transition band
-                fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+                fft::window::window_t window = fft::window::window_t::HAMMING,
                 double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!
@@ -304,7 +304,7 @@ public:
      * \param high_cutoff_freq    center of transition band (Hz)
      * \param transition_width    width of transition band (Hz).
      * \param attenuation_dB      out of band attenuation
-     * \param window              one of fft::window::win_type
+     * \param window              one of fft::window::window_t
      * \param param               parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
@@ -314,18 +314,18 @@ public:
                   double high_cutoff_freq, // Hz beginning transition band
                   double transition_width, // Hz width of transition band
                   double attenuation_dB,   // out of band attenuation dB
-                  fft::window::win_type window = fft::window::win_type::WIN_HAMMING,
+                  fft::window::window_t window = fft::window::window_t::HAMMING,
                   double param = 6.76); // used for Kaiser, Exp., Gaussian, Tukey windows
 
     /*!\brief design a Hilbert Transform Filter
      *
      * \param ntaps           number of taps, must be odd
-     * \param windowtype      one kind of fft::window::win_type
+     * \param windowtype      one kind of fft::window::window_t
      * \param param           parameter for Kaiser, Exp., Gaussian, Tukey windows
      */
     static std::vector<float>
     hilbert(unsigned int ntaps = 19,
-            fft::window::win_type windowtype = fft::window::win_type::WIN_RECTANGULAR,
+            fft::window::window_t windowtype = fft::window::window_t::RECTANGULAR,
             double param = 6.76);
 
     /*!
@@ -369,7 +369,7 @@ private:
 
     static int compute_ntaps(double sampling_freq,
                              double transition_width,
-                             fft::window::win_type window_type,
+                             fft::window::window_t window_type,
                              double param);
 
     static int compute_ntaps_windes(double sampling_freq,

--- a/kernel/include/gnuradio/kernel/filter/pfb_arb_resampler.h
+++ b/kernel/include/gnuradio/kernel/filter/pfb_arb_resampler.h
@@ -71,7 +71,7 @@ namespace filter {
  * interpolation rate (<EM>32</EM>).
  *
  *   <B><EM>self._taps = filter.firdes.low_pass_2(32, 32*fs, BW, TB,
- *      attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
+ *      attenuation_dB=ATT, window=fft.window.BLACKMAN_hARRIS)</EM></B>
  *
  * The theory behind this block can be found in Chapter 7.5 of
  * the following book:

--- a/kernel/include/gnuradio/kernel/filter/polyphase_filterbank.h
+++ b/kernel/include/gnuradio/kernel/filter/polyphase_filterbank.h
@@ -73,7 +73,7 @@ namespace filter {
  * unity.
  *
  *    <B><EM>self._taps = filter.firdes.low_pass_2(1, fs, BW, TB,
- *       attenuation_dB=ATT, window=fft.window.WIN_BLACKMAN_hARRIS)</EM></B>
+ *       attenuation_dB=ATT, window=fft.window.BLACKMAN_hARRIS)</EM></B>
  *
  * More on the theory of polyphase filterbanks can be found in
  * the following book:

--- a/kernel/lib/digital/constellation.cc
+++ b/kernel/lib/digital/constellation.cc
@@ -46,10 +46,10 @@ constellation::constellation(std::vector<gr_complex> constell,
     unsigned int constsize = d_constellation.size();
     float summed_mag = 0;
     switch (normalization) {
-    case NO_NORMALIZATION:
+    case normalization_t::NO_NORMALIZATION:
         break;
 
-    case POWER_NORMALIZATION:
+    case normalization_t::POWER_NORMALIZATION:
         // Scale constellation points so that average power is 1.
         for (unsigned int i = 0; i < constsize; i++) {
             gr_complex c = d_constellation[i];
@@ -61,7 +61,7 @@ constellation::constellation(std::vector<gr_complex> constell,
         }
         break;
 
-    case AMPLITUDE_NORMALIZATION:
+    case normalization_t::AMPLITUDE_NORMALIZATION:
         // Scale constellation points so that average magnitude is 1.
         for (unsigned int i = 0; i < constsize; i++) {
             gr_complex c = d_constellation[i];
@@ -185,13 +185,13 @@ void constellation::calc_metric(const gr_complex* sample,
                                 trellis_metric_type_t type)
 {
     switch (type) {
-    case TRELLIS_EUCLIDEAN:
+    case trellis_metric_type_t::EUCLIDEAN:
         calc_euclidean_metric(sample, metric);
         break;
-    case TRELLIS_HARD_SYMBOL:
+    case trellis_metric_type_t::HARD_SYMBOL:
         calc_hard_symbol_metric(sample, metric);
         break;
-    case TRELLIS_HARD_BIT:
+    case trellis_metric_type_t::HARD_BIT:
         throw std::runtime_error("Invalid metric type (not yet implemented).");
         break;
     default:

--- a/kernel/lib/fft/window.cc
+++ b/kernel/lib/fft/window.cc
@@ -51,43 +51,43 @@ double freq(int ntaps) { return 2.0 * GR_M_PI / ntaps; }
 
 double rate(int ntaps) { return 1.0 / (ntaps >> 1); }
 
-double window::max_attenuation(win_type type, double param)
+double window::max_attenuation(window_t type, double param)
 {
     switch (type) {
-    case (WIN_HAMMING):
+    case (window_t::HAMMING):
         return 53;
-    case (WIN_HANN):
+    case (window_t::HANN):
         return 44;
-    case (WIN_BLACKMAN):
+    case (window_t::BLACKMAN):
         return 74;
-    case (WIN_RECTANGULAR):
+    case (window_t::RECTANGULAR):
         return 21;
-    case (WIN_KAISER):
+    case (window_t::KAISER):
         // linear approximation
         return (param / 0.1102 + 8.7);
-    case (WIN_BLACKMAN_hARRIS):
+    case (window_t::BLACKMAN_hARRIS):
         return 92;
-    case (WIN_BARTLETT):
+    case (window_t::BARTLETT):
         return 27;
-    case (WIN_FLATTOP):
+    case (window_t::FLATTOP):
         return 93;
-    case WIN_NUTTALL:
+    case window_t::NUTTALL:
         return 114;
-    case WIN_NUTTALL_CFD:
+    case window_t::NUTTALL_CFD:
         return 112;
-    case WIN_WELCH:
+    case window_t::WELCH:
         return 31;
-    case WIN_PARZEN:
+    case window_t::PARZEN:
         return 56;
-    case WIN_EXPONENTIAL:
+    case window_t::EXPONENTIAL:
         // varies slightly depending on the decay factor, but this is a safe return value
         return 26;
-    case WIN_RIEMANN:
+    case window_t::RIEMANN:
         return 39;
-    case WIN_GAUSSIAN:
+    case window_t::GAUSSIAN:
         // value not meaningful for gaussian windows, but return something reasonable
         return 100;
-    case WIN_TUKEY:
+    case window_t::TUKEY:
         // low end is a rectangular window, attenuation exponentially approaches Hann
         // piecewise linear estimate, determined empirically via curve fitting, median
         // error is less than 0.5dB and maximum error is 2.5dB; the returned value will
@@ -374,7 +374,7 @@ std::vector<float> window::gaussian(int ntaps, float sigma)
 }
 
 std::vector<float>
-window::build(win_type type, int ntaps, double param, const bool normalize)
+window::build(window_t type, int ntaps, double param, const bool normalize)
 {
     // If we want a normalized window, we get a non-normalized one first, then
     // normalize it here:
@@ -395,37 +395,37 @@ window::build(win_type type, int ntaps, double param, const bool normalize)
 
     // Create non-normalized window:
     switch (type) {
-    case WIN_RECTANGULAR:
+    case window_t::RECTANGULAR:
         return rectangular(ntaps);
-    case WIN_HAMMING:
+    case window_t::HAMMING:
         return hamming(ntaps);
-    case WIN_HANN:
+    case window_t::HANN:
         return hann(ntaps);
-    case WIN_BLACKMAN:
+    case window_t::BLACKMAN:
         return blackman(ntaps);
-    case WIN_BLACKMAN_hARRIS:
+    case window_t::BLACKMAN_hARRIS:
         return blackman_harris(ntaps);
-    case WIN_KAISER:
+    case window_t::KAISER:
         return kaiser(ntaps, param);
-    case WIN_BARTLETT:
+    case window_t::BARTLETT:
         return bartlett(ntaps);
-    case WIN_FLATTOP:
+    case window_t::FLATTOP:
         return flattop(ntaps);
-    case WIN_NUTTALL:
+    case window_t::NUTTALL:
         return nuttall(ntaps);
-    case WIN_NUTTALL_CFD:
+    case window_t::NUTTALL_CFD:
         return nuttall_cfd(ntaps);
-    case WIN_WELCH:
+    case window_t::WELCH:
         return welch(ntaps);
-    case WIN_PARZEN:
+    case window_t::PARZEN:
         return parzen(ntaps);
-    case WIN_EXPONENTIAL:
+    case window_t::EXPONENTIAL:
         return exponential(ntaps, param);
-    case WIN_RIEMANN:
+    case window_t::RIEMANN:
         return riemann(ntaps);
-    case WIN_GAUSSIAN:
+    case window_t::GAUSSIAN:
         return gaussian(ntaps, param);
-    case WIN_TUKEY:
+    case window_t::TUKEY:
         return tukey(ntaps, param);
     default:
         throw std::out_of_range("window::build: type out of range");

--- a/kernel/lib/filter/firdes.cc
+++ b/kernel/lib/filter/firdes.cc
@@ -18,7 +18,7 @@ namespace gr {
 namespace kernel {
 namespace filter {
 
-std::vector<float> firdes::window(fft::window::win_type type, int ntaps, double param)
+std::vector<float> firdes::window(fft::window::window_t type, int ntaps, double param)
 {
     return fft::window::build(type, ntaps, param);
 }
@@ -32,7 +32,7 @@ vector<float> firdes::low_pass_2(double gain,
                                  double cutoff_freq,   // Hz BEGINNING of transition band
                                  double transition_width, // Hz width of transition band
                                  double attenuation_dB,   // attenuation dB
-                                 fft::window::win_type window_type,
+                                 fft::window::window_t window_type,
                                  double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -75,7 +75,7 @@ vector<float> firdes::low_pass(double gain,
                                double sampling_freq,
                                double cutoff_freq,      // Hz center of transition band
                                double transition_width, // Hz width of transition band
-                               fft::window::win_type window_type,
+                               fft::window::window_t window_type,
                                double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -124,7 +124,7 @@ vector<float> firdes::high_pass_2(double gain,
                                   double cutoff_freq,      // Hz center of transition band
                                   double transition_width, // Hz width of transition band
                                   double attenuation_dB,   // attenuation dB
-                                  fft::window::win_type window_type,
+                                  fft::window::window_t window_type,
                                   double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -168,7 +168,7 @@ vector<float> firdes::high_pass(double gain,
                                 double sampling_freq,
                                 double cutoff_freq,      // Hz center of transition band
                                 double transition_width, // Hz width of transition band
-                                fft::window::win_type window_type,
+                                fft::window::window_t window_type,
                                 double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_1f(sampling_freq, cutoff_freq, transition_width);
@@ -217,7 +217,7 @@ vector<float> firdes::band_pass_2(double gain,
                                   double high_cutoff_freq, // Hz center of transition band
                                   double transition_width, // Hz width of transition band
                                   double attenuation_dB,   // attenuation dB
-                                  fft::window::win_type window_type,
+                                  fft::window::window_t window_type,
                                   double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -260,7 +260,7 @@ vector<float> firdes::band_pass(double gain,
                                 double low_cutoff_freq,  // Hz center of transition band
                                 double high_cutoff_freq, // Hz center of transition band
                                 double transition_width, // Hz width of transition band
-                                fft::window::win_type window_type,
+                                fft::window::window_t window_type,
                                 double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -310,7 +310,7 @@ firdes::complex_band_pass_2(double gain,
                             double high_cutoff_freq, // Hz center of transition band
                             double transition_width, // Hz width of transition band
                             double attenuation_dB,   // attenuation dB
-                            fft::window::win_type window_type,
+                            fft::window::window_t window_type,
                             double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -354,7 +354,7 @@ firdes::complex_band_pass(double gain,
                           double low_cutoff_freq,  // Hz center of transition band
                           double high_cutoff_freq, // Hz center of transition band
                           double transition_width, // Hz width of transition band
-                          fft::window::win_type window_type,
+                          fft::window::window_t window_type,
                           double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -403,7 +403,7 @@ firdes::complex_band_reject_2(double gain,
                               double high_cutoff_freq, // Hz center of transition band
                               double transition_width, // Hz width of transition band
                               double attenuation_dB,   // attenuation dB
-                              fft::window::win_type window_type,
+                              fft::window::window_t window_type,
                               double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -448,7 +448,7 @@ firdes::complex_band_reject(double gain,
                             double low_cutoff_freq,  // Hz center of transition band
                             double high_cutoff_freq, // Hz center of transition band
                             double transition_width, // Hz width of transition band
-                            fft::window::win_type window_type,
+                            fft::window::window_t window_type,
                             double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f_c(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -497,7 +497,7 @@ firdes::band_reject_2(double gain,
                       double high_cutoff_freq, // Hz center of transition band
                       double transition_width, // Hz width of transition band
                       double attenuation_dB,   // attenuation dB
-                      fft::window::win_type window_type,
+                      fft::window::window_t window_type,
                       double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -541,7 +541,7 @@ vector<float> firdes::band_reject(double gain,
                                   double low_cutoff_freq,  // Hz center of transition band
                                   double high_cutoff_freq, // Hz center of transition band
                                   double transition_width, // Hz width of transition band
-                                  fft::window::win_type window_type,
+                                  fft::window::window_t window_type,
                                   double param) // used with Kaiser, Exp., Gaussian, Tukey
 {
     sanity_check_2f(sampling_freq, low_cutoff_freq, high_cutoff_freq, transition_width);
@@ -585,7 +585,7 @@ vector<float> firdes::band_reject(double gain,
 //
 
 vector<float>
-firdes::hilbert(unsigned int ntaps, fft::window::win_type windowtype, double param)
+firdes::hilbert(unsigned int ntaps, fft::window::window_t windowtype, double param)
 {
     if (!(ntaps & 1))
         throw std::out_of_range("Hilbert:  Must have odd number of taps");
@@ -705,7 +705,7 @@ int firdes::compute_ntaps_windes(
 
 int firdes::compute_ntaps(double sampling_freq,
                           double transition_width,
-                          fft::window::win_type window_type,
+                          fft::window::window_t window_type,
                           double param)
 {
     double a = fft::window::max_attenuation(window_type, param);

--- a/kernel/python/kernel/digital/bindings/constellation_pybind.cc
+++ b/kernel/python/kernel/digital/bindings/constellation_pybind.cc
@@ -36,10 +36,10 @@ void bind_constellation(py::module& m)
         m, "constellation", D(constellation));
 
     py::enum_<constellation::normalization_t>(constellation_class, "normalization")
-        .value("NO_NORMALIZATION", constellation::NO_NORMALIZATION)
-        .value("POWER_NORMALIZATION", constellation::POWER_NORMALIZATION)
-        .value("AMPLITUDE_NORMALIZATION", constellation::AMPLITUDE_NORMALIZATION)
-        .export_values();
+        .value("NO_NORMALIZATION", constellation::normalization_t::NO_NORMALIZATION)
+        .value("POWER_NORMALIZATION", constellation::normalization_t::POWER_NORMALIZATION)
+        .value("AMPLITUDE_NORMALIZATION",
+               constellation::normalization_t::AMPLITUDE_NORMALIZATION);
 
     py::implicitly_convertible<int,
                                gr::kernel::digital::constellation::normalization_t>();
@@ -195,7 +195,8 @@ void bind_constellation(py::module& m)
              py::arg("pre_diff_code"),
              py::arg("rotational_symmetry"),
              py::arg("dimensionality"),
-             py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
+             py::arg("normalization") =
+                 constellation::normalization_t::AMPLITUDE_NORMALIZATION,
              D(constellation_calcdist, make))
 
 
@@ -233,7 +234,8 @@ void bind_constellation(py::module& m)
              py::arg("imag_sectors"),
              py::arg("width_real_sectors"),
              py::arg("width_imag_sectors"),
-             py::arg("normalization") = constellation::AMPLITUDE_NORMALIZATION,
+             py::arg("normalization") =
+                 constellation::normalization_t::AMPLITUDE_NORMALIZATION,
              D(constellation_rect, make));
 
 

--- a/kernel/python/kernel/fft/bindings/window_pybind.cc
+++ b/kernel/python/kernel/fft/bindings/window_pybind.cc
@@ -31,29 +31,30 @@ void bind_window(py::module& m)
 
     py::class_<window, std::shared_ptr<window>> window_class(m, "window");
 
-    py::enum_<gr::kernel::fft::window::win_type>(window_class, "win_type")
-        .value("WIN_HAMMING", gr::kernel::fft::window::WIN_HAMMING)                   // 0
-        .value("WIN_HANN", gr::kernel::fft::window::WIN_HANN)                         // 1
-        .value("WIN_HANNING", gr::kernel::fft::window::WIN_HANNING)                   // 1
-        .value("WIN_BLACKMAN", gr::kernel::fft::window::WIN_BLACKMAN)                 // 2
-        .value("WIN_RECTANGULAR", gr::kernel::fft::window::WIN_RECTANGULAR)           // 3
-        .value("WIN_KAISER", gr::kernel::fft::window::WIN_KAISER)                     // 4
-        .value("WIN_BLACKMAN_hARRIS", gr::kernel::fft::window::WIN_BLACKMAN_hARRIS)   // 5
-        .value("WIN_BLACKMAN_HARRIS", gr::kernel::fft::window::WIN_BLACKMAN_HARRIS)   // 5
-        .value("WIN_BARTLETT", gr::kernel::fft::window::WIN_BARTLETT)                 // 6
-        .value("WIN_FLATTOP", gr::kernel::fft::window::WIN_FLATTOP)                   // 7
-        .value("WIN_NUTTALL", gr::kernel::fft::window::WIN_NUTTALL)                   // 8
-        .value("WIN_BLACKMAN_NUTTALL", gr::kernel::fft::window::WIN_BLACKMAN_NUTTALL) // 8
-        .value("WIN_NUTTALL_CFD", gr::kernel::fft::window::WIN_NUTTALL_CFD)           // 9
-        .value("WIN_WELCH", gr::kernel::fft::window::WIN_WELCH)             // 10
-        .value("WIN_PARZEN", gr::kernel::fft::window::WIN_PARZEN)           // 11
-        .value("WIN_EXPONENTIAL", gr::kernel::fft::window::WIN_EXPONENTIAL) // 12
-        .value("WIN_RIEMANN", gr::kernel::fft::window::WIN_RIEMANN)         // 13
-        .value("WIN_GAUSSIAN", gr::kernel::fft::window::WIN_GAUSSIAN)       // 14
-        .value("WIN_TUKEY", gr::kernel::fft::window::WIN_TUKEY)             // 15
+    py::enum_<gr::kernel::fft::window::window_t>(window_class, "window_t")
+        .value("HAMMING", gr::kernel::fft::window::window_t::HAMMING)                 // 0
+        .value("HANN", gr::kernel::fft::window::window_t::HANN)                       // 1
+        .value("HANNING", gr::kernel::fft::window::window_t::HANNING)                 // 1
+        .value("BLACKMAN", gr::kernel::fft::window::window_t::BLACKMAN)               // 2
+        .value("RECTANGULAR", gr::kernel::fft::window::window_t::RECTANGULAR)         // 3
+        .value("KAISER", gr::kernel::fft::window::window_t::KAISER)                   // 4
+        .value("BLACKMAN_hARRIS", gr::kernel::fft::window::window_t::BLACKMAN_hARRIS) // 5
+        .value("BLACKMAN_HARRIS", gr::kernel::fft::window::window_t::BLACKMAN_HARRIS) // 5
+        .value("BARTLETT", gr::kernel::fft::window::window_t::BARTLETT)               // 6
+        .value("FLATTOP", gr::kernel::fft::window::window_t::FLATTOP)                 // 7
+        .value("NUTTALL", gr::kernel::fft::window::window_t::NUTTALL)                 // 8
+        .value("BLACKMAN_NUTTALL",
+               gr::kernel::fft::window::window_t::BLACKMAN_NUTTALL)           // 8
+        .value("NUTTALL_CFD", gr::kernel::fft::window::window_t::NUTTALL_CFD) // 9
+        .value("WELCH", gr::kernel::fft::window::window_t::WELCH)             // 10
+        .value("PARZEN", gr::kernel::fft::window::window_t::PARZEN)           // 11
+        .value("EXPONENTIAL", gr::kernel::fft::window::window_t::EXPONENTIAL) // 12
+        .value("RIEMANN", gr::kernel::fft::window::window_t::RIEMANN)         // 13
+        .value("GAUSSIAN", gr::kernel::fft::window::window_t::GAUSSIAN)       // 14
+        .value("TUKEY", gr::kernel::fft::window::window_t::TUKEY)             // 15
         .export_values();
 
-    py::implicitly_convertible<int, gr::kernel::fft::window::win_type>();
+    py::implicitly_convertible<int, gr::kernel::fft::window::window_t>();
 
     window_class
         .def_static("max_attenuation",

--- a/kernel/python/kernel/filter/bindings/firdes_pybind.cc
+++ b/kernel/python/kernel/filter/bindings/firdes_pybind.cc
@@ -47,7 +47,7 @@ void bind_firdes(py::module& m)
                     py::arg("sampling_freq"),
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -58,7 +58,7 @@ void bind_firdes(py::module& m)
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -68,7 +68,7 @@ void bind_firdes(py::module& m)
                     py::arg("sampling_freq"),
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -79,7 +79,7 @@ void bind_firdes(py::module& m)
                     py::arg("cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -90,7 +90,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -102,7 +102,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -113,7 +113,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -125,7 +125,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -136,7 +136,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -148,7 +148,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -159,7 +159,7 @@ void bind_firdes(py::module& m)
                     py::arg("low_cutoff_freq"),
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -171,7 +171,7 @@ void bind_firdes(py::module& m)
                     py::arg("high_cutoff_freq"),
                     py::arg("transition_width"),
                     py::arg("attenuation_dB"),
-                    py::arg("window") = ::gr::kernel::fft::window::win_type::WIN_HAMMING,
+                    py::arg("window") = ::gr::kernel::fft::window::window_t::HAMMING,
                     py::arg("param") = 6.7599999999999998)
 
 
@@ -179,7 +179,7 @@ void bind_firdes(py::module& m)
                     &firdes::hilbert,
                     py::arg("ntaps") = 19,
                     py::arg("windowtype") =
-                        ::gr::kernel::fft::window::win_type::WIN_RECTANGULAR,
+                        ::gr::kernel::fft::window::window_t::RECTANGULAR,
                     py::arg("param") = 6.7599999999999998)
 
 

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/graph_executor.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/graph_executor.h
@@ -39,7 +39,7 @@ public:
         d_blocks = blocks;
     }
 
-    std::map<nodeid_t, executor_iteration_status>
+    std::map<nodeid_t, executor_iteration_status_t>
     run_one_iteration(std::vector<block_sptr> blocks = std::vector<block_sptr>());
 };
 

--- a/schedulers/nbt/lib/thread_wrapper.cc
+++ b/schedulers/nbt/lib/thread_wrapper.cc
@@ -75,7 +75,7 @@ bool thread_wrapper::handle_work_notification()
     // Based on state of the run_one_iteration, do things
     // If any of the blocks are done, notify the flowgraph monitor
     for (auto elem : s) {
-        if (elem.second == executor_iteration_status::DONE) {
+        if (elem.second == executor_iteration_status_t::DONE) {
             d_debug_logger->debug("Signalling DONE to RTMON from block {}", elem.first);
             d_rtmon->push_message(
                 rt_monitor_message::make(rt_monitor_message_t::DONE, id(), elem.first));
@@ -87,15 +87,15 @@ bool thread_wrapper::handle_work_notification()
     // bool kick = false;
     bool all_blkd = true;
     for (auto elem : s) {
-        if (elem.second == executor_iteration_status::READY ||
-            elem.second == executor_iteration_status::BLKD_OUT) {
+        if (elem.second == executor_iteration_status_t::READY ||
+            elem.second == executor_iteration_status_t::BLKD_OUT) {
             notify_self_ = true;
         }
-        else if (elem.second == executor_iteration_status::BLKD_IN) {
+        else if (elem.second == executor_iteration_status_t::BLKD_IN) {
             // kick = true;
         }
 
-        if (elem.second == executor_iteration_status::MSG_ONLY) {
+        if (elem.second == executor_iteration_status_t::MSG_ONLY) {
             //     gr_log_debug(d_debug_logger,
             //                  "size_approx {}",
             //                  msgq.size_approx());
@@ -104,8 +104,8 @@ bool thread_wrapper::handle_work_notification()
             //     all_blkd = false;
             // }
         }
-        else if (elem.second != executor_iteration_status::BLKD_IN &&
-                 elem.second != executor_iteration_status::BLKD_OUT) {
+        else if (elem.second != executor_iteration_status_t::BLKD_IN &&
+                 elem.second != executor_iteration_status_t::BLKD_OUT) {
             // Ignore source blocks
             if (d_block_id_to_block_map[elem.first]->input_stream_ports().empty()) {
                 all_blkd = false;

--- a/test/cuda/qa_python_block_cuda.py
+++ b/test/cuda/qa_python_block_cuda.py
@@ -37,7 +37,7 @@ class add_2_f32_1_f32(gr.cupy_sync_block):
         outbuf1[:] = inbuf1 + inbuf2
 
 
-        return gr.work_return_t.WORK_OK
+        return gr.work_return_t.OK
 
 
 class copy_f32(gr.cupy_sync_block):
@@ -64,7 +64,7 @@ class copy_f32(gr.cupy_sync_block):
         outbuf1[:] = inbuf1
 
 
-        return gr.work_return_t.WORK_OK
+        return gr.work_return_t.OK
 
 class test_block_gateway(gr_unittest.TestCase):
 

--- a/test/qa_optional_ports.py
+++ b/test/qa_optional_ports.py
@@ -29,7 +29,7 @@ class add_optional(gr.sync_block):
         if (len(wio.inputs()) > 2):
             outbuf1[:] = outbuf1[:] + inbuf3
 
-        return gr.work_return_t.WORK_OK
+        return gr.work_return_t.OK
 
 class test_optional_ports(gr_unittest.TestCase):
 

--- a/test/qa_python_block.py
+++ b/test/qa_python_block.py
@@ -33,7 +33,7 @@ class add_2_f32_1_f32(gr.sync_block):
 
         outbuf1[:] = inbuf1 + inbuf2
 
-        return gr.work_return_t.WORK_OK
+        return gr.work_return_t.OK
 
 class add_2_f32_1_f32_named(gr.sync_block):
     def __init__(self, shape=[1]):
@@ -55,7 +55,7 @@ class add_2_f32_1_f32_named(gr.sync_block):
         outbuf1[:] = inbuf1 + inbuf2
 
         out.produce(out.n_items)
-        return gr.work_return_t.WORK_OK
+        return gr.work_return_t.OK
 
 # This test extends the existing add_ff block by adding a custom python implementation
 class add_ff_numpy(math.add_ff):
@@ -74,7 +74,7 @@ class add_ff_numpy(math.add_ff):
 
         outbuf1[:] = inbuf1 + inbuf2
 
-        return gr.work_return_t.WORK_OK
+        return gr.work_return_t.OK
 
 class test_block_gateway(gr_unittest.TestCase):
 

--- a/utils/blockbuilder/templates/blockname_pyshell.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell.h.j2
@@ -20,14 +20,14 @@ public:
     }
 
 {% if blocktype != "hier_block" %}
-    work_return_code_t
+    work_return_t
     work(work_io& wio) override
     {
         py::gil_scoped_acquire acquire;
 
         py::object ret = this->pb_detail()->handle().attr("work")(&wio);
 
-        return ret.cast<work_return_code_t>();
+        return ret.cast<work_return_t>();
     }
 
     bool start(void)

--- a/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
@@ -20,14 +20,14 @@ public:
         
     }
 
-    work_return_code_t
+    work_return_t
     work(work_io& wio) override
     {
         py::gil_scoped_acquire acquire;
 
         py::object ret = this->pb_detail()->handle().attr("work")(&wio);
 
-        return ret.cast<work_return_code_t>();
+        return ret.cast<work_return_t>();
     }
 
     bool start(void)

--- a/utils/blockbuilder/templates/module_enums.h.j2
+++ b/utils/blockbuilder/templates/module_enums.h.j2
@@ -6,7 +6,7 @@ namespace gr {
 namespace {{module}} {
 
 {% for e in enums %}
-    enum class {{e}} { {% for v in enums[e]['enumerators'] %}{{v['id']}}{{"="+v['value']|string() if 'value' in v }}{{"," if not loop.last}}{% endfor %} };
+    enum class {{e}} { {% for v in enums[e]['enumerators'] %}{{v['id']|upper}}{{"="+v['value']|string() if 'value' in v }}{{"," if not loop.last}}{% endfor %} };
 {% endfor %}
 
 } // namespace {{ module }}

--- a/utils/blockbuilder/templates/module_enums_pybind.cc.j2
+++ b/utils/blockbuilder/templates/module_enums_pybind.cc.j2
@@ -8,7 +8,7 @@ void bind_enums(py::module& m)
 {% for e in enums %}
     py::enum_<::gr::{{module}}::{{e}}>(m, "{{e}}")
 {% for v in enums[e]['enumerators'] -%}
-        .value("{{v['id']}}", ::gr::{{module}}::{{e}}::{{v['id']}})  
+        .value("{{v['id']|upper}}", ::gr::{{module}}::{{e}}::{{v['id']|upper}})  
 {% endfor -%};
 
     py::implicitly_convertible<int, ::gr::{{module}}::{{e}}>();

--- a/utils/modtool/newblock/newblock_cpu.cc
+++ b/utils/modtool/newblock/newblock_cpu.cc
@@ -16,11 +16,11 @@ namespace newmod {
 
 newblock_cpu::newblock_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
 
-work_return_code_t newblock_cpu::work(work_io& wio)
+work_return_t newblock_cpu::work(work_io& wio)
 {
     // Do <+signal processing+>
     // Block specific code goes here
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 

--- a/utils/modtool/newblock/newblock_cpu.h
+++ b/utils/modtool/newblock/newblock_cpu.h
@@ -19,7 +19,7 @@ class newblock_cpu : public virtual newblock
 {
 public:
     newblock_cpu(block_args args);
-    work_return_code_t work(work_io& wio) override;
+    work_return_t work(work_io& wio) override;
 
 private:
     // private variables here

--- a/utils/modtool/newblock/newblock_cpu_t.cc
+++ b/utils/modtool/newblock/newblock_cpu_t.cc
@@ -21,10 +21,10 @@ newblock_cpu<T>::newblock_cpu(const typename newblock<T>::block_args& args)
 }
 
 template <class T>
-work_return_code_t newblock_cpu<T>::work(work_io&)
+work_return_t newblock_cpu<T>::work(work_io&)
 {
     // Do work specific code here
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace newmod */

--- a/utils/modtool/newblock/newblock_cpu_t.h
+++ b/utils/modtool/newblock/newblock_cpu_t.h
@@ -21,7 +21,7 @@ class newblock_cpu : public newblock<T>
 public:
     newblock_cpu(const typename newblock<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     // Declare private variables here

--- a/utils/modtool/newblock/newblock_cuda.cc
+++ b/utils/modtool/newblock/newblock_cuda.cc
@@ -26,14 +26,14 @@ newblock_cuda::newblock_cuda(block_args args) : INHERITED_CONSTRUCTORS
     cudaStreamCreate(&d_stream);
 }
 
-work_return_code_t newblock_cuda::work(work_io& wio)
+work_return_t newblock_cuda::work(work_io& wio)
 {
     // Do <+signal processing+>
     // Block specific code goes here
     cudaStreamSynchronize(d_stream);
 
     // produce_each(n, work_output);
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 } // namespace newmod
 } // namespace gr

--- a/utils/modtool/newblock/newblock_cuda.h
+++ b/utils/modtool/newblock/newblock_cuda.h
@@ -23,7 +23,7 @@ class newblock_cuda : public newblock
 {
 public:
     newblock_cuda(block_args args);
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     int d_block_size;

--- a/utils/modtool/newblock/newblock_cuda_t.cc
+++ b/utils/modtool/newblock/newblock_cuda_t.cc
@@ -34,17 +34,17 @@ newblock_cuda<gr_complex>::newblock_cuda(
 
 
 template <class T>
-work_return_code_t newblock_cuda<T>::work(work_io& wio)
+work_return_t newblock_cuda<T>::work(work_io& wio)
 {
     // Do block specific code here
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 template <>
-work_return_code_t newblock_cuda<gr_complex>::work(work_io& wio)
+work_return_t newblock_cuda<gr_complex>::work(work_io& wio)
 {
     // Do block specific code here
-    return work_return_code_t::WORK_OK;
+    return work_return_t::OK;
 }
 
 } /* namespace newmod */

--- a/utils/modtool/newblock/newblock_cuda_t.h
+++ b/utils/modtool/newblock/newblock_cuda_t.h
@@ -25,7 +25,7 @@ class newblock_cuda : public newblock<T>
 public:
     newblock_cuda(const typename newblock<T>::block_args& args);
 
-    work_return_code_t work(work_io&) override;
+    work_return_t work(work_io&) override;
 
 private:
     T d_k;


### PR DESCRIPTION
Apply the following principles across enums:
1. Use `enum class`
2. Enum types get `_t` e.g. `waveform_t`
3. Enum members are capitalized - both in python and c++
4. Enum members are not prefixed (e.g. work_return_t::OK instead of work_return_t::OK)
5. Bindings should not be exported to the top module level (e.g. gr.WORK_OK should not exist, it should be gr.work_return_t.OK)

Also work_return_code_t was renamed work_return_t --> code implied enum
Module level yaml enums are forced to be upper case in the templates

## Related Issue
#6038 

## Which blocks/areas does this affect?
Most blocks

## Testing Done
CI 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
