### PR TITLE
uhd: allow GPS synchronization of the UHD time for RFNoC flowgraphs

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_graph.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_graph.block.yml
@@ -5,23 +5,186 @@ flags: [ show_id, python ]
 templates:
   imports: |-
       from gnuradio import uhd
+      import time
   var_make: |
-      <%
-          import ast
-          # Sanitize
-          graph_args = ast.literal_eval(dev_addr.strip())
-          dev_args_s = ast.literal_eval(dev_args.strip())
-          clock_source_s = ast.literal_eval(clock_source.strip())
-          time_source_s = ast.literal_eval(time_source.strip())
-          # Build full dev args
-          if dev_args_s:
-              graph_args += f",{clock_source_s}"
-          if clock_source_s:
-              graph_args += f",clock_source={clock_source_s}"
-          if time_source_s:
-              graph_args += f",time_source={time_source_s}"
-      %>
-      self.rfnoc_graph = ${id} = uhd.rfnoc_graph(uhd.device_addr("${graph_args}")))
+      self.rfnoc_graph = self.${id} = ${id} = uhd.rfnoc_graph(uhd.device_addr(",".join((${dev_addr}, ${dev_args}))))
+  make: |
+      % if int(num_mboards) > 0:
+      % if clock_source_0:
+      self.${id}.set_clock_source(${clock_source_0}, 0)
+      % endif
+      % if time_source_0:
+      self.${id}.set_time_source(${time_source_0}, 0)
+      % endif
+      % if time_sync_0 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 0)
+      % elif time_sync_0 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 0)
+      % elif time_sync_0 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(0).get_real_secs()
+      while(self.${id}.get_time_last_pps(0).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 0)
+      time.sleep(1)
+      % elif time_sync_0 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 0).to_int() + 1.0), 0)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 1:
+      % if clock_source_1:
+      self.${id}.set_clock_source(${clock_source_1}, 1)
+      % endif
+      % if time_source_1:
+      self.${id}.set_time_source(${time_source_1}, 1)
+      % endif
+      % if time_sync_1 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 1)
+      % elif time_sync_1 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 1)
+      % elif time_sync_1 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(1).get_real_secs()
+      while(self.${id}.get_time_last_pps(1).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 1)
+      time.sleep(1)
+      % elif time_sync_1 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 1).to_int() + 1.0), 1)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 2:
+      % if clock_source_2:
+      self.${id}.set_clock_source(${clock_source_2}, 2)
+      % endif
+      % if time_source_2:
+      self.${id}.set_time_source(${time_source_2}, 2)
+      % endif
+      % if time_sync_2 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 2)
+      % elif time_sync_2 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 2)
+      % elif time_sync_2 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(2).get_real_secs()
+      while(self.${id}.get_time_last_pps(2).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 2)
+      time.sleep(1)
+      % elif time_sync_2 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 2).to_int() + 1.0), 2)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 3:
+      % if clock_source_3:
+      self.${id}.set_clock_source(${clock_source_3}, 3)
+      % endif
+      % if time_source_3:
+      self.${id}.set_time_source(${time_source_3}, 3)
+      % endif
+      % if time_sync_3 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 3)
+      % elif time_sync_3 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 3)
+      % elif time_sync_3 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(3).get_real_secs()
+      while(self.${id}.get_time_last_pps(3).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 3)
+      time.sleep(1)
+      % elif time_sync_3 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 3).to_int() + 1.0), 3)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 4:
+      % if clock_source_4:
+      self.${id}.set_clock_source(${clock_source_4}, 4)
+      % endif
+      % if time_source_4:
+      self.${id}.set_time_source(${time_source_4}, 4)
+      % endif
+      % if time_sync_4 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 4)
+      % elif time_sync_4 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 4)
+      % elif time_sync_4 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(4).get_real_secs()
+      while(self.${id}.get_time_last_pps(4).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 4)
+      time.sleep(1)
+      % elif time_sync_4 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 4).to_int() + 1.0), 4)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 5:
+      % if clock_source_5:
+      self.${id}.set_clock_source(${clock_source_5}, 5)
+      % endif
+      % if time_source_5:
+      self.${id}.set_time_source(${time_source_5}, 5)
+      % endif
+      % if time_sync_5 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 5)
+      % elif time_sync_5 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 5)
+      % elif time_sync_5 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(5).get_real_secs()
+      while(self.${id}.get_time_last_pps(5).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 5)
+      time.sleep(1)
+      % elif time_sync_5 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 5).to_int() + 1.0), 5)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 6:
+      % if clock_source_6:
+      self.${id}.set_clock_source(${clock_source_6}, 6)
+      % endif
+      % if time_source_6:
+      self.${id}.set_time_source(${time_source_6}, 6)
+      % endif
+      % if time_sync_6 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 6)
+      % elif time_sync_6 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 6)
+      % elif time_sync_6 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(6).get_real_secs()
+      while(self.${id}.get_time_last_pps(6).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 6)
+      time.sleep(1)
+      % elif time_sync_6 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 6).to_int() + 1.0), 6)
+      time.sleep(1)
+      % endif
+      % endif
+      % if int(num_mboards) > 7:
+      % if clock_source_7:
+      self.${id}.set_clock_source(${clock_source_7}, 7)
+      % endif
+      % if time_source_7:
+      self.${id}.set_time_source(${time_source_7}, 7)
+      % endif
+      % if time_sync_7 == 'sync':
+      self.${id}.set_time_next_pps(uhd.time_spec(0), 7)
+      % elif time_sync_7 == 'pc_clock':
+      self.${id}.set_time_now(uhd.time_spec(time.time()), 7)
+      % elif time_sync_7 == 'pc_clock_next_pps':
+      _last_pps_time = self.${id}.get_time_last_pps(7).get_real_secs()
+      while(self.${id}.get_time_last_pps(7).get_real_secs() == _last_pps_time):
+          time.sleep(0.05)
+      self.${id}.set_time_next_pps(uhd.time_spec(int(time.time()) + 1.0), 7)
+      time.sleep(1)
+      % elif time_sync_7 == 'gps_time':
+      self.${id}.set_time_next_pps(uhd.time_spec(self.${id}.get_mboard_sensor("gps_time", 7).to_int() + 1.0), 7)
+      time.sleep(1)
+      % endif
+      % endif
 
 value: ${ 'RFNoC Graph' }
 
