### PR TITLE
runtime/qa: link against spdlog when not linking through the runtime library (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -341,7 +341,7 @@ if(ENABLE_TESTING)
 
     foreach(qa_file ${test_gnuradio_runtime_sources})
         gr_add_cpp_test("runtime_${qa_file}" ${CMAKE_CURRENT_SOURCE_DIR}/${qa_file})
-
+        target_link_libraries("runtime_${qa_file}" spdlog::spdlog)
     endforeach(qa_file)
 
     # Math tests:
@@ -357,6 +357,7 @@ if(ENABLE_TESTING)
 
     foreach(qa_file ${test_gnuradio_math_sources})
         gr_add_cpp_test("math_${qa_file}" ${CMAKE_CURRENT_SOURCE_DIR}/math/${qa_file})
+        target_link_libraries("math_${qa_file}" spdlog::spdlog)
         target_include_directories("math_${qa_file}"
                                    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/math)
     endforeach(qa_file)


### PR DESCRIPTION
Some tests use spdlog indirectly, but avoid linkage through the gnuradio::gnuradio-runtime target.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 860e8dacd44cafbcb69365f3929766a3b2c31b39)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6139