### PR TITLE
qtgui: Use different colours for Constellation Sink inputs

### DIFF
--- a/gr-qtgui/grc/qtgui_const_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_const_sink_x.block.yml
@@ -136,7 +136,7 @@ parameters:
     category: Config
     dtype: enum
     options: ['"blue"', '"red"', '"green"', '"black"', '"cyan"', '"magenta"', '"yellow"',
-        '"dark red"', '"dark green"', '"Dark Blue"']
+        '"dark red"', '"dark green"', '"dark blue"']
     option_labels: [Blue, Red, Green, Black, Cyan, Magenta, Yellow, Dark Red, Dark
             Green, Dark Blue]
     hide: ${ ('part' if int(nconnections) >= 1 else 'all') }
@@ -197,7 +197,7 @@ parameters:
 -   id: color3
     label: Line 3 Color
     base_key: color1
-    default: '"red"'
+    default: '"green"'
     hide: ${ ('part' if int(nconnections) >= 3 else 'all') }
 -   id: style3
     label: Line 3 Style
@@ -222,7 +222,7 @@ parameters:
 -   id: color4
     label: Line 4 Color
     base_key: color1
-    default: '"red"'
+    default: '"black"'
     hide: ${ ('part' if int(nconnections) >= 4 else 'all') }
 -   id: style4
     label: Line 4 Style
@@ -247,7 +247,7 @@ parameters:
 -   id: color5
     label: Line 5 Color
     base_key: color1
-    default: '"red"'
+    default: '"cyan"'
     hide: ${ ('part' if int(nconnections) >= 5 else 'all') }
 -   id: style5
     label: Line 5 Style
@@ -272,7 +272,7 @@ parameters:
 -   id: color6
     label: Line 6 Color
     base_key: color1
-    default: '"red"'
+    default: '"magenta"'
     hide: ${ ('part' if int(nconnections) >= 6 else 'all') }
 -   id: style6
     label: Line 6 Style
@@ -297,7 +297,7 @@ parameters:
 -   id: color7
     label: Line 7 Color
     base_key: color1
-    default: '"red"'
+    default: '"yellow"'
     hide: ${ ('part' if int(nconnections) >= 7 else 'all') }
 -   id: style7
     label: Line 7 Style
@@ -322,7 +322,7 @@ parameters:
 -   id: color8
     label: Line 8 Color
     base_key: color1
-    default: '"red"'
+    default: '"dark red"'
     hide: ${ ('part' if int(nconnections) >= 8 else 'all') }
 -   id: style8
     label: Line 8 Style
@@ -347,7 +347,7 @@ parameters:
 -   id: color9
     label: Line 9 Color
     base_key: color1
-    default: '"red"'
+    default: '"dark green"'
     hide: ${ ('part' if int(nconnections) >= 9 else 'all') }
 -   id: style9
     label: Line 9 Style
@@ -372,7 +372,7 @@ parameters:
 -   id: color10
     label: Line 10 Color
     base_key: color1
-    default: '"red"'
+    default: '"dark blue"'
     hide: ${ ('part' if int(nconnections) >= 10 else 'all') }
 -   id: style10
     label: Line 10 Style


### PR DESCRIPTION
## Description
The QT GUI Constellation Sink uses the red colour for inputs 2 through 10, making them indistinguishable. Here I've changed the default input colours to match the other sinks. I also changed the capitalization of "dark blue" for consistency with the other sinks.

## Which blocks/areas does this affect?
* QT GUI Constellation Sink

## Testing Done
![Screenshot from 2023-08-28 10-17-46](https://github.com/gnuradio/gnuradio/assets/583749/fe4ce3f8-2554-4f7a-8844-54ef4ba4114c)
![Screenshot from 2023-08-28 10-17-57](https://github.com/gnuradio/gnuradio/assets/583749/04c362bf-c92d-47ca-a20f-a21296418d23)

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.
