### PR TITLE
digital: remove reference to nonexistant self._mu in gfsk.py

### DIFF
--- a/gr-digital/python/digital/gfsk.py
+++ b/gr-digital/python/digital/gfsk.py
@@ -270,7 +270,6 @@ class gfsk_demod(gr.hier_block2):
         print("bits per symbol = %d" % self.bits_per_symbol())
         print("Symbol Sync M&M omega = %f" % self._omega)
         print("Symbol Sync M&M gain mu = %f" % self._gain_mu)
-        print("M&M clock recovery mu (Unused) = %f" % self._mu)
         print("Symbol Sync M&M omega rel. limit = %f" %
               self._omega_relative_limit)
         print("frequency error = %f" % self._freq_error)


### PR DESCRIPTION
## Description
Remove print statement that used a non-existant `self._mu`. There are other places that could use cleanup, e.g., the argument parsing and the existance of a default for this value. This is the mimimal fix to get rid of the error reported in #6517.

## Related Issue
Fixes #6517 

## Which blocks/areas does this affect?
GFSK Mod

## Testing Done

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
