### PR TITLE
qtgui: Add missing `#include <stdexcept>` for `std::runtime_error` (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/lib/TimeRasterDisplayPlot.cc
+++ b/gr-qtgui/lib/TimeRasterDisplayPlot.cc
@@ -21,6 +21,7 @@
 #include <qwt_scale_draw.h>
 #include <QColor>
 #include <cmath>
+#include <stdexcept>
 
 #if QWT_VERSION < 0x060100
 #include <qwt_legend_item.h>


### PR DESCRIPTION
Revealed in Windows build using Boost 1.78.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit 51ac1534dc6ef59bd5640c5e3f845a1e6c6d1855)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6176