### PR TITLE
Update clang format

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -15,11 +15,12 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
-    - uses: gnuradio/clang-format-lint-action@v0.5-4
+    - uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: '.'
         exclude: './volk'
         extensions: 'h,hpp,cpp,cc,cc.in'
+        clangFormatVersion: 14
   check-python-formatting:
     name: Check Python Formatting
     runs-on: ubuntu-latest

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/basic_block_python.cc
@@ -157,24 +157,24 @@ void bind_basic_block(py::module& m)
 
 
         .def("empty_p",
-             (bool (basic_block::*)(pmt::pmt_t)) & basic_block::empty_p,
+             (bool(basic_block::*)(pmt::pmt_t)) & basic_block::empty_p,
              py::arg("which_port"),
              D(basic_block, empty_p, 0))
 
 
         .def("empty_p",
-             (bool (basic_block::*)()) & basic_block::empty_p,
+             (bool(basic_block::*)()) & basic_block::empty_p,
              D(basic_block, empty_p, 1))
 
 
         .def("empty_handled_p",
-             (bool (basic_block::*)(pmt::pmt_t)) & basic_block::empty_handled_p,
+             (bool(basic_block::*)(pmt::pmt_t)) & basic_block::empty_handled_p,
              py::arg("which_port"),
              D(basic_block, empty_handled_p, 0))
 
 
         .def("empty_handled_p",
-             (bool (basic_block::*)()) & basic_block::empty_handled_p,
+             (bool(basic_block::*)()) & basic_block::empty_handled_p,
              D(basic_block, empty_handled_p, 1))
 
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_detail_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_detail_python.cc
@@ -142,11 +142,11 @@ void bind_block_detail(py::module& m)
 
 
         .def("get_tags_in_range",
-             (void (block_detail::*)(std::vector<gr::tag_t, std::allocator<gr::tag_t>>&,
-                                     unsigned int,
-                                     uint64_t,
-                                     uint64_t,
-                                     long int)) &
+             (void(block_detail::*)(std::vector<gr::tag_t, std::allocator<gr::tag_t>>&,
+                                    unsigned int,
+                                    uint64_t,
+                                    uint64_t,
+                                    long int)) &
                  block_detail::get_tags_in_range,
              py::arg("v"),
              py::arg("which_input"),
@@ -157,12 +157,12 @@ void bind_block_detail(py::module& m)
 
 
         .def("get_tags_in_range",
-             (void (block_detail::*)(std::vector<gr::tag_t, std::allocator<gr::tag_t>>&,
-                                     unsigned int,
-                                     uint64_t,
-                                     uint64_t,
-                                     pmt::pmt_t const&,
-                                     long int)) &
+             (void(block_detail::*)(std::vector<gr::tag_t, std::allocator<gr::tag_t>>&,
+                                    unsigned int,
+                                    uint64_t,
+                                    uint64_t,
+                                    pmt::pmt_t const&,
+                                    long int)) &
                  block_detail::get_tags_in_range,
              py::arg("v"),
              py::arg("which_input"),
@@ -221,7 +221,7 @@ void bind_block_detail(py::module& m)
 
 
         .def("pc_input_buffers_full",
-             (float (block_detail::*)(size_t)) & block_detail::pc_input_buffers_full,
+             (float(block_detail::*)(size_t)) & block_detail::pc_input_buffers_full,
              py::arg("which"),
              D(block_detail, pc_input_buffers_full, 0))
 
@@ -233,7 +233,7 @@ void bind_block_detail(py::module& m)
 
 
         .def("pc_output_buffers_full",
-             (float (block_detail::*)(size_t)) & block_detail::pc_output_buffers_full,
+             (float(block_detail::*)(size_t)) & block_detail::pc_output_buffers_full,
              py::arg("which"),
              D(block_detail, pc_output_buffers_full, 0))
 
@@ -258,7 +258,7 @@ void bind_block_detail(py::module& m)
 
 
         .def("pc_input_buffers_full_avg",
-             (float (block_detail::*)(size_t)) & block_detail::pc_input_buffers_full_avg,
+             (float(block_detail::*)(size_t)) & block_detail::pc_input_buffers_full_avg,
              py::arg("which"),
              D(block_detail, pc_input_buffers_full_avg, 0))
 
@@ -270,7 +270,7 @@ void bind_block_detail(py::module& m)
 
 
         .def("pc_output_buffers_full_avg",
-             (float (block_detail::*)(size_t)) & block_detail::pc_output_buffers_full_avg,
+             (float(block_detail::*)(size_t)) & block_detail::pc_output_buffers_full_avg,
              py::arg("which"),
              D(block_detail, pc_output_buffers_full_avg, 0))
 
@@ -302,7 +302,7 @@ void bind_block_detail(py::module& m)
 
 
         .def("pc_input_buffers_full_var",
-             (float (block_detail::*)(size_t)) & block_detail::pc_input_buffers_full_var,
+             (float(block_detail::*)(size_t)) & block_detail::pc_input_buffers_full_var,
              py::arg("which"),
              D(block_detail, pc_input_buffers_full_var, 0))
 
@@ -314,7 +314,7 @@ void bind_block_detail(py::module& m)
 
 
         .def("pc_output_buffers_full_var",
-             (float (block_detail::*)(size_t)) & block_detail::pc_output_buffers_full_var,
+             (float(block_detail::*)(size_t)) & block_detail::pc_output_buffers_full_var,
              py::arg("which"),
              D(block_detail, pc_output_buffers_full_var, 0))
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_gateway_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_gateway_python.cc
@@ -168,17 +168,17 @@ void bind_block_gateway(py::module& m)
              py::arg("out_sig"))
 
         .def("add_item_tag",
-             (void (block_gateway::*)(unsigned int, const gr::tag_t&)) &
+             (void(block_gateway::*)(unsigned int, const gr::tag_t&)) &
                  block_gateway::_add_item_tag,
              py::arg("which_output"),
              py::arg("tag"))
 
         .def("add_item_tag",
-             (void (block_gateway::*)(unsigned int,
-                                      uint64_t,
-                                      const pmt::pmt_t&,
-                                      const pmt::pmt_t&,
-                                      const pmt::pmt_t&)) &
+             (void(block_gateway::*)(unsigned int,
+                                     uint64_t,
+                                     const pmt::pmt_t&,
+                                     const pmt::pmt_t&,
+                                     const pmt::pmt_t&)) &
                  block_gateway::_add_item_tag,
              py::arg("which_output"),
              py::arg("abs_offset"),

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/block_python.cc
@@ -45,14 +45,14 @@ void bind_block(py::module& m)
 
 
         .def("declare_sample_delay",
-             (void (block::*)(int, unsigned int)) & block::declare_sample_delay,
+             (void(block::*)(int, unsigned int)) & block::declare_sample_delay,
              py::arg("which"),
              py::arg("delay"),
              D(block, declare_sample_delay, 0))
 
 
         .def("declare_sample_delay",
-             (void (block::*)(unsigned int)) & block::declare_sample_delay,
+             (void(block::*)(unsigned int)) & block::declare_sample_delay,
              py::arg("delay"),
              D(block, declare_sample_delay, 1))
 
@@ -143,7 +143,7 @@ void bind_block(py::module& m)
 
 
         .def("set_relative_rate",
-             (void (block::*)(double)) & block::set_relative_rate,
+             (void(block::*)(double)) & block::set_relative_rate,
              py::arg("relative_rate"),
              D(block, set_relative_rate, 0))
 
@@ -155,7 +155,7 @@ void bind_block(py::module& m)
 
 
         .def("set_relative_rate",
-             (void (block::*)(uint64_t, uint64_t)) & block::set_relative_rate,
+             (void(block::*)(uint64_t, uint64_t)) & block::set_relative_rate,
              py::arg("interpolation"),
              py::arg("decimation"),
              D(block, set_relative_rate, 1))
@@ -249,13 +249,13 @@ void bind_block(py::module& m)
 
 
         .def("set_max_output_buffer",
-             (void (block::*)(long int)) & block::set_max_output_buffer,
+             (void(block::*)(long int)) & block::set_max_output_buffer,
              py::arg("max_output_buffer"),
              D(block, set_max_output_buffer, 0))
 
 
         .def("set_max_output_buffer",
-             (void (block::*)(int, long int)) & block::set_max_output_buffer,
+             (void(block::*)(int, long int)) & block::set_max_output_buffer,
              py::arg("port"),
              py::arg("max_output_buffer"),
              D(block, set_max_output_buffer, 1))
@@ -268,13 +268,13 @@ void bind_block(py::module& m)
 
 
         .def("set_min_output_buffer",
-             (void (block::*)(long int)) & block::set_min_output_buffer,
+             (void(block::*)(long int)) & block::set_min_output_buffer,
              py::arg("min_output_buffer"),
              D(block, set_min_output_buffer, 0))
 
 
         .def("set_min_output_buffer",
-             (void (block::*)(int, long int)) & block::set_min_output_buffer,
+             (void(block::*)(int, long int)) & block::set_min_output_buffer,
              py::arg("port"),
              py::arg("min_output_buffer"),
              D(block, set_min_output_buffer, 1))
@@ -312,19 +312,19 @@ void bind_block(py::module& m)
 
 
         .def("pc_input_buffers_full",
-             (float (block::*)(int)) & block::pc_input_buffers_full,
+             (float(block::*)(int)) & block::pc_input_buffers_full,
              py::arg("which"),
              D(block, pc_input_buffers_full, 0))
 
 
         .def("pc_input_buffers_full_avg",
-             (float (block::*)(int)) & block::pc_input_buffers_full_avg,
+             (float(block::*)(int)) & block::pc_input_buffers_full_avg,
              py::arg("which"),
              D(block, pc_input_buffers_full_avg, 0))
 
 
         .def("pc_input_buffers_full_var",
-             (float (block::*)(int)) & block::pc_input_buffers_full_var,
+             (float(block::*)(int)) & block::pc_input_buffers_full_var,
              py::arg("which"),
              D(block, pc_input_buffers_full_var, 0))
 
@@ -348,19 +348,19 @@ void bind_block(py::module& m)
 
 
         .def("pc_output_buffers_full",
-             (float (block::*)(int)) & block::pc_output_buffers_full,
+             (float(block::*)(int)) & block::pc_output_buffers_full,
              py::arg("which"),
              D(block, pc_output_buffers_full, 0))
 
 
         .def("pc_output_buffers_full_avg",
-             (float (block::*)(int)) & block::pc_output_buffers_full_avg,
+             (float(block::*)(int)) & block::pc_output_buffers_full_avg,
              py::arg("which"),
              D(block, pc_output_buffers_full_avg, 0))
 
 
         .def("pc_output_buffers_full_var",
-             (float (block::*)(int)) & block::pc_output_buffers_full_var,
+             (float(block::*)(int)) & block::pc_output_buffers_full_var,
              py::arg("which"),
              D(block, pc_output_buffers_full_var, 0))
 

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/flowgraph_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/flowgraph_python.cc
@@ -43,7 +43,7 @@ void bind_flowgraph(py::module& m)
 
 
         .def("connect",
-             (void (flowgraph::*)(gr::endpoint const&, gr::endpoint const&)) &
+             (void(flowgraph::*)(gr::endpoint const&, gr::endpoint const&)) &
                  flowgraph::connect,
              py::arg("src"),
              py::arg("dst"),
@@ -51,7 +51,7 @@ void bind_flowgraph(py::module& m)
 
 
         .def("disconnect",
-             (void (flowgraph::*)(gr::endpoint const&, gr::endpoint const&)) &
+             (void(flowgraph::*)(gr::endpoint const&, gr::endpoint const&)) &
                  flowgraph::disconnect,
              py::arg("src"),
              py::arg("dst"),
@@ -59,7 +59,7 @@ void bind_flowgraph(py::module& m)
 
 
         .def("connect",
-             (void (flowgraph::*)(gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
+             (void(flowgraph::*)(gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
                  flowgraph::connect,
              py::arg("src_block"),
              py::arg("src_port"),
@@ -69,7 +69,7 @@ void bind_flowgraph(py::module& m)
 
 
         .def("disconnect",
-             (void (flowgraph::*)(gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
+             (void(flowgraph::*)(gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
                  flowgraph::disconnect,
              py::arg("src_block"),
              py::arg("src_port"),
@@ -79,7 +79,7 @@ void bind_flowgraph(py::module& m)
 
 
         .def("connect",
-             (void (flowgraph::*)(gr::msg_endpoint const&, gr::msg_endpoint const&)) &
+             (void(flowgraph::*)(gr::msg_endpoint const&, gr::msg_endpoint const&)) &
                  flowgraph::connect,
              py::arg("src"),
              py::arg("dst"),
@@ -87,7 +87,7 @@ void bind_flowgraph(py::module& m)
 
 
         .def("disconnect",
-             (void (flowgraph::*)(gr::msg_endpoint const&, gr::msg_endpoint const&)) &
+             (void(flowgraph::*)(gr::msg_endpoint const&, gr::msg_endpoint const&)) &
                  flowgraph::disconnect,
              py::arg("src"),
              py::arg("dst"),

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_nco_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_nco_python.cc
@@ -58,11 +58,11 @@ void bind_fxpt_nco(py::module& m)
              D(fxpt_nco, adjust_freq))
 
 
-        .def("step", (void (fxpt_nco::*)()) & fxpt_nco::step, D(fxpt_nco, step, 0))
+        .def("step", (void(fxpt_nco::*)()) & fxpt_nco::step, D(fxpt_nco, step, 0))
 
 
         .def("step",
-             (void (fxpt_nco::*)(int)) & fxpt_nco::step,
+             (void(fxpt_nco::*)(int)) & fxpt_nco::step,
              py::arg("n"),
              D(fxpt_nco, step, 1))
 
@@ -74,14 +74,14 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("sincos",
-             (void (fxpt_nco::*)(float*, float*) const) & fxpt_nco::sincos,
+             (void(fxpt_nco::*)(float*, float*) const) & fxpt_nco::sincos,
              py::arg("sinx"),
              py::arg("cosx"),
              D(fxpt_nco, sincos, 0))
 
 
         .def("sincos",
-             (void (fxpt_nco::*)(gr_complex*, int, double)) & fxpt_nco::sincos,
+             (void(fxpt_nco::*)(gr_complex*, int, double)) & fxpt_nco::sincos,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -89,7 +89,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("sin",
-             (void (fxpt_nco::*)(float*, int, double)) & fxpt_nco::sin,
+             (void(fxpt_nco::*)(float*, int, double)) & fxpt_nco::sin,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -97,7 +97,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("cos",
-             (void (fxpt_nco::*)(float*, int, double)) & fxpt_nco::cos,
+             (void(fxpt_nco::*)(float*, int, double)) & fxpt_nco::cos,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -105,7 +105,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("sin",
-             (void (fxpt_nco::*)(int8_t*, int, double)) & fxpt_nco::sin,
+             (void(fxpt_nco::*)(int8_t*, int, double)) & fxpt_nco::sin,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -113,7 +113,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("cos",
-             (void (fxpt_nco::*)(int8_t*, int, double)) & fxpt_nco::cos,
+             (void(fxpt_nco::*)(int8_t*, int, double)) & fxpt_nco::cos,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -121,7 +121,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("sin",
-             (void (fxpt_nco::*)(short int*, int, double)) & fxpt_nco::sin,
+             (void(fxpt_nco::*)(short int*, int, double)) & fxpt_nco::sin,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -129,7 +129,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("cos",
-             (void (fxpt_nco::*)(short int*, int, double)) & fxpt_nco::cos,
+             (void(fxpt_nco::*)(short int*, int, double)) & fxpt_nco::cos,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -137,7 +137,7 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("sin",
-             (void (fxpt_nco::*)(int*, int, double)) & fxpt_nco::sin,
+             (void(fxpt_nco::*)(int*, int, double)) & fxpt_nco::sin,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
@@ -145,17 +145,17 @@ void bind_fxpt_nco(py::module& m)
 
 
         .def("cos",
-             (void (fxpt_nco::*)(int*, int, double)) & fxpt_nco::cos,
+             (void(fxpt_nco::*)(int*, int, double)) & fxpt_nco::cos,
              py::arg("output"),
              py::arg("noutput_items"),
              py::arg("ampl") = 1.,
              D(fxpt_nco, cos, 3))
 
 
-        .def("cos", (float (fxpt_nco::*)() const) & fxpt_nco::cos, D(fxpt_nco, cos, 4))
+        .def("cos", (float(fxpt_nco::*)() const) & fxpt_nco::cos, D(fxpt_nco, cos, 4))
 
 
-        .def("sin", (float (fxpt_nco::*)() const) & fxpt_nco::sin, D(fxpt_nco, sin, 4))
+        .def("sin", (float(fxpt_nco::*)() const) & fxpt_nco::sin, D(fxpt_nco, sin, 4))
 
         ;
 }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_vco_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/fxpt_vco_python.cc
@@ -52,14 +52,14 @@ void bind_fxpt_vco(py::module& m)
 
 
         .def("sincos",
-             (void (fxpt_vco::*)(float*, float*) const) & fxpt_vco::sincos,
+             (void(fxpt_vco::*)(float*, float*) const) & fxpt_vco::sincos,
              py::arg("sinx"),
              py::arg("cosx"),
              D(fxpt_vco, sincos, 0))
 
 
         .def("sincos",
-             (void (fxpt_vco::*)(gr_complex*, float const*, int, float, float)) &
+             (void(fxpt_vco::*)(gr_complex*, float const*, int, float, float)) &
                  fxpt_vco::sincos,
              py::arg("output"),
              py::arg("input"),
@@ -70,8 +70,7 @@ void bind_fxpt_vco(py::module& m)
 
 
         .def("cos",
-             (void (fxpt_vco::*)(float*, float const*, int, float, float)) &
-                 fxpt_vco::cos,
+             (void(fxpt_vco::*)(float*, float const*, int, float, float)) & fxpt_vco::cos,
              py::arg("output"),
              py::arg("input"),
              py::arg("noutput_items"),
@@ -80,7 +79,7 @@ void bind_fxpt_vco(py::module& m)
              D(fxpt_vco, cos, 0))
 
 
-        .def("cos", (float (fxpt_vco::*)() const) & fxpt_vco::cos, D(fxpt_vco, cos, 1))
+        .def("cos", (float(fxpt_vco::*)() const) & fxpt_vco::cos, D(fxpt_vco, cos, 1))
 
 
         .def("sin", &fxpt_vco::sin, D(fxpt_vco, sin))

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/hier_block2_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/hier_block2_python.cc
@@ -44,19 +44,19 @@ void bind_hier_block2(py::module& m)
 
         .def("self", &hier_block2::self)
         .def("primitive_connect",
-             (void (hier_block2::*)(gr::basic_block_sptr)) & hier_block2::connect,
+             (void(hier_block2::*)(gr::basic_block_sptr)) & hier_block2::connect,
              py::arg("block"))
-        .def("primitive_connect",
-             (void (hier_block2::*)(
-                 gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
-                 hier_block2::connect,
-             py::arg("src"),
-             py::arg("src_port"),
-             py::arg("dst"),
-             py::arg("dst_port"),
-             D(hier_block2, connect, 1))
+        .def(
+            "primitive_connect",
+            (void(hier_block2::*)(gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
+                hier_block2::connect,
+            py::arg("src"),
+            py::arg("src_port"),
+            py::arg("dst"),
+            py::arg("dst_port"),
+            D(hier_block2, connect, 1))
         .def("primitive_msg_connect",
-             (void (hier_block2::*)(
+             (void(hier_block2::*)(
                  gr::basic_block_sptr, pmt::pmt_t, gr::basic_block_sptr, pmt::pmt_t)) &
                  hier_block2::msg_connect,
              py::arg("src"),
@@ -65,7 +65,7 @@ void bind_hier_block2(py::module& m)
              py::arg("dstport"),
              D(hier_block2, msg_connect, 0))
         .def("primitive_msg_connect",
-             (void (hier_block2::*)(
+             (void(hier_block2::*)(
                  gr::basic_block_sptr, std::string, gr::basic_block_sptr, std::string)) &
                  hier_block2::msg_connect,
              py::arg("src"),
@@ -74,7 +74,7 @@ void bind_hier_block2(py::module& m)
              py::arg("dstport"),
              D(hier_block2, msg_connect, 1))
         .def("primitive_msg_disconnect",
-             (void (hier_block2::*)(
+             (void(hier_block2::*)(
                  gr::basic_block_sptr, pmt::pmt_t, gr::basic_block_sptr, pmt::pmt_t)) &
                  hier_block2::msg_disconnect,
              py::arg("src"),
@@ -83,7 +83,7 @@ void bind_hier_block2(py::module& m)
              py::arg("dstport"),
              D(hier_block2, msg_disconnect, 0))
         .def("primitive_msg_disconnect",
-             (void (hier_block2::*)(
+             (void(hier_block2::*)(
                  gr::basic_block_sptr, std::string, gr::basic_block_sptr, std::string)) &
                  hier_block2::msg_disconnect,
              py::arg("src"),
@@ -92,18 +92,18 @@ void bind_hier_block2(py::module& m)
              py::arg("dstport"),
              D(hier_block2, msg_disconnect, 1))
         .def("primitive_disconnect",
-             (void (hier_block2::*)(gr::basic_block_sptr)) & hier_block2::disconnect,
+             (void(hier_block2::*)(gr::basic_block_sptr)) & hier_block2::disconnect,
              py::arg("block"),
              D(hier_block2, disconnect, 0))
-        .def("primitive_disconnect",
-             (void (hier_block2::*)(
-                 gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
-                 hier_block2::disconnect,
-             py::arg("src"),
-             py::arg("src_port"),
-             py::arg("dst"),
-             py::arg("dst_port"),
-             D(hier_block2, disconnect, 1))
+        .def(
+            "primitive_disconnect",
+            (void(hier_block2::*)(gr::basic_block_sptr, int, gr::basic_block_sptr, int)) &
+                hier_block2::disconnect,
+            py::arg("src"),
+            py::arg("src_port"),
+            py::arg("dst"),
+            py::arg("dst_port"),
+            D(hier_block2, disconnect, 1))
 
 
         .def("disconnect_all",
@@ -122,11 +122,11 @@ void bind_hier_block2(py::module& m)
              py::arg("port") = 0,
              D(hier_block2, max_output_buffer))
         .def("set_max_output_buffer",
-             (void (hier_block2::*)(int)) & hier_block2::set_max_output_buffer,
+             (void(hier_block2::*)(int)) & hier_block2::set_max_output_buffer,
              py::arg("max_output_buffer"),
              D(hier_block2, set_max_output_buffer, 0))
         .def("set_max_output_buffer",
-             (void (hier_block2::*)(size_t, int)) & hier_block2::set_max_output_buffer,
+             (void(hier_block2::*)(size_t, int)) & hier_block2::set_max_output_buffer,
              py::arg("port"),
              py::arg("max_output_buffer"),
              D(hier_block2, set_max_output_buffer, 1))
@@ -135,11 +135,11 @@ void bind_hier_block2(py::module& m)
              py::arg("port") = 0,
              D(hier_block2, min_output_buffer))
         .def("set_min_output_buffer",
-             (void (hier_block2::*)(int)) & hier_block2::set_min_output_buffer,
+             (void(hier_block2::*)(int)) & hier_block2::set_min_output_buffer,
              py::arg("min_output_buffer"),
              D(hier_block2, set_min_output_buffer, 0))
         .def("set_min_output_buffer",
-             (void (hier_block2::*)(size_t, int)) & hier_block2::set_min_output_buffer,
+             (void(hier_block2::*)(size_t, int)) & hier_block2::set_min_output_buffer,
              py::arg("port"),
              py::arg("min_output_buffer"),
              D(hier_block2, set_min_output_buffer, 1))

--- a/gr-filter/python/filter/bindings/fir_filter_with_buffer_python.cc
+++ b/gr-filter/python/filter/bindings/fir_filter_with_buffer_python.cc
@@ -45,14 +45,14 @@ void bind_fir_filter_with_buffer(py::module& m)
 
 
         .def("filter",
-             (float (fir_filter_with_buffer_fff::*)(float)) &
+             (float(fir_filter_with_buffer_fff::*)(float)) &
                  fir_filter_with_buffer_fff::filter,
              py::arg("input"),
              D(kernel, fir_filter_with_buffer_fff, filter, 0))
 
 
         .def("filter",
-             (float (fir_filter_with_buffer_fff::*)(float const*, long unsigned int)) &
+             (float(fir_filter_with_buffer_fff::*)(float const*, long unsigned int)) &
                  fir_filter_with_buffer_fff::filter,
              py::arg("input"),
              py::arg("dec"),

--- a/gr-qtgui/python/qtgui/bindings/eye_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/eye_sink_c_python.cc
@@ -242,14 +242,14 @@ void bind_eye_sink_c(py::module& m)
 
 
         .def("enable_tags",
-             (void (eye_sink_c::*)(unsigned int, bool)) & eye_sink_c::enable_tags,
+             (void(eye_sink_c::*)(unsigned int, bool)) & eye_sink_c::enable_tags,
              py::arg("which"),
              py::arg("en"),
              D(eye_sink_c, enable_tags, 0))
 
 
         .def("enable_tags",
-             (void (eye_sink_c::*)(bool)) & eye_sink_c::enable_tags,
+             (void(eye_sink_c::*)(bool)) & eye_sink_c::enable_tags,
              py::arg("en"),
              D(eye_sink_c, enable_tags, 1))
 

--- a/gr-qtgui/python/qtgui/bindings/eye_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/eye_sink_f_python.cc
@@ -241,14 +241,14 @@ void bind_eye_sink_f(py::module& m)
 
 
         .def("enable_tags",
-             (void (eye_sink_f::*)(unsigned int, bool)) & eye_sink_f::enable_tags,
+             (void(eye_sink_f::*)(unsigned int, bool)) & eye_sink_f::enable_tags,
              py::arg("which"),
              py::arg("en"),
              D(eye_sink_f, enable_tags, 0))
 
 
         .def("enable_tags",
-             (void (eye_sink_f::*)(bool)) & eye_sink_f::enable_tags,
+             (void(eye_sink_f::*)(bool)) & eye_sink_f::enable_tags,
              py::arg("en"),
              D(eye_sink_f, enable_tags, 1))
 

--- a/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/number_sink_python.cc
@@ -81,18 +81,18 @@ void bind_number_sink(py::module& m)
              D(number_sink, set_graph_type))
 
 
-        .def("set_color",
-             (void (number_sink::*)(
-                 unsigned int, std::string const&, std::string const&)) &
-                 number_sink::set_color,
-             py::arg("which"),
-             py::arg("min"),
-             py::arg("max"),
-             D(number_sink, set_color, 0))
+        .def(
+            "set_color",
+            (void(number_sink::*)(unsigned int, std::string const&, std::string const&)) &
+                number_sink::set_color,
+            py::arg("which"),
+            py::arg("min"),
+            py::arg("max"),
+            D(number_sink, set_color, 0))
 
 
         .def("set_color",
-             (void (number_sink::*)(unsigned int, int, int)) & number_sink::set_color,
+             (void(number_sink::*)(unsigned int, int, int)) & number_sink::set_color,
              py::arg("which"),
              py::arg("min"),
              py::arg("max"),

--- a/gr-qtgui/python/qtgui/bindings/time_sink_c_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_sink_c_python.cc
@@ -245,14 +245,14 @@ void bind_time_sink_c(py::module& m)
 
 
         .def("enable_tags",
-             (void (time_sink_c::*)(unsigned int, bool)) & time_sink_c::enable_tags,
+             (void(time_sink_c::*)(unsigned int, bool)) & time_sink_c::enable_tags,
              py::arg("which"),
              py::arg("en"),
              D(time_sink_c, enable_tags, 0))
 
 
         .def("enable_tags",
-             (void (time_sink_c::*)(bool)) & time_sink_c::enable_tags,
+             (void(time_sink_c::*)(bool)) & time_sink_c::enable_tags,
              py::arg("en"),
              D(time_sink_c, enable_tags, 1))
 

--- a/gr-qtgui/python/qtgui/bindings/time_sink_f_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/time_sink_f_python.cc
@@ -243,14 +243,14 @@ void bind_time_sink_f(py::module& m)
 
 
         .def("enable_tags",
-             (void (time_sink_f::*)(unsigned int, bool)) & time_sink_f::enable_tags,
+             (void(time_sink_f::*)(unsigned int, bool)) & time_sink_f::enable_tags,
              py::arg("which"),
              py::arg("en"),
              D(time_sink_f, enable_tags, 0))
 
 
         .def("enable_tags",
-             (void (time_sink_f::*)(bool)) & time_sink_f::enable_tags,
+             (void(time_sink_f::*)(bool)) & time_sink_f::enable_tags,
              py::arg("en"),
              D(time_sink_f, enable_tags, 1))
 

--- a/gr-soapy/python/soapy/bindings/block_python.cc
+++ b/gr-soapy/python/soapy/bindings/block_python.cc
@@ -95,14 +95,14 @@ void bind_block(py::module& m)
 
 
         .def("set_frequency",
-             (void (block::*)(size_t, double)) & block::set_frequency,
+             (void(block::*)(size_t, double)) & block::set_frequency,
              py::arg("channel"),
              py::arg("freq"),
              D(block, set_frequency, 0))
 
 
         .def("set_frequency",
-             (void (block::*)(size_t, const std::string&, double)) & block::set_frequency,
+             (void(block::*)(size_t, const std::string&, double)) & block::set_frequency,
              py::arg("channel"),
              py::arg("name"),
              py::arg("freq"),
@@ -110,13 +110,13 @@ void bind_block(py::module& m)
 
 
         .def("get_frequency",
-             (double (block::*)(size_t) const) & block::get_frequency,
+             (double(block::*)(size_t) const) & block::get_frequency,
              py::arg("channel"),
              D(block, get_frequency, 0))
 
 
         .def("get_frequency",
-             (double (block::*)(size_t, const std::string&) const) & block::get_frequency,
+             (double(block::*)(size_t, const std::string&) const) & block::get_frequency,
              py::arg("channel"),
              py::arg("name"),
              D(block, get_frequency, 1))
@@ -208,14 +208,14 @@ void bind_block(py::module& m)
 
 
         .def("set_gain",
-             (void (block::*)(size_t, double)) & block::set_gain,
+             (void(block::*)(size_t, double)) & block::set_gain,
              py::arg("channel"),
              py::arg("gain"),
              D(block, set_gain, 0))
 
 
         .def("set_gain",
-             (void (block::*)(size_t, const std::string&, double)) & block::set_gain,
+             (void(block::*)(size_t, const std::string&, double)) & block::set_gain,
              py::arg("channel"),
              py::arg("name"),
              py::arg("gain"),
@@ -223,13 +223,13 @@ void bind_block(py::module& m)
 
 
         .def("get_gain",
-             (double (block::*)(size_t) const) & block::get_gain,
+             (double(block::*)(size_t) const) & block::get_gain,
              py::arg("channel"),
              D(block, get_gain, 0))
 
 
         .def("get_gain",
-             (double (block::*)(size_t, const std::string&) const) & block::get_gain,
+             (double(block::*)(size_t, const std::string&) const) & block::get_gain,
              py::arg("channel"),
              py::arg("name"),
              D(block, get_gain, 1))
@@ -562,15 +562,14 @@ void bind_block(py::module& m)
 
 
         .def("write_gpio",
-             (void (block::*)(const std::string&, unsigned)) & block::write_gpio,
+             (void(block::*)(const std::string&, unsigned)) & block::write_gpio,
              py::arg("bank"),
              py::arg("value"),
              D(block, write_gpio, 0))
 
 
         .def("write_gpio",
-             (void (block::*)(const std::string&, unsigned, unsigned)) &
-                 block::write_gpio,
+             (void(block::*)(const std::string&, unsigned, unsigned)) & block::write_gpio,
              py::arg("bank"),
              py::arg("value"),
              py::arg("mask"),
@@ -581,14 +580,14 @@ void bind_block(py::module& m)
 
 
         .def("write_gpio_dir",
-             (void (block::*)(const std::string&, unsigned)) & block::write_gpio_dir,
+             (void(block::*)(const std::string&, unsigned)) & block::write_gpio_dir,
              py::arg("bank"),
              py::arg("value"),
              D(block, write_gpio_dir, 0))
 
 
         .def("write_gpio_dir",
-             (void (block::*)(const std::string&, unsigned, unsigned)) &
+             (void(block::*)(const std::string&, unsigned, unsigned)) &
                  block::write_gpio_dir,
              py::arg("bank"),
              py::arg("value"),

--- a/gr-uhd/python/uhd/bindings/rfnoc_rx_radio_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_rx_radio_python.cc
@@ -75,21 +75,20 @@ void bind_rfnoc_rx_radio(py::module& m)
 
 
         .def("set_gain",
-             (double (rfnoc_rx_radio::*)(double const, size_t const)) &
+             (double(rfnoc_rx_radio::*)(double const, size_t const)) &
                  rfnoc_rx_radio::set_gain,
              py::arg("gain"),
              py::arg("chan"),
              D(rfnoc_rx_radio, set_gain, 0))
 
 
-        .def(
-            "set_gain",
-            (double (rfnoc_rx_radio::*)(double const, std::string const&, size_t const)) &
-                rfnoc_rx_radio::set_gain,
-            py::arg("gain"),
-            py::arg("name"),
-            py::arg("chan"),
-            D(rfnoc_rx_radio, set_gain, 1))
+        .def("set_gain",
+             (double(rfnoc_rx_radio::*)(double const, std::string const&, size_t const)) &
+                 rfnoc_rx_radio::set_gain,
+             py::arg("gain"),
+             py::arg("name"),
+             py::arg("chan"),
+             D(rfnoc_rx_radio, set_gain, 1))
 
 
         .def("set_agc",
@@ -138,7 +137,7 @@ void bind_rfnoc_rx_radio(py::module& m)
 
 
         .def("set_dc_offset",
-             (void (rfnoc_rx_radio::*)(bool const, size_t const)) &
+             (void(rfnoc_rx_radio::*)(bool const, size_t const)) &
                  rfnoc_rx_radio::set_dc_offset,
              py::arg("enable"),
              py::arg("chan"),
@@ -146,7 +145,7 @@ void bind_rfnoc_rx_radio(py::module& m)
 
 
         .def("set_dc_offset",
-             (void (rfnoc_rx_radio::*)(std::complex<double> const&, size_t const)) &
+             (void(rfnoc_rx_radio::*)(std::complex<double> const&, size_t const)) &
                  rfnoc_rx_radio::set_dc_offset,
              py::arg("offset"),
              py::arg("chan"),
@@ -154,7 +153,7 @@ void bind_rfnoc_rx_radio(py::module& m)
 
 
         .def("set_iq_balance",
-             (void (rfnoc_rx_radio::*)(bool const, size_t const)) &
+             (void(rfnoc_rx_radio::*)(bool const, size_t const)) &
                  rfnoc_rx_radio::set_iq_balance,
              py::arg("enable"),
              py::arg("chan"),
@@ -162,7 +161,7 @@ void bind_rfnoc_rx_radio(py::module& m)
 
 
         .def("set_iq_balance",
-             (void (rfnoc_rx_radio::*)(std::complex<double> const&, size_t const)) &
+             (void(rfnoc_rx_radio::*)(std::complex<double> const&, size_t const)) &
                  rfnoc_rx_radio::set_iq_balance,
              py::arg("correction"),
              py::arg("chan"),

--- a/gr-uhd/python/uhd/bindings/rfnoc_tx_radio_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_tx_radio_python.cc
@@ -75,21 +75,20 @@ void bind_rfnoc_tx_radio(py::module& m)
 
 
         .def("set_gain",
-             (double (rfnoc_tx_radio::*)(double const, size_t const)) &
+             (double(rfnoc_tx_radio::*)(double const, size_t const)) &
                  rfnoc_tx_radio::set_gain,
              py::arg("gain"),
              py::arg("chan"),
              D(rfnoc_tx_radio, set_gain, 0))
 
 
-        .def(
-            "set_gain",
-            (double (rfnoc_tx_radio::*)(double const, std::string const&, size_t const)) &
-                rfnoc_tx_radio::set_gain,
-            py::arg("gain"),
-            py::arg("name"),
-            py::arg("chan"),
-            D(rfnoc_tx_radio, set_gain, 1))
+        .def("set_gain",
+             (double(rfnoc_tx_radio::*)(double const, std::string const&, size_t const)) &
+                 rfnoc_tx_radio::set_gain,
+             py::arg("gain"),
+             py::arg("name"),
+             py::arg("chan"),
+             D(rfnoc_tx_radio, set_gain, 1))
 
 
         .def("set_gain_profile",

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -93,7 +93,7 @@ void bind_usrp_block(py::module& m)
 
 
         .def("set_gain",
-             (void (usrp_block::*)(double, size_t, pmt::pmt_t)) & usrp_block::set_gain,
+             (void(usrp_block::*)(double, size_t, pmt::pmt_t)) & usrp_block::set_gain,
              py::arg("gain"),
              py::arg("chan") = 0,
              py::arg("direction") = pmt::PMT_NIL,
@@ -101,7 +101,7 @@ void bind_usrp_block(py::module& m)
 
 
         .def("set_gain",
-             (void (usrp_block::*)(double, std::string const&, size_t)) &
+             (void(usrp_block::*)(double, std::string const&, size_t)) &
                  usrp_block::set_gain,
              py::arg("gain"),
              py::arg("name"),
@@ -117,13 +117,13 @@ void bind_usrp_block(py::module& m)
 
 
         .def("get_gain",
-             (double (usrp_block::*)(size_t)) & usrp_block::get_gain,
+             (double(usrp_block::*)(size_t)) & usrp_block::get_gain,
              py::arg("chan") = 0,
              D(usrp_block, get_gain, 0))
 
 
         .def("get_gain",
-             (double (usrp_block::*)(std::string const&, size_t)) & usrp_block::get_gain,
+             (double(usrp_block::*)(std::string const&, size_t)) & usrp_block::get_gain,
              py::arg("name"),
              py::arg("chan") = 0,
              D(usrp_block, get_gain, 1))


### PR DESCRIPTION
## Description
There is a mismatch between the output of clang-format locally using many distros (ones that have clang-format v14) and that run by the CI.  This updates the github action to use clang-format v14 as well as reformat in-tree to match

## Related Issue

## Which blocks/areas does this affect?
Appears to only affect the clang-formatting of the pybind files

## Testing Done
CI should be sufficient

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
