### PR TITLE
uhd: rename replay stop

### DIFF
--- a/gr-uhd/include/gnuradio/uhd/rfnoc_replay.h
+++ b/gr-uhd/include/gnuradio/uhd/rfnoc_replay.h
@@ -104,7 +104,7 @@ public:
      *                  time to occur, rather, it will tag the first outgoing
      *                  packet with this time stamp.
      * \param repeat Determines whether the data should be played repeatedly or
-     *               just once. If set to true, stop() must be called to stop
+     *               just once. If set to true, stop_playback() must be called to stop
      *               the play back.
      * \throws uhd::value_error if offset+size exceeds the available memory.
      * \throws uhd::op_failed Too many play commands are queued.
@@ -122,7 +122,7 @@ public:
      *
      * \param port Which output port of the replay block to use
      */
-    virtual void stop(const size_t port = 0) = 0;
+    virtual void stop_playback(const size_t port = 0) = 0;
 
     /*! Sets the data type for items in the current record buffer for the given input
      * port.

--- a/gr-uhd/lib/rfnoc_replay_impl.cc
+++ b/gr-uhd/lib/rfnoc_replay_impl.cc
@@ -108,7 +108,7 @@ void rfnoc_replay_impl::play(const uint64_t offset,
     d_wrapped_ref->play(offset, size, port, time_spec, repeat);
 }
 
-void rfnoc_replay_impl::stop(const size_t port) { d_wrapped_ref->stop(port); }
+void rfnoc_replay_impl::stop_playback(const size_t port) { d_wrapped_ref->stop(port); }
 
 void rfnoc_replay_impl::set_record_type(const std::string type, const size_t port)
 {
@@ -202,7 +202,7 @@ void rfnoc_replay_impl::_command_handler(pmt::pmt_t msg)
         return;
     }
     if (command == "stop") {
-        stop();
+        stop_playback();
         return;
     }
     if (command == "get_record_fullness") {

--- a/gr-uhd/lib/rfnoc_replay_impl.h
+++ b/gr-uhd/lib/rfnoc_replay_impl.h
@@ -33,7 +33,7 @@ public:
               const size_t port,
               const ::uhd::time_spec_t time_spec,
               const bool repeat) override;
-    void stop(const size_t port = 0) override;
+    void stop_playback(const size_t port = 0) override;
     void set_record_type(const std::string type, const size_t port = 0) override;
     void set_play_type(const std::string type, const size_t port = 0) override;
     void issue_stream_cmd(const ::uhd::stream_cmd_t& cmd, const size_t port = 0) override;

--- a/gr-uhd/python/uhd/bindings/docstrings/rfnoc_replay_pydoc_template.h
+++ b/gr-uhd/python/uhd/bindings/docstrings/rfnoc_replay_pydoc_template.h
@@ -28,10 +28,30 @@ static const char* __doc_gr_uhd_rfnoc_replay_record_restart = R"doc()doc";
 
 static const char* __doc_gr_uhd_rfnoc_replay_play = R"doc()doc";
 
-static const char* __doc_gr_uhd_rfnoc_replay_stop = R"doc()doc";
+static const char* __doc_gr_uhd_rfnoc_replay_stop_playback = R"doc()doc";
 
 static const char* __doc_gr_uhd_rfnoc_replay_set_record_type = R"doc()doc";
 
 static const char* __doc_gr_uhd_rfnoc_replay_set_play_type = R"doc()doc";
 
 static const char* __doc_gr_uhd_rfnoc_replay_issue_stream_cmd = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_cmd_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_cmd_port_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_cmd_offset_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_cmd_size_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_cmd_time_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_cmd_repeat_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_debug_port_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_mem_fullness_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_mem_size_key = R"doc()doc";
+
+static const char* __doc_gr_uhd_replay_word_size_key = R"doc()doc";

--- a/gr-uhd/python/uhd/bindings/rfnoc_replay_python.cc
+++ b/gr-uhd/python/uhd/bindings/rfnoc_replay_python.cc
@@ -16,7 +16,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0) */
 /* BINDTOOL_USE_PYGCCXML(0) */
 /* BINDTOOL_HEADER_FILE(rfnoc_replay.h) */
-/* BINDTOOL_HEADER_FILE_HASH(31a0a718c0a7208a4a53dbdfbec60a11) */
+/* BINDTOOL_HEADER_FILE_HASH(5fc8dd6289e5e69628d6c15d73802262) */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -68,7 +68,10 @@ void bind_rfnoc_replay(py::module& m)
              py::arg("repeat") = false,
              D(rfnoc_replay, play))
 
-        .def("stop", &rfnoc_replay::stop, py::arg("port") = 0, D(rfnoc_replay, stop))
+        .def("stop_playback",
+             &rfnoc_replay::stop_playback,
+             py::arg("port") = 0,
+             D(rfnoc_replay, stop_playback))
 
         .def("set_record_type",
              &rfnoc_replay::set_record_type,
@@ -89,4 +92,34 @@ void bind_rfnoc_replay(py::module& m)
              D(rfnoc_replay, issue_stream_cmd))
 
         ;
+
+    m.def("replay_cmd_key", &::gr::uhd::replay_cmd_key, D(replay_cmd_key));
+
+    m.def("replay_cmd_port_key", &::gr::uhd::replay_cmd_port_key, D(replay_cmd_port_key));
+
+    m.def("replay_cmd_offset_key",
+          &::gr::uhd::replay_cmd_offset_key,
+          D(replay_cmd_offset_key));
+
+    m.def("replay_cmd_size_key", &::gr::uhd::replay_cmd_size_key, D(replay_cmd_size_key));
+
+    m.def("replay_cmd_time_key", &::gr::uhd::replay_cmd_time_key, D(replay_cmd_time_key));
+
+    m.def("replay_cmd_repeat_key",
+          &::gr::uhd::replay_cmd_repeat_key,
+          D(replay_cmd_repeat_key));
+
+    m.def("replay_debug_port_key",
+          &::gr::uhd::replay_debug_port_key,
+          D(replay_debug_port_key));
+
+    m.def("replay_mem_fullness_key",
+          &::gr::uhd::replay_mem_fullness_key,
+          D(replay_mem_fullness_key));
+
+    m.def("replay_mem_size_key", &::gr::uhd::replay_mem_size_key, D(replay_mem_size_key));
+
+    m.def("replay_word_size_key",
+          &::gr::uhd::replay_word_size_key,
+          D(replay_word_size_key));
 }


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
Rename stop for replay block to stop_playback

Also adds some other items to pybind that looks like were missed on initial add

## Related Issue
Fixes fedora 38 CI

## Which blocks/areas does this affect?
gr-uhd rfnoc replay block

## Testing Done
Sanity checked that simple replay example still worked

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
