### PR TITLE
io_signature: API cleanup

### DIFF
--- a/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_single_mapped.h
@@ -12,7 +12,6 @@
 #define INCLUDED_GR_RUNTIME_BUFFER_SINGLE_MAPPED_H
 
 #include <cstddef>
-#include <functional>
 
 #include <gnuradio/api.h>
 #include <gnuradio/buffer.h>

--- a/gnuradio-runtime/include/gnuradio/buffer_type.h
+++ b/gnuradio-runtime/include/gnuradio/buffer_type.h
@@ -16,9 +16,7 @@
 
 #include <cstdint>
 #include <functional>
-#include <mutex>
 #include <string>
-#include <typeinfo>
 #include <vector>
 
 namespace gr {

--- a/gnuradio-runtime/include/gnuradio/io_signature.h
+++ b/gnuradio-runtime/include/gnuradio/io_signature.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2007 Free Software Foundation, Inc.
+ * Copyright 2023 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -11,17 +12,20 @@
 #ifndef INCLUDED_IO_SIGNATURE_H
 #define INCLUDED_IO_SIGNATURE_H
 
+#include <gnuradio/api.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
+#include <memory>
+
+#include <gnuradio/buffer_type.h>
 // For testing purposes, force single mapped buffers to make all QA use them
 // #define FORCE_SINGLE_MAPPED
-
-#include <gnuradio/api.h>
 #ifdef FORCE_SINGLE_MAPPED
 #include <gnuradio/host_buffer.h>
 #else
 #include <gnuradio/buffer_double_mapped.h>
 #endif
-#include <gnuradio/buffer_type.h>
-#include <gnuradio/runtime_types.h>
+
 
 namespace gr {
 
@@ -33,16 +37,22 @@ class GR_RUNTIME_API io_signature
 {
     int d_min_streams;
     int d_max_streams;
-    std::vector<int> d_sizeof_stream_item;
+    std::vector<size_t> d_sizeof_stream_item;
     gr_vector_buffer_type d_stream_buffer_type;
 
     io_signature(int min_streams,
                  int max_streams,
-                 const std::vector<int>& sizeof_stream_items,
-                 gr_vector_buffer_type buftypes);
+                 const std::vector<size_t>& sizeof_stream_items,
+                 const gr_vector_buffer_type& buftypes);
 
 public:
     typedef std::shared_ptr<io_signature> sptr;
+
+#ifdef FORCE_SINGLE_MAPPED
+    using default_buftype = host_buffer;
+#else
+    using default_buftype = buffer_double_mapped;
+#endif
 
     static constexpr int IO_INFINITE = -1;
 
@@ -61,11 +71,25 @@ public:
     static sptr make(int min_streams,
                      int max_streams,
                      int sizeof_stream_item,
-#ifdef FORCE_SINGLE_MAPPED
-                     buffer_type buftype = host_buffer::type);
-#else
-                     buffer_type buftype = buffer_double_mapped::type);
-#endif
+                     buffer_type buftype = default_buftype::type);
+
+
+    /*!
+     * \brief Create an i/o signature
+     *
+     * \ingroup internal
+     * \param min_streams  specify minimum number of streams (>= 0)
+     * \param max_streams  specify maximum number of streams (>= min_streams or -1 ->
+     * infinite)
+     * \param sizeof_stream_items specify the size of the items in each stream
+     * \param buftypes  type of buffers the streams should use (defaults to standard host
+     * double mapped buffer)
+     */
+    static sptr make(int min_streams,
+                     int max_streams,
+                     const std::vector<size_t>& sizeof_stream_items,
+                     const gr::gr_vector_buffer_type& buftypes =
+                         gr::gr_vector_buffer_type(1, default_buftype::type));
 
     /*!
      * \brief Create an i/o signature
@@ -80,17 +104,13 @@ public:
      * \param buftype2  type of buffers the second and subsequent streams should use
      * (defaults to standard host double mapped buffer)
      */
