### PR TITLE
Fix incorrect tag propagation and loss on flowgraph reconfiguration

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer_reader.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader.h
@@ -104,13 +104,9 @@ public:
 
     gr::thread::mutex* mutex() { return d_buffer->mutex(); }
 
-    uint64_t nitems_read() const { return d_abs_read_offset; }
+    uint64_t nitems_read();
 
-    void reset_nitem_counter()
-    {
-        d_read_index = 0;
-        d_abs_read_offset = 0;
-    }
+    void reset_nitem_counter() { d_read_index = 0; }
 
     size_t get_sizeof_item() { return d_buffer->get_sizeof_item(); }
 
@@ -159,7 +155,7 @@ public:
 
     // -------------------------------------------------------------------------
     unsigned int get_read_index() const { return d_read_index; }
-    uint64_t get_abs_read_offset() const { return d_abs_read_offset; }
+    uint64_t get_abs_read_offset() { return nitems_read(); }
 
 protected:
     friend class buffer;
@@ -174,7 +170,6 @@ protected:
 
     buffer_sptr d_buffer;
     unsigned int d_read_index;   // in items [0,d->buffer.d_bufsize) ** see NB
-    uint64_t d_abs_read_offset;  // num items seen since the start   ** see NB
     std::weak_ptr<block> d_link; // block that reads via this buffer reader
     unsigned d_attr_delay;       // sample delay attribute for tag propagation
     // ** NB: buffer::d_mutex protects d_read_index and d_abs_read_offset

--- a/gnuradio-runtime/include/gnuradio/buffer_reader_sm.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_reader_sm.h
@@ -26,7 +26,7 @@ public:
     /*!
      * \brief Return number of items available for reading.
      */
