### PR TITLE
dev-4.0: grc fails to use alsa_sink block

### DIFF
--- a/utils/blockbuilder/scripts/filters.py
+++ b/utils/blockbuilder/scripts/filters.py
@@ -81,6 +81,9 @@ def grc_type(input, vec=False, ref=False):
                     x = f'${{{x}.vec}}'
                 else:
                     x = f'${{{x}}}'
+            elif input.startswith('parameters/'):
+                x = get_linked_value(input)
+                x = f'${{{x}}}'
             else:
                 x = 'raw'
         else:


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Trying to load an ALSA_SINK in grc fails with

Traceback (most recent call last):
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/gui/MainWindow.py", line 156, in _add_block_to_current_flow_graph
    self.current_flow_graph.add_new_block(key)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/gui/canvas/flowgraph.py", line 165, in add_new_block
    block = self.new_block(key)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/FlowGraph.py", line 328, in new_block
    block = self.parent_platform.make_block(self, block_id, **kwargs)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/platform.py", line 432, in make_block
    return cls(parent, **kwargs)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/gui/canvas/block.py", line 30, in __init__
    super(self.__class__, self).__init__(parent, **n)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/blocks/block.py", line 71, in __init__
    self.sinks = [port_factory(parent=self, **params)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/blocks/block.py", line 71, in <listcomp>
    self.sinks = [port_factory(parent=self, **params)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/platform.py", line 440, in make_port
    return cls(parent, **kwargs)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/gui/canvas/port.py", line 30, in __init__
    super(self.__class__, self).__init__(parent, direction, **n)
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/ports/port.py", line 64, in __init__
    self.multiplicity = multiplicity
  File "/usr/local/gnuradio/lib64/python3.10/site-packages/gnuradio/grc/core/utils/descriptors/evaluated.py", line 62, in __set__
    attribs[self.name] = type(self.default)(value)
ValueError: invalid literal for int() with base 10: 'int'

This is due to e68a3c83d246e02ad6ed163cffa33c663ca3fe92. grc_type now returns always raw for refs that do not start with typekeys. 

https://github.com/gnuradio/gnuradio/blob/adeb26e4cd8ef686f272d2b48069a3f44801cb2f/utils/blockbuilder/scripts/filters.py#L77-L110

This patch returns the correct value for inputs that start with parameters.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
At least alsa_sink block.
## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Start grc
Try to add an alsa_sink to a new or existing flowgraph.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
