### PR TITLE
Fix whitespace in **/bindings/* files

### DIFF
--- a/gr-dtv/python/dtv/bindings/atsc_consts_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_consts_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_consts.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_consts.h)                                             */
 /* BINDTOOL_HEADER_FILE_HASH(d1e577adb91a05ccc8d86ec5e698806f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_deinterleaver_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_deinterleaver_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_deinterleaver.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_deinterleaver.h)                                      */
 /* BINDTOOL_HEADER_FILE_HASH(c2b4faaeef490bb4425bcc373a7b7cbc)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_depad_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_depad_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_depad.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_depad.h)                                              */
 /* BINDTOOL_HEADER_FILE_HASH(42cdfee46c39a6ab7c069fd51af2394a)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_derandomizer_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_derandomizer_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_derandomizer.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_derandomizer.h)                                       */
 /* BINDTOOL_HEADER_FILE_HASH(b2794152d0b34ea575b8797f241dbe9f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_equalizer_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_equalizer_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_equalizer.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_equalizer.h)                                          */
 /* BINDTOOL_HEADER_FILE_HASH(33ffb39eb30666aadee1df49711f0fe1)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_field_sync_mux_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_field_sync_mux_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_field_sync_mux.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_field_sync_mux.h)                                     */
 /* BINDTOOL_HEADER_FILE_HASH(14a86391f54bff3694965574fffb2f46)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_fpll_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_fpll_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_fpll.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_fpll.h)                                               */
 /* BINDTOOL_HEADER_FILE_HASH(4b77159b6a7c3b733259a7d99df6f1d5)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_fs_checker_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_fs_checker_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_fs_checker.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_fs_checker.h)                                         */
 /* BINDTOOL_HEADER_FILE_HASH(4e43a317cf181560a97431eb667af75f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_pad_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_pad_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_pad.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_pad.h)                                                */
 /* BINDTOOL_HEADER_FILE_HASH(1bde5569b757d9d70cce04e449e00b92)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_randomizer_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_randomizer_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_randomizer.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_randomizer.h)                                         */
 /* BINDTOOL_HEADER_FILE_HASH(76ffed0a2e924572e06035fd164a8f0d)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_rs_decoder_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_rs_decoder_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_rs_decoder.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_rs_decoder.h)                                         */
 /* BINDTOOL_HEADER_FILE_HASH(cbe28bd1f21db51457244b761eaddce4)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_rs_encoder_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_rs_encoder_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_rs_encoder.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_rs_encoder.h)                                         */
 /* BINDTOOL_HEADER_FILE_HASH(78e082a24091021c3b55036ade4d7ba2)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_sync_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_sync_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_sync.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_sync.h)                                               */
 /* BINDTOOL_HEADER_FILE_HASH(5ce95227b23b794b142bd4e75e6557a8)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_trellis_encoder_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_trellis_encoder_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_trellis_encoder.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_trellis_encoder.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(54e8ce920a8d66154e6e5c5ed15a90be)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/atsc_viterbi_decoder_python.cc
+++ b/gr-dtv/python/dtv/bindings/atsc_viterbi_decoder_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(atsc_viterbi_decoder.h)                                        */
+/* BINDTOOL_HEADER_FILE(atsc_viterbi_decoder.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(d880535937753848a53110ab890678fb)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/catv_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_config_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(catv_config.h)                                        */
+/* BINDTOOL_HEADER_FILE(catv_config.h)                                             */
 /* BINDTOOL_HEADER_FILE_HASH(fe49dc21788df88d41abc50779439db5)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/catv_frame_sync_enc_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_frame_sync_enc_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(catv_frame_sync_enc_bb.h) */
+/* BINDTOOL_HEADER_FILE(catv_frame_sync_enc_bb.h)                                  */
 /* BINDTOOL_HEADER_FILE_HASH(95b5201d218824bff384ce642554c6ab)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/catv_randomizer_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_randomizer_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(catv_randomizer_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(catv_randomizer_bb.h)                                      */
 /* BINDTOOL_HEADER_FILE_HASH(605e5867408b4d4ecbe934f8bd0f7a8f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/catv_reed_solomon_enc_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_reed_solomon_enc_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(catv_reed_solomon_enc_bb.h) */
+/* BINDTOOL_HEADER_FILE(catv_reed_solomon_enc_bb.h)                                */
 /* BINDTOOL_HEADER_FILE_HASH(b8647d40529c9eb4e897cb0070e2ccf8)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/catv_transport_framing_enc_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_transport_framing_enc_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(catv_transport_framing_enc_bb.h) */
