### PR TITLE
grc: Continue processing connections after an invalid one occurs

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -466,9 +466,9 @@ class FlowGraph(Element):
         had_connect_errors = False
         _blocks = {block.name: block for block in self.blocks}
 
-        try:
-            # TODO: Add better error handling if no connections exist in the flowgraph file.
-            for src_blk_id, src_port_id, snk_blk_id, snk_port_id in data.get('connections', []):
+        # TODO: Add better error handling if no connections exist in the flowgraph file.
+        for src_blk_id, src_port_id, snk_blk_id, snk_port_id in data.get('connections', []):
+            try:
                 source_block = _blocks[src_blk_id]
                 sink_block = _blocks[snk_blk_id]
 
@@ -485,11 +485,11 @@ class FlowGraph(Element):
 
                 self.connect(source_port, sink_port)
 
-        except (KeyError, LookupError) as e:
-            Messages.send_error_load(
-                'Connection between {}({}) and {}({}) could not be made.\n\t{}'.format(
-                    src_blk_id, src_port_id, snk_blk_id, snk_port_id, e))
-            had_connect_errors = True
+            except (KeyError, LookupError) as e:
+                Messages.send_error_load(
+                    'Connection between {}({}) and {}({}) could not be made.\n\t{}'.format(
+                        src_blk_id, src_port_id, snk_blk_id, snk_port_id, e))
+                had_connect_errors = True
 
         for block in self.blocks:
             if block.is_dummy_block:


### PR DESCRIPTION
## Description
While working on #6342, I noticed the following bug:

When opening a GRC file, if any invalid connection is present, then all subsequent valid connections will fail to be loaded. This occurs because the loop that processes connections exits on the first error.

For example, the following flowgraph was generated in GNU Radio 3.10.4.0, which has a message output in the QT GUI Range block. When attempting to load it in another version of GNU Radio which lacks this port, all of the connections vanish:

![Screenshot from 2022-11-06 08-23-36](https://user-images.githubusercontent.com/583749/200173268-4b29a51e-e4e9-4489-b377-85143cae2f91.png)

It appears that this bug was introduced in GNU Radio 3.8, in the following commit: dbf58fa349002d94c26883b130ed8864ead79ea6

Moving the `try` back inside the loop allows the valid connections to be loaded again:

![Screenshot from 2022-11-06 08-31-50](https://user-images.githubusercontent.com/583749/200173705-954ce59d-ed9e-4033-91e0-5575c7804f6e.png)

It would seem that the motivation behind dbf58fa349002d94c26883b130ed8864ead79ea6 was to swallow up exceptions generated by `data.get('connections', [])`, but I haven't yet found a scenario where an exception would occur there.

## Which blocks/areas does this affect?
Loading flow graphs in GRC.

## Testing Done
I generated a flow graph that includes a QT GUI Range block with its new message output port (added in #5566) connected, then loaded it it a branch where #5566 has been reverted.

I also tried loading a flowgraph with zero connection to see if that would cause problems, but it did not.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
