### PR TITLE
Fix invalid pch and deprecation warnings (backport to maint-3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -64,22 +64,22 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E ""'
             ldpath:
           - distro: 'Ubuntu 22.04'
             containerid: 'gnuradio/ci:ubuntu-22.04-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
           - distro: 'Fedora 36'
             containerid: 'gnuradio/ci:fedora-36-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations 
+            cxxflags: -Werror -Wno-error=deprecated-declarations 
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           - distro: 'Fedora 37'
             containerid: 'gnuradio/ci:fedora-37-3.9'
-            cxxflags: -Werror -Wno-error=invalid-pch -Wno-error=deprecated-declarations
+            cxxflags: -Werror -Wno-error=deprecated-declarations
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'
@@ -89,13 +89,13 @@ jobs:
           #   ldpath: /usr/local/lib64/
           - distro: 'Debian 11'
             containerid: 'gnuradio/ci:debian-11-3.10'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
           - distro: 'Debian 11 (32-bit)'
             containerid: 'gnuradio/ci:debian-i386-11-3.10'
             containeroptions: '--platform linux/i386'
-            cxxflags: -Werror -Wno-error=invalid-pch
+            cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
     name: ${{ matrix.distro }}
@@ -144,7 +144,7 @@ jobs:
       name: Checkout Project
     - name: CMake
       env:
-        CXXFLAGS: -Werror -Wno-error=invalid-pch
+        CXXFLAGS: -Werror
       run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF -DENABLE_PYTHON=OFF'
     - name: Make
       run: 'cd /build && make -j2 -k'

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -74,12 +74,12 @@ jobs:
             ldpath:
           - distro: 'Fedora 36'
             containerid: 'gnuradio/ci:fedora-36-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations 
+            cxxflags: -Werror
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           - distro: 'Fedora 37'
             containerid: 'gnuradio/ci:fedora-37-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations
+            cxxflags: -Werror
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'

--- a/.github/workflows/pkg-debian.yml
+++ b/.github/workflows/pkg-debian.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           - distro: 'Ubuntu 20.04'
             containerid: 'gnuradio/ci:ubuntu-20.04-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations
+            cxxflags: -Werror
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/.github/workflows/pkg-fedora.yml
+++ b/.github/workflows/pkg-fedora.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - distro: 'Fedora 34'
             containerid: 'ghcr.io/gnuradio/ci:fedora-34-3.9'
-            cxxflags: -Werror -Wno-error=deprecated-declarations
+            cxxflags: -Werror
     name: ${{ matrix.distro }}
     container:
       image: ${{ matrix.containerid }}

--- a/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
+++ b/gnuradio-runtime/include/gnuradio/rpcserver_thrift.h
@@ -16,6 +16,7 @@
 #include <gnuradio/logger.h>
 #include <gnuradio/rpcpmtconverters_thrift.h>
 #include <gnuradio/rpcserver_base.h>
+#include <functional>
 #include <map>
 #include <mutex>
 #include <string>
@@ -111,7 +112,7 @@ private:
 
 
     template <typename T, typename TMap>
-    struct set_f : public std::unary_function<T, void> {
+    struct set_f : public std::function<void(T)> {
         set_f(TMap& _setcallbackmap, const priv_lvl_t& _cur_priv)
             : d_setcallbackmap(_setcallbackmap), cur_priv(_cur_priv)
         {
@@ -142,7 +143,7 @@ private:
     };
 
     template <typename T, typename TMap>
-    struct get_f : public std::unary_function<T, void> {
+    struct get_f : public std::function<void(T)> {
         get_f(TMap& _getcallbackmap,
               const priv_lvl_t& _cur_priv,
               GNURadio::KnobMap& _outknobs)
@@ -178,7 +179,7 @@ private:
     };
 
     template <typename T, typename TMap, typename TKnobMap>
-    struct get_all_f : public std::unary_function<T, void> {
+    struct get_all_f : public std::function<void(T)> {
         get_all_f(TMap& _getcallbackmap, const priv_lvl_t& _cur_priv, TKnobMap& _outknobs)
             : d_getcallbackmap(_getcallbackmap), cur_priv(_cur_priv), outknobs(_outknobs)
         {
@@ -204,7 +205,7 @@ private:
     };
 
     template <typename T, typename TMap, typename TKnobMap>
-    struct properties_all_f : public std::unary_function<T, void> {
+    struct properties_all_f : public std::function<void(T)> {
         properties_all_f(QueryCallbackMap_t& _getcallbackmap,
                          const priv_lvl_t& _cur_priv,
                          GNURadio::KnobPropMap& _outknobs)
@@ -238,7 +239,7 @@ private:
     };
 
     template <class T, typename TMap, typename TKnobMap>
-    struct properties_f : public std::unary_function<T, void> {
+    struct properties_f : public std::function<void(T)> {
         properties_f(TMap& _getcallbackmap,
                      const priv_lvl_t& _cur_priv,
                      TKnobMap& _outknobs)

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -186,7 +186,8 @@ target_include_directories(
     gnuradio-blocks PUBLIC $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
-set_source_files_properties(file_source_impl.cc PROPERTIES COMPILE_FLAGS
+set_source_files_properties(file_source_impl.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON
+                                                           COMPILE_FLAGS
                                                            -D_FILE_OFFSET_BITS=64)
 
 if(ENABLE_GR_CTRLPORT)


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/6366
Backport https://github.com/gnuradio/gnuradio/pull/6365

Backported these together since they both remove compiler flags for CI.