### PR TITLE
network: change type of bytes_read UDP Source

### DIFF
--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -251,7 +251,7 @@ int udp_source_impl::work(int noutput_items,
         }
     }
 
-    int bytes_read;
+    size_t bytes_read;
 
     // we could get here even if no data was received but there's still data in
     // the queue. however read blocks so we want to make sure we have data before
@@ -271,13 +271,13 @@ int udp_source_impl::work(int noutput_items,
             const char* read_data = asio::buffer_cast<const char*>(d_read_buffer.data());
 
             // Discard bytes if the input is longer than the buffer
-            long overrun = bytes_read - d_localqueue_writer->bufsize();
-            if (overrun > 0) {
+            if (bytes_read > d_localqueue_writer->bufsize()) {
+                size_t overrun = bytes_read - d_localqueue_writer->bufsize();
                 bytes_read -= overrun;
                 read_data += overrun;
             }
 
-            if (d_localqueue_writer->space_available() < bytes_read)
+            if ((size_t)d_localqueue_writer->space_available() < bytes_read)
                 d_localqueue_reader->update_read_pointer(
                     bytes_read - d_localqueue_writer->space_available());
             memcpy(d_localqueue_writer->write_pointer(), read_data, bytes_read);


### PR DESCRIPTION
## Description
bytes_read, the result of asio::ip::udp::socket::receive_from(), was an int, but the function returns size_t. This resulted in an overflow of the int and a subsequent comparison.

Since the int result of buffer space_available() should never be negative, it is safe to cast the result to size_t. If that result is ever changed to something larger than size_t, this could cause trouble, but that seems unlikely.

## Related Issue
Fixes #6485 

## Which blocks/areas does this affect?
UDP Source

## Testing Done
Ran random data into `mbuffer | nc` to the source's UDP port at various rates and verified data showed up on GUI sinks. This crashed or produced bad data before the change, and works after the change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
