### PR TITLE
4.0: meson: move pkgconfig/cmake to lib dir for all modules

### DIFF
--- a/blocklib/analog/lib/meson.build
+++ b/blocklib/analog/lib/meson.build
@@ -32,3 +32,23 @@ gnuradio_blocklib_analog_lib = library('gnuradio-blocklib-analog',
 gnuradio_blocklib_analog_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_analog_lib,
                        dependencies : analog_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'analog')
+cmake.configure_package_config_file(
+  name : 'gnuradio-analog',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-analog',
+             filebase : 'gnuradio-analog',
+             description : 'GNU Radio Analog Module')

--- a/blocklib/audio/lib/meson.build
+++ b/blocklib/audio/lib/meson.build
@@ -20,3 +20,23 @@ gnuradio_blocklib_audio_lib = library('gnuradio-blocklib-audio',
 gnuradio_blocklib_audio_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_audio_lib,
                        dependencies : audio_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'audio')
+cmake.configure_package_config_file(
+  name : 'gnuradio-audio',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-audio',
+             filebase : 'gnuradio-audio',
+             description : 'GNU Radio Audio Module')

--- a/blocklib/blocks/include/gnuradio/blocks/meson.build
+++ b/blocklib/blocks/include/gnuradio/blocks/meson.build
@@ -3,23 +3,3 @@ blocks_headers = [
 ]
 
 install_headers(blocks_headers, subdir : 'gnuradio/blocks')
-
-cmake_conf = configuration_data()
-cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
-cmake_conf.set('module', 'blocks')
-cmake.configure_package_config_file(
-  name : 'gnuradio-blocks',
-  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
-  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
-  configuration : cmake_conf
-)
-
-pkg = import('pkgconfig')
-libs = []     # the library/libraries users need to link against
-h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
-pkg.generate(libraries : libs,
-             subdirs : h,
-             version : meson.project_version(),
-             name : 'libgnuradio-blocks',
-             filebase : 'gnuradio-blocks',
-             description : 'GNU Radio General Purpose Blocks')

--- a/blocklib/blocks/lib/meson.build
+++ b/blocklib/blocks/lib/meson.build
@@ -31,3 +31,23 @@ gnuradio_blocklib_blocks_lib = library('gnuradio-blocklib-blocks',
 gnuradio_blocklib_blocks_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_blocks_lib,
                        dependencies : blocks_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'blocks')
+cmake.configure_package_config_file(
+  name : 'gnuradio-blocks',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-blocks',
+             filebase : 'gnuradio-blocks',
+             description : 'GNU Radio General Purpose Blocks')

--- a/blocklib/fec/lib/meson.build
+++ b/blocklib/fec/lib/meson.build
@@ -18,4 +18,4 @@ pkg.generate(libraries : libs,
              version : meson.project_version(),
              name : 'libgnuradio-fec',
              filebase : 'gnuradio-fec',
-             description : 'GNU Radio FEC Blocks')
+             description : 'GNU Radio FEC Module')

--- a/blocklib/fft/lib/meson.build
+++ b/blocklib/fft/lib/meson.build
@@ -59,4 +59,4 @@ pkg.generate(libraries : libs,
              version : meson.project_version(),
              name : 'libgnuradio-fft',
              filebase : 'gnuradio-fft',
-             description : 'GNU Radio FFT Blocks')
+             description : 'GNU Radio FFT Module')

--- a/blocklib/fileio/lib/meson.build
+++ b/blocklib/fileio/lib/meson.build
@@ -30,3 +30,23 @@ gnuradio_blocklib_fileio_lib = library('gnuradio-blocklib-fileio',
 gnuradio_blocklib_fileio_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_fileio_lib,
                        dependencies : fileio_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'fileio')
+cmake.configure_package_config_file(
+  name : 'gnuradio-fileio',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-fileio',
+             filebase : 'gnuradio-fileio',
+             description : 'GNU Radio FileIO Module')

--- a/blocklib/filter/lib/meson.build
+++ b/blocklib/filter/lib/meson.build
@@ -59,4 +59,4 @@ pkg.generate(libraries : libs,
              version : meson.project_version(),
              name : 'libgnuradio-filter',
              filebase : 'gnuradio-filter',
-             description : 'GNU Radio Filter Blocks')
+             description : 'GNU Radio Filter Module')

--- a/blocklib/math/lib/meson.build
+++ b/blocklib/math/lib/meson.build
@@ -56,4 +56,4 @@ pkg.generate(libraries : libs,
              version : meson.project_version(),
              name : 'libgnuradio-math',
              filebase : 'gnuradio-math',
-             description : 'GNU Radio Math Blocks')
+             description : 'GNU Radio Math Module')

--- a/blocklib/soapy/lib/meson.build
+++ b/blocklib/soapy/lib/meson.build
@@ -18,3 +18,23 @@ gnuradio_blocklib_soapy_lib = library('gnuradio-blocklib-soapy',
 gnuradio_blocklib_soapy_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_soapy_lib,
                        dependencies : soapy_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'soapy')
+cmake.configure_package_config_file(
+  name : 'gnuradio-soapy',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-soapy',
+             filebase : 'gnuradio-soapy',
+             description : 'GNU Radio Soapy Module')

--- a/blocklib/streamops/lib/meson.build
+++ b/blocklib/streamops/lib/meson.build
@@ -36,3 +36,23 @@ gnuradio_blocklib_streamops_lib = library('gnuradio-blocklib-streamops',
 gnuradio_blocklib_streamops_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_streamops_lib,
                        dependencies : streamops_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'streamops')
+cmake.configure_package_config_file(
+  name : 'gnuradio-streamops',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-streamops',
+             filebase : 'gnuradio-streamops',
+             description : 'GNU Radio StreamOps Module')

--- a/blocklib/zeromq/lib/meson.build
+++ b/blocklib/zeromq/lib/meson.build
@@ -14,3 +14,23 @@ gnuradio_blocklib_zeromq_lib = library('gnuradio-blocklib-zeromq',
 gnuradio_blocklib_zeromq_dep = declare_dependency(include_directories : incdir,
 					   link_with : gnuradio_blocklib_zeromq_lib,
                        dependencies : zeromq_deps)
+
+cmake_conf = configuration_data()
+cmake_conf.set('libdir', join_paths(prefix,get_option('libdir')))
+cmake_conf.set('module', 'zeromq')
+cmake.configure_package_config_file(
+  name : 'gnuradio-zeromq',
+  input : join_paths(meson.source_root(),'cmake','Modules','gnuradioConfigModule.cmake.in'),
+  install_dir : get_option('prefix') / get_option('libdir') / 'cmake' / 'gnuradio',
+  configuration : cmake_conf
+)
+
+pkg = import('pkgconfig')
+libs = []     # the library/libraries users need to link against
+h = ['.'] # subdirectories of ${prefix}/${includedir} to add to header path
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : meson.project_version(),
+             name : 'libgnuradio-zeromq',
+             filebase : 'gnuradio-zeromq',
+             description : 'GNU Radio ZeroMQ Module')


### PR DESCRIPTION
This way modules can be referenced out of tree - it was done this way for some but not all modules