### PR TITLE
uhd: Fix consistent override warnings (backport to maint-3.10)

### DIFF
--- a/gr-uhd/lib/rfnoc_block_generic_impl.h
+++ b/gr-uhd/lib/rfnoc_block_generic_impl.h
@@ -18,7 +18,7 @@ class rfnoc_block_generic_impl : public rfnoc_block_generic
 {
 public:
     rfnoc_block_generic_impl(::uhd::rfnoc::noc_block_base::sptr block_ref);
-    ~rfnoc_block_generic_impl();
+    ~rfnoc_block_generic_impl() override;
 };
 
 } // namespace uhd

--- a/gr-uhd/lib/rfnoc_ddc_impl.h
+++ b/gr-uhd/lib/rfnoc_ddc_impl.h
@@ -19,13 +19,13 @@ class rfnoc_ddc_impl : public rfnoc_ddc
 {
 public:
     rfnoc_ddc_impl(::uhd::rfnoc::noc_block_base::sptr block_ref);
-    ~rfnoc_ddc_impl();
+    ~rfnoc_ddc_impl() override;
 
     /*** API *****************************************************************/
     double set_freq(const double freq,
                     const size_t chan,
-                    const ::uhd::time_spec_t time = ::uhd::time_spec_t::ASAP);
-    double set_output_rate(const double rate, const size_t chan);
+                    const ::uhd::time_spec_t time = ::uhd::time_spec_t::ASAP) override;
+    double set_output_rate(const double rate, const size_t chan) override;
 
 private:
     ::uhd::rfnoc::ddc_block_control::sptr d_ddc_ref;

--- a/gr-uhd/lib/rfnoc_duc_impl.h
+++ b/gr-uhd/lib/rfnoc_duc_impl.h
@@ -19,13 +19,13 @@ class rfnoc_duc_impl : public rfnoc_duc
 {
 public:
     rfnoc_duc_impl(::uhd::rfnoc::noc_block_base::sptr block_ref);
-    ~rfnoc_duc_impl();
+    ~rfnoc_duc_impl() override;
 
     /*** API *****************************************************************/
     double set_freq(const double freq,
                     const size_t chan,
-                    const ::uhd::time_spec_t time = ::uhd::time_spec_t::ASAP);
-    double set_input_rate(const double rate, const size_t chan);
+                    const ::uhd::time_spec_t time = ::uhd::time_spec_t::ASAP) override;
+    double set_input_rate(const double rate, const size_t chan) override;
 
 private:
     ::uhd::rfnoc::duc_block_control::sptr d_duc_ref;

--- a/gr-uhd/lib/rfnoc_rx_radio_impl.h
+++ b/gr-uhd/lib/rfnoc_rx_radio_impl.h
@@ -19,27 +19,32 @@ class rfnoc_rx_radio_impl : public rfnoc_rx_radio
 {
 public:
     rfnoc_rx_radio_impl(::uhd::rfnoc::noc_block_base::sptr block_ref);
-    ~rfnoc_rx_radio_impl();
+    ~rfnoc_rx_radio_impl() override;
 
     /*** API *****************************************************************/
-    double set_rate(const double rate);
-    void set_antenna(const std::string& antenna, const size_t chan);
-    double set_frequency(const double frequency, const size_t chan);
-    void set_tune_args(const ::uhd::device_addr_t& args, const size_t chan);
-    double set_gain(const double gain, const size_t chan);
-    double set_gain(const double gain, const std::string& name, const size_t chan);
-    void set_agc(const bool enable, const size_t chan);
-    void set_gain_profile(const std::string& profile, const size_t chan);
-    double set_bandwidth(const double bandwidth, const size_t chan);
-    void
-    set_lo_source(const std::string& source, const std::string& name, const size_t chan);
-    void
-    set_lo_export_enabled(const bool enabled, const std::string& name, const size_t chan);
-    double set_lo_freq(const double freq, const std::string& name, const size_t chan);
-    void set_dc_offset(const bool enable, const size_t chan);
-    void set_dc_offset(const std::complex<double>& offset, const size_t chan);
-    void set_iq_balance(const bool enable, const size_t chan);
-    void set_iq_balance(const std::complex<double>& correction, const size_t chan);
+    double set_rate(const double rate) override;
+    void set_antenna(const std::string& antenna, const size_t chan) override;
+    double set_frequency(const double frequency, const size_t chan) override;
+    void set_tune_args(const ::uhd::device_addr_t& args, const size_t chan) override;
+    double set_gain(const double gain, const size_t chan) override;
+    double
+    set_gain(const double gain, const std::string& name, const size_t chan) override;
+    void set_agc(const bool enable, const size_t chan) override;
+    void set_gain_profile(const std::string& profile, const size_t chan) override;
+    double set_bandwidth(const double bandwidth, const size_t chan) override;
+    void set_lo_source(const std::string& source,
+                       const std::string& name,
+                       const size_t chan) override;
+    void set_lo_export_enabled(const bool enabled,
+                               const std::string& name,
+                               const size_t chan) override;
+    double
+    set_lo_freq(const double freq, const std::string& name, const size_t chan) override;
+    void set_dc_offset(const bool enable, const size_t chan) override;
+    void set_dc_offset(const std::complex<double>& offset, const size_t chan) override;
+    void set_iq_balance(const bool enable, const size_t chan) override;
+    void set_iq_balance(const std::complex<double>& correction,
+                        const size_t chan) override;
 
 private:
     ::uhd::rfnoc::radio_control::sptr d_radio_ref;

--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.h
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.h
@@ -22,7 +22,7 @@ public:
                            const ::uhd::stream_args_t& stream_args,
                            const size_t vlen,
                            const bool issue_stream_cmd_on_start);
