### PR TITLE
runtime: getpagesize for windows

### DIFF
--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2003,2013 Free Software Foundation, Inc.
+ * Copyright 2023 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -12,37 +13,74 @@
 #include "config.h"
 #endif
 
-#include <gnuradio/logger.h>
-#include <gnuradio/prefs.h>
-
 #include "pagesize.h"
-#include <unistd.h>
+#include <gnuradio/logger.h>
 
 namespace gr {
 
-#if defined(_WIN32) && defined(HAVE_GETPAGESIZE)
-extern "C" size_t getpagesize(void);
+#if defined(_WIN32)
+
+#include <Sysinfoapi.h>
+
+int native_pagesize(const gr::logger_ptr logger)
+{
+    SYSTEM_INFO win_sysinfo;
+    GetNativeSystemInfo(&win_sysinfo);
+    auto psize = win_sysinfo.dwPageSize;
+    if (psize <= 0) {
+        logger->error("GetNativeSystemInfo: Got invalid dwPageSize {}", psize);
+        return -1;
+    }
+    return psize;
+}
+
+#elif defined(HAVE_GETPAGESIZE) //_WIN32 undefined,  getpagesize available
+
+#include <unistd.h>
+
+int native_pagesize(const gr::logger_ptr logger) { return getpagesize(); }
+
+#elif defined(HAVE_SYSCONF) //_WIN32 undefined, sysconf available
+
+#include <unistd.h>
+
+int native_pagesize(const gr::logger_ptr logger)
+{
+    int pagesize = sysconf(_SC_PAGESIZE);
+    if (pagesize < 1) {
+        logger->error("sysconf: _SC_PAGESIZE = {} < 1: {:s}", pagesize, strerror(errno));
+        return -1;
+    }
+    return pagesize;
+}
+
+#else // neither _WIN32, nor getpagesize, nor sysconf
+
+int native_pagesize(const gr::logger_ptr logger)
+{
+    logger->warning("No supported method of determining the pagesize available.");
+    return -1;
+}
+
 #endif
+
 
 int pagesize()
 {
     static int s_pagesize = -1;
-    gr::logger_ptr logger, debug_logger;
-    gr::configure_default_loggers(logger, debug_logger, "pagesize");
 
     if (s_pagesize == -1) {
-#if defined(HAVE_GETPAGESIZE)
-        s_pagesize = getpagesize();
-#elif defined(HAVE_SYSCONF)
-        s_pagesize = sysconf(_SC_PAGESIZE);
-        if (s_pagesize == -1) {
-            logger->error("_SC_PAGESIZE: {:s}", strerror(errno));
-            s_pagesize = 4096;
+        // only make a logger for the one time we actually intend to log anything.
+        gr::logger_ptr logger, debug_logger;
+        gr::configure_default_loggers(logger, debug_logger, "pagesize");
+        s_pagesize = native_pagesize(logger);
+        if (s_pagesize <= 0) {
+            constexpr int default_pagesize = 4096;
+            logger->error("Unable to determine page size. Using default of {} B instead.",
+                          default_pagesize);
+            s_pagesize = default_pagesize;
         }
-#else
-        logger->error("no info; setting pagesize = 4096");
-        s_pagesize = 4096;
-#endif
+        logger->info("Setting pagesize to {} B", s_pagesize);
     }
     return s_pagesize;
 }


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Windows users shouldn't be faced with an error when determining the page size – adressing that.

- removed unused prefs include
- moved pagesize determination into separate function, to reduce the ugliness of the #ifdefs
- More specific logging

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Fixes #6500

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

runtime

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Here's the catch – the usual ctest suite runs through fine, but I don't have a Windows machine to test this with.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [-] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
