### PR TITLE
blocks: Convert argument to int in Python callbacks (backport to maint-3.10)

### DIFF
--- a/gr-blocks/grc/blocks_delay.block.yml
+++ b/gr-blocks/grc/blocks_delay.block.yml
@@ -49,7 +49,7 @@ templates:
     imports: from gnuradio import blocks
     make: blocks.delay(${type.size}*${vlen}, ${delay})
     callbacks:
-    - set_dly(${delay})
+    - set_dly(int(${delay}))
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/delay.h>']

--- a/gr-blocks/grc/blocks_exponentiate_const_cci.block.yml
+++ b/gr-blocks/grc/blocks_exponentiate_const_cci.block.yml
@@ -39,7 +39,7 @@ templates:
     imports: from gnuradio import blocks
     make: blocks.exponentiate_const_cci(${exponent}, ${vlen})
     callbacks:
-    - set_exponent(${exponent})
+    - set_exponent(int(${exponent}))
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/exponentiate_const_cci.h>']


### PR DESCRIPTION
Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 339cdaaaa6f3f41c84a97ecf0e17718c738d1d05)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6224