### PR TITLE
grc: add a pass if snippet is empty

### DIFF
--- a/grc/core/FlowGraph.py
+++ b/grc/core/FlowGraph.py
@@ -115,8 +115,11 @@ class FlowGraph(Element):
             d['lines'] = snip.params['code'].value.splitlines()
             d['def'] = 'def snipfcn_{}(self):'.format(snip.name)
             d['call'] = 'snipfcn_{}(tb)'.format(snip.name)
-            if not section or sect == section:
-                output.append(d)
+            if not len(d['lines']):
+                Messages.send_warning("Ignoring empty snippet from canvas")
+            else:
+                if not section or sect == section:
+                    output.append(d)
 
         # Sort by descending priority
         if section:


### PR DESCRIPTION
Signed-off-by: Josh Morman <jmorman@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
See related [issue](https://github.com/gnuradio/gnuradio/issues/6444)

An empty snippet prior to this PR will cause an invalid rendered flowgraph 

## Related Issue
Fixes #6444 

## Which blocks/areas does this affect?
GRC files with snippets

## Testing Done
empty and non-empty snippet. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [N/A] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
