### PR TITLE
network: Fix various bugs

### DIFF
--- a/gr-network/lib/tcp_sink_impl.cc
+++ b/gr-network/lib/tcp_sink_impl.cc
@@ -98,6 +98,7 @@ bool tcp_sink_impl::start()
         // In this mode, we're starting a local port listener and waiting
         // for inbound connections.
         d_start_new_listener = true;
+        d_is_ipv6 = false;
         d_listener_thread = new std::thread([this] { run_listener(); });
     }
 
@@ -202,9 +203,7 @@ bool tcp_sink_impl::stop()
     }
 
     if (d_listener_thread) {
-        while (d_thread_running)
-            std::this_thread::sleep_for(std::chrono::microseconds(5));
-
+        d_listener_thread->join();
         delete d_listener_thread;
         d_listener_thread = NULL;
     }

--- a/gr-network/lib/udp_sink_impl.cc
+++ b/gr-network/lib/udp_sink_impl.cc
@@ -174,7 +174,8 @@ bool udp_sink_impl::stop()
         }
 
         d_udpsocket->close();
-        d_udpsocket = NULL;
+        delete d_udpsocket;
+        d_udpsocket = nullptr;
 
         d_io_context.reset();
         d_io_context.stop();

--- a/gr-network/lib/udp_sink_impl.h
+++ b/gr-network/lib/udp_sink_impl.h
@@ -51,7 +51,7 @@ protected:
 
     asio::io_context d_io_context;
     asio::ip::udp::endpoint d_endpoint;
-    asio::ip::udp::socket* d_udpsocket;
+    asio::ip::udp::socket* d_udpsocket = nullptr;
 
     virtual void
     build_header(); // returns header size.  Header is stored in tmpHeaderBuff

--- a/gr-network/lib/udp_source_impl.cc
+++ b/gr-network/lib/udp_source_impl.cc
@@ -153,8 +153,8 @@ bool udp_source_impl::stop()
 {
     if (d_udpsocket) {
         d_udpsocket->close();
-
-        d_udpsocket = NULL;
+        delete d_udpsocket;
+        d_udpsocket = nullptr;
 
         d_io_context.reset();
         d_io_context.stop();

--- a/gr-network/lib/udp_source_impl.h
+++ b/gr-network/lib/udp_source_impl.h
@@ -46,7 +46,7 @@ protected:
 
     asio::io_context d_io_context;
     asio::ip::udp::endpoint d_endpoint;
-    asio::ip::udp::socket* d_udpsocket;
+    asio::ip::udp::socket* d_udpsocket = nullptr;
 
     asio::streambuf d_read_buffer;
 


### PR DESCRIPTION
## Description
This fixes the following bugs:

* `udp_sink_impl::stop` leaks `d_udpsocket` (80 bytes on my system)
* `udp_sink_impl::stop` reads uninitialized `d_udpsocket` (and often crashes) if the block was not previously started
* `udp_source_impl::stop` leaks `d_udpsocket` (80 bytes on my system)
* `udp_source_impl::stop` reads uninitialized `d_udpsocket` (and often crashes) if the block was not previously started
* `tcp_sink_impl::connect` reads uninitialized `d_is_ipv6` if the block is in server mode
* `tcp_sink_impl::stop` crashes in server mode because it fails to join `d_listener_thread`

## Which blocks/areas does this affect?
* UDP Sink
* UDP Source
* TCP Sink

## Testing Done
To test the blocks, I used valgrind (`valgrind --leak-check=full --show-leak-kinds=definite python3`), and ran the following Python code:
```python
from gnuradio import network

u_sink = network.udp_sink(1, 1, "localhost", 1234, 0, 1448, True)
del u_sink

u_sink = network.udp_sink(1, 1, "localhost", 1234, 0, 1448, True)
u_sink.start()
u_sink.stop()
del u_sink

u_source = network.udp_source(1, 1, 1234, 0, 1448, True, True, False)
del u_source

u_source = network.udp_source(1, 1, 1234, 0, 1448, True, True, False)
u_source.start()
u_source.stop()
del u_source

t_sink = network.tcp_sink(1, 1, "localhost", 1234, 2)
t_sink.start()
t_sink.stop()
del t_sink
```

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
