### PR TITLE
blocks: Allow for floating point error in moving average test

### DIFF
--- a/gr-blocks/python/blocks/qa_moving_average.py
+++ b/gr-blocks/python/blocks/qa_moving_average.py
@@ -147,7 +147,7 @@ class test_moving_average(gr_unittest.TestCase):
         ref_data = ref_dst.data()
 
         # make sure result is close to zero
-        self.assertEqual(dut_data, ref_data)
+        self.assertListAlmostEqual(dut_data, ref_data, tol=3)
 
     def test_complex_scalar(self):
         tb = self.tb


### PR DESCRIPTION
## Description
As noted in #5973, `qa_moving_average` fails on i686 with the following error:

```
======================================================================
FAIL: test_vector_complex (__main__.test_moving_average)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/gnuradio-3.10.3.0/gr-blocks/python/blocks/qa_moving_average.py", line 150, in test_vector_complex
    self.assertEqual(dut_data, ref_data)
AssertionError: Lists differ: [(705[443 chars].3553466796875+406.9476318359375j), (208.45861[1463 chars]25j)] != [(705[443 chars].35531616210938+406.9476318359375j), (208.4586[1474 chars]75j)]
First differing element 11:
(207.3553466796875+406.9476318359375j)
(207.35531616210938+406.9476318359375j)
Diff is 4376 characters long. Set self.maxDiff to None to see it.
----------------------------------------------------------------------
```

This happens because the `test_vector_complex` test requires the scalar and vector versions of the Moving Average block to produce identical results. This is unreasonable, because moving average calculations are subject to floating point error. The Moving Average block uses separate implementations (`std::accumulate` vs. VOLK) for the scalar and vector cases, so it's expected that the results may differ slightly.

A relatively large tolerance of 3 decimal places is required because the input values are in the range -2^10 to +2^10.

## Related Issue
* #5973

## Which blocks/areas does this affect?
CI for the Moving Average block.

## Testing Done
I ran the updated test an on a 32-bit Debian VM and confirmed that it executed without errors.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
