### PR TITLE
runtime: do not set max buffer size as side effect of allocation

### DIFF
--- a/gnuradio-runtime/lib/block.cc
+++ b/gnuradio-runtime/lib/block.cc
@@ -410,13 +410,14 @@ void block::allocate_detail(int ninputs,
 
         // Update the block's max_output_buffer based on what was actually allocated.
         if ((max_output_buffer(i) != static_cast<long>(buffer->bufsize())) &&
-            (max_output_buffer(i) != -1))
+            (max_output_buffer(i) != -1)) {
             d_logger->warn("Block ({:s}) max output buffer set to {:d}"
                            " instead of requested {:d}",
                            alias(),
                            buffer->bufsize(),
                            max_output_buffer(i));
-        set_max_output_buffer(i, buffer->bufsize());
+            set_max_output_buffer(i, buffer->bufsize());
+        }
     }
 
     // Store the block_detail that was created above


### PR DESCRIPTION
## Description
max_output_buffer was being set after allocation regardless of whether the user originally specified a max buffer size. In addition to setting an non-required max, this interfered with a user set min buffer size, since max is given priority over min.

## Related Issue
Several issues discussed on chat for GNU Radio and Gqrx where setting a min buffer size had no effect, and also where max buffer size warnings are printed even though no max buffer size was set.

## Which blocks/areas does this affect?
Block

## Testing Done
Setting min buffer size in https://github.com/gqrx-sdr/gqrx/pull/1249 for https://github.com/gqrx-sdr/gqrx/issues/1233 has the desired effect and produces no max buf size warning.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
