### PR TITLE
pdu: Don't enable blocks and filter (backport to maint-3.10)

### DIFF
--- a/gr-pdu/CMakeLists.txt
+++ b/gr-pdu/CMakeLists.txt
@@ -13,8 +13,7 @@
 # Register component
 ########################################################################
 include(GrComponent)
-gr_register_component("gr-pdu" ENABLE_GR_PDU ENABLE_GNURADIO_RUNTIME ENABLE_GR_BLOCKS
-                      ENABLE_GR_FILTER)
+gr_register_component("gr-pdu" ENABLE_GR_PDU ENABLE_GNURADIO_RUNTIME)
 
 set(GR_PKG_PDU_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/pdu)
 


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/6450