### PR TITLE
global: fix various typos (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/block.h
+++ b/gnuradio-runtime/include/gnuradio/block.h
@@ -815,7 +815,7 @@ protected:
      *
      * \param which_output an integer of which output stream to attach the tag
      * \param abs_offset   a uint64 number of the absolute item number
-     *                     assicated with the tag. Can get from nitems_written.
+     *                     associated with the tag. Can get from nitems_written.
      * \param key          the tag key as a PMT symbol
      * \param value        any PMT holding any value for the given key
      * \param srcid        optional source ID specifier; defaults to PMT_F
@@ -847,7 +847,7 @@ protected:
      *
      * \param which_input an integer of which input stream to remove the tag from
      * \param abs_offset   a uint64 number of the absolute item number
-     *                     assicated with the tag. Can get from nitems_written.
+     *                     associated with the tag. Can get from nitems_written.
      * \param key          the tag key as a PMT symbol
      * \param value        any PMT holding any value for the given key
      * \param srcid        optional source ID specifier; defaults to PMT_F

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(block.h)                                                   */
-/* BINDTOOL_HEADER_FILE_HASH(5c67dfcdc307149740d954becd79ba12)                     */
+/* BINDTOOL_HEADER_FILE_HASH(18c70c95c54b95bab0af13e9fb687530)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/include/gnuradio/blocks/control_loop.h
+++ b/gr-blocks/include/gnuradio/blocks/control_loop.h
@@ -322,7 +322,7 @@ static float tanh_lut_table[256] = {
 };
 
 /*!
- * A look-up table (LUT) tanh calcuation. This function returns an
+ * A look-up table (LUT) tanh calculation. This function returns an
  * estimate to tanh(x) based on a 256-point LUT between -2 and
  * 2. If x < -2, it returns -1; if > 2, it returns 1.
  *

--- a/gr-blocks/python/blocks/bindings/control_loop_python.cc
+++ b/gr-blocks/python/blocks/bindings/control_loop_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(control_loop.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(26a23d368e328fb578707a7c18cafbe1)                     */
+/* BINDTOOL_HEADER_FILE(control_loop.h)                                            */
+/* BINDTOOL_HEADER_FILE_HASH(2136814678ebb25b6a18e6de1aaa4eb7)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-blocks/python/blocks/qa_python_message_passing.py
+++ b/gr-blocks/python/blocks/qa_python_message_passing.py
@@ -90,7 +90,7 @@ class test_python_message_passing(gr_unittest.TestCase):
         # Connect message generator to message consumer
         self.tb.msg_connect(msg_gen, 'out_port', msg_cons, 'in_port')
 
-        # Verify that the messgae port query functions work
+        # Verify that the message port query functions work
         self.assertEqual(
             pmt.to_python(
                 msg_gen.message_ports_out())[0],

--- a/gr-digital/examples/snr_estimators.py
+++ b/gr-digital/examples/snr_estimators.py
@@ -21,7 +21,7 @@ except ImportError:
 try:
     from matplotlib import pyplot
 except ImportError:
-    print("Error: Program requires Matplotlib (matplotlib.sourceforge.net).")
+    print("Error: Program requires Matplotlib (matplotlib.org).")
     sys.exit(1)
 
 from gnuradio import gr, digital, filter
@@ -34,7 +34,7 @@ from gnuradio.eng_option import eng_option
 This example program uses Python and GNU Radio to calculate SNR of a
 noise BPSK signal to compare them.
 
-For an explination of the online algorithms, see:
+For an explanation of the online algorithms, see:
 http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Higher-order_statistics
 '''
 

--- a/gr-digital/include/gnuradio/digital/crc_check.h
+++ b/gr-digital/include/gnuradio/digital/crc_check.h
@@ -47,7 +47,7 @@ public:
      * \param swap_endianness true if the CRC is stored as little-endian in the PDU,
        false if not
      * \param discard_crc If true, the CRC is removed from the PDU before sending
-       it to the output port. If false, the CRC is preserved in the outupt PDU.
+       it to the output port. If false, the CRC is preserved in the output PDU.
      * \param skip_header_bytes gives the number of header byte to skip in the CRC
        calculation
      */

--- a/gr-digital/lib/clock_tracking_loop.h
+++ b/gr-digital/lib/clock_tracking_loop.h
@@ -177,7 +177,7 @@ namespace digital {
  * error, which has some gain \f$K_{ted}\f$.  The gain, \f$K_{ted}\f$, is
  * defined as the slope of a TED's S-curve plot at a symbol clock phase
  * offset of \f$\tau = 0\f$.  The S-curve shape and central slope, and
- * hence the gain \f$K_{ted}\f$, depend on the TED's estimator espression,
+ * hence the gain \f$K_{ted}\f$, depend on the TED's estimator expression,
  * the input signal level, the pulse shaping filter, and the \f$E_s/N_0\f$
  * of the incoming signal.  The user must determine the TED's
  * S-curve by analysis or simulation of the particular situation, in order

--- a/gr-digital/lib/interpolating_resampler.cc
+++ b/gr-digital/lib/interpolating_resampler.cc
@@ -380,7 +380,7 @@ interp_resampler_pfb_mf_ccf::interp_resampler_pfb_mf_ccf(const std::vector<float
     diff_taps[0] = 0.0f;
     diff_taps[diff_taps.size() - 1] = 0.0f;
 
-    // Normalize the prototype derviative filter gain to the number of
+    // Normalize the prototype derivative filter gain to the number of
     // filter arms
     n = diff_taps.size();
     float mag = 0.0f;
@@ -518,7 +518,7 @@ interp_resampler_pfb_mf_fff::interp_resampler_pfb_mf_fff(const std::vector<float
     diff_taps[0] = 0.0f;
     diff_taps[diff_taps.size() - 1] = 0.0f;
 
-    // Normalize the prototype derviative filter gain to the number of
+    // Normalize the prototype derivative filter gain to the number of
     // filter arms
     n = diff_taps.size();
     float mag = 0.0f;

--- a/gr-digital/python/digital/bindings/crc_check_python.cc
+++ b/gr-digital/python/digital/bindings/crc_check_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(crc_check.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4170f8e1b07d628ce6b354c65f2f0502)                     */
+/* BINDTOOL_HEADER_FILE(crc_check.h)                                               */
+/* BINDTOOL_HEADER_FILE_HASH(5266839fdf5c69c9020ed8a7e571d80d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/soft_dec_lut_gen.py
+++ b/gr-digital/python/digital/soft_dec_lut_gen.py
@@ -169,7 +169,7 @@ def calc_soft_dec_from_table(sample, table, prec, Es=1.0):
 
 def calc_soft_dec(sample, constel, symbols, npwr=1):
     '''
-    This function takes in any consteallation and symbol symbol set
+    This function takes in any constellation and symbol set
     (where symbols[i] is the set of bits at constellation point
     constel[i] and an estimate of the noise power and produces the
     soft decisions for the given sample.

--- a/gr-fec/python/fec/extended_decoder.py
+++ b/gr-fec/python/fec/extended_decoder.py
@@ -137,7 +137,7 @@ class extended_decoder(gr.hier_block2):
                 if 1.0 / self.ann.count("1") >= i:
                     synd_garble = self.garbletable[i]
             print(
-                "using syndrom garble threshold " +
+                "using syndrome garble threshold " +
                 str(synd_garble) +
                 "for conv_bit_corr_bb"
             )

--- a/gr-fec/python/fec/extended_tagged_decoder.py
+++ b/gr-fec/python/fec/extended_tagged_decoder.py
@@ -144,7 +144,7 @@ class extended_tagged_decoder(gr.hier_block2):
                 if 1.0 / self.ann.count("1") >= i:
                     synd_garble = self.garbletable[i]
             print(
-                "using syndrom garble threshold " +
+                "using syndrome garble threshold " +
                 str(synd_garble) +
                 "for conv_bit_corr_bb"
             )

--- a/gr-filter/include/gnuradio/filter/fft_filter.h
+++ b/gr-filter/include/gnuradio/filter/fft_filter.h
@@ -348,7 +348,7 @@ public:
     /*!
      * \brief Returns the actual size of the filter.
      *
-     * \details This value could be equal to ntaps, but we ofter
+     * \details This value could be equal to ntaps, but we often
      * build a longer filter to allow us to calculate a more
      * efficient FFT. This value is the actual size of the filters
      * used in the calculation of the overlap-and-save operation.

--- a/gr-filter/include/gnuradio/filter/firdes.h
+++ b/gr-filter/include/gnuradio/filter/firdes.h
@@ -58,7 +58,7 @@ public:
      * normalized width of the transition band and the required stop band
      * attenuation is what sets the number of taps required.  Narrow --> more
      * taps More attenuation --> more taps. The window type determines
-     * maximum attentuation and passband ripple.
+     * maximum attenuation and passband ripple.
      *
      * \param gain                overall gain of filter (typically 1.0)
      * \param sampling_freq       sampling freq (Hz)

--- a/gr-filter/lib/gen_interpolator_taps/diff_objective_fct.c
+++ b/gr-filter/lib/gen_interpolator_taps/diff_objective_fct.c
@@ -35,7 +35,7 @@ gsl_integration_workspace* global_gsl_int_workspace = NULL;
  * approximation defined by the FIR coefficients in global_h[]
  *
  * See eqn (9-7), "Digital Communication Receivers", Meyr, Moeneclaey
- * and Fechtel, Wiley, 1998. for the jist of what going on here.
+ * and Fechtel, Wiley, 1998. for the gist of what's going on here.
  *
  * See eqns (7.99) and (7.100), "Discrete Time Signal Processing",
  * Oppenheim, Alan V., Schafer, Ronald W., Prentice Hall 1989. for the

--- a/gr-filter/python/filter/bindings/fft_filter_python.cc
+++ b/gr-filter/python/filter/bindings/fft_filter_python.cc
@@ -13,8 +13,8 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(fft_filter.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(dad8d136a3842f0e989324232efb2949)                     */
+/* BINDTOOL_HEADER_FILE(fft_filter.h)                                              */
+/* BINDTOOL_HEADER_FILE_HASH(209a90728e0accc2186c762cf484e0ad)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/bindings/firdes_python.cc
+++ b/gr-filter/python/filter/bindings/firdes_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(firdes.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(10cf0c4b9664ba7e2931c2375c13c68c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(be6fcf3be3d516d7f3e0ebac0c929c82)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-utils/plot_tools/gr_plot_qt
+++ b/gr-utils/plot_tools/gr_plot_qt
@@ -577,7 +577,7 @@ class gr_plot_qt(QtGui.QMainWindow):
         self.rightAxis.setColorMap(self.spec.data().range(),
                                    self.spec.colorMap())
 
-        # Set the new axis base; include right axis for the intenisty color bar
+        # Set the new axis base; include right axis for the intensity color bar
         self.gui.specPlot.setAxisScale(self.gui.specPlot.xBottom,
                                        min(self.spec_f),
                                        max(self.spec_f))

--- a/gr-vocoder/examples/loopback-codec2.grc
+++ b/gr-vocoder/examples/loopback-codec2.grc
@@ -21,7 +21,7 @@ options:
     run_options: prompt
     sizing_mode: fixed
     thread_safe_setters: ''
-    title: Codec2 Looback Test
+    title: Codec2 Loopback Test
     window_size: 1280, 1024
   states:
     coordinate: [0, -1]

--- a/gr-vocoder/examples/loopback-gsmfr.grc
+++ b/gr-vocoder/examples/loopback-gsmfr.grc
@@ -21,7 +21,7 @@ options:
     run_options: prompt
     sizing_mode: fixed
     thread_safe_setters: ''
-    title: GSM Full-Rate 06.10 Codec Looback Test
+    title: GSM Full-Rate 06.10 Codec Loopback Test
     window_size: 1280, 1024
   states:
     coordinate: [0, -1]

--- a/grc/core/generator/cpp_top_block.py
+++ b/grc/core/generator/cpp_top_block.py
@@ -305,7 +305,7 @@ class CppTopBlockGenerator(object):
 
         type_translation = {'complex': 'gr_complex', 'real': 'double', 'float': 'float', 'int': 'int', 'complex_vector': 'std::vector<gr_complex>',
                             'real_vector': 'std::vector<double>', 'float_vector': 'std::vector<float>', 'int_vector': 'std::vector<int>', 'string': 'std::string', 'bool': 'bool'}
-        # If the type is explcitly specified, translate to the corresponding C++ type
+        # If the type is explicitly specified, translate to the corresponding C++ type
         for var in list(variables):
             if var.params['value'].dtype != 'raw':
                 var.vtype = type_translation[var.params['value'].dtype]


### PR DESCRIPTION
* Fix various typos

Found via `codespell -q 3 -L ans,busses,circularly,fo,hist,impres,inh,inout,ist,ith,merchantibility,nd,nin,numer,ro,shif,sinc,uint -S ./volk,CHANGELOG.md,./docs/RELEASE-NOTES*,/home/beast/Projects/repos/gnuradio/.packaging/debian/changelog,/home/beast/Projects/repos/gnuradio/.packaging/fedora/gnuradio.spec`

Signed-off-by: luz paz <luzpaz@github.com>

* Update the hash in the corresponding pybind11 bind file

Signed-off-by: luz paz <luzpaz@github.com>

Signed-off-by: luz paz <luzpaz@github.com>
(cherry picked from commit 6c34c6bb795639a7f85ed74421ef1316999da4b8)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6051