### PR TITLE
pdu: Don't enable blocks and filter

### DIFF
--- a/gr-pdu/CMakeLists.txt
+++ b/gr-pdu/CMakeLists.txt
@@ -13,8 +13,7 @@
 # Register component
 ########################################################################
 include(GrComponent)
-gr_register_component("gr-pdu" ENABLE_GR_PDU ENABLE_GNURADIO_RUNTIME ENABLE_GR_BLOCKS
-                      ENABLE_GR_FILTER)
+gr_register_component("gr-pdu" ENABLE_GR_PDU ENABLE_GNURADIO_RUNTIME)
 
 set(GR_PKG_PDU_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/pdu)
 


### PR DESCRIPTION
Not required:
e36f2fab5 ("pdu: Remove unused dependencies", 2022-06-01)

Signed-off-by: Chris Mayo <aklhfex@gmail.com>

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Testing Done
Build 3.10.5.0 with this patch.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
