### PR TITLE
filter: Update QMessageBox to work in Qt5

### DIFF
--- a/gr-filter/python/filter/design/fir_design.py
+++ b/gr-filter/python/filter/design/fir_design.py
@@ -8,7 +8,7 @@
 
 import scipy
 from gnuradio import filter, fft
-from PyQt5 import QtGui
+from PyQt5 import QtGui, QtWidgets
 
 
 # Filter design functions using a window
@@ -28,8 +28,8 @@ def design_win_lpf(fs, gain, wintype, mainwin):
             taps = filter.firdes.low_pass_2(gain, fs, pb, tb,
                                             atten, wintype)
         except (RuntimeError, IndexError) as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], ret)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
@@ -56,8 +56,8 @@ def design_win_bpf(fs, gain, wintype, mainwin):
             taps = filter.firdes.band_pass_2(gain, fs, pb1, pb2, tb,
                                              atten, wintype)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], ret)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
@@ -84,8 +84,8 @@ def design_win_cbpf(fs, gain, wintype, mainwin):
             taps = filter.firdes.complex_band_pass_2(gain, fs, pb1, pb2, tb,
                                                      atten, wintype)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], ret)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
@@ -112,8 +112,8 @@ def design_win_bnf(fs, gain, wintype, mainwin):
             taps = filter.firdes.band_reject_2(gain, fs, pb1, pb2, tb,
                                                atten, wintype)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], ret)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
@@ -139,8 +139,8 @@ def design_win_hpf(fs, gain, wintype, mainwin):
             taps = filter.firdes.high_pass_2(gain, fs, pb, tb,
                                              atten, wintype)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
                       "filttype": "hpf", "sbend": sb, "pbstart": pb,
@@ -164,8 +164,8 @@ def design_win_hb(fs, gain, wintype, mainwin):
                fft.window.WIN_BLACKMAN_hARRIS: 'blackmanharris'}
 
     if int(filtord) & 1:
-        reply = QtGui.QMessageBox.information(mainwin, "Filter order should be even",
-                                              "Filter order should be even", QtGui.QMessageBox.Ok)
+        reply = QtWidgets.QMessageBox.information(mainwin, "Filter order should be even",
+                                                  "Filter order should be even", QtWidgets.QMessageBox.Ok)
         return ([], [], False)
 
     if(ret):
@@ -193,8 +193,8 @@ def design_win_rrc(fs, gain, wintype, mainwin):
             taps = filter.firdes.root_raised_cosine(gain, fs, sr,
                                                     alpha, ntaps)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
                       "filttype": "rrc", "srate": sr, "alpha": alpha,
@@ -219,8 +219,8 @@ def design_win_gaus(fs, gain, wintype, mainwin):
             taps = filter.firdes.gaussian(gain, spb, bt, ntaps)
 
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Runtime Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Runtime Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
         else:
             params = {"fs": fs, "gain": gain, "wintype": wintype,
                       "filttype": "gaus", "srate": sr, "bt": bt,
@@ -247,8 +247,8 @@ def design_opt_lpf(fs, gain, mainwin):
             taps = filter.optfir.low_pass(gain, fs, pb, sb,
                                           ripple, atten)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Filter did not converge",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], False)
         else:
             params = {"fs": fs, "gain": gain, "wintype": mainwin.EQUIRIPPLE_FILT,
@@ -279,8 +279,8 @@ def design_opt_bpf(fs, gain, mainwin):
             taps = filter.optfir.band_pass(gain, fs, sb1, pb1, pb2, sb2,
                                            ripple, atten)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Filter did not converge",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], False)
 
         else:
@@ -313,8 +313,8 @@ def design_opt_cbpf(fs, gain, mainwin):
             taps = filter.optfir.complex_band_pass(gain, fs, sb1, pb1, pb2, sb2,
                                                    ripple, atten)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Filter did not converge",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], False)
         else:
             params = {"fs": fs, "gain": gain, "wintype": mainwin.EQUIRIPPLE_FILT,
@@ -346,8 +346,8 @@ def design_opt_bnf(fs, gain, mainwin):
             taps = filter.optfir.band_reject(gain, fs, pb1, sb1, sb2, pb2,
                                              ripple, atten)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Filter did not converge",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], False)
         else:
             params = {"fs": fs, "gain": gain, "wintype": mainwin.EQUIRIPPLE_FILT,
@@ -366,8 +366,8 @@ def design_opt_hb(fs, gain, mainwin):
     trwidth, r = getfloat(mainwin.gui.firhbtrEdit.text())
     ret = r and ret
     if int(filtord) & 1:
-        reply = QtGui.QMessageBox.information(mainwin, "Filter order should be even",
-                                              "Filter order should be even", QtGui.QMessageBox.Ok)
+        reply = QtWidgets.QMessageBox.information(mainwin, "Filter order should be even",
+                                                  "Filter order should be even", QtWidgets.QMessageBox.Ok)
         return ([], [], False)
 
     if(ret):
@@ -376,8 +376,8 @@ def design_opt_hb(fs, gain, mainwin):
             taps = scipy.signal.remez(int(filtord) + 1, bands, [1, 0], [1, 1])
             taps[abs(taps) <= 1e-6] = 0.
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Filter Design Error",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Filter Design Error",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], False)
         else:
             params = {"fs": fs, "gain": gain, "wintype": mainwin.EQUIRIPPLE_FILT,
@@ -403,8 +403,8 @@ def design_opt_hpf(fs, gain, mainwin):
             taps = filter.optfir.high_pass(gain, fs, sb, pb,
                                            atten, ripple)
         except RuntimeError as e:
-            reply = QtGui.QMessageBox.information(mainwin, "Filter did not converge",
-                                                  e.args[0], QtGui.QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
             return ([], [], False)
         else:
             params = {"fs": fs, "gain": gain, "wintype": mainwin.EQUIRIPPLE_FILT,


### PR DESCRIPTION
## Description
In `gr_filter_design`, the following unhandled exception occurs when filter generation fails:
```
Traceback (most recent call last):
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/fir_design.py", line 247, in design_opt_lpf
    taps = filter.optfir.low_pass(gain, fs, pb, sb,
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/optfir.py", line 46, in low_pass
    taps = filter.pm_remez(n + nextra_taps, fo, ao, w, "bandpass")
RuntimeError: insufficient extremals -- cannot continue

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/filter_design.py", line 832, in design
    self.design_fir(ftype, fs, gain, winstr)
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/filter_design.py", line 855, in design_fir
    taps, params, r = designer[ftype](fs, gain, self)
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/fir_design.py", line 250, in design_opt_lpf
    reply = QtGui.QMessageBox.information(mainwin, "Filter did not converge",
AttributeError: module 'PyQt5.QtGui' has no attribute 'QMessageBox'
```
To trigger this:
1. Run `gr_filter_design`.
2. Change the window type to "Equiripple".
3. Change "Filter Gain" to 1.
4. Click "Design".

The exception happens because various `QMessageBox` invocations have not been updated for Qt5, where the class moved from `QtGui` to `QtWidgets`.

## Which blocks/areas does this affect?
* Filter Design Tool (`gr_filter_design`)

## Testing Done
I verified that errors while generating Equiripple filters are presented to the user in a message box:

![Screenshot from 2023-04-09 13-12-33](https://user-images.githubusercontent.com/583749/230786639-436111ac-eaaf-4105-bd54-f0c294afe9d3.png)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
