### PR TITLE
iio: make gr::io_signature for device_source and device_sink dynamic

### DIFF
--- a/gr-iio/grc/iio_device_sink.block.yml
+++ b/gr-iio/grc/iio_device_sink.block.yml
@@ -48,9 +48,16 @@ parameters:
     dtype: string
     hide: ${( 'part' )}
 
+-   id: ch_type
+    label: Channel type
+    dtype: enum
+    options: [ complex, float, int, short, byte]
+    default: short
+    hide: part
+
 inputs:
 -   domain: stream
-    dtype: short
+    dtype: ${ ch_type }
     multiplicity: ${ len(channels) }
 
 asserts:

--- a/gr-iio/grc/iio_device_source.block.yml
+++ b/gr-iio/grc/iio_device_source.block.yml
@@ -42,9 +42,16 @@ parameters:
     default: packet_len
     hide: part
 
+-   id: ch_type
+    label: Channel type
+    dtype: enum
+    options: [ complex, float, int, short, byte]
+    default: short
+    hide: part
+
 outputs:
 -   domain: stream
-    dtype: short
+    dtype: ${ ch_type }
     multiplicity: ${ len(channels) }
 -   domain: message
     id: msg


### PR DESCRIPTION
This modification enables using devices that have arbitrary channel size or channels with different sizes accross the same device

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Internally we found that when using gr-iio blocks with devices that do not have 16 bit channels, the data received is malformed.
This is due to the signature being hardcoded to multiple "short" channels.

The output type added to the blocks in grc is there to prevent the companion from erroring - has no real effect on building the block. There is still a problem with devices that have heterogenous outputs such as accelerometers:
X - 32 bit signed int
Y - 32 bit signed int
Z - 32 bit signed int
Timestamp - 64bit unsigned int
However these come by pretty rarely when using gnuradio.


## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
iio::device_source and iio::device_sink

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
We tested this internally with various IIO devices. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
