### PR TITLE
fec: Fix LDPC output size calculation

### DIFF
--- a/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_gen_mtrx_encoder_impl.cc
@@ -55,7 +55,7 @@ bool ldpc_gen_mtrx_encoder_impl::set_frame_size(unsigned int frame_size)
 
     d_frame_size = frame_size;
 
-    d_output_size = static_cast<int>(d_rate * d_frame_size);
+    d_output_size = static_cast<int>(round(d_rate * d_frame_size));
 
     return ret;
 }

--- a/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
+++ b/gr-fec/lib/ldpc_par_mtrx_encoder_impl.cc
@@ -75,7 +75,7 @@ bool ldpc_par_mtrx_encoder_impl::set_frame_size(unsigned int frame_size)
 
     d_frame_size = frame_size;
 
-    d_output_size = static_cast<int>(d_rate * d_frame_size);
+    d_output_size = static_cast<int>(round(d_rate * d_frame_size));
 
     return ret;
 }


### PR DESCRIPTION
## Description
As noted in #989 and #5973, `qa_fecapi_ldpc` fails on i686 systems. This happens because the output size of the LDPC encoder is miscalculated. The frame size is multiplied by the code rate in floating point, and the result is cast to an integer without rounding. As a result, the output size may be one too small.

## Related Issue
Fixes #989.

## Which blocks/areas does this affect?
* LDPC Generator Matrix
* LDPC Parity Check Matrix

## Testing Done
I verified that the QA tests pass on i686 and x86_64.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.