### PR TITLE
fec: Fix ldpc_G_matrix bugs

### DIFF
--- a/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
+++ b/gr-fec/include/gnuradio/fec/ldpc_G_matrix.h
@@ -68,6 +68,14 @@ public:
                 unsigned int frame_size,
                 unsigned int max_iterations) const override = 0;
 
+    //! Get the codeword length n
+    //  Handled in fec_mtrx parent class.
+    unsigned int n() const override = 0;
+
+    //! Get the information word length k
+    //  Handled in fec_mtrx parent class.
+    unsigned int k() const override = 0;
+
     /*!
      * \brief A pointer to make SWIG work
      *

--- a/gr-fec/lib/ldpc_G_matrix_impl.cc
+++ b/gr-fec/lib/ldpc_G_matrix_impl.cc
@@ -114,7 +114,7 @@ ldpc_G_matrix_impl::ldpc_G_matrix_impl(const std::string filename) : fec_mtrx_im
     d_G_transp_ptr = gsl_matrix_alloc(d_n, d_k);
     gsl_matrix_transpose_memcpy(d_G_transp_ptr, G);
 
-    d_H_sptr = matrix_sptr((matrix*)H_ptr);
+    d_H_sptr = matrix_sptr((matrix*)H_ptr, matrix_free);
 
     // Free memory
     gsl_matrix_free(P);

--- a/gr-fec/lib/ldpc_G_matrix_impl.h
+++ b/gr-fec/lib/ldpc_G_matrix_impl.h
@@ -65,8 +65,10 @@ public:
                 unsigned int frame_size,
                 unsigned int max_iterations) const override;
 
+    //! Redefine these here as part of the public interface
     unsigned int n() const override { return fec_mtrx_impl::n(); }
 
+    //! Redefine these here as part of the public interface
     unsigned int k() const override { return fec_mtrx_impl::k(); }
 
     gsl_matrix* generate_H();

--- a/gr-fec/python/fec/bindings/docstrings/ldpc_G_matrix_pydoc_template.h
+++ b/gr-fec/python/fec/bindings/docstrings/ldpc_G_matrix_pydoc_template.h
@@ -33,4 +33,10 @@ static const char* __doc_gr_fec_code_ldpc_G_matrix_encode = R"doc()doc";
 static const char* __doc_gr_fec_code_ldpc_G_matrix_decode = R"doc()doc";
 
 
+static const char* __doc_gr_fec_code_ldpc_G_matrix_n = R"doc()doc";
+
+
+static const char* __doc_gr_fec_code_ldpc_G_matrix_k = R"doc()doc";
+
+
 static const char* __doc_gr_fec_code_ldpc_G_matrix_get_base_sptr = R"doc()doc";

--- a/gr-fec/python/fec/bindings/ldpc_G_matrix_python.cc
+++ b/gr-fec/python/fec/bindings/ldpc_G_matrix_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(ldpc_G_matrix.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(00ec42731c51e3dd1f19befea06ebac1)                     */
+/* BINDTOOL_HEADER_FILE_HASH(4acdd03bcf89f8a19434e8f2de545c1d)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -58,6 +58,12 @@ void bind_ldpc_G_matrix(py::module& m)
              py::arg("frame_size"),
              py::arg("max_iterations"),
              D(code, ldpc_G_matrix, decode))
+
+
+        .def("n", &ldpc_G_matrix::n, D(code, ldpc_G_matrix, n))
+
+
+        .def("k", &ldpc_G_matrix::k, D(code, ldpc_G_matrix, k))
 
 
         .def("get_base_sptr",


### PR DESCRIPTION
## Description
While working on #6276, I noticed that the `test_parallelism0_03_gen` test in qa_fecapi_ldpc.py crashes on Windows. This is due to two bugs:

* `ldpc_G_matrix::n` and `ldpc_G_matrix::k` are missing Python bindings
* a smart pointer to a matrix doesn't have its deleter set

I've fixed those bugs here.

## Which blocks/areas does this affect?
LDPC G matrix

## Testing Done
I verified that the `qa_fecapi_ldpc` tests pass.

Here's a test run (on my fork) with both #6276 and this PR, and `qa_fecapi_ldpc` re-enabled on Windows: https://github.com/argilo/gnuradio/actions/runs/3303639617

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