@@ -42,17 +205,149 @@ parameters:
   default: 1
   options: [1, 2, 3, 4, 5, 6, 7, 8]
   hide: part
-- id: clock_source
-  label: Clock Source
+- id: clock_source_0
+  label: 'Mb0: Clock Source'
   dtype: string
-  options: ['', internal, external, gpsdo]
-  option_labels: [Default, Internal, External, O/B GPSDO]
-  hide: ${ 'none' if clock_source else 'part' }
-- id: time_source
-  label: Time Source
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 0) else ( 'none' if clock_source_0 else 'part')}
+- id: time_source_0
+  label: 'Mb0: Time Source'
   dtype: string
-  options: ['', internal, external, gpsdo]
-  option_labels: [Default, Internal, External, O/B GPSDO]
-  hide: ${ 'none' if time_source else 'part' }
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 0) else ('none' if time_source_0 else 'part')}
+- id: time_sync_0
+  label: 'Mb0: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 0) else ('none' if time_sync_0 else 'part')}
+- id: clock_source_1
+  label: 'Mb1: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 1) else ( 'none' if clock_source_1 else 'part')}
+- id: time_source_1
+  label: 'Mb1: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 1) else ('none' if time_source_1 else 'part')}
+- id: time_sync_1
+  label: 'Mb1: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 1) else ('none' if time_sync_1 else 'part')}
+- id: clock_source_2
+  label: 'Mb2: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 2) else ( 'none' if clock_source_2 else 'part')}
+- id: time_source_2
+  label: 'Mb2: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 2) else ('none' if time_source_2 else 'part')}
+- id: time_sync_2
+  label: 'Mb2: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 2) else ('none' if time_sync_2 else 'part')}
+- id: clock_source_3
+  label: 'Mb3: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 3) else ( 'none' if clock_source_3 else 'part')}
+- id: time_source_3
+  label: 'Mb3: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 3) else ('none' if time_source_3 else 'part')}
+- id: time_sync_3
+  label: 'Mb3: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 3) else ('none' if time_sync_3 else 'part')}
+- id: clock_source_4
+  label: 'Mb4: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 4) else ( 'none' if clock_source_4 else 'part')}
+- id: time_source_4
+  label: 'Mb4: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 4) else ('none' if time_source_4 else 'part')}
+- id: time_sync_4
+  label: 'Mb4: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 4) else ('none' if time_sync_4 else 'part')}
+- id: clock_source_5
+  label: 'Mb5: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 5) else ( 'none' if clock_source_5 else 'part')}
+- id: time_source_5
+  label: 'Mb5: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 5) else ('none' if time_source_5 else 'part')}
+- id: time_sync_5
+  label: 'Mb5: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 5) else ('none' if time_sync_5 else 'part')}
+- id: clock_source_6
+  label: 'Mb6: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 6) else ( 'none' if clock_source_6 else 'part')}
+- id: time_source_6
+  label: 'Mb6: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 6) else ('none' if time_source_6 else 'part')}
+- id: time_sync_6
+  label: 'Mb6: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 6) else ('none' if time_sync_6 else 'part')}
+- id: clock_source_7
+  label: 'Mb7: Clock Source'
+  dtype: string
+  options: ['', internal, external, mimo, gpsdo]
+  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 7) else ( 'none' if clock_source_7 else 'part')}
+- id: time_source_7
+  label: 'Mb7: Time Source'
+  dtype: string
+  options: ['', external, mimo, gpsdo]
+  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  hide: ${ 'all' if not (num_mboards > 7) else ('none' if time_source_7 else 'part')}
+- id: time_sync_7
+  label: 'Mb7: Time Sync'
+  dtype: enum
+  options: ['', sync, pc_clock, pc_clock_next_pps, gps_time]
+  option_labels: [No Sync, Unknown PPS, PC Clock, PC Clock on Next PPS, GPS Time on Next PPS]
+  hide: ${ 'all' if not (num_mboards > 7) else ('none' if time_sync_7 else 'part')}
 
 file_format: 1

