### PR TITLE
runtime: Fix Thrift deprecation warning

### DIFF
--- a/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
+++ b/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift
@@ -32,7 +32,7 @@ enum BaseTypes { BOOL, BYTE, SHORT, INT, LONG, DOUBLE, STRING, COMPLEX,
 
 struct KnobBase {
   1: bool a_bool;
-  2: byte a_byte;
+  2: i8 a_byte;
   3: i16 a_short;
   4: i32 a_int;
   5: i64 a_long;


### PR DESCRIPTION
## Description
Conda Linux builds show the following warning:

`[WARNING:$SRC_DIR/gnuradio-runtime/lib/controlport/thrift/gnuradio.thrift:35] The "byte" type is a compatibility alias for "i8". Use "i8" to emphasize the signedness of this type.`

The `i8` type was added in Thrift 0.10.0 (released in 2017) and the `byte` type was deprecated at the same time. Since GNU Radio 3.10 requires recent dependencies, I think it's reasonable to require Thrift >= 0.10.0. Ubuntu 20.04 has Thrift 0.13.0.

## Which blocks/areas does this affect?
ControlPort

## Testing Done
None yet.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
