### PR TITLE
Backport better probe rate

### DIFF
--- a/gr-blocks/grc/blocks_probe_rate.block.yml
+++ b/gr-blocks/grc/blocks_probe_rate.block.yml
@@ -24,6 +24,9 @@ parameters:
     label: Update Alpha
     dtype: real
     default: '0.15'
+-   id: name
+    label: Name
+    dtype: string
 
 inputs:
 -   domain: stream
@@ -40,11 +43,15 @@ asserts:
 
 templates:
     imports: from gnuradio import blocks
-    make: blocks.probe_rate(${type.size}*${vlen}, ${mintime}, ${alpha})
+    make: blocks.probe_rate(${type.size}*${vlen}, ${mintime}, ${alpha}, ${name})
+    callbacks:
+    - set_alpha(${alpha})
+    - set_name(${name})
+
 
 cpp_templates:
     includes: ['#include <gnuradio/blocks/probe_rate.h>']
     declarations: 'blocks::probe_rate::sptr ${id};'
-    make: 'this->${id} = blocks::probe_rate::make(${type.size}*${vlen}, ${mintime}, ${alpha});'
+    make: 'this->${id} = blocks::probe_rate::make(${type.size}*${vlen}, ${mintime}, ${alpha}, ${name});'
 
 file_format: 1

--- a/gr-blocks/include/gnuradio/blocks/probe_rate.h
+++ b/gr-blocks/include/gnuradio/blocks/probe_rate.h
@@ -13,6 +13,7 @@
 
 #include <gnuradio/blocks/api.h>
 #include <gnuradio/sync_block.h>
+#include <string_view>
 
 namespace gr {
 namespace blocks {
@@ -32,11 +33,26 @@ public:
      * \param itemsize size of each stream item
      * \param update_rate_ms minimum update time in milliseconds
      * \param alpha gain for running average filter
+     * \param name name for this probe (used in generated dictionaries)
+     *
+     * If the name is empty, the "name" field in the emitted dictionaries is
+     * omitted.
      */
-    static sptr
-    make(size_t itemsize, double update_rate_ms = 500.0, double alpha = 0.0001);
+    static sptr make(size_t itemsize,
+                     double update_rate_ms = 500.0,
+                     double alpha = 0.0001,
+                     std::string_view name = "");
 
+    /*!
+     * \brief Set the decay of the exponential rate average
+     */
     virtual void set_alpha(double alpha) = 0;
+
+    /*!
+     * \brief Set the name of this probe
+     * Used in the emitted dictionaries if not empty
+     */
+    virtual void set_name(std::string_view name) = 0;
 
     virtual double rate() = 0;
 

--- a/gr-blocks/lib/probe_rate_impl.h
+++ b/gr-blocks/lib/probe_rate_impl.h
@@ -11,8 +11,11 @@
 #ifndef INCLUDED_GR_PROBE_RATE_IMPL_H
 #define INCLUDED_GR_PROBE_RATE_IMPL_H
 
+#include "pmt/pmt.h"
 #include <gnuradio/blocks/probe_rate.h>
+#include <string_view>
 #include <chrono>
+#include <map>
 
 namespace gr {
 namespace blocks {
@@ -28,11 +31,16 @@ private:
 
     const pmt::pmt_t d_port;
     const pmt::pmt_t d_dict_avg, d_dict_now;
+    std::map<pmt::pmt_t, pmt::pmt_t> d_data_dict;
 
 public:
-    probe_rate_impl(size_t itemsize, double update_rate_ms, double alpha = 0.0001);
+    probe_rate_impl(size_t itemsize,
+                    double update_rate_ms,
+                    double alpha = 0.0001,
+                    std::string_view name = "");
     ~probe_rate_impl() override;
     void set_alpha(double alpha) override;
+    void set_name(std::string_view name) override;
     double rate() override;
     double timesincelast();
     bool start() override;

--- a/gr-blocks/python/blocks/bindings/docstrings/probe_rate_pydoc_template.h
+++ b/gr-blocks/python/blocks/bindings/docstrings/probe_rate_pydoc_template.h
@@ -30,6 +30,9 @@ static const char* __doc_gr_blocks_probe_rate_make = R"doc()doc";
 static const char* __doc_gr_blocks_probe_rate_set_alpha = R"doc()doc";
 
 
+static const char* __doc_gr_blocks_probe_rate_set_name = R"doc()doc";
+
+
 static const char* __doc_gr_blocks_probe_rate_rate = R"doc()doc";
 
 

--- a/gr-blocks/python/blocks/bindings/probe_rate_python.cc
+++ b/gr-blocks/python/blocks/bindings/probe_rate_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(probe_rate.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(6217f03a5dbd6c39f9dcdea629362e39)                     */
+/* BINDTOOL_HEADER_FILE_HASH(5af71a4dfd73a4001d02a2253e28bd64)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -43,6 +43,7 @@ void bind_probe_rate(py::module& m)
              py::arg("itemsize"),
              py::arg("update_rate_ms") = 500.,
              py::arg("alpha") = 1.0E-4,
+             py::arg("name") = "",
              D(probe_rate, make))
 
 
@@ -50,6 +51,8 @@ void bind_probe_rate(py::module& m)
              &probe_rate::set_alpha,
              py::arg("alpha"),
              D(probe_rate, set_alpha))
+
+        .def("set_name", &probe_rate::set_name, py::arg("name"), D(probe_rate, set_name))
 
 
         .def("rate", &probe_rate::rate, D(probe_rate, rate))


### PR DESCRIPTION
backport of #5996, rebased on top of #5994 's backport, #6669

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
