### PR TITLE
blocks: Reset item count when starting throttle (backport to maint-3.10)

### DIFF
--- a/gr-blocks/lib/throttle_impl.cc
+++ b/gr-blocks/lib/throttle_impl.cc
@@ -54,6 +54,7 @@ throttle_impl::~throttle_impl() {}
 
 bool throttle_impl::start()
 {
+    d_total_items = 0;
     d_start = std::chrono::steady_clock::now();
     return block::start();
 }


### PR DESCRIPTION
Backport https://github.com/gnuradio/gnuradio/pull/6647