### PR TITLE
fft: Increase tolerance in qa_window test

### DIFF
--- a/gr-fft/python/fft/qa_window.py
+++ b/gr-fft/python/fft/qa_window.py
@@ -35,7 +35,7 @@ class test_window(gr_unittest.TestCase):
             21,
             normalize=True)
         power = numpy.sum([x * x for x in win]) / len(win)
-        self.assertAlmostEqual(power, 1.0)
+        self.assertAlmostEqual(power, 1.0, places=6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
As noted in #5973, `qa_window` fails on i686 with the following error:

```
======================================================================
FAIL: test_normwin (__main__.test_window)
Verify window normalization
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/gnuradio-3.10.3.0/gr-fft/python/fft/qa_window.py", line 38, in test_normwin
    self.assertAlmostEqual(power, 1.0)
AssertionError: 0.9999999411865508 != 1.0 within 7 places (5.8813449221872816e-08 difference)
----------------------------------------------------------------------
```

This happens because the tolerance is too tight; `assertAlmostEqual` defaults to 7 decimal places, but the window calculations are done with single precision floats, which are only accurate to 6 significant figures. I've increased the tolerance here.

## Related Issue
* #5973

## Which blocks/areas does this affect?
CI for `fft.window`.

## Testing Done
I ran the updated test an on a 32-bit Debian VM and confirmed that it executed without errors.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
