### PR TITLE
blocks: Remove duplicate test case

### DIFF
--- a/gr-blocks/python/blocks/qa_repack_bits_bb.py
+++ b/gr-blocks/python/blocks/qa_repack_bits_bb.py
@@ -63,19 +63,6 @@ class qa_repack_bits_bb (gr_unittest.TestCase):
         self.tb.run()
         self.assertEqual(sink.data(), expected_data)
 
-    def test_002_three(self):
-        """ 8 -> 3 """
-        src_data = [0b11111101, 0b11111111, 0b11111111]
-        expected_data = [0b101, ] + [0b111, ] * 7
-        k = 8
-        l = 3
-        src = blocks.vector_source_b(src_data, False, 1)
-        repack = blocks.repack_bits_bb(k, l)
-        sink = blocks.vector_sink_b()
-        self.tb.connect(src, repack, sink)
-        self.tb.run()
-        self.assertEqual(sink.data(), expected_data)
-
     def test_002_three_msb(self):
         """ 8 -> 3 """
         src_data = [0b11111101, 0b11111111, 0b11111111]


### PR DESCRIPTION
## Description
There are two copies of the `test_002_three` test in qa_repack_bits_bb.py. It looks like the second copy was a copy-paste error made while adding MSB tests in ccebbe0a028158df250aae02c1dd893dd1551dda.

Here I have removed the duplicate test.

## Which blocks/areas does this affect?
Removing this test should have no effect, since it overwrites an identical test.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
