### PR TITLE
Fix CRC16 endianness

### DIFF
--- a/gr-digital/python/digital/qa_crc16_async_bb.py
+++ b/gr-digital/python/digital/qa_crc16_async_bb.py
@@ -43,7 +43,7 @@ class qa_crc16_async_bb(gr_unittest.TestCase):
 
         self.assertEqual(dbg_append.num_messages(), 1)
         out_append = pmt.u8vector_elements(pmt.cdr(dbg_append.get_message(0)))
-        self.assertEqual(out_append, data + [0x37, 0x3b])
+        self.assertEqual(out_append, data + [0x3b, 0x37])
 
         self.assertEqual(dbg_check.num_messages(), 1)
         out_check = pmt.u8vector_elements(pmt.cdr(dbg_check.get_message(0)))


### PR DESCRIPTION
Signed-off-by: Michael Roe <michael-roe@users.noreply.github.com>

Fixes issues #6086
The CRC had the endianness of the host computer -- typically little endian -- rather than network (big) endian.

Modules affected: gr-digital/lib/crc16_async_bb_impl.cc, qa_crc16_async_bb

Tests carried out: "make test" with the new qa_crc16_async_bb


- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
