### PR TITLE
4.0: gr: install custom_lock header

### DIFF
--- a/gr/include/gnuradio/meson.build
+++ b/gr/include/gnuradio/meson.build
@@ -47,7 +47,8 @@ runtime_headers = [
     'executor.h',
     'constants.h',
     'registry.h',
-    'high_res_timer.h'
+    'high_res_timer.h',
+    'custom_lock.h'
 ]
 
 install_headers(runtime_headers, subdir : 'gnuradio')


### PR DESCRIPTION
was accidentally left off from the list of installed header files