### PR TITLE
grc: remove duplicate import, move imports to template code

### DIFF
--- a/grc/blocks/options.block.yml
+++ b/grc/blocks/options.block.yml
@@ -137,20 +137,6 @@ asserts:
 - ${ all(i >= 0 for i in placement) }
 
 templates:
-    imports: |-
-        from gnuradio import gr
-        from gnuradio.filter import firdes
-        from gnuradio.fft import window
-        import sys
-        import signal
-        % if generate_options == 'qt_gui':
-        from PyQt5 import Qt
-        % endif
-        % if not generate_options.startswith('hb'):
-        from argparse import ArgumentParser
-        from gnuradio.eng_arg import eng_float, intx
-        from gnuradio import eng_notation
-        % endif
     callbacks:
     - 'if ${run}: self.start()
 

--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -24,6 +24,16 @@
 ########################################################
 ##Create Imports
 ########################################################
+import sys
+import signal
+from gnuradio import gr
+from gnuradio.filter import firdes
+from gnuradio.fft import window
+% if not generate_options.startswith('hb'):
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+% endif
 % if generate_options == 'qt_gui':
 from packaging.version import Version as StrictVersion
 from PyQt5 import Qt


### PR DESCRIPTION
## Description
In ada1f1c168 "from PyQt5 import Qt" was moved from individual yml files to the Python flowgraph template. This line also existed in the GRC Options block yml, resulting in the line being emitted twice.

This commit removes that duplicate code, and also moves several imports not related to options from the Options block to the template.

## Which blocks/areas does this affect?
Built-in Option block, Python flowgraph mako template

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
