### PR TITLE
grc: py template: only XinitThreads if $DISPLAY is set

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -25,9 +25,10 @@
 from packaging.version import Version as StrictVersion
 
 if __name__ == '__main__':
-    import ctypes
-    import sys
-    if sys.platform.startswith('linux'):
+    from sys import platform
+    from os import environ as argp
+    if platform.startswith('linux') and "WAYLAND_DISPLAY" not in argp and "DISPLAY" in argp:
+        import ctypes
         try:
             x11 = ctypes.cdll.LoadLibrary('libX11.so')
             x11.XInitThreads()


### PR DESCRIPTION
Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Currently, on every Linux system, a GRC-generated flowgraph tries to load X11 libraries and then tries to run `XInitThreads`, in an attempt to make our multi-thread drawing threadsafe (this might be a design bug, or not even necessar anymore).

This at least checks whether the famous `DISPLAY` environment variable is set, as it should be on any X11 session, and whether the `WAYLAND_SESSION` environment variable is unset, which would indicate we're running on wayland instead of X.

**HOWEVER** I don't have a wayland system to try with.

**ALSO** zero input from WSL/X11 usage and FreeBSD and other X-based systems.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

#4030, #3779 , and a lot of newbie confusion
## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

GRC-generated Python Flowgraphs

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [-] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [-] I have added tests to cover my changes, and all previous tests pass.
