### PR TITLE
4.0: modtool: alias py3 to py3_inst

### DIFF
--- a/utils/modtool/newmod/meson.build
+++ b/utils/modtool/newmod/meson.build
@@ -10,6 +10,7 @@ project('ns-newmod', 'cpp',
 python3_dep = dependency('python3', required : get_option('enable_python'))
 python3_embed_dep = dependency('python3-embed', required : get_option('enable_python'))
 py3_inst = import('python').find_installation('python3')
+py3 = py3_inst
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 json_dep = dependency('nlohmann_json')
 


### PR DESCRIPTION
Small change for modtool in OOTs to enable minimal changes for numpy blocks
