### PR TITLE
wavelet: Remove --no-as-needed linker option (backport to maint-3.10)

### DIFF
--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -43,11 +43,6 @@ target_include_directories(gnuradio-wavelet
   )
 
 
-# we need -no-as-needed or else -lgslcblas gets stripped out on newer version of gcc
-if(CMAKE_COMPILER_IS_GNUCC AND NOT APPLE)
-    SET_TARGET_PROPERTIES(gnuradio-wavelet PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
-endif()
-
 if(BUILD_SHARED_LIBS)
   GR_LIBRARY_FOO(gnuradio-wavelet)
 endif()


### PR DESCRIPTION
This option causes a lot of extraneous libraries to be linked. It may no longer be needed.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit bd7238e3a326d5d75ce5ccc9330c52b622247dc8)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5913