### PR TITLE
GrPython.cmake: update method for determining installation directory (backport to maint-3.10)

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -158,16 +158,14 @@ try:
 except AttributeError: pass
 
 if not install_dir:
-    #find where to install the python module
-    #for Python 3.11+, we could use the 'venv' scheme for all platforms
-    if os.name == 'nt':
+    # Newer Python versions have 'venv' scheme, use for all OSs.
+    if 'venv' in sysconfig.get_scheme_names():
+        scheme = 'venv'
+    elif os.name == 'nt':
         scheme = 'nt'
     else:
         scheme = 'posix_prefix'
-    install_dir = sysconfig.get_path('platlib', scheme)
-    prefix = sysconfig.get_path('data')
-
-#strip the prefix to return a relative path
+    install_dir = sysconfig.get_path('platlib', scheme=scheme, vars={'base': prefix, 'platbase': prefix})
 print(os.path.relpath(install_dir, prefix))"
     OUTPUT_STRIP_TRAILING_WHITESPACE
     OUTPUT_VARIABLE GR_PYTHON_DIR


### PR DESCRIPTION
In 6ff02a5289, we changed the method of determining the installation
directory to work with Fedora 36 and Ubuntu 22.04. For custom prefixes,
this did not end up working on Ubuntu 22.04.

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 307c0859b4b52e50cd4236a8ff2c10c3674e1dc0)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5979