### PR TITLE
qtgui: Fix code generation for Toggle Button & Toggle Switch

### DIFF
--- a/gr-qtgui/grc/qtgui_togglebutton.block.yml
+++ b/gr-qtgui/grc/qtgui_togglebutton.block.yml
@@ -86,15 +86,14 @@ templates:
         <%
             win = '_%s_toggle_button'%id
         %>\
-        if ${type} == bool:
-        	self._${id}_choices = {'Pressed': bool(${pressed}), 'Released': bool(${released})}
-        elif ${type} == str:
-        	self._${id}_choices = {'Pressed': "${pressed}".replace("'",""), 'Released': "${released}".replace("'","")}
-        else:
-        	self._${id}_choices = {'Pressed': ${pressed}, 'Released': ${released}}
-        	
-        ${win} = qtgui.ToggleButton(${ 'self.set_' + context.get('id')() }, ${(label if (len(label) - 2 > 0) else repr(id))}, self._${id}_choices, ${initPressed},"${outputmsgname}".replace("'",""))
-        ${win}.setColors("${relBackgroundColor}","${relFontColor}","${pressBackgroundColor}","${pressFontColor}")
+        % if type == 'bool':
+        self._${id}_choices = {'Pressed': bool(${pressed}), 'Released': bool(${released})}
+        % else:
+        self._${id}_choices = {'Pressed': ${pressed}, 'Released': ${released}}
+        % endif
+
+        ${win} = qtgui.ToggleButton(${ 'self.set_' + context.get('id')() }, ${(label if (len(label) - 2 > 0) else repr(id))}, self._${id}_choices, ${initPressed}, ${outputmsgname})
+        ${win}.setColors("${relBackgroundColor}", "${relFontColor}", "${pressBackgroundColor}", "${pressFontColor}")
         self.${id} = ${win}
 
         ${gui_hint() % win}

--- a/gr-qtgui/grc/qtgui_toggleswitch.block.yml
+++ b/gr-qtgui/grc/qtgui_toggleswitch.block.yml
@@ -91,16 +91,15 @@ templates:
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%
-            win = '_%s_toggle_button'%id
+            win = '_%s_toggle_switch'%id
         %>\
-        if ${type} == bool:
-        	self._${id}_choices = {'Pressed': bool(${pressed}), 'Released': bool(${released})}
-        elif ${type} == str:
-        	self._${id}_choices = {'Pressed': "${pressed}".replace("'",""), 'Released': "${released}".replace("'","")}
-        else:
-        	self._${id}_choices = {'Pressed': ${pressed}, 'Released': ${released}}
-        	
-        ${win} = qtgui.GrToggleSwitch(${ 'self.set_' + context.get('id')() }, ${label}, self._${id}_choices, ${initPressed},"${switchOnBackground}","${switchOffBackground}",${position}, 50, ${cellalignment}, ${verticalalignment},self,"${outputmsgname}".replace("'",""))
+        % if type == 'bool':
+        self._${id}_choices = {'Pressed': bool(${pressed}), 'Released': bool(${released})}
+        % else:
+        self._${id}_choices = {'Pressed': ${pressed}, 'Released': ${released}}
+        % endif
+
+        ${win} = qtgui.GrToggleSwitch(${ 'self.set_' + context.get('id')() }, ${label}, self._${id}_choices, ${initPressed}, "${switchOnBackground}", "${switchOffBackground}", ${position}, 50, ${cellalignment}, ${verticalalignment}, self, ${outputmsgname})
         self.${id} = ${win}
 
         ${gui_hint() % win}
@@ -108,7 +107,7 @@ templates:
 documentation: |-
     This block creates a modern toggle switch. The variable will take on one value or the other as set in the dialog.
 
-    This button will also produce a state message matching the set values.
+    This switch will also produce a state message matching the set values.
 
     The GUI hint can be used to position the widget within the application. The hint is of the form [tab_id@tab_index]: [row, col, row_span, col_span]. Both the tab specification and the grid position are optional.
 


### PR DESCRIPTION
## Description
The QT GUI Toggle Button and Toggle Switch blocks generate invalid Python code if the Type is set to Float or String:

```
Traceback (most recent call last):
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 193, in <module>
    main()
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 171, in main
    tb = top_block_cls()
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 98, in __init__
    if real == bool:
NameError: name 'real' is not defined
```

```
Traceback (most recent call last):
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 193, in <module>
    main()
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 171, in main
    tb = top_block_cls()
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 98, in __init__
    if string == bool:
NameError: name 'string' is not defined
```

In addition to being broken, the generated code is rather complex:
```python
        if string == bool:
        	self._button_choices = {'Pressed': bool('foo'), 'Released': bool('baz')}
        elif string == str:
        	self._button_choices = {'Pressed': "'foo'".replace("'",""), 'Released': "'baz'".replace("'","")}
        else:
        	self._button_choices = {'Pressed': 'foo', 'Released': 'baz'}
```
And it will have syntax errors if the choices happen to contain double quotes.

I've fixed this by doing the following:

1. Do the type checking in mako instead of Python.
2. Get rid of the special handling for strings, which doesn't seem to be needed.

## Which blocks/areas does this affect?
* QT GUI Toggle Button
* QT GUI Toggle Switch

## Testing Done
I tested out both blocks with all four input types. When testing the string type, I also tried out special characters (e.g. `foo ' bar " baz`) and everything worked as expected.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