-    ~rfnoc_rx_streamer_impl();
+    ~rfnoc_rx_streamer_impl() override;
 
     std::string get_unique_id() const override { return d_unique_id; }
 

--- a/gr-uhd/lib/rfnoc_tx_radio_impl.h
+++ b/gr-uhd/lib/rfnoc_tx_radio_impl.h
@@ -19,24 +19,29 @@ class rfnoc_tx_radio_impl : public rfnoc_tx_radio
 {
 public:
     rfnoc_tx_radio_impl(::uhd::rfnoc::noc_block_base::sptr block_ref);
-    ~rfnoc_tx_radio_impl();
+    ~rfnoc_tx_radio_impl() override;
 
     /*** API *****************************************************************/
-    double set_rate(const double rate);
-    void set_antenna(const std::string& antenna, const size_t chan);
-    double set_frequency(const double frequency, const size_t chan);
-    void set_tune_args(const ::uhd::device_addr_t& args, const size_t chan);
-    double set_gain(const double gain, const size_t chan);
-    double set_gain(const double gain, const std::string& name, const size_t chan);
-    void set_gain_profile(const std::string& profile, const size_t chan);
-    double set_bandwidth(const double bandwidth, const size_t chan);
-    void
-    set_lo_source(const std::string& source, const std::string& name, const size_t chan);
-    void
-    set_lo_export_enabled(const bool enabled, const std::string& name, const size_t chan);
-    double set_lo_freq(const double freq, const std::string& name, const size_t chan);
-    void set_dc_offset(const std::complex<double>& offset, const size_t chan);
-    void set_iq_balance(const std::complex<double>& correction, const size_t chan);
+    double set_rate(const double rate) override;
+    void set_antenna(const std::string& antenna, const size_t chan) override;
+    double set_frequency(const double frequency, const size_t chan) override;
+    void set_tune_args(const ::uhd::device_addr_t& args, const size_t chan) override;
+    double set_gain(const double gain, const size_t chan) override;
+    double
+    set_gain(const double gain, const std::string& name, const size_t chan) override;
+    void set_gain_profile(const std::string& profile, const size_t chan) override;
+    double set_bandwidth(const double bandwidth, const size_t chan) override;
+    void set_lo_source(const std::string& source,
+                       const std::string& name,
+                       const size_t chan) override;
+    void set_lo_export_enabled(const bool enabled,
+                               const std::string& name,
+                               const size_t chan) override;
+    double
+    set_lo_freq(const double freq, const std::string& name, const size_t chan) override;
+    void set_dc_offset(const std::complex<double>& offset, const size_t chan) override;
+    void set_iq_balance(const std::complex<double>& correction,
+                        const size_t chan) override;
 
 private:
     ::uhd::rfnoc::radio_control::sptr d_wrapped_ref;

--- a/gr-uhd/lib/rfnoc_tx_streamer_impl.h
+++ b/gr-uhd/lib/rfnoc_tx_streamer_impl.h
@@ -21,7 +21,7 @@ public:
                            const size_t num_chans,
                            const ::uhd::stream_args_t& stream_args,
                            const size_t vlen);
-    ~rfnoc_tx_streamer_impl();
+    ~rfnoc_tx_streamer_impl() override;
 
     /***** API ***************************************************************/
     std::string get_unique_id() const override { return d_unique_id; }


### PR DESCRIPTION
The RFNoC block impls had some missing overrides.

Signed-off-by: Martin Braun <martin.braun@ettus.com>
(cherry picked from commit b22cddf8ab6cb1243a13be9b5180bb84545a9299)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6219