### PR TITLE
soapy: fix variable naming in RTL grc

### DIFF
--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -52,7 +52,6 @@ parameters:
   - id: bias
     label: 'Bias Tee Power'
     dtype: bool
-    default: 'False'
     hide: 'part'
 
 inputs:
@@ -79,12 +78,13 @@ templates:
       def _set_${id}_gain_mode(channel, agc):
           self.${id}.set_gain_mode(channel, agc)
           if not agc:
-                self.${id}.set_gain(channel, self.gain)
+                self.${id}.set_gain(channel, self._${id}_gain_value)
       self.set_${id}_gain_mode = _set_${id}_gain_mode
 
       ## Intercept set_gain to keep it from turning off agc mode
       def _set_${id}_gain(channel, name, gain):
-          if not self.agc:
+          self._${id}_gain_value = gain
+          if not self.${id}.get_gain_mode(channel):
               self.${id}.set_gain(channel, gain)
       self.set_${id}_gain = _set_${id}_gain
 
@@ -93,7 +93,9 @@ templates:
       self.${id}.set_sample_rate(0, ${samp_rate})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      self.${id}.write_setting('biastee', ${bias})
+      if '${bias}' != '':
+          self.${id}.write_setting('biastee', ${bias})
+      self._${id}_gain_value = ${gain}
       self.set_${id}_gain_mode(0, ${agc})
       self.set_${id}_gain(0, 'TUNER', ${gain})
 


### PR DESCRIPTION
## Description
Fix variable names, which just happened to work if a control with the same name already existed. This is the same type of fix Tommi made recently for SDRPlay.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
