### PR TITLE
4.0: Fixes for single mapped buffers

### DIFF
--- a/bench/bm_copy.cc
+++ b/bench/bm_copy.cc
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
     unsigned int nthreads = 0;
     int veclen = 1;
     int buffer_type = 1;
-    int buffer_size = 32768;
+    size_t buffer_size = 32768;
     bool rt_prio = false;
 
     std::vector<unsigned int> cpu_affinity;
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
 
         std::cout << "Initializing NBT scheduler with buffer size of " << buffer_size
                   << std::endl;
-        auto sched = schedulers::scheduler_nbt::make("nbt", buffer_size);
+        auto sched = schedulers::scheduler_nbt::make({ "nbt", buffer_size });
 
         if (buffer_type == 1) {
             sched->set_default_buffer_factory(BUFFER_CPU_VMCIRC_ARGS);

--- a/bench/bm_nop.cc
+++ b/bench/bm_nop.cc
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
                 ->set_custom_buffer(BUFFER_CPU_VMCIRC_ARGS);
         }
 
-        auto sched = schedulers::scheduler_nbt::make("nbt", 32768);
+        auto sched = schedulers::scheduler_nbt::make();
         if (buffer_type == 1) {
             sched->set_default_buffer_factory(BUFFER_CPU_VMCIRC_ARGS);
         }

--- a/gr/gr.conf.yml
+++ b/gr/gr.conf.yml
@@ -3,3 +3,7 @@ LOG:
   log_level: debug
   debug_level: error
   log_file: stderr
+
+DEFAULT:
+  scheduler: nbt
+  

--- a/gr/include/gnuradio/buffer.h
+++ b/gr/include/gnuradio/buffer.h
@@ -269,7 +269,7 @@ public:
     virtual bool output_blocked_callback(bool force = false)
     {
         // Only singly mapped buffers need to do anything with this callback
-        return true;
+        return false;
     }
 };
 
@@ -344,7 +344,7 @@ public:
     virtual bool input_blocked_callback(size_t items_required)
     {
         // Only singly mapped buffers need to do anything with this callback
-        return true;
+        return false;
     }
 
     std::vector<tag_t> tags_in_window(const uint64_t item_start, const uint64_t item_end);

--- a/gr/include/gnuradio/buffer_sm.h
+++ b/gr/include/gnuradio/buffer_sm.h
@@ -19,6 +19,7 @@ class buffer_sm : public buffer
 {
 private:
     std::vector<uint8_t> _buffer;
+    uint8_t* _raw_buffer;
 
     // logger_ptr d_logger;
     // logger_ptr d_debug_logger;
@@ -51,6 +52,14 @@ public:
                                   size_t itemsize) override;
 
     bool adjust_buffer_data(memcpy_func_t memcpy_func, memmove_func_t memmove_func);
+
+    // Wipes away the default single mapped buffer and replaces it with something
+    // defined externally in the derived class
+    void set_bufp(uint8_t* ptr)
+    {
+        _raw_buffer = ptr;
+        _buffer.resize(0);
+    }
 };
 
 class buffer_sm_reader : public buffer_reader

--- a/gr/include/gnuradio/meson.build
+++ b/gr/include/gnuradio/meson.build
@@ -44,7 +44,8 @@ runtime_headers = [
     'runtime_proxy.h',
     'sptr_magic.h',
     'realtime.h',
-    'runtime.h'
+    'runtime.h',
+    'buffer_sm.h'
 ]
 
 install_headers(runtime_headers, subdir : 'gnuradio')

--- a/gr/include/gnuradio/sync_block.h
+++ b/gr/include/gnuradio/sync_block.h
@@ -50,6 +50,9 @@ public:
         for (auto& w : wio.inputs()) {
             min_num_items = std::min(min_num_items, w.n_items);
         }
+        if (min_num_items < output_multiple()) {
+            return work_return_t::INSUFFICIENT_INPUT_ITEMS;
+        }
         for (auto& w : wio.outputs()) {
             min_num_items = std::min(min_num_items, w.n_items);
         }

--- a/gr/lib/runtime.cc
+++ b/gr/lib/runtime.cc
@@ -17,7 +17,7 @@ runtime::runtime()
     std::shared_ptr<scheduler> (*factory)(const std::string&) =
         (std::shared_ptr<scheduler>(*)(const std::string&))dlsym(handle, "factory");
     // Instantiate the default scheduler
-    d_default_scheduler = factory("{name: nbt, buffer_size: 32768}");
+    d_default_scheduler = factory("{}");
     d_schedulers = { d_default_scheduler };
 }
 

