### PR TITLE
utils/blockbuilder: correct vector type for typekeys and raw

### DIFF
--- a/blocklib/blocks/vector_source/vector_source.yml
+++ b/blocklib/blocks/vector_source/vector_source.yml
@@ -17,7 +17,7 @@ typekeys:
 parameters:
 -   id: data
     label: Data
-    dtype: T
+    dtype: typekeys/T
     container: vector
     settable: false
     grc:

--- a/utils/blockbuilder/scripts/filters.py
+++ b/utils/blockbuilder/scripts/filters.py
@@ -72,13 +72,21 @@ def grc_type(input, vec=False, ref=False):
     
     if input in type_lookup:
         x = type_lookup[input][2]
+
     else:
-        x = get_linked_value(input)
         if (ref):
-            x = f'${{{x}}}'
+            if input.startswith('typekeys/'):
+                x = get_linked_value(input)
+                if (vec):
+                    x = f'${{{x}.vec}}'
+                else:
+                    x = f'${{{x}}}'
+            else:
+                x = 'raw'
+        else:
+            x = 'raw'
         
-    if (vec):
-        return f'{x}_vector'
+
 
     return x
 

--- a/utils/blockbuilder/templates/blockname.grc.j2
+++ b/utils/blockbuilder/templates/blockname.grc.j2
@@ -42,6 +42,7 @@ parameters:
     options: [{% for opt in key['options'] %}{{opt|grc_type}}{{"," if not loop.last}} {% endfor %}]
     option_attributes:
         fcn: [{% for opt in key['options'] %}{{macros.typekey_suffix(opt,key['id'],ports)}}{{"," if not loop.last}} {% endfor %}]
+        vec: [{% for opt in key['options'] %}{{opt|grc_type}}_vector{{"," if not loop.last}} {% endfor %}]
     hide: part
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Fixes the grc generation for vector parameters

## Related Issue
Fixes #6201 

## Which blocks/areas does this affect?
Vector source for sure

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

