### PR TITLE
Header format: Fix CRC and OFDM formats, header_buffer refactoring

### DIFF
--- a/gr-digital/examples/packet/formatter_crc.grc
+++ b/gr-digital/examples/packet/formatter_crc.grc
@@ -162,7 +162,7 @@ blocks:
     alias: ''
     align_output: 'False'
     comment: ''
-    endianness: gr.GR_MSB_FIRST
+    endianness: gr.GR_LSB_FIRST
     k: '8'
     l: '1'
     len_tag_key: len_key
@@ -179,7 +179,7 @@ blocks:
     alias: ''
     align_output: 'False'
     comment: ''
-    endianness: gr.GR_MSB_FIRST
+    endianness: gr.GR_LSB_FIRST
     k: '8'
     l: '1'
     len_tag_key: len_key

--- a/gr-digital/examples/packet/formatter_crc_header_payload_demux.grc
+++ b/gr-digital/examples/packet/formatter_crc_header_payload_demux.grc
@@ -161,7 +161,7 @@ blocks:
     alias: ''
     align_output: 'False'
     comment: ''
-    endianness: gr.GR_MSB_FIRST
+    endianness: gr.GR_LSB_FIRST
     k: '8'
     l: '1'
     len_tag_key: len_key
@@ -181,7 +181,7 @@ blocks:
     alias: ''
     align_output: 'False'
     comment: ''
-    endianness: gr.GR_MSB_FIRST
+    endianness: gr.GR_LSB_FIRST
     k: '1'
     l: '8'
     len_tag_key: '"packet_len"'
@@ -682,3 +682,4 @@ connections:
 
 metadata:
   file_format: 1
+  grc_version: 3.10.7.0

--- a/gr-digital/examples/packet/formatter_ofdm.grc
+++ b/gr-digital/examples/packet/formatter_ofdm.grc
@@ -227,7 +227,7 @@ blocks:
     alias: ''
     align_output: 'False'
     comment: ''
-    endianness: gr.GR_MSB_FIRST
+    endianness: gr.GR_LSB_FIRST
     k: '8'
     l: '1'
     len_tag_key: len_key
@@ -247,7 +247,7 @@ blocks:
     alias: ''
     align_output: 'False'
     comment: ''
-    endianness: gr.GR_MSB_FIRST
+    endianness: gr.GR_LSB_FIRST
     k: '8'
     l: '1'
     len_tag_key: len_key

--- a/gr-digital/include/gnuradio/digital/header_buffer.h
+++ b/gr-digital/include/gnuradio/digital/header_buffer.h
@@ -252,23 +252,47 @@ public:
      */
     void insert_bit(int bit);
 
+
+    /*!
+     * Returns a field in the packet header.
+     *
+     * \param pos Bit position of the start of the field.
+     * \param len The number of bits in the field.
+     * \param bs Set to 'true' to byte swap the data.
+     * \param lsb_first Set to 'true' to read field encoded as least significant bit first
+     */
+    template <class T>
+    T extract_field(int pos,
+                    int len = 8 * sizeof(T),
+                    bool bs = false,
+                    bool lsb_first = false);
+
     /*!
      * Returns up to an 8-bit field in the packet header.
      *
      * \param pos Bit position of the start of the field.
      * \param len The number of bits in the field.
      * \param bs Set to 'true' to byte swap the data.
+     * \param lsb_first Set to 'true' to read field encoded as least significant bit first
      */
-    uint8_t extract_field8(int pos, int len = 8, bool bs = false);
-
+    uint8_t extract_field8(int pos, int len = 8, bool bs = false, bool lsb_first = false)
+    {
+        return extract_field<uint8_t>(pos, len, bs, lsb_first);
+    };
+    // constexpr auto& extract_field8 = extract_field<uint8_t>;
     /*!
      * Returns up to a 16-bit field in the packet header.
      *
      * \param pos Bit position of the start of the field.
      * \param len The number of bits in the field.
      * \param bs Set to 'true' to byte swap the data.
+     * \param lsb_first Set to 'true' to read field encoded as least significant bit first
      */
