### PR TITLE
4.0: Make python blocks more integrated

### DIFF
--- a/blocklib/analog/agc/.gitignore
+++ b/blocklib/analog/agc/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/analog/fm_deemph/.gitignore
+++ b/blocklib/analog/fm_deemph/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/analog/noise_source/.gitignore
+++ b/blocklib/analog/noise_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/analog/quadrature_demod/.gitignore
+++ b/blocklib/analog/quadrature_demod/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/audio/alsa_sink/.gitignore
+++ b/blocklib/audio/alsa_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/message_debug/.gitignore
+++ b/blocklib/blocks/message_debug/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/msg_forward/.gitignore
+++ b/blocklib/blocks/msg_forward/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/nop_source/.gitignore
+++ b/blocklib/blocks/nop_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/null_sink/.gitignore
+++ b/blocklib/blocks/null_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/null_source/.gitignore
+++ b/blocklib/blocks/null_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/tags_strobe/.gitignore
+++ b/blocklib/blocks/tags_strobe/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/vector_sink/.gitignore
+++ b/blocklib/blocks/vector_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/blocks/vector_source/.gitignore
+++ b/blocklib/blocks/vector_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/fft/fft/.gitignore
+++ b/blocklib/fft/fft/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/fileio/file_sink/.gitignore
+++ b/blocklib/fileio/file_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/fileio/file_source/.gitignore
+++ b/blocklib/fileio/file_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/filter/dc_blocker/.gitignore
+++ b/blocklib/filter/dc_blocker/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/filter/fir_filter/.gitignore
+++ b/blocklib/filter/fir_filter/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/filter/iir_filter/.gitignore
+++ b/blocklib/filter/iir_filter/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/filter/moving_average/.gitignore
+++ b/blocklib/filter/moving_average/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/filter/pfb_arb_resampler/.gitignore
+++ b/blocklib/filter/pfb_arb_resampler/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/filter/pfb_channelizer/.gitignore
+++ b/blocklib/filter/pfb_channelizer/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/add/.gitignore
+++ b/blocklib/math/add/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/add/add.yml
+++ b/blocklib/math/add/add.yml
@@ -45,5 +45,6 @@ implementations:
 -   id: cuda
 -   id: numpy
     lang: python
+    domain: cpu
 
 file_format: 2

--- a/blocklib/math/add/numpy/.gitignore
+++ b/blocklib/math/add/numpy/.gitignore
@@ -1,1 +1,0 @@
-!meson.build

--- a/blocklib/math/add/numpy/add.py
+++ b/blocklib/math/add/numpy/add.py
@@ -1,20 +1,22 @@
 from gnuradio import math
 from gnuradio import gr
 
-class add_ff(math.add_ff):
-    def __init__(self, *args, **kwargs):
-        math.add_ff.__init__(self, *args, **kwargs, impl = math.add_ff.available_impl.pyshell)
-        self.set_pyblock_detail(gr.pyblock_detail(self))
-    
+class add_ff:
+    def __init__(self, blk, **kwargs):
+        self.blk = blk
+        self.nports = kwargs["nports"]
+
     def work(self, wio):
         out = wio.outputs()[0]
         noutput_items = out.n_items
         out.produce(noutput_items)
 
-        inbuf1 = gr.get_input_array(self, wio, 0)
-        inbuf2 = gr.get_input_array(self, wio, 1)
-        outbuf1 = gr.get_output_array(self, wio, 0)
+        inbuf1 = gr.get_input_array(self.blk, wio, 0)
+        outbuf1 = gr.get_output_array(self.blk, wio, 0)
 
-        outbuf1[:] = inbuf1 + inbuf2
+        outbuf1[:] = inbuf1
+        for i in range(1, self.nports):
+            inbufN = gr.get_input_array(self.blk, wio, i)
+            outbuf1[:] += inbufN
 
         return gr.work_return_t.OK 

--- a/blocklib/math/add/numpy/add.py
+++ b/blocklib/math/add/numpy/add.py
@@ -1,7 +1,7 @@
 from gnuradio import math
 from gnuradio import gr
 
-class add_ff:
+class add_blk:
     def __init__(self, blk, **kwargs):
         self.blk = blk
         self.nports = kwargs["nports"]
@@ -20,3 +20,23 @@ class add_ff:
             outbuf1[:] += inbufN
 
         return gr.work_return_t.OK 
