### PR TITLE
grc: add xfce4-terminal to the grc auto-detector for XTERM_EXE

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -102,7 +102,7 @@ endif(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
 
 if(UNIX)
     find_program(GRC_XTERM_EXE
-        NAMES x-terminal-emulator gnome-terminal konsole xterm foot
+        NAMES x-terminal-emulator gnome-terminal konsole xfce4-terminal urxvt xterm foot
         HINTS ENV PATH
         DOC "graphical terminal emulator used in GRC's no-gui-mode"
     )


### PR DESCRIPTION
xfce4-terminal is the terminal emulator for xfce users.  Support for
gnome and kde specific terminal emulators are already here, so please
accept this as well.

Signed-off-by: Rick Farina (Zero_Chaos) <zerochaos@gentoo.org>
## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
