### PR TITLE
uhd: rfnoc: fix literal_eval error

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_graph.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_graph.block.yml
@@ -9,10 +9,25 @@ templates:
       <%
           import ast
           # Sanitize
-          graph_args = ast.literal_eval(dev_addr.strip())
-          dev_args_s = ast.literal_eval(dev_args.strip())
-          clock_source_s = ast.literal_eval(clock_source.strip())
-          time_source_s = ast.literal_eval(time_source.strip())
+          # literal_eval requires a string containing a literal (e.g. string), on drag/drop
+          # the params are just strings, so they cause an exception, call literal_eval again
+          # with params enclosed in a string
+          try:
+              graph_args = ast.literal_eval(dev_addr.strip())
+          except SyntaxError:
+              graph_args = ast.literal_eval("'{}'".format(dev_addr.strip()))
+          try:
+              dev_args_s = ast.literal_eval(dev_args.strip())
+          except SyntaxError:
+              dev_args_s = ast.literal_eval("'{}'".format(dev_args.strip()))
+          try:
+              clock_source_s = ast.literal_eval(clock_source.strip())
+          except SyntaxError:
+              clock_source_s = ast.literal_eval("'{}'".format(clock_source.strip()))
+          try:
+              time_source_s = ast.literal_eval(time_source.strip())
+          except SyntaxError:
+              time_source_s = ast.literal_eval("'{}'".format(time_source.strip()))
           # Build full dev args
           if dev_args_s:
               graph_args += f",{clock_source_s}"


### PR DESCRIPTION
literal_eval() was throwing an exception on drag and drop because it requires a string containing a literal (e.g. string) rather than just a string itself, it then returns the contained string.

This was only an issue on drag/drop as the block code later does this transformation itself, but not before the first var_make()

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Dragging and dropping a graph block from the right panel caused the block to not show up, and looking at the terminal that launched the gnuradio-companion it threw a Syntax EOF exception. This was because during the initial var_make from drag and drop, literal_eval was being passed something like 'type=n3xx', whereas later var_make passed it "'type=n3xx'". I traced this enclosing to the param rewrite in grc. There is likely also the option of trying to reorder operations in grc to ensure this encapsulating before calling var_make, but it seemed the best option to only be touching one block rather than inadvertently breaking another block.

Only drag/drop was previously broken, and you could workaround by drag/drop then save .grc file, close it then open it up and the block would be there, so starting from an example and reworking it also worked fine.

## Related Issue
Drag/drop of rfnoc graph threw exception

## Which blocks/areas does this affect?
gr-uhd graph block

## Testing Done
Tested dragging and dropping a graph block, ensured it was placed as expected. Also tested running applications and opening applications that already had a graph block.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
