### PR TITLE
Analog: max_gain parameter added to AGC constructors

### DIFF
--- a/gr-analog/grc/analog_agc2_xx.block.yml
+++ b/gr-analog/grc/analog_agc2_xx.block.yml
@@ -42,8 +42,7 @@ outputs:
 templates:
     imports: from gnuradio import analog
     make: |-
-        analog.agc2_${type.fcn}(${attack_rate}, ${decay_rate}, ${reference}, ${gain})
-        self.${id}.set_max_gain(${max_gain})
+        analog.agc2_${type.fcn}(${attack_rate}, ${decay_rate}, ${reference}, ${gain}, ${max_gain})
     callbacks:
     - set_attack_rate(${attack_rate})
     - set_decay_rate(${decay_rate})
@@ -55,8 +54,7 @@ cpp_templates:
     includes: ['#include <gnuradio/analog/agc2_${type.fcn}.h>']
     declarations: 'analog::agc2_${type.fcn}::sptr ${id};'
     make: |-
-        this->${id} = analog::agc2_${type.fcn}::make(${attack_rate}, ${decay_rate}, ${reference}, ${gain});
-        this->${id}->set_max_gain(${max_gain});
+        this->${id} = analog::agc2_${type.fcn}::make(${attack_rate}, ${decay_rate}, ${reference}, ${gain}, ${max_gain});
     callbacks:
     - set_attack_rate(${attack_rate})
     - set_decay_rate(${decay_rate})

--- a/gr-analog/grc/analog_agc3_xx.block.yml
+++ b/gr-analog/grc/analog_agc3_xx.block.yml
@@ -46,8 +46,7 @@ outputs:
 templates:
     imports: from gnuradio import analog
     make: |-
-        analog.agc3_${type.fcn}(${attack_rate}, ${decay_rate}, ${reference}, ${gain}, ${iir_update_decim})
-        self.${id}.set_max_gain(${max_gain})
+        analog.agc3_${type.fcn}(${attack_rate}, ${decay_rate}, ${reference}, ${gain}, ${iir_update_decim}, ${max_gain})
     callbacks:
     - set_attack_rate(${attack_rate})
     - set_decay_rate(${decay_rate})
@@ -59,8 +58,7 @@ cpp_templates:
     includes: ['#include <gnuradio/analog/agc3_${type.fcn}.h>']
     declarations: 'analog::agc3_${type.fcn}::sptr ${id};'
     make: |-
-        this->${id} = analog::agc3_${type.fcn}::make(${attack_rate}, ${decay_rate}, ${reference}, ${gain}, ${iir_update_decim});
-        this->${id}->set_max_gain(${max_gain});
+        this->${id} = analog::agc3_${type.fcn}::make(${attack_rate}, ${decay_rate}, ${reference}, ${gain}, ${iir_update_decim}, ${max_gain});
     callbacks:
     - set_attack_rate(${attack_rate})
     - set_decay_rate(${decay_rate})

--- a/gr-analog/grc/analog_agc_xx.block.yml
+++ b/gr-analog/grc/analog_agc_xx.block.yml
@@ -38,8 +38,7 @@ outputs:
 templates:
     imports: from gnuradio import analog
     make: |-
-        analog.agc_${type.fcn}(${rate}, ${reference}, ${gain})
-        self.${id}.set_max_gain(${max_gain})
+        analog.agc_${type.fcn}(${rate}, ${reference}, ${gain}, ${max_gain})
     callbacks:
     - set_rate(${rate})
     - set_reference(${reference})
@@ -50,8 +49,7 @@ cpp_templates:
     includes: ['#include <gnuradio/analog/agc_${type.fcn}.h>']
     declarations: 'analog::agc_${type.fcn}::sptr ${id};'
     make: |-
-        this->${id} = analog::agc_${type.fcn}::make(${rate}, ${reference}, ${gain});
-        this->${id}->set_max_gain(${max_gain});
+        this->${id} = analog::agc_${type.fcn}::make(${rate}, ${reference}, ${gain}, ${max_gain});
     callbacks:
     - set_rate(${rate})
     - set_reference(${reference})

