### PR TITLE
docs: Update RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,8 @@
 version: 2
 
 # Set the version of Python and other tools you might need
-#build:
-  #os: ubuntu-20.04
+build:
+  os: ubuntu-22.04
   #tools:
     #python: "3.9"
     # You can also specify other tool versions:


### PR DESCRIPTION
This specifies build.os, which was previously relying on the default value. According to RTD documentation, this key is required and its abscence was causing warnings.
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
