### PR TITLE
zmq: user-selectable connect/bind for all zmq blocks

### DIFF
--- a/gr-zeromq/grc/zeromq_pub_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_pub_sink.block.yml
@@ -47,6 +47,13 @@ parameters:
     options: ['True', 'False']
     option_labels: ['Drop', 'Block']
     hide: 'part'
+-   id: bind
+    label: Connection
+    category: Advanced
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['Bind', 'Connect']
 
 inputs:
 -   domain: stream
@@ -56,20 +63,21 @@ inputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.pub_sink(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm}, ${key}, ${drop_on_hwm})
-        
+        ${hwm}, ${key}, ${drop_on_hwm}, ${bind})
+
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/pub_sink.h>' ]
     declarations: gr::zeromq::pub_sink::sptr ${id};
-    make: this->${id} = gr::zeromq::pub_sink::make(${type.itemsize}, 
-        ${vlen}, 
+    make: this->${id} = gr::zeromq::pub_sink::make(${type.itemsize},
+        ${vlen},
         const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'},
-        ${timeout}, 
-        ${pass_tags}, 
+        ${timeout},
+        ${pass_tags},
         ${hwm},
         ${key},
-        ${drop_on_hwm});
-    link: ['gnuradio::gnuradio-zeromq']      
+        ${drop_on_hwm},
+        ${bind});
+    link: ['gnuradio::gnuradio-zeromq']
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_pull_source.block.yml
+++ b/gr-zeromq/grc/zeromq_pull_source.block.yml
@@ -35,6 +35,13 @@ parameters:
     dtype: int
     default: '-1'
     hide: ${ ('part' if hwm == -1 else 'none') }
+-   id: bind
+    label: Connection
+    category: Advanced
+    dtype: enum
+    default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Bind', 'Connect']
 
 outputs:
 -   domain: stream
@@ -44,18 +51,19 @@ outputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.pull_source(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm})
+        ${hwm}, ${bind})
 
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/pull_source.h>' ]
     declarations: gr::zeromq::pull_source::sptr ${id};
-    make: this->${id} = gr::zeromq::pull_source::make(${type.itemsize}, 
-              ${vlen}, 
-              const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\''else ')'}, 
-              ${timeout}, 
-              ${pass_tags}, 
-              ${hwm});
-    link: ['gnuradio::gnuradio-zeromq']      
+    make: this->${id} = gr::zeromq::pull_source::make(${type.itemsize},
+              ${vlen},
+              const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\''else ')'},
+              ${timeout},
+              ${pass_tags},
+              ${hwm},
+              ${bind});
+    link: ['gnuradio::gnuradio-zeromq']
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_push_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_push_sink.block.yml
@@ -35,6 +35,13 @@ parameters:
     dtype: int
     default: '-1'
     hide: ${ ('part' if hwm == -1 else 'none') }
+-   id: bind
+    label: Connection
+    category: Advanced
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['Bind', 'Connect']
 
 inputs:
 -   domain: stream
@@ -44,18 +51,19 @@ inputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.push_sink(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm})
+        ${hwm}, ${bind})
 
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/push_sink.h>' ]
     declarations: gr::zeromq::push_sink::sptr ${id};
-    make: this->${id} = gr::zeromq::push_sink::make(${type.itemsize}, 
-              ${vlen}, 
-              const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'}, 
-              ${timeout}, 
-              ${pass_tags}, 
-              ${hwm});
-    link: ['gnuradio::gnuradio-zeromq']          
+    make: this->${id} = gr::zeromq::push_sink::make(${type.itemsize},
+              ${vlen},
+              const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'},
+              ${timeout},
+              ${pass_tags},
+              ${hwm},
+              ${bind});
+    link: ['gnuradio::gnuradio-zeromq']
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_rep_sink.block.yml
+++ b/gr-zeromq/grc/zeromq_rep_sink.block.yml
@@ -36,6 +36,13 @@ parameters:
     dtype: int
     default: '-1'
     hide: ${ ('part' if hwm == -1 else 'none') }
+-   id: bind
+    label: Connection
+    category: Advanced
+    dtype: enum
+    default: 'True'
+    options: ['True', 'False']
+    option_labels: ['Bind', 'Connect']
 
 inputs:
 -   domain: stream
@@ -45,18 +52,19 @@ inputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.rep_sink(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm})
-        
+        ${hwm}, ${bind})
+
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/rep_sink.h>' ]
     declarations: gr::zeromq::rep_sink::sptr ${id};
