### PR TITLE
CI: Lower timeouts on formatting & Doxygen jobs (backport to maint-3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -12,6 +12,7 @@ jobs:
   check-formatting:
     name: Check C++ Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
     - uses: gnuradio/clang-format-lint-action@v0.5-4
@@ -22,6 +23,7 @@ jobs:
   check-python-formatting:
     name: Check Python Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v2
     - uses: quentinguidee/pep8-action@v1
@@ -31,6 +33,7 @@ jobs:
   doxygen:
     name: Doxygen
     runs-on: ubuntu-latest # This can run on whatever
+    timeout-minutes: 15
     container:
       image: 'gnuradio/ci:ubuntu-20.04-3.9'
       volumes:


### PR DESCRIPTION
GitHub Actions has a default timeout of 360 minutes. The formatting and Doxygen jobs only take about two minutes each, so we should lower the timeout to ensure that these jobs fail in a timely manner if a hang occurs.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 81987d0a9fae566494ed74673c125dff4db9d752)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6311