-    uint16_t extract_field16(int pos, int len = 16, bool bs = false);
+    uint16_t
+    extract_field16(int pos, int len = 16, bool bs = false, bool lsb_first = false)
+    {
+        return extract_field<uint16_t>(pos, len, bs, lsb_first);
+    };
 
     /*!
      * Returns up to a 32-bit field in the packet header.
@@ -276,8 +300,13 @@ public:
      * \param pos Bit position of the start of the field.
      * \param len The number of bits in the field.
      * \param bs Set to 'true' to byte swap the data.
+     * \param lsb_first Set to 'true' to read field encoded as least significant bit first
      */
-    uint32_t extract_field32(int pos, int len = 32, bool bs = false);
+    uint32_t
+    extract_field32(int pos, int len = 32, bool bs = false, bool lsb_first = false)
+    {
+        return extract_field<uint32_t>(pos, len, bs, lsb_first);
+    };
 
     /*!
      * Returns up to a 64-bit field in the packet header.
@@ -285,8 +314,13 @@ public:
      * \param pos Bit position of the start of the field.
      * \param len The number of bits in the field.
      * \param bs Set to 'true' to byte swap the data.
+     * \param lsb_first Set to 'true' to read field encoded as least significant bit first
      */
-    uint64_t extract_field64(int pos, int len = 64, bool bs = false);
+    uint64_t
+    extract_field64(int pos, int len = 64, bool bs = false, bool lsb_first = false)
+    {
+        return extract_field<uint64_t>(pos, len, bs, lsb_first);
+    };
 };
 
 } // namespace digital

--- a/gr-digital/lib/header_buffer.cc
+++ b/gr-digital/lib/header_buffer.cc
@@ -78,81 +78,34 @@ void header_buffer::add_field64(uint64_t data, int len, bool bs)
 
 void header_buffer::insert_bit(int bit) { d_input.push_back(bit); }
 
-uint8_t header_buffer::extract_field8(int pos, int len, bool bs)
+template <class T>
+T header_buffer::extract_field(int pos, int len, bool bs, bool lsb_first)
 {
-    if (len > 8) {
-        throw std::runtime_error("header_buffer::extract_field for "
-                                 "uint8_t length must be <= 8");
+    if (len > 8 * (int)sizeof(T)) {
+        throw std::runtime_error(
+            std::string("header_buffer::extract_field for length must be <= ") +
+            std::to_string(8 * sizeof(T)));
     }
 
-    uint8_t field = 0x00;
+    T field = 0;
     std::vector<bool>::iterator itr;
-    for (itr = d_input.begin() + pos; itr != d_input.begin() + pos + len; itr++) {
-        field = (field << 1) | ((*itr) & 0x1);
+    if (lsb_first) {
+        for (itr = d_input.begin() + pos + len - 1; itr >= d_input.begin() + pos; itr--) {
+            field = (field << 1) | ((*itr) & 0x1);
+        }
+    } else {
+        for (itr = d_input.begin() + pos; itr != d_input.begin() + pos + len; itr++) {
+            field = (field << 1) | ((*itr) & 0x1);
+        }
     }
 
     return field;
 }
 
-uint16_t header_buffer::extract_field16(int pos, int len, bool bs)
-{
-    if (len > 16) {
-        throw std::runtime_error("header_buffer::extract_field for "
-                                 "uint16_t length must be <= 16");
-    }
-
-    uint16_t field = 0x0000;
-    std::vector<bool>::iterator itr;
-    for (itr = d_input.begin() + pos; itr != d_input.begin() + pos + len; itr++) {
-        field = (field << 1) | ((*itr) & 0x1);
-    }
-
-    if (bs) {
-        volk_16u_byteswap(&field, 1);
-    }
-
-    return field;
-}
-
-uint32_t header_buffer::extract_field32(int pos, int len, bool bs)
-{
-    if (len > 32) {
-        throw std::runtime_error("header_buffer::extract_field for "
-                                 "uint32_t length must be <= 32");
-    }
-
-    uint32_t field = 0x00000000;
-    std::vector<bool>::iterator itr;
-    for (itr = d_input.begin() + pos; itr != d_input.begin() + pos + len; itr++) {
-        field = (field << 1) | ((*itr) & 0x1);
-    }
-
-    if (bs) {
-        volk_32u_byteswap(&field, 1);
-    }
-
-    return field;
-}
-
-uint64_t header_buffer::extract_field64(int pos, int len, bool bs)
-{
-    if (len > 64) {
-        throw std::runtime_error("header_buffer::extract_field for "
-                                 "uint64_t length must be <= 64");
-    }
-
-    uint64_t field = 0x0000000000000000;
-    std::vector<bool>::iterator itr;
-    for (itr = d_input.begin() + pos; itr != d_input.begin() + pos + len; itr++) {
-        field = (field << 1) | ((*itr) & 0x1);
-    }
-
-    if (bs) {
-        volk_64u_byteswap(&field, 1);
-    }
-
-    return field;
-}
+template DIGITAL_API uint8_t header_buffer::extract_field(int, int, bool, bool);
+template DIGITAL_API uint16_t header_buffer::extract_field(int, int, bool, bool);
+template DIGITAL_API uint32_t header_buffer::extract_field(int, int, bool, bool);
+template DIGITAL_API uint64_t header_buffer::extract_field(int, int, bool, bool);
 
 } /* namespace digital */
 } /* namespace gr */

