### PR TITLE
uhd: rfnoc_graph: Added logging

### DIFF
--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include "gr_uhd_common.h"
+#include <gnuradio/logger.h>
 #include <gnuradio/uhd/rfnoc_block.h>
 #include <gnuradio/uhd/rfnoc_graph.h>
 #include <uhd/rfnoc/mb_controller.hpp>
@@ -30,7 +31,7 @@ public:
     rfnoc_graph_impl(const device_addr_t& dev_addr)
         : _graph(::uhd::rfnoc::rfnoc_graph::make(dev_addr))
     {
-        // nop
+        gr::configure_default_loggers(d_logger, d_debug_logger, "rfnoc_graph");
     }
 
     void connect(const std::string& src_block_id,
@@ -39,6 +40,11 @@ public:
                  const size_t dst_block_port,
                  const bool skip_property_propagation) override
     {
+        d_logger->debug("Connecting {:s}:{:d} -> {:s}:{:d}",
+                        src_block_id,
+                        src_block_port,
+                        dst_block_id,
+                        dst_block_port);
         if (_tx_streamers.count(src_block_id)) {
             if (_rx_streamers.count(dst_block_id)) {
                 throw std::runtime_error("Cannot connect RFNoC streamers directly!");
@@ -203,6 +209,8 @@ private:
     std::mutex _block_ref_mutex;
     std::unordered_map<std::string, size_t> _acqd_block_refs;
     std::unordered_map<std::string, size_t> _max_ref_count;
+
+    gr::logger_ptr d_logger, d_debug_logger;
 };
 
 


### PR DESCRIPTION
- Adds loggers
- Logs RFNoC connections made

## Description

This is part of the effort to improve RFNoC support in GNU Radio.

## Which blocks/areas does this affect?

RFNoC graphs.

## Testing Done

I ran this as part of testing new block controllers.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.