### PR TITLE
qtgui: conditionally install fosphor yaml files

### DIFF
--- a/gr-qtgui/grc/CMakeLists.txt
+++ b/gr-qtgui/grc/CMakeLists.txt
@@ -8,6 +8,14 @@
 ########################################################################
 file(GLOB yml_files "*.yml")
 
+if(NOT ENABLE_GR_QTGUI_OPENGL)
+    list(REMOVE_ITEM yml_files 
+        "${CMAKE_CURRENT_SOURCE_DIR}/qtgui_fosphor_display.block.yml"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qtgui_fosphor_formatter.block.yml"
+        "${CMAKE_CURRENT_SOURCE_DIR}/qtgui_fosphorgl_sink.block.yml"
+    )
+endif()
+
 macro(REPLACE_IN_FILE _yml_block match replace)
     set(yml_block_src "${CMAKE_CURRENT_SOURCE_DIR}/${_yml_block}")
     set(yml_block "${CMAKE_CURRENT_BINARY_DIR}/${_yml_block}")


### PR DESCRIPTION
Don't install fosphor YAML files without OpenGL support, which is necessary for fosphor blocks

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
In the commits to add support for the fosphor blocks, the support was disabled conditionally if OpenGL was not installed, however the blocks would still be installed, this doesn't install the related blocks if support for them is disabled.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
Fosphor QTGUI blocks

## Testing Done
Removed QTGUI yml files, uninstalled libqt5opengl5-dev, ran 'make install', the Core->GUI Widgets->QT tree populated, but the fosphor blocks do not.

I installed libqt5opengl5-dev again, re-ran cmake and 'make install', the fosphor blocks are now populated, and I sanity checked that the example still worked.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
