### PR TITLE
GRC: py tmpl: don't try to load libX11, done by Qt5; template cleanup

### DIFF
--- a/gr-qtgui/grc/qtgui_autocorrelator_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_autocorrelator_sink.block.yml
@@ -57,7 +57,6 @@ inputs:
     dtype: complex
 
 templates:
-    imports: from gnuradio import qtgui
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/grc/qtgui_azelplot.block.yml
+++ b/gr-qtgui/grc/qtgui_azelplot.block.yml
@@ -33,7 +33,6 @@ inputs:
     optional: false
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = None
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
+++ b/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
@@ -323,7 +323,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
         import numpy
     make: |-

--- a/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
+++ b/gr-qtgui/grc/qtgui_ber_sink_b.block.yml
@@ -324,7 +324,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
         import numpy
     make: |-

--- a/gr-qtgui/grc/qtgui_check_box.block.yml
+++ b/gr-qtgui/grc/qtgui_check_box.block.yml
@@ -39,7 +39,6 @@ asserts:
 - ${value in (true, false)}
 
 templates:
-    imports: from PyQt5 import Qt
     var_make: self.${id} = ${id} = ${value}
     callbacks:
     - self.set_${id}(${value})

--- a/gr-qtgui/grc/qtgui_chooser.block.yml
+++ b/gr-qtgui/grc/qtgui_chooser.block.yml
@@ -106,7 +106,6 @@ asserts:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from PyQt5.QtCore import QObject, pyqtSlot
     var_make: self.${id} = ${id} = ${value}
     callbacks:

--- a/gr-qtgui/grc/qtgui_compass.block.yml
+++ b/gr-qtgui/grc/qtgui_compass.block.yml
@@ -82,7 +82,6 @@ inputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -395,7 +395,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -396,7 +396,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_dialcontrol.block.yml
+++ b/gr-qtgui/grc/qtgui_dialcontrol.block.yml
@@ -67,7 +67,6 @@ outputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_dialgauge.block.yml
+++ b/gr-qtgui/grc/qtgui_dialgauge.block.yml
@@ -77,7 +77,6 @@ inputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     make: |-
         <%
             win = '_%s_lg_win'%id

--- a/gr-qtgui/grc/qtgui_distanceradar.block.yml
+++ b/gr-qtgui/grc/qtgui_distanceradar.block.yml
@@ -43,7 +43,6 @@ inputs:
     optional: false
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = None
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
+++ b/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
@@ -53,7 +53,6 @@ outputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
+++ b/gr-qtgui/grc/qtgui_edit_box_msg.block.yml
@@ -54,7 +54,6 @@ outputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -29,7 +29,6 @@ value: ${ value }
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio import eng_notation
     var_make: self.${id} = ${id} = ${value}
     callbacks:

--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -928,7 +928,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -929,7 +929,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -406,7 +406,6 @@ asserts:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -405,7 +405,6 @@ asserts:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_graphicitem.block.yml
+++ b/gr-qtgui/grc/qtgui_graphicitem.block.yml
@@ -40,7 +40,6 @@ inputs:
     optional: true
     
 templates:
-    imports: from gnuradio import qtgui
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/grc/qtgui_graphicoverlay.block.yml
+++ b/gr-qtgui/grc/qtgui_graphicoverlay.block.yml
@@ -23,7 +23,6 @@ outputs:
     id: overlay
     
 templates:
-    imports: from gnuradio import qtgui
     make: qtgui.GrGraphicOverlay(${overlayList},${listDelay},${repeat})
 
 documentation: |-

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -359,7 +359,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_histogram_sink_x.block.yml
@@ -360,7 +360,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_label.block.yml
+++ b/gr-qtgui/grc/qtgui_label.block.yml
@@ -34,7 +34,6 @@ value: ${ value }
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio import eng_notation
     var_make: self.${id} = ${id} = ${value}
     callbacks:

--- a/gr-qtgui/grc/qtgui_ledindicator.block.yml
+++ b/gr-qtgui/grc/qtgui_ledindicator.block.yml
@@ -62,7 +62,6 @@ inputs:
     optional: true
     
 templates:
-    imports: from gnuradio import qtgui
     make: |-
         <%
             win = 'self._%s_win'%id

--- a/gr-qtgui/grc/qtgui_levelgauge.block.yml
+++ b/gr-qtgui/grc/qtgui_levelgauge.block.yml
@@ -89,7 +89,6 @@ inputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     make: |-
         <%
             win = '_%s_lg_win'%id

