### PR TITLE
qtgui: cmake: Align CMake structure with other modules

### DIFF
--- a/gr-qtgui/CMakeLists.txt
+++ b/gr-qtgui/CMakeLists.txt
@@ -12,7 +12,9 @@ include(GrPython)
 
 # Note: gr-qtgui requires Qt5.
 
-find_package(Qt5Widgets QUIET)
+find_package(Qt5 QUIET
+    COMPONENTS Widgets
+)
 set(QT_FOUND ${Qt5Widgets_FOUND})
 
 gr_python_check_module("PyQt5" PyQt5 True PYQT5_FOUND)

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -9,8 +9,7 @@
 # Setup the QT file generations stuff
 ########################################################################
 
-add_library(
-    gnuradio-qtgui
+set(QTGUI_SOURCES
     DisplayPlot.cc
     FrequencyDisplayPlot.cc
     EyeDisplayPlot.cc
@@ -59,15 +58,39 @@ add_library(
     ber_sink_b_impl.cc
     vectordisplayform.cc
     vector_sink_f_impl.cc
-    edit_box_msg_impl.cc)
-target_compile_definitions(gnuradio-qtgui PRIVATE -DQWT_DLL) #setup QWT library linkage
+    edit_box_msg_impl.cc
+)
+
+set(QTGUI_LIBS
+    gnuradio-runtime
+    gnuradio-fft
+    gnuradio-filter
+    Volk::volk
+    qwt::qwt
+    Qt5::Widgets
+)
+
+if(ENABLE_COMMON_PCH)
+    set(PRIVATE_LIBS common-precompiled-headers)
+endif()
+
+
+add_library(
+    gnuradio-qtgui
+    ${QTGUI_SOURCES}
+)
+
+# Set up QWT library linkage:
+target_compile_definitions(gnuradio-qtgui PRIVATE -DQWT_DLL)
 target_include_directories(
     gnuradio-qtgui
     PUBLIC $<INSTALL_INTERFACE:include>
            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(gnuradio-qtgui PUBLIC gnuradio-runtime gnuradio-fft gnuradio-filter
-                                            Volk::volk qwt::qwt Qt5::Widgets)
+target_link_libraries(gnuradio-qtgui
+    PUBLIC ${QTGUI_LIBS}
+    PRIVATE ${PRIVATE_LIBS}
+)
 if(WIN32)
     target_link_libraries(gnuradio-qtgui PUBLIC dwrite)
 endif(WIN32)


### PR DESCRIPTION
This adds two changes to the qtgui CMake:

- The structure of lib/CMakeLists.txt now matches that of other
  in-tree modules. This is so that in the future, we can have optional
  sources, e.g. if we make QtOpenGL an optional dependency, and want to
  add blocks based on its existence.
- We find the Qt5 package with QtWidgets as a COMPONENT, rather than
  directly for Qt5Widgets. This allows adding OPTIONAL_COMPONENTS later
  on.



## Testing Done

built yo


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.