### PR TITLE
pdu: Remove --no-as-needed linker option (backport to maint-3.10)

### DIFF
--- a/gr-pdu/lib/CMakeLists.txt
+++ b/gr-pdu/lib/CMakeLists.txt
@@ -51,11 +51,6 @@ target_include_directories(gnuradio-pdu
   )
 
 
-# we need -no-as-needed or else -lgslcblas gets stripped out on newer version of gcc
-if(CMAKE_COMPILER_IS_GNUCC AND NOT APPLE)
-    SET_TARGET_PROPERTIES(gnuradio-pdu PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
-endif()
-
 if(BUILD_SHARED_LIBS)
   GR_LIBRARY_FOO(gnuradio-pdu)
 endif()


### PR DESCRIPTION
It appears this workaround was copied from the gr-wavelet module,
but it's not needed here because gr-pdu doesn't depend on GSL.
Removing it reduces the number of libraries that gr-pdu links to.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 5d2e3ab5e59a0ff0f6d3a7c7b349847f095c2be1)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5912