### PR TITLE
4.0: pdu: Initial PDU module with stream/pdu blocks

### DIFF
--- a/blocklib/meson.build
+++ b/blocklib/meson.build
@@ -32,3 +32,6 @@ endif
 if get_option('enable_gr_audio')
 subdir('audio')
 endif
+if get_option('enable_gr_pdu')
+subdir('pdu')
+endif

--- a/blocklib/pdu/.gitignore
+++ b/blocklib/pdu/.gitignore
@@ -1,0 +1,4 @@
+meson.build
+!include/gnuradio/pdu/meson.build
+!lib/meson.build
+!test/meson.build

--- a/blocklib/pdu/include/gnuradio/pdu/meson.build
+++ b/blocklib/pdu/include/gnuradio/pdu/meson.build
@@ -1,0 +1,3 @@
+headers = []
+
+install_headers(headers, subdir : 'gnuradio/pdu')

--- a/blocklib/pdu/lib/meson.build
+++ b/blocklib/pdu/lib/meson.build
@@ -1,0 +1,19 @@
+pdu_sources += []
+pdu_deps += [gnuradio_gr_dep, volk_dep, fmt_dep, pmtf_dep, python3_embed_dep]
+
+link_args = []
+block_cpp_args = ['-DHAVE_CPU']
+
+incdir = include_directories(['../include/gnuradio/pdu','../include'])
+gnuradio_blocklib_pdu_lib = library('gnuradio-blocklib-pdu', 
+    pdu_sources, 
+    include_directories : incdir, 
+    install : true,
+    link_language: 'cpp',
+    dependencies : pdu_deps,
+    link_args : link_args,
+    cpp_args : block_cpp_args)
+
+gnuradio_blocklib_pdu_dep = declare_dependency(include_directories : incdir,
+					   link_with : gnuradio_blocklib_pdu_lib,
+                       dependencies : pdu_deps)

--- a/blocklib/pdu/pdu_to_stream/.gitignore
+++ b/blocklib/pdu/pdu_to_stream/.gitignore
@@ -1,0 +1,1 @@
+meson.build

--- a/blocklib/pdu/pdu_to_stream/pdu_to_stream.yml
+++ b/blocklib/pdu/pdu_to_stream/pdu_to_stream.yml
@@ -1,0 +1,31 @@
+module: pdu
+block: pdu_to_stream
+label: pdu_to_stream
+blocktype: sync_block
+
+typekeys:
+    - id: T
+      type: class
+      options:
+          - cf32
+          - rf32
+          - ri32
+          - ri16
+          - ri8
+
+ports:
+    - domain: message
+      id: pdus
+      direction: input
+      optional: true
+
+    - domain: stream
+      id: out
+      direction: output
+      type: typekeys/T
+
+implementations:
+    - id: cpu
+# -   id: cuda
+
+file_format: 1

--- a/blocklib/pdu/pdu_to_stream/pdu_to_stream_cpu.cc
+++ b/blocklib/pdu/pdu_to_stream/pdu_to_stream_cpu.cc
@@ -1,0 +1,71 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include "pdu_to_stream_cpu.h"
+#include "pdu_to_stream_cpu_gen.h"
+
+namespace gr {
+namespace pdu {
+
+template <class T>
+pdu_to_stream_cpu<T>::pdu_to_stream_cpu(const typename pdu_to_stream<T>::block_args& args)
+    : INHERITED_CONSTRUCTORS(T)
+{
+}
+
+template <class T>
+void pdu_to_stream_cpu<T>::handle_msg_pdus(pmtf::pmt msg)
+{
+    d_pmt_queue.push(msg);
+    this->notify_scheduler_output();
+}
+
+template <class T>
+work_return_t pdu_to_stream_cpu<T>::work(work_io& wio)
+{
+    auto out = wio.outputs()[0].items<T>();
+    auto noutput_items = wio.outputs()[0].n_items;
+
+    // fill up the output buffer with the data from the pdus
+    size_t i = 0;
+    while (i < noutput_items) {
+        if (!d_vec_ready && !d_pmt_queue.empty()) {
+            d_pdu_meta = pmtf::map(pmtf::map(d_pmt_queue.front())["meta"]);
+            d_pdu_data = pmtf::vector<T>(pmtf::map(d_pmt_queue.front())["data"]);
+            d_pmt_queue.pop();
+            d_vec_idx = 0;
+            d_vec_ready = true;
+        }
+
+        if (d_vec_ready) {
+            auto items_in_this_pmt =
+                std::min(noutput_items - i, (d_pdu_data.size() - d_vec_idx));
+
+            std::copy(d_pdu_data.data() + d_vec_idx,
+                      d_pdu_data.data() + d_vec_idx + items_in_this_pmt,
+                      out + i);
+            i += items_in_this_pmt;
+            d_vec_idx += items_in_this_pmt;
+
+            if (d_vec_idx >= d_pdu_data.size()) {
+                d_vec_ready = false;
+            }
+        }
+        else {
+            break;
+        }
+    }
+
+    wio.produce_each(i);
+    return work_return_t::OK;
+}
+
+} /* namespace pdu */
+} /* namespace gr */

