### PR TITLE
blocks: Fix typo in test name

### DIFF
--- a/gr-blocks/python/blocks/qa_mute.py
+++ b/gr-blocks/python/blocks/qa_mute.py
@@ -68,7 +68,7 @@ class test_mute(gr_unittest.TestCase):
         op = blocks.mute_cc(False)
         self.help_cc((src_data,), expected_result, op)
 
-    def test_unmute_cc(self):
+    def test_mute_cc(self):
         src_data = [1 + 5j, 2 + 5j, 3 + 5j, 4 + 5j, 5 + 5j]
         expected_result = [0 + 0j, 0 + 0j, 0 + 0j, 0 + 0j, 0 + 0j]
         op = blocks.mute_cc(True)


### PR DESCRIPTION
## Description
The `mute_cc(True)` test in qa_mute.py has a typo in its name. Because it has the same name as the test above, it overwrites that test and prevents it from executing.

Here I've corrected the typo.

## Which blocks/areas does this affect?
QA tests for the Mute block.

## Testing Done
I verified that all four tests execute after making this change. (Before the change, only 3 tests ran.)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
