### PR TITLE
uhd: Add uhd.find to the pybind11 interface

### DIFF
--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -25,6 +25,8 @@ void bind_usrp_block(py::module& m)
     m.attr("ALL_MBOARDS") = py::int_(::uhd::usrp::multi_usrp::ALL_MBOARDS);
     m.attr("ALL_LOS") = py::str(::uhd::usrp::multi_usrp::ALL_LOS);
 
+    m.def("find", [](const uhd::device_addr_t& hint) { return uhd::device::find(hint); });
+
     py::class_<usrp_block,
                gr::sync_block,
                gr::block,


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
`uhd_find_devices` would be the default shell function to discover available USRPs. PyUHD provides a function `uhd.find("")` that does the job. Besides, in `gr-uhd/python/uhd/__init__.py` there is a definition of `find_devices`. However, this function is broken at the moment because it tries to use a `find_devices_raw` function from the gr-uhd pybind11 interface that is not available. With this commit, we may be able to fix `find_devices` as well.

The actual change is just copied from UHD `host/lib/device_python.cpp`. Alternative solutions would include a new function in C++ and a pybind11 wrapper.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gr-uhd pybind11 interface

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
```python
from gnuradio import uhd
devices = uhd.find("")
```
yields a list of `gnuradio.uhd.uhd_python.device_addr_t` objects.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
