### PR TITLE
pdu: Remove unused dependencies (backport to maint-3.10)

### DIFF
--- a/gr-pdu/lib/CMakeLists.txt
+++ b/gr-pdu/lib/CMakeLists.txt
@@ -39,8 +39,6 @@ endif(MSVC)
 
 target_link_libraries(gnuradio-pdu PUBLIC
     gnuradio-runtime
-    gnuradio-blocks
-    gnuradio-filter
 )
 
 if(ENABLE_COMMON_PCH)


### PR DESCRIPTION
The gr-pdu module has gnuradio-blocks and gnuradio-filter in its
target_link_libraries even though it doesn't use these modules. Removing
them will prevent extraneous libraries from being linked.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit e36f2fab5f1fccfbc15a496e2beaecf7db9143ec)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5914