### PR TITLE
doxygen reproducible paths

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -161,14 +161,22 @@ STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@/gnuradio-runtime/include \
                          @PROJECT_BINARY_DIR@/gr-fft/include \
                          @PROJECT_SOURCE_DIR@/gr-filter/include \
                          @PROJECT_BINARY_DIR@/gr-filter/include \
+                         @PROJECT_SOURCE_DIR@/gr-iio/include \
+                         @PROJECT_BINARY_DIR@/gr-iio/include \
+                         @PROJECT_SOURCE_DIR@/gr-network/include \
+                         @PROJECT_BINARY_DIR@/gr-network/include \
                          @PROJECT_SOURCE_DIR@/gr-pdu/include \
                          @PROJECT_BINARY_DIR@/gr-pdu/include \
                          @PROJECT_SOURCE_DIR@/gr-qtgui/include \
                          @PROJECT_BINARY_DIR@/gr-qtgui/include \
+                         @PROJECT_SOURCE_DIR@/gr-soapy/include \
+                         @PROJECT_BINARY_DIR@/gr-soapy/include \
                          @PROJECT_SOURCE_DIR@/gr-trellis/include \
                          @PROJECT_BINARY_DIR@/gr-trellis/include \
                          @PROJECT_SOURCE_DIR@/gr-uhd/include \
                          @PROJECT_BINARY_DIR@/gr-uhd/include \
+                         @PROJECT_SOURCE_DIR@/gr-utils/include \
+                         @PROJECT_BINARY_DIR@/gr-utils/include \
                          @PROJECT_SOURCE_DIR@/gr-video-sdl/include \
                          @PROJECT_BINARY_DIR@/gr-video-sdl/include \
                          @PROJECT_SOURCE_DIR@/gr-vocoder/include \
@@ -764,10 +772,20 @@ EXCLUDE                = @abs_top_builddir@/cmake/msvc \
                          @abs_top_builddir@/gr-filter/lib \
                          @abs_top_srcdir@/gr-fft/lib \
                          @abs_top_builddir@/gr-fft/lib \
+                         @abs_top_srcdir@/gr-iio/lib \
+                         @abs_top_builddir@/gr-iio/lib \
+                         @abs_top_srcdir@/gr-network/lib \
+                         @abs_top_builddir@/gr-network/lib \
                          @abs_top_srcdir@/gr-pdu/lib \
                          @abs_top_builddir@/gr-pdu/lib \
                          @abs_top_srcdir@/gr-qtgui/lib \
                          @abs_top_builddir@/gr-qtgui/lib \
+                         @abs_top_srcdir@/gr-qtgui/examples \
+                         @abs_top_builddir@/gr-qtgui/examples \
+                         @abs_top_srcdir@/gr-soapy/lib \
+                         @abs_top_builddir@/gr-soapy/lib \
+                         @abs_top_srcdir@/gr-soapy/python \
+                         @abs_top_builddir@/gr-soapy/python \
                          @abs_top_srcdir@/gr-trellis/lib \
                          @abs_top_builddir@/gr-trellis/lib \
                          @abs_top_srcdir@/gr-uhd/lib \


### PR DESCRIPTION
Update STRIP_FROM_INC_PATH and EXCLUDE so that build paths
are not part of the generated documentation.

Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>

## Description
The Debian tool lintian noticed build paths being captured in the Doxygen
generated HTML files.

This would make the builds unreproducible .

Doxygen settings strip the build directory from the generated output,
but new gnuradio source directories gr-iio, gr-network, and gr-soapy
have not been added to the Doxygen config file.

## Testing Done
Preparing gnuradio 3.10.3.0-3 for Debian with this patch, and
lintian no longer complains about HTML files in gnuradio-doc.

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
