### PR TITLE
blocks: Read WAV file frames correctly in qa_wavfile

### DIFF
--- a/gr-blocks/python/blocks/qa_wavfile.py
+++ b/gr-blocks/python/blocks/qa_wavfile.py
@@ -164,7 +164,7 @@ def wav_read_frames(w):
     def grouper(iterable, n): return list(zip(* ([iter(iterable)] * n)))
     assert w.getsampwidth() == 2  # Assume 16 bits
     return [
-        struct.unpack('<h', bytes(frame_g))[0]
+        struct.unpack('h', bytes(frame_g))[0]
         for frame_g in grouper(w.readframes(w.getnframes()), 2)
     ]
 


### PR DESCRIPTION
## Description
Although the [documentation](https://docs.python.org/3/library/wave.html#wave.Wave_read.readframes) doesn't mention it, Python's `Wave_read.readframes()` function returns samples in machine order. This can be seen in the source code:

https://github.com/python/cpython/blob/c5f3f296f4c9ec5a294dedc805be69929fe169cc/Lib/wave.py#L364-L365

A git blame shows that the behaviour has been the same for at least the last 25 years.

This means that samples should be unpacked in machine order, rather than little-endian. Making this change fixes the following test failure on big-endian systems:

```
======================================================================
FAIL: test_003_checkwav_append_copy (__main__.test_wavefile)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/gr-blocks/python/blocks/qa_wavfile.py", line 142, in test_003_checkwav_append_copy
    self.assertEqual(data_in_halved, data_out[2 * len(data_in):])
AssertionError: Lists differ: [96, 0, 32, 6418] != [224, 0, 32, -26351]

First differing element 0:
96
224

- [96, 0, 32, 6418]
+ [224, 0, 32, -26351]

----------------------------------------------------------------------
```

## Related Issue
* #6300

## Which blocks/areas does this affect?
QA tests for Wav File Source & Wav File Sink.

## Testing Done
I verified that `qa_wavfile` passes on both amd64 (little-endian) and s390x (big-endian).

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
