### PR TITLE
fec: fix regression in async_decoder and add tests

### DIFF
--- a/gr-fec/lib/async_decoder_impl.cc
+++ b/gr-fec/lib/async_decoder_impl.cc
@@ -133,7 +133,7 @@ void async_decoder_impl::decode(const pmt::pmt_t& msg)
     const float shift = d_decoder->get_shift();
 
     if (std::string_view(d_decoder->get_input_conversion()) == "uchar") {
-        convert_32f_to_8u(d_tmp_u8.data(), f32in, 48.0f, shift, nitems_out);
+        convert_32f_to_8u(d_tmp_u8.data(), f32in, 48.0f, shift, nbits_in);
 
         for (size_t i = 0; i < nblocks; i++) {
             d_decoder->generic_work(

--- a/gr-fec/python/fec/_qa_helper_async.py
+++ b/gr-fec/python/fec/_qa_helper_async.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Copyright 2014 Free Software Foundation, Inc.
+# Copyright 2023 Daniel Estevez <daniel@destevez.net>
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+# This is similar to _qa_helper.py but uses async_encoder and async_decoder
+# instead of extended_encoder and extended_decoder.
+
+
+import numpy as np
+
+from gnuradio import gr, blocks, fec, pdu
+# Must use absolute import here because this file is not installed as part
+# of the module
+from gnuradio.fec import async_encoder, async_decoder
+import pmt
+
+from _qa_helper import map_bb
+
+
+class _qa_helper_async(gr.top_block):
+
+    def __init__(self, frame_size, enc, dec, packed, rev_pack):
+        gr.top_block.__init__(self, "_qa_helper_async")
+
+        self.enc = enc
+        self.dec = dec
+        self.frame_size = frame_size
+        # These options are for the decoder only. The encoder is always run in
+        # unpacked mode.
+        self.packed = packed
+        self.rev_pack = rev_pack
+
+        self.async_encoder = async_encoder(enc)
+        self.async_decoder = async_decoder(
+            dec, packed=packed, rev_pack=rev_pack)
+
+        num_frames = 64
+        frame_size_bits = 8 * frame_size
+        data_in = np.random.randint(
+            2, size=frame_size_bits * num_frames, dtype='uint8')
+        tags = [
+            gr.tag_utils.python_to_tag((
+                frame_size_bits * j, pmt.intern('packet_len'),
+                pmt.from_long(frame_size_bits), pmt.intern('src')))
+            for j in range(num_frames)]
+        self.src = blocks.vector_source_b(data_in, False, tags=tags)
+        self.tagged_to_pdu_enc = pdu.tagged_stream_to_pdu(
+            gr.types.byte_t, 'packet_len')
+        self.pdu_to_tagged_enc = pdu.pdu_to_tagged_stream(
+            gr.types.byte_t, 'packet_len')
+        self.map = map_bb([-1, 1])
+        self.to_float = blocks.char_to_float(1)
+        self.tagged_to_pdu_dec = pdu.tagged_stream_to_pdu(
+            gr.types.float_t, 'packet_len')
+        self.pdu_to_tagged_dec = pdu.pdu_to_tagged_stream(
+            gr.types.byte_t, 'packet_len')
+        self.snk_input = blocks.vector_sink_b()
+        self.snk_output = blocks.vector_sink_b()
+        if packed:
+            self.unpack_decoder = blocks.packed_to_unpacked_bb(
+                1, gr.GR_LSB_FIRST if rev_pack else gr.GR_MSB_FIRST)
+
+        self.connect(self.src, self.tagged_to_pdu_enc)
+        self.msg_connect((self.tagged_to_pdu_enc, 'pdus'),
+                         (self.async_encoder, 'in'))
+        self.msg_connect((self.async_encoder, 'out'),
+                         (self.pdu_to_tagged_enc, 'pdus'))
+        self.connect(
+            self.pdu_to_tagged_enc, self.map, self.to_float,
+            self.tagged_to_pdu_dec)
+        self.msg_connect((self.tagged_to_pdu_dec, 'pdus'),
+                         (self.async_decoder, 'in'))
+        self.msg_connect((self.async_decoder, 'out'),
+                         (self.pdu_to_tagged_dec, 'pdus'))
+        self.connect(self.src, self.snk_input)
+        if packed:
+            self.connect(
+                self.pdu_to_tagged_dec, self.unpack_decoder, self.snk_output)
+        else:
+            self.connect(self.pdu_to_tagged_dec, self.snk_output)
+
+
+if __name__ == '__main__':
+    frame_size = 30
+    enc = fec.dummy_encoder_make(frame_size * 8)
+    dec = fec.dummy_decoder.make(frame_size * 8)
+
+    for packed in [True, False]:
+        for rev_pack in [True, False]:
+            tb = _qa_helper_async(frame_size, enc, dec, packed, rev_pack)
+            tb.run()
+
+            errs = 0
+            for i, o in zip(tb.snk_input.data(), tb.snk_output.data()):
+                if i - o != 0:
+                    errs += 1
+
+            if errs == 0:
+                print("Decoded properly")
+            else:
+                print("Problem Decoding")

--- a/gr-fec/python/fec/qa_fecapi_cc.py
+++ b/gr-fec/python/fec/qa_fecapi_cc.py
@@ -13,6 +13,7 @@ from gnuradio import gr, gr_unittest
 from gnuradio import fec
 
 from _qa_helper import _qa_helper
+from _qa_helper_async import _qa_helper_async
 
 
 class test_fecapi_cc(gr_unittest.TestCase):
@@ -190,6 +191,28 @@ class test_fecapi_cc(gr_unittest.TestCase):
         data_in = self.test.snk_input.data()[0:len(data_out)]
 
         self.assertEqual(data_in, data_out)
+
+    def test_async_00(self):
+        frame_size = 30
+        k = 7
+        rate = 2
+        polys = [109, 79]
+        for mode in [fec.CC_TRUNCATED, fec.CC_TERMINATED, fec.CC_TAILBITING]:
+            for packed in [True, False]:
+                for rev_pack in [True, False]:
+                    with self.subTest(mode=mode, packed=packed,
+                                      rev_pack=rev_pack):
+                        enc = fec.cc_encoder_make(
+                            frame_size * 8, k, rate, polys, mode=mode)
+                        dec = fec.cc_decoder.make(
+                            frame_size * 8, k, rate, polys, mode=mode)
+                        self.test = _qa_helper_async(
+                            frame_size, enc, dec, packed, rev_pack)
+                        self.test.run()
+
+                        data_in = self.test.snk_input.data()
+                        data_out = self.test.snk_output.data()
+                        self.assertEqual(data_in, data_out)
 
 
 if __name__ == '__main__':

--- a/gr-fec/python/fec/qa_fecapi_dummy.py
+++ b/gr-fec/python/fec/qa_fecapi_dummy.py
@@ -17,6 +17,7 @@ from gnuradio.fec import extended_encoder
 from gnuradio.fec import extended_decoder
 
 from _qa_helper import _qa_helper
+from _qa_helper_async import _qa_helper_async
 
 
 class test_fecapi_dummy(gr_unittest.TestCase):
@@ -260,6 +261,22 @@ class test_fecapi_dummy(gr_unittest.TestCase):
         self.assertSequenceEqualGR(data, r1)
         self.assertSequenceEqualGR(packed_data, r2)
         self.assertSequenceEqualGR(data, r3)
+
+    def test_async_00(self):
+        frame_size = 30
+        enc = fec.dummy_encoder_make(frame_size * 8)
+        dec = fec.dummy_decoder.make(frame_size * 8)
+        for packed in [True, False]:
+            for rev_pack in [True, False]:
+                with self.subTest(packed=packed, rev_pack=rev_pack):
+                    self.test = _qa_helper_async(
+                        frame_size, enc, dec, packed, rev_pack)
+                    self.test.run()
+
+                    data_in = self.test.snk_input.data()
+                    data_out = self.test.snk_output.data()
+
+                    self.assertSequenceEqualGR(data_in, data_out)
 
 
 if __name__ == '__main__':

--- a/gr-fec/python/fec/qa_fecapi_ldpc.py
+++ b/gr-fec/python/fec/qa_fecapi_ldpc.py
@@ -17,6 +17,7 @@ from gnuradio.fec import extended_encoder
 from gnuradio.fec import extended_decoder
 
 from _qa_helper import _qa_helper
+from _qa_helper_async import _qa_helper_async
 
 
 # Get location of the alist files. If run in 'ctest' or 'make test',
@@ -307,6 +308,25 @@ class test_fecapi_ldpc(gr_unittest.TestCase):
                 dec,
                 threading=threading,
                 puncpat="11"))
+
+    def test_async_00(self):
+        filename = LDPC_ALIST_DIR + "n_0100_k_0027_gap_04.alist"
+        gap = 4
+        LDPC_matrix_object = fec.ldpc_H_matrix(filename, gap)
+        k = LDPC_matrix_object.k()
+        enc = fec.ldpc_par_mtrx_encoder.make_H(LDPC_matrix_object)
+        dec = fec.ldpc_bit_flip_decoder.make(
+            LDPC_matrix_object.get_base_sptr())
+        for packed in [True, False]:
+            for rev_pack in [True, False]:
+                with self.subTest(packed=packed, rev_pack=rev_pack):
+                    self.test = _qa_helper_async(k, enc, dec, packed, rev_pack)
+                    self.test.run()
+
+                    data_in = self.test.snk_input.data()
+                    data_out = self.test.snk_output.data()
+
+                    self.assertEqual(data_in, data_out)
 
 
 if __name__ == '__main__':

--- a/gr-fec/python/fec/qa_fecapi_repetition.py
+++ b/gr-fec/python/fec/qa_fecapi_repetition.py
@@ -13,6 +13,7 @@ from gnuradio import gr, gr_unittest
 from gnuradio import fec
 
 from _qa_helper import _qa_helper
+from _qa_helper_async import _qa_helper_async
 
 
 class test_fecapi_repetition(gr_unittest.TestCase):
@@ -154,6 +155,23 @@ class test_fecapi_repetition(gr_unittest.TestCase):
         data_out = self.test.snk_output.data()
 
         self.assertSequenceEqualGR(data_in, data_out)
+
+    def test_async_00(self):
+        frame_size = 30
+        rep = 3
+        enc = fec.repetition_encoder_make(frame_size * 8, rep)
+        dec = fec.repetition_decoder.make(frame_size * 8, rep)
+        for packed in [True, False]:
+            for rev_pack in [True, False]:
+                with self.subTest(packed=packed, rev_pack=rev_pack):
+                    self.test = _qa_helper_async(
+                        frame_size, enc, dec, packed, rev_pack)
+                    self.test.run()
+
+                    data_in = self.test.snk_input.data()
+                    data_out = self.test.snk_output.data()
+
+                    self.assertSequenceEqualGR(data_in, data_out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

The `async_decoder` was broken in 4e50c99ab38f816d56145133ce6b7cc68e164e90. The reason was a mistake when rewriting the PR to address comments. In the case where the decoder input needs to be converted to `uchar`, `nitems_out` rather than `nbits_in` was wrongly used as the length of the data to be converted. Effectively, we are passing only the first half of the input to a rate=1/2 decoder such as the CC decoder.

Since there are no tests of the async_decoder that would have caught the bug, this adds some tests. A new `_qa_helper_async` `top_block` similar to `_qa_helper` is added. This is used in an additional test case in the `qa_fecapi_* `tests to run the `async_encoder` and `async_decoder` with all the different FECAPI encoders/decoders.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

The Async Decoder FECAPI block. This also adds tests for Async Encoder.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

The new tests pass when the bug is fixed. They don't pass if the bug is not fixed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] ~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~ => No necessary changes.
- [x] I have added tests to cover my changes, and all previous tests pass.
