### PR TITLE
4.0: Fix some single mapped buffer issues and add test

### DIFF
--- a/gr/include/gnuradio/buffer_cpu_host.h
+++ b/gr/include/gnuradio/buffer_cpu_host.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include <gnuradio/buffer_sm.h>
+
+namespace gr {
+enum class buffer_cpu_host_type { D2D, H2D, D2H, UNKNOWN };
+class buffer_cpu_host_reader;
+class buffer_cpu_host : public buffer_sm
+{
+private:
+    uint8_t* _host_buffer;
+    uint8_t* _device_buffer;
+    buffer_cpu_host_type _transfer_type = buffer_cpu_host_type::UNKNOWN;
+
+public:
+    buffer_cpu_host(size_t num_items,
+                    size_t item_size,
+                    buffer_cpu_host_type type,
+                    std::shared_ptr<buffer_properties> buf_properties);
+
+    static buffer_uptr make(size_t num_items,
+                            size_t item_size,
+                            std::shared_ptr<buffer_properties> buffer_properties);
+
+    void* read_ptr(size_t index) override;
+    void* write_ptr() override;
+
+    void post_write(int num_items) override;
+
+    buffer_cpu_host_type transfer_type() { return _transfer_type; }
+
+    buffer_reader_uptr add_reader(std::shared_ptr<buffer_properties> buf_props,
+                                  size_t itemsize) override;
+
+    virtual bool output_blocked_callback(bool force = false) override
+    {
+        switch (_transfer_type) {
+        case buffer_cpu_host_type::H2D:
+            return output_blocked_callback_logic(force, std::memmove);
+        case buffer_cpu_host_type::D2D:
+        case buffer_cpu_host_type::D2H:
+            return output_blocked_callback_logic(force, std::memmove);
+        default:
+            return false;
+        }
+    }
+};
+
+class buffer_cpu_host_reader : public buffer_sm_reader
+{
+private:
+    buffer_cpu_host* _buffer_cpu_host;
+
+public:
+    buffer_cpu_host_reader(buffer_cpu_host* bufp,
+                           std::shared_ptr<buffer_properties> buf_props,
+                           size_t itemsize,
+                           size_t read_index = 0)
+        : buffer_sm_reader(bufp, itemsize, buf_props, read_index), _buffer_cpu_host(bufp)
+    {
+    }
+
+    virtual bool input_blocked_callback(size_t items_required) override
+    {
+        // Only singly mapped buffers need to do anything with this callback
+        // std::scoped_lock guard(*(_buffer->mutex()));
+        std::lock_guard<std::mutex> guard(*(_buffer->mutex()));
+
+        auto items_avail = items_available();
+
+        // GR_LOG_DEBUG(d_debug_logger,
+        //              "input_blocked_callback: items_avail {}, _read_index {}, "
+        //              "_write_index {}, items_required {}",
+        //              items_avail,
+        //              _read_index,
+        //              _buffer->write_index(),
+        //              items_required);
+
+        // GR_LOG_DEBUG(d_debug_logger,
+        //              "input_blocked_callback: total_written {}, total_read {}",
+        //              _buffer->total_written(),
+        //              total_read());
+
+
+        // Maybe adjust read pointers from min read index?
+        // This would mean that *all* readers must be > (passed) the write index
+        if (items_avail < items_required && _buffer->write_index() < read_index()) {
+            // GR_LOG_DEBUG(d_debug_logger, "Calling adjust_buffer_data ");
+
+            switch (_buffer_cpu_host->transfer_type()) {
+            case buffer_cpu_host_type::H2D:
+            case buffer_cpu_host_type::D2D:
+                return _buffer_cpu_host->adjust_buffer_data(std::memcpy, std::memmove);
+            case buffer_cpu_host_type::D2H:
+                return _buffer_cpu_host->adjust_buffer_data(std::memcpy, std::memmove);
+            default:
+                return false;
+            }
+        }
+
+        return false;
+    }
+};
+
+class buffer_cpu_host_properties : public buffer_properties
+{
+public:
+    // using std::shared_ptr<buffer_properties> = sptr;
+    buffer_cpu_host_properties(buffer_cpu_host_type buffer_type_)
+        : buffer_properties(), _buffer_type(buffer_type_)
+    {
+        _bff = buffer_cpu_host::make;
+    }
+    buffer_cpu_host_type buffer_type() { return _buffer_type; }
+    static std::shared_ptr<buffer_properties>
+    make(buffer_cpu_host_type buffer_type_ = buffer_cpu_host_type::D2D)
+    {
+        return std::static_pointer_cast<buffer_properties>(
+            std::make_shared<buffer_cpu_host_properties>(buffer_type_));
+    }
+
+private:
+    buffer_cpu_host_type _buffer_type;
+};
+
+
+#define BUFFER_CPU_HOST_ARGS_H2D \
+    buffer_cpu_host_properties::make(buffer_cpu_host_type::H2D)
+#define BUFFER_CPU_HOST_ARGS_D2H \
+    buffer_cpu_host_properties::make(buffer_cpu_host_type::D2H)
+#define BUFFER_CPU_HOST_ARGS_D2D \
+    buffer_cpu_host_properties::make(buffer_cpu_host_type::D2D)
+
+
+} // namespace gr

