### PR TITLE
gr-blocks: print correct error message for soundfile sf_open

### DIFF
--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -110,10 +110,18 @@ bool wavfile_sink_impl::open(const char* filename)
     if (d_append) {
         // We are appending to an existing file, be extra careful here.
         sfinfo.format = 0;
+        errno = 0;
         if (!(d_new_fp = sf_open(filename, SFM_RDWR, &sfinfo))) {
-            GR_LOG_ERROR(d_logger,
-                         boost::format("sf_open failed: %s: %s") % filename %
-                             strerror(errno));
+            if (errno) {
+                GR_LOG_ERROR(d_logger,
+                             boost::format("sf_open failed: %s: %s") % filename %
+                                 strerror(errno));
+            } else {
+                GR_LOG_ERROR(d_logger,
+                             boost::format("sf_open failed: %s: %s") % filename %
+                                 sf_strerror(NULL));
+            }
+
             return false;
         }
         if (d_h.sample_rate != sfinfo.samplerate || d_h.nchans != sfinfo.channels ||
@@ -198,10 +206,18 @@ bool wavfile_sink_impl::open(const char* filename)
             }
             break;
         }
+        errno = 0;
         if (!(d_new_fp = sf_open(filename, SFM_WRITE, &sfinfo))) {
-            GR_LOG_ERROR(d_logger,
-                         boost::format("sf_open failed: %s: %s") % filename %
-                             strerror(errno));
+            if (errno) {
+                GR_LOG_ERROR(d_logger,
+                             boost::format("sf_open failed: %s: %s") % filename %
+                                 strerror(errno));
+            } else {
+                GR_LOG_ERROR(d_logger,
+                             boost::format("sf_open failed: %s: %s") % filename %
+                                 sf_strerror(NULL));
+            }
+
             return false;
         }
     }

--- a/gr-blocks/lib/wavfile_source_impl.cc
+++ b/gr-blocks/lib/wavfile_source_impl.cc
@@ -38,10 +38,17 @@ wavfile_source_impl::wavfile_source_impl(const char* filename, bool repeat)
     SF_INFO sfinfo;
 
     sfinfo.format = 0;
+    errno = 0;
     if (!(d_fp = sf_open(filename, SFM_READ, &sfinfo))) {
-        GR_LOG_ERROR(d_logger,
-                     boost::format("sf_open failed: %s: %s") % filename %
-                         strerror(errno));
+        if (errno) {
+            GR_LOG_ERROR(d_logger,
+                         boost::format("sf_open failed: %s: %s") % filename %
+                             strerror(errno));
+        } else {
+            GR_LOG_ERROR(d_logger,
+                         boost::format("sf_open failed: %s: %s") % filename %
+                             sf_strerror(NULL));
+        }
         throw std::runtime_error("Can't open WAV file.");
     }
 


### PR DESCRIPTION
The wavfile_sink and wavfile_source  now prints invalid error messages when eg. the existing WAV file is broken.

Now description for `errno` error is printed, but soundfile library does not set `errno` on error, but have its own way to get error message. If sf_open fails, textual description of the error message should be retrieved by calling `sf_strerror(NULL)`, not `strerror(errno)`. But in case of error related for example to opening a file, the decription from `sf_strerror` is pretty crappy and misleading. This patch combines both aproaches to get the best from it.

I have manualy (on my project tested):
 * to create file in nonexisting directory
 * to open non-wav file as wav

Bot returned expected error description.

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
