### PR TITLE
qtgui: Revert changes to Range widget

### DIFF
--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -53,29 +53,11 @@ parameters:
     dtype: int
     default: '200'
     hide: part
--   id: outputmsgname
-    label: Message Property Name
-    dtype: string
-    default: 'value'
-    hide: part
--   id: showports
-    label: Show Msg Ports
-    dtype: enum
-    options: ['True', 'False']
-    option_labels: ['Yes', 'No']
-    default: 'False'
-    hide: part
 -   id: gui_hint
     label: GUI Hint
     dtype: gui_hint
     hide: part
 value: ${ value }
-
-outputs:
--   domain: message
-    id: out
-    optional: true
-    hide: ${ showports != 'True' }
 
 asserts:
 - ${start <= value <= stop}
@@ -83,7 +65,7 @@ asserts:
 
 templates:
     imports: |- 
-        from gnuradio.qtgui import Range, GrRangeWidget
+        from gnuradio.qtgui import Range, RangeWidget
         from PyQt5 import QtCore
     var_make: self.${id} = ${id} = ${value}
     callbacks:
@@ -94,9 +76,7 @@ templates:
             range = 'self._%s_range'%id
         %>\
         ${range} = Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
-        ${win} = GrRangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient}, "${no_quotes(outputmsgname)}")
-        self.${id} = ${win}
-
+        ${win} = RangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient})
         ${gui_hint() % win}
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_range.block.yml
+++ b/gr-qtgui/grc/qtgui_range.block.yml
@@ -95,6 +95,7 @@ templates:
         %>\
         ${range} = Range(${start}, ${stop}, ${step}, ${value}, ${min_len})
         ${win} = GrRangeWidget(${range}, self.set_${id}, "${no_quotes(label,repr(id))}", "${widget}", ${rangeType}, ${orient}, "${no_quotes(outputmsgname)}")
+        self.${id} = ${win}
 
         ${gui_hint() % win}
 

--- a/gr-qtgui/python/qtgui/__init__.py
+++ b/gr-qtgui/python/qtgui/__init__.py
@@ -31,7 +31,7 @@ except ImportError:
     gr.log.warn("Matplotlib is a required dependency to use DistanceRadar and AzElPlot."
                 "  Please install matplotlib to use these blocks (https://matplotlib.org/)")
 
-from .range import Range, RangeWidget, GrRangeWidget
+from .range import Range, RangeWidget
 from . import util
 
 from .compass import GrCompass

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -411,7 +411,7 @@ class GrRangeWidget(gr.sync_block, RangeWidget):
         if self.varCallback is not None:
             self.varCallback(new_value)
         self.message_port_pub(self.outputportname_pmt,
-                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(new_value)))
+                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
 
 
 if __name__ == "__main__":

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -12,9 +12,7 @@
 @PY_QT_IMPORT@
 from .util import check_set_qss
 import gnuradio.eng_notation as eng_notation
-from gnuradio import gr
 import re
-import pmt
 
 class Range(object):
     def __init__(self, minv, maxv, step, default, min_length):
@@ -103,7 +101,7 @@ class RangeWidget(QtWidgets.QWidget):
         # Top-block function to call when any value changes
         # Some widgets call this directly when their value changes.
         # Others have intermediate functions to map the value into the right range.
-        self.__slot = slot
+        self.notifyChanged = slot
 
         layout = Qt.QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -134,10 +132,6 @@ class RangeWidget(QtWidgets.QWidget):
 
         layout.addWidget(self.d_widget)
         self.setLayout(layout)
-
-    def notifyChanged(self, value):
-        self.message_port_pub(self.outputportname_pmt, pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
-        self.__slot(value)
 
     class Dial(QtWidgets.QDial):
         """ Creates the range using a dial """
@@ -396,23 +390,6 @@ class RangeWidget(QtWidgets.QWidget):
                 self.slider.setValue(new)
                 self.first = False
 
-class GrRangeWidget(gr.sync_block, RangeWidget):
-    def __init__(self, ranges, varCallback, label, style, rangeType=float,
-            orientation=QtCore.Qt.Horizontal, outputmsgname='value'):
-        RangeWidget.__init__(self, ranges, varCallback, label, style, rangeType, orientation)
-        gr.sync_block.__init__(self, name='GrRangeWidget', in_sig=None, out_sig=None)
-        self.outputportname_pmt = pmt.intern('out')
-        self.outputmsgname_pmt = pmt.intern(outputmsgname)
-        self.message_port_register_out(self.outputportname_pmt)
-        self.value_to_pmt = (pmt.from_float if self.rangeType is float else pmt.from_long)
-        self.varCallback = varCallback
-
-    def valueChanged(self, new_value):
-        if self.varCallback is not None:
-            self.varCallback(new_value)
-        self.message_port_pub(self.outputportname_pmt,
-                pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
-
 
 if __name__ == "__main__":
     from PyQt5 import Qt
@@ -422,7 +399,7 @@ if __name__ == "__main__":
         print("Value updated - " + str(frequency))
 
     app = Qt.QApplication(sys.argv)
-    widget = GrRangeWidget(Range(0, 100, 10, 1, 100),
+    widget = RangeWidget(Range(0, 100, 10, 1, 100),
                          valueChanged, "Test", "counter_slider", int)
 
     widget.show()


### PR DESCRIPTION
## Description
In #5566, a message output port was added to the QT GUI Range widget. This caused two new bugs:

First, if the Range variable was used in the same expression as another variable, and that other variable was changed before the Range slider was first moved, then an exception would occur:
```
Traceback (most recent call last):
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 204, in changed
    self.notifyChanged(self.rangeType(val))
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 308, in sliderChanged
    self.notifyChanged(self.rangeType(value))
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 140, in notifyChanged
    self.__slot(value)
  File "/home/argilo/epy_test.py", line 193, in set_ampl
    self.epy_block_0.example_param = self.ampl * self.ampl2
TypeError: unsupported operand type(s) for *: 'float' and 'GrRangeWidget'
```

Second, the uhd_fft and uhd_siggen_gui programs would crash whenever a Range slider was adjusted: #6320. Also, any Python code generated by GRC prior to #5566 has the same issue. These problems are due to changes that were made to the `RangeWidget` class.

The first of these bugs was fixed in #6144, however that change introduced a new bug that made the message output port inoperable. If the port is connected to another block, then the following crash occurs:
```
Traceback (most recent call last):
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 204, in changed
    self.notifyChanged(self.rangeType(val))
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 308, in sliderChanged
    self.notifyChanged(self.rangeType(value))
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/qtgui/range.py", line 139, in notifyChanged
    self.message_port_pub(self.outputportname_pmt, pmt.cons(self.outputmsgname_pmt, self.value_to_pmt(value)))
AttributeError: 'RangeWidget' object has no attribute 'message_port_pub'
```

As explained in https://github.com/gnuradio/gnuradio/issues/6320#issuecomment-1303983799, I don't believe the current design of GRC allows a "variable" block like the Range widget to have ports. (Some of the widgets added in #3165 do, but they suffer from the first bug described above.)

To resolve the bugs, I think the best course of action is to revert the changes that were made to the Range widget, removing the recently-added message port.

## Related Issue
Fixes #6320.
Reverts #5566.
Reverts #6144.

## Which blocks/areas does this affect?
* QT GUI Range

## Testing Done
I ran uhd_fft and uhd_siggen_gui to verify that they work, and created a simple flow graph containing some Range widgets to verify that they work.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~ (The message port does not appear to be documented in the wiki.)
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