--- a/blocklib/pdu/pdu_to_stream/pdu_to_stream_cpu.h
+++ b/blocklib/pdu/pdu_to_stream/pdu_to_stream_cpu.h
@@ -1,0 +1,40 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#pragma once
+
+#include <gnuradio/pdu/pdu_to_stream.h>
+
+namespace gr {
+namespace pdu {
+
+template <class T>
+class pdu_to_stream_cpu : public pdu_to_stream<T>
+{
+public:
+    pdu_to_stream_cpu(const typename pdu_to_stream<T>::block_args& args);
+
+    work_return_t work(work_io&) override;
+
+private:
+    // data_type_t d_data_type;
+
+    std::queue<pmtf::pmt> d_pmt_queue;
+    pmtf::map d_pdu_meta;
+    pmtf::vector<T> d_pdu_data;
+    bool d_vec_ready = false;
+    size_t d_vec_idx = 0;
+
+    void handle_msg_pdus(pmtf::pmt msg) override;
+};
+
+
+} // namespace pdu
+} // namespace gr

--- a/blocklib/pdu/python/pdu/__init__.py
+++ b/blocklib/pdu/python/pdu/__init__.py
@@ -1,0 +1,9 @@
+
+import os
+
+try:
+    from .pdu_python import *
+except ImportError:
+    dirname, filename = os.path.split(os.path.abspath(__file__))
+    __path__.append(os.path.join(dirname, "bindings"))
+    from .pdu_python import *

--- a/blocklib/pdu/stream_to_pdu/.gitignore
+++ b/blocklib/pdu/stream_to_pdu/.gitignore
@@ -1,0 +1,1 @@
+meson.build

--- a/blocklib/pdu/stream_to_pdu/stream_to_pdu.yml
+++ b/blocklib/pdu/stream_to_pdu/stream_to_pdu.yml
@@ -1,0 +1,39 @@
+module: pdu
+block: stream_to_pdu
+label: stream_to_pdu
+blocktype: sync_block
+
+typekeys:
+    - id: T
+      type: class
+      options:
+          - cf32
+          - rf32
+          - ri32
+          - ri16
+          - ri8
+
+parameters:
+    #TODO: make this block handle SOB/EOB/pkt_len tags as well
+    - id: packet_len
+      label: Packet Length
+      dtype: size_t
+      grc:
+          default: 96
+
+ports:
+    - domain: stream
+      id: in
+      direction: input
+      type: typekeys/T
+
+    - domain: message
+      id: pdus
+      direction: output
+      optional: true
+
+implementations:
+    - id: cpu
+# -   id: cuda
+
+file_format: 1

