### PR TITLE
soapy: sdrplay agc and gain fixes

### DIFF
--- a/gr-soapy/grc/soapy_sdrplay_source.block.yml
+++ b/gr-soapy/grc/soapy_sdrplay_source.block.yml
@@ -35,6 +35,12 @@ parameters:
     default: 'RX'
     hide: part
 
+  - id: bias
+    label: Bias Tee Power
+    dtype: bool
+    default: 'False'
+    hide: part
+
   - id: center_freq
     label: 'Center Freq (Hz)'
     category: RF Options
@@ -55,12 +61,26 @@ parameters:
     default: 'False'
     hide: part
 
-  - id: gain
-    label: 'RF Gain (-47dB - 0dB)'
+  - id: agc_setpoint
+    label: AGC Setpoint (-60dB - 0dB)'
     category: RF Options
-    dtype: real
-    default: '-20'
-    hide: ${'all' if agc else 'part'}
+    dtype: int
+    default: '-30'
+    hide: part
+
+  - id: gain
+    label: 'Gain (0dB - 39dB)'
+    category: RF Options
+    dtype: int
+    default: '20'
+    hide: part
+
+  - id: lna_state
+    label: 'LNA State (atten step)'
+    category: RF Options
+    dtype: int
+    default: '3'
+    hide: part
 
 inputs:
   - domain: message
@@ -74,29 +94,64 @@ outputs:
 
 templates:
   imports: from gnuradio import soapy
-  make: |
+
+  make: |-
       None
+      ## Negative value for agc_setpoint is placed in parens by GRC.
+      ## This code turns it into an int and bounds checks
+      _agc_setpoint = int(${agc_setpoint})
+      _agc_setpoint = max(min(_agc_setpoint, -20), -70)
+
       dev = 'driver=sdrplay'
       stream_args = ''
       tune_args = ['']
       settings = ['']
+
+      ## Intercept the agc callback and restore the gain when agc is
+      ## disabled. The driver does not do this. LNA state is preserved.
+      def _set_${id}_gain_mode(channel, agc):
+          self.${id}.set_gain_mode(channel, agc)
+          if not agc:
+              self.set_${id}_gain(channel, self.gain)
+      self.set_${id}_gain_mode = _set_${id}_gain_mode
+
+      ## Intercept the gain callback. The soapysdrplay driver prints an
+      ## error message every time gain is adjusted with agc on. Defer
+      ## setting IFGR until agc is turned off. Bounds check.
+      def _set_${id}_gain(channel, gain):
+          if not self.agc:
+              self.${id}.set_gain(channel, 'IFGR', min(max(59 - gain, 20), 59))
+      self.set_${id}_gain = _set_${id}_gain
+
+      ## Valid values for LNA state (RFGR here) vary by model, so runtime
+      ## changes may cause errors.
+      def _set_${id}_lna_state(channel, lna_state):
+              self.${id}.set_gain(channel, 'RFGR', min(max(lna_state, 0), 9))
+      self.set_${id}_lna_state = _set_${id}_lna_state
 
       self.${id} = soapy.source(dev, "${type}", 1, ${dev_args},
                                 stream_args, tune_args, settings)
       self.${id}.set_sample_rate(0, ${samp_rate})
       self.${id}.set_bandwidth(0, ${bandwidth})
       self.${id}.set_antenna(0, ${antenna})
-      self.${id}.set_gain_mode(0, ${agc})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      self.${id}.set_gain(0, min(max(-${gain}, 0.0), 47.0))
+      self.${id}.write_setting('biasT_ctrl', ${bias})
+      self.${id}.write_setting('agc_setpoint', ${agc_setpoint})
+      self.set_${id}_gain_mode(0, ${agc})
+      self.set_${id}_gain(0, ${gain})
+      self.set_${id}_lna_state(0, ${lna_state})
+
   callbacks:
     - set_sample_rate(0, ${samp_rate})
     - set_bandwidth(0, ${bandwidth})
     - set_antenna(0, ${antenna})
-    - set_gain_mode(0, ${agc})
     - set_frequency(0, ${center_freq})
     - set_frequency_correction(0, ${freq_correction})
-    - set_gain(0, min(max(-${gain}, 0.0), 47.0))
+    - write_setting('biasT_ctrl', ${bias})
+    - write_setting('agc_setpoint', ${agc_setpoint})
+    - self.set_${id}_gain_mode(0, ${agc})
+    - self.set_${id}_gain(0, ${gain})
+    - self.set_${id}_lna_state(0, ${lna_state})
 
 file_format: 1


### PR DESCRIPTION
## Description
SDRPlay gains are actually attenuations
- grdb: gain reduction of 20 to 59 dB
- lna state: model-specific attenuation steps for LNA

LNA state is independent of AGC. Gain reduction is N/A when AGC is on.

SoapySDR attempts to do automatic distributions of gains if setGain() is called without a gain name. This is what gr-soapy was trying to do and it resulted in invalid gain values.

AGC has a setpoint, which was not being set. This is probably why a crash was happening when AGC was set.

This change:
- Adds the AGC setpoint
- Separates gain and lna state
- Makes gain positive instead of the previous negative range
- LNA state is still an attenuation with device-specific stages
- Sets gain when agc is turned off (not done by driver)
- Defers setting IFGR gain when agc is on, to avoid warnings
- Enables bias tee control
- gain, lna_state, agc, agc_setpoint and bias are runtime settable

## Related Issue
Fixes #6652

## Which blocks/areas does this affect?
Soapy SDRPlay

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
