### PR TITLE
Set the frequency sink's output multiple on start

### DIFF
--- a/gr-qtgui/lib/freq_sink_c_impl.cc
+++ b/gr-qtgui/lib/freq_sink_c_impl.cc
@@ -503,6 +503,12 @@ void freq_sink_c_impl::_test_trigger_norm(int nitems,
     }
 }
 
+bool freq_sink_c_impl::start()
+{
+    set_output_multiple(d_fftsize);
+    return true;
+}
+
 int freq_sink_c_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)

--- a/gr-qtgui/lib/freq_sink_c_impl.h
+++ b/gr-qtgui/lib/freq_sink_c_impl.h
@@ -166,6 +166,7 @@ public:
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;
+    bool start() override;
 };
 
 } /* namespace qtgui */

--- a/gr-qtgui/lib/freq_sink_f_impl.cc
+++ b/gr-qtgui/lib/freq_sink_f_impl.cc
@@ -506,6 +506,12 @@ void freq_sink_f_impl::_test_trigger_norm(int nitems,
     }
 }
 
+bool freq_sink_f_impl::start()
+{
+    set_output_multiple(d_fftsize);
+    return true;
+}
+
 int freq_sink_f_impl::work(int noutput_items,
                            gr_vector_const_void_star& input_items,
                            gr_vector_void_star& output_items)

--- a/gr-qtgui/lib/freq_sink_f_impl.h
+++ b/gr-qtgui/lib/freq_sink_f_impl.h
@@ -166,6 +166,7 @@ public:
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
              gr_vector_void_star& output_items) override;
+    bool start() override;
 };
 
 } /* namespace qtgui */


### PR DESCRIPTION
## Description
The refresh rate of the QT GUI Time Sink can be painfully slow when the input sample rate is low. This was a side effect of #5442, which set the block's output multiple to `MAX_FFT_SIZE` = 32768 in the block's constructor, presumably to ensure that the scheduler allocates a large enough buffer to accommodate FFT size changes made in the GUI at runtime:

https://github.com/gnuradio/gnuradio/blob/0966207dbc5cc0077f7ee6cde0aaa95f7c7a8d99/gr-qtgui/lib/freq_sink_c_impl.cc#L128

If the FFT size is changed at runtime, the refresh rate speeds up because the output multiple is adjusted to the current FFT size:

https://github.com/gnuradio/gnuradio/blob/0966207dbc5cc0077f7ee6cde0aaa95f7c7a8d99/gr-qtgui/lib/freq_sink_c_impl.cc#L415

By doing the same in the `start()` method, the block will have the expected refresh rate, while still ensuring that the scheduler will allocate enough space to accommodate runtime FFT size changes.

## Related issue

Partially resolves #5759.

## Which blocks/areas does this affect?
* QT GUI Frequency Sink

## Testing Done
I tested with the following flowgraph:

![Screenshot from 2023-08-15 14-31-52](https://github.com/gnuradio/gnuradio/assets/583749/7f4db9cb-d498-4637-9ad0-b9e5bf1a47ab)

The frequency sinks have their update rates set to 0.01.

Before the change, the sinks update at 3 fps. After the change, they update at 100 fps.

Changing the FFT size at runtime still works properly, all the way up to the maximum FFT size of 32768.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes,~~ and all previous tests pass.
