### PR TITLE
pybind11: when no pygccxml, inherit gr::block

### DIFF
--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -286,6 +286,7 @@ class GenericHeaderParser(BlockTool):
             namespace_dict['name'] = "::".join(namespace_to_parse)
             class_dict = {}
             class_dict['name'] = blockname
+            class_dict['bases'] = ["::", "gr", "block"]
 
             mf_dict = {
                 "name": "make",


### PR DESCRIPTION
## Description
When pygccxml is not installed, the intention is that the user gets a basic functionality with parsing of the block implementation that gets automatically pybinded.  However, this doesn't appear to work at the moment because to have access to base class methods, the generated bindings need to list the base class.  

Prior to this fix, the following error occurs during flowgraph run when pygccxml is not installed and `gr_modtool bind` is called on a block:
```
ValueError: Unable to coerce endpoints: 'gnuradio.asdf.asdf_python.foo_general' object has no attribute 'to_basic_block'
```

This fix adds the minimally necessary gr::block and gr::basic_block to the inheritance chain

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
OOT modules using gr_modtool only when pygccxml is not installed

## Testing Done
Used modtool to add and bind blocks, then test in GRC

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
