### PR TITLE
grPyBind: fix invalid module suffix for cross-compile

### DIFF
--- a/cmake/Modules/GrPybind.cmake
+++ b/cmake/Modules/GrPybind.cmake
@@ -8,6 +8,12 @@ macro(GR_PYBIND_MAKE name updir filter files)
                    ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
     pybind11_add_module(${name}_python ${files})
+    
+    # Use normal .so suffix when crosscompiling
+    # See https://github.com/gnuradio/gnuradio/issues/5455
+    if (CMAKE_CROSSCOMPILING)
+        set_target_properties(${name}_python PROPERTIES SUFFIX ".so")
+    endif()
 
     set(MODULE_NAME ${name})
     if(${name} STREQUAL gr)
@@ -134,6 +140,12 @@ macro(GR_PYBIND_MAKE_CHECK_HASH name updir filter files)
     endforeach()
 
     pybind11_add_module(${name}_python ${files})
+
+    # Use normal .so suffix when crosscompiling
+    # See https://github.com/gnuradio/gnuradio/issues/5455
+    if (CMAKE_CROSSCOMPILING)
+        set_target_properties(${name}_python PROPERTIES SUFFIX ".so")
+    endif()
 
     set(MODULE_NAME ${name})
     if(${name} STREQUAL gr)
@@ -285,6 +297,12 @@ macro(GR_PYBIND_MAKE_OOT name updir filter files)
                    ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
     pybind11_add_module(${name}_python ${files})
+
+    # Use normal .so suffix when crosscompiling
+    # See https://github.com/gnuradio/gnuradio/issues/5455
+    if (CMAKE_CROSSCOMPILING)
+        set_target_properties(${name}_python PROPERTIES SUFFIX ".so")
+    endif()
 
     set(MODULE_NAME ${name})
     if(${name} STREQUAL gr)


### PR DESCRIPTION
This is required as pybind11 uses host python3 and therefore the host platform suffixes.

## Description

By default, module libraries have a suffix based on cpython version + host architecture: this is fine for a native compile when these libraries are used on the same computer (or similar computers). But when target architecture is not the same python is unable to find libraries due to the wrong suffix and produces unclear errors messages.
This PR, when `CMAKE_CROSSCOMPILING` is set, force libraries suffix extension to resolve this runtime issue.

## Related Issue

Fixe #5455

## Testing Done

Tested with 3 gnuradio 3.10 tags, and *main* in a cross-compilation environment

## Checklist

- [ x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ x] I have squashed my commits to have one significant change per commit. 
- [ x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).