### PR TITLE
digital: Pass tags vector to OFDM equalizer (backport to maint-3.10)

### DIFF
--- a/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
+++ b/gr-digital/lib/ofdm_frame_equalizer_vcvc_impl.cc
@@ -136,7 +136,7 @@ int ofdm_frame_equalizer_vcvc_impl::work(int noutput_items,
 
     // Do the equalizing
     d_eq->reset();
-    d_eq->equalize(out, frame_len, d_channel_state);
+    d_eq->equalize(out, frame_len, d_channel_state, tags);
     d_eq->get_channel_state(d_channel_state);
 
     // Update the channel state regarding the frequency offset


### PR DESCRIPTION
Change gr::digital::ofdm_frame_equalizer_vcvc block to pass the tags to the equalizer that it aggregates. The gr::digital::ofdm_equalizer_base interface allows passing the tags vector to equalize() but in current implementation the default argument is used (empty vector).

Backport https://github.com/gnuradio/gnuradio/pull/6424