### PR TITLE
cmake: make building with clang possible again

### DIFF
--- a/cmake/Modules/GrCompilerSettings.cmake
+++ b/cmake/Modules/GrCompilerSettings.cmake
@@ -34,7 +34,19 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
                 "\nCannot determine the version of the compiler selected to build GNU Radio (GCC : ${CMAKE_CXX_COMPILER}). This build may or not work. We highly recommend using GCC version ${GCC_MIN_VERSION} or more recent."
         )
     endif()
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang")
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+      # on moderner clangs, the libgcc_s C++ runtime might be used, which does not
+      # include atomic builtins; interestingly, this only starts mattering if the
+      # atomic builtins are pulled in through external libraries, so there's no
+      # easy compile check that could determine that.
+      #
+      # To remedy that, link against libatomic; has no downsides as far as I'm aware.
+      foreach(TARGETTYPE EXE SHARED MODULE)
+        set(CMAKE_${TARGETTYPE}_LINKER_FLAGS "${CMAKE_${TARGETTYPE}_LINKER_FLAGS} -latomic")
+      endforeach()
+    endif() # LINUX
+
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} -v
         RESULT_VARIABLE _res


### PR DESCRIPTION
## Description
This required quite a bit of experimentation. When using clang on a
Linux (i.e., GCC-dominated) system, it uses the libgcc_s C++ runtime.
Which doesn't contain atomics, and that hurts at later times when
linking GCC-built libraries that assume you'd be -latomic anyways
(looking at Boost *again*).

The sad part is that we need some kind of unpredictable mixed
compilation to trigger this. So a CMake-time compile check doesn't work.

To the best of my knowledge, this works on newer and older clangs on
arbitrary platforms. I'm still checking for Linux here; if the same
problem happens on some xBSD or other platform, it should be easy
enough to find the solution for

undefined reference to `__atomic_store'

being exactly this Linux hack.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->


## Which blocks/areas does this affect?

Building with Clang on Linux
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done

Builds locally (f35/f36)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
