### PR TITLE
grc: snippets before init is called

### DIFF
--- a/grc/blocks/snippet.block.yml
+++ b/grc/blocks/snippet.block.yml
@@ -6,8 +6,8 @@ parameters:
 -   id: section
     label: Section of Flowgraph
     dtype: string
-    options: ['main_after_init', 'main_after_start', 'main_after_stop' ]
-    option_labels: ['Main - After Init', 'Main - After Start', 'Main - After Stop']
+    options: ['main_after_init', 'main_after_start', 'main_after_stop', 'init_before_blocks' ]
+    option_labels: ['Main - After Init', 'Main - After Start', 'Main - After Stop', 'Init - Before Blocks']
 -   id: priority
     label: Priority
     dtype: int

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -55,7 +55,7 @@ ${indent(snip['def'])}
 % endfor
 \
 <%
-snippet_sections = ['main_after_init', 'main_after_start', 'main_after_stop']
+snippet_sections = ['main_after_init', 'main_after_start', 'main_after_stop', 'init_before_blocks']
 snippets = {}
 for section in snippet_sections:
     snippets[section] = flow_graph.get_snippets_dict(section)
@@ -205,6 +205,7 @@ gr.io_signature.makev(${len(io_sigs)}, ${len(io_sigs)}, [${', '.join(size_strs)}
         # Blocks
         ${'##################################################'}
         % endif
+        ${'snippets_init_before_blocks(self)' if snippets['init_before_blocks'] else ''}
         % for blk, blk_make in blocks:
         % if blk_make:
         ${ indent(blk_make.strip('\n')) }


### PR DESCRIPTION
## Description
There are situations where snippets need to be inserted before block initialization, such as when 
a block constructor makes contact with an external server, it might be handy to initialize the server
or check whether it is ready prior to calling the flowgraph init function that calls the block constructor

The problem with the current construct is snippets can only be injected after the flowgraph is initialized,
since they use `self` as a reference to the flowgraph object.  There is probably a better way to do this
but the easy solution is to pass `None` as what will become self, and snippets that are inserted before
main are not able to make calls to `self`

Notes:
1. Main Before Init is placed second on the list, so Main After Init is the default

I'm wondering if it would be more useful to have the injection point inside the `top_block.__init__` after variables 
are instantiated, then the snippet would have access to variables

## Related Issue
None

## Which blocks/areas does this affect?
Just GRC when snippets are used

## Testing Done


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
