### PR TITLE
filter: fir_design needs to check band edge specifications

### DIFF
--- a/gr-filter/python/filter/optfir.py
+++ b/gr-filter/python/filter/optfir.py
@@ -37,11 +37,16 @@ def low_pass(gain, Fs, freq1, freq2, passband_ripple_db, stopband_atten_db,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+    if(freq2 <= freq1):
+        raise ValueError("low pass filter must have pass band below stop band")
+
     passband_dev = passband_ripple_to_dev(passband_ripple_db)
     stopband_dev = stopband_atten_to_dev(stopband_atten_db)
     desired_ampls = (gain, 0)
     (n, fo, ao, w) = remezord([freq1, freq2], desired_ampls,
                               [passband_dev, stopband_dev], Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
     # The remezord typically under-estimates the filter order, so add 2 taps by default
     taps = filter.pm_remez(n + nextra_taps, fo, ao, w, "bandpass")
     return taps
@@ -64,6 +69,13 @@ def band_pass(gain, Fs, freq_sb1, freq_pb1, freq_pb2, freq_sb2,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+    if(freq_sb1 >= freq_pb1):
+        raise ValueError("band pass filter must have first stop band below pass band")
+    if(freq_pb1 >= freq_pb2):
+        raise ValueError("pass band corner frequencies must be ascending")
+    if(freq_pb2 >= freq_sb2):
+        raise ValueError("band pass filter must have pass band below second stop band")
+
     passband_dev = passband_ripple_to_dev(passband_ripple_db)
     stopband_dev = stopband_atten_to_dev(stopband_atten_db)
     desired_ampls = (0, gain, 0)
@@ -71,6 +83,9 @@ def band_pass(gain, Fs, freq_sb1, freq_pb1, freq_pb2, freq_sb2,
     desired_ripple = [stopband_dev, passband_dev, stopband_dev]
     (n, fo, ao, w) = remezord(desired_freqs, desired_ampls,
                               desired_ripple, Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
+
     # The remezord typically under-estimates the filter order, so add 2 taps by default
     taps = filter.pm_remez(n + nextra_taps, fo, ao, w, "bandpass")
     return taps
@@ -94,6 +109,14 @@ def complex_band_pass(gain, Fs, freq_sb1, freq_pb1, freq_pb2, freq_sb2,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+
+    if(freq_sb1 >= freq_pb1):
+        raise ValueError("band pass filter must have first stop band below pass band")
+    if(freq_pb1 >= freq_pb2):
+        raise ValueError("pass band corner frequencies must be ascending")
+    if(freq_pb2 >= freq_sb2):
+        raise ValueError("band pass filter must have pass band below second stop band")
+
     center_freq = (freq_pb2 + freq_pb1) / 2.0
     lp_pb = (freq_pb2 - center_freq) / 1.0
     lp_sb = freq_sb2 - center_freq
@@ -123,6 +146,13 @@ def complex_band_reject(gain, Fs, freq_pb1, freq_sb1, freq_sb2, freq_pb2,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+    if(freq_sb1 >= freq_pb1):
+        raise ValueError("band pass must have first stop band below pass band")
+    if(freq_pb1 >= freq_pb2):
+        raise ValueError("band pass corner frequencies must be ascending")
+    if(freq_pb2 >= freq_sb2):
+        raise ValueError("band pass must have pass band below second stop band")
+
     center_freq = (freq_sb2 + freq_sb1) / 2.0
     hp_pb = (freq_pb2 - center_freq) / 1.0
     hp_sb = freq_sb2 - center_freq
@@ -159,6 +189,8 @@ def band_reject(gain, Fs, freq_pb1, freq_sb1, freq_sb2, freq_pb2,
     desired_ripple = [passband_dev, stopband_dev, passband_dev]
     (n, fo, ao, w) = remezord(desired_freqs, desired_ampls,
                               desired_ripple, Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
     # Make sure we use an odd number of taps
     if((n + nextra_taps) % 2 == 1):
         n += 1
@@ -186,6 +218,8 @@ def high_pass(gain, Fs, freq1, freq2, passband_ripple_db, stopband_atten_db,
     desired_ampls = (0, 1)
     (n, fo, ao, w) = remezord([freq1, freq2], desired_ampls,
                               [stopband_dev, passband_dev], Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
     # For a HPF, we need to use an odd number of taps
     # In filter.remez, ntaps = n+1, so n must be even
     if((n + nextra_taps) % 2 == 1):


### PR DESCRIPTION
Formerly, it would just magically fail, when remezord returned impossible filter specs like n=0.


<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

In #6621, @argilo noticed how `gr_filter_design` lacks handling for non-`RuntimeError` errors.

In the same move, he unearthed the fact that the opt lpf/bpf/hpf design
routines just pass band edges unchecked to `remezord`, which then fails to find
a suitable filter order if the specifications are nonsensical. Which then gets
reported as the error that a filter with order <2 can't be designed – although
the user never asked for that.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Filter design routines, `gr_filter_design`.

**Backportability:** yep, new exceptions, changes API technically. But since it just fails … better, I think this is safe to backport; this just never worked.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Added new tests for these exceptions

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
