### PR TITLE
runtime: fix type replication in py_io_signature

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -79,7 +79,7 @@ class py_io_signature(object):
             return ()
         if nports <= ntypes:
             return self.__types[:nports]
-        return self.__types + [self.__types[-1]] * (nports - ntypes)
+        return self.__types + (self.__types[-1],) * (nports - ntypes)
 
     def __iter__(self):
         """


### PR DESCRIPTION
## Description
Original version of _py_io_signature.port_types()_ method concatenates tuple with a list - and that fails in modern Python. This PR makes sure everything in that operation is a tuple, so it works correctly.

## Related Issue
Fixes #6243

## Which blocks/areas does this affect?
From what I see, respective part of original code was unusable and always failed (though, perhaps it worked in Python 2? I'm not sure about that...). This patch should have no effect on current blocks or flowgraphs which were running correctly without the patch applied.

## Testing Done
With a patch applied, when py_io_signature is used in a way described in #6243, flowgraph now runs correctly instead of throwing `TypeError: can only concatenate tuple (not "list") to tuple` Python exception. Verified to work with a custom OOT block locally.

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
