### PR TITLE
CI: trim the list of skipped tests in Conda builds

### DIFF
--- a/.packaging/conda_recipe/bld.bat
+++ b/.packaging/conda_recipe/bld.bat
@@ -33,8 +33,6 @@ qa_agc^
 |qa_file_descriptor_source_sink^
 |qa_file_sink^
 |qa_file_source^
-|qa_rotator_cc^
-|qa_tcp_server_sink^
 |qa_wavfile^
 |test_modtool^
 %=EMPTY=%

--- a/.packaging/conda_recipe/build.sh
+++ b/.packaging/conda_recipe/build.sh
@@ -19,20 +19,11 @@ cmake --build . --config Release --target install
 
 if [[ $target_platform == linux* ]] ; then
     SKIP_TESTS=(
-        qa_cpp_py_binding
-        qa_cpp_py_binding_set
-        qa_ctrlport_probes
         qa_qtgui
-        qa_rotator_cc
-        test_modtool
     )
 else
     SKIP_TESTS=(
-        qa_add_system_time
         qa_block_gateway
-        qa_cpp_py_binding
-        qa_cpp_py_binding_set
-        qa_ctrlport_probes
         qa_fecapi_cc
         qa_fecapi_dummy
         qa_fecapi_ldpc
@@ -43,10 +34,7 @@ else
         qa_message_debug
         qa_message_strobe
         qa_python_message_passing
-        qa_rotator_cc
-        qa_tcp_server_sink
         qa_uncaught_exception
-        test_modtool
     )
 fi
 SKIP_TESTS_STR=$( IFS="|"; echo "${SKIP_TESTS[*]}" )


### PR DESCRIPTION
## Description
Conda builds skip many CI tests. Some of the tests do still fail, but others now pass reliably because bugs have been fixed. Here I've cleaned up the list of skipped tests:

* `qa_cpp_py_binding`, `qa_cpp_py_binding_set`, `qa_ctrlport_probes` → not executed because ControlPort is not enabled
* `qa_rotator_cc` → fixed in https://github.com/gnuradio/gnuradio/pull/5755
* `qa_tcp_server_sink` → removed in https://github.com/gnuradio/gnuradio/pull/4463
* `test_modtool` → only fails on Windows
* `qa_add_system_time` → fixed in https://github.com/gnuradio/gnuradio/pull/5749

## Which blocks/areas does this affect?
CI tests in Conda builds

## Testing Done
I had a look over recent Conda builds to see which tests are still failing. None of these tests failed in the past five runs.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.