### PR TITLE
qtgui: Add output message ports to range widgets (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -53,11 +53,29 @@ parameters:
     dtype: int
     default: '200'
     hide: part
+-   id: outputmsgname
+    label: Message Property Name
+    dtype: string
+    default: 'value'
+    hide: part
+-   id: showports
+    label: Show Msg Ports
+    dtype: enum
+    options: ['True', 'False']
+    option_labels: ['Yes', 'No']
+    default: 'False'
+    hide: part
 -   id: gui_hint
     label: GUI Hint
     dtype: gui_hint
     hide: part
 value: ${ value }
+
+outputs:
+-   domain: message
+    id: out
+    optional: true
+    hide: ${ showports != 'True' }
 
 asserts:
 - ${start <= value <= stop}
@@ -65,7 +83,7 @@ asserts:
 
 templates:
     imports: |- 
-        from gnuradio.qtgui import Range, RangeWidget
+        from gnuradio.qtgui import Range, GrRangeWidget
         from PyQt5 import QtCore
     var_make: self.${id} = ${id} = ${value}
     callbacks:
@@ -76,7 +94,9 @@ templates:
             range = 'self._%s_range'%id
         %>\
         ${range} = Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
-        ${win} = RangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient})
+        ${win} = GrRangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient}, "${no_quotes(outputmsgname)}")
+        self.${id} = ${win}
+
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/python/qtgui/__init__.py
+++ b/gr-qtgui/python/qtgui/__init__.py
@@ -31,7 +31,7 @@ except ImportError:
     gr.log.warn("Matplotlib is a required dependency to use DistanceRadar and AzElPlot."
                 "  Please install matplotlib to use these blocks (https://matplotlib.org/)")
 
-from .range import Range, RangeWidget
+from .range import Range, RangeWidget, GrRangeWidget
 from . import util
 
 from .compass import GrCompass

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -12,7 +12,9 @@
 @PY_QT_IMPORT@
 from .util import check_set_qss
 import gnuradio.eng_notation as eng_notation
+from gnuradio import gr
 import re
+import pmt
 
 class Range(object):
     def __init__(self, minv, maxv, step, default, min_length):
@@ -101,7 +103,7 @@ class RangeWidget(QtWidgets.QWidget):
         # Top-block function to call when any value changes
         # Some widgets call this directly when their value changes.
         # Others have intermediate functions to map the value into the right range.
-        self.notifyChanged = slot
+        self.__slot = slot
 
         layout = Qt.QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -132,6 +134,10 @@ class RangeWidget(QtWidgets.QWidget):
 
         layout.addWidget(self.d_widget)
         self.setLayout(layout)
+
+    def notifyChanged(self, value):
+        self.message_port_pub(self.outputportname_pmt, pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
+        self.__slot(value)
 
     class Dial(QtWidgets.QDial):
         """ Creates the range using a dial """
@@ -390,6 +396,23 @@ class RangeWidget(QtWidgets.QWidget):
                 self.slider.setValue(new)
                 self.first = False
 
+class GrRangeWidget(gr.sync_block, RangeWidget):
+    def __init__(self, ranges, varCallback, label, style, rangeType=float,
+            orientation=QtCore.Qt.Horizontal, outputmsgname='value'):
+        RangeWidget.__init__(self, ranges, varCallback, label, style, rangeType, orientation)
+        gr.sync_block.__init__(self, name='GrRangeWidget', in_sig=None, out_sig=None)
+        self.outputportname_pmt = pmt.intern('out')
+        self.outputmsgname_pmt = pmt.intern(outputmsgname)
+        self.message_port_register_out(self.outputportname_pmt)
+        self.value_to_pmt = (pmt.from_float if self.rangeType is float else pmt.from_long)
+        self.varCallback = varCallback
+
+    def valueChanged(self, new_value):
+        if self.varCallback is not None:
+            self.varCallback(new_value)
+        self.message_port_pub(self.outputportname_pmt,
+                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
+
 
 if __name__ == "__main__":
     from PyQt5 import Qt
@@ -399,7 +422,7 @@ if __name__ == "__main__":
         print("Value updated - " + str(frequency))
 
     app = Qt.QApplication(sys.argv)
-    widget = RangeWidget(Range(0, 100, 10, 1, 100),
+    widget = GrRangeWidget(Range(0, 100, 10, 1, 100),
                          valueChanged, "Test", "counter_slider", int)
 
     widget.show()


### PR DESCRIPTION
* qtgui: Add output message ports to range widgets

Signed-off-by: Charles Duffy <charles@dyfis.net>

* qtgui: move gui_hint below showports

Signed-off-by: Josh Morman <jmorman@gnuradio.org>

Co-authored-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 0427b2a6781a08cc57d82b27fbdd9a2300a34919)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5566