### PR TITLE
blocks: Increase number of samples and tolerance in qa_throttle

### DIFF
--- a/gr-blocks/python/blocks/qa_throttle.py
+++ b/gr-blocks/python/blocks/qa_throttle.py
@@ -23,9 +23,9 @@ class test_throttle(gr_unittest.TestCase):
         self.tb = None
 
     def test_throttling(self):
-        src_data = [1, 2, 3]
+        src_data = list(range(200))
         src = blocks.vector_source_c(src_data)
-        thr = blocks.throttle(gr.sizeof_gr_complex, 10)
+        thr = blocks.throttle(gr.sizeof_gr_complex, 100)
         dst = blocks.vector_sink_c()
         self.tb.connect(src, thr, dst)
 
@@ -34,21 +34,21 @@ class test_throttle(gr_unittest.TestCase):
         end_time = time.perf_counter()
 
         total_time = end_time - start_time
-        self.assertGreater(total_time, 0.3)
-        self.assertLess(total_time, 0.6)
+        self.assertGreater(total_time, 2.0)
+        self.assertLess(total_time, 3.0)
 
         dst_data = dst.data()
         self.assertEqual(src_data, dst_data)
 
     def test_rx_rate_tag(self):
-        src_data = [1, 2, 3, 4, 5, 6]
+        src_data = list(range(400))
         tag = gr.tag_t()
         tag.key = pmt.string_to_symbol("rx_rate")
-        tag.value = pmt.to_pmt(20)
+        tag.value = pmt.to_pmt(200)
         tag.offset = 0
 
         src = blocks.vector_source_c(src_data, tags=(tag,))
-        thr = blocks.throttle(gr.sizeof_gr_complex, 10, ignore_tags=False)
+        thr = blocks.throttle(gr.sizeof_gr_complex, 100, ignore_tags=False)
         dst = blocks.vector_sink_c()
         self.tb.connect(src, thr, dst)
 
@@ -57,8 +57,8 @@ class test_throttle(gr_unittest.TestCase):
         end_time = time.perf_counter()
 
         total_time = end_time - start_time
-        self.assertGreater(total_time, 0.3)
-        self.assertLess(total_time, 0.6)
+        self.assertGreater(total_time, 2.0)
+        self.assertLess(total_time, 3.0)
 
         dst_data = dst.data()
         self.assertEqual(src_data, dst_data)


### PR DESCRIPTION
## Description
Even after the tolerance increase in #6272, `qa_throttle` is still failing on Windows:

https://github.com/gnuradio/gnuradio/actions/runs/3357519882/jobs/5563380391
https://github.com/gnuradio/gnuradio/actions/runs/3360756897/jobs/5570335077

Let's bump it up again to stop the test failures.

## Related Issue
* https://github.com/gnuradio/gnuradio/pull/6272#issuecomment-1296459000

## Which blocks/areas does this affect?
Tests for the Throttle block.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
