### PR TITLE
filter: Improve "invalid fractional bandwidth" error message

### DIFF
--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/fft/window.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/io_signature.h>
+#include <spdlog/fmt/fmt.h>
 #include <numeric>
 #include <stdexcept>
 
@@ -40,7 +41,8 @@ std::vector<TAP_T> design_resampler_filter(const unsigned interpolation,
 {
 
     if (fractional_bw >= 0.5 || fractional_bw <= 0) {
-        throw std::range_error("Invalid fractional_bandwidth, must be in (0, 0.5)");
+        throw std::range_error(fmt::format(
+            "Invalid fractional_bandwidth {:.2f}, must be in (0, 0.5)", fractional_bw));
     }
 
     // These are default values used to generate the filter when no taps are known


### PR DESCRIPTION
Provide the invalid value of `fractional_bandwidth` within the error
message alongside the accepted range to ease with debugging.

# Pull Request Details

## Description

This change should simplify debugging of flowgraphs when using the
the Rational Resampler block with an invalid `fractional_bandwidth`
parameter.

Up until now the error message did not provide the invalid value itself.

## Related Issue

N/A inside gnuradio.
Downstream issue this might help with: [satnogs-flowgraphs#30](https://gitlab.com/librespacefoundation/satnogs/satnogs-flowgraphs/-/issues/30)

## Which blocks/areas does this affect?
* gr-filter: Rational Resampler Block

## Testing Done

None yet.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. (not applicable)
- [x] I have added tests to cover my changes, and all previous tests pass. (not applicable)