### PR TITLE
soapy: allow freq message on gr-soapy source block cmd port to add rx_freq tag (backport to maint-3.10)

### DIFF
--- a/gr-soapy/lib/source_impl.cc
+++ b/gr-soapy/lib/source_impl.cc
@@ -61,6 +61,11 @@ void source_impl::set_frequency(size_t channel, const std::string& name, double 
     block_impl::set_frequency(channel, name, frequency);
     _add_tag = true;
 }
+void source_impl::set_frequency(size_t channel, double frequency)
+{
+    block_impl::set_frequency(channel, frequency);
+    _add_tag = true;
+}
 void source_impl::set_hardware_time(long long timeNs, const std::string& what)
 {
     block_impl::set_hardware_time(timeNs, what);

--- a/gr-soapy/lib/source_impl.h
+++ b/gr-soapy/lib/source_impl.h
@@ -52,6 +52,7 @@ public:
 
     void
     set_frequency(size_t channel, const std::string& name, double frequency) override;
+    void set_frequency(size_t channel, double frequency) override;
     void set_hardware_time(long long timeNs, const std::string& what) override;
     void set_sample_rate(size_t channel, double sample_rate) override;
 


### PR DESCRIPTION
https://github.com/gnuradio/gnuradio/commit/3eea1057c53842476f809a62499ee6b8dc080d82 causes the gr-soapy block to add the rx_freq tag when set_frequency() is called with a name parameter.

However, gr-soapy source's cmd port handler calls set_frequency() without name, so add_tag_ is not set and the rx_freq tag is not added. This patch causes rx_freq to be added for both versions of set_frequency().


(cherry picked from commit 106e66f5bcb76c6995bc4a86d7a9cbeb9ae2a5cb)

Backport https://github.com/gnuradio/gnuradio/pull/6492