--- a/gr-qtgui/grc/qtgui_msgcheckbox.block.yml
+++ b/gr-qtgui/grc/qtgui_msgcheckbox.block.yml
@@ -64,7 +64,6 @@ outputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_msgdigitalnumbercontrol.block.yml
+++ b/gr-qtgui/grc/qtgui_msgdigitalnumbercontrol.block.yml
@@ -68,7 +68,6 @@ outputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_msgpushbutton.block.yml
+++ b/gr-qtgui/grc/qtgui_msgpushbutton.block.yml
@@ -50,7 +50,6 @@ outputs:
     optional: false
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = None
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -238,7 +238,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_number_sink.block.yml
+++ b/gr-qtgui/grc/qtgui_number_sink.block.yml
@@ -239,7 +239,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_push_button.block.yml
+++ b/gr-qtgui/grc/qtgui_push_button.block.yml
@@ -35,7 +35,6 @@ parameters:
 value: ${ value }
 
 templates:
-    imports: from PyQt5 import Qt
     var_make: self.${id} = ${id} = ${value}
     callbacks:
     - self.set_${id}(${value})

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -112,7 +112,6 @@ asserts:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -111,7 +111,6 @@ asserts:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_tab_widget.block.yml
+++ b/gr-qtgui/grc/qtgui_tab_widget.block.yml
@@ -115,7 +115,6 @@ parameters:
     hide: part
 
 templates:
-    imports: from PyQt5 import Qt
     make: |-
         <%
             win = 'self.%s'%id

--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -246,7 +246,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
     callbacks:
     - set_num_rows(${nrows})

--- a/gr-qtgui/grc/qtgui_time_raster_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_raster_x.block.yml
@@ -245,7 +245,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
     callbacks:
     - set_num_rows(${nrows})

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -998,7 +998,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -999,7 +999,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -256,7 +256,6 @@ inputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -257,7 +257,6 @@ inputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_togglebutton.block.yml
+++ b/gr-qtgui/grc/qtgui_togglebutton.block.yml
@@ -80,7 +80,6 @@ outputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_toggleswitch.block.yml
+++ b/gr-qtgui/grc/qtgui_toggleswitch.block.yml
@@ -87,7 +87,6 @@ outputs:
     optional: true
 
 templates:
-    imports: from gnuradio import qtgui
     var_make: self.${id} = ${id} = ${value}
     make: |-
         <%

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -301,7 +301,6 @@ outputs:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
+++ b/gr-qtgui/grc/qtgui_vector_sink_f.block.yml
@@ -302,7 +302,6 @@ outputs:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         import sip
     callbacks:
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -258,7 +258,6 @@ asserts:
 
 templates:
     imports: |-
-        from PyQt5 import Qt
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -259,7 +259,6 @@ asserts:
 templates:
     imports: |-
         from PyQt5 import Qt
-        from gnuradio import qtgui
         from gnuradio.filter import firdes
         import sip
     callbacks:

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -26,6 +26,7 @@
 ########################################################
 % if generate_options == 'qt_gui':
 from packaging.version import Version as StrictVersion
+from PyQt5 import Qt
 from gnuradio import qtgui
 %endif
 % for imp in imports:

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -21,23 +21,13 @@
 # GNU Radio version: ${version}
 ##################################################
 
-% if generate_options == 'qt_gui':
-from packaging.version import Version as StrictVersion
-
-if __name__ == '__main__':
-    import ctypes
-    import sys
-    if sys.platform.startswith('linux'):
-        try:
-            x11 = ctypes.cdll.LoadLibrary('libX11.so')
-            x11.XInitThreads()
-        except:
-            print("Warning: failed to XInitThreads()")
-
-% endif
 ########################################################
 ##Create Imports
 ########################################################
+% if generate_options == 'qt_gui':
+from packaging.version import Version as StrictVersion
+from gnuradio import qtgui
+%endif
 % for imp in imports:
 ##${imp.replace("  # grc-generated hier_block", "")}
 ${imp}
@@ -82,8 +72,6 @@ def snippets_${section}(tb):
     param_str = ', '.join(['self'] + ['%s=%s'%(param.name, param.templates.render('make')) for param in parameters])
 %>\
 % if generate_options == 'qt_gui':
-from gnuradio import qtgui
-
 class ${class_name}(gr.top_block, Qt.QWidget):
 
     def __init__(${param_str}):


### PR DESCRIPTION
This seems to be an anachronism, and done by Qt5 anyways – no reason to keep it around

Supersedes #6498 
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

I was trying to get X11 errors hidden from users on whose  operating system there would be no reason. As @willcode  figured out, there's no reason anywhere for this crutch anymore.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

https://github.com/gnuradio/gnuradio/issues/4030, and a lot of newbie confusion

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

GRC Python code gen

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Changed the template, built a few flowgraphs, test suite still runs

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [-] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [-] I have added tests to cover my changes, and all previous tests pass.
