### PR TITLE
soapy: more robust handling of bias and agc settings in rtlsdr yml

### DIFF
--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -52,6 +52,7 @@ parameters:
   - id: bias
     label: 'Bias Tee Power'
     dtype: bool
+    default: 'False'
     hide: 'part'
 
 inputs:
@@ -88,15 +89,28 @@ templates:
               self.${id}.set_gain(channel, gain)
       self.set_${id}_gain = _set_${id}_gain
 
+      ## Intercept bias tee setting and detect whether it is supported
+      def _set_${id}_bias(bias):
+          if 'biastee' in self._${id}_setting_keys:
+              self.${id}.write_setting('biastee', bias)
+      self.set_${id}_bias = _set_${id}_bias
+
       self.${id} = soapy.source(dev, "${type}", 1, ${dev_args},
                                 stream_args, tune_args, settings)
+
+      ## Get list of valid setting keys
+      self._${id}_setting_keys = [a.key for a in self.${id}.get_setting_info()]
+
+      ## Set initial values. Since Python casts pretty much anything to bool,
+      ## parameter type chaecking does not guarantee bool values here are
+      ## actually bools. Do the cast here to get the same result. Note that
+      ## non-empty strings (e.g., 'False') are cast to True!
       self.${id}.set_sample_rate(0, ${samp_rate})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      if '${bias}' != '':
-          self.${id}.write_setting('biastee', ${bias})
+      self.set_${id}_bias(bool(${bias}))
       self._${id}_gain_value = ${gain}
-      self.set_${id}_gain_mode(0, ${agc})
+      self.set_${id}_gain_mode(0, bool(${agc}))
       self.set_${id}_gain(0, 'TUNER', ${gain})
 
   callbacks:
@@ -105,6 +119,6 @@ templates:
     - set_frequency_correction(0, ${freq_correction})
     - self.set_${id}_gain_mode(0, ${agc})
     - self.set_${id}_gain(0, 'TUNER', ${gain})
-    - write_setting('biastee', ${bias})
+    - self.set_${id}_bias(${bias})
 
 file_format: 1


### PR DESCRIPTION
## Description
Check with soapy driver whether biastee is a valid setting, instead of relying on a black field as a default.

Protect bias and agc calls from blank fields. GRC allows a blank for bool. In the templates, this is an actual blank, not an empty string, so it can cause errors.

This is an improvement to #6738.

## Which blocks/areas does this affect?
Soapy RTLSDR Source

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