--- a/gr/lib/runtime_monitor.cc
+++ b/gr/lib/runtime_monitor.cc
@@ -45,7 +45,7 @@ runtime_monitor::runtime_monitor(std::vector<std::shared_ptr<scheduler>>& sched_
                     d_debug_logger->debug("DONE");
                     // One scheduler signaled it is done
                     // Notify the other schedulers that they need to flush
-                    // std::this_thread::sleep_for(std::chrono::milliseconds(100)); //
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10)); //
                     // DEBUG
                     for (auto& s : d_schedulers) {
                         s->push_message(std::make_shared<scheduler_action>(

--- a/gr/lib/runtime_monitor.cc
+++ b/gr/lib/runtime_monitor.cc
@@ -45,7 +45,8 @@ runtime_monitor::runtime_monitor(std::vector<std::shared_ptr<scheduler>>& sched_
                     d_debug_logger->debug("DONE");
                     // One scheduler signaled it is done
                     // Notify the other schedulers that they need to flush
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // DEBUG
+                    // std::this_thread::sleep_for(std::chrono::milliseconds(100)); //
+                    // DEBUG
                     for (auto& s : d_schedulers) {
                         s->push_message(std::make_shared<scheduler_action>(
                             scheduler_action_t::DONE, 0));

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/meson.build
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/meson.build
@@ -1,6 +1,7 @@
 header_files = [
     'graph_executor.h',
     'scheduler_nbt.h',
+    'scheduler_nbt_options.h',
     'thread_wrapper.h'
 ]
 

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt.h
@@ -4,27 +4,26 @@
 #include <gnuradio/graph_utils.h>
 #include <gnuradio/scheduler.h>
 
+#include "scheduler_nbt_options.h"
 #include "thread_wrapper.h"
 namespace gr {
 namespace schedulers {
+
 class scheduler_nbt : public scheduler
 {
 private:
     std::vector<thread_wrapper::sptr> _threads;
-    const int s_fixed_buf_size;
+    const scheduler_nbt_options _opts;
     std::map<nodeid_t, neighbor_interface_sptr> _block_thread_map;
     std::vector<block_group_properties> _block_groups;
 
 public:
     using sptr = std::shared_ptr<scheduler_nbt>;
-    static sptr make(const std::string name = "multi_threaded",
-                     const unsigned int fixed_buf_size = 32768)
+    static sptr make(const scheduler_nbt_options& opts = {})
     {
-        return std::make_shared<scheduler_nbt>(name, fixed_buf_size);
+        return std::make_shared<scheduler_nbt>(opts);
     }
-    scheduler_nbt(const std::string name = "multi_threaded",
-                  const unsigned int fixed_buf_size = 32768)
-        : scheduler(name), s_fixed_buf_size(fixed_buf_size)
+    scheduler_nbt(const scheduler_nbt_options& opts) : scheduler(opts.name), _opts(opts)
     {
         _default_buf_properties =
             buffer_cpu_vmcirc_properties::make(buffer_cpu_vmcirc_type::AUTO);

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt_options.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt_options.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace gr {
+namespace schedulers {
+
+struct scheduler_nbt_options {
+    std::string name = "nbt";
+    size_t default_buffer_size = 32768;
+    bool flush = true;
+    size_t flush_count = 8;
+    size_t flush_sleep_ms = 10;
+};
+
+} // namespace schedulers
+} // namespace gr

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/thread_wrapper.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/thread_wrapper.h
@@ -11,6 +11,7 @@
 #include <thread>
 
 #include "graph_executor.h"
+#include "scheduler_nbt_options.h"
 
 namespace gr {
 namespace schedulers {
@@ -48,21 +49,25 @@ private:
     int d_flush_cnt = 0;
     std::atomic<bool> kick_pending = false;
 
+    scheduler_nbt_options _opts;
+
 public:
     using sptr = std::shared_ptr<thread_wrapper>;
 
     static sptr make(int id,
                      block_group_properties bgp,
                      buffer_manager::sptr bufman,
-                     runtime_monitor_sptr rtmon)
+                     runtime_monitor_sptr rtmon,
+                     const scheduler_nbt_options& opts)
     {
-        return std::make_shared<thread_wrapper>(id, bgp, bufman, rtmon);
+        return std::make_shared<thread_wrapper>(id, bgp, bufman, rtmon, opts);
     }
 
     thread_wrapper(int id,
                    block_group_properties bgp,
                    buffer_manager::sptr bufman,
-                   runtime_monitor_sptr rtmon);
+                   runtime_monitor_sptr rtmon,
+                   const scheduler_nbt_options& opts);
     int id() { return _id; }
     const std::string& name() { return d_block_group.name(); }
 

--- a/schedulers/nbt/lib/thread_wrapper.cc
+++ b/schedulers/nbt/lib/thread_wrapper.cc
@@ -88,6 +88,7 @@ bool thread_wrapper::handle_work_notification()
     bool all_blkd = true;
     for (auto elem : s) {
         if (elem.second == executor_iteration_status_t::READY ||
+            elem.second == executor_iteration_status_t::READY_NO_OUTPUT ||
             elem.second == executor_iteration_status_t::BLKD_OUT) {
             notify_self_ = true;
         }

--- a/schedulers/nbt/meson.build
+++ b/schedulers/nbt/meson.build
@@ -5,3 +5,5 @@ subdir('lib')
 if (get_option('enable_python'))
     subdir('python/schedulers/nbt')
 endif
+
+install_data(sources : 'nbt.scheduler.conf.yml', install_dir : 'etc/gnuradio/conf.d')

--- a/schedulers/nbt/nbt.scheduler.conf.yml
+++ b/schedulers/nbt/nbt.scheduler.conf.yml
@@ -1,0 +1,10 @@
+# Default Logging Options
+scheduler.nbt:
+  # for benchmarking and comparing with GR 3.x
+  #  we may not want to go through the whole flushing
+  #  sequence (flush=true), instead - finish ungracefully (flush=false)
+  flush: true
+  flush_count: 8
+  flush_sleep_ms: 10
+  default_buffer_size: 32768 # in bytes
+

--- a/schedulers/nbt/python/schedulers/nbt/bindings/scheduler_nbt_pybind.cc
+++ b/schedulers/nbt/python/schedulers/nbt/bindings/scheduler_nbt_pybind.cc
@@ -38,12 +38,21 @@ PYBIND11_MODULE(scheduler_nbt_python, m)
 
     // Allow access to base block methods
     py::module::import("gnuradio.gr");
-
     using nbt = gr::schedulers::scheduler_nbt;
     py::class_<nbt, gr::scheduler, std::shared_ptr<nbt>>(m, "scheduler_nbt")
-        .def(py::init(&gr::schedulers::scheduler_nbt::make),
-             py::arg("name") = "multi_threaded",
-             py::arg("fixed_buf_size") = 32768)
+        .def(py::init([](const std::string& name = "nbt",
+                         size_t default_buffer_size = 32768,
+                         bool flush = true,
+                         size_t flush_count = 8,
+                         size_t flush_sleep_ms = 10) {
+                 return ::gr::schedulers::scheduler_nbt::make(
+                     { name, default_buffer_size, flush, flush_count, flush_sleep_ms });
+             }),
+             py::arg("name") = "nbt",
+             py::arg("default_buffer_size") = 32768,
+             py::arg("flush") = true,
+             py::arg("flush_count") = 8,
+             py::arg("flush_sleep_ms") = 10)
         .def("add_block_group",
              &gr::schedulers::scheduler_nbt::add_block_group,
              py::arg("blocks"),

--- a/test/qa_block_grouping.cc
+++ b/test/qa_block_grouping.cc
@@ -38,7 +38,7 @@ TEST(SchedulerBlockGrouping, BasicBlockGrouping)
 
             flowgraph_sptr fg(new flowgraph());
 
-            auto sch = schedulers::scheduler_nbt::make("nbtsched");
+            auto sch = schedulers::scheduler_nbt::make();
             fg->connect(src, 0, mult_blks[0], 0);
             for (int n = 0; n < ngroups; n++) {
                 std::vector<block_sptr> bg;

--- a/test/qa_scheduler_nbt.cc
+++ b/test/qa_scheduler_nbt.cc
@@ -61,8 +61,8 @@ TEST(SchedulerMTTest, MultiDomainBasic)
     fg->connect(mult1, mult2);
     fg->connect(mult2, snk);
 
-    auto sched1 = schedulers::scheduler_nbt::make("sched1");
-    auto sched2 = schedulers::scheduler_nbt::make("sched2");
+    auto sched1 = schedulers::scheduler_nbt::make();
+    auto sched2 = schedulers::scheduler_nbt::make();
 
     auto rt = runtime::make();
     rt->add_scheduler({ sched1, { src, mult1 } });


### PR DESCRIPTION
## Description
There were some issues in the scheduler handling single mapped buffers, especially when the block has output_multiple()

## Which blocks/areas does this affect?
cuda or other buffer_sm based blocks that use output_multiple

## Testing Done
Have some tests in my OOT - don't have a test block to do this directly

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
