### PR TITLE
qtgui: Fix code generation for Msg CheckBox & Digital Number Control

### DIFF
--- a/gr-qtgui/grc/qtgui_msgcheckbox.block.yml
+++ b/gr-qtgui/grc/qtgui_msgcheckbox.block.yml
@@ -68,11 +68,15 @@ templates:
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%
-            win = '_%s_toggle_button'%id
+            win = '_%s_msgcheckbox_win'%id
         %>\
+        % if type == 'bool':
+        self._${id}_choices = {'Pressed': bool(${pressed}), 'Released': bool(${released})}
+        % else:
         self._${id}_choices = {'Pressed': ${pressed}, 'Released': ${released}}
-        	
-        ${win} = qtgui.MsgCheckBox(${ 'self.set_' + context.get('id')() }, '${no_quotes(label,repr(id))}', self._${id}_choices, ${initPressed}, ${cellalignment}, ${verticalalignment},"${outputmsgname}".replace("'",""))
+        % endif
+
+        ${win} = qtgui.MsgCheckBox(${ 'self.set_' + context.get('id')() }, "${no_quotes(label,repr(id))}", self._${id}_choices, ${initPressed}, ${cellalignment}, ${verticalalignment}, ${outputmsgname})
         self.${id} = ${win}
 
         ${gui_hint() % win}

--- a/gr-qtgui/grc/qtgui_msgdigitalnumbercontrol.block.yml
+++ b/gr-qtgui/grc/qtgui_msgdigitalnumbercontrol.block.yml
@@ -61,7 +61,7 @@ inputs:
 -   domain: message
     id: valuein
     optional: true
-    
+
 outputs:
 -   domain: message
     id: valueout
@@ -74,11 +74,11 @@ templates:
         <%
             win = 'self._%s_msgdigctl_win'%id
         %>\
-        ${win} = qtgui.MsgDigitalNumberControl(lbl = ${lbl}, min_freq_hz = ${minFreqHz}, max_freq_hz=${maxFreqHz}, parent=self,  thousands_separator="${ThousandsSeparator}",background_color="${relBackgroundColor}",fontColor="${relFontColor}", var_callback=self.set_${id},outputmsgname="${outputmsgname}".replace("'",""))
+        ${win} = qtgui.MsgDigitalNumberControl(lbl=${lbl}, min_freq_hz=${minFreqHz}, max_freq_hz=${maxFreqHz}, parent=self, thousands_separator="${ThousandsSeparator}", background_color="${relBackgroundColor}", fontColor="${relFontColor}", var_callback=self.set_${id}, outputmsgname=${outputmsgname})
         ${win}.setValue(${value})
         ${win}.setReadOnly(${readOnly})
         self.${id} = ${win}
-        
+
         ${gui_hint() % win}
     callbacks:
     - self._${id}_msgdigctl_win.setValue(${value})

--- a/gr-qtgui/python/qtgui/msgcheckbox.py
+++ b/gr-qtgui/python/qtgui/msgcheckbox.py
@@ -78,7 +78,7 @@ class MsgCheckBox(gr.sync_block, QFrame):
         self.message_port_register_out(pmt.intern("state"))
 
         if initPressed:
-            self.chkctl.setChecked(True)
+            self.chkBox.setChecked(True)
 
         self.show()
 


### PR DESCRIPTION
## Description
After finishing #6316 I noticed a couple other blocks with broken code generation.

QT GUI Msg CheckBox generates invalid syntax:
```
  File "/home/argilo/git/bso2022/ultrasonic/tx.py", line 89
    _left_on_toggle_button = qtgui.MsgCheckBox(self.set_left_on, ''foo'', self._left_on_choices, False, 1, 1,"'value'".replace("'",""))
                                                                 ^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```
Also, when the Boolean type is selected, the value is not coerced to boolean (as it is in the Toggle Button & Toggle Switch blocks).

Finally, the QT GUI Digital Number Control uses `.replace("'","")` to munge a string; this is no longer needed, and by removing it the generated code is correct even if the name happens to contain a double quote.

## Which blocks/areas does this affect?
* QT GUI Msg Checkbox
* QT GUI Digital Number Control

## Testing Done
Made a simple flow graph and tested both blocks with various parameters.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
