### PR TITLE
grc: fix Choose Editor menu needs to stay above parent dialog (backport to maint-3.10)

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -176,6 +176,7 @@ class MessageDialogWrapper(Gtk.MessageDialog):
             self, transient_for=parent, modal=True, destroy_with_parent=True,
             message_type=message_type, buttons=buttons
         )
+        self.set_keep_above(True)
         if title:
             self.set_title(title)
         if markup:


### PR DESCRIPTION
(cherry picked from commit aae66983ebf84bd751186a3f3d56d2ae82c39d7f)

Backport https://github.com/gnuradio/gnuradio/pull/6491