### PR TITLE
file source: update d_items_remaining on seek (backport to maint-3.10)

### DIFF
--- a/gr-blocks/lib/file_source_impl.cc
+++ b/gr-blocks/lib/file_source_impl.cc
@@ -108,6 +108,7 @@ bool file_source_impl::seek(int64_t seek_point, int whence)
             d_logger->warn("bad seek point {:d}", seek_point);
             return 0;
         }
+        d_items_remaining = d_length_items - (seek_point - d_start_offset_items);
         return GR_FSEEK((FILE*)d_fp, seek_point * d_itemsize, SEEK_SET) == 0;
     } else {
         d_logger->warn("file not seekable");


### PR DESCRIPTION
d_items_remaining was not being updated during seek, so end/repeat
of playback would not happen at the correct time.

Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit e063a8ac02b9aa6ee503718c32bf6730d091f098)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6114