### PR TITLE
Add Debian 32-bit to CI and fix bugs affecting 32-bit systems

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -92,14 +92,20 @@ jobs:
             cxxflags: -Werror -Wno-error=invalid-pch
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
+          - distro: 'Debian 11 (32-bit)'
+            containerid: 'gnuradio/ci:debian-i386-11-3.10'
+            containeroptions: '--platform linux/i386'
+            cxxflags: -Werror -Wno-error=invalid-pch
+            ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
+            ldpath:
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}
       volumes:
         - build_data:/build
-      options: --cpus 2
+      options: --cpus 2 ${{ matrix.containeroptions }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       name: Checkout Project
     - name: CMake
       env:

--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -407,7 +407,8 @@ void block::allocate_detail(int ninputs,
         detail->set_output(i, buffer);
 
         // Update the block's max_output_buffer based on what was actually allocated.
-        if ((max_output_buffer(i) != buffer->bufsize()) && (max_output_buffer(i) != -1))
+        if ((max_output_buffer(i) != static_cast<long>(buffer->bufsize())) &&
+            (max_output_buffer(i) != -1))
             d_logger->warn("Block ({:s}) max output buffer set to {:d}"
                            " instead of requested {:d}",
                            alias(),

--- a/gnuradio-runtime/lib/terminate_handler.cc
+++ b/gnuradio-runtime/lib/terminate_handler.cc
@@ -29,6 +29,7 @@ void print_backtrace()
 {
     unw_cursor_t cursor;
     unw_context_t context;
+    std::ios_base::fmtflags saved_cerr_flags(std::cerr.flags());
 
     // Initialize cursor to current frame for local unwinding.
     unw_getcontext(&context);
@@ -41,7 +42,7 @@ void print_backtrace()
         if (pc == 0) {
             break;
         }
-        std::fprintf(stderr, "0x%lx:", pc);
+        std::cerr << "0x" << std::hex << pc << ":";
 
         char sym[256];
         if (unw_get_proc_name(&cursor, sym, sizeof(sym), &offset) == 0) {
@@ -51,13 +52,16 @@ void print_backtrace()
             if (status == 0) {
                 nameptr = demangled;
             }
-            std::fprintf(stderr, " (%s+0x%lx)\n", nameptr, offset);
+            std::cerr << " (" << nameptr << "+0x" << std::hex << offset << ")"
+                      << std::endl;
             std::free(demangled);
         } else {
-            std::fprintf(stderr,
-                         " -- error: unable to obtain symbol name for this frame\n");
+            std::cerr << " -- error: unable to obtain symbol name for this frame"
+                      << std::endl;
         }
     }
+
+    std::cerr.flags(saved_cerr_flags);
 }
 #endif
 

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -196,7 +196,7 @@ int device_sink_impl::work(int noutput_items,
                                          "disable tagged input or tag your stream!");
             }
 
-            auto required_size = buffer_size / (interpolation + 1);
+            long required_size = buffer_size / (interpolation + 1);
             for (auto& tag : d_tags) {
                 auto packet_len = pmt::to_long(tag.value);
                 if (packet_len != required_size) {


### PR DESCRIPTION
## Description
Running CI on a 32-bit system should help catch more bugs, like the ones identified in #5973.

On top of the bugs reported there, there were also some new compiler warnings which I've fixed here:

* `terminate_handler.cc` used incorrect format specifiers; I've switched to streaming to avoid the need for format specifiers
* `block.cc` made a signed-to-unsigned integer comparison
* `device_sink_impl.cc` made a signed-to-unsigned integer comparison

It was necessary to switch to an order release of actions/checkout, because later versions depend on Node, and the version supplied by GitHub Actions does not work inside 32-bit containers.

## Related Issue
Replaces #5976.

## Which blocks/areas does this affect?
* stack trace printing the runtime's terminate handler
* `gr_block`, specifically the `allocate_detail` method
* IIO Device Sink block

## Testing Done
So far I've just verified that all tests pass, including on 32-bit Debian.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
