### PR TITLE
fec: include cstdint in gr-fec's alist.h (backport to maint-3.10)

### DIFF
--- a/gr-fec/include/gnuradio/fec/alist.h
+++ b/gr-fec/include/gnuradio/fec/alist.h
@@ -23,6 +23,7 @@
 #define ALIST_H
 
 #include <gnuradio/fec/api.h>
+#include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <sstream>


### PR DESCRIPTION
Backport #6667 