### PR TITLE
qtgui: fix instrumentation sink save dialog

### DIFF
--- a/gr-qtgui/lib/displayform.cc
+++ b/gr-qtgui/lib/displayform.cc
@@ -303,6 +303,8 @@ void DisplayForm::saveFigure()
     QString filename, filetype;
     QFileDialog* filebox = new QFileDialog(0, "Save Image", "./", types);
     filebox->setViewMode(QFileDialog::Detail);
+    filebox->setAcceptMode(QFileDialog::AcceptSave);
+    filebox->setFileMode(QFileDialog::AnyFile);
     if (filebox->exec()) {
         filename = filebox->selectedFiles()[0];
         filetype = filebox->selectedNameFilter();
@@ -311,15 +313,15 @@ void DisplayForm::saveFigure()
     }
 
     if (filetype.contains(".jpg")) {
-        qpix.save(filename, "JPEG");
+        qpix.save(filename + ".jpg", "JPEG");
     } else if (filetype.contains(".png")) {
-        qpix.save(filename, "PNG");
+        qpix.save(filename + ".png", "PNG");
     } else if (filetype.contains(".bmp")) {
-        qpix.save(filename, "BMP");
+        qpix.save(filename + ".bmp", "BMP");
     } else if (filetype.contains(".tiff")) {
-        qpix.save(filename, "TIFF");
+        qpix.save(filename + ".tiff", "TIFF");
     } else {
-        qpix.save(filename, "JPEG");
+        qpix.save(filename + ".jpg", "JPEG");
     }
 
     delete filebox;

--- a/gr-qtgui/lib/eyedisplaysform.cc
+++ b/gr-qtgui/lib/eyedisplaysform.cc
@@ -339,6 +339,8 @@ void EyeDisplaysForm::saveFigure()
     QString filename, filetype;
     QFileDialog* filebox = new QFileDialog(0, "Save Image", "./", types);
     filebox->setViewMode(QFileDialog::Detail);
+    filebox->setAcceptMode(QFileDialog::AcceptSave);
+    filebox->setFileMode(QFileDialog::AnyFile);
     if (filebox->exec()) {
         filename = filebox->selectedFiles()[0];
         filetype = filebox->selectedNameFilter();
@@ -347,15 +349,15 @@ void EyeDisplaysForm::saveFigure()
     }
 
     if (filetype.contains(".jpg")) {
-        qpix.save(filename, "JPEG");
+        qpix.save(filename + ".jpg", "JPEG");
     } else if (filetype.contains(".png")) {
-        qpix.save(filename, "PNG");
+        qpix.save(filename + ".png", "PNG");
     } else if (filetype.contains(".bmp")) {
-        qpix.save(filename, "BMP");
+        qpix.save(filename + ".bmp", "BMP");
     } else if (filetype.contains(".tiff")) {
-        qpix.save(filename, "TIFF");
+        qpix.save(filename + ".tiff", "TIFF");
     } else {
-        qpix.save(filename, "JPEG");
+        qpix.save(filename + ".jpg", "JPEG");
     }
 
     delete filebox;

--- a/gr-qtgui/lib/numberdisplayform.cc
+++ b/gr-qtgui/lib/numberdisplayform.cc
@@ -186,6 +186,8 @@ void NumberDisplayForm::saveFigure()
     QString filename, filetype;
     QFileDialog* filebox = new QFileDialog(0, "Save Image", "./", types);
     filebox->setViewMode(QFileDialog::Detail);
+    filebox->setAcceptMode(QFileDialog::AcceptSave);
+    filebox->setFileMode(QFileDialog::AnyFile);
     if (filebox->exec()) {
         filename = filebox->selectedFiles()[0];
         filetype = filebox->selectedNameFilter();
@@ -194,15 +196,15 @@ void NumberDisplayForm::saveFigure()
     }
 
     if (filetype.contains(".jpg")) {
-        qpix.save(filename, "JPEG");
+        qpix.save(filename + ".jpg", "JPEG");
     } else if (filetype.contains(".png")) {
-        qpix.save(filename, "PNG");
+        qpix.save(filename + ".png", "PNG");
     } else if (filetype.contains(".bmp")) {
-        qpix.save(filename, "BMP");
+        qpix.save(filename + ".bmp", "BMP");
     } else if (filetype.contains(".tiff")) {
-        qpix.save(filename, "TIFF");
+        qpix.save(filename + ".tiff", "TIFF");
     } else {
-        qpix.save(filename, "JPEG");
+        qpix.save(filename + ".jpg", "JPEG");
     }
 
     delete filebox;


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
When middle click in a QT Instrumentation sink plot (Time or Frequency) is pressed and select save a save file dialog appear. We can give the file a name and navigate to the desired directory. The problem is that there is no save button, but a disabled open button instead. 
Added a save  option in place of open.
## Related Issue
Fixes #5991 
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
gr-qtgui/lib/displayform.cc - Line 303-324
gr-qtgui/lib/eyedisplaysform.cc - Line 339-360
gr-qtgui/lib/numberdisplayform.cc - Line 185-207

<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
Yes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
