### PR TITLE
runtime: fix type replication in py_io_signature (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr/gateway.py
+++ b/gnuradio-runtime/python/gnuradio/gr/gateway.py
@@ -79,7 +79,7 @@ class py_io_signature(object):
             return ()
         if nports <= ntypes:
             return self.__types[:nports]
-        return self.__types + [self.__types[-1]] * (nports - ntypes)
+        return self.__types + (self.__types[-1],) * (nports - ntypes)
 
     def __iter__(self):
         """


### PR DESCRIPTION
Original Python code concatenates list with a tuple, and that fails. This patch replaces list by a tuple, so now it works correctly.
This fixes issue #6243

Signed-off-by: Roman Dobrodii <ztcoils@gmail.com>
(cherry picked from commit dc855e08dacb36ef0d0f4a21032d01dde0d35431)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6244