### PR TITLE
uhd: rfnoc: fix literal_eval error

### DIFF
--- a/gr-uhd/grc/uhd_rfnoc_graph.block.yml
+++ b/gr-uhd/grc/uhd_rfnoc_graph.block.yml
@@ -7,15 +7,14 @@ templates:
       from gnuradio import uhd
   var_make: |
       <%
-          import ast
           # Sanitize
-          graph_args = ast.literal_eval(dev_addr.strip())
-          dev_args_s = ast.literal_eval(dev_args.strip())
-          clock_source_s = ast.literal_eval(clock_source.strip())
-          time_source_s = ast.literal_eval(time_source.strip())
+          graph_args = str(dev_addr()).strip()
+          dev_args_s = str(dev_args()).strip()
+          clock_source_s = str(clock_source()).strip()
+          time_source_s = str(time_source()).strip()
           # Build full dev args
           if dev_args_s:
-              graph_args += f",{clock_source_s}"
+              graph_args += f",{dev_args_s}"
           if clock_source_s:
               graph_args += f",clock_source={clock_source_s}"
           if time_source_s:


### PR DESCRIPTION
literal_eval() was used in the RFNoC graph GRC binding to sanitize
inputs. However, it was throwing an exception on drag and drop because
it requires a string containing a literal (e.g. string) rather than
just a string itself,

This was only an issue on drag/drop as the block code later does this transformation itself, but not before the first var_make()

However, the literal_eval() is not actually necessary, since the objects
passed in are of type TemplateArg, not just
string-or-something-that-evaluates-to-string, and thus we can use
facilities from TemplateArg to properly escape the values before usage.



<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Related Issue

Supersedes https://github.com/gnuradio/gnuradio/pull/6598

## Which blocks/areas does this affect?

RFNoC graphs in GRC

## Testing Done

Did some RFNoC graphs in GRC

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.