### PR TITLE
digital: Fix CRC16 endianness (backport to maint-3.10)

### DIFF
--- a/gr-digital/python/digital/qa_crc16_async_bb.py
+++ b/gr-digital/python/digital/qa_crc16_async_bb.py
@@ -43,7 +43,7 @@ class qa_crc16_async_bb(gr_unittest.TestCase):
 
         self.assertEqual(dbg_append.num_messages(), 1)
         out_append = pmt.u8vector_elements(pmt.cdr(dbg_append.get_message(0)))
-        self.assertEqual(out_append, data + [0x37, 0x3b])
+        self.assertEqual(out_append, data + [0x3b, 0x37])
 
         self.assertEqual(dbg_check.num_messages(), 1)
         out_check = pmt.u8vector_elements(pmt.cdr(dbg_check.get_message(0)))


### PR DESCRIPTION
Changing byte ordering for CRC16 is technically a break in backward compatibility. However, we do not believe this block is being used in a way that it would matter at the moment.

Signed-off-by: Michael Roe <michael-roe@users.noreply.github.com>
Co-authored-by: Michael Roe <michael-roe@users.noreply.github.com>
(cherry picked from commit 6e03c5699109f93a7e13ccfb7c391e913f2fc3d4)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6096