### PR TITLE
CI: Re-enable metainfo_test on Ubuntu 20.04

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -65,7 +65,7 @@ jobs:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
             cxxflags: -Werror -Wno-error=invalid-pch
-            ctest_args: '-E "qa_qtgui|metainfo_test"'
+            ctest_args: '-E "qa_qtgui"'
             ldpath:
           - distro: 'Ubuntu 22.04'
             containerid: 'gnuradio/ci:ubuntu-22.04-3.9'


### PR DESCRIPTION
## Description
metainfo_test was disabled in #5178 due to a certificate validation error. As noted in the pull request, this change was meant to be temporary.

I'm opening this pull request to revert that change and see whether CI now passes. 

## Related Issue
Fixes #5132.

## Which blocks/areas does this affect?
CI testing on Ubuntu 20.04 only.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
