### PR TITLE
4.0: modtool: pass gr_enable_python to gen_meson script

### DIFF
--- a/utils/modtool/newmod/meson.build
+++ b/utils/modtool/newmod/meson.build
@@ -66,8 +66,13 @@ fmt_dep = dependency('fmt', method: 'cmake', modules: ['fmt::fmt'])
 pmtf_dep = dependency('pmtf', version : '>= 0.0.2')
 gnuradio_gr_dep = dependency('gnuradio-runtime')
 
+if GR_ENABLE_PYTHON
+run_command('python3', join_paths(SCRIPTS_DIR,'gen_meson.py'), 
+  join_paths(meson.project_source_root(),'blocklib'), '--enable_python', check: true)
+else
 run_command('python3', join_paths(SCRIPTS_DIR,'gen_meson.py'), 
   join_paths(meson.project_source_root(),'blocklib'), check: true)
+endif
   
 subdir('blocklib/newmod')
 


### PR DESCRIPTION
One missing piece of the gen_meson script was passing whether python should be enabled for the module
