### PR TITLE
uhd: rfnoc: Improve settings for streamers

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
@@ -12,7 +12,7 @@ templates:
             cpu_format="${ output_type.type }",
             otw_format="${ otw.type }",
             channels=[],
-            args="",
+            args=${ args },
         ),
         1,
         True
@@ -23,6 +23,10 @@ parameters:
   label: Number of Channels
   dtype: int
   default: 1
+  hide: part
+- id: args
+  label: Args
+  dtype: string
   hide: part
 - id: otw
   label: Wire Format

--- a/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
@@ -14,7 +14,7 @@ templates:
             channels=[],
             args=${ args },
         ),
-        1,
+        ${ vlen },
         True
     )
 
@@ -28,21 +28,26 @@ parameters:
   label: Args
   dtype: string
   hide: part
+- id: vlen
+  label: Vector Length
+  dtype: int
+  default: 1
+  hide: part
 - id: otw
   label: Wire Format
   dtype: enum
-  options: ['', sc16]
-  option_labels: [Automatic, Complex int16]
+  options: ['', sc16, s8]
+  option_labels: [Automatic, Complex int16, Byte]
   option_attributes:
-    type: ['', sc16]
+    type: ['', sc16, s8]
   hide: part
 - id: output_type
   label: Output Type
   dtype: enum
-  options: [fc32, sc16]
-  option_labels: [Complex float32, Complex int16]
+  options: [fc32, sc16, s8]
+  option_labels: [Complex float32, Complex int16, Byte]
   option_attributes:
-    type: [fc32, sc16]
+    type: [fc32, sc16, s8]
   hide: part
 
 asserts:
@@ -57,5 +62,6 @@ outputs:
 - domain: stream
   dtype: ${ output_type.type }
   multiplicity: ${ num_chans }
+  vlen: ${ vlen }
 
 file_format: 1

--- a/gr-uhd/grc/uhd_rfnoc_tx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_tx_streamer.block.yml
@@ -14,7 +14,7 @@ templates:
             channels=[],
             args=${ args },
         ),
-        1
+        ${ vlen }
     )
 
 parameters:
@@ -26,6 +26,11 @@ parameters:
 - id: args
   label: Args
   dtype: string
+  hide: part
+- id: vlen
+  label: Vector Length
+  dtype: int
+  default: 1
   hide: part
 - id: input_type
   label: Input Type
@@ -48,6 +53,7 @@ inputs:
 - domain: stream
   dtype: ${ input_type.type }
   multiplicity: ${ num_chans }
+  vlen: ${ vlen }
 
 outputs:
 - domain: rfnoc

--- a/gr-uhd/grc/uhd_rfnoc_tx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_tx_streamer.block.yml
@@ -12,7 +12,7 @@ templates:
             cpu_format="${ input_type.type }",
             otw_format="${ otw.type }",
             channels=[],
-            args="",
+            args=${ args },
         ),
         1
     )
@@ -22,6 +22,10 @@ parameters:
   label: Number of Channels
   dtype: int
   default: 1
+  hide: part
+- id: args
+  label: Args
+  dtype: string
   hide: part
 - id: input_type
   label: Input Type


### PR DESCRIPTION
```
0dd955cbc (Martin Braun, 6 days ago)
   uhd: rfnoc: Enable vlen and types for streamers

   - RX and TX streamers can now set vector lengths
   - The RX streamer GRC binding gets a 'byte' type

0e42fe349 (Martin Braun, 6 days ago)
   uhd: rfnoc: Allow streamers to consume stream_args

   The GRC bindings for the TX/RX streamers now allow setting stream args.
```


## Description

The streamers were not able to handle all the RFNoC blocks without this
change:

- Adding vector lengths is important for when RFNoC blocks go straight
  into another GR block that expects vectors, e.g., blocks consuming FFT
  output.
- The 'byte' type is necessary to allow data coming from the fosphor
  block, which produces 8-bit integer data
- The stream args are necessary to pass additional parameters to UHD
  streamers, e.g., for raw UDP, or for spp values.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.