+    //[[deprecated("Use generic make(min, max, {…})")]]
     static sptr make2(int min_streams,
                       int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
-#ifdef FORCE_SINGLE_MAPPED
-                      buffer_type buftype1 = host_buffer::type,
-                      buffer_type buftype2 = host_buffer::type);
-#else
-                      buffer_type buftype1 = buffer_double_mapped::type,
-                      buffer_type buftype2 = buffer_double_mapped::type);
-#endif
+                      buffer_type buftype1 = default_buftype::type,
+                      buffer_type buftype2 = default_buftype::type);
 
     /*!
      * \brief Create an i/o signature
@@ -108,20 +128,15 @@ public:
      * \param buftype3  type of buffers the third and subsequent streams should use
      * (defaults to standard host double mapped buffer)
      */
+    //[[deprecated("Use generic make(min, max, {…})")]]
     static sptr make3(int min_streams,
                       int max_streams,
                       int sizeof_stream_item1,
                       int sizeof_stream_item2,
                       int sizeof_stream_item3,
-#ifdef FORCE_SINGLE_MAPPED
-                      buffer_type buftype1 = host_buffer::type,
-                      buffer_type buftype2 = host_buffer::type,
-                      buffer_type buftype3 = host_buffer::type);
-#else
-                      buffer_type buftype1 = buffer_double_mapped::type,
-                      buffer_type buftype2 = buffer_double_mapped::type,
-                      buffer_type buftype3 = buffer_double_mapped::type);
-#endif
+                      buffer_type buftype1 = default_buftype::type,
+                      buffer_type buftype2 = default_buftype::type,
+                      buffer_type buftype3 = default_buftype::type);
 
     /*!
      * \brief Create an i/o signature
@@ -135,6 +150,7 @@ public:
      * sizeof_stream_items is used for the missing values.
      * sizeof_stream_items must contain at least 1 entry.
      */
+    //[[deprecated("Use generic make(min, max, {…})")]]
     static sptr
     makev(int min_streams, int max_streams, const std::vector<int>& sizeof_stream_items);
 
@@ -152,19 +168,28 @@ public:
      * sizeof_stream_items is used for the missing values.
      * sizeof_stream_items must contain at least 1 entry.
      */
+    //[[deprecated("Use generic make(min, max, {…})")]]
     static sptr makev(int min_streams,
                       int max_streams,
                       const std::vector<int>& sizeof_stream_items,
-                      gr_vector_buffer_type buftypes);
+                      const gr_vector_buffer_type& buftypes);
 
     int min_streams() const { return d_min_streams; }
     int max_streams() const { return d_max_streams; }
     int sizeof_stream_item(int index) const;
+    // TODO: convert API to <size_t>
     std::vector<int> sizeof_stream_items() const;
     buffer_type stream_buffer_type(size_t index) const;
     gr_vector_buffer_type stream_buffer_types() const;
+    friend bool operator==(const io_signature& lhs, const io_signature& rhs);
 };
 
+bool operator==(const io_signature& lhs, const io_signature& rhs);
 } /* namespace gr */
 
+template <>
+struct GR_RUNTIME_API fmt::formatter<gr::io_signature> : formatter<std::string_view> {
+    fmt::format_context::iterator format(const gr::io_signature& iosig,
+                                         format_context& ctx) const;
+};
 #endif /* INCLUDED_IO_SIGNATURE_H */

--- a/gnuradio-runtime/include/gnuradio/io_signature.h
+++ b/gnuradio-runtime/include/gnuradio/io_signature.h
@@ -12,9 +12,7 @@
 #define INCLUDED_IO_SIGNATURE_H
 
 // For testing purposes, force single mapped buffers to make all QA use them
-//#define FORCE_SINGLE_MAPPED
-
-#include <functional>
+// #define FORCE_SINGLE_MAPPED
 
 #include <gnuradio/api.h>
 #ifdef FORCE_SINGLE_MAPPED

