### PR TITLE
4.0: fixed modtool using C++17 -> C++20

### DIFF
--- a/utils/modtool/newmod/meson.build
+++ b/utils/modtool/newmod/meson.build
@@ -5,7 +5,7 @@
 project('gr4-newmod', 'cpp', 
   version : '0.0.0',
   license : 'GPLv3',
-  default_options : ['cpp_std=c++17'])
+  default_options : ['cpp_std=c++20'])
 
 # Import python3 meson module which is used to find the Python dependencies.
 # Python3 is required for code generation


### PR DESCRIPTION
GR 4.0 already uses C++20, this fixes it's use also for the modtool and OOT modules. 

## Related Issue
See also issue #6400.

## Which blocks/areas does this affect?
OOT builds using GR 4.0

## Testing Done
see CI/CD checks.
N.B. does not include OOT module creation (yet).

## Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [X] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [X] I have added tests to cover my changes, and all previous tests pass.
