### PR TITLE
qtgui: Add missing <deque> include to spectrumdisplayform.h (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/spectrumdisplayform.h
+++ b/gr-qtgui/include/gnuradio/qtgui/spectrumdisplayform.h
@@ -23,6 +23,7 @@ class SpectrumGUIClass;
 #include <gnuradio/qtgui/WaterfallDisplayPlot.h>
 #include <QTimer>
 #include <QValidator>
+#include <deque>
 #include <vector>
 
 class SpectrumDisplayForm : public QWidget, public Ui::SpectrumDisplayForm


### PR DESCRIPTION
Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit d6b730f4b3a494ec6a845a04e30de04de56d86d1)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5952