### PR TITLE
GR 4.0: Add numpy include path to python bindings meson files

### DIFF
--- a/blocklib/filter/python/filter/meson.build
+++ b/blocklib/filter/python/filter/meson.build
@@ -30,15 +30,15 @@ gen_filter_pybind = custom_target('gen_filter_pybind',
                             '--blocks', d['blocks'],
                             '--imports', d['imports'],
                             '--module', d['module'],
-                            '--output_file', '@OUTPUT@', 
+                            '--output_file', '@OUTPUT@',
                             '--build_dir', join_paths(meson.build_root())],
-                        install : false)      
+                        install : false)
 
 filter_pybind_sources += gen_filter_pybind
 
 gnuradio_blocklib_filter_pybind = py3_inst.extension_module('filter_python',
-    filter_pybind_sources, 
-    include_directories: ['../../lib'],
+    filter_pybind_sources,
+    include_directories: ['../../lib', incdir_numpy],
     dependencies : [gnuradio_blocklib_filter_dep, python3_dep, pybind11_dep],
     link_language : 'cpp',
     install : true,

--- a/blocklib/math/python/math/meson.build
+++ b/blocklib/math/python/math/meson.build
@@ -31,15 +31,15 @@ gen_math_pybind = custom_target('gen_math_pybind',
                             '--blocks', d['blocks'],
                             '--imports', d['imports'],
                             '--module', d['module'],
-                            '--output_file', '@OUTPUT@', 
+                            '--output_file', '@OUTPUT@',
                             '--build_dir', join_paths(meson.build_root())],
-                        install : false)      
+                        install : false)
 
 math_pybind_sources += gen_math_pybind
 
 gnuradio_blocklib_math_pybind = py3_inst.extension_module('math_python',
-    math_pybind_sources, 
-    include_directories: ['../../lib'],
+    math_pybind_sources,
+    include_directories: ['../../lib', incdir_numpy],
     dependencies : [gnuradio_blocklib_math_dep, python3_dep, pybind11_dep],
     link_language : 'cpp',
     install : true,

--- a/gr/python/gr/bindings/meson.build
+++ b/gr/python/gr/bindings/meson.build
@@ -35,8 +35,9 @@ if USE_CUDA
     cpp_args = '-DHAVE_CUDA'
 endif
 gnuradio_runtime_pybind = py3_inst.extension_module('gr_python',
-    runtime_pybind_sources, 
+    runtime_pybind_sources,
     dependencies : runtime_pybind_deps,
+    include_directories: incdir_numpy,
     link_language : 'cpp',
     install : true,
     cpp_args : cpp_args,

--- a/kernel/python/kernel/digital/bindings/meson.build
+++ b/kernel/python/kernel/digital/bindings/meson.build
@@ -7,9 +7,9 @@ cpp_args = []
 deps = [python3_dep, pybind11_dep, gr_kernel_lib_dep]
 
 kernel_digital_pybind = py3_inst.extension_module('kernel_digital_python',
-    srcs, 
+    srcs,
     dependencies : deps,
-    include_directories: ['../../../../include/'],
+    include_directories: ['../../../../include/', incdir_numpy],
     link_language : 'cpp',
     install : true,
     cpp_args : cpp_args,

--- a/kernel/python/kernel/fft/bindings/meson.build
+++ b/kernel/python/kernel/fft/bindings/meson.build
@@ -7,9 +7,9 @@ cpp_args = []
 deps = [python3_dep, pybind11_dep, gr_kernel_lib_dep]
 
 kernel_fft_pybind = py3_inst.extension_module('kernel_fft_python',
-    srcs, 
+    srcs,
     dependencies : deps,
-    include_directories: ['../../../../include/'],
+    include_directories: ['../../../../include/', incdir_numpy],
     link_language : 'cpp',
     install : true,
     cpp_args : cpp_args,

--- a/kernel/python/kernel/filter/bindings/meson.build
+++ b/kernel/python/kernel/filter/bindings/meson.build
@@ -7,9 +7,9 @@ cpp_args = []
 deps = [python3_dep, pybind11_dep, gr_kernel_lib_dep]
 
 kernel_filter_pybind = py3_inst.extension_module('kernel_filter_python',
-    srcs, 
+    srcs,
     dependencies : deps,
-    include_directories: ['../../../../include/'],
+    include_directories: ['../../../../include/', incdir_numpy],
     link_language : 'cpp',
     install : true,
     cpp_args : cpp_args,

--- a/kernel/python/kernel/math/bindings/meson.build
+++ b/kernel/python/kernel/math/bindings/meson.build
@@ -7,9 +7,9 @@ cpp_args = []
 deps = [python3_dep, pybind11_dep, gr_kernel_lib_dep]
 
 kernel_math_pybind = py3_inst.extension_module('kernel_math_python',
-    srcs, 
+    srcs,
     dependencies : deps,
-    include_directories: ['../../../../include/'],
+    include_directories: ['../../../../include/', incdir_numpy],
     link_language : 'cpp',
     install : true,
     cpp_args : cpp_args,

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,11 @@ if py3_version.version_compare('< 3.6')
   error('Invalid python version!?')
 endif
 
+incdir_numpy = run_command(py3,
+  ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
+  check : true
+).stdout().strip()
+
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 threads_dep = dependency('threads')
 gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))

--- a/schedulers/nbt/python/schedulers/nbt/bindings/meson.build
+++ b/schedulers/nbt/python/schedulers/nbt/bindings/meson.build
@@ -5,6 +5,7 @@ scheduler_nbt_pybind_sources = files([
 gnuradio_scheduler_nbt_pybind = py3_inst.extension_module('scheduler_nbt_python',
     scheduler_nbt_pybind_sources, 
     dependencies : [gnuradio_gr_dep, gnuradio_scheduler_nbt_dep, python3_dep, pybind11_dep],
+    include_directories: incdir_numpy,
     link_language : 'cpp',
     install : true,
     install_dir : join_paths(py3_inst.get_install_dir(),'gnuradio','schedulers','nbt')

--- a/utils/blockbuilder/templates/module_python.meson.build.j2
+++ b/utils/blockbuilder/templates/module_python.meson.build.j2
@@ -38,7 +38,7 @@ gen_{{module}}_pybind = custom_target('gen_{{module}}_pybind',
 
 gnuradio_blocklib_{{module}}_pybind = py3_inst.extension_module('{{module}}_python',
     {{module}}_pybind_sources, 
-    include_directories: ['../../lib'],
+    include_directories: ['../../lib', incdir_numpy],
     dependencies : [gnuradio_blocklib_{{module}}_dep, python3_dep, pybind11_dep],
     link_language : 'cpp',
     install : true,


### PR DESCRIPTION
On some systems (e.g. openSuse and nixOS) python packages are split between different install directories. This leads to include errors where includes like `#include <numpy/arrayobject.h>` cannot be resolved.

This PR fixes this by determining the numpy include path in the main meson.build file and adding it manually to all the relevant meson files as well as the j2 template for the autogenerated block files.

The approach is inspired by the numpy documentation for using numpy from meson [1].

We have tested these changes to build on nixOS unstable and openSUSE, but I do not have an ubuntu or fedora machine which seem to be the platforms that were tested to work before. I do not see why this should break builds there, though and I'll trust in the CI.

I'm also new to meson, but I have some experience with other buildsystems and linux packaging. While this approach works, it relies on importing the installed package at build time, which might be unwanted by some packagers (https://github.com/gnuradio/gnuradio/pull/6057#issuecomment-1208433867) and also might return wrong paths for more complicated situations like cross compiling. Ideally we would specify `dependency = [ numpy ... ] ` and have meson figure out the correct compiler arguments instead of manually adding paths. As I understand from the linked issue this is not modeled in meson at least at the moment.

[1] https://numpy.org/devdocs/f2py/buildtools/meson.html

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
