### PR TITLE
4.0: soapy: fix up the bindings

### DIFF
--- a/blocklib/soapy/.gitignore
+++ b/blocklib/soapy/.gitignore
@@ -1,5 +1,5 @@
 meson.build
 !include/gnuradio/soapy/meson.build
 !lib/meson.build
-!python/soapy/bindings/meson.build
+!python/gnuradio/soapy/bindings/meson.build
 !test/meson.build

--- a/blocklib/soapy/python/gnuradio/soapy/bindings/meson.build
+++ b/blocklib/soapy/python/gnuradio/soapy/bindings/meson.build
@@ -1,0 +1,2 @@
+soapy_pybind_sources = [files('soapy_types_pybind.cc', 'soapy_common.cc', 'block_pybind.cc')] + soapy_pybind_sources
+soapy_pybind_names = ['soapy_types', 'block'] + soapy_pybind_names

--- a/blocklib/soapy/test/test_soapy.py
+++ b/blocklib/soapy/test/test_soapy.py
@@ -5,12 +5,12 @@ samp_rate = 250000
 src = soapy.source_c('driver=rtlsdr',1)
 src.set_sample_rate(0, samp_rate)
 src.set_gain_mode(0, False)
-src.set_frequency(0, 99500000)
+src.set_frequency(0, 90500000)
 src.set_frequency_correction(0, 0)
-src.set_gain(0, 'TUNER', 20)
+src.set_gain(0, 'TUNER', 40)
 
 hd = streamops.head(100000)
-snk = blocks.null_sink()
+snk = blocks.vector_sink_c()
 
 fg = gr.flowgraph()
 
@@ -19,3 +19,9 @@ fg.connect(hd,0,snk,0)
 
 fg.start()
 fg.wait()
+
+from matplotlib import pyplot as plt
+import numpy as np
+plt.plot(np.real(snk.data()))
+plt.plot(np.imag(snk.data()))
+plt.show()


### PR DESCRIPTION
The test soapy application would not run - this brings the base bindings into the python_bindings file.
