### PR TITLE
gr-fec: Remove GSL from public link interface (backport to maint-3.10)

### DIFF
--- a/gr-fec/lib/CMakeLists.txt
+++ b/gr-fec/lib/CMakeLists.txt
@@ -90,7 +90,7 @@ target_link_libraries(
 
 # Only include the LDPC work if we have GSL installed
 if(GSL_FOUND)
-    target_link_libraries(gnuradio-fec PUBLIC GSL::gsl)
+    target_link_libraries(gnuradio-fec PRIVATE GSL::gsl)
     target_sources(
         gnuradio-fec
         PRIVATE ldpc_bit_flip_decoder_impl.cc ldpc_par_mtrx_encoder_impl.cc


### PR DESCRIPTION
Signed-off-by: Vasil Velichkov <vvvelichkov@gmail.com>
(cherry picked from commit ecc6fb86b61f75fb6811c226750cc0350b29f2ff)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6172