### PR TITLE
runtime: (Re)make block buffer size customizable

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -27,7 +27,9 @@ namespace gr {
 // 32Kbyte buffer size between blocks
 #define GR_FIXED_BUFFER_SIZE (32 * (1L << 10))
 
-static const unsigned int s_fixed_buffer_size = GR_FIXED_BUFFER_SIZE;
+static const unsigned int s_fixed_buffer_size =
+    prefs::singleton()->get_long("DEFAULT", "buffer_size", GR_FIXED_BUFFER_SIZE);
+
 
 block::block(const std::string& name,
              io_signature::sptr input_signature,

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -27,13 +27,6 @@
 
 namespace gr {
 
-
-// 32Kbyte buffer size between blocks
-#define GR_FIXED_BUFFER_SIZE (32 * (1L << 10))
-
-static const unsigned int s_fixed_buffer_size =
-    prefs::singleton()->get_long("DEFAULT", "buffer_size", GR_FIXED_BUFFER_SIZE);
-
 flat_flowgraph_sptr make_flat_flowgraph()
 {
     return flat_flowgraph_sptr(new flat_flowgraph());


### PR DESCRIPTION
## Description
Make block buffer size customizable using the environment variable `GR_CONF_DEFAULT_BUFFER_SIZE`

## Which blocks/areas does this affect?
Affects maximum allowable buffer size for all blocks.

## Testing Done
I was testing a fft filter with a lot of taps (>100) which required a huge buffer size, and gnuradio complained. Changing the environment variable `GR_CONF_DEFAULT_BUFFER_SIZE` in previous versions of gnuradio made this possible, and now it is possible again after this change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
