### PR TITLE
uhd: rfnoc: Add property APIs

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
@@ -79,12 +79,80 @@ public:
                      gr_vector_const_void_star& input_items,
                      gr_vector_void_star& output_items);
 
+    /*! Set multiple properties coming from a dictionary
+     *
+     * See the [UHD
+     * manual](https://uhd.readthedocs.io/en/latest/classuhd_1_1rfnoc_1_1node__t.html#abf34d4be8fe7a602b27927194195f1f6)
+     * for details.
+     *
+     * This function allows the client to override the \p instance parameter
+     * for each property key/value pair passed in via the \p props parameter.
+     * If the key consists of the property name, followed by a colon (':') and
+     * then a number, the number following the colon is used to determine
+     * which instance of the property this set pertains to, and the \p
+     * instance parameter is ignored for that property. (Note that if the key
+     * does not have the colon and instance number override syntax, then
+     * \p instance is still used to determine which instance of the property
+     * to set. For example, in the following call:
+     *
+     *     node->set_properties("dog=10,cat:2=5,bird:0=0.5", 1)
+     *
+     * instance 1 of node's 'dog' property is set to 10, the 1 coming from the
+     * instance parameter, instance 2 of the node's 'cat' property is set to
+     * 5 due to the override syntax provided in the string, and instance 0 of
+     * the node's 'bird' property is set to 0.5 due to its override.
+     *
+     * If the instance override is malformed, that is, there is no
+     * number following the colon, or the number cannot be parsed as an
+     * integer, a value_error is thrown.
+     *
+     * If a key in \p props is not a valid property of this block, a warning is
+     * logged, but no error is raised.
+     */
+    void set_properties(const ::uhd::device_addr_t& props, const size_t instance = 0)
+    {
+        d_block_ref->set_properties(props, instance);
+    }
+
+    /*! Set a specific user property that belongs to this block.
+     *
+     * Setting a user property will trigger a property resolution. This means
+     * that changing this block can have effects on other RFNoC blocks or nodes
+     * (like streamers).
+     *
+     * If the property does not exist, or if the property can be determined to
+     * be of a different type than \p prop_data_t due to the usage of runtime
+     * type information (RTTI), a ::uhd::lookup_error is thrown.
+     *
+     * \tparam prop_data_t The data type of the property
+     * \param id The identifier of the property to write. To find out which
+     *           values of \p id are valid, call get_property_ids()
+     * \param instance The instance number of this property
+     * \param val The new value of the property.
+     */
     template <typename T>
     void set_property(const std::string& name, const T& value, const size_t port = 0)
     {
         d_block_ref->set_property<T>(name, value, port);
     }
 
+    /*! Get the value of a specific block argument. \p The type of an argument
+     *  must be known at compile time.
+     *
+     * If the property does not exist, or if the property can be determined to
+     * be of a different type than \p prop_data_t due to the usage of runtime
+     * type information (RTTI), a ::uhd::lookup_error is thrown.
+     *
+     * Note: Despite this being a "getter", this function is not declared const.
+     * This is because internally, it can resolve properties, which may cause
+     * changes within the object.
+     *
+     * \tparam prop_data_t The data type of the property
+     * \param id The identifier of the property to write.
+     * \param instance The instance number of this property
+     * \return The value of the property.
+     * \throws uhd::lookup_error if the property can't be found.
+     */
     template <typename T>
     const T get_property(const std::string& name, const size_t port = 0)
     {

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_block.h
@@ -77,7 +77,7 @@ public:
     int general_work(int noutput_items,
                      gr_vector_int& ninput_items,
                      gr_vector_const_void_star& input_items,
-                     gr_vector_void_star& output_items);
+                     gr_vector_void_star& output_items) override;
 
     /*! Set multiple properties coming from a dictionary
      *

--- a/gr-uhd/python/uhd/bindings/docstrings/rfnoc_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/rfnoc_block_pydoc_template.h
@@ -24,4 +24,4 @@ static const char* __doc_gr_uhd_rfnoc_block_make_block_ref = R"doc()doc";
 static const char* __doc_gr_uhd_rfnoc_block_get_unique_id = R"doc()doc";
 
 
-static const char* __doc_gr_uhd_rfnoc_block_general_work = R"doc()doc";
+static const char* __doc_gr_uhd_rfnoc_block_set_properties = R"doc()doc";

--- a/gr-uhd/python/uhd/bindings/docstrings/rfnoc_block_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/rfnoc_block_pydoc_template.h
@@ -25,3 +25,9 @@ static const char* __doc_gr_uhd_rfnoc_block_get_unique_id = R"doc()doc";
 
 
 static const char* __doc_gr_uhd_rfnoc_block_set_properties = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_block_set_property = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_block_get_property = R"doc()doc";

--- a/gr-uhd/python/uhd/bindings/rfnoc_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_block_python.cc
@@ -4,7 +4,6 @@
  * This file is part of GNU Radio
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
- *
  */
 
 /***********************************************************************************/
