### PR TITLE
uhd: Add uhd.find to the pybind11 interface (backport to maint-3.10)

### DIFF
--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -25,6 +25,8 @@ void bind_usrp_block(py::module& m)
     m.attr("ALL_MBOARDS") = py::int_(::uhd::usrp::multi_usrp::ALL_MBOARDS);
     m.attr("ALL_LOS") = py::str(::uhd::usrp::multi_usrp::ALL_LOS);
 
+    m.def("find", [](const uhd::device_addr_t& hint) { return uhd::device::find(hint); });
+
     py::class_<usrp_block,
                gr::sync_block,
                gr::block,


### PR DESCRIPTION
`uhd_find_devices` would be the default shell function to discover available USRPs. PyUHD provides a function `uhd.find("")` that does the job. Besides, in `gr-uhd/python/uhd/__init__.py` there is a definition of `find_devices`. However, this function is broken at the moment because it tries to use a `find_devices_raw` function from the gr-uhd pybind11 interface that is not available. With this commit, we may be able to fix `find_devices` as well.

The actual change is just copied from UHD `host/lib/device_python.cpp`. Alternative solutions would include a new function in C++ and a pybind11 wrapper.

Signed-off-by: Johannes Demel <demel@ant.uni-bremen.de>
(cherry picked from commit 9c64b6df0bffe1fd87965e6766e7ae762e5e9117)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6140