### PR TITLE
fosphor_formatter updates

### DIFF
--- a/gr-qtgui/include/gnuradio/qtgui/fosphor_formatter.h
+++ b/gr-qtgui/include/gnuradio/qtgui/fosphor_formatter.h
@@ -10,7 +10,7 @@
 #ifndef INCLUDED_QTGUI_FOSPHOR_FORMATTER_H
 #define INCLUDED_QTGUI_FOSPHOR_FORMATTER_H
 
-#include <gnuradio/hier_block2.h>
+#include <gnuradio/block.h>
 #include <gnuradio/qtgui/api.h>
 
 namespace gr {
@@ -20,7 +20,7 @@ namespace qtgui {
  * \brief Generic CPM modulator
  * \ingroup modulators_blk
  */
-class QTGUI_API fosphor_formatter : virtual public hier_block2
+class QTGUI_API fosphor_formatter : virtual public block
 {
 public:
     using sptr = std::shared_ptr<fosphor_formatter>;

--- a/gr-qtgui/lib/fosphor_formatter_impl.cc
+++ b/gr-qtgui/lib/fosphor_formatter_impl.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2023 Ettus Research, A National Instruments Brand
+ * Copyright 2023 Jeff Long
  *
  * This file is part of GNU Radio
  *
@@ -12,205 +13,223 @@
 #endif
 
 #include "fosphor_formatter_impl.h"
+#include <gnuradio/fft/fft.h>
 #include <gnuradio/fft/window.h>
 #include <gnuradio/io_signature.h>
+#include <volk/volk_32fc_32f_multiply_32fc.h>
+#include <volk/volk_32fc_x2_multiply_32fc.h>
 #include <cmath>
 #include <cstring>
 
-using namespace gr::qtgui;
+using gr::fft::window;
 
-namespace {
+namespace gr {
+namespace qtgui {
 
-// Helper function for converting float to unsigned char
-void float_array_to_uchar(const float* in,
-                          unsigned char* out,
-                          int nsamples,
-                          const float scaling = 1.0f)
+fosphor_formatter_impl::fosphor_formatter_impl(int fft_size,
+                                               int num_bins,
+                                               int input_decim,
+                                               int waterfall_decim,
+                                               int histo_decim,
+                                               double scale,
+                                               double alpha,
+                                               double epsilon,
+                                               double trise,
+                                               double tdecay)
+    : block("histo_proc",
+            gr::io_signature::make(1, 1, sizeof(gr_complex)),
+            gr::io_signature::make(2, 2, sizeof(unsigned char) * fft_size)),
+      d_fft_size(fft_size),
+      d_num_bins(num_bins),
+      d_input_decim(input_decim),
+      d_waterfall_decim(waterfall_decim),
+      d_histo_decim(histo_decim),
+      d_scale(static_cast<float>(scale)),
+      d_alpha(static_cast<float>(alpha)),
+      d_epsilon(static_cast<float>(epsilon)),
+      d_trise(static_cast<float>(trise)),
+      d_tdecay(static_cast<float>(tdecay)),
+      d_iir(fft_size, 0.0f),
+      d_maxhold_buf(fft_size, 0.0f),
+      d_histo_buf_f(fft_size * d_num_bins, 0.0f),
+      d_histo_buf_b(fft_size * d_num_bins, 0),
+      d_hit_count(fft_size * d_num_bins, 0),
+      d_input_count(0),
+      d_waterfall_count(0),
+      d_histo_count(0)
 {
-    constexpr int MIN_UCHAR = 0;
-    constexpr int MAX_UCHAR = 255;
-    for (int i = 0; i < nsamples; i++) {
-        long int r = (long int)rint(in[i] * scaling);
-        if (r < MIN_UCHAR) {
-            r = MIN_UCHAR;
-        } else if (r > MAX_UCHAR) {
-            r = MAX_UCHAR;
-        }
-        out[i] = r;
+    // Output is d_num_bins histogram levels, plus average and max rows. Ensure
+    // there is space, in case output is generated.
+    set_min_output_buffer(2 * (d_num_bins + 2));
+
+    // TODO: make sure decims are >0
+
+    d_fft = new gr::fft::fft_complex_fwd(fft_size);
+
+    // TODO: make normalization an option
+    const bool normalize = true;
+    d_window = window::build(
+        window::WIN_BLACKMAN_HARRIS, fft_size, window::INVALID_WIN_PARAM, normalize);
+
+    d_logfft.resize(d_fft_size);
+    d_logfft_b.resize(d_fft_size);
+    d_logfft_avg_b.resize(d_fft_size);
+}
+
+fosphor_formatter_impl::~fosphor_formatter_impl()
+{
+    if (d_fft) {
+        delete d_fft;
+        d_fft = nullptr;
     }
 }
 
-// Helper function to transform the scale factor to something we can put into
-// the nlog10_ff block
-float calculate_log10_scale(const double scale)
+void fosphor_formatter_impl::forecast(int noutput_items,
+                                      gr_vector_int& ninput_items_required)
 {
-    return static_cast<float>(scale) * 10.0f;
+    // Require a full fft vector, as if input was vectorized.
+    ninput_items_required[0] = d_fft_size;
 }
 
-class f2uchar_vfvb_impl : public fosphor_formatter_impl::f2uchar_vfvb
+int fosphor_formatter_impl::general_work(int noutput_items,
+                                         gr_vector_int& ninput_items,
+                                         gr_vector_const_void_star& input_items,
+                                         gr_vector_void_star& output_items)
 {
-public:
-    f2uchar_vfvb_impl(int vlen)
-        : sync_block("f2uchar_vfvb",
-                     gr::io_signature::make(1, 1, sizeof(float) * vlen),
-                     gr::io_signature::make(1, 1, sizeof(unsigned char) * vlen)),
-          d_vlen(vlen)
-    {
-    }
+    const gr_complex* in = static_cast<const gr_complex*>(input_items[0]);
+    uint8_t* out_histo = static_cast<uint8_t*>(output_items[0]);
+    uint8_t* out_waterfall = static_cast<uint8_t*>(output_items[1]);
 
-    int work(int noutput_items,
-             gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items) final
-    {
-        const float* in = static_cast<const float*>(input_items[0]);
-        unsigned char* out = static_cast<unsigned char*>(output_items[0]);
-        for (int i; i < noutput_items; i++) {
-            float_array_to_uchar(in, out, d_vlen);
-            in += d_vlen;
-            out += d_vlen;
+    float convert_mul = 3.5f;
+    float convert_add = 120.0f;
+
+    // Number of fft vectors
+    int n_in = ninput_items[0] / d_fft_size;
+
+    int n = 0;
+    int n_histo = 0;
+    int n_wf = 0;
+    while (n < n_in) {
+
+        // Decimate input by ignoring
+        ++d_input_count;
+        ++n;
+        if (d_input_count < d_input_decim) {
+            in += d_fft_size;
+            continue;
         }
-        return noutput_items;
-    }
+        d_input_count = 0;
 
-private:
-    const int d_vlen;
-};
-
-class histo_proc_impl : public fosphor_formatter_impl::histo_proc
-{
-public:
-    histo_proc_impl(int fft_size,
-                    int num_bins,
-                    int histo_decim,
-                    double epsilon,
-                    double trise,
-                    double tdecay)
-        : block("histo_proc",
-                gr::io_signature::make2(
-                    3, 3, sizeof(unsigned char) * fft_size, sizeof(float) * fft_size),
-                gr::io_signature::make(1, 1, sizeof(unsigned char) * fft_size)),
-          d_histo_decim(histo_decim),
-          d_fft_size(fft_size),
-          d_num_bins(num_bins),
-          d_epsilon(static_cast<float>(epsilon)),
-          d_trise(static_cast<float>(trise)),
-          d_tdecay(static_cast<float>(tdecay)),
-          d_maxhold_buf(fft_size, 0.0f),
-          d_histo_buf_f(fft_size * d_num_bins, 0.0f),
-          d_hit_count(fft_size * d_num_bins, 0)
-    {
-        set_output_multiple(d_num_bins + 2);
-    }
-
-
-    int general_work(int noutput_items,
-                     gr_vector_int& ninput_items,
-                     gr_vector_const_void_star& input_items,
-                     gr_vector_void_star& output_items) final
-    {
-        const int items_to_process = std::min<int>({ ninput_items[0],
-                                                     ninput_items[1],
-                                                     ninput_items[2],
-                                                     d_histo_decim - d_histo_count });
-        if (items_to_process == 0) {
-            return 0;
-        }
-        // We are guaranteed to have space for at least one histogram output,
-        // because we called set_output_multiple() in the ctor on the histo proc.
-
-        const unsigned char* in_logfft_b =
-            static_cast<const unsigned char*>(input_items[0]);
-        const float* in_logfft_f = static_cast<const float*>(input_items[1]);
-        const float* in_logfft_avg = static_cast<const float*>(input_items[2]);
-        unsigned char* out = static_cast<unsigned char*>(output_items[0]);
+        gr_complex* fft_in = d_fft->get_inbuf();
+        volk_32fc_32f_multiply_32fc(fft_in, in, d_window.data(), d_fft_size);
+        d_fft->execute();
+        gr_complex* fft_out = d_fft->get_outbuf();
+        const float scale_factor =
+            1.0f * 1.0f / static_cast<float>(d_fft_size * d_fft_size);
+        // values are divided by normalizationFactor before power calc, so invert
+        volk_32fc_s32f_power_spectrum_32f(d_logfft.data() + d_fft_size / 2,
+                                          fft_out,
+                                          1.0f / scale_factor,
+                                          d_fft_size / 2);
+        volk_32fc_s32f_power_spectrum_32f(d_logfft.data(),
+                                          fft_out + d_fft_size / 2,
+                                          1.0f / scale_factor,
+                                          d_fft_size / 2);
+        volk_32f_s32f_add_32f(d_logfft.data(), d_logfft.data(), 100.0f, d_fft_size);
 
         // Decay previous max hold value
         volk_32f_s32f_multiply_32f(
             d_maxhold_buf.data(), d_maxhold_buf.data(), d_epsilon, d_fft_size);
-        for (int i; i < items_to_process; i++) {
-            //// Update max hold:
-            // Compare with current max
-            volk_32f_x2_max_32f(
-                d_maxhold_buf.data(), d_maxhold_buf.data(), in_logfft_f, d_fft_size);
-            //// Update hit counter
+
+        // Update max
+        volk_32f_x2_max_32f(
+            d_maxhold_buf.data(), d_maxhold_buf.data(), d_logfft.data(), d_fft_size);
+
+        ++d_histo_count;
+        if (d_histo_count == d_histo_decim) {
+
+            ++n_histo;
+            d_histo_count = 0;
+
+            volk_32f_s32f_x2_convert_8u(
+                d_logfft_b.data(), d_logfft.data(), convert_mul, convert_add, d_fft_size);
+
+            // Update hit counter
             for (size_t i = 0; i < static_cast<size_t>(d_fft_size); i++) {
-                // This >>2 assumes d_num_bins is 64
-                const uint8_t bin_index = in_logfft_b[i] >> 2;
+                // TODO: allow num_bins other than 64 (implied here)
+                const uint8_t bin_index = d_logfft_b[i] >> 2;
                 d_hit_count[bin_index * d_fft_size + i]++;
             }
-            d_histo_count++;
-            in_logfft_f += d_fft_size;
-            in_logfft_b += d_fft_size;
-        }
-        consume_each(items_to_process);
-        if (d_histo_count < d_histo_decim) {
-            return 0;
-        }
-        d_histo_count = 0;
 
-        // Now update the output histogram buffer
-        for (size_t i = 0; i < d_histo_buf_f.size(); ++i) {
-            _update_histo_val(d_histo_buf_f[i], d_hit_count[i]);
+            // Now update the output histogram buffer
+            for (size_t i = 0; i < d_histo_buf_f.size(); ++i) {
+
+                const int16_t hc = d_hit_count[i];
+                float hv = d_histo_buf_f[i];
+
+                // Subtract from previous histogram values proportional to d_tdecay,
+                // and add in current hit count proportional to d_trise. Take
+                // decimation into account. (This code could be just a bit clearer).
+
+                // TODO: should be able to factor pow() out of the loop to help
+                // performance.
+                if (hv >= 0.01f || hc != 0) {
+                    const float a = static_cast<float>(hc) / d_histo_decim;
+                    const float b = a / d_trise;
+                    const float c = b + 1.0f / d_tdecay;
+                    const float d = b / c;
+                    const float e = std::pow(1.0f - c, d_histo_decim);
+                    hv = (hv - d) * e + d;
+                    hv = std::max(std::min(1.0f, hv), 0.0f);
+                    d_histo_buf_f[i] = hv;
+                }
+            }
+
+            // Copy the histogram buffer
+            volk_32f_s32f_x2_convert_8u(
+                out_histo, d_histo_buf_f.data(), 256.0f, 0.0f, d_fft_size * d_num_bins);
+            out_histo += d_fft_size * d_num_bins;
+            // Copy max hold to out buffer
+            volk_32f_s32f_x2_convert_8u(
+                out_histo, d_maxhold_buf.data(), convert_mul, convert_add, d_fft_size);
+            out_histo += d_fft_size;
+            // Copy average to out buffer
+            volk_32f_s32f_x2_convert_8u(
+                out_histo, d_iir.data(), convert_mul, convert_add, d_fft_size);
+            out_histo += d_fft_size;
+
+            int num_items_written = n_histo * (d_num_bins + 2);
+            // Insert stream tag
+            auto tag = gr::tag_t{};
+            tag.key = pmt::string_to_symbol("rx_eob");
+            tag.value = pmt::PMT_T;
+            tag.offset = nitems_written(0) + num_items_written - 1;
+            add_item_tag(0, tag);
+
+            // Reset hit counter
+            std::fill(d_hit_count.begin(), d_hit_count.end(), 0);
         }
 
-        // Copy the histogram buffer
-        float_array_to_uchar(d_histo_buf_f.data(), out, d_fft_size * d_num_bins, 256);
-        // Copy max hold to out buffer
-        const int maxhold_idx = d_num_bins * d_fft_size;
-        const int avg_idx = maxhold_idx + d_fft_size;
-        float_array_to_uchar(d_maxhold_buf.data(), out + maxhold_idx, d_fft_size);
-        // Copy average to out buffer
-        float_array_to_uchar(in_logfft_avg, out + avg_idx, d_fft_size);
-        const int num_items_written = d_num_bins + 2;
-        // Insert stream tag
-        auto tag = gr::tag_t{};
-        tag.key = pmt::string_to_symbol("rx_eob");
-        tag.value = pmt::PMT_T;
-        tag.offset = nitems_written(0) + num_items_written - 1;
-        add_item_tag(0, tag);
+        // WF Decim (output f2b to output 1)
+        ++d_waterfall_count;
+        if (d_waterfall_count == d_waterfall_decim) {
+            volk_32f_s32f_x2_convert_8u(
+                out_waterfall, d_logfft.data(), convert_mul, convert_add, d_fft_size);
+            d_waterfall_count = 0;
+            ++n_wf;
+            out_waterfall += d_fft_size;
+        }
 
-        // Reset hit counter
-        std::fill(d_hit_count.begin(), d_hit_count.end(), 0);
-        return num_items_written;
+        in += d_fft_size;
     }
 
+    // printf("%d %d %d\n", n_histo, n_wf, n);
+    produce(0, n_histo * (d_num_bins + 2));
+    produce(1, n_wf);
+    consume(0, n * d_fft_size);
 
-private:
-    const int d_histo_decim;
-    const int d_fft_size;
-    const int d_num_bins;
-    const float d_epsilon;
-    const float d_trise;
-    const float d_tdecay;
-    //! Count processed vectors for the histogram, resets to 0 when we have
-    // processed d_histo_decim vectors.
-    int d_histo_count = 0;
-
-    volk::vector<float> d_maxhold_buf;
-    volk::vector<float> d_histo_buf_f;
-    volk::vector<int16_t> d_hit_count;
-
-
-    void _update_histo_val(float& hv, const int16_t hc)
-    {
-        // All of this is copied from gr-fosphor
-        if (hv < 0.01f && hc == 0) {
-            return;
-        }
-
-        const float a = static_cast<float>(hc) / d_histo_decim;
-        const float b = a / d_trise;
-        const float c = b + 1.0f / d_tdecay;
-        const float d = b / c;
-        const float e = std::pow(1.0f - c, d_histo_decim);
-
-        hv = (hv - d) * e + d;
-        hv = std::max(std::min(1.0f, hv), 0.0f);
-    }
-};
-
-
-} // namespace
+    return WORK_CALLED_PRODUCE;
+}
 
 fosphor_formatter::sptr fosphor_formatter::make(int fft_size,
                                                 int num_bins,
@@ -235,52 +254,5 @@ fosphor_formatter::sptr fosphor_formatter::make(int fft_size,
                                                              tdecay);
 }
 
-
-fosphor_formatter_impl::fosphor_formatter_impl(int fft_size,
-                                               int num_bins,
-                                               int input_decim,
-                                               int waterfall_decim,
-                                               int histo_decim,
-                                               double scale,
-                                               double alpha,
-                                               double epsilon,
-                                               double trise,
-                                               double tdecay)
-    : hier_block2("fosphor_formatter",
-                  io_signature::make(1, 1, sizeof(gr_complex)),
-                  io_signature::make(2, 2, sizeof(unsigned char) * fft_size)),
-      // Init sub-blocks
-      d_s2v(gr::blocks::stream_to_vector::make(sizeof(gr_complex), fft_size)),
-      d_input_decim(
-          gr::blocks::keep_one_in_n::make(sizeof(gr_complex) * fft_size, input_decim)),
-      d_fft(gr::fft::fft_v<gr_complex, true /* forward */>::make(
-          fft_size, gr::fft::window::blackman_harris(fft_size), true /* shift */)),
-      d_c2m(gr::blocks::complex_to_mag_squared::make(fft_size)),
-      d_log(gr::blocks::nlog10_ff::make(calculate_log10_scale(scale),
-                                        fft_size,
-                                        20 * std::log10(static_cast<float>(fft_size)))),
-      d_f2byte(gnuradio::make_block_sptr<f2uchar_vfvb_impl>(fft_size)),
-
-      d_avg(gr::filter::single_pole_iir_filter_ff::make(alpha, fft_size)),
-      d_histo_proc(gnuradio::make_block_sptr<histo_proc_impl>(
-          fft_size, num_bins, histo_decim, epsilon, trise, tdecay)),
-      d_wf_decim(gr::blocks::keep_one_in_n::make(sizeof(unsigned char) * fft_size,
-                                                 waterfall_decim))
-{
-    // Common path
-    connect(self(), 0, d_s2v, 0);
-    connect(d_s2v, 0, d_input_decim, 0);
-    connect(d_input_decim, 0, d_fft, 0);
-    connect(d_fft, 0, d_c2m, 0);
-    connect(d_c2m, 0, d_log, 0);
-    connect(d_log, 0, d_f2byte, 0);
-    // Histogram path
-    connect(d_log, 0, d_avg, 0);
-    connect(d_f2byte, 0, d_histo_proc, 0);
-    connect(d_log, 0, d_histo_proc, 1);
-    connect(d_avg, 0, d_histo_proc, 2);
-    connect(d_histo_proc, 0, self(), 0);
-    // Waterfall path
-    connect(d_f2byte, 0, d_wf_decim, 0);
-    connect(d_wf_decim, 0, self(), 1);
-}
+} // namespace qtgui
+} // namespace gr

--- a/gr-qtgui/python/qtgui/bindings/fosphor_formatter_python.cc
+++ b/gr-qtgui/python/qtgui/bindings/fosphor_formatter_python.cc
@@ -16,7 +16,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0) */
 /* BINDTOOL_USE_PYGCCXML(0) */
 /* BINDTOOL_HEADER_FILE(fosphor_formatter.h) */
-/* BINDTOOL_HEADER_FILE_HASH(2c28006e177227780f16af6897d7633b) */
+/* BINDTOOL_HEADER_FILE_HASH(356e8c2ed3cb578530530c1497b3f9ad) */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -34,7 +34,7 @@ void bind_fosphor_formatter(py::module& m)
 
     using fosphor_formatter = ::gr::qtgui::fosphor_formatter;
 
-    py::class_<fosphor_formatter, gr::hier_block2, std::shared_ptr<fosphor_formatter>>(
+    py::class_<fosphor_formatter, gr::block, std::shared_ptr<fosphor_formatter>>(
         m, "fosphor_formatter", D(fosphor_formatter))
 
         .def(py::init(&fosphor_formatter::make),


### PR DESCRIPTION
## Description
Rework the formatter into a single block (vs many blocks in a heir block) and simplify the code.

WIP. Still need to work on:
- Average/IIR
- Scaling

Implementation of scaling is still unclear, since the fosphor display block can not currently be scaled.

## Which blocks/areas does this affect?
QT GUI Fosphor Formatter

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
