### PR TITLE
soapy: rtlsdr bias tee and restore gain after agc (backport to maint-3.10)

### DIFF
--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -47,7 +47,13 @@ parameters:
     category: RF Options
     dtype: real
     default: '20'
-    hide: ${'all' if agc else 'part'}
+    hide: 'part'
+
+  - id: bias
+    label: 'Bias Tee Power'
+    dtype: bool
+    default: 'False'
+    hide: 'part'
 
 inputs:
   - domain: message
@@ -68,18 +74,35 @@ templates:
       tune_args = ['']
       settings = ['']
 
+      ## Intercept the agc callback and restore the gain when agc is
+      ## disabled. The driver does not do this. LNA state is preserved.
+      def _set_${id}_gain_mode(channel, agc):
+          self.${id}.set_gain_mode(channel, agc)
+          if not agc:
+                self.${id}.set_gain(channel, self.gain)
+      self.set_${id}_gain_mode = _set_${id}_gain_mode
+
+      ## Intercept set_gain to keep it from turning off agc mode
+      def _set_${id}_gain(channel, name, gain):
+          if not self.agc:
+              self.${id}.set_gain(channel, gain)
+      self.set_${id}_gain = _set_${id}_gain
+
       self.${id} = soapy.source(dev, "${type}", 1, ${dev_args},
                                 stream_args, tune_args, settings)
       self.${id}.set_sample_rate(0, ${samp_rate})
-      self.${id}.set_gain_mode(0, ${agc})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      self.${id}.set_gain(0, 'TUNER', ${gain})
+      self.${id}.write_setting('biastee', ${bias})
+      self.set_${id}_gain_mode(0, ${agc})
+      self.set_${id}_gain(0, 'TUNER', ${gain})
+
   callbacks:
     - set_sample_rate(0, ${samp_rate})
-    - set_gain_mode(0, ${agc})
     - set_frequency(0, ${center_freq})
     - set_frequency_correction(0, ${freq_correction})
-    - set_gain(0, 'TUNER', ${gain})
+    - self.set_${id}_gain_mode(0, ${agc})
+    - self.set_${id}_gain(0, 'TUNER', ${gain})
+    - write_setting('biastee', ${bias})
 
 file_format: 1


### PR DESCRIPTION
Backport #6666