### PR TITLE
uhd: Re-enable uhd.find_devices() (backport to maint-3.10)

### DIFF
--- a/gr-uhd/python/uhd/bindings/python_bindings.cc
+++ b/gr-uhd/python/uhd/bindings/python_bindings.cc
@@ -8,10 +8,13 @@
  */
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#include <uhd/device.hpp>
+#include <uhd/types/device_addr.hpp>
 #include <uhd/types/time_spec.hpp>
 #include <uhd/version.hpp>
 
@@ -82,4 +85,6 @@ PYBIND11_MODULE(uhd_python, m)
         "get_version_string",
         []() { return ::uhd::get_version_string(); },
         "Returns UHD Version String");
+
+    m.def("find", [](const uhd::device_addr_t& hint) { return uhd::device::find(hint); });
 }

--- a/gr-uhd/python/uhd/bindings/usrp_block_python.cc
+++ b/gr-uhd/python/uhd/bindings/usrp_block_python.cc
@@ -25,8 +25,6 @@ void bind_usrp_block(py::module& m)
     m.attr("ALL_MBOARDS") = py::int_(::uhd::usrp::multi_usrp::ALL_MBOARDS);
     m.attr("ALL_LOS") = py::str(::uhd::usrp::multi_usrp::ALL_LOS);
 
-    m.def("find", [](const uhd::device_addr_t& hint) { return uhd::device::find(hint); });
-
     py::class_<usrp_block,
                gr::sync_block,
                gr::block,


### PR DESCRIPTION
This Python function was accidentally broken when converting from SWIG to Pybind11. In 9c64b6d, uhd.find() was created as a replacement, but that leaves uhd.find_devices() in a broken state.

This performes two changes:
- The binding for uhd.find() is moved into python_bindings.cc from usrp_block_python.cc.
- The Python version of find_devices() now correctly uses uhd.find() under the hood.
- The SWIG version differentiated between Python- and C++-versions of device_addr_t and remapped that, which we can skip with Pybind11

Signed-off-by: Martin Braun <martin@gnuradio.org>
(cherry picked from commit ab2ee30facad90255ddd2a4ac5850c322b408c87)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6353