--- a/blocklib/pdu/stream_to_pdu/stream_to_pdu_cpu.cc
+++ b/blocklib/pdu/stream_to_pdu/stream_to_pdu_cpu.cc
@@ -1,0 +1,44 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include "stream_to_pdu_cpu.h"
+#include "stream_to_pdu_cpu_gen.h"
+
+namespace gr {
+namespace pdu {
+
+template <class T>
+stream_to_pdu_cpu<T>::stream_to_pdu_cpu(const typename stream_to_pdu<T>::block_args& args)
+    : INHERITED_CONSTRUCTORS(T), d_packet_len(args.packet_len)
+{
+    d_msg_port = this->get_message_port("pdus");
+    this->set_output_multiple(d_packet_len);
+}
+
+template <class T>
+work_return_t stream_to_pdu_cpu<T>::work(work_io& wio)
+{
+    auto n_pdu = wio.inputs()[0].n_items / d_packet_len;
+    auto in = wio.inputs()[0].items<T>();
+
+    for (size_t n = 0; n < n_pdu; n++) {
+        auto pdu_out = pmtf::map{ { "meta", pmtf::map{} },
+                                  { "data",
+                                    pmtf::vector<T>(in + n * d_packet_len,
+                                                    in + (n + 1) * d_packet_len) } };
+        d_msg_port->post(pdu_out);
+    }
+
+    wio.consume_each(n_pdu * d_packet_len);
+    return work_return_t::OK;
+}
+
+} /* namespace pdu */
+} /* namespace gr */

--- a/blocklib/pdu/stream_to_pdu/stream_to_pdu_cpu.h
+++ b/blocklib/pdu/stream_to_pdu/stream_to_pdu_cpu.h
@@ -1,0 +1,33 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#pragma once
+
+#include <gnuradio/pdu/stream_to_pdu.h>
+
+namespace gr {
+namespace pdu {
+
+template <class T>
+class stream_to_pdu_cpu : public stream_to_pdu<T>
+{
+public:
+    stream_to_pdu_cpu(const typename stream_to_pdu<T>::block_args& args);
+
+    work_return_t work(work_io&) override;
+
+private:
+    size_t d_packet_len;
+    message_port_ptr d_msg_port;
+};
+
+
+} // namespace pdu
+} // namespace gr

--- a/blocklib/pdu/test/meson.build
+++ b/blocklib/pdu/test/meson.build
@@ -1,0 +1,7 @@
+###################################################
+#    QA
+###################################################
+
+if get_option('enable_testing')
+    test('PDU/Stream Conversions', py3, args : files('qa_pdu_stream.py'), env: TEST_ENV)
+endif

