### PR TITLE
runtime: Fix PMT serialization of C32 vectors

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -528,10 +528,8 @@ tail_recursion:
             for (size_t i = 0; i < npad; i++) {
                 ok &= serialize_untagged_u8(0, sb);
             }
-            // Note that if endianness causes byte swap that real/imag will also be
-            // swapped
-            ok &= serialize_untagged_u64_array(
-                (uint64_t*)&c32vector_elements(obj)[0], vec_len, sb);
+            ok &= serialize_untagged_u32_array(
+                (uint32_t*)&c32vector_elements(obj)[0], vec_len * 2, sb);
             return ok;
         }
 
@@ -729,9 +727,8 @@ pmt_t deserialize(std::streambuf& sb)
             return vec;
         }
         case (UVI_C32): {
-            // Data was serialized as uint64, so do the same here
-            deserialize_untagged_u64_vector(u64v, nitems, sb);
-            pmt_t vec = init_c32vector(nitems, (std::complex<float>*)&u64v[0]);
+            deserialize_untagged_u32_vector(u32v, 2 * nitems, sb);
+            pmt_t vec = init_c32vector(nitems, (std::complex<float>*)&u32v[0]);
             return vec;
         }
 

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -11,6 +11,7 @@
 
 import unittest
 import pmt
+import struct
 
 
 class test_pmt(unittest.TestCase):
@@ -345,13 +346,15 @@ class test_pmt(unittest.TestCase):
         in_vec = [0x01020304 - 1j, 3.1415 + 99.99j]
         # old serialization (c32 serialized as c64):
         # in_str = b'\n\n\x00\x00\x00\x02\x01\x00Ap 0@\x00\x00\x00\xbf\xf0\x00\x00\x00\x00\x00\x00@\t!\xca\xc0\x00\x00\x00@X\xff\\ \x00\x00\x00'
-        in_str = b'\n\n\x00\x00\x00\x02\x01\x00\xbf\x80\x00\x00K\x81\x01\x82B\xc7\xfa\xe1@I\x0eV'
+        in_str = struct.pack(">BBIBBffff", 0x0a, 0x0a, len(in_vec), 1, 0,
+                             in_vec[0].real, in_vec[0].imag, in_vec[1].real, in_vec[1].imag)
         out_str = pmt.serialize_str(pmt.init_c32vector(len(in_vec), in_vec))
         self.assertEqual(out_str, in_str)
+        in_vec = [1 + 1j, .125 - 9999999j]
         # old serialization (c32 serialized as c64):
         # in_str = b'\n\n\x00\x00\x00\x02\x01\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xc0\x00\x00\x00\x00\x00\x00\xc1c\x12\xcf\xe0\x00\x00\x00'
-        in_str = b'\n\n\x00\x00\x00\x02\x01\x00?\x80\x00\x00?\x80\x00\x00\xcb\x18\x96\x7f>\x00\x00\x00'
-        in_vec = [1 + 1j, .125 - 9999999j]
+        in_str = struct.pack(">BBIBBffff", 0x0a, 0x0a, len(in_vec), 1, 0,
+                             in_vec[0].real, in_vec[0].imag, in_vec[1].real, in_vec[1].imag)
         out_vec = pmt.c32vector_elements(pmt.deserialize_str(in_str))
         self.assertEqual(out_vec, in_vec)
 


### PR DESCRIPTION
## Description
#3320 made some changes to the PMT serialization format:

* Prior to the change, 32-bit complex vectors were serialized as (real, imag) big-endian doubles
* After the change (which went into the 3.9.0.0 release), 32-bit complex vectors were serialized as:
  * (imag, real) big-endian floats on little-endian systems
  * (real, imag) big-endian floats on big-endian systems

The platform-dependent behaviour causes the corresponding absolute serialization test (added in #3425) to fail on big-endian systems because it expects the (imag, real) ordering:

```
======================================================================
FAIL: test23_absolute_serialization_float_uvecs (__main__.test_pmt)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/gnuradio-runtime/python/pmt/qa_pmt.py", line 350, in test23_absolute_serialization_float_uvecs
    self.assertEqual(out_str, in_str)
AssertionError: b'\n\n\x00\x00\x00\x02\x01\x00K\x81\x01\x82\xbf\x80\x00\x00@I\x0eVB\xc7\xfa\xe1' != b'\n\n\x00\x00\x00\x02\x01\x00\xbf\x80\x00\x00K\x81\x01\x82B\xc7\xfa\xe1@I\x0eV'

----------------------------------------------------------------------
```

I think the platform-dependent ordering (which is out of order on the most commonly used platforms) would be confusing to users, so I'm proposing to change it back to (real, imag) on all platforms.

I've also updated the test, replacing the inscrutable byte arrays with `struct.pack()`.

## Related Issue
* #6300

## Which blocks/areas does this affect?
PMT serialization of 32-bit complex vectors.

## Testing Done
I verified that the tests pass on my amd64 system. ~~I'll try them on an s390x system shortly.~~ They also pass on a s390x system.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
