### PR TITLE
fec: fix some bugs and refactor async_decoder

### DIFF
--- a/gr-fec/lib/async_decoder_impl.h
+++ b/gr-fec/lib/async_decoder_impl.h
@@ -18,6 +18,8 @@
 namespace gr {
 namespace fec {
 
+static const pmt::pmt_t ITERATIONS_KEY = pmt::mp("iterations");
+
 class FEC_API async_decoder_impl : public async_decoder
 {
 private:
@@ -34,11 +36,16 @@ private:
 
     size_t d_max_bits_in;
     volk::vector<float> d_tmp_f32;
-    volk::vector<int8_t> d_tmp_u8;
+    volk::vector<uint8_t> d_tmp_u8;
     volk::vector<uint8_t> d_bits_out;
 
-    void decode_packed(pmt::pmt_t msg);
-    void decode_unpacked(pmt::pmt_t msg);
+    void decode(const pmt::pmt_t& msg);
+
+    inline void convert_32f_to_8u(uint8_t* output_vector,
+                                  const float* input_vector,
+                                  const float scale,
+                                  const float bias,
+                                  unsigned int num_points);
 
 public:
     async_decoder_impl(generic_decoder::sptr my_decoder,


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

This fixes a few bugs and shortcomings in `async_decoder` and refactors it to reduce code duplication by merging the `decode_unpacked()` and `decoded_packed()` functions into a single `decode()` function.

The problems solved are the following:

- `decode_packed()` wasn't considering the `diff` (Viterbi tail) properly, unlike `decode_unpacked()`. This caused undefined behaviour when working in packed output mode with the Viterbi decoder in terminated mode. Occasionally this would cause bit errors in the last bits of a packet. See #6445 for a very similar problem affecting `tagged_decoder`.

- `decode_packed()` didn't support multiple blocks for fixed-size decoders (unlike `decode_unpacked()`).

- In both `decode_unpacked()` and `decode_packed()`, the input conversion to `uint8_t` could overflow (see #6433). The behaviour has been changed to clipping, which is less harmful.

Taking into account that some of these problems affected `decode_packed()` and not `decode_unpacked()` because the two functions were quite similar but had some differences, it seems a good idea to reduce the code duplication by merging the two functions into one.

Additionally, there are these improvements:

- The opportunity to use `volk_32f_s32f_x2_convert_8u` (when it is released, see https://github.com/gnuradio/volk/pull/617) for the input conversion to `uint8_t` has been identified in a comment.

- When there is a decoder shift and no input conversion, the shift is applied with `volk_32f_s32f_add_32f` rather than with an element-by-element loop.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #6433.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

This affects the `async_decoder` block only.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

I have an in-house test case that replicates the problem with the `diff` (Viterbi tail) by failing to decode correctly good packets (At least when using the SSE3 spiral kernel. With the generic kernel I haven't been able to find a test case that does the same). After applying these modifications, the test now passes. I can't share this test, but if necessary I'll see if I can cobble together something similar that I can publish.

Since there aren't any QA tests for `async_decoder`, just in case I broke anything inadvertently, I have run the [gr-satellites AO-73 decoder](https://github.com/daniestevez/gr-satellites/blob/main/python/components/deframers/ao40_fec_deframer.py), which uses `async_decoder` in unpacked mode for Viterbi decoding. This works as expected.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- ~[ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~  -> Not applicable.
- [x] ~I have added tests to cover my changes,~ and all previous tests pass. -> I haven't added new tests. It isn't trivial to come up with tests that check some of the problems addressed here (plus it would be desirable to have some basic tests for `async_decoder` first).
