### PR TITLE
soapy: fix variable naming in RTL grc, more robust handling of agc and bias

### DIFF
--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -52,6 +52,7 @@ parameters:
   - id: bias
     label: 'Bias Tee Power'
     dtype: bool
+    default: 'False'
     hide: 'part'
 
 inputs:
@@ -88,15 +89,28 @@ templates:
               self.${id}.set_gain(channel, gain)
       self.set_${id}_gain = _set_${id}_gain
 
+      ## Intercept bias tee setting and detect whether it is supported
+      def _set_${id}_bias(bias):
+          if 'biastee' in self._${id}_setting_keys:
+              self.${id}.write_setting('biastee', bias)
+      self.set_${id}_bias = _set_${id}_bias
+
       self.${id} = soapy.source(dev, "${type}", 1, ${dev_args},
                                 stream_args, tune_args, settings)
+
+      ## Get list of valid setting keys
+      self._${id}_setting_keys = [a.key for a in self.${id}.get_setting_info()]
+
+      ## Set initial values. Since Python casts pretty much anything to bool,
+      ## parameter type chaecking does not guarantee bool values here are
+      ## actually bools. Do the cast here to get the same result. Note that
+      ## non-empty strings (e.g., 'False') are cast to True!
       self.${id}.set_sample_rate(0, ${samp_rate})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      if '${bias}' != '':
-          self.${id}.write_setting('biastee', ${bias})
+      self.set_${id}_bias(bool(${bias}))
       self._${id}_gain_value = ${gain}
-      self.set_${id}_gain_mode(0, ${agc})
+      self.set_${id}_gain_mode(0, bool(${agc}))
       self.set_${id}_gain(0, 'TUNER', ${gain})
 
   callbacks:
@@ -105,6 +119,6 @@ templates:
     - set_frequency_correction(0, ${freq_correction})
     - self.set_${id}_gain_mode(0, ${agc})
     - self.set_${id}_gain(0, 'TUNER', ${gain})
-    - write_setting('biastee', ${bias})
+    - self.set_${id}_bias(${bias})
 
 file_format: 1

--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -52,7 +52,6 @@ parameters:
   - id: bias
     label: 'Bias Tee Power'
     dtype: bool
-    default: 'False'
     hide: 'part'
 
 inputs:
@@ -79,12 +78,13 @@ templates:
       def _set_${id}_gain_mode(channel, agc):
           self.${id}.set_gain_mode(channel, agc)
           if not agc:
-                self.${id}.set_gain(channel, self.gain)
+                self.${id}.set_gain(channel, self._${id}_gain_value)
       self.set_${id}_gain_mode = _set_${id}_gain_mode
 
       ## Intercept set_gain to keep it from turning off agc mode
       def _set_${id}_gain(channel, name, gain):
-          if not self.agc:
+          self._${id}_gain_value = gain
+          if not self.${id}.get_gain_mode(channel):
               self.${id}.set_gain(channel, gain)
       self.set_${id}_gain = _set_${id}_gain
 
@@ -93,7 +93,9 @@ templates:
       self.${id}.set_sample_rate(0, ${samp_rate})
       self.${id}.set_frequency(0, ${center_freq})
       self.${id}.set_frequency_correction(0, ${freq_correction})
-      self.${id}.write_setting('biastee', ${bias})
+      if '${bias}' != '':
+          self.${id}.write_setting('biastee', ${bias})
+      self._${id}_gain_value = ${gain}
       self.set_${id}_gain_mode(0, ${agc})
       self.set_${id}_gain(0, 'TUNER', ${gain})
 


### PR DESCRIPTION
Backport #6738
Backport #6739