### PR TITLE
runtime: make logging in rpcpmtconverters_thift work with fmt v9 (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -111,7 +111,8 @@ GNURadio::Knob rpcpmtconverter::from_pmt(const pmt::pmt_t& knob)
         // FIXME: Don't get loggers every time we need to log something.
         gr::logger_ptr logger, debug_logger;
         gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
-        logger->error("ERROR Don't know how to handle Knob Type (from): {}", knob);
+        logger->error("ERROR Don't know how to handle Knob Type (from): {}",
+                      pmt::write_string(knob));
         assert(0);
     }
     return GNURadio::Knob();


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit 2e09660c8b0b96df470c583a6febb00463d6b921)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6288