### PR TITLE
network: Move boost::asio namespace to asio (backport to maint-3.10)

### DIFF
--- a/gr-network/lib/CMakeLists.txt
+++ b/gr-network/lib/CMakeLists.txt
@@ -35,7 +35,9 @@ endif()
 target_include_directories(
     gnuradio-network
     PUBLIC $<INSTALL_INTERFACE:include>
-    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/asio
+)
 
 if(HAVE_WINDOWS_H)
     target_compile_definitions(gnuradio-network PRIVATE -DHAVE_WINDOWS_H)

--- a/gr-network/lib/asio/asio.hpp
+++ b/gr-network/lib/asio/asio.hpp
@@ -1,0 +1,29 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Martin Braun <martin.braun@ettus.com>
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// This is a translation layer from boost::asio to non-Boost asio. It makes
+// boost::asio look like regular asio to allow easier transition.
+
+#ifndef INCLUDED_GR_ASIO_WRAPPER_H
+#define INCLUDED_GR_ASIO_WRAPPER_H
+
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
+
+namespace boost {
+namespace asio {
+using error_code = boost::system::error_code;
+using system_error = boost::system::system_error;
+} // namespace asio
+} // namespace boost
+
+namespace asio = boost::asio;
+
+#endif /* INCLUDED_GR_ASIO_WRAPPER_H */

--- a/gr-network/lib/socket_pdu_impl.cc
+++ b/gr-network/lib/socket_pdu_impl.cc
@@ -8,6 +8,7 @@
  *
  */
 
+
 #include <sstream>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -50,15 +51,11 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
         if (port_num == 0)
             throw std::invalid_argument(
                 "gr::pdu:socket_pdu: invalid port for TCP_SERVER");
