### PR TITLE
qtgui: Replace `QLineEdit::returnPressed()` with `editingFinished()`

### DIFF
--- a/gr-qtgui/grc/qtgui_entry.block.yml
+++ b/gr-qtgui/grc/qtgui_entry.block.yml
@@ -43,7 +43,7 @@ templates:
         ${win}.addWidget(Qt.QLabel("${no_quotes(label,repr(id))}" + ": "))
         self._${id}_line_edit = Qt.QLineEdit(str(self.${id}))
         self._${id}_tool_bar.addWidget(self._${id}_line_edit)
-        self._${id}_line_edit.returnPressed.connect(
+        self._${id}_line_edit.editingFinished.connect(
             lambda: self.set_${id}(${type.conv}(str(self._${id}_line_edit.text()))))
         ${gui_hint() % win}
 
@@ -68,7 +68,7 @@ cpp_templates:
         this->_${id}_tool_bar->addWidget(_${id}_label);
         this->_${id}_line_edit = new QLineEdit(QString::number(this->${id}));
         this->_${id}_tool_bar->addWidget(this->_${id}_line_edit);
-        QObject::connect(this->_${id}_line_edit, &QLineEdit::returnPressed, this, [this] () {this->set_${id}(this->_${id}_line_edit->text().toInt());});
+        QObject::connect(this->_${id}_line_edit, &QLineEdit::editingFinished, this, [this] () {this->set_${id}(this->_${id}_line_edit->text().toInt());});
 
         ${gui_hint() % win}
 documentation: |-

--- a/gr-qtgui/lib/edit_box_msg_impl.cc
+++ b/gr-qtgui/lib/edit_box_msg_impl.cc
@@ -134,7 +134,7 @@ edit_box_msg_impl::edit_box_msg_impl(data_type_t type,
     d_vlayout->addItem(d_hlayout);
     d_group->setLayout(d_vlayout);
 
-    QObject::connect(d_val, SIGNAL(returnPressed()), this, SLOT(edit_finished()));
+    QObject::connect(d_val, SIGNAL(editingFinished()), this, SLOT(edit_finished()));
 
     d_msg = pmt::PMT_NIL;
 

--- a/gr-qtgui/python/qtgui/range.py.cmakein
+++ b/gr-qtgui/python/qtgui/range.py.cmakein
@@ -253,7 +253,7 @@ class RangeWidget(QtWidgets.QWidget):
             self.notifyChanged = slot
 
             self.setMaximumWidth(100)
-            self.returnPressed.connect(self.changed)
+            self.editingFinished.connect(self.changed)
             self.setText(str(ranges.default))
             self.setValidator(QEngValidator(ranges.min, ranges.max, self))
             self.notifyChanged = slot

--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -149,7 +149,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self._samp_rate__line_edit = Qt.QLineEdit(
             eng_notation.num_to_str(self.samp_rate))
         self._samp_rate__tool_bar.addWidget(self._samp_rate__line_edit)
-        self._samp_rate__line_edit.returnPressed.connect(
+        self._samp_rate__line_edit.editingFinished.connect(
             lambda: self.set_samp_rate(eng_notation.str_to_num(
                 str(self._samp_rate__line_edit.text()))))
         self.top_grid_layout.addWidget(self._samp_rate__tool_bar, 3, 2, 1, 2)
@@ -181,7 +181,7 @@ class uhd_fft(UHDApp, gr.top_block, Qt.QWidget):
         self._freq_tool_bar.addWidget(Qt.QLabel("RX Tune Frequency: "))
         self._freq_line_edit = Qt.QLineEdit(eng_notation.num_to_str(self.freq))
         self._freq_tool_bar.addWidget(self._freq_line_edit)
-        self._freq_line_edit.returnPressed.connect(
+        self._freq_line_edit.editingFinished.connect(
             lambda: self.set_freq_qt(
                 eng_notation.str_to_num(str(self._freq_line_edit.text()))))
         self.top_grid_layout.addWidget(self._freq_tool_bar, 3, 0, 1, 2)

--- a/gr-uhd/apps/uhd_siggen_gui
+++ b/gr-uhd/apps/uhd_siggen_gui
@@ -247,7 +247,7 @@ class uhd_siggen_gui(Qt.QWidget):
         self._samp_rate_line_edit = Qt.QLineEdit(
             eng_notation.num_to_str(self._sg[uhd_siggen.SAMP_RATE_KEY]))
         self._samp_rate_tool_bar.addWidget(self._samp_rate_line_edit)
-        self._samp_rate_line_edit.returnPressed.connect(
+        self._samp_rate_line_edit.editingFinished.connect(
             lambda: self.set_samp_rate(eng_notation.str_to_num(
                 str(self._samp_rate_line_edit.text())))
         )


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
This affects the QT GUI Entry, Message Edit Box, and Range widgets which use QLineEdit for text entry. Previously, these text edit boxes would not trigger the callback to update the variable unless Return/Enter was pressed. With this change, the variable is updated both in that case and also when the field loses focus, e.g. by clicking somewhere else on the display. See
https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QLineEdit.html#detailed-description for a description of the two signals.

I'm not sure if `returnPressed` was chosen intentionally to avoid the behavior of `editingFinished`, but I at least find the `editingFinished` behavior to be what I'd expect. There's no visual indication that Return/Enter is needed to set the corresponding variable, so it is natural to enter some text, change focus to another widget (like, for example, clicking a button to act on the new value in the text box), and assume that the variable has been updated to the value shown in the text box because that is what's being displayed. Maybe there are use cases for the current behavior that I'm not aware of, so I'm open to discussion/rejection.

Find/replace also turned up the use of the Entry widget in two of the UHD apps, so this PR also updates those.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
QT GUI Entry, Message Edit Box, and Range widgets

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I tested this locally with a QT GUI Entry by modifying the Python script directly, and the `editingFinished` signal triggered as described. I have not tested the other two widgets or the UHD apps, but there shouldn't be any issues with those either.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
