### PR TITLE
zmq: add option to block/drop samples when high watermark reached

### DIFF
--- a/gr-zeromq/grc/zeromq_pub_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_sink.block.yml
@@ -39,6 +39,14 @@ parameters:
     label: Filter Key
     dtype: string
     default: ''
+-   id: drop_on_hwm
+    category: Advanced
+    label: On Full Buffer
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['Drop', 'Block']
+    hide: 'part'
 
 inputs:
 -   domain: stream
@@ -48,7 +56,7 @@ inputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.pub_sink(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm}, ${key})
+        ${hwm}, ${key}, ${drop_on_hwm})
         
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/pub_sink.h>' ]
@@ -58,7 +66,9 @@ cpp_templates:
         const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'},
         ${timeout}, 
         ${pass_tags}, 
-        ${hwm});
+        ${hwm},
+        ${key},
+        ${drop_on_hwm});
     link: ['gnuradio::gnuradio-zeromq']      
     translations:
       'True': 'true'

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -56,7 +56,8 @@ public:
                      int timeout = 100,
                      bool pass_tags = false,
                      int hwm = -1,
-                     const std::string& key = "");
+                     const std::string& key = "",
+                     bool drop_on_hwm = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/lib/pub_sink_impl.cc
+++ b/gr-zeromq/lib/pub_sink_impl.cc
@@ -25,10 +25,11 @@ pub_sink::sptr pub_sink::make(size_t itemsize,
                               int timeout,
                               bool pass_tags,
                               int hwm,
-                              const std::string& key)
+                              const std::string& key,
+                              bool drop_on_hwm)
 {
     return gnuradio::make_block_sptr<pub_sink_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm, key);
+        itemsize, vlen, address, timeout, pass_tags, hwm, key, drop_on_hwm);
 }
 
 pub_sink_impl::pub_sink_impl(size_t itemsize,
@@ -37,13 +38,20 @@ pub_sink_impl::pub_sink_impl(size_t itemsize,
                              int timeout,
                              bool pass_tags,
                              int hwm,
-                             const std::string& key)
+                             const std::string& key,
+                             bool drop_on_hwm)
     : gr::sync_block("pub_sink",
                      gr::io_signature::make(1, 1, itemsize * vlen),
                      gr::io_signature::make(0, 0, 0)),
       base_sink_impl(ZMQ_PUB, itemsize, vlen, address, timeout, pass_tags, hwm, key)
 {
-    /* All is delegated */
+    /* Socket option to prevent dropping of samples (backpressure) */
+    int no_drop = (drop_on_hwm == true) ? 0 : 1;
+#if USE_NEW_CPPZMQ_SET_GET
+    d_socket.set(zmq::sockopt::xpub_nodrop, no_drop);
+#else
+    d_socket.setsockopt(ZMQ_XPUB_NODROP, &no_drop, sizeof(no_drop));
+#endif
 }
 
 int pub_sink_impl::work(int noutput_items,

--- a/gr-zeromq/lib/pub_sink_impl.h
+++ b/gr-zeromq/lib/pub_sink_impl.h
@@ -27,7 +27,8 @@ public:
                   int timeout,
                   bool pass_tags,
                   int hwm,
-                  const std::string& key);
+                  const std::string& key,
+                  bool drop_on_hwm);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/python/zeromq/bindings/pub_sink_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/pub_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pub_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(f18c40db0abeb2a88831e0f804180feb)                     */
+/* BINDTOOL_HEADER_FILE_HASH(75da3fece8cba14e97b100b327b3088f)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -47,6 +47,7 @@ void bind_pub_sink(py::module& m)
              py::arg("pass_tags") = false,
              py::arg("hwm") = -1,
              py::arg("key") = "",
+             py::arg("drop_on_hwm") = true,
              D(pub_sink, make))
 
 


### PR DESCRIPTION
Signed-off-by: Sam <sam@whitings.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
When using the high watermark option in the zeroMQ PUB/SUB blocks, another relevant parameter is left default which silently drops samples when the high watermark is reached. This PR adds a parameter to allow a user to change this behavior to "block" which would result in backpressure. 

More can be read about the default ZMQ behavior at http://api.zeromq.org/4-2:zmq-setsockopt looking for "ZMQ_XPUB_NODROP".


## Related Issue

Fixes #6192 

## Which blocks/areas does this affect?
ZeroMQ PUB and SUB streaming blocks now have additional option to allow using the high watermark in drop/block modes.

## Testing Done
I have not been able to write a deterministic QA test that proves this fix works. The fix has only really been validated by running examples flowgraphs as shown in the related issue. The changes are consistent with ZeroMQ documentation about usage of the high watermark socket options.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
