### PR TITLE
blocks: Add lambda_block

### DIFF
--- a/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
+++ b/gr-blocks/include/gnuradio/blocks/CMakeLists.txt
@@ -101,6 +101,7 @@ install(
           interleaved_char_to_complex.h
           keep_m_in_n.h
           keep_one_in_n.h
+          lambda_block.h
           lfsr_32k_source_s.h
           message_debug.h
           message_strobe.h

--- a/gr-blocks/include/gnuradio/blocks/lambda_block.h
+++ b/gr-blocks/include/gnuradio/blocks/lambda_block.h
@@ -1,0 +1,73 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Ettus Research, A National Instruments Brand
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef INCLUDED_BLOCKS_LAMBDA_BLOCK_H
+#define INCLUDED_BLOCKS_LAMBDA_BLOCK_H
+
+#include <gnuradio/block.h>
+#include <gnuradio/blocks/api.h>
+#include <gnuradio/io_signature.h>
+#include <functional>
+
+namespace gr {
+namespace blocks {
+
+/*!
+ * \brief Map a generic function object or lambda into a GNU Radio block
+ * \ingroup misc_blk
+ *
+ * This block takes a function object as an argument, and uses that to execute
+ * the general_work() function.
+ *
+ * A neat use case for this block is for hierarchical blocks which require a
+ * kernel of custom processing; using the lambda block they can define their
+ * own partial work function.
+ */
+class BLOCKS_API lambda_block : virtual public block
+{
+public:
+    // gr::blocks::delay::sptr
+    typedef std::shared_ptr<lambda_block> sptr;
+
+    using general_work_func_t = std::function<int(lambda_block*,
+                                                  int,
+                                                  gr_vector_int&,
+                                                  gr_vector_const_void_star&,
+                                                  gr_vector_void_star&)>;
+
+    /*!
+     * \brief Make a delay block.
+     * \param itemsize size of the data items.
+     * \param delay number of samples to delay stream (>= 0).
+     */
+    static sptr make(general_work_func_t&& work_func,
+                     io_signature::sptr in,
+                     io_signature::sptr out,
+                     const std::string& name = "lambda_block");
+
+
+    inline void add_item_tag(unsigned int which_output,
+                             uint64_t abs_offset,
+                             const pmt::pmt_t& key,
+                             const pmt::pmt_t& value,
+                             const pmt::pmt_t& srcid = pmt::PMT_F)
+    {
+        gr::block::add_item_tag(which_output, abs_offset, key, value, srcid);
+    }
+
+    inline void add_item_tag(unsigned int which_output, const tag_t& tag)
+    {
+        gr::block::add_item_tag(which_output, tag);
+    }
+};
+
+} /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_BLOCKS_LAMBDA_BLOCK_H */

--- a/gr-blocks/lib/CMakeLists.txt
+++ b/gr-blocks/lib/CMakeLists.txt
@@ -111,6 +111,7 @@ set(BLOCKS_SOURCES
     interleaved_char_to_complex_impl.cc
     keep_m_in_n_impl.cc
     keep_one_in_n_impl.cc
+    lambda_block_impl.cc
     lfsr_32k_source_s_impl.cc
     message_debug_impl.cc
     message_strobe_impl.cc
@@ -227,6 +228,7 @@ if(ENABLE_TESTING)
         qa_gr_hier_block2.cc
         qa_gr_hier_block2_derived.cc
         qa_gr_top_block.cc
+        qa_lambda_block.cc
         qa_rotator.cc
         qa_set_msg_handler.cc)
     list(APPEND GR_TEST_TARGET_DEPS gnuradio-blocks)

--- a/gr-blocks/lib/lambda_block_impl.cc
+++ b/gr-blocks/lib/lambda_block_impl.cc
@@ -1,0 +1,49 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Ettus Research, A National Instruments Brand
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "lambda_block_impl.h"
+#include <gnuradio/io_signature.h>
+#include <utility>
+
+namespace gr {
+namespace blocks {
+
+lambda_block::sptr lambda_block::make(general_work_func_t&& work_func,
+                                      io_signature::sptr in,
+                                      io_signature::sptr out,
+                                      const std::string& name)
+{
+    return gnuradio::make_block_sptr<lambda_block_impl>(
+        std::move(work_func), in, out, name);
+}
+
+lambda_block_impl::lambda_block_impl(general_work_func_t&& work_func,
+                                     io_signature::sptr in,
+                                     io_signature::sptr out,
+                                     const std::string& name)
+    : block(name, in, out), _work_func(std::move(work_func))
+{
+}
+
+lambda_block_impl::~lambda_block_impl() {}
+
+int lambda_block_impl::general_work(int noutput_items,
+                                    gr_vector_int& ninput_items,
+                                    gr_vector_const_void_star& input_items,
+                                    gr_vector_void_star& output_items)
+{
+    return _work_func(this, noutput_items, ninput_items, input_items, output_items);
+}
+
+} /* namespace blocks */
+} /* namespace gr */

--- a/gr-blocks/lib/lambda_block_impl.h
+++ b/gr-blocks/lib/lambda_block_impl.h
@@ -1,0 +1,39 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Ettus Research, A National Instruments Brand
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef INCLUDED_GR_LAMBDA_BLOCK_IMPL_H
+#define INCLUDED_GR_LAMBDA_BLOCK_IMPL_H
+
+#include <gnuradio/blocks/lambda_block.h>
+
+namespace gr {
+namespace blocks {
+
+class lambda_block_impl : public lambda_block
+{
+private:
+    general_work_func_t _work_func;
+
+public:
+    lambda_block_impl(general_work_func_t&& work_func,
+                      io_signature::sptr in,
+                      io_signature::sptr out,
+                      const std::string& name);
+    ~lambda_block_impl() override;
+
+    int general_work(int noutput_items,
+                     gr_vector_int& ninput_items,
+                     gr_vector_const_void_star& input_items,
+                     gr_vector_void_star& output_items) override;
+};
+
+} /* namespace blocks */
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_LAMBDA_BLOCK_IMPL_H */

--- a/gr-blocks/lib/qa_lambda_block.cc
+++ b/gr-blocks/lib/qa_lambda_block.cc
@@ -1,0 +1,71 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Ettus Research, A National Instruments Brand
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <gnuradio/blocks/lambda_block.h>
+#include <gnuradio/blocks/vector_sink.h>
+#include <gnuradio/blocks/vector_source.h>
+#include <gnuradio/io_signature.h>
+#include <gnuradio/top_block.h>
+#include <boost/test/unit_test.hpp>
+
+#define VERBOSE 0
+
+BOOST_AUTO_TEST_CASE(lambda_block_run)
+{
+    auto tb = gr::make_top_block("top");
+
+    if (VERBOSE)
+        std::cout << "[lambda_block_run] Setting up blocks..." << std::endl;
+
+    auto src = gr::blocks::vector_source_f::make({ 0.0f, 1.0f, 2.0f, 4.0f });
+    auto lambda = gr::blocks::lambda_block::make(
+        [](gr::blocks::lambda_block* self,
+           int noutput_items,
+           gr_vector_int& ninput_items,
+           gr_vector_const_void_star& input_items,
+           gr_vector_void_star& output_items) -> int {
+            const float* in = static_cast<const float*>(input_items[0]);
+            float* out = static_cast<float*>(output_items[0]);
+            const size_t items_to_process =
+                static_cast<size_t>(std::min(noutput_items, ninput_items[0]));
+            if (VERBOSE)
+                std::cout << "[lambda_block_run] general_work(): Items to process: "
+                          << items_to_process << std::endl;
+            for (size_t i; i < items_to_process; i++) {
+                out[i] = 2 * in[i];
+            }
+            self->consume_each(items_to_process);
+            self->add_item_tag(0, 0, pmt::string_to_symbol("test"), pmt::PMT_T);
+            return static_cast<int>(items_to_process);
+        },
+        gr::io_signature::make(1, 1, sizeof(float)),
+        gr::io_signature::make(1, 1, sizeof(float)),
+        "my_doubler");
+
+    auto dst = gr::blocks::vector_sink_f::make();
+
+    if (VERBOSE)
+        std::cout << "[lambda_block_run] Connecting blocks..." << std::endl;
+    tb->connect(src, 0, lambda, 0);
+    tb->connect(lambda, 0, dst, 0);
+    if (VERBOSE)
+        std::cout << "[lambda_block_run] Running flow graph..." << std::endl;
+    tb->run();
+
+    const std::vector<float> expected{ 0.0f, 2.0f, 4.0f, 8.0f };
+    BOOST_TEST(dst->data() == expected, boost::test_tools::per_element());
+    auto tags = dst->tags();
+    BOOST_CHECK_EQUAL(tags.size(), 1);
+    BOOST_CHECK_EQUAL(tags[0].offset, 0);
+    BOOST_CHECK_EQUAL(tags[0].key, pmt::string_to_symbol("test"));
+}


### PR DESCRIPTION
## Description

This is the C++ equivalent of the embedded Python block. It allows
passing in the code to general_work() as a parameter.

This block can be particularly useful when designing hierarchical blocks
which have a small custom kernel. Previously, this would require first
adding this custom kernel as a custom block, and then building the
hierarchical block. Now, custom work functions can be included in the
hierarchical block itself.



## Which blocks/areas does this affect?

None, it's a new block. However, we use this in the upcoming C++ version of
the fosphor formatter block.

## Testing Done

Includes a unit test, also tested this as part of a hier block in the fosphor
formatter.


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.