### PR TITLE
CI: Re-enable qa_qtgui tests

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -65,32 +65,32 @@ jobs:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch
-            ctest_args: '-E "qa_qtgui"'
+            ctest_args: '-E ""'
             ldpath:
           - distro: 'Ubuntu 22.04'
             containerid: 'gnuradio/ci:ubuntu-22.04-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch
-            ctest_args: '-E "qa_qtgui|qa_polar_..coder_(sc_)?systematic"'
+            ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
           - distro: 'Fedora 35'
             containerid: 'gnuradio/ci:fedora-35-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
-            ctest_args: '-E "qa_qtgui"'
+            ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           - distro: 'Fedora 36 (with 0xFE memory initialization)'
             containerid: 'gnuradio/ci:fedora-36-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
-            ctest_args: '-E "qa_qtgui"'
+            ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'
           #   containerid: 'gnuradio/ci:centos-8.4-3.10'
           #   cxxflags: ''
-          #   ctest_args: '-E "qa_qtgui"'
+          #   ctest_args: '-E ""'
           #   ldpath: /usr/local/lib64/
           - distro: 'Debian 11'
             containerid: 'gnuradio/ci:debian-11-3.10'
             cxxflags: -Werror -Wno-error=invalid-pch
-            ctest_args: '-E "qa_qtgui|qa_polar_..coder_(sc_)?systematic"'
+            ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
     name: ${{ matrix.distro }}
     container:
@@ -110,6 +110,8 @@ jobs:
     - name: Make
       run: 'cd /build && make -j2 -k'
     - name: Make Test
+      env:
+        QT_QPA_PLATFORM: offscreen
       run: 'cd /build && ctest --output-on-failure ${{ matrix.ctest_args }}'
     - name: Make Install
       run: |

--- a/.packaging/conda_recipe/build.sh
+++ b/.packaging/conda_recipe/build.sh
@@ -18,8 +18,8 @@ cmake --build . --config Release -- -j${CPU_COUNT}
 cmake --build . --config Release --target install
 
 if [[ $target_platform == linux* ]] ; then
+    export QT_QPA_PLATFORM=offscreen
     SKIP_TESTS=(
-        qa_qtgui
     )
 else
     SKIP_TESTS=(
@@ -37,7 +37,7 @@ else
 fi
 SKIP_TESTS_STR=$( IFS="|"; echo "${SKIP_TESTS[*]}" )
 
-ctest --build-config Release --output-on-failure --timeout 120 -j${CPU_COUNT} -E $SKIP_TESTS_STR
+ctest --build-config Release --output-on-failure --timeout 120 -j${CPU_COUNT} -E "$SKIP_TESTS_STR"
 
 # now run the skipped tests to see the failures, but don't error out
-ctest --build-config Release --output-on-failure --timeout 120 -j${CPU_COUNT} -R $SKIP_TESTS_STR || exit 0
+ctest --build-config Release --output-on-failure --timeout 120 -j${CPU_COUNT} -R "$SKIP_TESTS_STR" || exit 0


### PR DESCRIPTION
## Description
The `qa_qtgui` tests are skipped in CI. From the Conda Linux build logs, it can be seen that the error is:
```
qt.qpa.xcb: could not connect to display 
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl, xcb.
```
This error can be avoided by switching to the "offscreen" plugin (which should be suitable for the headless CI environment).

## Which blocks/areas does this affect?
Qt GUI tests in CI.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