+/* BINDTOOL_HEADER_FILE(catv_transport_framing_enc_bb.h)                           */
 /* BINDTOOL_HEADER_FILE_HASH(1c764c0ea9e54d93023cebff6fd70834)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/catv_trellis_enc_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/catv_trellis_enc_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(catv_trellis_enc_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(catv_trellis_enc_bb.h)                                     */
 /* BINDTOOL_HEADER_FILE_HASH(5e6a03159276fb1eb3e139b3fce7e5bb)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvb_bbheader_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvb_bbheader_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvb_bbheader_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvb_bbheader_bb.h)                                         */
 /* BINDTOOL_HEADER_FILE_HASH(4cb7125c2672510bcdd0c4728fc080f0)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvb_bbscrambler_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvb_bbscrambler_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvb_bbscrambler_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvb_bbscrambler_bb.h)                                      */
 /* BINDTOOL_HEADER_FILE_HASH(784bda037d258851bd77e5ca4d797e16)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvb_bch_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvb_bch_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvb_bch_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvb_bch_bb.h)                                              */
 /* BINDTOOL_HEADER_FILE_HASH(fee883de5a12b6465fcdf77b20a77736)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvb_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvb_config_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvb_config.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvb_config.h)                                              */
 /* BINDTOOL_HEADER_FILE_HASH(a51e9bda5f13b96d3d09d0347395379e)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvb_ldpc_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvb_ldpc_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvb_ldpc_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvb_ldpc_bb.h)                                             */
 /* BINDTOOL_HEADER_FILE_HASH(fa0d5ad2fdc5bd4b427bf728736ef87c)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbs2_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbs2_config_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbs2_config.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbs2_config.h)                                            */
 /* BINDTOOL_HEADER_FILE_HASH(db5f4cebaba9807baacaf99342135375)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbs2_interleaver_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbs2_interleaver_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbs2_interleaver_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbs2_interleaver_bb.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(6ea090a711e8469c05b28f67e3711d45)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbs2_modulator_bc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbs2_modulator_bc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbs2_modulator_bc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbs2_modulator_bc.h)                                      */
 /* BINDTOOL_HEADER_FILE_HASH(e1a9f035f4e312f3e90dc68592c9c2c9)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbs2_physical_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbs2_physical_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbs2_physical_cc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbs2_physical_cc.h)                                       */
 /* BINDTOOL_HEADER_FILE_HASH(daa4f75e5b420ca14e4b7245b4328d87)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_cellinterleaver_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_cellinterleaver_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_cellinterleaver_cc.h) */
+/* BINDTOOL_HEADER_FILE(dvbt2_cellinterleaver_cc.h)                                */
 /* BINDTOOL_HEADER_FILE_HASH(bf73763c0dccee7ec30616bfbd9e56e0)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_config_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_config.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_config.h)                                            */
 /* BINDTOOL_HEADER_FILE_HASH(2e2157cfd74e3b7fd3b7421db4773ef7)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_framemapper_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_framemapper_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_framemapper_cc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_framemapper_cc.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(9ba36658362b995ce077d00e03fc9c7f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_freqinterleaver_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_freqinterleaver_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_freqinterleaver_cc.h) */
+/* BINDTOOL_HEADER_FILE(dvbt2_freqinterleaver_cc.h)                                */
 /* BINDTOOL_HEADER_FILE_HASH(f8bd23f42cf6c47adb3cdb980c4d53b3)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_interleaver_bb_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_interleaver_bb_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_interleaver_bb.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_interleaver_bb.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(01828a0a57077456ac6725972c8113a5)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_miso_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_miso_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_miso_cc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_miso_cc.h)                                           */
 /* BINDTOOL_HEADER_FILE_HASH(d31013333348186f65abf45c7548693f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_modulator_bc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_modulator_bc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_modulator_bc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_modulator_bc.h)                                      */
 /* BINDTOOL_HEADER_FILE_HASH(0aa462ecd69deb5ea7b88a14f4a7c810)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_p1insertion_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_p1insertion_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_p1insertion_cc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_p1insertion_cc.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(c35854bc4a5b05aa34fb881c9e3d35ab)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_paprtr_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_paprtr_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_paprtr_cc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt2_paprtr_cc.h)                                         */
 /* BINDTOOL_HEADER_FILE_HASH(fffef4d8dca4fd66f01f467741415bf4)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt2_pilotgenerator_cc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt2_pilotgenerator_cc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt2_pilotgenerator_cc.h) */
