### PR TITLE
blocks: Fix file tests to work on Windows

### DIFF
--- a/.packaging/conda_recipe/bld.bat
+++ b/.packaging/conda_recipe/bld.bat
@@ -30,9 +30,6 @@ set SKIP_TESTS=^
 qa_agc^
 |qa_dtv^
 |qa_fecapi_ldpc^
-|qa_file_descriptor_source_sink^
-|qa_file_sink^
-|qa_file_source^
 |qa_wavfile^
 |test_modtool^
 %=EMPTY=%

--- a/gr-blocks/python/blocks/qa_file_sink.py
+++ b/gr-blocks/python/blocks/qa_file_sink.py
@@ -19,30 +19,34 @@ class test_file_sink(gr_unittest.TestCase):
     def setUp(self):
         os.environ['GR_CONF_CONTROLPORT_ON'] = 'False'
         self.tb = gr.top_block()
+        temp = tempfile.NamedTemporaryFile(delete=False)
+        temp.close()
+        self._datafilename = temp.name
 
     def tearDown(self):
         self.tb = None
+        os.unlink(self._datafilename)
 
     def test_file_sink(self):
         data = range(1000)
         expected_result = data
 
-        with tempfile.NamedTemporaryFile() as temp:
-            src = blocks.vector_source_f(data)
-            snk = blocks.file_sink(gr.sizeof_float, temp.name)
-            snk.set_unbuffered(True)
-            self.tb.connect(src, snk)
-            self.tb.run()
+        src = blocks.vector_source_f(data)
+        snk = blocks.file_sink(gr.sizeof_float, self._datafilename)
+        snk.set_unbuffered(True)
+        self.tb.connect(src, snk)
+        self.tb.run()
+        snk.close()
 
-            # Check file length (float: 4 * nsamples)
-            file_size = os.stat(temp.name).st_size
-            self.assertEqual(file_size, 4 * len(data))
+        # Check file length (float: 4 * nsamples)
+        file_size = os.stat(self._datafilename).st_size
+        self.assertEqual(file_size, 4 * len(data))
 
-            # Check file contents
-            datafile = open(temp.name, 'rb')
-            result_data = array.array('f')
+        # Check file contents
+        result_data = array.array('f')
+        with open(self._datafilename, 'rb') as datafile:
             result_data.fromfile(datafile, len(data))
-            self.assertFloatTuplesAlmostEqual(expected_result, result_data)
+        self.assertFloatTuplesAlmostEqual(expected_result, result_data)
 
 
 if __name__ == '__main__':

--- a/gr-blocks/python/blocks/qa_file_source.py
+++ b/gr-blocks/python/blocks/qa_file_source.py
@@ -20,17 +20,14 @@ class test_file_source(gr_unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         os.environ['GR_CONF_CONTROLPORT_ON'] = 'False'
-        cls._datafile = tempfile.NamedTemporaryFile()
-        cls._datafilename = cls._datafile.name
-        cls._vector = [x for x in range(1000)]
-        with open(cls._datafilename, 'wb') as f:
-            array.array('f', cls._vector).tofile(f)
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            cls._datafilename = temp.name
+            cls._vector = list(range(1000))
+            array.array('f', cls._vector).tofile(temp)
 
     @classmethod
     def tearDownClass(cls):
-        del cls._vector
-        del cls._datafilename
-        del cls._datafile
+        os.unlink(cls._datafilename)
 
     def setUp(self):
         self.tb = gr.top_block()


### PR DESCRIPTION
## Description
Several file-related tests fail on Windows with "Permission denied" errors:

```
======================================================================
ERROR: test_file_descriptor (__main__.test_file_descriptor_source_sink)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "%SRC_DIR%\gr-blocks\python\blocks\qa_file_descriptor_source_sink.py", line 33, in test_file_descriptor
    fhandle0 = open(temp.name, "wb")
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpmfjxx9mx'

----------------------------------------------------------------------

======================================================================
ERROR: test_file_sink (__main__.test_file_sink)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "%SRC_DIR%\gr-blocks\python\blocks\qa_file_sink.py", line 32, in test_file_sink
    snk = blocks.file_sink(gr.sizeof_float, temp.name)
RuntimeError: can't open file

----------------------------------------------------------------------

======================================================================
ERROR: setUpClass (__main__.test_file_source)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "%SRC_DIR%\gr-blocks\python\blocks\qa_file_source.py", line 26, in setUpClass
    with open(cls._datafilename, 'wb') as f:
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp9haek5tv'

----------------------------------------------------------------------
```

This happens because the tests use `tempfile.NamedTemporaryFile` but do not close the file before it is opened in other places. The [documentation](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) states:

> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows).

Therefore, it is necessary to close temporary files before they are used in flowgraphs. The `delete=False` argument is necessary to prevent the file from being automatically deleted after being closed. This means that the file must be cleaned up manually (with `os.unlink()`) after the flowgraphs are executed.

With the problematic tests fixed, we can remove them from the list of skipped tests in Conda builds.

## Which blocks/areas does this affect?
Tests for File Source, File Sink, File Descriptor Source, and File Descriptor Sink.

## Testing Done
I verified that the tests still pass on my machine.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
