### PR TITLE
runtime: make logging in rpcpmtconverters_thift work with fmt v9

### DIFF
--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -111,7 +111,8 @@ GNURadio::Knob rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
         // FIXME: Don't get loggers every time we need to log something.
         gr::logger_ptr logger, debug_logger;
         gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
-        logger->error("ERROR Don't know how to handle Knob Type (from): {}", knob);
+        logger->error("ERROR Don't know how to handle Knob Type (from): {}",
+                      pmt::write_string(knob));
         assert(0);
     }
     return GNURadio::Knob();


### PR DESCRIPTION
## Description
Implicit cast in an error/log message did not work with newer versions of fmt (v9 on SUSE). Use `pmt::write_string()` instead.

## Related Issue
Fixes #6278

## Which blocks/areas does this affect?
Runtime

## Testing Done

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
