### PR TITLE
digital: Make the add_field functions portable

### DIFF
--- a/gr-digital/lib/header_buffer.cc
+++ b/gr-digital/lib/header_buffer.cc
@@ -57,43 +57,22 @@ void header_buffer::add_field8(uint8_t data, int len, bool bs)
 
 void header_buffer::add_field16(uint16_t data, int len, bool bs)
 {
-    int nbytes = len / 8;
-    if (d_buffer) {
-        uint16_t x = data;
-        if (!bs) {
-            volk_16u_byteswap(&x, 1);
-            x = x >> (16 - len);
-        }
-        memcpy(&d_buffer[d_offset], &x, nbytes);
-        d_offset += nbytes;
-    }
+    add_field64(data, len, bs);
 }
 
 void header_buffer::add_field32(uint32_t data, int len, bool bs)
 {
-    int nbytes = len / 8;
-    if (d_buffer) {
-        uint32_t x = data;
-        if (!bs) {
-            volk_32u_byteswap(&x, 1);
-            x = x >> (32 - len);
-        }
-        memcpy(&d_buffer[d_offset], &x, nbytes);
-        d_offset += nbytes;
-    }
+    add_field64(data, len, bs);
 }
 
 void header_buffer::add_field64(uint64_t data, int len, bool bs)
 {
     int nbytes = len / 8;
     if (d_buffer) {
-        uint64_t x = data;
-        if (!bs) {
-            volk_64u_byteswap(&x, 1);
-            x = x >> (64 - len);
+        for (int i = 0; i < nbytes; i++) {
+            int shift = bs ? i : (nbytes - i - 1);
+            d_buffer[d_offset++] = (data >> (8 * shift)) & 0xff;
         }
-        memcpy(&d_buffer[d_offset], &x, nbytes);
-        d_offset += nbytes;
     }
 }
 


### PR DESCRIPTION
## Description
The `add_field16`, `add_field32`, and `add_field64` functions have undefined behaviour because they copy the machine representation of multi-byte integers directly into the output buffer. As a result, they do not produce the correct output on big-endian systems. Switching to bit shifts will ensure consistent operation across platforms.

The errors on big-endian systems are as follows:
```
/home/argilo/gnuradio/gr-digital/lib/qa_header_format.cc(71): fatal error: in "test_default_format": critical check 0xAA == (int)h0 has failed [170 != 0]
/home/argilo/gnuradio/gr-digital/lib/qa_header_format.cc(154): fatal error: in "test_counter_format": critical check 0xAA == (int)h0 has failed [170 != 0]

/home/argilo/gnuradio/gr-digital/lib/qa_header_buffer.cc(48): fatal error: in "test_add16": critical check (uint8_t)0xAF == header.header()[0] has failed [0xaf != 0x5c]
/home/argilo/gnuradio/gr-digital/lib/qa_header_buffer.cc(87): fatal error: in "test_add32": critical check (uint8_t)0xAF == header.header()[0] has failed [0xaf != 0x54]
/home/argilo/gnuradio/gr-digital/lib/qa_header_buffer.cc(132): fatal error: in "test_add64": critical check (uint8_t)0xAF == header.header()[0] has failed [0xaf != 0x67]
/home/argilo/gnuradio/gr-digital/lib/qa_header_buffer.cc(193): fatal error: in "test_add_many": critical check (uint8_t)0x01 == header.header()[0] has failed [0x1 != 0x67]
```

## Related Issue
* #6300

## Which blocks/areas does this affect?
* `gr::digital::header_buffer` class
* `gr::digital::header_format_*` classes

## Testing Done
I verified that `digital_qa_header_buffer.cc` and `digital_qa_header_format.cc` now pass on both amd64 (little-endian) and s390x (big-endian) machines.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
