### PR TITLE
4.0: Continuation of standardized port types

### DIFF
--- a/blocklib/analog/fm_deemph/fm_deemph.yml
+++ b/blocklib/analog/fm_deemph/fm_deemph.yml
@@ -22,12 +22,12 @@ ports:
 -   domain: stream
     id: in
     direction: input
-    type: float
+    type: rf32
 
 -   domain: stream
     id: out
     direction: output
-    type: float
+    type: rf32
 
 implementations:
 -   id: cpu

--- a/blocklib/analog/quadrature_demod/quadrature_demod.yml
+++ b/blocklib/analog/quadrature_demod/quadrature_demod.yml
@@ -42,12 +42,12 @@ ports:
 -   domain: stream
     id: in
     direction: input
-    type: gr_complex
+    type: cf32
 
 -   domain: stream
     id: out
     direction: output
-    type: float
+    type: rf32
 
 
 implementations:

--- a/blocklib/audio/alsa_sink/alsa_sink.yml
+++ b/blocklib/audio/alsa_sink/alsa_sink.yml
@@ -39,7 +39,7 @@ ports:
 -   domain: stream
     id: in
     direction: input
-    type: float
+    type: rf32
     multiplicity: parameters/num_inputs
 
 implementations:

--- a/blocklib/math/complex_to_mag/complex_to_mag.yml
+++ b/blocklib/math/complex_to_mag/complex_to_mag.yml
@@ -15,13 +15,13 @@ ports:
 -   domain: stream
     id: in
     direction: input
-    type: gr_complex
+    type: cf32
     shape: parameters/vlen
 
 -   domain: stream
     id: out
     direction: output
-    type: float
+    type: rf32
     shape: parameters/vlen
 
 implementations:

--- a/blocklib/math/complex_to_mag_squared/complex_to_mag_squared.yml
+++ b/blocklib/math/complex_to_mag_squared/complex_to_mag_squared.yml
@@ -15,13 +15,13 @@ ports:
 -   domain: stream
     id: in
     direction: input
-    type: gr_complex
+    type: cf32
     shape: parameters/vlen
 
 -   domain: stream
     id: out
     direction: output
-    type: float
+    type: rf32
     shape: parameters/vlen
 
 implementations:

--- a/blocklib/math/conjugate/conjugate.yml
+++ b/blocklib/math/conjugate/conjugate.yml
@@ -8,12 +8,12 @@ ports:
 -   domain: stream
     id: in
     direction: input
-    type: gr_complex
+    type: cf32
 
 -   domain: stream
     id: out
     direction: output
-    type: gr_complex
+    type: cf32
 
 implementations:
 -   id: cpu

--- a/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex.yml
+++ b/blocklib/streamops/interleaved_short_to_complex/interleaved_short_to_complex.yml
@@ -26,7 +26,7 @@ ports:
 -   domain: stream
     id: out
     direction: output
-    type: gr_complex
+    type: cf32
 
 implementations:
 -   id: cpu

--- a/utils/blockbuilder/templates/blockname.grc.j2
+++ b/utils/blockbuilder/templates/blockname.grc.j2
@@ -93,7 +93,7 @@ inputs:
 {% else %}
     dtype: {{port['type']|grc_type(ref=True)}}
 {% endif %}
-    {%if 'shape' in port %}vlen: {{port['shape']|get_linked_value}}{% endif %}
+    {%if 'shape' in port %}vlen: {{port['shape']|grc_type(ref=True)}}{% endif %}
     {%if 'multiplicity' in port %}multiplicity: {{port['multiplicity']|grc_type(ref=True)}}{% endif %}
     label: {{port['id']}}
     optional: {{ port['optional'] if 'optional' in port else 'false' }}


### PR DESCRIPTION
## Description

In previous commits, the templated blocks were given standard type names
such as cf32 and rf32.  However the fixed type ports were still at the
c++ names.  This makes those consistent

## Related Issue
Some cleanup related to #6043 

## Which blocks/areas does this affect?
A handful of blocks that have fixed (not untyped) ports such as `complex_to_mag`

## Testing Done
Loaded the blocks up in grc

