### PR TITLE
fix two QtRangeWidget bugs:

### DIFF
--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -95,7 +95,6 @@ templates:
         %>\
         ${range} = Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
         ${win} = GrRangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient}, "${no_quotes(outputmsgname)}")
-        self.${id} = ${win}
 
         ${gui_hint() % win}
 

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -411,7 +411,7 @@ class GrRangeWidget(gr.sync_block, RangeWidget):
         if self.varCallback is not None:
             self.varCallback(new_value)
         self.message_port_pub(self.outputportname_pmt,
-                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
+                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(new_value)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- in the GRC yml file the widget was incorrectly stored in the variable
- in the py.cmakein file a variable was misspelled and caused errors

Signed-off-by: Miklos Maroti <mmaroti@gmail.com>
