### PR TITLE
digital: Pass tags vector to OFDM equalizer

### DIFF
--- a/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
@@ -136,7 +136,7 @@ int ofdm_frame_equalizer_vcvc_impl::work(int noutput_items,
 
     // Do the equalizing
     d_eq->reset();
-    d_eq->equalize(out, frame_len, d_channel_state);
+    d_eq->equalize(out, frame_len, d_channel_state, tags);
     d_eq->get_channel_state(d_channel_state);
 
     // Update the channel state regarding the frequency offset


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Changes gr::digital::ofdm_frame_equalizer_vcvc block to pass the tags to the equalizer that it aggregates. The gr::digital::ofdm_equalizer_base interface allows passing the tags vector to equalize() but in current implementation the default argument is used (empty vector).

Fixes #6422

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
gr::digital::ofdm_frame_equalizer_vcvc

## Testing Done
- run tests locally (v3.10.1.1)
- tested with a custom equalizer that uses the tags in an OOT (v3.10.1.1)

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary~~.
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