-    make: this->${id} = gr::zeromq::rep_sink::make(${type.itemsize}, 
-        ${vlen}, 
+    make: this->${id} = gr::zeromq::rep_sink::make(${type.itemsize},
+        ${vlen},
         const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'},
-        ${timeout}, 
-        ${pass_tags}, 
-        ${hwm});
-    link: ['gnuradio::gnuradio-zeromq']      
+        ${timeout},
+        ${pass_tags},
+        ${hwm},
+        ${bind});
+    link: ['gnuradio::gnuradio-zeromq']
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_req_source.block.yml
+++ b/gr-zeromq/grc/zeromq_req_source.block.yml
@@ -35,6 +35,13 @@ parameters:
     dtype: int
     default: '-1'
     hide: ${ ('part' if hwm == -1 else 'none') }
+-   id: bind
+    label: Connection
+    category: Advanced
+    dtype: enum
+    default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Bind', 'Connect']
 
 outputs:
 -   domain: stream
@@ -44,18 +51,19 @@ outputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.req_source(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm})
+        ${hwm}, ${bind})
 
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/req_source.h>' ]
     declarations: gr::zeromq::req_source::sptr ${id};
-    make: this->${id} = gr::zeromq::req_source::make(${type.itemsize}, 
-        ${vlen}, 
+    make: this->${id} = gr::zeromq::req_source::make(${type.itemsize},
+        ${vlen},
         const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'},
-        ${timeout}, 
-        ${pass_tags}, 
-        ${hwm});
-    link: ['gnuradio::gnuradio-zeromq']      
+        ${timeout},
+        ${pass_tags},
+        ${hwm},
+        ${bind});
+    link: ['gnuradio::gnuradio-zeromq']
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/grc/zeromq_sub_source.block.yml
+++ b/gr-zeromq/grc/zeromq_sub_source.block.yml
@@ -39,6 +39,13 @@ parameters:
     label: Filter Key
     dtype: string
     default: ''
+-   id: bind
+    label: Connection
+    category: Advanced
+    dtype: enum
+    default: 'False'
+    options: ['True', 'False']
+    option_labels: ['Bind', 'Connect']
 
 outputs:
 -   domain: stream
@@ -48,19 +55,20 @@ outputs:
 templates:
     imports: from gnuradio import zeromq
     make: zeromq.sub_source(${type.itemsize}, ${vlen}, ${address}, ${timeout}, ${pass_tags},
-        ${hwm}, ${key})
+        ${hwm}, ${key}, ${bind})
 
 cpp_templates:
     includes: [ '#include <gnuradio/zeromq/sub_source.h>' ]
     declarations: gr::zeromq::sub_source::sptr ${id};
-    make: this->${id} = gr::zeromq::sub_source::make(${type.itemsize}, 
-        ${vlen}, 
+    make: this->${id} = gr::zeromq::sub_source::make(${type.itemsize},
+        ${vlen},
         const_cast<char *>(${address}${'.c_str())' if str(address)[0] not in '"\'' else ')'},
-        ${timeout}, 
-        ${pass_tags}, 
+        ${timeout},
+        ${pass_tags},
         ${hwm},
-        ${key});
-    link: ['gnuradio::gnuradio-zeromq']      
+        ${key},
+        ${bind});
+    link: ['gnuradio::gnuradio-zeromq']
     translations:
       'True': 'true'
       'False': 'false'

--- a/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pub_sink.h
@@ -50,6 +50,8 @@ public:
      * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
      * \param key Prepend a key/topic to the start of each message (default is none)
      * \param drop_on_hwm Optionally drop samples when high watermark is reached.
+     * \param bind If true this block will bind to the address, otherwise it will
+     * connect; the default is to bind
      */
     static sptr make(size_t itemsize,
                      size_t vlen,
@@ -58,7 +60,8 @@ public:
                      bool pass_tags = false,
                      int hwm = -1,
                      const std::string& key = "",
-                     bool drop_on_hwm = true);
+                     bool drop_on_hwm = true,
+                     bool bind = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/pull_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/pull_source.h
@@ -39,13 +39,16 @@ public:
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
      * \param pass_tags Whether source will look for and deserialize tags.
      * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
+     * \param bind If true this block will bind to the address, otherwise it will
+     * connect; the default is to connect
      */
     static sptr make(size_t itemsize,
                      size_t vlen,
                      char* address,
                      int timeout = 100,
                      bool pass_tags = false,
-                     int hwm = -1);
+                     int hwm = -1,
+                     bool bind = false);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/push_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/push_sink.h
@@ -43,13 +43,16 @@ public:
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
      * \param pass_tags Whether sink will serialize and pass tags over the link.
      * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
