### PR TITLE
qtgui: fix QT GUI Histogram Sink produces implausible results #6494

### DIFF
--- a/gr-qtgui/lib/HistogramDisplayPlot.cc
+++ b/gr-qtgui/lib/HistogramDisplayPlot.cc
@@ -190,11 +190,11 @@ void HistogramDisplayPlot::_resetXAxisPoints(double left, double right)
         throw std::runtime_error("HistogramDisplayPlot::_resetXAxisPoints left and/or "
                                  "right values are invalid");
 
-    d_left = left * (1 - copysign(0.1, left));
-    d_right = right * (1 + copysign(0.1, right));
+    d_left = left;
+    d_right = right;
     d_width = (d_right - d_left) / (d_bins);
     for (unsigned int loc = 0; loc < d_bins; loc++) {
-        d_xdata[loc] = d_left + loc * d_width;
+        d_xdata[loc] = d_left + (loc + 0.5) * d_width; // center the value in each bin
     }
     QwtScaleDiv scalediv(d_left, d_right);
     setAxisScaleDiv(QwtPlot::xBottom, scalediv);


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
when the data range is very small, the leftmost bin can be too narrow, which can cause some data points to fall outside of the histogram.
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
Fixes #6494 
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
gr-qtgui/lib/HistogramDisplayPlot.cc: line no. 192-198
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
