### PR TITLE
CI: Lower timeouts on formatting & Doxygen jobs

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -12,6 +12,7 @@ jobs:
   check-formatting:
     name: Check C++ Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
     - uses: gnuradio/clang-format-lint-action@v0.5-4
@@ -22,6 +23,7 @@ jobs:
   check-python-formatting:
     name: Check Python Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
     - uses: quentinguidee/pep8-action@v1
@@ -31,6 +33,7 @@ jobs:
   doxygen:
     name: Doxygen
     runs-on: ubuntu-latest # This can run on whatever
+    timeout-minutes: 15
     container:
       image: 'gnuradio/ci:ubuntu-20.04-3.9'
       volumes:


### PR DESCRIPTION
## Description
GitHub Actions has a default timeout of 360 minutes. The formatting and Doxygen jobs only take about two minutes each, so we should lower the timeout to ensure that these jobs fail in a timely manner if a hang occurs.

## Related Issue
https://github.com/gnuradio/gnuradio/pull/6275#issuecomment-1295194054

## Which blocks/areas does this affect?
None; this is a CI-only change.

## Testing Done
None.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
