### PR TITLE
soapy: fix sdrplay biasT_ctrl/agc/gain settings

### DIFF
--- a/gr-soapy/grc/soapy_sdrplay_source.block.yml
+++ b/gr-soapy/grc/soapy_sdrplay_source.block.yml
@@ -38,7 +38,6 @@ parameters:
   - id: bias
     label: Bias Tee Power
     dtype: bool
-    default: 'False'
     hide: part
 
   - id: center_freq
@@ -112,14 +111,16 @@ templates:
       def _set_${id}_gain_mode(channel, agc):
           self.${id}.set_gain_mode(channel, agc)
           if not agc:
-              self.set_${id}_gain(channel, self.gain)
+              self.set_${id}_gain(channel, self._${id}_gain_value)
       self.set_${id}_gain_mode = _set_${id}_gain_mode
+      self._${id}_gain_value = ${gain}
 
       ## Intercept the gain callback. The soapysdrplay driver prints an
       ## error message every time gain is adjusted with agc on. Defer
       ## setting IFGR until agc is turned off. Bounds check.
       def _set_${id}_gain(channel, gain):
-          if not self.agc:
+          self._${id}_gain_value = gain
+          if not self.${id}.get_gain_mode(channel):
               self.${id}.set_gain(channel, 'IFGR', min(max(59 - gain, 20), 59))
       self.set_${id}_gain = _set_${id}_gain
 
@@ -136,7 +137,9 @@ templates:
       self.${id}.set_antenna(0, ${antenna})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      self.${id}.write_setting('biasT_ctrl', ${bias})
+      # biasT_ctrl is not always available and leaving it blank avoids errors
+      if '${bias}' != '':
+          self.${id}.write_setting('biasT_ctrl', ${bias})
       self.${id}.write_setting('agc_setpoint', ${agc_setpoint})
       self.set_${id}_gain_mode(0, ${agc})
       self.set_${id}_gain(0, ${gain})


### PR DESCRIPTION
## Description
When using Soapy SDRPLay Source alone without any variables using RSP1 (clone) there are errors:
* `biasT_ctrl` setting is unknown
* `self.agc` does not exist
* `self.gain` does not exist

## Related Issue
Original fixes https://github.com/gnuradio/gnuradio/pull/6665 seem to require extra variables / parameters in the flowgraph.

## Which blocks/areas does this affect?
Soapy SDRPlay Source

## Testing Done
Using gnuradio 3.10.6
1. Run a top block with nothing but Soapy SDRPlay Source and Null Sink
2. Create a custom hier block with nothing but Soapy SDRPlay Source and a Pad Sink
3. Run a top block with nothing but the previous hier block and Null Sink

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.