### PR TITLE
dev-4.0: In some grc blocks the flags parameter is missing

### DIFF
--- a/blocklib/analog/random_source/random_source.yml
+++ b/blocklib/analog/random_source/random_source.yml
@@ -2,6 +2,7 @@ module: analog
 block: random_source
 label: Random Source
 blocktype: grc
+
 category: '[Core]/Waveform Generators'
 
 typekeys:
@@ -13,6 +14,7 @@ typekeys:
         - ri8
 
 grc:
+    flags: [python]
     templates:
         imports: |-
             from gnuradio import blocks

--- a/blocklib/soapy/hackrf_sink/hackrf_sink.yml
+++ b/blocklib/soapy/hackrf_sink/hackrf_sink.yml
@@ -12,6 +12,7 @@ typekeys:
         # - rf32
 
 grc:
+  flags: [python]
   templates:
     imports: from gnuradio import soapy
     make: |-

--- a/blocklib/soapy/hackrf_source/hackrf_source.yml
+++ b/blocklib/soapy/hackrf_source/hackrf_source.yml
@@ -12,6 +12,7 @@ typekeys:
         # - rf32
 
 grc:
+    flags: [python]
     templates:
         imports: |-
             from gnuradio import soapy

--- a/blocklib/soapy/limesdr_source/limesdr_source.yml
+++ b/blocklib/soapy/limesdr_source/limesdr_source.yml
@@ -12,6 +12,7 @@ typekeys:
         # - rf32
 
 grc:
+    flags: [python]
     templates:
       imports: from gnuradio import soapy
       make: |

--- a/blocklib/soapy/rtlsdr_source/rtlsdr_source.yml
+++ b/blocklib/soapy/rtlsdr_source/rtlsdr_source.yml
@@ -12,6 +12,7 @@ typekeys:
         # - rf32
 
 grc:
+    flags: [python]
     templates:
         imports: |-
             from gnuradio import soapy


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Starting grc reports some errors like

analog_random_source.block.yml           block: error: Value type 'NoneType' for 'flags' not in valid types
soapy_hackrf_sink.block.yml              block: error: Value type 'NoneType' for 'flags' not in valid types
soapy_hackrf_source.block.yml            block: error: Value type 'NoneType' for 'flags' not in valid types
soapy_limesdr_source.block.yml           block: error: Value type 'NoneType' for 'flags' not in valid types
soapy_rtlsdr_source.block.yml            block: error: Value type 'NoneType' for 'flags' not in valid types

This pr adds the missing parameter to the *.yml source files.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Start grc without and with this patch.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
