### PR TITLE
filter: Fix exception when dragging plot axes in Filter Design Tool

### DIFF
--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -15,6 +15,7 @@ import warnings
 from optparse import OptionParser
 
 from gnuradio import filter, fft
+from .CustomViewBox import CustomViewBox
 
 try:
     import numpy as np
@@ -2334,23 +2335,6 @@ class gr_plot_filter(QtWidgets.QMainWindow):
             self.update_imp_curves()
 
         self.gui.nTapsEdit.setText(str(self.taps.size))
-
-
-class CustomViewBox(pg.ViewBox):
-    def __init__(self, *args, **kwds):
-        pg.ViewBox.__init__(self, *args, **kwds)
-        self.setMouseMode(self.RectMode)
-
-    # Reimplement right-click to zoom out.
-    def mouseClickEvent(self, ev):
-        if ev.button() == QtCore.Qt.RightButton:
-            self.autoRange()
-
-    def mouseDragEvent(self, ev):
-        if ev.button() == QtCore.Qt.RightButton:
-            ev.ignore()
-        else:
-            pg.ViewBox.mouseDragEvent(self, ev)
 
 
 def setup_options():

--- a/gr-filter/python/filter/gui/CustomViewBox.py
+++ b/gr-filter/python/filter/gui/CustomViewBox.py
@@ -4,6 +4,7 @@ from PyQt5 import QtCore
 
 class CustomViewBox(pg.ViewBox):
     def __init__(self, *args, **kwds):
+        kwds['enableMenu'] = False
         pg.ViewBox.__init__(self, *args, **kwds)
         self.setMouseMode(self.RectMode)
 
@@ -11,9 +12,3 @@ class CustomViewBox(pg.ViewBox):
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
-
-    def mouseDragEvent(self, ev):
-        if ev.button() == QtCore.Qt.RightButton:
-            ev.ignore()
-        else:
-            pg.ViewBox.mouseDragEvent(self, ev)


### PR DESCRIPTION
## Description
If an axis is dragged in one of Filter Design Tool's plots, the following exception occurs:
```
/usr/lib/python3/dist-packages/pyqtgraph/GraphicsScene/GraphicsScene.py:340: RuntimeWarning: Error sending drag event:
Traceback (most recent call last):
  File "/home/argilo/prefix_311/bin/gr_filter_design", line 15, in <module>
    filter_design.main(sys.argv)
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/filter_design.py", line 2392, in main
    app.exec_()
  File "/usr/lib/python3/dist-packages/pyqtgraph/widgets/GraphicsView.py", line 362, in mouseMoveEvent
    super().mouseMoveEvent(ev)
  File "/usr/lib/python3/dist-packages/pyqtgraph/GraphicsScene/GraphicsScene.py", line 215, in mouseMoveEvent
    if self.sendDragEvent(ev, init=init):
  File "/usr/lib/python3/dist-packages/pyqtgraph/GraphicsScene/GraphicsScene.py", line 340, in sendDragEvent
    debug.printExc("Error sending drag event:")
  --- exception caught here ---
  File "/usr/lib/python3/dist-packages/pyqtgraph/GraphicsScene/GraphicsScene.py", line 338, in sendDragEvent
    item.mouseDragEvent(event)
  File "/usr/lib/python3/dist-packages/pyqtgraph/graphicsItems/AxisItem.py", line 1241, in mouseDragEvent
    return lv.mouseDragEvent(event, axis=0)
TypeError: CustomViewBox.mouseDragEvent() got an unexpected keyword argument 'axis'
  debug.printExc("Error sending drag event:")
```
It appears the `CustomViewBox` class was copied over (twice) from PyQtGraph's custom plot example. This code had the same bug, which was fixed in https://github.com/pyqtgraph/pyqtgraph/pull/1443.

Here I've removed the duplicate code, and copied over PyQtGraph's fix. I removed the `mouseDragEvent` override, since its purpose was to disable the right click menu (which is now handled by setting `enableMenu` to false). With this change, it becomes possible to zoom by dragging on the axes while right clicking.

## Which blocks/areas does this affect?
Filter Design Tool (gr_filter_design)

## Testing Done
I generated various filters, then played with dragging & click-click dragging on the various plots and their axes. Dragging now works as expected, and exceptions no longer occur.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