-    virtual int items_available() const;
+    virtual int items_available();
 
     /*!
      * \brief Return true if thread is ready to call input_blocked_callback,

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -150,31 +150,40 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
             std::vector<tag_t>::iterator t;
             if (rrate == 1.0) {
                 for (t = rtags.begin(); t != rtags.end(); t++) {
-                    for (int o = 0; o < d->noutputs(); o++)
-                        out_buf[o]->add_item_tag(*t);
+                    for (int o = 0; o < d->noutputs(); o++) {
+                        tag_t new_tag = *t;
+                        new_tag.offset =
+                            new_tag.offset - start_nitems_read[i] + d->nitems_written(o);
+                        out_buf[o]->add_item_tag(new_tag);
+                    }
                 }
             } else if (use_fp_rrate) {
                 for (t = rtags.begin(); t != rtags.end(); t++) {
-                    tag_t new_tag = *t;
-                    new_tag.offset = std::llround((double)new_tag.offset * rrate);
-                    for (int o = 0; o < d->noutputs(); o++)
+                    for (int o = 0; o < d->noutputs(); o++) {
+                        tag_t new_tag = *t;
+                        new_tag.offset = new_tag.offset - start_nitems_read[i];
+                        new_tag.offset = std::llround((double)new_tag.offset * rrate) +
+                                         d->nitems_written(o);
                         out_buf[o]->add_item_tag(new_tag);
+                    }
                 }
             } else {
                 mpz_class offset;
                 for (t = rtags.begin(); t != rtags.end(); t++) {
-                    tag_t new_tag = *t;
-                    mpz_import(offset.get_mpz_t(),
-                               1,
-                               1,
-                               sizeof(new_tag.offset),
-                               0,
-                               0,
-                               &new_tag.offset);
-                    offset = offset * mp_rrate + one_half;
-                    new_tag.offset = offset.get_ui();
-                    for (int o = 0; o < d->noutputs(); o++)
+                    for (int o = 0; o < d->noutputs(); o++) {
+                        tag_t new_tag = *t;
+                        mpz_import(offset.get_mpz_t(),
+                                   1,
+                                   1,
+                                   sizeof(new_tag.offset),
+                                   0,
+                                   0,
+                                   &new_tag.offset);
+                        offset = (offset - start_nitems_read[i]) * mp_rrate + one_half +
+                                 d->nitems_written(o);
+                        new_tag.offset = offset.get_ui();
                         out_buf[o]->add_item_tag(new_tag);
+                    }
                 }
             }
         }
@@ -199,12 +208,17 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
                 std::vector<tag_t>::iterator t;
                 if (rrate == 1.0) {
                     for (t = rtags.begin(); t != rtags.end(); t++) {
-                        out_buf->add_item_tag(*t);
+                        tag_t new_tag = *t;
+                        new_tag.offset =
+                            new_tag.offset - start_nitems_read[i] + d->nitems_written(i);
+                        out_buf->add_item_tag(new_tag);
                     }
                 } else if (use_fp_rrate) {
                     for (t = rtags.begin(); t != rtags.end(); t++) {
                         tag_t new_tag = *t;
-                        new_tag.offset = std::llround((double)new_tag.offset * rrate);
+                        new_tag.offset = new_tag.offset - start_nitems_read[i];
+                        new_tag.offset = std::llround((double)new_tag.offset * rrate) +
+                                         d->nitems_written(i);
                         out_buf->add_item_tag(new_tag);
                     }
                 } else {
@@ -218,7 +232,8 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
                                    0,
                                    0,
                                    &new_tag.offset);
-                        offset = offset * mp_rrate + one_half;
+                        offset = (offset - start_nitems_read[i]) * mp_rrate + one_half +
+                                 d->nitems_written(i);
                         new_tag.offset = offset.get_ui();
                         out_buf->add_item_tag(new_tag);
                     }

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -151,10 +151,14 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
             if (rrate == 1.0) {
                 for (t = rtags.begin(); t != rtags.end(); t++) {
                     for (int o = 0; o < d->noutputs(); o++) {
-                        tag_t new_tag = *t;
-                        new_tag.offset =
-                            new_tag.offset - start_nitems_read[i] + d->nitems_written(o);
-                        out_buf[o]->add_item_tag(new_tag);
+                        if (start_nitems_read[i] == d->nitems_written(o))
+                            out_buf[o]->add_item_tag(*t);
+                        else {
+                            tag_t new_tag = *t;
+                            new_tag.offset = new_tag.offset - start_nitems_read[i] +
+                                             d->nitems_written(o);
+                            out_buf[o]->add_item_tag(new_tag);
+                        }
                     }
                 }
             } else if (use_fp_rrate) {
@@ -208,10 +212,14 @@ static bool propagate_tags(block::tag_propagation_policy_t policy,
                 std::vector<tag_t>::iterator t;
                 if (rrate == 1.0) {
                     for (t = rtags.begin(); t != rtags.end(); t++) {
-                        tag_t new_tag = *t;
-                        new_tag.offset =
-                            new_tag.offset - start_nitems_read[i] + d->nitems_written(i);
-                        out_buf->add_item_tag(new_tag);
+                        if (start_nitems_read[i] == d->nitems_written(i))
+                            out_buf->add_item_tag(*t);
+                        else {
+                            tag_t new_tag = *t;
+                            new_tag.offset = new_tag.offset - start_nitems_read[i] +
+                                             d->nitems_written(i);
+                            out_buf->add_item_tag(new_tag);
+                        }
                     }
                 } else if (use_fp_rrate) {
                     for (t = rtags.begin(); t != rtags.end(); t++) {

--- a/gnuradio-runtime/lib/buffer_reader.cc
+++ b/gnuradio-runtime/lib/buffer_reader.cc
@@ -65,11 +65,7 @@ buffer_add_reader(buffer_sptr buf, int nzero_preload, block_sptr link, int delay
 }
 
 buffer_reader::buffer_reader(buffer_sptr buffer, unsigned int read_index, block_sptr link)
-    : d_buffer(buffer),
-      d_read_index(read_index),
-      d_abs_read_offset(0),
-      d_link(link),
-      d_attr_delay(0)
+    : d_buffer(buffer), d_read_index(read_index), d_link(link), d_attr_delay(0)
 {
 #ifdef BUFFER_DEBUG
     gr::configure_default_loggers(d_logger, d_debug_logger, "buffer_reader");
@@ -124,7 +120,6 @@ void buffer_reader::update_read_pointer(int nitems)
 #endif
 
     d_read_index = d_buffer->index_add(d_read_index, nitems);
-    d_abs_read_offset += nitems;
 
 #ifdef BUFFER_DEBUG
     std::ostringstream msg;
@@ -133,6 +128,12 @@ void buffer_reader::update_read_pointer(int nitems)
         << " -- nitems: " << nitems << " -- d_read_index: " << d_read_index;
     GR_LOG_DEBUG(d_buffer->d_logger, msg.str());
 #endif
+}
+
+uint64_t buffer_reader::nitems_read()
+{
+    unsigned history = d_link.expired() ? 1 : d_link.lock()->history();
+    return d_buffer->nitems_written() - items_available() + history - 1;
 }
 
 void buffer_reader::get_tags_in_range(std::vector<tag_t>& v,

--- a/gnuradio-runtime/lib/buffer_reader_sm.cc
+++ b/gnuradio-runtime/lib/buffer_reader_sm.cc
@@ -25,7 +25,7 @@ namespace gr {
 
 buffer_reader_sm::~buffer_reader_sm() {}
 
-int buffer_reader_sm::items_available() const
+int buffer_reader_sm::items_available()
 {
     int available = 0;
 

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -355,12 +355,6 @@ void flat_flowgraph::merge_connections(flat_flowgraph_sptr old_ffg)
                 i->src().port(),
                 pmt::cons(i->dst().block()->alias_pmt(), i->dst().port()));
         }
-
-        // Now deal with the fact that the block details might have
-        // changed numbers of inputs and outputs vs. in the old
-        // flowgraph.
-        block->detail()->reset_nitem_counters();
-        block->detail()->clear_tags();
     }
 }
 


### PR DESCRIPTION
## Description
Do not use `buffer_reader` internal counter to calculate `nitems_read`
Correctly recalculate tag offsets taking into account possible rate changes.

## Related Issue
Fixes https://github.com/gnuradio/gnuradio/issues/6110 and maybe https://github.com/gnuradio/gnuradio/issues/6105
## Which blocks/areas does this affect?
All blocks that create/handle tags.

## Testing Done
TBD.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
