### PR TITLE
filter: Fix exception when dragging in Band Diagram plot

### DIFF
--- a/gr-filter/python/filter/gui/banditems.py
+++ b/gr-filter/python/filter/gui/banditems.py
@@ -45,7 +45,7 @@ class filtermovlineItem(QtWidgets.QGraphicsObject):
     # Allow only vertical movement and emit signals.
     def itemChange(self, change, value):
         if (change == QtWidgets.QGraphicsItem.ItemPositionChange):
-            newpos = value.toPointF()
+            newpos = QtCore.QPointF(value)
             div = 0
             if newpos.y() < self.pos().y():
                 div = 1


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
The following exception occurs when dragging the mouse over the "Band Diagram" plot in the Filter Design Tool:
```
Traceback (most recent call last):
  File "/home/argilo/prefix_311/lib/python3.10/site-packages/gnuradio/filter/banditems.py", line 48, in itemChange
    newpos = value.toPointF()
AttributeError: 'QPointF' object has no attribute 'toPointF'. Did you mean: 'toPoint'?
```
It is apparent from the error message that `value` is already a `QPointF`, so it can be copied by using the copy constructor.

## Which blocks/areas does this affect?
Filter Design Tool (gr_filter_design)

## Testing Done
I generated some filters, then opened the "Band Diagram" tab and dragged the mouse over the diagram. With the fix in place, it becomes possible to adjust the stop band attenuation using the mouse.

The feature itself seems to be buggy (attenuation is not adjusted evenly and moves in the wrong direction), but other fixes should probably be left to a separate pull request.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
