### PR TITLE
Repeat: itemwise, solve buffer allocation issue

### DIFF
--- a/gnuradio-runtime/include/gnuradio/CMakeLists.txt
+++ b/gnuradio-runtime/include/gnuradio/CMakeLists.txt
@@ -45,6 +45,7 @@ install(
           msg_handler.h
           msg_queue.h
           nco.h
+          pmt_fmt.h
           pdu.h
           prefs.h
           pycallback_object.h

--- a/gnuradio-runtime/include/gnuradio/pmt_fmt.h
+++ b/gnuradio-runtime/include/gnuradio/pmt_fmt.h
@@ -1,0 +1,23 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Marcus Müller
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+#ifndef INCLUDED_GNURADIO_PMT_FMT_H
+#define INCLUDED_GNURADIO_PMT_FMT_H
+#include <gnuradio/api.h>
+#include <pmt/pmt.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
+
+//!\brief enables PMTs to be formatted with fmt
+template <>
+struct GR_RUNTIME_API fmt::formatter<pmt::pmt_t> : formatter<std::string_view> {
+    fmt::format_context::iterator format(const pmt::pmt_t& obj,
+                                         format_context& ctx) const;
+};
+#endif

--- a/gnuradio-runtime/lib/CMakeLists.txt
+++ b/gnuradio-runtime/lib/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(
     msg_queue.cc
     pagesize.cc
     pdu.cc
+    pmt_fmt.cc
     prefs.cc
     realtime.cc
     realtime_impl.cc

--- a/gnuradio-runtime/lib/pmt_fmt.cc
+++ b/gnuradio-runtime/lib/pmt_fmt.cc
@@ -1,0 +1,19 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Marcus Müller
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+#include <gnuradio/pmt_fmt.h>
+#include <pmt/pmt.h>
+#include <spdlog/fmt/fmt.h>
+#include <string_view>
+
+fmt::format_context::iterator
+fmt::formatter<pmt::pmt_t>::format(const pmt::pmt_t& obj, fmt::format_context& ctx) const
+{
+    return fmt::format_to(ctx.out(), "{}", pmt::write_string(obj));
+}

--- a/gr-blocks/include/gnuradio/blocks/repeat.h
+++ b/gr-blocks/include/gnuradio/blocks/repeat.h
@@ -26,7 +26,7 @@ namespace blocks {
  *      Takes a pmt_pair(pmt::mp("interpolation"), pmt_long interp), setting the
  * interpolation to interp.
  */
-class BLOCKS_API repeat : virtual public sync_interpolator
+class BLOCKS_API repeat : virtual public block
 {
 public:
     // gr::blocks::repeat::sptr

--- a/gr-blocks/lib/repeat_impl.h
+++ b/gr-blocks/lib/repeat_impl.h
@@ -18,22 +18,25 @@ namespace blocks {
 
 class BLOCKS_API repeat_impl : public repeat
 {
-    const size_t d_itemsize;
-    int d_interp;
-
 public:
     repeat_impl(size_t itemsize, int d_interp);
 
     int interpolation() const override { return d_interp; }
     void set_interpolation(int interp) override;
 
-
-    int work(int noutput_items,
-             gr_vector_const_void_star& input_items,
-             gr_vector_void_star& output_items) override;
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+    int general_work(int noutput_items,
+                     gr_vector_int& ninput_items,
+                     gr_vector_const_void_star& input_items,
+                     gr_vector_void_star& output_items) override;
 
 private:
-    void msg_set_interpolation(pmt::pmt_t msg);
+    const size_t d_itemsize;
+    size_t d_interp;
+    size_t d_left_to_copy;
+
+    void msg_set_interpolation(const pmt::pmt_t& msg);
+    const pmt::pmt_t c_msg_port;
 };
 
 } /* namespace blocks */

--- a/gr-blocks/python/blocks/bindings/repeat_python.cc
+++ b/gr-blocks/python/blocks/bindings/repeat_python.cc
@@ -14,7 +14,7 @@
 /* BINDTOOL_GEN_AUTOMATIC(0)                                                       */
 /* BINDTOOL_USE_PYGCCXML(0)                                                        */
 /* BINDTOOL_HEADER_FILE(repeat.h)                                        */
-/* BINDTOOL_HEADER_FILE_HASH(e09b086b5c70662b6d397af93cdeb2e5)                     */
+/* BINDTOOL_HEADER_FILE_HASH(3bc3b9639597273078d551360a012379)                     */
 /***********************************************************************************/
 
 #include <pybind11/complex.h>
@@ -33,12 +33,8 @@ void bind_repeat(py::module& m)
     using repeat = ::gr::blocks::repeat;
 
 
-    py::class_<repeat,
-               gr::sync_interpolator,
-               gr::sync_block,
-               gr::block,
-               gr::basic_block,
-               std::shared_ptr<repeat>>(m, "repeat", D(repeat))
+    py::class_<repeat, gr::block, gr::basic_block, std::shared_ptr<repeat>>(
+        m, "repeat", D(repeat))
 
         .def(py::init(&repeat::make),
              py::arg("itemsize"),

--- a/gr-blocks/python/blocks/qa_repeat.py
+++ b/gr-blocks/python/blocks/qa_repeat.py
@@ -10,29 +10,30 @@
 
 
 from gnuradio import gr, gr_unittest, blocks
+import numpy as np
 
 
-class test_repeat (gr_unittest.TestCase):
-
+class test_repeat(gr_unittest.TestCase):
     def setUp(self):
         self.tb = gr.top_block()
 
     def tearDown(self):
         self.tb = None
 
-    def test_001_float(self):
-        src_data = [n * 1.0 for n in range(100)]
-        dst_data = []
-        for n in range(100):
-            dst_data += [1.0 * n, 1.0 * n, 1.0 * n]
-
-        src = blocks.vector_source_f(src_data)
-        rpt = blocks.repeat(gr.sizeof_float, 3)
-        dst = blocks.vector_sink_f()
+    def run_fg(self, N, r, msg=""):
+        src_data = np.arange(N)
+        src = blocks.vector_source_i(src_data)
+        rpt = blocks.repeat(gr.sizeof_int, r)
+        dst = blocks.vector_sink_i()
         self.tb.connect(src, rpt, dst)
         self.tb.run()
-        self.assertFloatTuplesAlmostEqual(dst_data, dst.data(), 6)
+        self.assertTrue(np.array_equal(dst.data(), src_data.repeat(r)), msg)
+
+    def test_001_various_sizes(self):
+        sizes = ((3**10 + 2, 3), (3**6, 1), (4, 5), (10**6, 1), (10 * 2, 10 * 3))
+        for size, repetitions in sizes:
+            self.run_fg(size, repetitions, f"N = {size}, r = {repetitions}: not equal")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     gr_unittest.run(test_repeat)


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Repeat is a block that's commonly runtime-reconfigured. However, if the new interpolation is larger than the one specified at instantiation, this can lead to unsatisfiable output buffer requirements.

This change makes it so that the block is not a `sync_interpolator` anymore, but simply keeps track of how many times the last item still has to be repeated.

On the way there:

- Changed block type from `sync_interpolator` to `block`
- Hence, implemented a correct `forecast`
- Constructor and interpolation setter check for interpolation >= 1
- `general_work`: aforementioned handling of partial repeats
- `qa_repeat`: original QA was totally insufficient and ignored most
  corner cases. Also, checking code was very slow.
- Add the PMT formatter for fmt/spdlog that's necessary for setter logging

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

Closes #6809

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->

No API changes

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->

significantly extended the test coverage: more items, more strange combinations

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
