### PR TITLE
CI: Avoid unnecessary test skips on OSX (backport to maint-3.10)

### DIFF
--- a/.packaging/conda_recipe/build.sh
+++ b/.packaging/conda_recipe/build.sh
@@ -24,18 +24,18 @@ if [[ $target_platform == linux* ]] ; then
 else
     SKIP_TESTS=(
         qa_block_gateway
+        qa_blocks_hier_block2
         qa_fecapi_cc
         qa_fecapi_dummy
         qa_fecapi_ldpc
         qa_fecapi_repetition
         qa_header_payload_demux
-        qa_hier_block2
         qa_hier_block2_message_connections
         qa_python_message_passing
         qa_uncaught_exception
     )
 fi
-SKIP_TESTS_STR=$( IFS="|"; echo "${SKIP_TESTS[*]}" )
+SKIP_TESTS_STR=$( IFS="|"; echo "^(${SKIP_TESTS[*]})$" )
 
 ctest --build-config Release --output-on-failure --timeout 120 -j${CPU_COUNT} -E "$SKIP_TESTS_STR"
 

--- a/gr-blocks/python/blocks/qa_blocks_hier_block2.py
+++ b/gr-blocks/python/blocks/qa_blocks_hier_block2.py
@@ -37,7 +37,7 @@ class multiply_const_ff(gr.sync_block):
         return len(output_items[0])
 
 
-class test_hier_block2(gr_unittest.TestCase):
+class test_blocks_hier_block2(gr_unittest.TestCase):
 
     def setUp(self):
         pass
@@ -518,4 +518,4 @@ class test_hier_block2(gr_unittest.TestCase):
 
 
 if __name__ == "__main__":
-    gr_unittest.run(test_hier_block2)
+    gr_unittest.run(test_blocks_hier_block2)


### PR DESCRIPTION
qa_fecapi_cc_buffer_overflow is skipped because qa_fecapi_cc is a substring of its test name. Tightening the test regex fixes tihs.

qa_hier_block2 in gnuradio-runtime is skipped because it shares the same name as a test in gr-blocks. I've renamed the gr-blocks test to avoid the conflict.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 66696bf27a24fea1df4b72a8f0b5936142da48b2)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6334