--- a/gr-analog/include/gnuradio/analog/agc2_cc.h
+++ b/gr-analog/include/gnuradio/analog/agc2_cc.h
@@ -39,11 +39,13 @@ public:
      * \param decay_rate the update rate of the loop when in decay mode.
      * \param reference reference value to adjust signal power to.
      * \param gain initial gain value.
+     * \param max_gain maximum gain value (0 for unlimited).
      */
     static sptr make(float attack_rate = 1e-1,
                      float decay_rate = 1e-2,
                      float reference = 1.0,
-                     float gain = 1.0);
+                     float gain = 1.0,
+                     float max_gain = 0.0);
 
     virtual float attack_rate() const = 0;
     virtual float decay_rate() const = 0;

--- a/gr-analog/include/gnuradio/analog/agc2_ff.h
+++ b/gr-analog/include/gnuradio/analog/agc2_ff.h
@@ -39,11 +39,13 @@ public:
      * \param decay_rate the update rate of the loop when in decay mode.
      * \param reference reference value to adjust signal power to.
      * \param gain initial gain value.
+     * \param max_gain maximum gain value (0 for unlimited).
      */
     static sptr make(float attack_rate = 1e-1,
                      float decay_rate = 1e-2,
                      float reference = 1.0,
-                     float gain = 1.0);
+                     float gain = 1.0,
+                     float max_gain = 0.0);
 
     virtual float attack_rate() const = 0;
     virtual float decay_rate() const = 0;

--- a/gr-analog/include/gnuradio/analog/agc3_cc.h
+++ b/gr-analog/include/gnuradio/analog/agc3_cc.h
@@ -44,12 +44,14 @@ public:
      * \param gain initial gain value.
      * \param iir_update_decim stride by this number of samples before
      *                         computing an IIR gain update
+     * \param max_gain maximum gain value (0 for unlimited).
      */
     static sptr make(float attack_rate = 1e-1,
                      float decay_rate = 1e-2,
                      float reference = 1.0,
                      float gain = 1.0,
-                     int iir_update_decim = 1);
+                     int iir_update_decim = 1,
+                     float max_gain = 0.0);
 
     virtual float attack_rate() const = 0;
     virtual float decay_rate() const = 0;

--- a/gr-analog/include/gnuradio/analog/agc_cc.h
+++ b/gr-analog/include/gnuradio/analog/agc_cc.h
@@ -37,8 +37,12 @@ public:
      * \param rate the update rate of the loop.
      * \param reference reference value to adjust signal power to.
      * \param gain initial gain value.
+     * \param max_gain maximum gain value (0 for unlimited).
      */
-    static sptr make(float rate = 1e-4, float reference = 1.0, float gain = 1.0);
+    static sptr make(float rate = 1e-4,
+                     float reference = 1.0,
+                     float gain = 1.0,
+                     float max_gain = 0.0);
 
     virtual float rate() const = 0;
     virtual float reference() const = 0;

--- a/gr-analog/include/gnuradio/analog/agc_ff.h
+++ b/gr-analog/include/gnuradio/analog/agc_ff.h
@@ -37,8 +37,12 @@ public:
      * \param rate the update rate of the loop.
      * \param reference reference value to adjust signal power to.
      * \param gain initial gain value.
+     * \param max_gain maximum gain value (0 for unlimited).
      */
-    static sptr make(float rate = 1e-4, float reference = 1.0, float gain = 1.0);
+    static sptr make(float rate = 1e-4,
+                     float reference = 1.0,
+                     float gain = 1.0,
+                     float max_gain = 0.0);
 
     virtual float rate() const = 0;
     virtual float reference() const = 0;