--- a/gr-uhd/grc/uhd_rfnoc_graph.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_graph.block.yml
@@ -208,14 +208,14 @@ parameters:
 - id: clock_source_0
   label: 'Mb0: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 0) else ( 'none' if clock_source_0 else 'part')}
 - id: time_source_0
   label: 'Mb0: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 0) else ('none' if time_source_0 else 'part')}
 - id: time_sync_0
   label: 'Mb0: Time Sync'
@@ -226,14 +226,14 @@ parameters:
 - id: clock_source_1
   label: 'Mb1: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 1) else ( 'none' if clock_source_1 else 'part')}
 - id: time_source_1
   label: 'Mb1: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 1) else ('none' if time_source_1 else 'part')}
 - id: time_sync_1
   label: 'Mb1: Time Sync'
@@ -244,14 +244,14 @@ parameters:
 - id: clock_source_2
   label: 'Mb2: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 2) else ( 'none' if clock_source_2 else 'part')}
 - id: time_source_2
   label: 'Mb2: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 2) else ('none' if time_source_2 else 'part')}
 - id: time_sync_2
   label: 'Mb2: Time Sync'
@@ -262,14 +262,14 @@ parameters:
 - id: clock_source_3
   label: 'Mb3: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 3) else ( 'none' if clock_source_3 else 'part')}
 - id: time_source_3
   label: 'Mb3: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 3) else ('none' if time_source_3 else 'part')}
 - id: time_sync_3
   label: 'Mb3: Time Sync'
@@ -280,14 +280,14 @@ parameters:
 - id: clock_source_4
   label: 'Mb4: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 4) else ( 'none' if clock_source_4 else 'part')}
 - id: time_source_4
   label: 'Mb4: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 4) else ('none' if time_source_4 else 'part')}
 - id: time_sync_4
   label: 'Mb4: Time Sync'
