### PR TITLE
iio: cmake: revert libad9361 linkage back to public

### DIFF
--- a/gr-iio/lib/CMakeLists.txt
+++ b/gr-iio/lib/CMakeLists.txt
@@ -31,7 +31,7 @@ if(libad9361_SUFFICIENT)
     target_sources(gnuradio-iio PRIVATE fmcomms2_sink_impl.cc fmcomms2_source_impl.cc
                                         pluto_utils.cc)
     target_link_libraries(gnuradio-iio PRIVATE libad9361::ad9361)
-    target_compile_definitions(gnuradio-iio PRIVATE -DGR_IIO_LIBAD9361)
+    target_compile_definitions(gnuradio-iio PUBLIC -DGR_IIO_LIBAD9361)
 endif(libad9361_SUFFICIENT)
 
 if(ENABLE_COMMON_PCH)


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>

## Description
In #6178, a number of unnecessary public linkages were removed, but this one was needed.

## Related Issue
Fixes #6481

## Which blocks/areas does this affect?
iio

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
