### PR TITLE
gr-blocks: print correct error message for soundfile sf_open

### DIFF
--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -112,8 +112,16 @@ bool wavfile_sink_impl::open(const char* filename)
     if (d_append) {
         // We are appending to an existing file, be extra careful here.
         sfinfo.format = 0;
+        errno = 0;
         if (!(d_new_fp = sf_open(filename, SFM_RDWR, &sfinfo))) {
-            d_logger->error("sf_open(1) failed: {:s}: {:s}", filename, strerror(errno));
+            if (errno) {
+                d_logger->error(
+                    "sf_open(1) failed: {:s}: {:s}", filename, strerror(errno));
+            } else {
+                d_logger->error(
+                    "sf_open(1) failed: {:s}: {:s}", filename, sf_strerror(NULL));
+            }
+
             return false;
         }
         if (d_h.sample_rate != sfinfo.samplerate || d_h.nchans != sfinfo.channels ||
@@ -204,8 +212,16 @@ bool wavfile_sink_impl::open(const char* filename)
             }
             break;
         }
+        errno = 0;
         if (!(d_new_fp = sf_open(filename, SFM_WRITE, &sfinfo))) {
-            d_logger->error("sf_open(2) failed: {:s}: {:s}", filename, strerror(errno));
+            if (errno) {
+                d_logger->error(
+                    "sf_open(2) failed: {:s}: {:s}", filename, strerror(errno));
+            } else {
+                d_logger->error(
+                    "sf_open(2) failed: {:s}: {:s}", filename, sf_strerror(NULL));
+            }
+
             return false;
         }
     }

--- a/gr-blocks/lib/wavfile_source_impl.cc
+++ b/gr-blocks/lib/wavfile_source_impl.cc
@@ -38,8 +38,13 @@ wavfile_source_impl::wavfile_source_impl(const char* filename, bool repeat)
     SF_INFO sfinfo;
 
     sfinfo.format = 0;
+    errno = 0;
     if (!(d_fp = sf_open(filename, SFM_READ, &sfinfo))) {
-        d_logger->error("sf_open failed: {:s}: {:s}", filename, strerror(errno));
+        if (errno) {
+            d_logger->error("sf_open failed: {:s}: {:s}", filename, strerror(errno));
+        } else {
+            d_logger->error("sf_open failed: {:s}: {:s}", filename, sf_strerror(NULL));
+        }
         throw std::runtime_error("Can't open WAV file.");
     }
 


### PR DESCRIPTION
The wavfile_sink and wavfile_source prints misleading error messages when eg. the existing WAV file is broken.

Description for `errno` error is printed and errors reported directly by `libsndfile` are ignored. The reason to use `errno` is likely because of `libsndfile` returns unhelpful error messages when the error is at the system IO level. This patch combines both approaches to get the best results.

I have manually tested (on my project):
 * to create file in nonexisting directory
 * to open non-wav file as wav

Bot returned expected error description.

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