--- a/gr-analog/lib/agc2_cc_impl.cc
+++ b/gr-analog/lib/agc2_cc_impl.cc
@@ -19,21 +19,19 @@
 namespace gr {
 namespace analog {
 
-agc2_cc::sptr
-agc2_cc::make(float attack_rate, float decay_rate, float reference, float gain)
+agc2_cc::sptr agc2_cc::make(
+    float attack_rate, float decay_rate, float reference, float gain, float max_gain)
 {
     return gnuradio::make_block_sptr<agc2_cc_impl>(
-        attack_rate, decay_rate, reference, gain);
+        attack_rate, decay_rate, reference, gain, max_gain);
 }
 
-agc2_cc_impl::agc2_cc_impl(float attack_rate,
-                           float decay_rate,
-                           float reference,
-                           float gain)
+agc2_cc_impl::agc2_cc_impl(
+    float attack_rate, float decay_rate, float reference, float gain, float max_gain)
     : sync_block("agc2_cc",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      kernel::agc2_cc(attack_rate, decay_rate, reference, gain, 65536)
+      kernel::agc2_cc(attack_rate, decay_rate, reference, gain, max_gain)
 {
     const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
     set_alignment(std::max(1, alignment_multiple));

--- a/gr-analog/lib/agc2_cc_impl.h
+++ b/gr-analog/lib/agc2_cc_impl.h
@@ -22,7 +22,8 @@ public:
     agc2_cc_impl(float attack_rate = 1e-1,
                  float decay_rate = 1e-2,
                  float reference = 1.0,
-                 float gain = 1.0);
+                 float gain = 1.0,
+                 float max_gain = 0.0);
     ~agc2_cc_impl() override;
 
     float attack_rate() const override { return kernel::agc2_cc::attack_rate(); }

--- a/gr-analog/lib/agc2_ff_impl.cc
+++ b/gr-analog/lib/agc2_ff_impl.cc
@@ -18,23 +18,21 @@
 namespace gr {
 namespace analog {
 
-agc2_ff::sptr
-agc2_ff::make(float attack_rate, float decay_rate, float reference, float gain)
+agc2_ff::sptr agc2_ff::make(
+    float attack_rate, float decay_rate, float reference, float gain, float max_gain)
 {
     return gnuradio::make_block_sptr<agc2_ff_impl>(
-        attack_rate, decay_rate, reference, gain);
+        attack_rate, decay_rate, reference, gain, max_gain);
 }
 
 agc2_ff_impl::~agc2_ff_impl() {}
 
-agc2_ff_impl::agc2_ff_impl(float attack_rate,
-                           float decay_rate,
-                           float reference,
-                           float gain)
+agc2_ff_impl::agc2_ff_impl(
+    float attack_rate, float decay_rate, float reference, float gain, float max_gain)
     : sync_block("agc2_ff",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(float))),
-      kernel::agc2_ff(attack_rate, decay_rate, reference, gain, 65536)
+      kernel::agc2_ff(attack_rate, decay_rate, reference, gain, max_gain)
 {
 }
 

--- a/gr-analog/lib/agc2_ff_impl.h
+++ b/gr-analog/lib/agc2_ff_impl.h
@@ -22,7 +22,8 @@ public:
     agc2_ff_impl(float attack_rate = 1e-1,
                  float decay_rate = 1e-2,
                  float reference = 1.0,
-                 float gain = 1.0);
+                 float gain = 1.0,
+                 float max_gain = 0.0);
     ~agc2_ff_impl() override;
 
     float attack_rate() const override { return kernel::agc2_ff::attack_rate(); }

--- a/gr-analog/lib/agc3_cc_impl.cc
+++ b/gr-analog/lib/agc3_cc_impl.cc
@@ -26,7 +26,8 @@ agc3_cc::sptr agc3_cc::make(float attack_rate,
                             float decay_rate,
                             float reference,
                             float gain,
-                            int iir_update_decim)
+                            int iir_update_decim,
+                            float max_gain)
 {
     return gnuradio::make_block_sptr<agc3_cc_impl>(
         attack_rate, decay_rate, reference, gain, iir_update_decim);
@@ -36,7 +37,8 @@ agc3_cc_impl::agc3_cc_impl(float attack_rate,
                            float decay_rate,
                            float reference,
                            float gain,
-                           int iir_update_decim)
+                           int iir_update_decim,
+                           float max_gain)
     : sync_block("agc3_cc",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
@@ -46,7 +48,7 @@ agc3_cc_impl::agc3_cc_impl(float attack_rate,
     set_attack_rate(attack_rate);
     set_decay_rate(decay_rate);
     set_gain(gain);
-    set_max_gain(65536);
+    set_max_gain(max_gain);
     test_and_log_value_domain(iir_update_decim, "input power sampling stride");
     d_iir_update_decim = iir_update_decim;
     set_output_multiple(iir_update_decim * 4);

--- a/gr-analog/lib/agc3_cc_impl.h
+++ b/gr-analog/lib/agc3_cc_impl.h
@@ -23,7 +23,8 @@ public:
                  float decay_rate = 1e-2,
                  float reference = 1.0,
                  float gain = 1.0,
-                 int iir_update_decim = 1);
+                 int iir_update_decim = 1,
+                 float max_gain = 0.0);
     ~agc3_cc_impl() override;
 
     float attack_rate() const override;