@@ -298,14 +298,14 @@ parameters:
 - id: clock_source_5
   label: 'Mb5: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 5) else ( 'none' if clock_source_5 else 'part')}
 - id: time_source_5
   label: 'Mb5: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 5) else ('none' if time_source_5 else 'part')}
 - id: time_sync_5
   label: 'Mb5: Time Sync'
@@ -316,14 +316,14 @@ parameters:
 - id: clock_source_6
   label: 'Mb6: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 6) else ( 'none' if clock_source_6 else 'part')}
 - id: time_source_6
   label: 'Mb6: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 6) else ('none' if time_source_6 else 'part')}
 - id: time_sync_6
   label: 'Mb6: Time Sync'
@@ -334,14 +334,14 @@ parameters:
 - id: clock_source_7
   label: 'Mb7: Clock Source'
   dtype: string
-  options: ['', internal, external, mimo, gpsdo]
-  option_labels: [Default, Internal, External, MIMO Cable, O/B GPSDO]
+  options: ['', internal, external, gpsdo]
+  option_labels: [Default, Internal, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 7) else ( 'none' if clock_source_7 else 'part')}
 - id: time_source_7
   label: 'Mb7: Time Source'
   dtype: string
-  options: ['', external, mimo, gpsdo]
-  option_labels: [Default, External, MIMO Cable, O/B GPSDO]
+  options: ['', external, gpsdo]
+  option_labels: [Default, External, O/B GPSDO]
   hide: ${ 'all' if not (num_mboards > 7) else ('none' if time_source_7 else 'part')}
 - id: time_sync_7
   label: 'Mb7: Time Sync'

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_graph.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_graph.h
@@ -116,6 +116,11 @@ public:
                                      const int device_select,
                                      const int block_select) = 0;
 
+    //! Returns the underlying UHD graph object.
+    //
+    // See ::uhd::rfnoc::rfnoc_graph for more documentation.
+    virtual ::uhd::rfnoc::rfnoc_graph::sptr get_uhd_graph() = 0;
+
     //! Set time source on the specified motherboard
     //
     // Note: This is a convenience call, it directly dereferences the underlying

--- a/gr-uhd/include/gnuradio/uhd/rfnoc_graph.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_graph.h
@@ -14,6 +14,7 @@
 #include <uhd/rfnoc_graph.hpp>
 #include <uhd/stream.hpp>
 #include <uhd/types/device_addr.hpp>
+#include <uhd/types/sensors.hpp>
 #include <memory>
 
 namespace gr {
@@ -148,6 +149,62 @@ public:
     //                            given out
     virtual ::uhd::rfnoc::noc_block_base::sptr
     get_block_ref(const std::string& block_id, const size_t max_ref_count) = 0;
+
+    /*!
+     * Get the current time registers.
+     *
+     * \param mboard the motherboard index 0 to M-1
+     * \param timekeeper the timekeeper index within the motherboard
+     * \return the current usrp time
+     */
+    virtual ::uhd::time_spec_t get_time_now(size_t mboard = 0, size_t timekeeper = 0) = 0;
+
+    /*!
+     * Get the time when the last pps pulse occurred.
+     * \param mboard the motherboard index 0 to M-1
+     * \param timekeeper the timekeeper index within the motherboard
+     * \return the current usrp time
+     */
+    virtual ::uhd::time_spec_t get_time_last_pps(size_t mboard = 0,
+                                                 size_t timekeeper = 0) = 0;
+
+    /*!
+     * Sets the time registers immediately.
+     * \param time_spec the new time
+     * \param mboard the motherboard index 0 to M-1
+     * \param timekeeper the timekeeper index within the motherboard
+     */
+    virtual void set_time_now(const ::uhd::time_spec_t& time_spec,
+                              size_t mboard = 0,
+                              size_t timekeeper = 0) = 0;
+
+    /*!
+     * Set the time registers at the next pps.
+     * \param time_spec the new time
+     * \param mboard the motherboard index 0 to M-1
+     * \param timekeeper the timekeeper index within the motherboard
+     */
+    virtual void set_time_next_pps(const ::uhd::time_spec_t& time_spec,
+                                   size_t mboard = 0,
+                                   size_t timekeeper = 0) = 0;
+
+    /*!
+     * Get a list of possible motherboard sensor names.
+     *
+     * \param mboard the motherboard index 0 to M-1
+     * \return a vector of sensor names
+     */
+    virtual std::vector<std::string> get_mboard_sensor_names(size_t mboard = 0) = 0;
+
+    /*!
+     * Get a motherboard sensor value.
+     *
+     * \param name the name of the sensor
+     * \param mboard the motherboard index 0 to M-1
+     * \return a sensor value object
+     */
+    virtual ::uhd::sensor_value_t get_mboard_sensor(const std::string& name,
+                                                    size_t mboard = 0) = 0;
 };
 
 } // namespace uhd

