### PR TITLE
uhd: Declare float to time_spec_t implicitly convertible

### DIFF
--- a/gr-uhd/python/uhd/bindings/python_bindings.cc
+++ b/gr-uhd/python/uhd/bindings/python_bindings.cc
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2020 Free Software Foundation, Inc.
  *
@@ -13,6 +12,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#include <uhd/types/time_spec.hpp>
 #include <uhd/version.hpp>
 
 namespace py = pybind11;
@@ -68,6 +68,9 @@ PYBIND11_MODULE(uhd_python, m)
     bind_rfnoc_tx_radio(m);
     bind_rfnoc_tx_streamer(m);
 #endif
+
+
+    py::implicitly_convertible<double, uhd::time_spec_t>();
 
     m.def(
         "get_version_string",


### PR DESCRIPTION
Without this declaration, function calls that require a time_spec_t
argument must be provided with such an argument, even if there is
a default argument.

For example, in the RFNoC DDC block, we couldn't call set_freq() as
such:

```python
ddc_block.set_freq(0.0, 0)
```

It would produce the following error:
```
TypeError: set_freq(): incompatible function arguments. The following
    argument types are supported:
1. (self: gnuradio.uhd.uhd_python.rfnoc_ddc,
    freq: float,
    chan: int,
    time: gnuradio.uhd.uhd_python.time_spec_t = 0.0) -> float
```

Even though the argument `time` is optional, the default value of 0.0 is
not able to satisfy the requirements. By adding the
`py::implicitly_convertible` call, we declare float convertible to time
spec, and the call above can proceed.



## Testing Done

Any of the examples that use the DDC fail without this patch, and pass
with it.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
~~- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes, and~~ all previous tests pass.