### PR TITLE
qtgui: Matrix Sink - use QVector initializer supported by Qt 5.12

### DIFF
--- a/gr-qtgui/lib/matrix_sink_impl.cc
+++ b/gr-qtgui/lib/matrix_sink_impl.cc
@@ -116,8 +116,8 @@ int matrix_sink_impl::work(int noutput_items,
     auto in = static_cast<const input_type*>(input_items[0]);
 
     for (int k = 0; k < noutput_items; k++) {
-        std::vector<input_type> a(in + k * d_vlen, in + (k + 1) * d_vlen);
-        QVector<double> qvec(a.begin(), a.end());
+        QVector<double> qvec(d_vlen);
+        std::copy(in + k * d_vlen, in + (k + 1) * d_vlen, qvec.begin());
         emit d_signal->data_ready(qvec);
     }
 


### PR DESCRIPTION
Update to #6718 for compatibility with Qt 5.12 (Ubuntu 20.04)