### PR TITLE
uhd: rfnoc streamers: Allow specifying adapter IDs

### DIFF
--- a/gr-uhd/examples/grc/rfnoc_duc_radio.grc
+++ b/gr-uhd/examples/grc/rfnoc_duc_radio.grc
@@ -1,0 +1,235 @@
+options:
+  parameters:
+    author: Martin Braun <martin.braun@ettus.com>
+    catch_exceptions: 'True'
+    category: '[GRC Hier Blocks]'
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: rfnoc_duc_radio
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: 'RFNoC: Radio -> DDC Example'
+    window_size: (1000,1000)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: freq
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Frequency (Hz)
+    type: real
+    value: 1e9
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 80.0]
+    rotation: 0
+    state: true
+- name: gain
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Gain (dB)
+    type: int
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 80.0]
+    rotation: 0
+    state: true
+- name: radio_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 200e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 112.0]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Sampling Rate (Hz)
+    type: real
+    value: 1e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [416, 80.0]
+    rotation: 0
+    state: true
+- name: tone_freq
+  id: variable_qtgui_entry
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Baseband Tone Frequency (Hz)
+    type: real
+    value: samp_rate/16
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [560, 80.0]
+    rotation: 0
+    state: true
+- name: uhd_rfnoc_graph
+  id: uhd_rfnoc_graph
+  parameters:
+    alias: ''
+    clock_source_0: ''
+    clock_source_1: ''
+    clock_source_2: ''
+    clock_source_3: ''
+    clock_source_4: ''
+    clock_source_5: ''
+    clock_source_6: ''
+    clock_source_7: ''
+    comment: ''
+    dev_addr: type=x300
+    dev_args: ''
+    num_mboards: '1'
+    time_source_0: ''
+    time_source_1: ''
+    time_source_2: ''
+    time_source_3: ''
+    time_source_4: ''
+    time_source_5: ''
+    time_source_6: ''
+    time_source_7: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [184, 8.0]
+    rotation: 0
+    state: true
+- name: analog_sig_source_x_0
+  id: analog_sig_source_x
+  parameters:
+    affinity: ''
+    alias: ''
+    amp: '.5'
+    comment: ''
+    freq: tone_freq
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    offset: '0'
+    phase: '0'
+    samp_rate: samp_rate
+    type: complex
+    waveform: analog.GR_COS_WAVE
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [64, 224.0]
+    rotation: 0
+    state: true
+- name: uhd_rfnoc_duc_0
+  id: uhd_rfnoc_duc
+  parameters:
+    affinity: ''
+    alias: ''
+    block_args: ''
+    comment: ''
+    device_select: '-1'
+    freq: '0'
+    input_rate: samp_rate
+    instance_index: '-1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_chans: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [512, 224.0]
+    rotation: 0
+    state: true
+- name: uhd_rfnoc_tx_radio_0
+  id: uhd_rfnoc_tx_radio
+  parameters:
+    affinity: ''
+    agc: Default
+    alias: ''
+    antenna: TX/RX
+    bandwidth: '0'
+    block_args: ''
+    comment: ''
+    device_select: '-1'
+    frequency: freq
+    gain: gain
+    instance_index: '-1'
+    num_chans: '1'
+    rate: radio_rate
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [800, 188.0]
+    rotation: 0
+    state: true
+- name: uhd_rfnoc_tx_streamer_0
+  id: uhd_rfnoc_tx_streamer
+  parameters:
+    adapter_id_list: '[0]'
+    affinity: ''
+    alias: ''
+    args: ''
+    comment: ''
+    input_type: fc32
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    num_chans: '1'
+    otw: sc16
+    use_default_adapter_id: 'True'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 272.0]
+    rotation: 0
+    state: true
+
+connections:
+- [analog_sig_source_x_0, '0', uhd_rfnoc_tx_streamer_0, '0']
+- [uhd_rfnoc_duc_0, '0', uhd_rfnoc_tx_radio_0, '0']
+- [uhd_rfnoc_tx_streamer_0, '0', uhd_rfnoc_duc_0, '0']
+
+metadata:
+  file_format: 1
+  grc_version: v3.11.0.0git-299-gf11a567f

--- a/gr-uhd/grc/uhd_rfnoc_duc.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_duc.block.yml
@@ -7,7 +7,6 @@ templates:
   make: |-
     uhd.rfnoc_duc(
         self.rfnoc_graph,
-        ${num_chans},
         uhd.device_addr(${block_args}),
         ${device_select},
         ${instance_index})

--- a/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_rx_streamer.block.yml
@@ -17,6 +17,11 @@ templates:
         ${ vlen },
         True
     )
+    %if use_default_adapter_id == 'False':
+    for port, adapter_id in enumerate(${ adapter_id_list }):
+        self.rfnoc_graph.set_streamer_adapter_id(
+            self.${id}.get_unique_id(), port, adapter_id)
+    %endif
 
 parameters:
 - id: num_chans
