### PR TITLE
fec: Fix LDPC G matrix implementation & tests

### DIFF
--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -267,7 +267,6 @@ ldpc_G_matrix_impl::~ldpc_G_matrix_impl()
 {
     // Call the gsl_matrix_free function to free memory.
     gsl_matrix_free(d_G_transp_ptr);
-    gsl_matrix_free(d_H_obj);
 }
 } /* namespace code */
 } /* namespace fec */

--- a/gr-fec/lib/ldpc_G_matrix_impl.h
+++ b/gr-fec/lib/ldpc_G_matrix_impl.h
@@ -49,8 +49,6 @@ private:
     // GSL matrix structure for transpose of G
     gsl_matrix* d_G_transp_ptr;
 
-    gsl_matrix* d_H_obj;
-
     //! Get the generator matrix (used during encoding)
     const gsl_matrix* G_transpose() const;
 

--- a/gr-fec/python/fec/qa_fecapi_ldpc.py
+++ b/gr-fec/python/fec/qa_fecapi_ldpc.py
@@ -87,7 +87,7 @@ class test_fecapi_ldpc(gr_unittest.TestCase):
 
         self.assertEqual(data_in, data_out)
 
-    def test_parallelism0_03(self):
+    def test_parallelism0_03_gen(self):
         filename = LDPC_ALIST_DIR + "n_0100_k_0058_gen_matrix.alist"
         gap = 4
         LDPC_matrix_object = fec.ldpc_G_matrix(filename)
@@ -105,7 +105,7 @@ class test_fecapi_ldpc(gr_unittest.TestCase):
 
         self.assertEqual(data_in, data_out)
 
-    def test_parallelism0_03(self):
+    def test_parallelism0_03_par(self):
         filename = LDPC_ALIST_DIR + "n_0100_k_0058_gen_matrix.alist"
         gap = 4
         k = 100 - 58


### PR DESCRIPTION
## Description
The `qa_fecapi_ldpc` test file has two different tests named `test_parallelism0_03`. The second one shadows the first, preventing it from executing. (This has been the case since the tests were created in ee6b68433b815c3bb66b44f8a6c12709059cf65a.)

After renaming the two tests, the first test segfaults. This happens because `ldpc_G_matrix_impl::~ldpc_G_matrix_impl` attempts to free `d_H_obj`, which was never allocated. In fact, this member variable is completely unused, so it can simply be removed. After removing it, both QA tests pass.

## Which blocks/areas does this affect?
* LDPC Generator Matrix
* LDPC Bit Flip Decoder

## Testing Done
All I've done is verify that the LDPC tests pass after this change. The `test_parallelism0_03_gen` test exercises both the generator matrix and the bit flip decoder.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
