### PR TITLE
dev-4.0:  suppress empty 'outputs:' statements in yml code

### DIFF
--- a/utils/blockbuilder/templates/blockname.grc.j2
+++ b/utils/blockbuilder/templates/blockname.grc.j2
@@ -86,7 +86,7 @@ parameters:
     hide: 'part'
 
 inputs:
-{% for port in ports -%}{%- if port['direction'] == 'input'%}
+{% for port in ports if port['direction'] == 'input'%}
 -   domain: {{'${impl.domain}' if port['domain'] == 'stream' else port['domain']}}
 {% if type_inst %}
     dtype: ${ type_inst.{{port['type']|grc_type}} }
@@ -97,16 +97,17 @@ inputs:
     {%if 'multiplicity' in port %}multiplicity: {{port['multiplicity']|grc_type(ref=True)}}{% endif %}
     label: {{port['id']}}
     optional: {{ port['optional'] if 'optional' in port else 'false' }}
-{% endif %}{% endfor %}
+{% endfor %}
 -   domain: message
     id: param_update
     label: param
     optional: true
     hide: ${ not showports }
 
+{% for port in ports if port['direction'] == 'output'%}
+{% if loop.first %}
 outputs:
-{% for port in ports -%}
-{% if port['direction'] == 'output'-%}
+{% endif %}
 -   domain: {{'${impl.domain}' if port['domain'] == 'stream' else port['domain']}}
 {% if type_inst %}
     dtype: ${ type_inst.{{port['type']|grc_type}} }
@@ -117,7 +118,6 @@ outputs:
     {%if 'multiplicity' in port %}multiplicity: {{port['multiplicity']|grc_type(ref=True)}}{% endif %}
     label: {{port['id']}}
     optional: {{ port['optional'] if 'optional' in port else 'false' }}
-{% endif -%}
 {% endfor -%}
 
 templates:


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
On grc startup some errors like
audio_alsa_sink.block.yml  block: error: Value type 'NoneType' for 'outputs' not in valid types
are reported.
This pr avoids empty 'outputs:' statements.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Start grc without and after applying this patch.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
