### PR TITLE
gtgui: removed imported firdes from yml and pytemplate (backport to maint-3.10)

### DIFF
--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -928,8 +928,8 @@ inputs:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+
     callbacks:
     - set_time_domain_axis(${min}, ${max})
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -405,8 +405,8 @@ asserts:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
@@ -466,7 +466,7 @@ templates:
         ${ gui_hint() % win}
 
 cpp_templates:
-    includes: ['#include <gnuradio/qtgui/${type.fcn}.h>', '#include <gnuradio/filter/firdes.h>']
+    includes: ['#include <gnuradio/qtgui/${type.fcn}.h>']
     declarations: 'qtgui::${type.fcn}::sptr ${id};'
     callbacks:
     - set_frequency_range(${fc}, ${bw})

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -111,7 +111,6 @@ asserts:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
     callbacks:
     - set_frequency_range(${fc}, ${bw})
@@ -140,7 +139,7 @@ templates:
 
 
 cpp_templates:
-  includes: ['#include <gnuradio/qtgui/${type.fcn}.h>', '#include <gnuradio/filter/firdes.h>']
+  includes: ['#include <gnuradio/qtgui/${type.fcn}.h>']
   declarations: gr::qtgui::${type.fcn}::sptr ${id};
   make: |-
     <%

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -998,8 +998,8 @@ inputs:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+    
     callbacks:
     - set_update_time(${update_time})
     - set_y_axis(${ymin}, ${ymax})

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -256,8 +256,8 @@ inputs:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+    
     callbacks:
     - set_time_domain_axis(${min}, ${max})
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -258,8 +258,8 @@ asserts:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+        
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/6524