### PR TITLE
adding default stream-tag definitions to GR 4.0

### DIFF
--- a/gr/include/gnuradio/tag.h
+++ b/gr/include/gnuradio/tag.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <pmtf/wrap.hpp>
+#include <map>
+#include <optional>
 #include <string>
 
 namespace gr {
@@ -32,7 +34,46 @@ public:
     bool operator!=(const tag_t& rhs) const;
 
     void set_offset(uint64_t offset) { _offset = offset; }
-    pmtf::pmt operator[](const std::string& key) const { return _map.at(key); }
+    [[deprecated("unsafe - use at(key) instead")]] pmtf::pmt
+    operator[](const std::string& key) const
+    {
+        return _map.at(key); // implementation violates std::map::operator[] contract
+    }
+
+    pmtf::pmt& at(const std::string& key) { return _map.at(key); }
+    const pmtf::pmt& at(const std::string& key) const { return _map.at(key); }
+
+    [[nodiscard]] std::optional<std::reference_wrapper<const pmtf::pmt>>
+    get(const std::string& key) const noexcept
+    {
+        try { // TODO: missing find function in pmtf::map -> exception based look-up
+            return _map.at(key);
+        } catch (std::out_of_range& e) {
+            return std::nullopt;
+        }
+    }
+    [[nodiscard]] std::optional<std::reference_wrapper<pmtf::pmt>>
+    get(const std::string& key) noexcept
+    {
+        try { // TODO: missing find function in pmtf::map -> exception based look-up
+            return _map.at(key);
+        } catch (std::out_of_range&) {
+            return std::nullopt;
+        }
+    }
+
+    void insert_or_assign(const std::pair<std::string, pmtf::pmt>& value)
+    {
+        // TODO: expose std::map compatible insert & insert_or_assign interface
+        _map[value.first] = value.second;
+    }
+    void insert_or_assign(const std::string& key, const pmtf::pmt& value)
+    {
+        // TODO: expose std::map compatible insert & insert_or_assign interface
+        _map[key] = value;
+        // return _map.insert_or_assign(key, std::move(value));
+    }
+
     uint64_t offset() const { return _offset; }
     pmtf::map map() const { return _map; }
 
@@ -43,5 +84,61 @@ private:
     uint64_t _offset = 0;
     pmtf::map _map;
 };
+
+// clang-format off
+constexpr const char* GR_TAG_PREFIX = "gr:";
+
+template <typename PMT_TYPE>
+    requires(pmtf::is_pmt_derived<PMT_TYPE>::value)
+class default_tag
+{ // TODO: consider replacing with a compile-time constexpr fixed-length string
+    const std::string _key;
+    const std::string _keyShort;
+    std::string _unit;
+    const std::string _description;
+
+public:
+    using value_type = PMT_TYPE::value_type;
+    default_tag(const std::string_view& key,
+                const std::string_view& unit = "",
+                const std::string_view& description = "")
+        : _key(std::string{ GR_TAG_PREFIX }.append(key)),
+          _keyShort(key),
+          _unit(unit),
+          _description(description)
+    {
+    }
+    default_tag() = delete;
+
+    [[nodiscard]] const std::string& key() const noexcept { return _key; }
+    [[nodiscard]] const std::string& shortKey() const noexcept { return _keyShort; }
+    [[nodiscard]] const std::string& unit() const noexcept { return _unit; }
+    [[nodiscard]] const std::string& description() const noexcept { return _description; }
+
+    [[nodiscard]] operator const std::string&() const noexcept { return _key; }
+
+    template <typename T>
+        requires std::is_same_v<value_type, T>
+    [[nodiscard]] std::pair<std::string, pmtf::pmt>
+    operator()(const T& newValue) const noexcept
+    {
+        return { _key, static_cast<pmtf::pmt>(PMT_TYPE(newValue)) };
+    }
+};
+
+namespace tag { // definition of default tags and names
+//TODO: change 'inline static const' to 'inline constexpr' once PMTF supports constexpr
+inline static const default_tag<pmtf::scalar<float>>    SAMPLE_RATE    = { "sample_rate", "Hz", "signal sample rate"};
+inline static const default_tag<pmtf::scalar<float>>    SIGNAL_RATE    = SAMPLE_RATE;
+inline static const default_tag<pmtf::string>           SIGNAL_NAME    = { "signal_name", "", "signal name"};
+inline static const default_tag<pmtf::string>           SIGNAL_UNIT    = { "signal_unit", "", "signal's physical SI unit"};
+inline static const default_tag<pmtf::scalar<float>>    SIGNAL_MIN     = { "signal_min", "a.u.", "signal physical max. (e.g. DAQ) limit"};
+inline static const default_tag<pmtf::scalar<float>>    SIGNAL_MAX     = { "signal_max", "a.u.", "signal physical max. (e.g. DAQ) limit"};
+inline static const default_tag<pmtf::string>           TRIGGER_NAME   = { "trigger_name"};
+inline static const default_tag<pmtf::scalar<uint64_t>> TRIGGER_TIME   = { "trigger_time", "ns", "UTC-based time-stamp"};
+inline static const default_tag<pmtf::scalar<float>>    TRIGGER_OFFSET = { "trigger_offset", "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"};
+
+} // namespace gr::tag
+// clang-format on
 
 } // namespace gr