+/* BINDTOOL_HEADER_FILE(dvbt2_pilotgenerator_cc.h)                                 */
 /* BINDTOOL_HEADER_FILE_HASH(7dee7329d159058fae8797792d25ec12)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_bit_inner_deinterleaver_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_bit_inner_deinterleaver_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_bit_inner_deinterleaver.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_bit_inner_deinterleaver.h)                            */
 /* BINDTOOL_HEADER_FILE_HASH(be24f106c1506c68ae78f42d801e905e)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_bit_inner_interleaver_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_bit_inner_interleaver_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_bit_inner_interleaver.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_bit_inner_interleaver.h)                              */
 /* BINDTOOL_HEADER_FILE_HASH(ffe3bf9243baf975d3e5b31b8c29aa7f)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_config_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_config_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_config.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_config.h)                                             */
 /* BINDTOOL_HEADER_FILE_HASH(1e8c8ddd5673aee22452fdba41394024)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_convolutional_deinterleaver_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_convolutional_deinterleaver_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_convolutional_deinterleaver.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_convolutional_deinterleaver.h)                        */
 /* BINDTOOL_HEADER_FILE_HASH(fdfc0d5f4cf75370a303fa860eb2a733)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_convolutional_interleaver_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_convolutional_interleaver_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_convolutional_interleaver.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_convolutional_interleaver.h)                          */
 /* BINDTOOL_HEADER_FILE_HASH(47d8af60ef59f5c5844acc2947890015)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_demap_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_demap_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_demap.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_demap.h)                                              */
 /* BINDTOOL_HEADER_FILE_HASH(9098240998c2f93453ed335eded924db)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_demod_reference_signals_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_demod_reference_signals_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_demod_reference_signals.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_demod_reference_signals.h)                            */
 /* BINDTOOL_HEADER_FILE_HASH(4697ae1c1b71c32c012c88b1f1ba0b80)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_energy_descramble_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_energy_descramble_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_energy_descramble.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_energy_descramble.h)                                  */
 /* BINDTOOL_HEADER_FILE_HASH(8e900d99d1e16a6e19caad951480ff7e)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_energy_dispersal_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_energy_dispersal_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_energy_dispersal.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_energy_dispersal.h)                                   */
 /* BINDTOOL_HEADER_FILE_HASH(2baa844650ab4696fde54fd0f93dd21b)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_map_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_map_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_map.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_map.h)                                                */
 /* BINDTOOL_HEADER_FILE_HASH(8b7bee6e57994459c9ce4e16c87e7c1e)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_ofdm_sym_acquisition_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_ofdm_sym_acquisition_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_ofdm_sym_acquisition.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_ofdm_sym_acquisition.h)                               */
 /* BINDTOOL_HEADER_FILE_HASH(5ca4962bf06014c90cf79fb2e80ee9ae)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_reed_solomon_dec_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_reed_solomon_dec_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_reed_solomon_dec.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_reed_solomon_dec.h)                                   */
 /* BINDTOOL_HEADER_FILE_HASH(f8375bfde79e00df1a85ea68f56f9a0e)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_reed_solomon_enc_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_reed_solomon_enc_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_reed_solomon_enc.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_reed_solomon_enc.h)                                   */
 /* BINDTOOL_HEADER_FILE_HASH(e29b90f275ff77ea0b91a12a0489b693)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_reference_signals_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_reference_signals_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_reference_signals.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_reference_signals.h)                                  */
 /* BINDTOOL_HEADER_FILE_HASH(04810b9d178855c02d11b942959453a5)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_symbol_inner_interleaver_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_symbol_inner_interleaver_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_symbol_inner_interleaver.h) */
+/* BINDTOOL_HEADER_FILE(dvbt_symbol_inner_interleaver.h)                           */
 /* BINDTOOL_HEADER_FILE_HASH(78211c22c4f55cd0f15b9385fe2187d7)                     */
 /***********************************************************************************/
 

--- a/gr-dtv/python/dtv/bindings/dvbt_viterbi_decoder_python.cc
+++ b/gr-dtv/python/dtv/bindings/dvbt_viterbi_decoder_python.cc
@@ -13,7 +13,7 @@
 /* If manual edits are made, the following tags should be modified accordingly.    */
 /* BINDTOOL_GEN_AUTOMATIC(1)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
-/* BINDTOOL_HEADER_FILE(dvbt_viterbi_decoder.h)                                        */
+/* BINDTOOL_HEADER_FILE(dvbt_viterbi_decoder.h)                                    */
 /* BINDTOOL_HEADER_FILE_HASH(1c434c20a4cc531c0c126d847eb9073f)                     */
 /***********************************************************************************/
 


### PR DESCRIPTION
## Description

Made bindings/* files more uniform

## Related Issue

n/a

## Which blocks/areas does this affect?

trivial

## Testing Done

n/a

## Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
