### PR TITLE
digital: Rename test to avoid duplicate name

### DIFF
--- a/gr-digital/python/digital/qa_ofdm_frame_equalizer_vcvc.py
+++ b/gr-digital/python/digital/qa_ofdm_frame_equalizer_vcvc.py
@@ -340,7 +340,7 @@ class qa_ofdm_frame_equalizer_vcvc (gr_unittest.TestCase):
         self.assertEqual(len(packets), 1)
         self.assertEqual(len(packets[0]), len(tx_data))
 
-    def test_002_static_wo_tags(self):
+    def test_002_static_wo_tags_2(self):
         fft_len = 8
         #           4   5  6  7   0  1  2   3
         tx_data = [-1, -1, 1, 2, -1, 3, 0, -1,  # 0

--- a/gr-digital/python/digital/qa_ofdm_frame_equalizer_vcvc.py
+++ b/gr-digital/python/digital/qa_ofdm_frame_equalizer_vcvc.py
@@ -219,13 +219,6 @@ class qa_ofdm_frame_equalizer_vcvc (gr_unittest.TestCase):
             0, 0, 1j, 1j, 0, 1j, 1j, 0,  # Go crazy here!
             0, 0, 1j, 1j, 0, 1j, 1j, 0
         ]
-        channel = [
-            0, 0, 1, 1, 0, 1, 1, 0,
-            # These coefficients will be rotated slightly (but less than \pi/2)
-            0, 0, 1, 1, 0, 1, 1, 0,
-            0, 0, 1j, 1j, 0, 1j, 1j, 0,  # Go crazy here!
-            0, 0, 1j, 1j, 0, 1j, 1j, 0
-        ]
         for idx in range(fft_len, 2 * fft_len):
             channel[idx] = channel[idx - fft_len] * \
                 numpy.exp(1j * .1 * numpy.pi * (numpy.random.rand() - .5))


### PR DESCRIPTION
## Description
qa_ofdm_frame_equalizer_vcvc.py has two tests named `test_002_static_wo_tags`. The second overwrites the first, preventing it from executing. The duplicate name was introduced in bb01988e75d50d82cbb44c1a49c86c1d08f05665, but that was a large merge commit so I'm not sure exactly what the test was meant to do. But it's different from the other test, so I think both should be kept. I've simply renamed the second test here.

**Edit:** I also removed a duplicate variable definition that @willcode noticed.

## Which blocks/areas does this affect?
QA tests for the OFDM Frame Equalizer block.

## Testing Done
I verified that all 8 tests pass. (Prior to this change, only 7 out of 8 tests executed.)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
