### PR TITLE
qtgui: cmake: Align CMake structure with other modules (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/CMakeLists.txt
+++ b/gr-qtgui/CMakeLists.txt
@@ -12,7 +12,9 @@ include(GrPython)
 
 # Note: gr-qtgui requires Qt5.
 
-find_package(Qt5Widgets QUIET)
+find_package(Qt5 QUIET
+    COMPONENTS Widgets
+)
 set(QT_FOUND ${Qt5Widgets_FOUND})
 
 gr_python_check_module("PyQt5" PyQt5 True PYQT5_FOUND)

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -9,8 +9,7 @@
 # Setup the QT file generations stuff
 ########################################################################
 
-add_library(
-    gnuradio-qtgui
+set(QTGUI_SOURCES
     DisplayPlot.cc
     FrequencyDisplayPlot.cc
     EyeDisplayPlot.cc
@@ -59,15 +58,39 @@ add_library(
     ber_sink_b_impl.cc
     vectordisplayform.cc
     vector_sink_f_impl.cc
-    edit_box_msg_impl.cc)
-target_compile_definitions(gnuradio-qtgui PRIVATE -DQWT_DLL) #setup QWT library linkage
+    edit_box_msg_impl.cc
+)
+
+set(QTGUI_LIBS
+    gnuradio-runtime
+    gnuradio-fft
+    gnuradio-filter
+    Volk::volk
+    qwt::qwt
+    Qt5::Widgets
+)
+
+if(ENABLE_COMMON_PCH)
+    set(PRIVATE_LIBS common-precompiled-headers)
+endif()
+
+
+add_library(
+    gnuradio-qtgui
+    ${QTGUI_SOURCES}
+)
+
+# Set up QWT library linkage:
+target_compile_definitions(gnuradio-qtgui PRIVATE -DQWT_DLL)
 target_include_directories(
     gnuradio-qtgui
     PUBLIC $<INSTALL_INTERFACE:include>
            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(gnuradio-qtgui PUBLIC gnuradio-runtime gnuradio-fft gnuradio-filter
-                                            Volk::volk qwt::qwt Qt5::Widgets)
+target_link_libraries(gnuradio-qtgui
+    PUBLIC ${QTGUI_LIBS}
+    PRIVATE ${PRIVATE_LIBS}
+)
 if(WIN32)
     target_link_libraries(gnuradio-qtgui PUBLIC dwrite)
 endif(WIN32)


### PR DESCRIPTION
This adds two changes to the qtgui CMake:

- The structure of lib/CMakeLists.txt now matches that of other in-tree modules. This is so that in the future, we can have optional sources, e.g. if we make QtOpenGL an optional dependency, and want to add blocks based on its existence.
- We find the Qt5 package with QtWidgets as a COMPONENT, rather than directly for Qt5Widgets. This allows adding OPTIONAL_COMPONENTS later on.

Signed-off-by: Martin Braun <martin.braun@ettus.com>
(cherry picked from commit 75bdf99946e98880b9d29f5e883768fbb9c2f022)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6221