### PR TITLE
Fix generated vector setter/getter signatures in non-templated blocks

### DIFF
--- a/utils/blockbuilder/templates/blockname.cc.j2
+++ b/utils/blockbuilder/templates/blockname.cc.j2
@@ -76,13 +76,13 @@ namespace {{module}} {
 {% if parameters %}
 {% for p in parameters -%}
 {% if p['settable']%}
-void {{block}}::set_{{p['id']}}({{p['dtype']|cpp_type}} {{p['id']}})
+void {{block}}::set_{{p['id']}}({{p['dtype']|cpp_type(vec=p['container']=='vector')}} {{p['id']}})
 {
     return request_parameter_change(params::id_{{p['id']}},{{p['id']}});
 }
 {% endif -%}
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
-{{p['dtype']|cpp_type}} {{block}}::{{p['id']}}()
+{{ p['dtype']|cpp_type(vec=p['container']=='vector')}} {{block}}::{{p['id']}}()
 {
     return pmtf::get_as<{{ p['dtype']|cpp_type(vec=p['container']=='vector')}}>(request_parameter_query(params::id_{{p['id']}}));
 }


### PR DESCRIPTION
Make sure setters and getters use std::vector<dtype> if they are declared with "container: vector".

Signed-off-by: Frank Osterfeld <frank.osterfeld@kdab.com>

## Description

This fixes the generated code when removing the template parameter from https://github.com/fair-acc/gr-digitizers/blob/gr40-port/blocklib/digitizers/chi_square_fit/chi_square_fit.yml
The templated block template (hah) has the correct signatures, this just applying the same to the nontemplated template.

## Testing Done

https://github.com/fair-acc/gr-digitizers/blob/gr40-port/blocklib/digitizers/chi_square_fit/chi_square_fit.yml works, I don't think there are tests for the code generation itself (other than that it has to work building the included blocks), so I haven't added any.

## Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [-] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
