### PR TITLE
uhd: rfnoc: Add Fosphor block support

### DIFF
--- a/gr-uhd/grc/CMakeLists.txt
+++ b/gr-uhd/grc/CMakeLists.txt
@@ -50,6 +50,7 @@ if(ENABLE_UHD_RFNOC)
               uhd_rfnoc_ddc.block.yml
               uhd_rfnoc_duc.block.yml
               uhd_rfnoc_fft.block.yml
+              uhd_rfnoc_fosphor.block.yml
               uhd_rfnoc_keep_one_in_n.block.yml
               uhd_rfnoc_graph.block.yml
               uhd_rfnoc_rx_radio.block.yml

--- a/gr-uhd/grc/uhd.tree.yml
+++ b/gr-uhd/grc/uhd.tree.yml
@@ -15,6 +15,7 @@
       - uhd_rfnoc_rx_streamer
       - uhd_rfnoc_tx_streamer
       - uhd_rfnoc_keep_one_in_n
+      - uhd_rfnoc_fosphor
   - RFNoC Image Builder:
     - Blocks:
       - uhd_fpga_ddc

--- a/gr-uhd/grc/uhd_rfnoc_fft.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_fft.block.yml
@@ -1,5 +1,5 @@
 id: uhd_rfnoc_fft
-label: RFNoC Fast Fourier Transform Block
+label: RFNoC Fast Fourier Transform (FFT) Block
 
 templates:
   imports: |-
@@ -11,24 +11,72 @@ templates:
         "FFT",
         ${device_select},
         ${instance_index})
+    self.${id}.set_property('length',       ${fft_length})
+    self.${id}.set_property('direction',    ${fft_direction.val})
+    self.${id}.set_property('magnitude',    ${fft_magnitude.val})
+    self.${id}.set_property('fft_scaling',  ${fft_scaling})
+    self.${id}.set_property('shift_config', ${fft_shift_config.val})
+  callbacks:
+    - set_property('length', ${fft_length})
+    - set_property('direction', ${fft_direction.val})
+    - set_property('magnitude', ${fft_magnitude.val})
+    - set_property('fft_scaling', ${fft_scaling})
+    - set_property('shift_config', ${fft_shift_config.val})
 
 parameters:
 - id: num_chans
   label: Number of Channels
   dtype: int
   default: 1
+  hide: ${ 'part' if num_chans == 1 else 'none'}
 - id: block_args
   label: Block Args
   dtype: string
   default: ""
+  hide: ${ 'part' if not block_args else 'none'}
 - id: device_select
   label: Device Select
   dtype: int
   default: -1
+  hide: ${ 'part' if device_select == -1 else 'none'}
 - id: instance_index
   label: Instance Select
   dtype: int
   default: -1
+  hide: ${ 'part' if instance_index == -1 else 'none'}
+- id: fft_length
+  label: FFT Length
+  dtype: int
+  default: 256
+- id: fft_direction
+  label: FFT Direction
+  dtype: enum
+  default: 'FORWARD'
+  options: ['REVERSE', 'FORWARD']
+  option_labels: ['Reverse', 'Forward']
+  option_attributes:
+    val: [0, 1]
+- id: fft_magnitude
+  label: FFT Magnitude Mode
+  dtype: enum
+  default: 'COMPLEX'
+  options: ['COMPLEX', 'MAGNITUDE', 'MAGNITUDE_SQUARED']
+  option_labels: ['Complex', 'Magnitude', 'Mag Squared']
+  option_attributes:
+    val: [0, 1, 2]
+- id: fft_shift_config
+  label: FFT Shift Configuration
+  dtype: enum
+  default: 'NORMAL'
+  options: ['NORMAL', 'REVERSE', 'NATURAL']
+  option_labels: ['Normal', 'Reverse', 'Natural']
+  option_attributes:
+    val: [0, 1, 2]
+- id: fft_scaling
+  label: FFT Scaling Schedule
+  dtype: int
+  default: 1706
+  hide: part
 
 inputs:
 - domain: rfnoc

