### PR TITLE
gr-iio: set_gain_mode does not set the gain paramter correctly (backport to maint-3.10)

### DIFF
--- a/gr-iio/lib/fmcomms2_source_impl.cc
+++ b/gr-iio/lib/fmcomms2_source_impl.cc
@@ -343,7 +343,7 @@ void fmcomms2_source_impl<T>::set_gain_mode(size_t chan, const std::string& mode
     iio_param_vec_t params;
 
     params.emplace_back("in_voltage" + std::to_string(chan) +
-                        "_gain_control_mode=" + d_gain_mode[chan]);
+                        "_gain_control_mode=" + mode);
 
     device_source_impl::set_params(params);
     d_gain_mode[chan] = mode;


### PR DESCRIPTION
set_gain_mode sets the gain value always to manual instead to the new value

(cherry picked from commit 46df5d775dd7e684ca64a6cbe159b7de21d21c48)

Backport Fixes #6401