### PR TITLE
uhd: Re-enable uhd.find_devices()

### DIFF
--- a/gr-uhd/python/uhd/bindings/python_bindings.cc
+++ b/gr-uhd/python/uhd/bindings/python_bindings.cc
@@ -8,10 +8,13 @@
  */
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#include <uhd/device.hpp>
+#include <uhd/types/device_addr.hpp>
 #include <uhd/types/time_spec.hpp>
 #include <uhd/version.hpp>
 
@@ -76,4 +79,6 @@ PYBIND11_MODULE(uhd_python, m)
         "get_version_string",
         []() { return ::uhd::get_version_string(); },
         "Returns UHD Version String");
+
+    m.def("find", [](const uhd::device_addr_t& hint) { return uhd::device::find(hint); });
 }

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -25,8 +25,6 @@ void bind_usrp_block(py::module& m)
     m.attr("ALL_MBOARDS") = py::int_(::uhd::usrp::multi_usrp::ALL_MBOARDS);
     m.attr("ALL_LOS") = py::str(::uhd::usrp::multi_usrp::ALL_LOS);
 
-    m.def("find", [](const uhd::device_addr_t& hint) { return uhd::device::find(hint); });
-
     py::class_<usrp_block,
                gr::sync_block,
                gr::block,


### PR DESCRIPTION
This Python function was accidentally broken when converting from SWIG
to Pybind11. In 9c64b6d, uhd.find() was created as a replacement, but
that leaves uhd.find_devices() in a broken state.

This performes two changes:
- The binding for uhd.find() is moved into python_bindings.cc from
  usrp_block_python.cc.
- The Python version of find_devices() now correctly uses uhd.find()
  under the hood.
- The SWIG version differentiated between Python- and C++-versions of
  device_addr_t and remapped that, which we can skip with Pybind11

## Related Issues
Fixes https://github.com/gnuradio/gnuradio/issues/6313

## Testing Done

Tested locally with USRPs attached.

```py
from gnuradio import uhd
x = uhd.find_devices("")
print(x)
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] ~~I have added tests to cover my changes, and ~~all previous tests pass.