### PR TITLE
cmake: Ensure that target names are unique

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -190,7 +190,7 @@ function(GR_UNIQUE_TARGET desc)
     file(RELATIVE_PATH reldir ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -c "import re, hashlib
-unique = hashlib.md5(b'${reldir}${ARGN}').hexdigest()[:5]
+unique = hashlib.md5(b'${reldir}${ARGN}').hexdigest()
 print(re.sub('\\W', '_', r'${desc} ${reldir} ' + unique))"
         OUTPUT_VARIABLE _target
         OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
## Description
CMake sometimes fails with:
```
| CMake Error at cmake/Modules/GrPython.cmake:197 (add_custom_target):
|   add_custom_target cannot create target "pygen_gr_digital_examples_c8263"
|   because another target with the same name already exists.  The existing
|   target is a custom target created in source directory
|   "/home/buildbot/worker/lyon-worker/build-master-qemu-next/build/build/tmp-glibc/work/cortexa57-oe-linux/gnuradio/3.10.3.0+gitAUTOINC+3f9c56abc8-r0/git/gr-digital/examples".
|   See documentation for policy CMP0002 for more details.
| Call Stack (most recent call first):
|   cmake/Modules/GrPython.cmake:391 (gr_unique_target)
|   gr-digital/examples/CMakeLists.txt:30 (gr_python_install)
```
This is because the code that generates unique target names for examples does so by appending a 20-bit hash, which is too short to avoid collisions:

https://github.com/gnuradio/gnuradio/blob/3f9c56abc81f92979760ef8c00dda173a4694f81/cmake/Modules/GrPython.cmake#L185-L198

Here I've increased it to the full 128-bit length of MD5.

## Related Issue
Fixes #4558.

## Which blocks/areas does this affect?
CMake build.

## Testing Done
I ran CMake and verified that it still works.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~`
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