--- a/gr-uhd/grc/uhd_rfnoc_fosphor.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_fosphor.block.yml
@@ -1,0 +1,155 @@
+id: uhd_rfnoc_fosphor
+label: RFNoC Fosphor Block
+category: '[Core]/UHD/RFNoC/Blocks'
+
+templates:
+  imports: |-
+    from gnuradio import uhd
+  make: |-
+    uhd.rfnoc_block_generic(
+        self.rfnoc_graph,
+        uhd.device_addr(""),
+        'Fosphor',
+        ${device_select},
+        ${instance_index})
+    self.${id}.set_property('enable_histogram',     True,             typename='bool')
+    self.${id}.set_property('enable_waterfall',     ${enable_wf},     typename='bool')
+    self.${id}.set_property('enable_noise',         ${enable_noise},  typename='bool')
+    self.${id}.set_property('enable_dither',        ${enable_dither}, typename='bool')
+    self.${id}.set_property('hist_decimation',      ${hist_decim}     )
+    self.${id}.set_property('offset',               ${offset}         )
+    self.${id}.set_property('scale',                ${scale}          )
+    self.${id}.set_property('trise',                ${trise}          )
+    self.${id}.set_property('tdecay',               ${tdecay}         )
+    self.${id}.set_property('alpha',                ${alpha}          )
+    self.${id}.set_property('epsilon',              ${epsilon}        )
+    self.${id}.set_property('wf_predivision_ratio', ${wf_prediv.val}  )
+    self.${id}.set_property('wf_mode',              ${wf_mode.val}    )
+    self.${id}.set_property('wf_decimation',        ${wf_decim}       )
+    self.${id}.set_property('clear_history',        True,             typename='bool')
+  callbacks:
+  - set_property('enable_waterfall', ${enable_wf}, typename='bool')
+  - set_property('enable_noise', ${enable_noise}, typename='bool')
+  - set_property('enable_dither', ${enable_dither}, typename='bool')
+  - set_property('hist_decimation', ${hist_decim})
+  - set_property('offset', ${offset})
+  - set_property('scale', ${scale})
+  - set_property('trise', ${trise})
+  - set_property('tdecay', ${tdecay})
+  - set_property('alpha', ${alpha})
+  - set_property('epsilon', ${epsilon})
+  - set_property('wf_predivision_ratio', ${wf_prediv.val})
+  - set_property('wf_mode', ${wf_mode.val})
+  - set_property('wf_decimation', ${wf_decim})
+
+parameters:
+- id: device_select
+  label: Device Select
+  dtype: int
+  default: -1
+  hide: ${ 'part' if device_select == -1 else 'none'}
+- id: instance_index
+  label: Instance Select
+  dtype: int
+  default: -1
+  hide: ${ 'part' if instance_index == -1 else 'none'}
+- id: enable_wf
+  label: Waterfall
+  dtype: enum
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: [Enabled, Disabled]
+- id: enable_noise
+  label: Randomization Enable
+  dtype: enum
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: [Enabled, Disabled]
+- id: enable_dither
+  label: Dither Enable
+  dtype: enum
+  default: 'True'
+  options: ['True', 'False']
+  option_labels: [Enabled, Disabled]
+- id: wf_mode
+  label: Waterfall Mode
+  dtype: enum
+  default: 'MODE_MAX_HOLD'
+  options: ['MODE_MAX_HOLD', 'MODE_AVERAGE']
+  option_labels: ['Max Hold', 'Average']
+  option_attributes:
+    val: [0, 1]
+- id: wf_prediv
+  label: Waterfall Predecimation Ratio
+  dtype: enum
+  default: 'RATIO_1_1'
+  options: ['RATIO_1_1', 'RATIO_1_8', 'RATIO_1_64', 'RATIO_1_256']
+  option_labels: ['1:1', '1:8', '1:64', '1:256']
+  option_attributes:
+    val: [0, 1, 2, 3]
+- id: wf_decim
+  label: Waterfall Decimation
+  dtype: int
+  default: '8'
+- id: hist_decim
+  label: Histogram Decimation
+  dtype: int
+  default: '2'
+  hide: part
+- id: offset
+  label: Histogram Offset
+  category: Advanced
+  dtype: int
+  default: '0'
+  hide: part
+- id: scale
+  label: Histogram Scale
+  category: Advanced
+  dtype: int
+  default: '256'
+  hide: part
+- id: trise
+  label: Histogram Rise Time
+  category: Advanced
+  dtype: int
+  default: '4096'
+  hide: part
+- id: tdecay
+  label: Histogram Decay Time
+  category: Advanced
+  dtype: int
+  default: '16384'
+  hide: part
+- id: alpha
+  label: Averaging Alpha
+  category: Advanced
+  dtype: int
+  default: '65280'
+  hide: part
+- id: epsilon
+  label: Max Hold Decay
+  category: Advanced
+  dtype: int
+  default: '1'
+  hide: part
+
+inputs:
+- domain: rfnoc
+  label: in
+  dtype: 'sc16'
+
+outputs:
+- domain: rfnoc
+  label: histo_out
+  dtype: 'byte'
+- domain: rfnoc
+  label: wf_out
+  dtype: 'byte'
+  optional: true
+
+documentation: |-
+  RFNoC Fosphor Block:
+  The fosphor block takes in complex 16-bit FFT data and produces two byte
+  streams, one stream of histogram data and one stream of waterfall data
+
+file_format: 1


### PR DESCRIPTION
## Description
These commits enable the addition of the fosphor block support for rfnoc. 
The main commit is adding the actual Fosphor block support. 
One minor commit because the rx_streamer, when connected to the fosphor block, was not erroring on flush(), and that was a requirement for continued execution. I added a timeout to get around this, as flush() is only called when stopping execution of the block.
The other minor commit adds properties to the FFT block to allow for full fosphor support.

Example output using example from PR #6515 

![image](https://user-images.githubusercontent.com/68391340/220209711-bec663f4-cee4-4e3e-97b0-586ff35c144a.png)


## Which blocks/areas does this affect?
Adds support for Fosphor block, adds properties to the FFT block

## Testing Done
I ran the example added with a known source, and I confirmed that the fosphor display showed the expected frequency.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
