### PR TITLE
soapy: freq message on gr-soapy source block cmd port adds rx_freq tag

### DIFF
--- a/gr-soapy/lib/source_impl.cc
+++ b/gr-soapy/lib/source_impl.cc
@@ -61,6 +61,11 @@ void source_impl::set_frequency(size_t channel, const std::string& name, double 
     block_impl::set_frequency(channel, name, frequency);
     _add_tag = true;
 }
+void source_impl::set_frequency(size_t channel, double frequency)
+{
+    block_impl::set_frequency(channel, frequency);
+    _add_tag = true;
+}
 void source_impl::set_hardware_time(long long timeNs, const std::string& what)
 {
     block_impl::set_hardware_time(timeNs, what);

--- a/gr-soapy/lib/source_impl.h
+++ b/gr-soapy/lib/source_impl.h
@@ -52,6 +52,7 @@ public:
 
     void
     set_frequency(size_t channel, const std::string& name, double frequency) override;
+    void set_frequency(size_t channel, double frequency) override;
     void set_hardware_time(long long timeNs, const std::string& what) override;
     void set_sample_rate(size_t channel, double sample_rate) override;
 


### PR DESCRIPTION
https://github.com/gnuradio/gnuradio/commit/3eea1057c53842476f809a62499ee6b8dc080d82 causes the gr-soapy block to add the rx_freq tag when set_frequency() is called with a name parameter.

However, gr-soapy source's cmd port handler calls set_frequency() without name, so add_tag_ is not set and the rx_freq tag is not added. This patch causes rx_freq to be added for both versions of set_frequency().

Signed-off-by: Josh Bailey <josh@vandervecken.com>

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
