### PR TITLE
digital: Fix buffer overrun in Chunks to Symbols block

### DIFF
--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -142,7 +142,8 @@ int chunks_to_symbols_impl<IN_T, OUT_T>::work(int noutput_items,
             }
 
             // after the last tag, continue working on the remaining items
-            for (; in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items;
+            for (;
+                 in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items / d_D;
                  ++in) {
                 auto key = static_cast<unsigned int>(*in) * d_D;
                 for (unsigned int idx = 0; idx < d_D; ++idx) {

--- a/gr-digital/python/digital/qa_chunks_to_symbols.py
+++ b/gr-digital/python/digital/qa_chunks_to_symbols.py
@@ -100,6 +100,28 @@ class test_chunks_to_symbols(gr_unittest.TestCase):
         actual_result = dst.data()
         self.assertEqual(expected_result, actual_result)
 
+    def test_bf_100d(self):
+        maxval = 48
+        dimensions = 100
+        const = list(range(maxval * dimensions))
+        src_data = [v * 13 % maxval for v in range(maxval)]
+        expected_result = []
+        for data in src_data:
+            for i in range(dimensions):
+                expected_result += [const[data * dimensions + i]]
+
+        self.assertEqual(len(src_data) * dimensions, len(expected_result))
+        src = blocks.vector_source_b(src_data)
+        op = digital.chunks_to_symbols_bf(const, dimensions)
+
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
     def test_ic_003(self):
         const = [1 + 0j, 0 + 1j,
                  -1 + 0j, 0 - 1j]


### PR DESCRIPTION
## Description
The Chunks to Symbols block overruns the input and output buffers when the dimension is greater than 1, because it miscalculates the number of input items. I've fixed that here.

## Related Issue
Fixes #6210.

## Which blocks/areas does this affect?
* Chunks to Symbols

## Testing Done
I tested with a simple flowgraph:

![Screenshot from 2022-10-06 22-41-34](https://user-images.githubusercontent.com/583749/194456752-59d136aa-58b6-49bb-bb99-764475f160b3.png)

I also added a new QA test which exercises the block with dimension 100. This demonstrates a segmentation fault on the main branch, whereas the test succeeds on the fix-c2s-dimension branch.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
