### PR TITLE
fix copy block cpp template

### DIFF
--- a/gr-blocks/grc/blocks_copy.block.yml
+++ b/gr-blocks/grc/blocks_copy.block.yml
@@ -58,7 +58,7 @@ cpp_templates:
     declarations: 'blocks::copy::sptr ${id};'
     make: |-
         this->${id} = blocks::copy::make(${type.size}*${vlen});
-        self->${id}.set_enabled(${enabled});
+        this->${id}->set_enabled(${enabled});
     callbacks:
     - set_enabled(${enabled})
     translations:


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Copy Block won't compile in GRC's CPPGEN (block YAML had python syntax in CPP template)
@haakov helped me with the changes

## Which blocks/areas does this affect?
Copy Block when compiling flowgraph with CPPGEN

## Testing Done
Fresh clone of ```main```, edited gr-blocks/grc/blocks_copy.block.yml, rebuilt. Simple flowgraph compiles with no issues.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x ] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ x] I have squashed my commits to have one significant change per commit. 
- [ x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).