--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -160,6 +160,8 @@ public:
         return block_ids.front().to_string();
     }
 
+    ::uhd::rfnoc::rfnoc_graph::sptr get_uhd_graph() override { return _graph; };
+
     void set_time_source(const std::string& source, const size_t mb_index) override
     {
         _graph->get_mb_controller(mb_index)->set_time_source(source);

--- a/gr-uhd/lib/rfnoc_graph_impl.cc
+++ b/gr-uhd/lib/rfnoc_graph_impl.cc
@@ -207,6 +207,52 @@ public:
         return block_ref;
     }
 
+    ::uhd::time_spec_t get_time_now(size_t mboard, size_t timekeeper)
+    {
+        auto keeper = _graph->get_mb_controller(mboard)->get_timekeeper(timekeeper);
+        if (keeper) {
+            return keeper->get_time_now();
+        }
+        return ::uhd::time_spec_t(0.0);
+    }
+
+    ::uhd::time_spec_t get_time_last_pps(size_t mboard, size_t timekeeper)
+    {
+        auto keeper = _graph->get_mb_controller(mboard)->get_timekeeper(timekeeper);
+        if (keeper) {
+            return keeper->get_time_last_pps();
+        }
+        return ::uhd::time_spec_t(0.0);
+    }
+
+    void
+    set_time_now(const ::uhd::time_spec_t& time_spec, size_t mboard, size_t timekeeper)
+    {
+        auto keeper = _graph->get_mb_controller(mboard)->get_timekeeper(timekeeper);
+        if (keeper) {
+            return keeper->set_time_now(time_spec);
+        }
+    }
+
+    void set_time_next_pps(const ::uhd::time_spec_t& time_spec,
+                           size_t mboard,
+                           size_t timekeeper)
+    {
+        auto keeper = _graph->get_mb_controller(mboard)->get_timekeeper(timekeeper);
+        if (keeper) {
+            return keeper->set_time_next_pps(time_spec);
+        }
+    }
+
+    std::vector<std::string> get_mboard_sensor_names(size_t mboard)
+    {
+        return _graph->get_mb_controller(mboard)->get_sensor_names();
+    }
+
+    ::uhd::sensor_value_t get_mboard_sensor(const std::string& name, size_t mboard)
+    {
+        return _graph->get_mb_controller(mboard)->get_sensor(name);
+    }
 
 private:
     size_t _get_adapter_id(const std::string& streamer_id, const size_t port)

--- a/gr-uhd/python/uhd/bindings/docstrings/rfnoc_graph_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/rfnoc_graph_pydoc_template.h
@@ -48,6 +48,9 @@ static const char* __doc_gr_uhd_rfnoc_graph_commit = R"doc()doc";
 static const char* __doc_gr_uhd_rfnoc_graph_get_block_id = R"doc()doc";
 
 
+static const char* __doc_gr_uhd_rfnoc_graph_get_uhd_graph = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_rfnoc_graph_set_time_source = R"doc()doc";
 
 

--- a/gr-uhd/python/uhd/bindings/docstrings/rfnoc_graph_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/rfnoc_graph_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Marcus Müller
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -17,22 +17,59 @@
 
 static const char* __doc_gr_uhd_rfnoc_graph = R"doc()doc";
 
