### PR TITLE
qtgui: Set stop button to correct state when opening control panel

### DIFF
--- a/gr-qtgui/lib/eyedisplayform.cc
+++ b/gr-qtgui/lib/eyedisplayform.cc
@@ -198,6 +198,9 @@ void EyeDisplayForm::setupControlPanel()
     d_controlpanel->toggleGrid(d_grid_act->isChecked());
     d_controlpanel->toggleTriggerMode(getTriggerMode());
     d_controlpanel->toggleTriggerSlope(getTriggerSlope());
+    if (d_stop_state) {
+        d_controlpanel->toggleStopButton();
+    }
 
     d_controlpanelmenu->setChecked(true);
 }

--- a/gr-qtgui/lib/freqdisplayform.cc
+++ b/gr-qtgui/lib/freqdisplayform.cc
@@ -210,6 +210,9 @@ void FreqDisplayForm::setupControlPanel()
     d_controlpanel->toggleMaxHold(d_maxhold_act->isChecked());
     d_controlpanel->toggleMinHold(d_minhold_act->isChecked());
     d_controlpanel->setFFTAverage(getFFTAverage());
+    if (d_stop_state) {
+        d_controlpanel->toggleStopButton();
+    }
 
     emit signalFFTSize(getFFTSize());
     emit signalFFTWindow(getFFTWindowType());

--- a/gr-qtgui/lib/timedisplayform.cc
+++ b/gr-qtgui/lib/timedisplayform.cc
@@ -207,6 +207,9 @@ void TimeDisplayForm::setupControlPanel()
     d_controlpanel->toggleGrid(d_grid_act->isChecked());
     d_controlpanel->toggleTriggerMode(getTriggerMode());
     d_controlpanel->toggleTriggerSlope(getTriggerSlope());
+    if (d_stop_state) {
+        d_controlpanel->toggleStopButton();
+    }
 
     d_controlpanelmenu->setChecked(true);
 }


### PR DESCRIPTION
## Description
In the Eye, Frequency, and Time sinks, if the display is stopped (middle click --> Stop) and then the control panel is opened (middle click --> Control Panel), the state of the Start/Stop button in the control panel is inverted. ("Stop" is displayed when the display is already stopped, and "Start" is displayed if it is restarted.)

To fix this, I've added code to set the control panel's Start/Stop button to the correct state when it is opened.

## Which blocks/areas does this affect?
* QT GUI Eye Sink
* QT GUI Frequency Sink
* QT GUI Time Sink

## Testing Done
I used the following flow graph for testing:

![Screenshot from 2023-08-30 23-19-21](https://github.com/gnuradio/gnuradio/assets/583749/d0d889cb-ce16-4ac1-9b40-445699c848d5)

While running the flow graph, I tried various sequences of the following operations:
* middle click --> Start/Stop
* middle click --> Control Panel
* click Start/Stop in the control panel

The control panel's Start/Stop button behaved correctly in all cases.

## Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] ~~I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.~~
- [x] ~~I have added tests to cover my changes~~, and all previous tests pass.