--- a/gr/lib/buffer_cpu_host.cc
+++ b/gr/lib/buffer_cpu_host.cc
@@ -1,0 +1,101 @@
+#include <string.h>
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <gnuradio/buffer_cpu_host.h>
+
+namespace gr {
+buffer_cpu_host::buffer_cpu_host(size_t num_items,
+                               size_t item_size,
+                               buffer_cpu_host_type type,
+                               std::shared_ptr<buffer_properties> buf_properties)
+    : gr::buffer_sm(num_items, item_size, buf_properties), _transfer_type(type)
+{
+    static std::vector<uint8_t> __host_buffer(_buf_size);
+    static std::vector<uint8_t> __device_buffer(_buf_size);
+
+    _host_buffer = __host_buffer.data();
+    _device_buffer = __device_buffer.data();
+
+    set_type("buffer_cpu_host_" + std::to_string((int)_transfer_type));
+}
+
+buffer_uptr buffer_cpu_host::make(size_t num_items,
+                                 size_t item_size,
+                                 std::shared_ptr<buffer_properties> buffer_properties)
+{
+    auto cbp = std::static_pointer_cast<buffer_cpu_host_properties>(buffer_properties);
+    if (cbp != nullptr) {
+        return buffer_uptr(new buffer_cpu_host(
+            num_items, item_size, cbp->buffer_type(), buffer_properties));
+    }
+    else {
+        throw std::runtime_error(
+            "Failed to cast buffer properties to buffer_cpu_host_properties");
+    }
+}
+
+void* buffer_cpu_host::read_ptr(size_t index)
+{
+    if (_transfer_type == buffer_cpu_host_type::D2H) {
+        return (void*)&_host_buffer[index];
+    }
+    else {
+        return (void*)&_device_buffer[index];
+    }
+}
+void* buffer_cpu_host::write_ptr()
+{
+    if (_transfer_type == buffer_cpu_host_type::H2D) {
+        return (void*)&_host_buffer[_write_index];
+    }
+    else {
+        return (void*)&_device_buffer[_write_index];
+    }
+}
+
+void buffer_cpu_host::post_write(int num_items)
+{
+    std::lock_guard<std::mutex> guard(_buf_mutex);
+
+    size_t bytes_written = num_items * _item_size;
+    size_t wi1 = _write_index;
+
+    // num_items were written to the buffer
+
+    if (_transfer_type == buffer_cpu_host_type::H2D) {
+        memcpy(&_device_buffer[wi1],
+                        &_host_buffer[wi1],
+                        bytes_written);
+    }
+    else if (_transfer_type == buffer_cpu_host_type::D2H) {
+        memcpy(&_host_buffer[wi1],
+                        &_device_buffer[wi1],
+                        bytes_written);
+    }
+
+    // advance the write pointer
+    _write_index += bytes_written;
+    if (_write_index == _buf_size) {
+        _write_index = 0;
+    }
+    if (_write_index > _buf_size) {
+        throw std::runtime_error("buffer_sm: Wrote too far into buffer");
+    }
+    _total_written += num_items;
+}
+
+buffer_reader_uptr
+buffer_cpu_host::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
+{
+    auto r =
+        std::make_unique<buffer_cpu_host_reader>(this, buf_props, itemsize, _write_index);
+    _readers.push_back(r.get());
+    return r;
+}
+
+
+} // namespace gr

