### PR TITLE
runtime: Fix PMT serialization of C32 vectors (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -528,10 +528,8 @@ tail_recursion:
             for (size_t i = 0; i < npad; i++) {
                 ok &= serialize_untagged_u8(0, sb);
             }
-            // Note that if endianness causes byte swap that real/imag will also be
-            // swapped
-            ok &= serialize_untagged_u64_array(
-                (uint64_t*)&c32vector_elements(obj)[0], vec_len, sb);
+            ok &= serialize_untagged_u32_array(
+                (uint32_t*)&c32vector_elements(obj)[0], vec_len * 2, sb);
             return ok;
         }
 
@@ -729,9 +727,8 @@ pmt_t deserialize(std::streambuf& sb)
             return vec;
         }
         case (UVI_C32): {
-            // Data was serialized as uint64, so do the same here
-            deserialize_untagged_u64_vector(u64v, nitems, sb);
-            pmt_t vec = init_c32vector(nitems, (std::complex<float>*)&u64v[0]);
+            deserialize_untagged_u32_vector(u32v, 2 * nitems, sb);
+            pmt_t vec = init_c32vector(nitems, (std::complex<float>*)&u32v[0]);
             return vec;
         }
 

--- a/gnuradio-runtime/python/pmt/qa_pmt.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt.py
@@ -11,6 +11,7 @@
 
 import unittest
 import pmt
+import struct
 
 
 class test_pmt(unittest.TestCase):
@@ -345,13 +346,15 @@ class test_pmt(unittest.TestCase):
         in_vec = [0x01020304 - 1j, 3.1415 + 99.99j]
         # old serialization (c32 serialized as c64):
         # in_str = b'\n\n\x00\x00\x00\x02\x01\x00Ap 0@\x00\x00\x00\xbf\xf0\x00\x00\x00\x00\x00\x00@\t!\xca\xc0\x00\x00\x00@X\xff\\ \x00\x00\x00'
-        in_str = b'\n\n\x00\x00\x00\x02\x01\x00\xbf\x80\x00\x00K\x81\x01\x82B\xc7\xfa\xe1@I\x0eV'
+        in_str = struct.pack(">BBIBBffff", 0x0a, 0x0a, len(in_vec), 1, 0,
+                             in_vec[0].real, in_vec[0].imag, in_vec[1].real, in_vec[1].imag)
         out_str = pmt.serialize_str(pmt.init_c32vector(len(in_vec), in_vec))
         self.assertEqual(out_str, in_str)
+        in_vec = [1 + 1j, .125 - 9999999j]
         # old serialization (c32 serialized as c64):
         # in_str = b'\n\n\x00\x00\x00\x02\x01\x00?\xf0\x00\x00\x00\x00\x00\x00?\xf0\x00\x00\x00\x00\x00\x00?\xc0\x00\x00\x00\x00\x00\x00\xc1c\x12\xcf\xe0\x00\x00\x00'
-        in_str = b'\n\n\x00\x00\x00\x02\x01\x00?\x80\x00\x00?\x80\x00\x00\xcb\x18\x96\x7f>\x00\x00\x00'
-        in_vec = [1 + 1j, .125 - 9999999j]
+        in_str = struct.pack(">BBIBBffff", 0x0a, 0x0a, len(in_vec), 1, 0,
+                             in_vec[0].real, in_vec[0].imag, in_vec[1].real, in_vec[1].imag)
         out_vec = pmt.c32vector_elements(pmt.deserialize_str(in_str))
         self.assertEqual(out_vec, in_vec)
 


### PR DESCRIPTION
Prior to this change, C32 vectors were inadvertently serialized as (imag, real) on little-endian platforms and (real, imag) on big-endian platforms.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 5ea0a3a63bad149829069419f0affa27ce31c141)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6307