### PR TITLE
runtime: expose mechanism for testing host_buffer (backport to maint-3.10)

### DIFF
--- a/gnuradio-runtime/include/gnuradio/io_signature.h
+++ b/gnuradio-runtime/include/gnuradio/io_signature.h
@@ -11,10 +11,17 @@
 #ifndef INCLUDED_IO_SIGNATURE_H
 #define INCLUDED_IO_SIGNATURE_H
 
+// For testing purposes, force single mapped buffers to make all QA use them
+//#define FORCE_SINGLE_MAPPED
+
 #include <functional>
 
 #include <gnuradio/api.h>
+#ifdef FORCE_SINGLE_MAPPED
+#include <gnuradio/host_buffer.h>
+#else
 #include <gnuradio/buffer_double_mapped.h>
+#endif
 #include <gnuradio/buffer_type.h>
 #include <gnuradio/runtime_types.h>
 
@@ -56,7 +63,11 @@ public:
     static sptr make(int min_streams,
                      int max_streams,
                      int sizeof_stream_item,
+#ifdef FORCE_SINGLE_MAPPED
+                     buffer_type buftype = host_buffer::type);
+#else
                      buffer_type buftype = buffer_double_mapped::type);
+#endif
 
     /*!
      * \brief Create an i/o signature
@@ -75,8 +86,13 @@ public:
                       int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
+#ifdef FORCE_SINGLE_MAPPED
+                      buffer_type buftype1 = host_buffer::type,
+                      buffer_type buftype2 = host_buffer::type);
+#else
                       buffer_type buftype1 = buffer_double_mapped::type,
                       buffer_type buftype2 = buffer_double_mapped::type);
+#endif
 
     /*!
      * \brief Create an i/o signature
@@ -99,9 +115,15 @@ public:
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
                       int sizeof_stream_item3,
+#ifdef FORCE_SINGLE_MAPPED
+                      buffer_type buftype1 = host_buffer::type,
+                      buffer_type buftype2 = host_buffer::type,
+                      buffer_type buftype3 = host_buffer::type);
+#else
                       buffer_type buftype1 = buffer_double_mapped::type,
                       buffer_type buftype2 = buffer_double_mapped::type,
                       buffer_type buftype3 = buffer_double_mapped::type);
+#endif
 
     /*!
      * \brief Create an i/o signature

--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -23,7 +23,11 @@ gr::io_signature::sptr io_signature::makev(int min_streams,
                                            const std::vector<int>& sizeof_stream_items)
 {
     gr_vector_buffer_type buftypes(sizeof_stream_items.size(),
+#ifdef FORCE_SINGLE_MAPPED
+                                   host_buffer::type);
+#else
                                    buffer_double_mapped::type);
+#endif
     return gr::io_signature::sptr(
         new io_signature(min_streams, max_streams, sizeof_stream_items, buftypes));
 }

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/io_signature_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/io_signature_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(io_signature.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2d21df486462de11f4eb25681101c0c6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(fe931f4f10b5b363b55e9ae43c178b7a)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -40,7 +40,11 @@ void bind_io_signature(py::module& m)
              py::arg("min_streams"),
              py::arg("max_streams"),
              py::arg("sizeof_stream_item"),
+#ifdef FORCE_SINGLE_MAPPED
+             py::arg("buftype") = gr::host_buffer::type,
+#else
              py::arg("buftype") = gr::buffer_double_mapped::type,
+#endif
              D(io_signature, make))
 
 
@@ -50,8 +54,13 @@ void bind_io_signature(py::module& m)
                     py::arg("max_streams"),
                     py::arg("sizeof_stream_item1"),
                     py::arg("sizeof_stream_item2"),
+#ifdef FORCE_SINGLE_MAPPED
+                    py::arg("buftype1") = gr::host_buffer::type,
+                    py::arg("buftype2") = gr::host_buffer::type,
+#else
                     py::arg("buftype1") = gr::buffer_double_mapped::type,
                     py::arg("buftype2") = gr::buffer_double_mapped::type,
+#endif
                     D(io_signature, make2))
 
 
@@ -62,9 +71,15 @@ void bind_io_signature(py::module& m)
                     py::arg("sizeof_stream_item1"),
                     py::arg("sizeof_stream_item2"),
                     py::arg("sizeof_stream_item3"),
+#ifdef FORCE_SINGLE_MAPPED
+                    py::arg("buftype1") = gr::host_buffer::type,
+                    py::arg("buftype2") = gr::host_buffer::type,
+                    py::arg("buftype3") = gr::host_buffer::type,
+#else
                     py::arg("buftype1") = gr::buffer_double_mapped::type,
                     py::arg("buftype2") = gr::buffer_double_mapped::type,
                     py::arg("buftype3") = gr::buffer_double_mapped::type,
+#endif
                     D(io_signature, make3))
 
         .def_static(


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>
(cherry picked from commit 2bab99dbb0698d30212f5c272d78b93f95aec047)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/5647

Note: this is test code that is turned on using `#define FORCE_SINGLE_MAPPED`. No impact when turned off, so backporting to keep the branches sync'd.