### PR TITLE
utils: Allow fallback when readline is not available

### DIFF
--- a/.packaging/conda_recipe/bld.bat
+++ b/.packaging/conda_recipe/bld.bat
@@ -37,7 +37,6 @@ qa_agc^
 |qa_tcp_server_sink^
 |qa_throttle^
 |qa_wavfile^
-|test_modtool^
 %=EMPTY=%
 
 ctest --build-config Release --output-on-failure --timeout 120 -j%CPU_COUNT% -E "%SKIP_TESTS%"

--- a/gr-utils/modtool/tests/test_modtool.py
+++ b/gr-utils/modtool/tests/test_modtool.py
@@ -9,6 +9,7 @@
 """ The file for testing the gr-modtool scripts """
 
 
+import os
 import shutil
 import tempfile
 import unittest
@@ -51,11 +52,13 @@ class TestModToolCore(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """ create a temporary directory """
+        cls.start_dir = os.getcwd()
         cls.test_dir = tempfile.mkdtemp()
 
     @classmethod
     def tearDownClass(cls):
         """ remove the directory after the test """
+        os.chdir(cls.start_dir)
         shutil.rmtree(cls.test_dir)
 
     def setUp(self):
@@ -83,6 +86,7 @@ class TestModToolCore(unittest.TestCase):
         # in setup will throw exception after first test
         # cannot remove if directory is not created
         if not self.f_newmod:
+            os.chdir(self.start_dir)
             rmdir = self.test_dir + '/gr-howto'
             shutil.rmtree(rmdir)
 

--- a/gr-utils/modtool/tools/util_functions.py
+++ b/gr-utils/modtool/tools/util_functions.py
@@ -11,7 +11,11 @@
 
 import re
 import sys
-import readline
+try:
+    import readline
+    have_readline = True
+except ImportError:
+    have_readline = False
 
 # None of these must depend on other modtool stuff!
 
@@ -184,9 +188,11 @@ class SequenceCompleter(object):
             return self._tmp_matches[state]
 
     def __enter__(self):
-        self._old_completer = readline.get_completer()
-        readline.set_completer(self.completefunc)
-        readline.parse_and_bind("tab: complete")
+        if have_readline:
+            self._old_completer = readline.get_completer()
+            readline.set_completer(self.completefunc)
+            readline.parse_and_bind("tab: complete")
 
     def __exit__(self, exception_type, exception_value, traceback):
-        readline.set_completer(self._old_completer)
+        if have_readline:
+            readline.set_completer(self._old_completer)


### PR DESCRIPTION
## Description
As indicated by the `test_modtool` test, `gr_modtool` does not work on Windows because Python's readline module is not available on that platform. We can avoid the problem by making `SequenceCompleter` a no-op when readline is missing. Since this approach doesn't add any new dependencies, it is safe to backport.

## Related Issue
Fixes #6280.

## Which blocks/areas does this affect?
gr_modtool

## Testing Done
I verified that readline functionality still works on Linux, and that gr_modtool works on Windows. I also intentionally modified the `import readline` line to `import readlinezz` to verify that the fallback works as expected.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
