### PR TITLE
QTGUI: Applications show a confusing error message on first start

### DIFF
--- a/grc/core/generator/flow_graph.py.mako
+++ b/grc/core/generator/flow_graph.py.mako
@@ -99,10 +99,11 @@ class ${class_name}(gr.top_block, Qt.QWidget):
         self.settings = Qt.QSettings("GNU Radio", "${class_name}")
 
         try:
-            if StrictVersion(Qt.qVersion()) < StrictVersion("5.0.0"):
-                self.restoreGeometry(self.settings.value("geometry").toByteArray())
-            else:
-                self.restoreGeometry(self.settings.value("geometry"))
+            if self.settings.value("geometry"):
+                if StrictVersion(Qt.qVersion()) < StrictVersion("5.0.0"):
+                    self.restoreGeometry(self.settings.value("geometry").toByteArray())
+                else:
+                    self.restoreGeometry(self.settings.value("geometry"))
         except BaseException as exc:
             print(f"Qt GUI: Could not restore geometry: {str(exc)}", file=sys.stderr)
 % elif generate_options == 'bokeh_gui':


### PR DESCRIPTION

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Create a new qt based flowgraph in grc and run it.
Than you get on the first run:
Qt GUI: Could not restore geometry: restoreGeometry(self, Union[QByteArray, bytes, bytearray]): argument 1 has unexpected type 'NoneType'
but the fg starts.

On the second run this message has gone.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
For testing you can use the gui_sink example in the gr-qtgui/examples directory.

Make sure that no gui_sink.conf exists in the ~/.config/GNU Radio/ directory.
Running the flowgraph shows the mentioned error message and creates gui_sink.conf, so on the second run the fg starts without errors.  But if you delete the config file , you'll get this error again.
 
## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