+     * \param bind If true this block will bind to the address, otherwise it will
+     * connect; the default is to bind
      */
     static sptr make(size_t itemsize,
                      size_t vlen,
                      char* address,
                      int timeout = 100,
                      bool pass_tags = false,
-                     int hwm = -1);
+                     int hwm = -1,
+                     bool bind = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
+++ b/gr-zeromq/include/gnuradio/zeromq/rep_sink.h
@@ -41,13 +41,16 @@ public:
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
      * \param pass_tags Whether sink will serialize and pass tags over the link.
      * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
+     * \param bind If true this block will bind to the address, otherwise it will
+     * connect; the default is to bind
      */
     static sptr make(size_t itemsize,
                      size_t vlen,
                      char* address,
                      int timeout = 100,
                      bool pass_tags = false,
-                     int hwm = -1);
+                     int hwm = -1,
+                     bool bind = true);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/req_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/req_source.h
@@ -39,13 +39,16 @@ public:
      * \param timeout  Receive timeout in milliseconds, default is 100ms, 1us increments.
      * \param pass_tags Whether source will look for and deserialize tags.
      * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
+     * \param bind If true this block will bind to the address, otherwise it will
+     * connect; the default is to connect
      */
     static sptr make(size_t itemsize,
                      size_t vlen,
                      char* address,
                      int timeout = 100,
                      bool pass_tags = false,
-                     int hwm = -1);
+                     int hwm = -1,
+                     bool bind = false);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/include/gnuradio/zeromq/sub_source.h
+++ b/gr-zeromq/include/gnuradio/zeromq/sub_source.h
@@ -40,6 +40,8 @@ public:
      * \param pass_tags Whether source will look for and deserialize tags.
      * \param hwm High Watermark to configure the socket to (-1 => zmq's default)
      * \param key Subscriber filter key. Leave empty to pass all messages.
+     * \param bind If true this block will bind to the address, otherwise it will
+     * connect; the default is to connect
      */
     static sptr make(size_t itemsize,
                      size_t vlen,
@@ -47,7 +49,8 @@ public:
                      int timeout = 100,
                      bool pass_tags = false,
                      int hwm = -1,
-                     const std::string& key = "");
+                     const std::string& key = "",
+                     bool bind = false);
 
     /*!
      * \brief Return a std::string of ZMQ_LAST_ENDPOINT from the underlying ZMQ socket.

--- a/gr-zeromq/lib/base_impl.h
+++ b/gr-zeromq/lib/base_impl.h
@@ -23,8 +23,12 @@ public:
     base_impl(int type,
               size_t itemsize,
               size_t vlen,
+              char* address,
               int timeout,
               bool pass_tags,
+              int hwm,   // high watermark
+              bool sink, // is sink, else source
+              bool bind, // do bind, else connect
               const std::string& key = "");
     ~base_impl() override;
 
@@ -48,6 +52,7 @@ public:
                    int timeout,
                    bool pass_tags,
                    int hwm,
+                   bool bind,
                    const std::string& key = "");
 
 protected:
@@ -64,6 +69,7 @@ public:
                      int timeout,
                      bool pass_tags,
                      int hwm,
+                     bool bind,
                      const std::string& key = "");
 
 protected:

--- a/gr-zeromq/lib/pub_sink_impl.cc
+++ b/gr-zeromq/lib/pub_sink_impl.cc
@@ -26,10 +26,11 @@ pub_sink::sptr pub_sink::make(size_t itemsize,
                               bool pass_tags,
                               int hwm,
                               const std::string& key,
-                              bool drop_on_hwm)
+                              bool drop_on_hwm,
+                              bool bind)
 {
     return gnuradio::make_block_sptr<pub_sink_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm, key, drop_on_hwm);
+        itemsize, vlen, address, timeout, pass_tags, hwm, key, drop_on_hwm, bind);
 }
 
 pub_sink_impl::pub_sink_impl(size_t itemsize,
@@ -39,11 +40,12 @@ pub_sink_impl::pub_sink_impl(size_t itemsize,
                              bool pass_tags,
                              int hwm,
                              const std::string& key,
-                             bool drop_on_hwm)
+                             bool drop_on_hwm,
+                             bool bind)
     : gr::sync_block("pub_sink",
                      gr::io_signature::make(1, 1, itemsize * vlen),
                      gr::io_signature::make(0, 0, 0)),
-      base_sink_impl(ZMQ_PUB, itemsize, vlen, address, timeout, pass_tags, hwm, key)
+      base_sink_impl(ZMQ_PUB, itemsize, vlen, address, timeout, pass_tags, hwm, bind, key)
 {
     /* Socket option to prevent dropping of samples (backpressure) */
     int no_drop = (drop_on_hwm == true) ? 0 : 1;

