### PR TITLE
config files: fix misleading config hints

### DIFF
--- a/grc/grc.yml.in
+++ b/grc/grc.yml.in
@@ -1,10 +1,10 @@
 # This file contains system wide configuration data for GNU Radio.
 # You may override any setting on a per-user basis by editing
-# ~/.gnuradio/config.conf
+# ~/.gnuradio/config.yml
 
 grc:
     global_blocks_path: @blocksdir@
-    local_blocks_path:
+    local_blocks_path: @localblocks@
     default_flow_graph:
     xterm_executable: @GRC_XTERM_EXE@
     canvas_font_size: 8

--- a/grc/gui/Config.py
+++ b/grc/gui/Config.py
@@ -17,8 +17,8 @@ from . import Constants
 HEADER = """\
 # This contains only GUI settings for GRC and is not meant for users to edit.
 #
-# GRC settings not accessible through the GUI are in config.conf under
-# section [grc].
+# GRC settings not accessible through the GUI are in config.yml under
+# section grc:.
 
 """
 

--- a/grc/meson.build
+++ b/grc/meson.build
@@ -7,6 +7,12 @@ if (prefix == '/usr')
   blocksdir = blocksdir + ':' + join_paths('/usr/local/',GRC_BLOCKS_DIR)
 endif
 
+if ( get_option('custom_blocks_path') != '' )
+  localblocksdir = join_paths(get_option('custom_blocks_path'),GRC_BLOCKS_DIR)
+else
+  localblocksdir = ''
+endif
+
 grc_xterm_program = find_program('xterminal-emulator','gnome-terminal','konsole','xterm', required : false)
 GRC_XTERM_EXE = ''
 if grc_xterm_program.found()
@@ -16,6 +22,7 @@ endif
 cdata = configuration_data()
 cdata.set('GRC_XTERM_EXE', GRC_XTERM_EXE)
 cdata.set('blocksdir', blocksdir)
+cdata.set('localblocks',localblocksdir)
 grc_conf_file = configure_file(input: 'grc.yml.in',
                             output: 'grc.yml',
                             configuration: cdata,

--- a/meson.build
+++ b/meson.build
@@ -156,6 +156,6 @@ summary({'bindir': get_option('bindir'),
         'libdir': get_option('libdir'),
         'datadir': get_option('datadir'),
         'prefix': get_option('prefix'),
+        'Custom blocks path': get_option('custom_blocks_path'),
+        'Python dir': py3_install_dir,
         }, section: 'Directories')
-message('Python dir:')
-message(py3_install_dir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,3 +20,5 @@ option('enable_gr_audio', type : 'boolean', value : true)
 
 option('enable_grc', type : 'boolean', value : true)
 
+option('custom_blocks_path', type: 'string', value : '', description: 'Path to OOT blocks for grc, empty if in tree')
+


### PR DESCRIPTION


## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
OOT's build out of tree are not found by grc.
To find these blocks a path entry either in
etc/gnuradio/conf.d/grc.yml ( global setting )
or in ~/.gnuradio/config.yml(user specific ) is necessary.

At the moment the hint points to config.conf wich is only valid for 3.0.

In addition I added an configuration option to set the OOT block path during installation. An empty string keeps the old behaviour.


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Applied this fix and had a look at 
etc/gnuradio/conf.d/grc.yml 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [ ] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
