### PR TITLE
digital: deprecate crc32/16_async blocks (backport to maint-3.10)

### DIFF
--- a/gr-digital/grc/digital_crc16_async_bb.block.yml
+++ b/gr-digital/grc/digital_crc16_async_bb.block.yml
@@ -1,6 +1,6 @@
 id: digital_crc16_async_bb
 label: Async CRC16
-flags: [ python, cpp ]
+flags: [ python, cpp, deprecated ]
 
 parameters:
 -   id: check

--- a/gr-digital/grc/digital_crc32_async_bb.block.yml
+++ b/gr-digital/grc/digital_crc32_async_bb.block.yml
@@ -1,6 +1,6 @@
 id: digital_crc32_async_bb
 label: Async CRC32
-flags: [ python, cpp ]
+flags: [ python, cpp, deprecated ]
 
 parameters:
 -   id: check

--- a/gr-digital/include/gnuradio/digital/crc16_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc16_async_bb.h
@@ -23,6 +23,7 @@ namespace digital {
 /*!
  * \brief Byte-stream CRC block for async messages
  * \ingroup packet_operators_blk
+ * \ingroup deprecated_blk
  *
  * \details
  *

--- a/gr-digital/include/gnuradio/digital/crc32_async_bb.h
+++ b/gr-digital/include/gnuradio/digital/crc32_async_bb.h
@@ -21,6 +21,7 @@ namespace digital {
 /*!
  * \brief Byte-stream CRC block for async messages
  * \ingroup packet_operators_blk
+ * \ingroup deprecated_blk
  *
  * \details
  *

--- a/gr-digital/python/digital/bindings/crc16_async_bb_python.cc
+++ b/gr-digital/python/digital/bindings/crc16_async_bb_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc16_async_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(c751e985e9d0790c891979f57c198f6f)                     */
+/* BINDTOOL_HEADER_FILE_HASH(d1808d11786099ca539fd06a68399bf0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-digital/python/digital/bindings/crc32_async_bb_python.cc
+++ b/gr-digital/python/digital/bindings/crc32_async_bb_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(crc32_async_bb.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(21a4e7d0804db99d0f75ddbe2fe9ef51)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c6faeb06c567c64a737809562e98beea)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
These are functionally superceded by the generic crc_append and crc_check blocks and will be removed in a future release

Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit c1b88ff2670f88311fc2e9e3a37f0781987fe698)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6128