### PR TITLE
digital: Apply symbol map on hard variable constellation decodes

### DIFF
--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -407,7 +407,11 @@ constellation_calcdist::constellation_calcdist(std::vector<gr_complex> constell,
 // Inefficient.
 unsigned int constellation_calcdist::decision_maker(const gr_complex* sample)
 {
-    return get_closest_point(sample);
+    const auto point = get_closest_point(sample);
+    if (d_apply_pre_diff_code) {
+        return d_pre_diff_code.at(point);
+    }
+    return point;
 }
 
 


### PR DESCRIPTION
## Description

Allow symbol map to actually work, when using hard decision `Constellation Decoder`.

## Related Issue

This is PR and bug report in one.

## Which blocks/areas does this affect?

`Constellation Object`

## Testing Done

No testing done. Currently my building for source is segfaulting, but hoping that the github-triggered testing will be a bit useful.

Marking WIP until I can get it properly tested, and add a unit test.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [maybe] I [have signed my commits before making this PR] (https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
