### PR TITLE
4.0: meson: missing include headers for install

### DIFF
--- a/gr/include/gnuradio/meson.build
+++ b/gr/include/gnuradio/meson.build
@@ -42,7 +42,9 @@ runtime_headers = [
     'port_interface.h',
     'hier_block.h',
     'runtime_proxy.h',
-    'sptr_magic.h'
+    'sptr_magic.h',
+    'realtime.h',
+    'runtime.h'
 ]
 
 install_headers(runtime_headers, subdir : 'gnuradio')


### PR DESCRIPTION
Just a couple of missing headers needed by OOTs potentially