### PR TITLE
4.0: meson: check python module dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,16 @@ if py3_version.version_compare('< 3.6')
   error('Invalid python version!?')
 endif
 
+# Python module min versions
+py_check_script = join_paths(meson.project_source_root(),'utils','py_module_check.py')
+run_command('python3', py_check_script, 'numpy', '1.22', check:true)
+run_command('python3', py_check_script, 'jinja2', '3.0.2', check:true)
+run_command('python3', py_check_script, 'yaml', '5.3.1', check:true)
+run_command('python3', py_check_script, 'zmq', '22.3.0', check:true)
+run_command('python3', py_check_script, 'jsonschema', '3.2.0', check:true)
+run_command('python3', py_check_script, 'jsonschema_default', check:true)
+
+
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 threads_dep = dependency('threads')
 gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))

--- a/utils/py_module_check.py
+++ b/utils/py_module_check.py
@@ -1,0 +1,27 @@
+from packaging import version
+import argparse
+
+def argParse():
+    """Parses commandline args."""
+    desc = 'Compares python module version'
+    parser = argparse.ArgumentParser(description=desc)
+
+    parser.add_argument("module")
+    parser.add_argument("min_version", nargs='?', default=None)
+
+    return parser.parse_args()
+
+
+def main():
+    args = argParse()
+
+    m = __import__(args.module)
+    if args.min_version:
+        v = m.__version__
+
+        if version.parse(v) < version.parse(args.min_version[0]):
+            raise ValueError(f'Min version of {args.module} not met, {v} < {args.min_version}')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As brought up by @marcusmueller in chat, there is currently no way in meson to check versions of python deps.  This is a workaround for our limited set of deps by routing the import and version check to an external python script