### PR TITLE
audio: Remove support for OSX 10.3 and earlier

### DIFF
--- a/gr-audio/include/gnuradio/audio/osx_impl.h
+++ b/gr-audio/include/gnuradio/audio/osx_impl.h
@@ -20,17 +20,6 @@
 #include <AudioToolbox/AudioToolbox.h>
 #include <AudioUnit/AudioUnit.h>
 
-// Check the version of MacOSX being used
-#ifdef __APPLE_CC__
-#include <AvailabilityMacros.h>
-#ifndef MAC_OS_X_VERSION_10_6
-#define MAC_OS_X_VERSION_10_6 1060
-#endif
-#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6
-#define GR_USE_OLD_AUDIO_UNIT
-#endif
-#endif
-
 // helper function to print an ASBD
 
 std::ostream& GR_AUDIO_API operator<<(std::ostream& s,

--- a/gr-audio/lib/osx/osx_sink.h
+++ b/gr-audio/lib/osx/osx_sink.h
@@ -81,10 +81,6 @@ private:
                                        UInt32 in_number_frames,
                                        AudioBufferList* io_data);
 
-#ifndef GR_USE_OLD_AUDIO_UNIT
-
-    // OSX 10.4 and newer
-
     static OSStatus hardware_listener(AudioObjectID in_object_id,
                                       UInt32 in_num_addresses,
                                       const AudioObjectPropertyAddress in_addresses[],
@@ -94,18 +90,6 @@ private:
                                      UInt32 in_num_addresses,
                                      const AudioObjectPropertyAddress in_addresses[],
                                      void* in_client_data);
-
-#else
-
-    // OSX 10.6 and older; removed as of 10.7
-
-    static OSStatus hardware_listener(AudioHardwarePropertyID in_property_id,
-                                      void* in_client_data);
-
-    static OSStatus default_listener(AudioHardwarePropertyID in_property_id,
-                                     void* in_client_data);
-
-#endif
 };
 } /* namespace audio */
 } /* namespace gr */

--- a/gr-audio/lib/osx/osx_source.h
+++ b/gr-audio/lib/osx/osx_source.h
@@ -116,10 +116,6 @@ private:
                                       UInt32 in_number_frames,
                                       AudioBufferList* io_data);
 
-#ifndef GR_USE_OLD_AUDIO_UNIT
-
-    // OSX 10.4 and newer
-
     static OSStatus hardware_listener(AudioObjectID in_object_id,
                                       UInt32 in_num_addresses,
                                       const AudioObjectPropertyAddress in_addresses[],
@@ -129,18 +125,6 @@ private:
                                      UInt32 in_num_addresses,
                                      const AudioObjectPropertyAddress in_addresses[],
                                      void* in_client_data);
-
-#else
-
-    // OSX 10.6 and older; removed as of 10.7
-
-    static OSStatus hardware_listener(AudioHardwarePropertyID in_property_id,
-                                      void* in_client_data);
-
-    static OSStatus default_listener(AudioHardwarePropertyID in_property_id,
-                                     void* in_client_data);
-
-#endif
 };
 } /* namespace audio */
 } /* namespace gr */


### PR DESCRIPTION
## Description
A change in OSX's audio API prompted the addition of some conditionally compiled code in 28d1a3fab5e2ccb593df9cd3a05b3911be326d9e. The new API was added in OSX 10.4 (released in 2005) and the old API was removed in OSX 10.7 (released in 2011). Enough time has passed that I think we should remove support for the old API.

## Which blocks/areas does this affect?
* Audio Source (OSX)
* Audio Sink (OSX)

## Testing Done
None yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
