### PR TITLE
Backport PMT: modern interfaces for dicts 

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt.h
+++ b/gnuradio-runtime/include/pmt/pmt.h
@@ -637,6 +637,25 @@ PMT_API pmt_t dcons(const pmt_t& x, const pmt_t& y);
 //! Make an empty dictionary
 PMT_API pmt_t make_dict();
 
+/*!
+ * \brief Make a dictionary from an existing mapping type.
+ * The constraint for this to work is the ability for the map_t to iterate over [key,
+ * value] pairs, that is, to be able to be used in a
+ *
+ * <pre>for(const auto& [key, val] : prototype)<pre>
+ *
+ * loop.
+ */
+template <typename map_t>
+pmt_t dict_from_mapping(const map_t& prototype)
+{
+    pmt_t protodict = make_dict();
+    for (const auto& [key, value] : prototype) {
+        protodict = dict_add(protodict, key, value);
+    }
+    return protodict;
+}
+
 //! Return a new dictionary with \p key associated with \p value.
 PMT_API pmt_t dict_add(const pmt_t& dict, const pmt_t& key, const pmt_t& value);
 


### PR DESCRIPTION
As promised, a backport of #5994 which doesn't touch the PMT API by converting from `const std::string&` to `std::string_view`.

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

- #5994 (this is a backport)
- #6670  (backports #5996, which depends on the above)
- #6671 (backports #5997, which depends on both)

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
