### PR TITLE
4.0: Couple of pmtv lib merge cleanups

### DIFF
--- a/utils/blockbuilder/templates/blockname.cc.j2
+++ b/utils/blockbuilder/templates/blockname.cc.j2
@@ -84,7 +84,15 @@ void {{block}}::set_{{p['id']}}({{p['dtype']|cpp_type(vec=p['container']=='vecto
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
 {{ p['dtype']|cpp_type(vec=p['container']=='vector')}} {{block}}::{{p['id']}}()
 {
+{% if p['is_enum'] %}
+{% if 'container' in p and p['container'] == 'vector' %}
+    return pmtv::cast<{{ 'std::vector<int>' }}>(request_parameter_query(params::id_{{p['id']}}));
+{% else %}
+    return ({{p['dtype']|cpp_type}}) pmtv::cast<int>(request_parameter_query(params::id_{{p['id']}}));
+{% endif %}
+{% else %}
     return pmtv::cast<{{ p['dtype']|cpp_type(vec=p['container']=='vector')}}>(request_parameter_query(params::id_{{p['id']}}));
+{% endif %}
 }
 {% endif %}
 {% endfor -%}

--- a/utils/modtool/newmod/meson.build
+++ b/utils/modtool/newmod/meson.build
@@ -71,7 +71,7 @@ SCRIPTS_DIR = join_paths(share_dir, 'utils','blockbuilder','scripts' )
 volk_dep = dependency('volk', version : '>=2.2')
 fmt_dep = dependency('fmt', method: 'cmake', modules: ['fmt::fmt'])
 spdlog_dep = dependency('spdlog')
-pmt_dep = dependency('pmtv', version : '>= 0.0.2')
+pmt_dep = dependency('pmt', version : '>= 0.0.2')
 
 if GR_ENABLE_PYTHON
 run_command('python3', join_paths(SCRIPTS_DIR,'gen_meson.py'), 


### PR DESCRIPTION
## Description
Couple of things that were missed in the merge of the variant based PMT

## Related Issue
Fixes #6453
related to: https://github.com/gnuradio/gnuradio/pull/6398

## Which blocks/areas does this affect?
non-templated blocks with automatically generated getter functions using enums

## Testing Done
Tested on OOT module with enum parameter

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
