### PR TITLE
Add buffer size parameter to RTLSDR Source

### DIFF
--- a/gr-soapy/grc/soapy_rtlsdr_source.block.yml
+++ b/gr-soapy/grc/soapy_rtlsdr_source.block.yml
@@ -55,6 +55,15 @@ parameters:
     default: 'False'
     hide: 'part'
 
+  - id: bufflen
+    label: 'USB Buffer Size'
+    dtype: int
+    default: 16384
+    hide: 'part'
+
+asserts:
+  - ${ bufflen % 512 == 0 }
+
 inputs:
   - domain: message
     id: cmd
@@ -70,7 +79,7 @@ templates:
   make: |
       None
       dev = 'driver=rtlsdr'
-      stream_args = ''
+      stream_args = 'bufflen=${bufflen}'
       tune_args = ['']
       settings = ['']
 


### PR DESCRIPTION
## Description
Currently, there is no way to set the Buffer Size (`bufflen`) parameter of an RTLSDR source from within GNU Radio Companion. The default value (262144 bytes / 131072 samples) can be excessively large, particularly when operating at low sample rates. For instance, at 240000 sps the buffer is 546 ms long. This causes high latency and very slow update rates for GUI sinks.

Here I've added a USB Buffer Size parameter which allows this value to be adjusted.

![Screenshot from 2023-08-15 17-29-38](https://github.com/gnuradio/gnuradio/assets/583749/c4c8b612-b928-4764-942c-13c8ca5df541)

## Which blocks/areas does this affect?
* Soapy RTLSDR Source

## Testing Done
I tested using a flowgraph with an RTLSDR source connected to a Time Sink & Frequency Sink. With the sample rate set to 240000, the display becomes much more responsive when the buffer size is decreased to 16384.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary. **I'll do this if and when this PR is merged.**
- [ ] ~~I have added tests to cover my changes,~~ and all previous tests pass.
