### PR TITLE
blocks: Convert argument to int in Python callbacks

### DIFF
--- a/gr-blocks/grc/blocks_delay.block.yml
+++ b/gr-blocks/grc/blocks_delay.block.yml
@@ -49,7 +49,7 @@ templates:
     imports: from gnuradio import blocks
     make: blocks.delay(${type.size}*${vlen}, ${delay})
     callbacks:
-    - set_dly(${delay})
+    - set_dly(int(${delay}))
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/delay.h>']

--- a/gr-blocks/grc/blocks_exponentiate_const_cci.block.yml
+++ b/gr-blocks/grc/blocks_exponentiate_const_cci.block.yml
@@ -39,7 +39,7 @@ templates:
     imports: from gnuradio import blocks
     make: blocks.exponentiate_const_cci(${exponent}, ${vlen})
     callbacks:
-    - set_exponent(${exponent})
+    - set_exponent(int(${exponent}))
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/exponentiate_const_cci.h>']


### PR DESCRIPTION
## Description
@reald noticed that the parameters of the Delay and Exponentiate Const Int blocks fail to update at runtime if a floating point value is given. The QT GUI Range block defaults to floating point, making it likely to encounter this issue.

Updates fail with the following error:

```
Traceback (most recent call last):
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 204, in changed
    self.notifyChanged(self.rangeType(val))
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 308, in sliderChanged
    self.notifyChanged(self.rangeType(value))
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 140, in notifyChanged
    self.__slot(value)
  File "/home/argilo/prefix_311/src/gnuradio/dealy.py", line 177, in set_delay_s
    self.blocks_delay_0.set_dly(self.delay_s)
TypeError: set_dly(): incompatible function arguments. The following argument types are supported:
    1. (self: gnuradio.blocks.blocks_python.delay, d: int) -> None

Invoked with: <gnuradio.blocks.blocks_python.delay object at 0x7fa2152e2070>, 45.0
```

By converting the argument to `int` in the callback, this problem is avoided.

## Related Issue
Fixes #6107.

## Which blocks/areas does this affect?
* Delay
* Exponentiate Const Int

## Testing Done
I used the following flow graph for testing:

![Screenshot from 2022-10-06 23-23-56](https://user-images.githubusercontent.com/583749/194461359-f74daddf-850d-448c-9a42-b2ecb941aef9.png)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