+
+class add_cc(add_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class add_ff(add_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class add_ii(add_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class add_ss(add_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class add_bb(add_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)

--- a/blocklib/math/add/numpy/meson.build
+++ b/blocklib/math/add/numpy/meson.build
@@ -1,5 +1,0 @@
-r = run_command('python3', join_paths(SCRIPTS_DIR,'copyfile.py'), 
-    '--input_file', join_paths(meson.current_source_dir(), 'add.py'), '--output_file', 
-    join_paths(meson.project_build_root(),'blocklib','math','python','math','numpy','add.py'),
-    check:true)
-

--- a/blocklib/math/complex_to_mag/.gitignore
+++ b/blocklib/math/complex_to_mag/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/complex_to_mag_squared/.gitignore
+++ b/blocklib/math/complex_to_mag_squared/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/conjugate/.gitignore
+++ b/blocklib/math/conjugate/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/divide/.gitignore
+++ b/blocklib/math/divide/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/multiply/.gitignore
+++ b/blocklib/math/multiply/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/multiply_const/.gitignore
+++ b/blocklib/math/multiply_const/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/math/multiply_const/multiply_const.yml
+++ b/blocklib/math/multiply_const/multiply_const.yml
@@ -42,5 +42,6 @@ implementations:
 -   id: cuda
 -   id: numpy
     lang: python
+    domain: cpu
 
 file_format: 1

--- a/blocklib/math/multiply_const/numpy/.gitignore
+++ b/blocklib/math/multiply_const/numpy/.gitignore
@@ -1,1 +1,0 @@
-!meson.build

--- a/blocklib/math/multiply_const/numpy/meson.build
+++ b/blocklib/math/multiply_const/numpy/meson.build
@@ -1,4 +1,0 @@
-r = run_command('python3', join_paths(SCRIPTS_DIR,'copyfile.py'), 
-    '--input_file', join_paths(meson.current_source_dir(), 'multiply_const.py'), '--output_file', 
-    join_paths(meson.project_build_root(),'blocklib','math','python','math','numpy','multiply_const.py'),
-    check:true)

--- a/blocklib/math/multiply_const/numpy/multiply_const.py
+++ b/blocklib/math/multiply_const/numpy/multiply_const.py
@@ -1,7 +1,7 @@
 from gnuradio import math
 from gnuradio import gr
 
-class multiply_const_ff:
+class multiply_const_blk:
     def __init__(self, blk, **kwargs):
     
         # In the future we should be able to use the block parameters
@@ -24,3 +24,19 @@ class multiply_const_ff:
 
         wio.produce_each(noutput_items)
         return gr.work_return_t.OK 
+
+class multiply_const_cc(multiply_const_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class multiply_const_ff(multiply_const_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class multiply_const_ii(multiply_const_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)
+
+class multiply_const_ss(multiply_const_blk):
+    def __init__(self, blk, **kwargs):
+        super().__init__(blk, **kwargs)

--- a/blocklib/math/multiply_const/numpy/multiply_const.py
+++ b/blocklib/math/multiply_const/numpy/multiply_const.py
@@ -1,28 +1,26 @@
 from gnuradio import math
 from gnuradio import gr
 
-class multiply_const_ff(math.multiply_const_ff):
-    def __init__(self, *args, **kwargs):
-        math.multiply_const_ff.__init__(self, *args, **kwargs, 
-            impl = math.multiply_const_ff.available_impl.pyshell)
-        self.set_pyblock_detail(gr.pyblock_detail(self))
+class multiply_const_ff:
+    def __init__(self, blk, **kwargs):
     
         # In the future we should be able to use the block parameters
         #  But the pmts are not properly pybinded yet
         #  For now, just grab the arg
+        self.blk = blk
 
-        self.k = kwargs['k'] if 'k' in kwargs else args[0] # should throw 
-        self.vlen = kwargs['vlen'] if 'vlen' in kwargs else 1
+        self.k = kwargs['k']
+        self.vlen = kwargs['vlen']
 
 
     def work(self, wio):
         out = wio.outputs()[0]
         noutput_items = out.n_items
-        out.produce(noutput_items)
 
-        inbuf1 = gr.get_input_array(self, wio, 0)
-        outbuf1 = gr.get_output_array(self, wio, 0)
+        inbuf1 = gr.get_input_array(self.blk, wio, 0)
+        outbuf1 = gr.get_output_array(self.blk, wio, 0)
 
         outbuf1[:] = inbuf1 * self.k
 
+        wio.produce_each(noutput_items)
         return gr.work_return_t.OK 

--- a/blocklib/math/test/qa_add_numpy.py
+++ b/blocklib/math/test/qa_add_numpy.py
@@ -1,5 +1,6 @@
 from gnuradio import blocks
-from gnuradio.math.numpy import add_ff, multiply_const_ff
+# from gnuradio.math.numpy import add_ff, multiply_const_ff
+from gnuradio import math
 from gnuradio import gr
 from gnuradio import gr_unittest
 
@@ -16,8 +17,8 @@ class test_add_numpy(gr_unittest.TestCase):
         src0 = blocks.vector_source_f([1, 3, 5, 7, 9], False)
         src1 = blocks.vector_source_f([0, 2, 4, 6, 8], False)
         expected_result = [3,15,27,13*3,17*3]
-        adder = add_ff()
-        mult = multiply_const_ff(3)
+        adder = math.add_ff(impl=math.add_ff.available_impl.numpy)
+        mult = math.multiply_const_ff(3, impl=math.multiply_const_ff.available_impl.numpy)
         sink = blocks.vector_sink_f()
         self.tb.connect((src0, 0), (adder, 0))
         self.tb.connect((src1, 0), (adder, 1))

--- a/blocklib/streamops/annotator/.gitignore
+++ b/blocklib/streamops/annotator/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/copy/.gitignore
+++ b/blocklib/streamops/copy/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/deinterleave/.gitignore
+++ b/blocklib/streamops/deinterleave/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/delay/.gitignore
+++ b/blocklib/streamops/delay/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/head/.gitignore
+++ b/blocklib/streamops/head/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/interleave/.gitignore
+++ b/blocklib/streamops/interleave/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/interleaved_short_to_complex/.gitignore
+++ b/blocklib/streamops/interleaved_short_to_complex/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/keep_m_in_n/.gitignore
+++ b/blocklib/streamops/keep_m_in_n/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/load/.gitignore
+++ b/blocklib/streamops/load/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/nop/.gitignore
+++ b/blocklib/streamops/nop/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/nop_head/.gitignore
+++ b/blocklib/streamops/nop_head/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/probe_signal/.gitignore
+++ b/blocklib/streamops/probe_signal/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/probe_signal_v/.gitignore
+++ b/blocklib/streamops/probe_signal_v/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/selector/.gitignore
+++ b/blocklib/streamops/selector/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/stream_to_streams/.gitignore
+++ b/blocklib/streamops/stream_to_streams/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/streamops/throttle/.gitignore
+++ b/blocklib/streamops/throttle/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/pub_sink/.gitignore
+++ b/blocklib/zeromq/pub_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/pull_msg_source/.gitignore
+++ b/blocklib/zeromq/pull_msg_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/pull_source/.gitignore
+++ b/blocklib/zeromq/pull_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/push_msg_sink/.gitignore
+++ b/blocklib/zeromq/push_msg_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/push_sink/.gitignore
+++ b/blocklib/zeromq/push_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/rep_sink/.gitignore
+++ b/blocklib/zeromq/rep_sink/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/req_source/.gitignore
+++ b/blocklib/zeromq/req_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/blocklib/zeromq/sub_source/.gitignore
+++ b/blocklib/zeromq/sub_source/.gitignore
@@ -1,1 +1,0 @@
-meson.build

--- a/test/qa_python_block.py
+++ b/test/qa_python_block.py
@@ -57,25 +57,6 @@ class add_2_f32_1_f32_named(gr.sync_block):
         out.produce(out.n_items)
         return gr.work_return_t.OK
 
-# This test extends the existing add_ff block by adding a custom python implementation
-class add_ff_numpy(math.add_ff):
-    def __init__(self, shape=[1]):
-        math.add_ff.__init__(self, impl = math.add_ff.available_impl.pyshell)
-        self.set_pyblock_detail(gr.pyblock_detail(self))
-
-    def work(self, wio):
-        noutput_items = wio.outputs()[0].n_items
-        
-        wio.outputs()[0].produce(noutput_items)
-
-        inbuf1 = gr.get_input_array(self, wio, 0)
-        inbuf2 = gr.get_input_array(self, wio, 1)
-        outbuf1 = gr.get_output_array(self, wio, 0)
-
-        outbuf1[:] = inbuf1 + inbuf2
-
-        return gr.work_return_t.OK
-
 class test_block_gateway(gr_unittest.TestCase):
 
     def test_add_ff_deriv(self):
@@ -83,7 +64,7 @@ class test_block_gateway(gr_unittest.TestCase):
         rt = gr.runtime()
         src0 = blocks.vector_source_f([1, 3, 5, 7, 9]*10000, False)
         src1 = blocks.vector_source_f([0, 2, 4, 6, 8]*10000, False)
-        adder = add_ff_numpy()
+        adder = math.add_ff(impl=math.add_ff.available_impl.numpy)
         sink = blocks.vector_sink_f()
         tb.connect((src0, 0), (adder, 0))
         tb.connect((src1, 0), (adder, 1))

--- a/utils/blockbuilder/scripts/gen_meson.py
+++ b/utils/blockbuilder/scripts/gen_meson.py
@@ -9,7 +9,7 @@ import glob
 
 def argParse():
     """Parses commandline args."""
-    desc='Scrape the doxygen generated xml for docstrings to insert into python bindings'
+    desc='Generates meson.build for each block'
     parser = argparse.ArgumentParser(description=desc)
     
     parser.add_argument("blocklib_path")
@@ -51,6 +51,18 @@ def main():
                 with open(new_meson_filename, 'w') as file:
                     print(f'generating: {root}/{new_meson_filename}')
                     file.write(rendered)
+                if 'implementations' in d:
+                    for impl in d['implementations']:
+                        if 'lang' in impl and impl['lang'] == 'python':
+                            template = env.get_template('blockname_python_impl_meson.build.j2')
+                            tmp = d
+                            tmp['impl'] = impl
+                            rendered = template.render(tmp)
+                            meson_filename = os.path.join(root,impl['id'],'meson.build')
+                            with open(meson_filename, 'w') as file:
+                                print("generating " + meson_filename)
+                                file.write(rendered)
+
 
     modulesdirs = []
     for x in [x for x in os.listdir(args.blocklib_path)]:

--- a/utils/blockbuilder/scripts/gen_pyshell.py
+++ b/utils/blockbuilder/scripts/gen_pyshell.py
@@ -35,9 +35,10 @@ def main():
     
     blockname = os.path.basename(os.path.dirname(os.path.realpath(args.yaml_file)))
     
-
+    root = os.path.dirname(os.path.realpath(args.yaml_file))
     with open(args.yaml_file) as file:
         d = yaml.load(file, Loader=yaml.FullLoader)
+        
         # Does this block specify a templated version
         templated = 0
         if ('typekeys' in d and len(d['typekeys']) > 0):

--- a/utils/blockbuilder/templates/blockname.cc.j2
+++ b/utils/blockbuilder/templates/blockname.cc.j2
@@ -18,9 +18,9 @@ namespace {{module}} {
         return make_{{ impl['id'] | lower }}(args);
         break;
     #endif
-    {% elif 'lang' in impl and impl['lang'] == 'python' and not vars.pyshell -%}
-    case available_impl::PYSHELL:
-        return make_pyshell(args);
+    {% elif 'lang' in impl and impl['lang'] == 'python' -%}
+    case available_impl::{{ impl['id'] | upper }}:
+        return make_pyshell("{{ impl['id'] | lower }}", args);
         break;
     {% if vars.update({'pyshell': True}) %} {% endif %}
     {% endif -%}

--- a/utils/blockbuilder/templates/blockname_pybind.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind.cc.j2
@@ -18,14 +18,8 @@ void bind_{{block}}(py::module& m)
     std::shared_ptr<{{block}}>> {{block}}_class(m, "{{block}}"{{macros.block_docstring(doc,parameters,ports)}});
 
     py::enum_<::gr::{{ module }}::{{ block }}::available_impl>({{block}}_class, "available_impl")
-    {% set vars = {'pyshell': False} -%}
     {% for impl in implementations -%}
-    {% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
         .value("{{ impl['id'] | lower }}", ::gr::{{module}}::{{block}}::available_impl::{{ impl['id'] | upper }}) 
-    {% elif 'lang' in impl and impl['lang'] == 'python' and not vars.pyshell -%}
-        .value("pyshell", ::gr::{{module}}::{{block}}::available_impl::PYSHELL) 
-    {% if vars.update({'pyshell': True}) %} {% endif %}
-    {% endif -%}
     {% endfor -%}
         .export_values();
 

--- a/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pybind_templated.cc.j2
@@ -20,14 +20,8 @@ void bind_{{ block }}_template(py::module& m, const char* classname)
     std::shared_ptr<gr::{{ module }}::{{ block }}<{{typestr}}>>> {{block}}_class(m, classname);
 
     py::enum_<typename ::gr::{{ module }}::{{ block }}<{{typestr}}>::available_impl>({{block}}_class, "available_impl")
-    {% set vars = {'pyshell': False} -%}
     {% for impl in implementations -%}
-    {% if 'lang' not in impl or impl['lang'] == 'cpp' -%}
         .value("{{ impl['id'] | lower }}", ::gr::{{module}}::{{block}}<{{typestr}}>::available_impl::{{ impl['id'] | upper }}) 
-    {% elif 'lang' in impl and impl['lang'] == 'python' and not vars.pyshell -%}
-        .value("pyshell", ::gr::{{module}}::{{block}}<{{typestr}}>::available_impl::PYSHELL) 
-    {% if vars.update({'pyshell': True}) %} {% endif %}
-    {% endif -%}
     {% endfor -%}
         //.value("base", ::gr::{{module}}::{{block}}<{{typestr}}>::available_impl::BASE ) 
         .export_values();

--- a/utils/blockbuilder/templates/blockname_pyshell.cc.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell.cc.j2
@@ -9,14 +9,14 @@ namespace {{module}} {
 
 {%if typekeys | length > 0 -%}
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
-typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::sptr {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::make_pyshell(const block_args& args)
+typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::sptr {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::make_pyshell(const std::string& impl, const block_args& args)
 {
-    return gnuradio::make_block_sptr<{{block}}_pyshell<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>>(args);
+    return gnuradio::make_block_sptr<{{block}}_pyshell<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>>(impl, args);
 }
 {%else-%}
-{{block}}::sptr {{block}}::make_pyshell(const block_args& args)
+{{block}}::sptr {{block}}::make_pyshell(const std::string& impl, const block_args& args)
 {
-    return gnuradio::make_block_sptr<{{block}}_pyshell>(args);
+    return gnuradio::make_block_sptr<{{block}}_pyshell>(impl, args);
 }
 {%endif-%}
 

--- a/utils/blockbuilder/templates/blockname_pyshell.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell.h.j2
@@ -3,6 +3,7 @@
 #include <pybind11/embed.h>
 #include <pybind11/pybind11.h> // must be first
 #include <pybind11/stl.h>
+#include <pybind11/complex.h>
 namespace py = pybind11;
 using namespace py::literals;
 

--- a/utils/blockbuilder/templates/blockname_pyshell.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell.h.j2
@@ -4,6 +4,7 @@
 #include <pybind11/pybind11.h> // must be first
 #include <pybind11/stl.h>
 namespace py = pybind11;
+using namespace py::literals;
 
 #include <gnuradio/{{module}}/{{block}}.h>
 #include <gnuradio/pyblock_detail.h>
@@ -13,10 +14,23 @@ namespace {{module}} {
 
 class {{block}}_pyshell : public {{block}}
 {
+private:
+    py::object _block;
 public:
-    {{block}}_pyshell(const typename {{block}}::block_args& args) : {{blocktype}}("{{block}}", "{{module}}"), {{block}}(args)
+    {{block}}_pyshell(const std::string& impl, const typename {{block}}::block_args& args) : {{blocktype}}("{{block}}", "{{module}}"), {{block}}(args)
     {
-        
+        py::module_ mod = py::module_::import(std::string("gnuradio.{{module}}." + impl).c_str());
+        auto kwargs = py::dict(
+        {%- if parameters -%}
+        {%- for p in parameters -%}
+        {%- if 'cotr' not in p or p['cotr'] %}
+        "{{p['id']}}"_a = args.{{p['id']}}{{"," if not loop.last}}
+        {%- endif -%}
+        {%- endfor -%}
+        {%- endif -%});
+
+        _pyimpl = mod.attr("{{block}}")(dynamic_cast<{{block}}*>(this), **kwargs);
+    
     }
 
 {% if blocktype != "hier_block" %}
@@ -25,7 +39,7 @@ public:
     {
         py::gil_scoped_acquire acquire;
 
-        py::object ret = this->pb_detail()->handle().attr("work")(&wio);
+        py::object ret = _pyimpl.attr("work")(&wio);
 
         return ret.cast<work_return_t>();
     }
@@ -33,8 +47,8 @@ public:
     bool start(void)
     {
         py::gil_scoped_acquire acquire;
-        if (py::hasattr(this->pb_detail()->handle(), "start")) {
-            py::object ret = this->pb_detail()->handle().attr("start")();
+        if (py::hasattr(_pyimpl, "start")) {
+            py::object ret = _pyimpl.attr("start")();
             return ret.cast<bool>() && block::start();
         }
         else
@@ -44,8 +58,8 @@ public:
     bool stop(void)
     {
         py::gil_scoped_acquire acquire;
-        if (py::hasattr(this->pb_detail()->handle(), "stop")) {
-            py::object ret = this->pb_detail()->handle().attr("stop")();
+        if (py::hasattr(_pyimpl, "stop")) {
+            py::object ret = _pyimpl.attr("stop")();
             return ret.cast<bool>() && block::stop();
         }
         else
@@ -58,8 +72,8 @@ public:
     virtual void handle_msg_{{port['id']}}(pmtf::pmt msg) override
     {
         py::gil_scoped_acquire acquire;
-        if (py::hasattr(this->pb_detail()->handle(), "{{"handle_msg_" + port['id']}}")) {
-            py::object ret = this->pb_detail()->handle().attr("{{"handle_msg_" + port['id']}}")(msg);
+        if (py::hasattr(_pyimpl, "{{"handle_msg_" + port['id']}}")) {
+            py::object ret = _pyimpl.attr("{{"handle_msg_" + port['id']}}")(msg);
         }
         else
             throw std::runtime_error("Message port handler not found");

--- a/utils/blockbuilder/templates/blockname_pyshell.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell.h.j2
@@ -8,7 +8,6 @@ namespace py = pybind11;
 using namespace py::literals;
 
 #include <gnuradio/{{module}}/{{block}}.h>
-#include <gnuradio/pyblock_detail.h>
 
 namespace gr {
 namespace {{module}} {

--- a/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
@@ -3,6 +3,7 @@
 #include <pybind11/embed.h>
 #include <pybind11/pybind11.h> // must be first
 #include <pybind11/stl.h>
+#include <pybind11/complex.h>
 namespace py = pybind11;
 using namespace py::literals;
 

--- a/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
@@ -8,8 +8,6 @@ namespace py = pybind11;
 using namespace py::literals;
 
 #include <gnuradio/{{module}}/{{block}}.h>
-#include <gnuradio/pyblock_detail.h>
-
 namespace gr {
 namespace {{module}} {
 

--- a/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
+++ b/utils/blockbuilder/templates/blockname_pyshell_templated.h.j2
@@ -4,6 +4,7 @@
 #include <pybind11/pybind11.h> // must be first
 #include <pybind11/stl.h>
 namespace py = pybind11;
+using namespace py::literals;
 
 #include <gnuradio/{{module}}/{{block}}.h>
 #include <gnuradio/pyblock_detail.h>
@@ -11,13 +12,27 @@ namespace py = pybind11;
 namespace gr {
 namespace {{module}} {
 
+// This is the artifact of pybind11 fvisibility settings
+#pragma GCC visibility push(hidden)
 template <class T>
 class {{block}}_pyshell : public {{block}}<T>
 {
+private:
+    py::object _pyimpl;
 public:
-    {{block}}_pyshell(const typename {{block}}<T>::block_args& args) : {{blocktype}}("{{block}}", "{{module}}"), {{block}}<T>(args)
+    {{block}}_pyshell(const std::string& impl, const typename {{block}}<T>::block_args& args) : {{blocktype}}("{{block}}", "{{module}}"), {{block}}<T>(args)
     {
-        
+        py::module_ mod = py::module_::import(std::string("gnuradio.{{module}}." + impl).c_str());
+        auto kwargs = py::dict(
+        {%- if parameters -%}
+        {%- for p in parameters -%}
+        {%- if 'cotr' not in p or p['cotr'] %}
+        "{{p['id']}}"_a = args.{{p['id']}}{{"," if not loop.last}}
+        {%- endif -%}
+        {%- endfor -%}
+        {%- endif -%});
+
+        _pyimpl = mod.attr((std::string("{{block}}")+this->suffix()).c_str())(dynamic_cast<{{block}}<T>*>(this), **kwargs);
     }
 
     work_return_t
@@ -25,7 +40,7 @@ public:
     {
         py::gil_scoped_acquire acquire;
 
-        py::object ret = this->pb_detail()->handle().attr("work")(&wio);
+        py::object ret = _pyimpl.attr("work")(&wio);
 
         return ret.cast<work_return_t>();
     }
@@ -33,8 +48,8 @@ public:
     bool start(void)
     {
         py::gil_scoped_acquire acquire;
-        if (py::hasattr(this->pb_detail()->handle(), "start")) {
-            py::object ret = this->pb_detail()->handle().attr("start")();
+        if (py::hasattr(_pyimpl, "start")) {
+            py::object ret = _pyimpl.attr("start")();
             return ret.cast<bool>() && block::start();
         }
  
@@ -44,8 +59,8 @@ public:
     bool stop(void)
     {
         py::gil_scoped_acquire acquire;
-        if (py::hasattr(this->pb_detail()->handle(), "stop")) {
-            py::object ret = this->pb_detail()->handle().attr("stop")();
+        if (py::hasattr(_pyimpl, "stop")) {
+            py::object ret = _pyimpl.attr("stop")();
             return ret.cast<bool>() && block::stop();
         }
 
@@ -53,6 +68,7 @@ public:
     }
 
 };
+#pragma GCC visibility pop
 
 
 } // namespace {{module}}

--- a/utils/blockbuilder/templates/blockname_python_impl_meson.build.j2
+++ b/utils/blockbuilder/templates/blockname_python_impl_meson.build.j2
@@ -1,0 +1,5 @@
+r = run_command('python3', join_paths(SCRIPTS_DIR,'copyfile.py'), 
+    '--input_file', join_paths(meson.current_source_dir(), '{{block}}.py'), '--output_file', 
+    join_paths(meson.project_build_root(),'blocklib','{{module}}','python','{{module}}','{{impl['id']}}','{{block}}.py'),
+    check:true)
+

--- a/utils/blockbuilder/templates/blockname_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_templated.cc.j2
@@ -18,14 +18,14 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
         return make_{{ impl['id'] | lower }}(args);
         break;
     #endif
-    {% elif 'lang' in impl and impl['lang'] == 'python' and not vars.pyshell -%}
-    case available_impl::PYSHELL:
-        return make_pyshell(args);
+    {% elif 'lang' in impl and impl['lang'] == 'python' -%}
+    case available_impl::{{ impl['id'] | upper }}:
+        return make_pyshell("{{ impl['id'] | lower }}", args);
         break;
     {% if vars.update({'pyshell': True}) %} {% endif %}
     {% endif -%}
     {% endfor %}
-        
+
     default:
         throw std::invalid_argument(
             "invalid implementation specified");

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -91,7 +91,7 @@ class {{ block }} : virtual public {{blocktype}}{% for inh in inherits %}, publi
      */
     static sptr make_{{impl['id']}}(const block_args& args);
     {% elif 'lang' in impl and impl['lang'] == 'python' and not vars.pyshell -%}
-    static sptr make_pyshell(const block_args& args);
+    static sptr make_pyshell(const std::string& py_impl, const block_args& args);
     {% if vars.update({'pyshell': True}) %} {% endif %}
     {% endif -%}
     {% endfor %}


### PR DESCRIPTION
## Description
Prior to this PR, in-tree python blocks were more loosely coupled with the .yaml block workflow.  You still had to call the blocks directly from their python implementations, and the interface was fairly awkward

This also brings the python implementation into GRC as a dropdown

The net result for implementation is that in the python block, it holds a pointer back to the block that lives in the flowgraph.  This can be used for getting parameters, ports and other things that happen in the autogeneration

## Related Issue

## Which blocks/areas does this affect?
So far, only `multiply_const` and `add` have numpy implementations as examples

## Testing Done
QA tests updated
Tested in GRC with dropdown

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
