### PR TITLE
grc: gui_hint avoid useless error messages (backport to maint-3.9)

### DIFF
--- a/grc/core/params/dtypes.py
+++ b/grc/core/params/dtypes.py
@@ -115,6 +115,9 @@ def validate_vector(param, black_listed_ids):
 @validates('gui_hint')
 def validate_gui_hint(param, black_listed_ids):
     try:
+        # Only parse the param if there are no errors
+        if len(param.get_error_messages()) > 0:
+            return
         param.parse_gui_hint(param.value)
     except Exception as e:
         raise ValidateError(str(e))

--- a/grc/core/params/param.py
+++ b/grc/core/params/param.py
@@ -347,7 +347,7 @@ class Param(Element):
             e = self.parent_flowgraph.evaluate(pos)
 
             if not isinstance(e, (list, tuple)) or len(e) not in (2, 4) or not all(isinstance(ei, int) for ei in e):
-                raise Exception(
+                self.add_error_message(
                     'Invalid GUI Hint entered: {e!r} (Must be a list of {{2,4}} non-negative integers).'.format(e=e))
 
             if len(e) == 2:
@@ -357,11 +357,11 @@ class Param(Element):
                 row, col, row_span, col_span = e
 
             if (row < 0) or (col < 0):
-                raise Exception(
-                    'Invalid GUI Hint entered: {e!r} (non-negative integers only).'.format(e=e))
+                self.add_error_message(
+                    'Invalid GUI Hint entered: {e!r} (non-negative rows/cols only).'.format(e=e))
 
             if (row_span < 1) or (col_span < 1):
-                raise Exception(
+                self.add_error_message(
                     'Invalid GUI Hint entered: {e!r} (positive row/column span required).'.format(e=e))
 
             return row, col, row_span, col_span
@@ -371,13 +371,14 @@ class Param(Element):
                     if block.key == 'qtgui_tab_widget' and block.name == tab)
             tab_block = next(iter(tabs), None)
             if not tab_block:
-                raise Exception(
+                self.add_error_message(
                     'Invalid tab name entered: {tab} (Tab name not found).'.format(tab=tab))
+                return
 
             tab_index_size = int(tab_block.params['num_tabs'].value)
             if index >= tab_index_size:
-                raise Exception('Invalid tab index entered: {tab}@{index} (Index out of range).'.format(
-                    tab=tab, index=index))
+                self.add_error_message(
+                    'Invalid tab index entered: {tab}@{index} (Index out of range).'.format(tab=tab, index=index))
 
         # Collision Detection
         def collision_detection(row, col, row_span, col_span):
@@ -394,7 +395,7 @@ class Param(Element):
                 collision = next(
                     iter(self.hostage_cells & other.hostage_cells), None)
                 if collision:
-                    raise Exception('Block {block!r} is also using parent {parent!r}, cell {cell!r}.'.format(
+                    self.add_error_message('Block {block!r} is also using parent {parent!r}, cell {cell!r}.'.format(
                         block=other.parent_block.name, parent=collision[0], cell=collision[1]
                     ))
 


### PR DESCRIPTION
Wrong values in the GUI HINT field are correctly handled in the gui
but lead to useless error messages in the terminal window

Signed-off-by: Volker Schroer <3470424+dl1ksv@users.noreply.github.com>
(cherry picked from commit b10d6e0eb989b85ed0ebcacf3695bc4d1dea2404)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5907