### PR TITLE
uhd: Fix inconsistent override warnings

### DIFF
--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -114,7 +114,7 @@ public:
 
     void set_streamer_adapter_id(const std::string& stream_block_id,
                                  const size_t port,
-                                 const size_t adapter_id)
+                                 const size_t adapter_id) override
     {
         _adapter_id_map[stream_block_id][port] = adapter_id;
     }

--- a/gr-uhd/lib/rfnoc_window_impl.h
+++ b/gr-uhd/lib/rfnoc_window_impl.h
@@ -22,10 +22,10 @@ public:
     ~rfnoc_window_impl() override;
 
     /*** API *****************************************************************/
-    void set_coefficients(const std::vector<float>& coeffs, const size_t chan);
-    void set_coefficients(const std::vector<int16_t>& coeffs, const size_t chan);
-    size_t get_max_num_coefficients(const size_t chan);
-    std::vector<int16_t> get_coefficients(const size_t chan);
+    void set_coefficients(const std::vector<float>& coeffs, const size_t chan) override;
+    void set_coefficients(const std::vector<int16_t>& coeffs, const size_t chan) override;
+    size_t get_max_num_coefficients(const size_t chan) override;
+    std::vector<int16_t> get_coefficients(const size_t chan) override;
 
 private:
     ::uhd::rfnoc::window_block_control::sptr d_window_ref;


### PR DESCRIPTION
## Description
OSX CI shows several warnings about inconsistent use of the `override` specifier. Here I've added the missing specifiers.

```
[1530/1760] Building CXX object gr-uhd/lib/CMakeFiles/gnuradio-uhd.dir/rfnoc_window_impl.cc.o
In file included from $SRC_DIR/gr-uhd/lib/rfnoc_window_impl.cc:13:
$SRC_DIR/gr-uhd/lib/rfnoc_window_impl.h:25:10: warning: 'set_coefficients' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void set_coefficients(const std::vector<float>& coeffs, const size_t chan);
         ^
$SRC_DIR/gr-uhd/lib/../include/gnuradio/uhd/rfnoc_window.h:43:18: note: overridden virtual function is here
    virtual void set_coefficients(const std::vector<float>& coeffs,
                 ^
In file included from $SRC_DIR/gr-uhd/lib/rfnoc_window_impl.cc:13:
$SRC_DIR/gr-uhd/lib/rfnoc_window_impl.h:26:10: warning: 'set_coefficients' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void set_coefficients(const std::vector<int16_t>& coeffs, const size_t chan);
         ^
$SRC_DIR/gr-uhd/lib/../include/gnuradio/uhd/rfnoc_window.h:51:18: note: overridden virtual function is here
    virtual void set_coefficients(const std::vector<int16_t>& coeffs,
                 ^
In file included from $SRC_DIR/gr-uhd/lib/rfnoc_window_impl.cc:13:
$SRC_DIR/gr-uhd/lib/rfnoc_window_impl.h:27:12: warning: 'get_max_num_coefficients' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    size_t get_max_num_coefficients(const size_t chan);
           ^
$SRC_DIR/gr-uhd/lib/../include/gnuradio/uhd/rfnoc_window.h:58:20: note: overridden virtual function is here
    virtual size_t get_max_num_coefficients(const size_t chan) = 0;
                   ^
In file included from $SRC_DIR/gr-uhd/lib/rfnoc_window_impl.cc:13:
$SRC_DIR/gr-uhd/lib/rfnoc_window_impl.h:28:26: warning: 'get_coefficients' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    std::vector<int16_t> get_coefficients(const size_t chan);
                         ^
$SRC_DIR/gr-uhd/lib/../include/gnuradio/uhd/rfnoc_window.h:64:34: note: overridden virtual function is here
    virtual std::vector<int16_t> get_coefficients(const size_t chan) = 0;
                                 ^
4 warnings generated.
```

```
[1533/1760] Building CXX object gr-uhd/lib/CMakeFiles/gnuradio-uhd.dir/rfnoc_graph_impl.cc.o
$SRC_DIR/gr-uhd/lib/rfnoc_graph_impl.cc:115:10: warning: 'set_streamer_adapter_id' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void set_streamer_adapter_id(const std::string& stream_block_id,
         ^
$SRC_DIR/gr-uhd/lib/../include/gnuradio/uhd/rfnoc_graph.h:100:18: note: overridden virtual function is here
    virtual void set_streamer_adapter_id(const std::string& stream_block_id,
                 ^
1 warning generated.
```

## Which blocks/areas does this affect?
RFNOC

## Testing Done
None.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