--- a/gr-digital/lib/header_format_crc.cc
+++ b/gr-digital/lib/header_format_crc.cc
@@ -102,11 +102,9 @@ size_t header_format_crc::header_nbits() const { return 32; }
 
 bool header_format_crc::header_ok()
 {
-    uint32_t pkt = d_hdr_reg.extract_field32(0, 24, true);
-    uint16_t pktlen = static_cast<uint16_t>((pkt >> 8) & 0x0fff);
-    uint16_t pktnum = static_cast<uint16_t>((pkt >> 20) & 0x0fff);
-    uint8_t crc_rcvd = d_hdr_reg.extract_field8(24);
-
+    uint16_t pktlen = d_hdr_reg.extract_field16(0, 12, false, true);
+    uint16_t pktnum = d_hdr_reg.extract_field16(12, 12, false, true);
+    uint8_t crc_rcvd = d_hdr_reg.extract_field8(24, 8, false, true);
     // Check CRC8
     unsigned char buffer[] = { (unsigned char)(pktlen & 0xFF),
                                (unsigned char)(pktlen >> 8),
@@ -119,9 +117,8 @@ bool header_format_crc::header_ok()
 
 int header_format_crc::header_payload()
 {
-    uint32_t pkt = d_hdr_reg.extract_field32(0, 24, true);
-    uint16_t pktlen = static_cast<uint16_t>((pkt >> 8) & 0x0fff);
-    uint16_t pktnum = static_cast<uint16_t>((pkt >> 20) & 0x0fff);
+    uint16_t pktlen = d_hdr_reg.extract_field16(0, 12, false, true);
+    uint16_t pktnum = d_hdr_reg.extract_field16(12, 12, false, true);
 
     d_info = pmt::make_dict();
     d_info = pmt::dict_add(d_info, d_len_key_name, pmt::from_long(8 * pktlen));

--- a/gr-digital/lib/qa_header_buffer.cc
+++ b/gr-digital/lib/qa_header_buffer.cc
@@ -227,11 +227,13 @@ BOOST_AUTO_TEST_CASE(test_extract8)
     uint8_t x0 = header.extract_field8(0);
     uint8_t x1 = header.extract_field8(12, 8);
     uint8_t x2 = header.extract_field8(12, 4);
+    uint8_t x3 = header.extract_field8(8, 8, false, true);
 
     BOOST_REQUIRE_EQUAL((size_t)64, header.length());
     BOOST_REQUIRE_EQUAL((uint8_t)0x80, x0);
     BOOST_REQUIRE_EQUAL((uint8_t)0x4A, x1);
     BOOST_REQUIRE_EQUAL((uint8_t)0x04, x2);
+    BOOST_REQUIRE_EQUAL((uint8_t)0x23, x3);
 }
 
 BOOST_AUTO_TEST_CASE(test_extract16)
@@ -250,11 +252,13 @@ BOOST_AUTO_TEST_CASE(test_extract16)
     uint16_t x0 = header.extract_field16(0);
     uint16_t x1 = header.extract_field16(12, 16);
     uint16_t x2 = header.extract_field16(12, 12);
+    uint16_t x3 = header.extract_field16(16, 16, false, true);
 
     BOOST_REQUIRE_EQUAL((size_t)64, header.length());
     BOOST_REQUIRE_EQUAL((uint16_t)0x80C4, x0);
     BOOST_REQUIRE_EQUAL((uint16_t)0x4A2E, x1);
     BOOST_REQUIRE_EQUAL((uint16_t)0x04A2, x2);
+    BOOST_REQUIRE_EQUAL((uint16_t)0x6745, x3);
 }
 
 BOOST_AUTO_TEST_CASE(test_extract32)
@@ -273,11 +277,13 @@ BOOST_AUTO_TEST_CASE(test_extract32)
     uint32_t x0 = header.extract_field32(0);
     uint32_t x1 = header.extract_field32(12, 32);
     uint32_t x2 = header.extract_field32(12, 24);
+    uint32_t x3 = header.extract_field32(16, 16, false, true);
 
     BOOST_REQUIRE_EQUAL((size_t)64, header.length());
     BOOST_REQUIRE_EQUAL((uint32_t)0x80C4A2E6, x0);
     BOOST_REQUIRE_EQUAL((uint32_t)0x4A2E680C, x1);
     BOOST_REQUIRE_EQUAL((uint32_t)0x004A2E68, x2);
+    BOOST_REQUIRE_EQUAL((uint32_t)0x00006745, x3);
 }
 
 BOOST_AUTO_TEST_CASE(test_extract64)
