### PR TITLE
update codec2 mode enums

### DIFF
--- a/gr-vocoder/grc/vocoder_codec2_decode_ps.block.yml
+++ b/gr-vocoder/grc/vocoder_codec2_decode_ps.block.yml
@@ -5,7 +5,7 @@ flags: [ python, cpp ]
 parameters:
 -   id: mode
     label: Bit rate
-    dtype: raw
+    dtype: enum
     default: codec2.MODE_2400
     options: [codec2.MODE_3200, codec2.MODE_2400, codec2.MODE_1600, codec2.MODE_1400,
         codec2.MODE_1300, codec2.MODE_1200, codec2.MODE_700, codec2.MODE_700B,

--- a/gr-vocoder/grc/vocoder_codec2_encode_sp.block.yml
+++ b/gr-vocoder/grc/vocoder_codec2_encode_sp.block.yml
@@ -5,7 +5,7 @@ flags: [ python, cpp ]
 parameters:
 -   id: mode
     label: Bit rate
-    dtype: raw
+    dtype: enum
     default: codec2.MODE_2400
     options: [codec2.MODE_3200, codec2.MODE_2400, codec2.MODE_1600, codec2.MODE_1400,
         codec2.MODE_1300, codec2.MODE_1200, codec2.MODE_700, codec2.MODE_700B,

--- a/gr-vocoder/grc/vocoder_freedv_rx_ss.block.yml
+++ b/gr-vocoder/grc/vocoder_freedv_rx_ss.block.yml
@@ -4,11 +4,25 @@ label: FreeDV demodulator
 parameters:
 -   id: mode
     label: Operating Mode
-    dtype: raw
+    dtype: enum
     default: freedv_api.MODE_1600
-    options: [freedv_api.MODE_1600, freedv_api.MODE_700, freedv_api.MODE_700B, freedv_api.MODE_2400A,
-        freedv_api.MODE_2400B, freedv_api.MODE_800XA, freedv_api.MODE_700C, freedv_api.MODE_700D]
-    option_labels: ['1600', '700', 700B, 2400A, 2400B, 800XA, 700C, 700D]
+    options: [freedv_api.MODE_1600, freedv_api.MODE_700, freedv_api.MODE_700B,
+          freedv_api.MODE_2400A, freedv_api.MODE_2400B, freedv_api.MODE_800XA,
+          freedv_api.MODE_700C, freedv_api.MODE_700D, freedv_api.MODE_700E,
+          freedv_api.MODE_2020, freedv_api.MODE_2020B, freedv_api.MODE_FSK_LDPC,
+          freedv_api.MODE_DATAC1, freedv_api.MODE_DATAC3,
+          freedv_api.MODE_DATAC0]
+    option_labels: [1600, 700, 700B, 2400A, 2400B, 800XA, 700C, 700D, 700E,
+                    2020, 2020B, FSK_LDPC, DATAC1, DATAC3, DATAC0]
+    option_attributes:
+        cpp_options: [vocoder::freedv_api::MODE_1600, vocoder::freedv_api::MODE_700,
+          vocoder::freedv_api::MODE_700B, vocoder::freedv_api::MODE_2400A,
+          vocoder::freedv_api::MODE_2400B, vocoder::freedv_api::MODE_800XA,
+          vocoder::freedv_api::MODE_700C, vocoder::freedv_api::MODE_700D,
+          vocoder::freedv_api::MODE_700E, vocoder::freedv_api::MODE_2020,
+          vocoder::freedv_api::MODE_2020B, vocoder::freedv_api::MODE_FSK_LDPC,
+          vocoder::freedv_api::MODE_DATAC1, vocoder::freedv_api::MODE_DATAC3,
+          vocoder::freedv_api::MODE_DATAC0]
 -   id: squelch_thresh
     label: Squelch Threshold
     dtype: float

--- a/gr-vocoder/grc/vocoder_freedv_tx_ss.block.yml
+++ b/gr-vocoder/grc/vocoder_freedv_tx_ss.block.yml
@@ -4,11 +4,25 @@ label: FreeDV modulator
 parameters:
 -   id: mode
     label: Operating Mode
-    dtype: raw
+    dtype: enum
     default: freedv_api.MODE_1600
-    options: [freedv_api.MODE_1600, freedv_api.MODE_700, freedv_api.MODE_700B, freedv_api.MODE_2400A,
-        freedv_api.MODE_2400B, freedv_api.MODE_800XA, freedv_api.MODE_700C, freedv_api.MODE_700D]
-    option_labels: ['1600', '700', 700B, 2400A, 2400B, 800XA, 700C, 700D]
+    options: [freedv_api.MODE_1600, freedv_api.MODE_700, freedv_api.MODE_700B,
+             freedv_api.MODE_2400A, freedv_api.MODE_2400B, freedv_api.MODE_800XA,
+             freedv_api.MODE_700C, freedv_api.MODE_700D, freedv_api.MODE_700E,
+             freedv_api.MODE_2020, freedv_api.MODE_2020B, freedv_api.MODE_FSK_LDPC,
+             freedv_api.MODE_DATAC1, freedv_api.MODE_DATAC3,
+             freedv_api.MODE_DATAC0]
+    option_labels: [1600, 700, 700B, 2400A, 2400B, 800XA, 700C, 700D, 700E,
+                   2020, 2020B, FSK_LDPC, DATAC1, DATAC3, DATAC0]
+    option_attributes:
+      cpp_options: [vocoder::freedv_api::MODE_1600, vocoder::freedv_api::MODE_700,
+        vocoder::freedv_api::MODE_700B, vocoder::freedv_api::MODE_2400A,
+        vocoder::freedv_api::MODE_2400B, vocoder::freedv_api::MODE_800XA,
+        vocoder::freedv_api::MODE_700C, vocoder::freedv_api::MODE_700D,
+        vocoder::freedv_api::MODE_700E, vocoder::freedv_api::MODE_2020,
+        vocoder::freedv_api::MODE_2020B, vocoder::freedv_api::MODE_FSK_LDPC,
+        vocoder::freedv_api::MODE_DATAC1, vocoder::freedv_api::MODE_DATAC3,
+        vocoder::freedv_api::MODE_DATAC0]
 -   id: txt_msg
     label: Text Message
     dtype: string

--- a/gr-vocoder/include/gnuradio/vocoder/codec2.h
+++ b/gr-vocoder/include/gnuradio/vocoder/codec2.h
@@ -42,6 +42,12 @@ public:
 #ifdef CODEC2_MODE_WB
         MODE_WB = CODEC2_MODE_WB,
 #endif
+#ifdef CODEC2_MODE_450
+        MODE_450 = CODEC2_MODE_450,
+#endif
+#ifdef CODEC2_MODE_450PWB
+        MODE_450PWB = CODEC2_MODE_450PWB,
+#endif
     };
 
 private:

--- a/gr-vocoder/include/gnuradio/vocoder/freedv_api.h
+++ b/gr-vocoder/include/gnuradio/vocoder/freedv_api.h
@@ -59,6 +59,27 @@ public:
         SYNC_AUTO = FREEDV_SYNC_AUTO,
         SYNC_MANUAL = FREEDV_SYNC_MANUAL,
 #endif
+#ifdef FREEDV_MODE_2020
+        MODE_2020 = FREEDV_MODE_2020,
+#endif
+#ifdef FREEDV_MODE_2020B
+        MODE_2020B = FREEDV_MODE_2020B,
+#endif
+#ifdef FREEDV_MODE_700E
+        MODE_700E = FREEDV_MODE_700E,
+#endif
+#ifdef FREEDV_MODE_FSK_LDPC
+        MODE_FSK_LDPC = FREEDV_MODE_FSK_LDPC,
+#endif
+#ifdef FREEDV_MODE_DATAC1
+        MODE_DATAC1 = FREEDV_MODE_DATAC1,
+#endif
+#ifdef FREEDV_MODE_DATAC3
+        MODE_DATAC3 = FREEDV_MODE_DATAC3,
+#endif
+#ifdef FREEDV_MODE_DATAC0
+        MODE_DATAC0 = FREEDV_MODE_DATAC0,
+#endif
     };
 
 private:

