### PR TITLE
4.0: modtool: put default qa test in the block dir

### DIFF
--- a/utils/blockbuilder/templates/blockname.meson.build.j2
+++ b/utils/blockbuilder/templates/blockname.meson.build.j2
@@ -93,5 +93,11 @@ if GR_ENABLE_PYTHON
 
     {{module}}_pybind_sources += gen_srcs[2]
     {{module}}_pybind_names += '{{block}}'
+
+    fs = import('fs')
+    if fs.exists('qa_{{block}}.py')
+        test('qa_{{block}}', py3, args : files('qa_{{block}}.py'), env: TEST_ENV)
+    endif
+    
 endif
 {% endif %}

--- a/utils/modtool/newblock/qa_newblock.py
+++ b/utils/modtool/newblock/qa_newblock.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+#
+# Copyright <COPYRIGHT_YEAR> <COPYRIGHT_AUTHOR>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gnuradio import gr, gr_unittest, blocks, newmod
+
+class test_newblock(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.flowgraph()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_instantiate(self):
+        # If this is a templated block, be sure to add the appropriate suffix
+        op = newmod.newblock()
+
+    def test_give_descriptive_name(self):
+        # Set up a flowgraph, run, validate the results
+        pass
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_newblock)
+


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>


## Description
This puts a default qa file in the block directory and links it into the module testing

## Related Issue
Fixes #6200 

## Which blocks/areas does this affect?
OOT blocks, though it can also be used in tree

## Testing Done
created a new OOT, made a block, and it passed QA (no changes needed)