--- a/gr-analog/lib/agc_cc_impl.cc
+++ b/gr-analog/lib/agc_cc_impl.cc
@@ -19,16 +19,16 @@
 namespace gr {
 namespace analog {
 
-agc_cc::sptr agc_cc::make(float rate, float reference, float gain)
+agc_cc::sptr agc_cc::make(float rate, float reference, float gain, float max_gain)
 {
-    return gnuradio::make_block_sptr<agc_cc_impl>(rate, reference, gain);
+    return gnuradio::make_block_sptr<agc_cc_impl>(rate, reference, gain, max_gain);
 }
 
-agc_cc_impl::agc_cc_impl(float rate, float reference, float gain)
+agc_cc_impl::agc_cc_impl(float rate, float reference, float gain, float max_gain)
     : sync_block("agc_cc",
                  io_signature::make(1, 1, sizeof(gr_complex)),
                  io_signature::make(1, 1, sizeof(gr_complex))),
-      kernel::agc_cc(rate, reference, gain, 65536)
+      kernel::agc_cc(rate, reference, gain, max_gain)
 {
     const int alignment_multiple = volk_get_alignment() / sizeof(gr_complex);
     set_alignment(std::max(1, alignment_multiple));

--- a/gr-analog/lib/agc_cc_impl.h
+++ b/gr-analog/lib/agc_cc_impl.h
@@ -19,7 +19,10 @@ namespace analog {
 class agc_cc_impl : public agc_cc, kernel::agc_cc
 {
 public:
-    agc_cc_impl(float rate = 1e-4, float reference = 1.0, float gain = 1.0);
+    agc_cc_impl(float rate = 1e-4,
+                float reference = 1.0,
+                float gain = 1.0,
+                float max_gain = 0.0);
     ~agc_cc_impl() override;
 
     float rate() const override { return kernel::agc_cc::rate(); }

--- a/gr-analog/lib/agc_ff_impl.cc
+++ b/gr-analog/lib/agc_ff_impl.cc
@@ -18,16 +18,16 @@
 namespace gr {
 namespace analog {
 
-agc_ff::sptr agc_ff::make(float rate, float reference, float gain)
+agc_ff::sptr agc_ff::make(float rate, float reference, float gain, float max_gain)
 {
-    return gnuradio::make_block_sptr<agc_ff_impl>(rate, reference, gain);
+    return gnuradio::make_block_sptr<agc_ff_impl>(rate, reference, gain, max_gain);
 }
 
-agc_ff_impl::agc_ff_impl(float rate, float reference, float gain)
+agc_ff_impl::agc_ff_impl(float rate, float reference, float gain, float max_gain)
     : sync_block("agc_ff",
                  io_signature::make(1, 1, sizeof(float)),
                  io_signature::make(1, 1, sizeof(float))),
-      kernel::agc_ff(rate, reference, gain, 65536)
+      kernel::agc_ff(rate, reference, gain, max_gain)
 {
 }
 

--- a/gr-analog/lib/agc_ff_impl.h
+++ b/gr-analog/lib/agc_ff_impl.h
@@ -19,7 +19,10 @@ namespace analog {
 class agc_ff_impl : public agc_ff, kernel::agc_ff
 {
 public:
-    agc_ff_impl(float rate = 1e-4, float reference = 1.0, float gain = 1.0);
+    agc_ff_impl(float rate = 1e-4,
+                float reference = 1.0,
+                float gain = 1.0,
+                float max_gain = 0.0);
     ~agc_ff_impl() override;
 
     float rate() const override { return kernel::agc_ff::rate(); }

--- a/gr-analog/python/analog/bindings/agc2_cc_python.cc
+++ b/gr-analog/python/analog/bindings/agc2_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(agc2_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(2b5f9a8e9b8b290d5d48493dbfb651cd)                     */
+/* BINDTOOL_HEADER_FILE_HASH(884743560bcaeddd51319b06f3a0674b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -44,6 +44,7 @@ void bind_agc2_cc(py::module& m)
              py::arg("decay_rate") = 0.01,
              py::arg("reference") = 1.,
              py::arg("gain") = 1.,
+             py::arg("max_gain") = 0.,
              D(agc2_cc, make))
 
 

--- a/gr-analog/python/analog/bindings/agc2_ff_python.cc
+++ b/gr-analog/python/analog/bindings/agc2_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(agc2_ff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(9109f8c396a1a49bea1306f6edd36ea7)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5e1d2da6d6800f26f91c43aa7829628e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -44,6 +44,7 @@ void bind_agc2_ff(py::module& m)
              py::arg("decay_rate") = 0.01,
              py::arg("reference") = 1.,
              py::arg("gain") = 1.,
+             py::arg("max_gain") = 0.,
              D(agc2_ff, make))
 
 

--- a/gr-analog/python/analog/bindings/agc3_cc_python.cc
+++ b/gr-analog/python/analog/bindings/agc3_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(agc3_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(a3249a33ccef3b89642aa41df853772e)                     */
+/* BINDTOOL_HEADER_FILE_HASH(12cadbccb30acab3c1f27d0f05454c2b)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -45,6 +45,7 @@ void bind_agc3_cc(py::module& m)
              py::arg("reference") = 1.,
              py::arg("gain") = 1.,
              py::arg("iir_update_decim") = 1,
+             py::arg("max_gain") = 0.,
              D(agc3_cc, make))
 
 

--- a/gr-analog/python/analog/bindings/agc_cc_python.cc
+++ b/gr-analog/python/analog/bindings/agc_cc_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(agc_cc.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(5c6f25a10209aa7d146e36b5aef27010)                     */
+/* BINDTOOL_HEADER_FILE_HASH(75e609d34c4d8fb4bb17373ed70befc3)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,6 +43,7 @@ void bind_agc_cc(py::module& m)
              py::arg("rate") = 1.0E-4,
              py::arg("reference") = 1.,
              py::arg("gain") = 1.,
+             py::arg("max_gain") = 0.,
              D(agc_cc, make))
 
 

--- a/gr-analog/python/analog/bindings/agc_ff_python.cc
+++ b/gr-analog/python/analog/bindings/agc_ff_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(agc_ff.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e6b71daceff3aa1c28b2efab1e459066)                     */
+/* BINDTOOL_HEADER_FILE_HASH(a49484d20f81c4123534cb2131c8afd8)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,6 +43,7 @@ void bind_agc_ff(py::module& m)
              py::arg("rate") = 1.0E-4,
              py::arg("reference") = 1.,
              py::arg("gain") = 1.,
+             py::arg("max_gain") = 0.,
              D(agc_ff, make))
 
 


### PR DESCRIPTION

## Description
Max_gain parameter has been added to AGC constructors & make functions.

## Related Issue
[#6613](https://github.com/gnuradio/gnuradio/issues/6613)

## Which blocks/areas does this affect?
Analog AGC, AGC2 & AGC3 blocks.

## Testing Done
I have manually tested the modified blocks without getting any warning or error, also checking that max_gain value is assigned properly.

## Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
