### PR TITLE
filter: designer rework and fixes (backport to maint-3.10)

### DIFF
--- a/gr-filter/include/gnuradio/filter/pm_remez.h
+++ b/gr-filter/include/gnuradio/filter/pm_remez.h
@@ -13,8 +13,8 @@
 
 #include <gnuradio/filter/api.h>
 #include <gnuradio/types.h>
-#include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace gr {
 namespace filter {
@@ -41,7 +41,7 @@ namespace filter {
  *
  * \returns vector of computed taps
  *
- * \throws std::runtime_error if args are invalid or calculation
+ * \throws std::invalid_argument if args are invalid and std::runtime_error if calculation
  * fails to converge.
  */
 

--- a/gr-filter/lib/pm_remez.cc
+++ b/gr-filter/lib/pm_remez.cc
@@ -33,30 +33,27 @@
 #include <gnuradio/logger.h>
 #include <cassert>
 #include <cmath>
-
-#ifndef LOCAL_BUFFER
+#include <stdexcept>
 #include <vector>
-#define LOCAL_BUFFER(T, buf, size)     \
-    std::vector<T> buf##_vector(size); \
-    T* buf = &(buf##_vector[0])
-#endif
 
 namespace gr {
 namespace filter {
 
-#define CONST const
-#define BANDPASS 1
-#define DIFFERENTIATOR 2
-#define HILBERT 3
+// helper types
+enum class filter_type { BANDPASS = 1, DIFFERENTIATOR = 2, HILBERT = 3 };
+enum class symmetry_type { NEGATIVE, POSITIVE };
 
-#define NEGATIVE 0
-#define POSITIVE 1
+constexpr unsigned int MAXITERATIONS = 40;
+constexpr double PI = 3.14159265358979323846;
+constexpr double PI2 = 2 * PI;
 
-#define Pi 3.14159265358979323846
-#define Pi2 (2 * Pi)
-
-#define GRIDDENSITY 16
-#define MAXITERATIONS 40
+#ifndef CPP20CONSTEXPR
+#if __cplusplus >= 202002L
+#define CPP20CONSTEXPR constexpr
+#else
+#define CPP20CONSTEXPR
+#endif
+#endif
 
 /*******************
  * create_dense_grid
@@ -69,13 +66,13 @@ namespace filter {
  *
  * INPUT:
  * ------
- * int      r        - 1/2 the number of filter coefficients
+ * unsigned int n_taps_half - 1/2 the number of filter coefficients
  * int      numtaps  - Number of taps in the resulting filter
  * int      numband  - Number of bands in user specification
  * double   bands[]  - User-specified band edges [2*numband]
  * double   des[]    - Desired response per band [2*numband]
  * double   weight[] - Weight per band [numband]
- * int      symmetry - Symmetry of filter - used for grid check
+ * symmetry_type symmetry - Symmetry of filter - used for grid check
  * int      griddensity
  *
  * OUTPUT:
@@ -86,36 +83,32 @@ namespace filter {
  * double W[]        - Weight function on the dense grid [gridsize]
  *******************/
 
-static void create_dense_grid(int r,
+static void create_dense_grid(unsigned int n_taps_half,
                               int numtaps,
                               int numband,
-                              const double bands[],
-                              const double des[],
-                              const double weight[],
+                              const std::vector<double>& bands,
+                              const std::vector<double>& des,
+                              const std::vector<double>& weight,
                               int gridsize,
-                              double Grid[],
-                              double D[],
-                              double W[],
-                              int symmetry,
+                              std::vector<double>& Grid,
+                              std::vector<double>& D,
+                              std::vector<double>& W,
+                              symmetry_type symmetry,
                               int griddensity)
 {
-    int i, j, k, band;
-    double delf, lowf, highf, grid0;
-
-    delf = 0.5 / (griddensity * r);
-
+    double delf = 0.5 / (griddensity * n_taps_half);
     /*
      * For differentiator, hilbert,
      *   symmetry is odd and Grid[0] = max(delf, bands[0])
      */
-    grid0 = (symmetry == NEGATIVE) && (delf > bands[0]) ? delf : bands[0];
+    double grid0 =
+        (symmetry == symmetry_type::NEGATIVE) && (delf > bands[0]) ? delf : bands[0];
 
-    j = 0;
-    for (band = 0; band < numband; band++) {
-        lowf = (band == 0 ? grid0 : bands[2 * band]);
-        highf = bands[2 * band + 1];
-        k = (int)((highf - lowf) / delf + 0.5); /* .5 for rounding */
-        for (i = 0; i < k; i++) {
+    for (int band = 0, j = 0; band < numband; band++) {
+        double lowf = (band == 0 ? grid0 : bands[2 * band]);
+        double highf = bands[2 * band + 1];
+        int k = (int)((highf - lowf) / delf + 0.5); /* .5 for rounding */
+        for (int i = 0; i < k; i++) {
             D[j] = des[2 * band] + i * (des[2 * band + 1] - des[2 * band]) / (k - 1);
             W[j] = weight[band];
             Grid[j] = lowf;
@@ -129,7 +122,8 @@ static void create_dense_grid(int r,
      * Similar to above, if odd symmetry, last grid point can't be .5
      *  - but, if there are even taps, leave the last grid point at .5
      */
-    if ((symmetry == NEGATIVE) && (Grid[gridsize - 1] > (0.5 - delf)) && (numtaps % 2)) {
+    if ((symmetry == symmetry_type::NEGATIVE) && (Grid[gridsize - 1] > (0.5 - delf)) &&
+        (numtaps % 2)) {
         Grid[gridsize - 1] = 0.5 - delf;
     }
 }
@@ -143,7 +137,7 @@ static void create_dense_grid(int r,
  *
  * INPUT:
  * ------
- * int r        - 1/2 the number of filter coefficients
+ * unsigned int n_taps_half - 1/2 the number of filter coefficients
  * int gridsize - Number of elements in the dense frequency grid
  *
  * OUTPUT:
@@ -151,12 +145,11 @@ static void create_dense_grid(int r,
  * int ext[]    - Extremal indexes to dense frequency grid [r+1]
  ********************/
 
-static void initial_guess(int r, int Ext[], int gridsize)
+static CPP20CONSTEXPR void
+initial_guess(unsigned int n_taps_half, std::vector<int>& Ext, int gridsize)
 {
-    int i;
-
-    for (i = 0; i <= r; i++)
-        Ext[i] = i * (gridsize - 1) / r;
+    for (unsigned int i = 0; i <= n_taps_half; i++)
+        Ext[i] = i * (gridsize - 1) / n_taps_half;
 }
 
 
@@ -167,7 +160,7 @@ static void initial_guess(int r, int Ext[], int gridsize)
  *
  * INPUT:
  * ------
- * int    r      - 1/2 the number of filter coefficients
+ * unsigned int n_taps_half - 1/2 the number of filter coefficients
  * int    Ext[]  - Extremal indexes to dense frequency grid [r+1]
  * double Grid[] - Frequencies (0 to 0.5) on the dense grid [gridsize]
  * double D[]    - Desired response on the dense grid [gridsize]
@@ -180,36 +173,35 @@ static void initial_guess(int r, int Ext[], int gridsize)
  * double y[]    - 'C' in Oppenheim & Schafer [r+1]
  ***********************/
 
-static void calc_parms(int r,
-                       int Ext[],
-                       double Grid[],
-                       double D[],
-                       double W[],
-                       double ad[],
-                       double x[],
-                       double y[])
+static constexpr void calc_parms(unsigned int n_taps_half,
+                                 const std::vector<int>& Ext,
+                                 const std::vector<double>& Grid,
+                                 const std::vector<double>& D,
+                                 const std::vector<double>& W,
+                                 std::vector<double>& ad,
+                                 std::vector<double>& x,
+                                 std::vector<double>& y)
 {
-    int i, j, k, ld;
-    double sign, xi, delta, denom, numer;
-
     /*
      * Find x[]
      */
-    for (i = 0; i <= r; i++)
-        x[i] = cos(Pi2 * Grid[Ext[i]]);
+    for (unsigned int i = 0; i <= n_taps_half; i++)
+        x[i] = cos(PI2 * Grid[Ext[i]]);
 
     /*
      * Calculate ad[]  - Oppenheim & Schafer eq 7.132
      */
-    ld = (r - 1) / 15 + 1; /* Skips around to avoid round errors */
-    for (i = 0; i <= r; i++) {
-        denom = 1.0;
-        xi = x[i];
-        for (j = 0; j < ld; j++) {
-            for (k = j; k <= r; k += ld)
+    unsigned int ld = (n_taps_half - 1) / 15 + 1; /* Skips around to avoid round errors */
+    for (unsigned int i = 0; i <= n_taps_half; i++) {
+        double denom = 1.0;
+        double xi = x[i];
+        for (unsigned int j = 0; j < ld; j++) {
+            for (unsigned int k = j; k <= n_taps_half; k += ld)
                 if (k != i)
                     denom *= 2.0 * (xi - x[k]);
         }
+
+        // FIXME: 0.00001 seems far too large for double and cos accuracy
         if (fabs(denom) < 0.00001)
             denom = 0.00001;
         ad[i] = 1.0 / denom;
@@ -218,20 +210,21 @@ static void calc_parms(int r,
     /*
      * Calculate delta  - Oppenheim & Schafer eq 7.131
      */
-    numer = denom = 0;
-    sign = 1;
-    for (i = 0; i <= r; i++) {
+    double numer = 0;
+    double denom = 0;
+    double sign = 1;
+    for (unsigned int i = 0; i <= n_taps_half; i++) {
         numer += ad[i] * D[Ext[i]];
         denom += sign * ad[i] / W[Ext[i]];
         sign = -sign;
     }
-    delta = numer / denom;
-    sign = 1;
 
     /*
      * Calculate y[]  - Oppenheim & Schafer eq 7.133b
      */
-    for (i = 0; i <= r; i++) {
+    double delta = numer / denom;
+    sign = 1;
+    for (unsigned int i = 0; i <= n_taps_half; i++) {
         y[i] = D[Ext[i]] - sign * delta / W[Ext[i]];
         sign = -sign;
     }
@@ -249,7 +242,7 @@ static void calc_parms(int r,
  * INPUT:
  * ------
  * double freq - Frequency (0 to 0.5) at which to calculate A
- * int    r    - 1/2 the number of filter coefficients
+ * unsigned n_taps_half - 1/2 the number of filter coefficients
  * double ad[] - 'b' in Oppenheim & Schafer [r+1]
  * double x[]  - [r+1]
  * double y[]  - 'C' in Oppenheim & Schafer [r+1]
@@ -259,15 +252,17 @@ static void calc_parms(int r,
  * Returns double value of A[freq]
  *********************/
 
-static double compute_A(double freq, int r, double ad[], double x[], double y[])
+static CPP20CONSTEXPR double compute_A(double freq,
+                                       unsigned int n_taps_half,
+                                       const std::vector<double>& ad,
+                                       const std::vector<double>& x,
+                                       const std::vector<double>& y)
 {
-    int i;
-    double xc, c, denom, numer;
-
-    denom = numer = 0;
-    xc = cos(Pi2 * freq);
-    for (i = 0; i <= r; i++) {
-        c = xc - x[i];
+    double denom = 0;
+    double numer = 0;
+    const double xc = cos(PI2 * freq);
+    for (unsigned int i = 0; i <= n_taps_half; i++) {
+        double c = xc - x[i];
         if (fabs(c) < 1.0e-7) {
             numer = y[i];
             denom = 1;
@@ -291,7 +286,7 @@ static double compute_A(double freq, int r, double ad[], double x[], double y[])
  *
  * INPUT:
  * ------
- * int    r      - 1/2 the number of filter coefficients
+ * unsigned n_taps_half - 1/2 the number of filter coefficients
  * double ad[]   - [r+1]
  * double x[]    - [r+1]
  * double y[]    - [r+1]
@@ -305,21 +300,18 @@ static double compute_A(double freq, int r, double ad[], double x[], double y[])
  * double E[]    - Error function on dense grid [gridsize]
  ************************/
 
-static void calc_error(int r,
-                       double ad[],
-                       double x[],
-                       double y[],
-                       int gridsize,
-                       double Grid[],
-                       double D[],
-                       double W[],
-                       double E[])
+static CPP20CONSTEXPR void calc_error(unsigned int n_taps_half,
+                                      const std::vector<double>& ad,
+                                      const std::vector<double>& x,
+                                      const std::vector<double>& y,
+                                      int gridsize,
+                                      const std::vector<double>& Grid,
+                                      const std::vector<double>& D,
+                                      const std::vector<double>& W,
+                                      std::vector<double>& E)
 {
-    int i;
-    double A;
-
-    for (i = 0; i < gridsize; i++) {
-        A = compute_A(Grid[i], r, ad, x, y);
+    for (int i = 0; i < gridsize; i++) {
+        double A = compute_A(Grid[i], n_taps_half, ad, x, y);
         E[i] = W[i] * (D[i] - A);
     }
 }
@@ -340,7 +332,7 @@ static void calc_error(int r,
  *
  * INPUT:
  * ------
- * int    r        - 1/2 the number of filter coefficients
+ * unsigned n_taps_half - 1/2 the number of filter coefficients
  * int    Ext[]    - Indexes to Grid[] of extremal frequencies [r+1]
  * int    gridsize - Number of elements in the dense frequency grid
  * double E[]      - Array of error values.  [gridsize]
@@ -348,17 +340,13 @@ static void calc_error(int r,
  * -------
  * int    Ext[]    - New indexes to extremal frequencies [r+1]
  ************************/
-static int search(int r, int Ext[], int gridsize, double E[])
+static int search(unsigned int n_taps_half,
+                  std::vector<int>& Ext,
+                  int gridsize,
+                  const std::vector<double>& E)
 {
-    int i, j, k, l, extra; /* Counters */
-    int up, alt;
-    int* foundExt; /* Array of found extremals */
-
-    /*
-     * Allocate enough space for found extremals.
-     */
-    foundExt = (int*)malloc((2 * r) * sizeof(int));
-    k = 0;
+    std::vector<int> foundExt(2 * n_taps_half);
+    unsigned int k = 0;
 
     /*
      * Check for extremum at 0.
@@ -369,12 +357,11 @@ static int search(int r, int Ext[], int gridsize, double E[])
     /*
      * Check for extrema inside dense grid
      */
-    for (i = 1; i < gridsize - 1; i++) {
+    for (int i = 1; i < gridsize - 1; i++) {
         if (((E[i] >= E[i - 1]) && (E[i] > E[i + 1]) && (E[i] > 0.0)) ||
             ((E[i] <= E[i - 1]) && (E[i] < E[i + 1]) && (E[i] < 0.0))) {
             // PAK: we sometimes get too many extremal frequencies
-            if (k >= 2 * r) {
-                free(foundExt);
+            if (k >= 2 * n_taps_half) {
                 return -3;
             }
             foundExt[k++] = i;
@@ -384,36 +371,33 @@ static int search(int r, int Ext[], int gridsize, double E[])
     /*
      * Check for extremum at 0.5
      */
-    j = gridsize - 1;
-    if (((E[j] > 0.0) && (E[j] > E[j - 1])) || ((E[j] < 0.0) && (E[j] < E[j - 1]))) {
-        if (k >= 2 * r) {
-            free(foundExt);
+    int extrempos = gridsize - 1;
+    if (((E[extrempos] > 0.0) && (E[extrempos] > E[extrempos - 1])) ||
+        ((E[extrempos] < 0.0) && (E[extrempos] < E[extrempos - 1]))) {
+        if (k >= 2 * n_taps_half) {
             return -3;
         }
-        foundExt[k++] = j;
+        foundExt[k++] = extrempos;
     }
 
     // PAK: we sometimes get not enough extremal frequencies
-    if (k < r + 1) {
-        free(foundExt);
+    if (k < n_taps_half + 1) {
         return -2;
     }
 
     /*
      * Remove extra extremals
      */
-    extra = k - (r + 1);
+    int extra = k - (n_taps_half + 1);
     assert(extra >= 0);
 
     while (extra > 0) {
-        if (E[foundExt[0]] > 0.0)
-            up = 1; /* first one is a maxima */
-        else
-            up = 0; /* first one is a minima */
+        // is first one a maximum (1) or a minimum (0)?
+        int up = E[foundExt[0]] > 0.0; // C++ guarantees true == 1;
 
-        l = 0;
-        alt = 1;
-        for (j = 1; j < k; j++) {
+        int l = 0;
+        int alt = 1;
+        for (unsigned int j = 1; j < k; j++) {
             if (fabs(E[foundExt[j]]) < fabs(E[foundExt[l]]))
                 l = j; /* new smallest error. */
             if ((up) && (E[foundExt[j]] < 0.0))
@@ -447,7 +431,7 @@ static int search(int r, int Ext[], int gridsize, double E[])
             // PAK: changed from l = foundExt[0];
         }
 
-        for (j = l; j < k - 1; j++) { /* Loop that does the deletion */
+        for (unsigned int j = l; j < k - 1; j++) { /* Loop that does the deletion */
             foundExt[j] = foundExt[j + 1];
             assert(foundExt[j] < gridsize);
         }
@@ -455,12 +439,11 @@ static int search(int r, int Ext[], int gridsize, double E[])
         extra--;
     }
 
-    for (i = 0; i <= r; i++) {
+    for (unsigned int i = 0; i <= n_taps_half; i++) {
         assert(foundExt[i] < gridsize);
         Ext[i] = foundExt[i]; /* Copy found extremals to Ext[] */
     }
 
-    free(foundExt);
     return 0;
 }
 
@@ -476,50 +459,50 @@ static int search(int r, int Ext[], int gridsize, double E[])
  * ------
  * int      N        - Number of filter coefficients
  * double   A[]      - Sample points of desired response [N/2]
- * int      symmetry - Symmetry of desired filter
+ * symmmetry_type symmetry - Symmetry of desired filter
  *
  * OUTPUT:
  * -------
  * double h[] - Impulse Response of final filter [N]
  *********************/
-static void freq_sample(int N, double A[], double h[], int symm)
+static CPP20CONSTEXPR void freq_sample(int N,
+                                       const std::vector<double>& A,
+                                       std::vector<double>& h,
+                                       symmetry_type symm)
 {
-    int n, k;
-    double x, val, M;
-
-    M = (N - 1.0) / 2.0;
-    if (symm == POSITIVE) {
+    double M = (N - 1.0) / 2.0;
+    if (symm == symmetry_type::POSITIVE) {
         if (N % 2) {
-            for (n = 0; n < N; n++) {
-                val = A[0];
-                x = Pi2 * (n - M) / N;
-                for (k = 1; k <= M; k++)
+            for (int n = 0; n < N; n++) {
+                double val = A[0];
+                double x = PI2 * (n - M) / N;
+                for (int k = 1; k <= M; k++)
                     val += 2.0 * A[k] * cos(x * k);
                 h[n] = val / N;
             }
         } else {
-            for (n = 0; n < N; n++) {
-                val = A[0];
-                x = Pi2 * (n - M) / N;
-                for (k = 1; k <= (N / 2 - 1); k++)
+            for (int n = 0; n < N; n++) {
+                double val = A[0];
+                double x = PI2 * (n - M) / N;
+                for (int k = 1; k <= (N / 2 - 1); k++)
                     val += 2.0 * A[k] * cos(x * k);
                 h[n] = val / N;
             }
         }
     } else {
         if (N % 2) {
-            for (n = 0; n < N; n++) {
-                val = 0;
-                x = Pi2 * (n - M) / N;
-                for (k = 1; k <= M; k++)
+            for (int n = 0; n < N; n++) {
+                double val = 0;
+                double x = PI2 * (n - M) / N;
+                for (int k = 1; k <= M; k++)
                     val += 2.0 * A[k] * sin(x * k);
                 h[n] = val / N;
             }
         } else {
-            for (n = 0; n < N; n++) {
-                val = A[N / 2] * sin(Pi * (n - M));
-                x = Pi2 * (n - M) / N;
-                for (k = 1; k <= (N / 2 - 1); k++)
+            for (int n = 0; n < N; n++) {
+                double val = A[N / 2] * sin(PI * (n - M));
+                double x = PI2 * (n - M) / N;
+                for (int k = 1; k <= (N / 2 - 1); k++)
                     val += 2.0 * A[k] * sin(x * k);
                 h[n] = val / N;
             }
@@ -535,30 +518,35 @@ static void freq_sample(int N, double A[], double h[], int symm)
  *
  * INPUT:
  * ------
- * int    r     - 1/2 the number of filter coefficients
+ * unsigned n_taps_half - 1/2 the number of filter coefficients
  * int    Ext[] - Indexes to extremal frequencies [r+1]
  * double E[]   - Error function on the dense grid [gridsize]
+ * double tolerace - threshold under which to consider being done
  *
  * OUTPUT:
  * -------
  * Returns 1 if the result converged
  * Returns 0 if the result has not converged
  ********************/
-
-static bool is_done(int r, int Ext[], double E[])
+static CPP20CONSTEXPR bool is_done(int n_taps_half,
+                                   const std::vector<int>& Ext,
+                                   const std::vector<double>& E,
+                                   double tolerance = 0.0001)
 {
-    int i;
-    double min, max, current;
+    // FIXME default tolerance of 1e-4 seems very high
 
-    min = max = fabs(E[Ext[0]]);
-    for (i = 1; i <= r; i++) {
-        current = fabs(E[Ext[i]]);
+    const double initial = E[Ext[0]];
+    double min = fabs(initial);
+    double max = min;
+
+    for (int i = 1; i <= n_taps_half; i++) {
+        double current = fabs(E[Ext[i]]);
         if (current < min)
             min = current;
         if (current > max)
             max = current;
     }
-    return (((max - min) / max) < 0.0001);
+    return (((max - min) / max) < tolerance);
 }
 
 /********************
@@ -571,12 +559,12 @@ static bool is_done(int r, int Ext[], double E[])
  *
  * INPUT:
  * ------
- * int     numtaps     - Number of filter coefficients
- * int     numband     - Number of bands in filter specification
- * double  bands[]     - User-specified band edges [2 * numband]
- * double  des[]       - User-specified band responses [2 * numband]
- * double  weight[]    - User-specified error weights [numband]
- * int     type        - Type of filter
+ * unsigned int numtaps - Number of filter coefficients
+ * unsgined int numband - Number of bands in filter specification
+ * double  bands[]      - User-specified band edges [2 * numband]
+ * double  response[]   - User-specified band responses [2 * numband]
+ * double  weight[]     - User-specified error weights [numband]
+ * filter_type type     - Type of filter
  *
  * OUTPUT:
  * -------
@@ -584,63 +572,57 @@ static bool is_done(int r, int Ext[], double E[])
  * returns         - true on success, false on failure to converge
  ********************/
 
-static int remez(double h[],
-                 int numtaps,
-                 int numband,
-                 const double bands[],
-                 const double des[],
-                 const double weight[],
-                 int type,
+static int remez(std::vector<double>& h,
+                 unsigned int numtaps,
+                 unsigned int numband,
+                 const std::vector<double>& bands,
+                 const std::vector<double>& response,
+                 const std::vector<double>& weight,
+                 filter_type type,
                  int griddensity)
 {
-    double *Grid, *W, *D, *E;
-    int i, iter, gridsize, r, *Ext;
-    double *taps, c;
-    double *x, *y, *ad;
-    int symmetry;
+    symmetry_type symmetry = (type == filter_type::BANDPASS) ? symmetry_type::POSITIVE
+                                                             : symmetry_type::NEGATIVE;
 
-    if (type == BANDPASS)
-        symmetry = POSITIVE;
-    else
-        symmetry = NEGATIVE;
-
-    r = numtaps / 2; /* number of extrema */
-    if ((numtaps % 2) && (symmetry == POSITIVE))
-        r++;
+    int n_extrema = numtaps / 2; /* number of extrema */
+    if ((numtaps % 2) && (symmetry == symmetry_type::POSITIVE))
+        n_extrema++;
 
     /*
      * Predict dense grid size in advance for memory allocation
      *   .5 is so we round up, not truncate
      */
-    gridsize = 0;
-    for (i = 0; i < numband; i++) {
-        gridsize += (int)(2 * r * griddensity * (bands[2 * i + 1] - bands[2 * i]) + .5);
+    unsigned int gridsize = 0;
+    for (unsigned int i = 0; i < numband; i++) {
+        gridsize +=
+            (int)(2 * n_extrema * griddensity * (bands[2 * i + 1] - bands[2 * i]) + .5);
     }
-    if (symmetry == NEGATIVE) {
+    if (symmetry == symmetry_type::NEGATIVE) {
         gridsize--;
     }
 
     /*
      * Dynamically allocate memory for arrays with proper sizes
      */
-    Grid = (double*)malloc(gridsize * sizeof(double));
-    D = (double*)malloc(gridsize * sizeof(double));
-    W = (double*)malloc(gridsize * sizeof(double));
-    E = (double*)malloc(gridsize * sizeof(double));
-    Ext = (int*)malloc((r + 1) * sizeof(int));
-    taps = (double*)malloc((r + 1) * sizeof(double));
-    x = (double*)malloc((r + 1) * sizeof(double));
-    y = (double*)malloc((r + 1) * sizeof(double));
-    ad = (double*)malloc((r + 1) * sizeof(double));
+    std::vector<double> Grid(gridsize);
+    std::vector<double> D(gridsize);
+    std::vector<double> W(gridsize);
+    std::vector<double> E(gridsize);
+    std::vector<int> Ext((n_extrema + 1));
+    std::vector<double> taps((n_extrema + 1));
+    std::vector<double> x((n_extrema + 1));
+    std::vector<double> y((n_extrema + 1));
+    std::vector<double> ad((n_extrema + 1));
+
 
     /*
      * Create dense frequency grid
      */
-    create_dense_grid(r,
+    create_dense_grid(n_extrema,
                       numtaps,
                       numband,
                       bands,
-                      des,
+                      response,
                       weight,
                       gridsize,
                       Grid,
@@ -648,13 +630,13 @@ static int remez(double h[],
                       W,
                       symmetry,
                       griddensity);
-    initial_guess(r, Ext, gridsize);
+    initial_guess(n_extrema, Ext, gridsize);
 
     /*
      * For Differentiator: (fix grid)
      */
-    if (type == DIFFERENTIATOR) {
-        for (i = 0; i < gridsize; i++) {
+    if (type == filter_type::DIFFERENTIATOR) {
+        for (unsigned int i = 0; i < gridsize; i++) {
             /* D[i] = D[i]*Grid[i]; */
             if (D[i] > 0.0001)
                 W[i] = W[i] / Grid[i];
@@ -665,24 +647,24 @@ static int remez(double h[],
      * For odd or Negative symmetry filters, alter the
      * D[] and W[] according to Parks McClellan
      */
-    if (symmetry == POSITIVE) {
+    if (symmetry == symmetry_type::POSITIVE) {
         if (numtaps % 2 == 0) {
-            for (i = 0; i < gridsize; i++) {
-                c = cos(Pi * Grid[i]);
+            for (unsigned int i = 0; i < gridsize; i++) {
+                double c = cos(PI * Grid[i]);
                 D[i] /= c;
                 W[i] *= c;
             }
         }
     } else {
         if (numtaps % 2) {
-            for (i = 0; i < gridsize; i++) {
-                c = sin(Pi2 * Grid[i]);
+            for (unsigned int i = 0; i < gridsize; i++) {
+                double c = sin(PI2 * Grid[i]);
                 D[i] /= c;
                 W[i] *= c;
             }
         } else {
-            for (i = 0; i < gridsize; i++) {
-                c = sin(Pi * Grid[i]);
+            for (unsigned int i = 0; i < gridsize; i++) {
+                double c = sin(PI * Grid[i]);
                 D[i] /= c;
                 W[i] *= c;
             }
@@ -692,48 +674,41 @@ static int remez(double h[],
     /*
      * Perform the Remez Exchange algorithm
      */
+    unsigned int iter;
     for (iter = 0; iter < MAXITERATIONS; iter++) {
-        calc_parms(r, Ext, Grid, D, W, ad, x, y);
-        calc_error(r, ad, x, y, gridsize, Grid, D, W, E);
-        int err = search(r, Ext, gridsize, E);
+        calc_parms(n_extrema, Ext, Grid, D, W, ad, x, y);
+        calc_error(n_extrema, ad, x, y, gridsize, Grid, D, W, E);
+        int err = search(n_extrema, Ext, gridsize, E);
         if (err) {
-            free(Grid);
-            free(W);
-            free(D);
-            free(E);
-            free(Ext);
-            free(taps);
-            free(x);
-            free(y);
-            free(ad);
             return err;
         }
-        for (int i = 0; i <= r; i++)
+        for (int i = 0; i <= n_extrema; i++)
             assert(Ext[i] < gridsize);
-        if (is_done(r, Ext, E))
+        if (is_done(n_extrema, Ext, E))
             break;
     }
 
-    calc_parms(r, Ext, Grid, D, W, ad, x, y);
+    calc_parms(n_extrema, Ext, Grid, D, W, ad, x, y);
 
     /*
      * Find the 'taps' of the filter for use with Frequency
      * Sampling.  If odd or Negative symmetry, fix the taps
      * according to Parks McClellan
      */
-    for (i = 0; i <= numtaps / 2; i++) {
-        if (symmetry == POSITIVE) {
+    for (unsigned int i = 0; i <= numtaps / 2; i++) {
+        double c;
+        if (symmetry == symmetry_type::POSITIVE) {
             if (numtaps % 2)
                 c = 1;
             else
-                c = cos(Pi * (double)i / numtaps);
+                c = cos(PI * (double)i / numtaps);
         } else {
             if (numtaps % 2)
-                c = sin(Pi2 * (double)i / numtaps);
+                c = sin(PI2 * (double)i / numtaps);
             else
-                c = sin(Pi * (double)i / numtaps);
+                c = sin(PI * (double)i / numtaps);
         }
-        taps[i] = compute_A((double)i / numtaps, r, ad, x, y) * c;
+        taps[i] = compute_A((double)i / numtaps, n_extrema, ad, x, y) * c;
     }
 
     /*
@@ -741,113 +716,96 @@ static int remez(double h[],
      */
     freq_sample(numtaps, taps, h, symmetry);
 
-    /*
-     * Delete allocated memory
-     */
-    free(Grid);
-    free(W);
-    free(D);
-    free(E);
-    free(Ext);
-    free(taps);
-    free(x);
-    free(y);
-    free(ad);
-
     return iter < MAXITERATIONS ? 0 : -1;
 }
 
+
+template <typename error_t = std::runtime_error>
+static void punt(const std::string msg)
+{
+    gr::logger logger("pm_remez");
+    logger.error("{:s}", msg);
+    throw error_t(msg);
+}
 //////////////////////////////////////////////////////////////////////////////
 //
 //			    GNU Radio interface
 //
 //////////////////////////////////////////////////////////////////////////////
 
-static void punt(gr::logger_ptr logger, const std::string msg)
-{
-    logger->error("{:s}", msg);
-    throw std::runtime_error(msg);
-}
-
 std::vector<double> pm_remez(int order,
                              const std::vector<double>& arg_bands,
                              const std::vector<double>& arg_response,
                              const std::vector<double>& arg_weight,
-                             const std::string filter_type,
+                             const std::string filter_type_str,
                              int grid_density) noexcept(false)
 {
-    static bool loggers_set_up = false;
 
-    gr::logger_ptr logger, debug_logger;
-    if (!loggers_set_up) {
-        gr::configure_default_loggers(logger, debug_logger, "pm_remez");
-        loggers_set_up = true;
-    }
     int numtaps = order + 1;
     if (numtaps < 4)
-        punt(logger, "number of taps must be >= 3");
+        punt<std::invalid_argument>("number of taps must be >= 3");
 
     int numbands = arg_bands.size() / 2;
-    LOCAL_BUFFER(double, bands, numbands * 2);
     if (numbands < 1 || arg_bands.size() % 2 == 1)
-        punt(logger, "must have an even number of band edges");
+        punt<std::invalid_argument>("must have an even number of band edges");
 
     for (unsigned int i = 1; i < arg_bands.size(); i++) {
         if (arg_bands[i] < arg_bands[i - 1])
-            punt(logger, "band edges must be nondecreasing");
+            punt<std::invalid_argument>("band edges must be nondecreasing");
     }
 
     if (arg_bands[0] < 0 || arg_bands[arg_bands.size() - 1] > 1)
-        punt(logger, "band edges must be in the range [0,1]");
+        punt<std::domain_error>("band edges must be in the range [0,1]");
 
+    std::vector<double> bands(numbands * 2);
     // Divide by 2 to fit with the implementation that uses a
     // sample rate of [0, 0.5] instead of [0, 1.0]
     for (int i = 0; i < 2 * numbands; i++)
         bands[i] = arg_bands[i] / 2;
 
-    LOCAL_BUFFER(double, response, numbands * 2);
     if (arg_response.size() != arg_bands.size())
-        punt(logger, "must have one response magnitude for each band edge");
+        punt<std::invalid_argument>(
+            "must have one response magnitude for each band edge");
 
+    std::vector<double> response(numbands * 2);
     for (int i = 0; i < 2 * numbands; i++)
         response[i] = arg_response[i];
 
-    LOCAL_BUFFER(double, weight, numbands);
-    for (int i = 0; i < numbands; i++)
-        weight[i] = 1.0;
+    std::vector<double> weight(numbands, 1.0);
 
     if (!arg_weight.empty()) {
         if ((int)arg_weight.size() != numbands)
-            punt(logger, "need one weight for each band [=length(band)/2]");
+            punt<std::invalid_argument>(
+                "need one weight for each band [=length(band)/2]");
         for (int i = 0; i < numbands; i++)
             weight[i] = arg_weight[i];
     }
 
-    int itype = 0;
-    if (filter_type == "bandpass")
-        itype = BANDPASS;
-    else if (filter_type == "differentiator")
-        itype = DIFFERENTIATOR;
-    else if (filter_type == "hilbert")
-        itype = HILBERT;
+    filter_type filttype;
+    if (filter_type_str == "bandpass")
+        filttype = filter_type::BANDPASS;
+    else if (filter_type_str == "differentiator")
+        filttype = filter_type::DIFFERENTIATOR;
+    else if (filter_type_str == "hilbert")
+        filttype = filter_type::HILBERT;
     else
-        punt(logger, "unknown ftype '" + filter_type + "'");
+        punt<std::invalid_argument>("unknown ftype '" + filter_type_str + "'");
 
     if (grid_density < 16)
-        punt(logger, "grid_density is too low; must be >= 16");
+        punt<std::invalid_argument>("grid_density is too low; must be >= 16");
 
-    LOCAL_BUFFER(double, coeff, numtaps + 5); // FIXME why + 5?
+    std::vector<double> coeff(numtaps + 5); // FIXME why + 5?
     int err =
-        remez(coeff, numtaps, numbands, bands, response, weight, itype, grid_density);
+        remez(coeff, numtaps, numbands, bands, response, weight, filttype, grid_density);
 
     if (err == -1)
-        punt(logger, "failed to converge");
+        punt("failed to converge");
 
     if (err == -2)
-        punt(logger, "insufficient extremals -- cannot continue");
+        punt("insufficient extremals -- cannot continue");
 
     if (err == -3)
-        punt(logger, "too many extremals -- cannot continue");
+        punt("too many extremals -- cannot continue");
 
     return std::vector<double>(&coeff[0], &coeff[numtaps]);
 }

--- a/gr-filter/python/filter/bindings/pm_remez_python.cc
+++ b/gr-filter/python/filter/bindings/pm_remez_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(pm_remez.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(f640b8dda4d0684055c44803604c457b)                     */
+/* BINDTOOL_HEADER_FILE_HASH(36288e30d78a39eb4d38cbbdde47dc0e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gr-filter/python/filter/design/filter_design.py
+++ b/gr-filter/python/filter/design/filter_design.py
@@ -15,6 +15,7 @@ import warnings
 from optparse import OptionParser
 
 from gnuradio import filter, fft
+from .CustomViewBox import CustomViewBox
 
 try:
     import numpy as np
@@ -2334,23 +2335,6 @@ class gr_plot_filter(QtWidgets.QMainWindow):
             self.update_imp_curves()
 
         self.gui.nTapsEdit.setText(str(self.taps.size))
-
-
-class CustomViewBox(pg.ViewBox):
-    def __init__(self, *args, **kwds):
-        pg.ViewBox.__init__(self, *args, **kwds)
-        self.setMouseMode(self.RectMode)
-
-    # Reimplement right-click to zoom out.
-    def mouseClickEvent(self, ev):
-        if ev.button() == QtCore.Qt.RightButton:
-            self.autoRange()
-
-    def mouseDragEvent(self, ev):
-        if ev.button() == QtCore.Qt.RightButton:
-            ev.ignore()
-        else:
-            pg.ViewBox.mouseDragEvent(self, ev)
 
 
 def setup_options():

--- a/gr-filter/python/filter/design/fir_design.py
+++ b/gr-filter/python/filter/design/fir_design.py
@@ -246,6 +246,10 @@ def design_opt_lpf(fs, gain, mainwin):
         try:
             taps = filter.optfir.low_pass(gain, fs, pb, sb,
                                           ripple, atten)
+        except ValueError as e:
+            reply = QtWidgets.QMessageBox.information(mainwin, "Invalid filter parameters",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
+            return ([], [], False)
         except RuntimeError as e:
             reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
                                                       e.args[0], QtWidgets.QMessageBox.Ok)
@@ -278,6 +282,10 @@ def design_opt_bpf(fs, gain, mainwin):
         try:
             taps = filter.optfir.band_pass(gain, fs, sb1, pb1, pb2, sb2,
                                            ripple, atten)
+        except ValueError as e:
+            reply = QtWidgets.QMessageBox.information(mainwin, "Invalid filter parameters",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
+            return ([], [], False)
         except RuntimeError as e:
             reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
                                                       e.args[0], QtWidgets.QMessageBox.Ok)
@@ -312,6 +320,10 @@ def design_opt_cbpf(fs, gain, mainwin):
         try:
             taps = filter.optfir.complex_band_pass(gain, fs, sb1, pb1, pb2, sb2,
                                                    ripple, atten)
+        except ValueError as e:
+            reply = QtWidgets.QMessageBox.information(mainwin, "Invalid filter parameters",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
+            return ([], [], False)
         except RuntimeError as e:
             reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
                                                       e.args[0], QtWidgets.QMessageBox.Ok)
@@ -345,6 +357,10 @@ def design_opt_bnf(fs, gain, mainwin):
         try:
             taps = filter.optfir.band_reject(gain, fs, pb1, sb1, sb2, pb2,
                                              ripple, atten)
+        except ValueError as e:
+            reply = QtWidgets.QMessageBox.information(mainwin, "Invalid filter parameters",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
+            return ([], [], False)
         except RuntimeError as e:
             reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
                                                       e.args[0], QtWidgets.QMessageBox.Ok)
@@ -402,6 +418,10 @@ def design_opt_hpf(fs, gain, mainwin):
         try:
             taps = filter.optfir.high_pass(gain, fs, sb, pb,
                                            atten, ripple)
+        except ValueError as e:
+            reply = QtWidgets.QMessageBox.information(mainwin, "Invalid filter parameters",
+                                                      e.args[0], QtWidgets.QMessageBox.Ok)
+            return ([], [], False)
         except RuntimeError as e:
             reply = QtWidgets.QMessageBox.information(mainwin, "Filter did not converge",
                                                       e.args[0], QtWidgets.QMessageBox.Ok)

--- a/gr-filter/python/filter/gui/CustomViewBox.py
+++ b/gr-filter/python/filter/gui/CustomViewBox.py
@@ -4,6 +4,7 @@ from PyQt5 import QtCore
 
 class CustomViewBox(pg.ViewBox):
     def __init__(self, *args, **kwds):
+        kwds['enableMenu'] = False
         pg.ViewBox.__init__(self, *args, **kwds)
         self.setMouseMode(self.RectMode)
 
@@ -11,9 +12,3 @@ class CustomViewBox(pg.ViewBox):
     def mouseClickEvent(self, ev):
         if ev.button() == QtCore.Qt.RightButton:
             self.autoRange()
-
-    def mouseDragEvent(self, ev):
-        if ev.button() == QtCore.Qt.RightButton:
-            ev.ignore()
-        else:
-            pg.ViewBox.mouseDragEvent(self, ev)

--- a/gr-filter/python/filter/gui/banditems.py
+++ b/gr-filter/python/filter/gui/banditems.py
@@ -45,7 +45,7 @@ class filtermovlineItem(QtWidgets.QGraphicsObject):
     # Allow only vertical movement and emit signals.
     def itemChange(self, change, value):
         if (change == QtWidgets.QGraphicsItem.ItemPositionChange):
-            newpos = value.toPointF()
+            newpos = QtCore.QPointF(value)
             div = 0
             if newpos.y() < self.pos().y():
                 div = 1

--- a/gr-filter/python/filter/optfir.py
+++ b/gr-filter/python/filter/optfir.py
@@ -37,11 +37,16 @@ def low_pass(gain, Fs, freq1, freq2, passband_ripple_db, stopband_atten_db,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+    if(freq2 <= freq1):
+        raise ValueError("low pass filter must have pass band below stop band")
+
     passband_dev = passband_ripple_to_dev(passband_ripple_db)
     stopband_dev = stopband_atten_to_dev(stopband_atten_db)
     desired_ampls = (gain, 0)
     (n, fo, ao, w) = remezord([freq1, freq2], desired_ampls,
                               [passband_dev, stopband_dev], Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
     # The remezord typically under-estimates the filter order, so add 2 taps by default
     taps = filter.pm_remez(n + nextra_taps, fo, ao, w, "bandpass")
     return taps
@@ -64,6 +69,13 @@ def band_pass(gain, Fs, freq_sb1, freq_pb1, freq_pb2, freq_sb2,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+    if(freq_sb1 >= freq_pb1):
+        raise ValueError("band pass filter must have first stop band below pass band")
+    if(freq_pb1 >= freq_pb2):
+        raise ValueError("pass band corner frequencies must be ascending")
+    if(freq_pb2 >= freq_sb2):
+        raise ValueError("band pass filter must have pass band below second stop band")
+
     passband_dev = passband_ripple_to_dev(passband_ripple_db)
     stopband_dev = stopband_atten_to_dev(stopband_atten_db)
     desired_ampls = (0, gain, 0)
@@ -71,6 +83,9 @@ def band_pass(gain, Fs, freq_sb1, freq_pb1, freq_pb2, freq_sb2,
     desired_ripple = [stopband_dev, passband_dev, stopband_dev]
     (n, fo, ao, w) = remezord(desired_freqs, desired_ampls,
                               desired_ripple, Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
+
     # The remezord typically under-estimates the filter order, so add 2 taps by default
     taps = filter.pm_remez(n + nextra_taps, fo, ao, w, "bandpass")
     return taps
@@ -94,6 +109,14 @@ def complex_band_pass(gain, Fs, freq_sb1, freq_pb1, freq_pb2, freq_sb2,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+
+    if(freq_sb1 >= freq_pb1):
+        raise ValueError("band pass filter must have first stop band below pass band")
+    if(freq_pb1 >= freq_pb2):
+        raise ValueError("pass band corner frequencies must be ascending")
+    if(freq_pb2 >= freq_sb2):
+        raise ValueError("band pass filter must have pass band below second stop band")
+
     center_freq = (freq_pb2 + freq_pb1) / 2.0
     lp_pb = (freq_pb2 - center_freq) / 1.0
     lp_sb = freq_sb2 - center_freq
@@ -123,6 +146,13 @@ def complex_band_reject(gain, Fs, freq_pb1, freq_sb1, freq_sb2, freq_pb2,
         stopband_atten_db: Stop band attenuation in dB (should be large, >= 60)
         nextra_taps: Extra taps to use in the filter (default=2)
     """
+    if(freq_sb1 >= freq_pb1):
+        raise ValueError("band pass must have first stop band below pass band")
+    if(freq_pb1 >= freq_pb2):
+        raise ValueError("band pass corner frequencies must be ascending")
+    if(freq_pb2 >= freq_sb2):
+        raise ValueError("band pass must have pass band below second stop band")
+
     center_freq = (freq_sb2 + freq_sb1) / 2.0
     hp_pb = (freq_pb2 - center_freq) / 1.0
     hp_sb = freq_sb2 - center_freq
@@ -159,6 +189,8 @@ def band_reject(gain, Fs, freq_pb1, freq_sb1, freq_sb2, freq_pb2,
     desired_ripple = [passband_dev, stopband_dev, passband_dev]
     (n, fo, ao, w) = remezord(desired_freqs, desired_ampls,
                               desired_ripple, Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
     # Make sure we use an odd number of taps
     if((n + nextra_taps) % 2 == 1):
         n += 1
@@ -186,6 +218,8 @@ def high_pass(gain, Fs, freq1, freq2, passband_ripple_db, stopband_atten_db,
     desired_ampls = (0, 1)
     (n, fo, ao, w) = remezord([freq1, freq2], desired_ampls,
                               [stopband_dev, passband_dev], Fs)
+    if n == 0:
+        raise RuntimeError("can't determine sufficient order for filter")
     # For a HPF, we need to use an odd number of taps
     # In filter.remez, ntaps = n+1, so n must be even
     if((n + nextra_taps) % 2 == 1):

--- a/gr-filter/python/filter/pfb.py
+++ b/gr-filter/python/filter/pfb.py
@@ -69,7 +69,10 @@ class channelizer_ccf(gr.hier_block2):
         while True:
             try:
                 taps = optfir.low_pass(1, numchans, bw, bw + tb, ripple, atten)
-                return taps
+                return tap
+            except ValueError as e:
+                # This shouldn't happen, unless numchans is strange
+                raise RuntimeError("couldn't design filter; this probably constitutes a bug")
             except RuntimeError:
                 ripple += 0.01
                 print("Warning: set ripple to %.4f dB. If this is a problem, adjust the attenuation or create your own filter taps." % (ripple))
@@ -133,6 +136,7 @@ class interpolator_ccf(gr.hier_block2):
                 if(ripple >= 1.0):
                     raise RuntimeError(
                         "optfir could not generate an appropriate filter.")
+            # We bubble up ValueError – probably caused by user input
 
 
 class decimator_ccf(gr.hier_block2):
@@ -195,6 +199,7 @@ class decimator_ccf(gr.hier_block2):
                 if(ripple >= 1.0):
                     raise RuntimeError(
                         "optfir could not generate an appropriate filter.")
+            # Not handling ValueError – probably a user input caused this.
 
 
 class arb_resampler_ccf(gr.hier_block2):
@@ -279,6 +284,7 @@ class arb_resampler_ccf(gr.hier_block2):
                     if(ripple >= 1.0):
                         raise RuntimeError(
                             "optfir could not generate an appropriate filter.")
+                # We intentionally don't handle ValueError here, because it's most likely caused by user input
 
 
 class arb_resampler_fff(gr.hier_block2):
@@ -362,6 +368,7 @@ class arb_resampler_fff(gr.hier_block2):
                     if(ripple >= 1.0):
                         raise RuntimeError(
                             "optfir could not generate an appropriate filter.")
+                # If a ValueError happens here, it's probably due to specific user input
 
 
 class arb_resampler_ccc(gr.hier_block2):
@@ -424,6 +431,7 @@ class arb_resampler_ccc(gr.hier_block2):
                 if(ripple >= 1.0):
                     raise RuntimeError(
                         "optfir could not generate an appropriate filter.")
+                # If a ValueError happens here, it's probably due to specific user input
 
 
 class channelizer_hier_ccf(gr.hier_block2):

--- a/gr-filter/python/filter/qa_pm_remez.py
+++ b/gr-filter/python/filter/qa_pm_remez.py
@@ -139,7 +139,7 @@ class test_pm_remez(gr_unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_low_pass(self):
+    def test_001_low_pass(self):
         gain = 1
         Fs = 1
         freq1 = 0.1
@@ -175,6 +175,17 @@ class test_pm_remez(gr_unittest.TestCase):
                       -0.0008370135734511828)
 
         self.assertFloatTuplesAlmostEqual(known_taps, new_taps, 5)
+
+    def test_002_test_invalid_args(self):
+        with self.assertRaises(ValueError):
+            # two taps are too few
+            filter.pm_remez(2, [0, 0.1], [1, 2e-4], [1, 0.25], "bandpass")
+        with self.assertRaises(ValueError):
+            # frequencies need to be ordered
+            filter.pm_remez(200, [0.1, 0], [1, 2e-4], [1, 0.25], "bandpass")
+        with self.assertRaises(ValueError):
+            # bands, gains need to be of same length
+            filter.pm_remez(200, [0, 0.1], [1, 2e-4, 2e-6], [1, 0.25], "bandpass")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Backport #6621 #6629 #6639 #6640 

There is a change in exceptions `pm_remez()`:

> throws std::invalid_argument if args are invalid and std::runtime_error if calculation fails to converge

where previously only `std::runtime_error` was thrown.

Given that so many checks were missing and the risk of bad results, it seems like a good idea to backport this behavior change.