### PR TITLE
qtgui: Set a minimum size for the Distance Radar widget

### DIFF
--- a/gr-qtgui/python/qtgui/distanceradar.py
+++ b/gr-qtgui/python/qtgui/distanceradar.py
@@ -80,6 +80,7 @@ class DistanceRadar(gr.sync_block, FigureCanvas):
         FigureCanvas.setSizePolicy(self,
                                    QtWidgets.QSizePolicy.Expanding,
                                    QtWidgets.QSizePolicy.Expanding)
+        self.setMinimumSize(240, 230)
         FigureCanvas.updateGeometry(self)
 
     def msgHandler(self, msg):


### PR DESCRIPTION
## Description
Unlike some other QT GUI widgets, the Distance Radar widget has no minimum size. As a result, it can be rendered with a height or width of zero, which causes the following exception:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_qt.py", line 455, in _draw_idle
    self.draw()
  File "/usr/lib/python3/dist-packages/matplotlib/backends/backend_agg.py", line 436, in draw
    self.figure.draw(self.renderer)
  File "/usr/lib/python3/dist-packages/matplotlib/artist.py", line 73, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/matplotlib/artist.py", line 50, in draw_wrapper
    return draw(artist, renderer)
  File "/usr/lib/python3/dist-packages/matplotlib/figure.py", line 2796, in draw
    artists = self._get_draw_artists(renderer)
  File "/usr/lib/python3/dist-packages/matplotlib/figure.py", line 238, in _get_draw_artists
    ax.apply_aspect()
  File "/usr/lib/python3/dist-packages/matplotlib/axes/_base.py", line 1890, in apply_aspect
    pb1 = pb.shrunk_to_aspect(box_aspect, pb, fig_aspect)
  File "/usr/lib/python3/dist-packages/matplotlib/transforms.py", line 558, in shrunk_to_aspect
    raise ValueError("'box_aspect' and 'fig_aspect' must be positive")
ValueError: 'box_aspect' and 'fig_aspect' must be positive
```

Since the Distance Radar widget is visually similar to the Az-El Plot, I copied over the minimum size from that block. This avoids the exception, and ensures that the Distance Radar widget is always visible.

## Which blocks/areas does this affect?
* QT GUI Distance Radar

## Testing Done
I used this simple flow graph for testing:

![Screenshot from 2022-11-06 11-37-54](https://user-images.githubusercontent.com/583749/200183018-8f312b1e-2148-401e-beac-1beee79a87f0.png)

**Before:**

![Screenshot from 2022-11-06 11-36-06](https://user-images.githubusercontent.com/583749/200183030-400eaaea-ad5f-465f-aeec-d876047e9792.png)

Reducing the height of the window causes an exception.

**After:**

![Screenshot from 2022-11-06 11-37-43](https://user-images.githubusercontent.com/583749/200183038-11d21a04-8859-4280-b14a-435345255ed1.png)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