-        d_tcp_endpoint =
-            boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port_num);
+        d_tcp_endpoint = asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port_num);
     } else if ((type == "TCP_SERVER") || (type == "TCP_CLIENT")) {
-        boost::asio::ip::tcp::resolver resolver(d_io_service);
-        boost::asio::ip::tcp::resolver::query query(
-            boost::asio::ip::tcp::v4(),
-            addr,
-            port,
-            boost::asio::ip::resolver_query_base::passive);
+        asio::ip::tcp::resolver resolver(d_io_context);
+        asio::ip::tcp::resolver::query query(
+            asio::ip::tcp::v4(), addr, port, asio::ip::resolver_query_base::passive);
         d_tcp_endpoint = *resolver.resolve(query);
     } else if ((type == "UDP_SERVER") &&
                ((addr.empty()) || (addr == "0.0.0.0"))) { // Bind on all interfaces
@@ -66,15 +63,11 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
         if (port_num == 0)
             throw std::invalid_argument(
                 "gr::pdu:socket_pdu: invalid port for UDP_SERVER");
-        d_udp_endpoint =
-            boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), port_num);
+        d_udp_endpoint = asio::ip::udp::endpoint(asio::ip::udp::v4(), port_num);
     } else if ((type == "UDP_SERVER") || (type == "UDP_CLIENT")) {
-        boost::asio::ip::udp::resolver resolver(d_io_service);
-        boost::asio::ip::udp::resolver::query query(
-            boost::asio::ip::udp::v4(),
-            addr,
-            port,
-            boost::asio::ip::resolver_query_base::passive);
+        asio::ip::udp::resolver resolver(d_io_context);
+        asio::ip::udp::resolver::query query(
+            asio::ip::udp::v4(), addr, port, asio::ip::resolver_query_base::passive);
 
         if (type == "UDP_SERVER")
             d_udp_endpoint = *resolver.resolve(query);
@@ -83,37 +76,37 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
     }
 
     if (type == "TCP_SERVER") {
-        d_acceptor_tcp = std::make_shared<boost::asio::ip::tcp::acceptor>(d_io_service,
-                                                                          d_tcp_endpoint);
-        d_acceptor_tcp->set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+        d_acceptor_tcp =
+            std::make_shared<asio::ip::tcp::acceptor>(d_io_context, d_tcp_endpoint);
+        d_acceptor_tcp->set_option(asio::ip::tcp::acceptor::reuse_address(true));
 
         start_tcp_accept();
 
         set_msg_handler(msgport_names::pdus(),
                         [this](pmt::pmt_t msg) { this->tcp_server_send(msg); });
     } else if (type == "TCP_CLIENT") {
-        boost::system::error_code error = boost::asio::error::host_not_found;
-        d_tcp_socket = std::make_shared<boost::asio::ip::tcp::socket>(d_io_service);
+        asio::error_code error = asio::error::host_not_found;
+        d_tcp_socket = std::make_shared<asio::ip::tcp::socket>(d_io_context);
         d_tcp_socket->connect(d_tcp_endpoint, error);
         if (error)
-            throw boost::system::system_error(error);
-        d_tcp_socket->set_option(boost::asio::ip::tcp::no_delay(d_tcp_no_delay));
+            throw asio::system_error(error);
+        d_tcp_socket->set_option(asio::ip::tcp::no_delay(d_tcp_no_delay));
 
         set_msg_handler(msgport_names::pdus(),
                         [this](pmt::pmt_t msg) { this->tcp_client_send(msg); });
 
         d_tcp_socket->async_read_some(
-            boost::asio::buffer(d_rxbuf),
-            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+            asio::buffer(d_rxbuf),
+            [this](const asio::error_code& error, size_t bytes_transferred) {
                 handle_tcp_read(error, bytes_transferred);
             });
     } else if (type == "UDP_SERVER") {
         d_udp_socket =
-            std::make_shared<boost::asio::ip::udp::socket>(d_io_service, d_udp_endpoint);
+            std::make_shared<asio::ip::udp::socket>(d_io_context, d_udp_endpoint);
         d_udp_socket->async_receive_from(
-            boost::asio::buffer(d_rxbuf),
+            asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
-            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+            [this](const asio::error_code& error, size_t bytes_transferred) {
                 handle_udp_read(error, bytes_transferred);
             });
 
@@ -121,11 +114,11 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
                         [this](pmt::pmt_t msg) { this->udp_send(msg); });
     } else if (type == "UDP_CLIENT") {
         d_udp_socket =
-            std::make_shared<boost::asio::ip::udp::socket>(d_io_service, d_udp_endpoint);
+            std::make_shared<asio::ip::udp::socket>(d_io_context, d_udp_endpoint);
         d_udp_socket->async_receive_from(
-            boost::asio::buffer(d_rxbuf),
+            asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
-            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+            [this](const asio::error_code& error, size_t bytes_transferred) {
                 handle_udp_read(error, bytes_transferred);
             });
 
@@ -134,7 +127,7 @@ socket_pdu_impl::socket_pdu_impl(std::string type,
     } else
         throw std::runtime_error("gr::pdu:socket_pdu: unknown socket type");
 
-    d_thread = gr::thread::thread([this] { run_io_service(); });
+    d_thread = gr::thread::thread([this] { run_io_context(); });
     d_started = true;
 }
 
@@ -143,7 +136,7 @@ socket_pdu_impl::~socket_pdu_impl() { stop(); }
 bool socket_pdu_impl::stop()
 {
     if (d_started) {
-        d_io_service.stop();
+        d_io_context.stop();
         d_thread.interrupt();
         d_thread.join();
     }
@@ -151,7 +144,7 @@ bool socket_pdu_impl::stop()
     return true;
 }
 