@@ -14,7 +13,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rfnoc_block.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2d5f9f02a6ee17b513f4378f9d9a7730)                     */
+/* BINDTOOL_HEADER_FILE_HASH(d4b0fa51a20eefe3df893fb2a20b0139)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -51,10 +50,156 @@ void bind_rfnoc_block(py::module& m)
         .def("get_unique_id", &rfnoc_block::get_unique_id, D(rfnoc_block, get_unique_id))
 
 
-        .def("set_properties", &rfnoc_block::set_properties,
-                py::arg("props"),
-                py::arg("instance") = 0,
-                D(rfnoc_block, set_properties))
+        .def("set_properties",
+             &rfnoc_block::set_properties,
+             py::arg("props"),
+             py::arg("instance") = 0,
+             D(rfnoc_block, set_properties))
+
+
+        // clang-format off
+        .def(
+            "set_property",
+            [](rfnoc_block& self,
+               const std::string& name,
+               py::object& value,
+               const size_t port,
+               const std::string& type_hint) {
+
+                // Note: set_property<> is a templated function in C++. For
+                // maximum Pythonicity, we will try and keep things simple by
+                // faking the templated nature of set_property.
+                // This means we don't know what type 'value' is, and we have to
+                // take a guess -- unless the user was kind enough to give us a
+                // type hint.
+                std::string type = type_hint;
+
+                // First, we see if a type hint was provided that we understand,
+                // but that C++ does not understand, and sanitize accordingly.
+#define _SANITIZE_TYPE(typename, sanitized_tn) \
+                if (type == #typename) { \
+                    type = #sanitized_tn; \
+                }
+                _SANITIZE_TYPE(string, std::string)
+
+                // If no type hint was provided, we infer the type by trying to
+                // cast the py::object to various types.
+#define _INFER_TYPE(typename) \
+                if (type.empty()) { \
+                    try { \
+                        typename __val = value.cast<typename>(); \
+                        type = #typename; \
+                    } catch (const py::cast_error&) { \
+                        /* pass */ \
+                    } \
+                }
+                _INFER_TYPE(int)
+                _INFER_TYPE(double)
+                _INFER_TYPE(std::string)
+                _INFER_TYPE(bool)
+
+                // At this point, 'type' must be set or we throw an exception
+                // (see the first 'if' clause). If it's set, we cast 'value' to
+                // the desired type and call set_property<>() in C++-land.
+#define _SET_PROP_WITH_TYPE(typename) \
+                else if (type == #typename) { \
+                    self.set_property<typename>(name, value.cast<typename>(), port); \
+                }
+                if (type.empty()) {
+                    throw std::runtime_error("rfnoc_block::set_property(): Could not infer "
+                                             "property type when setting property " +
+                                             name + " on port " + std::to_string(port) + "!");
+                }
+                _SET_PROP_WITH_TYPE(bool)
+                _SET_PROP_WITH_TYPE(int)
+                _SET_PROP_WITH_TYPE(float)
+                _SET_PROP_WITH_TYPE(double)
+                _SET_PROP_WITH_TYPE(uint64_t)
+                _SET_PROP_WITH_TYPE(uint32_t)
+                _SET_PROP_WITH_TYPE(std::string)
+                else {
+                    throw std::runtime_error(
+                        "rfnoc_block::set_property(): Invalid property type " + type + "!");
+                }
+
+                return;
+            },
+            py::arg("name"),
+            py::arg("value"),
+            py::arg("port") = 0,
+            py::arg("typename") = "",
+            D(rfnoc_block, set_property))
+
+
+        .def(
+            "get_property",
+            [](rfnoc_block& self,
+               const std::string& name,
+               const size_t port,
+               const std::string& type_hint) -> py::object {
+                // Note: get_property<> is a templated function in C++. For
+                // maximum Pythonicity, we will try and keep things simple by
+                // faking the templated nature of set_property.
+                // This means we don't know what type 'value' is, and we have to
+                // take a guess -- unless the user was kind enough to give us a
+                // type hint.
+                std::string type = type_hint;
+
+                // First, we see if a type hint was provided that we understand,
+                // but that C++ does not understand, and sanitize accordingly.
+#define _SANITIZE_TYPE(typename, sanitized_tn) \
+                if (type == #typename) { \
+                    type = #sanitized_tn; \
+                }
+                _SANITIZE_TYPE(string, std::string)
+
+
+                if (!type.empty()) {
+                    // Here, we first use the type_hint on get_property<>, before we
+                    // try and infer.
+#define _GET_PROP_WITH_TYPE(typename) \
+                    if (type == #typename) { \
+                        return py::cast(self.get_property<typename>(name, port)); \
+                    }
+                    _GET_PROP_WITH_TYPE(bool)
+                    _GET_PROP_WITH_TYPE(int)
+                    _GET_PROP_WITH_TYPE(float)
+                    _GET_PROP_WITH_TYPE(double)
+                    _GET_PROP_WITH_TYPE(uint64_t)
+                    _GET_PROP_WITH_TYPE(uint32_t)
+                    _GET_PROP_WITH_TYPE(std::string)
+                    // If type wasn't empty, but we reach this line, that means
+                    // the user gave us a type hint we can't handle.
+                    throw std::runtime_error(
+                        "rfnoc_block::get_property(): Invalid property type " + type + "!");
+                }
+
+                // If we're here, that means the user didn't give us a type hint
+                // and we need to guess the type using RTTI.
+#define _RETURN_INFERRED_TYPE(typename) \
+                try { \
+                    typename value = self.get_property<typename>(name, port); \
+                    return py::cast(value); \
+                } catch (const uhd::type_error&) { \
+                    /* pass */ \
+                }
+                _RETURN_INFERRED_TYPE(double)
+                _RETURN_INFERRED_TYPE(int)
+                _RETURN_INFERRED_TYPE(bool)
+
+                // If none of these worked, we give up.
+                throw std::runtime_error("rfnoc_block::get_property(): Could not infer "
+                                         "property type when setting property " +
+                                         name + " on port " + std::to_string(port) + "!");
+
+                return py::none{}; // For some linters
+            },
+            py::arg("name"),
+            py::arg("port") = 0,
+            py::arg("typename") = "",
+            D(rfnoc_block, set_property))
+        // clang-format on
+
 
         ;
 }