--- a/gr/lib/buffer_sm.cc
+++ b/gr/lib/buffer_sm.cc
@@ -154,7 +154,7 @@ size_t buffer_sm::space_available()
     // Only half fill the buffer
     // Leave extra space in case the reader gets stuck and needs realignment
 
-    space = std::min(space, _num_items / 2);
+    space = std::min(space, _num_items);
 
     return space;
 }

--- a/gr/lib/buffer_sm.cc
+++ b/gr/lib/buffer_sm.cc
@@ -328,14 +328,14 @@ size_t buffer_sm_reader::bytes_available()
     //              total_read(),
     //              _buffer->total_written());
 
-    if (_buffer->total_written() - total_read() < ret * _itemsize) {
-        // GR_LOG_DEBUG(d_debug_logger,
-        //              "check_math {} {} {} {}",
-        //              _buffer->total_written() - total_read(),
-        //              ret,
-        //              total_read(),
-        //              _buffer->total_written());
-    }
+    // if (_itemsize*(_buffer->total_written() - total_read()) < ret) {
+    //     d_debug_logger->debug(
+    //                  "check_math {} {} {} {}",
+    //                  _buffer->total_written() - total_read(),
+    //                  ret,
+    //                  total_read(),
+    //                  _buffer->total_written());
+    // }
 
     return ret; // in bytes
 }

--- a/gr/lib/meson.build
+++ b/gr/lib/meson.build
@@ -61,7 +61,8 @@ runtime_sources = [
   'hier_block.cc',
   'prefs.cc',
   'tag.cc',
-  'registry.cc'
+  'registry.cc',
+  'buffer_cpu_host.cc'
 ]
 
 if IMPLEMENT_CUDA

--- a/gr/meson.build
+++ b/gr/meson.build
@@ -6,4 +6,8 @@ if (get_option('enable_python'))
     subdir('python/gnuradio/gr')
 endif
 
+if (get_option('enable_testing'))
+    subdir('test')
+endif
+
 install_data(sources : 'gr.conf.yml', install_dir : 'etc/gnuradio/conf.d')

--- a/gr/test/meson.build
+++ b/gr/test/meson.build
@@ -1,0 +1,16 @@
+
+# GR namespace tests
+qa_srcs = ['qa_host_buffer',
+          ]
+deps = [gnuradio_gr_dep,
+                gtest_dep,]
+
+foreach qa : qa_srcs
+    e = executable(qa, 
+        qa + '.cc', 
+        include_directories : incdir, 
+        link_language : 'cpp',
+        dependencies: deps, 
+        install : false)
+    test(qa, e, env: TEST_ENV)
+endforeach

