### PR TITLE
runtime: c++20 friendly logging

### DIFF
--- a/gnuradio-runtime/include/gnuradio/logger.h
+++ b/gnuradio-runtime/include/gnuradio/logger.h
@@ -36,6 +36,7 @@ using logger_ptr = std::shared_ptr<void>;
 #include <spdlog/common.h>
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/fmt/ostr.h>
+#include <spdlog/version.h>
 #include <memory>
 
 #include <spdlog/spdlog.h>
@@ -120,6 +121,22 @@ private:
     std::string _name;
     using underlying_logger_ptr = std::shared_ptr<spdlog::logger>;
 
+#if SPDLOG_VERSION >= 11000
+    // spdlog 1.10 onwards can depend either on fmt or std format, so it defined
+    // its own alias for format strings
+    template <typename... Args>
+    using format_string_t = spdlog::format_string_t<Args...>;
+#elif SPDLOG_VERSION >= 10910
+    // spdlog 1.9.1 supported/enforced fmt compile time format string validation
+    // in c++20 by using fmt::format_string in its logging functions
+    template <typename... Args>
+    using format_string_t = fmt::format_string<Args...>;
+#else
+    // lower versions of spdlog did not support compile time validation
+    template <typename... Args>
+    using format_string_t = const spdlog::string_view_t&;
+#endif
+
 public:
     /*!
      * \brief constructor Provide name of logger to associate with this class
@@ -152,80 +169,79 @@ public:
 
     /*! \brief inline function, wrapper for TRACE message */
     template <typename... Args>
-    inline void trace(const spdlog::string_view_t& msg, const Args&... args)
+    inline void trace(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->trace(msg, args...);
+        d_logger->trace(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for DEBUG message */
     template <typename... Args>
-    inline void debug(const spdlog::string_view_t& msg, const Args&... args)
+    inline void debug(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->debug(msg, args...);
+        d_logger->debug(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for INFO message */
     template <typename... Args>
-    inline void info(const spdlog::string_view_t& msg, const Args&... args)
+    inline void info(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->info(msg, args...);
+        d_logger->info(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for INFO message, DEPRECATED */
     template <typename... Args>
-    inline void notice(const spdlog::string_view_t& msg, const Args&... args)
+    inline void notice(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->info(msg, args...);
+        d_logger->info(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for WARN message */
     template <typename... Args>
-    inline void warn(const spdlog::string_view_t& msg, const Args&... args)
+    inline void warn(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->warn(msg, args...);
+        d_logger->warn(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for ERROR message */
     template <typename... Args>
-    inline void error(const spdlog::string_view_t& msg, const Args&... args)
+    inline void error(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->error(msg, args...);
+        d_logger->error(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for CRITICAL message */
     template <typename... Args>
-    inline void crit(const spdlog::string_view_t& msg, const Args&... args)
+    inline void crit(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->critical(msg, args...);
+        d_logger->critical(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for CRITICAL message, DEPRECATED */
     template <typename... Args>
-    inline void alert(const spdlog::string_view_t& msg, const Args&... args)
+    inline void alert(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->critical(msg, args...);
+        d_logger->critical(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for CRITICAL message, DEPRECATED */
     template <typename... Args>
-    inline void fatal(const spdlog::string_view_t& msg, const Args&... args)
+    inline void fatal(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->critical(msg, args...);
+        d_logger->critical(msg, std::forward<Args>(args)...);
     }
 
     /*! \brief inline function, wrapper for CRITICAL message, DEPRECATED */
     template <typename... Args>
-    inline void emerg(const spdlog::string_view_t& msg, const Args&... args)
+    inline void emerg(format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->critical(msg, args...);
+        d_logger->critical(msg, std::forward<Args>(args)...);
     }
     /*! \brief inline function, wrapper for logging with ad-hoc adjustable level*/
     template <typename... Args>
-    inline void log(spdlog::level::level_enum level,
-                    const spdlog::string_view_t& msg,
-                    const Args&... args)
+    inline void
+    log(spdlog::level::level_enum level, format_string_t<Args...> msg, Args&&... args)
     {
-        d_logger->log(level, msg, args...);
+        d_logger->log(level, msg, std::forward<Args>(args)...);
     }
 };
 using logger_ptr = std::shared_ptr<logger>;

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/logger_python.cc
@@ -15,7 +15,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(logger.h)                                                  */
-/* BINDTOOL_HEADER_FILE_HASH(b62b327197c0c1d4d5c662725810d1b6)                     */
+/* BINDTOOL_HEADER_FILE_HASH(aa1fad0b5f0d52d36816dfeb45194212)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
when compiling in c++20 mode, fmt checks at compile time that the format string is constant expression. this is not the case with spdlog::string_view, and we get the error: ‘msg’ is not a constant expression so instead use spdlog::format_string_t (which actually defaults to string_view when using older compilers that don't support it)

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
