### PR TITLE
CI: F38 as clang build

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -78,9 +78,10 @@ jobs:
             cxxflags: -Werror -ftrivial-auto-var-init=pattern
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
-          - distro: 'Fedora 38 (with 0xFE memory initialization)'
+          - distro: 'Fedora 38 (clang)'
             containerid: 'gnuradio/ci:fedora-38-3.10'
-            cxxflags: -Werror -ftrivial-auto-var-init=pattern
+            cxxflags: -Werror
+            cmakeflags: -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
             ctest_args: '-E ""'
             ldpath: /usr/local/lib64/
           # - distro: 'CentOS 8.4'
@@ -111,7 +112,7 @@ jobs:
     - name: CMake
       env:
         CXXFLAGS: ${{ matrix.cxxflags }}
-      run: 'cd /build && cmake ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
+      run: 'cd /build && cmake ${{ matrix.cmakeflags }} ${GITHUB_WORKSPACE} -DENABLE_DOXYGEN=OFF'
     - name: Dump compile commands
       run: 'cd /build && cat compile_commands.json'
     - name: Make

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -479,7 +479,6 @@ void flat_flowgraph::replace_endpoint(const msg_endpoint& e,
                                       const msg_endpoint& r,
                                       bool is_src)
 {
-    size_t n_replr(0);
     d_debug_logger->debug("flat_flowgraph::replace_endpoint( {}, {}, {:d} )\n",
                           e.block()->identifier(),
                           r.block()->identifier(),
@@ -492,7 +491,6 @@ void flat_flowgraph::replace_endpoint(const msg_endpoint& e,
                     r.identifier(),
                     d_msg_edges[i].dst().identifier());
                 d_msg_edges.push_back(msg_edge(r, d_msg_edges[i].dst()));
-                n_replr++;
             }
         } else {
             if (d_msg_edges[i].dst() == e) {
@@ -501,7 +499,6 @@ void flat_flowgraph::replace_endpoint(const msg_endpoint& e,
                     r.identifier(),
                     d_msg_edges[i].src().identifier());
                 d_msg_edges.push_back(msg_edge(d_msg_edges[i].src(), r));
-                n_replr++;
             }
         }
     }

--- a/gr-digital/lib/constellation_decoder_cb_impl.h
+++ b/gr-digital/lib/constellation_decoder_cb_impl.h
@@ -28,7 +28,7 @@ public:
     constellation_decoder_cb_impl(constellation_sptr constellation);
     ~constellation_decoder_cb_impl() override;
 
-    void set_constellation(constellation_sptr constellation);
+    void set_constellation(constellation_sptr constellation) override;
 
     void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 

--- a/gr-digital/lib/constellation_encoder_bc_impl.h
+++ b/gr-digital/lib/constellation_encoder_bc_impl.h
@@ -27,7 +27,7 @@ public:
     constellation_encoder_bc_impl(constellation_sptr constellation);
     ~constellation_encoder_bc_impl() override;
 
-    void set_constellation(constellation_sptr constellation);
+    void set_constellation(constellation_sptr constellation) override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-digital/lib/constellation_soft_decoder_cf_impl.h
+++ b/gr-digital/lib/constellation_soft_decoder_cf_impl.h
@@ -31,7 +31,7 @@ public:
     constellation_soft_decoder_cf_impl(constellation_sptr constellation);
     ~constellation_soft_decoder_cf_impl() override;
 
-    void set_constellation(constellation_sptr constellation);
+    void set_constellation(constellation_sptr constellation) override;
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,

--- a/gr-qtgui/lib/fosphor_display_impl.cc
+++ b/gr-qtgui/lib/fosphor_display_impl.cc
@@ -36,7 +36,6 @@ fosphor_display_impl::fosphor_display_impl(const int fft_bins,
                 gr::io_signature::make(0, 0, 0)),
       d_fft_bins(fft_bins),
       d_pwr_bins(pwr_bins),
-      d_wf_lines(wf_lines),
       d_subframe_num(pwr_bins + 2)
 {
     /* Message Port output */

--- a/gr-qtgui/lib/fosphor_display_impl.h
+++ b/gr-qtgui/lib/fosphor_display_impl.h
@@ -58,7 +58,6 @@ private:
 
     int d_fft_bins;
     int d_pwr_bins;
-    int d_wf_lines;
 
     double d_center_freq = 0.0;
     double d_samp_rate = 0.0;


### PR DESCRIPTION
## Description

We have a lot of different platforms for test builds; but on Linux we really just test building with one compiler, GCC.

This converts the 0xFE-initializing F38 GCC builder to a (non-special-initalizing) F38 clang++ builder.

I guess this would uncover warnings introduced by new code a bit earlier, potentially 

## Related Issue

Nöne.

## Which blocks/areas does this affect?

CI

## Testing Done

This test build

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
