### PR TITLE
filter: use non-zero taps for fft filter qa

### DIFF
--- a/gr-filter/python/filter/qa_fft_filter.py
+++ b/gr-filter/python/filter/qa_fft_filter.py
@@ -16,18 +16,12 @@ import random
 
 
 def make_random_complex_tuple(L):
-    result = []
-    for x in range(L):
-        result.append(complex(2 * random.random() - 1,
-                              2 * random.random() - 1))
-    return tuple(result)
+    return [complex(2 * random.random() - 1,
+                    2 * random.random() - 1) for _ in range(L)]
 
 
 def make_random_float_tuple(L):
-    result = []
-    for x in range(L):
-        result.append(float(int(2 * random.random() - 1)))
-    return tuple(result)
+    return [(2 * random.random() - 1) for _ in range(L)]
 
 
 def reference_filter_ccc(dec, taps, input):
@@ -492,7 +486,7 @@ class test_fft_filter(gr_unittest.TestCase):
             result_data = op.taps()
             # print result_data
 
-            self.assertEqual(taps, result_data)
+            self.assertFloatTuplesAlmostEqual(taps, result_data, 4)
 
     def test_ccc_get0(self):
         random.seed(0)


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
The method to generate taps in qa_fft_filter was always returning 0 due to `float(int(..))`

## Which blocks/areas does this affect?
qa for fft filter

## Testing Done
Should pass QA as before

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