--- a/gnuradio-runtime/lib/buffer_single_mapped.cc
+++ b/gnuradio-runtime/lib/buffer_single_mapped.cc
@@ -16,13 +16,10 @@
 #include <gnuradio/buffer_single_mapped.h>
 #include <gnuradio/math.h>
 #include <gnuradio/thread/thread.h>
-#include <assert.h>
 #include <algorithm>
 #include <cstdlib>
-#include <cstring>
-#include <iostream>
+#include <limits>
 #include <numeric>
-#include <stdexcept>
 
 namespace gr {
 

--- a/gnuradio-runtime/lib/io_signature.cc
+++ b/gnuradio-runtime/lib/io_signature.cc
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2004,2007,2013 Free Software Foundation, Inc.
+ * Copyright 2023 Marcus Müller
  *
  * This file is part of GNU Radio
  *
@@ -8,49 +9,67 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include <gnuradio/io_signature.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
 #include <algorithm>
+#include <memory>
 #include <stdexcept>
 
 namespace gr {
+// The one we actually implement, the rest is just convenience wrappers
+gr::io_signature::sptr io_signature::make(int min_streams,
+                                          int max_streams,
+                                          const std::vector<size_t>& sizeof_stream_items,
+                                          const gr::gr_vector_buffer_type& buftypes)
+{
+    return sptr(
+        new io_signature(min_streams, max_streams, sizeof_stream_items, buftypes));
+}
 
+// keep as <int> for backwards compatibility
 gr::io_signature::sptr io_signature::makev(int min_streams,
                                            int max_streams,
                                            const std::vector<int>& sizeof_stream_items)
 {
-    gr_vector_buffer_type buftypes(sizeof_stream_items.size(),
-#ifdef FORCE_SINGLE_MAPPED
-                                   host_buffer::type);
-#else
-                                   buffer_double_mapped::type);
-#endif
-    return gr::io_signature::sptr(
-        new io_signature(min_streams, max_streams, sizeof_stream_items, buftypes));
+    return io_signature::make(
+        min_streams,
+        max_streams,
+        std::vector<size_t>(sizeof_stream_items.begin(), sizeof_stream_items.end()),
+        gr_vector_buffer_type(sizeof_stream_items.size(), default_buftype::type));
 }
 
+// keep as <int> for backwards compatibility
 gr::io_signature::sptr io_signature::makev(int min_streams,
                                            int max_streams,
                                            const std::vector<int>& sizeof_stream_items,
-                                           gr_vector_buffer_type buftypes)
+                                           const gr_vector_buffer_type& buftypes)
 {
-    return gr::io_signature::sptr(
-        new io_signature(min_streams, max_streams, sizeof_stream_items, buftypes));
+    return io_signature::make(
+        min_streams,
+        max_streams,
+        std::vector<size_t>(sizeof_stream_items.begin(), sizeof_stream_items.end()),
+        buftypes);
 }
 
+// keep as <int> for backwards compatibility
 gr::io_signature::sptr io_signature::make(int min_streams,
                                           int max_streams,
                                           int sizeof_stream_item,
                                           buffer_type buftype)
 {
-    std::vector<int> sizeof_items{ sizeof_stream_item };
-    gr_vector_buffer_type buftypes{ buftype };
-    return io_signature::makev(min_streams, max_streams, sizeof_items, buftypes);
+    if (max_streams && sizeof_stream_item < 1) {
+        throw std::invalid_argument(
+            fmt::format("Item sizes need to be >= 1, but got {:d}", sizeof_stream_item));
+    }
+    return io_signature::make(
+        min_streams,
+        max_streams,
+        std::vector<size_t>{ static_cast<size_t>(sizeof_stream_item) },
+        gr::gr_vector_buffer_type{ buftype });
 }
 
