### PR TITLE
Replace calls to get_initial_sptr with make_block_sptr (backport to maint-3.9)

### DIFF
--- a/gr-digital/lib/constellation_encoder_bc_impl.cc
+++ b/gr-digital/lib/constellation_encoder_bc_impl.cc
@@ -21,7 +21,7 @@ namespace digital {
 constellation_encoder_bc::sptr
 constellation_encoder_bc::make(constellation_sptr constellation)
 {
-    return gnuradio::get_initial_sptr(new constellation_encoder_bc_impl(constellation));
+    return gnuradio::make_block_sptr<constellation_encoder_bc_impl>(constellation);
 }
 
 constellation_encoder_bc_impl::constellation_encoder_bc_impl(

--- a/gr-fft/lib/fft_v_fftw.cc
+++ b/gr-fft/lib/fft_v_fftw.cc
@@ -26,8 +26,8 @@ typename fft_v<T, forward>::sptr fft_v<T, forward>::make(int fft_size,
                                                          bool shift,
                                                          int nthreads)
 {
-    return gnuradio::get_initial_sptr(
-        new fft_v_fftw<T, forward>(fft_size, window, shift, nthreads));
+    return gnuradio::make_block_sptr<fft_v_fftw<T, forward>>(
+        fft_size, window, shift, nthreads);
 }
 
 template <class T, bool forward>


### PR DESCRIPTION
In 30643f01609e915296023adc37123e27e2c86d3f all the calls to
get_initial_sptr were replaced by make_block_sptr. However, there
are a few places where get_initial_sptr still remains. This replaces
the reminaing get_initial_sptr calls.

Signed-off-by: Daniel Estévez <daniel@destevez.net>
(cherry picked from commit e7b6e78bfd0b9edc8915a6386be0219151ade6e5)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5906