### PR TITLE
gr-blocks: print correct error message for soundfile sf_open (backport to maint-3.10)

### DIFF
--- a/gr-blocks/lib/wavfile_sink_impl.cc
+++ b/gr-blocks/lib/wavfile_sink_impl.cc
@@ -112,8 +112,16 @@ bool wavfile_sink_impl::open(const char* filename)
     if (d_append) {
         // We are appending to an existing file, be extra careful here.
         sfinfo.format = 0;
+        errno = 0;
         if (!(d_new_fp = sf_open(filename, SFM_RDWR, &sfinfo))) {
-            d_logger->error("sf_open(1) failed: {:s}: {:s}", filename, strerror(errno));
+            if (errno) {
+                d_logger->error(
+                    "sf_open(1) failed: {:s}: {:s}", filename, strerror(errno));
+            } else {
+                d_logger->error(
+                    "sf_open(1) failed: {:s}: {:s}", filename, sf_strerror(NULL));
+            }
+
             return false;
         }
         if (d_h.sample_rate != sfinfo.samplerate || d_h.nchans != sfinfo.channels ||
@@ -204,8 +212,16 @@ bool wavfile_sink_impl::open(const char* filename)
             }
             break;
         }
+        errno = 0;
         if (!(d_new_fp = sf_open(filename, SFM_WRITE, &sfinfo))) {
-            d_logger->error("sf_open(2) failed: {:s}: {:s}", filename, strerror(errno));
+            if (errno) {
+                d_logger->error(
+                    "sf_open(2) failed: {:s}: {:s}", filename, strerror(errno));
+            } else {
+                d_logger->error(
+                    "sf_open(2) failed: {:s}: {:s}", filename, sf_strerror(NULL));
+            }
+
             return false;
         }
     }

--- a/gr-blocks/lib/wavfile_source_impl.cc
+++ b/gr-blocks/lib/wavfile_source_impl.cc
@@ -38,8 +38,13 @@ wavfile_source_impl::wavfile_source_impl(const char* filename, bool repeat)
     SF_INFO sfinfo;
 
     sfinfo.format = 0;
+    errno = 0;
     if (!(d_fp = sf_open(filename, SFM_READ, &sfinfo))) {
-        d_logger->error("sf_open failed: {:s}: {:s}", filename, strerror(errno));
+        if (errno) {
+            d_logger->error("sf_open failed: {:s}: {:s}", filename, strerror(errno));
+        } else {
+            d_logger->error("sf_open failed: {:s}: {:s}", filename, sf_strerror(NULL));
+        }
         throw std::runtime_error("Can't open WAV file.");
     }
 


### PR DESCRIPTION
Signed-off-by: Jiří Pinkava <j-pi@seznam.cz>
(cherry picked from commit c11667ef6ebbe528289f528bb303d4668732e942)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6209