### PR TITLE
hier_block2: fix recursive setters

### DIFF
--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -142,6 +142,8 @@ std::vector<int> hier_block2::processor_affinity()
 
 void hier_block2::set_log_level(const std::string& level)
 {
+    d_logger->set_level(level);
+    d_debug_logger->set_level(level);
     d_detail->set_log_level(level);
 }
 

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -16,6 +16,8 @@
 #include <gnuradio/logger.h>
 #include <flat_flowgraph.h>
 
+#include <set>
+
 namespace gr {
 
 /*!
@@ -82,6 +84,9 @@ private:
     void set_parent(hier_block2* parent);
     void reset_parent(bool force = false);
     void reset_hier_blocks_parent();
+
+    //! Traverse the internal flow graph to give a list of all blocks, hier and regular
+    std::set<basic_block_sptr> all_blocks();
 };
 
 } /* namespace gr */

--- a/gnuradio-runtime/python/gnuradio/gr/qa_hier_block2.py
+++ b/gnuradio-runtime/python/gnuradio/gr/qa_hier_block2.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2014 Free Software Foundation, Inc.
-# Copyright 2021 Marcus Müller
+# Copyright 2021-2023 Marcus Müller
+# Copyright 2023 Daniel Estévez
 #
 # This file is part of GNU Radio
 #
@@ -142,6 +143,37 @@ class test_hier_block2(gr_unittest.TestCase):
         time.sleep(0.5)
         tb.stop()
         tb.wait()
+
+    def test_013_recursive_setting(self):
+        """
+        Build a message-recursive hier block
+        Check whether setting processor affinity crashes the flow graph
+        """
+        class msg_source_block(gr.sync_block):
+            def __init__(self):
+                gr.sync_block.__init__(self, "msg_src", in_sig=[], out_sig=[])
+                self.message_port_register_out(pmt.intern("output"))
+
+            def work(self, _, __):
+                pass
+
+        class recursive_hier_block(gr.hier_block2):
+            def __init__(self):
+                gr.hier_block2.__init__(self, "recursive_hier_block",
+                                        gr.io_signature(0, 0, 0),
+                                        gr.io_signature(0, 0, 0))
+                self.message_port_register_hier_out('pdus')
+                self.src = msg_source_block()
+                self.msg_connect((self.src, 'output'), (self, 'pdus'))
+
+        class test_fg(gr.top_block):
+            def __init__(self):
+                gr.top_block.__init__(self, "test_fg", catch_exceptions=True)
+                self.recursive_hier = recursive_hier_block()
+                self.recursive_hier.set_processor_affinity([0])
+
+        tb = test_fg()
+        tb.start()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On the way, fix the fact that setting the logger level on a hier block never set the logger level of the block itself, only its contained blocks.


<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Setting things on hier blocks is hard, because the setting needs to be done recursively, and the cycle-allowing message port hierarchy offers a wide variety of pitfalls when it comes to enumerating blocks.

To solve that, actually *don't* do the first-semester thing of setting things
recursively; have a queue of blocks containing further blocks, and a set of
blocks you've already encountered. When there's no more blocks on queue, work
through that set.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes #6558

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

`hier_block2`. It should be noted that `flowgraph::calc_used_blocks` is questionable in efficiency, but that's an aside.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Minimized and added Daniel's test from #6558, and verified it fails without, and passes with this change :confetti:.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
