### PR TITLE
file source: update d_items_remaining on seek

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -108,6 +108,7 @@ bool file_source_impl::seek(int64_t seek_point, int whence)
             d_logger->warn("bad seek point {:d}", seek_point);
             return 0;
         }
+        d_items_remaining = d_length_items - (seek_point - d_start_offset_items);
         return GR_FSEEK((FILE*)d_fp, seek_point * d_itemsize, SEEK_SET) == 0;
     } else {
         d_logger->warn("file not seekable");


### PR DESCRIPTION
## Description
d_items_remaining was not being updated during seek, so end/repeat
of playback would not happen at the correct time.

## Which blocks/areas does this affect?
File Source

## Testing Done
Problem found and tested using Gqrx playback.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
