### PR TITLE
4.0: ci: add OpenSUSE Tumbleweed to targets

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,6 +41,9 @@ jobs:
           - distro: 'Fedora 36'
             containerid: 'mormj/newsched-ci-docker:fedora-36'
             cxxflags: ''
+          - distro: 'OpenSUSE Tumbleweed'
+            containerid: 'mormj/newsched-ci-docker:opensuse-tumbleweed'
+            cxxflags: ''
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}


### PR DESCRIPTION
This adds openSUSE tumbleweed as a CI worker

Will fail now due to some known issues with numpy 