### PR TITLE
modtool: fix formatting of python qa template (backport to maint-3.10)

### DIFF
--- a/gr-utils/modtool/templates/templates.py
+++ b/gr-utils/modtool/templates/templates.py
@@ -502,7 +502,7 @@ from gnuradio import gr, gr_unittest
 % if lang == 'cpp':
 try:
 % if version in ['310']:
-  from gnuradio.${modname} import ${blockname}
+    from gnuradio.${modname} import ${blockname}
 % else:
     from ${modname} import ${blockname}
 % endif


### PR DESCRIPTION
https://github.com/willcode/gnuradio/pull/new/backport/maint-3.10/6603