-void socket_pdu_impl::handle_tcp_read(const boost::system::error_code& error,
+void socket_pdu_impl::handle_tcp_read(const asio::error_code& error,
                                       size_t bytes_transferred)
 {
     if (!error) {
@@ -161,29 +154,23 @@ void socket_pdu_impl::handle_tcp_read(const boost::system::error_code& error,
         message_port_pub(msgport_names::pdus(), pdu);
 
         d_tcp_socket->async_read_some(
-            boost::asio::buffer(d_rxbuf),
-            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+            asio::buffer(d_rxbuf),
+            [this](const asio::error_code& error, size_t bytes_transferred) {
                 handle_tcp_read(error, bytes_transferred);
             });
     } else
-        throw boost::system::system_error(error);
+        throw asio::system_error(error);
 }
 
 void socket_pdu_impl::start_tcp_accept()
 {
-#if (BOOST_VERSION >= 107000)
     tcp_connection::sptr new_connection =
-        tcp_connection::make(d_io_service, d_rxbuf.size(), d_tcp_no_delay);
-#else
-    tcp_connection::sptr new_connection = tcp_connection::make(
-        d_acceptor_tcp->get_io_service(), d_rxbuf.size(), d_tcp_no_delay);
-#endif
+        tcp_connection::make(d_io_context, d_rxbuf.size(), d_tcp_no_delay);
 
-    d_acceptor_tcp->async_accept(
-        new_connection->socket(),
-        [this, new_connection](const boost::system::error_code& error) {
-            handle_tcp_accept(new_connection, error);
-        });
+    d_acceptor_tcp->async_accept(new_connection->socket(),
+                                 [this, new_connection](const asio::error_code& error) {
+                                     handle_tcp_accept(new_connection, error);
+                                 });
 }
 
 void socket_pdu_impl::tcp_server_send(pmt::pmt_t msg)
@@ -194,7 +181,7 @@ void socket_pdu_impl::tcp_server_send(pmt::pmt_t msg)
 }
 
 void socket_pdu_impl::handle_tcp_accept(tcp_connection::sptr new_connection,
-                                        const boost::system::error_code& error)
+                                        const asio::error_code& error)
 {
     if (!error) {
         // Garbage collect closed sockets
@@ -224,7 +211,7 @@ void socket_pdu_impl::tcp_client_send(pmt::pmt_t msg)
         size_t send_len = std::min((len - offset), txbuf.size());
         memcpy(&txbuf[0], pmt::uniform_vector_elements(vector, offset), send_len);
         offset += send_len;
-        d_tcp_socket->send(boost::asio::buffer(txbuf, send_len));
+        d_tcp_socket->send(asio::buffer(txbuf, send_len));
     }
 }
 
@@ -241,11 +228,11 @@ void socket_pdu_impl::udp_send(pmt::pmt_t msg)
         size_t send_len = std::min((len - offset), txbuf.size());
         memcpy(&txbuf[0], pmt::uniform_vector_elements(vector, offset), send_len);
         offset += send_len;
-        d_udp_socket->send_to(boost::asio::buffer(txbuf, send_len), d_udp_endpoint_other);
+        d_udp_socket->send_to(asio::buffer(txbuf, send_len), d_udp_endpoint_other);
     }
 }
 