+// keep as <int> for backwards compatibility
 gr::io_signature::sptr io_signature::make2(int min_streams,
                                            int max_streams,
                                            int sizeof_stream_item1,
@@ -58,11 +77,15 @@ gr::io_signature::sptr io_signature::make2(int min_streams,
                                            buffer_type buftype1,
                                            buffer_type buftype2)
 {
-    std::vector<int> sizeof_items{ sizeof_stream_item1, sizeof_stream_item2 };
-    gr_vector_buffer_type buftypes{ buftype1, buftype2 };
-    return io_signature::makev(min_streams, max_streams, sizeof_items, buftypes);
+    return io_signature::make(
+        min_streams,
+        max_streams,
+        std::vector<size_t>({ static_cast<size_t>(sizeof_stream_item1),
+                              static_cast<size_t>(sizeof_stream_item2) }),
+        { buftype1, buftype2 });
 }
 
+// keep as <int> for backwards compatibility
 gr::io_signature::sptr io_signature::make3(int min_streams,
                                            int max_streams,
                                            int sizeof_stream_item1,
@@ -72,34 +95,65 @@ gr::io_signature::sptr io_signature::make3(int min_streams,
                                            buffer_type buftype2,
                                            buffer_type buftype3)
 {
-    std::vector<int> sizeof_items{ sizeof_stream_item1,
-                                   sizeof_stream_item2,
-                                   sizeof_stream_item3 };
-    gr_vector_buffer_type buftypes{ buftype1, buftype2, buftype3 };
-    return io_signature::makev(min_streams, max_streams, sizeof_items, buftypes);
+    return io_signature::make(
+        min_streams,
+        max_streams,
+        std::vector<size_t>{ static_cast<size_t>(sizeof_stream_item1),
+                             static_cast<size_t>(sizeof_stream_item2),
+                             static_cast<size_t>(sizeof_stream_item3) },
+        { buftype1, buftype2, buftype3 });
 }
 
 // ------------------------------------------------------------------------
-
+template <class container>
+auto subrange_helper(int max,
+                     const container& cont,
+                     std::string_view what = "sizeof_stream_items")
+{
+    if (max == io_signature::IO_INFINITE) {
+        return cont.end();
+    }
+    if (max < 0) {
+        throw std::invalid_argument(fmt::format("Negative maximum count {:d}", max));
+    }
+    if (static_cast<size_t>(max) < cont.size()) {
+        return cont.begin() + max;
+    }
+    return cont.end();
+}
 io_signature::io_signature(int min_streams,
                            int max_streams,
-                           const std::vector<int>& sizeof_stream_items,
-                           gr_vector_buffer_type buftypes)
+                           const std::vector<size_t>& sizeof_stream_items,
+                           const gr_vector_buffer_type& buftypes)
     : d_min_streams(min_streams),
       d_max_streams(max_streams),
-      d_sizeof_stream_item(sizeof_stream_items),
+      d_sizeof_stream_item(sizeof_stream_items.begin(),
+                           subrange_helper(max_streams, sizeof_stream_items)),
       d_stream_buffer_type(buftypes)
 {
-    if (min_streams < 0 || (max_streams != IO_INFINITE && max_streams < min_streams))
-        throw std::invalid_argument("gr::io_signature(1)");
-
-    if (sizeof_stream_items.empty()) {
-        throw std::invalid_argument("gr::io_signature(2)");
+    if (min_streams < 0) {
+        throw std::invalid_argument(
+            fmt::format("Minimum number of streams must be >= 0, is {:d}", min_streams));
     }
-
-    for (size_t i = 0; i < sizeof_stream_items.size(); i++) {
-        if (max_streams != 0 && sizeof_stream_items[i] < 1)
-            throw std::invalid_argument("gr::io_signature(3)");
+    if (max_streams != IO_INFINITE && max_streams < min_streams) {
+        throw std::invalid_argument(
+            fmt::format("Maximum number of streams ({:d}) needs to be at least as "
+                        "large as minimum number of streams ({:d})",
+                        max_streams,
+                        min_streams));
+    }
+    if (sizeof_stream_items.empty()) {
+        throw std::invalid_argument("Item size vector cannot be empty");
+    }
+    if (max_streams) {
+        size_t index = 0;
+        for (const auto size : sizeof_stream_items) {
+            if (size < 1) {
+                throw std::invalid_argument(fmt::format(
+                    "No item size can be < 1, but position [{:d}] is {:d}", index, size));
+            }
+            ++index;
+        }
     }
 }
 
@@ -116,7 +170,7 @@ int io_signature::sizeof_stream_item(int _index) const
 
 std::vector<int> io_signature::sizeof_stream_items() const
 {
-    return d_sizeof_stream_item;
+    return { d_sizeof_stream_item.begin(), d_sizeof_stream_item.end() };
 }
 
 buffer_type io_signature::stream_buffer_type(size_t index) const
@@ -129,4 +183,42 @@ gr_vector_buffer_type io_signature::stream_buffer_types() const
     return d_stream_buffer_type;
 }
 
+bool operator==(const io_signature& lhs, const io_signature& rhs)
+{
+    return lhs.d_min_streams == rhs.d_max_streams &&
+           lhs.d_max_streams == rhs.d_max_streams &&
+           lhs.d_sizeof_stream_item == rhs.d_sizeof_stream_item;
+    // TODO: implement buffer_type comparator
+    //&&lhs.d_stream_buffer_type == rhs.d_stream_buffer_type;
+}
 } /* namespace gr */
+
+fmt::format_context::iterator
+fmt::formatter<gr::io_signature>::format(const gr::io_signature& iosig,
+                                         fmt::format_context& ctx) const
+{
+    auto min_streams = iosig.min_streams();
+    auto max_streams = iosig.max_streams();
+    const auto itemsizes = iosig.sizeof_stream_items();
+
+    const auto stream_range = (max_streams == gr::io_signature::IO_INFINITE)
+                                  ? fmt::format("{} – {}", min_streams, max_streams)
+                                  : fmt::format("{} – ∞", min_streams);
+
+    const auto sizes = (itemsizes.size() < static_cast<size_t>(max_streams))
+                           ? fmt::format("{}, …", fmt::join(itemsizes, ", "))
+                           : fmt::format("{}", fmt::join(itemsizes, ", "));
+
+    return fmt::format_to(ctx.out(),
+                          "Stream Range: {:>20s}\n"
+                          "Item Sizes:   {:>20s}\n"
+                          "Buffer Types: {:>20s}",
+                          (max_streams == gr::io_signature::IO_INFINITE)
+                              ? fmt::format("{} – {}", min_streams, max_streams)
+                              : fmt::format("{} – ∞", min_streams),
+                          (itemsizes.size() < static_cast<size_t>(max_streams))
+                              ? fmt::format("{}, …", fmt::join(itemsizes, ", "))
+                              : fmt::format("{}", fmt::join(itemsizes, ", ")),
+                          // TODO: Implement printing of buffer types
+                          "printing not implemented");
+}

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_type_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/buffer_type_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(buffer_type.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(02a0b4a46ed0e72d2854190c469e86e2)                     */
+/* BINDTOOL_HEADER_FILE_HASH(daf4c66b477389a2a4a9fb2a94a752de)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>

--- a/gnuradio-runtime/python/gnuradio/gr/bindings/io_signature_python.cc
+++ b/gnuradio-runtime/python/gnuradio/gr/bindings/io_signature_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(io_signature.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(fe931f4f10b5b363b55e9ae43c178b7a)                     */
+/* BINDTOOL_HEADER_FILE_HASH(ef85ed5bf4e4f555e587ee777400609e)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>


### PR DESCRIPTION
`io_signature` is around the oldest code we have in the API, and its `make` variants make little sense.

Clean these up, deprecate the current API; and then, if consensus for that can be found, remove "bad" `makeX`s from main.

## Related Issue

Fixes #6758 

#6758 illustrated needs for better inspectabilty, and more sensible types, in `io_signature`.
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
Tree-wide

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
