### PR TITLE
cmake: Fix excess quoting of srcdir environment variable

### DIFF
--- a/.packaging/conda_recipe/bld.bat
+++ b/.packaging/conda_recipe/bld.bat
@@ -28,9 +28,6 @@ if errorlevel 1 exit 1
 :: test
 set SKIP_TESTS=^
 qa_agc^
-|qa_dtv^
-|qa_fecapi_ldpc^
-|qa_wavfile^
 %=EMPTY=%
 
 ctest --build-config Release --output-on-failure --timeout 120 -j%CPU_COUNT% -E "%SKIP_TESTS%"

--- a/cmake/Modules/GrTest.cmake
+++ b/cmake/Modules/GrTest.cmake
@@ -57,7 +57,7 @@ function(GR_ADD_TEST test_name)
     endif(WIN32)
 
     gr_convert_quoted_string("${CMAKE_CURRENT_BINARY_DIR}" bindir)
-    gr_convert_quoted_string("${CMAKE_CURRENT_SOURCE_DIR}" srcdir)
+    file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" srcdir)
     gr_convert_quoted_string("${GR_TEST_LIBRARY_DIRS}" libpath)
     #GR_CONVERT_QUOTED_STRING("${GR_TEST_PYTHON_DIRS}" pypath)
     # Keep the original path conversion for pypath - the above commented line breaks CI tests

--- a/gr-dtv/python/dtv/qa_dtv.py
+++ b/gr-dtv/python/dtv/qa_dtv.py
@@ -24,13 +24,14 @@ class test_dtv(gr_unittest.TestCase):
 
     def setUp(self):
         self.tb = gr.top_block()
+        self.outfile = "vv.cfile"
 
     def tearDown(self):
         self.tb = None
+        os.remove(self.outfile)
 
     def test_000(self):
         infile = ts_in_file
-        outfile = "vv.cfile"
         testfile = complex_out_file
         file_source = blocks.file_source(
             gr.sizeof_char * 1, infile, False, 0, 0)
@@ -141,7 +142,7 @@ class test_dtv(gr_unittest.TestCase):
             dtv.SHOWLEVELS_OFF,
             3.01
         )
-        file_sink = blocks.file_sink(gr.sizeof_gr_complex * 1, outfile, False)
+        file_sink = blocks.file_sink(gr.sizeof_gr_complex * 1, self.outfile, False)
         file_sink.set_unbuffered(True)
         self.tb.connect(
             file_source,
@@ -162,14 +163,12 @@ class test_dtv(gr_unittest.TestCase):
         self.tb.run()
         file_sink.close()
 
-        self.assertEqual(getsize(outfile), getsize(testfile))
+        self.assertEqual(getsize(self.outfile), getsize(testfile))
 
-        out_data = np.fromfile(outfile, dtype=np.float32)
+        out_data = np.fromfile(self.outfile, dtype=np.float32)
         expected_data = np.fromfile(testfile, dtype=np.float32)
-        os.remove(outfile)
 
         self.assertFloatTuplesAlmostEqual(out_data, expected_data, 5)
-        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
All tests that use the `srcdir` environment variable to refer to files from the GNU Radio source directory currently fail on Windows, with errors like the following:
```
======================================================================
ERROR: test_003_checkwav_append_copy (__main__.test_wavefile)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "%SRC_DIR%\gr-blocks\python\blocks\qa_wavfile.py", line 89, in test_003_checkwav_append_copy
    copyfile(infile, outfile)
  File "%PREFIX%\lib\shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc:
OSError: [Errno 22] Invalid argument: '"C:\\Miniconda3\\conda-bld\\gnuradio-dev_1666264729221\\work\\gr-blocks\\python\\blocks"\\test_16bit_1chunk_normal.wav'

----------------------------------------------------------------------
```
It is apparent from the error messages that extraneous double-quote characters appear around the `srcdir` value, breaking the path. Switching from `gr_convert_quoted_string` to `file(TO_NATIVE_PATH)` resolves the problem, allowing `srcdir` to work on all platforms.

After this change, the affected tests pass on all platforms, with the exception of `gr_dtv` on Windows. This test asks the File Sink block to close its file before deleting it, but (as noted in https://github.com/gnuradio/gnuradio/pull/6275#issuecomment-1287171777) the `close()` function is currently broken. As a temporary workaround, I've moved the file close operation into `tearDown`, as was done in some other tests in #6275.

## Which blocks/areas does this affect?
Tests for DTV, LDPC Encoders/Decoders, and Wav File Source/Sink.

## Testing Done
I verified that the affected tests pass on all platforms after these changes.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