+
+static const char* __doc_gr_uhd_rfnoc_graph_rfnoc_graph_0 = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_rfnoc_graph_1 = R"doc()doc";
+
+
 static const char* __doc_gr_uhd_rfnoc_graph_make = R"doc()doc";
 
-static const char* __doc_gr_uhd_rfnoc_graph_connect = R"doc()doc";
+
+static const char* __doc_gr_uhd_rfnoc_graph_connect_0 = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_connect_1 = R"doc()doc";
+
 
 static const char* __doc_gr_uhd_rfnoc_graph_create_rx_streamer = R"doc()doc";
 
+
 static const char* __doc_gr_uhd_rfnoc_graph_create_tx_streamer = R"doc()doc";
+
 
 static const char* __doc_gr_uhd_rfnoc_graph_set_streamer_adapter_id = R"doc()doc";
 
+
 static const char* __doc_gr_uhd_rfnoc_graph_commit = R"doc()doc";
+
 
 static const char* __doc_gr_uhd_rfnoc_graph_get_block_id = R"doc()doc";
 
+
 static const char* __doc_gr_uhd_rfnoc_graph_set_time_source = R"doc()doc";
+
 
 static const char* __doc_gr_uhd_rfnoc_graph_set_clock_source = R"doc()doc";
 
+
 static const char* __doc_gr_uhd_rfnoc_graph_get_block_ref = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_get_time_now = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_get_time_last_pps = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_set_time_now = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_set_time_next_pps = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_get_mboard_sensor_names = R"doc()doc";
+
+
+static const char* __doc_gr_uhd_rfnoc_graph_get_mboard_sensor = R"doc()doc";

