### PR TITLE
analog: fix agc3 on windows, logical bugs (backport to maint-3.10)

### DIFF
--- a/.packaging/conda_recipe/bld.bat
+++ b/.packaging/conda_recipe/bld.bat
@@ -27,7 +27,6 @@ if errorlevel 1 exit 1
 
 :: test
 set SKIP_TESTS=^
-qa_agc^
 %=EMPTY=%
 
 ctest --build-config Release --output-on-failure --timeout 120 -j%CPU_COUNT% -E "%SKIP_TESTS%"

--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -8,16 +8,16 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <cfloat>
-#include <vector>
-
 #include "agc3_cc_impl.h"
+
 #include <gnuradio/io_signature.h>
+#include <spdlog/fmt/fmt.h>
 #include <volk/volk.h>
+#include <volk/volk_alloc.hh>
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
 
 namespace gr {
 namespace analog {
@@ -40,14 +40,15 @@ agc3_cc_impl::agc3_cc_impl(float attack_rate,
     : sync_block("agc3_cc",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      d_attack(attack_rate),
-      d_decay(decay_rate),
-      d_reference(reference),
-      d_gain(gain),
-      d_max_gain(65536),
-      d_reset(true),
-      d_iir_update_decim(iir_update_decim)
+      d_reset(true)
 {
+    set_reference(reference);
+    set_attack_rate(attack_rate);
+    set_decay_rate(decay_rate);
+    set_gain(gain);
+    set_max_gain(65536);
+    test_and_log_value_domain(iir_update_decim, "input power sampling stride");
+    d_iir_update_decim = iir_update_decim;
     set_output_multiple(iir_update_decim * 4);
     const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
     set_alignment(std::max(1, alignment_multiple));
@@ -55,82 +56,121 @@ agc3_cc_impl::agc3_cc_impl(float attack_rate,
 
 agc3_cc_impl::~agc3_cc_impl() {}
 
+void agc3_cc_impl::test_and_log_value_domain(float value, std::string_view description)
+{
+    if (value <= 0.0f) {
+        d_logger->error(
+            "Can't set {} that is not strictly positive: {:g}", description, value);
+        throw std::domain_error(fmt::format("non-positive {}", description));
+    }
+}
+
+float agc3_cc_impl::attack_rate() const
+{
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    return d_attack;
+}
+float agc3_cc_impl::decay_rate() const
+{
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    return d_decay;
+}
+float agc3_cc_impl::reference() const
+{
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    return d_reference;
+}
+float agc3_cc_impl::gain() const
+{
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    return d_gain;
+}
+float agc3_cc_impl::max_gain() const
+{
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    return d_max_gain;
+}
+
+void agc3_cc_impl::set_attack_rate(float rate)
+{
+    test_and_log_value_domain(rate, "attack rate");
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    d_attack = rate;
+}
+void agc3_cc_impl::set_decay_rate(float rate)
+{
+    test_and_log_value_domain(rate, "decay rate");
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    d_decay = rate;
+}
+void agc3_cc_impl::set_reference(float reference)
+{
+    test_and_log_value_domain(reference, "reference");
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    d_reference = reference;
+}
+void agc3_cc_impl::set_gain(float gain)
+{
+    test_and_log_value_domain(gain, "gain");
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    d_gain = gain;
+}
+void agc3_cc_impl::set_max_gain(float max_gain)
+{
+    if (max_gain != 0.0f) {
+        test_and_log_value_domain(max_gain, "maximum gain");
+    }
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    d_max_gain = max_gain;
+}
 
 int agc3_cc_impl::work(int noutput_items,
                        gr_vector_const_void_star& input_items,
                        gr_vector_void_star& output_items)
 {
-    const gr_complex* in = (const gr_complex*)input_items[0];
-    gr_complex* out = (gr_complex*)output_items[0];
-
-#ifdef __GNUC__
-    // Compute a linear average on reset (no expected)
-    if (__builtin_expect(d_reset, false)) {
-        float mags[noutput_items] __attribute__((aligned(16)));
-        volk_32fc_magnitude_32f(mags, &in[0], noutput_items);
-#else
-    // Compute a linear average on reset (no expected)
-    if (!d_reset) {
-        _declspec(align(16)) std::vector<float> mags(noutput_items);
-        volk_32fc_magnitude_32f(&mags[0], &in[0], noutput_items);
-#endif
-        float mag(0.0);
-        for (int i = 0; i < noutput_items; i++) {
-            mag += mags[i];
+    auto in = reinterpret_cast<const gr_complex*>(input_items[0]);
+    auto out = reinterpret_cast<gr_complex*>(output_items[0]);
+    gr::thread::scoped_lock guard(d_setter_mutex);
+    unsigned int index = 0;
+    if (d_reset) {
+        float magnitude = 0.0f;
+        for (unsigned int idx = 0; idx < d_iir_update_decim * 4; ++idx) {
+            magnitude += std::abs(in[idx]);
         }
-        d_gain = d_reference * (noutput_items / mag);
+        d_gain = d_reference * (d_iir_update_decim * 4 / magnitude);
 
-        if (d_gain < 0.0)
-            d_gain = 10e-5;
-
-        if (d_max_gain > 0.0 && d_gain > d_max_gain) {
-            d_gain = d_max_gain;
+        if (d_max_gain > 0.0f) {
+            d_gain = std::min(d_gain, d_max_gain);
         }
 
         // scale output values
-        for (int i = 0; i < noutput_items; i++) {
-            out[i] = in[i] * d_gain;
-        }
+        volk_32f_s32f_multiply_32f(reinterpret_cast<float*>(out),
+                                   reinterpret_cast<const float*>(in),
+                                   d_gain,
+                                   d_iir_update_decim * 4 * 2);
         d_reset = false;
-    } else {
-        // Otherwise perform a normal iir update
-#ifdef _MSC_VER
-        __declspec(align(16)) std::vector<float> mag_sq(noutput_items /
-                                                        d_iir_update_decim);
-        __declspec(align(16)) std::vector<float> inv_mag(noutput_items /
-                                                         d_iir_update_decim);
-#else
-        float mag_sq[noutput_items / d_iir_update_decim] __attribute__((aligned(16)));
-        float inv_mag[noutput_items / d_iir_update_decim] __attribute__((aligned(16)));
-#endif
+        index = d_iir_update_decim * 4;
+    }
 
-        // generate squared magnitudes at decimated rate (gather operation)
-        for (int i = 0; i < noutput_items / d_iir_update_decim; i++) {
-            int idx = i * d_iir_update_decim;
-            mag_sq[i] = in[idx].real() * in[idx].real() + in[idx].imag() * in[idx].imag();
+    // If not on the first run, do the usual IIR update
+    for (; index < static_cast<unsigned int>(noutput_items);
+         index += d_iir_update_decim) {
+        float mag = std::abs(in[index]);
+        // check whether the inverse magnitude would be unbounded
+        if (std::isnormal(mag)) {
+            float rate = (d_reference > d_gain * mag) ? d_decay : d_attack;
+            /* we're not using any C inverse sqrt, nor the VOLK function: The memory
+             * allocation / calling overhead for VOLK cannot be justified */
+            d_gain = d_gain * (1 - rate) + d_reference * rate / mag;
+        } else {
+            d_gain *= 1 - d_decay;
         }
-
-        // compute inverse square roots
-        volk_32f_invsqrt_32f(&inv_mag[0], &mag_sq[0], noutput_items / d_iir_update_decim);
-
-        // apply updates
-        for (int i = 0; i < noutput_items / d_iir_update_decim; i++) {
-            float magi = inv_mag[i];
-#if defined(_MSC_VER) && _MSC_VER < 1900
-            if (!_finite(magi)) {
-#else
-            if (std::isfinite(magi)) {
-#endif
-                float rate = (magi > d_gain / d_reference) ? d_decay : d_attack;
-                d_gain = d_gain * (1 - rate) + d_reference * magi * rate;
-            } else {
-                d_gain = d_gain * (1 - d_decay);
-            }
-            for (int j = i * d_iir_update_decim; j < (i + 1) * d_iir_update_decim; j++) {
-                out[j] = in[j] * d_gain;
-            }
+        // scale output values
+        for (auto out_idx = index; out_idx < index + d_iir_update_decim; ++out_idx) {
+            out[out_idx] = in[out_idx] * d_gain;
         }
     }
+
     return noutput_items;
 }
 

--- a/gr-analog/lib/agc3_cc_impl.h
+++ b/gr-analog/lib/agc3_cc_impl.h
@@ -26,30 +26,32 @@ public:
                  int iir_update_decim = 1);
     ~agc3_cc_impl() override;
 
-    float attack_rate() const override { return d_attack; }
-    float decay_rate() const override { return d_decay; }
-    float reference() const override { return d_reference; }
-    float gain() const override { return d_gain; }
-    float max_gain() const override { return d_max_gain; }
+    float attack_rate() const override;
+    float decay_rate() const override;
+    float reference() const override;
+    float gain() const override;
+    float max_gain() const override;
 
-    void set_attack_rate(float rate) override { d_attack = rate; }
-    void set_decay_rate(float rate) override { d_decay = rate; }
-    void set_reference(float reference) override { d_reference = reference; }
-    void set_gain(float gain) override { d_gain = gain; }
-    void set_max_gain(float max_gain) override { d_max_gain = max_gain; }
+    void set_attack_rate(float rate) override;
+    void set_decay_rate(float rate) override;
+    void set_reference(float reference) override;
+    void set_gain(float gain) override;
+    void set_max_gain(float max_gain) override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;
 
 private:
+    void test_and_log_value_domain(float value, std::string_view description);
+    mutable gr::thread::mutex d_setter_mutex;
     float d_attack;
     float d_decay;
     float d_reference;
     float d_gain;
     float d_max_gain;
+    unsigned int d_iir_update_decim;
     bool d_reset;
-    int d_iir_update_decim;
 };
 
 } /* namespace analog */


### PR DESCRIPTION
* Windows implementation had several bugs
  * inverted "is this the first items" logic
  * inverted "1/magnitude finite" logic
  * allocations/deallocations every work()
  * specifying alignment of std::vector header doesn't align data
* non-windows / GNU implementation had bug
  * Variable-length arrays in C++ are GCC extension
* both versions had several bugs, both hard and perf
  * thread-safety of setters of floating point numbers
  * first-run work code's numerical output values depend on workload size (but we're in output_multiple mode, so easy to fix)
  * counter-productive cache thrashing to improve vectorization at the expense of having VLA/runtime allocation
  * unnecessary division in comparison
* AGC3 test on windows was disabled, which hid the above bugs

By removing one unnecessary hot-loop division, at worst-case identical performance replace VOLK's invsqrt with a plain sqrt, by which I divide.

Introduced mutable setter lock.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>
(cherry picked from commit 56ecd45cd49ef2bc2338afa9c402cb7a3f1941e3)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6274