### PR TITLE
CI: Avoid unnecessary test skips on OSX

### DIFF
--- a/.packaging/conda_recipe/build.sh
+++ b/.packaging/conda_recipe/build.sh
@@ -35,18 +35,18 @@ if [[ $target_platform == linux* ]] ; then
 else
     SKIP_TESTS=(
         qa_block_gateway
+        qa_blocks_hier_block2
         qa_fecapi_cc
         qa_fecapi_dummy
         qa_fecapi_ldpc
         qa_fecapi_repetition
         qa_header_payload_demux
-        qa_hier_block2
         qa_hier_block2_message_connections
         qa_python_message_passing
         qa_uncaught_exception
     )
 fi
-SKIP_TESTS_STR=$( IFS="|"; echo "${SKIP_TESTS[*]}" )
+SKIP_TESTS_STR=$( IFS="|"; echo "^(${SKIP_TESTS[*]})$" )
 
 ctest --build-config Release --output-on-failure --timeout 120 -j${CPU_COUNT} -E "$SKIP_TESTS_STR"
 

--- a/gr-blocks/python/blocks/qa_blocks_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_blocks_hier_block2.py
@@ -37,7 +37,7 @@ class multiply_const_ff(gr.sync_block):
         return len(output_items[0])
 
 
-class test_hier_block2(gr_unittest.TestCase):
+class test_blocks_hier_block2(gr_unittest.TestCase):
 
     def setUp(self):
         pass
@@ -518,4 +518,4 @@ class test_hier_block2(gr_unittest.TestCase):
 
 
 if __name__ == "__main__":
-    gr_unittest.run(test_hier_block2)
+    gr_unittest.run(test_blocks_hier_block2)


### PR DESCRIPTION
## Description
Two tests are skipped unnecessarily on OSX:

* `qa_fecapi_cc_buffer_overflow` is skipped because `qa_fecapi_cc` is a substring of its test name. Tightening the test regex fixes this.
* `qa_hier_block2` in gnuradio-runtime is skipped because it shares the same name as a test in gr-blocks. I've renamed the gr-blocks test to avoid the conflict.

After this change, we should be down to 10 skipped tests on OSX instead of 12.

## Which blocks/areas does this affect?
CI tests.

## Testing Done
Once the CI test runs are complete, we can verify that the correct number of tests executed.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] I have added tests to cover my changes, and all previous tests pass.
