### PR TITLE
4.0: streamops: size_adapter block

### DIFF
--- a/blocklib/streamops/size_adapter/qa_size_adapter.py
+++ b/blocklib/streamops/size_adapter/qa_size_adapter.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Josh Morman
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+from gnuradio import gr, gr_unittest, streamops, blocks
+
+
+class test_size_adapter(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_stream_adapter_vector_stream(self):
+        src_len = 1024*100
+        src_data = list(range(src_len))
+        expected_results = src_data
+
+        src = blocks.vector_source_i(src_data)
+        op = streamops.size_adapter()
+        dst = blocks.vector_sink_i(1024)
+
+        self.tb.connect([src, op, dst])
+
+        self.tb.run()
+        self.assertEqual(expected_results, dst.data())
+
+    def test_stream_adapter_stream_vector(self):
+        src_len = 1024*100
+        src_data = list(range(src_len))
+        expected_results = src_data
+
+        src = blocks.vector_source_i(src_data, False, 1024)
+        op = streamops.size_adapter()
+        dst = blocks.vector_sink_i()
+
+        self.tb.connect([src, op, dst])
+
+        self.tb.run()
+        self.assertEqual(expected_results, dst.data())
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_size_adapter)

--- a/blocklib/streamops/size_adapter/size_adapter.yml
+++ b/blocklib/streamops/size_adapter/size_adapter.yml
@@ -1,0 +1,28 @@
+module: streamops
+block: size_adapter
+label: Size Adapter
+blocktype: block
+
+doc:
+    brief: Takes on the itemsize of the input and output ports and does memcpy accordingly
+
+parameters: []
+
+ports:
+-   domain: stream
+    id: in
+    direction: input
+    type: untyped
+    size: "0"
+
+-   domain: stream
+    id: out
+    direction: output
+    type: untyped
+    size: "0"
+
+implementations:
+-   id: cpu
+# -   id: cuda
+
+file_format: 1

--- a/blocklib/streamops/size_adapter/size_adapter_cpu.cc
+++ b/blocklib/streamops/size_adapter/size_adapter_cpu.cc
@@ -1,0 +1,60 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Block Author
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include "size_adapter_cpu.h"
+#include "size_adapter_cpu_gen.h"
+
+namespace gr {
+namespace streamops {
+
+size_adapter_cpu::size_adapter_cpu(block_args args) : INHERITED_CONSTRUCTORS {}
+
+work_return_t size_adapter_cpu::work(work_io& wio)
+{
+    if (!_itemsize_in) {
+        _itemsize_in = wio.inputs()[0].buf().item_size();
+    }
+
+    if (!_itemsize_out) {
+        _itemsize_out = wio.outputs()[0].buf().item_size();
+    }
+
+    auto nin = wio.inputs()[0].n_items;
+    auto nout = wio.outputs()[0].n_items;
+
+    auto in = wio.inputs()[0].items<uint8_t>();
+    auto out = wio.outputs()[0].items<uint8_t>();
+
+    auto min_bytes = std::min(nout * _itemsize_out, nin * _itemsize_in);
+    auto nproduce = min_bytes / _itemsize_out;
+    auto nconsume = min_bytes / _itemsize_in;
+
+    if (nproduce == 0) {
+        return work_return_t::INSUFFICIENT_INPUT_ITEMS;
+    }
+
+    if (nconsume == 0) {
+        return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
+    }
+
+    // This block might be an interpolator or decimator
+    memcpy(out, in, min_bytes);
+
+
+    wio.consume_each(nconsume);
+    wio.produce_each(nproduce);
+
+
+    return work_return_t::OK;
+}
+
+
+} // namespace streamops
+} // namespace gr

--- a/blocklib/streamops/size_adapter/size_adapter_cpu.h
+++ b/blocklib/streamops/size_adapter/size_adapter_cpu.h
@@ -1,0 +1,30 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Block Author
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#pragma once
+
+#include <gnuradio/streamops/size_adapter.h>
+
+namespace gr {
+namespace streamops {
+
+class size_adapter_cpu : public virtual size_adapter
+{
+public:
+    size_adapter_cpu(block_args args);
+    work_return_t work(work_io& wio) override;
+
+private:
+    size_t _itemsize_in = 0;
+    size_t _itemsize_out = 0;
+};
+
+} // namespace streamops
+} // namespace gr


### PR DESCRIPTION
Performs the work of stream_to_vector and vector_to_stream

Signed-off-by: Josh Morman <jmorman@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
The stream_to_vector and vector_to_stream blocks can be handled a bit more generically with the untyped ports

![image](https://user-images.githubusercontent.com/34754695/194636611-26410aaf-25dc-4733-b8bc-26d5ac755fd8.png)

Might be some more things to work out with buffer sizing and such.
The eventual goal is that compatible ports can be directly connected.  This is a placeholder to do that adaption a bit more generically


