### PR TITLE
blocks: Use mutex instead of std::atomic for probe synchronization

### DIFF
--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -212,10 +212,6 @@ if(MSVC)
     target_sources(gnuradio-blocks PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-blocks.rc)
 endif(MSVC)
 
-if(MSVC)
-    target_compile_definitions(gnuradio-blocks PUBLIC _ENABLE_ATOMIC_ALIGNMENT_FIX)
-endif()
-
 if(BUILD_SHARED_LIBS)
     if(SNDFILE_FOUND)
         gr_library_foo(gnuradio-blocks SNDFILE)

--- a/gr-blocks/lib/probe_signal_impl.cc
+++ b/gr-blocks/lib/probe_signal_impl.cc
@@ -46,6 +46,7 @@ int probe_signal_impl<T>::work(int noutput_items,
 {
     const T* in = (const T*)input_items[0];
 
+    gr::thread::scoped_lock guard(d_mutex);
     if (noutput_items > 0)
         d_level = in[noutput_items - 1];
 
@@ -57,5 +58,13 @@ template class probe_signal<std::int16_t>;
 template class probe_signal<std::int32_t>;
 template class probe_signal<float>;
 template class probe_signal<gr_complex>;
+
+template <class T>
+T probe_signal_impl<T>::level() const
+{
+    gr::thread::scoped_lock guard(d_mutex);
+    return d_level;
+}
+
 } /* namespace blocks */
 } /* namespace gr */

--- a/gr-blocks/lib/probe_signal_impl.h
+++ b/gr-blocks/lib/probe_signal_impl.h
@@ -13,7 +13,6 @@
 #define PROBE_SIGNAL_IMPL_H
 
 #include <gnuradio/blocks/probe_signal.h>
-#include <atomic>
 
 namespace gr {
 namespace blocks {
@@ -22,13 +21,14 @@ template <class T>
 class probe_signal_impl : public probe_signal<T>
 {
 private:
-    std::atomic<T> d_level;
+    T d_level;
+    mutable gr::thread::mutex d_mutex;
 
 public:
     probe_signal_impl();
     ~probe_signal_impl() override;
 
-    T level() const override { return d_level; }
+    T level() const override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,


### PR DESCRIPTION
## Description
@balister noticed that `test_003_race_condition_regression_test` (added in #5744) fails on ARM:

```
Traceback (most recent call last):
  File "/usr/lib/gnuradio/ptest/gr-blocks/python/blocks/qa_probe_[signal.py](http://signal.py/)", line 64, in test_003_race_condition_regression_test
    self.assertIn(output, [1 + 2j, 3 + 4j])
AssertionError: (1+4j) not found in [(1+2j), (3+4j)]
```

It's apparent from the error message that the probe level is not being updated atomically, so the I value from one sample and the Q value from another are mixed together. I suspect the problem is that `std::atomic` is not supported on all platforms.

The vector version of the Probe Signal block uses a mutex (since `std::atomic` cannot be used with vectors) and the corresponding test always passes on ARM. We can fix the problem with the scalar version by switching to a mutex. This brings the two implementations closer together, and removes the need to define the `_ENABLE_ATOMIC_ALIGNMENT_FIX` macro (which was needed to work around a `std::atomic` bug in MSVC, and added it #5744).

## Which blocks/areas does this affect?
* Probe Signal

## Testing Done
I ran qa_probe_signal in a loop to verify that the race condition never occurs (at least on x86_64).

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
