### PR TITLE
uhd: rfnoc: Fix property setting on rfnoc_block

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2020 Ettus Research, A National Instruments Brand.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -77,6 +78,20 @@ public:
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items);
+
+    template <typename T>
+    void set_property(const std::string& name, const T& value, const size_t port = 0)
+    {
+        d_block_ref->set_property<T>(name, value, port);
+    }
+
+    template <typename T>
+    const T get_property(const std::string& name, const size_t port = 0)
+    {
+        return d_block_ref->get_property<T>(name, port);
+    }
+
+    std::vector<std::string> get_property_ids();
 
 private:
     //! Reference to the underlying RFNoC block

--- a/gr-uhd/lib/rfnoc_block.cc
+++ b/gr-uhd/lib/rfnoc_block.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2020 Ettus Research, A National Instruments Brand.
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -31,7 +32,12 @@ rfnoc_block::make_block_ref(rfnoc_graph::sptr graph,
         throw std::runtime_error("Cannot find block!");
     }
 
-    return graph->get_block_ref(block_id, max_ref_count);
+    auto block = graph->get_block_ref(block_id, max_ref_count);
+    if (block) {
+        block->set_properties(block_args, 0);
+    }
+
+    return block;
 }
 
 rfnoc_block::rfnoc_block(::uhd::rfnoc::noc_block_base::sptr block_ref)
@@ -56,6 +62,11 @@ int rfnoc_block::general_work(int /*noutput_items*/,
     // We should never land here
     throw std::runtime_error("Unexpected call to general_work() in an RFNoC block!");
     return 0;
+}
+
+std::vector<std::string> rfnoc_block::get_property_ids()
+{
+    return d_block_ref->get_property_ids();
 }
 
 } /* namespace uhd */


### PR DESCRIPTION
This adds the set_/get_property APIs into rfnoc_block and uses it in the
constructor to provide user settings.

## Testing Done

Tested as part of adding new RFNoC block controllers.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.