### PR TITLE
Fix build with fmt-10.1

### DIFF
--- a/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
+++ b/gnuradio-runtime/lib/controlport/thrift/rpcpmtconverters_thrift.cc
@@ -255,7 +255,8 @@ pmt::pmt_t rpcpmtconverter::to_pmt_f::operator()(const GNURadio::Knob& knob)
     // FIXME: Don't get loggers every time we need to log something.
     gr::logger_ptr logger, debug_logger;
     gr::configure_default_loggers(logger, debug_logger, "rpcpmtconverter");
-    debug_logger->error("ERROR Don't know how to handle Knob Type (from): {}", knob.type);
+    debug_logger->error("ERROR Don't know how to handle Knob Type (from): {}",
+                        to_string(knob.type));
     assert(0);
     return pmt::pmt_t();
 }


### PR DESCRIPTION
## Description
fmt doesn't format enums implicitly any more, causing the build to fail. Calling `to_string` fixes it.

## Related Issue
Fixes #6774

## Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [ ] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