--- a/test/qa_tags.cc
+++ b/test/qa_tags.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <type_traits>
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -249,3 +250,19 @@ TEST(SchedulerMTTags, t5)
     BOOST_REQUIRE_EQUAL(tags2.size(), (size_t)8);
 }
 #endif
+
+TEST(SchedulerMTTags, DefaultTags)
+{
+    tag_t testTag;
+
+    testTag.insert_or_assign(tag::SAMPLE_RATE, pmtf::pmt(3.0f));
+    testTag.insert_or_assign(tag::SAMPLE_RATE(4.0f));
+    // testTag.insert_or_assign(tag::SAMPLE_RATE(5.0)); // type-mismatch -> won't compile
+    EXPECT_EQ(testTag.at(tag::SAMPLE_RATE), 4.0f);
+    EXPECT_EQ(tag::SAMPLE_RATE.shortKey(), "sample_rate");
+    EXPECT_EQ(tag::SAMPLE_RATE.key(), std::string{ GR_TAG_PREFIX }.append("sample_rate"));
+
+    EXPECT_TRUE(testTag.get(tag::SAMPLE_RATE).has_value());
+    EXPECT_FALSE(std::is_const_v<decltype(testTag.get(tag::SAMPLE_RATE).value())>);
+    EXPECT_FALSE(testTag.get(tag::SIGNAL_NAME).has_value());
+}


### PR DESCRIPTION
This is a follow-up of #6252 and #6253 and provides the following SigMF-inspired definitions and some additional helper methods in `class tag_t` to be used in the context of processing stream tags, e.g.:
```cpp
using namespace gr;
tag_t testTag;

testTag.insert_or_assign(tag::SAMPLE_RATE(4.0f));
//testTag.insert_or_assign(tag::SAMPLE_RATE(5.0)); // type-mismatch -> won't compile
EXPECT_EQ(testTag.at(tag::SAMPLE_RATE), 4.0f);
EXPECT_EQ(tag::SAMPLE_RATE.shortKey(), "sample_rate");

EXPECT_TRUE(testTag.get(tag::SAMPLE_RATE).has_value()); // future: allows for monadic expressions
EXPECT_FALSE(testTag.get(tag::SIGNAL_NAME).has_value());
```
These tags are definitions only and the specific naming be changed if necessary.

These definitions should be replaced by `inlinse constexpr` once PMTF supports `constexpr` constructors. 

N.B. The `pmtf::map` lacks some of the methods compared to STL maps, thus the unusual try-catch and bracket operator usage. Maybe this could be refactored towards the STL contracts?

## Related Issue
  * #6252
  * #6253

## Which blocks/areas does this affect?
No blocks are affected. For the time being, these are just re-usable definitions of recurring stream tag key values.

## Testing Done
added the corresponding unit-tests to the existing ones in `qa_tags.cc`.

## Checklist
- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
