### PR TITLE
blocks: Reset item count when starting throttle

### DIFF
--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -54,6 +54,7 @@ throttle_impl::~throttle_impl() {}
 
 bool throttle_impl::start()
 {
+    d_total_items = 0;
     d_start = std::chrono::steady_clock::now();
     return block::start();
 }


### PR DESCRIPTION
## Description
https://github.com/gnuradio/gnuradio/pull/5670 removed the line of code that resets the sample / item count in `throttle_impl::start()`: https://github.com/gnuradio/gnuradio/pull/5670#discussion_r1181567087. This causes a long delay when the throttle restarts after being stopped. Here I've added it back.

## Related Issue
Fixes https://github.com/gqrx-sdr/gqrx/issues/1234.

## Which blocks/areas does this affect?
Throttle

## Testing Done
I verified that pausing & restarting playback of I/Q files in Gqrx works without delay after this change.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