--- a/gr-zeromq/lib/pub_sink_impl.h
+++ b/gr-zeromq/lib/pub_sink_impl.h
@@ -28,7 +28,8 @@ public:
                   bool pass_tags,
                   int hwm,
                   const std::string& key,
-                  bool drop_on_hwm);
+                  bool drop_on_hwm,
+                  bool bind);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/lib/pull_source_impl.cc
+++ b/gr-zeromq/lib/pull_source_impl.cc
@@ -19,19 +19,29 @@
 namespace gr {
 namespace zeromq {
 
-pull_source::sptr pull_source::make(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+pull_source::sptr pull_source::make(size_t itemsize,
+                                    size_t vlen,
+                                    char* address,
+                                    int timeout,
+                                    bool pass_tags,
+                                    int hwm,
+                                    bool bind)
 {
     return gnuradio::make_block_sptr<pull_source_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm);
+        itemsize, vlen, address, timeout, pass_tags, hwm, bind);
 }
 
-pull_source_impl::pull_source_impl(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+pull_source_impl::pull_source_impl(size_t itemsize,
+                                   size_t vlen,
+                                   char* address,
+                                   int timeout,
+                                   bool pass_tags,
+                                   int hwm,
+                                   bool bind)
     : gr::sync_block("pull_source",
                      gr::io_signature::make(0, 0, 0),
                      gr::io_signature::make(1, 1, itemsize * vlen)),
-      base_source_impl(ZMQ_PULL, itemsize, vlen, address, timeout, pass_tags, hwm)
+      base_source_impl(ZMQ_PULL, itemsize, vlen, address, timeout, pass_tags, hwm, bind)
 {
     /* All is delegated */
 }

--- a/gr-zeromq/lib/pull_source_impl.h
+++ b/gr-zeromq/lib/pull_source_impl.h
@@ -26,7 +26,8 @@ public:
                      char* address,
                      int timeout,
                      bool pass_tags,
-                     int hwm);
+                     int hwm,
+                     bool bind);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/lib/push_sink_impl.cc
+++ b/gr-zeromq/lib/push_sink_impl.cc
@@ -19,19 +19,29 @@
 namespace gr {
 namespace zeromq {
 
-push_sink::sptr push_sink::make(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+push_sink::sptr push_sink::make(size_t itemsize,
+                                size_t vlen,
+                                char* address,
+                                int timeout,
+                                bool pass_tags,
+                                int hwm,
+                                bool bind)
 {
     return gnuradio::make_block_sptr<push_sink_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm);
+        itemsize, vlen, address, timeout, pass_tags, hwm, bind);
 }
 
-push_sink_impl::push_sink_impl(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+push_sink_impl::push_sink_impl(size_t itemsize,
+                               size_t vlen,
+                               char* address,
+                               int timeout,
+                               bool pass_tags,
+                               int hwm,
+                               bool bind)
     : gr::sync_block("push_sink",
                      gr::io_signature::make(1, 1, itemsize * vlen),
                      gr::io_signature::make(0, 0, 0)),
-      base_sink_impl(ZMQ_PUSH, itemsize, vlen, address, timeout, pass_tags, hwm)
+      base_sink_impl(ZMQ_PUSH, itemsize, vlen, address, timeout, pass_tags, hwm, bind)
 {
     /* All is delegated */
 }

--- a/gr-zeromq/lib/push_sink_impl.h
+++ b/gr-zeromq/lib/push_sink_impl.h
@@ -26,7 +26,8 @@ public:
                    char* address,
                    int timeout,
                    bool pass_tags,
-                   int hwm);
+                   int hwm,
+                   bool bind);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/lib/rep_sink_impl.cc
+++ b/gr-zeromq/lib/rep_sink_impl.cc
@@ -19,19 +19,29 @@
 namespace gr {
 namespace zeromq {
 
-rep_sink::sptr rep_sink::make(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+rep_sink::sptr rep_sink::make(size_t itemsize,
+                              size_t vlen,
+                              char* address,
+                              int timeout,
+                              bool pass_tags,
+                              int hwm,
+                              bool bind)
 {
     return gnuradio::make_block_sptr<rep_sink_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm);
+        itemsize, vlen, address, timeout, pass_tags, hwm, bind);
 }
 
-rep_sink_impl::rep_sink_impl(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+rep_sink_impl::rep_sink_impl(size_t itemsize,
+                             size_t vlen,
+                             char* address,
+                             int timeout,
+                             bool pass_tags,
+                             int hwm,
+                             bool bind)
     : gr::sync_block("rep_sink",
                      gr::io_signature::make(1, 1, itemsize * vlen),
                      gr::io_signature::make(0, 0, 0)),
-      base_sink_impl(ZMQ_REP, itemsize, vlen, address, timeout, pass_tags, hwm)
+      base_sink_impl(ZMQ_REP, itemsize, vlen, address, timeout, pass_tags, hwm, bind)
 {
     /* All is delegated */
 }

--- a/gr-zeromq/lib/rep_sink_impl.h
+++ b/gr-zeromq/lib/rep_sink_impl.h
@@ -25,7 +25,8 @@ public:
                   char* address,
                   int timeout,
                   bool pass_tags,
-                  int hwm);
+                  int hwm,
+                  bool bind);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/lib/req_source_impl.cc
+++ b/gr-zeromq/lib/req_source_impl.cc
@@ -19,19 +19,29 @@
 namespace gr {
 namespace zeromq {
 
-req_source::sptr req_source::make(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+req_source::sptr req_source::make(size_t itemsize,
+                                  size_t vlen,
+                                  char* address,
+                                  int timeout,
+                                  bool pass_tags,
+                                  int hwm,
+                                  bool bind)
 {
     return gnuradio::make_block_sptr<req_source_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm);
+        itemsize, vlen, address, timeout, pass_tags, hwm, bind);
 }
 
-req_source_impl::req_source_impl(
-    size_t itemsize, size_t vlen, char* address, int timeout, bool pass_tags, int hwm)
+req_source_impl::req_source_impl(size_t itemsize,
+                                 size_t vlen,
+                                 char* address,
+                                 int timeout,
+                                 bool pass_tags,
+                                 int hwm,
+                                 bool bind)
     : gr::sync_block("req_source",
                      gr::io_signature::make(0, 0, 0),
                      gr::io_signature::make(1, 1, itemsize * vlen)),
-      base_source_impl(ZMQ_REQ, itemsize, vlen, address, timeout, pass_tags, hwm),
+      base_source_impl(ZMQ_REQ, itemsize, vlen, address, timeout, pass_tags, hwm, bind),
       d_req_pending(false)
 {
     /* All is delegated */

--- a/gr-zeromq/lib/req_source_impl.h
+++ b/gr-zeromq/lib/req_source_impl.h
@@ -26,7 +26,8 @@ public:
                     char* address,
                     int timeout,
                     bool pass_tags,
-                    int hwm);
+                    int hwm,
+                    bool bind);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/lib/sub_source_impl.cc
+++ b/gr-zeromq/lib/sub_source_impl.cc
@@ -25,10 +25,11 @@ sub_source::sptr sub_source::make(size_t itemsize,
                                   int timeout,
                                   bool pass_tags,
                                   int hwm,
-                                  const std::string& key)
+                                  const std::string& key,
+                                  bool bind)
 {
     return gnuradio::make_block_sptr<sub_source_impl>(
-        itemsize, vlen, address, timeout, pass_tags, hwm, key);
+        itemsize, vlen, address, timeout, pass_tags, hwm, key, bind);
 }
 
 sub_source_impl::sub_source_impl(size_t itemsize,
@@ -37,11 +38,13 @@ sub_source_impl::sub_source_impl(size_t itemsize,
                                  int timeout,
                                  bool pass_tags,
                                  int hwm,
-                                 const std::string& key)
+                                 const std::string& key,
+                                 bool bind)
     : gr::sync_block("sub_source",
                      gr::io_signature::make(0, 0, 0),
                      gr::io_signature::make(1, 1, itemsize * vlen)),
