### PR TITLE
runtime: change default log level in conf file to info

### DIFF
--- a/gnuradio-runtime/gnuradio-runtime.conf.in
+++ b/gnuradio-runtime/gnuradio-runtime.conf.in
@@ -15,7 +15,7 @@ max_messages = 8192
 [LOG]
 # Levels can be (case insensitive):
 #       DEBUG, INFO, WARN, TRACE, ERROR, ALERT, CRIT, FATAL, EMERG
-log_level = debug
+log_level = info
 debug_level = emerg
 
 # These file names can either be 'stdout' to output to standard output

--- a/gnuradio-runtime/lib/pagesize.cc
+++ b/gnuradio-runtime/lib/pagesize.cc
@@ -80,7 +80,7 @@ int pagesize()
                           default_pagesize);
             s_pagesize = default_pagesize;
         }
-        logger->info("Setting pagesize to {} B", s_pagesize);
+        logger->debug("Setting pagesize to {} B", s_pagesize);
     }
     return s_pagesize;
 }


### PR DESCRIPTION
## Description
The default log level in the code was previously changed to "info" but an installed conf file overrode it to be "debug". Also change the pagesize notice to debug instead of info.

## Related Issue
Discussion in #6544 

## Which blocks/areas does this affect?
Runtime

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
