### PR TITLE
4.0: Minor Modtool updates

### DIFF
--- a/utils/modtool/newblock/newblock.yml
+++ b/utils/modtool/newblock/newblock.yml
@@ -7,7 +7,7 @@ blocktype: sync_block
 parameters:
 -   id: itemsize
     label: Item Size
-    dtype: size_t
+    dtype: size
     settable: false
     default: 0
     grc:

--- a/utils/modtool/newmod/meson.build
+++ b/utils/modtool/newmod/meson.build
@@ -14,6 +14,11 @@ py3 = py3_inst
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))
 json_dep = dependency('nlohmann_json')
 
+incdir_numpy = run_command(py3,
+  ['-c', 'import os; os.chdir(".."); import numpy; print(numpy.get_include())'],
+  check : true
+).stdout().strip()
+
 if (get_option('enable_testing'))
     TEST_ENV = environment()
     TEST_ENV.prepend('LD_LIBRARY_PATH', 


### PR DESCRIPTION
Addresses the default type of a parameter in the yaml, as well as the newly introduced numpy_incdir