### PR TITLE
Qt GRC Feature Addition: Core Block Wiki Tab

### DIFF
--- a/grc/gui_qt/components/__init__.py
+++ b/grc/gui_qt/components/__init__.py
@@ -1,6 +1,7 @@
 
 from .block_library import BlockLibrary
 from .documentation_tab import DocumentationTab
+from .wiki_tab import WikiTab
 from .console import Console
 from .flowgraph import FlowgraphView
 from .project_manager import ProjectManager

--- a/grc/gui_qt/components/block_library.py
+++ b/grc/gui_qt/components/block_library.py
@@ -25,6 +25,7 @@ import six
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtGui import QStandardItemModel
+from PyQt5.QtCore import QUrl
 
 # Custom modules
 from .canvas.block import Block
@@ -77,6 +78,8 @@ class LibraryView(QtWidgets.QTreeView):
         if label in self.parent().parent()._block_tree_flat:
             block_key = self.parent().parent()._block_tree_flat[label].key
             self.parent().parent().app.DocumentationTab.setText(self.parent().parent()._block_tree_flat[label].documentation[block_key])
+            prefix = str(self.parent().parent().app.platform.Config.wiki_block_docs_url_prefix)
+            self.parent().parent().app.WikiTab.setURL(QUrl(prefix + label.replace(" ", "_")))
 
 
 class BlockLibrary(QtWidgets.QDockWidget, base.Component):

--- a/grc/gui_qt/components/canvas/block.py
+++ b/grc/gui_qt/components/canvas/block.py
@@ -2,7 +2,7 @@ import logging
 
 # third-party modules
 from PyQt5 import QtGui, QtCore, QtWidgets
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QUrl
 
 from . import colors
 from ... import Constants
@@ -351,6 +351,8 @@ class Block(QtWidgets.QGraphicsItem, CoreBlock):
         self.parent.registerBlockMovement(self)
         try:
             self.parent.app.DocumentationTab.setText(self.documentation[self.key])
+            prefix = str(self.parent.app.platform.Config.wiki_block_docs_url_prefix)
+            self.parent.app.WikiTab.setURL(QUrl(prefix + self.label.replace(" ", "_")))
         except KeyError:
             pass
 

--- a/grc/gui_qt/components/wiki_tab.py
+++ b/grc/gui_qt/components/wiki_tab.py
@@ -1,0 +1,96 @@
+# Copyright 2014-2022 Free Software Foundation, Inc.
+# This file is part of GNU Radio
+#
+# GNU Radio Companion is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# GNU Radio Companion is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+from __future__ import absolute_import, print_function
+
+# Standard modules
+import logging
+
+# Third-party  modules
+import six
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtGui import QStandardItemModel
+from PyQt5.QtWebEngineWidgets import *
+
+# Custom modules
+from .canvas.block import Block
+from .. import base
+
+# Logging
+log = logging.getLogger(__name__)
+
+class WikiTab(QtWidgets.QDockWidget, base.Component):
+
+    def __init__(self):
+        QtWidgets.QDockWidget.__init__(self)
+        base.Component.__init__(self)
+
+        self.setObjectName('wiki_tab')
+        self.setWindowTitle('Wiki')
+
+        # TODO: Pull from preferences and revert to default if not found?
+        self.setFloating(False)
+
+        ### GUI Widgets
+
+        # Create the layout widget
+        container = QtWidgets.QWidget(self)
+        container.setObjectName('wiki_tab::container')
+        self._container = container
+
+        layout = QtWidgets.QVBoxLayout(container)
+        layout.setObjectName('block_library::layout')
+        layout.setSpacing(0)
+        layout.setContentsMargins(5, 0, 5, 5)
+        self._text = QWebEngineView()
+        layout.addWidget(self._text)
+        self._layout = layout
+
+        container.setLayout(layout)
+        self.setWidget(container)
+
+        # TODO: Move to the base controller and set actions as class attributes
+        # Automatically create the actions, menus and toolbars.
+        # Child controllers need to call the register functions to integrate into the mainwindow
+        self.actions = {}
+        self.menus = {}
+        self.toolbars = {}
+        self.createActions(self.actions)
+        self.createMenus(self.actions, self.menus)
+        self.createToolbars(self.actions, self.toolbars)
+        self.connectSlots()
+
+        # Register the dock widget through the AppController.
+        # The AppController then tries to find a saved dock location from the preferences
+        # before calling the MainWindow Controller to add the widget.
+        self.app.registerDockWidget(self, location=self.settings.window.WIKI_TAB_DOCK_LOCATION)
+
+    def setURL(self, url):
+        self._text.load(url)
+        self._text.show()
+
+    ### Actions
+
+    def createActions(self, actions):
+        log.debug("Creating actions")
+
+    def createMenus(self, actions, menus):
+        log.debug("Creating menus")
+
+    def createToolbars(self, actions, toolbars):
+        log.debug("Creating toolbars")

--- a/grc/gui_qt/grc.py
+++ b/grc/gui_qt/grc.py
@@ -72,6 +72,8 @@ class Application(QtWidgets.QApplication):
         stopwatch.lap('blocklibrary')
         self.DocumentationTab = components.DocumentationTab()
         stopwatch.lap('documentationtab')
+        self.WikiTab = components.WikiTab()
+        stopwatch.lap('wikitab')
 
         # Debug times
         log.debug("Loaded MainWindow controller - {:.4f}s".format(stopwatch.elapsed("mainwindow")))

--- a/grc/gui_qt/properties.py
+++ b/grc/gui_qt/properties.py
@@ -103,6 +103,7 @@ class Window(object):
     REPORTS_DOCK_LOCATION = 8
     BLOCK_LIBRARY_DOCK_LOCATION = 1
     DOCUMENTATION_TAB_DOCK_LOCATION = 2
+    WIKI_TAB_DOCK_LOCATION = 2
 
     # Define the top level menus.
     # This does not actually define the menus; it simply defines a list of constants that


### PR DESCRIPTION
GR 4.0: Qt GRC Feature Addition: Core Block Wiki Tab

## Description
In the Documentation workshop at GRCon 2022, we discussed the possibility of having GRC embed wiki.gnuradio.org for each of the core blocks rather than just linking out to it.

If a user does not have internet access/offline installation situation, the possibility of exporting the state of mediawiki at build and embedding it in the local docs for loading was proposed as an option
The tools here could enable this: https://github.com/SolidCharity/exportMediaWiki2HTML

The code used in this PR support loading from the web or directly embedding local HTML (QtWebEngine)

## Which blocks/areas does this affect?
The GRC Qt port - only affects Core blocks with wiki pages

## Testing Done
Tested on Fedora 36, KDE.  Needs to be tested more for blocks without wiki pages, or difficulty regularizing URLs for the Mediawiki path.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
