### PR TITLE
meson: fixed typo in meson.build for prefix == '/usr'

### DIFF
--- a/grc/meson.build
+++ b/grc/meson.build
@@ -4,7 +4,7 @@
 ########################################################################
 blocksdir = join_paths(prefix, GRC_BLOCKS_DIR)
 if (prefix == '/usr')
-  blocksdir = blocksdir + ':' + join_paths('/usr/local/',GRC_BLOcKS_DIR)
+  blocksdir = blocksdir + ':' + join_paths('/usr/local/',GRC_BLOCKS_DIR)
 endif
 
 grc_xterm_program = find_program('xterminal-emulator','gnome-terminal','konsole','xterm', required : false)


### PR DESCRIPTION
## Description
trivial fix for failing `meson setup build --prefix=/usr --libdir=lib64`

## Which blocks/areas does this affect?
<none>

## Testing Done
it builds when specifying `/usr` as prefix

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
