### PR TITLE
soapy: add discrete rates for AirspyHF, always show gain in params

### DIFF
--- a/gr-soapy/grc/soapy_airspyhf_source.block.yml
+++ b/gr-soapy/grc/soapy_airspyhf_source.block.yml
@@ -20,7 +20,9 @@ parameters:
   - id: samp_rate
     label: Sample Rate
     dtype: float
-    default: 'samp_rate'
+    options: [912000, 768000, 456000, 384000, 256000, 192000]
+    option_labels: [912k, 768k, 456k, 384k, 256k, 192k]
+    default: 768000
 
   - id: center_freq
     label: 'Center Freq (Hz)'
@@ -47,7 +49,7 @@ parameters:
     category: RF Options
     dtype: real
     default: '-24'
-    hide: ${'all' if agc else 'part'}
+    hide: part
 
   - id: lna
     label: 'LNA On (+6 dB)'


### PR DESCRIPTION
## Description
AirspyHF has specific sample rates. Add them as options.

Also, make gain visible in params dialog even if agc is on, to help with wiring UI elements.

## Which blocks/areas does this affect?
Soapy AirspyHF Source

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
