### PR TITLE
digital: Fix buffer overrun in Chunks to Symbols block (backport to maint-3.10)

### DIFF
--- a/gr-digital/lib/chunks_to_symbols_impl.cc
+++ b/gr-digital/lib/chunks_to_symbols_impl.cc
@@ -142,7 +142,8 @@ int chunks_to_symbols_impl<IN_T, OUT_T>::work(int noutput_items,
             }
 
             // after the last tag, continue working on the remaining items
-            for (; in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items;
+            for (;
+                 in < reinterpret_cast<const IN_T*>(input_items[m]) + noutput_items / d_D;
                  ++in) {
                 auto key = static_cast<unsigned int>(*in) * d_D;
                 for (unsigned int idx = 0; idx < d_D; ++idx) {

--- a/gr-digital/python/digital/qa_chunks_to_symbols.py
+++ b/gr-digital/python/digital/qa_chunks_to_symbols.py
@@ -100,6 +100,28 @@ class test_chunks_to_symbols(gr_unittest.TestCase):
         actual_result = dst.data()
         self.assertEqual(expected_result, actual_result)
 
+    def test_bf_100d(self):
+        maxval = 48
+        dimensions = 100
+        const = list(range(maxval * dimensions))
+        src_data = [v * 13 % maxval for v in range(maxval)]
+        expected_result = []
+        for data in src_data:
+            for i in range(dimensions):
+                expected_result += [const[data * dimensions + i]]
+
+        self.assertEqual(len(src_data) * dimensions, len(expected_result))
+        src = blocks.vector_source_b(src_data)
+        op = digital.chunks_to_symbols_bf(const, dimensions)
+
+        dst = blocks.vector_sink_f()
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()
+
+        actual_result = dst.data()
+        self.assertEqual(expected_result, actual_result)
+
     def test_ic_003(self):
         const = [1 + 0j, 0 + 1j,
                  -1 + 0j, 0 - 1j]


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit e791ebb447a627a872287c1e0f8f4d208791a01d)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6223