### PR TITLE
filter: Improve "invalid fractional bandwidth" error message (backport to maint-3.10)

### DIFF
--- a/gr-filter/lib/rational_resampler_impl.cc
+++ b/gr-filter/lib/rational_resampler_impl.cc
@@ -16,6 +16,7 @@
 #include <gnuradio/fft/window.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/io_signature.h>
+#include <spdlog/fmt/fmt.h>
 #include <numeric>
 #include <stdexcept>
 
@@ -40,7 +41,8 @@ std::vector<TAP_T> design_resampler_filter(const unsigned interpolation,
 {
 
     if (fractional_bw >= 0.5 || fractional_bw <= 0) {
-        throw std::range_error("Invalid fractional_bandwidth, must be in (0, 0.5)");
+        throw std::range_error(fmt::format(
+            "Invalid fractional_bandwidth {:.2f}, must be in (0, 0.5)", fractional_bw));
     }
 
     // These are default values used to generate the filter when no taps are known


### PR DESCRIPTION
Provide the invalid value alongside the accepted range to ease with
debugging.

Signed-off-by: Fabian P. Schmidt <kerel@mailbox.org>
(cherry picked from commit a52d1805772e297593e4d94c4edc6a69e9cfc344)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6069