### PR TITLE
gr-qtgui: waterfall sink float Spectrum Width setting fails (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -343,10 +343,9 @@ cpp_templates:
             this->${id}->disable_legend(); // if (!legend)
         }
 
-        /* C++ doesn't have this
-        if ("${type}" == "float" or "${type}" == "msg_float") {
-            this->${id}->set_plot_pos_half(not ${freqhalf});
-        }*/
+        % if type.endswith('float'):
+        ${id}->set_plot_pos_half(not ${freqhalf});
+        % endif
         {
             std::string labels[10] = {"${label1.strip("'")}", "${label2.strip("'")}", "${label3.strip("'")}", "${label4.strip("'")}", "${label5.strip("'")}",
                 "${label6.strip("'")}", "${label7.strip("'")}", "${label8.strip("'")}", "${label9.strip("'")}", "${label10.strip("'")}"};


### PR DESCRIPTION
When generating cpp code for the waterfall sink (float),
the setting of the Spectrum Width ( Half, Full ) is ignored
and always set to Full

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit 49d0618398dc810e45fe2f1566dae6cbb60e97dc)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5962