### PR TITLE
pdu: Increase tolerance in flaky test again

### DIFF
--- a/gr-pdu/python/pdu/qa_time_delta.py
+++ b/gr-pdu/python/pdu/qa_time_delta.py
@@ -89,7 +89,7 @@ class qa_time_delta(gr_unittest.TestCase):
         delta_tag = pmt.dict_ref(a_meta, pmt.intern(
             "sys time delta (ms)"), pmt.PMT_NIL)
         self.assertAlmostEqual(tnow - 10.0, pmt.to_double(time_tag), delta=1e-6)
-        self.assertAlmostEqual(10000, pmt.to_double(delta_tag), delta=250)
+        self.assertAlmostEqual(10000, pmt.to_double(delta_tag), delta=500)
 
 
 if __name__ == '__main__':

--- a/gr-pdu/python/pdu/qa_time_delta.py
+++ b/gr-pdu/python/pdu/qa_time_delta.py
@@ -66,14 +66,6 @@ class qa_time_delta(gr_unittest.TestCase):
             'system_time'), pmt.from_double(tnow - 10.0))
         in_pdu = pmt.cons(meta, pmt.init_c32vector(len(in_data), in_data))
 
-        e_data = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1,
-                  1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1]
-        e_meta = pmt.dict_add(pmt.make_dict(), pmt.intern(
-            'system_time'), pmt.from_double(tnow))
-        e_meta = pmt.dict_add(e_meta, pmt.intern(
-            'sys time delta (ms)'), pmt.from_double(10000.0))
-        e_pdu = pmt.cons(e_meta, pmt.init_c32vector(len(e_data), e_data))
-
         # set up fg
         self.tb.start()
         self.time_delta.to_basic_block()._post(pmt.intern("pdu"), in_pdu)


### PR DESCRIPTION
## Description
The tolerance for this test was increased in #5764, but that was not enough. Another test failure occurred on Windows:

https://github.com/gnuradio/gnuradio/actions/runs/3364269344/jobs/5578423969

## Related Issue
* #5764

## Which blocks/areas does this affect?
CI tests for the Time Delta block.

## Testing Done
I verified that the test still passes on my machine, even when stressed with `stress -c 128`.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