@@ -296,11 +302,20 @@ BOOST_AUTO_TEST_CASE(test_extract64)
     uint64_t x0 = header.extract_field64(0);
     uint64_t x1 = header.extract_field64(0, 32);
     uint64_t x2 = header.extract_field64(0, 44);
+    uint64_t x3 = header.extract_field32(16, 16, false, true);
 
     BOOST_REQUIRE_EQUAL((size_t)64, header.length());
     BOOST_REQUIRE_EQUAL((uint64_t)0x80C4A2E680C4A2E6, x0);
     BOOST_REQUIRE_EQUAL((uint64_t)0x0000000080C4A2E6, x1);
     BOOST_REQUIRE_EQUAL((uint64_t)0x0000080C4A2E680C, x2);
+    BOOST_REQUIRE_EQUAL((uint64_t)0x0000000000006745, x3);
+}
+
+bool check_error_msg(const std::runtime_error& ex)
+{
+    BOOST_CHECK_EQUAL(
+        ex.what(), std::string("header_buffer::extract_field for length must be <= 16"));
+    return true;
 }
 
 BOOST_AUTO_TEST_CASE(test_extract_many)
@@ -321,6 +336,11 @@ BOOST_AUTO_TEST_CASE(test_extract_many)
     uint32_t x2 = header.extract_field32(40, 21);
     uint16_t x3 = header.extract_field16(1, 12);
     uint8_t x4 = header.extract_field8(7, 5);
