### PR TITLE
gr-uhd/lib: support fmtlib 10

### DIFF
--- a/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
+++ b/gr-uhd/lib/rfnoc_rx_streamer_impl.cc
@@ -143,7 +143,7 @@ int rfnoc_rx_streamer_impl::work(int noutput_items,
     default:
         d_logger->warn("RFNoC Streamer block received error {:s} (Code: {})",
                        d_metadata.strerror(),
-                       d_metadata.error_code);
+                       static_cast<int>(d_metadata.error_code));
     }
 
     if (d_metadata.end_of_burst) {


### PR DESCRIPTION
In rfnoc_rx_streamer_impl::work , d_metadata.error_code has type uhd::rx_metadata_t::error_code_t , which is just enum.

But with fmtlib 10, fmt::format won't accept enum by default. So just cast this variable error_code to int to make fmtlib-10 accept this.

Closes #6735 .

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
