### PR TITLE
blocktool: when no pygccxml, inherit gr::block (backpoirt to maint-3.10)

### DIFF
--- a/gr-utils/blocktool/core/parseheader_generic.py
+++ b/gr-utils/blocktool/core/parseheader_generic.py
@@ -286,6 +286,7 @@ class GenericHeaderParser(BlockTool):
             namespace_dict['name'] = "::".join(namespace_to_parse)
             class_dict = {}
             class_dict['name'] = blockname
+            class_dict['bases'] = ["::", "gr", "block"]
 
             mf_dict = {
                 "name": "make",


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit ba354f7ad95680ff8e913a0b7e4df89119efadcc)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6166