+    uint8_t x5 = header.extract_field8(7, 5, false, true);
+    uint8_t x6 = header.extract_field<uint8_t>(7, 5, false, true);
+    BOOST_CHECK_EXCEPTION(header.extract_field<uint16_t>(7, 20, false, true),
+                          std::runtime_error,
+                          check_error_msg);
 
     BOOST_REQUIRE_EQUAL((size_t)64, header.length());
     BOOST_REQUIRE_EQUAL((uint64_t)0x80C4A2E680C4A2E6, x0);
@@ -328,4 +348,6 @@ BOOST_AUTO_TEST_CASE(test_extract_many)
     BOOST_REQUIRE_EQUAL((uint32_t)0x0018945C, x2);
     BOOST_REQUIRE_EQUAL((uint16_t)0x0018, x3);
     BOOST_REQUIRE_EQUAL((uint8_t)0x0C, x4);
+    BOOST_REQUIRE_EQUAL((uint8_t)0x06, x5);
+    BOOST_REQUIRE_EQUAL((uint8_t)0x06, x6);
 }

--- a/gr-digital/python/digital/bindings/header_buffer_python.cc
+++ b/gr-digital/python/digital/bindings/header_buffer_python.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Free Software Foundation, Inc.
+ * Copyright 2023 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(header_buffer.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(22afb7f4d4128f03a2a8f67f1e6ea6e0)                     */
+/* BINDTOOL_HEADER_FILE_HASH(c8ccc58a0efc5332b29a6fa9c2f0e828)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -93,6 +93,7 @@ void bind_header_buffer(py::module& m)
              py::arg("pos"),
              py::arg("len") = 8,
              py::arg("bs") = false,
+             py::arg("lsb_first") = false,
              D(header_buffer, extract_field8))
 
 
@@ -101,6 +102,7 @@ void bind_header_buffer(py::module& m)
              py::arg("pos"),
              py::arg("len") = 16,
              py::arg("bs") = false,
+             py::arg("lsb_first") = false,
              D(header_buffer, extract_field16))
 
 
@@ -109,6 +111,7 @@ void bind_header_buffer(py::module& m)
              py::arg("pos"),
              py::arg("len") = 32,
              py::arg("bs") = false,
+             py::arg("lsb_first") = false,
              D(header_buffer, extract_field32))
 
 
@@ -117,6 +120,7 @@ void bind_header_buffer(py::module& m)
              py::arg("pos"),
              py::arg("len") = 64,
              py::arg("bs") = false,
+             py::arg("lsb_first") = false,
              D(header_buffer, extract_field64))
 
         ;


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
As described in #6550 and #6575, the `header_format_crc` and `header_format_ofdm` classes don't operate on a header with the documented format. This comes from the fact that the `header_buffer` api does not allow parsing with least significant bit first.
It also prevents the scrambling feature of `header_format_ofdm` from working (I guess that's why it has been commented out for years).

So I added a LSB first option to the extract field functions of the `header_buffer`, putting it last and false by default to keep compatibility. I also templated the function to reduce code duplication.

I modified `header_format_crc` to use this LSB option, and reactivated the scrambling feature of `header_format_ofdm`.

I believe this could be back-ported at least to 3.10, if not to 3.9.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
 * Fixes #6550
 * #6575

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
* Protocol Formatter
* Protocol Parser
* Protocol Formatter (async)
The changes made here should be transparent to block users, except for the fact that one now needs to use the LSB endianness parameter for the Repack Bits block

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
I've tested on Linux Mint 21 (based on Ubuntu 22.04)
And added some test cases for the new lsb_first option of `header_buffer`, as well as the templated extract_field function.
I also added a test case for a Formatter/Parser chain using the `header_format_ofdm` object, to test scrambling, and by extension, `header_format_crc`.
I modified the example flowgraphs to work lsb_first.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
