### PR TITLE
modtool: parse io signatures without gr:: prefix (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/tools/parser_cc_block.py
+++ b/gr-utils/modtool/tools/parser_cc_block.py
@@ -72,9 +72,9 @@ class ParserCCBlock(object):
             elif len(vlen_parts) > 1:
                 return '*'.join(vlen_parts).strip()
         iosig = {}
-        iosig_regex = r'(?P<incall>gr::io_signature::make[23v]?)\s*\(\s*(?P<inmin>[^,]+),\s*(?P<inmax>[^,]+),' + \
+        iosig_regex = r'(?P<incall>(gr::)?io_signature::make[23v]?)\s*\(\s*(?P<inmin>[^,]+),\s*(?P<inmax>[^,]+),' + \
                       r'\s*(?P<intype>(\([^\)]*\)|[^)])+)\),\s*' + \
-                      r'(?P<outcall>gr::io_signature::make[23v]?)\s*\(\s*(?P<outmin>[^,]+),\s*(?P<outmax>[^,]+),' + \
+                      r'(?P<outcall>(gr::)?io_signature::make[23v]?)\s*\(\s*(?P<outmin>[^,]+),\s*(?P<outmax>[^,]+),' + \
                       r'\s*(?P<outtype>(\([^\)]*\)|[^)])+)\)'
         iosig_match = re.compile(
             iosig_regex, re.MULTILINE).search(self.code_cc)


### PR DESCRIPTION
Previously, parsing signatures would fail if the io_signature call was
not prefixed with gr::, which is not necessary if currently in the gr
namespace anyway. This error may be encountered when copying gnuradio
source files into a new module, which don't use the gr:: prefix. This
patch addresses #5800.

Signed-off-by: esrh <esrh@gatech.edu>
(cherry picked from commit ba14ada01fefc052240dd21b6170a10b24e7b8eb)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6007