### PR TITLE
gr-iio: fix deadlock when destroying fmcomms2_source that didn't start (backport to maint-3.10)

### DIFF
--- a/gr-iio/lib/device_source_impl.cc
+++ b/gr-iio/lib/device_source_impl.cc
@@ -173,7 +173,8 @@ device_source_impl::device_source_impl(iio_context* ctx,
       buf(NULL),
       buffer_size(buffer_size),
       decimation(decimation),
-      destroy_ctx(destroy_ctx)
+      destroy_ctx(destroy_ctx),
+      thread_stopped(false)
 {
     unsigned int nb_channels, i;
 

--- a/gr-iio/lib/fmcomms2_source_impl.h
+++ b/gr-iio/lib/fmcomms2_source_impl.h
@@ -40,8 +40,10 @@ private:
 
     int work(int noutput_items,
              gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items);
+             gr_vector_void_star& output_items) override;
 
+    bool start() override;
+    bool stop() override;
 
 public:
     fmcomms2_source_impl(iio_context* ctx,
@@ -50,18 +52,18 @@ public:
 
     ~fmcomms2_source_impl();
 
-    virtual void set_len_tag_key(const std::string& len_tag_key);
-    virtual void set_frequency(double frequency);
-    virtual void set_samplerate(unsigned long samplerate);
-    virtual void set_gain_mode(size_t chan, const std::string& mode);
-    virtual void set_gain(size_t chan, double gain_value);
-    virtual void set_quadrature(bool quadrature);
-    virtual void set_rfdc(bool rfdc);
-    virtual void set_bbdc(bool bbdc);
-    virtual void set_filter_params(const std::string& filter_source,
-                                   const std::string& filter_filename,
-                                   float fpass,
-                                   float fstop);
+    void set_len_tag_key(const std::string& len_tag_key) override;
+    void set_frequency(double frequency) override;
+    void set_samplerate(unsigned long samplerate) override;
+    void set_gain_mode(size_t chan, const std::string& mode) override;
+    void set_gain(size_t chan, double gain_value) override;
+    void set_quadrature(bool quadrature) override;
+    void set_rfdc(bool rfdc) override;
+    void set_bbdc(bool bbdc) override;
+    void set_filter_params(const std::string& filter_source,
+                           const std::string& filter_filename,
+                           float fpass,
+                           float fstop) override;
 
 protected:
     void update_dependent_params();


### PR DESCRIPTION
Backport #6776 