@@ -49,9 +54,23 @@ parameters:
   option_attributes:
     type: [fc32, sc16, s8]
   hide: part
+- id: use_default_adapter_id
+  label: Default Adapter ID
+  dtype: bool
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+  hide: part
+- id: adapter_id_list
+  label: Adapter ID List
+  dtype: int_vector
+  default: [0,]
+  hide: ${ 'all' if use_default_adapter_id else 'none' }
 
 asserts:
   - ${ num_chans > 0 }
+  - ${ vlen > 0 }
+  - ${ use_default_adapter_id or len(adapter_id_list) == num_chans }
 
 inputs:
 - domain: rfnoc

--- a/gr-uhd/grc/uhd_rfnoc_tx_streamer.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_tx_streamer.block.yml
@@ -16,6 +16,11 @@ templates:
         ),
         ${ vlen }
     )
+    %if use_default_adapter_id == 'False':
+    for port, adapter_id in enumerate(${ adapter_id_list }):
+        self.rfnoc_graph.set_streamer_adapter_id(
+            self.${id}.get_unique_id(), port, adapter_id)
+    %endif
 
 parameters:
 - id: num_chans
@@ -48,6 +53,23 @@ parameters:
   option_attributes:
     type: ['', sc16]
   hide: part
+- id: use_default_adapter_id
+  label: Default Adapter ID
+  dtype: bool
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: ['Yes', 'No']
+  hide: part
+- id: adapter_id_list
+  label: Adapter ID List
+  dtype: int_vector
+  default: [0,]
+  hide: ${ 'all' if use_default_adapter_id else 'none' }
+
+asserts:
+  - ${ num_chans > 0 }
+  - ${ vlen > 0 }
+  - ${ use_default_adapter_id or len(adapter_id_list) == num_chans }
 
 inputs:
 - domain: stream

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_graph.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_graph.h
@@ -11,6 +11,7 @@
 
 #include <gnuradio/uhd/api.h>
 #include <uhd/rfnoc/noc_block_base.hpp>
+#include <uhd/rfnoc_graph.hpp>
 #include <uhd/stream.hpp>
 #include <uhd/types/device_addr.hpp>
 #include <memory>
@@ -29,6 +30,9 @@ class GR_UHD_API rfnoc_graph
 {
 public:
     using sptr = std::shared_ptr<rfnoc_graph>;
+
+    static const size_t NULL_ADAPTER_ID =
+        static_cast<size_t>(::uhd::transport::NULL_ADAPTER_ID);
 
     static sptr make(const ::uhd::device_addr_t& dev_addr);
 
@@ -79,6 +83,23 @@ public:
     // \param args Stream args.
     virtual ::uhd::tx_streamer::sptr
     create_tx_streamer(const size_t num_ports, const ::uhd::stream_args_t& args) = 0;
+
+    //! Set the desired adapter ID for a streamer connection
+    //
+    // If it is desired to connect a streamer to the device using a specific
+    // adapter ID, this method needs to be called before calling connect().
+    //
+    // For more detail on adapter IDs, see the UHD documentation (e.g.,
+    // ::uhd::rfnoc::rfnoc_graph::connect()). Note that this does not have a
+    // corresponding API call in UHD: There, the connect() call is atomic and
+    // takes the adapter ID as an argument. The reason this is different in the
+    // GNU Radio implementation is that this makes it much easier to generate
+    // code from GRC for C++ and Python. It reduces the number of connect calls
+    // down to 1 (from 3 in UHD) and allows the streamer blocks to set this
+    // property on the streamer-edges before connect calls are made later on.
+    virtual void set_streamer_adapter_id(const std::string& stream_block_id,
+                                         const size_t port,
+                                         const size_t adapter_id) = 0;
 
     //! Commit the graph and run initial checks
     //

--- a/gr-uhd/lib/rfnoc_block.cc
+++ b/gr-uhd/lib/rfnoc_block.cc
@@ -29,7 +29,11 @@ rfnoc_block::make_block_ref(rfnoc_graph::sptr graph,
     const std::string block_id =
         graph->get_block_id(block_name, device_select, block_select);
     if (block_id.empty()) {
-        throw std::runtime_error("Cannot find block!");
+        throw std::runtime_error(
+            fmt::format("Cannot find block with ID: {:s} Device/Instance: {:d}/{:d}",
+                        block_name,
+                        device_select,
+                        block_select));
     }
 
     auto block = graph->get_block_ref(block_id, max_ref_count);

--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -52,14 +52,16 @@ public:
             _graph->connect(_tx_streamers.at(src_block_id),
                             src_block_port,
                             block_id_t(dst_block_id),
-                            dst_block_port);
+                            dst_block_port,
+                            _get_adapter_id(src_block_id, src_block_port));
             return;
         }
         if (_rx_streamers.count(dst_block_id)) {
             _graph->connect(src_block_id,
                             src_block_port,
                             _rx_streamers.at(dst_block_id),
-                            dst_block_port);
+                            dst_block_port,
+                            _get_adapter_id(dst_block_id, dst_block_port));
             return;
         }
 
