### PR TITLE
4.0: some assorted small fixes

### DIFF
--- a/gr/include/gnuradio/meson.build
+++ b/gr/include/gnuradio/meson.build
@@ -45,7 +45,9 @@ runtime_headers = [
     'sptr_magic.h',
     'realtime.h',
     'runtime.h',
-    'buffer_sm.h'
+    'buffer_sm.h',
+    'executor.h',
+    'constants.h'
 ]
 
 install_headers(runtime_headers, subdir : 'gnuradio')

--- a/gr/lib/buffer_management.cc
+++ b/gr/lib/buffer_management.cc
@@ -16,8 +16,9 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
             if (!e->src().port()->get_buffer()) {
 
                 // If src block is in this domain
-                if (std::find(fg->nodes().begin(), fg->nodes().end(), e->src().node()) !=
-                    fg->nodes().end()) {
+                if (std::find(fg->all_nodes().begin(),
+                              fg->all_nodes().end(),
+                              e->src().node()) != fg->all_nodes().end()) {
 
                     buffer_uptr buf;
                     if (e->has_custom_buffer()) {
@@ -71,8 +72,9 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
 
             // TODO: more robust way of ensuring readers don't get double-added
             // If dst block is in this domain, then add the reader to the source port
-            if (std::find(fg->nodes().begin(), fg->nodes().end(), ed[0]->dst().node()) !=
-                fg->nodes().end()) {
+            if (std::find(fg->all_nodes().begin(),
+                          fg->all_nodes().end(),
+                          ed[0]->dst().node()) != fg->all_nodes().end()) {
 
                 if (ed[0]->buf_properties() &&
                     ed[0]->buf_properties()->reader_factory()) {

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/thread_wrapper.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/thread_wrapper.h
@@ -46,7 +46,7 @@ private:
     runtime_monitor_sptr d_rtmon;
 
     bool d_flushing = false;
-    int d_flush_cnt = 0;
+    size_t d_flush_cnt = 0;
     std::atomic<bool> kick_pending = false;
 
     scheduler_nbt_options _opts;

--- a/schedulers/nbt/lib/scheduler_nbt.cc
+++ b/schedulers/nbt/lib/scheduler_nbt.cc
@@ -48,14 +48,11 @@ void scheduler_nbt::initialize(flat_graph_sptr fg, runtime_monitor_sptr fgmon)
             auto t = thread_wrapper::make(id(), bg, bufman, fgmon, _opts);
             _threads.push_back(t);
 
-            std::vector<node_sptr> node_vec;
             for (auto& b : bg.blocks()) {
                 auto it = std::find(blocks.begin(), blocks.end(), b);
                 if (it != blocks.end()) {
                     blocks.erase(it);
                 }
-
-                node_vec.push_back(b);
 
                 b->set_parent_intf(t);
                 for (auto& p : b->all_ports()) {
@@ -68,10 +65,6 @@ void scheduler_nbt::initialize(flat_graph_sptr fg, runtime_monitor_sptr fgmon)
 
     // For the remaining blocks that weren't in block groups
     for (auto& b : blocks) {
-
-        std::vector<node_sptr> node_vec;
-        node_vec.push_back(b);
-
         auto t = thread_wrapper::make(
             id(), block_group_properties({ b }), bufman, fgmon, _opts);
         _threads.push_back(t);

--- a/test/qa_scheduler_nbt.cc
+++ b/test/qa_scheduler_nbt.cc
@@ -56,7 +56,7 @@ TEST(SchedulerMTTest, MultiDomainBasic)
     auto mult2 = math::multiply_const_ff::make_cpu({ 200.0 });
     auto snk = blocks::vector_sink_f::make({});
 
-    flowgraph_sptr fg(new flowgraph());
+    auto fg = flowgraph::make();
     fg->connect(src, mult1);
     fg->connect(mult1, mult2);
     fg->connect(mult2, snk);

--- a/utils/blockbuilder/schema/gnuradio-block.json
+++ b/utils/blockbuilder/schema/gnuradio-block.json
@@ -27,6 +27,12 @@
                         "type": "string"
                     }
                 },
+                "inherits": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "grc": {
                     "$ref": "#/definitions/GrcTop"
                 },

--- a/utils/blockbuilder/templates/blockname.h.j2
+++ b/utils/blockbuilder/templates/blockname.h.j2
@@ -10,7 +10,7 @@
 namespace gr {
 namespace {{module}} {
 
-{{ macros.class_statement(block, blocktype) }}
+{{ macros.class_statement(block, blocktype, inherits) }}
 {
 public:
 {{ macros.block_args(parameters) }}

--- a/utils/blockbuilder/templates/blockname_pybind.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind.cc.j2
@@ -13,7 +13,7 @@ void bind_{{block}}(py::module& m)
 {
     using {{block}} = ::gr::{{module}}::{{block}};
 
-    py::class_<{{block}}, {{ inherits }}{{',' if inherits}}{% if blocktype != 'block'%} gr::{{blocktype}},{% endif %}
+    py::class_<{{block}}, {% if inherits %}{% for inh in inherits%}{{inh}},{%endfor%}{%endif%}{% if blocktype != 'block'%} gr::{{blocktype}},{% endif %}
     gr::block, gr::node,
     std::shared_ptr<{{block}}>> {{block}}_class(m, "{{block}}"{{macros.block_docstring(doc,parameters,ports)}});
 

--- a/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
@@ -15,7 +15,7 @@ void bind_{{ block }}_template(py::module& m, const char* classname)
 {
     // using block_class = gr::{{ module }}::{{ block }}<{{typestr}}>;
 
-    py::class_<gr::{{ module }}::{{ block }}<{{typestr}}>, {{ inherits }}{{',' if inherits}} {% if blocktype != 'block'%} {{ "gr::" if blocktype[:4] != "gr::" }}{{blocktype}},{% endif %}
+    py::class_<gr::{{ module }}::{{ block }}<{{typestr}}>, {% if inherits %}{% for inh in inherits%}{{inh}},{%endfor%}{%endif%} {% if blocktype != 'block'%} {{ "gr::" if blocktype[:4] != "gr::" }}{{blocktype}},{% endif %}
     gr::block, gr::node,
     std::shared_ptr<gr::{{ module }}::{{ block }}<{{typestr}}>>> {{block}}_class(m, classname);
 

--- a/utils/blockbuilder/templates/blockname_templated.h.j2
+++ b/utils/blockbuilder/templates/blockname_templated.h.j2
@@ -15,7 +15,7 @@ namespace gr {
 namespace {{module}} {
 
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
-{{ macros.class_statement(block, blocktype) }}
+{{ macros.class_statement(block, blocktype, inherits) }}
 {
 public:
 {{ macros.block_args(parameters) }}

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -27,8 +27,8 @@
 {% endif -%}
 {% endmacro %}
 
-{% macro class_statement(block, blocktype) -%}
-class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ inherits }}#}
+{% macro class_statement(block, blocktype, inherits) -%}
+class {{ block }} : virtual public {{blocktype}}{% for inh in inherits %}, public {{ inh }}{%endfor%}
 {% endmacro %}
 
 {% macro block_args(parameters) -%}


### PR DESCRIPTION
## Description
A few small fixes encountered on 4.0
1) fix some compiler warnings
2) remove some unused code
3) add back the `inherits` field to the block yml

This inherits field allows a block to have an additional interface, such as a domain specific block that inherits from a class that allows a callback to be set.
