### PR TITLE
iio/fmcomms2_sink.cc: Fix scalar value to match format le:S16/16>>0 (backport to maint-3.10)

### DIFF
--- a/gr-iio/lib/fmcomms2_sink_impl.cc
+++ b/gr-iio/lib/fmcomms2_sink_impl.cc
@@ -357,9 +357,9 @@ int fmcomms2_sink_impl<gr_complex>::work(int noutput_items,
             d_float_r.data(), d_float_i.data(), in, noutput_items);
         // float to short
         volk_32f_s32f_convert_16i(
-            d_device_bufs[2 * i].data(), d_float_r.data(), 2048.0, noutput_items);
+            d_device_bufs[2 * i].data(), d_float_r.data(), 32768.0, noutput_items);
         volk_32f_s32f_convert_16i(
-            d_device_bufs[2 * i + 1].data(), d_float_i.data(), 2048.0, noutput_items);
+            d_device_bufs[2 * i + 1].data(), d_float_i.data(), 32768.0, noutput_items);
     }
 
 


### PR DESCRIPTION
Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>
(cherry picked from commit 831fb91fbd23f808fbe0fc9bcadc7c5ec7ea3dc5)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6024