### PR TITLE
filter: fix reversed arguments in vector initializer

### DIFF
--- a/gr-filter/lib/pfb_arb_resampler.cc
+++ b/gr-filter/lib/pfb_arb_resampler.cc
@@ -44,7 +44,7 @@ pfb_arb_resampler_ccf::pfb_arb_resampler_ccf(float rate,
     d_last_filter = (taps.size() / 2) % filter_size;
 
     // Create an FIR filter for each channel and zero out the taps
-    const std::vector<float> vtaps(0, d_int_rate);
+    const std::vector<float> vtaps(d_int_rate, 0.0);
     d_filters.reserve(d_int_rate);
     d_diff_filters.reserve(d_int_rate);
     for (unsigned int i = 0; i < d_int_rate; i++) {
@@ -236,7 +236,7 @@ pfb_arb_resampler_ccc::pfb_arb_resampler_ccc(float rate,
     d_diff_filters.reserve(d_int_rate);
 
     // Create an FIR filter for each channel and zero out the taps
-    const std::vector<gr_complex> vtaps(0, d_int_rate);
+    const std::vector<gr_complex> vtaps(d_int_rate, 0.0);
     for (unsigned int i = 0; i < d_int_rate; i++) {
         d_filters.emplace_back(vtaps);
         d_diff_filters.emplace_back(vtaps);
@@ -429,7 +429,7 @@ pfb_arb_resampler_fff::pfb_arb_resampler_fff(float rate,
     d_diff_filters.reserve(d_int_rate);
 
     // Create an FIR filter for each channel and zero out the taps
-    const std::vector<float> vtaps(0, d_int_rate);
+    const std::vector<float> vtaps(d_int_rate, 0.0);
     for (unsigned int i = 0; i < d_int_rate; i++) {
         d_filters.emplace_back(vtaps);
         d_diff_filters.emplace_back(vtaps);

--- a/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
+++ b/gr-filter/lib/pfb_synthesizer_ccf_impl.cc
@@ -50,7 +50,7 @@ pfb_synthesizer_ccf_impl::pfb_synthesizer_ccf_impl(unsigned int numchans,
 
     // Create an FIR filter for each channel and zero out the taps
     // and set the default channel map
-    const std::vector<float> vtaps(0, d_twox * d_numchans);
+    const std::vector<float> vtaps(d_twox * d_numchans, 0.0);
     for (unsigned int i = 0; i < d_twox * d_numchans; i++) {
         d_filters.emplace_back(vtaps);
         d_channel_map[i] = i;


### PR DESCRIPTION
## Description
This bug was creating a zero-length vector which was being passed to fir_filter_with_buffer_ccf. A zero-length vector makes no sense for that block, and on systems with certain debug settings an out-of-range copy (of zero length) was detected, causing a crash.

## Related Issue
Fixes #6547 

## Which blocks/areas does this affect?
PFB Synthesizer

## Testing Done
Was unable to cause the reported crash on any systems I have.

Placing breakpoints in `set_taps()` showed that the correct vector was being passed after the change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
