### PR TITLE
CI: disable Python check E721 until fixes can be made

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: quentinguidee/pep8-action@v1
       with:
-        arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E722,E741,W504,W605 --exclude *.yml.py'
+        arguments: '--max-line-length=120 --ignore E265,E266,E275,E402,E501,E704,E712,E713,E714,E711,E721,E722,E741,W504,W605 --exclude *.yml.py'
   # Doxygen gets built separately. It has a lot of output and its own weirdness.
   doxygen:
     name: Doxygen


### PR DESCRIPTION
## Description
E721 enforces the use of "is"/"is not" vs "==" in type comparison. There are 150 instances that were recently flagged by CI.

## Related Issue
Reverse this change after #6770 is addressed.

## Which blocks/areas does this affect?
Many/CI

## Testing Done

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