--- a/gr/test/qa_host_buffer.cc
+++ b/gr/test/qa_host_buffer.cc
@@ -1,0 +1,281 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2021 BlackLynx Inc.
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <gnuradio/block.h>
+#include <gnuradio/buffer_cpu_host.h>
+
+#include <cstdlib>
+#include <iostream>
+
+
+using namespace gr;
+
+// ----------------------------------------------------------------------------
+// Basic checks for buffer_single_mapped using the buffer_cpu_host implementation
+// of the interface for testing.
+// ----------------------------------------------------------------------------
+TEST(HostBuffer, t0)
+{
+    size_t nitems = 65536 / sizeof(int);
+
+    auto buf_props = BUFFER_CPU_HOST_ARGS_H2D;
+    auto buf = buf_props->factory()(nitems, 1, buf_props);
+    auto rdr1 = buf->add_reader(buf_props, 1);
+
+    EXPECT_TRUE(buf->space_available() == nitems);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    for (size_t idx = 1; idx <= 16; ++idx) {
+        buf->post_write(1000);
+        EXPECT_TRUE(buf->space_available() == (nitems - (idx * 1000)));
+
+        EXPECT_TRUE(rdr1->items_available() == (idx * 1000));
+    }
+
+    EXPECT_TRUE(buf->space_available() == 384);
+
+    buf->post_write(buf->space_available());
+    EXPECT_TRUE(buf->space_available() == 0);
+    EXPECT_TRUE(rdr1->items_available() == nitems);
+    EXPECT_TRUE(buf->space_available() == 0);
+}
+
+// ----------------------------------------------------------------------------
+// Basic checks for buffer_single_mapped using the buffer_cpu_host implementation
+// of the interface for testing.
+// ----------------------------------------------------------------------------
+TEST(HostBuffer, t1)
+{
+    size_t nitems = 65536 / sizeof(int);
+
+    auto buf_props = BUFFER_CPU_HOST_ARGS_H2D;
+    auto buf = buf_props->factory()(nitems, 1, buf_props);
+    auto rdr1 = buf->add_reader(buf_props, 1);
+
+    size_t space = buf->space_available();
+    EXPECT_TRUE(nitems == space);
+
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    buf->post_write(nitems);
+    EXPECT_TRUE(buf->space_available() == 0);
+    EXPECT_TRUE(rdr1->items_available() == nitems);
+
+    for (size_t idx = 1; idx <= 16; ++idx) {
+        rdr1->post_read(1000);
+        EXPECT_TRUE(rdr1->items_available() == (nitems - (idx * 1000)));
+
+        space = buf->space_available();
+        EXPECT_TRUE(space == (idx * 1000));
+    }
+
+    EXPECT_TRUE(rdr1->items_available() == 384);
+    rdr1->post_read(384);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+}
+
+// ----------------------------------------------------------------------------
+// Basic check reader/write wrapping of buffer_single_mapped with 1 reader.
+// ----------------------------------------------------------------------------
+TEST(HostBuffer, t2)
+{
+    size_t nitems = 65536 / sizeof(int);
+
+    auto buf_props = BUFFER_CPU_HOST_ARGS_H2D;
+    auto buf = buf_props->factory()(nitems, 1, buf_props);
+    auto rdr1 = buf->add_reader(buf_props, 1);
+
+    size_t space = buf->space_available();
+    EXPECT_TRUE(nitems == space);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    buf->post_write(nitems);
+    EXPECT_TRUE(buf->space_available() == 0);
+
+    for (size_t idx = 1; idx <= 16; ++idx) {
+        rdr1->post_read(1000);
+        EXPECT_TRUE(rdr1->items_available() == (nitems - (idx * 1000)));
+
+        space = buf->space_available();
+
+        if (idx <= 9)
+            EXPECT_TRUE(space == (idx * 1000));
+        else
+            EXPECT_TRUE(space == ((idx * 1000) - (nitems / 2)));
+
+        if (idx == 9) {
+            buf->post_write(nitems / 2);
+        }
+    }
+
+    // At this point we can only read up until the end of the buffer even though
+    // additional data is available at the beginning of the buffer
+    EXPECT_TRUE(rdr1->items_available() == 384);
+    rdr1->post_read(384);
+
+    // Now the (nitems / 2) at the beginning of the buffer should be available
+    EXPECT_TRUE(rdr1->items_available() == (nitems / 2));
+
+    for (size_t idx = 0; idx < 4; ++idx)
+        rdr1->post_read(1024);
+
+    EXPECT_TRUE(buf->space_available() == (nitems / 2));
+    EXPECT_TRUE(rdr1->items_available() == (nitems / 4));
+
+    for (size_t idx = 0; idx < 4; ++idx)
+        rdr1->post_read(1000);
+
+    EXPECT_TRUE(buf->space_available() == (nitems / 2));
+    EXPECT_TRUE(rdr1->items_available() == 96);
+
+    rdr1->post_read(96);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    EXPECT_TRUE(buf->space_available() == (nitems / 2));
+}
+
+// ----------------------------------------------------------------------------
+// Basic check reader/write wrapping of buffer_single_mapped with 2 readers.
+// ----------------------------------------------------------------------------
+TEST(HostBuffer, t3)
+{
+    size_t nitems = 65536 / sizeof(int);
+
+    auto buf_props = BUFFER_CPU_HOST_ARGS_H2D;
+    auto buf = buf_props->factory()(nitems, 1, buf_props);
+    auto rdr1 = buf->add_reader(buf_props, 1);
+    auto rdr2 = buf->add_reader(buf_props, 1);
+
+    size_t space = buf->space_available();
+    EXPECT_TRUE(nitems == space);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+    EXPECT_TRUE(rdr2->items_available() == 0);
+
+    buf->post_write(nitems);
+    EXPECT_TRUE(buf->space_available() == 0);
+    EXPECT_TRUE(rdr1->items_available() == nitems);
+    EXPECT_TRUE(rdr2->items_available() == nitems);
+
+    for (size_t idx = 1; idx <= 16; ++idx) {
+        rdr1->post_read(1000);
+        EXPECT_TRUE(rdr1->items_available() == (nitems - (idx * 1000)));
+
+        // Reader 2 hasn't read anything so space available should remain 0
+        EXPECT_TRUE(buf->space_available() == 0);
+    }
+
+    size_t last_rdr1_available = rdr1->items_available();
+    size_t increment = last_rdr1_available / 4;
+
+    for (size_t idx = 1; idx <= 16; ++idx) {
+        rdr2->post_read(1000);
+        EXPECT_TRUE(rdr2->items_available() == (nitems - (idx * 1000)));
+
+        EXPECT_TRUE(rdr1->items_available() == last_rdr1_available);
+        if (idx % 4 == 0) {
+            rdr1->post_read(increment);
+            EXPECT_TRUE(rdr1->items_available() == (last_rdr1_available - increment));
+            last_rdr1_available = rdr1->items_available();
+        }
+
+        EXPECT_TRUE(buf->space_available() == (idx * 1000));
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Basic check of output blocked callback
+// ----------------------------------------------------------------------------
+TEST(HostBuffer, t4)
+{
+    size_t nitems = 65536 / sizeof(int);
+
+    auto buf_props = BUFFER_CPU_HOST_ARGS_H2D;
+    auto buf = buf_props->factory()(nitems, 1, buf_props);
+    auto rdr1 = buf->add_reader(buf_props, 1);
+
+    EXPECT_TRUE(nitems == buf->space_available());
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    buf->post_write(nitems / 2);
+    EXPECT_TRUE(buf->space_available() == (nitems / 2));
+    EXPECT_TRUE(rdr1->items_available() == (nitems / 2));
+
+    rdr1->post_read(nitems / 2);
+    EXPECT_TRUE(buf->space_available() == (nitems / 2));
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    buf->post_write(8000);
+    EXPECT_TRUE(buf->space_available() == 192);
+
+    // bool ready = buf->output_blkd_cb_ready(200);
+    // EXPECT_TRUE(ready == true);
+
+    bool success = buf->output_blocked_callback(200);
+    EXPECT_TRUE(success == true);
+    EXPECT_TRUE(buf->space_available() == 8384);
+    EXPECT_TRUE(rdr1->items_available() == 8000);
+
+    rdr1->post_read(4000);
+    EXPECT_TRUE(buf->space_available() == 8384);
+    EXPECT_TRUE(rdr1->items_available() == 4000);
+
+    buf->post_write(4000);
+    EXPECT_TRUE(buf->space_available() == 4384);
+    EXPECT_TRUE(rdr1->items_available() == 8000);
+
+    rdr1->post_read(8000);
+    EXPECT_TRUE(buf->space_available() == 4384);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+}
+
+// ----------------------------------------------------------------------------
+// Basic check of input blocked callback
+// ----------------------------------------------------------------------------
+TEST(HostBuffer, t5)
+{
+    size_t nitems = 65536 / sizeof(int);
+
+    auto buf_props = BUFFER_CPU_HOST_ARGS_H2D;
+    auto buf = buf_props->factory()(nitems, 1, buf_props);
+    auto rdr1 = buf->add_reader(buf_props, 1);
+
+    EXPECT_TRUE(nitems == buf->space_available());
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    buf->post_write(16000);
+    EXPECT_TRUE(buf->space_available() == 384);
+    EXPECT_TRUE(rdr1->items_available() == 16000);
+
+    rdr1->post_read(16000);
+    EXPECT_TRUE(buf->space_available() == 384);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+
+    buf->post_write(384);
+    EXPECT_TRUE(buf->space_available() == 16000);
+    EXPECT_TRUE(rdr1->items_available() == 384);
+
+    buf->post_write(116);
+    EXPECT_TRUE(buf->space_available() == 15884);
+    EXPECT_TRUE(rdr1->items_available() == 384);
+
+    // bool ready = rdr1->input_blkd_cb_ready(400);
+    // EXPECT_TRUE(ready == true);
+
+    bool success = rdr1->input_blocked_callback(400);
+    EXPECT_TRUE(success == true);
+    EXPECT_TRUE(rdr1->items_available() == 500);
+
+    rdr1->post_read(500);
+    EXPECT_TRUE(buf->space_available() == 15884);
+    EXPECT_TRUE(rdr1->items_available() == 0);
+}

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt.h
@@ -1,5 +1,6 @@
 #include <gnuradio/block_group_properties.h>
 #include <gnuradio/buffer_cpu_vmcirc.h>
+#include <gnuradio/buffer_cpu_host.h>
 // #include <gnuradio/buffer_cpu_simple.h>
 #include <gnuradio/graph_utils.h>
 #include <gnuradio/scheduler.h>
@@ -25,8 +26,10 @@ public:
     }
     scheduler_nbt(const scheduler_nbt_options& opts) : scheduler(opts.name), _opts(opts)
     {
+        // _default_buf_properties =
+        //     buffer_cpu_vmcirc_properties::make(buffer_cpu_vmcirc_type::AUTO);
         _default_buf_properties =
-            buffer_cpu_vmcirc_properties::make(buffer_cpu_vmcirc_type::AUTO);
+            buffer_cpu_host_properties::make(buffer_cpu_host_type::H2H);
     }
     ~scheduler_nbt() override{};
 

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt.h
@@ -1,6 +1,6 @@
 #include <gnuradio/block_group_properties.h>
-#include <gnuradio/buffer_cpu_vmcirc.h>
 #include <gnuradio/buffer_cpu_host.h>
+#include <gnuradio/buffer_cpu_vmcirc.h>
 // #include <gnuradio/buffer_cpu_simple.h>
 #include <gnuradio/graph_utils.h>
 #include <gnuradio/scheduler.h>
@@ -26,10 +26,14 @@ public:
     }
     scheduler_nbt(const scheduler_nbt_options& opts) : scheduler(opts.name), _opts(opts)
     {
-        // _default_buf_properties =
-        //     buffer_cpu_vmcirc_properties::make(buffer_cpu_vmcirc_type::AUTO);
-        _default_buf_properties =
-            buffer_cpu_host_properties::make(buffer_cpu_host_type::H2H);
+        if (opts.default_buffer_type == "cpu_host") {
+            _default_buf_properties =
+                buffer_cpu_host_properties::make(buffer_cpu_host_type::H2H);
+        }
+        else {
+            _default_buf_properties =
+                buffer_cpu_vmcirc_properties::make(buffer_cpu_vmcirc_type::AUTO);
+        }
     }
     ~scheduler_nbt() override{};
 

