### PR TITLE
GRC/Screenshots: create ImageSurface with int dimensions (backport to maint-3.10)

### DIFF
--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -108,7 +108,13 @@ def make_screenshot(flow_graph, file_path, transparent_bg=False):
     height = y_max - y_min + 2 * padding
 
     if file_path.endswith('.png'):
-        psurf = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
+        # ImageSurface is pixel-based, so dimensions need to be integers
+        # We don't round up here, because our padding should allow for up
+        # to half a pixel size in loss of image area without optically bad
+        # effects
+        psurf = cairo.ImageSurface(cairo.FORMAT_ARGB32,
+                                   round(width),
+                                   round(height))
     elif file_path.endswith('.pdf'):
         psurf = cairo.PDFSurface(file_path, width, height)
     elif file_path.endswith('.svg'):


### PR DESCRIPTION
Since cairo.ImageSurface is pixel-based, it only accepts integer dimensions.

No need to round up – proper rounding and padding make this quite safe.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 07716fbc81140cf39ece0872aedc50fc667fbaf6)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6004