### PR TITLE
network: Replace boost::circular_buffer with gr::buffer

### DIFF
--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -215,6 +215,13 @@ int udp_sink_impl::work(int noutput_items,
     long num_bytes_to_transmit = noutput_items * d_block_size;
     const char* in = (const char*)input_items[0];
 
+    // Discard bytes if the input is longer than the buffer
+    long overrun = num_bytes_to_transmit - d_localqueue_writer->bufsize();
+    if (overrun > 0) {
+        num_bytes_to_transmit -= overrun;
+        in += overrun;
+    }
+
     // Build a long local queue to pull from so we can break it up easier
     if (d_localqueue_writer->space_available() < num_bytes_to_transmit)
         d_localqueue_reader->update_read_pointer(num_bytes_to_transmit -

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -11,9 +11,10 @@
 #ifndef INCLUDED_NETWORK_UDP_SINK_IMPL_H
 #define INCLUDED_NETWORK_UDP_SINK_IMPL_H
 
+#include <gnuradio/buffer.h>
+#include <gnuradio/buffer_reader.h>
 #include <gnuradio/network/udp_sink.h>
 #include <asio.hpp>
-#include <boost/circular_buffer.hpp>
 
 #include <gnuradio/network/packet_headers.h>
 
@@ -43,7 +44,8 @@ protected:
 
     // A queue is required because we have 2 different timing
     // domains: The network packets and the GR work()/scheduler
-    boost::circular_buffer<char>* d_localqueue;
+    gr::buffer_sptr d_localqueue_writer;
+    gr::buffer_reader_sptr d_localqueue_reader;
     char* d_localbuffer;
 
     asio::error_code ec;

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -46,7 +46,6 @@ protected:
     // domains: The network packets and the GR work()/scheduler
     gr::buffer_sptr d_localqueue_writer;
     gr::buffer_reader_sptr d_localqueue_reader;
-    char* d_localbuffer;
 
     asio::error_code ec;
 

--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -269,6 +269,14 @@ int udp_source_impl::work(int noutput_items,
             // local queue in case we read more bytes than noutput_items is asking
             // for.  In that case we'll only return noutput_items bytes
             const char* read_data = asio::buffer_cast<const char*>(d_read_buffer.data());
+
+            // Discard bytes if the input is longer than the buffer
+            long overrun = bytes_read - d_localqueue_writer->bufsize();
+            if (overrun > 0) {
+                bytes_read -= overrun;
+                read_data += overrun;
+            }
+
             if (d_localqueue_writer->space_available() < bytes_read)
                 d_localqueue_reader->update_read_pointer(
                     bytes_read - d_localqueue_writer->space_available());

--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -192,15 +192,23 @@ uint64_t udp_source_impl::get_header_seqnum()
 
     switch (d_header_type) {
     case HEADERTYPE_SEQNUM: {
-        retVal = ((header_seq_num*)d_localqueue_reader->read_pointer())->seqnum;
+        header_seq_num seq_header;
+        memcpy(&seq_header, d_localqueue_reader->read_pointer(), sizeof(header_seq_num));
+        retVal = seq_header.seqnum;
     } break;
 
     case HEADERTYPE_SEQPLUSSIZE: {
-        retVal = ((header_seq_plus_size*)d_localqueue_reader->read_pointer())->seqnum;
+        header_seq_plus_size seq_header;
+        memcpy(&seq_header,
+               d_localqueue_reader->read_pointer(),
+               sizeof(header_seq_plus_size));
+        retVal = seq_header.seqnum;
     } break;
 
     case HEADERTYPE_OLDATA: {
-        retVal = ((ata_header*)d_localqueue_reader->read_pointer())->seq;
+        ata_header seq_header;
+        memcpy(&seq_header, d_localqueue_reader->read_pointer(), sizeof(ata_header));
+        retVal = seq_header.seq;
     } break;
     }
 

--- a/gr-network/lib/udp_source_impl.h
+++ b/gr-network/lib/udp_source_impl.h
@@ -42,8 +42,6 @@ protected:
     int d_precomp_data_over_item_size;
     size_t d_block_size;
 
-    char* d_local_buffer;
-
     asio::error_code ec;
 
     asio::io_context d_io_context;

--- a/gr-network/lib/udp_source_impl.h
+++ b/gr-network/lib/udp_source_impl.h
@@ -11,9 +11,10 @@
 #ifndef INCLUDED_NETWORK_UDP_SOURCE_IMPL_H
 #define INCLUDED_NETWORK_UDP_SOURCE_IMPL_H
 
+#include <gnuradio/buffer.h>
+#include <gnuradio/buffer_reader.h>
 #include <gnuradio/network/udp_source.h>
 #include <asio.hpp>
-#include <boost/circular_buffer.hpp>
 
 #include <gnuradio/network/packet_headers.h>
 
@@ -53,7 +54,8 @@ protected:
 
     // A queue is required because we have 2 different timing
     // domains: The network packets and the GR work()/scheduler
-    boost::circular_buffer<char>* d_localqueue;
+    gr::buffer_sptr d_localqueue_writer;
+    gr::buffer_reader_sptr d_localqueue_reader;
 
     uint64_t get_header_seqnum();
 


### PR DESCRIPTION
## Description
This is a continuation of the effort to remove unnecessary Boost from GNU radio. The UDP Source and UDP Sink blocks use `boost::circular_buffer` to buffer data, but this can be replaced with ~~`std::queue`. The only change that's needed is to check the queue size before each `push()` to check whether the oldest element needs to be discarded.~~ `gr::buffer`. This also allows the local buffers and associated `memcpy` calls to be eliminated.

## Which blocks/areas does this affect?
* UDP Source
* UDP Sink

## Testing Done
So far I've only verified that the tests still pass. I'll take the blocks for a spin soon.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