--- a/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt_options.h
+++ b/schedulers/nbt/include/gnuradio/schedulers/nbt/scheduler_nbt_options.h
@@ -8,6 +8,7 @@ namespace schedulers {
 struct scheduler_nbt_options {
     std::string name = "nbt";
     size_t default_buffer_size = 32768;
+    std::string default_buffer_type = "cpu_vmcirc";
     bool flush = true;
     size_t flush_count = 8;
     size_t flush_sleep_ms = 10;

--- a/schedulers/nbt/lib/scheduler_nbt.cc
+++ b/schedulers/nbt/lib/scheduler_nbt.cc
@@ -121,6 +121,8 @@ scheduler_nbt_options scheduler_nbt::opts_from_yaml(const std::string options)
     opts.default_buffer_size = opt_yaml["buffer_size"].as<size_t>(
         gr::prefs::get_long("scheduler.nbt", "default_buffer_size", 32768));
     opts.name = opt_yaml["name"].as<std::string>("nbt");
+    opts.default_buffer_type = opt_yaml["default_buffer_type"].as<std::string>(
+        gr::prefs::get_string("scheduler.nbt", "default_buffer_type", "cpu_vmcirc"));
     opts.flush =
         opt_yaml["flush"].as<bool>(gr::prefs::get_bool("scheduler.nbt", "flush", true));
     opts.flush_count = opt_yaml["flush_count"].as<long>(


### PR DESCRIPTION
## Description
There were some issues with single mapped buffers and they weren't being tested.  
This adds a buffer type: buffer_cpu_host (copied from GR 3.x) that simulates a host/device buffer type but can be used without specific hardware.  
The default buffer type can be configured in config.yml


## Testing Done
Added host_buffer test
Ran tests with default_buffer_type set to "cpu_host"
