### PR TITLE
fec: Remove duplicate test from qa_fecapi_ldpc

### DIFF
--- a/gr-fec/python/fec/qa_fecapi_ldpc.py
+++ b/gr-fec/python/fec/qa_fecapi_ldpc.py
@@ -289,25 +289,6 @@ class test_fecapi_ldpc(gr_unittest.TestCase):
                 threading=threading,
                 puncpat="11"))
 
-    def test_parallelism2_00(self):
-        filename = LDPC_ALIST_DIR + "n_0100_k_0027_gap_04.alist"
-        gap = 4
-        dims = 5
-        LDPC_matrix_object = fec.ldpc_H_matrix(filename, gap)
-        k = LDPC_matrix_object.k()
-        dims1 = 16
-        dims2 = 16
-        enc = list(map((lambda b: list(map((lambda a: fec.ldpc_par_mtrx_encoder.make_H(
-            LDPC_matrix_object)), list(range(0, dims1))))), list(range(0, dims2))))
-        threading = 'capillary'
-
-        self.assertRaises(
-            AttributeError,
-            lambda: extended_encoder(
-                enc,
-                threading=threading,
-                puncpat="11"))
-
     def test_parallelism2_01(self):
         filename = LDPC_ALIST_DIR + "n_0100_k_0027_gap_04.alist"
         gap = 4


### PR DESCRIPTION
## Description
qa_fecapi_ldpc.py has two identical copies of the `test_parallelism2_00` test. The tests have been identical since they were created in bbaa0294e50f2aab02b6413f7e2f17a23fca81b2, so I suspect this is a copy & paste error. I've deleted the second test here.

## Which blocks/areas does this affect?
QA for LDPC blocks.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
