### PR TITLE
wavelet: Remove unused dependency (backport to maint-3.10)

### DIFF
--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -30,7 +30,6 @@ endif(MSVC)
 
 target_link_libraries(gnuradio-wavelet PUBLIC
     gnuradio-runtime
-    gnuradio-blocks
     GSL::gsl
 )
 


### PR DESCRIPTION
The gr-wavelet module has gnuradio-blocks in its target_link_libraries
even though it doesn't use this module. Removing it will prevent
extraneous libraries from being linked.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit fef862b6c2e43531a715ce433d84e85e86cf76d9)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5915