### PR TITLE
Fix unmatched bracket

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_graph.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_graph.block.yml
@@ -21,7 +21,7 @@ templates:
           if time_source_s:
               graph_args += f",time_source={time_source_s}"
       %>
-      self.rfnoc_graph = ${id} = uhd.rfnoc_graph(uhd.device_addr("${graph_args}")))
+      self.rfnoc_graph = ${id} = uhd.rfnoc_graph(uhd.device_addr("${graph_args}"))
 
 value: ${ 'RFNoC Graph' }
 


### PR DESCRIPTION
Just fixing a typo from https://github.com/gnuradio/gnuradio/commit/86b5ab2898b3284345cf936eb519cc9fcc22da8e

@mbr0wn 

------------

Affects gr v3.10.5.0

Error message:
```
File "test.py", line 78
  self.rfnoc_graph = uhd_rfnoc_graph_0 = uhd.rfnoc_graph(uhd.device_addr("addr=192.168.10.2")))
                                                                                              ^
SyntaxError: unmatched ')'
```

A temporary workaround is to set address to `"+("addr=192.168.10.2`
