### PR TITLE
runtime: thread_group use set instead of list for set of threads

### DIFF
--- a/gnuradio-runtime/include/gnuradio/thread/thread_group.h
+++ b/gnuradio-runtime/include/gnuradio/thread/thread_group.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2001-2003 William E. Kempf
  * Copyright (C) 2007 Anthony Williams
  * Copyright 2008,2009 Free Software Foundation, Inc.
+ * Copyright 2023 Marcus Müller
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,7 +18,9 @@
 
 #include <gnuradio/api.h>
 #include <gnuradio/thread/thread.h>
+
 #include <shared_mutex>
+#include <unordered_set>
 #include <functional>
 #include <memory>
 
@@ -27,20 +30,20 @@ namespace thread {
 class GR_RUNTIME_API thread_group
 {
 public:
-    thread_group();
-    ~thread_group();
+    thread_group() = default;
+    ~thread_group() = default;
     thread_group(const thread_group&) = delete;
     thread_group& operator=(const thread_group&) = delete;
 
     boost::thread* create_thread(const std::function<void()>& threadfunc);
-    void add_thread(std::unique_ptr<boost::thread> thrd);
-    void remove_thread(boost::thread* thrd);
+    void add_thread(std::unique_ptr<boost::thread> thrd) noexcept;
+    void remove_thread(boost::thread* thrd) noexcept;
     void join_all();
     void interrupt_all();
-    size_t size() const;
+    size_t size() const noexcept;
 
 private:
-    std::list<std::unique_ptr<boost::thread>> m_threads;
+    std::unordered_set<std::unique_ptr<boost::thread>> m_threads;
     mutable std::shared_mutex m_mutex;
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

Currently, `thread_group` is using `std::list` to keep a set of thread unique ptrs, which is both inefficient computationally and complicated code-wise.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Fixes a missed `#include <mutex>`, which was hidden by precompiled headers (or so it seems!) on the way.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

Internal to `thread_group`; API doesn't change


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
