### PR TITLE
gr-uhd: fix infinite recursion in the case a device is poorly connected

### DIFF
--- a/gr-uhd/lib/usrp_source_impl.h
+++ b/gr-uhd/lib/usrp_source_impl.h
@@ -125,6 +125,13 @@ public:
     void setup_rpc() override;
 
 private:
+    //! Tries to receive data from the device
+    // returns the number of produced samples or -1 to request a retrial
+    int try_work(int noutput_items,
+                 gr_vector_const_void_star& input_items,
+                 gr_vector_void_star& output_items);
+
+private:
     //! Like set_center_freq(), but uses _curr_freq and _curr_lo_offset
     ::uhd::tune_result_t _set_center_freq_from_internals(size_t chan,
                                                          pmt::pmt_t direction) override;
@@ -143,12 +150,13 @@ private:
     bool _issue_stream_cmd_on_start;
     std::chrono::time_point<std::chrono::steady_clock> _last_log;
     unsigned int _overflow_count;
+    unsigned int _num_overflow_retries;
     std::chrono::milliseconds _overflow_log_interval;
 
     // tag shadows
     double _samp_rate;
 
-    std::recursive_mutex d_mutex;
+    std::mutex d_mutex;
 
     const pmt::pmt_t _direction() const override { return direction_rx(); };
 };


### PR DESCRIPTION
When using a usrp on a shaky ethernet connection, the device might repeatedly report overflow errors which caused an infinite recursion in the work function. This is problematic since this will prevent the gnuradio flowgraph from being stopped since this block will always be busy.

I added a variable for number of retries until quitting, but it has a hard coded value of 10. I didn't want to complicate the interface and make this value changeable from the outside since it doesn't seem likely that tuning this value could cause any benefits.

I also took the liberty to change the recursive mutex to a normal mutex. The mutex is used in only three functions:
1. work
2. start
3. stop

And none of them call each other anymore, so this should be safe.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
