### PR TITLE
grc: Error Open the source of a hierachical block

### DIFF
--- a/grc/gui/canvas/flowgraph.py
+++ b/grc/gui/canvas/flowgraph.py
@@ -670,7 +670,7 @@ class FlowGraph(CoreFlowgraph, Drawable):
         Returns:
             sub set of blocks in this flow graph
         """
-        return (e for e in self.selected_elements if e.is_block)
+        return (e for e in self.selected_elements.copy() if e.is_block)
 
     @property
     def selected_block(self):


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
1. Open a fg that contains a hierachical block
2. Select the hierachical block
3. Open the source of the selected hierachical block from the grc menu

gives the following error in the terminal

Loading: "/home/schroer/gnuradiocomponents/gr-noaa/examples/doppler_test.grc"
>>> Done

Loading: "/home/schroer/gnuradiocomponents/gr-funcube/examples/decodeapt.grc"
>>> Done
Traceback (most recent call last):
  File "/usr/local/gnuradio/lib64/python3.11/site-packages/gnuradio/grc/gui/Application.py", line 782, in _handle_action
    for b in flow_graph.selected_blocks():
  File "/usr/local/gnuradio/lib64/python3.11/site-packages/gnuradio/grc/gui/canvas/flowgraph.py", line 673, in <genexpr>
    return (e for e in self.selected_elements if e.is_block)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Set changed size during iteration

Despite the error messages the block is correctly displayed in grc.

I'm not sure why set is changed but according to the python recommendations changing to self.selected_elements.copy() fixes this issue.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
Tested with a complex flowgraph
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