-void socket_pdu_impl::handle_udp_read(const boost::system::error_code& error,
+void socket_pdu_impl::handle_udp_read(const asio::error_code& error,
                                       size_t bytes_transferred)
 {
     if (!error) {
@@ -256,9 +243,9 @@ void socket_pdu_impl::handle_udp_read(const boost::system::error_code& error,
         message_port_pub(msgport_names::pdus(), pdu);
 
         d_udp_socket->async_receive_from(
-            boost::asio::buffer(d_rxbuf),
+            asio::buffer(d_rxbuf),
             d_udp_endpoint_other,
-            [this](const boost::system::error_code& error, size_t bytes_transferred) {
+            [this](const asio::error_code& error, size_t bytes_transferred) {
                 handle_udp_read(error, bytes_transferred);
             });
     }

--- a/gr-network/lib/socket_pdu_impl.h
+++ b/gr-network/lib/socket_pdu_impl.h
@@ -20,36 +20,34 @@ namespace network {
 class socket_pdu_impl : public socket_pdu
 {
 private:
-    boost::asio::io_service d_io_service;
+    asio::io_context d_io_context;
     std::vector<char> d_rxbuf;
-    void run_io_service() { d_io_service.run(); }
+    void run_io_context() { d_io_context.run(); }
     gr::thread::thread d_thread;
     bool d_started;
 
     // TCP specific
-    boost::asio::ip::tcp::endpoint d_tcp_endpoint;
+    asio::ip::tcp::endpoint d_tcp_endpoint;
     std::vector<tcp_connection::sptr> d_tcp_connections;
-    void handle_tcp_read(const boost::system::error_code& error,
-                         size_t bytes_transferred);
+    void handle_tcp_read(const asio::error_code& error, size_t bytes_transferred);
     const bool d_tcp_no_delay;
 
     // TCP server specific
-    std::shared_ptr<boost::asio::ip::tcp::acceptor> d_acceptor_tcp;
+    std::shared_ptr<asio::ip::tcp::acceptor> d_acceptor_tcp;
     void start_tcp_accept();
     void tcp_server_send(pmt::pmt_t msg);
     void handle_tcp_accept(tcp_connection::sptr new_connection,
-                           const boost::system::error_code& error);
+                           const asio::error_code& error);
 
     // TCP client specific
-    std::shared_ptr<boost::asio::ip::tcp::socket> d_tcp_socket;
+    std::shared_ptr<asio::ip::tcp::socket> d_tcp_socket;
     void tcp_client_send(pmt::pmt_t msg);
 
     // UDP specific
-    boost::asio::ip::udp::endpoint d_udp_endpoint;
-    boost::asio::ip::udp::endpoint d_udp_endpoint_other;
-    std::shared_ptr<boost::asio::ip::udp::socket> d_udp_socket;
-    void handle_udp_read(const boost::system::error_code& error,
-                         size_t bytes_transferred);
+    asio::ip::udp::endpoint d_udp_endpoint;
+    asio::ip::udp::endpoint d_udp_endpoint_other;
+    std::shared_ptr<asio::ip::udp::socket> d_udp_socket;
+    void handle_udp_read(const asio::error_code& error, size_t bytes_transferred);
     void udp_send(pmt::pmt_t msg);
 
 public:

--- a/gr-network/lib/tcp_connection.h
+++ b/gr-network/lib/tcp_connection.h
@@ -11,8 +11,8 @@
 #ifndef INCLUDED_TCP_CONNECTION_H
 #define INCLUDED_TCP_CONNECTION_H
 
+#include <asio.hpp>
 #include <pmt/pmt.h>
-#include <boost/asio.hpp>
 #include <memory>
 
 namespace gr {
@@ -24,24 +24,22 @@ namespace network {
 class tcp_connection
 {
 private:
-    boost::asio::ip::tcp::socket d_socket;
+    asio::ip::tcp::socket d_socket;
     std::vector<char> d_buf;
     basic_block* d_block;
     bool d_no_delay;
 
-    tcp_connection(boost::asio::io_service& io_service,
-                   int MTU = 10000,
-                   bool no_delay = false);
+    tcp_connection(asio::io_context& io_context, int MTU = 10000, bool no_delay = false);
 
-    void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
+    void handle_read(const asio::error_code& error, size_t bytes_transferred);
 
 public:
     typedef std::shared_ptr<tcp_connection> sptr;
 
     static sptr
-    make(boost::asio::io_service& io_service, int MTU = 10000, bool no_delay = false);
+    make(asio::io_context& io_context, int MTU = 10000, bool no_delay = false);
 
-    boost::asio::ip::tcp::socket& socket() { return d_socket; };
+    asio::ip::tcp::socket& socket() { return d_socket; };
 
     void start(gr::basic_block* block);
     void send(pmt::pmt_t vector);

--- a/gr-network/lib/tcp_sink_impl.h
+++ b/gr-network/lib/tcp_sink_impl.h
@@ -12,8 +12,7 @@
 #define INCLUDED_NETWORK_TCP_SINK_IMPL_H
 
 #include <gnuradio/network/tcp_sink.h>
-#include <boost/asio.hpp>
-#include <boost/asio/ip/tcp.hpp>
+#include <asio.hpp>
 #include <thread>
 
 namespace gr {
@@ -37,12 +36,12 @@ protected:
     size_t d_block_size;
     bool d_is_ipv6;
 
-    boost::system::error_code ec;
+    asio::error_code ec;
 
-    boost::asio::io_service d_io_service;
-    boost::asio::ip::tcp::endpoint d_endpoint;
-    boost::asio::ip::tcp::socket* d_tcpsocket = NULL;
-    boost::asio::ip::tcp::acceptor* d_acceptor = NULL;
+    asio::io_context d_io_context;
+    asio::ip::tcp::endpoint d_endpoint;
+    asio::ip::tcp::socket* d_tcpsocket = NULL;
+    asio::ip::tcp::acceptor* d_acceptor = NULL;
 
     bool d_connected;
 
@@ -60,8 +59,8 @@ public:
     bool start() override;
     bool stop() override;
 
-    void accept_handler(boost::asio::ip::tcp::socket* new_connection,
-                        const boost::system::error_code& error);
+    void accept_handler(asio::ip::tcp::socket* new_connection,
+                        const asio::error_code& error);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -12,8 +12,7 @@
 #define INCLUDED_NETWORK_UDP_SINK_IMPL_H
 
 #include <gnuradio/network/udp_sink.h>
-#include <boost/asio.hpp>
-#include <boost/asio/ip/udp.hpp>
+#include <asio.hpp>
 #include <boost/circular_buffer.hpp>
 
 #include <gnuradio/network/packet_headers.h>
@@ -47,11 +46,11 @@ protected:
     boost::circular_buffer<char>* d_localqueue;
     char* d_localbuffer;
 
-    boost::system::error_code ec;
+    asio::error_code ec;
 
-    boost::asio::io_service d_io_service;
-    boost::asio::ip::udp::endpoint d_endpoint;
-    boost::asio::ip::udp::socket* d_udpsocket;
+    asio::io_context d_io_context;
+    asio::ip::udp::endpoint d_endpoint;
+    asio::ip::udp::socket* d_udpsocket;
 
     virtual void
     build_header(); // returns header size.  Header is stored in tmpHeaderBuff

--- a/gr-network/lib/udp_source_impl.h
+++ b/gr-network/lib/udp_source_impl.h
@@ -12,8 +12,7 @@
 #define INCLUDED_NETWORK_UDP_SOURCE_IMPL_H
 
 #include <gnuradio/network/udp_source.h>
-#include <boost/asio.hpp>
-#include <boost/asio/ip/udp.hpp>
+#include <asio.hpp>
 #include <boost/circular_buffer.hpp>
 
 #include <gnuradio/network/packet_headers.h>
@@ -44,13 +43,13 @@ protected:
 
     char* d_local_buffer;
 
-    boost::system::error_code ec;
+    asio::error_code ec;
 
-    boost::asio::io_service d_io_service;
-    boost::asio::ip::udp::endpoint d_endpoint;
-    boost::asio::ip::udp::socket* d_udpsocket;
+    asio::io_context d_io_context;
+    asio::ip::udp::endpoint d_endpoint;
+    asio::ip::udp::socket* d_udpsocket;
 
-    boost::asio::streambuf d_read_buffer;
+    asio::streambuf d_read_buffer;
 
     // A queue is required because we have 2 different timing
     // domains: The network packets and the GR work()/scheduler


### PR DESCRIPTION
This makes boost::asio look identical to non-Boost asio within our block definitions.

Signed-off-by: japm48 <japm48gh@gmail.com>
Co-authored-by: Martin Braun <martin.braun@ettus.com>
Signed-off-by: Martin Braun <martin.braun@ettus.com>
(cherry picked from commit e12214590586fce4de040e1d49f7bef749141101)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6260