### PR TITLE
constellation encoder/decoder: Add constellation callback

### DIFF
--- a/gr-digital/grc/digital_constellation_decoder_cb.block.yml
+++ b/gr-digital/grc/digital_constellation_decoder_cb.block.yml
@@ -18,11 +18,15 @@ outputs:
 templates:
     imports: from gnuradio import digital
     make: digital.constellation_decoder_cb(${constellation})
+    callbacks:
+    - set_constellation(${constellation})
 
 cpp_templates:
     includes: ['#include <gnuradio/digital/constellation_decoder_cb.h>']
     declarations: 'digital::constellation_decoder_cb::sptr ${id};'
     make: 'this->${id} = digital::constellation_decoder_cb::make(${constellation});'
     link: ['gnuradio::gnuradio-digital']
+    callbacks:
+    - set_constellation(constellation)
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_encoder_bc.block.yml
+++ b/gr-digital/grc/digital_constellation_encoder_bc.block.yml
@@ -18,11 +18,15 @@ inputs:
 templates:
     imports: from gnuradio import digital
     make: digital.constellation_encoder_bc(${constellation})
+    callbacks:
+    - set_constellation(${constellation})
 
 cpp_templates:
     includes: ['#include <gnuradio/digital/constellation_encoder_bc.h>']
     declarations: 'digital::constellation_encoder_bc::sptr ${id};'
     make: 'this->${id} = digital::constellation_encoder_bc::make(${constellation});'
     link: ['gnuradio::gnuradio-digital']
+    callbacks:
+    - set_constellation(constellation)
 
 file_format: 1

--- a/gr-digital/grc/digital_constellation_soft_decoder_cf.block.yml
+++ b/gr-digital/grc/digital_constellation_soft_decoder_cf.block.yml
@@ -18,6 +18,8 @@ outputs:
 templates:
     imports: from gnuradio import digital
     make: digital.constellation_soft_decoder_cf(${constellation})
+    callbacks:
+    - set_constellation(${constellation})
 
 cpp_templates:
     includes: ['#include <gnuradio/digital/constellation_soft_decoder_cf.h>']
@@ -25,5 +27,7 @@ cpp_templates:
     make: |-
         this->${id} = digital::constellation_soft_decoder_cf::make(${constellation});
     link: ['gnuradio::gnuradio-digital']
+    callbacks:
+    - set_constellation(constellation)
 
 file_format: 1

--- a/gr-digital/include/gnuradio/digital/constellation_decoder_cb.h
+++ b/gr-digital/include/gnuradio/digital/constellation_decoder_cb.h
@@ -41,6 +41,15 @@ public:
      * this base class type.
      */
     static sptr make(constellation_sptr constellation);
+
+    /*!
+     * Set a new constellation object for decoding
+     *
+     * \param constellation A constellation derived from class
+     * 'constellation'. Use base() method to get a shared pointer to
+     * this base class type.
+     */
+    virtual void set_constellation(constellation_sptr constellation) = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/constellation_encoder_bc.h
+++ b/gr-digital/include/gnuradio/digital/constellation_encoder_bc.h
@@ -33,13 +33,22 @@ public:
     typedef std::shared_ptr<constellation_encoder_bc> sptr;
 
     /*!
-     * \brief Make constellation decoder block.
+     * \brief Make constellation encoder block.
      *
      * \param constellation A constellation derived from class
      * 'constellation'. Use base() method to get a shared pointer to
      * this base class type.
      */
     static sptr make(constellation_sptr constellation);
+    
+    /*!
+     * Set a new constellation object for encoding
+     *
+     * \param constellation A constellation derived from class
+     * 'constellation'. Use base() method to get a shared pointer to
+     * this base class type.
+     */
+    virtual void set_constellation(constellation_sptr constellation) = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/include/gnuradio/digital/constellation_soft_decoder_cf.h
+++ b/gr-digital/include/gnuradio/digital/constellation_soft_decoder_cf.h
@@ -25,7 +25,9 @@ namespace digital {
  * \details
  * Decode a constellation's points from a complex space to soft
  * bits based on the map and soft decision LUT of the \p
- * consetllation object.
+ * constellation object.
+ * 
+ * Does not support constellations of dimensionality higher than 1
  */
 class DIGITAL_API constellation_soft_decoder_cf : virtual public sync_interpolator
 {
@@ -41,6 +43,15 @@ public:
      * this base class type.
      */
     static sptr make(constellation_sptr constellation);
+
+    /*!
+     * Set a new constellation object for decoding
+     *
+     * \param constellation A constellation derived from class
+     * 'constellation'. Use base() method to get a shared pointer to
+     * this base class type.
+     */
+    virtual void set_constellation(constellation_sptr constellation) = 0;
 };
 
 } /* namespace digital */

