### PR TITLE
runtime: Fix deprecation warnings

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -75,12 +75,12 @@ jobs:
             ldpath:
           - distro: 'Fedora 36 (with 0xFE memory initialization)'
             containerid: 'gnuradio/ci:fedora-36-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
+            cxxflags: -Werror -ftrivial-auto-var-init=pattern
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           - distro: 'Fedora 37 (with 0xFE memory initialization)'
             containerid: 'gnuradio/ci:fedora-37-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
+            cxxflags: -Werror -ftrivial-auto-var-init=pattern
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'

--- a/.github/workflows/pkg-debian.yml
+++ b/.github/workflows/pkg-debian.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations
+            cxxflags: -Werror
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/.github/workflows/pkg-fedora.yml
+++ b/.github/workflows/pkg-fedora.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - distro: 'Fedora 34'
             containerid: 'ghcr.io/gnuradio/ci:fedora-34-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations
+            cxxflags: -Werror
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -16,6 +16,7 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
+#include <functional>
 #include <map>
 #include <mutex>
 #include <string>
@@ -111,7 +112,7 @@ private:
 
 
     template <typename T, typename TMap>
-    struct set_f : public std::unary_function<T, void> {
+    struct set_f : public std::function<void(T)> {
         set_f(TMap& _setcallbackmap, const priv_lvl_t& _cur_priv)
             : d_setcallbackmap(_setcallbackmap), cur_priv(_cur_priv)
         {
@@ -142,7 +143,7 @@ private:
     };
 
     template <typename T, typename TMap>
-    struct get_f : public std::unary_function<T, void> {
+    struct get_f : public std::function<void(T)> {
         get_f(TMap& _getcallbackmap,
               const priv_lvl_t& _cur_priv,
               GNURadio::KnobMap& _outknobs)
@@ -178,7 +179,7 @@ private:
     };
 
     template <typename T, typename TMap, typename TKnobMap>
-    struct get_all_f : public std::unary_function<T, void> {
+    struct get_all_f : public std::function<void(T)> {
         get_all_f(TMap& _getcallbackmap, const priv_lvl_t& _cur_priv, TKnobMap& _outknobs)
             : d_getcallbackmap(_getcallbackmap), cur_priv(_cur_priv), outknobs(_outknobs)
         {
@@ -204,7 +205,7 @@ private:
     };
 
     template <typename T, typename TMap, typename TKnobMap>
-    struct properties_all_f : public std::unary_function<T, void> {
+    struct properties_all_f : public std::function<void(T)> {
         properties_all_f(QueryCallbackMap_t& _getcallbackmap,
                          const priv_lvl_t& _cur_priv,
                          GNURadio::KnobPropMap& _outknobs)
@@ -238,7 +239,7 @@ private:
     };
 
     template <class T, typename TMap, typename TKnobMap>
-    struct properties_f : public std::unary_function<T, void> {
+    struct properties_f : public std::function<void(T)> {
         properties_f(TMap& _getcallbackmap,
                      const priv_lvl_t& _cur_priv,
                      TKnobMap& _outknobs)


### PR DESCRIPTION
## Description
Fedora builds have several warnings due to `std::unary_function`, which was deprecated in C++11 and removed in C++17. As was done in #4159, I've replaced those with `std::function`.

The warnings are:
```
[ 21%] Building CXX object gnuradio-runtime/lib/CMakeFiles/gnuradio-runtime.dir/controlport/thrift/rpcserver_thrift.cc.o
In file included from /__w/gnuradio/gnuradio/gnuradio-runtime/lib/controlport/thrift/rpcserver_thrift.cc:12:
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:114:32: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  114 |     struct set_f : public std::unary_function<T, void> {
      |                                ^~~~~~~~~~~~~~
In file included from /usr/include/c++/12/bits/unique_ptr.h:37,
                 from /usr/include/c++/12/memory:76,
                 from /__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/block.h:14,
                 from /__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/sync_block.h:15,
                 from /build/gnuradio-runtime/lib/CMakeFiles/gnuradio-runtime.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:145:32: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  145 |     struct get_f : public std::unary_function<T, void> {
      |                                ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:181:36: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  181 |     struct get_all_f : public std::unary_function<T, void> {
      |                                    ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:207:43: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  207 |     struct properties_all_f : public std::unary_function<T, void> {
      |                                           ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:241:39: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  241 |     struct properties_f : public std::unary_function<T, void> {
      |                                       ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
[ 21%] Building CXX object gnuradio-runtime/lib/CMakeFiles/gnuradio-runtime.dir/controlport/thrift/rpcpmtconverters_thrift.cc.o
[ 21%] Building CXX object gnuradio-runtime/lib/CMakeFiles/gnuradio-runtime.dir/controlport/thrift/rpcserver_booter_thrift.cc.o
In file included from /__w/gnuradio/gnuradio/gnuradio-runtime/lib/controlport/thrift/rpcserver_booter_thrift.cc:12:
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:114:32: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  114 |     struct set_f : public std::unary_function<T, void> {
      |                                ^~~~~~~~~~~~~~
In file included from /usr/include/c++/12/bits/unique_ptr.h:37,
                 from /usr/include/c++/12/memory:76,
                 from /__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/block.h:14,
                 from /__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/sync_block.h:15,
                 from /build/gnuradio-runtime/lib/CMakeFiles/gnuradio-runtime.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:145:32: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  145 |     struct get_f : public std::unary_function<T, void> {
      |                                ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:181:36: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  181 |     struct get_all_f : public std::unary_function<T, void> {
      |                                    ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:207:43: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  207 |     struct properties_all_f : public std::unary_function<T, void> {
      |                                           ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
/__w/gnuradio/gnuradio/gnuradio-runtime/lib/../include/gnuradio/rpcserver_thrift.h:241:39: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
  241 |     struct properties_f : public std::unary_function<T, void> {
      |                                       ^~~~~~~~~~~~~~
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
```

## Which blocks/areas does this affect?
ControlPort

## Testing Done
None as yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
