### PR TITLE
blocks: Fix invalid PCH warning

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -64,22 +64,22 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E ""'
             ldpath:
           - distro: 'Ubuntu 22.04'
             containerid: 'gnuradio/ci:ubuntu-22.04-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
           - distro: 'Fedora 36 (with 0xFE memory initialization)'
             containerid: 'gnuradio/ci:fedora-36-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
+            cxxflags: -Werror -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           - distro: 'Fedora 37 (with 0xFE memory initialization)'
             containerid: 'gnuradio/ci:fedora-37-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
+            cxxflags: -Werror -Wno-error=deprecated-declarations -ftrivial-auto-var-init=pattern
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'
@@ -89,13 +89,13 @@ jobs:
           #   ldpath: /usr/local/lib64/
           - distro: 'Debian 11'
             containerid: 'gnuradio/ci:debian-11-3.10'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
           - distro: 'Debian 11 (32-bit)'
             containerid: 'gnuradio/ci:debian-i386-11-3.10'
             containeroptions: '--platform linux/i386'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
     name: ${{ matrix.distro }}
@@ -146,7 +146,7 @@ jobs:
       name: Checkout Project
     - name: CMake
       env:
-        CXXFLAGS: -Werror -Wno-error=invalid-pch
+        CXXFLAGS: -Werror
       run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF -DENABLE_PYTHON=OFF'
     - name: Make
       run: 'cd /build && make -j2 -k'

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -186,7 +186,8 @@ target_include_directories(
     gnuradio-blocks PUBLIC $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
-set_source_files_properties(file_source_impl.cc PROPERTIES COMPILE_FLAGS
+set_source_files_properties(file_source_impl.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON
+                                                           COMPILE_FLAGS
                                                            -D_FILE_OFFSET_BITS=64)
 
 if(ENABLE_GR_CTRLPORT)


### PR DESCRIPTION
## Description
The following warning occurs when building `file_source_impl.cc`:
```
[ 29%] Building CXX object gr-blocks/lib/CMakeFiles/gnuradio-blocks.dir/file_source_impl.cc.o
cc1plus: warning: /build/gr-blocks/lib/CMakeFiles/gnuradio-blocks.dir/cmake_pch.hxx.gch: not used because `_FILE_OFFSET_BITS' is defined [-Winvalid-pch]
```
This can be fixed by disabling precompiled headers for this file.

## Which blocks/areas does this affect?
File Source

## Testing Done
I verified that it's still possible to open a 5 GB file on 32-bit Linux.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
