### PR TITLE
gr-audio: update comments in wavfile_sink and wavfile_source and add list of supported audio files.

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_sink.h
@@ -19,12 +19,12 @@ namespace gr {
 namespace blocks {
 
 /*!
- * \brief Write stream to a Microsoft PCM (.wav) file.
+ * \brief Write samples to an audio file (uncompressed or compressed).
  * \ingroup audio_blk
  *
  * \details
  * Values must be floats within [-1;1].
- * Check gr_make_wavfile_sink() for extra info.
+ * List of all supported audio containers : [ WAV, FLAC, OGG, RF64 ]
  */
 class BLOCKS_API wavfile_sink : virtual public sync_block
 {

--- a/gr-blocks/include/gnuradio/blocks/wavfile_source.h
+++ b/gr-blocks/include/gnuradio/blocks/wavfile_source.h
@@ -18,12 +18,10 @@ namespace gr {
 namespace blocks {
 
 /*!
- * \brief Read stream from a Microsoft PCM (.wav) file, output floats
  * \ingroup audio_blk
  *
  * \details
  * Unless otherwise called, values are within [-1;1].
- * Check gr_make_wavfile_source() for extra info.
  */
 class BLOCKS_API wavfile_source : virtual public sync_block
 {
@@ -34,19 +32,19 @@ public:
     static sptr make(const char* filename, bool repeat = false);
 
     /*!
-     * \brief Read the sample rate as specified in the wav file header
+     * \brief Read the sample rate as specified in the audio file metadata
      */
     virtual unsigned int sample_rate() const = 0;
 
     /*!
      * \brief Return the number of bits per sample as specified in
-     * the wav file header. Only 8 or 16 bit are supported here.
+     * the audio file metadata.
      */
     virtual int bits_per_sample() const = 0;
 
     /*!
      * \brief Return the number of channels in the wav file as
-     * specified in the wav file header. This is also the max number
+     * specified in the audio file metadata. This is also the max number
      * of outputs you can have.
      */
     virtual int channels() const = 0;


### PR DESCRIPTION
Signed-off-by: Harshit Singh <singhh198@gmail.com>

## Description
- [x] Remove https://github.com/gnuradio/gnuradio/blob/main/gr-blocks/include/gnuradio/blocks/wavfile_source.h#L26.
- [x] Replace the `\brief` … sentence with "Write samples to an audio file (uncompressed or compressed)".
- [x] Add the list of supported audio containers from to the \details section
- [x] Replace all occurences of "wav file header" in the comments with "audio file metadata" .
- [x] Removed "Only 8 or 16 bit are supported here." from `\brief` since it is not the only supported bit anymore.

## Related Issue
Fixes #5971

## Which blocks/areas does this affect?
Comments of wavfile_sink and wavfile_source

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