--- a/gr-vocoder/python/vocoder/bindings/codec2_python.cc
+++ b/gr-vocoder/python/vocoder/bindings/codec2_python.cc
@@ -45,6 +45,12 @@ void bind_codec2(py::module& m)
 #ifdef CODEC2_MODE_WB
         .value("MODE_WB", gr::vocoder::codec2::MODE_WB)
 #endif
+#ifdef CODEC2_MODE_450
+        .value("MODE_450", gr::vocoder::codec2::MODE_450)
+#endif
+#ifdef CODEC2_MODE_450PWB
+        .value("MODE_450PWB", gr::vocoder::codec2::MODE_450PWB)
+#endif
         .export_values();
 
     py::implicitly_convertible<int, gr::vocoder::codec2::bit_rate>();

--- a/gr-vocoder/python/vocoder/bindings/freedv_api_python.cc
+++ b/gr-vocoder/python/vocoder/bindings/freedv_api_python.cc
@@ -52,6 +52,27 @@ void bind_freedv_api(py::module& m)
         .value("SYNC_AUTO", gr::vocoder::freedv_api::SYNC_AUTO)
         .value("SYNC_MANUAL", gr::vocoder::freedv_api::SYNC_MANUAL)
 #endif
+#ifdef FREEDV_MODE_2020
+        .value("MODE_2020", gr::vocoder::freedv_api::MODE_2020)
+#endif
+#ifdef FREEDV_MODE_2020B
+        .value("MODE_2020B", gr::vocoder::freedv_api::MODE_2020B)
+#endif
+#ifdef FREEDV_MODE_700E
+        .value("MODE_700E", gr::vocoder::freedv_api::MODE_700E)
+#endif
+#ifdef FREEDV_MODE_FSK_LDPC
+        .value("MODE_FSK_LDPC", gr::vocoder::freedv_api::MODE_FSK_LDPC)
+#endif
+#ifdef FREEDV_MODE_DATAC1
+        .value("MODE_DATAC1", gr::vocoder::freedv_api::MODE_DATAC1)
+#endif
+#ifdef FREEDV_MODE_DATAC3
+        .value("MODE_DATAC3", gr::vocoder::freedv_api::MODE_DATAC3)
+#endif
+#ifdef FREEDV_MODE_DATAC0
+        .value("MODE_DATAC0", gr::vocoder::freedv_api::MODE_DATAC0)
+#endif
         .export_values();
 
     py::implicitly_convertible<int, gr::vocoder::freedv_api::freedv_modes>();


### PR DESCRIPTION
Use newer modes from Codec2 and FreeDV as enums.

Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
For a while the FreeDV and Codec2 blocks in gnuradio-companion do
not list all available modes. This updates the list.

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This adds Codec2 and FreeDV mode enum names for use in C++,
Python and grc for newer modes found in libcodec2 when building
gr-vocoder.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Also, this sets the mode parameters using the enum dtype - so that there is
no longer chatter about unsupported options when starting gnuradio-companion.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
gr-vocoder: Codec2 and FreeDV blocks get a more complete list of modes
available in libcodec2.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
This patch is prepared in response to a user, and hopefully will get
in to Debian Bookworm.
These changes work for me when tested locally.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
