### PR TITLE
iio: make gr::io_signature for device_source dynamic

### DIFF
--- a/gr-iio/grc/iio_device_sink.block.yml
+++ b/gr-iio/grc/iio_device_sink.block.yml
@@ -48,9 +48,16 @@ parameters:
     dtype: string
     hide: ${( 'part' )}
 
+-   id: ch_type
+    label: Channel type
+    dtype: enum
+    options: [complex, int, short, byte]
+    default: short
+    hide: part
+
 inputs:
 -   domain: stream
-    dtype: short
+    dtype: ${ ch_type }
     multiplicity: ${ len(channels) }
 
 asserts:

--- a/gr-iio/grc/iio_device_source.block.yml
+++ b/gr-iio/grc/iio_device_source.block.yml
@@ -42,9 +42,16 @@ parameters:
     default: packet_len
     hide: part
 
+-   id: ch_type
+    label: Channel type
+    dtype: enum
+    options: [complex, int, short, byte]
+    default: short
+    hide: part
+
 outputs:
 -   domain: stream
-    dtype: short
+    dtype: ${ ch_type }
     multiplicity: ${ len(channels) }
 -   domain: message
     id: msg

--- a/gr-iio/lib/device_sink_impl.cc
+++ b/gr-iio/lib/device_sink_impl.cc
@@ -13,6 +13,7 @@
 
 #include "device_sink_impl.h"
 #include "device_source_impl.h"
+#include "iio_priv.h"
 #include <gnuradio/io_signature.h>
 
 #include <string>
@@ -90,6 +91,7 @@ device_sink_impl::device_sink_impl(iio_context* ctx,
       d_len_tag_key(pmt::PMT_NIL)
 {
     unsigned int nb_channels, i;
+    std::vector<int> signature;
 
     /* Set minimum input size */
     set_output_multiple(buffer_size / (interpolation + 1));
@@ -116,6 +118,8 @@ device_sink_impl::device_sink_impl(iio_context* ctx,
 
             iio_channel_enable(chn);
             channel_list.push_back(chn);
+
+            signature.push_back(channel_size(chn));
         }
     } else {
         for (std::vector<std::string>::const_iterator it = channels.begin();
@@ -132,10 +136,13 @@ device_sink_impl::device_sink_impl(iio_context* ctx,
             if (!iio_channel_is_enabled(chn))
                 throw std::runtime_error("Channel not enabled");
             channel_list.push_back(chn);
+
+            signature.push_back(channel_size(chn));
         }
     }
 
     set_params(params);
+    set_input_signature(gr::io_signature::makev(1, -1, signature));
 
     buf = iio_device_create_buffer(dev, buffer_size, cyclic);
     if (!buf)
@@ -215,7 +222,9 @@ int device_sink_impl::work(int noutput_items,
     }
 
     for (unsigned int i = 0; i < input_items.size(); i++)
-        channel_write(channel_list[i], input_items[i], noutput_items * sizeof(short));
+        channel_write(channel_list[i],
+                      input_items[i],
+                      noutput_items * channel_size(channel_list[i]));
 
     ret = iio_buffer_push(buf);
     if (ret < 0) {

--- a/gr-iio/lib/iio_priv.h
+++ b/gr-iio/lib/iio_priv.h
@@ -1,0 +1,30 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2023 Analog Devices Inc.
+ * Author: Adrian Suciu <adrian.suciu@analog.com>
+
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_IIO_IIO_PRIV_H
+#define INCLUDED_IIO_IIO_PRIV_H
+
+#include <iio.h>
+
+namespace gr {
+namespace iio {
+inline unsigned int channel_size(const iio_channel* chn)
+{
+    // to round up a / b without moving to float, you can do (a + (b-1)) / b
+    // (31 + 7) / 8 = 4 // 31 bits - 4 bytes
+    // (32 + 7) / 8 = 4 // 32 bits - 4 bytes
+    // (33 + 7) / 8 = 5 // 33 bits - 5 bytes
+    const iio_data_format* data = iio_channel_get_data_format(chn);
+    return (data->length + (8 - 1)) / 8;
+}
+
+} // namespace iio
+} // namespace gr
+
+#endif // INCLUDED_IIO_IIO_PRIV_H


### PR DESCRIPTION
This modification enables using devices that have arbitrary channel size or channels with different sizes across the same device

<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
Internally we found that when using gr-iio blocks with devices that do not have 16 bit channels, the data received is malformed.
This is due to the signature being hardcoded to multiple "short" channels. The solution consists in querying IIO for the channel format and setting the gr::io_signature at block consturction.

The output type added to the blocks in the gnuradio-companion is there to prevent the companion from erroring when connecting blocks to the device_source/device_sink that are not short. The output type in the companion has no real effect on building the block.  There is still a problem in the companion with devices that have heterogenous outputs such as accelerometers:
X - 32 bit signed int
Y - 32 bit signed int
Z - 32 bit signed int
Timestamp - 64bit unsigned int
However these come by pretty rarely when using gnuradio-companion with device_source / device_sink and specific blocks can be created if needed. The C++ blocks work correctly for these cases as well, it's just the companion that can get messed up.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
iio::device_source and iio::device_sink

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
We tested this internally with various IIO devices - Pluto, IIO accelerometers (with heterogeneous inputs), Precision ADCs (with 8 32-bit channels), etc

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [X] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