@@ -108,6 +110,13 @@ public:
             std::dynamic_pointer_cast<::uhd::rfnoc::node_t>(streamer)->get_unique_id();
         _tx_streamers.insert({ streamer_id, streamer });
         return streamer;
+    }
+
+    void set_streamer_adapter_id(const std::string& stream_block_id,
+                                 const size_t port,
+                                 const size_t adapter_id)
+    {
+        _adapter_id_map[stream_block_id][port] = adapter_id;
     }
 
     void commit() override
@@ -200,6 +209,16 @@ public:
 
 
 private:
+    size_t _get_adapter_id(const std::string& streamer_id, const size_t port)
+    {
+        if (_adapter_id_map.count(streamer_id) &&
+            _adapter_id_map.at(streamer_id).count(port)) {
+            return _adapter_id_map.at(streamer_id).at(port);
+        }
+
+        return NULL_ADAPTER_ID;
+    }
+
     std::atomic<bool> _commit_called{ false };
     ::uhd::rfnoc::rfnoc_graph::sptr _graph;
 
@@ -209,6 +228,8 @@ private:
     std::mutex _block_ref_mutex;
     std::unordered_map<std::string, size_t> _acqd_block_refs;
     std::unordered_map<std::string, size_t> _max_ref_count;
+
+    std::unordered_map<std::string, std::unordered_map<size_t, size_t>> _adapter_id_map;
 
     gr::logger_ptr d_logger, d_debug_logger;
 };

--- a/gr-uhd/python/uhd/bindings/docstrings/rfnoc_graph_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/rfnoc_graph_pydoc_template.h
@@ -25,6 +25,8 @@ static const char* __doc_gr_uhd_rfnoc_graph_create_rx_streamer = R"doc()doc";
 
 static const char* __doc_gr_uhd_rfnoc_graph_create_tx_streamer = R"doc()doc";
 
+static const char* __doc_gr_uhd_rfnoc_graph_set_streamer_adapter_id = R"doc()doc";
+
 static const char* __doc_gr_uhd_rfnoc_graph_commit = R"doc()doc";
 
 static const char* __doc_gr_uhd_rfnoc_graph_get_block_id = R"doc()doc";

--- a/gr-uhd/python/uhd/bindings/rfnoc_graph_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_graph_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rfnoc_graph.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1e32bbc2f1a925bf00fafbcf5a16bf24)                     */
+/* BINDTOOL_HEADER_FILE_HASH(859c22ff93c70b536a7dc6a1df68f256)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -54,6 +54,9 @@ void bind_rfnoc_graph(py::module& m)
         .def("create_tx_streamer",
              &rfnoc_graph::create_tx_streamer,
              D(rfnoc_graph, create_tx_streamer))
+        .def("set_streamer_adapter_id",
+             &rfnoc_graph::set_streamer_adapter_id,
+             D(rfnoc_graph, set_streamer_adapter_id))
         .def("commit", &rfnoc_graph::commit, D(rfnoc_graph, commit))
         .def("get_block_id", &rfnoc_graph::get_block_id, D(rfnoc_graph, get_block_id))
         .def("set_time_source",


### PR DESCRIPTION
```
Changes:

9caed287b (Martin Braun, 26 minutes ago)
   uhd: rfnoc streamers: Allow specifying adapter IDs

   Includes the following changes:
   - Add a set_streamer_adapter_id() API call to rfnoc_graph. This sets an
    adapter ID for later calls to connect().
   - Amend the GRC bindings for the RX and TX streamers to allow specifying
    the adapter ID. It will call rfnoc_graph::set_streamer_adapter_id() to
    do so in the autogenerated Python code.

   Signed-off-by: Martin Braun <martin.braun@ettus.com>

039fc47a9 (Martin Braun, 78 seconds ago)
   uhd: rfnoc: Improve error message when block not found

   When an RFNoC block is requested but not found, it now prints the exact 
   block it was looking for in the exception string.

   Signed-off-by: Martin Braun <martin.braun@ettus.com>

4e115903b (Martin Braun, 2 minutes ago)
   uhd: rfnoc: Add DUC->Radio Example

   Signed-off-by: Martin Braun <martin.braun@ettus.com>

96145a37a (Martin Braun, 2 minutes ago)
   uhd: rfnoc: duc block: Removed spurious num_chans

   This fixes the Python code generated by GRC.

   Signed-off-by: Martin Braun <martin.braun@ettus.com>
```

## Description

See https://github.com/EttusResearch/gr-ettus/issues/56. This is a fix
for that.

## Related Issue

Fixes https://github.com/EttusResearch/gr-ettus/issues/56 (for gr-uhd)

## Which blocks/areas does this affect?

RFNoC Tx and Rx streamer.

## Testing Done

I used the Radio/DUC and Radio/DDC demos to tie the streamer to
arbitrary adapter IDs. Worked like a charm!

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.