-      base_source_impl(ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm, key)
+      base_source_impl(
+          ZMQ_SUB, itemsize, vlen, address, timeout, pass_tags, hwm, bind, key)
 {
     /* Subscribe */
 #if USE_NEW_CPPZMQ_SET_GET

--- a/gr-zeromq/lib/sub_source_impl.h
+++ b/gr-zeromq/lib/sub_source_impl.h
@@ -27,7 +27,8 @@ public:
                     int timeout,
                     bool pass_tags,
                     int hwm,
-                    const std::string& key);
+                    const std::string& key,
+                    bool bind);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-zeromq/python/zeromq/bindings/pub_sink_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/pub_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pub_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(cd42d2bcb6b995a5ff36f7b829ca7d54)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0dc6073a224da6f95df9c04a2a507de3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -48,6 +48,7 @@ void bind_pub_sink(py::module& m)
              py::arg("hwm") = -1,
              py::arg("key") = "",
              py::arg("drop_on_hwm") = true,
+             py::arg("bind") = true,
              D(pub_sink, make))
 
 

--- a/gr-zeromq/python/zeromq/bindings/pull_source_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/pull_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pull_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(850f9a7d270eae47a20211408bf43d5e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0a2698efb9f937dc543d1185ffb94a66)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -46,6 +46,7 @@ void bind_pull_source(py::module& m)
              py::arg("timeout") = 100,
              py::arg("pass_tags") = false,
              py::arg("hwm") = -1,
