### PR TITLE
blocks: delay hide message port optionally in grc

### DIFF
--- a/gr-blocks/grc/blocks_delay.block.yml
+++ b/gr-blocks/grc/blocks_delay.block.yml
@@ -25,7 +25,14 @@ parameters:
     dtype: int
     default: '1'
     hide: ${ 'part' if vlen == 1 else 'none' }
-
+-   id: showports
+    label: Show Msg Ports
+    dtype: bool
+    default: 'True'
+    options: ['False', 'True']
+    option_labels: ['Yes', 'No']
+    hide: part
+    
 inputs:
 -   domain: stream
     dtype: ${ type }
@@ -34,6 +41,7 @@ inputs:
 -   domain: message
     id: dly
     optional: true
+    hide: ${ showports }
 
 outputs:
 -   domain: stream

--- a/gr-blocks/grc/blocks_delay.block.yml
+++ b/gr-blocks/grc/blocks_delay.block.yml
@@ -28,8 +28,8 @@ parameters:
 -   id: showports
     label: Show Msg Ports
     dtype: bool
-    default: 'True'
-    options: ['False', 'True']
+    default: 'False'
+    options: ['True', 'False']
     option_labels: ['Yes', 'No']
     hide: part
     
@@ -41,7 +41,7 @@ inputs:
 -   domain: message
     id: dly
     optional: true
-    hide: ${ showports }
+    hide: ${ not showports }
 
 outputs:
 -   domain: stream


### PR DESCRIPTION
## Description
Give the delay block the ability to hide the `dly` message port in grc

Ideally, a block with single in, single out and hidden message port should be able to be bypassed, but that is a separate issue

after:
![image](https://user-images.githubusercontent.com/34754695/223185048-6d978481-f8e1-46d9-9b10-3d0d7d5b5a85.png)
![image](https://user-images.githubusercontent.com/34754695/223185096-3c570733-20e1-4049-a0cd-573d8676e17e.png)

![image](https://user-images.githubusercontent.com/34754695/223185153-c365c633-e2cb-44b4-be6b-2a4404fa77ca.png)
![image](https://user-images.githubusercontent.com/34754695/223185212-6e229d3a-2a66-41fd-8643-33ff0d69efb8.png)


## Which blocks/areas does this affect?
delay block

## Testing Done
Tried in GRC 

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
