### PR TITLE
4.0 GRC only blocks via yaml file

### DIFF
--- a/blocklib/analog/random_source/random_source.yml
+++ b/blocklib/analog/random_source/random_source.yml
@@ -1,0 +1,57 @@
+module: analog
+block: random_source
+label: Random Source
+blocktype: grc
+category: '[Core]/Waveform Generators'
+
+typekeys:
+  - id: T
+    type: class
+    options: 
+        - ri32
+        - ri16
+        - ri8
+
+grc:
+    templates:
+        imports: |-
+            from gnuradio import blocks
+            import numpy
+        make: |-
+            blocks.vector_source_${T.fcn}(list(map(int, numpy.random.randint(${min}, ${max},
+            ${num_samps}))), ${repeat})
+
+# Example Parameters
+parameters:
+-   id: min
+    label: Minimum
+    dtype: typekeys/T
+    grc:
+        default: 0
+-   id: max
+    label: Maximum
+    dtype: typekeys/T
+    grc:
+        default: 2
+-   id: num_samps
+    label: Num Samples
+    dtype: size
+    grc:
+        default: 1000
+-   id: repeat
+    label: Repeat
+    dtype: bool
+    grc:    
+        default: true
+
+# Example Ports
+ports:
+-   domain: stream
+    id: out
+    direction: output
+    type: typekeys/T
+
+implementations:
+-   id: cpu
+
+file_format: 1

--- a/utils/blockbuilder/scripts/process_folder.py
+++ b/utils/blockbuilder/scripts/process_folder.py
@@ -14,10 +14,10 @@ def argParse():
     desc='Scrape the doxygen generated xml for docstrings to insert into python bindings'
     parser = argparse.ArgumentParser(description=desc)
     
-    parser.add_argument("--yaml_file")
-    parser.add_argument("--output-cc")
-    parser.add_argument("--output-hh")
-    parser.add_argument("--output-pybind")
+    parser.add_argument("--yaml_file", default=None)
+    parser.add_argument("--output-cc", default=None)
+    parser.add_argument("--output-hh", default=None)
+    parser.add_argument("--output-pybind", default=None)
     parser.add_argument("--output-grc", nargs='+')
     parser.add_argument("--grc-index", nargs='+')
     parser.add_argument("--build_dir")

--- a/utils/blockbuilder/templates/blockname.meson.build.j2
+++ b/utils/blockbuilder/templates/blockname.meson.build.j2
@@ -4,6 +4,18 @@
 # this file alone
 srcs = []
 
+{% if blocktype == 'grc' %}
+gen_srcs = custom_target('gen_{{block}}_srcs',
+                        input : ['{{block}}.yml'],
+                        output : ['{{module}}_{{block}}.block.yml'
+                        ], 
+                        command : ['python3', join_paths(SCRIPTS_DIR,'process_folder.py'),
+                            '--yaml_file', '@INPUT@', 
+                            '--output-grc', '@OUTPUT0@', 
+                            '--build_dir', join_paths(meson.build_root())],
+                        install : true,
+                        install_dir : ['share/gnuradio/grc/blocks'])
+{% else %}
 {% set vars = {'pyshell': False, 'cpp': False} %}
 {% for impl in implementations -%}
 {% if 'lang' not in impl or impl['lang'] == 'cpp'%}
@@ -77,3 +89,4 @@ if get_option('enable_python')
     {{module}}_pybind_sources += gen_srcs[2]
     {{module}}_pybind_names += '{{block}}'
 endif
+{% endif %}

--- a/utils/modtool/newblock/newblock_t.yml
+++ b/utils/modtool/newblock/newblock_t.yml
@@ -17,11 +17,11 @@ typekeys:
 parameters:
 -   id: k
     label: Constant
-    dtype: T
+    dtype: typekeys/T
     settable: true
 -   id: vlen
     label: Vec. Length
-    dtype: size_t
+    dtype: size
     settable: false
     default: 1
 

--- a/utils/modtool/newmod/.gitignore
+++ b/utils/modtool/newmod/.gitignore
@@ -1,0 +1,146 @@
+# Created by https://www.gitignore.io/api/emacs,vim,cmake,c++
+# Edit at https://www.gitignore.io/?templates=emacs,vim,cmake,c++
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
+# Visual Studio Code
+**/.vscode
+
+# End of https://www.gitignore.io/api/emacs,vim,cmake,c++
+build
+builddir
+callgrind.out.*
+perf.data
+trace.dat
+core
+!grc/core
+**/__pycache__/
+*.pyc
+
+# Archives
+*.tar.gz
+*.zip

--- a/utils/modtool/newmod/blocklib/newmod/lib/meson.build
+++ b/utils/modtool/newmod/blocklib/newmod/lib/meson.build
@@ -1,5 +1,5 @@
 newmod_sources += []
-newmod_deps += [gnuradio_gr_dep, volk_dep, fmt_dep, pmtf_dep, python3_embed_dep]
+newmod_deps += [gnuradio_gr_dep, volk_dep, fmt_dep, pmtf_dep, python3_embed_dep, json_dep]
 
 block_cpp_args = ['-DHAVE_CPU']
 

--- a/utils/modtool/newmod/meson.build
+++ b/utils/modtool/newmod/meson.build
@@ -11,6 +11,7 @@ python3_dep = dependency('python3', required : get_option('enable_python'))
 python3_embed_dep = dependency('python3-embed', required : get_option('enable_python'))
 py3_inst = import('python').find_installation('python3')
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
+json_dep = dependency('nlohmann_json')
 
 prefix = get_option('prefix')
 # Escape spaces

--- a/utils/modtool/newmod/subprojects/.gitignore
+++ b/utils/modtool/newmod/subprojects/.gitignore
@@ -1,0 +1,2 @@
+nlohmann_json-*
+packagecache/

--- a/utils/modtool/newmod/subprojects/nlohmann_json.wrap
+++ b/utils/modtool/newmod/subprojects/nlohmann_json.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = nlohmann_json-3.10.5
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip
+source_filename = nlohmann_json-3.10.5.zip
+source_hash = b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e
+
+[provide]
+nlohmann_json = nlohmann_json_dep
+


### PR DESCRIPTION

## Description
Block should have a top level yaml file but be able to not have any implementation other than grc

## Related Issue
Fixes #6036 

## Which blocks/areas does this affect?

## Testing Done
Random source block in grc

