### PR TITLE
QA: Make assertions more specific (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/python/gnuradio/gr_unittest.py
+++ b/gnuradio-runtime/python/gnuradio/gr_unittest.py
@@ -112,19 +112,13 @@ class TestCase(unittest.TestCase):
         Note this function exists because of this bug: https://bugs.python.org/issue19217
         Calling self.assertEqual(seqA, seqB) can hang if seqA and seqB are not equal.
         """
-        if len(data_in) != len(data_out):
-            print(
-                'Lengths do not match: {:d} -- {:d}'.format(len(data_in), len(data_out)))
-        self.assertTrue(len(data_in) == len(data_out))
-        total_miscompares = 0
+        self.assertEqual(len(data_in), len(data_out), msg="Lengths do not match")
+        miscompares = []
         for idx, item in enumerate(zip(data_in, data_out)):
             if item[0] != item[1]:
-                total_miscompares += 1
-                print(
-                    'Miscompare at: {:d} ({} -- {})'.format(idx, item[0], item[1]))
-        if total_miscompares > 0:
-            print('Total miscompares: {:d}'.format(total_miscompares))
-        self.assertTrue(total_miscompares == 0)
+                miscompares.append(f"Miscompare at: {idx} ({item[0]} -- {item[1]})")
+        self.assertEqual(len(miscompares), 0,
+                         msg=f"Total miscompares: {len(miscompares)}\n" + "\n".join(miscompares))
 
     def waitFor(
             self,

--- a/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
+++ b/gnuradio-runtime/python/pmt/qa_pmt_to_python.py
@@ -29,7 +29,7 @@ class test_pmt_to_python(unittest.TestCase):
         narr.imag[:] = np.random.uniform(size=N)
         uvector = pmt2py.numpy_to_uvector(narr)
         nparr = pmt2py.uvector_to_numpy(uvector)
-        self.assertTrue(nparr.dtype == narr.dtype)
+        self.assertEqual(nparr.dtype, narr.dtype)
         self.assertTrue(np.alltrue(nparr == narr))
 
 

--- a/gr-blocks/python/blocks/qa_file_metadata.py
+++ b/gr-blocks/python/blocks/qa_file_metadata.py
@@ -57,14 +57,9 @@ class test_file_metadata(gr_unittest.TestCase):
 
         handle = open(outfile, "rb")
         header_str = handle.read(blocks.parse_file_metadata.HEADER_LENGTH)
-        if(len(header_str) == 0):
-            self.assertFalse()
+        self.assertGreater(len(header_str), 0)
 
-        try:
-            header = pmt.deserialize_str(header_str)
-        except RuntimeError:
-            self.assertFalse()
-
+        header = pmt.deserialize_str(header_str)
         info = blocks.parse_header(header, False)
 
         extra_str = handle.read(info["extra_len"])
@@ -72,11 +67,7 @@ class test_file_metadata(gr_unittest.TestCase):
 
         handle.close()
 
-        try:
-            extra = pmt.deserialize_str(extra_str)
-        except RuntimeError:
-            self.assertFalse()
-
+        extra = pmt.deserialize_str(extra_str)
         extra_info = blocks.parse_extra_dict(extra, info, False)
 
         self.assertEqual(info['rx_rate'], samp_rate)
@@ -136,14 +127,9 @@ class test_file_metadata(gr_unittest.TestCase):
         # Open detached header for reading
         handle = open(outfile_hdr, "rb")
         header_str = handle.read(blocks.parse_file_metadata.HEADER_LENGTH)
-        if(len(header_str) == 0):
-            self.assertFalse()
+        self.assertGreater(len(header_str), 0)
 
-        try:
-            header = pmt.deserialize_str(header_str)
-        except RuntimeError:
-            self.assertFalse()
-
+        header = pmt.deserialize_str(header_str)
         info = blocks.parse_header(header, False)
 
         extra_str = handle.read(info["extra_len"])
@@ -152,11 +138,7 @@ class test_file_metadata(gr_unittest.TestCase):
 
         handle.close()
 
-        try:
-            extra = pmt.deserialize_str(extra_str)
-        except RuntimeError:
-            self.assertFalse()
-
+        extra = pmt.deserialize_str(extra_str)
         extra_info = blocks.parse_extra_dict(extra, info, False)
 
         self.assertEqual(info['rx_rate'], samp_rate)

--- a/gr-blocks/python/blocks/qa_file_source.py
+++ b/gr-blocks/python/blocks/qa_file_source.py
@@ -49,11 +49,8 @@ class test_file_source(gr_unittest.TestCase):
         """
         Try to open a non-existent file and verify exception is thrown.
         """
-        try:
-            _ = blocks.file_source(gr.sizeof_float, "___no_such_file___")
-            self.assertTrue(False)
-        except RuntimeError:
-            self.assertTrue(True)
+        with self.assertRaises(RuntimeError):
+            blocks.file_source(gr.sizeof_float, "___no_such_file___")
 
     def test_file_source_with_offset(self):
         expected_result = self._vector[100:]

--- a/gr-blocks/python/blocks/qa_multiply_matrix_xx.py
+++ b/gr-blocks/python/blocks/qa_multiply_matrix_xx.py
@@ -55,7 +55,7 @@ class test_multiply_matrix_xx (gr_unittest.TestCase):
         X_in = numpy.matrix(X_in)
         A_matrix = numpy.matrix(A)
         (N, M) = A_matrix.shape
-        self.assertTrue(N == X_in.shape[0])
+        self.assertEqual(N, X_in.shape[0])
         # Calc expected
         Y_out_exp = numpy.matrix(numpy.zeros((M, X_in.shape[1])))
         self.multiplier = BLOCK_LOOKUP[datatype]['mult'](A, tpp)

--- a/gr-blocks/python/blocks/qa_stream_demux.py
+++ b/gr-blocks/python/blocks/qa_stream_demux.py
@@ -339,14 +339,11 @@ class qa_stream_demux(gr_unittest.TestCase):
             tag for tag in tags if pmt.eq(
                 tag.key, pmt.intern('src3'))]
         for i in range(len(expected_tag_offsets_src1)):
-            self.assertTrue(
-                expected_tag_offsets_src1[i] == tags_src1[i].offset)
+            self.assertEqual(expected_tag_offsets_src1[i], tags_src1[i].offset)
         for i in range(len(expected_tag_offsets_src2)):
-            self.assertTrue(
-                expected_tag_offsets_src2[i] == tags_src2[i].offset)
+            self.assertEqual(expected_tag_offsets_src2[i], tags_src2[i].offset)
         for i in range(len(expected_tag_offsets_src3)):
-            self.assertTrue(
-                expected_tag_offsets_src3[i] == tags_src3[i].offset)
+            self.assertEqual(expected_tag_offsets_src3[i], tags_src3[i].offset)
 
         # check the tags - result1
         tags = result1.tags()
@@ -365,14 +362,11 @@ class qa_stream_demux(gr_unittest.TestCase):
             tag for tag in tags if pmt.eq(
                 tag.key, pmt.intern('src3'))]
         for i in range(len(expected_tag_offsets_src1)):
-            self.assertTrue(
-                expected_tag_offsets_src1[i] == tags_src1[i].offset)
+            self.assertEqual(expected_tag_offsets_src1[i], tags_src1[i].offset)
         for i in range(len(expected_tag_offsets_src2)):
-            self.assertTrue(
-                expected_tag_offsets_src2[i] == tags_src2[i].offset)
+            self.assertEqual(expected_tag_offsets_src2[i], tags_src2[i].offset)
         for i in range(len(expected_tag_offsets_src3)):
-            self.assertTrue(
-                expected_tag_offsets_src3[i] == tags_src3[i].offset)
+            self.assertEqual(expected_tag_offsets_src3[i], tags_src3[i].offset)
 
         # check the tags - result2
         tags = result2.tags()
@@ -392,14 +386,11 @@ class qa_stream_demux(gr_unittest.TestCase):
             tag for tag in tags if pmt.eq(
                 tag.key, pmt.intern('src3'))]
         for i in range(len(expected_tag_offsets_src1)):
-            self.assertTrue(
-                expected_tag_offsets_src1[i] == tags_src1[i].offset)
+            self.assertEqual(expected_tag_offsets_src1[i], tags_src1[i].offset)
         for i in range(len(expected_tag_offsets_src2)):
-            self.assertTrue(
-                expected_tag_offsets_src2[i] == tags_src2[i].offset)
+            self.assertEqual(expected_tag_offsets_src2[i], tags_src2[i].offset)
         for i in range(len(expected_tag_offsets_src3)):
-            self.assertTrue(
-                expected_tag_offsets_src3[i] == tags_src3[i].offset)
+            self.assertEqual(expected_tag_offsets_src3[i], tags_src3[i].offset)
 
 
 if __name__ == '__main__':

--- a/gr-blocks/python/blocks/qa_stream_mux.py
+++ b/gr-blocks/python/blocks/qa_stream_mux.py
@@ -227,14 +227,11 @@ class test_stream_mux (gr_unittest.TestCase):
                 tag.key, pmt.intern('src3'))]
 
         for i in range(len(expected_tag_offsets_src1)):
-            self.assertTrue(
-                expected_tag_offsets_src1[i] == tags_src1[i].offset)
+            self.assertEqual(expected_tag_offsets_src1[i], tags_src1[i].offset)
         for i in range(len(expected_tag_offsets_src2)):
-            self.assertTrue(
-                expected_tag_offsets_src2[i] == tags_src2[i].offset)
+            self.assertEqual(expected_tag_offsets_src2[i], tags_src2[i].offset)
         for i in range(len(expected_tag_offsets_src3)):
-            self.assertTrue(
-                expected_tag_offsets_src3[i] == tags_src3[i].offset)
+            self.assertEqual(expected_tag_offsets_src3[i], tags_src3[i].offset)
 
 
 if __name__ == '__main__':

--- a/gr-blocks/python/blocks/qa_vector_insert.py
+++ b/gr-blocks/python/blocks/qa_vector_insert.py
@@ -62,7 +62,7 @@ class test_vector_insert(gr_unittest.TestCase):
         tags = dst.tags()
         offsets = [tag.offset for tag in tags]
         for i in range(len(expected_result)):
-            self.assertTrue(expected_result[i] == offsets[i])
+            self.assertEqual(expected_result[i], offsets[i])
 
     def test_003(self):  # insert tags and check their propagation, non-zero offset
         period = 11000
@@ -83,7 +83,7 @@ class test_vector_insert(gr_unittest.TestCase):
         tags = dst.tags()
         offsets = [tag.offset for tag in tags]
         for i in range(len(expected_result)):
-            self.assertTrue(expected_result[i] == offsets[i])
+            self.assertEqual(expected_result[i], offsets[i])
 
     def test_004(self):  # insert tags and check their propagation, non-zero offset, multiple tags per copy region
         period = 11000
@@ -118,7 +118,7 @@ class test_vector_insert(gr_unittest.TestCase):
         tags = dst.tags()
         offsets = [tag.offset for tag in tags]
         for i in range(len(expected_result)):
-            self.assertTrue(expected_result[i] == offsets[i])
+            self.assertEqual(expected_result[i], offsets[i])
 
 
 if __name__ == '__main__':

--- a/gr-digital/python/digital/qa_constellation_receiver.py
+++ b/gr-digital/python/digital/qa_constellation_receiver.py
@@ -126,11 +126,8 @@ class test_constellation_receiver(gr_unittest.TestCase):
                 d2 = data[:int(len(data) * self.ignore_fraction)]
                 correct, overlap, offset, indices = alignment.align_sequences(
                     d1, d2, indices=self.indices)
-                if correct <= req_correct:
-                    print(
-                        "Constellation is {0}. Differential is {1}.  Required correct is {2}. Correct is {3}. FAIL.". format(
-                            constellation, differential, req_correct, correct))
-                self.assertTrue(correct > req_correct)
+                self.assertGreater(correct, req_correct,
+                                   msg=f"Constellation is {type(constellation)}. Differential is {differential}.")
 
     def test_tag(self):
         # Send data through bpsk receiver

--- a/gr-digital/python/digital/qa_lfsr.py
+++ b/gr-digital/python/digital/qa_lfsr.py
@@ -46,7 +46,7 @@ class test_lfsr(gr_unittest.TestCase):
         self.assertEqual(seq1, seq2)
 
         res = (np.convolve(seq1, [1, 0, 1, 0, 0, 1]) % 2)
-        self.assertTrue(sum(res[5:-5]) == 0, "LRS not generated properly")
+        self.assertEqual(sum(res[5:-5]), 0, msg="LRS not generated properly")
 
 
 if __name__ == '__main__':

--- a/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
+++ b/gr-digital/python/digital/qa_ofdm_chanest_vcvc.py
@@ -348,7 +348,7 @@ class qa_ofdm_chanest_vcvc (gr_unittest.TestCase):
                 if rx_sym_est[i] != data_sym[i]:
                     bit_errors += 1
         # This is much more than we could allow
-        self.assertTrue(bit_errors < n_iter)
+        self.assertLess(bit_errors, n_iter)
 
 
 if __name__ == '__main__':

--- a/gr-digital/python/digital/qa_ofdm_sync_sc_cfb.py
+++ b/gr-digital/python/digital/qa_ofdm_sync_sc_cfb.py
@@ -65,10 +65,8 @@ class qa_ofdm_sync_sc_cfb (gr_unittest.TestCase):
         self.tb.run()
         sig1_detect = sink_detect.data()[0:len(tx_signal) // 2]
         sig2_detect = sink_detect.data()[len(tx_signal) // 2:]
-        self.assertTrue(abs(sig1_detect.index(
-            1) - (n_zeros + fft_len + cp_len)) < cp_len)
-        self.assertTrue(abs(sig2_detect.index(
-            1) - (n_zeros + fft_len + cp_len)) < cp_len)
+        self.assertAlmostEqual(sig1_detect.index(1), n_zeros + fft_len + cp_len, delta=cp_len - 1)
+        self.assertAlmostEqual(sig2_detect.index(1), n_zeros + fft_len + cp_len, delta=cp_len - 1)
         self.assertEqual(numpy.sum(sig1_detect), 1)
         self.assertEqual(numpy.sum(sig2_detect), 1)
 

--- a/gr-digital/python/digital/qa_pfb_clock_sync.py
+++ b/gr-digital/python/digital/qa_pfb_clock_sync.py
@@ -165,8 +165,6 @@ class test_pfb_clock_sync(gr_unittest.TestCase):
         self.tb.stop()
         self.tb.wait()
 
-        self.assertTrue(True)
-
     def test03_f(self):
         # Test resting of taps
         excess_bw0 = 0.35
@@ -202,8 +200,6 @@ class test_pfb_clock_sync(gr_unittest.TestCase):
 
         self.tb.stop()
         self.tb.wait()
-
-        self.assertTrue(True)
 
 
 if __name__ == '__main__':

--- a/gr-digital/python/digital/qa_scrambler.py
+++ b/gr-digital/python/digital/qa_scrambler.py
@@ -42,7 +42,7 @@ class test_scrambler(gr_unittest.TestCase):
         reg = np.zeros(52, np.int8)
         reg[::-1][(51, 3, 0), ] = 1
         res = (np.convolve(seq, reg) % 2)
-        self.assertTrue(sum(res[52:-52]) == 0, "LRS not generated properly")
+        self.assertEqual(sum(res[52:-52]), 0, msg="LRS not generated properly")
 
     def test_scrambler_descrambler_001(self):
         src_data = np.random.randint(0, 2, 500, dtype=np.int8)

--- a/gr-pdu/python/pdu/qa_tags_to_pdu.py
+++ b/gr-pdu/python/pdu/qa_tags_to_pdu.py
@@ -155,7 +155,7 @@ class qa_tags_to_pdu (gr_unittest.TestCase):
         self.assertAlmostEqual(pmt.to_uint64(pmt.tuple_ref(
             time_tuple1, 0)) + pmt.to_double(pmt.tuple_ref(time_tuple1, 1)), expected_time)
         #wct = pmt.to_double(pmt.dict_ref(pmt.car(dbg.get_message(0)), pmt.intern("wall_clock_time"), pmt.PMT_NIL))
-        #self.assertTrue((wct - ts) < 1.0)
+        #self.assertLess(wct - ts, 1.0)
 
         self.tb = None
 

--- a/gr-pdu/python/pdu/qa_take_skip_to_pdu.py
+++ b/gr-pdu/python/pdu/qa_take_skip_to_pdu.py
@@ -21,19 +21,15 @@ class qa_take_skip_to_pdu_X (gr_unittest.TestCase):
     # the *contents* of a uniform vector
     def assertEqualPDU(self, pdu1, pdu2):
         # first check the equal() function:
-        if not pmt.equal(pdu1, pdu2):
-            self.assertTrue(False)
+        self.assertTrue(pmt.equal(pdu1, pdu2))
         # then check the dictionaries:
-        if not pmt.equal(pmt.car(pdu1), pmt.car(pdu2)):
-            self.assertTrue(False)
+        self.assertTrue(pmt.equal(pmt.car(pdu1), pmt.car(pdu2)))
         # then check the elements of the respective vectors
         vec1 = pmt.cdr(pdu1)
         vec2 = pmt.cdr(pdu2)
-        if not pmt.equal(vec1, vec2):
-            self.assertTrue(False)
-        if not (pmt.to_python(vec1) == pmt.to_python(vec2)).all():
-            print("vectors not equal? " + repr(vec1) + repr(vec2))
-            self.assertTrue(False)
+        self.assertTrue(pmt.equal(vec1, vec2))
+        self.assertTrue((pmt.to_python(vec1) == pmt.to_python(vec2)).all(),
+                        msg=f"vectors not equal? {vec1!r} {vec2!r}")
 
     def setUp(self):
         self.tb = gr.top_block()

--- a/gr-utils/blocktool/tests/test_blocktool.py
+++ b/gr-utils/blocktool/tests/test_blocktool.py
@@ -95,9 +95,8 @@ class TestBlocktoolCore(unittest.TestCase):
     def test_namespace(self):
         """ test for header namespace """
         module_name = os.path.basename(self.module)
-        self.assertTrue(self.test_obj['namespace'][0] == 'gr')
-        self.assertTrue(self.test_obj['namespace']
-                        [1] == module_name.split('-')[-1])
+        self.assertEqual(self.test_obj['namespace'][0], 'gr')
+        self.assertEqual(self.test_obj['namespace'][1], module_name.split('-')[-1])
 
     @unittest.skipIf(SKIP_BLOCK_TEST, 'pygccxml not found, skipping this unittest')
     def test_io_signature(self):


### PR DESCRIPTION
This will result in more detailed error messages, making it easier to diagnose test failures.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit 331f081c12e0b62123b8ac3c205e0686de7144ee)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6335