--- a/gr-digital/lib/constellation_decoder_cb_impl.cc
+++ b/gr-digital/lib/constellation_decoder_cb_impl.cc
@@ -47,6 +47,16 @@ void constellation_decoder_cb_impl::forecast(int noutput_items,
         ninput_items_required[i] = input_required;
 }
 
+void constellation_decoder_cb_impl::set_constellation(
+    constellation_sptr new_constellation)
+{
+    gr::thread::scoped_lock l(d_mutex);
+
+    d_constellation = new_constellation;
+    d_dim = d_constellation->dimensionality();
+    set_relative_rate(1, (uint64_t)d_dim);
+}
+
 int constellation_decoder_cb_impl::general_work(int noutput_items,
                                                 gr_vector_int& ninput_items,
                                                 gr_vector_const_void_star& input_items,
@@ -54,6 +64,8 @@ int constellation_decoder_cb_impl::general_work(int noutput_items,
 {
     gr_complex const* in = (const gr_complex*)input_items[0];
     unsigned char* out = (unsigned char*)output_items[0];
+
+    gr::thread::scoped_lock l(d_mutex);
 
     for (int i = 0; i < noutput_items; i++) {
         out[i] = d_constellation->decision_maker(&(in[i * d_dim]));

--- a/gr-digital/lib/constellation_decoder_cb_impl.h
+++ b/gr-digital/lib/constellation_decoder_cb_impl.h
@@ -12,6 +12,7 @@
 #define INCLUDED_DIGITAL_CONSTELLATION_DECODER_CB_IMPL_H
 
 #include <gnuradio/digital/constellation_decoder_cb.h>
+#include <gnuradio/thread/thread.h>
 
 namespace gr {
 namespace digital {
@@ -20,11 +21,14 @@ class constellation_decoder_cb_impl : public constellation_decoder_cb
 {
 private:
     constellation_sptr d_constellation;
-    const unsigned int d_dim;
+    unsigned int d_dim;
+    gr::thread::mutex d_mutex;
 
 public:
     constellation_decoder_cb_impl(constellation_sptr constellation);
     ~constellation_decoder_cb_impl() override;
+
+    void set_constellation(constellation_sptr constellation);
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 

--- a/gr-digital/lib/constellation_encoder_bc_impl.cc
+++ b/gr-digital/lib/constellation_encoder_bc_impl.cc
@@ -36,12 +36,23 @@ constellation_encoder_bc_impl::constellation_encoder_bc_impl(
 
 constellation_encoder_bc_impl::~constellation_encoder_bc_impl() {}
 
+void constellation_encoder_bc_impl::set_constellation(
+    constellation_sptr new_constellation)
+{
+    gr::thread::scoped_lock l(d_mutex);
+
+    d_constellation = new_constellation;
+    set_interpolation((uint64_t)d_constellation->dimensionality());
+}
+
 int constellation_encoder_bc_impl::work(int noutput_items,
                                         gr_vector_const_void_star& input_items,
                                         gr_vector_void_star& output_items)
 {
     unsigned char const* in = (const unsigned char*)input_items[0];
     gr_complex* out = (gr_complex*)output_items[0];
+
+    gr::thread::scoped_lock l(d_mutex);
 
     int ninput_items = noutput_items / d_constellation->dimensionality();
 

--- a/gr-digital/lib/constellation_encoder_bc_impl.h
+++ b/gr-digital/lib/constellation_encoder_bc_impl.h
@@ -12,6 +12,7 @@
 #define INCLUDED_DIGITAL_CONSTELLATION_ENCODER_BC_IMPL_H
 
 #include <gnuradio/digital/constellation_encoder_bc.h>
+#include <gnuradio/thread/thread.h>
 
 namespace gr {
 namespace digital {
@@ -20,11 +21,14 @@ class constellation_encoder_bc_impl : public constellation_encoder_bc
 {
 private:
     constellation_sptr d_constellation;
+    gr::thread::mutex d_mutex;
 
 public:
     constellation_encoder_bc_impl(constellation_sptr constellation);
     ~constellation_encoder_bc_impl() override;
 
+    void set_constellation(constellation_sptr constellation);
+    
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;

--- a/gr-digital/lib/constellation_soft_decoder_cf_impl.cc
+++ b/gr-digital/lib/constellation_soft_decoder_cf_impl.cc
@@ -38,6 +38,19 @@ constellation_soft_decoder_cf_impl::constellation_soft_decoder_cf_impl(
 
 constellation_soft_decoder_cf_impl::~constellation_soft_decoder_cf_impl() {}
 
+
+void constellation_soft_decoder_cf_impl::set_constellation(
+    constellation_sptr new_constellation)
+{
+    gr::thread::scoped_lock l(d_mutex);
+
+    d_constellation = new_constellation;
+    d_dim = d_constellation->dimensionality();
+    d_bps = d_constellation->bits_per_symbol();
+    set_interpolation(d_bps);
+    // set_relative_rate((uint64_t)d_dim, (uint64_t)d_bps); // For when d_dim is properly managed
+}
+
 int constellation_soft_decoder_cf_impl::work(int noutput_items,
                                              gr_vector_const_void_star& input_items,
                                              gr_vector_void_star& output_items)
@@ -46,6 +59,8 @@ int constellation_soft_decoder_cf_impl::work(int noutput_items,
     float* out = (float*)output_items[0];
 
     std::vector<float> bits;
+
+    gr::thread::scoped_lock l(d_mutex);
 
     // FIXME: figure out how to manage d_dim
     for (int i = 0; i < noutput_items / d_bps; i++) {

--- a/gr-digital/lib/constellation_soft_decoder_cf_impl.h
+++ b/gr-digital/lib/constellation_soft_decoder_cf_impl.h
@@ -12,6 +12,7 @@
 #define INCLUDED_DIGITAL_CONSTELLATION_SOFT_DECODER_CF_IMPL_H
 
 #include <gnuradio/digital/constellation_soft_decoder_cf.h>
+#include <gnuradio/thread/thread.h>
 
 namespace gr {
 namespace digital {
@@ -22,10 +23,13 @@ private:
     constellation_sptr d_constellation;
     unsigned int d_dim;
     int d_bps;
+    gr::thread::mutex d_mutex;
 
 public:
     constellation_soft_decoder_cf_impl(constellation_sptr constellation);
     ~constellation_soft_decoder_cf_impl() override;
+    
+    void set_constellation(constellation_sptr constellation);
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/python/digital/bindings/constellation_decoder_cb_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_decoder_cb_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constellation_decoder_cb.h) */
-/* BINDTOOL_HEADER_FILE_HASH(688ec1fa379a5cdd51c2b31886991b28)                     */
+/* BINDTOOL_HEADER_FILE_HASH(9e5f2cd8e6d2d5cc0826224e32fe2ed3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,6 +43,11 @@ void bind_constellation_decoder_cb(py::module& m)
              py::arg("constellation"),
              D(constellation_decoder_cb, make))
 
+
+        .def("set_constellation",
+             &constellation_decoder_cb::set_constellation,
+             py::arg("constellation"),
+             D(constellation_decoder_cb, set_constellation))
 
         ;
 }

--- a/gr-digital/python/digital/bindings/constellation_encoder_bc_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_encoder_bc_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constellation_encoder_bc.h) */
-/* BINDTOOL_HEADER_FILE_HASH(b7a40d63f0e359222f614398dd1483a3)                     */
+/* BINDTOOL_HEADER_FILE_HASH(f1d529cf492ac8010172948639f2b367)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -32,6 +32,7 @@ void bind_constellation_encoder_bc(py::module& m)
 
     using constellation_encoder_bc = ::gr::digital::constellation_encoder_bc;
 
+
     py::class_<constellation_encoder_bc,
                gr::sync_interpolator,
                std::shared_ptr<constellation_encoder_bc>>(
@@ -39,5 +40,13 @@ void bind_constellation_encoder_bc(py::module& m)
 
         .def(py::init(&constellation_encoder_bc::make),
              py::arg("constellation"),
-             D(constellation_encoder_bc, make));
+             D(constellation_encoder_bc, make))
+
+
+        .def("set_constellation",
+             &constellation_encoder_bc::set_constellation,
+             py::arg("constellation"),
+             D(constellation_encoder_bc, set_constellation))
+
+        ;
 }

--- a/gr-digital/python/digital/bindings/constellation_soft_decoder_cf_python.cc
+++ b/gr-digital/python/digital/bindings/constellation_soft_decoder_cf_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(constellation_soft_decoder_cf.h) */
-/* BINDTOOL_HEADER_FILE_HASH(e04415a59c793a639f43e03026ee8c0e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(76cdf271631feb80deec6fc17d9c60fa)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -35,9 +35,6 @@ void bind_constellation_soft_decoder_cf(py::module& m)
 
     py::class_<constellation_soft_decoder_cf,
                gr::sync_interpolator,
-               gr::sync_block,
-               gr::block,
-               gr::basic_block,
                std::shared_ptr<constellation_soft_decoder_cf>>(
         m, "constellation_soft_decoder_cf", D(constellation_soft_decoder_cf))
 
@@ -45,6 +42,11 @@ void bind_constellation_soft_decoder_cf(py::module& m)
              py::arg("constellation"),
              D(constellation_soft_decoder_cf, make))
 
+
+        .def("set_constellation",
+             &constellation_soft_decoder_cf::set_constellation,
+             py::arg("constellation"),
+             D(constellation_soft_decoder_cf, set_constellation))
 
         ;
 }

--- a/gr-digital/python/digital/bindings/docstrings/constellation_decoder_cb_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/constellation_decoder_cb_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -23,3 +23,7 @@ static const char* __doc_gr_digital_constellation_decoder_cb_constellation_decod
 
 
 static const char* __doc_gr_digital_constellation_decoder_cb_make = R"doc()doc";
+
+
+static const char* __doc_gr_digital_constellation_decoder_cb_set_constellation =
+    R"doc()doc";

--- a/gr-digital/python/digital/bindings/docstrings/constellation_encoder_bc_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/constellation_encoder_bc_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -23,3 +23,7 @@ static const char* __doc_gr_digital_constellation_encoder_bc_constellation_encod
 
 
 static const char* __doc_gr_digital_constellation_encoder_bc_make = R"doc()doc";
+
+
+static const char* __doc_gr_digital_constellation_encoder_bc_set_constellation =
+    R"doc()doc";

--- a/gr-digital/python/digital/bindings/docstrings/constellation_soft_decoder_cf_pydoc_template.h
+++ b/gr-digital/python/digital/bindings/docstrings/constellation_soft_decoder_cf_pydoc_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -24,3 +24,7 @@ static const char*
 
 
 static const char* __doc_gr_digital_constellation_soft_decoder_cf_make = R"doc()doc";
+
+
+static const char* __doc_gr_digital_constellation_soft_decoder_cf_set_constellation =
+    R"doc()doc";

--- a/gr-digital/python/digital/qa_constellation_decoder_cb.py
+++ b/gr-digital/python/digital/qa_constellation_decoder_cb.py
@@ -59,5 +59,35 @@ class test_constellation_decoder(gr_unittest.TestCase):
         self.assertFloatTuplesAlmostEqual(expected_result, actual_result)
 
 
+    def test_constellation_decoder_cb_bpsk_to_qpsk(self):
+        cnst = digital.constellation_bpsk()
+        src_data = (0.5 + 0.5j, 0.1 - 1.2j, -0.8 - 0.1j, -0.45 + 0.8j,
+                    0.8 + 1.0j, -0.5 + 0.1j, 0.1 - 1.2j)
+        src = blocks.vector_source_c(src_data)
+        op = digital.constellation_decoder_cb(cnst.base())
+        dst = blocks.vector_sink_b()
+
+        self.tb.connect(src, op)
+        self.tb.connect(op, dst)
+        self.tb.run()               # run the graph and wait for it to finish
+
+        cnst = digital.constellation_qpsk()
+        src_data = (0.5 + 0.5j, 0.1 - 1.2j, -0.8 - 0.1j, -0.45 + 0.8j,
+                    0.8 + 1.0j, -0.5 + 0.1j, 0.1 - 1.2j)
+        expected_result = (1, 1, 0, 0, # BPSK section
+                           1, 0, 1,
+                           3, 1, 0, 2, # QPSK section
+                           3, 2, 1)
+        src.set_data(src_data)
+        op.set_constellation(cnst.base())
+
+        self.tb.run()               # run the graph and wait for it to finish
+
+        actual_result = dst.data()  # fetch the contents of the sink
+        # print("actual result", actual_result)
+        # print("expected result", expected_result)
+        self.assertFloatTuplesAlmostEqual(expected_result, actual_result)
+
+
 if __name__ == '__main__':
     gr_unittest.run(test_constellation_decoder)


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Adds setter and GRC callback in the `constellation_encoder_bc`, `constellation_decoder_cb`, and `constellation_soft_decoder_cf` blocks to change the constellation object at runtime.

That way, one can change the operating constellation of a transmission without having to make copies of these blocks and relying on a selector to chose one.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->


## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
The qa tests pass, and I've added one (that pass) where a change of constellation is tried.
I've tested with a grc flowgraph to check that the encoder gives out a consistent result w.r.t. the chunks to symbols block.
And that an encoding/decoding chain allows to recover the original bit stream when the constellation is changed at runtime.

There is of course a transient period but that disappears once old samples are flushed, and the flow stays in sync.

I've not tested with constellations of dimensionality higher than one. It didn't find how to make one in GRC.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
