### PR TITLE
grc: add more terminals to the auto-detector (backport to maint-3.9)

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -102,7 +102,7 @@ endif(CMAKE_INSTALL_PREFIX STREQUAL "/usr")
 
 if(UNIX)
     find_program(GRC_XTERM_EXE
-        NAMES x-terminal-emulator gnome-terminal konsole xterm foot
+        NAMES x-terminal-emulator gnome-terminal konsole xfce4-terminal urxvt xterm foot
         HINTS ENV PATH
         DOC "graphical terminal emulator used in GRC's no-gui-mode"
     )


### PR DESCRIPTION
xfce4-terminal is the terminal emulator for xfce users urxvt is a commonly used terminal emulator preferred by many over xterm Support for gnome and kde specific terminal emulators are already here, so please accept this as well.

Signed-off-by: Rick Farina (Zero_Chaos) <zerochaos@gentoo.org>

Signed-off-by: Rick Farina (Zero_Chaos) <zerochaos@gentoo.org>
(cherry picked from commit 67ef0469a0dabb3e1d876b4ac7d79b505a26873d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6134