### PR TITLE
analog: Use approximate equality to check for standard CTCSS tones

### DIFF
--- a/gr-analog/lib/ctcss_squelch_ff_impl.cc
+++ b/gr-analog/lib/ctcss_squelch_ff_impl.cc
@@ -36,7 +36,7 @@ ctcss_squelch_ff::make(int rate, float freq, float level, int len, int ramp, boo
 int ctcss_squelch_ff_impl::find_tone(float freq)
 {
     for (int i = 0; i <= max_tone_index; i++)
-        if (ctcss_tones[i] == freq) // FIXME: make almost equal
+        if (std::abs(ctcss_tones[i] - freq) < 0.001)
             return i;
     return -1;
 }


### PR DESCRIPTION
## Description
The CTCSS Squelch block checks whether one of the standard CTCSS tones is being used, so that it can set its guard bands more accurately in this case. The comparison checks for exact floating point equality, which is not a good idea since some of the CTCSS frequencies do not have an exact floating point representation. Here I've change the check to allow a tolerance of 0.001 Hz.

## Which blocks/areas does this affect?
* CTCSS Squelch

## Testing Done
In addition to running the QA tests, I temporary added `printf` statements and passed in test values like 100.0, 100.0005, and 100.0015 to verify the behaviour of the `find_tone` method.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
