### PR TITLE
Fix sample dropouts on top_block::unlock()

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer.h
+++ b/gnuradio-runtime/include/gnuradio/buffer.h
@@ -126,11 +126,7 @@ public:
 
     uint64_t nitems_written() { return d_abs_write_offset; }
 
-    void reset_nitem_counter()
-    {
-        d_write_index = 0;
-        d_abs_write_offset = 0;
-    }
+    void reset_nitem_counter() { d_abs_write_offset = 0; }
 
     size_t get_sizeof_item() { return d_sizeof_item; }
 

--- a/gnuradio-runtime/include/gnuradio/buffer_reader.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader.h
@@ -106,11 +106,7 @@ public:
 
     uint64_t nitems_read() const { return d_abs_read_offset; }
 
-    void reset_nitem_counter()
-    {
-        d_read_index = 0;
-        d_abs_read_offset = 0;
-    }
+    void reset_nitem_counter() { d_abs_read_offset = 0; }
 
     size_t get_sizeof_item() { return d_buffer->get_sizeof_item(); }
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(8e570cc3747473c3774ae5ffef6653aa)                     */
+/* BINDTOOL_HEADER_FILE_HASH(291a90813b3621085dc1eb443ed3e6dc)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_reader_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer_reader.h)                                           */
-/* BINDTOOL_HEADER_FILE_HASH(f88a20e94ad6a628f5c8c13338474220)                     */
+/* BINDTOOL_HEADER_FILE_HASH(95e46bce21a5d8b6c4e5e6ac8a6a401f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
Locking and unlocking the top_block (even without actual reconfiguration) results in a huge sample loss if any block have large history.
This PR fixes this issue by not resetting `buffer_reader::d_read_index` and `buffer::d_write_index` when
resetting absolute offsets.

## Related Issue
Fixes https://github.com/gnuradio/gnuradio/issues/6105

## Which blocks/areas does this affect?
Any block with large history (FIR filters, delays, etc)

## Testing Done
Added a test "t13_unlock_history" to gr-blocks/lib/qa_gr_top_block.cc
The test is kept in a separate commit to make it possible to cherry-pick it onto the branch in question and confirm, that it is failing without a fix.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
