### PR TITLE
uhd: rfnoc: Generate correct Python when using clock/time source

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_graph.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_graph.block.yml
@@ -6,7 +6,22 @@ templates:
   imports: |-
       from gnuradio import uhd
   var_make: |
-      self.rfnoc_graph = ${id} = uhd.rfnoc_graph(uhd.device_addr(",".join((${dev_addr}, ${dev_args}))))
+      <%
+          import ast
+          # Sanitize
+          graph_args = ast.literal_eval(dev_addr.strip())
+          dev_args_s = ast.literal_eval(dev_args.strip())
+          clock_source_s = ast.literal_eval(clock_source.strip())
+          time_source_s = ast.literal_eval(time_source.strip())
+          # Build full dev args
+          if dev_args_s:
+              graph_args += f",{clock_source_s}"
+          if clock_source_s:
+              graph_args += f",clock_source={clock_source_s}"
+          if time_source_s:
+              graph_args += f",time_source={time_source_s}"
+      %>
+      self.rfnoc_graph = ${id} = uhd.rfnoc_graph(uhd.device_addr("${graph_args}")))
 
 value: ${ 'RFNoC Graph' }
 
@@ -27,101 +42,17 @@ parameters:
   default: 1
   options: [1, 2, 3, 4, 5, 6, 7, 8]
   hide: part
-- id: clock_source_0
-  label: 'Mb0: Clock Source'
+- id: clock_source
+  label: Clock Source
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 0) else ( 'none' if clock_source_0 else 'part')}
-- id: time_source_0
-  label: 'Mb0: Time Source'
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
+  hide: ${ 'none' if clock_source else 'part' }
+- id: time_source
+  label: Time Source
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 0) else ('none' if time_source_0 else 'part')}
-- id: clock_source_1
-  label: 'Mb1: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 1) else ( 'none' if clock_source_1 else 'part')}
-- id: time_source_1
-  label: 'Mb1: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 1) else ('none' if time_source_1 else 'part')}
-- id: clock_source_2
-  label: 'Mb2: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 2) else ( 'none' if clock_source_2 else 'part')}
-- id: time_source_2
-  label: 'Mb2: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 2) else ('none' if time_source_2 else 'part')}
-- id: clock_source_3
-  label: 'Mb3: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 3) else ( 'none' if clock_source_3 else 'part')}
-- id: time_source_3
-  label: 'Mb3: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 3) else ('none' if time_source_3 else 'part')}
-- id: clock_source_4
-  label: 'Mb4: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 4) else ( 'none' if clock_source_4 else 'part')}
-- id: time_source_4
-  label: 'Mb4: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 4) else ('none' if time_source_4 else 'part')}
-- id: clock_source_5
-  label: 'Mb5: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 5) else ( 'none' if clock_source_5 else 'part')}
-- id: time_source_5
-  label: 'Mb5: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 5) else ('none' if time_source_5 else 'part')}
-- id: clock_source_6
-  label: 'Mb6: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 6) else ( 'none' if clock_source_6 else 'part')}
-- id: time_source_6
-  label: 'Mb6: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 6) else ('none' if time_source_6 else 'part')}
-- id: clock_source_7
-  label: 'Mb7: Clock Source'
-  dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 7) else ( 'none' if clock_source_7 else 'part')}
-- id: time_source_7
-  label: 'Mb7: Time Source'
-  dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
-  hide: ${ 'all' if not (num_mboards > 7) else ('none' if time_source_7 else 'part')}
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
+  hide: ${ 'none' if time_source else 'part' }
 
 file_format: 1


### PR DESCRIPTION
In GRC, there was an issue where you could select a clock/time source
for the RFNoC graph, but it was never passed on to the graph object.
This fixes the issue such that the correct device args are generated.



<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description


Default graph object:
![image](https://user-images.githubusercontent.com/508035/200626569-f1ba45ba-2b5f-4ea4-8ae0-c884aa0c810d.png)

I can now change the clock/time source as such:
![image](https://user-images.githubusercontent.com/508035/200626767-e01ef728-f02d-456c-a79a-5b4701f06d80.png)

If I do, it will look like this:

![image](https://user-images.githubusercontent.com/508035/200626874-d3a0c1b6-2c26-4e2f-8b51-33459cc3522a.png)

If I do that, the autogenerated Python now looks like this:
```py
        ##################################################
        # Variables
        ##################################################

        self.rfnoc_graph = uhd_rfnoc_graph = uhd.rfnoc_graph(uhd.device_addr("type=x300,clock_source=external,time_source=external")))
        self.samp_rate = samp_rate = 1e6
        self.gain = gain = 0
        self.freq = freq = 1e9
```

Using device args to control time/clock source is valid for all RFNoC devices, so calling `set_sync_source()` (or `set_time_source()`/`set_clock_source()`) is not necessary.

## Related Issue

Issue is described here https://github.com/EttusResearch/gr-ettus/issues/62

Fixes https://github.com/EttusResearch/gr-ettus/issues/62

## Which blocks/areas does this affect?

Any GR flowgraph using RFNoC.

## Testing Done

This is very easily tested by generating some flow graphs and seeing how
the Python code for the RFNoC graph is generated.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] ``I have added tests to cover my changes,~~ and all previous tests pass.