### PR TITLE
ci: add E275 to ignored error list (backport to maint-3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: quentinguidee/pep8-action@v1
       with:
-        arguments: '--max-line-length=120 --ignore E265,E266,E402,E501,E704,E712,E713,E714,E711,E722,E741,W504,W605 --exclude *.yml.py'
+        arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E722,E741,W504,W605 --exclude *.yml.py'
   # Doxygen gets built separately. It has a lot of output and its own weirdness.
   doxygen:
     name: Doxygen


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit bdd49943b6eda1004d5bf20e294639ee047ab40a)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6055