--- a/gr-uhd/python/uhd/bindings/rfnoc_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_block_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rfnoc_block.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a090f45dcc320d7e1f19f63c585e5aa0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(2d5f9f02a6ee17b513f4378f9d9a7730)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -51,13 +51,10 @@ void bind_rfnoc_block(py::module& m)
         .def("get_unique_id", &rfnoc_block::get_unique_id, D(rfnoc_block, get_unique_id))
 
 
-        .def("general_work",
-             &rfnoc_block::general_work,
-             py::arg("noutput_items"),
-             py::arg("ninput_items"),
-             py::arg("input_items"),
-             py::arg("output_items"),
-             D(rfnoc_block, general_work))
+        .def("set_properties", &rfnoc_block::set_properties,
+                py::arg("props"),
+                py::arg("instance") = 0,
+                D(rfnoc_block, set_properties))
 
         ;
 }


### PR DESCRIPTION
```
Changes:

53f049110 (Martin Braun, 27 hours ago)
   uhd: rfnoc: Bind set/get_property APIs

   This adds gr::uhd::rfnoc_block::set_property and get_property to the Python
   API.

   The tricky bit is that these are templated functions. The Python versions
   therefore receive an optional, fourth argument 'type_hint' which loosely
   corresponds to the template argument in C++.

   If there is no type hint, we try and guess the correct type based on what
   came in from Python. However, that can be ambiguous (e.g., Python's integer
   could be an int, size_t, long long, uint32_t or whatever in C++). For these
   cases, we allow a string-based representation of the type.

   Signed-off-by: Martin Braun <martin.braun@ettus.com>

fc94efecc (Martin Braun, 4 days ago)
   uhd: rfnoc: Add set_properties to rfnoc_block

   This exposes uhd::rfnoc::node_t::set_properties() into GNU Radio space. It
   allows setting properties via string-based dictionary (string keys, string
   values).

   This commit also removes general_work() from the Python bindings, which was
   exposed accidentally via bindtool and should not be called from Python (it
   only throws an exception anyway).

   Signed-off-by: Martin Braun <martin.braun@ettus.com>
```


## Testing Done

Tested this with various blocks and types.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.