### PR TITLE
digital: Fix constellation soft decision LUT generation & tests

### DIFF
--- a/gr-digital/lib/constellation.cc
+++ b/gr-digital/lib/constellation.cc
@@ -245,9 +245,9 @@ void constellation::gen_soft_dec_lut(int precision, float npwr)
     float maxd = 1.0f;
     float step = (2.0f * maxd) / (d_lut_scale - 1);
     float y = -maxd;
-    while (y < maxd + step) {
+    while (y < maxd + (step / 2)) {
         float x = -maxd;
-        while (x < maxd + step) {
+        while (x < maxd + (step / 2)) {
             gr_complex pt = gr_complex(x, y);
             d_soft_dec_lut.push_back(calc_soft_dec(pt, npwr));
             x += step;

--- a/gr-digital/python/digital/qa_constellation.py
+++ b/gr-digital/python/digital/qa_constellation.py
@@ -117,10 +117,10 @@ difficult_constellation_info = (
 def slicer(x):
     ret = []
     for xi in x:
-        if(xi < 0):
+        if xi < 0:
             ret.append(0.0)
-    else:
-        ret.append(1.0)
+        else:
+            ret.append(1.0)
     return ret
 
 


### PR DESCRIPTION
## Description
As noted in #5973, `qa_constellation` fails on i686 with the following errors:

```
======================================================================
FAIL: test_soft_qam16_calc (__main__.test_constellation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/gnuradio-3.10.3.0/gr-digital/python/digital/qa_constellation.py", line 379, in test_soft_qam16_calc
    self.assertFloatTuplesAlmostEqual(y_cpp_raw_calc, y_cpp_table, 0)
  File "/builddir/gnuradio-3.10.3.0/gnuradio-runtime/python/gnuradio/gr_unittest.py", line 96, in assertFloatTuplesAlmostEqual
    self.assertEqual(len(a), len(b))
AssertionError: 17 != 25
======================================================================
FAIL: test_soft_qpsk_calc (__main__.test_constellation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/gnuradio-3.10.3.0/gr-digital/python/digital/qa_constellation.py", line 331, in test_soft_qpsk_calc
    self.assertEqual(y_cpp_raw_calc, y_cpp_table)
AssertionError: Lists differ: [0.0,[16 chars]1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1[13 chars] 1.0] != [0.0,[16 chars]1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1[28 chars] 1.0]
First differing element 5:
1.0
0.0
Second list contains 3 additional elements.
First extra element 17:
0.0
  [0.0,
   0.0,
   1.0,
   0.0,
   1.0,
+  0.0,
   1.0,
+  0.0,
+  1.0,
+  0.0,
+  1.0,
+  0.0,
   0.0,
   1.0,
   1.0,
   0.0,
-  0.0,
   1.0,
   0.0,
-  1.0,
-  1.0,
   0.0,
   1.0]
----------------------------------------------------------------------
```
These errors occur because `constellation::gen_soft_dec_lut` is in fact broken: the exit conditions in its `while` loops depend on floating point calculation being exact, and when error creeps in an extra row & column may be added to the resulting lookup table, causing lookups to fail. I've fixed this by adding half a step to the end condition instead of a full step; this should allow a floating point error of plus or minus a half step.

In addition, I noticed that the `slicer` function in `qa_constellation` is broken; a misplaced `else` means that it deletes all the `1.0` values that should be in the result, and instead always puts a single `1.0` at the end of the list.

## Related Issue
* #5973

## Which blocks/areas does this affect?
`gr::digital::constellation::soft_decision_maker`, when using the lookup table mode.

## Testing Done
I verified that the CI test runs correctly on both 32-bit and 64-bit machines after these changes.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
