### PR TITLE
modtool: add keywords for interp/decim py blocks

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -353,9 +353,9 @@ import numpy\
 % endif
 <%
     if blocktype == 'interpolator':
-        deciminterp = ', <+interpolation+>'
+        deciminterp = ', interp=<+interpolation+>'
     elif blocktype == 'decimator':
-        deciminterp = ', <+decimation+>'
+        deciminterp = ', decim=<+decimation+>'
     else:
         deciminterp = ''
     if arglist == '':
@@ -375,8 +375,8 @@ class ${blockname}(${parenttype}):
             gr.io_signature(${inputsig}),  # Input signature
             gr.io_signature(${outputsig})) # Output signature
 
-            # Define blocks and connect them
-            self.connect()
+        # Define blocks and connect them
+        self.connect()
 <% return %>
 % else:
             name="${blockname}",


### PR DESCRIPTION

## Description
The default templates when doing an interp or decim python block left out the necessary keyword for the interp/decim argument
Also, there was an indent error with the block implementation code

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