+             py::arg("bind") = false,
              D(pull_source, make))
 
 

--- a/gr-zeromq/python/zeromq/bindings/push_sink_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/push_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(push_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(4a194d42c300ebf21fc06f2fe1d31c92)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ee6d7190472ad0b669a7a6dd058dcae0)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -46,6 +46,7 @@ void bind_push_sink(py::module& m)
              py::arg("timeout") = 100,
              py::arg("pass_tags") = false,
              py::arg("hwm") = -1,
+             py::arg("bind") = true,
              D(push_sink, make))
 
 

--- a/gr-zeromq/python/zeromq/bindings/rep_sink_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/rep_sink_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(rep_sink.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(057f1522bfb66253664d7853c859a43c)                     */
+/* BINDTOOL_HEADER_FILE_HASH(32a625d1a17ff458a5526e0f19a396cb)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -46,6 +46,7 @@ void bind_rep_sink(py::module& m)
              py::arg("timeout") = 100,
              py::arg("pass_tags") = false,
              py::arg("hwm") = -1,
+             py::arg("bind") = true,
              D(rep_sink, make))
 
 

--- a/gr-zeromq/python/zeromq/bindings/req_source_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/req_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(req_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(588f6c72006327392f5bb7d064f3a56f)                     */
+/* BINDTOOL_HEADER_FILE_HASH(0dd45c0ce3f7a52ebfeb0784742579a2)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -46,6 +46,7 @@ void bind_req_source(py::module& m)
              py::arg("timeout") = 100,
              py::arg("pass_tags") = false,
              py::arg("hwm") = -1,
+             py::arg("bind") = false,
              D(req_source, make))
 
 

--- a/gr-zeromq/python/zeromq/bindings/sub_source_python.cc
+++ b/gr-zeromq/python/zeromq/bindings/sub_source_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(sub_source.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(8b138ada41a770bf3626b77f711e3833)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5532ff97c13c148a6c360417e2874799)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -47,6 +47,7 @@ void bind_sub_source(py::module& m)
              py::arg("pass_tags") = false,
              py::arg("hwm") = -1,
              py::arg("key") = "",
+             py::arg("bind") = false,
              D(sub_source, make))
 
 


### PR DESCRIPTION
## Description
Message-oriented ZMQ blocks already have selectable connect/bind. Here, the stream-oriented blocks are given the same option. Some refactoring of the base classes was necessary. The API and default behavior is unchanged.

## Related Issue
Various ZMQ improvements were dicussed in #6559. 
Specifically fixes #4782.

## Which blocks/areas does this affect?
ZMQ stream-oriented blocks.

## Testing Done
PUB (connect) to SUB (bind) tested in a flowgraph.

QA tests and documentation TBD.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
