### PR TITLE
4.0: Add using namespace for enums in pybind

### DIFF
--- a/utils/blockbuilder/templates/blockname_pybind.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind.cc.j2
@@ -6,8 +6,8 @@
 namespace py = pybind11;
 
 #include <gnuradio/{{module}}/{{block}}.h>
-// pydoc.h is automatically generated in the build directory
-// #include <{{block}}_pydoc.h>
+using namespace gr::{{module}};
+
 
 void bind_{{block}}(py::module& m)
 {


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
When the yml files includes enums, we need the namespace in the pybind file to have the proper scope for the enum types

## Which blocks/areas does this affect?
This was already done for templated blocks, so this adds the same feature for non-templated ones

