### PR TITLE
4.0: ci: remove Ubuntu 20.04 worker

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,9 +32,6 @@ jobs:
         # descriptive name, and one key 'containerid' with the name of the
         # container (i.e., what you want to docker-pull)
         include:
-          - distro: 'Ubuntu 20.04'
-            containerid: 'mormj/newsched-ci-docker:ubuntu-20.04'
-            cxxflags: -Werror
           - distro: 'Ubuntu 22.04'
             containerid: 'mormj/newsched-ci-docker:ubuntu-22.04'
             cxxflags: -Werror


### PR DESCRIPTION
## Description
Some libs in Ubuntu 20.04 create some issues going to c++20 - namely modern fmtlib.  Rather than work around these, just set our min supported distro to ubuntu 22.04

## Related Issue
#6050 

## Which blocks/areas does this affect?
just ci

## Testing Done
ci only changes

