### PR TITLE
cmake: Switch suitable PUBLIC target_link_libraries to PRIVATE (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/apps/CMakeLists.txt
+++ b/gnuradio-runtime/apps/CMakeLists.txt
@@ -9,5 +9,5 @@
 # Setup executables
 ########################################################################
 add_executable(gnuradio-config-info gnuradio-config-info.cc)
-target_link_libraries(gnuradio-config-info gnuradio-runtime)
+target_link_libraries(gnuradio-config-info gnuradio-runtime Boost::program_options)
 install(TARGETS gnuradio-config-info DESTINATION ${GR_RUNTIME_DIR})

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -122,11 +122,12 @@ target_link_libraries(
     PUBLIC
         gnuradio-pmt
         Volk::volk
-        Boost::program_options
         Boost::thread
         spdlog::spdlog
         MPLib::mplib
-    PRIVATE libunwind::libunwind)
+    PRIVATE
+        Boost::program_options
+        libunwind::libunwind)
 
 # Address linker issues with std::filesystem on Centos 8 and Debian
 target_link_libraries(

--- a/gnuradio-runtime/lib/pmt/CMakeLists.txt
+++ b/gnuradio-runtime/lib/pmt/CMakeLists.txt
@@ -11,7 +11,10 @@ add_library(
     ${CMAKE_CURRENT_SOURCE_DIR}/pmt_io.cc ${CMAKE_CURRENT_SOURCE_DIR}/pmt_pool.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/pmt_serialize.cc)
 
-target_link_libraries(gnuradio-pmt Boost::boost Boost::thread spdlog::spdlog Volk::volk)
+target_link_libraries(
+    gnuradio-pmt
+    PUBLIC Boost::boost
+    PRIVATE Volk::volk)
 
 target_include_directories(
     gnuradio-pmt

--- a/gr-analog/lib/CMakeLists.txt
+++ b/gr-analog/lib/CMakeLists.txt
@@ -42,14 +42,14 @@ add_library(
     sig_source_impl.cc
     simple_squelch_cc_impl.cc)
 
-if(ENABLE_COMMON_PCH)
-    set(PRIVATE_LIBS common-precompiled-headers)
-endif()
-
 target_link_libraries(
     gnuradio-analog
-    PUBLIC gnuradio-runtime gnuradio-blocks gnuradio-filter
-    PRIVATE ${PRIVATE_LIBS})
+    PUBLIC gnuradio-runtime gnuradio-blocks
+    PRIVATE gnuradio-filter)
+
+if(ENABLE_COMMON_PCH)
+    target_link_libraries(gnuradio-analog PRIVATE common-precompiled-headers)
+endif()
 
 target_include_directories(
     gnuradio-analog PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-audio/lib/CMakeLists.txt
+++ b/gr-audio/lib/CMakeLists.txt
@@ -23,13 +23,11 @@ list(APPEND gr_audio_confs ${CMAKE_CURRENT_SOURCE_DIR}/gr-audio.conf)
 ########################################################################
 find_package(ALSA)
 
-set(audio_deps "")
-
 if((ALSA_FOUND)
    AND NOT (CMAKE_SYSTEM_NAME STREQUAL "kFreeBSD")
    AND NOT (CMAKE_SYSTEM_NAME STREQUAL GNU))
     target_compile_definitions(gnuradio-audio PRIVATE -DALSA_FOUND)
-    target_link_libraries(gnuradio-audio PUBLIC ALSA::ALSA)
+    target_link_libraries(gnuradio-audio PRIVATE ALSA::ALSA)
     target_sources(
         gnuradio-audio
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/alsa/alsa_impl.cc
@@ -37,7 +35,6 @@ if((ALSA_FOUND)
                 ${CMAKE_CURRENT_SOURCE_DIR}/alsa/alsa_sink.cc)
 
     gr_append_subcomponent("alsa")
-    list(APPEND audio_deps "ALSA")
     list(APPEND gr_audio_confs ${CMAKE_CURRENT_SOURCE_DIR}/alsa/gr-audio-alsa.conf)
 endif()
 
@@ -48,12 +45,11 @@ find_package(OSS)
 
 if(OSS_FOUND)
     target_compile_definitions(gnuradio-audio PRIVATE -DOSS_FOUND)
-    target_link_libraries(gnuradio-audio PUBLIC OSS::OSS)
+    target_link_libraries(gnuradio-audio PRIVATE OSS::OSS)
     target_sources(gnuradio-audio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/oss/oss_source.cc
                                           ${CMAKE_CURRENT_SOURCE_DIR}/oss/oss_sink.cc)
 
     gr_append_subcomponent("oss")
-    list(APPEND audio_deps "OSS")
     list(APPEND gr_audio_confs ${CMAKE_CURRENT_SOURCE_DIR}/oss/gr-audio-oss.conf)
 endif(OSS_FOUND)
 
@@ -64,14 +60,13 @@ find_package(JACK)
 
 if(JACK_FOUND)
     target_compile_definitions(gnuradio-audio PRIVATE -DJACK_FOUND)
-    target_link_libraries(gnuradio-audio PUBLIC JACK::JACK)
+    target_link_libraries(gnuradio-audio PRIVATE JACK::JACK)
     target_sources(
         gnuradio-audio
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/jack/jack_impl.cc
                 ${CMAKE_CURRENT_SOURCE_DIR}/jack/jack_source.cc
                 ${CMAKE_CURRENT_SOURCE_DIR}/jack/jack_sink.cc)
     gr_append_subcomponent("jack")
-    list(APPEND audio_deps "JACK")
     list(APPEND gr_audio_confs ${CMAKE_CURRENT_SOURCE_DIR}/jack/gr-audio-jack.conf)
 endif(JACK_FOUND)
 
@@ -111,13 +106,12 @@ find_package(PORTAUDIO)
 
 if(PORTAUDIO2_FOUND)
     target_compile_definitions(gnuradio-audio PRIVATE -DPORTAUDIO_FOUND)
-    target_link_libraries(gnuradio-audio PUBLIC Portaudio::Portaudio)
+    target_link_libraries(gnuradio-audio PRIVATE Portaudio::Portaudio)
     target_sources(
         gnuradio-audio
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/portaudio/portaudio_impl.cc
                 ${CMAKE_CURRENT_SOURCE_DIR}/portaudio/portaudio_source.cc
                 ${CMAKE_CURRENT_SOURCE_DIR}/portaudio/portaudio_sink.cc)
-    list(APPEND audio_deps "PORTAUDIO")
     gr_append_subcomponent("portaudio")
     list(APPEND gr_audio_confs
          ${CMAKE_CURRENT_SOURCE_DIR}/portaudio/gr-audio-portaudio.conf)
@@ -128,7 +122,7 @@ endif(PORTAUDIO2_FOUND)
 ########################################################################
 if(WIN32)
     target_compile_definitions(gnuradio-audio PRIVATE -DWIN32_FOUND)
-    target_link_libraries(gnuradio-audio PUBLIC winmm.lib)
+    target_link_libraries(gnuradio-audio PRIVATE winmm.lib)
     target_sources(
         gnuradio-audio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/windows/windows_source.cc
                                ${CMAKE_CURRENT_SOURCE_DIR}/windows/windows_sink.cc)
@@ -149,5 +143,5 @@ if(ENABLE_COMMON_PCH)
     target_link_libraries(gnuradio-audio PRIVATE common-precompiled-headers)
 endif()
 
-gr_library_foo(gnuradio-audio ${audio_deps})
+gr_library_foo(gnuradio-audio)
 install(FILES ${gr_audio_confs} DESTINATION ${GR_PREFSDIR})

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -172,20 +172,15 @@ endif()
 
 add_library(gnuradio-blocks ${BLOCKS_SOURCES})
 
-set(BLOCKS_LIBS gnuradio-runtime Volk::volk)
+target_link_libraries(gnuradio-blocks PUBLIC gnuradio-runtime Volk::volk)
 
 if(SNDFILE_FOUND)
-    set(BLOCKS_LIBS ${BLOCKS_LIBS} sndfile::sndfile)
+    target_link_libraries(gnuradio-blocks PRIVATE sndfile::sndfile)
 endif()
 
 if(ENABLE_COMMON_PCH)
-    set(PRIVATE_LIBS common-precompiled-headers)
+    target_link_libraries(gnuradio-blocks PRIVATE common-precompiled-headers)
 endif()
-
-target_link_libraries(
-    gnuradio-blocks
-    PUBLIC ${BLOCKS_LIBS}
-    PRIVATE ${PRIVATE_LIBS})
 
 target_include_directories(
     gnuradio-blocks PUBLIC $<INSTALL_INTERFACE:include>
@@ -213,11 +208,7 @@ if(MSVC)
 endif(MSVC)
 
 if(BUILD_SHARED_LIBS)
-    if(SNDFILE_FOUND)
-        gr_library_foo(gnuradio-blocks SNDFILE)
-    else()
-        gr_library_foo(gnuradio-blocks)
-    endif()
+    gr_library_foo(gnuradio-blocks)
 endif()
 
 ########################################################################

--- a/gr-channels/lib/CMakeLists.txt
+++ b/gr-channels/lib/CMakeLists.txt
@@ -20,8 +20,10 @@ add_library(
     cfo_model_impl.cc
     sro_model_impl.cc)
 
-target_link_libraries(gnuradio-channels PUBLIC gnuradio-runtime gnuradio-filter
-                                               gnuradio-analog gnuradio-blocks)
+target_link_libraries(
+    gnuradio-channels
+    PUBLIC gnuradio-runtime
+    PRIVATE gnuradio-filter gnuradio-analog gnuradio-blocks)
 
 if(ENABLE_COMMON_PCH)
     target_link_libraries(gnuradio-channels PRIVATE common-precompiled-headers)

--- a/gr-dtv/lib/CMakeLists.txt
+++ b/gr-dtv/lib/CMakeLists.txt
@@ -69,8 +69,10 @@ add_library(
     catv/catv_frame_sync_enc_bb_impl.cc
     catv/catv_trellis_enc_bb_impl.cc)
 
-target_link_libraries(gnuradio-dtv PUBLIC gnuradio-runtime gnuradio-analog
-                                          gnuradio-filter gnuradio-fec Volk::volk)
+target_link_libraries(
+    gnuradio-dtv
+    PUBLIC gnuradio-runtime
+    PRIVATE gnuradio-analog gnuradio-filter gnuradio-fec Volk::volk)
 
 if(ENABLE_COMMON_PCH)
     target_link_libraries(gnuradio-dtv PRIVATE common-precompiled-headers)

--- a/gr-fec/python/fec/bindings/CMakeLists.txt
+++ b/gr-fec/python/fec/bindings/CMakeLists.txt
@@ -68,7 +68,6 @@ list(APPEND fec_python_files python_bindings.cc)
 
 gr_pybind_make_check_hash(fec ../../.. gr::fec "${fec_python_files}")
 
-target_link_libraries(fec_python PUBLIC gnuradio-runtime gnuradio-blocks)
 if(GSL_FOUND)
     target_compile_definitions(fec_python PUBLIC -DHAVE_GSL)
 endif(GSL_FOUND)

--- a/gr-fft/lib/CMakeLists.txt
+++ b/gr-fft/lib/CMakeLists.txt
@@ -10,7 +10,10 @@
 ########################################################################
 add_library(gnuradio-fft fft.cc fft_v_fftw.cc goertzel_fc_impl.cc goertzel.cc window.cc)
 
-target_link_libraries(gnuradio-fft PUBLIC gnuradio-runtime fftw3f::fftw3f Volk::volk)
+target_link_libraries(
+    gnuradio-fft
+    PUBLIC gnuradio-runtime Volk::volk
+    PRIVATE fftw3f::fftw3f)
 
 if(ENABLE_COMMON_PCH)
     target_link_libraries(gnuradio-fft PRIVATE common-precompiled-headers)
@@ -42,7 +45,7 @@ if(MSVC)
 endif(MSVC)
 
 if(BUILD_SHARED_LIBS)
-    gr_library_foo(gnuradio-fft FFTW3f)
+    gr_library_foo(gnuradio-fft)
 endif()
 
 if(ENABLE_TESTING)

--- a/gr-filter/lib/CMakeLists.txt
+++ b/gr-filter/lib/CMakeLists.txt
@@ -53,8 +53,10 @@ add_library(
     single_pole_iir_filter_cc_impl.cc
     single_pole_iir_filter_ff_impl.cc)
 
-target_link_libraries(gnuradio-filter PUBLIC gnuradio-runtime gnuradio-fft
-                                             gnuradio-blocks Volk::volk)
+target_link_libraries(
+    gnuradio-filter
+    PUBLIC gnuradio-runtime gnuradio-fft Volk::volk
+    PRIVATE gnuradio-blocks)
 
 if(ENABLE_COMMON_PCH)
     target_link_libraries(gnuradio-filter PRIVATE common-precompiled-headers)

--- a/gr-iio/lib/CMakeLists.txt
+++ b/gr-iio/lib/CMakeLists.txt
@@ -22,18 +22,16 @@ add_library(
 target_include_directories(
     gnuradio-iio PUBLIC $<INSTALL_INTERFACE:include>
                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
-set(iio_deps "libiio")
 target_link_libraries(
     gnuradio-iio
-    PUBLIC gnuradio-runtime libiio::iio ${GR_VOLK_LIB}
-    PRIVATE gnuradio-blocks)
+    PUBLIC gnuradio-runtime
+    PRIVATE gnuradio-blocks libiio::iio Volk::volk)
 
 if(libad9361_SUFFICIENT)
     target_sources(gnuradio-iio PRIVATE fmcomms2_sink_impl.cc fmcomms2_source_impl.cc
                                         pluto_utils.cc)
-    target_link_libraries(gnuradio-iio PUBLIC libad9361::ad9361)
-    target_compile_definitions(gnuradio-iio PUBLIC -DGR_IIO_LIBAD9361)
-    list(APPEND iio_deps "libad9361")
+    target_link_libraries(gnuradio-iio PRIVATE libad9361::ad9361)
+    target_compile_definitions(gnuradio-iio PRIVATE -DGR_IIO_LIBAD9361)
 endif(libad9361_SUFFICIENT)
 
 if(ENABLE_COMMON_PCH)
@@ -51,5 +49,5 @@ if(MSVC)
 endif(MSVC)
 
 if(BUILD_SHARED_LIBS)
-    gr_library_foo(gnuradio-iio ${iio_deps})
+    gr_library_foo(gnuradio-iio)
 endif()

--- a/gr-qtgui/lib/CMakeLists.txt
+++ b/gr-qtgui/lib/CMakeLists.txt
@@ -91,13 +91,6 @@ target_link_libraries(gnuradio-qtgui
     PUBLIC ${QTGUI_LIBS}
     PRIVATE ${PRIVATE_LIBS}
 )
-if(WIN32)
-    target_link_libraries(gnuradio-qtgui PUBLIC dwrite)
-endif(WIN32)
-
-if(ENABLE_COMMON_PCH)
-    target_link_libraries(gnuradio-qtgui PRIVATE common-precompiled-headers)
-endif()
 
 set(qtgui_mod_includedir ${CMAKE_CURRENT_SOURCE_DIR}/../include/gnuradio/qtgui)
 qt5_wrap_cpp(
@@ -150,5 +143,5 @@ if(MSVC)
 endif(MSVC)
 
 if(BUILD_SHARED_LIBS)
-    gr_library_foo(gnuradio-qtgui Qwt Qt5Widgets FFTW3f)
+    gr_library_foo(gnuradio-qtgui Qwt Qt5Widgets)
 endif()

--- a/gr-uhd/examples/c++/CMakeLists.txt
+++ b/gr-uhd/examples/c++/CMakeLists.txt
@@ -9,6 +9,6 @@
 # Build executable
 ########################################################################
 add_executable(tags_demo tags_demo.cc)
-target_link_libraries(tags_demo gnuradio-uhd)
+target_link_libraries(tags_demo gnuradio-uhd Boost::program_options)
 
 install(TARGETS tags_demo DESTINATION ${GR_PKG_UHD_EXAMPLES_DIR})

--- a/gr-uhd/lib/CMakeLists.txt
+++ b/gr-uhd/lib/CMakeLists.txt
@@ -31,7 +31,7 @@ endif(ENABLE_UHD_RFNOC)
 
 add_library(gnuradio-uhd ${LIB_GR_UHD_SOURCES})
 
-target_link_libraries(gnuradio-uhd gnuradio-runtime UHD::UHD)
+target_link_libraries(gnuradio-uhd PUBLIC gnuradio-runtime UHD::UHD)
 
 target_include_directories(
     gnuradio-uhd PUBLIC $<INSTALL_INTERFACE:include>

--- a/gr-video-sdl/lib/CMakeLists.txt
+++ b/gr-video-sdl/lib/CMakeLists.txt
@@ -8,42 +8,33 @@
 ########################################################################
 # Setup library
 ########################################################################
-add_library(gnuradio-video-sdl
-  sink_s_impl.cc
-  sink_uc_impl.cc
-)
+add_library(gnuradio-video-sdl sink_s_impl.cc sink_uc_impl.cc)
 
-target_link_libraries(gnuradio-video-sdl PUBLIC
-    gnuradio-runtime
-    ${SDL_LIBRARY}
-)
+target_link_libraries(
+    gnuradio-video-sdl
+    PUBLIC gnuradio-runtime
+    PRIVATE ${SDL_LIBRARY})
 
 if(ENABLE_COMMON_PCH)
-  target_link_libraries(gnuradio-video-sdl PRIVATE common-precompiled-headers)
+    target_link_libraries(gnuradio-video-sdl PRIVATE common-precompiled-headers)
 endif()
 
-target_include_directories(gnuradio-video-sdl
-  PUBLIC
-  $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-  ${SDL_INCLUDE_DIR}
-  )
-
+target_include_directories(
+    gnuradio-video-sdl
+    PUBLIC $<INSTALL_INTERFACE:include>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> ${SDL_INCLUDE_DIR})
 
 #Add Windows DLL resource file if using MSVC
-IF(MSVC)
+if(MSVC)
     include(${PROJECT_SOURCE_DIR}/cmake/Modules/GrVersion.cmake)
 
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-video-sdl.rc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-video-sdl.rc
-    @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-video-sdl.rc.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-video-sdl.rc @ONLY)
 
-    target_sources(gnuradio-video-sdl PRIVATE
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-video-sdl.rc
-    )
-ENDIF(MSVC)
+    target_sources(gnuradio-video-sdl
+                   PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-video-sdl.rc)
+endif(MSVC)
 
 if(BUILD_SHARED_LIBS)
-  GR_LIBRARY_FOO(gnuradio-video-sdl)
+    gr_library_foo(gnuradio-video-sdl)
 endif()

--- a/gr-vocoder/lib/CMakeLists.txt
+++ b/gr-vocoder/lib/CMakeLists.txt
@@ -8,7 +8,8 @@
 ########################################################################
 # Setup library
 ########################################################################
-add_library(gnuradio-vocoder
+add_library(
+    gnuradio-vocoder
     alaw_decode_bs_impl.cc
     alaw_encode_sb_impl.cc
     cvsd_decode_bs_impl.cc
@@ -20,77 +21,61 @@ add_library(gnuradio-vocoder
     g723_40_decode_bs_impl.cc
     g723_40_encode_sb_impl.cc
     ulaw_decode_bs_impl.cc
-    ulaw_encode_sb_impl.cc
-)
-target_include_directories(gnuradio-vocoder
-  PUBLIC $<INSTALL_INTERFACE:include>
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-)
-target_link_libraries(gnuradio-vocoder PUBLIC
-    gnuradio-runtime
-)
+    ulaw_encode_sb_impl.cc)
+target_include_directories(
+    gnuradio-vocoder
+    PUBLIC $<INSTALL_INTERFACE:include>
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
+target_link_libraries(gnuradio-vocoder PUBLIC gnuradio-runtime)
 
 if(ENABLE_COMMON_PCH)
-  target_link_libraries(gnuradio-vocoder PRIVATE common-precompiled-headers)
+    target_link_libraries(gnuradio-vocoder PRIVATE common-precompiled-headers)
 endif()
 
 if(LIBCODEC2_FOUND)
-  target_sources(gnuradio-vocoder PRIVATE
-    codec2.cc
-    codec2_decode_ps_impl.cc
-    codec2_encode_sp_impl.cc
-    )
+    target_sources(gnuradio-vocoder PRIVATE codec2.cc codec2_decode_ps_impl.cc
+                                            codec2_encode_sp_impl.cc)
 endif(LIBCODEC2_FOUND)
 if(LIBCODEC2_HAS_FREEDV_API)
-  target_sources(gnuradio-vocoder PRIVATE
-    freedv_api.cc
-    freedv_rx_ss_impl.cc
-    freedv_tx_ss_impl.cc
-    )
+    target_sources(gnuradio-vocoder PRIVATE freedv_api.cc freedv_rx_ss_impl.cc
+                                            freedv_tx_ss_impl.cc)
 endif(LIBCODEC2_HAS_FREEDV_API)
 if(LIBGSM_FOUND)
-  target_sources(gnuradio-vocoder PRIVATE
-    gsm_fr_decode_ps_impl.cc
-    gsm_fr_encode_sp_impl.cc
-    )
+    target_sources(gnuradio-vocoder PRIVATE gsm_fr_decode_ps_impl.cc
+                                            gsm_fr_encode_sp_impl.cc)
 endif(LIBGSM_FOUND)
 
 #Add Windows DLL resource file if using MSVC
 if(MSVC)
     include(${PROJECT_SOURCE_DIR}/cmake/Modules/GrVersion.cmake)
 
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-vocoder.rc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-vocoder.rc
-    @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-vocoder.rc.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-vocoder.rc @ONLY)
 
-    list(APPEND gr_uhd_sources
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-vocoder.rc
-    )
+    list(APPEND gr_uhd_sources ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-vocoder.rc)
 endif(MSVC)
 
 ########################################################################
 # Include subdirs rather to populate to the sources lists.
 ########################################################################
-target_sources(gnuradio-vocoder PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g711.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g72x.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g721.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g723_24.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g723_40.c
-)
+target_sources(
+    gnuradio-vocoder
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g711.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g72x.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g721.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g723_24.c
+            ${CMAKE_CURRENT_SOURCE_DIR}/g7xx/g723_40.c)
 
 set(external_deps "")
 if(LIBCODEC2_LIBRARIES)
-  target_link_libraries(gnuradio-vocoder PUBLIC CODEC2::CODEC2)
-  list(APPEND external_deps Codec2)
+    target_link_libraries(gnuradio-vocoder PUBLIC CODEC2::CODEC2)
+    list(APPEND external_deps Codec2)
 endif(LIBCODEC2_LIBRARIES)
 
 if(LIBGSM_LIBRARIES)
-  target_link_libraries(gnuradio-vocoder PUBLIC GSM::GSM)
-  list(APPEND external_deps GSM)
+    target_link_libraries(gnuradio-vocoder PRIVATE GSM::GSM)
 endif(LIBGSM_LIBRARIES)
 
-if (BUILD_SHARED_LIBS)
-  GR_LIBRARY_FOO(gnuradio-vocoder ${external_deps})
+if(BUILD_SHARED_LIBS)
+    gr_library_foo(gnuradio-vocoder ${external_deps})
 endif()

--- a/gr-wavelet/lib/CMakeLists.txt
+++ b/gr-wavelet/lib/CMakeLists.txt
@@ -8,41 +8,33 @@
 ########################################################################
 # Setup library
 ########################################################################
-add_library(gnuradio-wavelet
-    squash_ff_impl.cc
-    wavelet_ff_impl.cc
-    wvps_ff_impl.cc
-)
+add_library(gnuradio-wavelet squash_ff_impl.cc wavelet_ff_impl.cc wvps_ff_impl.cc)
 
 #Add Windows DLL resource file if using MSVC
 if(MSVC)
     include(${PROJECT_SOURCE_DIR}/cmake/Modules/GrVersion.cmake)
 
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-wavelet.rc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-wavelet.rc
-    @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-wavelet.rc.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-wavelet.rc @ONLY)
 
-    target_sources(gnuradio-wavelet PRIVATE
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-wavelet.rc
-    )
+    target_sources(gnuradio-wavelet
+                   PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-wavelet.rc)
 endif(MSVC)
 
-target_link_libraries(gnuradio-wavelet PUBLIC
-    gnuradio-runtime
-    GSL::gsl
-)
+target_link_libraries(
+    gnuradio-wavelet
+    PUBLIC gnuradio-runtime
+    PRIVATE GSL::gsl)
 
 if(ENABLE_COMMON_PCH)
-  target_link_libraries(gnuradio-wavelet PRIVATE common-precompiled-headers)
+    target_link_libraries(gnuradio-wavelet PRIVATE common-precompiled-headers)
 endif()
 
-target_include_directories(gnuradio-wavelet
-  PUBLIC $<INSTALL_INTERFACE:include>
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-  )
-
+target_include_directories(
+    gnuradio-wavelet
+    PUBLIC $<INSTALL_INTERFACE:include>
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 if(BUILD_SHARED_LIBS)
-  GR_LIBRARY_FOO(gnuradio-wavelet)
+    gr_library_foo(gnuradio-wavelet)
 endif()

--- a/gr-zeromq/lib/CMakeLists.txt
+++ b/gr-zeromq/lib/CMakeLists.txt
@@ -8,54 +8,46 @@
 ########################################################################
 # Setup library
 ########################################################################
-add_library(gnuradio-zeromq
-  base_impl.cc
-  pub_sink_impl.cc
-  pub_msg_sink_impl.cc
-  sub_source_impl.cc
-  sub_msg_source_impl.cc
-  pull_source_impl.cc
-  pull_msg_source_impl.cc
-  push_sink_impl.cc
-  push_msg_sink_impl.cc
-  rep_sink_impl.cc
-  rep_msg_sink_impl.cc
-  req_source_impl.cc
-  req_msg_source_impl.cc
-  tag_headers.cc
-  )
+add_library(
+    gnuradio-zeromq
+    base_impl.cc
+    pub_sink_impl.cc
+    pub_msg_sink_impl.cc
+    sub_source_impl.cc
+    sub_msg_source_impl.cc
+    pull_source_impl.cc
+    pull_msg_source_impl.cc
+    push_sink_impl.cc
+    push_msg_sink_impl.cc
+    rep_sink_impl.cc
+    rep_msg_sink_impl.cc
+    req_source_impl.cc
+    req_msg_source_impl.cc
+    tag_headers.cc)
 
-target_link_libraries(gnuradio-zeromq PUBLIC
-  gnuradio-runtime
-  ZeroMQ::ZeroMQ
-)
+target_link_libraries(
+    gnuradio-zeromq
+    PUBLIC gnuradio-runtime
+    PRIVATE ZeroMQ::ZeroMQ)
 
 if(ENABLE_COMMON_PCH)
-  target_link_libraries(gnuradio-zeromq PRIVATE common-precompiled-headers)
+    target_link_libraries(gnuradio-zeromq PRIVATE common-precompiled-headers)
 endif()
 
-target_include_directories(gnuradio-zeromq
-  PUBLIC
-  $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-  )
+target_include_directories(
+    gnuradio-zeromq PUBLIC $<INSTALL_INTERFACE:include>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 #Add Windows DLL resource file if using MSVC
 if(MSVC)
     include(${PROJECT_SOURCE_DIR}/cmake/Modules/GrVersion.cmake)
 
-    configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-zeromq.rc.in
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-zeromq.rc
-    @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gnuradio-zeromq.rc.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-zeromq.rc @ONLY)
 
-    target_sources(gnuradio-zeromq PRIVATE
-        ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-zeromq.rc
-    )
+    target_sources(gnuradio-zeromq PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gnuradio-zeromq.rc)
 endif(MSVC)
 
-
-
 if(BUILD_SHARED_LIBS)
-  GR_LIBRARY_FOO(gnuradio-zeromq ZeroMQ)
+    gr_library_foo(gnuradio-zeromq)
 endif()

--- a/grc/core/generator/cpp_templates/CMakeLists.txt.mako
+++ b/grc/core/generator/cpp_templates/CMakeLists.txt.mako
@@ -60,11 +60,13 @@ target_link_libraries(${class_name}
     % if generate_options == 'qt_gui':
     gnuradio::gnuradio-qtgui
     % endif
+    % if parameters:
+    Boost::program_options
+    % endif
     % for link in links:
     % if link:
     ${link}
     % endif
     % endfor
-
 )
 


### PR DESCRIPTION
Declaring a library as PUBLIC in target_link_libraries tells downstream linkers of the target to also need to link to the PUBLIC libraries. This is necessary when the headers of those libraries are required by the public headers of the target library. There were some instances where linked libraries were declared PUBLIC but were not required to use the public headers, so they have been switched to PRIVATE declarations. This will allow OOT modules to reduce their linking and dependencies in some cases.

Signed-off-by: Ryan Volz <ryan.volz@gmail.com>
(cherry picked from commit 501da230e07bee7cb78abd6a76fdca5a155419fa)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6178