### PR TITLE
docs: Improve documentation in hilbert_fc.h

### DIFF
--- a/gr-filter/include/gnuradio/filter/hilbert_fc.h
+++ b/gr-filter/include/gnuradio/filter/hilbert_fc.h
@@ -21,13 +21,16 @@ namespace gr {
 namespace filter {
 
 /*!
- * \brief Hilbert transformer.
+ * \brief Generate Analytic Signal.
  * \ingroup filter_blk
  *
  * \details
- * real output is input appropriately delayed.
- * imaginary output is hilbert filtered (90 degree phase shift)
- * version of input.
+ * Real part of the output is an appropriately delayed version of the input while
+ * the complex part of the output is the hilbert transform of the input.
+ *
+ * This is an indirect way of generating the hilbert transform of a signal.
+ *
+ * (https://en.wikipedia.org/wiki/Hilbert_transform#Analytic_representation)
  */
 class FILTER_API hilbert_fc : virtual public sync_block
 {
@@ -36,7 +39,7 @@ public:
     typedef std::shared_ptr<hilbert_fc> sptr;
 
     /*!
-     * Build a Hilbert transformer filter block.
+     * Build a Hilbert transformer filter block that generates the analytic signal.
      *
      * \param ntaps The number of taps for the filter.
      * \param window Window type (see fft::window::win_type) to use.

--- a/gr-filter/python/filter/bindings/hilbert_fc_python.cc
+++ b/gr-filter/python/filter/bindings/hilbert_fc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(hilbert_fc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(041e266d5e3108f725118a1f581b43f8)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4af4d39fee492eeb928684eb7e4fddd8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
## Description
This patch improves the description of an analytic signal and its relation with hilbert transform given in [hilbert_fc.h](https://github.com/gnuradio/gnuradio/blob/main/gr-filter/include/gnuradio/filter/hilbert_fc.h).

cc @mbr0wn 

## Related Issue
Fixes https://github.com/gnuradio/gnuradio/issues/5437
Supersedes #6177 

## Which blocks/areas does this affect?
The change is related to the hilbert transformer block. There shouldn't be a change in performance whatsoever.

## Testing Done
Documentation-related change, so no testing is required.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
