### PR TITLE
uhd: Declare float to time_spec_t implicitly convertible (backport to maint-3.10)

### DIFF
--- a/gr-uhd/python/uhd/bindings/python_bindings.cc
+++ b/gr-uhd/python/uhd/bindings/python_bindings.cc
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2020 Free Software Foundation, Inc.
  *
@@ -13,6 +12,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#include <uhd/types/time_spec.hpp>
 #include <uhd/version.hpp>
 
 namespace py = pybind11;
@@ -68,6 +68,9 @@ PYBIND11_MODULE(uhd_python, m)
     bind_rfnoc_tx_radio(m);
     bind_rfnoc_tx_streamer(m);
 #endif
+
+
+    py::implicitly_convertible<double, uhd::time_spec_t>();
 
     m.def(
         "get_version_string",


### PR DESCRIPTION
Without this declaration, function calls that require a time_spec_t argument must be provided with such an argument, even if there is a default argument.

For example, in the RFNoC DDC block, we couldn't call set_freq() as such:

```python
ddc_block.set_freq(0.0, 0)
```

It would produce the following error:
```
TypeError: set_freq(): incompatible function arguments. The following
    argument types are supported:
1. (self: gnuradio.uhd.uhd_python.rfnoc_ddc,
    freq: float,
    chan: int,
    time: gnuradio.uhd.uhd_python.time_spec_t = 0.0) -> float
```

Even though the argument `time` is optional, the default value of 0.0 is not able to satisfy the requirements. By adding the `py::implicitly_convertible` call, we declare float convertible to time spec, and the call above can proceed.

Signed-off-by: Martin Braun <martin.braun@ettus.com>
(cherry picked from commit 865b35ef514c97e83b6895e3c7d83a716ae84c78)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6263