### PR TITLE
grc: Fix Duplicate All_files filter entry in save screenshot dialog (backport to maint-3.10)

### DIFF
--- a/grc/gui/FileDialogs.py
+++ b/grc/gui/FileDialogs.py
@@ -58,7 +58,8 @@ class FileDialogHelper(Gtk.FileChooserDialog, object):
         set_default = True
         filters = filters or (
             [(self.filter_label, self.filter_ext)] if self.filter_label else [])
-        filters.append(('All Files', ''))
+        if ('All Files', '') not in filters:
+            filters.append(('All Files', ''))
         for label, ext in filters:
             if not label:
                 continue


### PR DESCRIPTION
(cherry picked from commit 515560b3ed7573635b7b0c4a2637b40e18a6d89b)

Backport https://github.com/gnuradio/gnuradio/pull/6479