### PR TITLE
runtime: Remove VLA macro, usage

### DIFF
--- a/gnuradio-runtime/include/gnuradio/attributes.h
+++ b/gnuradio-runtime/include/gnuradio/attributes.h
@@ -67,14 +67,4 @@
 #pragma warning(disable : 4290) // C++ exception specification ignored except to indicate
                                 // a function is not __declspec(nothrow)
 #endif
-
-////////////////////////////////////////////////////////////////////////
-// implement cross-compiler VLA macros
-////////////////////////////////////////////////////////////////////////
-#ifdef _MSC_VER
-#define __GR_VLA(TYPE, buf, size) TYPE* buf = (TYPE*)alloca(sizeof(TYPE) * (size))
-#else
-#define __GR_VLA(TYPE, buf, size) TYPE buf[size]
-#endif
-
 #endif /* INCLUDED_GNURADIO_ATTRIBUTES_H */

--- a/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.h
+++ b/gr-dtv/lib/dvbt/dvbt_ofdm_sym_acquisition_impl.h
@@ -27,7 +27,8 @@ private:
     volk::vector<gr_complex> d_corr;
     volk::vector<gr_complex> d_gamma;
     volk::vector<float> d_lambda;
-
+    std::vector<int> d_ml_sync_peak_pos;
+    std::vector<float> d_ml_sync_phi;
     // For peak detector
     float d_threshold_factor_rise;
     float d_avg_alpha;


### PR DESCRIPTION
VLA (Variable-Length Arrays) are a C (pre-C23) feature that only works
for some C++ compilers out of goodwill – in C++, an object's type is
known at compile time, and `int[3]` and `int[4]` are two different
types.

They do nothing special that std::vector couldn't do as well, and
there's only one usage within GNU Radio that should actually have used
allocation in the constructor, and a field. So, changed it that way.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
