### PR TITLE
blocks: selector: don't blindly consume same amount from all inputs

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/selector.h
+++ b/gr-blocks/include/gnuradio/blocks/selector.h
@@ -22,9 +22,13 @@ namespace blocks {
  * \ingroup misc_blk
  *
  * \details
- * Connect the sink at input index to the source at output index
- * Samples from other input ports are consumed and dumped
- * Other output ports produce no samples
+ * Connect the sink at input index to the source at output index.
+ *
+ * Samples from other input ports are consumed and dumped at a rate
+ * which is limited by (but not necessarily the same as) the rate of
+ * samples copied from the active input to the active output.
+ *
+ * Other output ports produce no samples.
  *
  */
 class BLOCKS_API selector : virtual public block
@@ -32,11 +36,20 @@ class BLOCKS_API selector : virtual public block
 public:
     typedef std::shared_ptr<selector> sptr;
 
+    /*!
+     * Create new selector block and return a shared pointer to it
+     *
+     * \param itemsize size of the input and output items
+     * \param input_index the initially active input index
+     * \param output_index the initally active output index
+     */
     static sptr
     make(size_t itemsize, unsigned int input_index, unsigned int output_index);
 
-    // When enabled is set to false, no output samples are produced
-    // Otherwise samples are copied to the selected output port
+    /*!
+     * When enabled is set to false, no output samples are produced.
+     * Otherwise samples are copied to the selected output port
+     */
     virtual void set_enabled(bool enable) = 0;
     virtual bool enabled() const = 0;
 

--- a/gr-blocks/lib/selector_impl.h
+++ b/gr-blocks/lib/selector_impl.h
@@ -21,12 +21,11 @@ class selector_impl : public selector
 {
 private:
     const size_t d_itemsize;
-    bool d_enabled;
     unsigned int d_input_index, d_output_index;
     unsigned int d_num_inputs, d_num_outputs; // keep track of the topology
+    bool d_enabled;
 
     gr::thread::mutex d_mutex;
-
 
 public:
     selector_impl(size_t itemsize, unsigned int input_index, unsigned int output_index);
@@ -35,9 +34,9 @@ public:
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
     bool check_topology(int ninputs, int noutputs) override;
     void setup_rpc() override;
-    void handle_msg_input_index(pmt::pmt_t msg);
-    void handle_msg_output_index(pmt::pmt_t msg);
-    void handle_enable(pmt::pmt_t msg);
+    void handle_msg_input_index(const pmt::pmt_t& msg);
+    void handle_msg_output_index(const pmt::pmt_t& msg);
+    void handle_enable(const pmt::pmt_t& msg);
     void set_enabled(bool enable) override
     {
         gr::thread::scoped_lock l(d_mutex);

--- a/gr-blocks/python/blocks/bindings/selector_python.cc
+++ b/gr-blocks/python/blocks/bindings/selector_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(selector.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(1a1e76afdb837ef8d8bb28d6246efdb2)                     */
+/* BINDTOOL_HEADER_FILE_HASH(39ee2f6ddb352793d6c64b14678c16a5)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
- introduce new sync consumption mode that consumes the same from all
  inputs
- default to mode where as much as possible is consumed from active, and
  at most that from inactive inputs

Since the old mode of operation was buggy, it can't be available. Also,
a dump-as-quickly-as-possible mode will be very surprising.


<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

@Notou noticed that selector consumes `noutput_items` from all inputs – regardless of item availability.

`consume_each` does no sanity checks. Hilarity ensues.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Selector.

This might unbreak other applications that inexplicably only worked with throttles or similar crutches.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

I haven't been able to come up with good tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
