### PR TITLE
grc: Fix unsaved changes lost if prompt dismissed w/ Esc or window-close

### DIFF
--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -334,13 +334,13 @@ class MainWindow(Gtk.ApplicationWindow):
             self._set_page(self.page_to_be_closed)
         # unsaved? ask the user
         if not self.page_to_be_closed.saved:
-            response = self._save_changes()  # return value is either OK, CLOSE, or CANCEL
+            response = self._save_changes()  # return value can be OK, CLOSE, CANCEL, DELETE_EVENT, or NONE
             if response == Gtk.ResponseType.OK:
                 Actions.FLOW_GRAPH_SAVE()  # try to save
                 if not self.page_to_be_closed.saved:  # still unsaved?
                     self.page_to_be_closed = None  # set the page to be closed back to None
                     return False
-            elif response == Gtk.ResponseType.CANCEL:
+            elif response != Gtk.ResponseType.CLOSE:
                 self.page_to_be_closed = None
                 return False
         # stop the flow graph if executing


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Unsaved changes are lost when the "Unsaved Changes!" prompt is dismissed by pressing <kbd>Esc</kbd> or by closing the dialog window.  These actions are erroneously treated by GRC the same as if `Close without Saving` had been selected.

This happens because a `DELETE_EVENT` response is returned by Gtk.MessageDialog in those cases, but GRC incorrectly assumes that any response that isn't `OK` or `CANCEL` must be `CLOSE`.

This patch corrects that behaviour.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

None.  The bug is both reported & fixed in this PR.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
GNU Radio Companion (GRC), in the unsaved-changes prompt.

## Testing Done
  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

Manual testing only.

### Environment

Debian unstable/sid amd64, KDE, X11.

### Procedure
* Start `gnuradio-companion`, ensuring that the correct version number and block paths are shown in the terminal.
* Open a flow graph.
* Move a block (so that the graph contains unsaved changes).
* Attempt to close the graph:
  - Using the menu: `File` -> `Close`, or
  - Using a keyboard shortcut: <kbd>Ctrl</kbd>+<kbd>W</kbd>, or <kbd>Alt</kbd>+<kbd>F4</kbd>, etc.
* At this point, you will see the prompt, "Would you like to save changes before closing?".
![image](https://github.com/gnuradio/gnuradio/assets/99377/ef532b11-5ff5-4fc5-8773-af7521f7f07c)
* Dismiss the message-dialog window:
  - By pressing <kbd>Esc</kbd> on the keyboard,
  - By closing the message-dialog window using its window-close gadget, or
  - By closing the message-dialog window using a hotkey such as <kbd>Alt</kbd>+<kbd>F4</kbd>.

### What happened before this change was applied
GRC behaved as if `Close without Saving` was selected, i.e. the flow graph was closed and any changes were lost.

### What happens after I apply this change
GRC behaves as if `Cancel` was selected, i.e. the flow graph remains open and unsaved changes are retained.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
  - Not applicable.
- [ ] I have added tests to cover my changes, and all previous tests pass.
  - No new `make test` failures are introduced by this change, but note that this functionality is not covered by `make test`.
  - No additional tests added, because I didn't find any framework/examples for performing this kind of GUI functionality under `grc/tests`.