--- a/blocklib/pdu/test/qa_pdu_stream.py
+++ b/blocklib/pdu/test/qa_pdu_stream.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Josh Morman
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gnuradio import gr, gr_unittest, blocks, pdu, streamops
+import numpy as np
+import pmtf as pmt
+import time
+
+
+class qa_pdu_basic (gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.flowgraph()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_001_pdu_to_stream(self):
+        p2s = pdu.pdu_to_stream_c()
+        snk = blocks.vector_sink_c()
+
+        self.tb.connect((p2s, 0), (snk, 0))
+
+        in_data = np.array(list(range(1000)), dtype=np.float32) + \
+            np.array(list(range(1000)), dtype=np.float32)*1j
+        in_pdu = pmt.pmt({"meta": pmt.pmt({}), "data": pmt.pmt(in_data)})
+
+        self.tb.start()
+
+        msg_port = p2s.get_message_port("pdus")
+
+        for _ in range(3):
+            msg_port.post(in_pdu)
+
+        time.sleep(0.25)
+
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertTrue(np.array_equal(snk.data(), 3*(in_data.tolist())))
+
+    def test_002_pdu_to_stream_f(self):
+        p2s = pdu.pdu_to_stream_f()
+        snk = blocks.vector_sink_f()
+
+        self.tb.connect((p2s, 0), (snk, 0))
+        in_data = np.array(list(range(1000)), dtype=np.float32)
+        in_pdu = pmt.pmt({"meta": pmt.pmt({}), "data": pmt.pmt(in_data)})
+        self.tb.start()
+
+        msg_port = p2s.get_message_port("pdus")
+        for _ in range(3):
+            msg_port.post(in_pdu)
+
+        time.sleep(0.25)
+
+        self.tb.stop()
+        self.tb.wait()
+
+        self.assertTrue(np.array_equal(snk.data(), 3*(in_data.tolist())))
+
+
+    def test_003_stream_to_stream(self):
+        nsamps = 1000
+        pktsize = 100
+        vec = list(range(pktsize))
+        src = blocks.vector_source_f(vec, repeat=True)
+        p2s = pdu.pdu_to_stream_f()
+        s2p = pdu.stream_to_pdu_f(100)
+        hd = streamops.head(nsamps)
+        snk = blocks.vector_sink_f()
+
+        self.tb.connect([src, s2p])
+        self.tb.connect([p2s, hd, snk])
+        self.tb.connect((s2p, "pdus"), (p2s, "pdus"))
+        self.tb.start()
+        self.tb.wait()
+
+        self.assertSequenceEqual(snk.data(), (nsamps//pktsize)*vec)
+
+
+    def test_004_pdu_to_pdu(self):
+        nsamps = 1000 # number of samples in the initial pdus
+        pktsize = 100 # pkt size of the pdus from stream_to_pdu
+        npdu = 17
+
+        vec = list(range(pktsize))
+        in_data = np.array( (nsamps // pktsize)*vec, dtype=np.float32)
+        in_pdu = pmt.pmt({"meta": pmt.pmt({}), "data": pmt.pmt(in_data)})
+
+        
+        p2s = pdu.pdu_to_stream_f()
+        s2p = pdu.stream_to_pdu_f(100)
+        snk = blocks.message_debug()
+
+        self.tb.connect([p2s, s2p])
+        self.tb.connect((s2p, "pdus"), (snk, "store"))
+
+
+        self.tb.start()
+
+        msg_port = p2s.get_message_port("pdus")
+        for _ in range(npdu):
+            msg_port.post(in_pdu)
+
+        time.sleep(0.5)
+        self.tb.stop()
+
+        for ii in range((nsamps // pktsize)*npdu):
+            rxpdu = snk.get_message(ii)
+            rxvec = pmt.map(rxpdu)["data"]()
+            self.assertTrue(np.array_equal(vec, rxvec ))
+
+
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_pdu_basic)

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,7 @@ if (get_option('enable_testing'))
     TEST_ENV = environment()
     TEST_ENV.prepend('LD_LIBRARY_PATH', 
       join_paths( meson.build_root(),'schedulers','nbt','lib'),
-      join_paths( meson.build_root(),'runtime','lib'),
+      join_paths( meson.build_root(),'gr','lib'),
       join_paths( meson.build_root(),'blocklib','analog','lib'),
       join_paths( meson.build_root(),'blocklib','blocks','lib'),
       join_paths( meson.build_root(),'blocklib','fec','lib'),
@@ -71,6 +71,7 @@ if (get_option('enable_testing'))
       join_paths( meson.build_root(),'blocklib','filter','lib'),
       join_paths( meson.build_root(),'blocklib','math','lib'),
       join_paths( meson.build_root(),'blocklib','streamops','lib'),
+      join_paths( meson.build_root(),'blocklib','pdu','lib'),
     )
     TEST_ENV.prepend('PYTHONPATH', join_paths(meson.build_root(),'python')+':'+join_paths(meson.build_root(), 'subprojects/pmt/python') )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,7 @@ option('enable_gr_soapy', type : 'boolean', value : true)
 option('enable_gr_streamops', type : 'boolean', value : true)
 option('enable_gr_zeromq', type : 'boolean', value : true)
 option('enable_gr_audio', type : 'boolean', value : true)
+option('enable_gr_pdu', type : 'boolean', value : true)
 
 option('enable_grc', type : 'boolean', value : true)
 

--- a/python/gnuradio/__init__.py
+++ b/python/gnuradio/__init__.py
@@ -49,3 +49,4 @@ if path.endswith(path_ending):
     __path__.append(os.path.join(build_path, 'blocklib', 'soapy', 'python'))
     __path__.append(os.path.join(build_path, 'blocklib', 'streamops', 'python'))
     __path__.append(os.path.join(build_path, 'blocklib', 'zeromq', 'python'))
+    __path__.append(os.path.join(build_path, 'blocklib', 'pdu', 'python'))


### PR DESCRIPTION
## Description
Basic aspects of PDU module to demonstrate and work through some of the new PMT api
Includes a stripped down functionality pdu_to_stream and stream_to_pdu blocks

## Related Issue

## Which blocks/areas does this affect?
new pdu blocks

## Testing Done
added QA test

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
