### PR TITLE
cmake: Ensure that target names are unique (backport to maint-3.10)

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -190,7 +190,7 @@ function(GR_UNIQUE_TARGET desc)
     file(RELATIVE_PATH reldir ${PROJECT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
     execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -c "import re, hashlib
-unique = hashlib.md5(b'${reldir}${ARGN}').hexdigest()[:5]
+unique = hashlib.md5(b'${reldir}${ARGN}').hexdigest()
 print(re.sub('\\W', '_', r'${desc} ${reldir} ' + unique))"
         OUTPUT_VARIABLE _target
         OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
The current 20-bit hash is prone to collisions. Using the full hash avoids that problem.

Signed-off-by: Clayton Smith <argilo@gmail.com>
(cherry picked from commit f46e521a4119f55bf6a27e5b5f8915e55dc3b769)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6318