### PR TITLE
ci: Remove Fedora 36, add Fedora 38 (backport to maint-3.10)

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -73,11 +73,6 @@ jobs:
             cxxflags: -Werror
             ctest_args: '-E "qa_polar_..coder_(sc_)?systematic"'
             ldpath:
-          - distro: 'Fedora 36'
-            containerid: 'gnuradio/ci:fedora-36-3.9'
-            cxxflags: -Werror
-            ctest_args: '-E ""'
-            ldpath: /usr/local/lib64/
           - distro: 'Fedora 37'
             containerid: 'gnuradio/ci:fedora-37-3.9'
             cxxflags: -Werror

--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -78,6 +78,11 @@ jobs:
             cxxflags: -Werror
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
+          - distro: 'Fedora 38'
+            containerid: 'gnuradio/ci:fedora-38-3.10'
+            cxxflags: -Werror
+            ctest_args: '-E ""'
+            ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'
           #   containerid: 'gnuradio/ci:centos-8.4-3.10'
           #   cxxflags: ''


### PR DESCRIPTION
Backport #6672 #6677 

Note that we are still not using memory fill in CI for maint-3.10, only in main.