### PR TITLE
global: Fix build failures with libfmt-9.0.0 in logger (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/flowgraph.cc
+++ b/gnuradio-runtime/lib/flowgraph.cc
@@ -77,7 +77,7 @@ void flowgraph::validate()
         std::vector<int> used_ports;
         int ninputs, noutputs;
 
-        d_debug_logger->debug("Validating block: {}", *p);
+        d_debug_logger->debug("Validating block: {}", (*p)->identifier());
 
         used_ports = calc_used_ports(*p, true); // inputs
         ninputs = used_ports.size();
@@ -125,15 +125,16 @@ void flowgraph::check_valid_port(gr::io_signature::sptr sig, int port)
 
 void flowgraph::check_valid_port(const msg_endpoint& e)
 {
-    d_debug_logger->debug("check_valid_port({}, {})", e.block(), e.port());
+    d_debug_logger->debug(
+        "check_valid_port({}, {})", e.block()->identifier(), pmt::write_string(e.port()));
 
     if (!e.block()->has_msg_port(e.port())) {
         const gr::basic_block::msg_queue_map_t& msg_map = e.block()->get_msg_map();
-        d_logger->warn("Could not find port {} in:", e.port());
+        d_logger->warn("Could not find port {} in:", pmt::write_string(e.port()));
         for (gr::basic_block::msg_queue_map_t::const_iterator it = msg_map.begin();
              it != msg_map.end();
              ++it)
-            d_logger->warn("  {}", it->first);
+            d_logger->warn("  {}", pmt::write_string(it->first));
         throw std::invalid_argument("invalid msg port in connect() or disconnect()");
     }
 }

--- a/gr-analog/lib/sig_source_impl.cc
+++ b/gr-analog/lib/sig_source_impl.cc
@@ -113,7 +113,7 @@ void sig_source_impl<T>::set_cmd_msg(pmt::pmt_t msg)
                 this->d_logger->warn("offset value needs to be a number");
             }
         } else {
-            this->d_logger->warn("unsupported message key {}", key);
+            this->d_logger->warn("unsupported message key {}", pmt::write_string(key));
         }
 
         // advance to next item, if any

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -433,7 +433,8 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     // hopefully remove this:
     if (pmt::is_tuple(msg)) {
         if (pmt::length(msg) != 2 && pmt::length(msg) != 3) {
-            d_logger->alert("Error while unpacking command PMT: {}", msg);
+            d_logger->alert("Error while unpacking command PMT: {}",
+                            pmt::write_string(msg));
             return;
         }
         pmt::pmt_t new_msg = pmt::make_dict();
@@ -441,7 +442,8 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
         if (pmt::length(msg) == 3) {
             new_msg = pmt::dict_add(new_msg, cmd_chan_key(), pmt::tuple_ref(msg, 2));
         }
-        d_debug_logger->warn("Using legacy message format (tuples): {}", msg);
+        d_debug_logger->warn("Using legacy message format (tuples): {}",
+                             pmt::write_string(msg));
         return msg_handler_command(new_msg);
     }
     // End of legacy backward compat code.
@@ -451,15 +453,16 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     if (!(pmt::is_dict(msg)) && pmt::is_pair(msg)) {
         d_logger->debug(
             "Command message is pair, converting to dict: '{}': car({}), cdr({})",
-            msg,
-            pmt::car(msg),
-            pmt::cdr(msg));
+            pmt::write_string(msg),
+            pmt::write_string(pmt::car(msg)),
+            pmt::write_string(pmt::cdr(msg)));
         msg = pmt::dict_add(pmt::make_dict(), pmt::car(msg), pmt::cdr(msg));
     }
 
     // Make sure, we use dicts!
     if (!pmt::is_dict(msg)) {
-        d_logger->error("Command message is neither dict nor pair: {}", msg);
+        d_logger->error("Command message is neither dict nor pair: {}",
+                        pmt::write_string(msg));
         return;
     }
 
@@ -494,7 +497,7 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
     _force_tune = pmt::dict_has_key(msg, cmd_direction_key());
 
     /// 4) Loop through all the values
-    d_debug_logger->debug("Processing command message {}", msg);
+    d_debug_logger->debug("Processing command message {}", pmt::write_string(msg));
     pmt::pmt_t msg_items = pmt::dict_items(msg);
     for (size_t i = 0; i < pmt::length(msg_items); i++) {
         try {
@@ -504,8 +507,8 @@ void usrp_block_impl::msg_handler_command(pmt::pmt_t msg)
                                      msg);
         } catch (pmt::wrong_type& e) {
             d_logger->alert("Invalid command value for key {}: {}",
-                            pmt::car(pmt::nth(i, msg_items)),
-                            pmt::cdr(pmt::nth(i, msg_items)));
+                            pmt::write_string(pmt::car(pmt::nth(i, msg_items))),
+                            pmt::write_string(pmt::cdr(pmt::nth(i, msg_items))));
             break;
         }
     }
@@ -672,7 +675,8 @@ void usrp_block_impl::_cmd_handler_gpio(const pmt::pmt_t& gpio_attr,
         ));
 
     if (!pmt::is_dict(gpio_attr)) {
-        d_logger->error("gpio_attr in  message is neither dict nor pair: {}", gpio_attr);
+        d_logger->error("gpio_attr in  message is neither dict nor pair: {}",
+                        pmt::write_string(gpio_attr));
         return;
     }
     if (!pmt::dict_has_key(gpio_attr, pmt::mp("bank")) ||


### PR DESCRIPTION
libfmt-9.0.0 disabled automatic std::ostream insertion operator (operator<<) discovery when fmt/ostream.h is included to prevent ODR violations. It require explicit tagging of ARG types.

Tried the following:
fmt::streamed and fmt::ostream_formatter not compatible with older versions, FMT_DEPRECATED_OSTREAM will be removed in the next major release so can't use.

With the help of @mormj, fixed this issue by not passing pointers of types not supported by libfmt into the logging functions.

Bug: https://bugs.gentoo.org/858659
Closes: https://github.com/gnuradio/gnuradio/issues/6052
Signed-off-by: Huang Rui <vowstar@gmail.com>

(cherry picked from commit 0019f292f526242a12c88489b56b63aa57f14ffb)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6053