### PR TITLE
iio: cmake: revert libad9361 linkage back to public

### DIFF
--- a/gr-iio/lib/CMakeLists.txt
+++ b/gr-iio/lib/CMakeLists.txt
@@ -31,7 +31,7 @@ if(libad9361_SUFFICIENT)
     target_sources(gnuradio-iio PRIVATE fmcomms2_sink_impl.cc fmcomms2_source_impl.cc
                                         pluto_utils.cc)
     target_link_libraries(gnuradio-iio PRIVATE libad9361::ad9361)
-    target_compile_definitions(gnuradio-iio PRIVATE -DGR_IIO_LIBAD9361)
+    target_compile_definitions(gnuradio-iio PUBLIC -DGR_IIO_LIBAD9361)
 endif(libad9361_SUFFICIENT)
 
 if(ENABLE_COMMON_PCH)


### PR DESCRIPTION
Signed-off-by: Jeff Long <willcode4@gmail.com>
(cherry picked from commit d0202d04e9635ec9063671a18fdc793fea00a534)
Signed-off-by: Jeff Long <willcode4@gmail.com>

Backport https://github.com/gnuradio/gnuradio/pull/6483