--- a/gr-uhd/python/uhd/bindings/rfnoc_graph_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_graph_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Marcus Müller
+ * Copyright 2022 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rfnoc_graph.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(859c22ff93c70b536a7dc6a1df68f256)                     */
+/* BINDTOOL_HEADER_FILE_HASH(47af41ba186763799382ccda11611448)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -36,34 +36,128 @@ void bind_rfnoc_graph(py::module& m)
     py::class_<rfnoc_graph, std::shared_ptr<rfnoc_graph>>(
         m, "rfnoc_graph", D(rfnoc_graph))
 
-        .def(py::init(&rfnoc_graph::make), D(rfnoc_graph, make))
+        .def(py::init(&rfnoc_graph::make), py::arg("dev_addr"), D(rfnoc_graph, make))
+
+
         .def("connect",
-             py::overload_cast<const std::string&,
-                               const size_t,
-                               const std::string&,
-                               const size_t,
-                               const bool>(&rfnoc_graph::connect),
-             D(rfnoc_graph, connect))
+             (void(rfnoc_graph::*)(std::string const&,
+                                   size_t const,
+                                   std::string const&,
+                                   size_t const,
+                                   bool const)) &
+                 rfnoc_graph::connect,
+             py::arg("src_block"),
+             py::arg("src_block_port"),
+             py::arg("dst_block"),
+             py::arg("dst_block_port"),
+             py::arg("skip_property_propagation") = false,
+             D(rfnoc_graph, connect, 0))
+
+
         .def("connect",
-             py::overload_cast<const std::string&, const std::string&, const bool>(
-                 &rfnoc_graph::connect),
-             D(rfnoc_graph, connect))
+             (void(rfnoc_graph::*)(std::string const&, std::string const&, bool const)) &
+                 rfnoc_graph::connect,
+             py::arg("src_block"),
+             py::arg("dst_block"),
+             py::arg("skip_property_propagation") = false,
+             D(rfnoc_graph, connect, 1))
+
+
         .def("create_rx_streamer",
              &rfnoc_graph::create_rx_streamer,
+             py::arg("num_ports"),
+             py::arg("args"),
              D(rfnoc_graph, create_rx_streamer))
+
+
         .def("create_tx_streamer",
              &rfnoc_graph::create_tx_streamer,
+             py::arg("num_ports"),
+             py::arg("args"),
              D(rfnoc_graph, create_tx_streamer))
+
+
         .def("set_streamer_adapter_id",
              &rfnoc_graph::set_streamer_adapter_id,
+             py::arg("stream_block_id"),
+             py::arg("port"),
+             py::arg("adapter_id"),
              D(rfnoc_graph, set_streamer_adapter_id))
+
+
         .def("commit", &rfnoc_graph::commit, D(rfnoc_graph, commit))
-        .def("get_block_id", &rfnoc_graph::get_block_id, D(rfnoc_graph, get_block_id))
+
+
+        .def("get_block_id",
+             &rfnoc_graph::get_block_id,
+             py::arg("block_name"),
+             py::arg("device_select"),
+             py::arg("block_select"),
+             D(rfnoc_graph, get_block_id))
+
+
         .def("set_time_source",
              &rfnoc_graph::set_time_source,
+             py::arg("source"),
+             py::arg("mb_index"),
              D(rfnoc_graph, set_time_source))
+
+
         .def("set_clock_source",
              &rfnoc_graph::set_clock_source,
+             py::arg("source"),
+             py::arg("mb_index"),
              D(rfnoc_graph, set_clock_source))
-        .def("get_block_ref", &rfnoc_graph::get_block_ref, D(rfnoc_graph, get_block_ref));
+
+
+        .def("get_block_ref",
+             &rfnoc_graph::get_block_ref,
+             py::arg("block_id"),
+             py::arg("max_ref_count"),
+             D(rfnoc_graph, get_block_ref))
+
+
+        .def("get_time_now",
+             &rfnoc_graph::get_time_now,
+             py::arg("mboard") = 0,
+             py::arg("timekeeper") = 0,
+             D(rfnoc_graph, get_time_now))
+
+
+        .def("get_time_last_pps",
+             &rfnoc_graph::get_time_last_pps,
+             py::arg("mboard") = 0,
+             py::arg("timekeeper") = 0,
+             D(rfnoc_graph, get_time_last_pps))
+
+
+        .def("set_time_now",
+             &rfnoc_graph::set_time_now,
+             py::arg("time_spec"),
+             py::arg("mboard") = 0,
+             py::arg("timekeeper") = 0,
+             D(rfnoc_graph, set_time_now))
+
+
+        .def("set_time_next_pps",
+             &rfnoc_graph::set_time_next_pps,
+             py::arg("time_spec"),
+             py::arg("mboard") = 0,
+             py::arg("timekeeper") = 0,
+             D(rfnoc_graph, set_time_next_pps))
+
+
+        .def("get_mboard_sensor_names",
+             &rfnoc_graph::get_mboard_sensor_names,
+             py::arg("mboard") = 0,
+             D(rfnoc_graph, get_mboard_sensor_names))
+
+
+        .def("get_mboard_sensor",
+             &rfnoc_graph::get_mboard_sensor,
+             py::arg("name"),
+             py::arg("mboard") = 0,
+             D(rfnoc_graph, get_mboard_sensor))
+
+        ;
 }

--- a/gr-uhd/python/uhd/bindings/rfnoc_graph_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_graph_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rfnoc_graph.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(47af41ba186763799382ccda11611448)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a6cdab494fc7d1ff9f19bc379b66f492)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -94,6 +94,9 @@ void bind_rfnoc_graph(py::module& m)
              py::arg("device_select"),
              py::arg("block_select"),
              D(rfnoc_graph, get_block_id))
+
+
+        .def("get_uhd_graph", &rfnoc_graph::get_uhd_graph, D(rfnoc_graph, get_uhd_graph))
 
 
         .def("set_time_source",


### PR DESCRIPTION
The purpose of this PR is to allow GPS synchronization of the UHD time for RFNoC flowgraphs, which was not 
possible before. In this series we have implemented similar functionality to the Multi USRP block:

1) Exposed the missing time and sensor related functionality of UHD in the rfnoc-graph block.
2) Regenerated the python bindings and replaced the hand crafted one (which had missing argument names).
3) Reworked the rfnoc_graph GRC yaml file to allow time synchronization just like in the multi USRP block (e.g. set the UHD time to GPS time).
4) Also adopted the way how the clock and time sources are set up (not through the device argument but individual calls), and allow multiple motherboards to be present, just like in multi USRP.
 
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
