### PR TITLE
fec: fix typo in upper_convolve()

### DIFF
--- a/gr-fec/python/fec/polar/channel_construction_awgn.py
+++ b/gr-fec/python/fec/polar/channel_construction_awgn.py
@@ -198,7 +198,7 @@ def upper_convolve(tpm, mu):
     idx = -1
     for i in range(mu):
         idx += 1
-        q[0, idx] = (tpm[0 / i] ** 2 + tpm[1, i] ** 2, 2)
+        q[0, idx] = (tpm[0, i] ** 2 + tpm[1, i] ** 2, 2)
         q[1, idx] = tpm[0, i] * tpm[1, i]
         for j in range(i + 1, mu):
             idx += 1
@@ -219,8 +219,8 @@ def lower_convolve(tpm, mu):
     idx = -1
     for i in range(0, mu):
         idx += 1
-        q[0, idx] = (tpm[0 / i] ** 2, 2)
-        q[1, idx] = (tpm[1 / i] ** 2, 2)
+        q[0, idx] = (tpm[0, i] ** 2, 2)
+        q[1, idx] = (tpm[1, i] ** 2, 2)
         if q[0, idx] < q[1, idx]:
             q[0, idx], q[1, idx] = swap_values(q[0, idx], q[1, idx])
         idx += 1


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>

## Description
Type in `upper_convolve` was generating /0 error, and doesn't look like the intended code. Note that I don't know anything about polar codes!

## Related Issue
Fixes #5430 

## Testing Done
None

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
