### PR TITLE
fec: Prevent integer overflow in path metric calculations

### DIFF
--- a/gr-fec/lib/decode_ccsds_27_fb_impl.cc
+++ b/gr-fec/lib/decode_ccsds_27_fb_impl.cc
@@ -66,6 +66,14 @@ int decode_ccsds_27_fb_impl::work(int noutput_items,
                 viterbi_get_output(d_state0, out++);
                 // printf("%li\n", *(out-1), metric);
             }
+
+            // Periodically normalize the path metrics to prevent overflow
+            if (d_count % 65536 == 65535) {
+                long diff = d_state0[0].metric;
+                for (int j = 0; j < 64; j++) {
+                    d_state0[j].metric -= diff;
+                }
+            }
         }
 
         d_count++;

--- a/gr-fec/lib/decode_ccsds_27_fb_impl.h
+++ b/gr-fec/lib/decode_ccsds_27_fb_impl.h
@@ -26,7 +26,7 @@ private:
     struct viterbi_state d_state1[64];
     unsigned char d_viterbi_in[16];
 
-    int d_count;
+    unsigned int d_count;
 
 public:
     decode_ccsds_27_fb_impl();

--- a/gr-fec/lib/viterbi/viterbi.cc
+++ b/gr-fec/lib/viterbi/viterbi.cc
@@ -49,7 +49,7 @@
  */
 #define BUTTERFLY(i, sym)                                         \
     {                                                             \
-        int m0, m1;                                               \
+        long m0, m1;                                              \
                                                                   \
         /* ACS for 0 branch */                                    \
         m0 = state[i].metric + mets[sym];          /* 2*i */      \

--- a/gr-fec/python/fec/qa_ecc_ccsds_27.py
+++ b/gr-fec/python/fec/qa_ecc_ccsds_27.py
@@ -11,6 +11,7 @@
 
 from gnuradio import gr, gr_unittest, blocks
 from gnuradio import fec
+import numpy as np
 
 
 class test_ccsds_27 (gr_unittest.TestCase):
@@ -21,9 +22,9 @@ class test_ccsds_27 (gr_unittest.TestCase):
     def tearDown(self):
         self.tb = None
 
-    def xtest_ccsds_27(self):
-        src_data = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-        expected = (0, 0, 0, 0, 1, 2, 3, 4, 5, 6)
+    def test_ccsds_27(self):
+        src_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        expected = [0, 0, 0, 0, 1, 2, 3, 4, 5, 6]
         src = blocks.vector_source_b(src_data)
         enc = fec.encode_ccsds_27_bb()
         b2f = blocks.char_to_float()
@@ -35,6 +36,20 @@ class test_ccsds_27 (gr_unittest.TestCase):
         self.tb.run()
         dst_data = dst.data()
         self.assertEqual(expected, dst_data)
+
+    def test_ccsds_27_long(self):
+        src_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 100000
+        src = blocks.vector_source_b(src_data)
+        enc = fec.encode_ccsds_27_bb()
+        b2f = blocks.char_to_float()
+        add = blocks.add_const_ff(-0.5)
+        mul = blocks.multiply_const_ff(2.0)
+        dec = fec.decode_ccsds_27_fb()
+        dst = blocks.vector_sink_b()
+        self.tb.connect(src, enc, b2f, add, mul, dec, dst)
+        self.tb.run()
+        dst_data = dst.data()
+        self.assertEqual([0, 0, 0, 0] + src_data[:-4], dst_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
The Decode CCSDS 27 block fails after processing approximately 4.2 million input bits. This happens because Viterbi path metric calculations are done using signed 32-bit integers, even though they are stored in signed 64-bit integers. Switching the calculations to signed 64-bit integers resolves the issue.

## Related Issue
Fixes #5851.

## Which blocks/areas does this affect?
* Viterbi decoder

## Testing Done
I ran @daniestevez's test script (https://destevez.net/2017/07/degradation-bug-in-gnu-radio-decode-ccsds-27/) and also added a QA test which fails without this change and passes with it.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.